### PR TITLE
colord-kde: 2016-02-24 -> 0.5.0

### DIFF
--- a/pkgs/tools/misc/colord-kde/0.5.nix
+++ b/pkgs/tools/misc/colord-kde/0.5.nix
@@ -1,16 +1,17 @@
-{ stdenv, lib, fetchgit
+{ stdenv, lib, fetchurl
 , extra-cmake-modules, ki18n
 , kconfig, kconfigwidgets, kcoreaddons, kdbusaddons, kiconthemes, kcmutils
 , kio, knotifications, plasma-framework, kwidgetsaddons, kwindowsystem
 , kitemviews, lcms2, libXrandr, qtx11extras
 }:
 
-stdenv.mkDerivation {
-  name = "colord-kde-0.5.0.20160224";
-  src = fetchgit {
-    url = "git://anongit.kde.org/colord-kde";
-    rev = "3729d1348c57902b74283bc8280ffb5561b221db";
-    sha256 = "03ww8nskgxl38dwkbb39by18gxvrcm6w2zg9s7q05i76rpl6kkkw";
+stdenv.mkDerivation rec {
+  name = "colord-kde-${version}";
+  version = "0.5.0";
+
+  src = fetchurl {
+    url = "http://download.kde.org/stable/colord-kde/${version}/src/${name}.tar.xz";
+    sha256 = "0brdnpflm95vf4l41clrqxwvjrdwhs859n7401wxcykkmw4m0m3c";
   };
 
   nativeBuildInputs = [ extra-cmake-modules ki18n ];


### PR DESCRIPTION
###### Motivation for this change

An official version was released - I've been using this version locally for months.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

