### PR TITLE
diagrams: Fix the 1.4.* versions of the ecosystem

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -675,8 +675,38 @@ self: super: {
     '';
   }));
 
-  # Requires optparse-applicative 0.13.0.0
+  # Packages of the diagrams ecosystem that require:
+  #   diagrams-core ==1.4.*
+  #   diagrams-lib ==1.4.*
+  #   optparse-applicative ==0.13.*
+  diagrams_1_4 = super.diagrams_1_4.overrideScope (self: super: {
+    diagrams-contrib = self.diagrams-contrib_1_4_0_1;
+    diagrams-core = self.diagrams-core_1_4;
+    diagrams-lib = self.diagrams-lib_1_4_0_1;
+    diagrams-svg = self.diagrams-svg_1_4_1;
+    optparse-applicative = self.optparse-applicative_0_13_0_0;
+  });
+  diagrams-contrib_1_4_0_1 = super.diagrams-contrib_1_4_0_1.overrideScope (self: super: {
+    diagrams-core = self.diagrams-core_1_4;
+    diagrams-lib = self.diagrams-lib_1_4_0_1;
+  });
+  diagrams-lib_1_4_0_1 = super.diagrams-lib_1_4_0_1.overrideScope (self: super: {
+    diagrams-core = self.diagrams-core_1_4;
+    optparse-applicative = self.optparse-applicative_0_13_0_0;
+  });
   diagrams-pgf = super.diagrams-pgf.overrideScope (self: super: {
+    diagrams-core = self.diagrams-core_1_4;
+    diagrams-lib = self.diagrams-lib_1_4_0_1;
+    optparse-applicative = self.optparse-applicative_0_13_0_0;
+  });
+  diagrams-rasterific_1_4 = super.diagrams-rasterific_1_4.overrideScope (self: super: {
+    diagrams-core = self.diagrams-core_1_4;
+    diagrams-lib = self.diagrams-lib_1_4_0_1;
+    optparse-applicative = self.optparse-applicative_0_13_0_0;
+  });
+  diagrams-svg_1_4_1 = super.diagrams-svg_1_4_1.overrideScope (self: super: {
+    diagrams-core = self.diagrams-core_1_4;
+    diagrams-lib = self.diagrams-lib_1_4_0_1;
     optparse-applicative = self.optparse-applicative_0_13_0_0;
   });
 


### PR DESCRIPTION
The affected packages now depend on:

   diagrams-core ==1.4.*
   diagrams-lib ==1.4.*
   optparse-applicative ==0.13.*


CC: @peti

###### Motivation for this change

Fix `diagrams_1_4` and `diagrams-pgf`

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

