### PR TITLE
perl::List-Compare: 0.39 -> 0.53

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -386,11 +386,13 @@ let self = _self // overrides; _self = with self; {
     buildInputs = [ TestNoWarnings Moo TypeTiny ];
   };
 
-  ListCompare = buildPerlPackage {
-    name = "List-Compare-1.18";
+  ListCompare = buildPerlPackage rec {
+    # http://search.cpan.org/~jkeenan/ -> List-Compare lastest version
+    # https://github.com/jkeenan/list-compare
+    name = "List-Compare-0.53";
     src = fetchurl {
-      url = mirror://cpan/authors/id/J/JK/JKEENAN/List-Compare-0.39.tar.gz;
-      sha256 = "1v4gn176faanzf1kr9axdp1220da7nkvz0d66mnk34nd0skjjxcl";
+      url = "mirror://cpan/authors/id/J/JK/JKEENAN/${name}.tar.gz";
+      sha256 = "0l451yqhx1hlm7f2c3bjsl3n8w6l1jngrxzyfm2d8d9iggv4zgzx";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Building nixos-unstable (http://hydra.hydra.prunetwork.fr/jobset/nixos/unstable-small#tabs-configuration) from fresh installed hydra without binarycache fails.

A dependency is missing : http://hydra.hydra.prunetwork.fr/build/83  and can't be fetched (file not found)

Something is strange in `perl-packages.nix`. Expected package version is 1.18 but fetch version is 0.39 https://github.com/NixOS/nixpkgs/blame/master/pkgs/top-level/perl-packages.nix#L389

###### Things done

- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @rycee 