### PR TITLE
polybar: init at 3.0.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -20,6 +20,7 @@
   adolfogc = "Adolfo E. García Castro <adolfo.garcia.cr@gmail.com>";
   aespinosa = "Allan Espinosa <allan.espinosa@outlook.com>";
   aflatter = "Alexander Flatter <flatter@fastmail.fm>";
+  afldcr   = "James Alexander Feldman-Crough <alex@fldcr.com>";
   aforemny = "Alexander Foremny <alexanderforemny@googlemail.com>";
   afranchuk = "Alex Franchuk <alex.franchuk@gmail.com>";
   aherrmann = "Andreas Herrmann <andreash87@gmx.ch>";

--- a/pkgs/applications/misc/polybar/default.nix
+++ b/pkgs/applications/misc/polybar/default.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
       url = "https://github.com/jaagr/polybar";
       rev = "1f31870d43f5cd87a5529a55b1d2d3e64105e0af";
       sha256 = "1nhj4npqhs6zy161931sbdi52gz6163lik0wri9wr122sjf90jas";
-      fetchSubmodules = true;
     };
 
     meta = with stdenv.lib; {

--- a/pkgs/applications/misc/polybar/default.nix
+++ b/pkgs/applications/misc/polybar/default.nix
@@ -1,0 +1,61 @@
+{ cairo, cmake, fetchgit, libXdmcp, libpthreadstubs, libxcb, pcre, pkgconfig
+, python2 , stdenv, xcbproto, xcbutil, xcbutilimage, xcbutilrenderutil
+, xcbutilwm, xcbutilxrm
+
+# optional packages-- override the variables ending in 'Support' to enable or
+# disable modules
+, alsaSupport   ? true,  alsaLib       ? null
+, iwSupport     ? true,  wirelesstools ? null
+, githubSupport ? false, curl          ? null
+, mpdSupport    ? false, mpd_clientlib ? null
+, i3Support ? false, i3GapsSupport ? false, i3 ? null, i3-gaps ? null, jsoncpp ? null
+}:
+
+assert alsaSupport   -> alsaLib       != null;
+assert githubSupport -> curl          != null;
+assert iwSupport     -> wirelesstools != null;
+assert mpdSupport    -> mpd_clientlib != null;
+
+assert i3Support     -> ! i3GapsSupport && jsoncpp != null && i3      != null;
+assert i3GapsSupport -> ! i3Support     && jsoncpp != null && i3-gaps != null;
+
+stdenv.mkDerivation rec {
+    name = "polybar-${version}";
+    version = "3.0.4";
+    src = fetchgit {
+      url = "https://github.com/jaagr/polybar";
+      rev = "1f31870d43f5cd87a5529a55b1d2d3e64105e0af";
+      sha256 = "1nhj4npqhs6zy161931sbdi52gz6163lik0wri9wr122sjf90jas";
+      fetchSubmodules = true;
+    };
+
+    meta = with stdenv.lib; {
+      description = "A fast and easy-to-use tool for creatin status bars.";
+      longDescription = ''
+        Polybar aims to help users build beautiful and highly customizable
+        status bars for their desktop environment, without the need of 
+        having a black belt in shell scripting.
+      ''; 
+      license = licenses.mit;
+      maintainers = [ maintainers.afldcr ];
+      platforms = platforms.unix;
+    };
+
+    buildInputs = [
+      cairo libXdmcp libpthreadstubs libxcb pcre python2 xcbproto xcbutil
+      xcbutilimage xcbutilrenderutil xcbutilwm xcbutilxrm
+
+      (if alsaSupport   then alsaLib       else null)
+      (if githubSupport then curl          else null)
+      (if iwSupport     then wirelesstools else null)
+      (if mpdSupport    then mpd_clientlib else null)
+
+      (if i3Support || i3GapsSupport then jsoncpp else null)
+      (if i3Support then i3 else null)
+      (if i3GapsSupport then i3-gaps else null)
+    ];
+
+    nativeBuildInputs = [
+      cmake pkgconfig
+    ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14293,6 +14293,8 @@ with pkgs;
      stdenv = stdenv_32bit;
   };
 
+  polybar = callPackage ../applications/misc/polybar { };
+
   scudcloud = callPackage ../applications/networking/instant-messengers/scudcloud { };
 
   shotcut = qt5.callPackage ../applications/video/shotcut { };


### PR DESCRIPTION
Polybar is a nice X11 status bar in the vein of i3bar or xmobar.

https://github.com/jaagr/polybar

Ignore the source branch name-- this developer moves fairly quickly :)

##### Reviewed points

- [ ] package path fits guidelines
- [ ] package name fits guidelines
- [ ] package version fits guidelines
- [ ] package build on ARCHITECTURE
- [ ] executables tested on ARCHITECTURE
- [ ] `meta.description` is set and fits guidelines
- [ ] `meta.license` fits upstream license
- [ ] `meta.platforms` is set
- [ ] `meta.maintainers` is set
- [ ] build time only dependencies are declared in `nativeBuildInputs`
- [ ] source is fetched using the appropriate function
- [ ] phases are respected
- [ ] patches that are remotely available are fetched with `fetchpatch`

##### Possible improvements

- [ ] Is there an easier way to maintain optional dependencies?
- [ ] Is there any way to read the `config.environment` setting on NixOS?

##### Comments
