### PR TITLE
roboto: 2.135 -> 2.136

### DIFF
--- a/pkgs/data/fonts/roboto/default.nix
+++ b/pkgs/data/fonts/roboto/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "roboto-${version}";
-  version = "2.135";
+  version = "2.136";
 
   src = fetchurl {
     url = "https://github.com/google/roboto/releases/download/v${version}/roboto-unhinted.zip";
-    sha256 = "1ndlh36bcx4mhi58sxfx6ywbib586brh6s5sk3jyji78h1i7j8zr";
+    sha256 = "0yx3q5wbbl1qkxfx1fglzy3rvms98jr8fcfj70vvvz3r3lppv201";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).