### PR TITLE
firefox, firefox-bin: 51.0 -> 51.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/sources.nix
@@ -1,925 +1,925 @@
 {
-  version = "51.0";
+  version = "51.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ach/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ach/firefox-51.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "28041c7cb96e90ba3c9fbe689b000f56e144543b83f1280da785f70a299b229c72638f206425049ecefdec5f33c66fbc588a2032c392e637428fa03cc5cd9fd5";
+      sha512 = "b03b784892648b2df1c3f5acc9e0a8bab9a7e95afbeda249dfa57f4bbabfd2d750602c64b85ff6d1ea4676294086ea2b847e64a8920450ca6849d6c54b3f881e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/af/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/af/firefox-51.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "73196f42a1932782a7ae682c461a1c0f443b7369c4c9d74e4f45af73db5d0ae6926dc8055cdabc68ee63dc669e8846b5a529bbc16759b0160119ee750eace1c9";
+      sha512 = "4d1c5407450e9afbf8e630fa588d6b26c6cd5d9c405d422413064f1e81d089f65f59df4022dbf6f0601cc36d56b222a45f925b792ed7df3182e0999d5655e393";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/an/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/an/firefox-51.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "eee39ff92c9354b4d6fcbf801e899f123053a6509e9cb857ff25e76e198d8c71d2c8979b7bab8393ab130a3518f564d1ca5e2d528432168f2e679f5cc3b0755e";
+      sha512 = "71938ac8176197164408b389c28061d634dd3d895b28a7ad35c4236e3a6561be7e4f04c0c4fd14dfa9e4c87d0c9cd245ed656cfc2bb68d4666a5bb2e93740a49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ar/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ar/firefox-51.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "cfcf6ad7e8aa2350207ccb26840757765ab702ab414eb6c657a58cc5ff8422089fcc6544149278d627cc397cc5797c42a44f0bc18fdc2a961379e58cbeabdb9c";
+      sha512 = "a0b1ca6edaa03e5e73e7a298490f394a2884690c0e012678686eba4d32a16c1f049a0fc2417627cf36e54c918dd0f86ef37fe6555b5ce80de18999ea08a537a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/as/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/as/firefox-51.0.1.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "7e2b8862528b7a58ee598f56069f6c685cb23aee23f5aa708b4a3fd8c6164dabc5b3cdec418aa2280fbf3948980b5cb9bb6980ef39ed9c96568ad791bcf7873b";
+      sha512 = "1e07c2cf24eb3aa244134d8ed1d11dd3b1151b9e700921afb60336491c0f301fcc4b289e354b490f9d84cca96417b09dab7df06951f8568019976e2baf999894";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ast/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ast/firefox-51.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "ef636ef3f1b6a258dd01e1df91b6beba0d8fea6ce3ce09b62e6702fb145bf670a91df0faf23604d066f44e4bfef11c89e34951cc9993bee7be6ddda966f10f22";
+      sha512 = "dbdaf693ea1143f78fe3a06461d0a1653c57459633b1d5236a9c3ce74f1c888664d7b455fd0fb2733c0823c22088d58314ee9f4ccfa62726257b83fe1cdac435";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/az/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/az/firefox-51.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "0527b6c09d9cf6d785a17d3bf7934374f8d9f8470bf7aea884040bcf1faa29c1038640840dff6bfdba8786796d42d41b5acafc724e11af9cc654377d7dab7b3b";
+      sha512 = "1fbb9efa1dddf1577b5532fb59f73994c54aac26e4ccfe643204224844f5dc1398ae077703b5df33589646257ad2f46ce4bc38a3e9575c8842c716bf18d1c497";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/bg/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/bg/firefox-51.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "91d97992a0382b36c051e6b82f41121464df8ab9a24addf22c402a660b0340babb3a03ba5ae2144fdae6fd89b7960c542d382a116d303c1b660e8c58b22dae38";
+      sha512 = "fee53d9245bffeaa7c696b1cdc2119b0f683caf9352ac2e8336745e45a799ef1729577af968006cb2240a49872673175f3ec0a706b76d4bc5962c56912b895bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/bn-BD/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/bn-BD/firefox-51.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "0264a2989ce61684eaaeb68f9a55f0498c58e621e39c89d3b6b54d17e95b8034d00730858a13bba685fcd24bcbdc9751abd10aa0a4bc528fe7a215c578c4f20f";
+      sha512 = "d6909918b51dd5a1c80909e480de0503ef85ffb1b53a7421d134386e5db94850c1605eccddf588b4646aef90e91917b3fb0c74f6560e1c0543d45a2f9fbd8bc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/bn-IN/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/bn-IN/firefox-51.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "f7023475fe832243845d5200fe0ed14fca9be37f6dad21075eee0b40361b5b30e0859a5878063099975ccd06e89ba431c277243f48b8d21357066f9fe73c4c97";
+      sha512 = "cfea68c984ca43b840d3d8d13347c3ac2ba38e5d38623384aa5a3559b6fe175415124ca06ef3f4848193fc20e0ee0a6c4a497c5bc3b7589e05cd756bfa56bf53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/br/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/br/firefox-51.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "824810456fd3d4c0b705d8adcbd6a87aa03373f24a6282011c010e88c1bfb19854695c8989f62f432004c7f84bb517f3849454f06748a7f9c73b99035e64637a";
+      sha512 = "1225ec28b6f63cd5be087a61f0f6761362bae12ae975c2805e109019fce0b0fc7dce4bb0e7891bffd18a8395ee41f6344ae654314894c1fa1eb0a30851ea3b21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/bs/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/bs/firefox-51.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "d71a70756807065b64ef25f359913d292b92220e3e6a76018478c592f10f31bdfe393fc8067243274d17a51bb7d37cf2f2c80dff05d00eeff9b5c4360b8204e2";
+      sha512 = "7d5bc886b60a04aa81ea77d412738ef350dfa6c76c9c653d5c9f7627717ee94a0ed9131d3a1a75f25306bd496eba225e9a645b44f59fcd5a16bea64a128664bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ca/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ca/firefox-51.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "0bac177c381cb9a40e5d58280e29ed7a143ee3c9f49c35444066c14191ba14fa45214ffd830a8ca7e7f01f8a029f93cbc5bf2c703f8fed8761abd2a800153697";
+      sha512 = "ebeecb92f79a67c1bba9ec43509a431328318607c7c460f13ddfc17d3253ad4f2de06cef27ba7adbffaab2562af48f3eec8b1b5137d4b8abc8b2a960515fe9b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/cak/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/cak/firefox-51.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "106ae220caec8528c8251a4dcd785a7ed11621968b35964b1e5a5c5eac6dda8540b63fef2c4a74b6f33a2ce32c7e34ce8d5cde18b4951969b2a7dfc1b11a27bf";
+      sha512 = "d507417ce14e60af385d8cc3eb16b74d311ae50797bc836d0f137d2ed69f41aceeb4273a4f10de64dc1d93ec29952e3a95bea6bb1c628467c410266edf8ddfc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/cs/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/cs/firefox-51.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "c42915c13ccb30025d29582ff10b52f69681e44c835a049cc4d3ccd2d554da9f02d9286e2f49f1b14879474c18391dea539cd407e4aa8daf2586df42ef242415";
+      sha512 = "60b1690077c1375df44642ec55954f690af6240a2d1782c93ca1df6cda7c64f50bd0034f6d66f4629e8d6d5716fb46afeb2850201d63d72f6122da57bc278788";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/cy/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/cy/firefox-51.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "6fc312a3e0303a95e0e00d1e22d9c347decb3764e568dddf871ca87becece14fd5d2ad3d064ef03855b3c498237ce68377c1c8bb6881fd897b7a041637e95023";
+      sha512 = "dfad805b88d1b928253a8d86a89581b0db4cb505b373d6488cb05701048a1e99131b6078d337cce16f5fc7daa0af331ec4fb328329af2c663af8ae28a221c58a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/da/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/da/firefox-51.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "0bb5b30f76fb68e27ec653e627874e9d3828ae419d968b0582197d5db2cf0454c466feae4cc884daa2e2cf4e47b77da76ff2f9e554f5a25f0dff743d7b14d2ae";
+      sha512 = "6fcc47e0a019fc5af5fb14753221a89bb63c18d4695ed2a369781b2d89ae0c1c127cada90582908ff690d4b08015686f963bd0df137686cad99eefb31dcf1bb9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/de/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/de/firefox-51.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "631774f6e95d0e0c9177c0cab012b9b9618b1cdc69489accf4dc535db19b6b64f388e510a5adb5a6bb06fbe0a2f2518747eda2a2361dc4d444db9302bee67256";
+      sha512 = "31efe6ee9551246018811a63d89274dc126955745ca68c97035f207ca0b5ad250b2f8672132f6ca5c70676e09174f227ef9e1b5488857a9a5da5b5fd41fe2aad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/dsb/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/dsb/firefox-51.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "ba2fb7fb575df8f873ad4a6f7d2ca9c3f5ba150e2754d5f7c8fca637cc8c71198b8ed400d9654b1ee9348c6a39d7e9f501f7e56d9cc6b4cf0c962257c200bb66";
+      sha512 = "f93c6bc53c51454128f0435eca79cd46f94e49e1513854ceb9835322c84b282f81536efefb6520f01842ad10c70c0d85b72a89de9952c03fe8626b3a02ad2bf3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/el/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/el/firefox-51.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "4256085411d80fe590fb678b186be0a5422502b8260ffccc3f0e01486b4a463d23821c50b2c92e7dbeca26a3a8473f4a4972c6c752c3f4997ec38d69f959d950";
+      sha512 = "8acdcbe7ef6a977a7f59e1543b960b428faacfab756b298310c0971d0e90b10c382ec211d7866ac5aec2bfb15cc9b276be8bb82b8f036babedba989ffed3664f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/en-GB/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/en-GB/firefox-51.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "cc9ded644135ad6362ef711cb96b84fbb57033775009182106d3681492cfc9df366408ac03f2494c217e46b368075f5f81642f3de17d2ca936867ebc7e03afab";
+      sha512 = "3aaa1f296dc15a5e2555c5aa1d5c2e2f2ff91ac76a65955cc633b19bb50c449e0d0e1f2b6772278884d4d9fbe3d35c2bbcfdb3f85e23838bf132aabe37b5f117";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/en-US/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/en-US/firefox-51.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "b585f100d3b9728dd3d1922f12385cf4ffd025ef5ab72a9b0a84e6cc6d4a77bff48bb184f7de63e1d5ac40296a301c2be9607fc502539b89320463c310ac89fa";
+      sha512 = "58bfd3dd0aef94d735ae73779ef8d729bf421e48e345baf413c0bdb5085644a79dd786a4e21713bd8006ba2e48d3a3cb3c94b97dbfb5d90f546549518770c88d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/en-ZA/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/en-ZA/firefox-51.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "5435a360bca5dd865d4f1dc51f6d93eed6bf71abbb6c63d416934283878c7b0d05c212e60c1269c58d54438f9b3219b6599a2d95e80fc915f1f627a3b95d3635";
+      sha512 = "67b05904cfef62154aac12a5bcd77046672a599f3df323fda5f12e1bfcccd0bacc31556c6708dea70c1b459e7dbcfc7284248b528aed1fdc1bf336eabcbbbcfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/eo/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/eo/firefox-51.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "d5ac355f4e9e08dcd0782e7bef428e6606711673353b5159b1fa153f32dc9c4df53bfdcdbd74aa8e9420c7b8a13d8013778c4bf31b59b4913d1447f901cab25e";
+      sha512 = "87cd52dea514edffa98ce40f45a209a11d1543b7f23007639e66557dd687824a9aa785f1eeb4b1f3aab17ffa8ee18e3628eba592dd3b91c940677e18adbca0a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/es-AR/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/es-AR/firefox-51.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "1a173345039821ccb0bab091433523a6eb3c485b7f5083bf41d830576d63cc983d354c473971e174af0de724791be31b57f1de371a8386957c5dd3319b25b0ce";
+      sha512 = "d731b583b8b0ff0ecccd3bd1b32fcbd0152a353c6eb9525866185d8e42eaf4dbf13ff008893b7c35045ac8a699608e7b7aef4a02c69fc764cde12cc507f5afb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/es-CL/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/es-CL/firefox-51.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "9c43565a6bf05ed30a8a79b12ca5d88c30c98bb96949e32c688be9b994bcf9f1ac3a2c670ba8afbbb25c19e2921b046278542068e1918b3ff59ac3b0ad5596ae";
+      sha512 = "4d2064a404832b26364691eaf8923adabad698bc8ad1bb0681be36ef7b154f02f3a63c8e45ffe848891cc33af9f4992e3a8ff0240db78028a8148ee250cbee58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/es-ES/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/es-ES/firefox-51.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "6bcf1b218f940a2c0ab6fc9f899d63555e49e45907dce4026312a767708662032c5c6f8b9958d30ae4adc97d037018407d91cf69c4993a8865ef92f3e8cdab2f";
+      sha512 = "1ce27c43e05606d837c65f218e144e695a081146b868e7a3706a876744db0e183392c63f992efe8484d398ae02d521ed6092518131cf4b53647bdde015cb8cd0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/es-MX/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/es-MX/firefox-51.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "1092239baa8016968dd8daeb69f6891f12ddc572bd1010c3800d07598a1a7596ebf8d68d1e6d3de4db33f4dd003a463d9ffe69c3a841c65ceaf44133c5eb74e8";
+      sha512 = "2f0d6765fa85678f8b9a4c820e2e36ef3ad8fbe50db07cd3ccb5749b62aff3026eb09316d4840fb9dd537581ec39753205923460a150dd7b3d4c812fef8dcbeb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/et/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/et/firefox-51.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "4fb536071e23f2f55674fe790f3dc567c2edabb529c0d3b52b07aa02d9898f3b2d7c7cb694bf22a8e0f921c62d4f33b1ddfc6ee9bdafa42a9405e497677628df";
+      sha512 = "3b6675306eb32e809778386ea92db02a5b4274ac2e62e0f071527fe4ea38e862180d2fe992c3e37f49e8157c1910ba6600256121bb191c00c80c236d3333c3e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/eu/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/eu/firefox-51.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "cafe7b1ce89402c961d90c5f28e14ac05884da13236766b04c444f61b3fe259e5bde9460c31bbdad2192b5e1712b13578a165a49a08879fc251d0e6b3c96cc19";
+      sha512 = "09b87fad711ce298c53b468dfa561526390c8c45c3c2edf25a76212889b7a1b965d1cfcd8c60a15fd6072ba3a7fc3a26e40a9c92ae363295ec9e2a0d12039fd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/fa/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/fa/firefox-51.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "25b2834300a3b48e9cea461dc3b2c5513e81c6b428a96ca7c89e022cfeb4435cad0ec1fbb22806be0adf971c728ff2152e7ba097e0189ace7e15d083670fcee5";
+      sha512 = "b5cb640ddb95ed2f7a36435b5a6c22d562b35e44506d0acc61adb5341cb0fd1a092f1b64257af190d8e6d8e8e5d956cafae3f6d116c69bd22e4c19bb78fa494e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ff/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ff/firefox-51.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "c4eb46a438a5174de003c9ec24cbe9de02c3ca66b485e74fb09f1e6cc2c558d4b45df58fb8fb5b97fdce9e3ea4c473d7568f5d197a2e5ba0c27317204a76cf78";
+      sha512 = "15cbf240bd5302d984e2d63a239e3d83f48b9a31413d81c2b76c389d9ff59e9da69c759efa925c2731d070f8e12fbd7c9791769b4315a991857282a745b261bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/fi/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/fi/firefox-51.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "5bc78cebb1414049625da3e3f9f1b33ed8efdc01d4a0b29d2b5c7c69c8b7b4639fcca89f5d75f434c28e3235613094f1e51d35a0bfb9943ebc1993360f8a517b";
+      sha512 = "b8785753cd8192653e459ad92fbeeedc88bb860d8b2a1eab97a4eb16726ffe4c70f4a27d14fba3d987f0f5c187a69fa473f8ffcbe34240cb0bf0379ea72e713a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/fr/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/fr/firefox-51.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "aeba94f928e6632db44e181e3d6aa8b53943f59effa5cccd2bab5b7141c17c6362adbbfe5a28f0e4318adee9d488c336591cd602a55656b966f57312e20798be";
+      sha512 = "418292c6cefc45a33057062d2a86299479ca0001fafe30a8369cb79e2390195dabc379001d2060ff3175fb96bbc0ce6063a2fcd0e8294aa8fcd4c231eb7a6dd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/fy-NL/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/fy-NL/firefox-51.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "952b0cb604cc8f3ca39bda118c543aeb1a7dd25d266439c56bed600e136864251ffb866915cf8d92cb8437cac0d9e1d6ec0a8468e89eb0c6df192ad21fb8aaab";
+      sha512 = "07db4c4d56e4d9416d8e2c94b712b27071e66c906c189f615d1e15ebbf9b2df6354f433ce71ba8ea60da870e1551bce477d256cccc5f7b03ce2df37249b183f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ga-IE/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ga-IE/firefox-51.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "dcffd355c1d911a00cdd3ebaeae98e6fa5346934a6ef5b1f66c7698bc188878ab75686ae07d0cc885535bc674ab55931a03a60247431da53bed921ad4ef44edc";
+      sha512 = "950fd2a1d7280574ce4f50cd6be29d00cd322fc63c41b7babadd5b615cd12f350e2f2aed8cf744a753583ef313a2fd6948d5b3d444d49bcfd865b1df92b80c11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/gd/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/gd/firefox-51.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "50104f1ba8ebe3505488030de273b04b83568ade8d777fa5dbc75d4b74433f194b16d8e963ea56686563b6aed129cdf64d8db9bad34c68295c5457b3b66812c3";
+      sha512 = "7d0174ae5c3874350b8c2444c12dcecc180261445f1cce36a196196f0040057d8b78ba4ae081d287343e7e3455410662b55a306d021c536e3b5ffc4705048051";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/gl/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/gl/firefox-51.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "61436f89c5353e06c29b5aac6ba1ad1ceeab1f580a40643d6afc5f27801b1d67c9f5343bc2e3bc911547389d6b7ce81d75faf9c7882436562fff4fbcf379d057";
+      sha512 = "68b2d8a3f53ed32826c70850af3c8e7507e7aa5b19c0ceba86d4ca5759630f28250b67cbb3727b524c80b66b03af4e6ad7a6d1494743e28bdc8cdcd4bab10824";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/gn/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/gn/firefox-51.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "14c0b3f085f3bceebd6a75e96efd71d6c8f5e50485f2d7b6b18fca42ded88f5f3b8b90afafda388e7b41cbe39ea2410fae37cbdf8ef0a32d8204ddb7ffee8b6c";
+      sha512 = "ed0786dca5c95efede7c9c58b0f8b2a08068fe309b7456807d96c0681fb963ddcda1fb461cbac96c20472b0b084abc5fb2dba3f24f5f763d2d31728a3b16adb9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/gu-IN/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/gu-IN/firefox-51.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "abc5baa41ac6e41813c43838e94b68a63f83058cdf37d25bd315bfdcd27a2a294c91205ec0ce13e7b28508e0ca982bbb6ef3384007d8f857935139e8546b40a9";
+      sha512 = "f9d6ab4c713d3f3f1c9a2328290668b7b65abbb739419f74f262da090f2b88cab96fa1ebb768626b9fe84908ba92554a1c556281ec7c97f65801af053a14f195";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/he/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/he/firefox-51.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "ca90c15c7100b40262879fbf12df5ddb440d4808d94679fa6cd32b9579582721b707843d4c65b4593414e139a7f360b437741c627c3b6e1b238994203a2580b9";
+      sha512 = "c1129b0826fe24b3bef9b0e1464fe8e6116f595e8d201d31c1d442255ba218d3614d88fcfbf14c3f52ce7119de61542a49cd2b4cda6be92323006c59073e6d29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/hi-IN/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/hi-IN/firefox-51.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "a27ca89b01034d75719f0e736d82e8240e24cb5ac4e9a21829e72cf8ffaebbfcc6a8906ff1db93f392380481f160e748deda23685b12bcc647d7a6f68e764bfc";
+      sha512 = "0e409a2ad739a6f180811cd6df64840c1f35179ee2a3cda615b774784962b1cad8a35196ce05ff332778fdf250b23dcf0e7a157524b43759cc89ea39424dbd60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/hr/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/hr/firefox-51.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "fb91245060ff025230c3cfa45d15cb96974462642be3f86be44af108da966439575907f8a1b8665311ec599115a3dd66a4fbe09d4ac3f6c09a85bad64d7b2982";
+      sha512 = "159edb41972a2abb884c8b5910260554fed8d14d26e828f78fde9a13d9fc7a1e57803965e36e23173c224e02c49ad9d483729c72acf94e80824d4d74ecb9a694";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/hsb/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/hsb/firefox-51.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "d649432eccc384e4c83e292649008ffc87f82b41584d91d37f7c9ef4189039b4ef32f9209428051475671fe79961c2f142a6f44a1ab7d371e17a0bf34a58cce9";
+      sha512 = "190ed5d87aced775d35b1bf909c1c832a61bd6ec8c2053724d948952d8eb2a83b7015b62589286f90ca09b02acc75f904f46a5a155720e7b728e9cd9c3187a30";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/hu/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/hu/firefox-51.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "a07e3b8c9b6fc306e068ab6311df45d9cad475561993fa8c576942a3c94ba5677b291d7fb1c390a2b48b2a5c199e25053bfef556d6361fa482a13e17204c7f4e";
+      sha512 = "a45a9a5e6af526acaa23d4b7f84d91ead0eb581989def50d57ed82ca4b8aa00c0bb6bec2ec891d5c154d0f4472fd72e7bce9a619c1860ea27dc9dc3f627ac8a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/hy-AM/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/hy-AM/firefox-51.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "246fe80d9e73aec2744534b16e211083277b40cb6fd894e1cbaeee9f94dbafdacf912069917945260208f2446f080c6c90daa91ef07b3485538b5cdfb26ea1d9";
+      sha512 = "242a85f6329090814ed94a3cfea96f3c4459fe751e7741844104ad93913e5f3a27335ab736746baf89b06c619e062b5efe94de000137e4f26309cf2dacbecfe1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/id/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/id/firefox-51.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "79cb7fbccd0e6cc199c44a8da8a80fc91a195409145cba768edb02e07f11dfbac15774a67d6a088ed8569e46038b629e998185fa52e5d749d33ad1c91468c3e2";
+      sha512 = "3ee7915e8b8d6cfb3bb2714ee8c5c6d25e27e4612389c33a1ae34b230afef9ed24dc4bc2debbbf5c1fedeb60d843c1849f754050a0c1153db3ed6116cc7c0a70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/is/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/is/firefox-51.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "dc63ebf359f00a0ae47988e3ae868a92c79ee35de2e426aa9a15ae3fd3adc35cedbe957ac08e6a3af84ae0be9ead2d405ecf034c698626ef402e6eb01a519bac";
+      sha512 = "8df53c86d929fdfe64393d8005c4e5a8c1d7cc25a088699f26827cc917d8150582faac8d312e209e72d5a0d3ea53c17688f64f58f76944519df1e55d8fccb82e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/it/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/it/firefox-51.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "34a7a1e39c4d03bd43d5613091b71e1c817fbbb235f801171220f43b71c3be258958e0aaa860ba241c1bd27e2c7d473310cf32e14b02ae4e757029d4f51d7214";
+      sha512 = "3fc00fcb1ed9d024aaf87ef82978131333958661644ade9aba463247dc1c0f9110e0123b9a3ad050ad1eed449300bb4280ae92f9721e67809acd5fd4842b7192";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ja/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ja/firefox-51.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "a5b90e23a17e7c8582223e66565c44e9564575ece1df0a749db021405137c3b1593f6ca70c42bdaa97cc83e69d6799d84d3d3d1520f82ba236dd7c99190c0b0e";
+      sha512 = "0edf9c17390ca3f75441808f7b54b2f5b61028b641a35d296d7265acb64322827845ea089c2d1149c55514513a3c76903ea3ddbe5d1bafe7b8f1e35fa16ba5cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ka/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ka/firefox-51.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "ae8f709eb4222ab67111ca596bdb466f92826cbddfa42cf5134b75773f40d6d7aeb8d384c8defc5469b569f21f4e6e8f2208b01f1e0e33d2b9cbe79f06527e4c";
+      sha512 = "996747630e56969a5a1fe238a1503d33353c25202b8c795300bb6b6c5ff313847f85ec5ee5b53d6862d124bda0628c734098a446e62d229dd4858ff33c41a911";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/kab/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/kab/firefox-51.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "5090ad81a159dbddd37bba2c36dab62d5cc306c09d3df08562f625a43eb19c8c9456eed19290134ede37e882b2ee7be9b3ada037ce348827273ce05ae49977ed";
+      sha512 = "128e2f29ceb1c22376ebe81a494ba94d50a7cb4693ab77dbebcd5096ed9494758a989aa6db88274c9e397945f6b6cd8d2a94ba35ead6be05c1e78eff3c0c2618";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/kk/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/kk/firefox-51.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "01b58e772c65b233cb51dc9ff43d98c64727b02cd5293882271a25625728d9d1b2f61429ce157ac4e7eee17460722201f6d7b6fa6013d25385c76067136d963c";
+      sha512 = "6055133f8531df38726ec46e6a9f864cee6b04fb323c8008b098cf5fef4b1cddc1683bd94d8659614c3379a9cae38ae1e0a9f8e2f976ab0eda40d66a6a04f8bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/km/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/km/firefox-51.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "e54cc5c2516a79e4981addb237571593af0bd052ca8fc7ed5c7919524ff8ea73b2ff8857d9e6627ff3de5819722c13c3abf633759e9770cad1e04a2fbf28e1f9";
+      sha512 = "4ebc9142914314e8dbde018dcd245d3905781dfe5c31969ad647b6c6c88bb82dcdb1cd943c735f00130a1da26dd08b64990c51b1852465138e0689556b300e21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/kn/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/kn/firefox-51.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "79c827a477cf369c57fb51708d1d889637ade4b4ced1d60f8cb57c2b69519ef2b3ca8730657691953e7c3d660f4e97a2fd5f0ee212430ed9be4e2d9c90339b0e";
+      sha512 = "3444bcb239eb034b2d9d18b0b957c9ce69a7bb884e6283825553a1aabf343865f914e965ed8d25a7534ee0ea33622f85a6c13c48ae455703ff5322000cdcb335";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ko/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ko/firefox-51.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "66fe892eab193087be04ceef0a73fb5af5cc153b6218480a20f7ad32da45845a4d5e6a3f9ed130c6c8d2fd0de704c87093a9739233da444848b32b34f0d41445";
+      sha512 = "b81ab42cd90ebd07b9d39b2cd12cbfd16e732890b5b9abbb7753bb5980c2c777de93a2ee3415f2ad28928eb7176fbfc86e4fb59e6d01b2dc69c3652f49aa1b07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/lij/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/lij/firefox-51.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "ae85fbb36573e547bc35ce92fa82d8fd8359a38dc218811ade333d0ba7d02da17ac45490edc4b1ecfb59b6dd0eae31fe9e21c8154ae443f36b52c46e9bf66c29";
+      sha512 = "1e14cfd6d66e8fdf3397bec910be3cfa032b5653f5b0ed5a8abd5eed4e43d7ee81b51d933e1ec1afaf000d5c4dee2f2c091c834b0559be7addf0c706ac87e3ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/lt/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/lt/firefox-51.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "c9f9bdc80d2e4963c2e4416cc7387a4b5f1b95d5135870ff38d6be6bb01042647ff0df5061a91260dbf48b7a43bcad79d6b974e9e4df67bb0c55541027a9ef8f";
+      sha512 = "8c8ad13eb19ebe66f3920fbcc51e99902a66224f2ac3035e929709597522a29d65ee69d6aa00e0b6994b34069088f8e34abf527d7f23e8f216aa5824b8b0a200";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/lv/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/lv/firefox-51.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "5cac54d12457684cb5cd2ea03647f5bca8c75221837e4e241a4d86d25a99c3464f8f10f8489dc8afeadb4c47f8a2e0a73e78533362c488aca0987a61f75d040f";
+      sha512 = "0eca04ee8090706d24c481e7dfc8424fbba1106cb42565c57c2071c8089da043bae76294761960d23e0c52fa17b6bb43a74fe61c481875639ed956625d055c20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/mai/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/mai/firefox-51.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "274de5a51b2fe6696f3eb9372c7adeecf2e43b7c9e9a88c84cbe91c5cccd2a843d141cf89a816af3e1fc53e097da9902ca835608a3098a0b3c72bbc3cb0fe8e2";
+      sha512 = "7c033b5f2960e697ff21fe20be9e59e80906fc0b6e40edd8f12857b7e53c79cff2c3f5b90f084a11750ee4a9e8d7db014b40362bbf70d857db013929e3ce503f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/mk/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/mk/firefox-51.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "91f1b9336aaaab24aea8837c96214cf79c0be4e7e81ce4342751ab38cadb1f1fe294fee53bc3132fca971bb192eadd5e206069001d80391cfd35b00cd334c69d";
+      sha512 = "5af4666ba379a7c70ef23776deaef3a14724e2c4acd498702c7acd84548d978e2f563def0227152864ac047979b24dd6de601dd53dea046e7bb7555c914b9f26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ml/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ml/firefox-51.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "d48e26a22a81ff4655732f099aecc1c003d0930a1a73859ee13db4e866181e7aebc77d7fd816dab7c5574b0810089476682ef128c2fcfcc04750160a1e19b856";
+      sha512 = "acc0c1a8ea26e245d031462c9a535a149a3e99867f65117c427868920413b0c7397505f36fedcbc4fa3b4307380196abc04a6b4f50da07ca2a072a6add0432ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/mr/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/mr/firefox-51.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "bf8a614300090c4a24a37dcbf0d6b69cc114f346fd9a4b729f9de54be7a15440a49c46aac3a1b6b1321825d1e617bdd7cb2b1f48eb25bf9c6610d7040a1cef72";
+      sha512 = "adc68983863c262bebf01c3cec52690a8351e161b857fb4d12acf4b24b9985d74fc8d55c48f09410dc14ffb0090303c8a604d3f3f427c57d8bd7383073504ae7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ms/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ms/firefox-51.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "8a75fd728889a5164d1e610241f558f083e3dbb107592cb26cd6c230b44f52d8d9b3859fca04c1172f128bd7d809171f170fb81118d0e8eb4c64e6e939e68d30";
+      sha512 = "976a78fcc2db7a52353f14ee47ab80f7467675cd88855b22ad01ebdf3f793771adbde902e2e717f860d112654a13e4ebc0f9a93220166493df34e602176a5509";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/nb-NO/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/nb-NO/firefox-51.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "48b5e8bad93c5d6d7307dbbd790bdc9b5dd3e52a7b7f4f52d4598ccfe3fef97d36eed763394a7cb594682c1fbc8acb9e0cdab52f445ecc6f957bbb1cdfffb8ac";
+      sha512 = "7ed2c61c430ea79a21ddfdf6915fddfd8c3fa92f39f25483eb2ac333fc904e7a338af7318fccdb569938ad4b9f72bdbed94cbd57f56ce2cbe61d038d9df754b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/nl/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/nl/firefox-51.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "bd964b338ae332b5db9b9c5a2bc4bda320eb7824bddc4b6df87a05987b7f82fd8ead21e190d1b6bdf4daad17896612554272170d0e00c88ba94d7f03ac45a33c";
+      sha512 = "fdddc7f023aeedaed6494b2f67bf372284280c9d99bf77186150dab0882dafb185fadeebeaf77c6ba87cffbc409eb68b610cde39795a23a28635e68022a6cbf8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/nn-NO/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/nn-NO/firefox-51.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "4e534e4590727582273ee97e3889ecd7354a02210678a33fb80403438718eac6a8c213bb158f36eac438b85821c49f4a2fb32a79601ea12573382fed28ef7a24";
+      sha512 = "104e51e300cf628d36c4d5fd677a489b67bf197266787ad2ba531bc33869afa4b49d14a43e23ab7f1c750fb4f2ce07a0945dc779d88b21305545503c2f9d4574";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/or/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/or/firefox-51.0.1.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "92c182fe90312ad1f603cda7989b0e48be790c2f6cedb6e184fe85cba1d8e06b2fae309af86691676c305709fb08553c8ff0b32021b427184419aaf45e396eeb";
+      sha512 = "2f847576b9b4dd5d231c21526c7886c21b7d11671f23165263eb555233d89eded61a6a6f1ac4c56823d0a2649702f285fb6e8efd8cec86cefb84c94bb762c7b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/pa-IN/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/pa-IN/firefox-51.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "8ae2a4d0b8488cde54668b8b49895b67da9f43dbd9524b503fbb552baffb0714518bffc1d3f9bb94c7e00386ff5d2431a4fcb1cb0268ccd65b7d69057ba65bbe";
+      sha512 = "4fbec873e3eaa04a1f3842aa0865454b3f13ad3b7e2959fcaa518236cbf99391e48b638934f1950d889994f76ada4eab946c9f28f9ff07796d46d5e5c37235d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/pl/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/pl/firefox-51.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "26380ab557d16082ed012dbe781a168484825ac86396ef811ef043296c45569c89e38065708770633d603d5f4fee7e2637db00a2bc1820d8dcbf081cc39dd673";
+      sha512 = "4155fcaf556d5fdd5d4e74a3f70927035236432a83c9e20e4b3900e2c75f74a04d630ea7a74c0e3325231c36e0c06a32a36ced31897d36a15b55ecfcfbd53c21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/pt-BR/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/pt-BR/firefox-51.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "50761924143f0b619d47f93df04ef38d7cb689230d5b1dbc1385211f3f2a808816a73a70a75c4bb05b2ab8bf1ee0c1905c396338d12b1b9588830e19a1ed1e3d";
+      sha512 = "60e70d619c46ea9e7b8822a309f95bc51ad4d3cdd1ce49afb3fa0d7c6bf6f478a27e0cafdeed9217af1ea51b527394551a0ec6ee85ab62d59425c409c0a6d2a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/pt-PT/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/pt-PT/firefox-51.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "fc4b858423b8d0d4c5ca93951548487070bc4f398c993ee88e5d51c82ec808468d49f32f80a9754d459844a208183af4774d69214bee3253b53b2aa64e29d08d";
+      sha512 = "ebae124b88595082fedd8a692ed3e5399ae5666bfa92d2c0d0cb75bbe9c763679beb2cd27eb31ab99adec15f723ec62096bba028655ae094808a8cc05071aae8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/rm/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/rm/firefox-51.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "8680c7739422ac11f1f5728a5822376096de49c01005b25906513ed9eff262a5a038f4d69e2fb3d049b7106c9e1dca5c307ebdefd07ae59b11a3cafe13174481";
+      sha512 = "ccf8792db2fb2d0c3e26c2ab080dd6c03587b5827a77a15aafb6db1a2924eb8987b27e0c9ef8160c6e91377785e998926b69f3acbca050c79a8d5efedda7460a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ro/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ro/firefox-51.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "2d5c66437d2edabd40570d2ff22b146ec3583b7c40bfb8846ccee1b2570f876ec62dd6e3d01d3df59ba5828c910cc812c0c4f3c9ab1f872a19bccabd2f69e450";
+      sha512 = "af62128c8bc705feaecc52c3dfd15970e085dcfd7912e6a00e598f471a45b346d56530209869f34069f5b7830ff0a486d5bdd0b095f7a9a6285ba9ae9f2aa2a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ru/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ru/firefox-51.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "4ccab70b429afd51f14e398181a08549426c1c73d58b3610ed36a93675ac34f72526f01a1fa3b0d1d6a9d3e9c42503759de73877c5e70bd53a0812da2eca3bdf";
+      sha512 = "f48264fa017ba40a0e43af9fdf2c3591b2337b09ac5146d94da16a2ddee0a5237dd1d99210e3baf94b949ac03e3cfe04468fd9ed27543b62d3b0c10e77835de6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/si/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/si/firefox-51.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "113d34f2819b4a315764128a4dfdd83c521df2c91bf2bd7b264771b6d475a1a051396d5f6382d60d6f521513c265248f54041e9fe45f0f40a6cae81393cdc77b";
+      sha512 = "d4496babb189fc5077b6c6689a54258534b94ce7034cc57a2892f2164e10eb5ac128b905e6e1e5cb6ffaf3e15ac7a0b0c141516a5e03b58ea1458fc3aefeb904";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/sk/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/sk/firefox-51.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "d6ff2bdd96f3a3f3f14d45bfb28b08a4db48db3be570c19a79ce226f243366e698aeca1b1682ad216c5e0f9d0edc6c2116ff01c6bd13394325e922d8afd3b98f";
+      sha512 = "657dc82b1067ba145d8431157411dae31420d0fa3145005319d7978736a7faf48aede2dbbeec1994d591c0ba54293b83340da5105ca298ca79407015ac90a338";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/sl/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/sl/firefox-51.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "296fd1291590fa677ac0208f8d555586b5377a575845d6d7e066f46b541e523166b4be4ea10c69cf4fc043abe2c73a34d1dc670582b49dbb15588edd17d15ee3";
+      sha512 = "d4122054acaf61d4258ed5646296702d68d869d96a1d39636ea1ee833ef4649003fe76173be4aac5e829cb946dfac709c69c82d668729c2b75376067300cc06f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/son/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/son/firefox-51.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "fd3462198ac73d24db0e17a8bd427d3798adeb6af82a775655265e91bdec90e53c49a7317ad98609f24a77ca540cd5864bbce2283e0a82c64d0107dc2a6cb7a5";
+      sha512 = "f74a90d235203adf179c4874a8e429d3618effe4bd5d8928318b74769fad093c5e8adbd69c7629fbac108d13fd5dade65e268dfd419650498a0be3c925e5088f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/sq/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/sq/firefox-51.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "a8428c4061730e089621551006e28c7caa6381e43c443e40a03a91fd5bce72ed608b5e49a309597547913767e147efc4d7be37e645f6372bace1b445cdda76b5";
+      sha512 = "815df30c1180c9859a3ed3c34daf8c1ffa434ccddf356691b92bf7db7a3daf6e7e62446d5720d03fc7cd98aeee0eead2e62def2410cca6cf25fc7f139027b8b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/sr/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/sr/firefox-51.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "2f946bede46671690652c44dda2df106d0f56c4af7a40f61c827b7a7c2126abe3082843eede2fba251efc62c2466cfc42cc7ecc63cd63062ccc2d052ceed21a1";
+      sha512 = "70264d2aef00a51cf773f1643745b84baa239bf7cd8b32fade26f7d8f56fb7ad00ae95922bde87e2ce368876d3946f7193501314444ac42c69ed0c0d9c811b65";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/sv-SE/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/sv-SE/firefox-51.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "a9c9d6246ce4a3af9277fe8ef8d9a8f3b4f7ee459c525e6b5e93a6ecface87db56ba01a3e1407c9a638f78fef0684a27328fd00e2ab4bb43e56f28db0e333cd4";
+      sha512 = "1252256ae15324828995d9ae3f1db02de62ed78f1fd127a98f63b0122e52ed3d526ce2fb83eceb704a11c6e113108bf58e44d88254247a523ef53a2bd35ae9cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/ta/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ta/firefox-51.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "02f45309ab4f2995ed2404c8cc596d111dffc54d391c028960f4c181e409cecf4117dc1ae8aee900f7ac72c29109d7bfa5bca228d35a1b5907e25fc748aafbeb";
+      sha512 = "f29232bbe2c154e7db72c6f6a510cc113544c0f78e362f595558a4e20a9f2e7a211918a96985ce54cf88dfc51f701af99dd5c6db1719763624d038ccea55c713";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/te/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/te/firefox-51.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "897448ac3dbf5ae75319feac7c32845cb2c8c60138df429f0171ae71b0346ff71efe005f3a6792087104cfabe6843a9f7e5406c26de2eefe325d4ef6ec172021";
+      sha512 = "5fadafe8657fa30af9771603c369abce6bda416a725394282fdf3443b1b50e8078212c0d016a146940e5fb5d3e485847d4754c690d81f5cb61256abfeff3e0bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/th/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/th/firefox-51.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "262176b096a9025681f8b3f191ad46d8f0b83f9ec9abe9c34b5da4fea57ec2720545957041e3ff1c1044b470411b158d96785315bbe7d2c8bb29cb00c54facbf";
+      sha512 = "9e831d2a54a9bb5bb6be7a07163395755f1a5fbeb2515f57e28f714c6480497d9203c49356849e908db5788427ef9a6be1bd90c36c787183e6cf1aed4c3627f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/tr/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/tr/firefox-51.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "40e948f12456caa572bd78e5bf8d089428432653cf5bfab0ba23dc120f1cc36f370f745f1965ab0687f41f7617da78f75aa4429f51e5b650c7bf979f600ac5f4";
+      sha512 = "4bb5562a2c4e0feb215cb2d6da6f793824a5622bbe245c6d87c19350e3134e1191474f8091063b2c8e0fe63233739035fa6d92c330892c5ac6ab8d6457390c90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/uk/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/uk/firefox-51.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "b82936161c27b5bafdaf340cb26c49c14bf9b3ac39e1831efcfd51b968ff4bfc953f8aed99ea6aa1b23b1a73129d221f0ec5c55de41dc81c405a531a4dce0934";
+      sha512 = "42f2e6cc7cd7f6f2af6cec1bb22645df65f493bc432660f72af74a16d30afe2dd7954a1fa2c6b8e1471ff813ba6921dd34483b32d6fc849c37c3e1c549cae795";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/uz/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/uz/firefox-51.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "b096c35ee124320ec625d3481015715570d56d6b6b4490c818dd40856bae4aea21c066c18bbe2cdd267d92716d8ed05e9cfdd34e12ebf4517d2b835e76a2c8a3";
+      sha512 = "e45f93233461588cb89e3e8b9d0c52c9600835c76baf8bc44886b6f230ba96f189068199b0f5ca5fe15a92cc2051461edb13e5fce94029459c2cee7be18871a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/vi/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/vi/firefox-51.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "9802425d5866ec036c542545e9bce34fb0e0f80b9b6146bb36a5999a02787095c3e786b9b7e1173f992c054caf8716295bd6084f411553df35586bf725c375db";
+      sha512 = "445e13bd76b01cfe01c6869139d896614931ccc37754998e063390788c2fcabba7e4e182fe8152a6c028477fb21619f3fd18bdde1dd05bb8dd84372db922ef0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/xh/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/xh/firefox-51.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "afba6b174855327a08d404b555a41982f6ef9f42d1067be40b5cae2ba5b62d232faa70936e02e7a313938b5fbd9acd3fb2af5cbc51128c47f2d2630f052a0741";
+      sha512 = "9bbcc96b73024fb0b618a373f5b9e64943e24207fac2e1504b25daafc45c08f2c7f69027f5a392c0e6d1995b8ff54742cd4998af039cd89bd376ff0008b61551";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/zh-CN/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/zh-CN/firefox-51.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "fd952a6e825784b19179e2214755659c31c1be15ad8f42bfe4fe4905b57b5aaad7df9a0c0e9500ce75eff3f12743bc309dff10f9fd72a5849948e91c4d3f58de";
+      sha512 = "6242bf215048a46692062de813f8b0653b8ba9efe5f39d5fbb98a9f73309c1e6af7f9095cb7c7ce7ff8c5b1f1fd8bc6a57bb420b6679f26ae19e3622f779d5d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-x86_64/zh-TW/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/zh-TW/firefox-51.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "8b9c643ac91fcf01e6708a3ebabc735de5dbdeb8897a9d57560d69c04746e2a9b9902ae356416435010bd4f3e5241140b0a27162afafd5ee5c097f41dd34cfc7";
+      sha512 = "37664a08df20a85eb5b5551eb206c4bae7e357ca8fb9de5472e3a52156a1fe9711335204e7cc88766a13a50a64967e48c55a99afec3f08ffe46048a5f68ec538";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ach/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ach/firefox-51.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "cfbfa3136edb8786e6a573b4af9aab3250b3eda10c4a9bcade7e489e3bf0cf4761339e811397d938b46ab5cb708531fb036bfe379f54c4857e31b91f003584be";
+      sha512 = "9e7e313b7e8a37da5678e2fc6e2b810816f3c5f433b82341c351922ddc551046d6668aaf9b983ab63e6240f97b543169a0cce165029c4c1284e6c715313091dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/af/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/af/firefox-51.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "15e9023b2434c037bc7f0871d97c0371a78ac5ca4981b30f7f9b95202ca299f3b23b07d711c1d33bf3f9d58969816bb2b06c77488ecf9812e79ad2158b9d102c";
+      sha512 = "6aa4de8f06c227dd22bf1e1f3f8f4572aafb499e3d30fe5b528d24ee905d8770d177d8ed954e1d3e8ad94aa6e716d31918cea0a7194729db2dc51cc40078091d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/an/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/an/firefox-51.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "6aa27e98598b8aa89c5f4b09bcbd86722e0ce3fd54d428814ccde7630a1a34cf593550cdd201d0d4dab53c3f185ae82ff2edae9b10f63d0773c494f8b89be931";
+      sha512 = "2b9b54b35abc72edfa64d957a9b0d95cc5713a4b36beac47464d4947a0a2e640664fecbcd8aa579df2353f6836e0f81d4674fa16d33e168a4adbc002821de4fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ar/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ar/firefox-51.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "1a4ef1198431566aeda1ead37c7af435834ffe60530e078463c7ec239a1b9cd8cde76216f90920628b7db12459deb25b9b56907de9f29444fe3c70ee02d76624";
+      sha512 = "44c966f2563538178b1cd0950bead8d2df67ec0425ca7327e9e4e2cff7bebac06aeae5d26503c1339d7ac59f2e01520a6a1a7205d948d8febcc953bf30d56af4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/as/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/as/firefox-51.0.1.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "028353834513d8b693f1bc053dafb4cf31f038b3c2a58c48454b5990bfc235712ba5c64da0390a9ede4a046167b5ddb5aa24cb86be5ed8272dd7dc5fce7eabe6";
+      sha512 = "99cf367af60162c073783539eb99afda545cef701616ae33ed66994c00052cf90812efd5c874a8b98dc2c51dba8330ab8ce99176858f6cc5ae640ab2fedbc210";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ast/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ast/firefox-51.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "be3338ad2a7b86bb3424984860009f9035888e86dabdbf5beb47f3020504c888d5aead0b7f818c00b373a33a73fea48d0d4d9ac549009f37a897f76121bba667";
+      sha512 = "536d4bde6cdd888bd06f844f16d16fd15fbf1a7743f8dae2240414a348e64568959a7655f0f69a0338826154b959066e1d5097cb51fb8e59f6366a61c6091b40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/az/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/az/firefox-51.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "c775af957145fa138761bdf0d5c8e76b59a0c496a46e9bac708fad7b70741b337e2d639bbab9536504bb20bf8e889fe516d129ccc301df6a405ef73c6d5d39a4";
+      sha512 = "4c46637588a9b0874e2982ad4130bc42c3a4b2defed8ee81e4e86b06deb66bb9e9b877c381de4f247e8e13992891be2c5a01dcccd7b62655a26fc62ddee1c9b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/bg/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/bg/firefox-51.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "2e38d0de9d284514803afe24e697ad4491bb27b386c0a0d032db5e175d3b7d2dc1a3f29a874c9b9661951817761588491578025adf675545a7e3c1f1396d5efa";
+      sha512 = "a8fb6c9f9c7041e833b6f05944b9769cb38565a773817962dc7cc0698c85b15c5f9dec6b354edbf0baa34101d44d33057e6bb78364ae294989b3da8d88b3c605";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/bn-BD/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/bn-BD/firefox-51.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "cba31a0dada3915105ef0a000040040f10cdb1908402fa41065266575db5ee7996a49e373f289524216b7e2d3b65fbaf1ba201bf73d1d5a6b844df9e5b305ed6";
+      sha512 = "deaf8b9e7a825c62ca4a7135e070f0be616e7e9b4387976edd7492f4b40d94a57ff2db01d5ad2546831fde9a7ed346f298ae3e1ca2c070b723aec9cbdf0260b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/bn-IN/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/bn-IN/firefox-51.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "127b84f3e3dacd303f9341ae90239a1077039fffbda642c619c1225fd13687f4e5068a111b84b02afb61b36a4fc8fa09c8ff9979eea263c41e8115108148d599";
+      sha512 = "da97d24ade2c241ba37ad20b1a6efc4a3742c218e4ccb8063e1255afcb4e03d77cb3f14b5591e7235ec42318f3e509d3c6b48a9bb94c5ac2c5e82bd270fbb3e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/br/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/br/firefox-51.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "65dfbc7ec3c54000ffff66bc28191fdec7e29df43e6856c81a999adc1d8bf17c645204064932548b47822e779125ed171ab8d22c02ade3a64ce2327d3b4bdd94";
+      sha512 = "6780103e36db348986fc3a442bb32afb1cfa238a800eab81d6b0629452d6915a6b199501c53730143cd4fcffa97a96718dd6be10a3fa10db6145c7dd0c5663c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/bs/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/bs/firefox-51.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "ed542247e77146515d5a808d745769cd0f76f950ec6029e2a7673d2fe520e2d7540921f5e8c9c6c7681d2cb08f63e742272c3f4daf55c6ef0d8e46195ae597af";
+      sha512 = "f9a0bb76c68ab8d78e095f9e41d95875f76f2052e9ad1e06dd8b6d16a70d35db91f109ad20c3c904b1a1190aa5c851cace0c56ac253c72b97a2e45992d783014";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ca/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ca/firefox-51.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "0cfb11b0d869b0466d477ac99e4dc65ee60f0d2d08a8af307c2c149e2d10bd8df17b16024947872d5b4513ed5b0188716dd5d23132429a180209d187b62732f5";
+      sha512 = "b246544190cb1d6336046df019a21e84d7cbf360d96e4b9259379b5885e870e55041916534987d12cc7c215c46524a48ea8085ef09f2d5286adc76be4070be92";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/cak/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/cak/firefox-51.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "92b08671ddd98e4ee1158dd0fbbd0ce0d45794732f34a3ad43f8698ed2085fd4e1b5124da3ad47fb1ed01ea372655a3d04b82200b8af5cc0ad997c61dc2dd855";
+      sha512 = "98ea4dde99fdfe6f1b18e39f1d5d9eb5c805c7f6287fe6c1206b71622df184c57982560fe836493d351bb0ab6fdd37bab41e5f89be2a18a6d705595f618a507f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/cs/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/cs/firefox-51.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "f5bef965360f84821f3b39990c6dcddc12f52851f1d33cc8d72d8772e770ced14784a1e29667b7047f3c9bb9510086eec2f16d2a4401c2b0cafc6b1275c00b28";
+      sha512 = "7b8dac698df7c415ad1b200ab437119fa39ca7a601c241145c0f2bffb89a5b97210f4f2173ad626818f006bf5f7ff5f3571911a2058f224326268bd53f11cee5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/cy/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/cy/firefox-51.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "d6bae2da5f69e95ae8e751653d66917571279f44810666553bb7dde4cd41af954c0002276afe7d28dceb83210877bc19db48d7fb7498cefa256e609201e89db0";
+      sha512 = "30f1f7453f62bc18cb65d76590e6a780757600c7bef187debde4a1f68c1355148fd2dc4b63e5b98f6516f6542b47c1165ab594dbda0be4c5a2dc6a8d948db4d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/da/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/da/firefox-51.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "bb705294c74406eb7dd50dc6a9b70acc7db297e1bf4c4087523a5f6ce653c0e98fac64f0b9bc34442c8cb8d2da3e5077c06b72495a83ffb0a1c5dac04cc3ec36";
+      sha512 = "00daf69b001ecac3fb11c410fec9619e7f9b9ad32fe40fbe1baf96d555678d3c6addf78d55ff6c607e525618931e441276967b92124fd8c0ea5857d2880f8b31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/de/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/de/firefox-51.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "c77daf84ee3bf5f3d04039f897c603cfb5d067f6da1dc767d2df6a29a7ea479ec69814d9e7e83be94285970b69ff700e972d526b5fe029258a3adf592688c1a4";
+      sha512 = "0c7cb4ea4929d7f807eef1a74ed1e9324e2e14c79651bd6ebce523d9c8668111304556aab2656ecdd6fa82028304439782ea9f654ee2108019fa5238e707b61a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/dsb/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/dsb/firefox-51.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "c95d409c97e65e4ae8ff5a57c1e626b638096801c04eb70b3d0f737f7ea66c0572327760db4595ab05025b727df8be233df3bf79e9e79504df2b7b26423af8c7";
+      sha512 = "53c2ead4d133f3b69ffb32ec7f6ac037d30e313cb85a6baff97ca997e3fccb0bc44c7258cb21e03231cd2283d8cfe50d0f6d1d64489a9b1e12e0a69fc57d6271";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/el/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/el/firefox-51.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "0008bf61cbaf9f79318ba48ed34e5d63e26cfe8876e7faef410e5953b8eccef9ef2380a8796d0fbea326a6ed8d4c1ca4c437db46a5b8981d7c05788d054bff58";
+      sha512 = "088a6357c7e0fbd0060b8ba1369a0611c896ea2d5a23d4d38d7803c6ca9871807d9453c9a831762f27cdaa43a9827097c344441d2da1ca03aebbef922d0b1e31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/en-GB/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/en-GB/firefox-51.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "7069ae86235e354b0485c7a2764915138dd030496340fd4717b37c47ac109e452a41c13450e7c1520d698f0e2aa036919516a6473a1ee5c3f6e14fb45441b7e6";
+      sha512 = "e65c80fdfb097deb980df7021908e8db839b82f89b5076f213a562572e6e6ad7072fa88cef68c9d1e5c6e21925691e90ad6a9ce96fb4d71b3da4b52d11fb457e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/en-US/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/en-US/firefox-51.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "509ce17388209ea19197ec42bee61b4cb9e31d80a829de3e7f751f7cfad9da5d6ec4827ca47499e40662a1eeaa4c74726ab687440a99f9c0fc81415916aadf33";
+      sha512 = "119643dda37b8ea552450302aec2b115c2fedaf707acce9ac314b464f47d03ee76358f63c30cf788298fdb6a25af0efbecae1ab1e72d2cb53190c648154b2e4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/en-ZA/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/en-ZA/firefox-51.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "30598fca931008beb5f7d01f1ba24f61192f2b2cc9e8cc073f7ab3318b4b5c82ba4abd9324a46126ab9fa7adc7d207947d63eee8211aecf7cb5d5d360dc7284c";
+      sha512 = "adcbbc09fe61f04daef46c673b4b7e294ad8c107b76ea1a22e46a1a5ab5eb3e84aae711c7b9edc882be67c529abd26f6183583da3423afd152325a98742763ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/eo/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/eo/firefox-51.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "c887c7819cc2115a637f5454249061ee8a1b9733a11c70f0ef0e0ee0445c4bd072cd553f39dd830fc841f9893906a721b1288b1d7edea1ec437161ec5db1892b";
+      sha512 = "247f1b6f90de42abab245390a8a66fc7095ad058b6cdb5f930efc77d47e6b9c1062cea0367c266a192c64916cc8cf8fb55b09c35f92823131c22c35b0305ffac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/es-AR/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/es-AR/firefox-51.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "3167d335115b1861debebb96fd9b190c959fe6d89c085e0c792bb33243cfb7fe80d82a1360a72041d5df422342b3abb4c97779bac85da1caad3e6ad1330af3e8";
+      sha512 = "4c456158008b7e355ddaecde20cd655b772164aa976abf612ac021ead6aa82420284dc6f16327f79cc12bd9c66854b8e5c9a6ae05f53b4e9901f0d6eff75d5a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/es-CL/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/es-CL/firefox-51.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "1c6cdd5f526b342b234a007d3861c54326edfcea40b06ee691c1bd3d0d9f49c9b426e98286a85736f67d1b328dedbcb27a80610cee63d95ab1eefccce166e723";
+      sha512 = "de45a4d7660416e8da164be585c468c24c4b80fcf0a602b93cd60556759aee619d59d08d58e2ecf28e86e5de31c2bd820905861b441d9ae1bba693204ba67779";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/es-ES/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/es-ES/firefox-51.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "d9ce835f0125063d0be546b9507a9ab00c84ddcc1a83f7a4a4428ec26e3ce5a308845884a6488212b5abe8901300e976068269db03de45a6bb3b684ba9a6186f";
+      sha512 = "b3dc903cedf008894c3afa52e503ca5266094c4766925b725f761d19a0bf7dad0ef546b36c9581c4b42de32ecf8727f752b7d3023ff97a307049fdc54045bbdf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/es-MX/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/es-MX/firefox-51.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "fb31254aaf29d8f843576d3dd1f7d9172ff3f021efbe862aba7409fb9b6269107d982219f519778d1bf8e984589b034fd948367f7d6be7c95b778aaf6ed71db7";
+      sha512 = "afc6090847e00c1ff9940516e7d15c048295e30e1055f9bae7f07990fb447d7ddb61a4ffa336b6f2283cadc972df86fd59f5abaa07d0399d999b8fd0c8d8354b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/et/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/et/firefox-51.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "24b7e8070c92cec844fd13e5fbab3abf549bb2685fd7a09397c8a6a0c1742fb58eaace43542b3f7399639348a5c34427f0b162114cdef99946e673108e899e13";
+      sha512 = "1258aa0f0eeb2902ccf86e5aa97e5d174e926b57adfddced2667a9e3253a103866431dcded2ecff7411ff4f4e1866aef133eaca0921738a0bbf4a98faf813880";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/eu/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/eu/firefox-51.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "ec30e182f42fa2c3a6ff09b8354fea55da91748b9ab024466ec5fe9dfee47ba0b8732d43c61858c4e46a48d8bca9b45a03e972afbcbac113640b44951a67b81b";
+      sha512 = "540cf167ac1739e1c90290dfd0faec82924cd80e1db1d700b9a7e4ebd064895830b1b5675c5800eb4e5cc8042373e5e1b174d6fcbd0751204853e94809b89d5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/fa/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/fa/firefox-51.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "89e96bdd179fd5e3aeaca6967fb40c1c3310fb390fa62a4dc7ab419cf57ecbf11cf57a01f0ecde64a387a784135f2a6e90c7ff1ee9953508fafe6a8bee236309";
+      sha512 = "0a3ca143ccac6d9fc950d9345839edeaceb68565b5f86706c3f39f1cab5aa74699f1f573c6768869bcbc0335042f11a8651401a0e6cff0849c36878b08e58a89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ff/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ff/firefox-51.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "ebe06e58b607791f91522314558506ba4179a23cc3ce64418bee68aeacff6680571013a8af99645f53761564b5b8672c3ec39ff879731c37d2ae69cc81144879";
+      sha512 = "fd2588b2c179cfdbef55f43ca11218673a7ec818cb8e5002ba7d6957ac61dd4d1f296b00f2d39de85a14c5fffe3500ba939edadd15374e0eb6a9183d3fb4a856";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/fi/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/fi/firefox-51.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "c6acadf1d77cb9b82918dba4ae6421bfd2054d20c852a08bd28e2f908a6d2acaf9c29fe6b347e9493fe2ff14a5c0e9f4896d1d0a91c4f4c23ad7817b1497eb04";
+      sha512 = "6dac643deb4db9139c522abf0b7cd86910d9f3783c3a7c41c60d2f017af742b495d64dd80e5945f045f7ade98e2668a5b5a684f61fb768cbc6ad7a22975a2246";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/fr/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/fr/firefox-51.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "75f0efa7a2c4954dc86b5cf4b0e2d2a38bafc9f484d9cb455168ad9b80b2e8201175d5d1ae398da3fd2d5fdcabeff881fc12970cbb48b33175d0d180c90cfdce";
+      sha512 = "161bd06d7299a8dbc08e767c043864b77670f6919f028a746312709b84808d56d5f38558a3a4ddea19e0ebb03f283d020de8c60df9a2e7d67468a1d96fd08dff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/fy-NL/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/fy-NL/firefox-51.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "77e76e4f485a886a9e32c9ba9663a51d0bc25170237b48a5a42bd895592ad04170d415313eae2a7573495d2a15603e5195c014be621bdb6e078bc8d58f668bb0";
+      sha512 = "b77fdd714cc5076981afcaec137065527f93e500a074b9a0beeb7ba85c78233d9a52735648688622f9a1e137a4e097081489d6307c5454330ac931e57f2ab469";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ga-IE/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ga-IE/firefox-51.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "0f9745299df4b31137286ee985ea526f33a127fb91a6568f7c2fc922c44e1cf83cc6e728fb1f05c7e68d3365c43045c61020261318a76100a716b7d35948bbc7";
+      sha512 = "265f422077a2ec1bd63a54295e6581ce1a559e9aab5b59cee79b4d38e1a494c6d15a7a1e4a211bdfe1c5671457a5ec8a8d67b436f31165f7b27e240bdaf2aec4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/gd/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/gd/firefox-51.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "fd015052565985956dd89cd96b3f3148704010529db96b3f68a7eff3e78c813ef090d79e9b112710439fd07ee3c0745c1ecffb708a62c9b5c12cc40b4ce05645";
+      sha512 = "a0f9b3f528f189004eed28ff2a9582e8a992c127d62c20514afdad69bde793a6f63a12bd92fce9d900cf600147b0d8c462d69d2d9f48613d27997b1f3fceaa8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/gl/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/gl/firefox-51.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "4cd8b4aa4f5f450c7a8eff57592cc584300c64e8976544e5de3c16e358330d5db91c5ce504a2576654dee2f80557f8c439e359e8050518784846f0f8b9c36dbb";
+      sha512 = "605fdaac3f85a2c64eeec3373fe8a6ddcf78529398f76f5c2ec06a10ea783d2a7962f03fae9dbbc08dd7c4aa8eab07bda55cb2f2f477f4b9971d7149d4a72dc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/gn/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/gn/firefox-51.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "baba3e61db17d04224c08595de42c4c76ef7e0c05e259772f8265c07f311613552024256ddf0e209358be3780d3fea97b20854284b3a15d8be3f52193df86501";
+      sha512 = "126eb2659750de31bdd346a0e1a255bcc1bd3e6e310c3739f5ec345a95cd2f1f78e381f6ce3d9a1079d3dd07ebc4cbab4af8544db746f42375f02e6a224a9b77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/gu-IN/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/gu-IN/firefox-51.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "5423af4164dcb39954cf32f6ec6aca508d06b3fde8b9946ce9adef03877625db3567000ed5a1e812c5accefcbfda3c89d332e7e3cb373e89d6d7e3be664d63e1";
+      sha512 = "12e7b20d5344d9b866392814aba44ded081c200543ff7db4653df22358f4627b9cb93f1e93ca546b3eef864787342a02ab996b10248eaca8468b70f2347c358e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/he/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/he/firefox-51.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "7ed6b2d4c108a3a6bfb146bd35682f5c7ddf1c2f84998bc70d362352d6e0ddf2887bf6c84d9dbcaaf6289cca0c29036c4295d4d3b45c52c613ad8a9ed51c334a";
+      sha512 = "1f0a125f1febc79218cf0bf929a6f6e3ae7c0046ad738cfd6a4ca84cacdb4a7b6a52e1934ac6b9dee25860e23b944d2636a176ca47439e7920fc45fe026a88b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/hi-IN/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/hi-IN/firefox-51.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "f85636573a871214848cc1785adf6b57a993d0ceea7920654a5b6e92fea62ef91a637a2baeee03e2b5a54469447307b2116dc85338493756768469920deec284";
+      sha512 = "cef6b463aa184cbef529c985e916f5ccf33bc4d8bcf693c685e92f4b211044efab5cd9966eafe75c0f933c716c3c519fc3df84653cecfe2a8452025e2674ae23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/hr/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/hr/firefox-51.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "ee4474ceb010040153b9527b4455846b4486be09d8ffbb5604021ace790e4f8937a3ea358cd81513aaa515d5c546f323a309c4afb0acf8092f88d7ab5b4ef96e";
+      sha512 = "591e79886225686fcec87dfba67548decd953ebf8a06005e76ddcce545d6b060300ed7cd2e8abe222a5900f3dc44e81036356bcb7471a9e086a320946cdc8cfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/hsb/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/hsb/firefox-51.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "bc67effad488c2baafc516e51faa2b897d167dff34d8153e4cc3af6069a1621284f497c8135336bb4a52294f4b3cb0cf6aee165fe2a0b09106948a0537be7aff";
+      sha512 = "722a4f539dddf2d076d2e6eab4c5eb50229bdf0142473ce13488e106a115df2470b381b6f68827a80febe200a274de9a2532cc27ed61498051186e4c1b6e6e85";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/hu/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/hu/firefox-51.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "0b38ef74627415300a6575f73c9bfa8eaf5672e82e98524e02f9d79a98d817b217e1238ce485249b0d094903d88c545e1e5469a4a0593322273db5c88e456a01";
+      sha512 = "992beb0c027990939a0536fcb77dd6a04f3cacac584df3349fc9ed3c06bae3b162bc530c1a4ec26a39240f8db0bad84686d4352e273d495c6d0f69b23ddbdfc2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/hy-AM/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/hy-AM/firefox-51.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "d492943011b7ea58e211d4a4d5cede973d02928519849be8cdd2287edd92b45d963368dfa556b811cd1353f048e406a1e907899c89cab29c7e28200b5518eb15";
+      sha512 = "00ac6027b5dac840325f6bb21a13383cfc417827eb14e21948b768062eea52fda1b3b4c9d87e39255dd8a21d05e1120d0f39d3fd878edac9eb93c698be0f7682";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/id/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/id/firefox-51.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "b0cf8c192350878ab3502ce077dd0ac85f21329b7bb96e3d3040cb959b20fbd4a21c315d8c2c528eadc9388af63e8f2789b3fa610269e658145afe5c4069d834";
+      sha512 = "3d6a12dfc4377cb180d4231c26df99058860103aa5395ff777799766f9786093cad0fceb9b72fb73325d1d1aa60b26e9be4cdb00cb875039fe2b0ec455f444a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/is/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/is/firefox-51.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "28e18d3978a7c4510eeea68fec06014e8ac6789c6297048002ec85317e9e1a304dbe530d93d970bc1f4166be91f6ed7fb4961270e91533dc0d9c8314828b06b9";
+      sha512 = "fe74d79704315a2d8568280e56dc735050e91de4467989e81db3b65a6d42ba9c6401b1aa0e50bfa3442c902c8b5b5feb3e9d39d31ada0266f33993ab9fe2522f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/it/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/it/firefox-51.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "76b25e5ce6fdc96143cbe20e348c45e13c519e0db506ad8f39084734d33bc29dfcb6ce7e4e13c33890c1a6d8d69ae886324e63ef9d3c697f97713b8f4b95f65d";
+      sha512 = "60b419cff2d17621fdeadb7b8f3dd5123a6a1aec1cae8ad60ed0e516d31483e7cd827cecbd10cfc8262b662c7950097a6da87c873a0c4cb4faa46c08b1467410";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ja/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ja/firefox-51.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "01887c81b4806356041be5ff3c7e2a5e9fd3903c3ec3ab8c2f578799375f19bfaaefe18bc41f3055312a7654f91b67f43d1eaee609024cb83a482b05238cfebd";
+      sha512 = "43486b8e0044838e0fe57669e86308081a6a9f6e5dc77ea3cecd881e9dea95f9e9bfc7bd217f0ff6bc9d2e16d2bb7ba193e8c0d5fe8a76e5c7f74971a71990f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ka/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ka/firefox-51.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "595e766c2be521013f755f85dd33c9aef3deeb6824b170fcd948d6d8afad556d4b6e6772041227bf26de23b8a103c39c6c62326c6d30454acd9f73706c53780f";
+      sha512 = "f94aa635d7804ea9145e88d2bb6c9ba0a53b33d02def9821ddb9693f2461858bbe1f05b26f2a60b019743dec3f48305fb4fe2f8ba249e9baf50b13c25fbd38ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/kab/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/kab/firefox-51.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "49b72ae5e248d55aa20d719b57ebb569ef7470761aa5358a9ff46e495868507431ba2d081de2ee170cdaf7d6c5a20aaf5a3a463e0ac8ce772a7369a5049b0aa4";
+      sha512 = "a88287ed1d391986ec290c09b7b04fd484c1ea6b78669dc430ff8aeb63851fe8bc5e51896a8afdea648aa70f9bbc7f8d3ee82868766d2477d50c23af21d17640";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/kk/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/kk/firefox-51.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "04329c30d403a516ef459beb9290c0dd3db21de2cc3d2258423771146724dc6ecb97174d0d55520943c5558d1160974937de0d6f6192ef85ec9a23f1770a5217";
+      sha512 = "0170abbaf6d9765c5bb6bf8b1667b51ddc8694f5470884d864b259f23ca824233459cb5a19e8f2411d89df07bc860fc89a16d7ace3f87ceabb50a487c5829eab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/km/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/km/firefox-51.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "7773700766cd12c320981b97510743d5414a0ad4c0bc3eaedf2dcd2f48a8bdfa367f68d5ebfdfa1f9df19fd3596da17b249bf41fd9ade6ba4d547dad2e2ec8e7";
+      sha512 = "c7239821e3aafbcbcb8c8ad46e0aa981ad77725f034105d6aa0566f3375639b77f9201391fd91df440a402d2465cf000695e495c9e678c5dfa66c085b7fc09e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/kn/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/kn/firefox-51.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "43a84c6aa11c9672c3c5a248306d1cf386a37a14efe5bb3c6e469d6dea8c52b31d4222ff9b54cba4a934569d322b2dae2942acda26e91f9a1eb63000f64ac9f2";
+      sha512 = "8088cd7a361ea4b231b61d24b289816f8c5e689eeb1b4f063df70d540f44065a0e9ce284db020a44704b48e2276dd5c555537380e39d2854327a64390be0d37d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ko/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ko/firefox-51.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "4d7d43042a54e495be869ede9904f54ed5dfc3685a693564fa1fd9805fecb5d617659eb68b09f21cb8c976369f62a9e76fea56111919ac4f19b5bd4252916716";
+      sha512 = "676ac2be52a7980d007f498e3efa1574d68415ee5b8648597345de22b6fd80df483d9b8a309a4ad22f4a927d45d1c9d9b21447fdb1b8fa57f420227da5a72c18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/lij/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/lij/firefox-51.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "b8388bfb293177564c09509e8db3f2e2151fb735fd4ddb55adf0045ac096e5e17753632ccb8866e08a0b5fe5edda967c1c9958c7361907bd08b1b27191bed729";
+      sha512 = "e93d9d9337299528d569810388a5bc1dbd53d083df090a9308d4cf60f138aea786f7d96ca8b62612252deaa092176cdcda5280e04a9b680f3d63a166dc2478f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/lt/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/lt/firefox-51.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "fd9ce324c49dc042be215167272eb7f81c653e5a03dbe09bc573dd1a8852406d0f9e002a7db2e04089004e9f30e86e989f8556527e87efe8cfb5b33da5931bad";
+      sha512 = "6c4a21aa700cf9a551f57516349d0e1ac490713fbd51aa8beeb0de6506c7ff5c06788a196132e53b4c4ab314ccd6598ac03df9a99a61b3d4998bfca86d1261ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/lv/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/lv/firefox-51.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "07f4d39b46c8e96908a0d7a144874d8a054c115941014c8fdadbdfce84cfd468226c8da2e82c2f61854af1abd645986b42e038768f3644208afeb4fa5b376088";
+      sha512 = "b41fc13a30af028f605eca804640a085e711c810debcd44cf148fe142bbd410c491b9edd7f0792200e77c3cbfcb3d75a3cd4aadf8bda9837f1006ab919540c4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/mai/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/mai/firefox-51.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "3b16658b9a09d9334ce3da90d05e8af0bd163fb7292c6b858a9098a45305e1b6a689687ad02a47259610b0269ed64f58ed0a3611676f5f282bbdc5b048e13351";
+      sha512 = "ef6ed49b36976b243452b866315b664d4fb949dd54ace116d86d1de74df5744c1aefb69bde7926f5b2cd78d904596c80b53971bc21e3e893201a25466abd284f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/mk/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/mk/firefox-51.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "e4c13520ac45271fe9d11f7f89fe50ef6299137084a0ea46c0ec4a3a64d1a1b311df4f7c54dd6a0f1d351e78e1d328039aa1d547f1bda7a4a386a60b850a4366";
+      sha512 = "28fdd392fe782836a47f8a547108990cba1796f92fdeea5f63e8d466e470b13b3fa0ca805b0de580b2620b3674ae1d25c3daaceac723179bea7da615de9dc0c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ml/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ml/firefox-51.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "342286c05b755482bf19b38aad1f288c0b333b99c39177bf846f46e22ee9b08914e65be2277939a400a514e6603613dfce0bbdecfdb69ceaa77bdec73d1e6082";
+      sha512 = "14c1e47a65bdfec98cc0fa3c1cb9ed58de49526fbc0b934ba2d4dbbed2ae6e3942c4f4c3f15a637156fb50347e62fd32bd661621171039a178167f7fb69bef64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/mr/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/mr/firefox-51.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "e1c4b4e41aafc5fc015883b91bef7d94a8d2f228cd37692d35b10b509036b0cf434f9eee56f7a490db5e2d58f5602ffd63c6413d8220211253dce5fd4b805393";
+      sha512 = "8f42dbefce445d592946f91acc7cc7323a0ea1a3e3c023222146f7650f4f4ef7c416e833c40c1b911273ca8ba100f20f5a8882165532c62f1d8af6d0e03cb022";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ms/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ms/firefox-51.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "7ba605a491acba8d1dee3858e0c0ef19b66f95b65565e0fb4bccd7d46d9e01aceba01b2a59bcd6d2a58f0978f446fde838b21edd253afe3de9b856d4c0c1ea62";
+      sha512 = "05a23010aebce6a79129883102dad6d82ae941b2dbec92b2d1b532c52250f49122f11a8c0837f26e6a7142f88e4fe71b0133c9fe1cf88cfbb18eb66fa88e567e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/nb-NO/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/nb-NO/firefox-51.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "26d8bb5183dff82a0515936f33cfae5197c0bc3d90e2294622e37062d33c531a6508d0b129579dbfec13941e155d052a2a292591992bb201256a59c7a192bb9a";
+      sha512 = "c2e48ec2489e854f76200de5940a17000c80a6f93f5c797a6e0c7e43a76b67a82bbbf9d3eec917f50170522a92cf09a08a2ca25ca892bc452fa4d8cbc6fa3989";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/nl/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/nl/firefox-51.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "5b410bde9763eccfff227b0f667877997be6df08e73748034d411363cfef1fcd33a8639f5bbe883dc52bdb1dd9b728e217b1d4033b5ee3e7b2b5cd1d616b2b69";
+      sha512 = "975713ddd22a227ba289ade6a8b7e6141b2c4923de4b33f22711b2b816af2c5305aa43c7bceb7a2f7aa35a0c6e59e4dfb577ba8282dbd1a322ac99dec8245b91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/nn-NO/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/nn-NO/firefox-51.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "f4da4e20d6fec450669feb9f31a2f8a49f2670f24c88cab08948043331f8cca44908f25a0028d0a1d73707afb156cc763dbdf7726d427acdc8639066e9fa1273";
+      sha512 = "0918907a3ec9283c2d2d60db6d4d5efdab0f25b6c3522d8289bb46ca6f7b42a461342ffb2611e5e38e52f88846836688fa9f5b461d69f3c9f838413759f4ac5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/or/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/or/firefox-51.0.1.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "75c69e7d49436dd14108ce1395236401157ec8e55e417bb56f54e0c601335cbe3613da69ba90a7a6f25cc658d36349b3273ec134a4011bffd955aa320fb603b5";
+      sha512 = "fb09ee90b4a4f97687310946b260caa8e115b6475305fbdef7d5d54d649d4f8cfbb2be5a3bd567f115f25ab294258726bdf34af25380c5cccc9647db0a523280";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/pa-IN/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/pa-IN/firefox-51.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "2a219eab022bc38c51c0ab91cdf0058840d306a7b420367e2b887627d0cc9af66367cfdff8ea9d4868e3f6e8686db20dd268a5a603e73349bb66a620af594958";
+      sha512 = "ef266ef4b57c3efae929fb4061dad5768746383e70a813b5d0cdb32206aa2b5ffc6ef8fa91952d37b61c72c0477050642103f5c63bc0ed0001ec514e9e65494d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/pl/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/pl/firefox-51.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "542093af3bee169ca314c592d456f0b8f350ab4ebdc203488ce6881983b7acb8c210c8d195e309a5c6936d43c2c2b2336638efae3ecbe1400bf3ec5c70494070";
+      sha512 = "f02f704f24109b34300ad7de8582b3c59a480d162dfadf7eb1d4821fa94e793978ec9f584468b3e0bc948adc1d0296b28dc7189e09752e5c2db31c7ce3596b76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/pt-BR/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/pt-BR/firefox-51.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "b6ad50d05e9023a8cad99000ff368fd1bacac1df5fb1400c44209f9af7a13234b262dd875ad84fcda3b9f52c6fcbaeb4d51363277d4eb09d917e25d790e45547";
+      sha512 = "4e8e8fad4dabb933392ecbda9ed5938a3dab018e95c11ce5f70eaa810ef64525d8e71d61a5203d1e6feb1fe198312eb6f929ce2f0dd4cc93fbc3006cfdf7e0a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/pt-PT/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/pt-PT/firefox-51.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "dbdbece91863c98a2fe5e50961b613cc9c3989a519599b554e59bc7fcde86235deffa76381b317aa033af565c781894e0a7f4533cddf41bb14cb4abc93c6bc9d";
+      sha512 = "eecc2fe5fdb7fc8ce98f0df3a838d6c44d0471eb95fc27271bbcbea5178752e1d974c4e8f0b97efa2d9743fd7695286aaaf44015ae6b5efdfd334d57094b787c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/rm/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/rm/firefox-51.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "b31b0e52f1b368271877fe56f868e64bfdfc4c5f1533883d90ee1b794cea8f54e7df2704f87a4f1913acf35e105ee5fbf4d4535474e1da1ab6919cf702d58aaf";
+      sha512 = "ed02a26930398b4b6e63a532fce29943b634568c6dc21ba931ae0e054c0b95eea1da8949f39f47272e7ff34c6b87caa14cff5ad4ebb956630a7178e2fbc3b440";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ro/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ro/firefox-51.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "6f86862438e13213398e5d4ac1a2bf0ade1d56d7ee0ccb217e8ba9383c237871caad4a6c067758babdd571b0bb936890681553cd481ae5790caf52b1b3246930";
+      sha512 = "b356ed1dd25084e1ebc5421c9925a7d6339d1bfff7d0fd69ab392b199a904cf31c8124c0ed3df3691be727492f0334b7edb3e1cec210f7eb84a64e37dd4d4847";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ru/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ru/firefox-51.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "ed01bb4eef1014d403626e4eb68aa1b86e0a54067c51aad5d0caa255b5cecac45d81ef535d2c50d72cc5568cf45f6cdb7eedd8d527e985e605614e395894a1f2";
+      sha512 = "da92e1e769dd673201d157bfdb4070fda84610ec2e313da7a44e75d33a269cd59927409a665689c5145f6e6f463246296aa070f2c471572545443c73f110714c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/si/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/si/firefox-51.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "fa3d1fb7c5c223e6195b2f65148db2eed268a3cef74e51a27e3e3df025d98209c1854cd393dfa1d8a7206c0aff966da981463b8b11880d76bc1b21498ad9d56d";
+      sha512 = "08499f564b5c05dca975201d2d8e32fb09385a3596af9e0fa2965968231bd93fa00158e2746769abb17c891f6059221cd0dfc3bfda11ae7df5cf54f013e73d02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/sk/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/sk/firefox-51.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "d6d3a459e390f4b768de3017f611f619e98f93fd6676b77b3f83173c34df23ac8425b43a57fa79aba37e8f3f406e3507ce4d709ed65d0b41b4ff3a241d1892a7";
+      sha512 = "c6e778692f3d3d6c01eb61652cdd698192a7df305b6328d1627443e815aee5369ec4d2409becc32798debb3441d588d8d9ff4c76e3038e58d50c1ba812dd5567";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/sl/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/sl/firefox-51.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "578720764a2af9b62eccdad2a95b2233e6f81e1f4c321cc5c6fad0106ef8d8fe944f8e160b7c3386cb561e385e54d2124aac11505ba2e90af88c6f3a57e0754c";
+      sha512 = "a041cde5bf67eb46f328ea90ec84cf293751959e11e952e2da77fe883cf105fd70ceeddef76b2e84d7a849d0cb3c3ac89dc7d839db910fa508a1261f3fbb0a99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/son/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/son/firefox-51.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "c01bdddb9382357a85f86c494977df1185d3fc00b290c6076ccdb48823da8ab73b0af0a7d6d61510f24e881a206e3149070be38dfdaacc8a7a7311e8540acba6";
+      sha512 = "3e74bd82ca8259bba5e8ded47bdde199ed64a5fdb44f381d2e981dd05c009159a811348f8369eb345c8cb0fc8ef9377d69ab069be0c3d0238cb3a8e634f3b188";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/sq/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/sq/firefox-51.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "4027be0b161a175fa9576c31a223120ebd559873b622ae0a658bcd85b7afa73e0353aa7dcb379fa196f32c6a7a615cd4e8321bc081c195d78ca1bf63d443912b";
+      sha512 = "637e81118bf019d916e26f229a02756ebb1b7eb3f2a9131905320a4fd4a8bc13efbb2d2c85fb52b7ccdf3c02afe7a439754cd0222501c5ebd18069bcbb8146e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/sr/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/sr/firefox-51.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "3e975eae9b281af3e44c72aec6684c668186c67f99b3a3f584e319b5784eb3dbde710bfade02ef0158d7191b831861aa292842aed2c58b63877fca22caa95481";
+      sha512 = "6ebfd3264b6daaf2726614f12ccae7485773b1fcb3d55b8cba748157bdd81e9d57de5e65553fc928b6fc59a9bf346761b37321caa07b461fa757885d551bbf2d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/sv-SE/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/sv-SE/firefox-51.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "130af7c0ff6bce178119b88a585f4216effb0d08b17965b75c8eee0c0af728849f5c78ec1732db1ef4c18a2b004ad031b34221921ff7fee1a580e954fd90f123";
+      sha512 = "3ba5a114559edb15375abf9011d9c7cef5b35d1182f43d2ee7d38d37e5ae802506c207c0a96dbce8f8a87ed35cc874a4c0748968cc86b460693144240cc2f22d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/ta/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ta/firefox-51.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "afd344db4d2e8f64bb2cbdb9cd29bae258aefe0dece1f784fa683d27107d863ca1000d47f0764edb5c2deb80ba5ba36778396f94aba85ee5ff569a6364bfb64a";
+      sha512 = "ccc13342dd8d110bb63670c1beacf2ec3e0aa48ddf775f9f8181d2733f0072dbcd465e88a4ea2c2ade503b7bc41c193d16cf4f3a6857748600cdda002c5bda00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/te/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/te/firefox-51.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "e6dde9414cb8a75616bdfd7590aab3b4b9c70b43dc8218eddcda7b5d82968f702438cf6f9fcbac8d1c4aa68d10a7b7aa0b144229a1ddee190a670a93b96b8068";
+      sha512 = "6df83ac1eb710aa56bfeba8f2bbb52b002ba5d4a63a3ffa0fd2b9dda076d1594d5507753478ceea89c703ba07b2b78be5b2f0bc7ad15365164f251f6cfb13f3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/th/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/th/firefox-51.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "3a3a78429127cd9b4677618c583135e4b6adacfd26b411442e7654cc1dba6fe97bdb2485b63cffd212e9dca708e260740cd70a8b8213f241cabb2d0ee651ada4";
+      sha512 = "ed32a1b1d7bbbe625c8b528fadff8195c81bca4fa64a9b3e230066e801cd315d14d6c356fe48253a8d796127cbfb0ff0db58b25953054a2c83f55549c6c3cfdf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/tr/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/tr/firefox-51.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "f0e75b3edbfc1d254c28e545cd15f0dae01c54361f65b7d3fc9e28cfbe4f620dc995725302e9e77c94b85458c60a25cb2ca3ef11839303fa6a1a55829e01944c";
+      sha512 = "3e69c04d8993d290293c2d925bd93e1f4269733992c260d5ff61d111acfe0cfb82ee7ac03c78332d45742e36e3a3c8ec4b22110e6feeb5484fc5c4a7568b431f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/uk/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/uk/firefox-51.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "e00212ba3205a6ce8ce3e66e430cc653b607501900f50cecfac67c73cb7e3ba6cecff276903aa8bf9fc99a2e3d6e9d30021c12ae74be027b6c775ba8f5ef58db";
+      sha512 = "7f52ba8eef6515e267b05a48a97eafc5672b5cc77b67836d44207cc72f7b886b8d9aacd8259359433d1515046d72f97836980b9d01c281c8620b0ff693abe7e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/uz/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/uz/firefox-51.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "e3d3bbfc59c5d8db89edff8be8dd40a8b4d63821bb0661d8b7af73ffaffbaf955e441ba2f51a3bcd60e0a9fdb972ee02c5eb9e9b1639982be4dd8685bd18b57a";
+      sha512 = "d3af1571479bfceb3a9118cf90d5c5530072ff1845d2624f33549ce42581eb257d01e8e5985866114772d8c0e1a8be5d52e7d6d0a30ccee4dc9536cd6a07f4e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/vi/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/vi/firefox-51.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "bbba8a10fa3d3958ee2310bf7c72886a94808ac2dc55bf717b0fb073ab2a38dcf258578e653fea2cbc89daaf996915da441d49639f38a3a25ae00b66380e10b5";
+      sha512 = "7fd67bb789c2520b9a4a1cd59f0a5713ca2eb8eddca3188a041907047ddb28d2bddfe439f2c85f75c473ddb3df08f4e783d4312af2da5bb13b57ad8dda3aed4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/xh/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/xh/firefox-51.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "1e67a4b168e582d8528192b7f15f4c87edf0a9b5f6113c1a22818e0a31ccf9c9d11f934c043a4f12541ffcf2cc7d7dcbe15ab9df14c37f0bbcfa2a54c6f74017";
+      sha512 = "81678e379685fe35a23c4c2f490837c8454ae9b65f6f91ac18cb3a4e0c5c475021aa175783e09d99151014604a3aec944252812cce0355b75b7a39bb8b498400";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/zh-CN/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/zh-CN/firefox-51.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "1bdd72ad912894961872da41d76498863bb67ba6bf26ab551cac1da450fc79d5196050968ba0786c32254af83fa86dc2c368e8c9703cdf27309475b1ff4ee899";
+      sha512 = "1212c93a2ac3f77e13199fe5c7a518bbe9a5ce573c241777e462167c02ccf3d232dfc9b15c05ad85110ff14df0cf31dfb74209dc50f7a99db068928aa3f723a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0/linux-i686/zh-TW/firefox-51.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/zh-TW/firefox-51.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "7920151c1d99fda897b8cfc62eb1e6ec7b984dc56253478fb49e3182695313c3c0fd21a49f37993024e5898377bed23e6d943f6d8d5a851aba30fff8922287a2";
+      sha512 = "cd2a813befedf187cc11e8374043658a78bed9620681e66e226292c8f754f0b21c865cdb71c7b289acfb040c77361ee5c3a1ab42c34b9e893293270b1a9151a8";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -148,8 +148,8 @@ in {
 
   firefox-unwrapped = common {
     pname = "firefox";
-    version = "51.0";
-    sha512 = "4406f840a7a2b4e76a74e846d702b717618fb5b677f1c6df864c3428033dd22aad295d656f1fc57e581fd202d894c5483a16691a60b6ca7710315b157b812467";
+    version = "51.0.1";
+    sha512 = "556e31b717c0640ef5e181e00b9d2a6ea0ace7c16ae04333d0f2e9e120d0ab9efe82a4ca314ef43594c080523edf37953e65dbf694c7428be0a024f3719d8312";
     updateScript = import ./update.nix {
         name = "firefox";
         inherit writeScript xidel coreutils gnused gnugrep curl ed;


### PR DESCRIPTION
###### Motivation for this change

- Multiprocess incompatibility did not correctly register with some add-ons (Bug 1333423)

https://www.mozilla.org/en-US/firefox/51.0.1/releasenotes/

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

