### PR TITLE
Nikola CMS: init at 7.8.3

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8427,7 +8427,7 @@ in {
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/n/natsort/${name}.tar.gz";
-      sha256 = "4ad6b4d1153451e345967989bd3ca30abf33f615b116eeadfcc51a456e6974a9";
+      sha256 = "1abld5p4a6n5zjnyw5mi2pv37gqalcybv2brjr2y6l9l2p8v9mja";
     };
 
     buildInputs = with self;
@@ -8447,7 +8447,6 @@ in {
       description = "Natural sorting for python";
       homepage = https://github.com/SethMMorton/natsort;
       license = licenses.mit;
-      broken = true;
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14574,6 +14574,26 @@ in {
     };
   };
 
+  micawber= self.buildPythonPackage rec {
+    pname = "micawber";
+    version = "0.3.3";
+    name = "${pname}-${version}";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/m/${pname}/${name}.tar.gz";
+      sha256 = "18lna1bgzw4l3kqdi3nr1l557rj3wddrcj81x0rf8f4p87xsg9fq";
+    };
+
+    doCheck = false;
+
+    meta = {
+      description = "Small library for extracting rich content from urls";
+      homepage = "http://github.com/coleifer/micawber/";
+      license = licenses.mit;
+    };
+  };
+
+
   minimock = buildPythonPackage rec {
     version = "1.2.8";
     name = "minimock-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -30054,6 +30054,31 @@ EOF
     };
   };
 
+  ghp-import2 = buildPythonPackage rec {
+    pname = "ghp-import2";
+    version = "1.0.1";
+    name = "${pname}-${version}";
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/g/ghp-import2/${name}.tar.gz";
+      sha256 = "0zvdr67f1gr21ygnahmagfxbn1r1yb2gyiii9fb44nvcn935iygx";
+    };
+
+    disabled = isPyPy;
+    buildInputs = [ pkgs.glibcLocales ];
+
+    LC_ALL="en_US.UTF-8";
+
+    # No tests available
+    doCheck = false;
+
+    meta = {
+      description = "A GitHub Pages import tool";
+      homepage = "https://github.com/ionelmc/python-ghp-import";
+      license = "Tumbolia Public License";
+      maintainers = with maintainers; [ ];
+    };
+  };
+
   typogrify = buildPythonPackage rec {
     name = "typogrify-2.0.7";
     src = pkgs.fetchurl {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -28816,14 +28816,13 @@ EOF
   };
 
   ws4py = buildPythonPackage rec {
+    pname = "ws4py";
+    version = "0.3.5";
     name = "ws4py-${version}";
 
-    version = "git-20130303";
-
-    src = pkgs.fetchgit {
-      url = "https://github.com/Lawouach/WebSocket-for-Python.git";
-      rev = "ace276500ca7e4c357595e3773be151d37bcd6e2";
-      sha256 = "1g7nmhjjxjf6vx75dyzns8bpid3b5i02kakk2lh1i297b5rw2rjq";
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/w/${pname}/${name}.tar.gz";
+      sha256 = "1af79v1lh2njip4zmkm45772wp6nns7a6hk1d80adxi7423lmk64";
     };
 
     # python zip complains about old timestamps

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6481,6 +6481,28 @@ in {
     };
   };
 
+  doit  = buildPythonPackage (rec {
+    pname = "doit";
+    version= "0.30.0";
+    name = "${pname}-${version}";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/d/${pname}/${name}.tar.gz";
+      sha256 = "0ghj3bsrc5bm30w97bn8nvf5jlabg06xs16g7284mimyr7q9z0j0";
+    };
+
+    propagatedBuildInputs = with self; [ cloudpickle pyinotify pytest ];
+
+    doCheck = false;
+
+    meta = {
+      homepage = "http://pydoit.org";
+      description = "Build make task automation pipeline";
+      license = licenses.mit;
+      maintainers = with maintainers; [ ];
+    };
+  });
+
   dotfiles = buildPythonPackage rec {
     name = "dotfiles-0.6.3";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21160,12 +21160,16 @@ in {
   });
 
   pyrss2gen = buildPythonPackage (rec {
-    name = "PyRSS2Gen-1.0.0";
+    pname = "PyRSS2Gen";
+    version= "1.1";
+    name = "${pname}-${version}";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/P/PyRSS2Gen/${name}.tar.gz";
-      sha256 = "4929d022713129401160fd47550d5158931e4ea6a7136b5d8dfe3b13ac16f2f0";
+      sha256 = "1rvf5jw9hknqz02rp1vg8abgb1lpa0bc65l7ylmlillqx7bswq3r";
     };
+
+    propagatedBuildInputs = with self; [ feedparser six ];
 
     meta = {
       homepage = http://www.dalkescientific.om/Python/PyRSS2Gen.html;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15373,6 +15373,25 @@ in {
     };
   };
 
+  piexif = self.buildPythonPackage rec {
+    pname = "piexif";
+    version = "1.0.10";
+    name = "${pname}-${version}";
+
+    doCheck = false;
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/p/${pname}/${name}.zip";
+      sha256 = "1j20kl3655k4qx0ydc38fmr242qjvwpk5dyfm2f1chgjg26y23s6";
+    };
+
+    meta = {
+      description = "Simplify exif manipulations with python";
+      homepage = "https://github.com/hMatoba/Piexif";
+      license = licenses.mit;
+    };
+  };
+
   pint = buildPythonPackage rec {
     name = "pint-${version}";
     version = "0.7.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12694,6 +12694,21 @@ in {
     };
   };
 
+  husl = buildPythonPackage rec {
+    pname    = "husl";
+    name    = "${pname}-${version}";
+    version = "4.0.3";
+
+    # ImportError: No module named tests
+    doCheck = false;
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/h/husl/${name}.tar.gz";
+      sha256 = "1fahd35yrpvdqzdd1r6r416d0csg4jbxwlkzm19sa750cljn47ca";
+    };
+
+  };
+
   hvac = buildPythonPackage rec {
     name    = "hvac-${version}";
     version = "0.2.15";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15513,6 +15513,23 @@ in {
     };
   };
 
+  pyphen = self.buildPythonPackage rec {
+    pname = "Pyphen";
+    version = "0.9.4";
+    name = "${pname}-${version}";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/P/${pname}/${name}.tar.gz";
+      sha256 = "1mqb5jrigxipxzp1d8nbwkq0cfjw77pnn6hc4mp1yd2mn059mymb";
+    };
+
+    meta = {
+      description = "Hyphenate text using existing Hunspell hyphenation dictionaries";
+      homepage = https://github.com/Kozea/Pyphen;
+      license = licenses.gpl2Plus;
+    };
+  };
+
   monotonic = buildPythonPackage rec {
     name = "monotonic-0.4";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14681,6 +14681,25 @@ in {
     };
   };
 
+  phpserialize = self.buildPythonPackage rec {
+    pname = "phpserialize";
+    version = "1.3";
+    name = "${pname}-${version}";
+
+    doCheck = false;
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/p/${pname}/${name}.tar.gz";
+      sha256 = "19qgkb9z4zjbjxlpwh2w6pxkz2j3iymnydi69jl0jg905lqjsrxz";
+    };
+
+    meta = {
+      description = "Port of serialize and unserialize functions of php to python";
+      homepage = "http://github.com/mitsuhiko/phpserialize";
+      license = licenses.bsd3;
+    };
+  };
+
   rainbowstream = buildPythonPackage rec {
     name = "rainbowstream-${version}";
     version = "1.3.6";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15409,16 +15409,15 @@ in {
   };
 
   pygal = buildPythonPackage rec {
-    version = "2.0.10";
-    name = "pygal-${version}";
+    pname = "pygal";
+    version = "2.3.1";
+    name = "${pname}-${version}";
 
     doCheck = !isPyPy;  # one check fails with pypy
 
-    src = pkgs.fetchFromGitHub {
-      owner = "Kozea";
-      repo = "pygal";
-      rev = version;
-      sha256 = "1j7qjgraapvfc80yp8xcbddqrw8379gqi7pwkvfml3qcqm0z0d33";
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/p/${pname}/${name}.tar.gz";
+      sha256 = "0rq6hwd1vn44p3jx79wvln1p9mrbwh36plmlyj5js31x4f8s39bv";
     };
 
     buildInputs = with self; [ flask pyquery pytest ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14651,6 +14651,36 @@ in {
     };
   };
 
+  nikola = buildPythonPackage rec {
+    pname = "Nikola";
+    name = "${pname}-${version}";
+
+    version = "7.8.3";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/N/${pname}/${name}.tar.gz";
+      sha256 = "12kcnvwy9dr194riji6iird1zpdcv252d19lfvabr39rsi9658jl";
+    };
+
+    meta = {
+      description = "A static content management system";
+      homepage    = "https://www.getnikola.com/";
+      license     = "MIT";
+      maintainers = with maintainers; [ ];
+    };
+
+    # No tests included in archive
+    doCheck = false;
+
+    propagatedBuildInputs = with self; [
+      markdown jinja2 husl pyphen micawber pygal typogrify phpserialize
+      webassets notebook ipykernel ghp-import2 ws4py watchdog pillow
+      Yapsy pyrss2gen piexif doit natsort blinker Mako unidecode
+      dateutil Logbook
+    ];
+  };
+
+
   nototools = buildPythonPackage rec {
     version = "git-2016-03-25";
     name = "nototools-${version}";


### PR DESCRIPTION
###### Motivation for this change

Nikola is quite a popular and advanced python-based CMS, similar to Lektor.
It required a lot of updates to dependencies, and some new python dependencies, all of which are included.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

