### PR TITLE
NagiosPlugins: 2.1.4 -> 2.2.0, add SSL

### DIFF
--- a/pkgs/servers/monitoring/nagios/plugins/official-2.x.nix
+++ b/pkgs/servers/monitoring/nagios/plugins/official-2.x.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "nagios-plugins-${version}";
-  version = "2.1.4";
+  version = "2.2.0";
 
   src = fetchurl {
     url = "http://nagios-plugins.org/download/${name}.tar.gz";
-    sha256 = "146hrpcwciz0niqsv4k5yvkhaggs9mr5v02xnnxp5yp0xpdbama3";
+    sha256 = "074yia04py5y07sbgkvri10dv8nf41kqq1x6kmwqcix5vvm9qyy3";
   };
 
   # !!! Awful hack. Grrr... this of course only works on NixOS.

--- a/pkgs/servers/monitoring/nagios/plugins/official-2.x.nix
+++ b/pkgs/servers/monitoring/nagios/plugins/official-2.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssh }:
+{ stdenv, fetchurl, openssh, openssl }:
 
 stdenv.mkDerivation rec {
   name = "nagios-plugins-${version}";
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   postInstall = "ln -s libexec $out/bin";
 
   # !!! make openssh a runtime dependency only
-  buildInputs = [ openssh ];
+  buildInputs = [ openssh openssl ];
 
   meta = {
     description = "Official plugins for Nagios";


### PR DESCRIPTION
###### Motivation for this change
- Update Nagios-Plugins to newest version
- Add openssl to buildinputs to configure with ssl-support (e. g. to use nagios-command check_imap with **--ssl** option). 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of some binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

