### PR TITLE
buildRustPackage: use frozen cargo fetches

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -71,7 +71,7 @@ in stdenv.mkDerivation (args // {
     (
         cd $sourceRoot
 
-        cargo fetch
+        cargo fetch --frozen
         cargo clean
     )
   '' + (args.postUnpack or "");

--- a/pkgs/tools/misc/heatseeker/default.nix
+++ b/pkgs/tools/misc/heatseeker/default.nix
@@ -4,15 +4,15 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "heatseeker-${version}";
-  version = "1.4.0";
+  version = "1.5.0";
 
-  depsSha256 = "1acimdkl6ra9jlyiydzzd6ccdygr5is2xf9gw8i45xzh0xnsq226";
+  depsSha256 = "0rv622rli3prsk6vizv9xw50mf5ihb4an9v72rcb7fcxyvh66qnj";
 
   src = fetchFromGitHub {
     owner = "rschmitt";
     repo = "heatseeker";
     rev = "v${version}";
-    sha256 = "1v2p6l4bdmvn9jggb12p0j5ajjvnbcdjsiavlcqiijz2w8wcdgs8";
+    sha256 = "0h6ny0wdrqm583b36393xwsh8wlwhl8ddyjxcgk84p7lyabj9zky";
   };
 
   # some tests require a tty, this variable turns them off for Travis CI,


### PR DESCRIPTION
cargo will not try to download anything from the web but will instead
return a clean error message stating which dependency is not up to date.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

