### PR TITLE
Install ssh permitroot

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -37,6 +37,11 @@
   first disable network-manager with
   <command>systemctl stop network-manager</command>.</para></listitem>
 
+  <listitem><para>If you would like to continue the installation from a different
+  machine you need to activate the SSH daemon via <literal>systemctl start sshd</literal>.
+  In order to be able to login you also need to set a password for
+  <literal>root</literal> using <literal>passwd<literal>.</para></listitem>
+
   <listitem><para>The NixOS installer doesn’t do any partitioning or
   formatting yet, so you need to do that yourself.  Use the following
   commands:

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -45,7 +45,7 @@ with lib;
             "Type `systemctl start display-manager' to\nstart the graphical user interface."}
       '';
 
-    # Allow sshd to be started manually through "start sshd".
+    # Allow sshd to be started manually through "systemctl start sshd".
     services.openssh = {
       enable = true;
       # Allow password login to the installation, if the user sets a password via "passwd"

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -46,7 +46,12 @@ with lib;
       '';
 
     # Allow sshd to be started manually through "start sshd".
-    services.openssh.enable = true;
+    services.openssh = {
+      enable = true;
+      # Allow password login to the installation, if the user sets a password via "passwd"
+      # It is safe as root doesn't have a password by default and SSH is disabled by default
+      permitRootLogin = "yes";
+    };
     systemd.services.sshd.wantedBy = mkOverride 50 [];
 
     # Enable wpa_supplicant, but don't start it by default.


### PR DESCRIPTION
###### Motivation for this change

To make it easier to do an installation from a remote machine root login should be permitted on an installation CD.

For a discussion see: #20718

###### Things done

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of iso (usually in `./result/iso/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

