### PR TITLE
supertuxkart: 0.9 -> 0.9.2

### DIFF
--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -1,45 +1,51 @@
-{ fetchgit, fetchsvn, cmake, stdenv, plib, SDL, openal, freealut, mesa
-, libvorbis, libogg, gettext, libXxf86vm, curl, pkgconfig
-, fribidi, autoconf, automake, libtool, bluez, libjpeg, libpng }:
+{ stdenv, fetchFromGitHub, fetchsvn, cmake, pkgconfig
+, openal, freealut, mesa, libvorbis, libogg, gettext, curl, freetype
+, fribidi, libtool, bluez, libjpeg, libpng, zlib, libX11, libXrandr }:
 
-stdenv.mkDerivation rec {
+let
+  dir = "stk-code";
+
+in stdenv.mkDerivation rec {
   name = "supertuxkart-${version}";
 
-  version = "0.9";
+  version = "0.9.2";
   srcs = [
-    (fetchgit {
-      url = "https://github.com/supertuxkart/stk-code";
-      rev = "28a525f6d4aba2667c41a549b027149fcceda97e";
-      sha256 = "0b5izr7j3clm6pcxanwwaas06f17wi454s6hwmgv1mg48aay2v97";
-      name = "stk-code";
+    (fetchFromGitHub {
+      owner  = "supertuxkart";
+      repo   = "stk-code";
+      rev    = version;
+      sha256 = "1zsc5nw8il8xwppk624jampfk6qhqzjnni8zicrhqix0xg07nxca";
+      name   = dir;
     })
     (fetchsvn {
-      url = "https://svn.code.sf.net/p/supertuxkart/code/stk-assets";
-      rev = "16293";
-      sha256 = "07jdkli28xr3rcxvixyy5bwi26n5i7dkhd9q0j4wifgs4pymm8r5";
-      name = "stk-assets";
+      url    = "https://svn.code.sf.net/p/supertuxkart/code/stk-assets";
+      rev    = "16503"; # 0.9.2 crashes with 16937. Refer to stk-code/doc/assets_version
+      sha256 = "0j1dy27gxm4hx26xddr2ak6vw0lim0nqmjnszfb4c61y92j12cqp";
+      name   = "stk-assets";
     })
   ];
-  
+
   buildInputs = [
-    plib SDL openal freealut mesa libvorbis libogg gettext
-    libXxf86vm curl pkgconfig fribidi autoconf automake libtool cmake bluez libjpeg libpng
+    cmake libtool pkgconfig
+    libX11 libXrandr
+    openal freealut mesa libvorbis libogg gettext zlib freetype
+    curl fribidi bluez libjpeg libpng
   ];
 
   enableParallelBuilding = true;
 
-  sourceRoot = "stk-code";
+  sourceRoot = dir;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A Free 3D kart racing game";
     longDescription = ''
       SuperTuxKart is a Free 3D kart racing game, with many tracks,
       characters and items for you to try, similar in spirit to Mario
       Kart.
     '';
-    homepage = http://supertuxkart.sourceforge.net/;
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [ c0dehero fuuzetsu ];
-    platforms = with stdenv.lib.platforms; linux;
+    homepage = https://supertuxkart.net/;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ c0dehero fuuzetsu peterhoeg ];
+    platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Also known as the "get ready for babysitting the nieces" release.

There were a number of obsolete dependencies, so I stripped out the unnecessary ones.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
