### PR TITLE
syncthing: create dataDir on PreStart

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -135,6 +135,7 @@ in {
           Group = cfg.group;
           PermissionsStartOnly = true;
           ExecStart = "${cfg.package}/bin/syncthing -no-browser -home=${cfg.dataDir}";
+          PreStart = "mkdir -m 0755 -p ${cfg.dataDir}";
         };
       };
 


### PR DESCRIPTION
###### Motivation for this change
Syncthing service fails on new deployment as configured directory had to be manually created

