### PR TITLE
neofetch: init at 2.0.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -27,6 +27,7 @@
   akaWolf = "Artjom Vejsel <akawolf0@gmail.com>";
   akc = "Anders Claesson <akc@akc.is>";
   algorith = "Dries Van Daele <dries_van_daele@telenet.be>";
+  alibabzo = "Alistair Bill <alistair.bill@gmail.com>";
   all = "Nix Committers <nix-commits@lists.science.uu.nl>";
   ambrop72 = "Ambroz Bizjak <ambrop7@gmail.com>";
   amiddelk = "Arie Middelkoop <amiddelk@gmail.com>";

--- a/pkgs/tools/misc/neofetch/default.nix
+++ b/pkgs/tools/misc/neofetch/default.nix
@@ -23,11 +23,11 @@ stdenv.mkDerivation rec {
     "PREFIX="
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A fast, highly customizable system info script";
     homepage = https://github.com/dylanaraps/neofetch;
-    license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.mit;
+    platforms = platforms.all;
     maintainers = with maintainers; [ alibabzo ];
   };
 }

--- a/pkgs/tools/misc/neofetch/default.nix
+++ b/pkgs/tools/misc/neofetch/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "neofetch-${version}";
+  version = "2.0.2";
+  src = fetchFromGitHub {
+    owner = "dylanaraps";
+    repo = "neofetch";
+    rev = version;
+    sha256 = "15fpm6nflf6w0c758xizfifvvxrkmcc2hpzrnfw6fcngfqcvajmd";
+  };
+
+  patchPhase = ''
+    substituteInPlace ./neofetch \
+    --replace "/usr/share" "$out/share"
+  '';
+
+  dontBuild = true;
+
+
+  makeFlags = [
+    "DESTDIR=$(out)"
+    "PREFIX="
+  ];
+
+  meta = {
+    description = "A fast, highly customizable system info script";
+    homepage = https://github.com/dylanaraps/neofetch;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = with maintainers; [ alibabzo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2925,6 +2925,8 @@ in
 
   ndjbdns = callPackage ../tools/networking/ndjbdns { };
 
+  neofetch = callPackage ../tools/misc/neofetch { };
+
   nerdfonts = callPackage ../data/fonts/nerdfonts { };
 
   nestopia = callPackage ../misc/emulators/nestopia { };


### PR DESCRIPTION
###### Motivation for this change
Neofetch is a useful system utility [which is in many distro repositories][1]. It's not yet in nixpkgs.

[1]: https://github.com/dylanaraps/neofetch/wiki/Installation#osdistro-packages
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

