### PR TITLE
emby: 3.0.8500 -> 3.1.5

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -1,33 +1,36 @@
-{ stdenv, fetchurl, pkgs, makeWrapper, mono, ffmpeg, ... }:
+{ stdenv, fetchurl, pkgs, unzip, sqlite, makeWrapper, mono46, ffmpeg, ... }:
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
-  version = "3.0.8500";
+  version = "3.1.5";
 
   src = fetchurl {
-    url = "https://github.com/MediaBrowser/Emby/archive/${version}.tar.gz";
-    sha256 = "0vm2yvwyhswsp31g48qdzm17c4p7c25vyiy1029hgy8nd5qy4shc";
+    url = "https://github.com/MediaBrowser/Emby/releases/download/${version}/Emby.Mono.zip";
+    sha256 = "0s0m456rxdrj58zbaby6mdgc1ndc3zx2c07n94hn3hdlgralgwaa";
   };
 
   buildInputs = with pkgs; [
+    unzip
     makeWrapper
   ];
   propagatedBuildInputs = with pkgs; [
-    mono
+    mono46
     sqlite
   ];
 
+  # Need to set sourceRoot as unpacker will complain about multiple directory output
+  sourceRoot = ".";
+
   buildPhase = ''
-    xbuild /p:Configuration="Release Mono" /p:Platform="Any CPU" /t:build MediaBrowser.Mono.sln
-    substituteInPlace MediaBrowser.Server.Mono/bin/Release\ Mono/System.Data.SQLite.dll.config --replace libsqlite3.so ${pkgs.sqlite.out}/lib/libsqlite3.so
-    substituteInPlace MediaBrowser.Server.Mono/bin/Release\ Mono/MediaBrowser.Server.Mono.exe.config --replace ProgramData-Server "/var/lib/emby/ProgramData-Server"
+    substituteInPlace SQLitePCLRaw.provider.sqlite3.dll.config --replace libsqlite3.so ${sqlite.out}/lib/libsqlite3.so
+    substituteInPlace MediaBrowser.Server.Mono.exe.config --replace ProgramData-Server "/var/lib/emby/ProgramData-Server"
   '';
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -r MediaBrowser.Server.Mono/bin/Release\ Mono/* $out/bin/
+    cp -r * $out/bin
 
-    makeWrapper "${mono}/bin/mono" $out/bin/MediaBrowser.Server.Mono \
+    makeWrapper "${mono46}/bin/mono" $out/bin/MediaBrowser.Server.Mono \
       --add-flags "$out/bin/MediaBrowser.Server.Mono.exe -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
   '';
 


### PR DESCRIPTION
Notable changes:
* mono46 is now required by emby
* switch back to pre-built binaries due to problems building from source
* sqlite path is now configured in SQLitePCLRaw.provider.sqlite3.dll.config

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

