### PR TITLE
apache-kafka service: change default brokerId to -1

### DIFF
--- a/nixos/modules/services/misc/apache-kafka.nix
+++ b/nixos/modules/services/misc/apache-kafka.nix
@@ -38,7 +38,7 @@ in {
 
     brokerId = mkOption {
       description = "Broker ID.";
-      default = 0;
+      default = -1;
       type = types.int;
     };
 


### PR DESCRIPTION
A default of 0 means that if you deploy two NixOS boxes with the default configuration, the second will fail because the brokerId was already in use. Using -1 instead tells it to pick one automatically at first start.

Fixes #22100 

cc @ragnard @shlevy