### PR TITLE
ghc: support building with integer-simple

### DIFF
--- a/doc/languages-frameworks/haskell.md
+++ b/doc/languages-frameworks/haskell.md
@@ -793,6 +793,41 @@ It's important to realize, however, that most system libraries in Nix are built
 as shared libraries only, i.e. there is just no static library available that
 Cabal could link!
 
+### Building GHC with integer-simple
+
+By default GHC implements the Integer type using the
+[GNU Multiple Precision Arithmetic (GMP) library](https://gmplib.org/).
+The implementation can be found in the
+[integer-gmp](http://hackage.haskell.org/package/integer-gmp) package.
+
+A potential problem with this is that GMP is licensed under the
+[​GNU Lesser General Public License (LGPL)](http://www.gnu.org/copyleft/lesser.html),
+a kind of "copyleft" license. According to the terms of the LGPL, paragraph 5,
+you may distribute a program that is designed to be compiled and dynamically
+linked with the library under the terms of your choice (i.e., commercially) but
+if your program incorporates portions of the library, if it is linked
+statically, then your program is a "derivative"--a "work based on the
+library"--and according to paragraph 2, section c, you "must cause the whole of
+the work to be licensed" under the terms of the LGPL (including for free).
+
+The LGPL licensing for GMP is a problem for the overall licensing of binary
+programs compiled with GHC because most distributions (and builds) of GHC use
+static libraries. (Dynamic libraries are currently distributed only for OS X.)
+The LGPL licensing situation may be worse: even though
+​[The Glasgow Haskell Compiler License](https://www.haskell.org/ghc/license)
+is essentially a "free software" license (BSD3), according to
+paragraph 2 of the LGPL, GHC must be distributed under the terms of the LGPL!
+
+To work around these problems GHC can be build with a slower but LGPL-free
+alternative implemention for Integer called
+[integer-simple](http://hackage.haskell.org/package/integer-simple).
+
+To get a compiler build with `integer-simple` instead of `integer-gmp` override an
+existing compiler and set `enableIntegerSimple = true`. For example:
+
+    $ nix-build -E '(import <nixpkgs> {}).pkgs.haskell.compiler.ghc802.override {enableIntegerSimple = true;}'
+    $ result/bin/ghc-pkg list | grep integer
+        integer-simple-0.1.1.1
 
 ## Other resources
 

--- a/doc/languages-frameworks/haskell.md
+++ b/doc/languages-frameworks/haskell.md
@@ -822,12 +822,35 @@ To work around these problems GHC can be build with a slower but LGPL-free
 alternative implemention for Integer called
 [integer-simple](http://hackage.haskell.org/package/integer-simple).
 
-To get a compiler build with `integer-simple` instead of `integer-gmp` override an
-existing compiler and set `enableIntegerSimple = true`. For example:
+To get a GHC compiler build with `integer-simple` instead of `integer-gmp` use
+the attribute: `pkgs.haskell.compiler.integer-simple."${ghcVersion}"`.
+For example:
 
-    $ nix-build -E '(import <nixpkgs> {}).pkgs.haskell.compiler.ghc802.override {enableIntegerSimple = true;}'
+    $ nix-build -E '(import <nixpkgs> {}).pkgs.haskell.compiler.integer-simple.ghc802'
+    ...
     $ result/bin/ghc-pkg list | grep integer
         integer-simple-0.1.1.1
+
+The following command displays the complete list of GHC compilers build with `integer-simple`:
+
+    $ nix-env -f "<nixpkgs>" -qaP -A haskell.compiler.integer-simple
+    haskell.compiler.integer-simple.ghc7102  ghc-7.10.2
+    haskell.compiler.integer-simple.ghc7103  ghc-7.10.3
+    haskell.compiler.integer-simple.ghc722   ghc-7.2.2
+    haskell.compiler.integer-simple.ghc742   ghc-7.4.2
+    haskell.compiler.integer-simple.ghc763   ghc-7.6.3
+    haskell.compiler.integer-simple.ghc783   ghc-7.8.3
+    haskell.compiler.integer-simple.ghc784   ghc-7.8.4
+    haskell.compiler.integer-simple.ghc801   ghc-8.0.1
+    haskell.compiler.integer-simple.ghc802   ghc-8.0.2
+    haskell.compiler.integer-simple.ghcHEAD  ghc-8.1.20170106
+
+To get a package set supporting `integer-simple` use the attribute:
+`pkgs.haskell.packages.integer-simple."${ghcVersion}"`. For example
+use the following to get the `scientific` package build with `integer-simple`:
+
+    $ nix-build -A pkgs.haskell.packages.integer-simple.ghc802.scientific
+
 
 ## Other resources
 

--- a/pkgs/development/compilers/ghc/7.10.2.nix
+++ b/pkgs/development/compilers/ghc/7.10.2.nix
@@ -1,20 +1,27 @@
-{ stdenv, fetchurl, fetchpatch, bootPkgs, perl, gmp, ncurses, libiconv, binutils, coreutils
+{ stdenv, fetchurl, fetchpatch, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
 , libxml2, libxslt, docbook_xsl, docbook_xml_dtd_45, docbook_xml_dtd_42, hscolour
+
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # library instead of the faster but GPLed integer-gmp library.
+, enableIntegerSimple ? false, gmp
 }:
 
 let
   inherit (bootPkgs) ghc;
 
   buildMK = ''
-    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
-    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     ${stdenv.lib.optionalString stdenv.isDarwin ''
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"
     ''}
-  '';
+  '' + (if enableIntegerSimple then ''
+    INTEGER_LIBRARY=integer-simple
+  '' else ''
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
+  '');
 
 in
 
@@ -46,8 +53,9 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-gcc=${stdenv.cc}/bin/cc"
-    "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
     "--datadir=$doc/share/doc/ghc"
+  ] ++ stdenv.lib.optional (! enableIntegerSimple) [
+    "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
   ];
 
   # required, because otherwise all symbols from HSffi.o are stripped, and

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -1,5 +1,9 @@
-{ stdenv, fetchurl, fetchpatch, bootPkgs, perl, gmp, ncurses, libiconv, binutils, coreutils
+{ stdenv, fetchurl, fetchpatch, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
 , libxml2, libxslt, docbook_xsl, docbook_xml_dtd_45, docbook_xml_dtd_42, hscolour
+
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # library instead of the faster but GPLed integer-gmp library.
+, enableIntegerSimple ? false, gmp
 }:
 
 let
@@ -38,13 +42,16 @@ stdenv.mkDerivation rec {
     export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export NIX_LDFLAGS+=" -no_dtrace_dof"
+  '' + stdenv.lib.optionalString enableIntegerSimple ''
+    echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
   '';
 
   configureFlags = [
     "--with-gcc=${stdenv.cc}/bin/cc"
-    "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
     "--datadir=$doc/share/doc/ghc"
+  ] ++ stdenv.lib.optional (! enableIntegerSimple) [
+    "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
   ] ++ stdenv.lib.optional stdenv.isDarwin [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ];

--- a/pkgs/development/compilers/ghc/7.2.2.nix
+++ b/pkgs/development/compilers/ghc/7.2.2.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchurl, ghc, perl, gmp, ncurses, libiconv }:
+{ stdenv, fetchurl, ghc, perl, ncurses, libiconv
+
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # library instead of the faster but GPLed integer-gmp library.
+, enableIntegerSimple ? false, gmp
+}:
 
 stdenv.mkDerivation rec {
   version = "7.2.2";
@@ -11,18 +16,22 @@ stdenv.mkDerivation rec {
 
   patches = [ ./fix-7.2.2-clang.patch ./relocation.patch ];
 
-  buildInputs = [ ghc perl gmp ncurses ];
+  buildInputs = [ ghc perl ncurses ]
+                ++ stdenv.lib.optional (!enableIntegerSimple) gmp;
 
   buildMK = ''
-    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
-    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     ${stdenv.lib.optionalString stdenv.isDarwin ''
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"
     ''}
-  '';
+  '' + (if enableIntegerSimple then ''
+    INTEGER_LIBRARY=integer-simple
+  '' else ''
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
+  '');
 
   preConfigure = ''
     echo "${buildMK}" > mk/build.mk

--- a/pkgs/development/compilers/ghc/7.8.3.nix
+++ b/pkgs/development/compilers/ghc/7.8.3.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchurl, ghc, perl, gmp, ncurses, libiconv }:
+{ stdenv, fetchurl, ghc, perl, ncurses, libiconv
+
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # library instead of the faster but GPLed integer-gmp library.
+, enableIntegerSimple ? false, gmp
+}:
 
 stdenv.mkDerivation rec {
   version = "7.8.3";
@@ -11,13 +16,12 @@ stdenv.mkDerivation rec {
 
   patches = [ ./relocation.patch ];
 
-  buildInputs = [ ghc perl gmp ncurses ];
+  buildInputs = [ ghc perl ncurses ]
+                ++ stdenv.lib.optional (!enableIntegerSimple) gmp;
 
   enableParallelBuilding = true;
 
   buildMK = ''
-    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
-    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     DYNAMIC_BY_DEFAULT = NO
@@ -25,7 +29,12 @@ stdenv.mkDerivation rec {
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"
     ''}
-  '';
+  '' + (if enableIntegerSimple then ''
+    INTEGER_LIBRARY=integer-simple
+  '' else ''
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
+  '');
 
   preConfigure = ''
     echo "${buildMK}" > mk/build.mk

--- a/pkgs/development/compilers/ghc/7.8.4.nix
+++ b/pkgs/development/compilers/ghc/7.8.4.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchurl, ghc, perl, gmp, ncurses, libiconv }:
+{ stdenv, fetchurl, ghc, perl, ncurses, libiconv
+
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # library instead of the faster but GPLed integer-gmp library.
+, enableIntegerSimple ? false, gmp
+}:
 
 stdenv.mkDerivation (rec {
   version = "7.8.4";
@@ -11,13 +16,12 @@ stdenv.mkDerivation (rec {
 
   patches = [ ./relocation.patch ];
 
-  buildInputs = [ ghc perl gmp ncurses ];
+  buildInputs = [ ghc perl ncurses ]
+                ++ stdenv.lib.optional (!enableIntegerSimple) gmp;
 
   enableParallelBuilding = true;
 
   buildMK = ''
-    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
-    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     DYNAMIC_BY_DEFAULT = NO
@@ -25,7 +29,12 @@ stdenv.mkDerivation (rec {
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"
     ''}
-  '';
+  '' + (if enableIntegerSimple then ''
+    INTEGER_LIBRARY=integer-simple
+  '' else ''
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
+  '');
 
   preConfigure = ''
     echo "${buildMK}" > mk/build.mk

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -1,5 +1,9 @@
-{ stdenv, fetchurl, fetchpatch, bootPkgs, perl, gmp, ncurses, libiconv, binutils, coreutils
+{ stdenv, fetchurl, fetchpatch, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
 , hscolour, patchutils, sphinx
+
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # library instead of the faster but GPLed integer-gmp library.
+, enableIntegerSimple ? false, gmp
 }:
 
 let
@@ -35,13 +39,16 @@ stdenv.mkDerivation rec {
     export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export NIX_LDFLAGS+=" -no_dtrace_dof"
+  '' + stdenv.lib.optionalString enableIntegerSimple ''
+    echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
   '';
 
   configureFlags = [
     "--with-gcc=${stdenv.cc}/bin/cc"
-    "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
     "--datadir=$doc/share/doc/ghc"
+  ] ++ stdenv.lib.optional (! enableIntegerSimple) [
+    "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
   ] ++ stdenv.lib.optional stdenv.isDarwin [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ];

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -1,6 +1,10 @@
-{ stdenv, fetchgit, bootPkgs, perl, gmp, ncurses, libiconv, binutils, coreutils
+{ stdenv, fetchgit, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
 , autoconf, automake, happy, alex, python3, buildPlatform, targetPlatform
 , selfPkgs, cross ? null
+
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # library instead of the faster but GPLed integer-gmp library.
+, enableIntegerSimple ? false, gmp
 }:
 
 let
@@ -20,6 +24,8 @@ let
     export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export NIX_LDFLAGS+=" -no_dtrace_dof"
+  '' + stdenv.lib.optionalString enableIntegerSimple ''
+    echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
   '';
 in stdenv.mkDerivation (rec {
   inherit version rev;
@@ -41,8 +47,9 @@ in stdenv.mkDerivation (rec {
 
   configureFlags = [
     "CC=${stdenv.cc}/bin/cc"
-    "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
+  ] ++ stdenv.lib.optional (! enableIntegerSimple) [
+    "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
   ] ++ stdenv.lib.optional stdenv.isDarwin [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ];


### PR DESCRIPTION
If the flag `enableIntegerSimple` is true GHC will be build with the GPL-free but slower `integer-simple` library instead of the faster but GPLed `integer-gmp` library.
