### PR TITLE
top-level: no more need to expose `splicedPackages`

### DIFF
--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -55,33 +55,32 @@ let
     if toolsArch == "armv6l" then raspberrypiCrossSystem else
     if toolsArch == "armv7l" then armv7l-hf-multiplatform-crossSystem else null;
 
-  pkgsUnspliced = pkgsFun ({inherit system;} // selectedCrossSystem);
-  pkgs = pkgsUnspliced.splicedPackages;
+  pkgs = pkgsFun ({inherit system;} // selectedCrossSystem);
 
-  inherit (pkgsUnspliced.buildPackages) stdenv nukeReferences cpio binutilsCross;
+  inherit (pkgs.buildPackages) stdenv nukeReferences cpio binutilsCross;
 
-  glibc = pkgs.libcCross.nativeDrv;
-  bash = pkgs.bash.crossDrv;
-  findutils = pkgs.findutils.crossDrv;
-  diffutils = pkgs.diffutils.crossDrv;
-  gnused = pkgs.gnused.crossDrv;
-  gnugrep = pkgs.gnugrep.crossDrv;
-  gawk = pkgs.gawk.crossDrv;
-  gzip = pkgs.gzip.crossDrv;
-  bzip2 = pkgs.bzip2.crossDrv;
-  gnumake = pkgs.gnumake.crossDrv;
-  patch = pkgs.patch.crossDrv;
-  patchelf = pkgs.patchelf.crossDrv;
-  gcc = pkgs.gcc.crossDrv.cc;
-  gmpxx = pkgs.gmpxx.crossDrv;
-  mpfr = pkgs.mpfr.crossDrv;
-  zlib = pkgs.zlib.crossDrv;
-  libmpc = pkgs.libmpc.crossDrv;
-  binutils = pkgs.binutils.crossDrv;
-  libelf = pkgs.libelf.crossDrv;
+  glibc = pkgs.buildPackages.libcCross;
+  bash = pkgs.bash;
+  findutils = pkgs.findutils;
+  diffutils = pkgs.diffutils;
+  gnused = pkgs.gnused;
+  gnugrep = pkgs.gnugrep;
+  gawk = pkgs.gawk;
+  gzip = pkgs.gzip;
+  bzip2 = pkgs.bzip2;
+  gnumake = pkgs.gnumake;
+  patch = pkgs.patch;
+  patchelf = pkgs.patchelf;
+  gcc = pkgs.gcc.cc;
+  gmpxx = pkgs.gmpxx;
+  mpfr = pkgs.mpfr;
+  zlib = pkgs.zlib;
+  libmpc = pkgs.libmpc;
+  binutils = pkgs.binutils;
+  libelf = pkgs.libelf;
 
   # Keep these versions in sync with the versions used in the current GCC!
-  isl = pkgs.isl_0_14.crossDrv;
+  isl = pkgs.isl_0_14;
 in
 
 rec {
@@ -116,7 +115,7 @@ rec {
 
     stdenv.mkDerivation {
       name = "stdenv-bootstrap-tools-cross";
-      crossConfig = pkgsUnspliced.hostPlatform.config;
+      crossConfig = pkgs.hostPlatform.config;
 
       buildInputs = [nukeReferences cpio binutilsCross];
 
@@ -174,7 +173,7 @@ rec {
         cp -d ${patch}/bin/* $out/bin
         cp ${patchelf}/bin/* $out/bin
 
-        cp -d ${gnugrep.pcre.crossDrv.out}/lib/libpcre*.so* $out/lib # needed by grep
+        cp -d ${gnugrep.pcre.out}/lib/libpcre*.so* $out/lib # needed by grep
 
         # Copy what we need of GCC.
         cp -d ${gcc.out}/bin/gcc $out/bin

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -14,17 +14,17 @@ let
 
   /* Basic list of packages to cross-build */
   basicCrossDrv = {
-    gccCrossStageFinal = nativePlatforms;
-    bison.crossDrv = nativePlatforms;
-    busybox.crossDrv = nativePlatforms;
-    coreutils.crossDrv = nativePlatforms;
-    dropbear.crossDrv = nativePlatforms;
+    bison = nativePlatforms;
+    busybox = nativePlatforms;
+    coreutils = nativePlatforms;
+    dropbear = nativePlatforms;
   };
 
   /* Basic list of packages to be natively built,
      but need a crossSystem defined to get meaning */
   basicNativeDrv = {
-    gdbCross.nativeDrv = nativePlatforms;
+    buildPackages.gccCrossStageFinal = nativePlatforms;
+    buildPackages.gdbCross = nativePlatforms;
   };
 
   basic = basicCrossDrv // basicNativeDrv;
@@ -85,7 +85,7 @@ in
       openssl.system = "linux-generic32";
     };
   in mapTestOnCross crossSystem (basic // {
-    ubootSheevaplug.crossDrv = nativePlatforms;
+    ubootSheevaplug = nativePlatforms;
   });
 
 
@@ -98,14 +98,14 @@ in
       platform = {};
     };
   in mapTestOnCross crossSystem {
-    coreutils.crossDrv = nativePlatforms;
-    boehmgc.crossDrv = nativePlatforms;
-    gmp.crossDrv = nativePlatforms;
-    guile_1_8.crossDrv = nativePlatforms;
-    libffi.crossDrv = nativePlatforms;
-    libtool.crossDrv = nativePlatforms;
-    libunistring.crossDrv = nativePlatforms;
-    windows.wxMSW.crossDrv = nativePlatforms;
+    coreutils = nativePlatforms;
+    boehmgc = nativePlatforms;
+    gmp = nativePlatforms;
+    guile_1_8 = nativePlatforms;
+    libffi = nativePlatforms;
+    libtool = nativePlatforms;
+    libunistring = nativePlatforms;
+    windows.wxMSW = nativePlatforms;
   };
 
 
@@ -119,14 +119,14 @@ in
       platform = {};
     };
   in mapTestOnCross crossSystem {
-    coreutils.crossDrv = nativePlatforms;
-    boehmgc.crossDrv = nativePlatforms;
-    gmp.crossDrv = nativePlatforms;
-    guile_1_8.crossDrv = nativePlatforms;
-    libffi.crossDrv = nativePlatforms;
-    libtool.crossDrv = nativePlatforms;
-    libunistring.crossDrv = nativePlatforms;
-    windows.wxMSW.crossDrv = nativePlatforms;
+    coreutils = nativePlatforms;
+    boehmgc = nativePlatforms;
+    gmp = nativePlatforms;
+    guile_1_8 = nativePlatforms;
+    libffi = nativePlatforms;
+    libtool = nativePlatforms;
+    libunistring = nativePlatforms;
+    windows.wxMSW = nativePlatforms;
   };
 
 
@@ -156,9 +156,9 @@ in
       };
     };
   in mapTestOnCross crossSystem {
-    coreutils.crossDrv = nativePlatforms;
-    ed.crossDrv = nativePlatforms;
-    patch.crossDrv = nativePlatforms;
+    coreutils = nativePlatforms;
+    ed = nativePlatforms;
+    patch = nativePlatforms;
   };
 
 
@@ -182,16 +182,16 @@ in
       };
     };
   in mapTestOnCross crossSystem {
-    coreutils.crossDrv = nativePlatforms;
-    ed.crossDrv = nativePlatforms;
-    patch.crossDrv = nativePlatforms;
-    vim.crossDrv = nativePlatforms;
-    unzip.crossDrv = nativePlatforms;
-    ddrescue.crossDrv = nativePlatforms;
-    lynx.crossDrv = nativePlatforms;
-    patchelf.crossDrv = nativePlatforms;
-    binutils.crossDrv = nativePlatforms;
-    mpg123.crossDrv = nativePlatforms;
+    coreutils = nativePlatforms;
+    ed = nativePlatforms;
+    patch = nativePlatforms;
+    vim = nativePlatforms;
+    unzip = nativePlatforms;
+    ddrescue = nativePlatforms;
+    lynx = nativePlatforms;
+    patchelf = nativePlatforms;
+    buildPackages.binutils = nativePlatforms;
+    mpg123 = nativePlatforms;
   };
 
 

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -76,9 +76,8 @@ rec {
    * parameter for allPackages, defining the target platform for cross builds,
    * and triggering the build of the host derivation (cross built - crossDrv). */
   mapTestOnCross = crossSystem: mapAttrsRecursive
-    (path: systems: testOnCross crossSystem systems (pkgs: addMetaAttrs
-      { maintainers = crossMaintainers; }
-      (getAttrFromPath path pkgs.splicedPackages)));
+    (path: systems: testOnCross crossSystem systems
+      (pkgs: addMetaAttrs { maintainers = crossMaintainers; } (getAttrFromPath path pkgs)));
 
 
   /* Recursively map a (nested) set of derivations to an isomorphic

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -70,8 +70,6 @@ let
 in
 
 {
-  splicedPackages = splicedPackages // { recurseForDerivations = false; };
-
   # We use `callPackage' to be able to omit function arguments that can be
   # obtained `pkgs` or `buildPackages` and their `xorg` package sets. Use
   # `newScope' for sets of packages in `pkgs' (see e.g. `gnome' below).


### PR DESCRIPTION
This was just done temporarily on the last cross-overhauling PR for testing purposes.