### PR TITLE
khd: 1.1.4 -> 2.0.0

### DIFF
--- a/pkgs/os-specific/darwin/khd/default.nix
+++ b/pkgs/os-specific/darwin/khd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "khd-${version}";
-  version = "1.1.4";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "koekeishiya";
     repo = "khd";
     rev = "v${version}";
-    sha256 = "1klia3fywl0c88zbp5wdn6kxhdwdry1jwmkj27vpv8vzvdfzwfmy";
+    sha256 = "02v2bq095h1ylx700kayakg7f9p43vrz6p9ry3g7lq37s6apgm8h";
   };
 
   buildInputs = [ Carbon Cocoa ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] macOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

