### PR TITLE
os-prober: 1.65 -> 1.71

### DIFF
--- a/pkgs/tools/misc/os-prober/default.nix
+++ b/pkgs/tools/misc/os-prober/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, makeWrapper, 
+{ stdenv, fetchurl, makeWrapper,
 systemd, # udevadm
-busybox, 
+busybox,
 coreutils, # os-prober desn't seem to work with pure busybox
 devicemapper, # lvs
 # optional dependencies
@@ -11,11 +11,11 @@ ntfs3g ? null
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.65";
+  version = "1.71";
   name = "os-prober-${version}";
   src = fetchurl {
     url = "mirror://debian/pool/main/o/os-prober/os-prober_${version}.tar.xz";
-    sha256 = "c4a7661a52edae722f7e6bacb3f107cf7086cbe768275fadf5398d04360bfc84";
+    sha256 = "5d6141e02b58e82194422b97d683d61c7ff78175d89c2f055f5d2e7a363bdd20";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
New upstream release

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

