### PR TITLE
yaft: init at 0.2.9

### DIFF
--- a/pkgs/applications/misc/yaft/default.nix
+++ b/pkgs/applications/misc/yaft/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, pkgconfig, ncurses, readline }:
+
+stdenv.mkDerivation rec {
+  version = "0.2.9";
+  name = "yaft-${version}";
+
+  src = fetchFromGitHub {
+    owner = "uobikiemukot";
+    repo = "yaft";
+    rev = "v${version}";
+    sha256 = "0l1ig8wm545kpn4l7186rymny83jkahnjim290wsl7hsszfq1ckd";
+  };
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/man}
+    DESTDIR=$out PREFIX=$out/bin/ MANPREFIX=$out/share/man/
+  '';
+
+  meta = {
+    homepage = "https://github.com/uobikiemukot/yaft";
+    description = "yet another framebuffer terminal";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/applications/misc/yaft/default.nix
+++ b/pkgs/applications/misc/yaft/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, ncurses, readline }:
+{ stdenv, fetchFromGitHub, ncurses }:
 
 stdenv.mkDerivation rec {
   version = "0.2.9";
@@ -11,14 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "0l1ig8wm545kpn4l7186rymny83jkahnjim290wsl7hsszfq1ckd";
   };
 
-  installPhase = ''
-    mkdir -p $out/{bin,share/man}
-    DESTDIR=$out PREFIX=$out/bin/ MANPREFIX=$out/share/man/
-  '';
+  buildInputs = [ ncurses ];
+
+  installFlags = [ "PREFIX=$(out)" "MANPREFIX=$(out)/share/man" ];
 
   meta = {
-    homepage = "https://github.com/uobikiemukot/yaft";
-    description = "yet another framebuffer terminal";
+    homepage = https://github.com/uobikiemukot/yaft;
+    description = "Yet another framebuffer terminal";
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4528,6 +4528,8 @@ with pkgs;
 
   xwinmosaic = callPackage ../tools/X11/xwinmosaic {};
 
+  yaft = callPackage ../applications/misc/yaft { };
+
   yarn = callPackage ../development/tools/yarn  { };
 
   yank = callPackage ../tools/misc/yank { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

