### PR TITLE
smokeping: setuid for fping6

### DIFF
--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -273,7 +273,7 @@ in
         message = "services.smokeping: sendmail and Mailhost cannot both be enabled.";
       }
     ];
-    security.setuidPrograms = [ "fping" ];
+    security.setuidPrograms = [ "fping" "fping6" ];
     environment.systemPackages = [ pkgs.fping ];
     users.extraUsers = singleton {
       name = cfg.user;


### PR DESCRIPTION
###### Motivation for this change
The new fping6 binary (#21950) needs to be setuid same as fping binary to be used by smokeping.

###### Things done
- [x] Used this change for a week on our smokeping instance
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

