### PR TITLE
yank 0.7.1 -> 0.8.0

### DIFF
--- a/pkgs/tools/misc/yank/default.nix
+++ b/pkgs/tools/misc/yank/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "mptre";
     repo = "yank";
     rev = "v${meta.version}";
-    sha256 = "1m8pnarm8n5x6ylbzxv8j9amylrllw166arrj4cx9f2jp2zbzcic";
+    sha256 = "0d1vvmz6wg1m2byd22bxikywnm2970kyfsm46fhagxardsxbp6hj";
     inherit name;
   };
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     '';
     downloadPage = "https://github.com/mptre/yank/releases";
     license = licenses.mit;
-    version = "0.7.1";
+    version = "0.8.0";
     maintainers = [ maintainers.dochang ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change

Bump version

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

