### PR TITLE
Revert "libmsgpack_1_4: remove"

### DIFF
--- a/pkgs/development/libraries/libmsgpack/1.4.nix
+++ b/pkgs/development/libraries/libmsgpack/1.4.nix
@@ -1,0 +1,12 @@
+{ callPackage, fetchFromGitHub, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "msgpack";
+    repo = "msgpack-c";
+    rev = "cpp-${version}";
+    sha256 = "0zlanifi5hmm303pzykpidq5jbapl891zwkwhkllfn8ab1jvzbaa";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8191,6 +8191,7 @@ with pkgs;
   libmtp = callPackage ../development/libraries/libmtp { };
 
   libmsgpack = callPackage ../development/libraries/libmsgpack { };
+  libmsgpack_1_4 = callPackage ../development/libraries/libmsgpack/1.4.nix { };
 
   libmysqlconnectorcpp = callPackage ../development/libraries/libmysqlconnectorcpp {
     mysql = mysql57;


### PR DESCRIPTION
This reverts commit ff89e8189800db204eb251c410f7cd7699b9c36b.

###### Motivation for this change

There are references to this variable.



###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

