### PR TITLE
geogebra: 5.0.271.0 -> 5-0-320-0

### DIFF
--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -2,18 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "geogebra-${version}";
-  version = "5.0.271.0";
+  version = "5-0-320-0";
 
   preferLocalBuild = true;
 
   src = fetchurl {
     url = "http://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2";
-    sha256 = "5dd5be1cde27c9b567f79c38048045864064b69c0d2b469ae93e1fca5f543475";
+    sha256 = "039mrjwgkj3z51zq4xpchzr4msz5xgscgmp36dr1wms1kl42vibk";
   };
 
   srcIcon = fetchurl {
     url = "http://static.geogebra.org/images/geogebra-logo.svg";
-    sha256 = "55ded6b5ec9ad382494f858d8ab5def0ed6c7d529481cd212863b2edde3b5e07";
+    sha256 = "01sy7ggfvck350hwv0cla9ynrvghvssqm3c59x4q5lwsxjsxdpjm";
   };
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
###### Motivation for this change

`download.geogebra.org` doesn't provide version `5.0.271.0` anymore, so the installation ends up in a 404.
Furthermore they changed the dots to dashes (http://download.geogebra.org/installers/5.0/)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

