### PR TITLE
nix-exec: patch to compile with nix-0.12pre

### DIFF
--- a/pkgs/development/interpreters/nix-exec/default.nix
+++ b/pkgs/development/interpreters/nix-exec/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, nix, git }: let
+{ stdenv, fetchurl, pkgconfig, nix, git }:
+let
   version = "4.1.5";
 in stdenv.mkDerivation {
   name = "nix-exec-${version}";
@@ -10,6 +11,10 @@ in stdenv.mkDerivation {
   };
 
   buildInputs = [ pkgconfig nix git ];
+
+  patches = [
+    ./nix-0.12.patch
+  ];
 
   meta = {
     description = "Run programs defined in nix expressions";

--- a/pkgs/development/interpreters/nix-exec/nix-0.12.patch
+++ b/pkgs/development/interpreters/nix-exec/nix-0.12.patch
@@ -1,0 +1,33 @@
+diff --git a/src/fetchgit.cc b/src/fetchgit.cc
+index d6dec1e..1e5d287 100644
+--- a/src/fetchgit.cc
++++ b/src/fetchgit.cc
+@@ -78,7 +78,7 @@ extern "C" void fetchgit( nix::EvalState & state
+   auto submodules_iter = args[0]->attrs->find(submodules_sym);
+   auto do_submodules = submodules_iter == args[0]->attrs->end() ?
+     true :
+-    state.forceBool(*submodules_iter->value);
++    state.forceBool(*submodules_iter->value, *submodules_iter->pos);
+ 
+   constexpr char fetchgit_path[] = NIXEXEC_LIBEXEC_DIR "/fetchgit.sh";
+   const char * const argv[] = { fetchgit_path
+@@ -96,15 +96,15 @@ extern "C" void fetchgit( nix::EvalState & state
+     case -1:
+       throw SysError("forking to run fetchgit");
+     case 0:
+-      pipe.readSide.close();
+-      if (dup2(pipe.writeSide, STDOUT_FILENO) == -1)
++      pipe.readSide = -1;
++      if (dup2(pipe.writeSide.get(), STDOUT_FILENO) == -1)
+         err(214, "duping pipe to stdout");
+       /* const-correct, execv doesn't modify it c just has dumb casting rules */
+       execv(fetchgit_path, const_cast<char * const *>(argv));
+       err(212, "executing %s", fetchgit_path);
+   }
+-  pipe.writeSide.close();
+-  auto path = nix::drainFD(pipe.readSide);
++  pipe.writeSide = -1;
++  auto path = nix::drainFD(pipe.readSide.get());
+ 
+   int status;
+   errno = 0;


### PR DESCRIPTION
###### Motivation for this change

fix #22315

###### Things done

- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

