### PR TITLE
ocamlPackages.apron: init at 20160125

### DIFF
--- a/pkgs/development/ocaml-modules/apron/default.nix
+++ b/pkgs/development/ocaml-modules/apron/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchzip, perl, gmp, mpfr, ppl, ocaml, findlib, camlidl, mlgmpidl }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-apron-${version}";
+  version = "20160125";
+  src = fetchzip {
+    url = "http://apron.gforge.inria.fr/apron-${version}.tar.gz";
+    sha256 = "1a7b7b9wsd0gdvm41lgg6ayb85wxc2a3ggcrghy4qiphs4b9v4m4";
+  };
+
+  buildInputs = [ perl gmp mpfr ppl ocaml findlib camlidl ];
+  propagatedBuildInputs = [ mlgmpidl ];
+
+  prefixKey = "-prefix ";
+  createFindlibDestdir = true;
+
+  meta = {
+    license = stdenv.lib.licenses.lgpl21;
+    homepage = http://apron.cri.ensmp.fr/library/;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    description = "Numerical abstract domain library";
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/development/ocaml-modules/mlgmpidl/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmpidl/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, camlidl, gmp, mpfr }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-mlgmpidl-${version}";
+  version = "1.2.4";
+  src = fetchFromGitHub {
+    owner = "nberth";
+    repo = "mlgmpidl";
+    rev = version;
+    sha256 = "09f9rk2bavhb7cdwjpibjf8bcjk59z85ac9dr8nvks1s842dp65s";
+  };
+
+  buildInputs = [ gmp mpfr ocaml findlib camlidl ];
+
+  configurePhase = ''
+    cp Makefile.config.model Makefile.config
+    sed -i Makefile.config \
+      -e 's|^MLGMPIDL_PREFIX.*$|MLGMPIDL_PREFIX = $out|' \
+      -e 's|^GMP_PREFIX.*$|GMP_PREFIX = ${gmp.dev}|' \
+      -e 's|^MPFR_PREFIX.*$|MPFR_PREFIX = ${mpfr.dev}|' \
+      -e 's|^CAMLIDL_DIR.*$|CAMLIDL_DIR = ${camlidl}/lib/ocaml/${ocaml.version}/site-lib/camlidl|'
+    echo HAS_NATIVE_PLUGINS = 1 >> Makefile.config
+    sed -i Makefile \
+      -e 's|^	/bin/rm |	rm |'
+  '';
+
+  createFindlibDestdir = true;
+
+  meta = {
+    description = "OCaml interface to the GMP library";
+    homepage = https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlgmpidl/;
+    license = stdenv.lib.licenses.lgpl21;
+    inherit (ocaml.meta) platforms;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/tools/analysis/frama-c/dynamic.diff
+++ b/pkgs/development/tools/analysis/frama-c/dynamic.diff
@@ -1,0 +1,12 @@
+--- a/src/kernel_services/plugin_entry_points/dynamic.ml	2016-05-30 16:15:22.000000000 +0200
++++ b/src/kernel_services/plugin_entry_points/dynamic.ml	2016-10-13 18:25:31.000000000 +0200
+@@ -287,7 +287,8 @@
+         (List.fold_right (add_dir ~user:false) Config.plugin_dir []) ;
+     let pkgs = ref [] in
+     List.iter (scan_directory pkgs) !load_path ;
+-    let findlib_path = String.concat ":" !load_path in
++    let findlib_path = String.concat ":" (!load_path @
++      try [Sys.getenv "OCAMLPATH"] with Not_found -> []) in
+     Klog.debug ~dkey "setting findlib path to %s" findlib_path;
+     Findlib.init ~env_ocamlpath:findlib_path ();
+     load_packages (List.rev !pkgs) ;

--- a/pkgs/development/tools/ocaml/camlidl/default.nix
+++ b/pkgs/development/tools/ocaml/camlidl/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     substituteInPlace config/Makefile --replace BINDIR=/usr/local/bin BINDIR=$out
     substituteInPlace config/Makefile --replace OCAMLLIB=/usr/local/lib/ocaml OCAMLLIB=$out/lib/ocaml/${ocaml.version}/site-lib/camlidl
     substituteInPlace config/Makefile --replace CPP=/lib/cpp CPP=${stdenv.cc}/bin/cpp
+    substituteInPlace config/Makefile --replace "OCAMLC=ocamlc -g" "OCAMLC=ocamlc -g -warn-error -31"
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/camlidl/caml
   '';
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -263,6 +263,8 @@ let
 
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
+    mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };
+
     nocrypto =  callPackage ../development/ocaml-modules/nocrypto {
       lwt = ocaml_lwt;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -20,6 +20,8 @@ let
 
     ansiterminal = callPackage ../development/ocaml-modules/ansiterminal { };
 
+    apron = callPackage ../development/ocaml-modules/apron { };
+
     asn1-combinators = callPackage ../development/ocaml-modules/asn1-combinators { };
 
     astring = callPackage ../development/ocaml-modules/astring { };


### PR DESCRIPTION
###### Motivation for this change

APRON is an OCaml library that is dedicated to the static analysis of the numerical variables of a program by Abstract Interpretation. It is in particular used in the Frama-C static analyzer.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

