### PR TITLE
drake: init at 0.9.2.0.3.1

### DIFF
--- a/pkgs/development/tools/build-managers/drake/Gemfile
+++ b/pkgs/development/tools/build-managers/drake/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'drake'

--- a/pkgs/development/tools/build-managers/drake/Gemfile.lock
+++ b/pkgs/development/tools/build-managers/drake/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    comp_tree (1.1.3)
+    drake (0.9.2.0.3.1)
+      comp_tree (>= 1.1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  drake
+
+BUNDLED WITH
+   1.13.7

--- a/pkgs/development/tools/build-managers/drake/default.nix
+++ b/pkgs/development/tools/build-managers/drake/default.nix
@@ -1,0 +1,18 @@
+{ lib, bundlerEnv, ruby }:
+
+bundlerEnv {
+  name = "drake-0.9.2.0.3.1";
+
+  inherit ruby;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+  
+  meta = with lib; {
+    description = "A branch of Rake supporting automatic parallelizing of tasks";
+    homepage = http://quix.github.io/rake/;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/development/tools/build-managers/drake/gemset.nix
+++ b/pkgs/development/tools/build-managers/drake/gemset.nix
@@ -1,0 +1,18 @@
+{
+  comp_tree = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dj9lkfxcczn67l1j12dcxswrfxxd1zgxa344zk6vqs2gwwhy9m9";
+      type = "gem";
+    };
+    version = "1.1.3";
+  };
+  drake = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09gkmdshwdmdnkdxi03dv4rk1dip0wdv6dx14wscrmi0jyk86yag";
+      type = "gem";
+    };
+    version = "0.9.2.0.3.1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6293,6 +6293,8 @@ in
 
   doxygen_gui = lowPrio (doxygen.override { inherit qt4; });
 
+  drake = callPackage ../development/tools/build-managers/drake { };
+
   drush = callPackage ../development/tools/misc/drush { };
 
   editorconfig-core-c = callPackage ../development/tools/misc/editorconfig-core-c { };


### PR DESCRIPTION
###### Motivation for this change

[Drake](https://rubygems.org/gems/drake/) is an auto-parallelizing branch of Rake, a Make-like program implemented in Ruby.

It is needed to build MKVToolNix, which as of v9.8.0 does not bundle it anymore. See the pull request https://github.com/NixOS/nixpkgs/pull/22111.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).