### PR TITLE
{lib,pcman}fm: 1.2.4 -> 1.2.5 

### DIFF
--- a/pkgs/applications/misc/pcmanfm/default.nix
+++ b/pkgs/applications/misc/pcmanfm/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, glib, gtk2, intltool, libfm, libX11, pango, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "pcmanfm-1.2.4";
+  name = "pcmanfm-1.2.5";
   src = fetchurl {
     url = "mirror://sourceforge/pcmanfm/${name}.tar.xz";
-    sha256 = "04z3vd9si24yi4c8calqncdpb9b6mbj4cs4f3fs86i6j05gvpk9q";
+    sha256 = "0rxdh0dfzc84l85c54blq42gczygq8adhr3l9hqzy1dp530cm1hc";
   };
 
   buildInputs = [ glib gtk2 intltool libfm libX11 pango pkgconfig ];

--- a/pkgs/development/libraries/libfm/default.nix
+++ b/pkgs/development/libraries/libfm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, gtk2, intltool, menu-cache, pango, pkgconfig, vala_0_23
+{ stdenv, fetchurl, glib, gtk2, intltool, menu-cache, pango, pkgconfig, vala_0_34
 , extraOnly ? false }:
 let
     inherit (stdenv.lib) optional;
@@ -7,14 +7,14 @@ stdenv.mkDerivation rec {
   name = if extraOnly
     then "libfm-extra-${version}"
     else "libfm-${version}";
-  version = "1.2.4";
+  version = "1.2.5";
 
   src = fetchurl {
     url = "mirror://sourceforge/pcmanfm/libfm-${version}.tar.xz";
-    sha256 = "0bsh4p7h2glhxf1cc1lvbxyb4qy0y1zsnl9izf7vrldkikrgc13q";
+    sha256 = "0nlvfwh09gbq8bkbvwnw6iqr918rrs9gc9ljb9pjspyg408bn1n7";
   };
 
-  buildInputs = [ glib gtk2 intltool pango pkgconfig vala_0_23 ]
+  buildInputs = [ glib gtk2 intltool pango pkgconfig vala_0_34 ]
                 ++ optional (!extraOnly) menu-cache;
 
   configureFlags = optional extraOnly "--with-extra-only";


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).