### PR TITLE
hexchat: 2.12.3 -> 2.12.4

### DIFF
--- a/pkgs/applications/networking/irc/hexchat/default.nix
+++ b/pkgs/applications/networking/irc/hexchat/default.nix
@@ -1,20 +1,24 @@
-{ stdenv, fetchurl, pkgconfig, gtk2, lua, perl, python
+{ stdenv, fetchFromGitHub, pkgconfig, gtk2, lua, perl, python
 , libtool, pciutils, dbus_glib, libcanberra_gtk2, libproxy
 , libsexy, enchant, libnotify, openssl, intltool
 , desktop_file_utils, hicolor_icon_theme
+, autoconf, automake, autoconf-archive
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.12.3";
+  version = "2.12.4";
   name = "hexchat-${version}";
 
-  src = fetchurl {
-    url = "http://dl.hexchat.net/hexchat/${name}.tar.xz";
-    sha256 = "1fpj2kk1p85snffchqxsz3sphhcgiripjw41mgzxi7ks5hvj4avg";
+  src = fetchFromGitHub {
+    owner = "hexchat";
+    repo = "hexchat";
+    rev = "v${version}";
+    sha256 = "1z8v7jg1mc2277k3jihnq4rixw1q27305aw6b6rpb1x7vpiy2zr3";
   };
 
   nativeBuildInputs = [
     pkgconfig libtool intltool
+    autoconf autoconf-archive automake
   ];
 
   buildInputs = [
@@ -24,9 +28,13 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
- #hexchat and heachat-text loads enchant spell checking library at run time and so it needs to have route to the path
+  #hexchat and heachat-text loads enchant spell checking library at run time and so it needs to have route to the path
   patchPhase = ''
     sed -i "s,libenchant.so.1,${enchant}/lib/libenchant.so.1,g" src/fe-gtk/sexy-spell-entry.c
+  '';
+
+  preConfigure = ''
+    ./autogen.sh
   '';
 
   configureFlags = [ "--enable-shm" "--enable-textfe" ];


### PR DESCRIPTION
###### Motivation for this change

There is a new release of `hexchat`.

[**ChangeLog**](https://hexchat.readthedocs.io/en/latest/changelog.html)
2.12.4 (2016-12-10)

- fix issue with timers causing ping timeouts
- fix building against OpenSSL 1.1
- fix /exec output printing invalid utf8
- replace doat plugin with an internal command
- change how tab colors interact with plugins

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).