### PR TITLE
haskellPackages.tinc: 20161102 -> 20161119

### DIFF
--- a/pkgs/development/tools/haskell/tinc/default.nix
+++ b/pkgs/development/tools/haskell/tinc/default.nix
@@ -7,12 +7,12 @@
 }:
 mkDerivation {
   pname = "tinc";
-  version = "20161102";
+  version = "20161119";
   src = fetchFromGitHub {
     owner = "sol";
     repo = "tinc";
-    rev = "411d0f319717d01dc71bd5c1faef8035656eaf3d";
-    sha256 = "040vyg9n7ihnqs6fyhhr5p4xscfxhji02wsfw4nncpxflzaciji5";
+    rev = "8e31ed920ad1660b3bc458b4f6b281bacaf4bd14";
+    sha256 = "0y9pvr20p9z4dddbfxgy9hl3ny7pxixxjg8ij7g8l14br6mcak30";
   };
   isLibrary = false;
   isExecutable = true;


### PR DESCRIPTION
###### Motivation for this change
Version upgrade. Documentation for actualizing a Cabal install plan with Nix can be found at https://github.com/sol/tinc/blob/nixpkgs/NIX.md.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

