### PR TITLE
epstool: add new pacakge at version 3.08

### DIFF
--- a/pkgs/applications/graphics/epstool/default.nix
+++ b/pkgs/applications/graphics/epstool/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "epstool-3.08";
+
+  src = fetchurl {
+    url = "http://pkgs.fedoraproject.org/repo/pkgs/epstool/epstool-3.08.tar.gz/465a57a598dbef411f4ecbfbd7d4c8d7/epstool-3.08.tar.gz";
+    sha256 = "1pfgqbipwk36clhma2k365jkpvyy75ahswn8jczzys382jalpwgk";
+  };
+
+  patches = [ ./epstool.patch ];
+
+  meta = {
+    description = "Edit preview images and fix bounding boxes in EPS files";
+    homepage = http://pages.cs.wisc.edu/~ghost/gsview/epstool.htm;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/graphics/epstool/epstool.patch
+++ b/pkgs/applications/graphics/epstool/epstool.patch
@@ -1,0 +1,76 @@
+diff --git a/../epstool-3.08/makefile b/./makefile
+index 63b2997..0941c11 100644
+--- a/../epstool-3.08/makefile
++++ b/./makefile
+@@ -45,8 +45,7 @@ TARGET=epstool
+ 
+ include $(SRCDIR)/common.mak
+ 
+-EPSTOOL_ROOT=/usr/local
+-EPSTOOL_BASE=$(prefix)$(EPSTOOL_ROOT)
++EPSTOOL_BASE=$(out)
+ EPSTOOL_DOCDIR=$(EPSTOOL_BASE)/share/doc/epstool-$(EPSTOOL_VERSION)
+ EPSTOOL_MANDIR=$(EPSTOOL_BASE)/man
+ EPSTOOL_BINDIR=$(EPSTOOL_BASE)/bin
+diff --git a/../epstool-3.08/src/epstool.mak b/./src/epstool.mak
+index 63b2997..0941c11 100644
+--- a/../epstool-3.08/src/epstool.mak
++++ b/./src/epstool.mak
+@@ -45,8 +45,7 @@ TARGET=epstool
+ 
+ include $(SRCDIR)/common.mak
+ 
+-EPSTOOL_ROOT=/usr/local
+-EPSTOOL_BASE=$(prefix)$(EPSTOOL_ROOT)
++EPSTOOL_BASE=$(out)
+ EPSTOOL_DOCDIR=$(EPSTOOL_BASE)/share/doc/epstool-$(EPSTOOL_VERSION)
+ EPSTOOL_MANDIR=$(EPSTOOL_BASE)/man
+ EPSTOOL_BINDIR=$(EPSTOOL_BASE)/bin
+diff --git a/../epstool-3.08/src/os2.mak b/./src/os2.mak
+index c01c993..cf64421 100644
+--- a/../epstool-3.08/src/os2.mak
++++ b/./src/os2.mak
+@@ -43,11 +43,10 @@ EMXOMF=-Zomf -Zmts
+ CDEFS=-DOS2 -DNONAG $(LONGFILEDEF)
+ GSCDEBUG= -g
+ GSCFLAGS= $(CDEFS) $(EMXOMF) -Wall -Wstrict-prototypes -Wmissing-declarations -Wmissing-prototypes -fno-builtin -fno-common -Wcast-qual -Wwrite-strings $(CDEBUG) $(GSCDEBUG) $(RPM_OPT_FLAGS) $(XINCLUDE) $(PFLAGS) $(LIBPNGCFLAGS) $(GTKCFLAGS)
+-CCAUX=gcc
+-CC=gcc
++CCAUX=$(CC)
+ LFLAGS=$(PLINK) $(LIBPNGLIBS) $(GTKLIBS)
+-CLINK=gcc $(LDFLAGS) $(EMXOMF)
+-LINK=gcc $(LDFLAGS) $(EMXOMF)
++CLINK=$(CC) $(LDFLAGS) $(EMXOMF)
++LINK=$(CC) $(LDFLAGS) $(EMXOMF)
+ 
+ COMP=$(CC) -I$(SRCDIR) -I$(OBJDIR) $(CFLAGS) $(GSCFLAGS)
+ 
+@@ -79,8 +78,7 @@ TARGET=epstool
+ 
+ !include $(SRCDIR)/common.mak
+ 
+-EPSTOOL_ROOT=/usr/local
+-EPSTOOL_BASE=$(prefix)$(EPSTOOL_ROOT)
++EPSTOOL_BASE=$(out)
+ EPSTOOL_DOCDIR=$(EPSTOOL_BASE)/share/doc/epstool-$(EPSTOOL_VERSION)
+ EPSTOOL_MANDIR=$(EPSTOOL_BASE)/man
+ EPSTOOL_BINDIR=$(EPSTOOL_BASE)/bin
+diff --git a/../epstool-3.08/src/unixcom.mak b/./src/unixcom.mak
+index d578976..cc2bb55 100644
+--- a/../epstool-3.08/src/unixcom.mak
++++ b/./src/unixcom.mak
+@@ -24,11 +24,10 @@ MAKE=make
+ CDEFS=-DX11 -DUNIX -DNONAG $(LONGFILEDEF)
+ GSCDEBUG= -g
+ GSCFLAGS= $(CDEFS) -Wall -Wstrict-prototypes -Wmissing-declarations -Wmissing-prototypes -fno-builtin -fno-common -Wcast-qual -Wwrite-strings $(CDEBUG) $(GSCDEBUG) $(RPM_OPT_FLAGS) $(XINCLUDE) $(PFLAGS) $(LIBPNGCFLAGS) $(GTKCFLAGS)
+-CCAUX=gcc
+-CC=gcc
++CCAUX=$(CC)
+ LFLAGS=$(PLINK) $(LIBPNGLIBS) $(GTKLIBS)
+-CLINK=gcc $(LDFLAGS)
+-LINK=gcc $(LDFLAGS)
++CLINK=$(CC) $(LDFLAGS)
++LINK=$(CC) $(LDFLAGS)
+ 
+ 
+ COMP=$(CC) -I$(SRCDIR) -I$(OBJDIR) $(CFLAGS) $(GSCFLAGS)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -843,6 +843,8 @@ with pkgs;
 
   ent = callPackage ../tools/misc/ent { };
 
+  epstool = callPackage ../applications/graphics/epstool { };
+
   f3 = callPackage ../tools/filesystems/f3 { };
 
   facter = callPackage ../tools/system/facter {


### PR DESCRIPTION
###### Motivation for this change

Add `epstool` package

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

