### PR TITLE
catch: 1.5.0 -> 1.7.0

### DIFF
--- a/pkgs/development/libraries/catch/default.nix
+++ b/pkgs/development/libraries/catch/default.nix
@@ -1,37 +1,28 @@
-{ stdenv, lib, cmake, fetchFromGitHub }:
+{ stdenv, cmake, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
 
   name = "catch-${version}";
-  version = "1.5.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "philsquared";
     repo = "Catch";
     rev = "v" + version;
-    sha256 = "1ag8siafg7fmb50qdqznryrg3lvv56f09nvqwqqn2rlk83zjnaw0";
+    sha256 = "0harki6irc4mqipjc24zyy0jimidr5ng3ss29bnpzbbwhrnkyrgm";
   };
 
   buildInputs = [ cmake ];
-  dontUseCmakeConfigure = true;
+  cmakeFlags = [ "-DUSE_CPP14=ON" ];
 
-  buildPhase = ''
-    cmake -Hprojects/CMake -BBuild -DCMAKE_BUILD_TYPE=Release -DUSE_CPP11=ON
-    cd Build
-    make
-    cd ..
-  '';
-
-  installPhase = ''
-    mkdir -p $out
-    mv include $out/.
-  '';
+  doCheck = true;
+  checkTarget = "test";
 
   meta = with stdenv.lib; {
     description = "A multi-paradigm automated test framework for C++ and Objective-C (and, maybe, C)";
     homepage = "http://catch-lib.net";
     license = licenses.boost;
-    maintainers = with maintainers; [ edwtjo ];
+    maintainers = with maintainers; [ edwtjo knedlsepp ];
     platforms = with platforms; unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Bump the version, because of lots of new features. The new cmake based installation process simplifies the build expression.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`): As this is a header-only library, only the unit tests are binaries.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

