### PR TITLE
paratype-pt-sane: s/sane/sans/

### DIFF
--- a/pkgs/data/fonts/paratype-pt/sans.nix
+++ b/pkgs/data/fonts/paratype-pt/sans.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, unzip }:
 
 stdenv.mkDerivation rec {
-  name = "paratype-pt-sane";
+  name = "paratype-pt-sans";
 
   src = fetchurl rec {
     url = "http://www.paratype.ru/uni/public/PTSans.zip";


### PR DESCRIPTION
###### Motivation for this change

The typo in the name of the package makes it much harder to find.

###### Things done

Is there more extensive documentation on these checks? The info available in this list and in the Nix manual wasn't sufficient for me to perform them. A lot of PRs get merged without any of these boxes checked, though, so I won't explain the troubles I run into unless someone wants me to.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

