### PR TITLE
mkvtoolnix: 9.6.0 -> 9.8.0

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoconf, automake
-, ruby, file, xdg_utils, gettext, expat, qt5, boost
+, drake, ruby, file, xdg_utils, gettext, expat, qt5, boost
 , libebml, zlib, libmatroska, libogg, libvorbis, flac
 , withGUI ? true
 }:
@@ -10,16 +10,16 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "mkvtoolnix-${version}";
-  version = "9.6.0";
+  version = "9.8.0";
 
   src = fetchFromGitHub {
     owner = "mbunkus";
     repo = "mkvtoolnix";
     rev = "release-${version}";
-    sha256 = "14v6iclzkqxibzcdxr65bb5frmnsjyyly0d3lwv1gg7g1mkcw3jd";
+    sha256 = "1hnk92ksgg290q4kwdl8jqrz7vzlwki4f85bb6kgdgzpjkblw76n";
   };
 
-  nativeBuildInputs = [ pkgconfig autoconf automake gettext ruby ];
+  nativeBuildInputs = [ pkgconfig autoconf automake gettext drake ruby ];
 
   buildInputs = [
     expat file xdg_utils boost libebml zlib libmatroska libogg
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
   ] ++ optional withGUI qt5.qtbase;
 
   preConfigure = "./autogen.sh; patchShebangs .";
-  buildPhase   = "./drake -j $NIX_BUILD_CORES";
-  installPhase = "./drake install -j $NIX_BUILD_CORES";
+  buildPhase   = "drake -j $NIX_BUILD_CORES";
+  installPhase = "drake install -j $NIX_BUILD_CORES";
 
   configureFlags = [
     "--enable-magic"
@@ -38,7 +38,6 @@ stdenv.mkDerivation rec {
     "--disable-profiling"
     "--disable-precompiled-headers"
     "--disable-static-qt"
-    "--without-curl"
     "--with-gettext"
     (enableFeature withGUI "qt")
   ];


### PR DESCRIPTION
###### Motivation for this change

- Update [MKVToolNix](https://mkvtoolnix.download/) to v9.8.0.
- Add a build dependency on drake, because it is not bundled with MKVToolNix anymore since v9.8.0.
- CURL is no longer used by MKVToolNix so the corresponding configure option is not valid anymore.
- Changes: https://mkvtoolnix.download/doc/NEWS.md

###### New build dependency

From now on MKVToolNix needs an external version of the drake package, which is added to the repository in pull request https://github.com/NixOS/nixpkgs/pull/22106.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).