### PR TITLE
mwprocapture: init at 1.2.3269

### DIFF
--- a/nixos/modules/hardware/video/capture/mwprocapture.nix
+++ b/nixos/modules/hardware/video/capture/mwprocapture.nix
@@ -27,6 +27,35 @@ in
 
     boot.extraModulePackages = [ kernelPackages.mwprocapture ];
 
+    boot.extraModprobeConfig = ''
+      # Set the png picture to be displayed when no input signal is detected.
+      options ProCapture nosignal_file=${kernelPackages.mwprocapture}/res/NoSignal.png
+
+      # Set the png picture to be displayed when an unsupported input signal is detected.
+      options ProCapture unsupported_file=${kernelPackages.mwprocapture}/res/Unsupported.png
+
+      # Set the png picture to be displayed when an loking input signal is detected.
+      options ProCapture locking_file=${kernelPackages.mwprocapture}/res/Locking.png
+
+      # Message signaled interrupts switch
+      #options ProCapture disable_msi=0
+
+      # Set the debug level
+      #options ProCapture debug_level=0
+
+      # Force init switch eeprom
+      #options ProCapture init_switch_eeprom=0
+
+      # Min frame interval for VIDIOC_ENUM_FRAMEINTERVALS (default: 166666(100ns))
+      #options ProCapture enum_frameinterval_min=166666
+
+      # VIDIOC_ENUM_FRAMESIZES type (1: DISCRETE; 2: STEPWISE; otherwise: CONTINUOUS )
+      #options ProCapture enum_framesizes_type=0
+
+      # Parameters for internal usage
+      #options ProCapture internal_params=""
+    '';
+
   };
 
 }

--- a/nixos/modules/hardware/video/capture/mwprocapture.nix
+++ b/nixos/modules/hardware/video/capture/mwprocapture.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.hardware.mwProCapture;
+
+  kernelPackages = config.boot.kernelPackages;
+
+in
+
+{
+
+  options.hardware.mwProCapture.enable = mkEnableOption "Magewell Pro Capture family kernel module";
+
+  config = mkIf cfg.enable {
+
+    assertions = singleton {
+      assertion = versionAtLeast kernelPackages.kernel.version "3.2";
+      message = "Magewell Pro Capture family module is not supported for kernels older than 3.2";
+    };
+
+    boot.kernelModules = [ "ProCapture" ];
+
+    environment.systemPackages = [ kernelPackages.mwprocapture ];
+
+    boot.extraModulePackages = [ kernelPackages.mwprocapture ];
+
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -41,6 +41,7 @@
   ./hardware/video/amdgpu.nix
   ./hardware/video/amdgpu-pro.nix
   ./hardware/video/ati.nix
+  ./hardware/video/capture/mwprocapture.nix
   ./hardware/video/bumblebee.nix
   ./hardware/video/displaylink.nix
   ./hardware/video/nvidia.nix

--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -8,7 +8,7 @@ assert (stdenv.system == "x86_64-linux") || (stdenv.system == "i686-linux");
 
 let
   bits =
-  if stdenv.system == "x86_64-linux" then "64"
+  if stdenv.is64bit then "64"
   else "32";
 
   libpath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc stdenv.glibc alsaLib ];

--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -43,10 +43,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib/udev/rules.d
     # source has a filename typo
     cp scripts/10-procatpure-event-dev.rules $out/lib/udev/rules.d/10-procapture-event-dev.rules
-    cp scripts/ProCapture.conf $out/modprobe.conf
     cp -r src/res $out
-
-    substituteInPlace "$out"/modprobe.conf --replace /usr/local/share/ProCapture/src/res "$out"/res
 
     patchelf \
       --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \

--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, fetchurl, kernel, alsaLib }:
+
+# The Magewell Pro Capture drivers are not supported for kernels older than 3.2
+assert stdenv.lib.versionAtLeast kernel.version "3.2.0";
+
+# this package currently only supports x86 and x86_64, as I have no ARM device to test on
+assert (stdenv.system == "x86_64-linux") || (stdenv.system == "i686-linux");
+
+let
+  bits =
+  if stdenv.system == "x86_64-linux" then "64"
+  else "32";
+
+  libpath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc stdenv.glibc alsaLib ];
+
+in
+stdenv.mkDerivation rec {
+  name = "mwprocapture-1.2.${version}-${kernel.version}";
+  version = "3269";
+
+  src = fetchurl {
+    url = "http://www.magewell.com/files/ProCaptureForLinux_${version}.tar.gz";
+    sha256 = "0i1y50mf559flhxgaxy2gdpa7dvpp12ix9xfzgxa61rc135x0im4";
+  };
+
+  preConfigure =
+  ''
+    cd ./src
+    export INSTALL_MOD_PATH="$out"
+  '';
+
+  hardeningDisable = [ "pic" "format" ];
+
+  makeFlags = [
+    "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  postInstall = ''
+    cd ../
+    mkdir -p $out/bin
+    cp bin/mwcap-control_${bits} $out/bin/mwcap-control
+    cp bin/mwcap-info_${bits} $out/bin/mwcap-info
+    mkdir -p $out/lib/udev/rules.d
+    # source has a filename typo
+    cp scripts/10-procatpure-event-dev.rules $out/lib/udev/rules.d/10-procapture-event-dev.rules
+    cp scripts/ProCapture.conf $out/modprobe.conf
+    cp -r src/res $out
+
+    substituteInPlace "$out"/modprobe.conf --replace /usr/local/share/ProCapture/src/res "$out"/res
+
+    patchelf \
+      --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
+      --set-rpath "${libpath}" \
+      "$out"/bin/mwcap-control
+
+    patchelf \
+      --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
+      --set-rpath "${libpath}" \
+      "$out"/bin/mwcap-info
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.magewell.com/;
+    description = "Linux driver for the Magewell Pro Capture family";
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ MP2E ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11360,6 +11360,8 @@ with pkgs;
 
     mba6x_bl = callPackage ../os-specific/linux/mba6x_bl { };
 
+    mwprocapture = callPackage ../os-specific/linux/mwprocapture { };
+
     mxu11x0 = callPackage ../os-specific/linux/mxu11x0 { };
 
     /* compiles but has to be integrated into the kernel somehow


### PR DESCRIPTION
Looking for feedback as this is my first NixOS kernel module package.

a driver for the Magewell Pro Capture family of pci-e cards.
Also includes the mwcap-info and mwcap-control utilities, for
changing pixel format settings on the card, among other things.
Uses v4l2 for video output, alsa/pulse for audio output

System configuration option to enable package:
  hardware.mwProCapture.enable = true;

###### Motivation for this change
This allows anyone who owns a pci-e Magewell capture device to capture video or stream and may provide a good base for future capture card related packaging (which is admittedly niche)

###### Things done
Substituted all hardcoded paths with paths pointing to the correct nixpkgs store output
Executables are patchelf'd and all dependencies are satisfied.
Module has been tested with the 4.9 kernel series and works well

###### Things to possibly be done
Package the quickstart guide and the users manual somewhere as documentation? Currently nothing is done with these

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

