### PR TITLE
fix/ngspice update

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -350,6 +350,7 @@
   roconnor = "Russell O'Connor <roconnor@theorem.ca>";
   romildo = "José Romildo Malaquias <malaquias@gmail.com>";
   ronny = "Ronny Pfannschmidt <nixos@ronnypfannschmidt.de>";
+  rongcuid = "Rongcui Dong <rongcuid@outlook.com>";
   rszibele = "Richard Szibele <richard_szibele@hotmail.com>";
   rushmorem = "Rushmore Mushambi <rushmore@webenchanter.com>";
   rvl = "Rodney Lorrimar <dev+nix@rodney.id.au>";

--- a/pkgs/applications/science/electronics/ngspice/default.nix
+++ b/pkgs/applications/science/electronics/ngspice/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, readline, bison, libX11, libICE, libXaw, libXext}:
 
 stdenv.mkDerivation {
-  name = "ngspice-25";
+  name = "ngspice-26";
 
   src = fetchurl {
-    url = "mirror://sourceforge/ngspice/ngspice-25.tar.gz";
-    sha256 = "03hlxwvl2j1wlb5yg4swvmph9gja37c2gqvwvzv6z16vg2wvn06h";
+    url = "mirror://sourceforge/ngspice/ngspice-26.tar.gz";
+    sha256 = "51e230c8b720802d93747bc580c0a29d1fb530f3dd06f213b6a700ca9a4d0108";
   };
 
   buildInputs = [ readline libX11 bison libICE libXaw libXext ];
@@ -16,7 +16,8 @@ stdenv.mkDerivation {
     description = "The Next Generation Spice (Electronic Circuit Simulator)";
     homepage = "http://ngspice.sourceforge.net";
     license = with licenses; [ "BSD" gpl2 ];
-    maintainers = with maintainers; [ viric ];
+    maintainers = with maintainers; [ viric rongcuid ];
     platforms = platforms.linux;
   };
 }
+


### PR DESCRIPTION
###### Motivation for this change
Ngspice 26 was out in 2014, but NixOS always got 25.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

