### PR TITLE
[experiment, wip] proposal - use wheels in pythonpath for bootstrapped pip

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -386,6 +386,10 @@ rec {
   ];
 
   # Python PyPI mirrors
+  
+  pypiio = [
+    https://pypi.io/packages/
+  ];
   pypi = [
     https://pypi.io/packages/source/
   ];

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -1,42 +1,42 @@
-{ stdenv, python, fetchurl, makeWrapper, unzip }:
+{ stdenv, python, fetchurl, makeWrapper, unzip, fetchUniversalWheel, writeText }:
 
 let
-  wheel_source = fetchurl {
-    url = "https://pypi.python.org/packages/py2.py3/w/wheel/wheel-0.29.0-py2.py3-none-any.whl";
+  wheel_whl = fetchUniversalWheel {
+    name = "wheel-0.29.0";
     sha256 = "ea8033fc9905804e652f75474d33410a07404c1a78dd3c949a66863bd1050ebd";
   };
-  setuptools_source = fetchurl {
-    url = "https://files.pythonhosted.org/packages/b8/cb/b919f52dd81b4b2210d0c5529b6b629a4002e08d49a90183605d1181b10c/setuptools-30.2.0-py2.py3-none-any.whl";
+  setuptools_whl = fetchUniversalWheel {
+    name = "setuptools-30.2.0";
     sha256 = "b7e7b28d6a728ea38953d66e12ef400c3c153c523539f1b3997c5a42f3770ff1";
   };
-  argparse_source = fetchurl {
-    url = "https://pypi.python.org/packages/2.7/a/argparse/argparse-1.4.0-py2.py3-none-any.whl";
+  argparse_whl = fetchUniversalWheel {
+    name = "argparse-1.4.0";
     sha256 = "0533cr5w14da8wdb2q4py6aizvbvsdbk3sj7m1jx9lwznvnlf5n3";
   };
+
+  pip_whl = fetchUniversalWheel {
+    name = "pip-9.0.1";
+    sha256 = "690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0";
+  };
+
+  inputs = [
+    wheel_whl
+    setuptools_whl
+    pip_whl
+  ] ++ stdenv.lib.optional (python.isPy26 or false) argparse_whl;
+
+  
 in stdenv.mkDerivation rec {
   name = "${python.libPrefix}-bootstrapped-pip-${version}";
   version = "9.0.1";
 
-  src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/b6/ac/7015eb97dc749283ffdec1c3a88ddb8ae03b8fad0f0e611408f196358da3/pip-9.0.1-py2.py3-none-any.whl";
-    sha256 = "690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0";
-  };
-
-  unpackPhase = ''
-    mkdir -p $out/${python.sitePackages}
-    unzip -d $out/${python.sitePackages} $src
-    unzip -d $out/${python.sitePackages} ${setuptools_source}
-    unzip -d $out/${python.sitePackages} ${wheel_source}
-  '' + stdenv.lib.optionalString (python.isPy26 or false) ''
-    unzip -d $out/${python.sitePackages} ${argparse_source}
-  '';
-
-
+  PYTHONPATH = stdenv.lib.concatStringsSep ":" inputs;
   patchPhase = ''
     mkdir -p $out/bin
   '';
-
-  buildInputs = [ python makeWrapper unzip ];
+  srcs = inputs;
+  unpackPhase = "true";
+  buildInputs = [ python makeWrapper];
 
   installPhase = ''
 
@@ -46,9 +46,6 @@ in stdenv.mkDerivation rec {
     echo 'sys.exit(main())' >> $out/bin/pip
     chmod +x $out/bin/pip
 
-    # wrap binaries with PYTHONPATH
-    for f in $out/bin/*; do
-      wrapProgram $f --prefix PYTHONPATH ":" $out/${python.sitePackages}/
-    done
+    wrapProgram $out/bin/pip --prefix PYTHONPATH ":" $PYTHONPATH/
   '';
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -37,6 +37,17 @@ let
 
   graphiteVersion = "0.9.15";
 
+  fetchSource = ({ name ? null , pname ? null, version ? null, type ? "tar.gz", sha256}:
+    let
+      _name = if name == null then "${pname}-${version}" else name;
+      _pdrv = builtins.parseDrvName _name;
+    in
+      pkgs.fetchurl {
+  
+        url = "mirror://pypiio/source/${builtins.substring 0 1 _name}/${_pdrv.name}/${_pdrv.name}-${_pdrv.version}.${type}";
+        sha256 = sha256;
+   });
+
 in {
 
   inherit python bootstrapped-pip pythonAtLeast pythonOlder isPy26 isPy27 isPy33 isPy34 isPy35 isPy36 isPyPy isPy3k mkPythonDerivation buildPythonPackage buildPythonApplication;
@@ -59,8 +70,8 @@ in {
     buildInputs = with self; [ cython pytest ];
     propagatedBuildInputs = with self; [ numpy scipy matplotlib pandas tabulate ];
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+    src = fetchSource {
+      inherit pname version;
       sha256 = "b75a47de700d01e704de95953a6e969922b2f510d7eefe59f7f8980ad44ad1b7";
     };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23,7 +23,7 @@ let
 
   callPackage = pkgs.newScope self;
 
-  bootstrapped-pip = callPackage ../development/python-modules/bootstrapped-pip { };
+  bootstrapped-pip = callPackage ../development/python-modules/bootstrapped-pip { inherit fetchUniversalWheel; };
 
   mkPythonDerivation = makeOverridable( callPackage ../development/interpreters/python/mk-python-derivation.nix {
   });
@@ -41,11 +41,15 @@ let
     let
       _name = if name == null then "${pname}-${version}" else name;
       _pdrv = builtins.parseDrvName _name;
-    in
-      pkgs.fetchurl {
+      data = rec {
         inherit sha256;
+        name = _name;
+        pname = _pdrv.name;
+        version = pdrv.version;
         url = "mirror://pypiio/${kind}/${builtins.substring 0 1 _name}/${_pdrv.name}/${_name}${ext}";
-   });
+      };
+    in
+      pkgs.fetchurl { inherit (data) sha256 url; } // data );
 
   fetchSource = args: fetchPypiMirror (args // { kind = "source"; ext=".tar.gz"; });
   fetchSourceZip = args: fetchPypiMirror (args // { kind = "source"; ext = ".zip";});

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -37,17 +37,20 @@ let
 
   graphiteVersion = "0.9.15";
 
-  fetchSource = ({ name ? null , pname ? null, version ? null, type ? "tar.gz", sha256}:
+  fetchPypiMirror = ({ name ? null , pname ? null, version ? null, kind, ext, sha256}:
     let
       _name = if name == null then "${pname}-${version}" else name;
       _pdrv = builtins.parseDrvName _name;
     in
       pkgs.fetchurl {
-  
-        url = "mirror://pypiio/source/${builtins.substring 0 1 _name}/${_pdrv.name}/${_pdrv.name}-${_pdrv.version}.${type}";
-        sha256 = sha256;
+        inherit sha256;
+        url = "mirror://pypiio/${kind}/${builtins.substring 0 1 _name}/${_pdrv.name}/${_name}${ext}";
    });
 
+  fetchSource = args: fetchPypiMirror (args // { kind = "source"; ext=".tar.gz"; });
+  fetchSourceZip = args: fetchPypiMirror (args // { kind = "source"; ext = ".zip";});
+  fetchWheel = args: fetchPypiMirror (args // rec { kind = if  "source" then "py3" else "py2"; ext = "-${kind}-none-any.whl";});
+  fetchUniversalWheel = args: fetchPypiMirror (args // rec { kind = "py2.py3"; ext = "-${kind}-none-any.whl";});
 in {
 
   inherit python bootstrapped-pip pythonAtLeast pythonOlder isPy26 isPy27 isPy33 isPy34 isPy35 isPy36 isPyPy isPy3k mkPythonDerivation buildPythonPackage buildPythonApplication;
@@ -64,14 +67,14 @@ in {
 
   acoustics = buildPythonPackage rec {
     pname = "acoustics";
+    name = "acoustics-${version}";
     version = "0.1.2";
-    name = pname + "-" + version;
 
     buildInputs = with self; [ cython pytest ];
     propagatedBuildInputs = with self; [ numpy scipy matplotlib pandas tabulate ];
 
     src = fetchSource {
-      inherit pname version;
+      inherit name;
       sha256 = "b75a47de700d01e704de95953a6e969922b2f510d7eefe59f7f8980ad44ad1b7";
     };
 
@@ -99,8 +102,8 @@ in {
 
     propagatedBuildInputs = with self; [ discid six parsedatetime isodate Babel pytimeparse ];
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/agate/${name}.tar.gz";
+    src = fetchSource {
+      inherit name;
       sha256 = "0h2w30a0zhylivz86d823a05hvg8w8p61lmm855z1wwkgml9l9d4";
     };
   };
@@ -766,8 +769,8 @@ in {
   almir = buildPythonPackage rec {
     name = "almir-0.1.8";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/almir/${name}.zip";
+    src = fetchSourceZip {
+      inherit name;
       sha256 = "5dc0b8a5071f3ff46cd2d92608f567ba446e4c733c063b17d89703caeb9868fe";
     };
 


### PR DESCRIPTION
###### Motivation for this change

this is an experiment to clean up the python path of the bootstrapped pip

i accidentally started it, and it shows many python packages have implicit setup requirements
that just arent listed

rebase to master upcoming


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

