### PR TITLE
libnl: 3.2.23 -> 2.3.29 to revert accidental downgrade.

### DIFF
--- a/pkgs/os-specific/linux/libnl/default.nix
+++ b/pkgs/os-specific/linux/libnl/default.nix
@@ -5,8 +5,8 @@ stdenv.mkDerivation {
   name = "libnl-${version}";
 
   src = fetchFromGitHub {
-    sha256 = "1078sbfgcb6ijal9af6lv26sy233wq14afyrc4bkdbnfl0zgsbwi";
-    rev = "libnl3_2_23";
+    sha256 = "0y8fcb1bfbdvxgckq5p6l4jzx0kvv3g11svy6d5v3i6zy9kkq8wh";
+    rev = "libnl3_2_29";
     repo = "libnl";
     owner = "thom311";
   };


### PR DESCRIPTION
libnl was accidentally downgrades to 2.3.29 in
8d342d20b5ea7df31b0a29fc5e3664868c81d832 instead of being upgraded to
2.3.29 so this fixes that.

###### Motivation for this change

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc:  grahamc
Fixes: #22213