### PR TITLE
speedcrunch: 0.11 -> 0.12.0

### DIFF
--- a/pkgs/applications/science/math/speedcrunch/default.nix
+++ b/pkgs/applications/science/math/speedcrunch/default.nix
@@ -1,19 +1,23 @@
-{ stdenv, fetchurl, qt, cmake }:
+{ stdenv, fetchgit, cmake, qtbase, qttools }:
 
 stdenv.mkDerivation rec {
   name = "speedcrunch-${version}";
-  version = "0.11";
+  version = "0.12.0";
 
-  src = fetchurl {
-    url = "https://bitbucket.org/heldercorreia/speedcrunch/get/${version}.tar.gz";
-    sha256 = "0phba14z9jmbmax99klbxnffwzv3awlzyhpcwr1c9lmyqnbcsnkd";
+  src = fetchgit {
+    # the tagging is not standard, so you probably need to check this when updating
+    rev = "refs/tags/release-${version}";
+    url = "https://bitbucket.org/heldercorreia/speedcrunch";
+    sha256 = "0vh7cd1915bjqzkdp3sk25ngy8cq624mkh8c53c5bnzk357kb0fk";
   };
 
-  buildInputs = [cmake qt];
+  buildInputs = [ qtbase qttools ];
 
-  dontUseCmakeBuildDir = true;
+  nativeBuildInputs = [ cmake ];
 
-  cmakeDir = "src";
+  preConfigure = ''
+    cd src
+  '';
 
   meta = with stdenv.lib; {
     homepage    = http://speedcrunch.org;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17254,11 +17254,7 @@ with pkgs;
 
   yacas = callPackage ../applications/science/math/yacas { };
 
-  speedcrunch = callPackage ../applications/science/math/speedcrunch {
-    qt = qt4;
-    cmake = cmakeCurses;
-  };
-
+  speedcrunch = qt5.callPackage ../applications/science/math/speedcrunch { };
 
   ### SCIENCE / MISC
 


### PR DESCRIPTION
###### Motivation for this change

Also:
  - build against qt5 instead of qt4

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
