### PR TITLE
minikube: pull kubernetes into PATH and 0.15.0 -> 0.16.0

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -1,15 +1,18 @@
-{ stdenv, fetchurl, kubernetes }:
+{ stdenv, lib, fetchurl, makeWrapper, docker-machine-kvm, kubernetes, libvirt, qemu }:
+
 let
   arch = if stdenv.isLinux
          then "linux-amd64"
          else "darwin-amd64";
   checksum = if stdenv.isLinux
-             then "1g6k3va84nm2h9z2ywbbkc8jabgkarqlf8wv1sp2p6s6hw7hi5h3"
-             else "0jpwyvgpl34n07chcyd7ldvk3jq3rx72cp8yf0bh7gnzr5lcnxnc";
-in
-stdenv.mkDerivation rec {
+             then "0njx4vzr0cpr3dba08w0jrlpfb8qrmxq5lqfrk3qrx29x5y6i6hi"
+             else "0i21m1pys6rdxcwsk987l08lhzpcbg4bdrznaam02g6jj6jxvq0x";
+
+# TODO: compile from source
+
+in stdenv.mkDerivation rec {
   pname = "minikube";
-  version = "0.15.0";
+  version = "0.16.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
@@ -17,26 +20,24 @@ stdenv.mkDerivation rec {
     sha256 = "${checksum}";
   };
 
-  buildInputs = [ ];
+  phases = [ "installPhase" ];
 
-  propagatedBuildInputs = [ kubernetes ];
+  buildInputs = [ makeWrapper ];
 
-  phases = [ "buildPhase" "installPhase" ];
-
-  buildPhase = ''
-    mkdir -p $out/bin
-  '';
+  binPath = lib.makeBinPath [ docker-machine-kvm kubernetes libvirt qemu ];
 
   installPhase = ''
-    cp $src $out/bin/${pname}
-    chmod +x $out/bin/${pname}
+    install -Dm755 ${src} $out/bin/${pname}
+
+    wrapProgram $out/bin/${pname} \
+      --prefix PATH : ${binPath}
   '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/kubernetes/minikube;
     description = "A tool that makes it easy to run Kubernetes locally";
     license = licenses.asl20;
-    maintainers = [ maintainers.ebzzry ];
-    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ ebzzry ];
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

minikube requires ```kubectl``` on the PATH, so we need to wrap ```kubernetes``` or it basically doesn't work without kubernetes in ```environment.systemPackages```.

We really should build this from source, but that'll be another time.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
