### PR TITLE
exercism: Broaden platforms to include darwin, etc

### DIFF
--- a/pkgs/applications/misc/exercism/default.nix
+++ b/pkgs/applications/misc/exercism/default.nix
@@ -18,6 +18,6 @@ buildGoPackage rec {
    homepage    = http://exercism.io/cli;
    license     = licenses.mit;
    maintainers = [ maintainers.rbasso ];
-   platforms   = platforms.linux;
+   platforms   = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

wanna use exercism on my mac

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

