### PR TITLE
Revert "nmap: use python infra's .withPackages"

### DIFF
--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -1,12 +1,13 @@
 { stdenv, fetchurl, libpcap, pkgconfig, openssl
 , graphicalSupport ? false
-, gtk2 ? null
 , libX11 ? null
+, gtk2 ? null
 , withPython ? false # required for the `ndiff` binary
-, python2 ? null
+, python2Packages ? null
+, makeWrapper ? null
 }:
 
-assert withPython -> python2 != null;
+assert withPython -> python2Packages != null;
 
 with stdenv.lib;
 
@@ -15,10 +16,6 @@ let
   # Zenmap (the graphical program) also requires Python,
   # so automatically enable pythonSupport if graphicalSupport is requested.
   pythonSupport = withPython || graphicalSupport;
-
-  pythonEnv = python2.withPackages(ps: with ps; []
-    ++ optionals graphicalSupport [ pycairo pygobject2 pygtk pysqlite ]
-  );
 
 in stdenv.mkDerivation rec {
   name = "nmap${optionalString graphicalSupport "-graphical"}-${version}";
@@ -36,10 +33,17 @@ in stdenv.mkDerivation rec {
     ++ optional (!graphicalSupport) "--without-zenmap"
     ;
 
-  buildInputs = [ libpcap pkgconfig openssl ]
-    ++ optional pythonSupport pythonEnv
-    ++ optionals graphicalSupport [ gtk2 libX11 ]
-    ;
+  postInstall = optionalString pythonSupport ''
+      wrapProgram $out/bin/ndiff --prefix PYTHONPATH : "$(toPythonPath $out)" --prefix PYTHONPATH : "$PYTHONPATH"
+  '' + optionalString graphicalSupport ''
+      wrapProgram $out/bin/zenmap --prefix PYTHONPATH : "$(toPythonPath $out)" --prefix PYTHONPATH : "$PYTHONPATH" --prefix PYTHONPATH : $(toPythonPath $pygtk)/gtk-2.0 --prefix PYTHONPATH : $(toPythonPath $pygobject)/gtk-2.0 --prefix PYTHONPATH : $(toPythonPath $pycairo)/gtk-2.0
+  '';
+
+  buildInputs = with python2Packages; [ libpcap pkgconfig openssl ]
+    ++ optionals pythonSupport [ makeWrapper python ]
+    ++ optionals graphicalSupport [
+      libX11 gtk2 pygtk pysqlite pygobject2 pycairo
+    ];
 
   meta = {
     description = "A free and open source utility for network discovery and security auditing";


### PR DESCRIPTION
###### Motivation for this change

This reverts commit 278d3050ae85e959e4c6485b5ad43bbba96eb829 because it
breaks zenmap:

```
$ zenmap
Could not import the zenmapGUI.App module: 'No module named
zenmapGUI.App'.
I checked in these directories:
    /nix/store/2hiz11plgjdrk2mziwc2jcxqalqh9hii-nmap-graphical-7.12/bin
    /home/bfo/forks/nixpkgs
    /nix/store/0l4lriqf07qah8c0kh9kcyc8l5iyij16-python-2.7.12/lib/python27.zip
    /nix/store/0l4lriqf07qah8c0kh9kcyc8l5iyij16-python-2.7.12/lib/python2.7
    /nix/store/0l4lriqf07qah8c0kh9kcyc8l5iyij16-python-2.7.12/lib/python2.7/plat-linux2
    /nix/store/0l4lriqf07qah8c0kh9kcyc8l5iyij16-python-2.7.12/lib/python2.7/lib-tk
    /nix/store/0l4lriqf07qah8c0kh9kcyc8l5iyij16-python-2.7.12/lib/python2.7/lib-old
    /nix/store/0l4lriqf07qah8c0kh9kcyc8l5iyij16-python-2.7.12/lib/python2.7/lib-dynload
    /nix/store/0l4lriqf07qah8c0kh9kcyc8l5iyij16-python-2.7.12/lib/python2.7/site-packages
If you installed Zenmap in another directory, you may have to add the
modules directory to the PYTHONPATH environment variable.
```

(And I'm not motivated enough to forward-fixing it, so just revert.)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

