### PR TITLE
Backport Linux 4.9 to release-16.09

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -17,7 +17,10 @@ with stdenv.lib;
 let
   buildType = "release";
 
-  inherit (importJSON ./upstream-info.json) version extpackRev extpack main;
+  extpack = "baddb7cc49224ecc1147f82d77fce2685ac39941ac9b0aac83c270dd6570ea85";
+  extpackRev = 112924;
+  main = "8267bb026717c6e55237eb798210767d9c703cfcdf01224d9bc26f7dac9f228a";
+  version = "5.1.14";
 
   # See https://github.com/NixOS/nixpkgs/issues/672 for details
   extensionPack = requireFile rec {

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = (lib.importJSON ../upstream-info.json).guest;
+    sha256 = "1b206b76050dccd3ed979307230f9ddea79551e1c0aba93faee77416733cdc8a";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/*/build";

--- a/pkgs/applications/virtualization/virtualbox/update.py
+++ b/pkgs/applications/virtualization/virtualbox/update.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python3
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p python3
+
 import os
 import re
 import json

--- a/pkgs/applications/virtualization/virtualbox/upstream-info.json
+++ b/pkgs/applications/virtualization/virtualbox/upstream-info.json
@@ -1,8 +1,8 @@
 {
   "__NOTE": "Generated using update.py from the same directory.",
-  "extpack": "d28bcd01c14eb07eedd2b964d1abe4876f0a7e0e89530e7ba285a5d6267bf322",
-  "extpackRev": "111374",
-  "guest": "347fd39df6ddee8079ad41fbc038e2fb64952a40255d75292e8e49a0a0cbf657",
-  "main": "e447031de468aee746529b2cf60768922f9beff22a13c54284aa430f5e925933",
-  "version": "5.1.8"
+  "extpack": "3982657fd4853bcbc79b9162e618545a479b65aca08e9ced43a904aeeba3ffa5",
+  "extpackRev": "112026",
+  "guest": "29fa0af66a3dd273b0c383c4adee31a52061d52f57d176b67f444698300b8c41",
+  "main": "98073b1b2adee4e6553df73cb5bb6ea8ed7c3a41a475757716fd9400393bea40",
+  "version": "5.1.10"
 }

--- a/pkgs/applications/virtualization/virtualbox/upstream-info.json
+++ b/pkgs/applications/virtualization/virtualbox/upstream-info.json
@@ -1,8 +1,8 @@
 {
   "__NOTE": "Generated using update.py from the same directory.",
-  "extpack": "3982657fd4853bcbc79b9162e618545a479b65aca08e9ced43a904aeeba3ffa5",
-  "extpackRev": "112026",
-  "guest": "29fa0af66a3dd273b0c383c4adee31a52061d52f57d176b67f444698300b8c41",
-  "main": "98073b1b2adee4e6553df73cb5bb6ea8ed7c3a41a475757716fd9400393bea40",
-  "version": "5.1.10"
+  "extpack": "baddb7cc49224ecc1147f82d77fce2685ac39941ac9b0aac83c270dd6570ea85",
+  "extpackRev": "112924",
+  "guest": "1b206b76050dccd3ed979307230f9ddea79551e1c0aba93faee77416733cdc8a",
+  "main": "8267bb026717c6e55237eb798210767d9c703cfcdf01224d9bc26f7dac9f228a",
+  "version": "5.1.14"
 }

--- a/pkgs/applications/virtualization/virtualbox/upstream-info.json
+++ b/pkgs/applications/virtualization/virtualbox/upstream-info.json
@@ -1,8 +1,0 @@
-{
-  "__NOTE": "Generated using update.py from the same directory.",
-  "extpack": "baddb7cc49224ecc1147f82d77fce2685ac39941ac9b0aac83c270dd6570ea85",
-  "extpackRev": "112924",
-  "guest": "1b206b76050dccd3ed979307230f9ddea79551e1c0aba93faee77416733cdc8a",
-  "main": "8267bb026717c6e55237eb798210767d9c703cfcdf01224d9bc26f7dac9f228a",
-  "version": "5.1.14"
-}


### PR DESCRIPTION
###### Motivation for this change

Also need to to bump virtualbox (bea3209d5f1f0d9f55efb4489a3a47540529a2bd) in order to get it to build.

Both Kernel & Virtualbox seem to work fine. Only thing I noticed is VirtualBox complains about not being able to emit audio. (Audio works fine outside of VirtualBox)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

