### PR TITLE
pgroonga: init at 1.1.9

### DIFF
--- a/pkgs/servers/sql/postgresql/pgroonga/default.nix
+++ b/pkgs/servers/sql/postgresql/pgroonga/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, pkgconfig, postgresql, libmsgpack, groonga }:
+
+stdenv.mkDerivation rec {
+  name = "pgroonga-${version}";
+  version = "1.1.9";
+
+  src = fetchurl {
+    url = "http://packages.groonga.org/source/pgroonga/${name}.tar.gz";
+    sha256 = "07afgwll8nxfb7ziw3qrvw0ryjjw3994vj2f6alrjwpg7ynb46ag";
+  };
+
+  buildInputs = [ postgresql pkgconfig libmsgpack groonga ];
+
+  makeFlags = [ "HAVE_MSGPACK=1" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D pgroonga.so -t $out/lib/
+    install -D ./{pgroonga-*.sql,pgroonga.control} -t $out/share/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A PostgreSQL extension to use Groonga as the index";
+    longDescription = "PGroonga is a PostgreSQL extension to use Groonga as the index. PostgreSQL supports full text search against languages that use only alphabet and digit. It means that PostgreSQL doesn't support full text search against Japanese, Chinese and so on. You can use super fast full text search feature against all languages by installing PGroonga into your PostgreSQL.";
+    homepage = https://pgroonga.github.io/;
+    license = licenses.postgresql;
+    maintainers = with maintainers; [ DerTim1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9053,6 +9053,8 @@ with pkgs;
 
   pg_similarity = callPackage ../servers/sql/postgresql/pg_similarity {};
 
+  pgroonga = callPackage ../servers/sql/postgresql/pgroonga {};
+
   phonon = callPackage ../development/libraries/phonon {};
 
   phonon-backend-gstreamer = callPackage ../development/libraries/phonon/backends/gstreamer.nix {};


### PR DESCRIPTION
###### Motivation for this change
Add Postgresql Plugin pgroonga.

Can e.g. be used with:
```
services.postgresql = {
    enable = true;
    package = pkgs.postgresql95;
    dataDir = "/var/db/postgresql";
    extraPlugins = [ pkgs.pgroonga ];
  };
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [-] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

