### PR TITLE
chocolate-doom: 2.2.1 -> 2.3.0

### DIFF
--- a/pkgs/games/chocolate-doom/default.nix
+++ b/pkgs/games/chocolate-doom/default.nix
@@ -1,10 +1,10 @@
 { stdenv, autoreconfHook, pkgconfig, SDL, SDL_mixer, SDL_net, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "chocolate-doom-2.2.1";
+  name = "chocolate-doom-2.3.0";
   src = fetchurl {
     url = "https://github.com/chocolate-doom/chocolate-doom/archive/${name}.tar.gz";
-    sha256 = "140xnz0vc14ypy30l6yxbb9s972g2ffwd4lbic54zp6ayd9414ma";
+    sha256 = "0i57smxmbhxj0wgvxq845ba9zsn5nx5wmzkl71rdchyd4q5jmida";
   };
   buildInputs = [ autoreconfHook pkgconfig SDL SDL_mixer SDL_net ];
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x]  (nothing depends on chocolate-doom) Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

