### PR TITLE
purple-hangouts-hg: 2016-10-01 -> 2016-12-22

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-hangouts/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-hangouts/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "purple-hangouts-hg-${version}";
-  version = "2016-10-01";
+  version = "2016-12-22";
 
   src = fetchhg {
     url = "https://bitbucket.org/EionRobb/purple-hangouts/";
-    rev = "00e28b7";
-    sha256 = "08jllhhww3cqlw6dg9w1hli3havdfzb47grcdl184537gl2bl49d";
+    rev = "754e3bb971cfe913b90c7fd028fe47a42f9e83cb";
+    sha256 = "0b826hj5jgfdckzh9wyycxxhpyxhrhxm3n0mhaf3f57gqarriics";
   };
 
   buildInputs = [ pidgin glib json_glib protobuf protobufc ];
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -Dm755 -t $out/lib/pidgin/ libhangouts.so
     for size in 16 22 24 48; do
-      install -TDm644 hangouts$size.png $out/pixmaps/pidgin/protocols/$size/hangouts.png
+      install -TDm644 hangouts$size.png $out/share/pixmaps/pidgin/protocols/$size/hangouts.png
     done
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Upstream bugfixes, corrected pixmap install location.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

