### PR TITLE
minetest 0.4.14 -> 0.4.15

### DIFF
--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -4,19 +4,19 @@
 }:
 
 let
-  version = "0.4.14";
+  version = "0.4.15";
   sources = {
     src = fetchFromGitHub {
       owner = "minetest";
       repo = "minetest";
       rev = "${version}";
-      sha256 = "1f74wsiqj8x1m8wqmxijb00df5ljlvy4ac0ahbh325vfzi0bjla3";
+      sha256 = "0bn4102d0hq774bn6hqhrs6qzl4sancrs4j15w4318bqdndk4676";
     };
     data = fetchFromGitHub {
       owner = "minetest";
       repo = "minetest_game";
       rev = "${version}";
-      sha256 = "1dc9zfbp603h2nlk39bw37kjbswrfmpd9yg3v72z1jb89pcxzsqs";
+      sha256 = "1mjj40slfiw0khg9nrq8yfmnay237z5jm1cg9hrsiq2fkjrr8w2m";
     };
   };
 in stdenv.mkDerivation {


### PR DESCRIPTION
###### Motivation for this change
Outdated version of Minetest.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

