### PR TITLE
Fixing the wrong Git Commit hash in docker version

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -12,6 +12,7 @@ with lib;
 stdenv.mkDerivation rec {
   name = "docker-${version}";
   version = "1.13.0";
+  rev = "49bf474"; # should match the version commit
 
   src = fetchFromGitHub {
     owner = "docker";
@@ -79,7 +80,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     patchShebangs .
     export AUTO_GOPATH=1
-    export DOCKER_GITCOMMIT="23cf638"
+    export DOCKER_GITCOMMIT="${rev}"
     ./hack/make.sh dynbinary
   '';
 


### PR DESCRIPTION
`DOCKER_GITCOMMIT` needs to match the tagged commit used to build the
binary. The current commit refers to 1.12.1 and wasn't update each
time we updated the package. Using a variable near the version and
adding a comment so we don't forget to update next time.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

The current output of `docker version` is incoherent (tag is 1.13.0 but the commit refers to 1.12.1). My bad for not seeing this when updating the package 😅 🐻.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

