### PR TITLE
Python: redo setuptools bootstrapping

### DIFF
--- a/pkgs/development/interpreters/python/build-python-package-setuptools.nix
+++ b/pkgs/development/interpreters/python/build-python-package-setuptools.nix
@@ -3,12 +3,14 @@
 { lib
 , python
 , bootstrapped-pip
+, setuptools
+, wheel
 }:
 
-{
+{ buildInputs ? []
 # passed to "python setup.py build_ext"
 # https://github.com/pypa/pip/issues/881
-  setupPyBuildFlags ? []
+,  setupPyBuildFlags ? []
 # Execute before shell hook
 , preShellHook ? ""
 # Execute after shell hook
@@ -35,6 +37,8 @@ in attrs // {
     ${python.interpreter} nix_run_setup.py test
     runHook postCheck
   '';
+
+  buildInputs = buildInputs ++ [ setuptools wheel ];
 
   # Python packages that are installed with setuptools
   # are typically distributed with tests.

--- a/pkgs/development/interpreters/python/build-python-package-setuptools.nix
+++ b/pkgs/development/interpreters/python/build-python-package-setuptools.nix
@@ -17,24 +17,16 @@
 , postShellHook ? ""
 , ... } @ attrs:
 
-let
-  # use setuptools shim (so that setuptools is imported before distutils)
-  # pip does the same thing: https://github.com/pypa/pip/pull/3265
-  setuppy = ./run_setup.py;
-
-in attrs // {
-  # we copy nix_run_setup.py over so it's executed relative to the root of the source
-  # many project make that assumption
+attrs // {
   buildPhase = attrs.buildPhase or ''
     runHook preBuild
-    cp ${setuppy} nix_run_setup.py
-    ${python.interpreter} nix_run_setup.py ${lib.optionalString (setupPyBuildFlags != []) ("build_ext " + (lib.concatStringsSep " " setupPyBuildFlags))} bdist_wheel
+    ${python.interpreter} -m setuptools.launch setup.py ${lib.optionalString (setupPyBuildFlags != []) ("build_ext " + (lib.concatStringsSep " " setupPyBuildFlags))} bdist_wheel
     runHook postBuild
   '';
 
   installCheckPhase = attrs.checkPhase or ''
     runHook preCheck
-    ${python.interpreter} nix_run_setup.py test
+    ${python.interpreter} -m setuptools.launch setup.py test
     runHook postCheck
   '';
 

--- a/pkgs/development/interpreters/python/build-python-package.nix
+++ b/pkgs/development/interpreters/python/build-python-package.nix
@@ -8,10 +8,12 @@
 , mkPythonDerivation
 , bootstrapped-pip
 , flit
+, setuptools
+, wheel
 }:
 
 let
-  setuptools-specific = import ./build-python-package-setuptools.nix { inherit lib python bootstrapped-pip; };
+  setuptools-specific = import ./build-python-package-setuptools.nix { inherit lib python bootstrapped-pip setuptools wheel; };
   flit-specific = import ./build-python-package-flit.nix { inherit python flit; };
   wheel-specific = import ./build-python-package-wheel.nix { };
   common = import ./build-python-package-common.nix { inherit python bootstrapped-pip; };

--- a/pkgs/development/interpreters/python/build-python-package.nix
+++ b/pkgs/development/interpreters/python/build-python-package.nix
@@ -5,10 +5,12 @@
 
 { lib
 , python
-, mkPythonDerivation
+, wrapPython
+, unzip
+, ensureNewerSourcesHook
+, setuptools
 , bootstrapped-pip
 , flit
-, setuptools
 , wheel
 }:
 
@@ -35,5 +37,9 @@ let
     else if format == "wheel" then common (wheel-specific attrs)
     else if format == "other" then {}
     else throw "Unsupported format ${format}";
+
+    mkPythonDerivation = import ./mk-python-derivation.nix {
+      inherit lib python wrapPython unzip ensureNewerSourcesHook setuptools;
+    };
 
 in mkPythonDerivation ( attrs // formatspecific )

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -3,9 +3,9 @@
 { lib
 , python
 , wrapPython
-, setuptools
 , unzip
 , ensureNewerSourcesHook
+, setuptools
 }:
 
 { name
@@ -67,10 +67,11 @@ python.stdenv.mkDerivation (builtins.removeAttrs attrs ["disabled"] // {
   buildInputs = [ wrapPython ] ++ buildInputs ++ pythonPath
     ++ [ (ensureNewerSourcesHook { year = "1980"; }) ]
     ++ (lib.optional (lib.hasSuffix "zip" attrs.src.name or "") unzip)
-    ++ lib.optionals doCheck checkInputs;
+    ++ lib.optionals doCheck checkInputs
+    ++ lib.optional catchConflicts setuptools; # setuptools contains pkg_resources
 
   # propagate python/setuptools to active setup-hook in nix-shell
-  propagatedBuildInputs = propagatedBuildInputs ++ [ python setuptools ];
+  propagatedBuildInputs = propagatedBuildInputs ++ [ python ];
 
   # Python packages don't have a checkPhase, only an installCheckPhase
   doCheck = false;

--- a/pkgs/development/interpreters/python/run_setup.py
+++ b/pkgs/development/interpreters/python/run_setup.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-
-import setuptools
-import tokenize
-
-__file__='setup.py';
-
-exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
   unpackPhase = ''
     mkdir -p $out/${python.sitePackages}
     unzip -d $out/${python.sitePackages} $src
-    unzip -d $out/${python.sitePackages} ${setuptools_source}
+#     unzip -d $out/${python.sitePackages} ${setuptools_source}
     unzip -d $out/${python.sitePackages} ${wheel_source}
   '' + stdenv.lib.optionalString (python.isPy26 or false) ''
     unzip -d $out/${python.sitePackages} ${argparse_source}

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -1,19 +1,6 @@
 { stdenv, python, fetchurl, makeWrapper, unzip }:
 
-let
-  wheel_source = fetchurl {
-    url = "https://pypi.python.org/packages/py2.py3/w/wheel/wheel-0.29.0-py2.py3-none-any.whl";
-    sha256 = "ea8033fc9905804e652f75474d33410a07404c1a78dd3c949a66863bd1050ebd";
-  };
-  setuptools_source = fetchurl {
-    url = "https://files.pythonhosted.org/packages/b8/cb/b919f52dd81b4b2210d0c5529b6b629a4002e08d49a90183605d1181b10c/setuptools-30.2.0-py2.py3-none-any.whl";
-    sha256 = "b7e7b28d6a728ea38953d66e12ef400c3c153c523539f1b3997c5a42f3770ff1";
-  };
-  argparse_source = fetchurl {
-    url = "https://pypi.python.org/packages/2.7/a/argparse/argparse-1.4.0-py2.py3-none-any.whl";
-    sha256 = "0533cr5w14da8wdb2q4py6aizvbvsdbk3sj7m1jx9lwznvnlf5n3";
-  };
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "${python.libPrefix}-bootstrapped-pip-${version}";
   version = "9.0.1";
 
@@ -25,10 +12,6 @@ in stdenv.mkDerivation rec {
   unpackPhase = ''
     mkdir -p $out/${python.sitePackages}
     unzip -d $out/${python.sitePackages} $src
-#     unzip -d $out/${python.sitePackages} ${setuptools_source}
-    unzip -d $out/${python.sitePackages} ${wheel_source}
-  '' + stdenv.lib.optionalString (python.isPy26 or false) ''
-    unzip -d $out/${python.sitePackages} ${argparse_source}
   '';
 
 

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "setuptools";
-  version = "34.3.2";
+  version = "35.0.0";
   name = "${pname}-${version}";
 
   format = "wheel";       # Wheel required for bootstrapping setuptools.
   catchConflicts = false; # For bootstrapping
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "6483f8412313ec787fa71379147a4605d3b1cc303c3648d02542a9160d3db72b";
+    sha256 = "b427014a0cf196e57727e141899c20381051233094783aa6274780a100eb65d9";
   };
 
   propagatedBuildInputs = [ appdirs six packaging ];

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ appdirs six packaging ];
-  installFlags = [ "--ignore-installed" ];
+  installFlags = [ "--ignore-installed" "--no-dependencies" ];
 
   meta = with lib; {
     description = "Utilities to facilitate the installation of Python packages";

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "f865709919903e3399343c0b3c42f95e9aeddc41e38cfb334fb2bb5dfa384857";
   };
 
-  buildInputs = [ python wrapPython ];
+  buildInputs = [ wrapPython ];
+  propagatedBuildInputs = [ python ];
   doCheck = false;  # requires pytest
   installPhase = ''
       dst=$out/${python.sitePackages}

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -1,31 +1,27 @@
-{ stdenv, lib, fetchurl, python, wrapPython }:
+{ lib
+, fetchPypi
+, buildPythonPackage
+, appdirs
+, six
+, packaging
+}:
 
-stdenv.mkDerivation rec {
+buildPythonPackage rec {
   pname = "setuptools";
-  shortName = "${pname}-${version}";
-  name = "${python.libPrefix}-${shortName}";
+  version = "34.3.2";
+  name = "${pname}-${version}";
 
-  version = "30.2.0";
-
-  src = fetchurl {
-    url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${shortName}.tar.gz";
-    sha256 = "f865709919903e3399343c0b3c42f95e9aeddc41e38cfb334fb2bb5dfa384857";
+  format = "wheel";       # Wheel required for bootstrapping setuptools.
+  catchConflicts = false; # For bootstrapping
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "6483f8412313ec787fa71379147a4605d3b1cc303c3648d02542a9160d3db72b";
   };
 
-  buildInputs = [ wrapPython ];
-  propagatedBuildInputs = [ python ];
-  doCheck = false;  # requires pytest
-  installPhase = ''
-      dst=$out/${python.sitePackages}
-      mkdir -p $dst
-      export PYTHONPATH="$dst:$PYTHONPATH"
-      ${python.interpreter} setup.py install --prefix=$out
-      wrapPythonPrograms
-  '';
+  propagatedBuildInputs = [ appdirs six packaging ];
+  installFlags = [ "--ignore-installed" ];
 
-  pythonPath = [];
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Utilities to facilitate the installation of Python packages";
     homepage = http://pypi.python.org/pypi/setuptools;
     license = with lib.licenses; [ psfl zpt20 ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25,10 +25,7 @@ let
 
   bootstrapped-pip = callPackage ../development/python-modules/bootstrapped-pip { };
 
-  mkPythonDerivation = makeOverridable( callPackage ../development/interpreters/python/mk-python-derivation.nix {
-  });
   buildPythonPackage = makeOverridable (callPackage ../development/interpreters/python/build-python-package.nix {
-    inherit mkPythonDerivation;
     inherit bootstrapped-pip;
     flit = self.flit;
   });
@@ -58,7 +55,7 @@ let
 
 in {
 
-  inherit python bootstrapped-pip pythonAtLeast pythonOlder isPy26 isPy27 isPy33 isPy34 isPy35 isPy36 isPyPy isPy3k mkPythonDerivation buildPythonPackage buildPythonApplication;
+  inherit python bootstrapped-pip pythonAtLeast pythonOlder isPy26 isPy27 isPy33 isPy34 isPy35 isPy36 isPyPy isPy3k buildPythonPackage buildPythonApplication;
   inherit fetchPypi;
 
   # helpers

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1100,11 +1100,15 @@ in {
   };
 
   appdirs = buildPythonPackage rec {
-    name = "appdirs-1.4.0";
+    pname = "appdirs";
+    version = "1.4.3";
+    name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/appdirs/appdirs-1.4.0.tar.gz";
-      sha256 = "8fc245efb4387a4e3e0ac8ebcc704582df7d72ff6a42a53f5600bbb18fdaadc5";
+    format = "wheel";       # Wheel required for bootstrapping setuptools.
+    catchConflicts = false; # For bootstrapping
+    src = fetchPypi {
+      inherit pname version format;
+      sha256 = "d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e";
     };
 
     meta = {
@@ -18798,16 +18802,18 @@ in {
     version = "9.0.1";
     name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
-      sha256 = "09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d";
+    format = "wheel";       # Wheel required for bootstrapping setuptools.
+    catchConflicts = false; # For bootstrapping
+    src = fetchPypi {
+      inherit pname version format;
+      sha256 = "690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0";
     };
 
     # pip detects that we already have bootstrapped_pip "installed", so we need
     # to force it a little.
     installFlags = [ "--ignore-installed" ];
 
-    buildInputs = with self; [ mock scripttest virtualenv pretend pytest ];
+    checkInputs = with self; [ mock scripttest virtualenv pretend pytest ];
     # Pip wants pytest, but tests are not distributed
     doCheck = false;
 
@@ -20811,9 +20817,11 @@ in {
     name = "pyparsing-${version}";
     version = "2.1.10";
 
+    format = "wheel";       # Wheel required for bootstrapping setuptools.
+    catchConflicts = false; # For bootstrapping
     src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pyparsing/${name}.tar.gz";
-      sha256 = "811c3e7b0031021137fc83e051795025fcb98674d07eb8fe922ba4de53d39188";
+      url = "https://files.pythonhosted.org/packages/2b/f7/e5a178fc3ea4118a0edce2a8d51fc14e680c745cf4162e4285b437c43c94/pyparsing-2.1.10-py2.py3-none-any.whl";
+      sha256 = "67101d7acee692962f33dd30b5dce079ff532dd9aa99ff48d52a3dad51d2fe84";
     };
 
     # Not everything necessary to run the tests is included in the distribution
@@ -24372,18 +24380,24 @@ in {
 
 
   six = buildPythonPackage rec {
-    name = "six-1.10.0";
-
+    pname = "six";
+    version = "1.10.0";
+    name = "${pname}-${version}";
+    format = "wheel";       # Wheel required for bootstrapping setuptools.
+    catchConflicts = false; # For bootstrapping
     src = pkgs.fetchurl {
-      url = "mirror://pypi/s/six/${name}.tar.gz";
-      sha256 = "0snmb8xffb3vsma0z67i0h0w2g2dy0p3gsgh9gi4i0kgc5l8spqh";
+      url = "https://files.pythonhosted.org/packages/c8/0a/b6723e1bc4c516cb687841499455a8505b44607ab535be01091c0f24f079/six-1.10.0-py2.py3-none-any.whl";
+      sha256 = "0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1";
     };
 
-    buildInputs = with self; [ pytest ];
+    # checkInputs = with self; [ pytest ];
 
-    checkPhase = ''
-      py.test test_six.py
-    '';
+    # Wheel does not include tests. We would have to retrieve the tests from another source.
+    #checkPhase = ''
+    #  py.test test_six.py
+    #'';
+
+    #propagatedBuildInputs = optionals (!isPy3k) [ setuptools];
 
     meta = {
       description = "A Python 2 and 3 compatibility library";
@@ -27002,17 +27016,20 @@ EOF
   };
 
   wheel = buildPythonPackage rec {
-    name = "wheel-${version}";
+    pname = "wheel";
     version = "0.29.0";
+    name = "${pname}-${version}";
+    format = "wheel";       # Wheel required for bootstrapping setuptools.
+    catchConflicts = false; # For bootstrapping
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/w/wheel/${name}.tar.gz";
-      sha256 = "1ebb8ad7e26b448e9caa4773d2357849bf80ff9e313964bcaf79cbf0201a1648";
+    src = fetchPypi {
+      inherit pname version format;
+      sha256 = "ea8033fc9905804e652f75474d33410a07404c1a78dd3c949a66863bd1050ebd";
     };
 
-    buildInputs = with self; [ pytest pytestcov coverage ];
+    #checkInputs = with self; [ pytest pytestcov coverage jsonschema ];
 
-    propagatedBuildInputs = with self; [ jsonschema ];
+    #propagatedBuildInputs = with self; [  ];
 
     # We add this flag to ignore the copy installed by bootstrapped-pip
     installFlags = [ "--ignore-installed" ];
@@ -31788,13 +31805,20 @@ EOF
   };
 
   packaging = buildPythonPackage rec {
-    name = "packaging-16.8";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/packaging/${name}.tar.gz";
-      sha256 = "5d50835fdf0a7edf0b55e311b7c887786504efea1177abd7e69329a8e5ea619e";
+    pname = "packaging";
+    version = "16.8";
+    name = "${pname}-${version}";
+
+    format = "wheel";       # Wheel required for bootstrapping setuptools.
+    catchConflicts = false; # For bootstrapping
+    src = fetchPypi {
+      inherit pname version format;
+      sha256 = "99276dc6e3a7851f32027a68f1095cd3f77c148091b092ea867a351811cfe388";
     };
+
+    # checkInputs = with self; [ pytest pretend ];
     propagatedBuildInputs = with self; [ pyparsing six ];
-    buildInputs = with self; [ pytest pretend ];
+
     meta = with pkgs.stdenv.lib; {
       description = "Core utilities for Python packages";
       homepage = "https://github.com/pypa/packaging";


### PR DESCRIPTION
###### Motivation for this change

As I mentioned in https://github.com/NixOS/nixpkgs/issues/22139 setuptools will no longer vendor its dependencies.

This PR reimplements part of the bootstrapping. All dependencies of setuptools as well as setuptools itself are installed from wheels.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
