### PR TITLE
trezord: init at 1.2.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -81,6 +81,7 @@
   c0dehero = "CodeHero <codehero@nerdpol.ch>";
   calrama = "Moritz Maxeiner <moritz@ucworks.org>";
   campadrenalin = "Philip Horger <campadrenalin@gmail.com>";
+  canndrew = "Andrew Cann <shum@canndrew.org>";
   carlsverre = "Carl Sverre <accounts@carlsverre.com>";
   cdepillabout = "Dennis Gosnell <cdep.illabout@gmail.com>";
   cfouche = "Chaddaï Fouché <chaddai.fouche@gmail.com>";

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -287,7 +287,6 @@
       pdns-recursor = 269;
       kresd = 270;
       rpc = 271;
-      trezord = 269;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -544,7 +543,6 @@
       gogs = 268;
       kresd = 270;
       #rpc = 271; # unused
-      trezord = 269;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -287,6 +287,7 @@
       pdns-recursor = 269;
       kresd = 270;
       rpc = 271;
+      trezord = 269;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -543,6 +544,7 @@
       gogs = 268;
       kresd = 270;
       #rpc = 271; # unused
+      trezord = 269;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -206,6 +206,7 @@
   ./services/hardware/tcsd.nix
   ./services/hardware/tlp.nix
   ./services/hardware/thinkfan.nix
+  ./services/hardware/trezord.nix
   ./services/hardware/udev.nix
   ./services/hardware/udisks2.nix
   ./services/hardware/upower.nix

--- a/nixos/modules/services/hardware/trezord.nix
+++ b/nixos/modules/services/hardware/trezord.nix
@@ -16,18 +16,6 @@ in {
           Enable Trezor bridge daemon, for use with Trezor hardware bitcoin wallets.
         '';
       };
-
-      user = mkOption {
-        type = types.str;
-        default = "trezord";
-        description = "User under which Trezor bridge daemon would be running";
-      };
-
-      group = mkOption {
-        type = types.str;
-        default = "trezord";
-        description = "Group under which Trezor bridge daemon would be running";
-      };
     };
   };
   
@@ -51,20 +39,18 @@ in {
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.trezord}/bin/trezord -f";
-        User = "${cfg.user}";
+        User = "trezord";
       };
     };
 
-    users.extraUsers = if cfg.user != "trezord" then {} else singleton {
+    users.extraUsers = singleton {
       name = "trezord";
       group = "trezord";
-      uid = config.ids.uids.trezord;
       description = "Trezor bridge daemon user";
     };
 
-    users.extraGroups = if cfg.group != "trezord" then {} else singleton {
+    users.extraGroups = singleton {
       name = "trezord";
-      gid = config.ids.gids.trezord;
     };
   };
 }

--- a/nixos/modules/services/hardware/trezord.nix
+++ b/nixos/modules/services/hardware/trezord.nix
@@ -35,7 +35,7 @@ in {
       description = "TREZOR Bridge";
       after = [ "systemd-udev-settle.service" "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.trezord ];
+      path = [];
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.trezord}/bin/trezord -f";
@@ -43,15 +43,12 @@ in {
       };
     };
 
-    users.extraUsers = singleton {
-      name = "trezord";
+    users.users.trezord = {
       group = "trezord";
       description = "Trezor bridge daemon user";
     };
 
-    users.extraGroups = singleton {
-      name = "trezord";
-    };
+    users.groups.trezord = {};
   };
 }
 

--- a/nixos/modules/services/hardware/trezord.nix
+++ b/nixos/modules/services/hardware/trezord.nix
@@ -1,0 +1,71 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.trezord;
+in {
+  
+  ### interface
+
+  options = {
+    services.trezord = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable Trezor bridge daemon, for use with Trezor hardware bitcoin wallets.
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "trezord";
+        description = "User under which Trezor bridge daemon would be running";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "trezord";
+        description = "Group under which Trezor bridge daemon would be running";
+      };
+    };
+  };
+  
+  ### implementation
+
+  config = mkIf cfg.enable {
+    services.udev.packages = lib.singleton (pkgs.writeTextFile {
+      name = "trezord-udev-rules";
+      destination = "/etc/udev/rules.d/51-trezor.rules";
+      text = ''
+        SUBSYSTEM=="usb", ATTR{idVendor}=="534c", ATTR{idProduct}=="0001", MODE="0666", GROUP="dialout", SYMLINK+="trezor%n"
+        KERNEL=="hidraw*", ATTRS{idVendor}=="534c", ATTRS{idProduct}=="0001",  MODE="0666", GROUP="dialout"
+      '';
+    });
+
+    systemd.services.trezord = {
+      description = "TREZOR Bridge";
+      after = [ "systemd-udev-settle.service" "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.trezord ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.trezord}/bin/trezord -f";
+        User = "${cfg.user}";
+      };
+    };
+
+    users.extraUsers = if cfg.user != "trezord" then {} else singleton {
+      name = "trezord";
+      group = "trezord";
+      uid = config.ids.uids.trezord;
+      description = "Trezor bridge daemon user";
+    };
+
+    users.extraGroups = if cfg.group != "trezord" then {} else singleton {
+      name = "trezord";
+      gid = config.ids.gids.trezord;
+    };
+  };
+}
+

--- a/pkgs/servers/trezord/default.nix
+++ b/pkgs/servers/trezord/default.nix
@@ -9,9 +9,8 @@ in
 stdenv.mkDerivation rec {
   name = "trezord-${version}";
 
-  src = fetchFromGitHub {
-    owner  = "trezor";
-    repo   = "trezord";
+  src = fetchgit {
+    url    = "https://github.com/trezor/trezord";
     rev    = "refs/tags/v${version}";
     sha256 = "1606j5cfngryk4q21yiga1zvc3zpx4q8vqn6ljrvr679hpvlwni4";
   };

--- a/pkgs/servers/trezord/default.nix
+++ b/pkgs/servers/trezord/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchgit, curl, cmake, boost, gcc5, protobuf, pkgconfig, jsoncpp
+, libusb1, libmicrohttpd
+}:
+
+let
+  version = "1.2.0";
+in
+
+stdenv.mkDerivation rec {
+  name = "trezord-${version}";
+
+  src = fetchgit {
+    url    = "https://github.com/trezor/trezord";
+    rev    = "refs/tags/v${version}";
+    sha256 = "1606j5cfngryk4q21yiga1zvc3zpx4q8vqn6ljrvr679hpvlwni4";
+  };
+
+  meta = with stdenv.lib; {
+    description = "TREZOR Bridge daemon for TREZOR bitcoin hardware wallet";
+    homepage = https://mytrezor.com;
+    license = licenses.gpl3;
+    maintainers = [];
+    platforms = platforms.linux;
+  };
+
+  patches = [ ./dynamic-link.patch ];
+
+  nativeBuildInputs = [
+    cmake
+    gcc5
+    pkgconfig
+  ];
+
+  buildInputs = [
+    curl
+    boost
+    protobuf
+    libusb1
+    libmicrohttpd
+    jsoncpp
+  ];
+
+  LD_LIBRARY_PATH = "${stdenv.lib.makeLibraryPath [ curl ]}";
+  cmakeFlags="-DJSONCPP_LIBRARY='${jsoncpp}/lib/libjsoncpp.so'";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp trezord $out/bin
+  '';
+}
+

--- a/pkgs/servers/trezord/default.nix
+++ b/pkgs/servers/trezord/default.nix
@@ -9,8 +9,9 @@ in
 stdenv.mkDerivation rec {
   name = "trezord-${version}";
 
-  src = fetchgit {
-    url    = "https://github.com/trezor/trezord";
+  src = fetchFromGitHub {
+    owner  = "trezor";
+    repo   = "trezord";
     rev    = "refs/tags/v${version}";
     sha256 = "1606j5cfngryk4q21yiga1zvc3zpx4q8vqn6ljrvr679hpvlwni4";
   };
@@ -19,7 +20,7 @@ stdenv.mkDerivation rec {
     description = "TREZOR Bridge daemon for TREZOR bitcoin hardware wallet";
     homepage = https://mytrezor.com;
     license = licenses.gpl3;
-    maintainers = [];
+    maintainers = with stdenv.lib.maintainers; [ canndrew jb55 ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/servers/trezord/dynamic-link.patch
+++ b/pkgs/servers/trezord/dynamic-link.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7c0e2cf..0e3f4ac 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -59,13 +59,6 @@ target_link_libraries(trezord ${OS_LIBRARIES})
+ find_package(CURL REQUIRED)
+ find_package(libmicrohttpd REQUIRED)
+ 
+-# add static libs
+-if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+-  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+-  set(BUILD_SHARED_LIBS off)
+-  set(Boost_USE_STATIC_LIBS on)
+-  set(CMAKE_FIND_STATIC FIRST)
+-endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+ find_package(Boost 1.53.0 REQUIRED
+   regex thread system unit_test_framework program_options chrono)
+ find_package(Protobuf 2.5.0 REQUIRED)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4086,6 +4086,8 @@ with pkgs;
 
   tpm-luks = callPackage ../tools/security/tpm-luks { };
 
+  trezord = callPackage ../servers/trezord { };
+
   tthsum = callPackage ../applications/misc/tthsum { };
 
   chaps = callPackage ../tools/security/chaps { };


### PR DESCRIPTION
###### Motivation for this change

I want to use my trezor with NixOS.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

