### PR TITLE
vimPlugins.alchemist-vim: init at rev c22d4883b7

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -281,6 +281,17 @@ rec {
     sourceRoot = ".";
   };
 
+  alchemist-vim = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "alchemist.vim-2017-01-02";
+    src = fetchgit {
+      url = "git://github.com/slashmili/alchemist.vim";
+      rev = "c22d4883b7e2bfed78b70b557d816bf0491d7dd4";
+      sha256 = "0iv91mfj3lxc41xb8sxhl9mby5dllzyvw8508igrj5lvyrd1ikkf";
+    };
+    dependencies = [];
+
+  };
+
   commentary = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "commentary-2016-03-10";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -97,6 +97,7 @@
 "github:shougo/vimproc.vim"
 "github:shougo/vimshell.vim"
 "github:sjl/gundo.vim"
+"github:slashmili/alchemist.vim"
 "github:takac/vim-hardtime"
 "github:terryma/vim-expand-region"
 "github:tex/vimpreviewpandoc"


### PR DESCRIPTION
###### Motivation for this change

Added more tooling for vim user for elixir-lang.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

