### PR TITLE
Add vim-elixir to vim plugins

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -2049,6 +2049,16 @@ rec {
 
   };
 
+  vim-elixir = buildVimPluginFrom2Nix {
+      name = "vim-elixir-2017-02-01";
+      src = fetchgit {
+        url = "https://github.com/elixir-lang/vim-elixir";
+        rev = "9cbb3ee3865c594ed017f8118a80b355cd7e238f";
+        sha256 = "14mlnjpmgfal4vai2k8jjmhszwgyhnf3v75rssj05n47qnzlddk4";
+      };
+      dependencies = [];
+    };
+
   vim-gista = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "vim-gista-2016-09-21";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -40,6 +40,7 @@
 "github:dracula/vim"
 "github:eagletmt/neco-ghc"
 "github:eikenb/acp"
+"github:elixir-lang/vim-elixir"
 "github:elmcast/elm-vim"
 "github:embear/vim-localvimrc"
 "github:enomsg/vim-haskellConcealPlus"


### PR DESCRIPTION
###### Motivation for this change

Adding vim-elixir plugin to vim plugin. Nixpgs already contains elixir, but no editor plugin support for those who use and configure vim directly with vim_configurable.

I'm a first time contributor. Please feel free to comment on the changes and critique on the code style and methodology, All help is appreciated.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ X ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ NA ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

