### PR TITLE
bashdb: init at 4.4-0.92

### DIFF
--- a/pkgs/development/tools/misc/bashdb/default.nix
+++ b/pkgs/development/tools/misc/bashdb/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "bashdb-4.4-0.92";
+
+  src = fetchurl {
+    url =  "mirror://sourceforge/sourceforge/bashdb/bashdb-4.4-0.92.tar.bz2";
+    sha256 = "6a8c2655e04339b954731a0cb0d9910e2878e45b2fc08fe469b93e4f2dbaaf92";
+  };
+
+  meta = { 
+    description = "Bash script debugger";
+    homepage = http://bashdb.sourceforge.net/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/development/tools/misc/bashdb/default.nix
+++ b/pkgs/development/tools/misc/bashdb/default.nix
@@ -1,15 +1,10 @@
 { stdenv, fetchurl }:
 
-let
-  basename = "bashdb-4.4-0.92";
-
-in
-
-stdenv.mkDerivation {
-  name = basename;
+stdenv.mkDerivation rec {
+  name = "bashdb-4.4-0.92";
 
   src = fetchurl {
-    url =  "mirror://sourceforge/bashdb/${basename}.tar.bz2";
+    url =  "mirror://sourceforge/bashdb/${name}.tar.bz2";
     sha256 = "6a8c2655e04339b954731a0cb0d9910e2878e45b2fc08fe469b93e4f2dbaaf92";
   };
 

--- a/pkgs/development/tools/misc/bashdb/default.nix
+++ b/pkgs/development/tools/misc/bashdb/default.nix
@@ -1,10 +1,15 @@
 { stdenv, fetchurl }:
 
+let
+  basename = "bashdb-4.4-0.92";
+
+in
+
 stdenv.mkDerivation {
-  name = "bashdb-4.4-0.92";
+  name = basename;
 
   src = fetchurl {
-    url =  "mirror://sourceforge/sourceforge/bashdb/bashdb-4.4-0.92.tar.bz2";
+    url =  "mirror://sourceforge/bashdb/${basename}.tar.bz2";
     sha256 = "6a8c2655e04339b954731a0cb0d9910e2878e45b2fc08fe469b93e4f2dbaaf92";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6728,6 +6728,8 @@ with pkgs;
     ruby = ruby_2_2;
   };
 
+  bashdb = callPackage ../development/tools/misc/bashdb { };
+
   gdb = callPackage ../development/tools/misc/gdb {
     guile = null;
     hurd = gnu.hurdCross;


### PR DESCRIPTION
###### Motivation for this change
To introduce the Bash script debugger.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

