### PR TITLE
zookeeper: 3.4.6 -> 3.4.9

### DIFF
--- a/pkgs/servers/zookeeper/default.nix
+++ b/pkgs/servers/zookeeper/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, jre, makeWrapper, bash }:
 
 stdenv.mkDerivation rec {
-  name = "zookeeper-3.4.6";
+  name = "zookeeper-3.4.9";
 
   src = fetchurl {
     url = "mirror://apache/zookeeper/${name}/${name}.tar.gz";
-    sha256 = "01b3938547cd620dc4c93efe07c0360411f4a66962a70500b163b59014046994";
+    sha256 = "0dgmja1lm7qn92x2xfmz5qj2k6sj2f6yzyj3a55r7iv1590l1wz7";
   };
 
   buildInputs = [ makeWrapper jre ];
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     homepage = "http://zookeeper.apache.org";
     description = "Apache Zookeeper";
     license = licenses.asl20;
-    maintainers = with maintainers; [ nathan-gs cstrahan ];
+    maintainers = with maintainers; [ nathan-gs cstrahan pradeepchhetri ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

