### PR TITLE
tsearch-extras: init at 0.2

### DIFF
--- a/pkgs/servers/sql/postgresql/tsearch_extras/default.nix
+++ b/pkgs/servers/sql/postgresql/tsearch_extras/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, pkgconfig, postgresql }:
+
+stdenv.mkDerivation rec {
+  name = "tsearch-extras-${version}";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "zulip";
+    repo = "tsearch_extras";
+    rev = version;
+    sha256 = "1ivg9zn7f1ks31ixxwywifwhzxn6py8s5ky1djyxnb0s60zckfjg";
+  };
+
+  nativebuildInputs = [ pkgconfig ];
+  buildInputs = [ postgresql ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D tsearch_extras.so -t $out/lib/
+    install -D ./{tsearch_extras--1.0.sql,tsearch_extras.control} -t $out/share/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Provides a few PostgreSQL functions for a lower-level data full text search";
+    homepage = https://github.com/zulip/tsearch_extras/;
+    license = licenses.postgresql;
+    maintainers = with maintainers; [ DerTim1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15310,6 +15310,8 @@ with pkgs;
   # We need QtWebkit which was deprecated in Qt 5.6 although it can still be build
   trojita = with qt55; callPackage ../applications/networking/mailreaders/trojita { };
 
+  tsearch_extras = callPackage ../servers/sql/postgresql/tsearch_extras { };
+
   tudu = callPackage ../applications/office/tudu { };
 
   tuxguitar = callPackage ../applications/editors/music/tuxguitar { };


### PR DESCRIPTION
###### Motivation for this change
Add Postgresql Plugin tsearch_extras (e.g. necessary for zulip)

Can e.g. be used with:
```
services.postgresql = {
    enable = true;
    package = pkgs.postgresql95;
    dataDir = "/var/db/postgresql";
    extraPlugins = [ pkgs.tsearch_extras ];
  };
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [-] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

