### PR TITLE
firefox-bin: Update sha512 hash (backporting)

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/sources.nix
@@ -4,922 +4,922 @@
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ach/firefox-51.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "b03b784892648b2df1c3f5acc9e0a8bab9a7e95afbeda249dfa57f4bbabfd2d750602c64b85ff6d1ea4676294086ea2b847e64a8920450ca6849d6c54b3f881e";
+      sha512 = "264a80d657603925d3ac0e848e60e3593a94e20eaaad4aba1767fc35c8bdd826d7fffbf7aa7be9fc8e380bbc174d53937eb24f887db18fa69ee375f72e8ef092";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/af/firefox-51.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "4d1c5407450e9afbf8e630fa588d6b26c6cd5d9c405d422413064f1e81d089f65f59df4022dbf6f0601cc36d56b222a45f925b792ed7df3182e0999d5655e393";
+      sha512 = "ca4498387c7786f96e3e7220b6a072cb5df0daaf00dade13a149e61ba725229e47f84622f196034caa608c9c2ef49a14450a9816fd3accb62c29063344d354ca";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/an/firefox-51.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "71938ac8176197164408b389c28061d634dd3d895b28a7ad35c4236e3a6561be7e4f04c0c4fd14dfa9e4c87d0c9cd245ed656cfc2bb68d4666a5bb2e93740a49";
+      sha512 = "7abba14523671201798f8abb53233472f56fd961d679aee52b4ae9be1c9b5afe547cb1c10a5f6aa80cd5b41eeb0a3d04edc60a62ed00b1bc21ad8cb9dc86906e";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ar/firefox-51.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "a0b1ca6edaa03e5e73e7a298490f394a2884690c0e012678686eba4d32a16c1f049a0fc2417627cf36e54c918dd0f86ef37fe6555b5ce80de18999ea08a537a2";
+      sha512 = "429aa2cf388d1efd0e6d9658b9464d06bf6aa42cce1b9b0d4bf2d85a350fbf307d45a205d9303ff386fbbba56a637c19d6c7695a78b9947d29ccaec285053864";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/as/firefox-51.0.1.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "1e07c2cf24eb3aa244134d8ed1d11dd3b1151b9e700921afb60336491c0f301fcc4b289e354b490f9d84cca96417b09dab7df06951f8568019976e2baf999894";
+      sha512 = "670102d9e6b50aa44d9d035af068dfd55d5b009a8e189e0e0d1e6d3404918c0e009e3e573b3de2601801e7c792746885d32aeb48235921c4cbf7874b82f06a73";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ast/firefox-51.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "dbdaf693ea1143f78fe3a06461d0a1653c57459633b1d5236a9c3ce74f1c888664d7b455fd0fb2733c0823c22088d58314ee9f4ccfa62726257b83fe1cdac435";
+      sha512 = "e6e6236bc496bab83bb64c7fcd2444d4f81fa49c9b6914d2d9abd2cced829f22b75705b3755525277d0d5a1193d0766cdaf936423889c77a2773ab28d953c738";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/az/firefox-51.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "1fbb9efa1dddf1577b5532fb59f73994c54aac26e4ccfe643204224844f5dc1398ae077703b5df33589646257ad2f46ce4bc38a3e9575c8842c716bf18d1c497";
+      sha512 = "16b6fed737a5d2fdeb18945cd71f8e844abfcc1402ade665260d2644612579e76111a53548dd5c645c5816fec7c8162df91d687eb6b9dc84ad520af2a9580dde";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/bg/firefox-51.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "fee53d9245bffeaa7c696b1cdc2119b0f683caf9352ac2e8336745e45a799ef1729577af968006cb2240a49872673175f3ec0a706b76d4bc5962c56912b895bb";
+      sha512 = "dd311d55e182408ba16853dec80d13fabc957e9ff9e6098f040698b35fea28b4579827ca35b21188f1e6287b749fd1ac94b3bb9979b75caf5b10b90686f425ac";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/bn-BD/firefox-51.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "d6909918b51dd5a1c80909e480de0503ef85ffb1b53a7421d134386e5db94850c1605eccddf588b4646aef90e91917b3fb0c74f6560e1c0543d45a2f9fbd8bc6";
+      sha512 = "857a13768160d71dfe5dd806933c85006e63508b6dce63545a0618c20531204b672dac7b2634dbba3a453277cfc53a9395215287ea51b18642d8e8c97258c704";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/bn-IN/firefox-51.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "cfea68c984ca43b840d3d8d13347c3ac2ba38e5d38623384aa5a3559b6fe175415124ca06ef3f4848193fc20e0ee0a6c4a497c5bc3b7589e05cd756bfa56bf53";
+      sha512 = "602c352dd5de9a90128318c72496b2439531a5f4c4d16b28060686396db0b84c1300255eb8cb5dc6e6560971e6283d3c4bbe4376939177e4fbc0192898922a7f";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/br/firefox-51.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "1225ec28b6f63cd5be087a61f0f6761362bae12ae975c2805e109019fce0b0fc7dce4bb0e7891bffd18a8395ee41f6344ae654314894c1fa1eb0a30851ea3b21";
+      sha512 = "fa8ba39abf6691c4127b5d4f6002405eff04fee2522ac274ce57c349ae042f5f47ee7cdb3519608d6415629aadf6a5894f575dab79ae3055fba383cf2680cc54";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/bs/firefox-51.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "7d5bc886b60a04aa81ea77d412738ef350dfa6c76c9c653d5c9f7627717ee94a0ed9131d3a1a75f25306bd496eba225e9a645b44f59fcd5a16bea64a128664bc";
+      sha512 = "c8960b8cf4055c7a9032a3d5c10bbc59bf1b828909bfcb57f45a8d05dff07111d18da1644a18cdccb653630d77ebc17d435109d289f1d378335db043ae2c142f";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ca/firefox-51.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "ebeecb92f79a67c1bba9ec43509a431328318607c7c460f13ddfc17d3253ad4f2de06cef27ba7adbffaab2562af48f3eec8b1b5137d4b8abc8b2a960515fe9b3";
+      sha512 = "3b8cbbb0b8a14640f2b919fcfb67d4274e6ac9c6f612bb4baf5c368752d76fcdbea7c795cdf23b00f3bd64ddb2ae4af950cdb7a0637f621ab0ef382c1f6933cc";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/cak/firefox-51.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "d507417ce14e60af385d8cc3eb16b74d311ae50797bc836d0f137d2ed69f41aceeb4273a4f10de64dc1d93ec29952e3a95bea6bb1c628467c410266edf8ddfc6";
+      sha512 = "e7a325d7ffed7db337c5fa4c3bfd31bf8b7703041de16f8024821f1d89487f36131616d460db8518d71d20af4285d43a040331d304c5b828fabdce181f736965";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/cs/firefox-51.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "60b1690077c1375df44642ec55954f690af6240a2d1782c93ca1df6cda7c64f50bd0034f6d66f4629e8d6d5716fb46afeb2850201d63d72f6122da57bc278788";
+      sha512 = "32a4b758b2cfac67f19a7fe7ad7d04b49122921e2b3c1c8236d8be3452b665aa54c13dcd9e2d2b298dc017b864f56aa9b6f06d174be46ca41a722226a15eaf01";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/cy/firefox-51.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "dfad805b88d1b928253a8d86a89581b0db4cb505b373d6488cb05701048a1e99131b6078d337cce16f5fc7daa0af331ec4fb328329af2c663af8ae28a221c58a";
+      sha512 = "908bc9d3d9ada201a2fa81a83f6773c635c3dbec0e08b464c6dab5a311d667291fe7f5ee403ff13e5cd923d01cbfc0d9e2a0de3a2a7469af4bbf4afc8368ef4d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/da/firefox-51.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "6fcc47e0a019fc5af5fb14753221a89bb63c18d4695ed2a369781b2d89ae0c1c127cada90582908ff690d4b08015686f963bd0df137686cad99eefb31dcf1bb9";
+      sha512 = "e10fd9c7ee4496a674cb18414f0bfbd1671d21aad4bf41a63432540555a6f4059faf50e488bb76241a1e15884fdf7c43ec289e2641d9ee13f63985062526cd07";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/de/firefox-51.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "31efe6ee9551246018811a63d89274dc126955745ca68c97035f207ca0b5ad250b2f8672132f6ca5c70676e09174f227ef9e1b5488857a9a5da5b5fd41fe2aad";
+      sha512 = "07221eea748fbad6ffca0b7f77e4995039e28e506a790d5e858d4d88cd80737f1a366735a4a826358a9aa76ee1b454d99f8fc8732f4082e91c9a9e5ce40a9b81";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/dsb/firefox-51.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "f93c6bc53c51454128f0435eca79cd46f94e49e1513854ceb9835322c84b282f81536efefb6520f01842ad10c70c0d85b72a89de9952c03fe8626b3a02ad2bf3";
+      sha512 = "9e2f1eee45e5dc1b8f7ab5c72c734c85bdd21544500c45ba1b85580cc110c02499cc69b596d979633e64b3aee7b1408e27862c761d4451b749399815199d3694";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/el/firefox-51.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "8acdcbe7ef6a977a7f59e1543b960b428faacfab756b298310c0971d0e90b10c382ec211d7866ac5aec2bfb15cc9b276be8bb82b8f036babedba989ffed3664f";
+      sha512 = "270b1fd5fcf6958929e81c38a5ae2d8b5ee3de62e64eb6e7e7b80a8520759f1bddf03eec408165853ae624918194c57c2b7b496b4146a78ef42bc4b5b77a1d55";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/en-GB/firefox-51.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "3aaa1f296dc15a5e2555c5aa1d5c2e2f2ff91ac76a65955cc633b19bb50c449e0d0e1f2b6772278884d4d9fbe3d35c2bbcfdb3f85e23838bf132aabe37b5f117";
+      sha512 = "79bc0e031f3ad065e5309dc20ff509d9d6fa85c2669548b24be9e2b8fd9347ce354b51faea65943b421941ba20d8d0fb22c79b89ad380a37ff52ccf330343f33";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/en-US/firefox-51.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "58bfd3dd0aef94d735ae73779ef8d729bf421e48e345baf413c0bdb5085644a79dd786a4e21713bd8006ba2e48d3a3cb3c94b97dbfb5d90f546549518770c88d";
+      sha512 = "724a778bf54c6778838378c07481c5eed2cc7984c1a9809e352b6bcbd2562c060f6f39b6308caec2e62c05f8631753796a7b2714afda0606bab70b3ef3acc15c";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/en-ZA/firefox-51.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "67b05904cfef62154aac12a5bcd77046672a599f3df323fda5f12e1bfcccd0bacc31556c6708dea70c1b459e7dbcfc7284248b528aed1fdc1bf336eabcbbbcfb";
+      sha512 = "ffb4d4554ffdab057507fe29c0fb56a74e683b3bfbf19b26a52f23336918c788a476b549df3b4f57dc79c555bc36af620f46bcbb7c6467855952a024c75f7213";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/eo/firefox-51.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "87cd52dea514edffa98ce40f45a209a11d1543b7f23007639e66557dd687824a9aa785f1eeb4b1f3aab17ffa8ee18e3628eba592dd3b91c940677e18adbca0a5";
+      sha512 = "42768a6de7144ccd63c6a58c6fa2913004cdc3d7f35bfbb3d47ecc8a705672d2b95e8e8389fdc6715bcaff48b2c1a335c23f39a2c07d03b4cb660146fa811a7d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/es-AR/firefox-51.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "d731b583b8b0ff0ecccd3bd1b32fcbd0152a353c6eb9525866185d8e42eaf4dbf13ff008893b7c35045ac8a699608e7b7aef4a02c69fc764cde12cc507f5afb3";
+      sha512 = "36da6cd0f8aea2419ba618b11f47764510c109c18bfbac380234b10c864a991a211742be3c058b4a8a59944324c7b32f65b4b3b8a9bc25460e6b4ef99e5d12e5";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/es-CL/firefox-51.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "4d2064a404832b26364691eaf8923adabad698bc8ad1bb0681be36ef7b154f02f3a63c8e45ffe848891cc33af9f4992e3a8ff0240db78028a8148ee250cbee58";
+      sha512 = "e3dbcdad48741a73aeebc46ab4771b4ea2324e6b0a9e6af020e0c5929528458cc3d66931dc67de4bf93b90afbb7f79078436c3da1ddc35779fbf40b8aad0ef1f";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/es-ES/firefox-51.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "1ce27c43e05606d837c65f218e144e695a081146b868e7a3706a876744db0e183392c63f992efe8484d398ae02d521ed6092518131cf4b53647bdde015cb8cd0";
+      sha512 = "1353c9d7fbe55d579486488d94d34b5acc0a87f6155ec2aa106ad6b2df53ee6813e19346bbfd920d5d0582bdb9c16dee667ebc384d48e06026fcf79590dc30fd";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/es-MX/firefox-51.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "2f0d6765fa85678f8b9a4c820e2e36ef3ad8fbe50db07cd3ccb5749b62aff3026eb09316d4840fb9dd537581ec39753205923460a150dd7b3d4c812fef8dcbeb";
+      sha512 = "fc93aaa68159c75d5c53d253e71aa87d099f499ff54a10606f0b87912837a1b85d897719d69753f6f84d389cbdf64a4a9306a9d19b809892032431d1a142b03c";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/et/firefox-51.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "3b6675306eb32e809778386ea92db02a5b4274ac2e62e0f071527fe4ea38e862180d2fe992c3e37f49e8157c1910ba6600256121bb191c00c80c236d3333c3e0";
+      sha512 = "e665a3e923bcd1ed070c1c4852d385f61ef43b5e6b39ad1eb0f547666d9c1cf82022638b9b60ef25f1621499ec930fec09367634ac972f7ce4c95f9bfb21cd15";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/eu/firefox-51.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "09b87fad711ce298c53b468dfa561526390c8c45c3c2edf25a76212889b7a1b965d1cfcd8c60a15fd6072ba3a7fc3a26e40a9c92ae363295ec9e2a0d12039fd4";
+      sha512 = "aaad849c7de92f4dcda618b882b82f9c1ccf1de45454162f90f7beebe060d2f2c53e21dbc7a50ccfe24c505608f45aebd1744900647d7131234a55e79e4e8a6d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/fa/firefox-51.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "b5cb640ddb95ed2f7a36435b5a6c22d562b35e44506d0acc61adb5341cb0fd1a092f1b64257af190d8e6d8e8e5d956cafae3f6d116c69bd22e4c19bb78fa494e";
+      sha512 = "ac4f9518cf658c2438bc6037cccbdfc5f3af40b4c2ec89c6ef82f43b171f3d781ff067ad096322cf316c4b46dd27f7e0da68291289d6f03e81d1b90f3c436d2c";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ff/firefox-51.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "15cbf240bd5302d984e2d63a239e3d83f48b9a31413d81c2b76c389d9ff59e9da69c759efa925c2731d070f8e12fbd7c9791769b4315a991857282a745b261bd";
+      sha512 = "0a788a34a6f8ac67da73ff0531ceda803a911f30b77957d31b47e5acab221a55501daa94643ebd2d824b475591edb147ae66a06fe2641915c8a18adaaedeecd6";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/fi/firefox-51.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "b8785753cd8192653e459ad92fbeeedc88bb860d8b2a1eab97a4eb16726ffe4c70f4a27d14fba3d987f0f5c187a69fa473f8ffcbe34240cb0bf0379ea72e713a";
+      sha512 = "c163e07e2097469be8dfaa57b6b722e9787c617cd8833e043b742a4d1424e7835e2c661412aae353fe0373bd163548102fd0b30dc37fbffe53444f0791c1777b";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/fr/firefox-51.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "418292c6cefc45a33057062d2a86299479ca0001fafe30a8369cb79e2390195dabc379001d2060ff3175fb96bbc0ce6063a2fcd0e8294aa8fcd4c231eb7a6dd8";
+      sha512 = "481a00f96cd79c04fde00ea39e560193575c1244d6e13c38ff4a81299cf944909a24bc8c8e0ff2a280bd9d4d7e8ca77b66e0532dc0643967ab52f27148dcab5a";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/fy-NL/firefox-51.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "07db4c4d56e4d9416d8e2c94b712b27071e66c906c189f615d1e15ebbf9b2df6354f433ce71ba8ea60da870e1551bce477d256cccc5f7b03ce2df37249b183f2";
+      sha512 = "37d8b6df59f8433efbd55de434b2639e83b6306065017b62c8f2d1730dc84842081abd9669eb48ea862b36c0c62f84a0ec03eaac7be17463129b46a03426d8da";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ga-IE/firefox-51.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "950fd2a1d7280574ce4f50cd6be29d00cd322fc63c41b7babadd5b615cd12f350e2f2aed8cf744a753583ef313a2fd6948d5b3d444d49bcfd865b1df92b80c11";
+      sha512 = "a6516adb884d070f4e6265e89e9a20b99f06f4093eb01df612f19748a1dc5fa07ed949a5d90030b8c512203717f0c9cdfdb307e1dfc2fbcd9def2bb7caf92dd3";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/gd/firefox-51.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "7d0174ae5c3874350b8c2444c12dcecc180261445f1cce36a196196f0040057d8b78ba4ae081d287343e7e3455410662b55a306d021c536e3b5ffc4705048051";
+      sha512 = "1d8710d83abf7e185aa73da047efd15d7e0b9667b80737528900a15b9a6aacd20588c963366f2aa08c7772444843b642e53bb2d3ababbb8b9812926d7c5a858e";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/gl/firefox-51.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "68b2d8a3f53ed32826c70850af3c8e7507e7aa5b19c0ceba86d4ca5759630f28250b67cbb3727b524c80b66b03af4e6ad7a6d1494743e28bdc8cdcd4bab10824";
+      sha512 = "08fee9be09fa365e188cfbe00dfb50c9b82a5228ec9d9feac7b4f01de43097f20dae4cd4f05da9983cff7d9504a5443854e8c13e8114a0977e65875406942007";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/gn/firefox-51.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "ed0786dca5c95efede7c9c58b0f8b2a08068fe309b7456807d96c0681fb963ddcda1fb461cbac96c20472b0b084abc5fb2dba3f24f5f763d2d31728a3b16adb9";
+      sha512 = "4a21dc3c3355c08bf98d6366acfceb84841f50f5686dac61e87def3995c0e0df399834640722ce1c278e461096996320d7eac9af400bb08d1bbfb95cbfafb694";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/gu-IN/firefox-51.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "f9d6ab4c713d3f3f1c9a2328290668b7b65abbb739419f74f262da090f2b88cab96fa1ebb768626b9fe84908ba92554a1c556281ec7c97f65801af053a14f195";
+      sha512 = "0d565d1e41f9b57cd71d30034f576877650941c4e2250b49668232aa7cfc9a3e8c37dbda3e1e8eafc594fab09ac90e4b3f6b52c90613a9b236d9dc4092c65e50";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/he/firefox-51.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "c1129b0826fe24b3bef9b0e1464fe8e6116f595e8d201d31c1d442255ba218d3614d88fcfbf14c3f52ce7119de61542a49cd2b4cda6be92323006c59073e6d29";
+      sha512 = "c0c87223d0c51b2d4df51ccf1d48938cbc2860f90b32a8d32fa69c7a4768c550deb9e9ee3f720404d51fb1461e0f25b56dc927449acc6a5d5dd23ac64fb4bf61";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/hi-IN/firefox-51.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "0e409a2ad739a6f180811cd6df64840c1f35179ee2a3cda615b774784962b1cad8a35196ce05ff332778fdf250b23dcf0e7a157524b43759cc89ea39424dbd60";
+      sha512 = "6c0de623688af6a3eefa1a5a230979d2342d2414d27acca2e64646a9c82356cad47898d9fa791202bbe97464fad6e0903a12d73b15088d36062e89132c8e6d79";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/hr/firefox-51.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "159edb41972a2abb884c8b5910260554fed8d14d26e828f78fde9a13d9fc7a1e57803965e36e23173c224e02c49ad9d483729c72acf94e80824d4d74ecb9a694";
+      sha512 = "637ab29f7bc717b33007970bc23abbf75bcdc39df3be75c71830ec27874269a948aefdec854bf051d702f4201525a279f3f250734a35b773bbcc44e47888cb10";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/hsb/firefox-51.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "190ed5d87aced775d35b1bf909c1c832a61bd6ec8c2053724d948952d8eb2a83b7015b62589286f90ca09b02acc75f904f46a5a155720e7b728e9cd9c3187a30";
+      sha512 = "92b7c0e1ecdeb485ea616ed025589add7305be63d401c37ea0372b2bf75d90c41fb8fbdb99de1c21c61da6f8f59ab1c403d512cc0c19828c10336a9f1a315903";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/hu/firefox-51.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "a45a9a5e6af526acaa23d4b7f84d91ead0eb581989def50d57ed82ca4b8aa00c0bb6bec2ec891d5c154d0f4472fd72e7bce9a619c1860ea27dc9dc3f627ac8a1";
+      sha512 = "04e1aa441756e4452d1f8d762a5ba16af0121a3dae2a1fd1f33c223531a5f17f5cd1713b9fe81ee2c3746117df8942c26ed8e27e39e82644684babb060e32eb3";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/hy-AM/firefox-51.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "242a85f6329090814ed94a3cfea96f3c4459fe751e7741844104ad93913e5f3a27335ab736746baf89b06c619e062b5efe94de000137e4f26309cf2dacbecfe1";
+      sha512 = "a962703c41aa3a9712b9ec98b5c00b621b844de5e277f98db65f9b682222ef580e2bfb259cdd6fc4a165ff319ba62daba3e0445b4cff0c47e4582249e6dd1add";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/id/firefox-51.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "3ee7915e8b8d6cfb3bb2714ee8c5c6d25e27e4612389c33a1ae34b230afef9ed24dc4bc2debbbf5c1fedeb60d843c1849f754050a0c1153db3ed6116cc7c0a70";
+      sha512 = "fb8a70915b978d61510f843de20e3f6549331fa5e625fd831b1ad7745e33c55cbfdf0afc8fad51e82b92ff60cf88a8a9bfdf4471036aebb75380b713401d03fc";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/is/firefox-51.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "8df53c86d929fdfe64393d8005c4e5a8c1d7cc25a088699f26827cc917d8150582faac8d312e209e72d5a0d3ea53c17688f64f58f76944519df1e55d8fccb82e";
+      sha512 = "28af7725b79fbb2ea49514413e886c7e8572d55d943c99c2a08887ba8371526e3879735ca29989465a5fc7a35b09d781740b97988c3667d212c5d3eed5467e00";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/it/firefox-51.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "3fc00fcb1ed9d024aaf87ef82978131333958661644ade9aba463247dc1c0f9110e0123b9a3ad050ad1eed449300bb4280ae92f9721e67809acd5fd4842b7192";
+      sha512 = "c470694846df0b78cf0a9b43215d3e187720953508109e04b6d11c2803dd981bf4c0c2116e804246f95643ea8a8c47c4c4cebe7cf45a867ae50e98b34cd68681";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ja/firefox-51.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "0edf9c17390ca3f75441808f7b54b2f5b61028b641a35d296d7265acb64322827845ea089c2d1149c55514513a3c76903ea3ddbe5d1bafe7b8f1e35fa16ba5cf";
+      sha512 = "96c6f130818df3e642c3f43ea05180629ab9ce80cce7da668873c7cac7745d5448815d00c9dc7be88e48384c0603e2019fabd5743e4c48da6aff4495bb54c740";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ka/firefox-51.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "996747630e56969a5a1fe238a1503d33353c25202b8c795300bb6b6c5ff313847f85ec5ee5b53d6862d124bda0628c734098a446e62d229dd4858ff33c41a911";
+      sha512 = "7559a392bb227029cc6950d21e222f48744fa7cdba666219ce66697b7ab97c7d036539ee4527d956a0d74c2fe9fd6129c71c6a0faf36062cf001c2b68c973ceb";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/kab/firefox-51.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "128e2f29ceb1c22376ebe81a494ba94d50a7cb4693ab77dbebcd5096ed9494758a989aa6db88274c9e397945f6b6cd8d2a94ba35ead6be05c1e78eff3c0c2618";
+      sha512 = "f98b871784261f0569aac50f10780bcc79e338d0b385c605a3e348b050e54279e4387daffec826710b8703b2ad38fe8d63d54cf3c12d94da8368091668d9ab3b";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/kk/firefox-51.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "6055133f8531df38726ec46e6a9f864cee6b04fb323c8008b098cf5fef4b1cddc1683bd94d8659614c3379a9cae38ae1e0a9f8e2f976ab0eda40d66a6a04f8bf";
+      sha512 = "6ecfba23dce0b0ec23c4b309aafc6b6d89a69e889be31dcdffbeed90da4bbecc58c18dfbee6dcb9e09d65a495fc57535457aa7750ebab364cb46a73c548724a4";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/km/firefox-51.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "4ebc9142914314e8dbde018dcd245d3905781dfe5c31969ad647b6c6c88bb82dcdb1cd943c735f00130a1da26dd08b64990c51b1852465138e0689556b300e21";
+      sha512 = "b9eef61d168e7f73c537e276c7c4d4ec5ef4e886c10c5c1e0d16c22e07fb68ca39d64b7c0308ae662c73ebd1d1a760638da6000db4ed7a07853f096632df690a";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/kn/firefox-51.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "3444bcb239eb034b2d9d18b0b957c9ce69a7bb884e6283825553a1aabf343865f914e965ed8d25a7534ee0ea33622f85a6c13c48ae455703ff5322000cdcb335";
+      sha512 = "df5cae66a6b62d74d3b55e96135099bee9744edca2e5f3b0e8b21aa9f3cb6228d4477c63d62c18f95eeb06ba774187d214cdf0161be20c7aed7ca9d835722f11";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ko/firefox-51.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "b81ab42cd90ebd07b9d39b2cd12cbfd16e732890b5b9abbb7753bb5980c2c777de93a2ee3415f2ad28928eb7176fbfc86e4fb59e6d01b2dc69c3652f49aa1b07";
+      sha512 = "c5d023c4f0034950dbef00bf4ac4945f1e8853e10fbcdb904268bcbb855f5997fa091d7739683776af097524a5a0a602bd05dbab9ede702ec8532b18465ed47e";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/lij/firefox-51.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "1e14cfd6d66e8fdf3397bec910be3cfa032b5653f5b0ed5a8abd5eed4e43d7ee81b51d933e1ec1afaf000d5c4dee2f2c091c834b0559be7addf0c706ac87e3ec";
+      sha512 = "1c25e8bdae267c9673783f55dc99a23ba14c904a6763950098591f3a5db2e0007d11fa52506ed86018edfdffa5c3e6a7d3000bc0d30a69381b3a92d9f14192a0";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/lt/firefox-51.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "8c8ad13eb19ebe66f3920fbcc51e99902a66224f2ac3035e929709597522a29d65ee69d6aa00e0b6994b34069088f8e34abf527d7f23e8f216aa5824b8b0a200";
+      sha512 = "7c95e21dae9a449617f3405614f8ab934fadd93de771a4aa44a718ccb20e2976922cf88121d9dd3f2fbee892de7d435915b0fc7aa80ec720b297e668beeb042f";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/lv/firefox-51.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "0eca04ee8090706d24c481e7dfc8424fbba1106cb42565c57c2071c8089da043bae76294761960d23e0c52fa17b6bb43a74fe61c481875639ed956625d055c20";
+      sha512 = "61928f84cd78ca91ad758e4b4fe391a3d50cdae457c66a14511e8770c0f1ba76c986c8a1e07728717642d77557fe8d7f70513f5cf2884566e092482f5b98e18d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/mai/firefox-51.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "7c033b5f2960e697ff21fe20be9e59e80906fc0b6e40edd8f12857b7e53c79cff2c3f5b90f084a11750ee4a9e8d7db014b40362bbf70d857db013929e3ce503f";
+      sha512 = "61ccb7600c1510d6e0480f35f63286cfd095edfeaa24e9ac2540a22fd1ea0c246d221e6e5b4d1f68bdbb1c9071b480240bc660097d2a761ff4166e1b3a6a629c";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/mk/firefox-51.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "5af4666ba379a7c70ef23776deaef3a14724e2c4acd498702c7acd84548d978e2f563def0227152864ac047979b24dd6de601dd53dea046e7bb7555c914b9f26";
+      sha512 = "89ba4db24bc1e1689925885446846a915adc1bc590f2f65752c54cdf6a69ca21333a4d6ef1b3e9d7252fb890de0ec41b0c6c229b9cd0d03b167e1bf4829befa0";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ml/firefox-51.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "acc0c1a8ea26e245d031462c9a535a149a3e99867f65117c427868920413b0c7397505f36fedcbc4fa3b4307380196abc04a6b4f50da07ca2a072a6add0432ae";
+      sha512 = "2889ed4020dd1ef59d90dcf727d2758937708b1189bee785640bde9d12b32fdd252cc181c193462fb01421fcac7fe71f5989cdb21a46d8a27939bd814dec1177";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/mr/firefox-51.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "adc68983863c262bebf01c3cec52690a8351e161b857fb4d12acf4b24b9985d74fc8d55c48f09410dc14ffb0090303c8a604d3f3f427c57d8bd7383073504ae7";
+      sha512 = "d85c03d1dde8003d7f877585e1bd86bf1cd9c3685fa2a3b25d1a0cbe5496b9cf09aa44940babe42fecbe22ab8a261d585695bb441b2e84f29fe4d9721b494361";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ms/firefox-51.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "976a78fcc2db7a52353f14ee47ab80f7467675cd88855b22ad01ebdf3f793771adbde902e2e717f860d112654a13e4ebc0f9a93220166493df34e602176a5509";
+      sha512 = "9e88c9ca69dcc1acb3509d8197a73af221b38e0154e19a0912743064c1a877e23f9966ca111caadebd0245aba019832720aa7e95ac9bcd41c45852aadf7607e3";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/nb-NO/firefox-51.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "7ed2c61c430ea79a21ddfdf6915fddfd8c3fa92f39f25483eb2ac333fc904e7a338af7318fccdb569938ad4b9f72bdbed94cbd57f56ce2cbe61d038d9df754b4";
+      sha512 = "2b59fc05c2bb90cdd1c8841aca920bb9dd2f4ce125384b1cc91279f3e125668e54bbe8e73efab1d3dc018130f9c1188f0ef7d2d0031255bab6bc16b820b53ddd";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/nl/firefox-51.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "fdddc7f023aeedaed6494b2f67bf372284280c9d99bf77186150dab0882dafb185fadeebeaf77c6ba87cffbc409eb68b610cde39795a23a28635e68022a6cbf8";
+      sha512 = "cdd2c8feacd7e22dab6762289f9fe7b42dd8581adf70df47f5fe1c69083ad369da2daa8964f846787085bf6932abada8c447b15a7b5693cdd32f4c00eecbb3e8";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/nn-NO/firefox-51.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "104e51e300cf628d36c4d5fd677a489b67bf197266787ad2ba531bc33869afa4b49d14a43e23ab7f1c750fb4f2ce07a0945dc779d88b21305545503c2f9d4574";
+      sha512 = "c902e7ad7024e0e2b1acc5ac3b1006edf1d4abc4213db17da4c92628ee3687051363645829db08fd2776221a3048f8373e3a13c6b02f4f13d81f420c93b03df9";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/or/firefox-51.0.1.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "2f847576b9b4dd5d231c21526c7886c21b7d11671f23165263eb555233d89eded61a6a6f1ac4c56823d0a2649702f285fb6e8efd8cec86cefb84c94bb762c7b4";
+      sha512 = "c62a5a2135553015bbbf688bc35fa4ebee02cebb5593f7d31e30f8648bdb715b37161d34ac8310a1a0c0f651c6f336e44a71097c6b09f5cb480b0f0a17e3fff8";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/pa-IN/firefox-51.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "4fbec873e3eaa04a1f3842aa0865454b3f13ad3b7e2959fcaa518236cbf99391e48b638934f1950d889994f76ada4eab946c9f28f9ff07796d46d5e5c37235d5";
+      sha512 = "d993d5808649dc7367c38aefe9dbd49d3e434784dc515e1203260da6a6d13968971cb63949f1cf9188d5a05467f07b420825ab752e7ef3f556ca37853f841733";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/pl/firefox-51.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "4155fcaf556d5fdd5d4e74a3f70927035236432a83c9e20e4b3900e2c75f74a04d630ea7a74c0e3325231c36e0c06a32a36ced31897d36a15b55ecfcfbd53c21";
+      sha512 = "e58720685e6e55671c332f916d65ea04301fabb05bc250a56c5aed1f9b1044b333d60ef729e08ca382d775dd35b86d84dd266cd5d5bc0d275f58350a598b7464";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/pt-BR/firefox-51.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "60e70d619c46ea9e7b8822a309f95bc51ad4d3cdd1ce49afb3fa0d7c6bf6f478a27e0cafdeed9217af1ea51b527394551a0ec6ee85ab62d59425c409c0a6d2a1";
+      sha512 = "f26934daddb1f43ef364cb4c97eb9f625a816a2aede791adbfeb3cf959ef1b1c9b75f2e1bdb907be1ea4640956e55ae4facdb67a3323099b12cb23faea0891c1";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/pt-PT/firefox-51.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "ebae124b88595082fedd8a692ed3e5399ae5666bfa92d2c0d0cb75bbe9c763679beb2cd27eb31ab99adec15f723ec62096bba028655ae094808a8cc05071aae8";
+      sha512 = "ea0657b1966553e286bb7c610adcea89da7d435675cf575ed4858f207092f0eda5dd3e91a5127679aaa3b8a17efcc660c363327f4ea20590a890cc43d2ebd5ae";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/rm/firefox-51.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "ccf8792db2fb2d0c3e26c2ab080dd6c03587b5827a77a15aafb6db1a2924eb8987b27e0c9ef8160c6e91377785e998926b69f3acbca050c79a8d5efedda7460a";
+      sha512 = "197b212a29f056b22d3cf5c881bc9dc1b2cd8f47ef5e90573975a180743d81e696f5a3a3ddcd414fcff66979c6fa0e33332e5ef5586ce6e0d2f3ae7e939cd9b9";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ro/firefox-51.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "af62128c8bc705feaecc52c3dfd15970e085dcfd7912e6a00e598f471a45b346d56530209869f34069f5b7830ff0a486d5bdd0b095f7a9a6285ba9ae9f2aa2a3";
+      sha512 = "06143af441806517a03a2ba1293316f1b2979cefa8395ed3b9f3579cc6d23da8ecdd219c8cb53f871d544149e0e2f18ffa9387cd57b2407336866775c56dbcf2";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ru/firefox-51.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "f48264fa017ba40a0e43af9fdf2c3591b2337b09ac5146d94da16a2ddee0a5237dd1d99210e3baf94b949ac03e3cfe04468fd9ed27543b62d3b0c10e77835de6";
+      sha512 = "9680dc697f2760163737a443b345c657da6eb2cd6d6bfab5016675815cdc4a4b393f6f9b91277bdbb2962c7cbd5cce3670a633398a5c59d86d45d47072a72b1a";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/si/firefox-51.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "d4496babb189fc5077b6c6689a54258534b94ce7034cc57a2892f2164e10eb5ac128b905e6e1e5cb6ffaf3e15ac7a0b0c141516a5e03b58ea1458fc3aefeb904";
+      sha512 = "24a870b434a3b58cb93d229f12b58b2316f83e0be6c5e30ff724468116679a90887269af42ffb0080b4bf0866084afdf7767d8d17d3f34a6dd9c30de8de3aa1d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/sk/firefox-51.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "657dc82b1067ba145d8431157411dae31420d0fa3145005319d7978736a7faf48aede2dbbeec1994d591c0ba54293b83340da5105ca298ca79407015ac90a338";
+      sha512 = "60e5947239a89b616616c1a45375c46463b3a0ff0b2c5d37a4f5eeb6cc8992f21ee5ea87592710a89e1237512179fb84a93f471cbd8e8d7a8dfb506cec39eaac";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/sl/firefox-51.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "d4122054acaf61d4258ed5646296702d68d869d96a1d39636ea1ee833ef4649003fe76173be4aac5e829cb946dfac709c69c82d668729c2b75376067300cc06f";
+      sha512 = "c3b87002895c5cf12314f7f7c1d784228b50b892eda9c2e94a7630aa5f5bbd35a27963cb008063b53869ff18d6d003deb456ce6506f8a52c5ea11df3b736c312";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/son/firefox-51.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "f74a90d235203adf179c4874a8e429d3618effe4bd5d8928318b74769fad093c5e8adbd69c7629fbac108d13fd5dade65e268dfd419650498a0be3c925e5088f";
+      sha512 = "14437f5b71bc9902fad66e9d7cd3ce144c1dd19a8bfe1f6ce66f7f456da165cc9453b9f314e67e19fca3516d9b2a03b950befa96c2d36cd96593554eaa8a1aff";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/sq/firefox-51.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "815df30c1180c9859a3ed3c34daf8c1ffa434ccddf356691b92bf7db7a3daf6e7e62446d5720d03fc7cd98aeee0eead2e62def2410cca6cf25fc7f139027b8b4";
+      sha512 = "286d680dabb398e160a1454513938b46d32ab054136b5682533e41d1fea4d860ee192b7de48b822c17ee0386feb05ee2325fe1f135f82b28e8c98b1ab485be1d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/sr/firefox-51.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "70264d2aef00a51cf773f1643745b84baa239bf7cd8b32fade26f7d8f56fb7ad00ae95922bde87e2ce368876d3946f7193501314444ac42c69ed0c0d9c811b65";
+      sha512 = "980ade36ef136932d668222af83d8be9180070c210813abd896ccf90cca0149af2f1b634d147dc63d88bc91a4a9b2411ac24ad50632e49281fb704875e537383";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/sv-SE/firefox-51.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "1252256ae15324828995d9ae3f1db02de62ed78f1fd127a98f63b0122e52ed3d526ce2fb83eceb704a11c6e113108bf58e44d88254247a523ef53a2bd35ae9cc";
+      sha512 = "95a23a1d149cb95927446fcbc74a6e083b390f1f844d3e783a003f2f7a6699e5f0c72b5090ff9f0cda27df90fb2d1bc34c9c70dca33ef22bd1330e916a1de42d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/ta/firefox-51.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "f29232bbe2c154e7db72c6f6a510cc113544c0f78e362f595558a4e20a9f2e7a211918a96985ce54cf88dfc51f701af99dd5c6db1719763624d038ccea55c713";
+      sha512 = "0fff10acf1d6f427ad848ad852395d70b441cb6a1fb4191ed4671dcf4320665bdd6b3bf697b75331650adcea2bcde8bb07b98e6d0c65912b1573bad6509e35a8";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/te/firefox-51.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "5fadafe8657fa30af9771603c369abce6bda416a725394282fdf3443b1b50e8078212c0d016a146940e5fb5d3e485847d4754c690d81f5cb61256abfeff3e0bd";
+      sha512 = "97fd1e8ce3b2910b99a10bae70b8b2f70abbe7d6306045bdd9b2cda65be070fa2cde5ef950716a22eafb6ac4f841179fe7b982575e8c7ed43e056c8277e5f744";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/th/firefox-51.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "9e831d2a54a9bb5bb6be7a07163395755f1a5fbeb2515f57e28f714c6480497d9203c49356849e908db5788427ef9a6be1bd90c36c787183e6cf1aed4c3627f3";
+      sha512 = "9da048c44fc7d219d1c6ee0c1298cf98019b1cb14a552d832cb858063e00e3750c364a0bce93bd89a84156ed5cf0e09d5addf0723baf6e607b6516fe1a2a2c6f";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/tr/firefox-51.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "4bb5562a2c4e0feb215cb2d6da6f793824a5622bbe245c6d87c19350e3134e1191474f8091063b2c8e0fe63233739035fa6d92c330892c5ac6ab8d6457390c90";
+      sha512 = "7e8aad1d86a396de699c103e2ea422fc2740cd9d70128b30280901ec9df9453fcaf60346db8b1cb82c06ae51108176ef8bcdd4278c1050cefbe71a4f29b3a1e2";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/uk/firefox-51.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "42f2e6cc7cd7f6f2af6cec1bb22645df65f493bc432660f72af74a16d30afe2dd7954a1fa2c6b8e1471ff813ba6921dd34483b32d6fc849c37c3e1c549cae795";
+      sha512 = "23be58f1f0f75a89fe5ca96c8322b1d3c60b136f479a23b0b96c62767520aa1f09864d7bfc111e924da6c035b03b1eb3f271aecc5799c3c97b7a928c7c8c4a65";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/uz/firefox-51.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "e45f93233461588cb89e3e8b9d0c52c9600835c76baf8bc44886b6f230ba96f189068199b0f5ca5fe15a92cc2051461edb13e5fce94029459c2cee7be18871a7";
+      sha512 = "fb1f9f93ca6db9510d00c2dc55745cdce67c1e274a952f678d3377d3b3911b20b7a3649acc49c8ad4ca276ae42900ef6560a7a17bf90f758d67208655b9b203d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/vi/firefox-51.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "445e13bd76b01cfe01c6869139d896614931ccc37754998e063390788c2fcabba7e4e182fe8152a6c028477fb21619f3fd18bdde1dd05bb8dd84372db922ef0b";
+      sha512 = "925aed6825e77fa78453cab5fc1c2e92e91be01c2890f4fc93bf148c0423a37c3b4deadfb96b466f56cdb95ea0a983f0f4bc2cc41fb1926a4659a701c1d7362a";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/xh/firefox-51.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "9bbcc96b73024fb0b618a373f5b9e64943e24207fac2e1504b25daafc45c08f2c7f69027f5a392c0e6d1995b8ff54742cd4998af039cd89bd376ff0008b61551";
+      sha512 = "1b4297ae13c799cc43b9420c3c6edc7d92700788e77f6871b939fba18120745ad316919b4f8d18528df8da12dea0896ff5e1d78f8699edc72b6cf1f0357c0b6f";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/zh-CN/firefox-51.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "6242bf215048a46692062de813f8b0653b8ba9efe5f39d5fbb98a9f73309c1e6af7f9095cb7c7ce7ff8c5b1f1fd8bc6a57bb420b6679f26ae19e3622f779d5d2";
+      sha512 = "2e9683de094417d96718fb60222d85206b9610123db9bced5905c50da21b42e03133160ad523eeb74df33206e44a6889909dfaa2418b043c5e8024ef871a1502";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-x86_64/zh-TW/firefox-51.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "37664a08df20a85eb5b5551eb206c4bae7e357ca8fb9de5472e3a52156a1fe9711335204e7cc88766a13a50a64967e48c55a99afec3f08ffe46048a5f68ec538";
+      sha512 = "aa1abf501d2ca6bbe71cea5ab885c85f57b88ee68390bdb5a33047f10dbb4e5d4f3c506ee44c62ca293edd3515e32da70d23027aeae23526cbfb9e16402cd803";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ach/firefox-51.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "9e7e313b7e8a37da5678e2fc6e2b810816f3c5f433b82341c351922ddc551046d6668aaf9b983ab63e6240f97b543169a0cce165029c4c1284e6c715313091dc";
+      sha512 = "b01fe99df4dd612bd6e5033782e2dedb5416c7cc9f1de0d659f056371e24340423cd098e7775164c8e605bf895b69a0aae287b131c1533d3175d8ef8b183ae3f";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/af/firefox-51.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "6aa4de8f06c227dd22bf1e1f3f8f4572aafb499e3d30fe5b528d24ee905d8770d177d8ed954e1d3e8ad94aa6e716d31918cea0a7194729db2dc51cc40078091d";
+      sha512 = "e42c48a74351afee8e40a791dfa1a20a7a867b4fbf6fbdc9141d4905293646a099c032cb9b52859612d9d16983d11d876bcea0dbc40fa9aa88333345d1d1a788";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/an/firefox-51.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "2b9b54b35abc72edfa64d957a9b0d95cc5713a4b36beac47464d4947a0a2e640664fecbcd8aa579df2353f6836e0f81d4674fa16d33e168a4adbc002821de4fd";
+      sha512 = "06670ef25bea3800b7a5639ac945c99b7ca67183f89425f597e515385b63c803159a0b18dc27805b9e718c4751ef5232ce9b6ba39c16073e35f47e7910e47624";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ar/firefox-51.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "44c966f2563538178b1cd0950bead8d2df67ec0425ca7327e9e4e2cff7bebac06aeae5d26503c1339d7ac59f2e01520a6a1a7205d948d8febcc953bf30d56af4";
+      sha512 = "662cc92061ee62619d4b4f397057ec8142572c74a370be74d75c837e853b97eb17dc798f77e0736f3ca6acd0a4183048e81c5f8a32d57776fa72ab0dfd4f1558";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/as/firefox-51.0.1.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "99cf367af60162c073783539eb99afda545cef701616ae33ed66994c00052cf90812efd5c874a8b98dc2c51dba8330ab8ce99176858f6cc5ae640ab2fedbc210";
+      sha512 = "e18f231ea53351d473a0ac4a84abc458fc88eafacc4fac7093657c4b226eef7e52c5b3a4d06616e5556a49929fa79dd68a2f3c1a73e04b9d85ede8ff5b8167c5";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ast/firefox-51.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "536d4bde6cdd888bd06f844f16d16fd15fbf1a7743f8dae2240414a348e64568959a7655f0f69a0338826154b959066e1d5097cb51fb8e59f6366a61c6091b40";
+      sha512 = "05e174a85606820829b279b2226b6f1d2b0f24f6c0b73162b3eaa5955270be8db38c5512aa33c51b0a5df1db304537df5975f061029963eefb5eb06c0174b9b7";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/az/firefox-51.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "4c46637588a9b0874e2982ad4130bc42c3a4b2defed8ee81e4e86b06deb66bb9e9b877c381de4f247e8e13992891be2c5a01dcccd7b62655a26fc62ddee1c9b4";
+      sha512 = "b8fc2bf0d78e511b6c97a731742eb5d36a1ed74f4f6f5a58c8f6652d507b99a51dd6036654d0954488055caeb449be235d006377c3e376b7a650cd14f92945dc";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/bg/firefox-51.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "a8fb6c9f9c7041e833b6f05944b9769cb38565a773817962dc7cc0698c85b15c5f9dec6b354edbf0baa34101d44d33057e6bb78364ae294989b3da8d88b3c605";
+      sha512 = "e10684f0a0f841cbce17a6dba5aacf780fa0c3226f0638d48a29ecd5c22f21b0b882623be6269edba707394f92a581e8719a78dcf28e31505654557add711049";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/bn-BD/firefox-51.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "deaf8b9e7a825c62ca4a7135e070f0be616e7e9b4387976edd7492f4b40d94a57ff2db01d5ad2546831fde9a7ed346f298ae3e1ca2c070b723aec9cbdf0260b2";
+      sha512 = "a5bc927ef7615543b6ad8afa5b61ac08570be96ac0806c8330150ea9bd7e8dbcbc7c51a79bef45c865a05cfb776898435730954ba5b4d336063e0be4880b699c";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/bn-IN/firefox-51.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "da97d24ade2c241ba37ad20b1a6efc4a3742c218e4ccb8063e1255afcb4e03d77cb3f14b5591e7235ec42318f3e509d3c6b48a9bb94c5ac2c5e82bd270fbb3e5";
+      sha512 = "72d23cf99c23a4ba414469e823ff0b30947f37f0aeeaa857ab09b22fddb6b224a18f3c3a796288030a1a9ef03f9bf14faf7292e58682e75c5ddb1981a47c8171";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/br/firefox-51.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "6780103e36db348986fc3a442bb32afb1cfa238a800eab81d6b0629452d6915a6b199501c53730143cd4fcffa97a96718dd6be10a3fa10db6145c7dd0c5663c4";
+      sha512 = "cd5111cd1831c7d7f0498cca21a78f225b9a403cc7e791e0903c88012b6ba31c95b726e8f9df644791350b12a8df5a1d431331a75eb76c8c529935d6447797a7";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/bs/firefox-51.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "f9a0bb76c68ab8d78e095f9e41d95875f76f2052e9ad1e06dd8b6d16a70d35db91f109ad20c3c904b1a1190aa5c851cace0c56ac253c72b97a2e45992d783014";
+      sha512 = "0871b142576517d4dc2ec2a24322bd8cdc5206356f71ddfb3c71832a9f5e825b2c38471287f2b2e3a699b2331b088dab1291535b66bbd52805ae1dd78f64315f";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ca/firefox-51.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "b246544190cb1d6336046df019a21e84d7cbf360d96e4b9259379b5885e870e55041916534987d12cc7c215c46524a48ea8085ef09f2d5286adc76be4070be92";
+      sha512 = "4477a8b0650e39a27035913a956acb952f70f0a7c557ee2b97380b195296db4e2af03d08ea6ddf9d1aab699686375db06074796cb16d71807bca0afaa993840d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/cak/firefox-51.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "98ea4dde99fdfe6f1b18e39f1d5d9eb5c805c7f6287fe6c1206b71622df184c57982560fe836493d351bb0ab6fdd37bab41e5f89be2a18a6d705595f618a507f";
+      sha512 = "e0cf154538d8580faafeea44494df16995605eae0f7afb97ebad219f4371de3d92127a05dfcc227eeb3cc161a7013f71e45848c41919e3a1ab918521c6e7bc32";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/cs/firefox-51.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "7b8dac698df7c415ad1b200ab437119fa39ca7a601c241145c0f2bffb89a5b97210f4f2173ad626818f006bf5f7ff5f3571911a2058f224326268bd53f11cee5";
+      sha512 = "f6d94786b8068452de617afbfb19d662defc0c00ec412e84ed0fc58ac0510f3b9b98cbe0e26ef98b2fee41d794b46cfbfd307373a04a71a0dbccb49fa29ea916";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/cy/firefox-51.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "30f1f7453f62bc18cb65d76590e6a780757600c7bef187debde4a1f68c1355148fd2dc4b63e5b98f6516f6542b47c1165ab594dbda0be4c5a2dc6a8d948db4d0";
+      sha512 = "a794ee2a28402fa0f671b727b16840a8cdf6152e44ff9b0c9bee7bf121a955e570f8d643ae9688db385850e6abd1b9f47574922ad0b3184772184e50370ac788";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/da/firefox-51.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "00daf69b001ecac3fb11c410fec9619e7f9b9ad32fe40fbe1baf96d555678d3c6addf78d55ff6c607e525618931e441276967b92124fd8c0ea5857d2880f8b31";
+      sha512 = "895da18fcfb79737dcfeac111be8a867df75473cc3efa65c81511b9f10a8b1b7373005e42ebafbad9e1f9bb6b1cae23034e66b012cd766c1d0826ac3c919b1a0";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/de/firefox-51.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "0c7cb4ea4929d7f807eef1a74ed1e9324e2e14c79651bd6ebce523d9c8668111304556aab2656ecdd6fa82028304439782ea9f654ee2108019fa5238e707b61a";
+      sha512 = "d212a73bcb4ce90982058e942ec08dbd4054149755dd1cb8f963984b5ad5e7a0c5847760fde105510476f2cea2cb1dca4ccde78a21e9a5769e605e61162505a3";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/dsb/firefox-51.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "53c2ead4d133f3b69ffb32ec7f6ac037d30e313cb85a6baff97ca997e3fccb0bc44c7258cb21e03231cd2283d8cfe50d0f6d1d64489a9b1e12e0a69fc57d6271";
+      sha512 = "bbbec4179f5ccd5569c0442deaa23015ea9b21a91eccc150838659d399608124ed34b4c57716c1386504e3b74088df705cb4807bf1a12e29b8bc22c5ed15907c";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/el/firefox-51.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "088a6357c7e0fbd0060b8ba1369a0611c896ea2d5a23d4d38d7803c6ca9871807d9453c9a831762f27cdaa43a9827097c344441d2da1ca03aebbef922d0b1e31";
+      sha512 = "f73864a004d1f1bc5460a30ca60f589e7a98d0017b299376e0166ba9bb64b1af6b1523739133c1651945345228130c53bb13c9e9a846afef363a74a9eaf780c4";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/en-GB/firefox-51.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "e65c80fdfb097deb980df7021908e8db839b82f89b5076f213a562572e6e6ad7072fa88cef68c9d1e5c6e21925691e90ad6a9ce96fb4d71b3da4b52d11fb457e";
+      sha512 = "e7e547490b3dd9ed8260c18077e056beab6d523323c51230200a9f1e019fbb8f691e4ad42d936aca546367434d1fe901eb00c1bb16663e47dd8c6f40f0793589";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/en-US/firefox-51.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "119643dda37b8ea552450302aec2b115c2fedaf707acce9ac314b464f47d03ee76358f63c30cf788298fdb6a25af0efbecae1ab1e72d2cb53190c648154b2e4d";
+      sha512 = "cf81bd8ea9a98bef6a4ba99e1ed1058bf9cecd2f43bbac310bee8226409512cde220b6a891421adb7166eac83715cbe7e8b41aa96a7ab1cb4d0d8d8a0f15dcbe";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/en-ZA/firefox-51.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "adcbbc09fe61f04daef46c673b4b7e294ad8c107b76ea1a22e46a1a5ab5eb3e84aae711c7b9edc882be67c529abd26f6183583da3423afd152325a98742763ab";
+      sha512 = "853dd3491519ad29536f0ec078aa2f1ab73f4e436aaf9f367a8ad74188818575016292b0b3b1f9da2e94f6b6caeacfc1fc64460d4f7360be63840e45c82361b3";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/eo/firefox-51.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "247f1b6f90de42abab245390a8a66fc7095ad058b6cdb5f930efc77d47e6b9c1062cea0367c266a192c64916cc8cf8fb55b09c35f92823131c22c35b0305ffac";
+      sha512 = "dd8be779d5bc57be841580a891cb22a2b0743f9cdcd014a6d2e7b430663c74b0d8553571eab972b902dfd5e2f5c19bd9caf6e6d82499595cb7e97ca57580be22";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/es-AR/firefox-51.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "4c456158008b7e355ddaecde20cd655b772164aa976abf612ac021ead6aa82420284dc6f16327f79cc12bd9c66854b8e5c9a6ae05f53b4e9901f0d6eff75d5a6";
+      sha512 = "7c8928c448295799e73dcdd2c762f52c4c239d09f16c83dbfd1ed1e3f7910144fa41a7d58fa721418d6ed6e6e6f7973de417af67b9dcd68f1db9d32e31d59b93";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/es-CL/firefox-51.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "de45a4d7660416e8da164be585c468c24c4b80fcf0a602b93cd60556759aee619d59d08d58e2ecf28e86e5de31c2bd820905861b441d9ae1bba693204ba67779";
+      sha512 = "58ddc5c2020191308d4a6ae23fe2f948592574bb5546a479d7fbfb0e3ace2e9bfbf53a0c26b2bee91e214d2284e8f1c38037b26bfc932c62c5d34dd11e24a84d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/es-ES/firefox-51.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "b3dc903cedf008894c3afa52e503ca5266094c4766925b725f761d19a0bf7dad0ef546b36c9581c4b42de32ecf8727f752b7d3023ff97a307049fdc54045bbdf";
+      sha512 = "2aa9e83b82b23e7360cfe1aa8e70131ddd3ec32271ce951fe50aaefa1b45d083c01dfcbd2581dc2377cfca127c16d79f818e1ee09a858f6b0138574a5b8b6b33";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/es-MX/firefox-51.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "afc6090847e00c1ff9940516e7d15c048295e30e1055f9bae7f07990fb447d7ddb61a4ffa336b6f2283cadc972df86fd59f5abaa07d0399d999b8fd0c8d8354b";
+      sha512 = "689d87ac2ea33dadb20cf6b44426a63e5f058e899c29121caf2d83cf37b13de572e9c32c9e483dedb56f7de198c1745f7e5cab85988399e6790fdf337d85d2e6";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/et/firefox-51.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "1258aa0f0eeb2902ccf86e5aa97e5d174e926b57adfddced2667a9e3253a103866431dcded2ecff7411ff4f4e1866aef133eaca0921738a0bbf4a98faf813880";
+      sha512 = "18382e5c6cff469357ea010653665d03a7e9ff9588aa2d6657b98c09ae7f30c2c04c1507475596635843f222419f5caffcd95556eb9b4176ad8d60bf7c5d7f68";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/eu/firefox-51.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "540cf167ac1739e1c90290dfd0faec82924cd80e1db1d700b9a7e4ebd064895830b1b5675c5800eb4e5cc8042373e5e1b174d6fcbd0751204853e94809b89d5e";
+      sha512 = "5e5464dbfed7e91a087c7b67d715060ff97e24c83b99a68439b823992cd93bbdf994a2977a187761f92d911b19b5f53ce473628a45a8ea160c65bdab3f51c300";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/fa/firefox-51.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "0a3ca143ccac6d9fc950d9345839edeaceb68565b5f86706c3f39f1cab5aa74699f1f573c6768869bcbc0335042f11a8651401a0e6cff0849c36878b08e58a89";
+      sha512 = "34242b1cf86c83920947862561ceff073f818389164f05e88cab01d8949bba2b30a43e212be1bb71e2bb9a2498bd6ab604c52fa169d31b96864c07b747e4e5de";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ff/firefox-51.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "fd2588b2c179cfdbef55f43ca11218673a7ec818cb8e5002ba7d6957ac61dd4d1f296b00f2d39de85a14c5fffe3500ba939edadd15374e0eb6a9183d3fb4a856";
+      sha512 = "ee83ecc78c8b3c7c304971110df8fc9402e67ddcaa8d38bc6a7d0471f3122cbab2a69b578ed85b0d58b0f67bf5e775696e18685e706aacf5787b0d24931df517";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/fi/firefox-51.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "6dac643deb4db9139c522abf0b7cd86910d9f3783c3a7c41c60d2f017af742b495d64dd80e5945f045f7ade98e2668a5b5a684f61fb768cbc6ad7a22975a2246";
+      sha512 = "9eac668caa56dd7d819e388d994caa8633d18828e9ce469d0044b90e260a2fcf9b056c5d43274e6392830fa48420b6f3718988e88db70f2820ded2ed6b4527b0";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/fr/firefox-51.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "161bd06d7299a8dbc08e767c043864b77670f6919f028a746312709b84808d56d5f38558a3a4ddea19e0ebb03f283d020de8c60df9a2e7d67468a1d96fd08dff";
+      sha512 = "9abb5cac7ee05039c374444f7c03604df1b3a79055b1afb42550765ac3f337dcee93cb30f2076697149f560d3d0de4840304259dc9c79325ea04d5585432c1e9";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/fy-NL/firefox-51.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "b77fdd714cc5076981afcaec137065527f93e500a074b9a0beeb7ba85c78233d9a52735648688622f9a1e137a4e097081489d6307c5454330ac931e57f2ab469";
+      sha512 = "197d3aa8d9954f4bc6a3a318869310bcd4745b9c611c6df421c0c3f8bbacca48c7118322990a650e00104a429f16cc0eaa81fb56b68c4dca957b14cf2e2746c3";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ga-IE/firefox-51.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "265f422077a2ec1bd63a54295e6581ce1a559e9aab5b59cee79b4d38e1a494c6d15a7a1e4a211bdfe1c5671457a5ec8a8d67b436f31165f7b27e240bdaf2aec4";
+      sha512 = "b26159956597932d413e40789e8eda3191cd2e2581e22a4c450bf6a901dd3c40e330fd486a401fed5f2bd94d3affe4763debb118d524aa31d1ff7d1676e02c2d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/gd/firefox-51.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "a0f9b3f528f189004eed28ff2a9582e8a992c127d62c20514afdad69bde793a6f63a12bd92fce9d900cf600147b0d8c462d69d2d9f48613d27997b1f3fceaa8f";
+      sha512 = "38623b6b077c5cee3f4f39bdad198d2a7453a851547a966fc211f4194bff6fee47e7e6022a7600726109fd7043b83ff37275958a1fccb863f57c4e60d175997e";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/gl/firefox-51.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "605fdaac3f85a2c64eeec3373fe8a6ddcf78529398f76f5c2ec06a10ea783d2a7962f03fae9dbbc08dd7c4aa8eab07bda55cb2f2f477f4b9971d7149d4a72dc7";
+      sha512 = "d9a4287c5c5c28c15d6ac3913ea8cd51b88701ee0c5c091a9127e753d5417eefa7d10bdd159ba63204111ad032498bf80b4c944a194d60a14343db4ee1770d56";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/gn/firefox-51.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "126eb2659750de31bdd346a0e1a255bcc1bd3e6e310c3739f5ec345a95cd2f1f78e381f6ce3d9a1079d3dd07ebc4cbab4af8544db746f42375f02e6a224a9b77";
+      sha512 = "f8ad4718fe88e594eca07cd8ceabd19a51cffb17337eead004b9871f7576fbea35cd5a51434b4225e831f4a76c4fb47f1669936d4ded0953160e978f07e3e6ee";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/gu-IN/firefox-51.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "12e7b20d5344d9b866392814aba44ded081c200543ff7db4653df22358f4627b9cb93f1e93ca546b3eef864787342a02ab996b10248eaca8468b70f2347c358e";
+      sha512 = "0cd44e6375a7c11826428a7d13e9b59e73075452806f6f2d8d1e20cd9d32c36e4de684c511544aaf9845ddb6320f8f72657a9f56cae2ab10cc880428bcc55048";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/he/firefox-51.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "1f0a125f1febc79218cf0bf929a6f6e3ae7c0046ad738cfd6a4ca84cacdb4a7b6a52e1934ac6b9dee25860e23b944d2636a176ca47439e7920fc45fe026a88b3";
+      sha512 = "963562443976aa856b5d7e389d057c8bf17bb6045d5f763f5e3f46c500c5f6877d046bebb5515c726bb652b986bde4189fad3c84bc6b8812c7ab6aa47b629d8e";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/hi-IN/firefox-51.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "cef6b463aa184cbef529c985e916f5ccf33bc4d8bcf693c685e92f4b211044efab5cd9966eafe75c0f933c716c3c519fc3df84653cecfe2a8452025e2674ae23";
+      sha512 = "2ea7bdbf502a950863574bf3502df03a6d2ce8128934f52aa33f2f1d41d41320a0eb0da6b51d0fffe8ffda1ab7dccf72fc904230f2b3f11b82421f55e494a4a8";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/hr/firefox-51.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "591e79886225686fcec87dfba67548decd953ebf8a06005e76ddcce545d6b060300ed7cd2e8abe222a5900f3dc44e81036356bcb7471a9e086a320946cdc8cfb";
+      sha512 = "f7f865feab6b90082a59b2d1cf4d5f73380baecdbdda5eabffab3926747c83f3668a5feb4a792e35b56ae47e2c690b2f97b23662f2d5868f6e7be4ec4828f43e";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/hsb/firefox-51.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "722a4f539dddf2d076d2e6eab4c5eb50229bdf0142473ce13488e106a115df2470b381b6f68827a80febe200a274de9a2532cc27ed61498051186e4c1b6e6e85";
+      sha512 = "5aefabeef739ce224cc4d1d3a83f9cca3a5626cb6a3d0026ecf068e5b4283bc16735107f78d5b4ca3748e56489a0463701f1ddc021772f3d3b97ea04254a7d4b";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/hu/firefox-51.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "992beb0c027990939a0536fcb77dd6a04f3cacac584df3349fc9ed3c06bae3b162bc530c1a4ec26a39240f8db0bad84686d4352e273d495c6d0f69b23ddbdfc2";
+      sha512 = "fe1c8538d5df66ddf27b2e8e4b2e01fffdba689103371bd5a58f0ed6fe08f704438c440277272a5eeb2c261e51cd6b81d92fc28c23fbd78f87afef3564656199";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/hy-AM/firefox-51.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "00ac6027b5dac840325f6bb21a13383cfc417827eb14e21948b768062eea52fda1b3b4c9d87e39255dd8a21d05e1120d0f39d3fd878edac9eb93c698be0f7682";
+      sha512 = "8ed0da0f6df8d2c6ef65f58fc06a25ea1d96b6c69161600b104772c61ddaa3d7a572b9e971e616a6870f57668bdea326b59bdcd968ffcff5485bf8e7399a60aa";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/id/firefox-51.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "3d6a12dfc4377cb180d4231c26df99058860103aa5395ff777799766f9786093cad0fceb9b72fb73325d1d1aa60b26e9be4cdb00cb875039fe2b0ec455f444a8";
+      sha512 = "6f90d870f2964e76b394ba419479f87ad30c0b7677b37305592e028f1611690fa59fe50f32bae694bd30854d8d0cb36c1dd0ff5cb04e3e8d0a3caa779797f734";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/is/firefox-51.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "fe74d79704315a2d8568280e56dc735050e91de4467989e81db3b65a6d42ba9c6401b1aa0e50bfa3442c902c8b5b5feb3e9d39d31ada0266f33993ab9fe2522f";
+      sha512 = "68559b8cc00c5d0ec92e274e30a10bcacf5c87096617e0a7a0ce30e495482ffd5f2b4f4bc9f61e0f5d41aba722ae2ee12d9a17e2124199717720bd6e4d1a4874";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/it/firefox-51.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "60b419cff2d17621fdeadb7b8f3dd5123a6a1aec1cae8ad60ed0e516d31483e7cd827cecbd10cfc8262b662c7950097a6da87c873a0c4cb4faa46c08b1467410";
+      sha512 = "3bbbdeae057aafe87b9b7c7c99b67de5c4a2642569570cba9456d680f726a5bace48d785f6871d1731375d0d92084bf30fc60a390dddbd410573f9ffc9c81fce";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ja/firefox-51.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "43486b8e0044838e0fe57669e86308081a6a9f6e5dc77ea3cecd881e9dea95f9e9bfc7bd217f0ff6bc9d2e16d2bb7ba193e8c0d5fe8a76e5c7f74971a71990f4";
+      sha512 = "38dbf45822d7d2cabe38f3d0b36a5c0dc93436d42554fc9802c9f69f34241553fc95256edaeb410c9eb16e640e1ba09fd3f6cef48c507660234a892ee1abef43";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ka/firefox-51.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "f94aa635d7804ea9145e88d2bb6c9ba0a53b33d02def9821ddb9693f2461858bbe1f05b26f2a60b019743dec3f48305fb4fe2f8ba249e9baf50b13c25fbd38ae";
+      sha512 = "d49b3024a54f3ff2ee08b5e9a416b4e3b5ff0a69407d34b8b66a165cd5c9d167adee6cc7107a611a250bbabbf90b798d152d049bcb5c6d59846098035a081afa";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/kab/firefox-51.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "a88287ed1d391986ec290c09b7b04fd484c1ea6b78669dc430ff8aeb63851fe8bc5e51896a8afdea648aa70f9bbc7f8d3ee82868766d2477d50c23af21d17640";
+      sha512 = "6baebe38ecb1412b464702e6ab5d2d46166fc3e4ccaa4e4fb3f012ef5049146136a0eec94849148800d4fc4a1f803caec9fe9ae60b330fd4d97662a61d9bb1a0";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/kk/firefox-51.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "0170abbaf6d9765c5bb6bf8b1667b51ddc8694f5470884d864b259f23ca824233459cb5a19e8f2411d89df07bc860fc89a16d7ace3f87ceabb50a487c5829eab";
+      sha512 = "8300f42545782543318c789f4537bcf12a4e1a1674ed34e11ad3ebc2583aa944ba4f7fb9a92268d36f4c95f4ab06d8b79bb6cf3bd859edbb98c0fc5bc2ac1891";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/km/firefox-51.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "c7239821e3aafbcbcb8c8ad46e0aa981ad77725f034105d6aa0566f3375639b77f9201391fd91df440a402d2465cf000695e495c9e678c5dfa66c085b7fc09e6";
+      sha512 = "8352dc1b0eee5476bc40ba81bd7e387bb36b781df823e900bff4cffa2fce5295aec05aaefe01e24640d3ca015d83d320e95caed91539504f71b2c4591ea9707a";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/kn/firefox-51.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "8088cd7a361ea4b231b61d24b289816f8c5e689eeb1b4f063df70d540f44065a0e9ce284db020a44704b48e2276dd5c555537380e39d2854327a64390be0d37d";
+      sha512 = "0767e6bbcd9db184206dbd8d6a8519bee3824451ef1f856608ebf6eb6bfff0266b3f4f680d47fccbe5e86f4b14d8243354f3ca8683d6741d76aa8fa77621e10e";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ko/firefox-51.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "676ac2be52a7980d007f498e3efa1574d68415ee5b8648597345de22b6fd80df483d9b8a309a4ad22f4a927d45d1c9d9b21447fdb1b8fa57f420227da5a72c18";
+      sha512 = "f9b18473ffddd1f9d9f63d29ce7ba7fbaddf195d57e791a7c2a03e634714b2dc2f811730d9ad1534f2bb6271a79522f32f1e88d365b664df54146db9366f6911";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/lij/firefox-51.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "e93d9d9337299528d569810388a5bc1dbd53d083df090a9308d4cf60f138aea786f7d96ca8b62612252deaa092176cdcda5280e04a9b680f3d63a166dc2478f0";
+      sha512 = "b72a26fc384860a17bd81f075b7080129711fc9b640b5c332958ece8c47540d2b3ca41c46f35999afdacb15e4f7928b2ba943ae10ed1ea3863a7222f30329756";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/lt/firefox-51.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "6c4a21aa700cf9a551f57516349d0e1ac490713fbd51aa8beeb0de6506c7ff5c06788a196132e53b4c4ab314ccd6598ac03df9a99a61b3d4998bfca86d1261ad";
+      sha512 = "2b8e656a402b935c640a17db9d3907bb99498180d36fc0b8f2eab2a007fea9d0dddd7283292f549aead49c6ec2c926eeba728e03975905adfc561f159eae5e42";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/lv/firefox-51.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "b41fc13a30af028f605eca804640a085e711c810debcd44cf148fe142bbd410c491b9edd7f0792200e77c3cbfcb3d75a3cd4aadf8bda9837f1006ab919540c4f";
+      sha512 = "b571c834c1181c5ba2685c8ae77165cc0dad5a60d45717d2fe9e2528814b2352748295a0817fc127057a1403bd5ee2c154d8eb2d876d3ac428638562c19fa3f6";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/mai/firefox-51.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "ef6ed49b36976b243452b866315b664d4fb949dd54ace116d86d1de74df5744c1aefb69bde7926f5b2cd78d904596c80b53971bc21e3e893201a25466abd284f";
+      sha512 = "1f703f3f3456d6fdb69f6702a8c7b8e069387862b99e09d9e85ba0d34d35f5ce30bca8268d1332930f55a9d7e614ae77afbfdae5caec7c1fbbc7abb8c9898710";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/mk/firefox-51.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "28fdd392fe782836a47f8a547108990cba1796f92fdeea5f63e8d466e470b13b3fa0ca805b0de580b2620b3674ae1d25c3daaceac723179bea7da615de9dc0c4";
+      sha512 = "526b2b8709942a6c3d071c39b03625e90aba2e298b89934c3623dd61bc0beb8680729ef8f716375abb0d487507eafe885407a995f3d4365cdaea8b2d0fb55070";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ml/firefox-51.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "14c1e47a65bdfec98cc0fa3c1cb9ed58de49526fbc0b934ba2d4dbbed2ae6e3942c4f4c3f15a637156fb50347e62fd32bd661621171039a178167f7fb69bef64";
+      sha512 = "0c36352abe8088a2d0fe151e6e7d39273dafc370e1222e8251859f99b89baa8782bf108cd97c2df7dc22fc1231c6cac5409a3c0bcdb1a849c7f894732bebf78a";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/mr/firefox-51.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "8f42dbefce445d592946f91acc7cc7323a0ea1a3e3c023222146f7650f4f4ef7c416e833c40c1b911273ca8ba100f20f5a8882165532c62f1d8af6d0e03cb022";
+      sha512 = "ba013b86e7b16f1d90b1e6328ef9932e3fed6b6e9f2961944ff4a3a00afd0d0c94f9db1b25c54191b50b798bad9e5f740c2b63e094077df562d39634074d1b01";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ms/firefox-51.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "05a23010aebce6a79129883102dad6d82ae941b2dbec92b2d1b532c52250f49122f11a8c0837f26e6a7142f88e4fe71b0133c9fe1cf88cfbb18eb66fa88e567e";
+      sha512 = "a5df3ab9feaaaf459f545154a0f30dafb384febc269e701974e221a6a33e2701777141b7ca15624eeae009e984f4e813d134823ba733955d2deaeccfb1add161";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/nb-NO/firefox-51.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "c2e48ec2489e854f76200de5940a17000c80a6f93f5c797a6e0c7e43a76b67a82bbbf9d3eec917f50170522a92cf09a08a2ca25ca892bc452fa4d8cbc6fa3989";
+      sha512 = "81e16991c9e68b8fffc47eda12c1858879781a1e512a244cdb5ea202ed4abc8366b587433568b1d31a943520bbf56416b62bd00a52a2db313de619f037f5e87e";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/nl/firefox-51.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "975713ddd22a227ba289ade6a8b7e6141b2c4923de4b33f22711b2b816af2c5305aa43c7bceb7a2f7aa35a0c6e59e4dfb577ba8282dbd1a322ac99dec8245b91";
+      sha512 = "31bc837dd0a974e51712f0e3be8fbd114ebb285d34329a4282d9d41c4927bb031738958997ba77f8ec5ecff09342d2c2dbc13bc8161e8d54d331c55e7df3684c";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/nn-NO/firefox-51.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "0918907a3ec9283c2d2d60db6d4d5efdab0f25b6c3522d8289bb46ca6f7b42a461342ffb2611e5e38e52f88846836688fa9f5b461d69f3c9f838413759f4ac5c";
+      sha512 = "361730a873a3912a10437eb3f766fde1a79f2a8f9f2302e6515fb5fdc34d615fea07a225f9ef25314d4cba2b83b35f9fceda7dbdb31433ebe9cacc2dbcc4794d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/or/firefox-51.0.1.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "fb09ee90b4a4f97687310946b260caa8e115b6475305fbdef7d5d54d649d4f8cfbb2be5a3bd567f115f25ab294258726bdf34af25380c5cccc9647db0a523280";
+      sha512 = "cbdc0f8f11194bec2894daa29d92ac6c644ba55a6921315d3e30c560d761c226c0673a35c98e19e31afda3992583ce14ecb51ced97077a6a52196f30da7c127d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/pa-IN/firefox-51.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "ef266ef4b57c3efae929fb4061dad5768746383e70a813b5d0cdb32206aa2b5ffc6ef8fa91952d37b61c72c0477050642103f5c63bc0ed0001ec514e9e65494d";
+      sha512 = "21819c58f4c7e9f98f714e6392283bb2e5aedc3866a5f7360535050d75f8b54b527593af4b0004accce95459545c176cbbefb09199be15e088123556e378c5b2";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/pl/firefox-51.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "f02f704f24109b34300ad7de8582b3c59a480d162dfadf7eb1d4821fa94e793978ec9f584468b3e0bc948adc1d0296b28dc7189e09752e5c2db31c7ce3596b76";
+      sha512 = "293090773a416b8282e8eda9904646390a0b17215a156cb63bee043bf68e69a28656ab880f9c825c280deea9b6c9e13ae55e08284f540c7b50d7b7844c5989f4";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/pt-BR/firefox-51.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "4e8e8fad4dabb933392ecbda9ed5938a3dab018e95c11ce5f70eaa810ef64525d8e71d61a5203d1e6feb1fe198312eb6f929ce2f0dd4cc93fbc3006cfdf7e0a9";
+      sha512 = "ce58560445849eb90798150ebe4ffe6bad23a6cf2bdffe1688b1e0e8da01c088334604a2d32ed9317ba63f9064f4a3ba406a282cf74ca64bbb5abfb0a6c37f6e";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/pt-PT/firefox-51.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "eecc2fe5fdb7fc8ce98f0df3a838d6c44d0471eb95fc27271bbcbea5178752e1d974c4e8f0b97efa2d9743fd7695286aaaf44015ae6b5efdfd334d57094b787c";
+      sha512 = "04f86eb4d434190f313a76a3b366c35cd132930ec5fbcdf6f5bafacbaa7433cb161c278ee28a120dcdb0ea70cd9d2a36cb5fd52d45b6811bf748bde11dc43398";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/rm/firefox-51.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "ed02a26930398b4b6e63a532fce29943b634568c6dc21ba931ae0e054c0b95eea1da8949f39f47272e7ff34c6b87caa14cff5ad4ebb956630a7178e2fbc3b440";
+      sha512 = "0e1307cae4e83a0c0b883c8b84c623ccdf5f91b2d39097eb4ba86db7cbca70982c9ddf76b7036ce5dc574fbec0f02ccede1bf5ff28e2a53c4afcecab33c0073b";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ro/firefox-51.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "b356ed1dd25084e1ebc5421c9925a7d6339d1bfff7d0fd69ab392b199a904cf31c8124c0ed3df3691be727492f0334b7edb3e1cec210f7eb84a64e37dd4d4847";
+      sha512 = "cb93e5a9ba39abab21069206a6267d87773177cda7d5966dfe76cf2a6ea83a00348a7f4b1aadfa890585874a9b2cc2e27cbaba73037f4026a56f7790ce0b7df4";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ru/firefox-51.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "da92e1e769dd673201d157bfdb4070fda84610ec2e313da7a44e75d33a269cd59927409a665689c5145f6e6f463246296aa070f2c471572545443c73f110714c";
+      sha512 = "3972def5e0d34011e33476306d748e6e8936bedd3a3a4746c21a572bbf1dc71db364b5b4f83506d677d9d148dfe49aefeb56bff91e4943910348e7ec58c791ae";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/si/firefox-51.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "08499f564b5c05dca975201d2d8e32fb09385a3596af9e0fa2965968231bd93fa00158e2746769abb17c891f6059221cd0dfc3bfda11ae7df5cf54f013e73d02";
+      sha512 = "216f65d5f9ec399cb4317123d4fe9186c3caa1c403df16acf86d1987c356c32db809155bc3d9904c7396951a09b8398e402bb93d269372c924da7e690a7569d1";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/sk/firefox-51.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "c6e778692f3d3d6c01eb61652cdd698192a7df305b6328d1627443e815aee5369ec4d2409becc32798debb3441d588d8d9ff4c76e3038e58d50c1ba812dd5567";
+      sha512 = "a23944d43660d5d151b8fa618303aa5cc673eec16868ceb3b1b1c7e197f6a707cc511f63ea07263fabf20ec75d630dd699f0ec8cb2c5fc53d1642b35c90b4e2d";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/sl/firefox-51.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "a041cde5bf67eb46f328ea90ec84cf293751959e11e952e2da77fe883cf105fd70ceeddef76b2e84d7a849d0cb3c3ac89dc7d839db910fa508a1261f3fbb0a99";
+      sha512 = "ff3bd653e64c26f387c231687d4f26502ba284138596bb1f5f75549476270be712242c42be07902faed80bc327bba49f2be37db3ffa5258a9c944c3408461cb0";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/son/firefox-51.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "3e74bd82ca8259bba5e8ded47bdde199ed64a5fdb44f381d2e981dd05c009159a811348f8369eb345c8cb0fc8ef9377d69ab069be0c3d0238cb3a8e634f3b188";
+      sha512 = "adfcae5aa31e9c153b53234c9c10ff51927b8785e0952c233aff08a3de800d7b0076c9304368a0ffd52ef91b9aab1dd0718a5228c28300b03fac69edfebba0dc";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/sq/firefox-51.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "637e81118bf019d916e26f229a02756ebb1b7eb3f2a9131905320a4fd4a8bc13efbb2d2c85fb52b7ccdf3c02afe7a439754cd0222501c5ebd18069bcbb8146e1";
+      sha512 = "32f039f1f05771766d0413d0ed9a526c5cb21a0ebf5688ed577afa73e39d482cbec87878c8acd2ddf56e048992ef0c37725a6209d89add9fab72c48bcf135553";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/sr/firefox-51.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "6ebfd3264b6daaf2726614f12ccae7485773b1fcb3d55b8cba748157bdd81e9d57de5e65553fc928b6fc59a9bf346761b37321caa07b461fa757885d551bbf2d";
+      sha512 = "22a0ec9854a80f0ca6aeaf8baa98d72d0781b6e67af899701686a8b4def205b90d9b9084a2d0b160b690d4fbfc6eb55c6bb6cfaffe9f1e394b484f264fade306";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/sv-SE/firefox-51.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "3ba5a114559edb15375abf9011d9c7cef5b35d1182f43d2ee7d38d37e5ae802506c207c0a96dbce8f8a87ed35cc874a4c0748968cc86b460693144240cc2f22d";
+      sha512 = "3f1204d3b069dbfcfac753ec72ca7265008f2543c14455fec81f4cab1cacb815c1529e7c9b50672552acf6855c2de81645428bb5ae43d514d2aeab3c750159d1";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/ta/firefox-51.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "ccc13342dd8d110bb63670c1beacf2ec3e0aa48ddf775f9f8181d2733f0072dbcd465e88a4ea2c2ade503b7bc41c193d16cf4f3a6857748600cdda002c5bda00";
+      sha512 = "4f32b734fd4e4cfa1f031516176ba82b9128cf7f9577eef1b5243aaf20dc719697c86330fe58feb54aa650109fd33a97ce3e6c0d5639ca7a40d90208a0a195f7";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/te/firefox-51.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "6df83ac1eb710aa56bfeba8f2bbb52b002ba5d4a63a3ffa0fd2b9dda076d1594d5507753478ceea89c703ba07b2b78be5b2f0bc7ad15365164f251f6cfb13f3c";
+      sha512 = "55cc6c548a2f0a89ecbced9aa9903089d04771d97e71f99ca943f73c489e8f3dd0fb0a3f999d641d5162b3f43a0b2058eec62ee5009f7d796ac89d013ac15426";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/th/firefox-51.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "ed32a1b1d7bbbe625c8b528fadff8195c81bca4fa64a9b3e230066e801cd315d14d6c356fe48253a8d796127cbfb0ff0db58b25953054a2c83f55549c6c3cfdf";
+      sha512 = "64202fab7515634d5cc12845902e4c0df6b1e4b59606f1c4ca779ed684edd329915b9e133b19b465ac6343d5af91572b767171f56c7ea2883d1dd216a39eb1b8";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/tr/firefox-51.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "3e69c04d8993d290293c2d925bd93e1f4269733992c260d5ff61d111acfe0cfb82ee7ac03c78332d45742e36e3a3c8ec4b22110e6feeb5484fc5c4a7568b431f";
+      sha512 = "aec62567d934fae018c8ab4273c7f3a7350ea1e14820990374ab2542c512e005536e851b6fe315667c9ec63d48ed391ffa896fe7cbd24405945ed7f8aca4d945";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/uk/firefox-51.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "7f52ba8eef6515e267b05a48a97eafc5672b5cc77b67836d44207cc72f7b886b8d9aacd8259359433d1515046d72f97836980b9d01c281c8620b0ff693abe7e4";
+      sha512 = "e1f3df0c6637cfa394ae0d2829b24b486d0af39d46f7747e77e579e0ad4325663ba312504f5cdbc5fc2da378e7205a5e9528df99e61af20b9df58f8cf1cd54db";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/uz/firefox-51.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "d3af1571479bfceb3a9118cf90d5c5530072ff1845d2624f33549ce42581eb257d01e8e5985866114772d8c0e1a8be5d52e7d6d0a30ccee4dc9536cd6a07f4e7";
+      sha512 = "c095ff29e2c42920975400b0f80a55e22b3334859d82dde662fd9a8889884bdb045601522e961f4d0f6c6c934a5d42cc838fd263e91337fa9838479acb2064fc";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/vi/firefox-51.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "7fd67bb789c2520b9a4a1cd59f0a5713ca2eb8eddca3188a041907047ddb28d2bddfe439f2c85f75c473ddb3df08f4e783d4312af2da5bb13b57ad8dda3aed4c";
+      sha512 = "14ae54681bd1a6e48f94c6d624e00a034689489e631f4216beb019baa51f35f00eb2a764c66a4e79762c9d1188659b78e5ad50b8187354863abe9b501d4fef77";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/xh/firefox-51.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "81678e379685fe35a23c4c2f490837c8454ae9b65f6f91ac18cb3a4e0c5c475021aa175783e09d99151014604a3aec944252812cce0355b75b7a39bb8b498400";
+      sha512 = "6bcba0e20540cb93811aae08f6b10e0cf6a9108528fd0f00aa84d2af9d982578d4e03f034e6d0f155fac4519ff0ea90f3d8aa4731aafc179a5a497a26d224ef9";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/zh-CN/firefox-51.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "1212c93a2ac3f77e13199fe5c7a518bbe9a5ce573c241777e462167c02ccf3d232dfc9b15c05ad85110ff14df0cf31dfb74209dc50f7a99db068928aa3f723a9";
+      sha512 = "ffa67e88d736bdb41dd7bc046bdfa02161f3c703e992615cd98df788cce5e9f97a610f8b7b31e825dcf17dff790029081aa13316433db2c2ecd06de6aec4f811";
     }
     { url = "http://archive.mozilla.org/pub/firefox/releases/51.0.1/linux-i686/zh-TW/firefox-51.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "cd2a813befedf187cc11e8374043658a78bed9620681e66e226292c8f754f0b21c865cdb71c7b289acfb040c77361ee5c3a1ab42c34b9e893293270b1a9151a8";
+      sha512 = "d67b82836f4035ac4050751b9235d49bafb2bbea2da9d1b209451e0fc3cbf54ce70b4111d66f107a22be30baa6b6a043c2736f6e05961f0aa3cff95531601134";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change

For some reason, SHA512 hashes are updated.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

