### PR TITLE
Update django guardian

### DIFF
--- a/pkgs/development/python-modules/django_guardian.nix
+++ b/pkgs/development/python-modules/django_guardian.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, python, fetchurl
+, django_environ, mock, django, six
+, pytest, pytestrunner, pytestdjango, setuptools_scm
+}:
+buildPythonPackage rec {
+  name = "django-guardian-${version}";
+  version = "1.4.6";
+
+  src = fetchurl {
+    url = "mirror://pypi/d/django-guardian/${name}.tar.gz";
+    sha256 = "1r3xj0ik0hh6dfak4kjndxk5v73x95nfbppgr394nhnmiayv4zc5";
+  };
+
+  buildInputs = [ pytest pytestrunner pytestdjango django_environ mock setuptools_scm ];
+  propagatedBuildInputs = [ django six ];
+
+  checkPhase = ''
+    ${python.interpreter} nix_run_setup.py test --addopts="--ignore build"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Per object permissions for Django";
+    homepage = https://github.com/django-guardian/django-guardian;
+    licenses = [ licenses.mit licenses.bsd2 ];
+  };
+}

--- a/pkgs/development/python-modules/pytest/2_7.nix
+++ b/pkgs/development/python-modules/pytest/2_7.nix
@@ -1,0 +1,28 @@
+{ stdenv, pkgs, buildPythonPackage, fetchurl, isPy26, argparse, py, selenium }:
+buildPythonPackage rec {
+  name = "pytest-2.7.3";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/pytest/${name}.tar.gz";
+    sha256 = "1z4yi986f9n0p8qmzmn21m21m8j1x78hk3505f89baqm6pdw7afm";
+  };
+
+  # Disabled temporarily because of Hydra issue with namespaces
+  doCheck = false;
+
+  preCheck = ''
+    # don't test bash builtins
+    rm testing/test_argcomplete.py
+  '';
+
+  propagatedBuildInputs = [ py ]
+    ++ (stdenv.lib.optional isPy26 argparse)
+    ++ stdenv.lib.optional
+      pkgs.config.pythonPackages.pytest.selenium or false
+      selenium;
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ domenkozar lovek323 madjar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/pytest/2_8.nix
+++ b/pkgs/development/python-modules/pytest/2_8.nix
@@ -1,0 +1,28 @@
+{ stdenv, pkgs, buildPythonPackage, fetchurl, isPy26, argparse, py, selenium }:
+buildPythonPackage rec {
+  name = "pytest-2.8.7";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/pytest/${name}.tar.gz";
+    sha256 = "1bwb06g64x2gky8x5hcrfpg6r351xwvafimnhm5qxq7wajz8ck7w";
+  };
+
+  # Disabled temporarily because of Hydra issue with namespaces
+  doCheck = false;
+
+  preCheck = ''
+    # don't test bash builtins
+    rm testing/test_argcomplete.py
+  '';
+
+  propagatedBuildInputs = [ py ]
+    ++ (stdenv.lib.optional isPy26 argparse)
+    ++ stdenv.lib.optional
+      pkgs.config.pythonPackages.pytest.selenium or false
+      selenium;
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ domenkozar lovek323 madjar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/pytest/2_9.nix
+++ b/pkgs/development/python-modules/pytest/2_9.nix
@@ -1,0 +1,28 @@
+{ stdenv, pkgs, buildPythonPackage, fetchurl, isPy26, argparse, py, selenium }:
+buildPythonPackage rec {
+  name = "pytest-2.9.2";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/pytest/${name}.tar.gz";
+    sha256 = "1n6igbc1b138wx1q5gca4pqw1j6nsyicfxds5n0b5989kaxqmh8j";
+  };
+
+  # Disabled temporarily because of Hydra issue with namespaces
+  doCheck = false;
+
+  preCheck = ''
+    # don't test bash builtins
+    rm testing/test_argcomplete.py
+  '';
+
+  propagatedBuildInputs = [ py ]
+    ++ (stdenv.lib.optional isPy26 argparse)
+    ++ stdenv.lib.optional
+      pkgs.config.pythonPackages.pytest.selenium or false
+      selenium;
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ domenkozar lovek323 madjar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchurl, hypothesis, py }:
+buildPythonPackage rec {
+  name = "pytest-${version}";
+  version = "3.0.5";
+
+  preCheck = ''
+    # don't test bash builtins
+    rm testing/test_argcomplete.py
+  '';
+
+  src = fetchurl {
+    url = "mirror://pypi/p/pytest/${name}.tar.gz";
+    sha256 = "1z9pj39w0r2gw5hsqndlmsqa80kgbrann5kfma8ww8zhaslkl02a";
+  };
+
+  propagatedBuildInputs = [ hypothesis py ];
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ domenkozar lovek323 madjar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, buildPythonPackage, fetchurl, hypothesis, py }:
+{ stdenv, buildPythonPackage, fetchurl, isPy26, argparse, hypothesis, py }:
 buildPythonPackage rec {
   name = "pytest-${version}";
-  version = "3.0.5";
+  version = "3.0.6";
 
   preCheck = ''
     # don't test bash builtins
@@ -10,13 +10,15 @@ buildPythonPackage rec {
 
   src = fetchurl {
     url = "mirror://pypi/p/pytest/${name}.tar.gz";
-    sha256 = "1z9pj39w0r2gw5hsqndlmsqa80kgbrann5kfma8ww8zhaslkl02a";
+    sha256 = "0h6rfp7y7c5mqwfm9fy5fq4l9idnp160c82ylcfjg251y6lk8d34";
   };
 
-  propagatedBuildInputs = [ hypothesis py ];
+  buildInputs = [ hypothesis ];
+  propagatedBuildInputs = [ py ]
+    ++ (stdenv.lib.optional isPy26 argparse);
 
   meta = with stdenv.lib; {
-    maintainers = with maintainers; [ domenkozar lovek323 madjar ];
+    maintainers = with maintainers; [ domenkozar lovek323 madjar lsix ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/pytestdjango.nix
+++ b/pkgs/development/python-modules/pytestdjango.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchurl
+, pytest, django, setuptools_scm
+}:
+buildPythonPackage rec {
+  name = "pytest-django-${version}";
+  version = "3.1.2";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/pytest-django/${name}.tar.gz";
+    sha256 = "02932m2sr8x22m4az8syr8g835g4ak77varrnw71n6xakmdcr303";
+  };
+
+  buildInputs = [ pytest setuptools_scm ];
+  propagatedBuildInputs = [ django ];
+
+  meta = with stdenv.lib; {
+    description = "py.test plugin for testing of Django applications";
+    homepage = http://pytest-django.readthedocs.org/en/latest/;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5077,27 +5077,8 @@ in {
     };
   };
 
-  pytestdjango = buildPythonPackage rec {
-    name = "pytest-django-${version}";
-    version = "2.9.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest-django/${name}.tar.gz";
-      sha256 = "1mmc7zsz3dlhs6sx4sppkj1vgshabi362r1a8b8wpj1qfximpqcb";
-    };
-
-    # doing this to allow depending packages to find
-    # pytest's binaries
-    pytest = self.pytest;
-
-    buildInputs = with self; [ pytest ];
-    propagatedBuildInputs = with self; [ django setuptools_scm_18 ];
-
-    meta = {
-      description = "py.test plugin for testing of Django applications";
-      homepage = http://pytest-django.readthedocs.org/en/latest/;
-      license = licenses.bsd3;
-    };
+  pytestdjango = callPackage ../development/python-modules/pytestdjango.nix {
+    pytest = self.pytest_30;
   };
 
   pytest-fixture-config = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10405,27 +10405,8 @@ in {
     };
   };
 
-  django_guardian = buildPythonPackage rec {
-    name = "django-guardian-${version}";
-    version = "1.4.4";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/django-guardian/${name}.tar.gz";
-      sha256 = "1m7y3brk3697hr2cvkzl8dry4pp7wkmhvxmf8db1ardz1r9d8895";
-    };
-
-    buildInputs = with self ; [ pytest pytestrunner pytestdjango django_environ mock ];
-    propagatedBuildInputs = with self ; [ django six ];
-
-    checkPhase = ''
-      ${python.interpreter} nix_run_setup.py test --addopts="--ignore build"
-    '';
-
-    meta = {
-      description = "Per object permissions for Django";
-      homepage = https://github.com/django-guardian/django-guardian;
-      licenses = [ licenses.mit licenses.bsd2 ];
-    };
+  django_guardian = callPackage ../development/python-modules/django_guardian.nix {
+    pytest = self.pytest_30;
   };
 
   django_tagging = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4997,61 +4997,13 @@ in {
 
   pytest = self.pytest_29;
 
-  pytest_27 = buildPythonPackage rec {
-    name = "pytest-2.7.3";
+  pytest_27 = callPackage ../development/python-modules/pytest/2_7.nix {};
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest/${name}.tar.gz";
-      sha256 = "1z4yi986f9n0p8qmzmn21m21m8j1x78hk3505f89baqm6pdw7afm";
-    };
+  pytest_28 = callPackage ../development/python-modules/pytest/2_8.nix {};
 
-    # Disabled temporarily because of Hydra issue with namespaces
-    doCheck = false;
+  pytest_29 = callPackage ../development/python-modules/pytest/2_9.nix {};
 
-    preCheck = ''
-      # don't test bash builtins
-      rm testing/test_argcomplete.py
-    '';
-
-    propagatedBuildInputs = with self; [ py ]
-      ++ (optional isPy26 argparse)
-      ++ stdenv.lib.optional
-        pkgs.config.pythonPackages.pytest.selenium or false
-        self.selenium;
-
-    meta = {
-      maintainers = with maintainers; [ domenkozar lovek323 madjar ];
-      platforms = platforms.unix;
-    };
-  };
-
-  pytest_28 = self.pytest_27.override rec {
-    name = "pytest-2.8.7";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest/${name}.tar.gz";
-      sha256 = "1bwb06g64x2gky8x5hcrfpg6r351xwvafimnhm5qxq7wajz8ck7w";
-    };
-  };
-
-  pytest_29 = self.pytest_27.override rec {
-    name = "pytest-2.9.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest/${name}.tar.gz";
-      sha256 = "1n6igbc1b138wx1q5gca4pqw1j6nsyicfxds5n0b5989kaxqmh8j";
-    };
-  };
-
-  pytest_30 = self.pytest_27.override rec {
-    name = "pytest-3.0.5";
-
-    propagatedBuildInputs = with self; [ hypothesis py ];
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest/${name}.tar.gz";
-      sha256 = "1z9pj39w0r2gw5hsqndlmsqa80kgbrann5kfma8ww8zhaslkl02a";
-    };
-  };
+  pytest_30 = callPackage ../development/python-modules/pytest {};
 
   pytestcache = buildPythonPackage rec {
     name = "pytest-cache-1.0";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

