### PR TITLE
compcert: adding clightgen to the build

### DIFF
--- a/pkgs/development/compilers/compcert/default.nix
+++ b/pkgs/development/compilers/compcert/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     substituteInPlace ./configure --replace pl2 pl3
     substituteInPlace ./configure --replace '{toolprefix}gcc' '{toolprefix}cc'
-    ./configure -prefix $out -toolprefix ${tools}/bin/ '' +
+    ./configure -clightgen -prefix $out -toolprefix ${tools}/bin/ '' +
     (if stdenv.isDarwin then "ia32-macosx" else "ia32-linux");
 
   installTargets = "documentation install";


### PR DESCRIPTION
clightgen is a tool for coverting C to C-light.
This patch enable the build of this tool which is added to $out/bin/.

###### Motivation for this change
clightgen is a tool required for using VST <http://vst.cs.princeton.edu/>

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

