### PR TITLE
smartmontools: 6.4 -> 6.5 and fix segfault on darwin

### DIFF
--- a/pkgs/tools/system/smartmontools/default.nix
+++ b/pkgs/tools/system/smartmontools/default.nix
@@ -1,30 +1,18 @@
-{ stdenv, fetchurl
-, IOKit ? null }:
+{ stdenv, fetchurl,
+IOKit ? null , ApplicationServices ? null }:
 
-let
-  version = "6.4";
-  drivedbBranch = "RELEASE_${builtins.replaceStrings ["."] ["_"] version}_DRIVEDB";
-  dbrev = "4167";
-  driverdb = fetchurl {
-    url = "http://sourceforge.net/p/smartmontools/code/${dbrev}/tree/branches/${drivedbBranch}/smartmontools/drivedb.h?format=raw";
-    sha256 = "14rv1cxbpmnq12hjwr3icjiahx5i0ak7j69310c09rah0241l5j1";
-    name = "smartmontools-drivedb.h";
-  };
-in
 stdenv.mkDerivation rec {
+  version = "6.5";
   name = "smartmontools-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/smartmontools/${name}.tar.gz";
-    sha256 = "11bsxcghh7adzdklcslamlynydxb708vfz892d5w7agdq405ddza";
+    sha256 = "1g25r6sx85b5lay5n6sbnqv05qxzj6xsafsp93hnrg1h044bps49";
   };
 
-  buildInputs = [] ++ stdenv.lib.optional stdenv.isDarwin IOKit;
+  buildInputs = [] ++ stdenv.lib.optionals stdenv.isDarwin [IOKit ApplicationServices];
 
-  patchPhase = ''
-    cp ${driverdb} drivedb.h
-    sed -i -e 's@which which >/dev/null || exit 1@alias which="type -p"@' update-smart-drivedb.in
-  '';
+  patches = [ ./smartmontools.patch ];
 
   meta = with stdenv.lib; {
     description = "Tools for monitoring the health of hard drives";

--- a/pkgs/tools/system/smartmontools/smartmontools.patch
+++ b/pkgs/tools/system/smartmontools/smartmontools.patch
@@ -1,0 +1,26 @@
+diff --git a/../smartmontools-6.5/configure b/./configure
+index acb028a..5e2c7a1 100755
+--- a/../smartmontools-6.5/configure
++++ b/./configure
+@@ -6703,7 +6703,7 @@ fi
+     ;;
+   *-*-darwin*)
+     os_deps='os_darwin.o'
+-    os_libs='-framework CoreFoundation -framework IOKit'
++    os_libs='-framework ApplicationServices -framework IOKit'
+     os_darwin=yes
+     os_man_filter=Darwin
+     ;;
+diff --git a/../smartmontools-6.5/configure.ac b/./configure.ac
+index 6bd61d7..32ff50c 100644
+--- a/../smartmontools-6.5/configure.ac
++++ b/./configure.ac
+@@ -508,7 +508,7 @@ case "${host}" in
+     ;;
+   *-*-darwin*)
+     os_deps='os_darwin.o'
+-    os_libs='-framework CoreFoundation -framework IOKit'
++    os_libs='-framework ApplicationServices -framework IOKit'
+     os_darwin=yes
+     os_man_filter=Darwin
+     ;;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3804,7 +3804,7 @@ with pkgs;
   slsnif = callPackage ../tools/misc/slsnif { };
 
   smartmontools = callPackage ../tools/system/smartmontools {
-    inherit (darwin.apple_sdk.frameworks) IOKit;
+    inherit (darwin.apple_sdk.frameworks) IOKit ApplicationServices;
   };
 
   smbldaptools = callPackage ../tools/networking/smbldaptools {


### PR DESCRIPTION
###### Motivation for this change

I was experiencing an segfault with `smartctl`, so I updated the derivation to fix it.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

