### PR TITLE
flannel service: fix enable expression

### DIFF
--- a/nixos/modules/services/networking/flannel.nix
+++ b/nixos/modules/services/networking/flannel.nix
@@ -149,6 +149,6 @@ in {
       serviceConfig.ExecStart = "${cfg.package}/bin/flannel";
     };
 
-    services.etcd.enable = mkDefault cfg.etcd.endpoints == ["http://127.0.0.1:2379"];
+    services.etcd.enable = mkDefault (cfg.etcd.endpoints == ["http://127.0.0.1:2379"]);
   };
 }


### PR DESCRIPTION
Need to surround the equality check in parentheses, otherwise the expression is interpreted as

```
services.etcd.enable = (mkDefault cfg.etcd.endpoints) == ["http://127.0.0.1:2379"];
```

which gets very confused.
