### PR TITLE
obs-studio: 0.15.2 -> 17.0.1

### DIFF
--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -22,13 +22,13 @@ let
   optional = stdenv.lib.optional;
 in stdenv.mkDerivation rec {
   name = "obs-studio-${version}";
-  version = "0.15.2";
+  version = "17.0.1";
 
   src = fetchFromGitHub {
     owner = "jp9000";
     repo = "obs-studio";
     rev = "${version}";
-    sha256 = "0vw203a1zj2npras589ml6gr5s11h9bhaica90plrh5ajayg0qwj";
+    sha256 = "0x5lnl1xkmm8x4g0f8rma8ir1bcldz9sssj2fzkv80hn79h2cvxm";
   };
 
   nativeBuildInputs = [ cmake


### PR DESCRIPTION
upstream version scheme change, this is the equivalent of 0.17.1.

###### Motivation for this change
Simple update to OBS Studio as I am using it on NixOS for streaming. 0.16.2 is recommend for linux on the main website, but I tested that version and it crashes when opening any menu dialogue related to recording. Other linux distributions package 17.0.1 so I tried that and it appears to run just fine.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] (nothing depends on obs-studio) Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

