### PR TITLE
quodlibet:  rename to quodlibet, quodlibet-without-gst-plugins

### DIFF
--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -12,7 +12,7 @@ let
   inherit (python2Packages) buildPythonApplication python mutagen pygtk pygobject2 dbus-python;
 in buildPythonApplication {
   # call the package quodlibet and just quodlibet
-  name = "quodlibet${stdenv.lib.optionalString withGstPlugins "-with-gst-plugins"}-${version}";
+  name = "quodlibet${stdenv.lib.optionalString (!withGstPlugins) "-without-gst-plugins"}-${version}";
 
   # XXX, tests fail
   doCheck = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14743,9 +14743,9 @@ in
 
   quiterss = qt5.callPackage ../applications/networking/newsreaders/quiterss {};
 
-  quodlibet = callPackage ../applications/audio/quodlibet { };
+  quodlibet-without-gst-plugins = callPackage ../applications/audio/quodlibet { };
 
-  quodlibet-with-gst-plugins = callPackage ../applications/audio/quodlibet {
+  quodlibet = callPackage ../applications/audio/quodlibet {
     withGstPlugins = true;
     gst_plugins_bad = null;
   };


### PR DESCRIPTION
###### Motivation for this change

The gst-plugin-less version is barely useful out of the box, so it is
the one that should be relegated to a less prominent spot in the namespace.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

