### PR TITLE
mkpasswd: make the package high priority

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2838,7 +2838,7 @@ with pkgs;
 
   mkcue = callPackage ../tools/cd-dvd/mkcue { };
 
-  mkpasswd = callPackage ../tools/security/mkpasswd { };
+  mkpasswd = hiPrio (callPackage ../tools/security/mkpasswd { });
 
   mkrand = callPackage ../tools/security/mkrand { };
 


### PR DESCRIPTION
###### Motivation for this change

Currently, if you have both the `mkpasswd` and the `expect` packages installed,
the `mkpasswd` binaries from both packages will conflict and the one from the `expect`
package can take precedence. This will result in the NixOS documentation instructions
for generating a hashed password to put into `configuration.nix` not working, for no
apparent reason.

Since usually, if someone installs the `mkpasswd` package it's because they are
specifically interested in its `mkpasswd` binary, then we should make the `mkpasswd`
package high priority so that it always take precedence.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

