### PR TITLE
DNS related changes

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -284,6 +284,7 @@
       glance = 266;
       couchpotato = 267;
       gogs = 268;
+      pdns-recursor = 269;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -370,6 +370,7 @@
   ./services/networking/dhcpd.nix
   ./services/networking/dnschain.nix
   ./services/networking/dnscrypt-proxy.nix
+  ./services/networking/dnscrypt-wrapper.nix
   ./services/networking/dnsmasq.nix
   ./services/networking/ejabberd.nix
   ./services/networking/fan.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -426,6 +426,7 @@
   ./services/networking/pdnsd.nix
   ./services/networking/polipo.nix
   ./services/networking/powerdns.nix
+  ./services/networking/pdns-recursor.nix
   ./services/networking/pptpd.nix
   ./services/networking/prayer.nix
   ./services/networking/privoxy.nix

--- a/nixos/modules/services/networking/dnschain.nix
+++ b/nixos/modules/services/networking/dnschain.nix
@@ -3,23 +3,31 @@
 with lib;
 
 let
-  cfg = config.services;
+  cfgs = config.services;
+  cfg  = cfgs.dnschain;
 
-  dnschainConf = pkgs.writeText "dnschain.conf" ''
+  dataDir  = "/var/lib/dnschain";
+  username = "dnschain";
+
+  configFile = pkgs.writeText "dnschain.conf" ''
     [log]
     level=info
 
     [dns]
-    host = 127.0.0.1
-    port = 5333
+    host = ${cfg.dns.address}
+    port = ${toString cfg.dns.port}
     oldDNSMethod = NO_OLD_DNS
-    # TODO: check what that address is acutally used for
-    externalIP = 127.0.0.1
+    externalIP = ${cfg.dns.address}
 
     [http]
-    host = 127.0.0.1
-    port=8088
-    tlsPort=4443
+    host = ${cfg.api.hostname}
+    port = ${toString cfg.api.port}
+    tlsPort = ${toString cfg.api.tlsPort}
+
+    [namecoin]
+    config=${optionalString cfgs.namecoind.enable cfg.namecoin.configFile}
+
+    ${cfg.extraConfig}
   '';
 
 in
@@ -32,28 +40,91 @@ in
 
     services.dnschain = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
+      enable = mkEnableOption ''
+        DNSChain, a blockchain based DNS + HTTP server.
+        To resolve .bit domains set <literal>services.namecoind.enable = true;</literal>
+        and an RPC username/password.
+      '';
+
+      dns.address = mkOption {
+        type = types.string;
+        default = "127.0.0.1";
         description = ''
-          Whether to run dnschain. That implies running
-          namecoind as well, so make sure to configure
-          it appropriately.
+          The IP address that will be used to reach this machine.
+          Leave this unchanged if you do not wish to directly expose the DNSChain resolver.
         '';
       };
+
+      dns.port = mkOption {
+        type = types.int;
+        default = 5333;
+        description = ''
+          The port the DNSChain resolver will bind to.
+        '';
+      };
+
+      api.hostname = mkOption {
+        type = types.string;
+        default = "0.0.0.0";
+        description = ''
+          The hostname (or IP address) the DNSChain API server will bind to.
+        '';
+      };
+
+      api.port = mkOption {
+        type = types.int;
+        default = 8080;
+        description = ''
+          The port the DNSChain API server (HTTP) will bind to.
+        '';
+      };
+
+      api.tlsPort = mkOption {
+        type = types.int;
+        default = 4433;
+        description = ''
+          The port the DNSChain API server (HTTPS) will bind to.
+        '';
+      };
+
+
+      namecoin.configFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          Path to namecoind configuration file (needed to access the RPC API).
+        '';
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          [log]
+          level = debug
+        '';
+        description = ''
+          Additional options that will be appended to the configuration file.
+        '';
+      };
+
 
     };
 
-    services.dnsmasq = {
-      resolveDnschainQueries = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Resolve <literal>.bit</literal> top-level domains
-          with dnschain and namecoind.
-        '';
-      };
+    services.dnsmasq.resolveDNSChainQueries = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Resolve <literal>.bit</literal> top-level domains using DNSChain and namecoin.
+      '';
+    };
 
+    services.pdns-recursor.resolveDNSChainQueries = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Resolve <literal>.bit</literal> top-level domains using DNSChain and namecoin.
+      '';
     };
 
   };
@@ -61,48 +132,47 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.dnschain.enable {
+  config = mkIf cfg.enable {
 
-    services.namecoind.enable = true;
+    services.dnsmasq.servers = optionals cfgs.dnsmasq.resolveDNSChainQueries
+      [ "/.bit/127.0.0.1#${toString cfg.dns.port}"
+        "/.dns/127.0.0.1#${toString cfg.dns.port}"
+      ];
 
-    services.dnsmasq.servers = optionals cfg.dnsmasq.resolveDnschainQueries [ "/.bit/127.0.0.1#5333" ];
-
-    users.extraUsers = singleton
-      { name = "dnschain";
-        uid = config.ids.uids.dnschain;
-        extraGroups = [ "namecoin" ];
-        description = "Dnschain daemon user";
-        home = "/var/lib/dnschain";
-        createHome = true;
+    services.pdns-recursor.forwardZones = mkIf cfgs.pdns-recursor.resolveDNSChainQueries
+      { bit = "127.0.0.1:${toString cfg.dns.port}";
+        dns = "127.0.0.1:${toString cfg.dns.port}";
       };
 
-    systemd.services.dnschain = {
-        description = "Dnschain Daemon";
-        after = [ "namecoind.target" ];
-        wantedBy = [ "multi-user.target" ];
-        path = [ pkgs.openssl ];
-        preStart = ''
-          # Link configuration file into dnschain HOME directory
-          if [ "$(${pkgs.coreutils}/bin/realpath /var/lib/dnschain/.dnschain.conf)" != "${dnschainConf}" ]; then
-              rm -rf /var/lib/dnschain/.dnschain.conf
-              ln -s ${dnschainConf} /var/lib/dnschain/.dnschain.conf
-          fi
+    users.extraUsers = singleton {
+      name = username;
+      description = "DNSChain daemon user";
+      home = dataDir;
+      createHome = true;
+      uid = config.ids.uids.dnschain;
+      extraGroups = optional cfgs.namecoind.enable "namecoin";
+    };
 
-          # Create empty namecoin.conf so that dnschain is not
-          # searching for /etc/namecoin/namecoin.conf
-          if [ ! -e /var/lib/dnschain/.namecoin/namecoin.conf ]; then
-              mkdir -p /var/lib/dnschain/.namecoin
-              touch /var/lib/dnschain/.namecoin/namecoin.conf
-          fi
-        '';
-        serviceConfig = {
-          Type = "simple";
-          User = "dnschain";
-          EnvironmentFile = config.services.namecoind.userFile;
-          ExecStart = "${pkgs.dnschain}/bin/dnschain --rpcuser=\${USER} --rpcpassword=\${PASSWORD} --rpcport=8336";
-          ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-          ExecStop = "${pkgs.coreutils}/bin/kill -KILL $MAINPID";
-        };
+    systemd.services.dnschain = {
+      description = "DNSChain daemon";
+      after    = [ "namecoind.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        User = "dnschain";
+        Restart = "on-failure";
+        ExecStart = "${pkgs.dnschain}/bin/dnschain";
+      };
+
+      preStart = ''
+        # Link configuration file into dnschain home directory
+        configPath=${dataDir}/.dnschain/dnschain.conf
+        mkdir -p ${dataDir}/.dnschain
+        if [ "$(realpath $configPath)" != "${configFile}" ]; then
+          rm -f $configPath
+          ln -s ${configFile} $configPath
+        fi
+      '';
     };
 
   };

--- a/nixos/modules/services/networking/dnscrypt-wrapper.nix
+++ b/nixos/modules/services/networking/dnscrypt-wrapper.nix
@@ -1,0 +1,187 @@
+{ config, lib, pkgs, ... }:
+with lib;
+
+let
+  cfg     = config.services.dnscrypt-wrapper;
+  dataDir = "/var/lib/dnscrypt-wrapper";
+
+  daemonArgs = with cfg; [
+    "--listen-address=${address}:${toString port}"
+    "--resolver-address=${upstream.address}:${toString upstream.port}"
+    "--provider-name=${providerName}"
+    "--provider-publickey-file=public.key"
+    "--provider-secretkey-file=secret.key"
+    "--provider-cert-file=${providerName}.crt"
+    "--crypt-secretkey-file=${providerName}.key"
+  ];
+
+  genKeys = ''
+    # generates time-limited keypairs
+    keyGen() {
+      dnscrypt-wrapper --gen-crypt-keypair \
+        --crypt-secretkey-file=${cfg.providerName}.key
+
+      dnscrypt-wrapper --gen-cert-file \
+        --crypt-secretkey-file=${cfg.providerName}.key \
+        --provider-cert-file=${cfg.providerName}.crt \
+        --provider-publickey-file=public.key \
+        --provider-secretkey-file=secret.key \
+        --cert-file-expire-days=${toString cfg.keys.expiration}
+    }
+
+    cd ${dataDir}
+
+    # generate provider keypair (first run only)
+    if [ ! -f public.key ] || [ ! -f secret.key ]; then
+      dnscrypt-wrapper --gen-provider-keypair
+    fi
+
+    # generate new keys for rotation
+    if [ ! -f ${cfg.providerName}.key ] || [ ! -f ${cfg.providerName}.crt ]; then
+      keyGen
+    fi
+  '';
+
+  rotateKeys = ''
+    # check if keys are not expired
+    keyValid() {
+      fingerprint=$(dnscrypt-wrapper --show-provider-publickey-fingerprint | awk '{print $(NF)}')
+      dnscrypt-proxy --test=${toString (cfg.keys.checkInterval + 1)} \
+        --resolver-address=127.0.0.1:${toString cfg.port} \
+        --provider-name=${cfg.providerName} \
+        --provider-key=$fingerprint
+    }
+
+    cd ${dataDir}
+
+    # archive old keys and restart the service
+    if ! keyValid; then
+      mkdir -p oldkeys
+      mv ${cfg.providerName}.key oldkeys/${cfg.providerName}-$(date +%F-%T).key
+      mv ${cfg.providerName}.crt oldkeys/${cfg.providerName}-$(date +%F-%T).crt
+      systemctl restart dnscrypt-wrapper
+    fi
+  '';
+
+in {
+
+
+  ###### interface
+
+  options.services.dnscrypt-wrapper = {
+    enable = mkEnableOption "DNSCrypt wrapper";
+
+    address = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = ''
+        The DNSCrypt wrapper will bind to this IP address.
+      '';
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 5353;
+      description = ''
+        The DNSCrypt wrapper will listen for DNS queries on this port.
+      '';
+    };
+
+    providerName = mkOption {
+      type = types.str;
+      default = "2.dnscrypt-cert.${config.networking.hostName}";
+      example = "2.dnscrypt-cert.myresolver";
+      description = ''
+        The name that will be given to this DNSCrypt resolver.
+        Note: the resolver name must start with <literal>2.dnscrypt-cert.</literal>.
+      '';
+    };
+
+    upstream.address = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = ''
+        The IP address of the upstream DNS server DNSCrypt will "wrap".
+      '';
+    };
+
+    upstream.port = mkOption {
+      type = types.int;
+      default = 53;
+      description = ''
+        The port of the upstream DNS server DNSCrypt will "wrap".
+      '';
+    };
+
+    keys.expiration = mkOption {
+      type = types.int;
+      default = 30;
+      description = ''
+        The duration (in days) of the time-limited secret key.
+        This will be automatically rotated before expiration.
+      '';
+    };
+
+    keys.checkInterval = mkOption {
+      type = types.int;
+      default = 1440;
+      description = ''
+        The time interval (in minutes) between key expiration checks.
+      '';
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    users.users.dnscrypt-wrapper = {
+      description = "dnscrypt-wrapper daemon user";
+      home = "${dataDir}";
+      createHome = true;
+    };
+    users.groups.dnscrypt-wrapper = { };
+
+
+    systemd.services.dnscrypt-wrapper = {
+      description = "dnscrypt-wrapper daemon";
+      after    = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path     = [ pkgs.dnscrypt-wrapper ];
+
+      serviceConfig = {
+        User = "dnscrypt-wrapper";
+        WorkingDirectory = dataDir;
+        Restart   = "on-failure";
+        ExecStart = "${pkgs.dnscrypt-wrapper}/bin/dnscrypt-wrapper ${toString daemonArgs}";
+      };
+
+      preStart = genKeys;
+    };
+
+
+    systemd.services.dnscrypt-wrapper-rotate = {
+      after    = [ "network.target" ];
+      requires = [ "dnscrypt-wrapper.service" ];
+      description = "Rotates DNSCrypt wrapper keys if soon to expire";
+
+      path   = with pkgs; [ dnscrypt-wrapper dnscrypt-proxy gawk ];
+      script = rotateKeys;
+    };
+
+
+    systemd.timers.dnscrypt-wrapper-rotate = {
+      description = "Periodically check DNSCrypt wrapper keys for expiration";
+      wantedBy = [ "multi-user.target" ];
+
+      timerConfig = {
+        Unit = "dnscrypt-wrapper-rotate.service";
+        OnBootSec = "1min";
+        OnUnitActiveSec = cfg.keys.checkInterval * 60;
+      };
+    };
+
+  };
+}

--- a/nixos/modules/services/networking/namecoind.nix
+++ b/nixos/modules/services/networking/namecoind.nix
@@ -3,25 +3,35 @@
 with lib;
 
 let
-  cfg = config.services.namecoind;
+  cfg     = config.services.namecoind;
+  dataDir = "/var/lib/namecoind";
+  useSSL  = (cfg.rpc.certificate != null) && (cfg.rpc.key != null);
+  useRPC  = (cfg.rpc.user != null) && (cfg.rpc.password != null);
 
-  namecoinConf =
-  let
-    useSSL = (cfg.rpcCertificate != null) && (cfg.rpcKey != null);
-  in
-  pkgs.writeText "namecoin.conf" ''
+  listToConf = option: list:
+    concatMapStrings (value :"${option}=${value}\n") list;
+
+  configFile = pkgs.writeText "namecoin.conf" (''
     server=1
     daemon=0
-    rpcallowip=127.0.0.1
-    walletpath=${cfg.wallet}
-    gen=${if cfg.generate then "1" else "0"}
-    rpcssl=${if useSSL then "1" else "0"}
-    ${optionalString useSSL "rpcsslcertificatechainfile=${cfg.rpcCertificate}"}
-    ${optionalString useSSL "rpcsslprivatekeyfile=${cfg.rpcKey}"}
-    ${optionalString useSSL "rpcsslciphers=TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH"}
     txindex=1
     txprevcache=1
-  '';
+    walletpath=${cfg.wallet}
+    gen=${if cfg.generate then "1" else "0"}
+    ${listToConf "addnode" cfg.extraNodes}
+    ${listToConf "connect" cfg.trustedNodes}
+  '' + optionalString useRPC ''
+    rpcbind=${cfg.rpc.address}
+    rpcport=${toString cfg.rpc.port}
+    rpcuser=${cfg.rpc.user}
+    rpcpassword=${cfg.rpc.password}
+    ${listToConf "rpcallowip" cfg.rpc.allowFrom}
+  '' + optionalString useSSL ''
+    rpcssl=1
+    rpcsslcertificatechainfile=${cfg.rpc.certificate}
+    rpcsslprivatekeyfile=${cfg.rpc.key}
+    rpcsslciphers=TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH
+  '');
 
 in
 
@@ -33,37 +43,14 @@ in
 
     services.namecoind = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to run namecoind.
-        '';
-      };
+      enable = mkEnableOption "namecoind, Namecoin client.";
 
       wallet = mkOption {
         type = types.path;
-        example = "/etc/namecoin/wallet.dat";
+        default = "${dataDir}/wallet.dat";
         description = ''
           Wallet file. The ownership of the file has to be
           namecoin:namecoin, and the permissions must be 0640.
-        '';
-      };
-
-      userFile = mkOption {
-        type = types.nullOr types.path;
-        default = null;
-        example = "/etc/namecoin/user";
-        description = ''
-          File containing the user name and user password to
-          authenticate RPC connections to namecoind.
-          The content of the file is of the form:
-          <literal>
-          USER=namecoin
-          PASSWORD=secret
-          </literal>
-          The ownership of the file has to be namecoin:namecoin,
-          and the permissions must be 0640.
         '';
       };
 
@@ -75,21 +62,80 @@ in
         '';
       };
 
-      rpcCertificate = mkOption {
+      extraNodes = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          List of additional peer IP addresses to connect to.
+        '';
+      };
+
+      trustedNodes = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          List of the only peer IP addresses to connect to. If specified
+          no other connection will be made.
+        '';
+      };
+
+      rpc.user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          User name for RPC connections.
+        '';
+      };
+
+      rpc.password = mkOption {
+        type = types.str;
+        default = null;
+        description = ''
+          Password for RPC connections.
+        '';
+      };
+
+      rpc.address = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        description = ''
+          IP address the RPC server will bind to.
+        '';
+      };
+
+      rpc.port = mkOption {
+        type = types.int;
+        default = 8332;
+        description = ''
+          Port the RPC server will bind to.
+        '';
+      };
+
+      rpc.certificate = mkOption {
         type = types.nullOr types.path;
         default = null;
-        example = "/etc/namecoin/server.cert";
+        example = "/var/lib/namecoind/server.cert";
         description = ''
           Certificate file for securing RPC connections.
         '';
       };
 
-      rpcKey = mkOption {
+      rpc.key = mkOption {
         type = types.nullOr types.path;
         default = null;
-        example = "/etc/namecoin/server.pem";
+        example = "/var/lib/namecoind/server.pem";
         description = ''
           Key file for securing RPC connections.
+        '';
+      };
+
+
+      rpc.allowFrom = mkOption {
+        type = types.listOf types.str;
+        default = [ "127.0.0.1" ];
+        description = ''
+          List of IP address ranges allowed to use the RPC API.
+          Wiledcards (*) can be user to specify a range.
         '';
       };
 
@@ -102,47 +148,52 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = singleton
-      { name = "namecoin";
-        uid = config.ids.uids.namecoin;
-        description = "Namecoin daemon user";
-        home = "/var/lib/namecoin";
-        createHome = true;
-      };
+    services.dnschain.namecoin.configFile =
+      mkIf config.services.dnschain.enable configFile;
 
-    users.extraGroups = singleton
-      { name = "namecoin";
-        gid = config.ids.gids.namecoin;
-      };
+    users.extraUsers = singleton {
+      name = "namecoin";
+      uid  = config.ids.uids.namecoin;
+      description = "Namecoin daemon user";
+      home = dataDir;
+      createHome = true;
+    };
+
+    users.extraGroups = singleton {
+      name = "namecoin";
+      gid  = config.ids.gids.namecoin;
+    };
 
     systemd.services.namecoind = {
-        description = "Namecoind Daemon";
-        after = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
-        preStart = ''
-          if [  "$(stat --printf '%u' ${cfg.userFile})" != "${toString config.ids.uids.namecoin}" \
-             -o "$(stat --printf '%g' ${cfg.userFile})" != "${toString config.ids.gids.namecoin}" \
-             -o "$(stat --printf '%a' ${cfg.userFile})" != "640" ]; then
-             echo "ERROR: bad ownership or rights on ${cfg.userFile}" >&2
-             exit 1
-          fi
-          if [  "$(stat --printf '%u' ${cfg.wallet})" != "${toString config.ids.uids.namecoin}" \
-             -o "$(stat --printf '%g' ${cfg.wallet})" != "${toString config.ids.gids.namecoin}" \
-             -o "$(stat --printf '%a' ${cfg.wallet})" != "640" ]; then
-             echo "ERROR: bad ownership or rights on ${cfg.wallet}" >&2
-             exit 1
-          fi
-        '';
-        serviceConfig = {
-          Type = "simple";
-          User = "namecoin";
-          EnvironmentFile = cfg.userFile;
-          ExecStart = "${pkgs.altcoins.namecoind}/bin/namecoind -conf=${namecoinConf} -rpcuser=\${USER} -rpcpassword=\${PASSWORD} -printtoconsole";
-          ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-          ExecStop = "${pkgs.coreutils}/bin/kill -KILL $MAINPID";
-          StandardOutput = "null";
-          Nice = "10";
-        };
+      description = "Namecoind daemon";
+      after    = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        User  = "namecoin";
+        Griup = "namecoin";
+        ExecStart  = "${pkgs.altcoins.namecoind}/bin/namecoind -conf=${configFile} -datadir=${dataDir} -printtoconsole";
+        ExecStop   = "${pkgs.coreutils}/bin/kill -KILL $MAINPID";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        Nice = "10";
+        PrivateTmp = true;
+        TimeoutStopSec     = "60s";
+        TimeoutStartSec    = "2s";
+        Restart            = "always";
+        StartLimitInterval = "120s";
+        StartLimitBurst    = "5";
+      };
+
+      preStart = optionalString (cfg.wallet != "${dataDir}/wallet.dat")  ''
+        # check wallet file permissions
+        if [ "$(stat --printf '%u' ${cfg.wallet})" != "${toString config.ids.uids.namecoin}" \
+           -o "$(stat --printf '%g' ${cfg.wallet})" != "${toString config.ids.gids.namecoin}" \
+           -o "$(stat --printf '%a' ${cfg.wallet})" != "640" ]; then
+           echo "ERROR: bad ownership or rights on ${cfg.wallet}" >&2
+           exit 1
+        fi
+      '';
+
     };
 
   };

--- a/nixos/modules/services/networking/pdns-recursor.nix
+++ b/nixos/modules/services/networking/pdns-recursor.nix
@@ -1,0 +1,168 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  dataDir  = "/var/lib/pdns-recursor";
+  username = "pdns-recursor";
+
+  cfg   = config.services.pdns-recursor;
+  zones = mapAttrsToList (zone: uri: "${zone}.=${uri}") cfg.forwardZones;
+
+  configFile = pkgs.writeText "recursor.conf" ''
+    local-address=${cfg.dns.address}
+    local-port=${toString cfg.dns.port}
+    allow-from=${concatStringsSep "," cfg.dns.allowFrom}
+
+    webserver-address=${cfg.api.address}
+    webserver-port=${toString cfg.api.port}
+    webserver-allow-from=${concatStringsSep "," cfg.api.allowFrom}
+
+    forward-zones=${concatStringsSep "," zones}
+    export-etc-hosts=${if cfg.exportHosts then "yes" else "no"}
+    dnssec=${cfg.dnssecValidation}
+    serve-rfc1918=${if cfg.serveRFC1918 then "yes" else "no"}
+
+    ${cfg.extraConfig}
+  '';
+
+in {
+  options.services.pdns-recursor = {
+    enable = mkEnableOption "PowerDNS Recursor, a recursive DNS server";
+
+    dns.address = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = ''
+        IP address Recursor DNS server will bind to.
+      '';
+    };
+
+    dns.port = mkOption {
+      type = types.int;
+      default = 53;
+      description = ''
+        Port number Recursor DNS server will bind to.
+      '';
+    };
+
+    dns.allowFrom = mkOption {
+      type = types.listOf types.str;
+      default = [ "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" ];
+      example = [ "0.0.0.0/0" ];
+      description = ''
+        IP address ranges of clients allowed to make DNS queries.
+      '';
+    };
+
+    api.address = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = ''
+        IP address Recursor REST API server will bind to.
+      '';
+    };
+
+    api.port = mkOption {
+      type = types.int;
+      default = 8082;
+      description = ''
+        Port number Recursor REST API server will bind to.
+      '';
+    };
+
+    api.allowFrom = mkOption {
+      type = types.listOf types.str;
+      default = [ "0.0.0.0/0" ];
+      description = ''
+        IP address ranges of clients allowed to make API requests.
+      '';
+    };
+
+    exportHosts = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+       Whether to export names and IP addresses defined in /etc/hosts.
+      '';
+    };
+
+    forwardZones = mkOption {
+      type = types.attrs;
+      example = { eth = "127.0.0.1:5353"; };
+      default = {};
+      description = ''
+        DNS zones to be forwarded to other servers.
+      '';
+    };
+
+    dnssecValidation = mkOption {
+      type = types.enum ["off" "process-no-validate" "process" "log-fail" "validate"];
+      default = "process-no-validate";
+      description = ''
+        Controls the level of DNSSEC processing done by the PowerDNS Recursor.
+        See https://doc.powerdns.com/md/recursor/dnssec/ for a detailed explanation.
+      '';
+    };
+
+    serveRFC1918 = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to directly resolve the RFC1918 reverse-mapping domains:
+        <literal>10.in-addr.arpa</literal>,
+        <literal>168.192.in-addr.arpa</literal>,
+        <literal>16-31.172.in-addr.arpa</literal>
+        This saves load on the AS112 servers.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra options to be appended to the configuration file.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    users.extraUsers."${username}" = {
+      home = dataDir;
+      createHome = true;
+      uid = config.ids.uids.pdns-recursor;
+      description = "PowerDNS Recursor daemon user";
+    };
+
+    systemd.services.pdns-recursor = {
+      unitConfig.Documentation = "man:pdns_recursor(1) man:rec_control(1)";
+      description = "PowerDNS recursive server";
+      wantedBy = [ "multi-user.target" ];
+      after    = [ "network.target" ];
+
+      serviceConfig = {
+        User = username;
+        Restart    ="on-failure";
+        RestartSec = "5";
+        PrivateTmp = true;
+        PrivateDevices = true;
+        AmbientCapabilities = "cap_net_bind_service";
+        ExecStart = ''${pkgs.pdns-recursor}/bin/pdns_recursor \
+          --config-dir=${dataDir} \
+          --socket-dir=${dataDir} \
+          --disable-syslog
+        '';
+      };
+
+      preStart = ''
+        # Link configuration file into recursor home directory
+        configPath=${dataDir}/recursor.conf
+        if [ "$(realpath $configPath)" != "${configFile}" ]; then
+          rm -f $configPath
+          ln -s ${configFile} $configPath
+        fi
+      '';
+    };
+  };
+}

--- a/pkgs/servers/dns/pdns-recursor/default.nix
+++ b/pkgs/servers/dns/pdns-recursor/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, pkgconfig, boost
+, openssl, systemd, lua, luajit, protobuf
+, enableLua ? false
+, enableProtoBuf ? false
+}:
+
+assert enableLua      -> lua != null && luajit != null;
+assert enableProtoBuf -> protobuf != null;
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "pdns-recursor-${version}";
+  version = "4.0.4";
+
+  src = fetchurl {
+    url = "https://downloads.powerdns.com/releases/pdns-recursor-${version}.tar.bz2";
+    sha256 = "0k8y9zxj2lz4rq782vgzr28yd43q0hwlnvszwq0k9l6c967pff13";
+  };
+
+  buildInputs = [
+    boost openssl pkgconfig systemd
+  ] ++ optional enableLua [ lua luajit ]
+    ++ optional enableProtoBuf protobuf;
+
+  configureFlags = [
+    "--enable-reproducible"
+    "--with-systemd"
+  ];
+
+  meta = {
+    description = "A recursive DNS server";
+    homepage = http://www.powerdns.com/;
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ rnhmjoj ];
+  };
+}

--- a/pkgs/servers/dnschain/default.nix
+++ b/pkgs/servers/dnschain/default.nix
@@ -1,11 +1,51 @@
-{ stdenv, nodePackages }:
-
-# to update dnschain, run npm2nix package.json package.nix, and
-# then add "coffee-script" manually as a dependecy for "dnschain"
-# in package.nix.
+{ stdenv, fetchFromGitHub, callPackage, makeWrapper, openssl }:
 
 let
-  np = nodePackages.override { generated = ./package.nix; self = np; };
-in
+  nodePackages = callPackage (import ../../top-level/node-packages.nix) {
+    self = nodePackages;
+    generated = ./package.nix;
+  };
 
-np.dnschain
+in nodePackages.buildNodePackage rec {
+  name    = "dnschain-${version}";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner  = "okTurtles";
+    repo   = "dnschain";
+    rev    = "a8d477f9ad33d7790f94ffc563e2205823e62515";
+    sha256 = "0j5glbxf0fxnxl4l1lysb3a619b18rk0l1ks57wd255llc2mw7zy";
+  };
+
+  deps = with nodePackages; [
+    by-spec."bluebird"."2.9.9"
+    by-spec."bottleneck"."1.5.x"
+    by-spec."event-stream"."3.2.2"
+    by-spec."express"."4.11.2"
+    by-spec."hiredis"."0.4.1"
+    by-spec."json-rpc2"."0.8.1"
+    by-spec."lodash"."3.1.0"
+    by-spec."native-dns"."git+https://github.com/okTurtles/node-dns.git#08433ec98f517eed3c6d5e47bdf62603539cd402"
+    by-spec."native-dns-packet"."0.1.1"
+    by-spec."nconf"."0.7.1"
+    by-spec."properties"."1.2.1"
+    by-spec."redis"."0.12.x"
+    by-spec."string"."2.0.1"
+    by-spec."winston"."0.8.0"
+    by-spec."superagent"."0.21.0"
+  ];
+
+  buildInputs = [ makeWrapper nodePackages.coffee-script ];
+  postInstall = ''
+      wrapProgram $out/bin/dnschain --suffix PATH : ${openssl.bin}/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A blockchain-based DNS + HTTP server";
+    homepage    = https://okturtles.com/;
+    license     = licenses.mpl20;
+    maintainers = with maintainers; [ rnhmjoj ];
+    platforms   = platforms.unix;
+  };
+
+}

--- a/pkgs/servers/dnschain/package.nix
+++ b/pkgs/servers/dnschain/package.nix
@@ -1,3 +1,4 @@
+
 { self, fetchurl, fetchgit ? null, lib }:
 
 {
@@ -8,13 +9,32 @@
     version = "1.2.13";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz";
+      url = "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz";
       name = "accepts-1.2.13.tgz";
       sha1 = "e5f1f3928c6d95fd96558c36ec3d9d0de4a6ecea";
     };
     deps = {
-      "mime-types-2.1.6" = self.by-version."mime-types"."2.1.6";
+      "mime-types-2.1.14" = self.by-version."mime-types"."2.1.14";
       "negotiator-0.5.3" = self.by-version."negotiator"."0.5.3";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."assert-plus"."^1.0.0" =
+    self.by-version."assert-plus"."1.0.0";
+  by-version."assert-plus"."1.0.0" = self.buildNodePackage {
+    name = "assert-plus-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz";
+      name = "assert-plus-1.0.0.tgz";
+      sha1 = "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525";
+    };
+    deps = {
     };
     optionalDependencies = {
     };
@@ -29,7 +49,7 @@
     version = "0.2.10";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/async/-/async-0.2.10.tgz";
+      url = "https://registry.npmjs.org/async/-/async-0.2.10.tgz";
       name = "async-0.2.10.tgz";
       sha1 = "b6bbe0b0674b9d719708ca38de8c237cb526c3d1";
     };
@@ -48,7 +68,7 @@
     version = "0.9.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/async/-/async-0.9.2.tgz";
+      url = "https://registry.npmjs.org/async/-/async-0.9.2.tgz";
       name = "async-0.9.2.tgz";
       sha1 = "aea74d5e61c1f899613bf64bda66d4c78f2fd17d";
     };
@@ -67,7 +87,7 @@
     version = "1.6.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/better-curry/-/better-curry-1.6.0.tgz";
+      url = "https://registry.npmjs.org/better-curry/-/better-curry-1.6.0.tgz";
       name = "better-curry-1.6.0.tgz";
       sha1 = "38f716b24c8cee07a262abc41c22c314e20e3869";
     };
@@ -86,7 +106,7 @@
     version = "0.0.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/binaryheap/-/binaryheap-0.0.3.tgz";
+      url = "https://registry.npmjs.org/binaryheap/-/binaryheap-0.0.3.tgz";
       name = "binaryheap-0.0.3.tgz";
       sha1 = "0d6136c84e9f1a5a90c0b97178c3e00df59820d6";
     };
@@ -105,7 +125,7 @@
     version = "1.2.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz";
+      url = "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz";
       name = "bindings-1.2.1.tgz";
       sha1 = "14ad6113812d2d37d72e67b4cacb4bb726505f11";
     };
@@ -124,7 +144,7 @@
     version = "2.9.9";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/bluebird/-/bluebird-2.9.9.tgz";
+      url = "https://registry.npmjs.org/bluebird/-/bluebird-2.9.9.tgz";
       name = "bluebird-2.9.9.tgz";
       sha1 = "61a26904d43d7f6b19dff7ed917dbc92452ad6d3";
     };
@@ -143,7 +163,7 @@
     version = "1.5.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/bottleneck/-/bottleneck-1.5.3.tgz";
+      url = "https://registry.npmjs.org/bottleneck/-/bottleneck-1.5.3.tgz";
       name = "bottleneck-1.5.3.tgz";
       sha1 = "55fa64920d9670087d44150404525d59f9511c20";
     };
@@ -162,12 +182,12 @@
     version = "0.0.12";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/buffercursor/-/buffercursor-0.0.12.tgz";
+      url = "https://registry.npmjs.org/buffercursor/-/buffercursor-0.0.12.tgz";
       name = "buffercursor-0.0.12.tgz";
       sha1 = "78a9a7f4343ae7d820a8999acc80de591e25a779";
     };
     deps = {
-      "verror-1.6.0" = self.by-version."verror"."1.6.0";
+      "verror-1.9.0" = self.by-version."verror"."1.9.0";
     };
     optionalDependencies = {
     };
@@ -178,15 +198,15 @@
   by-spec."buffercursor".">= 0.0.5" =
     self.by-version."buffercursor"."0.0.12";
   by-spec."coffee-script"."*" =
-    self.by-version."coffee-script"."1.10.0";
-  by-version."coffee-script"."1.10.0" = self.buildNodePackage {
-    name = "coffee-script-1.10.0";
-    version = "1.10.0";
+    self.by-version."coffee-script"."1.12.2";
+  by-version."coffee-script"."1.12.2" = self.buildNodePackage {
+    name = "coffee-script-1.12.2";
+    version = "1.12.2";
     bin = true;
     src = fetchurl {
-      url = "http://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz";
-      name = "coffee-script-1.10.0.tgz";
-      sha1 = "12938bcf9be1948fa006f92e0c4c9e81705108c0";
+      url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.2.tgz";
+      name = "coffee-script-1.12.2.tgz";
+      sha1 = "0d4cbdee183f650da95419570c4929d08ef91376";
     };
     deps = {
     };
@@ -196,7 +216,7 @@
     os = [ ];
     cpu = [ ];
   };
-  "coffee-script" = self.by-version."coffee-script"."1.10.0";
+  "coffee-script" = self.by-version."coffee-script"."1.12.2";
   by-spec."colors"."0.6.x" =
     self.by-version."colors"."0.6.2";
   by-version."colors"."0.6.2" = self.buildNodePackage {
@@ -204,7 +224,7 @@
     version = "0.6.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz";
+      url = "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz";
       name = "colors-0.6.2.tgz";
       sha1 = "2423fe6678ac0c5dae8852e5d0e5be08c997abcc";
     };
@@ -223,7 +243,7 @@
     version = "0.0.7";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz";
+      url = "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz";
       name = "combined-stream-0.0.7.tgz";
       sha1 = "0137e657baa5a7541c57ac37ac5fc07d73b4dc1f";
     };
@@ -243,7 +263,7 @@
     version = "1.1.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz";
+      url = "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz";
       name = "component-emitter-1.1.2.tgz";
       sha1 = "296594f2753daa63996d2af08d15a95116c9aec3";
     };
@@ -262,7 +282,7 @@
     version = "0.5.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz";
+      url = "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz";
       name = "content-disposition-0.5.0.tgz";
       sha1 = "4284fe6ae0630874639e44e80a418c2934135e9e";
     };
@@ -281,7 +301,7 @@
     version = "0.1.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz";
+      url = "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz";
       name = "cookie-0.1.2.tgz";
       sha1 = "72fec3d24e48a3432073d90c12642005061004b1";
     };
@@ -300,7 +320,7 @@
     version = "1.0.5";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz";
+      url = "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz";
       name = "cookie-signature-1.0.5.tgz";
       sha1 = "a122e3f1503eca0f5355795b0711bb2368d450f9";
     };
@@ -319,7 +339,7 @@
     version = "2.0.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz";
+      url = "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz";
       name = "cookiejar-2.0.1.tgz";
       sha1 = "3d12752f6adf68a892f332433492bd5812bb668f";
     };
@@ -331,16 +351,16 @@
     os = [ ];
     cpu = [ ];
   };
-  by-spec."core-util-is"."~1.0.0" =
-    self.by-version."core-util-is"."1.0.1";
-  by-version."core-util-is"."1.0.1" = self.buildNodePackage {
-    name = "core-util-is-1.0.1";
-    version = "1.0.1";
+  by-spec."core-util-is"."1.0.2" =
+    self.by-version."core-util-is"."1.0.2";
+  by-version."core-util-is"."1.0.2" = self.buildNodePackage {
+    name = "core-util-is-1.0.2";
+    version = "1.0.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz";
-      name = "core-util-is-1.0.1.tgz";
-      sha1 = "6b07085aef9a3ccac6ee53bf9d3df0c1521a5538";
+      url = "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz";
+      name = "core-util-is-1.0.2.tgz";
+      sha1 = "b5fd54220aa2bc5ab57aab7140c940754503c1a7";
     };
     deps = {
     };
@@ -350,6 +370,8 @@
     os = [ ];
     cpu = [ ];
   };
+  by-spec."core-util-is"."~1.0.0" =
+    self.by-version."core-util-is"."1.0.2";
   by-spec."crc"."3.2.1" =
     self.by-version."crc"."3.2.1";
   by-version."crc"."3.2.1" = self.buildNodePackage {
@@ -357,7 +379,7 @@
     version = "3.2.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/crc/-/crc-3.2.1.tgz";
+      url = "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz";
       name = "crc-3.2.1.tgz";
       sha1 = "5d9c8fb77a245cd5eca291e5d2d005334bab0082";
     };
@@ -376,7 +398,7 @@
     version = "1.0.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz";
+      url = "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz";
       name = "cycle-1.0.3.tgz";
       sha1 = "21e80b2be8580f98b468f379430662b046c34ad2";
     };
@@ -395,7 +417,7 @@
     version = "1.0.4";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/debug/-/debug-1.0.4.tgz";
+      url = "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz";
       name = "debug-1.0.4.tgz";
       sha1 = "5b9c256bd54b6ec02283176fa8a0ede6d154cbf8";
     };
@@ -409,18 +431,18 @@
     cpu = [ ];
   };
   by-spec."debug"."2" =
-    self.by-version."debug"."2.2.0";
-  by-version."debug"."2.2.0" = self.buildNodePackage {
-    name = "debug-2.2.0";
-    version = "2.2.0";
+    self.by-version."debug"."2.6.0";
+  by-version."debug"."2.6.0" = self.buildNodePackage {
+    name = "debug-2.6.0";
+    version = "2.6.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz";
-      name = "debug-2.2.0.tgz";
-      sha1 = "f87057e995b1a1f6ae6a4960664137bc56f039da";
+      url = "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz";
+      name = "debug-2.6.0.tgz";
+      sha1 = "bc596bcabe7617f11d9fa15361eded5608b8499b";
     };
     deps = {
-      "ms-0.7.1" = self.by-version."ms"."0.7.1";
+      "ms-0.7.2" = self.by-version."ms"."0.7.2";
     };
     optionalDependencies = {
     };
@@ -435,7 +457,7 @@
     version = "2.1.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz";
+      url = "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz";
       name = "debug-2.1.3.tgz";
       sha1 = "ce8ab1b5ee8fbee2bfa3b633cab93d366b63418e";
     };
@@ -455,7 +477,7 @@
     version = "0.0.5";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz";
+      url = "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz";
       name = "delayed-stream-0.0.5.tgz";
       sha1 = "d4b1f43a93e8296dfe02694f4680bc37a313c73f";
     };
@@ -474,7 +496,7 @@
     version = "1.0.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/depd/-/depd-1.0.1.tgz";
+      url = "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz";
       name = "depd-1.0.1.tgz";
       sha1 = "80aec64c9d6d97e65cc2a9caa93c0aa6abf73aaa";
     };
@@ -493,7 +515,7 @@
     version = "1.0.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz";
+      url = "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz";
       name = "destroy-1.0.3.tgz";
       sha1 = "b433b4724e71fd8551d9885174851c5fc377e2c9";
     };
@@ -505,42 +527,6 @@
     os = [ ];
     cpu = [ ];
   };
-  by-spec."dnschain"."*" =
-    self.by-version."dnschain"."0.5.3";
-  by-version."dnschain"."0.5.3" = self.buildNodePackage {
-    name = "dnschain-0.5.3";
-    version = "0.5.3";
-    bin = true;
-    src = fetchurl {
-      url = "http://registry.npmjs.org/dnschain/-/dnschain-0.5.3.tgz";
-      name = "dnschain-0.5.3.tgz";
-      sha1 = "9b21d9ac5e203295f372ac37df470e9f0854c470";
-    };
-    deps = {
-      "bluebird-2.9.9" = self.by-version."bluebird"."2.9.9";
-      "bottleneck-1.5.3" = self.by-version."bottleneck"."1.5.3";
-      "event-stream-3.2.2" = self.by-version."event-stream"."3.2.2";
-      "express-4.11.2" = self.by-version."express"."4.11.2";
-      "hiredis-0.4.1" = self.by-version."hiredis"."0.4.1";
-      "json-rpc2-0.8.1" = self.by-version."json-rpc2"."0.8.1";
-      "lodash-3.1.0" = self.by-version."lodash"."3.1.0";
-      "native-dns-0.6.1" = self.by-version."native-dns"."0.6.1";
-      "native-dns-packet-0.1.1" = self.by-version."native-dns-packet"."0.1.1";
-      "nconf-0.7.1" = self.by-version."nconf"."0.7.1";
-      "properties-1.2.1" = self.by-version."properties"."1.2.1";
-      "redis-0.12.1" = self.by-version."redis"."0.12.1";
-      "string-2.0.1" = self.by-version."string"."2.0.1";
-      "winston-0.8.0" = self.by-version."winston"."0.8.0";
-      "superagent-0.21.0" = self.by-version."superagent"."0.21.0";
-      "coffee-script-1.10.0" = self.by-version."coffee-script"."1.10.0";
-    };
-    optionalDependencies = {
-    };
-    peerDependencies = [];
-    os = [ ];
-    cpu = [ ];
-  };
-  "dnschain" = self.by-version."dnschain"."0.5.3";
   by-spec."duplexer"."~0.1.1" =
     self.by-version."duplexer"."0.1.1";
   by-version."duplexer"."0.1.1" = self.buildNodePackage {
@@ -548,7 +534,7 @@
     version = "0.1.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz";
+      url = "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz";
       name = "duplexer-0.1.1.tgz";
       sha1 = "ace6ff808c1ce66b57d1ebf97977acb02334cfc1";
     };
@@ -567,7 +553,7 @@
     version = "1.1.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz";
+      url = "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz";
       name = "ee-first-1.1.0.tgz";
       sha1 = "6a0d7c6221e490feefd92ec3f441c9ce8cd097f4";
     };
@@ -586,7 +572,7 @@
     version = "2.3.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/es5class/-/es5class-2.3.1.tgz";
+      url = "https://registry.npmjs.org/es5class/-/es5class-2.3.1.tgz";
       name = "es5class-2.3.1.tgz";
       sha1 = "42c5c18a9016bcb0db28a4d340ebb831f55d1b66";
     };
@@ -606,7 +592,7 @@
     version = "1.0.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz";
+      url = "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz";
       name = "escape-html-1.0.1.tgz";
       sha1 = "181a286ead397a39a92857cfb1d43052e356bff0";
     };
@@ -625,7 +611,7 @@
     version = "1.5.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/etag/-/etag-1.5.1.tgz";
+      url = "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz";
       name = "etag-1.5.1.tgz";
       sha1 = "54c50de04ee42695562925ac566588291be7e9ea";
     };
@@ -645,7 +631,7 @@
     version = "3.2.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/event-stream/-/event-stream-3.2.2.tgz";
+      url = "https://registry.npmjs.org/event-stream/-/event-stream-3.2.2.tgz";
       name = "event-stream-3.2.2.tgz";
       sha1 = "f79f9984c07ee3fd9b44ffb3cd0422b13e24084d";
     };
@@ -671,7 +657,7 @@
     version = "0.1.6";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz";
+      url = "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz";
       name = "eventemitter3-0.1.6.tgz";
       sha1 = "8c7ac44b87baab55cd50c828dc38778eac052ea5";
     };
@@ -690,7 +676,7 @@
     version = "4.11.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/express/-/express-4.11.2.tgz";
+      url = "https://registry.npmjs.org/express/-/express-4.11.2.tgz";
       name = "express-4.11.2.tgz";
       sha1 = "8df3d5a9ac848585f00a0777601823faecd3b148";
     };
@@ -705,13 +691,13 @@
       "finalhandler-0.3.3" = self.by-version."finalhandler"."0.3.3";
       "fresh-0.2.4" = self.by-version."fresh"."0.2.4";
       "media-typer-0.3.0" = self.by-version."media-typer"."0.3.0";
-      "methods-1.1.1" = self.by-version."methods"."1.1.1";
+      "methods-1.1.2" = self.by-version."methods"."1.1.2";
       "on-finished-2.2.1" = self.by-version."on-finished"."2.2.1";
-      "parseurl-1.3.0" = self.by-version."parseurl"."1.3.0";
+      "parseurl-1.3.1" = self.by-version."parseurl"."1.3.1";
       "path-to-regexp-0.1.3" = self.by-version."path-to-regexp"."0.1.3";
-      "proxy-addr-1.0.8" = self.by-version."proxy-addr"."1.0.8";
+      "proxy-addr-1.0.10" = self.by-version."proxy-addr"."1.0.10";
       "qs-2.3.3" = self.by-version."qs"."2.3.3";
-      "range-parser-1.0.2" = self.by-version."range-parser"."1.0.2";
+      "range-parser-1.0.3" = self.by-version."range-parser"."1.0.3";
       "send-0.11.1" = self.by-version."send"."0.11.1";
       "serve-static-1.8.1" = self.by-version."serve-static"."1.8.1";
       "type-is-1.5.7" = self.by-version."type-is"."1.5.7";
@@ -733,7 +719,7 @@
     version = "1.2.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/extend/-/extend-1.2.1.tgz";
+      url = "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz";
       name = "extend-1.2.1.tgz";
       sha1 = "a0f5fd6cfc83a5fe49ef698d60ec8a624dd4576c";
     };
@@ -745,16 +731,16 @@
     os = [ ];
     cpu = [ ];
   };
-  by-spec."extsprintf"."1.2.0" =
-    self.by-version."extsprintf"."1.2.0";
-  by-version."extsprintf"."1.2.0" = self.buildNodePackage {
-    name = "extsprintf-1.2.0";
-    version = "1.2.0";
+  by-spec."extsprintf"."^1.2.0" =
+    self.by-version."extsprintf"."1.3.0";
+  by-version."extsprintf"."1.3.0" = self.buildNodePackage {
+    name = "extsprintf-1.3.0";
+    version = "1.3.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz";
-      name = "extsprintf-1.2.0.tgz";
-      sha1 = "5ad946c22f5b32ba7f8cd7426711c6e8a3fc2529";
+      url = "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz";
+      name = "extsprintf-1.3.0.tgz";
+      sha1 = "96918440e3041a7a414f8c52e3c574eb3c3e1e05";
     };
     deps = {
     };
@@ -771,7 +757,7 @@
     version = "0.1.8";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz";
+      url = "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz";
       name = "eyes-0.1.8.tgz";
       sha1 = "62cf120234c683785d902348a800ef3e0cc20bc0";
     };
@@ -784,18 +770,18 @@
     cpu = [ ];
   };
   by-spec."faye-websocket"."0.x.x" =
-    self.by-version."faye-websocket"."0.10.0";
-  by-version."faye-websocket"."0.10.0" = self.buildNodePackage {
-    name = "faye-websocket-0.10.0";
-    version = "0.10.0";
+    self.by-version."faye-websocket"."0.11.0";
+  by-version."faye-websocket"."0.11.0" = self.buildNodePackage {
+    name = "faye-websocket-0.11.0";
+    version = "0.11.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz";
-      name = "faye-websocket-0.10.0.tgz";
-      sha1 = "4e492f8d04dfb6f89003507f6edbf2d501e7c6f4";
+      url = "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz";
+      name = "faye-websocket-0.11.0.tgz";
+      sha1 = "d9ccf0e789e7db725d74bc4877d23aa42972ac50";
     };
     deps = {
-      "websocket-driver-0.6.2" = self.by-version."websocket-driver"."0.6.2";
+      "websocket-driver-0.6.5" = self.by-version."websocket-driver"."0.6.5";
     };
     optionalDependencies = {
     };
@@ -810,7 +796,7 @@
     version = "0.3.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz";
+      url = "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz";
       name = "finalhandler-0.3.3.tgz";
       sha1 = "b1a09aa1e6a607b3541669b09bcb727f460cd426";
     };
@@ -832,7 +818,7 @@
     version = "0.1.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz";
+      url = "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz";
       name = "form-data-0.1.3.tgz";
       sha1 = "4ee4346e6eb5362e8344a02075bd8dbd8c7373ea";
     };
@@ -854,7 +840,7 @@
     version = "1.0.14";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz";
+      url = "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz";
       name = "formidable-1.0.14.tgz";
       sha1 = "2b3f4c411cbb5fdd695c44843e2a23514a43231a";
     };
@@ -873,7 +859,7 @@
     version = "0.1.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz";
+      url = "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz";
       name = "forwarded-0.1.0.tgz";
       sha1 = "19ef9874c4ae1c297bcf078fde63a09b66a84363";
     };
@@ -892,7 +878,7 @@
     version = "0.2.4";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz";
+      url = "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz";
       name = "fresh-0.2.4.tgz";
       sha1 = "3582499206c9723714190edd74b4604feb4a614c";
     };
@@ -911,7 +897,7 @@
     version = "0.1.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/from/-/from-0.1.3.tgz";
+      url = "https://registry.npmjs.org/from/-/from-0.1.3.tgz";
       name = "from-0.1.3.tgz";
       sha1 = "ef63ac2062ac32acf7862e0d40b44b896f22f3bc";
     };
@@ -930,13 +916,13 @@
     version = "0.4.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/hiredis/-/hiredis-0.4.1.tgz";
+      url = "https://registry.npmjs.org/hiredis/-/hiredis-0.4.1.tgz";
       name = "hiredis-0.4.1.tgz";
       sha1 = "aab4dcfd0fc4cbdb219d268005f2335a3c639e8f";
     };
     deps = {
       "bindings-1.2.1" = self.by-version."bindings"."1.2.1";
-      "nan-2.0.8" = self.by-version."nan"."2.0.8";
+      "nan-2.5.0" = self.by-version."nan"."2.5.0";
     };
     optionalDependencies = {
     };
@@ -945,15 +931,15 @@
     cpu = [ ];
   };
   by-spec."inherits"."~2.0.1" =
-    self.by-version."inherits"."2.0.1";
-  by-version."inherits"."2.0.1" = self.buildNodePackage {
-    name = "inherits-2.0.1";
-    version = "2.0.1";
+    self.by-version."inherits"."2.0.3";
+  by-version."inherits"."2.0.3" = self.buildNodePackage {
+    name = "inherits-2.0.3";
+    version = "2.0.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz";
-      name = "inherits-2.0.1.tgz";
-      sha1 = "b17d08d326b4423e568eff719f91b0b1cbdf69f1";
+      url = "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz";
+      name = "inherits-2.0.3.tgz";
+      sha1 = "633c2c83e3da42a502f52466022480f4208261de";
     };
     deps = {
     };
@@ -970,7 +956,7 @@
     version = "1.3.4";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/ini/-/ini-1.3.4.tgz";
+      url = "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz";
       name = "ini-1.3.4.tgz";
       sha1 = "0537cb79daf59b59a1a517dff706c86ec039162e";
     };
@@ -982,16 +968,16 @@
     os = [ ];
     cpu = [ ];
   };
-  by-spec."ipaddr.js"."1.0.1" =
-    self.by-version."ipaddr.js"."1.0.1";
-  by-version."ipaddr.js"."1.0.1" = self.buildNodePackage {
-    name = "ipaddr.js-1.0.1";
-    version = "1.0.1";
+  by-spec."ipaddr.js"."1.0.5" =
+    self.by-version."ipaddr.js"."1.0.5";
+  by-version."ipaddr.js"."1.0.5" = self.buildNodePackage {
+    name = "ipaddr.js-1.0.5";
+    version = "1.0.5";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.1.tgz";
-      name = "ipaddr.js-1.0.1.tgz";
-      sha1 = "5f38801dc73e0400fc7076386f6ed5215fbd8f95";
+      url = "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz";
+      name = "ipaddr.js-1.0.5.tgz";
+      sha1 = "5fa78cf301b825c78abc3042d812723049ea23c7";
     };
     deps = {
     };
@@ -1002,15 +988,15 @@
     cpu = [ ];
   };
   by-spec."ipaddr.js".">= 0.1.1" =
-    self.by-version."ipaddr.js"."1.0.3";
-  by-version."ipaddr.js"."1.0.3" = self.buildNodePackage {
-    name = "ipaddr.js-1.0.3";
-    version = "1.0.3";
+    self.by-version."ipaddr.js"."1.2.0";
+  by-version."ipaddr.js"."1.2.0" = self.buildNodePackage {
+    name = "ipaddr.js-1.2.0";
+    version = "1.2.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.3.tgz";
-      name = "ipaddr.js-1.0.3.tgz";
-      sha1 = "2a9df7be73ea92aadb0d7f377497decd8e6d01bb";
+      url = "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz";
+      name = "ipaddr.js-1.2.0.tgz";
+      sha1 = "8aba49c9192799585bdd643e0ccb50e8ae777ba4";
     };
     deps = {
     };
@@ -1027,7 +1013,7 @@
     version = "0.0.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz";
+      url = "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz";
       name = "isarray-0.0.1.tgz";
       sha1 = "8a18acfca9a8f4177e09abfc6038939b05d1eedf";
     };
@@ -1046,7 +1032,7 @@
     version = "0.8.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/json-rpc2/-/json-rpc2-0.8.1.tgz";
+      url = "https://registry.npmjs.org/json-rpc2/-/json-rpc2-0.8.1.tgz";
       name = "json-rpc2-0.8.1.tgz";
       sha1 = "efe8c9834605b556c488d1ed7bcf24ee381eeeb2";
     };
@@ -1055,7 +1041,7 @@
       "debug-1.0.4" = self.by-version."debug"."1.0.4";
       "lodash-2.4.2" = self.by-version."lodash"."2.4.2";
       "es5class-2.3.1" = self.by-version."es5class"."2.3.1";
-      "faye-websocket-0.10.0" = self.by-version."faye-websocket"."0.10.0";
+      "faye-websocket-0.11.0" = self.by-version."faye-websocket"."0.11.0";
       "eventemitter3-0.1.6" = self.by-version."eventemitter3"."0.1.6";
     };
     optionalDependencies = {
@@ -1071,7 +1057,7 @@
     version = "0.0.6";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/jsonparse/-/jsonparse-0.0.6.tgz";
+      url = "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.6.tgz";
       name = "jsonparse-0.0.6.tgz";
       sha1 = "ab599f19324d4ae178fa21a930192ab11ab61a4e";
     };
@@ -1090,7 +1076,7 @@
     version = "2.4.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz";
+      url = "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz";
       name = "lodash-2.4.2.tgz";
       sha1 = "fadd834b9683073da179b3eae6d9c0d15053f73e";
     };
@@ -1109,7 +1095,7 @@
     version = "3.1.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/lodash/-/lodash-3.1.0.tgz";
+      url = "https://registry.npmjs.org/lodash/-/lodash-3.1.0.tgz";
       name = "lodash-3.1.0.tgz";
       sha1 = "d41b8b33530cb3be088853208ad30092d2c27961";
     };
@@ -1128,7 +1114,7 @@
     version = "0.1.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz";
+      url = "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz";
       name = "map-stream-0.1.0.tgz";
       sha1 = "e56aa94c4c8055a16404a0674b78f215f7c8e194";
     };
@@ -1147,7 +1133,7 @@
     version = "0.3.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz";
+      url = "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz";
       name = "media-typer-0.3.0.tgz";
       sha1 = "8710d7af0aa626f8fffa1ce00168545263255748";
     };
@@ -1166,7 +1152,7 @@
     version = "0.0.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz";
+      url = "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz";
       name = "merge-descriptors-0.0.2.tgz";
       sha1 = "c36a52a781437513c57275f39dd9d317514ac8c7";
     };
@@ -1185,7 +1171,7 @@
     version = "1.0.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/methods/-/methods-1.0.1.tgz";
+      url = "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz";
       name = "methods-1.0.1.tgz";
       sha1 = "75bc91943dffd7da037cf3eeb0ed73a0037cd14b";
     };
@@ -1198,15 +1184,15 @@
     cpu = [ ];
   };
   by-spec."methods"."~1.1.1" =
-    self.by-version."methods"."1.1.1";
-  by-version."methods"."1.1.1" = self.buildNodePackage {
-    name = "methods-1.1.1";
-    version = "1.1.1";
+    self.by-version."methods"."1.1.2";
+  by-version."methods"."1.1.2" = self.buildNodePackage {
+    name = "methods-1.1.2";
+    version = "1.1.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/methods/-/methods-1.1.1.tgz";
-      name = "methods-1.1.1.tgz";
-      sha1 = "17ea6366066d00c58e375b8ec7dfd0453c89822a";
+      url = "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz";
+      name = "methods-1.1.2.tgz";
+      sha1 = "5529a4d67654134edcc5266656835b0f851afcee";
     };
     deps = {
     };
@@ -1223,7 +1209,7 @@
     version = "1.2.11";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz";
+      url = "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz";
       name = "mime-1.2.11.tgz";
       sha1 = "58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10";
     };
@@ -1244,7 +1230,7 @@
     version = "1.12.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz";
+      url = "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz";
       name = "mime-db-1.12.0.tgz";
       sha1 = "3d0c63180f458eb10d325aaa37d7c58ae312e9d7";
     };
@@ -1256,16 +1242,16 @@
     os = [ ];
     cpu = [ ];
   };
-  by-spec."mime-db"."~1.18.0" =
-    self.by-version."mime-db"."1.18.0";
-  by-version."mime-db"."1.18.0" = self.buildNodePackage {
-    name = "mime-db-1.18.0";
-    version = "1.18.0";
+  by-spec."mime-db"."~1.26.0" =
+    self.by-version."mime-db"."1.26.0";
+  by-version."mime-db"."1.26.0" = self.buildNodePackage {
+    name = "mime-db-1.26.0";
+    version = "1.26.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/mime-db/-/mime-db-1.18.0.tgz";
-      name = "mime-db-1.18.0.tgz";
-      sha1 = "5317e28224c08af1d484f60973dd386ba8f389e0";
+      url = "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz";
+      name = "mime-db-1.26.0.tgz";
+      sha1 = "eaffcd0e4fc6935cf8134da246e2e6c35305adff";
     };
     deps = {
     };
@@ -1282,7 +1268,7 @@
     version = "2.0.14";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz";
+      url = "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz";
       name = "mime-types-2.0.14.tgz";
       sha1 = "310e159db23e077f8bb22b748dabfa4957140aa6";
     };
@@ -1296,18 +1282,18 @@
     cpu = [ ];
   };
   by-spec."mime-types"."~2.1.6" =
-    self.by-version."mime-types"."2.1.6";
-  by-version."mime-types"."2.1.6" = self.buildNodePackage {
-    name = "mime-types-2.1.6";
-    version = "2.1.6";
+    self.by-version."mime-types"."2.1.14";
+  by-version."mime-types"."2.1.14" = self.buildNodePackage {
+    name = "mime-types-2.1.14";
+    version = "2.1.14";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/mime-types/-/mime-types-2.1.6.tgz";
-      name = "mime-types-2.1.6.tgz";
-      sha1 = "949f8788411864ddc70948a0f21c43f29d25667c";
+      url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz";
+      name = "mime-types-2.1.14.tgz";
+      sha1 = "f7ef7d97583fcaf3b7d282b6f8b5679dab1e94ee";
     };
     deps = {
-      "mime-db-1.18.0" = self.by-version."mime-db"."1.18.0";
+      "mime-db-1.26.0" = self.by-version."mime-db"."1.26.0";
     };
     optionalDependencies = {
     };
@@ -1322,7 +1308,7 @@
     version = "0.0.10";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz";
+      url = "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz";
       name = "minimist-0.0.10.tgz";
       sha1 = "de3f98543dbf96082be48ad1a0c7cda836301dcf";
     };
@@ -1341,7 +1327,7 @@
     version = "0.6.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz";
+      url = "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz";
       name = "ms-0.6.2.tgz";
       sha1 = "d89c2124c6fdc1353d65a8b77bf1aac4b193708c";
     };
@@ -1360,7 +1346,7 @@
     version = "0.7.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz";
+      url = "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz";
       name = "ms-0.7.0.tgz";
       sha1 = "865be94c2e7397ad8a57da6a633a6e2f30798b83";
     };
@@ -1372,16 +1358,16 @@
     os = [ ];
     cpu = [ ];
   };
-  by-spec."ms"."0.7.1" =
-    self.by-version."ms"."0.7.1";
-  by-version."ms"."0.7.1" = self.buildNodePackage {
-    name = "ms-0.7.1";
-    version = "0.7.1";
+  by-spec."ms"."0.7.2" =
+    self.by-version."ms"."0.7.2";
+  by-version."ms"."0.7.2" = self.buildNodePackage {
+    name = "ms-0.7.2";
+    version = "0.7.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz";
-      name = "ms-0.7.1.tgz";
-      sha1 = "9cd13c03adbff25b65effde7ce864ee952017098";
+      url = "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz";
+      name = "ms-0.7.2.tgz";
+      sha1 = "ae25cf2512b3885a1d95d7f037868d8431124765";
     };
     deps = {
     };
@@ -1392,15 +1378,15 @@
     cpu = [ ];
   };
   by-spec."nan"."^2.0.5" =
-    self.by-version."nan"."2.0.8";
-  by-version."nan"."2.0.8" = self.buildNodePackage {
-    name = "nan-2.0.8";
-    version = "2.0.8";
+    self.by-version."nan"."2.5.0";
+  by-version."nan"."2.5.0" = self.buildNodePackage {
+    name = "nan-2.5.0";
+    version = "2.5.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/nan/-/nan-2.0.8.tgz";
-      name = "nan-2.0.8.tgz";
-      sha1 = "c15fd99dd4cc323d1c2f94ac426313680e606392";
+      url = "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz";
+      name = "nan-2.5.0.tgz";
+      sha1 = "aa8f1e34531d807e9e27755b234b4a6ec0c152a8";
     };
     deps = {
     };
@@ -1422,7 +1408,7 @@
       sha256 = "9c3faf4d39fda7bb6dd52a82036625f37ed442d5e948d295acb2f055dd367080";
     };
     deps = {
-      "ipaddr.js-1.0.3" = self.by-version."ipaddr.js"."1.0.3";
+      "ipaddr.js-1.2.0" = self.by-version."ipaddr.js"."1.2.0";
       "native-dns-cache-0.0.2" = self.by-version."native-dns-cache"."0.0.2";
       "native-dns-packet-0.0.4" = self.by-version."native-dns-packet"."0.0.4";
     };
@@ -1460,13 +1446,13 @@
     version = "0.1.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/native-dns-packet/-/native-dns-packet-0.1.1.tgz";
+      url = "https://registry.npmjs.org/native-dns-packet/-/native-dns-packet-0.1.1.tgz";
       name = "native-dns-packet-0.1.1.tgz";
       sha1 = "97da90570b8438a00194701ce24d011fd3cc109a";
     };
     deps = {
       "buffercursor-0.0.12" = self.by-version."buffercursor"."0.0.12";
-      "ipaddr.js-1.0.3" = self.by-version."ipaddr.js"."1.0.3";
+      "ipaddr.js-1.2.0" = self.by-version."ipaddr.js"."1.2.0";
     };
     optionalDependencies = {
     };
@@ -1487,7 +1473,7 @@
     };
     deps = {
       "buffercursor-0.0.12" = self.by-version."buffercursor"."0.0.12";
-      "ipaddr.js-1.0.3" = self.by-version."ipaddr.js"."1.0.3";
+      "ipaddr.js-1.2.0" = self.by-version."ipaddr.js"."1.2.0";
     };
     optionalDependencies = {
     };
@@ -1508,7 +1494,7 @@
     };
     deps = {
       "buffercursor-0.0.12" = self.by-version."buffercursor"."0.0.12";
-      "ipaddr.js-1.0.3" = self.by-version."ipaddr.js"."1.0.3";
+      "ipaddr.js-1.2.0" = self.by-version."ipaddr.js"."1.2.0";
     };
     optionalDependencies = {
     };
@@ -1523,7 +1509,7 @@
     version = "0.7.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/nconf/-/nconf-0.7.1.tgz";
+      url = "https://registry.npmjs.org/nconf/-/nconf-0.7.1.tgz";
       name = "nconf-0.7.1.tgz";
       sha1 = "ee4b561dd979a3c58db122e38f196d49d61aeb5b";
     };
@@ -1545,7 +1531,7 @@
     version = "0.5.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz";
+      url = "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz";
       name = "negotiator-0.5.3.tgz";
       sha1 = "269d5c476810ec92edbe7b6c2f28316384f9a7e8";
     };
@@ -1564,7 +1550,7 @@
     version = "2.2.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz";
+      url = "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz";
       name = "on-finished-2.2.1.tgz";
       sha1 = "5c85c1cc36299f78029653f667f27b6b99ebc029";
     };
@@ -1584,7 +1570,7 @@
     version = "0.6.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz";
+      url = "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz";
       name = "optimist-0.6.1.tgz";
       sha1 = "da3ea74686fa21a19a111c326e90eb15a0196686";
     };
@@ -1599,15 +1585,15 @@
     cpu = [ ];
   };
   by-spec."parseurl"."~1.3.0" =
-    self.by-version."parseurl"."1.3.0";
-  by-version."parseurl"."1.3.0" = self.buildNodePackage {
-    name = "parseurl-1.3.0";
-    version = "1.3.0";
+    self.by-version."parseurl"."1.3.1";
+  by-version."parseurl"."1.3.1" = self.buildNodePackage {
+    name = "parseurl-1.3.1";
+    version = "1.3.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz";
-      name = "parseurl-1.3.0.tgz";
-      sha1 = "b58046db4223e145afa76009e61bac87cc2281b3";
+      url = "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz";
+      name = "parseurl-1.3.1.tgz";
+      sha1 = "c8ab8c9223ba34888aa64a297b28853bec18da56";
     };
     deps = {
     };
@@ -1624,7 +1610,7 @@
     version = "0.1.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz";
+      url = "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz";
       name = "path-to-regexp-0.1.3.tgz";
       sha1 = "21b9ab82274279de25b156ea08fd12ca51b8aecb";
     };
@@ -1643,7 +1629,7 @@
     version = "0.0.11";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz";
+      url = "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz";
       name = "pause-stream-0.0.11.tgz";
       sha1 = "fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445";
     };
@@ -1657,15 +1643,15 @@
     cpu = [ ];
   };
   by-spec."pkginfo"."0.3.x" =
-    self.by-version."pkginfo"."0.3.0";
-  by-version."pkginfo"."0.3.0" = self.buildNodePackage {
-    name = "pkginfo-0.3.0";
-    version = "0.3.0";
+    self.by-version."pkginfo"."0.3.1";
+  by-version."pkginfo"."0.3.1" = self.buildNodePackage {
+    name = "pkginfo-0.3.1";
+    version = "0.3.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz";
-      name = "pkginfo-0.3.0.tgz";
-      sha1 = "726411401039fe9b009eea86614295d5f3a54276";
+      url = "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz";
+      name = "pkginfo-0.3.1.tgz";
+      sha1 = "5b29f6a81f70717142e09e765bbeab97b4f81e21";
     };
     deps = {
     };
@@ -1682,7 +1668,7 @@
     version = "1.2.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/properties/-/properties-1.2.1.tgz";
+      url = "https://registry.npmjs.org/properties/-/properties-1.2.1.tgz";
       name = "properties-1.2.1.tgz";
       sha1 = "0ee97a7fc020b1a2a55b8659eda4aa8d869094bd";
     };
@@ -1695,19 +1681,19 @@
     cpu = [ ];
   };
   by-spec."proxy-addr"."~1.0.6" =
-    self.by-version."proxy-addr"."1.0.8";
-  by-version."proxy-addr"."1.0.8" = self.buildNodePackage {
-    name = "proxy-addr-1.0.8";
-    version = "1.0.8";
+    self.by-version."proxy-addr"."1.0.10";
+  by-version."proxy-addr"."1.0.10" = self.buildNodePackage {
+    name = "proxy-addr-1.0.10";
+    version = "1.0.10";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.8.tgz";
-      name = "proxy-addr-1.0.8.tgz";
-      sha1 = "db54ec878bcc1053d57646609219b3715678bafe";
+      url = "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz";
+      name = "proxy-addr-1.0.10.tgz";
+      sha1 = "0d40a82f801fc355567d2ecb65efe3f077f121c5";
     };
     deps = {
       "forwarded-0.1.0" = self.by-version."forwarded"."0.1.0";
-      "ipaddr.js-1.0.1" = self.by-version."ipaddr.js"."1.0.1";
+      "ipaddr.js-1.0.5" = self.by-version."ipaddr.js"."1.0.5";
     };
     optionalDependencies = {
     };
@@ -1722,7 +1708,7 @@
     version = "1.2.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/qs/-/qs-1.2.0.tgz";
+      url = "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz";
       name = "qs-1.2.0.tgz";
       sha1 = "ed079be28682147e6fd9a34cc2b0c1e0ec6453ee";
     };
@@ -1741,7 +1727,7 @@
     version = "2.3.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/qs/-/qs-2.3.3.tgz";
+      url = "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz";
       name = "qs-2.3.3.tgz";
       sha1 = "e9e85adbe75da0bbe4c8e0476a086290f863b404";
     };
@@ -1754,15 +1740,15 @@
     cpu = [ ];
   };
   by-spec."range-parser"."~1.0.2" =
-    self.by-version."range-parser"."1.0.2";
-  by-version."range-parser"."1.0.2" = self.buildNodePackage {
-    name = "range-parser-1.0.2";
-    version = "1.0.2";
+    self.by-version."range-parser"."1.0.3";
+  by-version."range-parser"."1.0.3" = self.buildNodePackage {
+    name = "range-parser-1.0.3";
+    version = "1.0.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz";
-      name = "range-parser-1.0.2.tgz";
-      sha1 = "06a12a42e5131ba8e457cd892044867f2344e549";
+      url = "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz";
+      name = "range-parser-1.0.3.tgz";
+      sha1 = "6872823535c692e2c2a0103826afd82c2e0ff175";
     };
     deps = {
     };
@@ -1779,15 +1765,15 @@
     version = "1.0.27-1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz";
+      url = "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz";
       name = "readable-stream-1.0.27-1.tgz";
       sha1 = "6b67983c20357cefd07f0165001a16d710d91078";
     };
     deps = {
-      "core-util-is-1.0.1" = self.by-version."core-util-is"."1.0.1";
+      "core-util-is-1.0.2" = self.by-version."core-util-is"."1.0.2";
       "isarray-0.0.1" = self.by-version."isarray"."0.0.1";
       "string_decoder-0.10.31" = self.by-version."string_decoder"."0.10.31";
-      "inherits-2.0.1" = self.by-version."inherits"."2.0.1";
+      "inherits-2.0.3" = self.by-version."inherits"."2.0.3";
     };
     optionalDependencies = {
     };
@@ -1802,7 +1788,7 @@
     version = "0.12.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/redis/-/redis-0.12.1.tgz";
+      url = "https://registry.npmjs.org/redis/-/redis-0.12.1.tgz";
       name = "redis-0.12.1.tgz";
       sha1 = "64df76ad0fc8acebaebd2a0645e8a48fac49185e";
     };
@@ -1821,7 +1807,7 @@
     version = "1.0.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz";
+      url = "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz";
       name = "reduce-component-1.0.1.tgz";
       sha1 = "e0c93542c574521bea13df0f9488ed82ab77c5da";
     };
@@ -1840,7 +1826,7 @@
     version = "0.11.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/send/-/send-0.11.1.tgz";
+      url = "https://registry.npmjs.org/send/-/send-0.11.1.tgz";
       name = "send-0.11.1.tgz";
       sha1 = "1beabfd42f9e2709f99028af3078ac12b47092d5";
     };
@@ -1854,7 +1840,7 @@
       "mime-1.2.11" = self.by-version."mime"."1.2.11";
       "ms-0.7.0" = self.by-version."ms"."0.7.0";
       "on-finished-2.2.1" = self.by-version."on-finished"."2.2.1";
-      "range-parser-1.0.2" = self.by-version."range-parser"."1.0.2";
+      "range-parser-1.0.3" = self.by-version."range-parser"."1.0.3";
     };
     optionalDependencies = {
     };
@@ -1869,13 +1855,13 @@
     version = "1.8.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/serve-static/-/serve-static-1.8.1.tgz";
+      url = "https://registry.npmjs.org/serve-static/-/serve-static-1.8.1.tgz";
       name = "serve-static-1.8.1.tgz";
       sha1 = "08fabd39999f050fc311443f46d5888a77ecfc7c";
     };
     deps = {
       "escape-html-1.0.1" = self.by-version."escape-html"."1.0.1";
-      "parseurl-1.3.0" = self.by-version."parseurl"."1.3.0";
+      "parseurl-1.3.1" = self.by-version."parseurl"."1.3.1";
       "send-0.11.1" = self.by-version."send"."0.11.1";
       "utils-merge-1.0.0" = self.by-version."utils-merge"."1.0.0";
     };
@@ -1892,7 +1878,7 @@
     version = "0.3.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/split/-/split-0.3.3.tgz";
+      url = "https://registry.npmjs.org/split/-/split-0.3.3.tgz";
       name = "split-0.3.3.tgz";
       sha1 = "cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f";
     };
@@ -1912,7 +1898,7 @@
     version = "0.0.9";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz";
+      url = "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz";
       name = "stack-trace-0.0.9.tgz";
       sha1 = "a8f6eaeca90674c333e7c43953f275b451510695";
     };
@@ -1931,7 +1917,7 @@
     version = "0.0.4";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz";
+      url = "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz";
       name = "stream-combiner-0.0.4.tgz";
       sha1 = "4d5e433c185261dde623ca3f44c586bcf5c4ad14";
     };
@@ -1951,7 +1937,7 @@
     version = "2.0.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/string/-/string-2.0.1.tgz";
+      url = "https://registry.npmjs.org/string/-/string-2.0.1.tgz";
       name = "string-2.0.1.tgz";
       sha1 = "ef1473b3e11cb8158671856556959b9aff5fd759";
     };
@@ -1970,7 +1956,7 @@
     version = "0.10.31";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz";
+      url = "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz";
       name = "string_decoder-0.10.31.tgz";
       sha1 = "62e203bc41766c6c28c9fc84301dab1c5310fa94";
     };
@@ -1989,7 +1975,7 @@
     version = "0.21.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/superagent/-/superagent-0.21.0.tgz";
+      url = "https://registry.npmjs.org/superagent/-/superagent-0.21.0.tgz";
       name = "superagent-0.21.0.tgz";
       sha1 = "fb15027984751ee7152200e6cd21cd6e19a5de87";
     };
@@ -2000,7 +1986,7 @@
       "component-emitter-1.1.2" = self.by-version."component-emitter"."1.1.2";
       "methods-1.0.1" = self.by-version."methods"."1.0.1";
       "cookiejar-2.0.1" = self.by-version."cookiejar"."2.0.1";
-      "debug-2.2.0" = self.by-version."debug"."2.2.0";
+      "debug-2.6.0" = self.by-version."debug"."2.6.0";
       "reduce-component-1.0.1" = self.by-version."reduce-component"."1.0.1";
       "extend-1.2.1" = self.by-version."extend"."1.2.1";
       "form-data-0.1.3" = self.by-version."form-data"."0.1.3";
@@ -2019,7 +2005,7 @@
     version = "2.3.8";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/through/-/through-2.3.8.tgz";
+      url = "https://registry.npmjs.org/through/-/through-2.3.8.tgz";
       name = "through-2.3.8.tgz";
       sha1 = "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5";
     };
@@ -2042,7 +2028,7 @@
     version = "1.5.7";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz";
+      url = "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz";
       name = "type-is-1.5.7.tgz";
       sha1 = "b9368a593cc6ef7d0645e78b2f4c64cbecd05e90";
     };
@@ -2063,7 +2049,7 @@
     version = "1.0.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz";
+      url = "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz";
       name = "utils-merge-1.0.0.tgz";
       sha1 = "0294fb922bb9375153541c4f7096231f287c8af8";
     };
@@ -2082,7 +2068,7 @@
     version = "1.0.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/vary/-/vary-1.0.1.tgz";
+      url = "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz";
       name = "vary-1.0.1.tgz";
       sha1 = "99e4981566a286118dfb2b817357df7993376d10";
     };
@@ -2095,18 +2081,20 @@
     cpu = [ ];
   };
   by-spec."verror"."^1.4.0" =
-    self.by-version."verror"."1.6.0";
-  by-version."verror"."1.6.0" = self.buildNodePackage {
-    name = "verror-1.6.0";
-    version = "1.6.0";
+    self.by-version."verror"."1.9.0";
+  by-version."verror"."1.9.0" = self.buildNodePackage {
+    name = "verror-1.9.0";
+    version = "1.9.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/verror/-/verror-1.6.0.tgz";
-      name = "verror-1.6.0.tgz";
-      sha1 = "7d13b27b1facc2e2da90405eb5ea6e5bdd252ea5";
+      url = "https://registry.npmjs.org/verror/-/verror-1.9.0.tgz";
+      name = "verror-1.9.0.tgz";
+      sha1 = "107a8a2d14c33586fc4bb830057cd2d19ae2a6ee";
     };
     deps = {
-      "extsprintf-1.2.0" = self.by-version."extsprintf"."1.2.0";
+      "assert-plus-1.0.0" = self.by-version."assert-plus"."1.0.0";
+      "core-util-is-1.0.2" = self.by-version."core-util-is"."1.0.2";
+      "extsprintf-1.3.0" = self.by-version."extsprintf"."1.3.0";
     };
     optionalDependencies = {
     };
@@ -2115,15 +2103,15 @@
     cpu = [ ];
   };
   by-spec."websocket-driver".">=0.5.1" =
-    self.by-version."websocket-driver"."0.6.2";
-  by-version."websocket-driver"."0.6.2" = self.buildNodePackage {
-    name = "websocket-driver-0.6.2";
-    version = "0.6.2";
+    self.by-version."websocket-driver"."0.6.5";
+  by-version."websocket-driver"."0.6.5" = self.buildNodePackage {
+    name = "websocket-driver-0.6.5";
+    version = "0.6.5";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.2.tgz";
-      name = "websocket-driver-0.6.2.tgz";
-      sha1 = "8281dba3e299e5bd7a42b65d4577a8928c26f898";
+      url = "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz";
+      name = "websocket-driver-0.6.5.tgz";
+      sha1 = "5cb2556ceb85f4373c6d8238aa691c8454e13a36";
     };
     deps = {
       "websocket-extensions-0.1.1" = self.by-version."websocket-extensions"."0.1.1";
@@ -2141,7 +2129,7 @@
     version = "0.1.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz";
+      url = "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz";
       name = "websocket-extensions-0.1.1.tgz";
       sha1 = "76899499c184b6ef754377c2dbb0cd6cb55d29e7";
     };
@@ -2160,7 +2148,7 @@
     version = "0.8.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/winston/-/winston-0.8.0.tgz";
+      url = "https://registry.npmjs.org/winston/-/winston-0.8.0.tgz";
       name = "winston-0.8.0.tgz";
       sha1 = "61d0830fa699706212206b0a2b5ca69a93043668";
     };
@@ -2169,7 +2157,7 @@
       "colors-0.6.2" = self.by-version."colors"."0.6.2";
       "cycle-1.0.3" = self.by-version."cycle"."1.0.3";
       "eyes-0.1.8" = self.by-version."eyes"."0.1.8";
-      "pkginfo-0.3.0" = self.by-version."pkginfo"."0.3.0";
+      "pkginfo-0.3.1" = self.by-version."pkginfo"."0.3.1";
       "stack-trace-0.0.9" = self.by-version."stack-trace"."0.0.9";
     };
     optionalDependencies = {
@@ -2185,7 +2173,7 @@
     version = "0.0.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz";
+      url = "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz";
       name = "wordwrap-0.0.3.tgz";
       sha1 = "a3d5da6cd5c0bc0008d37234bbaf1bed63059107";
     };

--- a/pkgs/tools/networking/dnscrypt-proxy/default.nix
+++ b/pkgs/tools/networking/dnscrypt-proxy/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "dnscrypt-proxy-${version}";
-  version = "1.9.1";
+  version = "1.9.3";
 
   src = fetchurl {
     url = "https://download.dnscrypt.org/dnscrypt-proxy/${name}.tar.bz2";
-    sha256 = "0aa1qw59b72wl922lfhg24xq2gkv95v1s0daiiqv9b4zpap3ynag";
+    sha256 = "1vh5ps3xqrfa39vx10rsxnpqkv5nnysqyz54csba4vwgw38ah0nb";
   };
 
   configureFlags = optional stdenv.isLinux "--with-systemd";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11666,6 +11666,8 @@ in
 
   powerdns = callPackage ../servers/dns/powerdns { };
 
+  pdns-recursor = callPackage ../servers/dns/pdns-recursor { };
+
   powertop = callPackage ../os-specific/linux/powertop { };
 
   prayer = callPackage ../servers/prayer { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10269,7 +10269,7 @@ in
 
   diod = callPackage ../servers/diod { lua = lua5_1; };
 
-  #dnschain = callPackage ../servers/dnschain { };
+  dnschain = callPackage ../servers/dnschain { };
 
   dovecot = callPackage ../servers/mail/dovecot { };
   dovecot_pigeonhole = callPackage ../servers/mail/dovecot/plugins/pigeonhole { };


### PR DESCRIPTION
###### Motivation for this change
I decided to migrate my homeserver to NixOS and found a few things still missing from nixpkgs.
This PR mainly focuses on the DNS stack, changes are:

 1.  DNSChain: fixed the broken node package and improved the service
 2. PDNS Recursor: added a package and a nixos module
 3. Namecoind: modified the server so that it can run even with the default config
 4. DNScrypt: added a nixos module for the wrapper server and updated the proxy package

###### Things done

- [x] Tested using sandboxing (I tested individually each commits in a VM and the whole changes in a real machine)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I think it should be possible to pull these commits separately if you think it's too much for a single PR.