### PR TITLE
illum: init at 0.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -111,6 +111,7 @@
   cwoac = "Oliver Matthews <oliver@codersoffortune.net>";
   DamienCassou = "Damien Cassou <damien@cassou.me>";
   danbst = "Danylo Hlynskyi <abcz2.uprola@gmail.com>";
+  dancek = "Hannu Hartikainen <hannu.hartikainen@gmail.com>";
   danielfullmer = "Daniel Fullmer <danielrf12@gmail.com>";
   dasuxullebt = "Christoph-Simon Senjak <christoph.senjak@googlemail.com>";
   davidak = "David Kleuker <post@davidak.de>";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -197,6 +197,7 @@
   ./services/hardware/bluetooth.nix
   ./services/hardware/brltty.nix
   ./services/hardware/freefall.nix
+  ./services/hardware/illum.nix
   ./services/hardware/irqbalance.nix
   ./services/hardware/nvidia-optimus.nix
   ./services/hardware/pcscd.nix

--- a/nixos/modules/services/hardware/illum.nix
+++ b/nixos/modules/services/hardware/illum.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.illum;
+in {
+
+  options = {
+
+    services.illum = {
+
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enable illum, a daemon for controlling screen brightness with brightness buttons.
+        '';
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.illum = {
+      description = "Backlight Adjustment Service";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig.ExecStart = "${pkgs.illum}/bin/illum-d";
+    };
+
+  };
+
+}

--- a/pkgs/tools/system/illum/default.nix
+++ b/pkgs/tools/system/illum/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchgit, pkgconfig, ninja, libevdev, libev }:
+
+stdenv.mkDerivation rec {
+  version = "0.4";
+  name = "illum-${version}";
+
+  src = fetchgit {
+    url = "https://github.com/jmesmon/illum.git";
+    fetchSubmodules = true;
+    rev = "48ce8631346b1c88a901a8e4fa5fa7e8ffe8e418";
+    sha256 = "05v3hz7n6b1mlhc6zqijblh1vpl0ja1y8y0lafw7mjdz03wxhfdb";
+  };
+
+  buildInputs = [ pkgconfig ninja libevdev libev ];
+
+  configurePhase = ''
+    bash ./configure
+  '';
+
+  buildPhase = ''
+    ninja
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv illum-d $out/bin
+  '';
+
+  meta = {
+    homepage = https://github.com/jmesmon/illum;
+    description = "Daemon that wires button presses to screen backlight level";
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.dancek ];
+    license = stdenv.lib.licenses.agpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17545,6 +17545,8 @@ with pkgs;
 
   hplipWithPlugin_3_15_9 = hplip_3_15_9.override { withPlugin = true; };
 
+  illum = callPackage ../tools/system/illum { };
+
   # using the new configuration style proposal which is unstable
   jack1 = callPackage ../misc/jackaudio/jack1.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

There seemed to be no easy/automatic solution in NixOS to get the screen brightness adjustment keys working. At least in the case that BIOS doesn't handle them and you run a simplistic system without KDE/GNOME/XFCE. [Illum](https://github.com/jmesmon/illum) is a simple daemon that listens to brightness keys and adjusts the screen backlight. Probably useful for other people, too.

Tested by running `nix-build -A 'config.systemd.units."illum.service".unit'`, copying the resulting service definition to `/run/systemd/system` and running the service.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

