### PR TITLE
mbedtls: 1.3.17 -> 1.3.18

### DIFF
--- a/pkgs/development/libraries/mbedtls/1.3.nix
+++ b/pkgs/development/libraries/mbedtls/1.3.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, perl }:
 
 stdenv.mkDerivation rec {
-  name = "mbedtls-1.3.17";
+  name = "mbedtls-1.3.18";
 
   src = fetchurl {
     url = "https://tls.mbed.org/download/${name}-gpl.tgz";
-    sha256 = "10nviv3d8w6sp3kn3yzdpssvzqxdbr4kg38g7rg930q2hlzb9gpm";
+    sha256 = "188fjm0zzggxrjxnqc7zv7zz8pvys6yp1jx3xdyq8970h9qj2ad2";
   };
 
   nativeBuildInputs = [ perl ];


### PR DESCRIPTION
###### Motivation for this change

Fixees security issue as mentioned in #22342

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

