### PR TITLE
haproxy: 1.6.6 -> 1.7.2

### DIFF
--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,13 +1,15 @@
 { stdenv, pkgs, fetchurl, openssl, zlib }:
 
 stdenv.mkDerivation rec {
-  majorVersion = "1.6";
-  version = "${majorVersion}.6";
-  name = "haproxy-${version}";
+  pname = "haproxy";
+  majorVersion = "1.7";
+  minorVersion = "2";
+  version = "${majorVersion}.${minorVersion}";
+  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "http://haproxy.1wt.eu/download/${majorVersion}/src/${name}.tar.gz";
-    sha256 = "1xamzzfvwgh3b72f3j74ar9xcn61viszqfbdpf4cdhwc0xikvc7x";
+    url = "http://www.haproxy.org/download/${majorVersion}/src/${name}.tar.gz";
+    sha256 = "0bsb5q3s1k5gqybv5p8zyvl6zh8iyidv3jb3wfmgwqad5bsl0nzr";
   };
 
   buildInputs = [ openssl zlib ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

