### PR TITLE
dbus: don't search for units in current-system

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -9,8 +9,9 @@ let
   version = "1.10.14";
   sha256 = "10x0wvv2ly4lyyfd42k4xw0ar5qdbi9cksw3l5fcwf1y6mq8y8r3";
 
-self =  stdenv.mkDerivation {
+self = stdenv.mkDerivation {
     name = "dbus-${version}";
+    inherit version;
 
     src = fetchurl {
       url = "http://dbus.freedesktop.org/releases/dbus/dbus-${version}.tar.gz";
@@ -49,8 +50,6 @@ self =  stdenv.mkDerivation {
       "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
       "--with-systemduserunitdir=$(out)/etc/systemd/user"
       "--enable-user-session"
-      # this package installs nothing into those dirs and they create a dependency
-      "--datadir=/run/current-system/sw/share"
       "--libexecdir=$(out)/libexec" # we don't need dbus-daemon-launch-helper
     ] ++ lib.optional (!x11Support) "--without-x";
 
@@ -64,7 +63,7 @@ self =  stdenv.mkDerivation {
 
     doCheck = true;
 
-    installFlags = "sysconfdir=$(out)/etc datadir=$(out)/share";
+    installFlags = [ "sysconfdir=$(out)/etc" ];
 
     # it's executed from $lib by absolute path
     postFixup = ''


### PR DESCRIPTION
###### Motivation for this change

Continuation of #22343. With this dbus always follows configuration files properly regardless of environment: upstream configuration -> NixOS's `-local.conf` -> other services and cofngiurations, including system path.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested in a VM together with #22343 and with strace to confirm that dbus reads all configuration files like before. cc @layus 