### PR TITLE
git-hub: 0.10 -> 0.11.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-hub/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-hub/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "git-hub-${version}";
-  version = "0.10";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
-    sha256 = "0zy1g6zzv6cw8ffj8ffm28qa922fys2826n5813p8icqypi04y0k";
+    sha256 = "1lpi373vzr6gda0gic7w37qhipfg7bjpn8nwjjgz44vf2vjlhf9k";
     rev = "v${version}";
     repo = "git-hub";
     owner = "sociomantic-tsunami";


### PR DESCRIPTION
###### Motivation for this change

To fix [CVE-2016-7793](http://cve.circl.lu/cve/CVE-2016-7793) and [CVE-2016-7794](http://cve.circl.lu/cve/CVE-2016-7794).

Should also be cherry-picked to stable.

###### Things done

- [X Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).