### PR TITLE
lumina: 1.1.0-p1 -> 1.2.0-p1

### DIFF
--- a/pkgs/desktops/lumina/default.nix
+++ b/pkgs/desktops/lumina/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "lumina-${version}";
-  version = "1.1.0-p1";
+  version = "1.2.0-p1";
 
   src = fetchFromGitHub {
     owner = "trueos";
     repo = "lumina";
     rev = "v${version}";
-    sha256 = "1kkb6v6p6w5mx1qdmcrq3r674k9ahpc6wlsb9pi2lq8qk9yaid0m";
+    sha256 = "0k16lcpxp9avwkadbbyqficd1wxsmwian5ji38wyax76v22yq7p6";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update the lumina desktop environment to version 1.2.0.

[Changes](https://lumina-desktop.org/version-1-2-0-released/).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).