### PR TITLE
viber: 6.0.1.5 -> 6.5.5.1481

### DIFF
--- a/pkgs/applications/networking/instant-messengers/viber/default.nix
+++ b/pkgs/applications/networking/instant-messengers/viber/default.nix
@@ -1,20 +1,17 @@
 {fetchurl, stdenv, dpkg, makeWrapper,
  alsaLib, cups, curl, dbus, expat, fontconfig, freetype, glib, gst_all_1, harfbuzz, libcap,
- libpulseaudio, mesa, nspr, nss, systemd, wayland, xorg, zlib, ...
+ libpulseaudio, libxml2, libxslt, mesa, nspr, nss, openssl, systemd, wayland, xorg, zlib, ...
 }:
 
 assert stdenv.system == "x86_64-linux";
 
-# BUG: Viber requires running tray application, segfaulting if it's missing
-# FIX: Start something like `stalonetray` if you DE doesn't provide tray
-
 stdenv.mkDerivation rec {
   name = "viber-${version}";
-  version = "6.0.1.5";
+  version = "6.5.5.1481";
 
   src = fetchurl {
     url = "http://download.cdn.viber.com/cdn/desktop/Linux/viber.deb";
-    sha256 = "026vp2pv66b2dlwi5w5wk4yjnnmnsqapdww98p7xdnz8n0hnsbbi";
+    sha256 = "0gvpaprfki04x66ga2ljksspdxd4cz455h92a7i2dnd69w1kik5s";
   };
 
   buildInputs = [ dpkg makeWrapper ];
@@ -35,9 +32,12 @@ stdenv.mkDerivation rec {
       harfbuzz
       libcap
       libpulseaudio
+      libxml2
+      libxslt
       mesa
       nspr
       nss
+      openssl
       stdenv.cc.cc
       systemd
       wayland


### PR DESCRIPTION
###### Motivation for this change

Upstream package updated, hash has changed.
Tray bug was fixed and I've removed workaround info.
Properly handles multi-display configurations with different DPI.


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

