### PR TITLE
wireshark: use cmake and move to gtk3/qt5

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchurl, pkgconfig, perl, flex, bison, libpcap, libnl, c-ares
-, gnutls, libgcrypt, geoip, openssl, lua5, makeDesktopItem, python, libcap, glib
-, zlib
-, withGtk ? false, gtk2 ? null, pango ? null, cairo ? null, gdk_pixbuf ? null
-, withQt ? false, qt4 ? null
+{ stdenv, lib, fetchurl, pkgconfig, pcre, perl, flex, bison, gettext, libpcap, libnl, c-ares
+, gnutls, libgcrypt, libgpgerror, geoip, openssl, lua5, makeDesktopItem, python, libcap, glib
+, libssh, zlib, cmake, ecm
+, withGtk ? false, gtk3 ? null, pango ? null, cairo ? null, gdk_pixbuf ? null
+, withQt ? false, qt5 ? null
 , ApplicationServices, SystemConfiguration, gmp
 }:
 
-assert withGtk -> !withQt && gtk2 != null;
-assert withQt -> !withGtk && qt4 != null;
+assert withGtk -> !withQt  && gtk3 != null;
+assert withQt  -> !withGtk && qt5  != null;
 
 with stdenv.lib;
 
 let
   version = "2.2.4";
   variant = if withGtk then "gtk" else if withQt then "qt" else "cli";
-in
 
-stdenv.mkDerivation {
+in stdenv.mkDerivation {
   name = "wireshark-${variant}-${version}";
 
   src = fetchurl {
@@ -25,45 +24,35 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    bison flex perl pkgconfig libpcap lua5 openssl libgcrypt gnutls
+    bison cmake ecm flex gettext pcre perl pkgconfig libpcap lua5 libssh openssl libgcrypt libgpgerror gnutls
     geoip c-ares python glib zlib
-  ] ++ optional withQt qt4
-    ++ (optionals withGtk [gtk2 pango cairo gdk_pixbuf])
-    ++ optionals stdenv.isLinux [ libcap libnl ]
+  ] ++ (optionals withQt  (with qt5; [ qtbase qtmultimedia qtsvg qttools ]))
+    ++ (optionals withGtk [ gtk3 pango cairo gdk_pixbuf ])
+    ++ optionals stdenv.isLinux  [ libcap libnl ]
     ++ optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ];
 
   patches = [ ./wireshark-lookup-dumpcap-in-path.patch ];
 
-  configureFlags = "--disable-usr-local --disable-silent-rules --with-ssl"
-    + (if withGtk then
-         " --with-gtk2 --without-gtk3 --without-qt"
-       else if withQt then
-         " --without-gtk2 --without-gtk3 --with-qt"
-       else " --disable-wireshark");
-
-  desktopItem = makeDesktopItem {
-    name = "Wireshark";
-    exec = "wireshark";
-    icon = "wireshark";
-    comment = "Powerful network protocol analysis suite";
-    desktopName = "Wireshark";
-    genericName = "Network packet analyzer";
-    categories = "Network;System";
-  };
-
   postInstall = optionalString (withQt || withGtk) ''
-    mkdir -p "$out"/share/applications/
-    mkdir -p "$out"/share/icons/
-    cp "$desktopItem/share/applications/"* "$out/share/applications/"
-    cp image/wsicon.svg "$out"/share/icons/wireshark.svg
+    ${optionalString withGtk ''
+      install -Dm644 -t $out/share/applications ../wireshark-gtk.desktop
+    ''}
+    ${optionalString withQt ''
+      install -Dm644 -t $out/share/applications ../wireshark.desktop
+    ''}
+
+    substituteInPlace $out/share/applications/*.desktop \
+      --replace "Exec=wireshark" "Exec=$out/bin/wireshark"
+
+    install -Dm644 ../image/wsicon.svg $out/share/icons/wireshark.svg
   '';
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.wireshark.org/;
     description = "Powerful network protocol analyzer";
-    license = stdenv.lib.licenses.gpl2;
+    license = licenses.gpl2;
 
     longDescription = ''
       Wireshark (formerly known as "Ethereal") is a powerful network
@@ -71,7 +60,7 @@ stdenv.mkDerivation {
       experts. It runs on UNIX, OS X and Windows.
     '';
 
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = with stdenv.lib.maintainers; [ bjornfor fpletz ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ bjornfor fpletz ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13268,6 +13268,7 @@ with pkgs;
     withGtk = false;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices SystemConfiguration;
   };
+  # The GTK UI is deprecated by upstream. You probably want the QT version.
   wireshark-gtk = wireshark-cli.override { withGtk = true; };
   wireshark-qt = wireshark-cli.override { withQt = true; };
   wireshark = wireshark-qt;


### PR DESCRIPTION
###### Motivation for this change

A few changes:

 - autotools -> cmake. This alone brought to light a few missing required dependencies.
 - use gtk3 instead of gtk2 (the GTK UI is deprecated though)
 - use qt5 instead of qt4
 - add support for SSH
 - use .desktop files from upstream instead of creating our own manually

Ref: #18559

Cc: @aske 

During ```nox-review```, ```ostinato``` fails, but that is currently broken anyway.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
