### PR TITLE
termite: unbreak by packaging vte-ng

### DIFF
--- a/pkgs/applications/misc/termite/default.nix
+++ b/pkgs/applications/misc/termite/default.nix
@@ -35,7 +35,6 @@ let
       homepage = https://github.com/thestinger/termite/;
       maintainers = with maintainers; [ koral garbas ];
       platforms = platforms.all;
-      broken = true;
     };
   };
 in if configFile == null then termite else symlinkJoin {

--- a/pkgs/desktops/gnome-3/3.22/core/vte/fix_g_test_init_calls.patch
+++ b/pkgs/desktops/gnome-3/3.22/core/vte/fix_g_test_init_calls.patch
@@ -1,0 +1,26 @@
+diff --git a/src/vteconv.cc b/src/vteconv.cc
+index b78d3928..5cb63e7e 100644
+--- a/src/vteconv.cc
++++ b/src/vteconv.cc
+@@ -771,7 +771,7 @@ int
+ main (int argc,
+       char *argv[])
+ {
+-        g_test_init (&argc, &argv, NULL);
++        g_test_init (&argc, &argv, (char *)NULL);
+ 
+         g_test_add_func ("/vte/conv/utf8/strlen", test_utf8_strlen);
+         g_test_add_func ("/vte/conv/utf8/validate", test_utf8_validate);
+diff --git a/src/vtetypes.cc b/src/vtetypes.cc
+index 1365a295..8f38c9d9 100644
+--- a/src/vtetypes.cc
++++ b/src/vtetypes.cc
+@@ -407,7 +407,7 @@ test_util_smart_fd(void)
+ int
+ main(int argc, char *argv[])
+ {
+-        g_test_init (&argc, &argv, NULL);
++        g_test_init (&argc, &argv, (char *)NULL);
+ 
+         g_test_add_func("/vte/c++/grid/coords", test_grid_coords);
+         g_test_add_func("/vte/c++/grid/span", test_grid_span);

--- a/pkgs/desktops/gnome-3/3.22/core/vte/fix_vteseq_n_lookup_declaration.patch
+++ b/pkgs/desktops/gnome-3/3.22/core/vte/fix_vteseq_n_lookup_declaration.patch
@@ -1,0 +1,13 @@
+diff --git a/src/vteseq.cc b/src/vteseq.cc
+index 2330939d..e0ac14eb 100644
+--- a/src/vteseq.cc
++++ b/src/vteseq.cc
+@@ -3409,7 +3409,7 @@ vte_sequence_handler_iterm2_1337(VteTerminalPrivate *that, GValueArray *params)
+ #define VTE_SEQUENCE_HANDLER(name) name
+ 
+ static const struct vteseq_n_struct *
+-vteseq_n_lookup (register const char *str, register unsigned int len);
++vteseq_n_lookup (register const char *str, register size_t len);
+ #include"vteseq-n.cc"
+ 
+ #undef VTE_SEQUENCE_HANDLER

--- a/pkgs/desktops/gnome-3/3.22/core/vte/ng.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/vte/ng.nix
@@ -1,0 +1,25 @@
+{ gnome3, fetchFromGitHub, autoconf, automake, gtk_doc, gettext, libtool, gperf }:
+
+gnome3.vte.overrideAttrs (oldAttrs: rec {
+  name = "vte-ng-${version}";
+  version = "0.46.1.a";
+
+  src = fetchFromGitHub {
+    owner = "thestinger";
+    repo = "vte-ng";
+    rev = version;
+    sha256 = "125fpibid1liz50d7vbxy71pnm8b01x90xnkr4z3419b90lybr0a";
+  };
+
+  # The patches apply the changes from https://github.com/GNOME/vte/pull/7 and
+  # can be removed once the commits are merged into vte-ng.
+  patches = [
+    ./fix_g_test_init_calls.patch
+    ./fix_vteseq_n_lookup_declaration.patch
+  ];
+
+  preConfigure = oldAttrs.preConfigure + "; ./autogen.sh";
+
+  nativeBuildInputs = [ gtk_doc autoconf automake gettext libtool ];
+  buildInputs = oldAttrs.buildInputs ++ [ gperf ];
+})

--- a/pkgs/desktops/gnome-3/3.22/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/default.nix
@@ -234,6 +234,8 @@ let
 
   vte_290 = callPackage ./core/vte/2.90.nix { };
 
+  vte-ng = callPackage ./core/vte/ng.nix { };
+
   vino = callPackage ./core/vino { };
 
   yelp = callPackage ./core/yelp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15167,7 +15167,9 @@ with pkgs;
     vte = gnome2.vte.override { pythonSupport = true; };
   };
 
-  termite = callPackage ../applications/misc/termite { vte = null; };
+  termite = callPackage ../applications/misc/termite {
+    vte = gnome3.vte-ng;
+  };
 
   tesseract = callPackage ../applications/graphics/tesseract { };
 


### PR DESCRIPTION
termite broke when upgrading Gnome, as this removed a
dependency from the tree. I packaged this dependency (vte-ng) based upon
the work of @globin in https://github.com/NixOS/nixpkgs/issues/22026.