### PR TITLE
vim: make it possible to build with --enable-gui=gtk3

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -78,7 +78,7 @@ in {
       };
 
       debug = mkEnableOption "gnome-session debug messages";
-    };  
+    };
 
     environment.gnome3.packageSet = mkOption {
       default = null;
@@ -86,7 +86,7 @@ in {
       description = "Which GNOME 3 package set to use.";
       apply = p: if p == null then pkgs.gnome3 else p;
     };
-    
+
     environment.gnome3.excludePackages = mkOption {
       default = [];
       example = literalExample "[ pkgs.gnome3.totem ]";
@@ -124,6 +124,9 @@ in {
     hardware.bluetooth.enable = mkDefault true;
     services.xserver.libinput.enable = mkDefault true; # for controlling touchpad settings via gnome control center
     services.udev.packages = [ pkgs.gnome3.gnome_settings_daemon ];
+
+    # If gnome3 is installed, build vim for gtk3 too.
+    nixpkgs.config.vim.gui = "gtk3";
 
     fonts.fonts = [ pkgs.dejavu_fonts pkgs.cantarell_fonts ];
 

--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -1,7 +1,7 @@
 # TODO tidy up eg The patchelf code is patching gvim even if you don't build it..
 # but I have gvim with python support now :) - Marc
 args@{ source ? "default", callPackage, fetchurl, stdenv, ncurses, pkgconfig, gettext
-, composableDerivation, writeText, lib, config, glib, gtk2, python, perl, tcl, ruby
+, composableDerivation, writeText, lib, config, glib, gtk2, gtk3, python, perl, tcl, ruby
 , libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu
 , libICE
 
@@ -69,8 +69,8 @@ composableDerivation {
     nativeBuildInputs = [ pkgconfig ];
 
     buildInputs
-      = [ ncurses gtk2 libX11 libXext libSM libXpm libXt libXaw libXau
-          libXmu glib libICE ];
+      = [ ncurses libX11 libXext libSM libXpm libXt libXaw libXau
+          libXmu glib libICE ] ++ (if args.gui == "gtk3" then [gtk3] else [gtk2]);
 
     # most interpreters aren't tested yet.. (see python for example how to do it)
     flags = {
@@ -149,7 +149,7 @@ composableDerivation {
     ftNixSupport     = config.vim.ftNix or true;
   };
 
-  #--enable-gui=OPTS     X11 GUI default=auto OPTS=auto/no/gtk/gtk2/gnome/gnome2/motif/athena/neXtaw/photon/carbon
+  #--enable-gui=OPTS     X11 GUI default=auto OPTS=auto/no/gtk/gtk2/gtk3/gnome/gnome2/motif/athena/neXtaw/photon/carbon
     /*
       // edf "gtk_check" "gtk_check" { } #If auto-select GUI, check for GTK default=yes
       // edf "gtk2_check" "gtk2_check" { } #If GTK GUI, check for GTK+ 2 default=yes
@@ -171,4 +171,3 @@ composableDerivation {
 
   dontStrip = 1;
 })
-


### PR DESCRIPTION
This doesn't change any defaults; I suspect that dropping gtk2 support
would annoy some people so I didn't want to do that without asking
around first.

###### Motivation for this change

gtk2 has no support for scalable UI elements, which makes life unpleasant on high-dpi displays. Building with gtk3 support makes it much nicer.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---