### PR TITLE
hubicfuse: 2.1.0 -> 3.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -227,6 +227,7 @@
   joko = "Ioannis Koutras <ioannis.koutras@gmail.com>";
   jonafato = "Jon Banafato <jon@jonafato.com>";
   jpbernardy = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";
+  jpierre03 = "Jean-Pierre PRUNARET <nix@prunetwork.fr>";
   jraygauthier = "Raymond Gauthier <jraygauthier@gmail.com>";
   juliendehos = "Julien Dehos <dehos@lisic.univ-littoral.fr>";
   jwiegley = "John Wiegley <johnw@newartisans.com>";

--- a/pkgs/tools/filesystems/hubicfuse/default.nix
+++ b/pkgs/tools/filesystems/hubicfuse/default.nix
@@ -23,5 +23,6 @@ stdenv.mkDerivation rec {
     description = "FUSE-based filesystem to access hubic cloud storage";
     platforms = platforms.linux;
     license = licenses.mit;
+    maintainers = [ maintainers.jpierre03 ];
   };
 }

--- a/pkgs/tools/filesystems/hubicfuse/default.nix
+++ b/pkgs/tools/filesystems/hubicfuse/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, pkgconfig, curl, openssl, fuse, libxml2, json_c, file }:
+{ stdenv, fetchFromGitHub, pkgconfig, curl, openssl, fuse, libxml2, json_c, file }:
 
 stdenv.mkDerivation rec {
   name = "hubicfuse-${version}";
-  version = "2.1.0";
+  version = "3.0.0";
 
-  src = fetchurl {
-    url = https://github.com/TurboGit/hubicfuse/archive/v2.1.0.tar.gz;
-    sha256 = "1mnijcwac6k3f6xknvdrsbmkkizpwbayqkb5l6jic15ymxv1fs7d";
+  src = fetchFromGitHub {
+    owner = "TurboGit";
+    repo = "hubicfuse";
+    rev = "v${version}";
+    sha256 = "1y4n63bk9vd6n1l5psjb9xm9h042kw4yh2ni33z7agixkanajv1s";
   };
 
   buildInputs = [ pkgconfig curl openssl fuse libxml2 json_c file ];


### PR DESCRIPTION
###### Motivation for this change

Package upgrade.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

