### PR TITLE
siji: init at 2016-05-14

### DIFF
--- a/pkgs/data/fonts/siji/default.nix
+++ b/pkgs/data/fonts/siji/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "siji-${date}";
+  date = "2016-05-13";
+
+  src = fetchFromGitHub {
+    owner = "stark";
+    repo = "siji";
+    rev = "95369afac3e661cb6d3329ade5219992c88688c1";
+    sha256 = "1408g4nxwdd682vjqpmgv0cp0bfnzzzwls62cjs9zrds16xa9dpf";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/pcf
+    cp -v */*.pcf $out/share/fonts/pcf
+  '';
+
+  meta = {
+    homepage = "https://github.com/stark/siji";
+    description = "An iconic bitmap font based on Stlarch with additional glyphs";
+    liscense = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ stdenv.lib.maintainers.asymmetric ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12248,6 +12248,8 @@ with pkgs;
 
   hasklig = callPackage ../data/fonts/hasklig {};
 
+  siji = callPackage ../data/fonts/siji { };
+
   sound-theme-freedesktop = callPackage ../data/misc/sound-theme-freedesktop { };
 
   source-code-pro = callPackage ../data/fonts/source-code-pro {};


### PR DESCRIPTION
###### Motivation for this change

Init package siji

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

