### PR TITLE
w3m: fix package name

### DIFF
--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -15,7 +15,7 @@ assert mouseSupport -> gpm-ncurses != null;
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "w3m-v0.5.3+git20161120";
+  name = "w3m-0.5.3+git20161120";
 
   src = fetchFromGitHub {
     owner = "tats";


### PR DESCRIPTION
```
nix-repl> builtins.parseDrvName "w3m-v0.5.3+git20161120"
{ name = "w3m-v0.5.3+git20161120"; version = ""; }

nix-repl> builtins.parseDrvName "w3m-0.5.3+git20161120"
{ name = "w3m"; version = "0.5.3+git20161120"; }
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

