### PR TITLE
cbatticon: 1.6.4 -> 1.6.5

### DIFF
--- a/pkgs/applications/misc/cbatticon/default.nix
+++ b/pkgs/applications/misc/cbatticon/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
 
   name = "cbatticon-${version}";
-  version = "1.6.4";
+  version = "1.6.5";
 
   src = fetchFromGitHub {
     owner = "valr";
     repo = "cbatticon";
     rev = version;
-    sha256 = "0m3bj408mbini97kq0cdf048lnfkdn7bd8ikbfijd7dwfdzv27i5";
+    sha256 = "1j7gbmmygvbrawqn1bbaf47lb600lylslzqbvfwlhifmi7qnm6ca";
   };
 
   makeFlags = "PREFIX=$(out)";


### PR DESCRIPTION
###### Motivation for this change

[ChangeLog](https://github.com/valr/cbatticon/blob/master/Changelog)


2016-12-27  Valère Monseur  <valere.monseur@ymail.com>

 * Release 1.6.5
 * Fix #30 : notification spam when there are multiple batteries
 * Fix #33 : added a man page
 * Fix #34 : added Japanese translation

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).