### PR TITLE
opencv: upgrade from 3.1.0 to 3.2.0

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -1,86 +1,103 @@
-{ lib, stdenv, fetchurl, fetchpatch, fetchFromGitHub, cmake, pkgconfig, unzip
-, zlib
-, enableIpp ? false
-, enableContrib ? false
-, enablePython ? false, pythonPackages
-, enableGtk2 ? false, gtk2
-, enableGtk3 ? false, gtk3
-, enableJPEG ? true, libjpeg
-, enablePNG ? true, libpng
-, enableTIFF ? true, libtiff
-, enableWebP ? true, libwebp
-, enableEXR ? true, openexr, ilmbase
-, enableJPEG2K ? true, jasper
-, enableFfmpeg ? false, ffmpeg
+{ lib, stdenv, fetchurl, fetchpatch, fetchFromGitHub, cmake, pkgconfig, unzip, zlib
+
+, enableJPEG      ? true, libjpeg
+, enablePNG       ? true, libpng
+, enableTIFF      ? true, libtiff
+, enableWebP      ? true, libwebp
+, enableEXR       ? true, openexr, ilmbase
+, enableJPEG2K    ? true, jasper
+
+, enableIpp       ? false
+, enableContrib   ? false, protobuf3_1
+, enablePython    ? false, pythonPackages
+, enableGtk2      ? false, gtk2
+, enableGtk3      ? false, gtk3
+, enableFfmpeg    ? false, ffmpeg
 , enableGStreamer ? false, gst_all_1
-, enableEigen ? false, eigen
-, enableCuda ? false, cudatoolkit, gcc5
+, enableEigen     ? false, eigen
+, enableCuda      ? false, cudatoolkit, gcc5
 }:
 
 let
-  version = "3.1.0";
+  version = "3.2.0";
+
+  src = fetchFromGitHub {
+    owner  = "opencv";
+    repo   = "opencv";
+    rev    = version;
+    sha256 = "0f59g0dvhp5xg1xa3r4lp351a7x0k03i77ylgcf69ns3y47qd16p";
+  };
 
   contribSrc = fetchFromGitHub {
-    owner = "Itseez";
-    repo = "opencv_contrib";
-    rev = version;
-    sha256 = "153yx62f34gl3zd6vgxv0fj3wccwmq78lnawlda1f6xhrclg9bax";
+    owner  = "opencv";
+    repo   = "opencv_contrib";
+    rev    = version;
+    sha256 = "1lynpbxz1jay3ya5y45zac5v8c6ifgk4ssn8d1chfdk3spi691jj";
+  };
+
+  vggFiles = fetchFromGitHub {
+    owner  = "opencv";
+    repo   = "opencv_3rdparty";
+    rev    = "fccf7cd6a4b12079f73bbfb21745f9babcd4eb1d";
+    sha256 = "0r9fam8dplyqqsd3qgpnnfgf9l7lj44di19rxwbm8mxiw0rlcdvy";
+  };
+
+  bootdescFiles = fetchFromGitHub {
+    owner  = "opencv";
+    repo   = "opencv_3rdparty";
+    rev    = "34e4206aef44d50e6bbcd0ab06354b52e7466d26";
+    sha256 = "13yig1xhvgghvxspxmdidss5lqiikpjr0ddm83jsi0k85j92sn62";
   };
 
   opencvFlag = name: enabled: "-DWITH_${name}=${if enabled then "ON" else "OFF"}";
-
 in
 
 stdenv.mkDerivation rec {
   name = "opencv-${version}";
-  inherit version;
+  inherit version src;
 
-  src = fetchFromGitHub {
-    owner = "Itseez";
-    repo = "opencv";
-    rev = version;
-    sha256 = "1l0w12czavgs0wzw1c594g358ilvfg2fn32cn8z7pv84zxj4g429";
-  };
+  postUnpack =
+    (lib.optionalString enableContrib ''
+      cp --no-preserve=mode -r "${contribSrc}/modules" "$NIX_BUILD_TOP/opencv_contrib"
 
-  patches =
-    lib.optionals enableCuda [
-      (fetchpatch { # Patch for CUDA 8 compatibility
-        url = "https://github.com/opencv/opencv/commit/10896129b39655e19e4e7c529153cb5c2191a1db.patch";
-        sha256 = "0jka3kxxywgs3prqqgym5kav6p73rrblwj50k1nf3fvfpk194ah1";
-      })
-      (fetchpatch { # Patch to add CUDA Compute Capability compilation targets up to 6.0
-        url = "https://github.com/opencv/opencv/commit/d76f258aebdf63f979a205cabe6d3e81700a7cd8.patch";
-        sha256 = "00b3msfgrcw7laij6qafn4b18c1dl96xxpzwx05wxzrjldqb6kqg";
-      })
-    ]
-    ++ lib.optional enablePython (fetchpatch { # Patch to fix FlannBasedMatcher under python
-      url = "https://github.com/opencv/opencv/commit/05cfe28612fd8dc8fb0ccb876df945c7b435dd26.patch";
-      sha256 = "0niza5lybr1ljzdkyiapr16laa468168qinpy5qn00yimnaygpm6";
-    });
+      for name in vgg_generated_48.i \
+                  vgg_generated_64.i \
+                  vgg_generated_80.i \
+                  vgg_generated_120.i; do
+        ln -s "${vggFiles}/$name" "$NIX_BUILD_TOP/opencv_contrib/xfeatures2d/src/$name"
+      done
 
+      for name in boostdesc_bgm.i          \
+                  boostdesc_bgm_bi.i       \
+                  boostdesc_bgm_hd.i       \
+                  boostdesc_binboost_064.i \
+                  boostdesc_binboost_128.i \
+                  boostdesc_binboost_256.i \
+                  boostdesc_lbgm.i; do
+        ln -s "${bootdescFiles}/$name" "$NIX_BUILD_TOP/opencv_contrib/xfeatures2d/src/$name"
+      done
+    '');
   preConfigure =
-    # By default ippicv gets downloaded by cmake each time opencv is build. See:
-    # https://github.com/opencv/opencv/blob/3.1.0/3rdparty/ippicv/downloader.cmake
-    # Fortunately cmake doesn't download ippicv if it's already there.
-    # So to prevent repeated downloads we store it in the nix store
-    # and create a symbolic link to it.
-    let version  = "20151201";
-        md5      = "808b791a6eac9ed78d32a7666804320e";
-        sha256   = "1nph0w0pdcxwhdb5lxkb8whpwd9ylvwl97hn0k425amg80z86cs3";
-        rev      = "81a676001ca8075ada498583e4166079e5744668";
-        platform = if stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux" then "linux"
-                   else throw "ICV is not available for this platform (or not yet supported by this package)";
-        name = "ippicv_${platform}_${version}.tgz";
-        ippicv = fetchurl {
-          url = "https://raw.githubusercontent.com/opencv/opencv_3rdparty/${rev}/ippicv/${name}";
-          inherit sha256;
-        };
-        dir = "3rdparty/ippicv/downloads/${platform}-${md5}";
-    in lib.optionalString enableIpp
-      ''
-        mkdir -p "${dir}"
-        ln -s "${ippicv}" "${dir}/${name}"
-      '';
+    (let version  = "20151201";
+         md5      = "808b791a6eac9ed78d32a7666804320e";
+         sha256   = "1nph0w0pdcxwhdb5lxkb8whpwd9ylvwl97hn0k425amg80z86cs3";
+         rev      = "81a676001ca8075ada498583e4166079e5744668";
+         platform = if stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux" then "linux"
+                    else throw "ICV is not available for this platform (or not yet supported by this package)";
+         name = "ippicv_${platform}_${version}.tgz";
+         ippicv = fetchurl {
+           url = "https://raw.githubusercontent.com/opencv/opencv_3rdparty/${rev}/ippicv/${name}";
+           inherit sha256;
+         };
+         dir = "3rdparty/ippicv/downloads/${platform}-${md5}";
+     in lib.optionalString enableIpp ''
+          mkdir -p "${dir}"
+          ln -s "${ippicv}" "${dir}/${name}"
+        ''
+    ) +
+    (lib.optionalString enableContrib ''
+      cmakeFlagsArray+=("-DOPENCV_EXTRA_MODULES_PATH=$NIX_BUILD_TOP/opencv_contrib")
+    '');
 
   buildInputs =
        [ zlib ]
@@ -96,7 +113,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableFfmpeg ffmpeg
     ++ lib.optionals enableGStreamer (with gst_all_1; [ gstreamer gst-plugins-base ])
     ++ lib.optional enableEigen eigen
-    ++ lib.optional enableCuda [ cudatoolkit gcc5 ]
+    ++ lib.optionals enableCuda [ cudatoolkit gcc5 ]
+    ++ lib.optional enableContrib protobuf3_1
     ;
 
   propagatedBuildInputs = lib.optional enablePython pythonPackages.numpy;
@@ -115,8 +133,8 @@ stdenv.mkDerivation rec {
     (opencvFlag "OPENEXR" enableEXR)
     (opencvFlag "CUDA" enableCuda)
     (opencvFlag "CUBLAS" enableCuda)
-  ] ++ lib.optionals enableContrib [ "-DOPENCV_EXTRA_MODULES_PATH=${contribSrc}/modules" ]
-    ++ lib.optionals enableCuda [ "-DCUDA_FAST_MATH=ON" ];
+  ] ++ lib.optionals enableCuda [ "-DCUDA_FAST_MATH=ON" ]
+    ++ lib.optional enableContrib "-DBUILD_PROTOBUF=off";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
@bjornfor  I tested the build by enabling all options (except for `enableGtk2`).