### PR TITLE
services: ipfs: separate system units, add offline mode

### DIFF
--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -104,30 +104,72 @@ in
       };
     };
 
-    systemd.services.ipfs = {
-      description = "IPFS Daemon";
+    systemd.services.ipfs-init = {
+      description = "IPFS Initializer";
 
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" "local-fs.target" ];
+      after = [ "local-fs.target" ];
+      before = [ "ipfs.service" "ipfs-offline.service" ];
+
       path  = [ pkgs.ipfs pkgs.su pkgs.bash ];
 
       preStart = ''
         install -m 0755 -o ${cfg.user} -g ${cfg.group} -d ${cfg.dataDir}
+      '';
+
+      script =  ''
         if [[ ! -d ${cfg.dataDir}/.ipfs ]]; then
           cd ${cfg.dataDir}
-          ${pkgs.su}/bin/su -s ${pkgs.bash}/bin/sh ${cfg.user} -c \
-             "${ipfs}/bin/ipfs init ${if cfg.emptyRepo then "-e" else ""}"
+          ${ipfs}/bin/ipfs init ${optionalString cfg.emptyRepo "-e"}
         fi
-        ${pkgs.su}/bin/su -s ${pkgs.bash}/bin/sh ${cfg.user} -c \
-           "${ipfs}/bin/ipfs --local config Addresses.API ${cfg.apiAddress} && \
-            ${ipfs}/bin/ipfs --local config Addresses.Gateway ${cfg.gatewayAddress}"
+        ${ipfs}/bin/ipfs --local config Addresses.API ${cfg.apiAddress}
+        ${ipfs}/bin/ipfs --local config Addresses.Gateway ${cfg.gatewayAddress}
       '';
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        Type = "oneshot";
+        RemainAfterExit = true;
+        PermissionsStartOnly = true;
+      };
+    };
+
+    systemd.services.ipfs = {
+      description = "IPFS Daemon";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "local-fs.target" "ipfs-init.service" ];
+
+      conflicts = [ "ipfs-offline.service" ];
+      wants = [ "ipfs-init.service" ];
+
+      path  = [ pkgs.ipfs ];
 
       serviceConfig = {
         ExecStart = "${ipfs}/bin/ipfs daemon ${ipfsFlags}";
         User = cfg.user;
         Group = cfg.group;
-        PermissionsStartOnly = true;
+        Restart = "on-failure";
+        RestartSec = 1;
+      };
+    };
+
+    systemd.services.ipfs-offline = {
+      description = "IPFS Daemon (offline mode)";
+
+      after = [ "local-fs.target" "ipfs-init.service" ];
+
+      conflicts = [ "ipfs.service" ];
+      wants = [ "ipfs-init.service" ];
+
+      path  = [ pkgs.ipfs ];
+
+      serviceConfig = {
+        ExecStart = "${ipfs}/bin/ipfs daemon ${ipfsFlags} --offline";
+        User = cfg.user;
+        Group = cfg.group;
+        Restart = "on-failure";
+        RestartSec = 1;
       };
     };
   };


### PR DESCRIPTION
###### Motivation for this change
Offline mode: When adding a lot of data, start this service.
It will will not flood the DHT since it only exposes the API.
When you are done simply reverse the process.

@fpletz: Fixed https://github.com/NixOS/nixpkgs/pull/21880#discussion_r96121820
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

