### PR TITLE
asterisk: 13.6.0 -> 13.13.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -440,6 +440,7 @@
   wscott = "Wayne Scott <wsc9tt@gmail.com>";
   wyvie = "Elijah Rum <elijahrum@gmail.com>";
   yarr = "Dmitry V. <savraz@gmail.com>";
+  yorickvP = "Yorick van Pelt <yorickvanpelt@gmail.com>";
   yurrriq = "Eric Bailey <eric@ericb.me>";
   z77z = "Marco Maggesi <maggesi@math.unifi.it>";
   zagy = "Christian Zagrodnick <cz@flyingcircus.io>";

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -56,6 +56,6 @@ stdenv.mkDerivation rec {
     description = "Software implementation of a telephone private branch exchange (PBX)";
     homepage = http://www.asterisk.org/;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ auntie ];
+    maintainers = with maintainers; [ auntie yorickvP ];
   };
 }

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "asterisk-${version}";
-  version = "13.6.0";
+  version = "13.13.1";
 
   src = fetchurl {
     url = "http://downloads.asterisk.org/pub/telephony/asterisk/old-releases/asterisk-${version}.tar.gz";
-    sha256 = "0nh0fnqx84as92kk9d73s0386cndd17l06y1c72jl2bdjhyba0ca";
+    sha256 = "0yh097rrp1i681qclvwyh7l1gg2i5wx5pjrcvwpbj6g949mc98vd";
   };
 
   # Note that these sounds are included with the release tarball. They are
@@ -57,8 +57,5 @@ stdenv.mkDerivation rec {
     homepage = http://www.asterisk.org/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ auntie ];
-    # Marked as broken due to needing an update for security issues.
-    # See: https://github.com/NixOS/nixpkgs/issues/18856
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

asterisk was marked broken in 655017d. This version is the latest release on the same LTS branch and does not have that CVE.

(cc: @grahamc)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`) (some of them depend on asterisk being in the $PATH)
- [x] Tested usage on my server. It didn't get worse than it was before.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

