### PR TITLE
fzf: from 0.15.9 to 0.16.2

### DIFF
--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "fzf-${version}";
-  version = "0.15.9";
+  version = "0.16.2";
   rev = "${version}";
 
   goPackagePath = "github.com/junegunn/fzf";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "junegunn";
     repo = "fzf";
-    sha256 = "0r099mk9r6f52qqhx0ifb1xa8f2isqvyza80z9mcpi5zkd96174l";
+    sha256 = "160474x0m3fzxi2ddy53chzhmlrx6lvialjknfxb72rm938fc845";
   };
 
   outputs = [ "bin" "out" "man" ];
@@ -31,13 +31,6 @@ buildGoPackage rec {
     cp -r $src/man/man1 $man/share/man
     mkdir -p $out/share/vim-plugins
     ln -s $out/share/go/src/github.com/junegunn/fzf $out/share/vim-plugins/${name}
-  '';
-
-  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
-    # fixes cycle between $out and $bin
-    # otool -l shows that the binary includes an LC_RPATH to $out/lib
-    # it seems safe to remove that since but the directory does not exist.
-    install_name_tool -delete_rpath $out/lib $bin/bin/fzf
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/fzf/deps.nix
+++ b/pkgs/tools/misc/fzf/deps.nix
@@ -23,8 +23,17 @@
     fetch = {
       type = "git";
       url = "https://github.com/junegunn/go-shellwords";
-      rev = "35d512af75e283aae4ca1fc3d44b159ed66189a4";
-      sha256 = "08la0axabk9hiba9mm4ypp6a116qhvdlxa1jvkxhv3d4zpjsp4n7";
+      rev = "33bd8f1ebe16d6e5eb688cc885749a63059e9167";
+      sha256 = "0xcymw0fm0ir8d9swh1bkpknnqgx5ijjsj433z4d9riy8h8ywpw8";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "854ae91cdcbf914b499b1d7641d07859f3653481";
+      sha256 = "19hj2nv2awc6zhpiapv8xv2yjdwfpxhvx5wnr99if6kg0y1ybsa7";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change
fzf has been updated

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

