### PR TITLE
gcalcli: init at 4.0.0a2

### DIFF
--- a/pkgs/applications/misc/gcalcli/default.nix
+++ b/pkgs/applications/misc/gcalcli/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, pkgs, lib, python, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  version = "4.0.0a2";
+  name = "gcalcli-${version}";
+
+  src = fetchFromGitHub {
+    owner = "insanum";
+    repo = "gcalcli";
+    rev = "v${version}";
+    sha256 = "0cw6985ixd3lndjb90ds7q4r4wwl7crljjsw2cl3dhrn029w885i";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [
+    dateutil
+    gflags
+    google_api_python_client
+    parsedatetime
+    six
+    vobject
+  ] ++ lib.optional (!pythonPackages.isPy3k) futures;
+
+  meta = with lib; {
+    homepage = https://github.com/insanum/gcalcli;
+    description = "Google Calendar Command Line Interface";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13383,6 +13383,8 @@ with pkgs;
 
   game-music-emu = callPackage ../applications/audio/game-music-emu { };
 
+  gcalcli = callPackage ../applications/misc/gcalcli { };
+
   gcolor2 = callPackage ../applications/graphics/gcolor2 { };
 
   get_iplayer = callPackage ../applications/misc/get_iplayer {};


### PR DESCRIPTION
###### Motivation for this change

Want to use this python interface for Google Calendar in my NixOS environment.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

