### PR TITLE
rtv: 1.13.0 -> 1.14.1

### DIFF
--- a/pkgs/applications/misc/rtv/default.nix
+++ b/pkgs/applications/misc/rtv/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, pkgs, lib, python, pythonPackages }:
 
 pythonPackages.buildPythonApplication rec {
-  version = "1.13.0";
+  version = "1.14.1";
   name = "rtv-${version}";
 
   src = fetchFromGitHub {
     owner = "michael-lazar";
     repo = "rtv";
     rev = "v${version}";
-    sha256 = "0rxncbzb4a7zlfxmnn5jm6yvwviaaj0v220vwv82hkjiwcdjj8jf";
+    sha256 = "03106sdsvj4zjjaqqg7qvm3n959plvy08a6n28ir1yf67kwzsx8a";
   };
 
   propagatedBuildInputs = with pythonPackages; [


### PR DESCRIPTION
###### Motivation for this change

The Reddit Terminal Viewer is a powerful CLI for using Reddit in the terminal.  This updates it to 1.14.1, which also resolve an issue that the current version (1.13.0) in `nixpks` has when trying to use the default parser (`less -R`) for long comments.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

