### PR TITLE
cmus: fix darwin

### DIFF
--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ncurses, pkgconfig
+{ stdenv, fetchFromGitHub, ncurses, pkgconfig, gcc
 
 , alsaSupport ? stdenv.isLinux, alsaLib ? null
 # simple fallback for everyone else
@@ -109,7 +109,7 @@ stdenv.mkDerivation rec {
     "CONFIG_WAV=y"
   ] ++ concatMap (a: a.flags) opts);
 
-  buildInputs = [ ncurses pkgconfig ] ++ concatMap (a: a.deps) opts;
+  buildInputs = [ ncurses pkgconfig gcc ] ++ concatMap (a: a.deps) opts;
 
   meta = {
     description = "Small, fast and powerful console music player for Linux and *BSD";

--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, ncurses, pkgconfig, gcc
+{ stdenv, fetchFromGitHub, ncurses, pkgconfig
+, gcc, libiconv, CoreAudio
 
 , alsaSupport ? stdenv.isLinux, alsaLib ? null
 # simple fallback for everyone else
@@ -18,7 +19,7 @@
 , cddbSupport ? true, libcddb ? null
 , cdioSupport ? true, libcdio ? null
 , cueSupport ? true, libcue ? null
-, discidSupport ? true, libdiscid ? null
+, discidSupport ? (!stdenv.isDarwin), libdiscid ? null
 , ffmpegSupport ? true, ffmpeg ? null
 , flacSupport ? true, flac ? null
 , madSupport ? true, libmad ? null
@@ -109,13 +110,16 @@ stdenv.mkDerivation rec {
     "CONFIG_WAV=y"
   ] ++ concatMap (a: a.flags) opts);
 
-  buildInputs = [ ncurses pkgconfig gcc ] ++ concatMap (a: a.deps) opts;
+  buildInputs = [ ncurses pkgconfig ]
+    ++ stdenv.lib.optional stdenv.cc.isClang gcc
+    ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv CoreAudio ]
+    ++ concatMap (a: a.deps) opts;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Small, fast and powerful console music player for Linux and *BSD";
     homepage = https://cmus.github.io/;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.oxij ];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.oxij ];
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, ncurses, pkgconfig
-, gcc, libiconv, CoreAudio
+{ stdenv, fetchFromGitHub, runCommand, ncurses, pkgconfig
+, libiconv, CoreAudio
 
 , alsaSupport ? stdenv.isLinux, alsaLib ? null
 # simple fallback for everyone else
@@ -90,6 +90,13 @@ let
     #(mkFlag vtxSupport    "CONFIG_VTX=y"     libayemu)
   ];
 
+  clangGCC = runCommand "clang-gcc" {} ''
+    #! ${stdenv.shell}
+    mkdir -p $out/bin
+    ln -s ${stdenv.cc}/bin/clang $out/bin/gcc
+    ln -s ${stdenv.cc}/bin/clang++ $out/bin/g++
+  '';
+
 in
 
 stdenv.mkDerivation rec {
@@ -111,7 +118,7 @@ stdenv.mkDerivation rec {
   ] ++ concatMap (a: a.flags) opts);
 
   buildInputs = [ ncurses pkgconfig ]
-    ++ stdenv.lib.optional stdenv.cc.isClang gcc
+    ++ stdenv.lib.optional stdenv.cc.isClang clangGCC
     ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv CoreAudio ]
     ++ concatMap (a: a.deps) opts;
 

--- a/pkgs/development/libraries/libcddb/default.nix
+++ b/pkgs/development/libraries/libcddb/default.nix
@@ -1,17 +1,19 @@
-{fetchurl, stdenv}:
+{ stdenv, fetchurl, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "libcddb-1.3.2";
-  
+
   src = fetchurl {
     url = "mirror://sourceforge/libcddb/${name}.tar.bz2";
     sha256 = "0fr21a7vprdyy1bq6s99m0x420c9jm5fipsd63pqv8qyfkhhxkim";
   };
 
-  meta = {
+  buildInputs = stdenv.lib.optional stdenv.isDarwin libiconv;
+
+  meta = with stdenv.lib; {
     description = "C library to access data on a CDDB server (freedb.org)";
-    license = stdenv.lib.licenses.lgpl2Plus;
     homepage = http://libcddb.sourceforge.net/;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.lgpl2Plus;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/libcdio/0.82.nix
+++ b/pkgs/development/libraries/libcdio/0.82.nix
@@ -1,19 +1,20 @@
-{ fetchurl, stdenv, libcddb, pkgconfig, ncurses, help2man }:
+{ stdenv, fetchurl, libcddb, pkgconfig, ncurses, help2man, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "libcdio-0.82";
-  
+
   src = fetchurl {
     url = "mirror://gnu/libcdio/${name}.tar.gz";
     sha256 = "0fax1dzy84dzs20bmpq2gfw6hc1x2x9mhk53wynhcycjw3l3vjqs";
   };
 
-  buildInputs = [ libcddb pkgconfig ncurses help2man ];
+  buildInputs = [ libcddb pkgconfig ncurses help2man ]
+    ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
   # Disabled because one test (check_paranoia.sh) fails.
   #doCheck = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A library for OS-independent CD-ROM and CD image access";
     longDescription = ''
       GNU libcdio is a library for OS-independent CD-ROM and
@@ -21,8 +22,8 @@ stdenv.mkDerivation rec {
       ISO-9660 filesystems (libiso9660), as well as utility
       programs such as an audio CD player and an extractor.
     '';
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
     homepage = http://www.gnu.org/software/libcdio/;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/libcdio/default.nix
+++ b/pkgs/development/libraries/libcdio/default.nix
@@ -1,19 +1,20 @@
-{ fetchurl, stdenv, libcddb, pkgconfig, ncurses, help2man }:
+{ stdenv, fetchurl, libcddb, pkgconfig, ncurses, help2man, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "libcdio-0.93";
-  
+
   src = fetchurl {
     url = "mirror://gnu/libcdio/${name}.tar.bz2";
     sha256 = "1a6x2c5bvpnkn7lhmxkjgz4axmh93m1clrlv41s1wzkc48lnc9zq";
   };
 
-  buildInputs = [ libcddb pkgconfig ncurses help2man ];
+  buildInputs = [ libcddb pkgconfig ncurses help2man ]
+    ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
   # Disabled because one test (check_paranoia.sh) fails.
   #doCheck = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A library for OS-independent CD-ROM and CD image access";
     longDescription = ''
       GNU libcdio is a library for OS-independent CD-ROM and
@@ -21,8 +22,8 @@ stdenv.mkDerivation rec {
       ISO-9660 filesystems (libiso9660), as well as utility
       programs such as an audio CD player and an extractor.
     '';
-    license = stdenv.lib.licenses.gpl2Plus;
     homepage = http://www.gnu.org/software/libcdio/;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/libcue/default.nix
+++ b/pkgs/development/libraries/libcue/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, bison, flex }:
+
 stdenv.mkDerivation rec {
   name = "libcue-${version}";
   version = "2.1.0";
@@ -12,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake bison flex ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "CUE Sheet Parser Library";
     longDescription = ''
       libcue is intended to parse a so called cue sheet from a char string or
@@ -20,8 +21,8 @@ stdenv.mkDerivation rec {
       available.
     '';
     homepage = http://sourceforge.net/projects/libcue/;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ astsmtl ];
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ astsmtl ];
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12690,6 +12690,7 @@ with pkgs;
   cmatrix = callPackage ../applications/misc/cmatrix { };
 
   cmus = callPackage ../applications/audio/cmus {
+    inherit (darwin.apple_sdk.frameworks) CoreAudio;
     libjack = libjack2;
     libcdio = libcdio082;
     ffmpeg = ffmpeg_2;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19883,9 +19883,8 @@ in {
       patchShebangs .
     '';
 
-    buildInputs = [
-      self.setuptools self.nose pkgs.pkgconfig pkgs.swig pkgs.libcdio
-    ];
+    buildInputs = [ self.setuptools self.nose pkgs.pkgconfig pkgs.swig pkgs.libcdio ]
+      ++ stdenv.lib.optional stdenv.isDarwin pkgs.libiconv;
 
     patches = [ ../development/python-modules/pycdio/add-cdtext-toc.patch ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes cmus for darwin based on the changes from #14204

###### Things done

- [x] Tested using sandboxing / without xcode
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] macOS
   - [x] No Changes
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

