### PR TITLE
aria2: 1.29.0 -> 1.31.0

### DIFF
--- a/pkgs/tools/networking/aria2/default.nix
+++ b/pkgs/tools/networking/aria2/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "aria2-${version}";
-  version = "1.29.0";
+  version = "1.31.0";
 
   src = fetchFromGitHub {
     owner = "aria2";
     repo = "aria2";
     rev = "release-${version}";
-    sha256 = "1ivxz2ld4cl9z29kdicban9dir6s0si2jqn4g11gz587x7pagbim";
+    sha256 = "0d7z4bss1plkvlw5kfwzivxryrh13zi58ii3vf8q4csaz4yqhcjy";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

Update `aria2` to version 1.31.0.

[Changes](https://github.com/aria2/aria2/releases/tag/release-1.31.0)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).