### PR TITLE
httpd: added serviceExpression which extends the serviceType concept …

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -63,6 +63,8 @@ let
       let
         svcFunction =
           if svc ? function then svc.function
+          # instead of using serviceType="mediawiki"; you can copy mediawiki.nix to any location outside nixpkgs, modify it at will, and use serviceExpression=./mediawiki.nix;
+          else if svc ? serviceExpression then import (toString svc.serviceExpression)
           else import (toString "${toString ./.}/${if svc ? serviceType then svc.serviceType else svc.serviceName}.nix");
         config = (evalModules
           { modules = [ { options = res.options; config = svc.config or svc; } ];


### PR DESCRIPTION
###### Motivation for this change

with this change **one can supply a httpd module as mediawiki.nix from outside of nixpkgs** which makes extending httpd much easier during development and deployment:

# example usage

```
  services.httpd = {
        enable = true;
        adminAddr = "admin@example.org";

        hostName = "example.org";
        extraSubservices =
        [ 
          { 
            serviceExpression=./httpd-module-nextcloud.nix;
            urlPrefix = "/nextcloud";
            dbPassword = "hallo";
            adminPassword = "mysuperpassword";
            trustedDomain="example.org";
          }
        ];
      };
  ...
```

**note:** this change only extends httpd abstraction and also changes the precedence: svc.function >  serviceExpression > serviceType

this patch is a huge relief as it makes httpd extensions trivial and one does not have to manage a nixpkgs checkout for simple httpd module tests/extensions.

#  Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

