### PR TITLE
usb-modeswitch: 2.2.1 -> 2.5.0 and nixos module

### DIFF
--- a/nixos/modules/hardware/usb-wwan.nix
+++ b/nixos/modules/hardware/usb-wwan.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  ###### interface
+
+  options = {
+
+    hardware.usbWwan = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable this option to support USB WWAN adapters.
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf config.hardware.usbWwan.enable {
+    services.udev.packages = with pkgs; [ usb-modeswitch-data ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -38,6 +38,7 @@
   ./hardware/network/rtl8192c.nix
   ./hardware/opengl.nix
   ./hardware/pcmcia.nix
+  ./hardware/usb-wwan.nix
   ./hardware/video/amdgpu.nix
   ./hardware/video/amdgpu-pro.nix
   ./hardware/video/ati.nix

--- a/pkgs/development/tools/misc/usb-modeswitch/data.nix
+++ b/pkgs/development/tools/misc/usb-modeswitch/data.nix
@@ -1,29 +1,27 @@
-{ stdenv, fetchurl, pkgconfig, libusb1, usb-modeswitch }:
-
-let
-   version = "20160112";
-in
+{ stdenv, fetchurl, pkgconfig, libusb1, tcl, usb-modeswitch }:
 
 stdenv.mkDerivation rec {
   name = "usb-modeswitch-data-${version}";
+  version = "20170205";
 
   src = fetchurl {
-     url = "http://www.draisberghof.de/usb_modeswitch/${name}.tar.bz2";
-     sha256 = "19yzqv0592b9mwgdi7apzw881q70ajyx5d56zr1z5ldi915a8yfn";
-   };
+    url    = "http://www.draisberghof.de/usb_modeswitch/${name}.tar.bz2";
+    sha256 = "1l9q4xk02zd0l50bqhyk906wbcs26ji7259q0f7qv3cj52fzvp72";
+  };
 
-  # make clean: we always build from source. It should be necessary on x86_64 only
+  inherit (usb-modeswitch) makeFlags;
+
   prePatch = ''
     sed -i 's@usb_modeswitch@${usb-modeswitch}/bin/usb_modeswitch@g' 40-usb_modeswitch.rules
-    sed -i "1 i\DESTDIR=$out" Makefile
   '';
 
-  buildInputs = [ pkgconfig libusb1 usb-modeswitch ];
+  buildInputs = [ libusb1 usb-modeswitch ];
+  # we add tcl here so we can patch in support for new devices by dropping config into
+  # the usb_modeswitch.d directory
+  nativeBuildInputs = [ pkgconfig tcl ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Device database and the rules file for 'multi-mode' USB devices";
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.marcweber ];
-    platforms = stdenv.lib.platforms.linux;
+    inherit (usb-modeswitch.meta) license maintainers platforms;
   };
 }

--- a/pkgs/development/tools/misc/usb-modeswitch/default.nix
+++ b/pkgs/development/tools/misc/usb-modeswitch/default.nix
@@ -1,31 +1,32 @@
 { stdenv, fetchurl, pkgconfig, libusb1 }:
 
-let
-   version = "2.3.0";
-in
-
 stdenv.mkDerivation rec {
   name = "usb-modeswitch-${version}";
+  version = "2.5.0";
 
   src = fetchurl {
-    url = "http://www.draisberghof.de/usb_modeswitch/${name}.tar.bz2";
-    sha256 = "1jqih1g0y78w03rchpw7fjvzwjfakak61qjp7hbr1m5nnsh2dn9p";
+    url    = "http://www.draisberghof.de/usb_modeswitch/${name}.tar.bz2";
+    sha256 = "0cvnd16n2sp3w46fy507nl29q39jxxdk5qqbvk1rxaa91llbxh1i";
   };
+
+  makeFlags = [
+    "DESTDIR=$(out)"
+    "PREFIX=$(out)"
+  ];
 
   # make clean: we always build from source. It should be necessary on x86_64 only
   preConfigure = ''
     find -type f | xargs sed 's@/bin/rm@rm@g' -i
     make clean
-    mkdir -p $out/{etc,lib/udev,share/man/man1}
-    makeFlags="DESTDIR=$out PREFIX=$out"
   '';
 
-  buildInputs = [ pkgconfig libusb1 ];
+  buildInputs = [ libusb1 ];
+  nativeBuildInputs = [ pkgconfig ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A mode switching tool for controlling 'multi-mode' USB devices";
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.marcweber ];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ marcweber peterhoeg ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

We were carrying v2.2.1 and not v2.3.0 due to the update only touching the version and not the sha256 sum.

Additionally, we add a nixos module for setting up udev to use the rules.

Unfortunately, I no longer have the hardware that made me write the module, so I cannot actually test if it works. I thought it would be better to get things into nixpkgs instead of lingering around here...

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

