### PR TITLE
wallabag: 2.1.4 -> 2.1.6

### DIFF
--- a/pkgs/servers/web-apps/wallabag/default.nix
+++ b/pkgs/servers/web-apps/wallabag/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "wallabag-${version}";
-  version = "2.1.4";
+  version = "2.1.6";
 
   # remember to rm -r var/cache/* after a rebuild or unexpected errors will occur
 
   src = fetchurl {
     url = "https://framabag.org/wallabag-release-${version}.tar.gz";
-    sha256 = "0s4p9jls7jqq9jbcac21ibz9k5yxx0ifv2yhxlkia5kw9md20r7b";
+    sha256 = "0znywkrjlmxhacfkdyba2cjhgmrh509mayrfsrnc0rx3haxam7fx";
   };
 
   outputs = [ "out" "doc" ];


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).