### PR TITLE
fetchbower: fix SSL support

### DIFF
--- a/pkgs/build-support/fetchbower/default.nix
+++ b/pkgs/build-support/fetchbower/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, bower2nix }:
+{ stdenv, lib, bower2nix, cacert }:
 let
   bowerVersion = version:
     let
@@ -9,6 +9,7 @@ let
 
   fetchbower = name: version: target: outputHash: stdenv.mkDerivation {
     name = "${name}-${bowerVersion version}";
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
     buildCommand = ''
       fetch-bower --quiet --out=$PWD/out "${name}" "${target}" "${version}"
       # In some cases, the result of fetchBower is different depending


### PR DESCRIPTION
###### Motivation for this change
`fetchbower` is does'nt handle SSL origins properly. This fixes #18454 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I tested this on a few bower packages and I successfully fetches them. 
