### PR TITLE
OCaml 4.04

### DIFF
--- a/pkgs/development/compilers/ocaml/4.04.nix
+++ b/pkgs/development/compilers/ocaml/4.04.nix
@@ -1,0 +1,6 @@
+import ./generic.nix {
+  major_version = "4";
+  minor_version = "04";
+  patch_version = "0";
+  sha256 = "1d2nk3kq4dyzz8dls45r13jprq5by3q8kshc8kvxzm8n4fnnvvb4";
+}

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (args // rec {
   buildFlags = "world" + optionalString useNativeCompilers " bootstrap world.opt";
   buildInputs = [ncurses] ++ optionals useX11 [ libX11 xproto ];
   installTargets = "install" + optionalString useNativeCompilers " installopt";
-  preConfigure = ''
+  preConfigure = optionalString (!stdenv.lib.versionAtLeast version "4.04") ''
     CAT=$(type -tp cat)
     sed -e "s@/bin/cat@$CAT@" -i config/auto-aux/sharpbang
   '';

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (args // rec {
 
   meta = with stdenv.lib; {
     homepage = http://caml.inria.fr/ocaml;
-    branch = "4.03";
+    branch = versionNoPatch;
     license = with licenses; [
       qpl /* compiler */
       lgpl2 /* library */

--- a/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchzip, ocaml, findlib, oasis, ocaml_optcomp, camlp4 }:
+{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, oasis, ocaml_optcomp, camlp4 }:
 
-let version = "0.7"; in
+let version = "0.7.1"; in
 
 stdenv.mkDerivation {
   name = "ocsigen-deriving-${version}";
   src = fetchzip {
     url = "https://github.com/ocsigen/deriving/archive/${version}.tar.gz";
-    sha256 = "05z606gly1iyan292x3mflg3zasgg68n8i2mivz0zbshx2hz2jbw";
+    sha256 = "0gg3nr3iic4rwqrcc0qvfm9x0x57zclvdsnpy0z8rv2fl5isbzms";
     };
 
-  buildInputs = [ ocaml findlib oasis ocaml_optcomp camlp4 ];
+  buildInputs = [ ocaml findlib ocamlbuild oasis ocaml_optcomp camlp4 ];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -1,19 +1,21 @@
 { stdenv, fetchFromGitHub, ocaml, findlib }:
 
-let
-  version =
-  if stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.03" then "5.0+4.03.0" else "5.0+4.02.0";
+let param = {
+  "4.02.3" = {
+    version = "5.0+4.02.0";
+    sha256 = "16drjk0qafjls8blng69qiv35a84wlafpk16grrg2i3x19p8dlj8"; };
+  "4.03.0" = {
+    version = "5.0+4.03.0";
+    sha256 = "061v1fl5z7z3ywi4ppryrlcywnvnqbsw83ppq72qmkc7ma4603jg"; };
+}."${ocaml.version}";
 in
   stdenv.mkDerivation {
-    name = "ocaml-ppx_tools-${version}";
+    name = "ocaml${ocaml.version}-ppx_tools-${param.version}";
     src = fetchFromGitHub {
       owner = "alainfrisch";
       repo = "ppx_tools";
-      rev = version;
-      sha256 = if version == "5.0+4.03.0"
-      then "061v1fl5z7z3ywi4ppryrlcywnvnqbsw83ppq72qmkc7ma4603jg"
-      else "16drjk0qafjls8blng69qiv35a84wlafpk16grrg2i3x19p8dlj8"
-      ;
+      rev = param.version;
+      inherit (param) sha256;
     };
 
     buildInputs = [ ocaml findlib ];

--- a/pkgs/development/ocaml-modules/spacetime_lib/default.nix
+++ b/pkgs/development/ocaml-modules/spacetime_lib/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, owee }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-spacetime_lib-${version}";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "lpw25";
+    repo = "spacetime_lib";
+    rev = version;
+    sha256 = "1g91y6wl3z18jhaz2q03wn54zj6xk1qcjidr1nc6nq9a8906lcq5";
+  };
+
+  buildInputs = [ ocaml findlib ];
+
+  propagatedBuildInputs = [ owee ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    description = "An OCaml library providing some simple operations for handling OCaml “spacetime” profiles";
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -7,6 +7,9 @@ let param = {
   "4.03.0" = {
      version = "4.03+1";
      sha256 = "1f2ndch6f1m4fgnxsjb94qbpwjnjgdlya6pard44y6n0dqxi1wsq"; };
+  "4.04.0" = {
+     version = "4.04+1";
+     sha256 = "1ad7rygqjxrc1im95gw9lp8q83nhdaf383f2808f1p63yl42xm7k"; };
   }."${ocaml.version}";
 in
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocaml_lwt, menhir, ocsigen_deriving, ppx_deriving, camlp4
+{ stdenv, fetchurl, ocaml, findlib, ocaml_lwt, menhir, ocsigen_deriving, ppx_deriving, camlp4, ocamlbuild
 , cmdliner, tyxml, reactivedata, cppo, which, base64, uchar
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     }."${version}";
   };
 
-  buildInputs = [ ocaml findlib menhir ocsigen_deriving
+  buildInputs = [ ocaml findlib menhir ocsigen_deriving ocamlbuild
                  cmdliner reactivedata cppo which base64 ]
   ++ stdenv.lib.optional (stdenv.lib.versionAtLeast ocaml.version "4.02") tyxml;
   propagatedBuildInputs = [ ocaml_lwt camlp4 ppx_deriving ]

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -727,7 +727,9 @@ in rec
 
   ocamlPackages_4_03 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.03.nix { }) (self: super: { });
 
-  ocamlPackages_latest = ocamlPackages_4_03;
+  ocamlPackages_4_04 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.04.nix { }) (self: super: { });
+
+  ocamlPackages_latest = ocamlPackages_4_04;
 
   ocamlPackages = ocamlPackages_4_01_0;
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -374,6 +374,8 @@ let
 
     sequence = callPackage ../development/ocaml-modules/sequence { };
 
+    spacetime_lib = callPackage ../development/ocaml-modules/spacetime_lib { };
+
     sqlexpr = callPackage ../development/ocaml-modules/sqlexpr { };
 
     tuntap = callPackage ../development/ocaml-modules/tuntap { };


### PR DESCRIPTION
###### Motivation for this change

Following upstream (4.05 is already on its way).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Many OCaml libraries do not build with 4.04. They don’t build with 4.03 neither, for most of them (the main cause being `sexplib` only available for 4.02). Notable exception is `ppx_tools`, for which there is no release compatible with 4.04.