### PR TITLE
msgpack-tools: init at 0.6

### DIFF
--- a/pkgs/development/tools/msgpack-tools/default.nix
+++ b/pkgs/development/tools/msgpack-tools/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "msgpack-tools-${version}";
+  version = "v0.6";
+
+  src = fetchFromGitHub {
+    owner = "ludocode";
+    repo = "msgpack-tools";
+    rev = version;
+    sha256 = "1ygjk25zlpqjckxgqmahnz999704zy2bd9id6hp5jych1szkjgs5";
+  };
+
+  buildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Command-line tools for converting between MessagePack and JSON";
+    homepage = https://github.com/ludocode/msgpack-tools;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ alibabzo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6480,6 +6480,8 @@ in
 
   mk = callPackage ../development/tools/build-managers/mk { };
 
+  msgpack-tools = callPackage ../development/tools/msgpack-tools { };
+
   msitools = callPackage ../development/tools/misc/msitools { };
 
   multi-ghc-travis = callPackage ../development/tools/haskell/multi-ghc-travis { };


### PR DESCRIPTION
###### Motivation for this change
msgpack-tools is a set of 2 useful utilities for converting between MessagePack and JSON format. It's useful both for debugging and for scripts that need to send MessagePack data.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

