### PR TITLE
NixOS: Respect nixpkgs.overlays

### DIFF
--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -45,9 +45,8 @@ let
 in
 
 {
-  options = {
-
-    nixpkgs.config = mkOption {
+  options.nixpkgs = {
+    config = mkOption {
       default = {};
       example = literalExample
         ''
@@ -61,7 +60,7 @@ in
       '';
     };
 
-    nixpkgs.overlays = mkOption {
+    overlays = mkOption {
       default = [];
       example = literalExample
         ''
@@ -85,7 +84,7 @@ in
       '';
     };
 
-    nixpkgs.system = mkOption {
+    system = mkOption {
       type = types.str;
       example = "i686-linux";
       description = ''
@@ -95,14 +94,9 @@ in
         multi-platform deployment, or when building virtual machines.
       '';
     };
-
   };
 
   config = {
-    _module.args.pkgs = import ../../.. {
-      system = config.nixpkgs.system;
-
-      inherit (config.nixpkgs) config;
-    };
+    _module.args.pkgs = import ../../.. config.nixpkgs;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I just tried switching from `packageOverrides` to `overlays`; they took effect for nixpkgs but not NixOS. Pass through the `overlays` parameter in the NixOS module.

cc @nbp

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).