### PR TITLE
terminology: 0.9.1 -> 1.0.0

### DIFF
--- a/pkgs/desktops/enlightenment/terminology.nix
+++ b/pkgs/desktops/enlightenment/terminology.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "terminology-${version}";
-  version = "0.9.1";
+  version = "1.0.0";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/terminology/${name}.tar.xz";
-    sha256 = "1kwv9vkhngdm5v38q93xpcykghnyawhjjcb5bgy0p89gpbk7mvpc";
+    sha256 = "1x4j2q4qqj10ckbka0zaq2r2zm66ff1x791kp8slv1ff7fw45vdz";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "The best terminal emulator written with the EFL";
     homepage = http://enlightenment.org/;
-    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.bsd2;
+    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update terminology to version 1.0.0.

This release introduces the following [changes](https://sourceforge.net/p/enlightenment/mailman/message/35603767/):

 - Bold/Italic support (on by default)
 - Add keybinding shift+home to go to the top of the backlog
 - Add keybinding shift+end to reset scroll
 - Add keybinding shift+left/right to switch between tabs
 - Add keybinding ctrl+alt+t to change terminal's title
 - Add ability to copy links on right-click menu
 - Font size can be changed by escape sequence
 - Rewrite link detection to be more efficient
 - Sanitize SHELL environment variable when using it
 - Fixes on selections
 - Many other fixes

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).