### PR TITLE
coqPackages.math-classes: init at 2016-06-08

### DIFF
--- a/pkgs/development/coq-modules/math-classes/default.nix
+++ b/pkgs/development/coq-modules/math-classes/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, coq_8_5 }:
+
+let coq = coq_8_5;
+in stdenv.mkDerivation {
+  name = "math-classes-${coq.coq-version}";
+
+  src = fetchFromGitHub {
+    owner  = "math-classes";
+    repo   = "math-classes";
+    rev    = "751e63b260bd2f78b280f2566c08a18034bd40b3";
+    sha256 = "0kjc2wzb6n9hcqb2ijx2pckn8jk5g09crrb87yb4s9m0mrw79smr";
+  };
+
+  buildInputs = [ coq ];
+  enableParallelBuilding = true;
+  installPhase = ''
+    COQLIB=$out/lib/coq/${coq.coq-version}/
+    mkdir -p $COQLIB/user-contrib/MathClasses
+    cp -pR . $COQLIB/user-contrib/MathClasses
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://math-classes.github.io;
+    description = "A library of abstract interfaces for mathematical structures in Coq.";
+    maintainers = with maintainers; [ siddharthist ];
+    platforms = coq.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17035,6 +17035,7 @@ with pkgs;
     flocq = callPackage ../development/coq-modules/flocq {};
     interval = callPackage ../development/coq-modules/interval {};
     mathcomp = callPackage ../development/coq-modules/mathcomp { };
+    math_classes = callPackage ../development/coq-modules/math-classes { };
     ssreflect = callPackage ../development/coq-modules/ssreflect { };
     fiat_HEAD = callPackage ../development/coq-modules/fiat/HEAD.nix {};
   };


### PR DESCRIPTION
###### Motivation for this change
math-classes is a very cool new approach to the algebraic hierarchy based on coq's new first-class typeclass mechanism!

@jwiegley I thought I'd take this time to ask you a question, somewhat related to this PR. In my `shell.nix` for coq projects, I define
```nix
  shellHook = ''
    COQPATH=${math-classes}/lib/coq/8.5/user-contrib/
  '';
```
Is there a better way? How can I check to see whether or not the library is accessible, e.g.\ for building other coq packages?

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
---