### PR TITLE
wmutils-opt: init at v1.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -495,6 +495,7 @@
   vcunat = "Vladimír Čunát <vcunat@gmail.com>";
   vdemeester = "Vincent Demeester <vincent@sbr.pm>";
   veprbl = "Dmitry Kalinkin <veprbl@gmail.com>";
+  vifino = "Adrian Pistol <vifino@tty.sh>";
   viric = "Lluís Batlle i Rossell <viric@viric.name>";
   vizanto = "Danny Wilson <danny@prime.vc>";
   vklquevs = "vklquevs <vklquevs@gmail.com>";

--- a/pkgs/tools/X11/wmutils-opt/default.nix
+++ b/pkgs/tools/X11/wmutils-opt/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, libxcb }:
+
+stdenv.mkDerivation rec {
+  name = "wmutils-opt-${version}";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "wmutils";
+    repo = "opt";
+    rev = "v${version}";
+    sha256 = "0gd05qsir1lnzfrbnfh08qwsryz7arwj20f886nqh41m87yqaljz";
+  };
+
+  buildInputs = [ libxcb ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Optional addons to wmutils";
+    homepage = https://github.com/wmutils/opt;
+    license = licenses.isc;
+    maintainers = with maintainers; [ vifino ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17879,6 +17879,8 @@ with pkgs;
 
   wmutils-core = callPackage ../tools/X11/wmutils-core { };
 
+  wmutils-opt = callPackage ../tools/X11/wmutils-opt { };
+
   wraith = callPackage ../applications/networking/irc/wraith { };
 
   wxmupen64plus = callPackage ../misc/emulators/wxmupen64plus { };


### PR DESCRIPTION
Hello!

###### Motivation for this change
wmutils-opt has some nice helpers that complement wmutils-core, but there was no package for that yet,
so I did it.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I hope that this is an acceptable PR. I have only used Nix for a few hours, so I am quite inexperienced.