### PR TITLE
pythonPackages.matplotlib: 1.5.3 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, python, buildPythonPackage, pycairo
 , which, cycler, dateutil, nose, numpy, pyparsing, sphinx, tornado
-, freetype, libpng, pkgconfig, mock, pytz, pygobject3
+, freetype, libpng, pkgconfig, mock, pytz, pygobject3, functools32, subprocess32
 , enableGhostscript ? false, ghostscript ? null, gtk3
 , enableGtk2 ? false, pygtk ? null, gobjectIntrospection
 , enableGtk3 ? false, cairo
 , enableTk ? false, tcl ? null, tk ? null, tkinter ? null, libX11 ? null
-, Cocoa, Foundation, CoreData, cf-private, libobjc, libcxx
+, enableQt ? false, pyqt4
+, libcxx
 }:
 
 assert enableGhostscript -> ghostscript != null;
@@ -15,14 +16,15 @@ assert enableTk -> (tcl != null)
                 && (tkinter != null)
                 && (libX11 != null)
                 ;
+assert enableQt -> pyqt4 != null;
 
 buildPythonPackage rec {
   name = "matplotlib-${version}";
-  version = "1.5.3";
+  version = "2.0.0";
 
   src = fetchurl {
     url = "mirror://pypi/m/matplotlib/${name}.tar.gz";
-    sha256 = "1g7bhr6v3wdxyx29rfxgf57l9w19s79cdlpyi0h4y0c5ywwxr9d0";
+    sha256 = "04zqymd5dw6lxvfbxf1sycdnibjk5qky5rfsn6wb46lwha2hkkrn";
   };
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
@@ -30,17 +32,17 @@ buildPythonPackage rec {
   XDG_RUNTIME_DIR = "/tmp";
 
   buildInputs = [ python which sphinx stdenv ]
-    ++ stdenv.lib.optional enableGhostscript ghostscript
-    ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa Foundation CoreData
-                                              cf-private libobjc ];
+    ++ stdenv.lib.optional enableGhostscript ghostscript;
 
   propagatedBuildInputs =
-    [ cycler dateutil nose numpy pyparsing tornado freetype 
-      libpng pkgconfig mock pytz  
+    [ cycler dateutil nose numpy pyparsing tornado freetype
+      libpng pkgconfig mock pytz
     ]
     ++ stdenv.lib.optional enableGtk2 pygtk
     ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobjectIntrospection pygobject3 ]
-    ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ];
+    ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ]
+    ++ stdenv.lib.optionals enableQt [ pyqt4 ]
+    ++ stdenv.lib.optionals (builtins.hasAttr "isPy2" python) [ functools32 subprocess32 ];
 
   patches =
     [ ./basedirlist.patch ] ++
@@ -64,8 +66,8 @@ buildPythonPackage rec {
     ${python.interpreter} tests.py
   '';
 
-  # The entry point for running tests, tests.py, is not included in the release.
-  # https://github.com/matplotlib/matplotlib/issues/6017
+  # Test data is not included in the distribution (the `tests` folder
+  # is missing)
   doCheck = false;
 
   prePatch = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14340,8 +14340,6 @@ in {
   matplotlib = callPackage ../development/python-modules/matplotlib/default.nix {
     stdenv = if stdenv.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
     enableGhostscript = true;
-    inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa Foundation CoreData;
-    inherit (pkgs.darwin) cf-private libobjc;
   };
 
 


### PR DESCRIPTION
###### Motivation for this change

All the derivations that fails to pass `nox-review` also fails to build before this update:

* `python35Packages.Pweave`
* `python35Packages.joblib`
* `python35Packages.librosa`
* `python35Packages.oger`

cc @FRidh 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

