### PR TITLE
rcm: 1.3.0 -> 1.3.1

### DIFF
--- a/pkgs/tools/misc/rcm/default.nix
+++ b/pkgs/tools/misc/rcm/default.nix
@@ -1,13 +1,14 @@
 { stdenv, fetchurl }:
 
-stdenv.mkDerivation {
-  name = "rcm-1.3.0";
+stdenv.mkDerivation rec {
+  name = "rcm-${version}";
+  version = "1.3.1";
 
   src = fetchurl {
-    url = https://thoughtbot.github.io/rcm/dist/rcm-1.3.0.tar.gz;
-    sha256 = "ddcf638b367b0361d8e063c29fd573dbe1712d1b83e8d5b3a868e4aa45ffc847";
+    url = "https://thoughtbot.github.io/rcm/dist/rcm-${version}.tar.gz";
+    sha256 = "9c8f92dba63ab9cb8a6b3d0ccf7ed8edf3f0fb388b044584d74778145fae7f8f";
   };
- 
+
   patches = [ ./fix-rcmlib-path.patch ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

