### PR TITLE
riemann: 0.2.9 -> 0.2.12

### DIFF
--- a/pkgs/servers/monitoring/riemann/default.nix
+++ b/pkgs/servers/monitoring/riemann/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "riemann-${version}";
-  version = "0.2.9";
+  version = "0.2.12";
 
   src = fetchurl {
-    url = "http://aphyr.com/riemann/${name}.tar.bz2";
-    sha256 = "10zz92sg9ak8g7xsfc05p4kic6hzwj7nqpkjgsd8f7f3slvfjqw3";
+    url = "https://github.com/riemann/riemann/releases/download/${version}/${name}.tar.bz2";
+    sha256 = "1x57gi301rg6faxm4q5scq9dpp0v9nqiwjpsgigdb8whmjr1zwkr";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/servers/monitoring/riemann/default.nix
+++ b/pkgs/servers/monitoring/riemann/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
   name = "riemann-${version}";
@@ -9,15 +9,19 @@ stdenv.mkDerivation rec {
     sha256 = "1x57gi301rg6faxm4q5scq9dpp0v9nqiwjpsgigdb8whmjr1zwkr";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   phases = [ "unpackPhase" "installPhase" ];
 
   installPhase = ''
-    sed -i 's#lib/riemann.jar#$out/share/java/riemann.jar#' bin/riemann
+    substituteInPlace bin/riemann --replace '$top/lib/riemann.jar' "$out/share/java/riemann.jar"
 
     mkdir -p $out/share/java $out/bin $out/etc
     mv lib/riemann.jar $out/share/java/
     mv bin/riemann $out/bin/
     mv etc/riemann.config $out/etc/
+
+    wrapProgram "$out/bin/riemann" --prefix PATH : "${jre}/bin"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

