### PR TITLE
top-level: add asOf helper

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -75,6 +75,14 @@ in
   inherit (lib) lowPrio hiPrio appendToName makeOverridable;
   inherit (misc) versionedDerivation;
 
+  # Conveniently hop to a specific version of nixpkgs. We might want to use fetchTarball once
+  # theres's a public released version that supports locking down the sha256.
+  asOf = { rev, sha256 }: import (fetchFromGitHub {
+    owner = "NixOS";
+    repo  = "nixpkgs";
+    inherit rev sha256;
+  }) { inherit system config platform; };
+
   # Applying this to an attribute set will cause nix-env to look
   # inside the set for derivations.
   recurseIntoAttrs = attrs: attrs // { recurseForDerivations = true; };


### PR DESCRIPTION
I discussed this on IRC a while back. It's currently using import-from-derivation which isn't ideal, but works fine in practice, and allows us to request specific versions of nixpkgs. I often use something like this inside local default.nix to guarantee that multiple developers are using the exact same versions of dependencies and to get fine-grained control over when we upgrade them. As I mention in the comment, `fetchTarball` would have nicer behavior here, but at least for my uses, I need to lock down the sha256, so I figured I'd stick with this until a new version of Nix that supports a locked-down `fetchTarball` is released.

I'd probably mandate that this not be used anywhere inside nixpkgs, but it can be really nice when depending on nixpkgs from external projects.

I wasn't sure which parameters to pass through (the `inherit system config platform;` thing I have right now). Just naming all the parameters we pass into top-level.nix and passing them in doesn't work, probably due to the factoring out of the fixed points and impurities that @Ericson2314's been doing recently. Open to suggestions on how to do that better.

cc @edolstra @shlevy @domenkozar