### PR TITLE
ZfsUnstable: 0.7.0-rc2 -> 0.7.0-rc3

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -66,7 +66,7 @@ in
       sha256 = "000yvaccqlkrq15sdz0734fp3lkmx58182cdcfpm4869i0q7rf0s";
     };
     splUnstable = common {
-      version = "0.7.0-rc2";
-      sha256 = "1y7jlyj8jwgrgnd6hiabms5h9430b6wjbnr3pwb16mv40wns1i65";
+      version = "0.7.0-rc3";
+      sha256 = "09v5gh7mqdl3bfq5an9iiw9fw3l1skprclxdz7r19bw3ids3lfja";
     };
   }

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -139,21 +139,16 @@ in
     };
     zfsUnstable = common {
       # comment/uncomment if breaking kernel versions are known
-      inkompatibleKernelVersion = "4.10";
+      inkompatibleKernelVersion = null;
 
-      version = "0.7.0-rc2";
+      version = "0.7.0-rc3";
 
       # this package should point to a version / git revision compatible with the latest kernel release
-      sha256 = "197y2jyav9h1ksri9kzqvrwmzpb58mlgw27vfvgd4bvxpwfxq53s";
+      sha256 = "0js3lazqq8wb4nklqxd6sgbvwqgwnjgz3xi3mm33xf4284gia6pc";
       extraPatches = [
         (fetchpatch {
-          url = "https://github.com/Mic92/zfs/compare/zfs-0.7.0-rc2...nixos-zfs-0.7.0-rc2.patch";
-          sha256 = "1p33bwd6p5r5phbqb657x8h9x3bd012k2mdmbzgnb09drh9v0r82";
-        })
-        (fetchpatch {
-          name = "Kernel_4.9_zfs_aio_fsync_removal.patch";
-          url = "https://github.com/zfsonlinux/zfs/commit/99ca173929cb693012dabe98bcee4f12ec7e6e92.patch";
-          sha256 = "10npvpj52rpq88vdsn7zkdhx2lphzvqypsd9abdadjbqkwxld9la";
+          url = "https://github.com/Mic92/zfs/compare/zfs-0.7.0-rc3...nixos-zfs-0.7.0-rc3.patch";
+          sha256 = "1vlw98v8xvi8qapzl1jwm69qmfslwnbg3ry1lmacndaxnyckkvhh";
         })
       ];
       spl = splUnstable;

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -13,11 +13,11 @@ let
   buildKernel = any (n: n == configFile) [ "kernel" "all" ];
   buildUser = any (n: n == configFile) [ "user" "all" ];
 
-  common = { version, sha256, extraPatches, spl, inkompatibleKernelVersion ? null } @ args:
+  common = { version, sha256, extraPatches, spl, incompatibleKernelVersion ? null } @ args:
     if buildKernel &&
-       (inkompatibleKernelVersion != null) &&
-       versionAtLeast kernel.version inkompatibleKernelVersion then
-      throw "linux v${kernel.version} is not yet supported by zfsonlinux v${version}"
+       (incompatibleKernelVersion != null) &&
+       versionAtLeast kernel.version incompatibleKernelVersion then
+      throw "Linux v${kernel.version} is not yet supported by zfsonlinux v${version}. Try zfsUnstable or set the NixOS option boot.zfs.enableUnstable."
     else stdenv.mkDerivation rec {
       name = "zfs-${configFile}-${version}${optionalString buildKernel "-${kernel.version}"}";
 
@@ -123,7 +123,7 @@ in
     # to be adapted
     zfsStable = common {
       # comment/uncomment if breaking kernel versions are known
-      inkompatibleKernelVersion = "4.9";
+      incompatibleKernelVersion = "4.9";
 
       version = "0.6.5.8";
 
@@ -139,7 +139,7 @@ in
     };
     zfsUnstable = common {
       # comment/uncomment if breaking kernel versions are known
-      inkompatibleKernelVersion = null;
+      incompatibleKernelVersion = null;
 
       version = "0.7.0-rc3";
 


### PR DESCRIPTION
###### Motivation for this change

As the default LTS kernel now requires zfsUnstable should we enable it by default? @fpletz 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

