### PR TITLE
pstoedit,plotutils: fix for darwin and mark not broken

### DIFF
--- a/pkgs/tools/graphics/plotutils/default.nix
+++ b/pkgs/tools/graphics/plotutils/default.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [ stdenv.lib.maintainers.marcweber ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/graphics/pstoedit/default.nix
+++ b/pkgs/tools/graphics/pstoedit/default.nix
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ zlib ghostscript imagemagick plotutils gd libjpeg libwebp libiconv ] 
+  buildInputs = [ zlib ghostscript imagemagick plotutils gd libjpeg libwebp ] 
   ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-    ApplicationServices
+    libiconv ApplicationServices
   ]);
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/graphics/pstoedit/default.nix
+++ b/pkgs/tools/graphics/pstoedit/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig
+{ stdenv, fetchurl, pkgconfig, darwin, lib
 , zlib, ghostscript, imagemagick, plotutils, gd
-, libjpeg, libwebp
+, libjpeg, libwebp, libiconv
 }:
 
 stdenv.mkDerivation rec {
@@ -13,13 +13,16 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ zlib ghostscript imagemagick plotutils gd libjpeg libwebp ];
+  buildInputs = [ zlib ghostscript imagemagick plotutils gd libjpeg libwebp libiconv ] 
+  ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    ApplicationServices
+  ]);
 
   meta = with stdenv.lib; {
     description = "Translates PostScript and PDF graphics into other vector formats";
     homepage = https://sourceforge.net/projects/pstoedit/;
     license = licenses.gpl2;
     maintainers = [ maintainers.marcweber ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

pstoedit and plotutils were marked broken for darwin, and pstoedit was not compiling due to a missing dependency on ApplicationServices.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

