### PR TITLE
mathcomp 1.6.1 and related fixes

### DIFF
--- a/pkgs/development/coq-modules/coquelicot/default.nix
+++ b/pkgs/development/coq-modules/coquelicot/default.nix
@@ -1,11 +1,26 @@
 { stdenv, fetchurl, which, coq, ssreflect }:
 
-stdenv.mkDerivation {
-  name = "coq${coq.coq-version}-coquelicot-2.1.1";
-  src = fetchurl {
+let param =
+  let
+  v2_1_1 = {
+    version = "2.1.1";
     url = https://gforge.inria.fr/frs/download.php/file/35429/coquelicot-2.1.1.tar.gz;
     sha256 = "1wxds73h26q03r2xiw8shplh97rsbim2i2s0r7af0fa490bp44km";
   };
+  v2_1_2 = {
+    version = "2.1.2";
+    url = https://gforge.inria.fr/frs/download.php/file/36320/coquelicot-2.1.2.tar.gz;
+    sha256 = "09q9xbzyndx8i68hn3ir4pmzgqd1q33qpk3xghf2l849g8w3q5an";
+  };
+  in {
+  "8.4" = v2_1_1;
+  "8.5" = v2_1_2;
+  "8.6" = v2_1_2;
+}."${coq.coq-version}"; in
+
+stdenv.mkDerivation {
+  name = "coq${coq.coq-version}-coquelicot-${param.version}";
+  src = fetchurl { inherit (param) url sha256; };
 
   nativeBuildInputs = [ which ];
   buildInputs = [ coq ];

--- a/pkgs/development/coq-modules/interval/default.nix
+++ b/pkgs/development/coq-modules/interval/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, which, coq, coquelicot, flocq, mathcomp }:
 
 stdenv.mkDerivation {
-  name = "coq-interval-${coq.coq-version}-2.2.1";
+  name = "coq${coq.coq-version}-interval-3.1.1";
 
   src = fetchurl {
-    url = https://gforge.inria.fr/frs/download.php/file/35431/interval-2.2.1.tar.gz;
-    sha256 = "1i6v7da9mf6907sa803xa0llsf9lj4akxbrl8rma6gsdgff2d78n";
+    url = https://gforge.inria.fr/frs/download.php/file/36342/interval-3.1.1.tar.gz;
+    sha256 = "0jzkb0xykiz9bfaminy9yd88b5w0gxcpw506yaaqmnmb43gdksyf";
   };
 
   nativeBuildInputs = [ which ];

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -1,20 +1,11 @@
 { callPackage, fetchurl, coq }:
 
 let param =
-  let v16 = {
-    version = "1.6";
-    url = http://ssr.msr-inria.inria.fr/FTP/mathcomp-1.6.tar.gz;
-    sha256 = "0adr556032r1jkvphbpfvrrv041qk0yqb7a1xnbam52ji0mdl2w8";
-  }; v161 = {
+  {
     version = "1.6.1";
     url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.1.tar.gz;
     sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
   }; in
-{
-  "8.4" = v16;
-  "8.5" = v16;
-  "8.6" = v161;
-}."${coq.coq-version}"; in
 
 callPackage ./generic.nix {
   name = "coq${coq.coq-version}-mathcomp-${param.version}";

--- a/pkgs/development/coq-modules/mathcomp/generic.nix
+++ b/pkgs/development/coq-modules/mathcomp/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, coq, ssreflect, ncurses, which
+{ stdenv, fetchurl, coq, ncurses, which
 , graphviz, withDoc ? false
 , src, name
 }:
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = stdenv.lib.optionals withDoc [ graphviz ];
   buildInputs = [ coq.ocaml coq.findlib coq.camlp5 ncurses which ];
-  propagatedBuildInputs = [ coq ssreflect ];
+  propagatedBuildInputs = [ coq ];
 
   enableParallelBuilding = true;
 
@@ -24,9 +24,6 @@ stdenv.mkDerivation {
 
   installPhase = ''
     make -f Makefile.coq COQLIB=$out/lib/coq/${coq.coq-version}/ install
-    rm -fr $out/lib/coq/${coq.coq-version}/user-contrib/mathcomp/ssreflect*
-    rm -fr $out/lib/coq/${coq.coq-version}/user-contrib/ssrmatching.cmi
-    rm -fr $out/share/coq/${coq.coq-version}/user-contrib/mathcomp/ssreflect*
   '' + stdenv.lib.optionalString withDoc ''
     make -f Makefile.coq install-doc DOCDIR=$out/share/coq/${coq.coq-version}/
   '';

--- a/pkgs/development/coq-modules/ssreflect/default.nix
+++ b/pkgs/development/coq-modules/ssreflect/default.nix
@@ -1,20 +1,11 @@
 { callPackage, fetchurl, coq }:
 
 let param =
-  let v16 = {
-    version = "1.6";
-    url = http://ssr.msr-inria.inria.fr/FTP/mathcomp-1.6.tar.gz;
-    sha256 = "0adr556032r1jkvphbpfvrrv041qk0yqb7a1xnbam52ji0mdl2w8";
-  }; v161 = {
+  {
     version = "1.6.1";
     url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.1.tar.gz;
     sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
   }; in
-{
-  "8.4" = v16;
-  "8.5" = v16;
-  "8.6" = v161;
-}."${coq.coq-version}"; in
 
 callPackage ./generic.nix {
   name = "coq${coq.coq-version}-ssreflect-${param.version}";


### PR DESCRIPTION
###### Motivation for this change

The Coq libraries mathcomp, coquelicot, and interval are currently broken in `nixpkgs` with Coq-8.6.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The `mathcomp` fix is as follows: the `mathcomp` install keeps its own copy of the `ssreflect` library (and therefore no longer uses it as input nor propagates it). This seems wrong, but I tested the `interval` library which depends on both `mathcomp` (directly) and `ssreflect` (through `coquelicot`) and that worked.