### PR TITLE
ghcjs-HEAD: upgrade to the latest HEAD

### DIFF
--- a/pkgs/development/compilers/ghcjs/head.nix
+++ b/pkgs/development/compilers/ghcjs/head.nix
@@ -10,8 +10,8 @@ bootPkgs.callPackage ./base.nix {
   ghcjsSrc = fetchFromGitHub {
     owner = "ghcjs";
     repo = "ghcjs";
-    rev = "899c834a36692bbbde9b9d16fe5b92ce55a623c4";
-    sha256 = "024yj4k0dxy7nvyq19n3xbhh4b4csdrgj19a3l4bmm1zn84gmpl6";
+    rev = "2dc14802e78d7d9dfa35395d5dbfc9c708fb83e6";
+    sha256 = "0cvmapbrwg0h1pbz648isc2l84z694ylnfm8ncd1g4as28lmj0pz";
   };
   ghcjsBootSrc = fetchgit {
     url = git://github.com/ghcjs/ghcjs-boot.git;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -61,8 +61,8 @@ rec {
     ghcjs = packages.ghc7103.callPackage ../development/compilers/ghcjs {
       bootPkgs = packages.ghc7103;
     };
-    ghcjsHEAD = packages.ghc801.callPackage ../development/compilers/ghcjs/head.nix {
-      bootPkgs = packages.ghc801;
+    ghcjsHEAD = packages.ghc802.callPackage ../development/compilers/ghcjs/head.nix {
+      bootPkgs = packages.ghc802;
     };
 
     jhc = callPackage ../development/compilers/jhc {


### PR DESCRIPTION
See the the [changelog of ghcjs](https://github.com/ghcjs/ghcjs/compare/899c834a36692bbbde9b9d16fe5b92ce55a623c4...2dc14802e78d7d9dfa35395d5dbfc9c708fb83e6).

ghcjs-HEAD now builds with GHC-8.0.2 so I switched to that as well.

It would be great if this could be cherry picked on `release-16.09`.