### PR TITLE
nginx-config-formatter: Init at 2016-06-16

### DIFF
--- a/pkgs/tools/misc/nginx-config-formatter/default.nix
+++ b/pkgs/tools/misc/nginx-config-formatter/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, python3 }:
+
+stdenv.mkDerivation rec {
+  version = "2016-06-16";
+  name = "nginx-config-formatter-${version}";
+
+  src = fetchFromGitHub {
+    owner = "1connect";
+    repo = "nginx-config-formatter";
+    rev = "fe5c77d2a503644bebee2caaa8b222c201c0603d";
+    sha256 = "0akpkbq5136k1i1z1ls6yksis35hbr70k8vd10laqwvr1jj41bga";
+  };
+
+  buildInputs = [ python3 ];
+
+  doCheck = true;
+  checkPhase = ''
+    python3 $src/test_nginxfmt.py
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m 0755 $src/nginxfmt.py $out/bin/nginxfmt
+  '';
+
+  meta = with stdenv.lib; {
+    description = "nginx config file formatter";
+    maintainers = with maintainers; [ baughn ];
+    license = licenses.asl20;
+    homepage = https://github.com/1connect/nginx-config-formatter;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2535,6 +2535,8 @@ in
 
   netsniff-ng = callPackage ../tools/networking/netsniff-ng { };
 
+  nginx-config-formatter = callPackage ../tools/misc/nginx-config-formatter { };
+
   ninka = callPackage ../development/tools/misc/ninka { };
 
   nodejs = hiPrio nodejs-6_x;


### PR DESCRIPTION
###### Motivation for this change

I'd like to automatically format the nginx config file, when generated using structured config. At present the result is quite unreadable.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

