### PR TITLE
rockbox_utility: use qt5 instead of qt4

### DIFF
--- a/pkgs/tools/misc/rockbox-utility/default.nix
+++ b/pkgs/tools/misc/rockbox-utility/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libusb1, qt4, qmake4Hook }:
+{ stdenv, fetchurl, libusb1, qt5 }:
 
 stdenv.mkDerivation  rec {
   name = "rockbox-utility-${version}";
@@ -9,16 +9,15 @@ stdenv.mkDerivation  rec {
     sha256 = "0k3ycga3b0jnj13whwiip2l0gx32l50pnbh7kfima87nq65aaa5w";
   };
 
-  buildInputs = [ libusb1 qt4 ];
-  nativeBuildInputs = [ qmake4Hook ];
+  buildInputs = [ libusb1 ] ++ (with qt5; [ qtbase qttools ]);
+  nativeBuildInputs = [ qt5.qmakeHook ];
 
   preConfigure = ''
     cd rbutil/rbutilqt
   '';
 
   installPhase = ''
-    mkdir -p $out/bin 
-    cp RockboxUtility $out/bin
+    install -Dm755 RockboxUtility $out/bin/RockboxUtility
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Stumbled over this one accidentally - let's get rid of qt4.


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
