### PR TITLE
Add tips for resolving https issues in containers

### DIFF
--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -523,6 +523,17 @@
   It is possible to inspect the arguments with which an image was built
   using its <varname>buildArgs</varname> attribute.
   </para>
+	
+	
+  <para>
+  If you see errors similar to <literal>getProtocolByName: does not exist (no such protocol name: tcp)</literal>
+  you may need to add <literal>pkgs.iana_etc</literal> to <varname>contents</varname>.
+  </para>
+	
+  <para>
+  If you see errors similar to <literal>Error_Protocol ("certificate has unknown CA",True,UnknownCa)</literal>
+  you may need to add <literal>pkgs.cacert</literal> to <varname>contents</varname>.
+  </para>
 
 </section>
 

--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -525,15 +525,20 @@
   </para>
 	
 	
+	
+  <note>
   <para>
   If you see errors similar to <literal>getProtocolByName: does not exist (no such protocol name: tcp)</literal>
   you may need to add <literal>pkgs.iana_etc</literal> to <varname>contents</varname>.
   </para>
+  </note>
 	
+  <note>
   <para>
   If you see errors similar to <literal>Error_Protocol ("certificate has unknown CA",True,UnknownCa)</literal>
   you may need to add <literal>pkgs.cacert</literal> to <varname>contents</varname>.
   </para>
+  </note>
 
 </section>
 


### PR DESCRIPTION
I ran into some issues making HTTPS requests from a container built with `buildImage`. I've added notes with tips for resolving similar issues.

###### Motivation for this change

Reduce frustration for new users of `buildImage` by providing advice for fixing common errors

###### Things done

I'm not sure what steps I should take for a documentation-only change, please let me know if I can add/do anything to improve this PR.