### PR TITLE
julia: fix build and execution on PaX.

### DIFF
--- a/pkgs/development/compilers/julia/0.5.nix
+++ b/pkgs/development/compilers/julia/0.5.nix
@@ -2,6 +2,7 @@
 # build tools
 , gfortran, m4, makeWrapper, patchelf, perl, which, python2
 , runCommand
+, paxctl
 # libjulia dependencies
 , libunwind, readline, utf8proc, zlib
 , llvm, libffi, ncurses
@@ -71,7 +72,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./0001.1-use-system-utf8proc.patch
     ./0002-use-system-suitesparse.patch
-  ];
+  ] ++ stdenv.lib.optional stdenv.needsPax ./0004-hardened.patch;
 
   postPatch = ''
     patchShebangs . contrib
@@ -89,7 +90,8 @@ stdenv.mkDerivation rec {
   ++ stdenv.lib.optionals stdenv.isDarwin [CoreServices ApplicationServices]
   ;
 
-  nativeBuildInputs = [ curl gfortran m4 makeWrapper patchelf perl python2 which ];
+  nativeBuildInputs = [ curl gfortran m4 makeWrapper patchelf perl python2 which ]
+    ++ stdenv.lib.optional stdenv.needsPax paxctl;
 
   makeFlags =
     let

--- a/pkgs/development/compilers/julia/0004-hardened-0.4.7.patch
+++ b/pkgs/development/compilers/julia/0004-hardened-0.4.7.patch
@@ -1,0 +1,25 @@
+From 0bdbe60325a22202f8e250a9578407648a0d29b9 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Wed, 1 Feb 2017 06:09:49 -0600
+Subject: [PATCH] Set pax flags on julia binaries to disable memory protection.
+
+---
+ Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 8d45a1baa..91ea33b21 100644
+--- a/Makefile
++++ b/Makefile
+@@ -61,6 +61,8 @@ julia-src-release julia-src-debug : julia-src-% : julia-deps
+ 
+ julia-ui-release julia-ui-debug : julia-ui-% : julia-src-%
+ 	@$(MAKE) $(QUIET_MAKE) -C ui julia-$*
++	@echo "setting PaX flags on $(JULIA_EXECUTABLE_$*)"
++	@paxctl -czexm $(JULIA_EXECUTABLE_$*)
+ 
+ julia-inference : julia-base julia-ui-$(JULIA_BUILD_MODE) $(build_prefix)/.examples
+ 	@$(MAKE) $(QUIET_MAKE) $(build_private_libdir)/inference.ji JULIA_BUILD_MODE=$(JULIA_BUILD_MODE)
+-- 
+2.11.0
+

--- a/pkgs/development/compilers/julia/0004-hardened.patch
+++ b/pkgs/development/compilers/julia/0004-hardened.patch
@@ -1,0 +1,25 @@
+From eddb251a00ace6e63e32e7dcb9e1ec632cac14e0 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Wed, 1 Feb 2017 06:09:49 -0600
+Subject: [PATCH] Set pax flags on julia binaries to disable memory protection.
+
+---
+ Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 0e28cc87b..aab8cfa8d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -91,6 +91,8 @@ julia-src-release julia-src-debug : julia-src-% : julia-deps julia_flisp.boot.in
+ 
+ julia-ui-release julia-ui-debug : julia-ui-% : julia-src-%
+ 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/ui julia-$*
++	@echo "setting PaX flags on $(JULIA_EXECUTABLE_$*)"
++	@paxctl -czexm $(JULIA_EXECUTABLE_$*)
+ 
+ julia-inference : julia-base julia-ui-$(JULIA_BUILD_MODE) $(build_prefix)/.examples
+ 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT) $(build_private_libdir)/inference.ji JULIA_BUILD_MODE=$(JULIA_BUILD_MODE)
+-- 
+2.11.0
+

--- a/pkgs/development/compilers/julia/default.nix
+++ b/pkgs/development/compilers/julia/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, fetchurl
 # build tools
-, gfortran, m4, makeWrapper, patchelf, perl, which, python2
+, gfortran, m4, makeWrapper, patchelf, perl, which, python2, paxctl
 # libjulia dependencies
 , libunwind, llvm, readline, utf8proc, zlib
 # standard library dependencies
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
     ./0001-use-system-utf8proc.patch
     ./0002-use-system-suitesparse.patch
     ./0003-no-ldconfig.patch
-  ];
+  ] ++ stdenv.lib.optional stdenv.needsPax ./0004-hardened-0.4.7.patch;
 
   postPatch = ''
     patchShebangs . contrib
@@ -79,7 +79,8 @@ stdenv.mkDerivation rec {
   ] ++
     stdenv.lib.optionals stdenv.isDarwin [CoreServices ApplicationServices] ;
 
-  nativeBuildInputs = [ curl gfortran m4 makeWrapper patchelf perl python2 which ];
+  nativeBuildInputs = [ curl gfortran m4 makeWrapper patchelf perl python2 which ]
+    ++ stdenv.lib.optional stdenv.needsPax paxctl;
 
   makeFlags =
     let

--- a/pkgs/development/compilers/julia/git.nix
+++ b/pkgs/development/compilers/julia/git.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, fetchurl
 # build tools
-, gfortran, m4, makeWrapper, patchelf, perl, which, python2
+, gfortran, m4, makeWrapper, patchelf, perl, which, python2, paxctl
 # libjulia dependencies
 , libunwind, readline, utf8proc, zlib
 , llvm
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./0001.1-use-system-utf8proc.patch
     ./0002-use-system-suitesparse.patch
-  ];
+  ] ++ stdenv.lib.optional stdenv.needsPax ./0004-hardened.patch;
 
   postPatch = ''
     patchShebangs . contrib
@@ -86,7 +86,8 @@ stdenv.mkDerivation rec {
   ++ stdenv.lib.optionals stdenv.isDarwin [CoreServices ApplicationServices]
   ;
 
-  nativeBuildInputs = [ curl gfortran m4 makeWrapper patchelf perl python2 which ];
+  nativeBuildInputs = [ curl gfortran m4 makeWrapper patchelf perl python2 which ]
+    ++ stdenv.lib.optional stdenv.needsPax paxctl;
 
   makeFlags =
     let


### PR DESCRIPTION
Alpine and Gentoo set the same flags here, FWIW.

###### Motivation for this change

Without this change, julia fails to build or execute on PaX-enabled hosts.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

