### PR TITLE
groonga: 6.1.1 -> 6.1.5

### DIFF
--- a/pkgs/servers/search/groonga/default.nix
+++ b/pkgs/servers/search/groonga/default.nix
@@ -1,46 +1,42 @@
 { stdenv, fetchurl, mecab, kytea, libedit, pkgconfig
 , suggestSupport ? false, zeromq, libevent, libmsgpack
-, lz4Support ? false, lz4
+, lz4Support  ? false, lz4
 , zlibSupport ? false, zlib
 }:
 
 stdenv.mkDerivation rec {
 
   name    = "groonga-${version}";
-  version = "6.1.1";
+  version = "6.1.5";
 
   src = fetchurl {
     url    = "http://packages.groonga.org/source/groonga/${name}.tar.gz";
-    sha256 = "03h65gycy0j2q4n5h62x3sw76ibdywdvmiciys5a7ppxb2mncabz";
+    sha256 = "0phh4qp7ky5rw8xgxv3gjzw2cadkjl604xrdyxxbpd30i354sh5x";
   };
 
-  buildInputs = with stdenv.lib; [ pkgconfig mecab kytea libedit ] ++
-    optional lz4Support lz4 ++
-    optional zlibSupport zlib ++
-    optional suggestSupport [ zeromq libevent libmsgpack ];
+  buildInputs = with stdenv.lib;
+     [ pkgconfig mecab kytea libedit ]
+    ++ optional lz4Support lz4
+    ++ optional zlibSupport zlib
+    ++ optionals suggestSupport [ zeromq libevent libmsgpack ];
 
-  configureFlags = with stdenv.lib; ''
-    ${optionalString zlibSupport "--with-zlib"}
-    ${optionalString lz4Support "--with-lz4"}
-  '';
+  configureFlags = with stdenv.lib;
+       optional zlibSupport "--with-zlib"
+    ++ optional lz4Support  "--with-lz4";
 
-  doInstallCheck = true;
-
+  doInstallCheck    = true;
   installCheckPhase = "$out/bin/groonga --version";
 
   meta = with stdenv.lib; {
-    homepage = http://groonga.org/;
+    homepage    = http://groonga.org/;
     description = "An open-source fulltext search engine and column store";
-
+    license     = licenses.lgpl21;
+    maintainers = [ maintainers.ericsagnes ];
+    platforms   = platforms.linux;
     longDescription = ''
       Groonga is an open-source fulltext search engine and column store. 
       It lets you write high-performance applications that requires fulltext search.
     '';
-
-    license = licenses.lgpl21;
-
-    maintainers = [ maintainers.ericsagnes ];
-    platforms = platforms.linux;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Update groonga to latest version.
Feature small aesthetic cleanup.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

