### PR TITLE
munin: 2.0.29 -> 2.0.30

### DIFF
--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, which, coreutils, rrdtool, perl, perlPackages
+{ stdenv, fetchFromGitHub, makeWrapper, which, coreutils, rrdtool, perl, perlPackages
 , python, ruby, jre, nettools
 }:
 
@@ -6,9 +6,11 @@ stdenv.mkDerivation rec {
   version = "2.0.29";
   name = "munin-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/munin-monitoring/munin/archive/${version}.tar.gz";
-    sha256 = "1zpv0p10iyx49z1hsqvlkk6hh46hp9dhbrdyx103hgx7p3xnxfnv";
+  src = fetchFromGitHub {
+    owner = "munin-monitoring";
+    repo = "munin";
+    rev = version;
+    sha256 = "058x023ciqzqn0n1qfhb2wskg24hjdl2kcrza2a33wfddh9nddwj";
   };
 
   buildInputs = [ 

--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -3,14 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.0.29";
+  version = "2.0.30";
   name = "munin-${version}";
 
   src = fetchFromGitHub {
     owner = "munin-monitoring";
     repo = "munin";
     rev = version;
-    sha256 = "058x023ciqzqn0n1qfhb2wskg24hjdl2kcrza2a33wfddh9nddwj";
+    sha256 = "1sxsdfq9a5d8b13jigr06gs7n4m3c95645sfyyl49bkfy0n5cxrg";
   };
 
   buildInputs = [ 


### PR DESCRIPTION
###### Motivation for this change

Munin http://munin-monitoring.org/ fixed some bugs and released a new stable version .

###### Things done

- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

