### PR TITLE
gnupg21: 2.1.17 -> 2.1.18

### DIFF
--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -15,11 +15,11 @@ assert guiSupport -> pinentry != null;
 stdenv.mkDerivation rec {
   name = "gnupg-${version}";
 
-  version = "2.1.17";
+  version = "2.1.18";
 
   src = fetchurl {
     url = "mirror://gnupg/gnupg/${name}.tar.bz2";
-    sha256 = "1js308b46ifx1gim0c9nivr5yxhans7iq1yvkf7zl2928gdm9p65";
+    sha256 = "157rrv3ly9j2k0acz43nhiba5hfl6h7048jvj55wwqjmgsmnyk6h";
   };
 
   buildInputs = [


### PR DESCRIPTION
See http://lists.gnu.org/archive/html/info-gnu/2017-01/msg00013.html
for release announcement.

###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

