### PR TITLE
gbsplay: init at version 2016-12-17

### DIFF
--- a/pkgs/applications/audio/gbsplay/default.nix
+++ b/pkgs/applications/audio/gbsplay/default.nix
@@ -11,26 +11,18 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ libpulseaudio ];
-
-  #CFLAGS = "-I${libpulseaudio}/include";
-  #LDFLAGS = "-L${libpulseaudio}/lib";
-
-#  preConfigure = ''
-#    sed -i "s:check_include pulse/simple.h:check_include pulse/simple.h ${libpulseaudio}/include:" ./configure;
-#  '';
   
-  configureFlagsArray = [
-   "--without-test" "--without-contrib" "--disable-devdsp"
-   "--enable-pulse" "--disable-alsa" "--disable-midi" "--disable-nas"
-   "--disable-dsound" "--disable-i18n"
-   ];
+  configureFlagsArray =
+   [ "--without-test" "--without-contrib" "--disable-devdsp"
+     "--enable-pulse" "--disable-alsa" "--disable-midi"
+     "--disable-nas" "--disable-dsound" "--disable-i18n" ];
 
-   makeFlagsArray = [ "tests=" ];
-
+  makeFlagsArray = [ "tests=" ];
 
   meta = with stdenv.lib; {
     description = "gameboy sound player";
     license = licenses.gpl1;
+    platforms = ["i686-linux" "x86_64-linux"];
     maintainers = with maintainers; [ dasuxullebt ];
   };
 }

--- a/pkgs/applications/audio/gbsplay/default.nix
+++ b/pkgs/applications/audio/gbsplay/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, libpulseaudio }:
+
+stdenv.mkDerivation {
+  name = "gbsplay-2016-12-17";
+
+  src = fetchFromGitHub {
+    owner = "mmitch";
+    repo = "gbsplay";
+    rev = "2c4486e17fd4f4cdea8c3fd79ae898c892616b70";
+    sha256 = "1214j67sr87zfhvym41cw2g823fmqh4hr451r7y1s9ql3jpjqhpz";
+  };
+
+  buildInputs = [ libpulseaudio ];
+
+  #CFLAGS = "-I${libpulseaudio}/include";
+  #LDFLAGS = "-L${libpulseaudio}/lib";
+
+#  preConfigure = ''
+#    sed -i "s:check_include pulse/simple.h:check_include pulse/simple.h ${libpulseaudio}/include:" ./configure;
+#  '';
+  
+  configureFlagsArray = [
+   "--without-test" "--without-contrib" "--disable-devdsp"
+   "--enable-pulse" "--disable-alsa" "--disable-midi" "--disable-nas"
+   "--disable-dsound" "--disable-i18n"
+   ];
+
+   makeFlagsArray = [ "tests=" ];
+
+
+  meta = with stdenv.lib; {
+    description = "gameboy sound player";
+    license = licenses.gpl1;
+    maintainers = with maintainers; [ dasuxullebt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -862,6 +862,8 @@ with pkgs;
 
   fzy = callPackage ../tools/misc/fzy { };
 
+  gbsplay = callPackage ../applications/audio/gbsplay { };
+
   gdrivefs = python27Packages.gdrivefs;
 
   go-dependency-manager = callPackage ../development/tools/gdm { };


### PR DESCRIPTION
###### Motivation for this change
I wanted to add a gbsplay package

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

