### PR TITLE
swig: fix problem similar to #16161.

### DIFF
--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake libtool bison ];
   buildInputs = [ pcre ];
 
+  configureFlags = "--without-tcl";
+
   postPatch = ''
     # Disable ccache documentation as it need yodl
     sed -i '/man1/d' CCache/Makefile.in


### PR DESCRIPTION
###### Motivation for this change

See issue #16161, where building libkrb5 fails on Debian machines when sandboxing isn't used.

The same problem happens when building swig.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

