### PR TITLE
heroku: 3.43.12 -> 3.43.16

### DIFF
--- a/pkgs/development/tools/heroku/default.nix
+++ b/pkgs/development/tools/heroku/default.nix
@@ -1,74 +1,56 @@
-{ stdenv, fetchurl, bash, buildFHSUserEnv, makeWrapper, writeTextFile
+{ stdenv, lib, fetchurl, makeWrapper, buildGoPackage, fetchFromGitHub
 , nodejs-6_x, postgresql, ruby }:
 
 with stdenv.lib;
 
 let
-  version = "3.43.12";
-  bin_ver = "5.4.7-8dc2c80";
+  cli = buildGoPackage rec {
+    name = "cli-${version}";
+    version = "5.6.14";
 
-  arch = {
-    "x86_64-linux" = "linux-amd64";
-  }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
+    goPackagePath = "github.com/heroku/cli";
 
-  sha256 = {
-    "x86_64-linux" = "0iqjxkdw53dvy54ahmr9yijlxrp5nbikh9z7iss93z753cgxdl06";
-  }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
-
-  fhsEnv = buildFHSUserEnv {
-    name = "heroku-fhs-env";
+    src = fetchFromGitHub {
+      owner  = "heroku";
+      repo   = "cli";
+      rev    = "v${version}";
+      sha256 = "11jccham1vkmh5284l6i30na4a4y7b1jhi2ci2z2wwx8m3gkypq9";
+    };
   };
 
-  heroku = stdenv.mkDerivation rec {
-    inherit version;
-    name = "heroku";
-
-    meta = {
-      homepage = "https://toolbelt.heroku.com";
-      description = "Everything you need to get started using Heroku";
-      maintainers = with maintainers; [ aflatter mirdhyn ];
-      license = licenses.mit;
-      platforms = with platforms; unix;
-    };
-
-    src = fetchurl {
-      url = "https://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client-${version}.tgz";
-      sha256 = "1z7z8sl2hkrc8rdvx3h00fbcrxs827xlfp6fji0ap97a6jc0v9x4";
-    };
-
-    bin = fetchurl {
-      url = "https://cli-assets.heroku.com/branches/stable/${bin_ver}/heroku-v${bin_ver}-${arch}.tar.gz";
-      inherit sha256;
-    };
-
-    installPhase = ''
-      cli=$out/share/heroku/cli
-      mkdir -p $cli
-
-      tar xzf $src -C $out --strip-components=1
-      tar xzf $bin -C $cli --strip-components=1
-
-      wrapProgram $out/bin/heroku \
-        --set HEROKU_NODE_PATH ${nodejs-6_x}/bin/node \
-        --set XDG_DATA_HOME    $out/share \
-        --set XDG_DATA_DIRS    $out/share
-
-      # When https://github.com/NixOS/patchelf/issues/66 is fixed, reinstate this and dump the fhsuserenv
-      #patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-      #  $cli/bin/heroku
-    '';
-
-    buildInputs = [ fhsEnv ruby postgresql makeWrapper ];
-
-    doUnpack = false;
-  };
-
-in writeTextFile {
+in stdenv.mkDerivation rec {
   name = "heroku-${version}";
-  destination = "/bin/heroku";
-  executable = true;
-  text = ''
-    #!${bash}/bin/bash -e
-    ${fhsEnv}/bin/heroku-fhs-env ${heroku}/bin/heroku
+  version = "3.43.16";
+
+  meta = {
+    homepage = "https://toolbelt.heroku.com";
+    description = "Everything you need to get started using Heroku";
+    maintainers = with maintainers; [ aflatter mirdhyn peterhoeg ];
+    license = licenses.mit;
+    platforms = with platforms; unix;
+  };
+
+  binPath = lib.makeBinPath [ postgresql ruby ];
+
+  buildInputs = [ makeWrapper ];
+
+  doUnpack = false;
+
+  src = fetchurl {
+    url = "https://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client-${version}.tgz";
+    sha256 = "08pai3cjaj7wshhyjcmkvyr1qxv5ab980whcm406798ng8f91hn7";
+  };
+
+  installPhase = ''
+    mkdir -p $out
+
+    tar xzf $src -C $out --strip-components=1
+    install -Dm755 ${cli}/bin/cli $out/share/heroku/cli/bin/heroku
+
+    wrapProgram $out/bin/heroku \
+      --set HEROKU_NODE_PATH ${nodejs-6_x}/bin/node \
+      --set XDG_DATA_HOME    $out/share \
+      --set XDG_DATA_DIRS    $out/share \
+      --prefix PATH : ${binPath}
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

This is the last version of the deprecated client but using the latest CLI.

We also lose the broken fhs wrapper script because the CLI is now compiled instead of just downloading the binary.

Fixes: #15262 and #20752

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
