### PR TITLE
Mark ihaskell as broken. Closes #22047.

### DIFF
--- a/pkgs/development/tools/haskell/ihaskell/wrapper.nix
+++ b/pkgs/development/tools/haskell/ihaskell/wrapper.nix
@@ -16,7 +16,7 @@ let
 in
 buildEnv {
   name = "ihaskell-with-packages";
-  paths = [ ihaskellEnv ipython ];
+  paths = [ ihaskellEnv ipython (abort "ihaskell is currently broken. See https://github.com/NixOS/nixpkgs/issues/22047.")];
   postBuild = ''
     . "${makeWrapper}/nix-support/setup-hook"
     ln -s ${ihaskellSh}/bin/ihaskell-notebook $out/bin/.


### PR DESCRIPTION
meta.broken doesn't work in buildEnv so we abort when the dependencies
are evaluated.

See bug for more context.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

