### PR TITLE
qgit: 2.5 -> 2.6

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -80,7 +80,7 @@ rec {
     inherit (darwin) Security;
   };
 
-  qgit = callPackage ./qgit { };
+  qgit = qt5.callPackage ./qgit { };
 
   stgit = callPackage ./stgit {
   };

--- a/pkgs/applications/version-management/git-and-tools/qgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/qgit/default.nix
@@ -1,27 +1,22 @@
-{ stdenv, fetchurl, qt4, qmake4Hook, libXext, libX11 }:
+{ stdenv, fetchurl, cmake, qtbase }:
 
 stdenv.mkDerivation rec {
-  name = "qgit-2.5";
+  name = "qgit-2.6";
 
   src = fetchurl {
-    url = "http://libre.tibirna.org/attachments/download/9/${name}.tar.gz";
-    sha256 = "25f1ca2860d840d87b9919d34fc3a1b05d4163671ed87d29c3e4a8a09e0b2499";
+    url = "http://libre.tibirna.org/attachments/download/12/${name}.tar.gz";
+    sha256 = "1brrhac6s6jrw3djhgailg5d5s0vgrfvr0sczqgzpp3i6pxf8qzl";
   };
 
-  hardeningDisable = [ "format" ];
+  buildInputs = [ qtbase ];
 
-  buildInputs = [ qt4 libXext libX11 ];
+  nativeBuildInputs = [ cmake ];
 
-  nativeBuildInputs = [ qmake4Hook ];
-
-  installPhase = ''
-    install -s -D -m 755 bin/qgit "$out/bin/qgit"
-  '';
-
-  meta = {
-    license = stdenv.lib.licenses.gpl2;
-    homepage = "http://libre.tibirna.org/projects/qgit/wiki/QGit";
+  meta = with stdenv.lib; {
+    license = licenses.gpl2;
+    homepage = http://libre.tibirna.org/projects/qgit/wiki/QGit;
     description = "Graphical front-end to Git";
-    inherit (qt4.meta) platforms;
+    maintainer = with maintainers; [ peterhoeg ];
+    inherit (qtbase.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Also:

 - build the qt5 version by default instead of qt4
 - use cmake

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

