### PR TITLE
rustNightlyBin: 2016-12-29 -> 2017-01-26

### DIFF
--- a/pkgs/development/compilers/rust/nightlyBin.nix
+++ b/pkgs/development/compilers/rust/nightlyBin.nix
@@ -9,7 +9,7 @@ let
 
   bootstrapHash =
     if stdenv.system == "x86_64-linux"
-    then "05bppmc6hqgv2g4x76rj95xf40x2aikqmcnql5li27rqwliyxznj"
+    then "1v7jvwigb29m15wilzcrk5jmlpaccpzbkhlzf7z5qw08320gvc91"
     else throw "missing boostrap hash for platform ${stdenv.system}";
 
   needsPatchelf = stdenv.isLinux;
@@ -19,7 +19,7 @@ let
      sha256 = bootstrapHash;
   };
 
-  version = "2016-12-29";
+  version = "2017-01-26";
 in
 
 rec {


### PR DESCRIPTION
###### Motivation for this change

I need it to package [alacritty](https://github.com/jwilm/alacritty)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

