### PR TITLE
wp-cli: add bash completion

### DIFF
--- a/pkgs/development/tools/wp-cli/default.nix
+++ b/pkgs/development/tools/wp-cli/default.nix
@@ -1,33 +1,44 @@
-{ stdenv, lib, writeText, writeScript, fetchurl, php }:
+{ stdenv, lib, fetchurl, php }:
 
 let
   version = "1.0.0";
-  name = "wp-cli-${version}";
 
-  phpIni = writeText "wp-cli-php.ini" ''
-    [Phar]
-    phar.readonly = Off
-  '';
+  bin  = "bin/wp";
+  ini  = "etc/php/wp-cli.ini";
+  phar = "share/wp-cli/wp-cli.phar";
 
-  wpBin = writeScript "wp" ''
-    #! ${stdenv.shell} -e
-    exec ${php}/bin/php \
-      -c ${phpIni} \
-      -f ${src} "$@"
-  '';
-
-  src = fetchurl {
-    url = "https://github.com/wp-cli/wp-cli/releases/download/v${version}/${name}.phar";
-    sha256 = "06a80fz9na9arjdpmnislwr0121kkg11kxfqmac0axa9vkv9fjcp";
+  completion = fetchurl {
+    url    = "https://raw.githubusercontent.com/wp-cli/wp-cli/v${version}/utils/wp-completion.bash";
+    sha256 = "15d330x6d3fizrm6ckzmdknqg6wjlx5fr87bmkbd5s6a1ihs0g24";
   };
 
 in stdenv.mkDerivation rec {
+  name = "wp-cli-${version}";
 
-  inherit name src;
+  src = fetchurl {
+    url    = "https://github.com/wp-cli/wp-cli/releases/download/v${version}/${name}.phar";
+    sha256 = "06a80fz9na9arjdpmnislwr0121kkg11kxfqmac0axa9vkv9fjcp";
+  };
 
   buildCommand = ''
-    mkdir -p $out/bin
-    ln -s ${wpBin} $out/bin/wp
+    mkdir -p $out/bin $out/etc/php
+
+    cat <<_EOF > $out/${bin}
+    #! ${stdenv.shell} -eu
+    exec ${lib.getBin php}/bin/php \\
+      -c $out/${ini} \\
+      -f $out/${phar} "\$@"
+    _EOF
+    chmod 755 $out/${bin}
+
+    cat <<_EOF > $out/${ini}
+    [Phar]
+    phar.readonly = Off
+    _EOF
+    chmod 644 $out/${ini}
+
+    install -Dm644 ${src}        $out/${phar}
+    install -Dm644 ${completion} $out/share/bash-completion/completions/wp
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Also, instead of creating multiple tiny derivations, just stick everything into 1.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

