### PR TITLE
pasystray: 0.5.2 -> 0.6.0

### DIFF
--- a/pkgs/tools/audio/pasystray/default.nix
+++ b/pkgs/tools/audio/pasystray/default.nix
@@ -2,13 +2,14 @@
 , gnome3, avahi, gtk3, libnotify, libpulseaudio, xlibsWrapper}:
 
 stdenv.mkDerivation rec {
-  name = "pasystray-0.5.2";
+  name = "pasystray-${version}";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "christophgysin";
     repo = "pasystray";
-    rev = "6709fc1e9f792baf4f7b4507a887d5876b2cfa70";
-    sha256 = "1z21wassdiwfnlcrkpdqh8ylblpd1xxjxcmib5mwix9va2lykdfv";
+    rev = name;
+    sha256 = "0k13s7pmz5ks3kli8pwhzd47hcjwv46gd2fgk7i4fbkfwf3z279h";
   };
 
   buildInputs = [ autoconf automake makeWrapper pkgconfig 
@@ -31,7 +32,7 @@ stdenv.mkDerivation rec {
     description = "PulseAudio system tray";
     homepage = "https://github.com/christophgysin/pasystray";
     license = licenses.lgpl21Plus;
-    maintainers = [ maintainers.exlevan ];
+    maintainers = with maintainers; [ exlevan kamilchm ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

