### PR TITLE
nginx: Format the config file

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -16,7 +16,20 @@ let
   ) cfg.virtualHosts;
   enableIPv6 = config.networking.enableIPv6;
 
-  configFile = pkgs.writeText "nginx.conf" ''
+  configFile = pkgs.runCommand "nginx.conf" {
+    inherit configFileUnformatted;
+    passAsFile = [ "configFileUnformatted" ];
+    # configFileUnformatted is created locally, therefore so should this be.
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+  } ''
+    cp ${configFileUnformatted} nginx.conf
+    chmod u+w nginx.conf
+    ${pkgs.nginx-config-formatter}/bin/nginxfmt nginx.conf
+    cp nginx.conf $out
+  '';
+
+  configFileUnformatted = pkgs.writeText "nginx.unformatted.conf" ''
     user ${cfg.user} ${cfg.group};
     error_log stderr;
     daemon off;


### PR DESCRIPTION
###### Motivation for this change

This makes nginx.conf human-readable.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

