### PR TITLE
kmix: init at 16.12.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -414,6 +414,7 @@
   roblabla = "Robin Lambertz <robinlambertz+dev@gmail.com>";
   roconnor = "Russell O'Connor <roconnor@theorem.ca>";
   romildo = "José Romildo Malaquias <malaquias@gmail.com>";
+  rongcuid = "Rongcui Dong <rongcuid@outlook.com>";
   ronny = "Ronny Pfannschmidt <nixos@ronnypfannschmidt.de>";
   rszibele = "Richard Szibele <richard_szibele@hotmail.com>";
   rushmorem = "Rushmore Mushambi <rushmore@webenchanter.com>";

--- a/pkgs/desktops/kde-5/applications/default.nix
+++ b/pkgs/desktops/kde-5/applications/default.nix
@@ -56,6 +56,7 @@ let
     khelpcenter = callPackage ./khelpcenter.nix {};
     kio-extras = callPackage ./kio-extras.nix {};
     kmime = callPackage ./kmime.nix {};
+    kmix = callPackage ./kmix.nix {};
     kompare = callPackage ./kompare.nix {};
     konsole = callPackage ./konsole.nix {};
     kwalletmanager = callPackage ./kwalletmanager.nix {};

--- a/pkgs/desktops/kde-5/applications/kmix.nix
+++ b/pkgs/desktops/kde-5/applications/kmix.nix
@@ -1,0 +1,30 @@
+{
+  kdeApp, lib, kdeWrapper,
+  ecm, kdoctools,
+  kglobalaccel, kxmlgui, kcoreaddons, kdelibs4support,
+  plasma-framework, libpulseaudio, alsaLib, libcanberra_kde
+}:
+
+let
+  unwrapped =
+    kdeApp {
+      name = "kmix";
+      meta = {
+        license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
+        maintainers = [ lib.maintainers.rongcuid ];
+      };
+      nativeBuildInputs = [ ecm kdoctools ];
+      buildInputs = [ libpulseaudio alsaLib libcanberra_kde ];
+      propagatedBuildInputs = [
+        kglobalaccel kxmlgui kcoreaddons kdelibs4support
+        plasma-framework
+      ];
+      cmakeFlags = [
+        "-DKMIX_KF5_BUILD=1"
+      ];
+    };
+in
+kdeWrapper {
+  inherit unwrapped;
+  targets = [ "bin/kmix" ];
+}


### PR DESCRIPTION
###### Motivation for this change
ALSA works, but KMix for KDE5 is not present. So I add it. I don't know how long I will keep using KDE or nix, so currently I didn't add myself as maintainer.

Note that I didn't test PulseAudio

Solves #22307 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

