### PR TITLE
default nixos config: add firewall options.

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -588,6 +588,12 @@ $bootLoaderConfig
   # Enable the OpenSSH daemon.
   # services.openssh.enable = true;
 
+  # Open ports in the firewall.
+  # networking.firewall.allowedTCPPorts = [ ... ];
+  # networking.firewall.allowedUDPPorts = [ ... ];
+  # Or disable the firewall altogether.
+  # networking.firewall.enable = false;
+
   # Enable CUPS to print documents.
   # services.printing.enable = true;
 


### PR DESCRIPTION
By showing how to open ports in the firewall and how to disable it, we make users aware that there is a firewall enabled by default.

This implements the idea behind #12957 (as outlined by https://github.com/NixOS/nixpkgs/pull/12957#issuecomment-186649143), without changing the default value.