### PR TITLE
mosh: use ssh from nixpkgs

### DIFF
--- a/pkgs/tools/networking/mosh/default.nix
+++ b/pkgs/tools/networking/mosh/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, zlib, protobuf, ncurses, pkgconfig, IOTty
-, makeWrapper, perl, openssl, autoreconfHook, fetchpatch }:
+, makeWrapper, perl, openssl, autoreconfHook, openssh }:
 
 stdenv.mkDerivation rec {
   name = "mosh-1.2.6";
@@ -10,6 +10,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ autoreconfHook protobuf ncurses zlib pkgconfig IOTty makeWrapper perl openssl ];
+
+  patches = [ ./ssh_path.patch ];
+  postPatch = ''
+    substituteInPlace scripts/mosh.pl \
+        --subst-var-by ssh "${openssh}/bin/ssh"
+  '';
 
   postInstall = ''
       wrapProgram $out/bin/mosh --prefix PERL5LIB : $PERL5LIB

--- a/pkgs/tools/networking/mosh/ssh_path.patch
+++ b/pkgs/tools/networking/mosh/ssh_path.patch
@@ -1,0 +1,13 @@
+diff --git i/scripts/mosh.pl w/scripts/mosh.pl
+index c511482..55bf5f3 100755
+--- i/scripts/mosh.pl
++++ w/scripts/mosh.pl
+@@ -66,7 +66,7 @@ my $use_remote_ip = 'proxy';
+ my $family = 'prefer-inet';
+ my $port_request = undef;
+ 
+-my @ssh = ('ssh');
++my @ssh = ('@ssh@');
+ 
+ my $term_init = 1;
+ 


### PR DESCRIPTION
###### Motivation for this change
Improve purity of mosh.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).