### PR TITLE
build-support: add `strings-replace` tool

### DIFF
--- a/pkgs/build-support/strings-replace/builder.sh
+++ b/pkgs/build-support/strings-replace/builder.sh
@@ -1,0 +1,9 @@
+source "$stdenv/setup"
+
+
+mkdir -p "$out/bin"
+cp "$src/strings-replace" "$out/bin"
+wrapProgram "$out/bin/strings-replace" \
+    --prefix PATH : "${binutils}/bin" \
+    --prefix PATH : "${coreutils}/bin" \
+    --prefix PATH : "${gnugrep}/bin"

--- a/pkgs/build-support/strings-replace/default.nix
+++ b/pkgs/build-support/strings-replace/default.nix
@@ -1,0 +1,14 @@
+{ stdenv
+, binutils
+, coreutils
+, gnugrep
+, makeWrapper
+}:
+
+stdenv.mkDerivation {
+  name = "strings-replace";
+  buildInputs = [ makeWrapper ];
+  src = ./.;
+  inherit binutils coreutils gnugrep;
+  builder = ./builder.sh;
+}

--- a/pkgs/build-support/strings-replace/strings-replace
+++ b/pkgs/build-support/strings-replace/strings-replace
@@ -1,0 +1,101 @@
+#!/bin/sh -eu
+
+
+PROG_NAME="$0"
+
+USAGE="$PROG_NAME [-h] PATTERN REPLACEMENT TARGET_BINARY_FILE
+
+Replace references as detected by the 'strings' command in a binary file.
+
+The replacement will be null terminated and overlaid on top of the
+original reference (in-place).  This means the replacement string can not
+be longer than the string replaced, which this script checks for.
+
+"
+
+
+main()
+(
+    while getopts h o
+    do
+        case $o in
+            h) echo "$USAGE"; exit 0;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    set +u
+    if [ -z "$1" -o -z "$2" -o -z "$3" ]
+    then echo "$USAGE"; exit 1
+    fi
+    set -u
+    target="$1"
+    pattern="$2"
+    replacement="$3"
+    work "$target" "$pattern" "$replacement"
+)
+
+
+work()
+(
+    target="$1"
+    pattern="$2"
+    replacement="$3"
+    replacement_file="$(make_replacement_file "$replacement")"
+    trap "rm $replacement_file" INT QUIT TSTP TERM EXIT
+    offsets="$(get_offsets "$target" "$pattern" "$replacement")"
+    for offset in $offsets
+    do replace "$replacement_file" "$offset" "$target"
+    done
+)
+
+
+get_offsets()
+(
+    target="$1"
+    pattern="$2"
+    replacement="$3"
+    strings -t d "$target" \
+        | grep -e "$pattern" \
+        | while read -r line
+            do
+                offset="$(echo "$line" | cut -d ' ' -f 1)"
+                orig="$(echo "$line" | cut -d ' ' -f 2)"
+                if [ "${#orig}" -lt "${#replacement}" ]
+                then
+                    msg="replacement too long"
+                    msg="${msg}\n    orig: ${orig}"
+                    msg="${msg}\n     new: ${replacement}"
+                    fail "$msg"
+                fi
+                echo "$offset"
+            done
+)
+
+
+make_replacement_file()
+(
+    replacement="$1"
+    tmpfile="$(mktemp)"
+    printf "$replacement\0" > "$tmpfile"
+    echo "$tmpfile"
+)
+
+
+replace()
+(
+    replacement_file="$1"
+    offset="$2"
+    target="$3"
+    dd if="$replacement_file" of="$target" obs=1 seek="$offset" conv=notrunc
+)
+
+
+fail()
+(
+    msg="$1"
+    echo "ERROR: $msg" > /dev/stderr
+    exit 1
+)
+
+
+main "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -280,6 +280,8 @@ with pkgs;
 
   nukeReferences = callPackage ../build-support/nuke-references/default.nix { };
 
+  stringsReplace = callPackage ../build-support/strings-replace/default.nix { };
+
   vmTools = callPackage ../build-support/vm/default.nix { };
 
   releaseTools = callPackage ../build-support/release/default.nix { };


### PR DESCRIPTION
This commit introduces a tool called "strings-replace" that allow for a simple substitution of strings as as discovered by

    strings -t d "$target" | grep e "$pattern"

Because this is a substitution of a null-terminated string into a binary, there's a fail-safe to make sure the substituted string is not longer than the original string.

This is my first commit to nixpkgs, and I read through all the contributors documentation.  Hopefully I didn't miss anything, but I'm happy to make changes as recommended.

###### Motivation for this change

This is similar to `nuke-refs`, only not /nix/store specific.  When attempting to make minimal closures, sometimes various build tools end up with hardcoded references to items in /nix/store.  `nuke-refs` is nice if these references are dead references.  But sometimes, you want to move these files to another derivation and swap these new locations into the binary file.

An example of this problem is Haskell Cabal, which has a feature called "data-files".  For example, a popular Haskell monitoring library called `ekg` uses this feature to compile in references to web assets like HTML and Javascript files.

We can have Cabal/GHC statically compile binaries to reduce the size of the transitive closure dramatically.  But this doesn't help with strings compiled into the data-section of a binary.

This problem has been discussed in Gabriel439/haskell-nix#12 and NixOS/nixpkgs#4504.

Even if Cabal/GHC were fixed such that this weren't needed for `ekg`, I think this might be a useful tool to have available.  It's a sharp knife, though, so care must be exercised when using it.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Testedcompilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---