### PR TITLE
frab: init at 2016-12-28 & module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -521,6 +521,7 @@
   ./services/web-apps/atlassian/confluence.nix
   ./services/web-apps/atlassian/crowd.nix
   ./services/web-apps/atlassian/jira.nix
+  ./services/web-apps/frab.nix
   ./services/web-apps/mattermost.nix
   ./services/web-apps/nixbot.nix
   ./services/web-apps/pump.io.nix

--- a/nixos/modules/services/web-apps/frab.nix
+++ b/nixos/modules/services/web-apps/frab.nix
@@ -1,0 +1,224 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.frab;
+
+  package = pkgs.frab;
+  ruby = package.ruby;
+
+  databaseConfig = builtins.toJSON { production = cfg.database; };
+
+  frabEnv = {
+    RAILS_ENV = "production";
+    RACK_ENV = "production";
+    SECRET_KEY_BASE = cfg.secretKeyBase;
+    FRAB_HOST = cfg.host;
+    FRAB_PROTOCOL = cfg.protocol;
+    FROM_EMAIL = cfg.fromEmail;
+    RAILS_SERVE_STATIC_FILES = "1";
+  } // cfg.extraEnvironment;
+
+  frab-rake = pkgs.stdenv.mkDerivation rec {
+    name = "frab-rake";
+    buildInputs = [ package.env pkgs.makeWrapper ];
+    phases = "installPhase fixupPhase";
+    installPhase = ''
+      mkdir -p $out/bin
+      makeWrapper ${package.env}/bin/bundle $out/bin/frab-bundle \
+          ${concatStrings (mapAttrsToList (name: value: "--set ${name} '${value}' ") frabEnv)} \
+          --set PATH '${lib.makeBinPath (with pkgs; [ nodejs file imagemagick ])}:$PATH' \
+          --set RAKEOPT '-f ${package}/share/frab/Rakefile' \
+          --run 'cd ${package}/share/frab'
+      makeWrapper $out/bin/frab-bundle $out/bin/frab-rake \
+          --add-flags "exec rake"
+     '';
+  };
+
+in
+
+{
+  options = {
+    services.frab = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the frab service.
+        '';
+      };
+
+      host = mkOption {
+        type = types.str;
+        example = "frab.example.com";
+        description = ''
+          Hostname under which this frab instance can be reached.
+        '';
+      };
+
+      protocol = mkOption {
+        type = types.str;
+        default = "https";
+        example = "http";
+        description = ''
+          Either http or https, depending on how your Frab instance
+          will be exposed to the public.
+        '';
+      };
+
+      fromEmail = mkOption {
+        type = types.str;
+        default = "frab@localhost";
+        description = ''
+          Email address used by frab.
+        '';
+      };
+
+      listenAddress = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = ''
+          Address or hostname frab should listen on.
+        '';
+      };
+
+      listenPort = mkOption {
+        type = types.int;
+        default = 3000;
+        description = ''
+          Port frab should listen on.
+        '';
+      };
+
+      statePath = mkOption {
+        type = types.str;
+        default = "/var/lib/frab";
+        description = ''
+          Directory where frab keeps its state.
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "frab";
+        description = ''
+          User to run frab.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "frab";
+        description = ''
+          Group to run frab.
+        '';
+      };
+
+      secretKeyBase = mkOption {
+        type = types.str;
+        description = ''
+          Your secret key is used for verifying the integrity of signed cookies.
+          If you change this key, all old signed cookies will become invalid!
+
+          Make sure the secret is at least 30 characters and all random,
+          no regular words or you'll be exposed to dictionary attacks.
+        '';
+      };
+
+      database = mkOption {
+        type = types.attrs;
+        default = {
+          adapter = "sqlite3";
+          database = "/var/lib/frab/db.sqlite3";
+          pool = 5;
+          timeout = 5000;
+        };
+        example = {
+          adapter = "postgresql";
+          database = "frab";
+          host = "localhost";
+          username = "frabuser";
+          password = "supersecret";
+          encoding = "utf8";
+          pool = 5;
+        };
+        description = ''
+          Rails database configuration for Frab as Nix attribute set.
+        '';
+      };
+
+      extraEnvironment = mkOption {
+        type = types.attrs;
+        default = {};
+        example = {
+          FRAB_CURRENCY_UNIT = "€";
+          FRAB_CURRENCY_FORMAT = "%n%u";
+          EXCEPTION_EMAIL = "frab-owner@example.com";
+          SMTP_ADDRESS = "localhost";
+          SMTP_PORT = "587";
+          SMTP_DOMAIN = "localdomain";
+          SMTP_USER_NAME = "root";
+          SMTP_PASSWORD = "toor";
+          SMTP_AUTHENTICATION = "1";
+          SMTP_NOTLS = "1";
+        };
+        description = ''
+          Additional environment variables to set for frab for further
+          configuration. See the frab documentation for more information.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ frab-rake ];
+
+    users.extraUsers = [
+      { name = cfg.user;
+        group = cfg.group;
+        home = "${cfg.statePath}";
+      }
+    ];
+
+    users.extraGroups = [ { name = cfg.group; } ];
+
+    systemd.services.frab = {
+      after = [ "network.target" "gitlab.service" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = frabEnv;
+
+      preStart = ''
+        mkdir -p ${cfg.statePath}/system/attachments
+        chown ${cfg.user}:${cfg.group} -R ${cfg.statePath}
+
+        mkdir /run/frab -p
+        ln -sf ${pkgs.writeText "frab-database.yml" databaseConfig} /run/frab/database.yml
+        ln -sf ${cfg.statePath}/system /run/frab/system
+
+        if ! test -e "${cfg.statePath}/db-setup-done"; then
+          ${frab-rake}/bin/frab-rake db:setup
+          touch ${cfg.statePath}/db-setup-done
+        else
+          ${frab-rake}/bin/frab-rake db:migrate
+        fi
+      '';
+
+      serviceConfig = {
+        PermissionsStartOnly = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        TimeoutSec = "300s";
+        Restart = "on-failure";
+        RestartSec = "10s";
+        WorkingDirectory = "${package}/share/frab";
+        ExecStart = "${frab-rake}/bin/frab-bundle exec rails server " +
+          "--binding=${cfg.listenAddress} --port=${toString cfg.listenPort}";
+      };
+    };
+
+  };
+}

--- a/pkgs/servers/web-apps/frab/Gemfile
+++ b/pkgs/servers/web-apps/frab/Gemfile
@@ -1,0 +1,88 @@
+source 'https://rubygems.org'
+
+if ENV['CUSTOM_RUBY_VERSION']
+  ruby ENV['CUSTOM_RUBY_VERSION'] # i.e.: '2.3'
+end
+
+gem 'rails', '~> 4.2'
+
+# Use SCSS for stylesheets
+gem 'sass-rails', '~> 5.0'
+# Use Uglifier as compressor for JavaScript assets
+gem 'uglifier', '>= 1.3.0'
+# Use CoffeeScript for .coffee assets and views
+gem 'coffee-rails', '~> 4.1.0'
+
+gem 'mysql2', group: :mysql
+gem 'pg', group: :postgresql
+gem 'sqlite3', group: :sqlite3
+
+# Use Puma as the app server
+gem 'puma'
+
+# Capistrano for deployment
+group :capistrano do
+  gem 'airbrussh'
+  gem 'capistrano', '~> 3.4.0', require: false
+  gem 'capistrano-rails',   require: false
+  gem 'capistrano-bundler', require: false
+  gem 'capistrano-rvm',     require: false
+  gem 'capistrano3-puma',   require: false
+end
+
+# Use jquery as the JavaScript library
+gem 'jquery-rails'
+gem 'jquery-migrate-rails'
+gem 'jquery-ui-rails'
+
+# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+gem 'jbuilder', '~> 2.0'
+
+gem 'activeresource'
+gem 'acts_as_commentable'
+gem 'bcrypt'
+gem 'cancancan'
+gem 'cocoon'
+gem 'dotenv-rails'
+gem 'haml'
+gem 'localized_language_select', github: 'frab/localized_language_select', branch: 'master'
+gem 'nokogiri'
+gem 'paperclip', '~> 4.1'
+gem 'paper_trail'
+gem 'prawn', '< 1.0'
+gem 'prawn_rails'
+gem 'ransack'
+gem 'ri_cal'
+gem 'roust'
+gem 'rqrcode'
+#gem 'roust', :git => 'git@github.com:bulletproofnetworks/roust.git'
+gem 'simple_form'
+gem 'sucker_punch'
+gem 'transitions', require: ['transitions', 'active_record/transitions']
+gem 'will_paginate'
+
+group :production do
+  gem 'exception_notification'
+end
+
+group :development, :test do
+  gem 'bullet'
+  gem 'pry-rails'
+  gem 'pry-byebug'
+  gem 'letter_opener'
+  gem 'faker'
+end
+
+group :test do
+  gem 'database_cleaner'
+  gem 'factory_girl_rails', '~> 4.0'
+  gem 'shoulda'
+end
+
+group :doc do
+  gem 'redcarpet'       # documentation
+  gem 'github-markdown' # documentation
+  gem 'yard'            # documentation
+  # gem 'rails-erd'      # graph
+  # gem 'ruby-graphviz', require: 'graphviz' # Optional: only required for graphing
+end

--- a/pkgs/servers/web-apps/frab/Gemfile.lock
+++ b/pkgs/servers/web-apps/frab/Gemfile.lock
@@ -1,0 +1,329 @@
+GIT
+  remote: git://github.com/frab/localized_language_select.git
+  revision: 85df6b97789de6e29c630808b630e56a1b76f80c
+  branch: master
+  specs:
+    localized_language_select (0.3.0)
+      rails (>= 4.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionmailer (4.2.7.1)
+      actionpack (= 4.2.7.1)
+      actionview (= 4.2.7.1)
+      activejob (= 4.2.7.1)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+    actionpack (4.2.7.1)
+      actionview (= 4.2.7.1)
+      activesupport (= 4.2.7.1)
+      rack (~> 1.6)
+      rack-test (~> 0.6.2)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (4.2.7.1)
+      activesupport (= 4.2.7.1)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activejob (4.2.7.1)
+      activesupport (= 4.2.7.1)
+      globalid (>= 0.3.0)
+    activemodel (4.2.7.1)
+      activesupport (= 4.2.7.1)
+      builder (~> 3.1)
+    activerecord (4.2.7.1)
+      activemodel (= 4.2.7.1)
+      activesupport (= 4.2.7.1)
+      arel (~> 6.0)
+    activeresource (4.1.0)
+      activemodel (~> 4.0)
+      activesupport (~> 4.0)
+      rails-observers (~> 0.1.2)
+    activesupport (4.2.7.1)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    acts_as_commentable (4.0.2)
+    addressable (2.4.0)
+    airbrussh (1.1.1)
+      sshkit (>= 1.6.1, != 1.7.0)
+    arel (6.0.3)
+    bcrypt (3.1.11)
+    builder (3.2.2)
+    bullet (5.4.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.10.0)
+    byebug (9.0.5)
+    cancancan (1.15.0)
+    capistrano (3.4.1)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (~> 1.3)
+    capistrano-bundler (1.1.4)
+      capistrano (~> 3.1)
+      sshkit (~> 1.2)
+    capistrano-rails (1.1.8)
+      capistrano (~> 3.1)
+      capistrano-bundler (~> 1.1)
+    capistrano-rvm (0.1.2)
+      capistrano (~> 3.0)
+      sshkit (~> 1.2)
+    capistrano3-puma (1.2.1)
+      capistrano (~> 3.0)
+      puma (>= 2.6)
+    chunky_png (1.3.7)
+    climate_control (0.0.3)
+      activesupport (>= 3.0)
+    cocaine (0.5.8)
+      climate_control (>= 0.0.3, < 1.0)
+    cocoon (1.2.9)
+    coderay (1.1.1)
+    coffee-rails (4.1.1)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0, < 5.1.x)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.10.0)
+    concurrent-ruby (1.0.2)
+    database_cleaner (1.5.3)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
+    erubis (2.7.0)
+    exception_notification (4.2.1)
+      actionmailer (>= 4.0, < 6)
+      activesupport (>= 4.0, < 6)
+    execjs (2.7.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
+    faker (1.6.6)
+      i18n (~> 0.5)
+    github-markdown (0.6.9)
+    globalid (0.3.7)
+      activesupport (>= 4.1.0)
+    haml (4.0.7)
+      tilt
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
+    i18n (0.7.0)
+    jbuilder (2.6.0)
+      activesupport (>= 3.0.0, < 5.1)
+      multi_json (~> 1.2)
+    jquery-migrate-rails (1.2.1)
+    jquery-rails (4.2.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+    jquery-ui-rails (5.0.5)
+      railties (>= 3.2.16)
+    json (1.8.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
+    loofah (2.0.3)
+      nokogiri (>= 1.5.9)
+    mail (2.6.4)
+      mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mimemagic (0.3.0)
+    mini_portile2 (2.1.0)
+    minitest (5.9.1)
+    multi_json (1.12.1)
+    multi_xml (0.5.5)
+    mysql2 (0.4.4)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.2.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+      pkg-config (~> 1.1.7)
+    paper_trail (5.2.2)
+      activerecord (>= 3.0, < 6.0)
+      request_store (~> 1.1)
+    paperclip (4.3.7)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      cocaine (~> 0.5.5)
+      mime-types
+      mimemagic (= 0.3.0)
+    pdf-core (0.1.6)
+    pg (0.19.0)
+    pkg-config (1.1.7)
+    polyamorous (1.3.1)
+      activerecord (>= 3.0)
+    prawn (0.15.0)
+      pdf-core (~> 0.1.3)
+      ttfunk (~> 1.1.0)
+    prawn_rails (0.0.11)
+      prawn (>= 0.11.1)
+      railties (>= 3.0.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
+    puma (3.6.0)
+    rack (1.6.4)
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rails (4.2.7.1)
+      actionmailer (= 4.2.7.1)
+      actionpack (= 4.2.7.1)
+      actionview (= 4.2.7.1)
+      activejob (= 4.2.7.1)
+      activemodel (= 4.2.7.1)
+      activerecord (= 4.2.7.1)
+      activesupport (= 4.2.7.1)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 4.2.7.1)
+      sprockets-rails
+    rails-deprecated_sanitizer (1.0.3)
+      activesupport (>= 4.2.0.alpha)
+    rails-dom-testing (1.0.7)
+      activesupport (>= 4.2.0.beta, < 5.0)
+      nokogiri (~> 1.6.0)
+      rails-deprecated_sanitizer (>= 1.0.1)
+    rails-html-sanitizer (1.0.3)
+      loofah (~> 2.0)
+    rails-observers (0.1.2)
+      activemodel (~> 4.0)
+    railties (4.2.7.1)
+      actionpack (= 4.2.7.1)
+      activesupport (= 4.2.7.1)
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+    rake (11.3.0)
+    ransack (1.8.2)
+      actionpack (>= 3.0)
+      activerecord (>= 3.0)
+      activesupport (>= 3.0)
+      i18n
+      polyamorous (~> 1.3)
+    redcarpet (3.3.4)
+    request_store (1.3.1)
+    ri_cal (0.8.8)
+    roust (1.8.9)
+      activesupport (>= 4.0.10)
+      httparty (>= 0.13.1)
+      mail (>= 2.5.4)
+    rqrcode (0.10.1)
+      chunky_png (~> 1.0)
+    sass (3.4.22)
+    sass-rails (5.0.6)
+      railties (>= 4.0.0, < 6)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
+    shoulda (3.5.0)
+      shoulda-context (~> 1.0, >= 1.0.1)
+      shoulda-matchers (>= 1.4.1, < 3.0)
+    shoulda-context (1.2.1)
+    shoulda-matchers (2.8.0)
+      activesupport (>= 3.0.0)
+    simple_form (3.3.1)
+      actionpack (> 4, < 5.1)
+      activemodel (> 4, < 5.1)
+    slop (3.6.0)
+    sprockets (3.7.0)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.2.0)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
+    sqlite3 (1.3.11)
+    sshkit (1.11.3)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
+    sucker_punch (2.0.2)
+      concurrent-ruby (~> 1.0.0)
+    thor (0.19.1)
+    thread_safe (0.3.5)
+    tilt (2.0.5)
+    transitions (1.2.0)
+    ttfunk (1.1.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    uglifier (3.0.2)
+      execjs (>= 0.3.0, < 3)
+    uniform_notifier (1.10.0)
+    will_paginate (3.1.3)
+    yard (0.9.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activeresource
+  acts_as_commentable
+  airbrussh
+  bcrypt
+  bullet
+  cancancan
+  capistrano (~> 3.4.0)
+  capistrano-bundler
+  capistrano-rails
+  capistrano-rvm
+  capistrano3-puma
+  cocoon
+  coffee-rails (~> 4.1.0)
+  database_cleaner
+  dotenv-rails
+  exception_notification
+  factory_girl_rails (~> 4.0)
+  faker
+  github-markdown
+  haml
+  jbuilder (~> 2.0)
+  jquery-migrate-rails
+  jquery-rails
+  jquery-ui-rails
+  letter_opener
+  localized_language_select!
+  mysql2
+  nokogiri
+  paper_trail
+  paperclip (~> 4.1)
+  pg
+  prawn (< 1.0)
+  prawn_rails
+  pry-byebug
+  pry-rails
+  puma
+  rails (~> 4.2)
+  ransack
+  redcarpet
+  ri_cal
+  roust
+  rqrcode
+  sass-rails (~> 5.0)
+  shoulda
+  simple_form
+  sqlite3
+  sucker_punch
+  transitions
+  uglifier (>= 1.3.0)
+  will_paginate
+  yard
+
+BUNDLED WITH
+   1.13.1

--- a/pkgs/servers/web-apps/frab/default.nix
+++ b/pkgs/servers/web-apps/frab/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, bundlerEnv, fetchFromGitHub, ruby, nodejs }:
+
+let
+  env = bundlerEnv {
+    name = "frab";
+    inherit ruby;
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+  };
+
+in
+
+stdenv.mkDerivation rec {
+  name = "frab-2016-12-28";
+
+  src = fetchFromGitHub {
+    owner = "frab";
+    repo = "frab";
+    rev = "e4bbcfd1a9db7f89f53a8702c236d9628bafb72c";
+    sha256 = "04pzmif8jxjww3fdf2zbg3k7cm49vxc9hhf4xhmvdmvywgin6fqp";
+  };
+
+  buildInputs = [ env nodejs ];
+
+  buildPhase = ''
+    cp config/database.yml.template config/database.yml
+    cp .env.development .env.production
+    bundler exec rake assets:precompile RAILS_ENV=production
+    rm .env.production
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp -r . $out/share/frab
+
+    ln -sf /run/frab/database.yml $out/share/frab/config/database.yml
+    rm -rf $out/share/frab/tmp $out/share/frab/public/system
+    ln -sf /run/frab/system $out/share/frab/public/system
+    ln -sf /tmp $out/share/frab/tmp
+  '';
+
+  passthru = {
+    inherit env ruby;
+  };
+}

--- a/pkgs/servers/web-apps/frab/gemset.nix
+++ b/pkgs/servers/web-apps/frab/gemset.nix
@@ -1,0 +1,932 @@
+{
+  actionmailer = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lw1pss1mrjm7x7qcg9pvxv55rz3d994yf3mwmlfg1y12fxq00n3";
+      type = "gem";
+    };
+    version = "4.2.7.1";
+  };
+  actionpack = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1ray5bvlmkimjax011zsw0mz9llfkqrfm7q1avjlp4i0kpcz8zlh";
+      type = "gem";
+    };
+    version = "4.2.7.1";
+  };
+  actionview = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11m2x5nlbqrw79fh6h7m444lrka7wwy32b0dvgqg7ilbzih43k0c";
+      type = "gem";
+    };
+    version = "4.2.7.1";
+  };
+  activejob = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ish5wd8nvmj7f6x1i22aw5ycizy5n1z1c7f3kyxmqwhw7lb0gaz";
+      type = "gem";
+    };
+    version = "4.2.7.1";
+  };
+  activemodel = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0acz0mbmahsc9mn41275fpfnrqwig5k09m3xhz3455kv90fn79v5";
+      type = "gem";
+    };
+    version = "4.2.7.1";
+  };
+  activerecord = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lk8l6i9p7qfl0pg261v5yph0w0sc0vysrdzc6bm5i5rxgi68flj";
+      type = "gem";
+    };
+    version = "4.2.7.1";
+  };
+  activeresource = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nr5is20cx18s7vg8bdrdc996s2abl3h7fsi1q6mqsrzw7nrv2fa";
+      type = "gem";
+    };
+    version = "4.1.0";
+  };
+  activesupport = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1gds12k7nxrcc09b727a458ndidy1nfcllj9x22jcaj7pppvq6r4";
+      type = "gem";
+    };
+    version = "4.2.7.1";
+  };
+  acts_as_commentable = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1p4bwyqmm4ybcscn292aixschdzvns2dpl8a7w4zm0rqy2619cc9";
+      type = "gem";
+    };
+    version = "4.0.2";
+  };
+  addressable = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mpn7sbjl477h56gmxsjqb89r5s3w7vx5af994ssgc3iamvgzgvs";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  airbrussh = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pv22d2kjdbsg9q45jca3f5gsylr2r1wfpn58g58xj4s4q4r95nx";
+      type = "gem";
+    };
+    version = "1.1.1";
+  };
+  arel = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1a270mlajhrmpqbhxcqjqypnvgrq4pgixpv3w9gwp1wrrapnwrzk";
+      type = "gem";
+    };
+    version = "6.0.3";
+  };
+  bcrypt = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d254sdhdj6mzak3fb5x3jam8b94pvl1srladvs53j05a89j5z50";
+      type = "gem";
+    };
+    version = "3.1.11";
+  };
+  builder = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "14fii7ab8qszrvsvhz6z2z3i4dw0h41a62fjr2h1j8m41vbrmyv2";
+      type = "gem";
+    };
+    version = "3.2.2";
+  };
+  bullet = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06pba7bdjnazbl0yhhvlina08nkawnm76zihkaam4k7fm0yrq1k0";
+      type = "gem";
+    };
+    version = "5.4.0";
+  };
+  byebug = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18sdnscwwm76i2kbcib2ckwfwpq8b1dbfr97gdcx3j1x547yqv9x";
+      type = "gem";
+    };
+    version = "9.0.5";
+  };
+  cancancan = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "05kb459laaw339n7mas37v4k83nwz228bfpaghgybza347341x85";
+      type = "gem";
+    };
+    version = "1.15.0";
+  };
+  capistrano = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0f73w6gpml0ickmwky1cn6d8392q075zy10a323f3vmyvxyhr0jb";
+      type = "gem";
+    };
+    version = "3.4.1";
+  };
+  capistrano-bundler = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1f4iikm7pn0li2lj6p53wl0d6y7svn0h76z9c6c582mmwxa9c72p";
+      type = "gem";
+    };
+    version = "1.1.4";
+  };
+  capistrano-rails = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "03lzihrq72rwcqq7jiqak79wy0xbdnymn5gxj0bfgfjlg5kpgssw";
+      type = "gem";
+    };
+    version = "1.1.8";
+  };
+  capistrano-rvm = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15sy8zcal041yy5kb7fcdqnxvndgdhg3w1kvb5dk7hfjk3ypznsa";
+      type = "gem";
+    };
+    version = "0.1.2";
+  };
+  capistrano3-puma = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ynz1arnr07kcl0vsaa1znhp2ywhhs4fwndnkw8sasr9bydksln8";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+  chunky_png = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1p1zy4gyfp7rapr2yxcljkw6qh0chkwf356i387b3fg85cwdj4xh";
+      type = "gem";
+    };
+    version = "1.3.7";
+  };
+  climate_control = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0krknwk6b8lwv1j9kjbxib6kf5zh4pxkf3y2vcyycx5d6nci1s55";
+      type = "gem";
+    };
+    version = "0.0.3";
+  };
+  cocaine = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01kk5xd7lspbkdvn6nyj0y51zhvia3z6r4nalbdcqw5fbsywwi7d";
+      type = "gem";
+    };
+    version = "0.5.8";
+  };
+  cocoon = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1gzznkrs6qy31v85cvdqyn5wd3vwlciwibf9clmd6gi4dns21pmv";
+      type = "gem";
+    };
+    version = "1.2.9";
+  };
+  coderay = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1x6z923iwr1hi04k6kz5a6llrixflz8h5sskl9mhaaxy9jx2x93r";
+      type = "gem";
+    };
+    version = "1.1.1";
+  };
+  coffee-rails = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1mv1kaw3z4ry6cm51w8pfrbby40gqwxanrqyqr0nvs8j1bscc1gw";
+      type = "gem";
+    };
+    version = "4.1.1";
+  };
+  coffee-script = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rc7scyk7mnpfxqv5yy4y5q1hx3i7q3ahplcp4bq2g5r24g2izl2";
+      type = "gem";
+    };
+    version = "2.4.1";
+  };
+  coffee-script-source = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1k4fg39rrkl3bpgchfj94fbl9s4ysaz16w8dkqncf2vyf79l3qz0";
+      type = "gem";
+    };
+    version = "1.10.0";
+  };
+  concurrent-ruby = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1kb4sav7yli12pjr8lscv8z49g52a5xzpfg3z9h8clzw6z74qjsw";
+      type = "gem";
+    };
+    version = "1.0.2";
+  };
+  database_cleaner = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0fx6zmqznklmkbjl6f713jyl11d4g9q220rcl86m2jp82r8kfwjj";
+      type = "gem";
+    };
+    version = "1.5.3";
+  };
+  dotenv = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1p6zz0xzb15vq8jphpw2fh6m4dianw7s76ci8vj9x3zxayrn4lfm";
+      type = "gem";
+    };
+    version = "2.1.1";
+  };
+  dotenv-rails = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17s6c0yqaz01xd5wywjscbvv0pa3grak2lhwby91j84qm6h95vxz";
+      type = "gem";
+    };
+    version = "2.1.1";
+  };
+  erubis = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fj827xqjs91yqsydf0zmfyw9p4l2jz5yikg3mppz6d7fi8kyrb3";
+      type = "gem";
+    };
+    version = "2.7.0";
+  };
+  exception_notification = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vclsr0rjfy1khvqyj67lgpa0v14nb542vvjkyaswn367nnmijhw";
+      type = "gem";
+    };
+    version = "4.2.1";
+  };
+  execjs = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yz55sf2nd3l666ms6xr18sm2aggcvmb8qr3v53lr4rir32y1yp1";
+      type = "gem";
+    };
+    version = "2.7.0";
+  };
+  factory_girl = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xzl4z9z390fsnyxp10c9if2n46zan3n6zwwpfnwc33crv4s410i";
+      type = "gem";
+    };
+    version = "4.7.0";
+  };
+  factory_girl_rails = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hzpirb33xdqaz44i1mbcfv0icjrghhgaz747llcfsflljd4pa4r";
+      type = "gem";
+    };
+    version = "4.7.0";
+  };
+  faker = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09amnh5d0m3q2gpb0vr9spbfa8l2nc0kl3s79y6sx7a16hrl4vvc";
+      type = "gem";
+    };
+    version = "1.6.6";
+  };
+  github-markdown = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nax4fyyhz9xmi7q6mmc6d1h8hc0cxda9d7q5z0pba88mj00s9fj";
+      type = "gem";
+    };
+    version = "0.6.9";
+  };
+  globalid = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11plkgyl3w9k4y2scc1igvpgwyz4fnmsr63h2q4j8wkb48nlnhak";
+      type = "gem";
+    };
+    version = "0.3.7";
+  };
+  haml = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mrzjgkygvfii66bbylj2j93na8i89998yi01fin3whwqbvx0m1p";
+      type = "gem";
+    };
+    version = "4.0.7";
+  };
+  httparty = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1msa213hclsv14ijh49i1wggf9avhnj2j4xr58m9jx6fixlbggw6";
+      type = "gem";
+    };
+    version = "0.14.0";
+  };
+  i18n = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1i5z1ykl8zhszsxcs8mzl8d0dxgs3ylz8qlzrw74jb0gplkx6758";
+      type = "gem";
+    };
+    version = "0.7.0";
+  };
+  jbuilder = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jbh1296imd0arc9nl1m71yfd7kg505p8srr1ijpsqv4hhbz5qci";
+      type = "gem";
+    };
+    version = "2.6.0";
+  };
+  jquery-migrate-rails = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pcfs339wki4ax4imb4qi2xb04bbj6j4xvn8x3yn6yf95frrvch6";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+  jquery-rails = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0prqyixv7j2qlq67qdr3miwcyvi27b9a82j51gbpb6vcl0ig2rik";
+      type = "gem";
+    };
+    version = "4.2.1";
+  };
+  jquery-ui-rails = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1gfygrv4bjpjd2c377lw7xzk1b77rxjyy3w6wl4bq1gkqvyrkx77";
+      type = "gem";
+    };
+    version = "5.0.5";
+  };
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nsby6ry8l9xg3yw4adlhk2pnc7i0h0rznvcss4vk3v74qg0k8lc";
+      type = "gem";
+    };
+    version = "1.8.3";
+  };
+  launchy = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "190lfbiy1vwxhbgn4nl4dcbzxvm049jwc158r2x7kq3g5khjrxa2";
+      type = "gem";
+    };
+    version = "2.4.3";
+  };
+  letter_opener = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pcrdbxvp2x5six8fqn8gf09bn9rd3jga76ds205yph5m8fsda21";
+      type = "gem";
+    };
+    version = "1.4.1";
+  };
+  localized_language_select = {
+    source = {
+      fetchSubmodules = false;
+      rev = "85df6b97789de6e29c630808b630e56a1b76f80c";
+      sha256 = "1b2pd8120nrl3s3idpgdzhrjkn9g5sxnkx4j671fjiyhadlr0q5j";
+      type = "git";
+      url = "git://github.com/frab/localized_language_select.git";
+    };
+    version = "0.3.0";
+  };
+  loofah = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "109ps521p0sr3kgc460d58b4pr1z4mqggan2jbsf0aajy9s6xis8";
+      type = "gem";
+    };
+    version = "2.0.3";
+  };
+  mail = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0c9vqfy0na9b5096i5i4qvrvhwamjnmajhgqi3kdsdfl8l6agmkp";
+      type = "gem";
+    };
+    version = "2.6.4";
+  };
+  method_source = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1g5i4w0dmlhzd18dijlqw5gk27bv6dj2kziqzrzb7mpgxgsd1sf2";
+      type = "gem";
+    };
+    version = "0.8.2";
+  };
+  mime-types = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0087z9kbnlqhci7fxh9f6il63hj1k02icq2rs0c6cppmqchr753m";
+      type = "gem";
+    };
+    version = "3.1";
+  };
+  mime-types-data = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04my3746hwa4yvbx1ranhfaqkgf6vavi1kyijjnw8w3dy37vqhkm";
+      type = "gem";
+    };
+    version = "3.2016.0521";
+  };
+  mimemagic = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "101lq4bnjs7ywdcicpw3vbz9amg5gbb4va1626fybd2hawgdx8d9";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+  mini_portile2 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1y25adxb1hgg1wb2rn20g3vl07qziq6fz364jc5694611zz863hb";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  minitest = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0300naf4ilpd9sf0k8si9h9sclkizaschn8bpnri5fqmvm9ybdbq";
+      type = "gem";
+    };
+    version = "5.9.1";
+  };
+  multi_json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wpc23ls6v2xbk3l1qncsbz16npvmw8p0b38l8czdzri18mp51xk";
+      type = "gem";
+    };
+    version = "1.12.1";
+  };
+  multi_xml = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0i8r7dsz4z79z3j023l8swan7qpbgxbwwz11g38y2vjqjk16v4q8";
+      type = "gem";
+    };
+    version = "0.5.5";
+  };
+  mysql2 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1v537b7865f4z610rljy8prwmq1yhk3zalp9mcbxn7aqb3g75pra";
+      type = "gem";
+    };
+    version = "0.4.4";
+  };
+  net-scp = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0b0jqrcsp4bbi4n4mzyf70cp2ysyp6x07j8k8cqgxnvb4i3a134j";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+  net-ssh = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11djaq0h3bzzy61dca3l84rrs91702hha4vgg387gviipgz7f3yy";
+      type = "gem";
+    };
+    version = "3.2.0";
+  };
+  nokogiri = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11sbmpy60ynak6s3794q32lc99hs448msjy8rkp84ay7mq7zqspv";
+      type = "gem";
+    };
+    version = "1.6.7.2";
+  };
+  paper_trail = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1w3y2h1w0kml2fmzx4sdcrhnbj273npwrs0cx91xdgy2qfjj6hmr";
+      type = "gem";
+    };
+    version = "5.2.2";
+  };
+  paperclip = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0r8krh5xg790845wzlc2r7l0jwskw4c4wk9xh4bpprqykwaghg0r";
+      type = "gem";
+    };
+    version = "4.3.7";
+  };
+  pdf-core = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1x121sznmhfmjnk0rzpp6djxgi28afpc8avnhn3kzlmpc87r7fyi";
+      type = "gem";
+    };
+    version = "0.1.6";
+  };
+  pg = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bplv27d0f8vwdj51967498pl1cjxq19hhcj4hdjr4h3s72l2z4j";
+      type = "gem";
+    };
+    version = "0.19.0";
+  };
+  pkg-config = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lljiqnm0b4z6iy87lzapwrdfa6ps63x2z5zbs038iig8dqx2g0z";
+      type = "gem";
+    };
+    version = "1.1.7";
+  };
+  polyamorous = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1501y9l81b2lwb93fkycq8dr1bi6qcdhia3qv4fddnmrdihkl3pv";
+      type = "gem";
+    };
+    version = "1.3.1";
+  };
+  prawn = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04pxzfmmy8a6bv3zvh1mmyy5zi4bj994kq1v6qnlq2xlhvg4cxjc";
+      type = "gem";
+    };
+    version = "0.15.0";
+  };
+  prawn_rails = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "19m1pv2rsl3rf9rni78l8137dy2sq1r2443biv19wi9nis2pvgdg";
+      type = "gem";
+    };
+    version = "0.0.11";
+  };
+  pry = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "05xbzyin63aj2prrv8fbq2d5df2mid93m81hz5bvf2v4hnzs42ar";
+      type = "gem";
+    };
+    version = "0.10.4";
+  };
+  pry-byebug = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pvc94kgxd33p6iz41ghyadq8zfbjhkk07nvz2mbh3yhrc8w7gmw";
+      type = "gem";
+    };
+    version = "3.4.0";
+  };
+  pry-rails = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0a2iinvabis2xmv0z7z7jmh7bbkkngxj2qixfdg5m6qj9x8k1kx6";
+      type = "gem";
+    };
+    version = "0.3.4";
+  };
+  puma = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rmcny3jr1jj01f9fqijwmikj212a5iql7ghifklm77x4a8pp399";
+      type = "gem";
+    };
+    version = "3.6.0";
+  };
+  rack = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09bs295yq6csjnkzj7ncj50i6chfxrhmzg1pk6p0vd2lb9ac8pj5";
+      type = "gem";
+    };
+    version = "1.6.4";
+  };
+  rack-test = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0h6x5jq24makgv2fq5qqgjlrk74dxfy62jif9blk43llw8ib2q7z";
+      type = "gem";
+    };
+    version = "0.6.3";
+  };
+  rails = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1avd16ir7qx23dcnz1b3cafq1lja6rq0w222bs658p9n33rbw54l";
+      type = "gem";
+    };
+    version = "4.2.7.1";
+  };
+  rails-deprecated_sanitizer = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qxymchzdxww8bjsxj05kbf86hsmrjx40r41ksj0xsixr2gmhbbj";
+      type = "gem";
+    };
+    version = "1.0.3";
+  };
+  rails-dom-testing = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1v8jl6803mbqpxh4hn0szj081q1a3ap0nb8ni0qswi7z4la844v8";
+      type = "gem";
+    };
+    version = "1.0.7";
+  };
+  rails-html-sanitizer = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "138fd86kv073zqfx0xifm646w6bgw2lr8snk16lknrrfrss8xnm7";
+      type = "gem";
+    };
+    version = "1.0.3";
+  };
+  rails-observers = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lsw19jzmvipvrfy2z04hi7r29dvkfc43h43vs67x6lsj9rxwwcy";
+      type = "gem";
+    };
+    version = "0.1.2";
+  };
+  railties = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04rz7cn64zzvq7lnhc9zqmaqmqkq84q25v0ym9lcw75j1cj1mrq4";
+      type = "gem";
+    };
+    version = "4.2.7.1";
+  };
+  rake = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cnjmbcyhm4hacpjn337mg1pnaw6hj09f74clwgh6znx8wam9xla";
+      type = "gem";
+    };
+    version = "11.3.0";
+  };
+  ransack = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cya3wygwjhj8rckckkl387bmva4nyfvqcl0qhp9hk3zv8y6wxjc";
+      type = "gem";
+    };
+    version = "1.8.2";
+  };
+  redcarpet = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04v85p0bnpf1c7w4n0yr03s35yimxh0idgdrrybl9y13zbw5kgvg";
+      type = "gem";
+    };
+    version = "3.3.4";
+  };
+  request_store = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1va9x0b3ww4chcfqlmi8b14db39di1mwa7qrjbh7ma0lhndvs2zv";
+      type = "gem";
+    };
+    version = "1.3.1";
+  };
+  ri_cal = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1flga63anfpfpdwz6lpm3icpdqmvjq757hihfaw63rlkwq4pf390";
+      type = "gem";
+    };
+    version = "0.8.8";
+  };
+  roust = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zdnwxxh34psv0iybcdnk9w4dpgpr07j3w1fvigkpccgz5vs82qk";
+      type = "gem";
+    };
+    version = "1.8.9";
+  };
+  rqrcode = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0h1pnnydgs032psakvg3l779w3ghbn08ajhhhw19hpmnfhrs8k0a";
+      type = "gem";
+    };
+    version = "0.10.1";
+  };
+  sass = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dkj6v26fkg1g0majqswwmhxva7cd6p3psrhdlx93qal72dssywy";
+      type = "gem";
+    };
+    version = "3.4.22";
+  };
+  sass-rails = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0iji20hb8crncz14piss1b29bfb6l89sz3ai5fny3iw39vnxkdcb";
+      type = "gem";
+    };
+    version = "5.0.6";
+  };
+  shoulda = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0csmf15a7mcinfq54lfa4arp0f4b2jmwva55m0p94hdf3pxnjymy";
+      type = "gem";
+    };
+    version = "3.5.0";
+  };
+  shoulda-context = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06wv2ika5zrbxn0m3qxwk0zkbspxids3zmlq3xxays5qmvl1qb55";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+  shoulda-matchers = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0d3ryqcsk1n9y35bx5wxnqbgw4m8b3c79isazdjnnbg8crdp72d0";
+      type = "gem";
+    };
+    version = "2.8.0";
+  };
+  simple_form = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ii3rkkbj5cc10f5rdiny18ncdh36kijr25cah0ybbr7kigh3v3b";
+      type = "gem";
+    };
+    version = "3.3.1";
+  };
+  slop = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "00w8g3j7k7kl8ri2cf1m58ckxk8rn350gp4chfscmgv6pq1spk3n";
+      type = "gem";
+    };
+    version = "3.6.0";
+  };
+  sprockets = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jzsfiladswnzbrwqfiaj1xip68y58rwx0lpmj907vvq47k87gj1";
+      type = "gem";
+    };
+    version = "3.7.0";
+  };
+  sprockets-rails = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zr9vk2vn44wcn4265hhnnnsciwlmqzqc6bnx78if1xcssxj6x44";
+      type = "gem";
+    };
+    version = "3.2.0";
+  };
+  sqlite3 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "19r06wglnm6479ffj9dl0fa4p5j2wi6dj7k6k3d0rbx7036cv3ny";
+      type = "gem";
+    };
+    version = "1.3.11";
+  };
+  sshkit = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wpqvr2dyxwp3shwh0221i1ahyg8vd2hyilmjvdi026l00gk2j4l";
+      type = "gem";
+    };
+    version = "1.11.3";
+  };
+  sucker_punch = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0l8b53mlzl568kdl4la8kcjjcnawmbl0q6hq9c3kkyippa5c0x55";
+      type = "gem";
+    };
+    version = "2.0.2";
+  };
+  thor = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08p5gx18yrbnwc6xc0mxvsfaxzgy2y9i78xq7ds0qmdm67q39y4z";
+      type = "gem";
+    };
+    version = "0.19.1";
+  };
+  thread_safe = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hq46wqsyylx5afkp6jmcihdpv4ynzzq9ygb6z2pb1cbz5js0gcr";
+      type = "gem";
+    };
+    version = "0.3.5";
+  };
+  tilt = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lgk8bfx24959yq1cn55php3321wddw947mgj07bxfnwyipy9hqf";
+      type = "gem";
+    };
+    version = "2.0.5";
+  };
+  transitions = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11byymi45s4pxbhj195277r16dyhxkqc2jwf7snbhan23izzay2c";
+      type = "gem";
+    };
+    version = "1.2.0";
+  };
+  ttfunk = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jvgqhp0i6v9d7davwdn20skgi508yd0xcf1h4p9f5dlslmpnkhj";
+      type = "gem";
+    };
+    version = "1.1.1";
+  };
+  tzinfo = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1c01p3kg6xvy1cgjnzdfq45fggbwish8krd0h864jvbpybyx7cgx";
+      type = "gem";
+    };
+    version = "1.2.2";
+  };
+  uglifier = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0f30s1631k03x4wm7xyc79g92pppzvyysa773zsaq2kcry1pmifc";
+      type = "gem";
+    };
+    version = "3.0.2";
+  };
+  uniform_notifier = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jha0l7x602g5rvah960xl9r0f3q25gslj39i0x1vai8i5z6zr1l";
+      type = "gem";
+    };
+    version = "1.10.0";
+  };
+  will_paginate = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xlls78hkkmk33q1rb84rgg2xr39g06a1z1239nq59c825g83k01";
+      type = "gem";
+    };
+    version = "3.1.3";
+  };
+  yard = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1gjl0sh7h0a9s67pllagw8192kscljg4y8nddfrqhji4g21yvcas";
+      type = "gem";
+    };
+    version = "0.9.5";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10299,6 +10299,8 @@ with pkgs;
 
   foswiki = callPackage ../servers/foswiki { };
 
+  frab = callPackage ../servers/web-apps/frab { };
+
   freepops = callPackage ../servers/mail/freepops { };
 
   freeradius = callPackage ../servers/freeradius { };


### PR DESCRIPTION
###### Motivation for this change

[frab](https://github.com/frab/frab) is a cool conference planning tool (with cfp, session submissions, scheduling, voting, etc.) used and developed for chaos events like the C3 (successor of pentabarf). It might come in handy soon.

It's a pretty standard rails application (with all its nicely hardcoded paths). I've used some ideas from the gitlab module.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
