### PR TITLE
gnome-tweak-tool: trick autoconf into using python2

### DIFF
--- a/pkgs/desktops/gnome-3/3.22/misc/gnome-tweak-tool/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/misc/gnome-tweak-tool/default.nix
@@ -12,6 +12,15 @@ in stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
 
+  # Make sure that Python 2 is first in $PATH because gnome3.gnome_shell
+  # propagates python3Packages.python.  If we do not do this, autoconf will use
+  # Python 3 instead which gnome-tweak-tool does not support at this time.  See:
+  # https://github.com/NixOS/nixpkgs/issues/21851
+  # https://github.com/NixOS/nixpkgs/pull/22370
+  preConfigure = ''
+    PATH="${python}/bin:$PATH"
+  '';
+
   makeFlags = [ "DESTDIR=/" ];
 
   buildInputs = [ pkgconfig gtk3 glib intltool itstool libxml2


### PR DESCRIPTION
###### Motivation for this change

Please see the discussion at issue #21851!

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

