### PR TITLE
pidgin-xmpp-receipts: init at 0.7

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -351,6 +351,7 @@
   olejorgenb = "Ole Jørgen Brønner <olejorgenb@yahoo.no>";
   orbekk = "KJ Ørbekk <kjetil.orbekk@gmail.com>";
   orbitz = "Malcolm Matalka <mmatalka@gmail.com>";
+  orivej = "Orivej Desh <orivej@gmx.fr>";
   osener = "Ozan Sener <ozan@ozansener.com>";
   otwieracz = "Slawomir Gonet <slawek@otwiera.cz>";
   oxij = "Jan Malakhovski <oxij@oxij.org>";

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-xmpp-receipts/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-xmpp-receipts/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, pidgin } :
+
+let
+  version = "0.7";
+in
+stdenv.mkDerivation rec {
+  name = "pidgin-xmpp-receipts-${version}";
+
+  src = fetchFromGitHub {
+    owner = "noonien-d";
+    repo = "pidgin-xmpp-receipts";
+    rev = "release_${version}";
+    sha256 = "1ackqwsqgy1nfggl9na4jicv7hd542aazkg629y2jmbyj1dl3kjm";
+  };
+
+  buildInputs = [ pidgin ];
+
+  installPhase = ''
+    mkdir -p $out/lib/pidgin/
+    cp xmpp-receipts.so $out/lib/pidgin/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://devel.kondorgulasch.de/pidgin-xmpp-receipts/;
+    description = "Message delivery receipts (XEP-0184) Pidgin plugin";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ orivej ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14546,6 +14546,8 @@ with pkgs;
 
   pidgin-skypeweb = callPackage ../applications/networking/instant-messengers/pidgin-plugins/pidgin-skypeweb { };
 
+  pidgin-xmpp-receipts = callPackage ../applications/networking/instant-messengers/pidgin-plugins/pidgin-xmpp-receipts { };
+
   pidginotr = callPackage ../applications/networking/instant-messengers/pidgin-plugins/otr { };
 
   pidginosd = callPackage ../applications/networking/instant-messengers/pidgin-plugins/pidgin-osd { };


### PR DESCRIPTION
###### Motivation for this change

This plugin implements visual indication of message delivery for Pidgin.

Tested with `pidgin-with-plugins`.

Links:
- https://github.com/noonien-d/pidgin-xmpp-receipts
- http://devel.kondorgulasch.de/pidgin-xmpp-receipts/

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).