### PR TITLE
heroku: fix runtime behavior

### DIFF
--- a/pkgs/development/tools/heroku/default.nix
+++ b/pkgs/development/tools/heroku/default.nix
@@ -17,6 +17,8 @@ let
 
   fhsEnv = buildFHSUserEnv {
     name = "heroku-fhs-env";
+    # heroku requires psql to run `heroku pg:psql` command
+    targetPkgs = pkgs: [ pkgs.postgresql ];
   };
 
   heroku = stdenv.mkDerivation rec {

--- a/pkgs/development/tools/heroku/default.nix
+++ b/pkgs/development/tools/heroku/default.nix
@@ -69,6 +69,6 @@ in writeTextFile {
   executable = true;
   text = ''
     #!${bash}/bin/bash -e
-    ${fhsEnv}/bin/heroku-fhs-env ${heroku}/bin/heroku
+    ${fhsEnv}/bin/heroku-fhs-env ${heroku}/bin/heroku "$@"
   '';
 }


### PR DESCRIPTION
###### Motivation for this change
The new wrapper for heroku did not pass any command line arguments in, so heroku was useless. This commit fixes it.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

