### PR TITLE
luaPackages.luazlib: fix on darwin

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -251,20 +251,22 @@ let
 
     buildInputs = [ zlib ];
 
+    preConfigure = "substituteInPlace Makefile --replace gcc cc --replace '-llua' ''";
+
     preBuild = ''
       makeFlagsArray=(
         ${platformString}
         LUAPATH="$out/share/lua/${lua.luaversion}"
         LUACPATH="$out/lib/lua/${lua.luaversion}"
         INCDIR="-I${lua}/include"
-        LIBDIR="-L$out/lib");
+        LIBDIR="-L${lua}/lib");
     '';
 
     preInstall = "mkdir -p $out/lib/lua/${lua.luaversion}";
 
     meta = with stdenv.lib; {
       homepage = https://github.com/brimworks/lua-zlib;
-      hydraPlatforms = platforms.linux;
+      hydraPlatforms = platforms.unix;
       license = licenses.mit;
       maintainers = [ maintainers.koral ];
     };

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -242,11 +242,11 @@ let
 
   luazlib = buildLuaPackage rec {
     name = "zlib-${version}";
-    version = "0.4";
+    version = "1.1";
 
     src = fetchzip {
       url = "https://github.com/brimworks/lua-zlib/archive/v${version}.tar.gz";
-      sha256 = "1pgxnjc0gvk25wsr69nsm60y5ad86z1nlq7mzj3ckygzkgi782dd";
+      sha256 = "1520lk4xpf094xn2zallqgqhs0zb4w61l49knv9y8pmhkdkxzzgy";
     };
 
     buildInputs = [ zlib ];


### PR DESCRIPTION
###### Motivation for this change

`luaPackage.luazlib` on master does not build on Darwin. Error: `gcc: command not found`

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

It does not build with luajit (error: `ld: library not found for -llua`). This can be fixed by changing `llua` into `lluajit-5.1` in the `Makefile`; but then non-luajit builds get broken.
