### PR TITLE
ark: add security patch for CVE-2017-5330

### DIFF
--- a/pkgs/desktops/kde-5/applications/ark/default.nix
+++ b/pkgs/desktops/kde-5/applications/ark/default.nix
@@ -7,7 +7,10 @@
   kservice, kpty, kwidgetsaddons, libarchive,
 
   # Archive tools
-  p7zip, unrar, unzipNLS, zip
+  p7zip, unrar, unzipNLS, zip,
+
+  # CVE fixe
+  fetchpatch
 }:
 
 let
@@ -20,6 +23,12 @@ let
       propagatedBuildInputs = [
         khtml ki18n kio karchive kconfig kcrash kdbusaddons kiconthemes kservice
         kpty kwidgetsaddons libarchive
+      ];
+      patches = [
+        (fetchpatch { # CVE-2017-5330
+          url = "https://github.com/KDE/ark/commit/49ce94df19607e234525afda5ad4190ce35300c3.patch";
+          sha256 = "06yvdn6m6fniyc798wbdyc9bzma230xafylx39bz9mhzfnypvfj8";
+        })
       ];
       postInstall =
         let


### PR DESCRIPTION
###### Motivation for this change

Fixes CVE-2017-5330 as mentioned in #21967

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

