### PR TITLE
buildPythonPackage: accept developmentPrefix and send `pip` output to stderr

### DIFF
--- a/pkgs/development/interpreters/python/build-python-package-setuptools.nix
+++ b/pkgs/development/interpreters/python/build-python-package-setuptools.nix
@@ -13,6 +13,7 @@
 , preShellHook ? ""
 # Execute after shell hook
 , postShellHook ? ""
+, developmentPrefix ? ""
 , ... } @ attrs:
 
 let
@@ -45,11 +46,14 @@ in attrs // {
   shellHook = attrs.shellHook or ''
     ${preShellHook}
     if test -e setup.py; then
-      tmp_path=$(mktemp -d)
-      export PATH="$tmp_path/bin:$PATH"
-      export PYTHONPATH="$tmp_path/${python.sitePackages}:$PYTHONPATH"
-      mkdir -p $tmp_path/${python.sitePackages}
-      ${bootstrapped-pip}/bin/pip install -e . --prefix $tmp_path
+      developmentPrefix='${developmentPrefix}'
+      if test -z "$developmentPrefix"; then
+        developmentPrefix=$(mktemp -d)
+      fi
+      export PATH="$developmentPrefix/bin:$PATH"
+      export PYTHONPATH="$developmentPrefix/${python.sitePackages}:$PYTHONPATH"
+      mkdir -p "$developmentPrefix/${python.sitePackages}"
+      ${bootstrapped-pip}/bin/pip install -e . --prefix "$developmentPrefix" >&2
     fi
     ${postShellHook}
   '';


### PR DESCRIPTION
###### Motivation for this change

This changes 2 small parts about `buildPythonPackage`. I'm happy to split them into two PRs if you prefer, but I figured I'd combine them since they require a rebuild of all python packages.

1) send `pip install` output to `stderr`. The nix integration in direnv (https://direnv.net/, from @zimbatm) relies on `nix-shell --run CMD` producing _only_ the output from `CMD` on stdout (it dumps the environment from inside nix-shell and recreates it in your current shell). The python shellHook logs the following `pip` boilerplate to stdout, which breaks this functionality:

```
Obtaining file:///home/tim/dev/python/test
Installing collected packages: test
  Running setup.py develop for test
Successfully installed test
```

This is clearly output that belongs on `stderr`, so I've added a `>&2` redirect in the shell hook.

2) allow passing `developmentPrefix` to `buildPythonPackage`. This is used only in the shellHook, and allows a specific path to be used for development installation, rather than creating a tempfile each time. This keeps the $PATH reproducible, which is important if you store it somewhere to be reused at a later time (since nix-shell can take a while on complex inputs, I cache the results used by `direnv` to set my environment). The default behaviour is unchanged.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

