### PR TITLE
ghc-8.0.2: remove unused fetchFilteredPatch function

### DIFF
--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -4,13 +4,6 @@
 
 let
   inherit (bootPkgs) ghc;
-
-  fetchFilteredPatch = args: fetchurl (args // {
-    downloadToTemp = true;
-    postFetch = ''
-      ${patchutils}/bin/filterdiff --clean --strip-match=1 -x 'testsuite/*' "$downloadedFile" > "$out"
-    ''; # fix syntax highlighting: */
-  });
 in
 stdenv.mkDerivation rec {
   version = "8.0.2";


### PR DESCRIPTION
Hi @peti, the `fetchFilteredPatch` function is only used in `ghc/8.0.1.nix` so we can remove it from `ghc/8.0.2.nix`.