### PR TITLE
postgis: 2.2.1 -> 2.3.1

### DIFF
--- a/pkgs/development/libraries/postgis/default.nix
+++ b/pkgs/development/libraries/postgis/default.nix
@@ -5,7 +5,7 @@ args@{fetchurl, composableDerivation, stdenv, perl, libxml2, postgresql, geos, p
   ### NixOS - usage:
   ==================
 
-    services.postgresql.extraPlugins = [ (pkgs.postgis.override { postgresql = pkgs.postgresql95; }).v_2_2_1 ];
+    services.postgresql.extraPlugins = [ (pkgs.postgis.override { postgresql = pkgs.postgresql95; }).v_2_3_1 ];
 
 
   ### important Postgis implementation details:
@@ -84,9 +84,9 @@ let
 
 in rec {
 
-  v_2_2_1 = pgDerivationBaseNewer.merge ( fix : {
-    version = "2.2.1";
-    sha256 = "02gsi1cm63kf0r7881444lrkzdjqhhpz9a5zav3al0q24nq01r8g";
+  v_2_3_1 = pgDerivationBaseNewer.merge ( fix : {
+    version = "2.3.1";
+    sha256 = "0xd21h2k6x3i1b3z6pgm3pmkfpxm6irxd5wbx68acjndjgd6p3ac";
     sql_srcs = ["postgis.sql" "spatial_ref_sys.sql"];
     builtInputs = [gdal json_c pkgconfig];
 


### PR DESCRIPTION
###### Motivation for this change

update Postgis to the lastest version

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

