### PR TITLE
wordpress: 4.7.1 -> 4.7.2 (Security fix)

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/wordpress.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/wordpress.nix
@@ -6,7 +6,7 @@ with lib;
 let
 
   # Upgrading? We have a test! nix-build ./nixos/tests/wordpress.nix
-  version = "4.7.1";
+  version = "4.7.2";
   fullversion = "${version}";
 
   # Our bare-bones wp-config.php file using the above settings
@@ -75,7 +75,7 @@ let
       owner = "WordPress";
       repo = "WordPress";
       rev = "${fullversion}";
-      sha256 = "1wb4f4zn55d23qi0whsfpbpcd4sjvzswgmni6f5rzrmlawq9ssgr";
+      sha256 = "0vph12708drf8ww0xd05hpdvbyy7n5gj9ca598lhdhy2i1j6wy32";
     };
     installPhase = ''
       mkdir -p $out


### PR DESCRIPTION
See: https://make.wordpress.org/core/2017/02/01/disclosure-of-additional-security-fix-in-wordpress-4-7-2/

This should also be cherry-picked on `release-16.09`.

I tested the build and upgraded my site to 4.7.2.