### PR TITLE
vokoscreen: init at 2.5.0

### DIFF
--- a/pkgs/applications/video/vokoscreen/default.nix
+++ b/pkgs/applications/video/vokoscreen/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchgit
+, pkgconfig, qt5, alsaLib, libv4l, xorg
+, ffmpeg
+}:
+
+stdenv.mkDerivation {
+  name = "vokoscreen-2.5.0";
+  src = fetchgit {
+    url = "https://github.com/vkohaupt/vokoscreen.git";
+    rev = "8325c8658d6e777d34d2e6b8c8bc03f8da9b3d2f";
+    sha256 = "1hvw7xz1mj16ishbaip73wddbmgibsz0pad4y586zbarpynss25z";
+  };
+
+  buildInputs = [
+    alsaLib.dev
+    libv4l.dev
+    pkgconfig
+    qt5.full
+    qt5.qmakeHook
+    qt5.qtx11extras
+    xorg.libXrandr.dev
+  ];
+
+  patches = [
+    ./ffmpeg-out-of-box.patch
+  ];
+
+  preConfigure = ''
+    sed -i 's/lrelease-qt5/lrelease/g' vokoscreen.pro
+  '';
+
+  postConfigure = ''
+    substituteInPlace settings/QvkSettings.cpp --subst-var-by ffmpeg ${ffmpeg}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple GUI screencast recorder, using ffmpeg";
+    homepage = "http://linuxecke.volkoh.de/vokoscreen/vokoscreen.html";
+    longDescription = ''
+      vokoscreen is an easy to use screencast creator to record
+      educational videos, live recordings of browser, installation,
+      videoconferences, etc.
+    '';
+    license = licenses.gpl2Plus;
+    maintainers = [maintainers.league];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/video/vokoscreen/ffmpeg-out-of-box.patch
+++ b/pkgs/applications/video/vokoscreen/ffmpeg-out-of-box.patch
@@ -1,0 +1,31 @@
+diff --git a/settings/QvkSettings.cpp b/settings/QvkSettings.cpp
+index bbf2abf..187efad 100644
+--- a/settings/QvkSettings.cpp
++++ b/settings/QvkSettings.cpp
+@@ -56,17 +56,8 @@ void QvkSettings::readAll()
+       GIFPlayer = settings.value( "GIFplayer" ).toString();
+       Minimized = settings.value( "Minimized", 0 ).toUInt();
+       Countdown = settings.value( "Countdown", 0 ).toUInt();
+-      QFile file;
+-      if ( file.exists( qApp->applicationDirPath().append( "/bin/ffmpeg" ) ) == true )
+-      {
+-	vokoscreenWithLibs = true;
+-        Recorder = qApp->applicationDirPath().append( "/bin/ffmpeg" );
+-      }
+-      else
+-      {
+-	vokoscreenWithLibs = false;
+-        Recorder = settings.value( "Recorder", "ffmpeg" ).toString();
+-      }
++      vokoscreenWithLibs = true;
++      Recorder = settings.value( "Recorder", "@ffmpeg@/bin/ffmpeg" ).toString();
+     settings.endGroup();
+     
+     settings.beginGroup( "Videooptions" );
+@@ -398,4 +389,4 @@ double QvkSettings::getShowClickTime()
+ int QvkSettings::getShowKeyOnOff()
+ {
+   return showKeyOnOff; 
+-}
+\ No newline at end of file
++}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17821,6 +17821,8 @@ with pkgs;
   vips = callPackage ../tools/graphics/vips { };
   nip2 = callPackage ../tools/graphics/nip2 { };
 
+  vokoscreen = callPackage ../applications/video/vokoscreen { };
+
   wavegain = callPackage ../applications/audio/wavegain { };
 
   wcalc = callPackage ../applications/misc/wcalc { };


### PR DESCRIPTION
vokoscreen is an easy to use screencast creator to record educational
videos, live recordings of browser, installation, videoconferences, etc.

It uses Qt5 and ffmpeg.

###### Motivation for this change

vokoscreen works well, and it wasn't part of nixpkgs before now.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

