### PR TITLE
khd: init at v1.1.4

### DIFF
--- a/pkgs/os-specific/darwin/khd/default.nix
+++ b/pkgs/os-specific/darwin/khd/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, Carbon, Cocoa }:
+
+stdenv.mkDerivation rec {
+  name = "khd-${version}";
+  version = "1.1.4";
+
+  src = fetchFromGitHub {
+    owner = "koekeishiya";
+    repo = "khd";
+    rev = "v${version}";
+    sha256 = "1klia3fywl0c88zbp5wdn6kxhdwdry1jwmkj27vpv8vzvdfzwfmy";
+  };
+
+  buildInputs = [ Carbon Cocoa ];
+
+  prePatch = ''
+    substituteInPlace makefile \
+      --replace g++ clang++
+  '';
+
+  buildPhase = ''
+    make install
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/khd $out/bin/khd
+
+    mkdir -p $out/Library/LaunchDaemons
+    cp ${./org.nixos.khd.plist} $out/Library/LaunchDaemons/org.nixos.khd.plist
+    substituteInPlace $out/Library/LaunchDaemons/org.nixos.khd.plist --subst-var out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple modal hototkey daemon for OSX";
+    homepage = https://github.com/koekeishiya/khd;
+    downloadPage = https://github.com/koekeishiya/khd/releases;
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ lnl7 ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/os-specific/darwin/khd/org.nixos.khd.plist
+++ b/pkgs/os-specific/darwin/khd/org.nixos.khd.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>org.nixos.khd</string>
+  <key>ProgramArguments</key>
+  <array>
+  <string>@out@/bin/khd</string>
+  </array>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>@out@/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>Sockets</key>
+  <dict>
+    <key>Listeners</key>
+    <dict>
+      <key>SockServiceName</key>
+      <string>3021</string>
+      <key>SockType</key>
+      <string>dgram</string>
+      <key>SockFamily</key>
+      <string>IPv4</string>
+    </dict>
+  </dict>
+</dict>
+</plist>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -524,6 +524,10 @@ in
 
   oracle-instantclient = callPackage ../development/libraries/oracle-instantclient { };
 
+  khd = callPackage ../os-specific/darwin/khd {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+  };
+
   reattach-to-user-namespace = callPackage ../os-specific/darwin/reattach-to-user-namespace {};
 
   install_name_tool = callPackage ../os-specific/darwin/install_name_tool { };


### PR DESCRIPTION
###### Motivation for this change

A simple modal hototkey daemon for OSX

###### Things done

- [x] Tested without xcode
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] macOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
