### PR TITLE
dbus service: use /etc/dbus-1 for configuration

### DIFF
--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -27,14 +27,6 @@ let
     ''
       mkdir -p $out
 
-      cp ${pkgs.dbus.out}/share/dbus-1/{system,session}.conf $out
-
-      # avoid circular includes
-      sed -ri 's@(<include ignore_missing="yes">/etc/dbus-1/(system|session)\.conf</include>)@<!-- \1 -->@g' $out/{system,session}.conf
-
-      # include by full path
-      sed -ri "s@/etc/dbus-1/(system|session)-@$out/\1-@" $out/{system,session}.conf
-
       sed '${./dbus-system-local.conf.in}' \
         -e 's,@servicehelper@,${config.security.wrapperDir}/dbus-daemon-launch-helper,g' \
         -e 's,@extra@,${systemExtraxml},' \

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -20,8 +20,6 @@ let
     "<includedir>${d}/etc/dbus-1/session.d</includedir>"
   ]));
 
-  daemonArgs = "--address=systemd: --nofork --nopidfile --systemd-activation";
-
   configDir = pkgs.runCommand "dbus-conf"
     { preferLocalBuild = true;
       allowSubstitutes = false;
@@ -30,6 +28,9 @@ let
       mkdir -p $out
 
       cp ${pkgs.dbus.out}/share/dbus-1/{system,session}.conf $out
+
+      # avoid circular includes
+      sed -ri 's@(<include ignore_missing="yes">/etc/dbus-1/(system|session)\.conf</include>)@<!-- \1 -->@g' $out/{system,session}.conf
 
       # include by full path
       sed -ri "s@/etc/dbus-1/(system|session)-@$out/\1-@" $out/{system,session}.conf
@@ -95,6 +96,11 @@ in
 
     environment.systemPackages = [ pkgs.dbus.daemon pkgs.dbus ];
 
+    environment.etc = singleton
+      { source = configDir;
+        target = "dbus-1";
+      };
+
     users.extraUsers.messagebus = {
       uid = config.ids.uids.messagebus;
       description = "D-Bus system message bus daemon user";
@@ -125,10 +131,6 @@ in
       # Don't restart dbus-daemon. Bad things tend to happen if we do.
       reloadIfChanged = true;
       restartTriggers = [ configDir ];
-      serviceConfig.ExecStart = [
-        "" # Default dbus.service has two entries, we need to override both.
-        "${lib.getBin pkgs.dbus}/bin/dbus-daemon --config-file=/run/current-system/dbus/system.conf ${daemonArgs}"
-      ];
     };
 
     systemd.user = {
@@ -136,18 +138,10 @@ in
         # Don't restart dbus-daemon. Bad things tend to happen if we do.
         reloadIfChanged = true;
         restartTriggers = [ configDir ];
-        serviceConfig.ExecStart = [
-          "" # Default dbus.service has two entries, we need to override both.
-          "${lib.getBin pkgs.dbus}/bin/dbus-daemon --config-file=/run/current-system/dbus/session.conf ${daemonArgs}"
-        ];
       };
       sockets.dbus.wantedBy = mkIf cfg.socketActivated [ "sockets.target" ];
     };
 
     environment.pathsToLink = [ "/etc/dbus-1" "/share/dbus-1" ];
-
-    system.extraSystemBuilderCmds = ''
-      ln -s ${configDir} $out/dbus
-    '';
   };
 }


### PR DESCRIPTION
Also use upstream systemd units.

###### Motivation for this change

Fixes #22302 and brings us closer to upstream.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Credits to @layus for noticing that if we use `/etc/dbus-1` we can also use upstream systemd `ExecStart`s as is.