### PR TITLE
networking.bonds: add support for arbitrary driverOptions

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -79,7 +79,7 @@ let
   checkBond = checkUnitConfig "Bond" [
     (assertOnlyFields [
       "Mode" "TransmitHashPolicy" "LACPTransmitRate" "MIIMonitorSec"
-      "UpDelaySec" "DownDelaySec"
+      "UpDelaySec" "DownDelaySec" "GratuitousARP"
     ])
     (assertValueOneOf "Mode" [
       "balance-rr" "active-backup" "balance-xor"

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -109,17 +109,65 @@ in
             Name = name;
             Kind = "bond";
           };
-          bondConfig =
-            (optionalAttrs (bond.lacp_rate != null) {
-              LACPTransmitRate = bond.lacp_rate;
-            }) // (optionalAttrs (bond.miimon != null) {
-              MIIMonitorSec = bond.miimon;
-            }) // (optionalAttrs (bond.mode != null) {
-              Mode = bond.mode;
-            }) // (optionalAttrs (bond.xmit_hash_policy != null) {
-              TransmitHashPolicy = bond.xmit_hash_policy;
-            });
+          bondConfig = let
+            # manual mapping as of 2017-02-03
+            # man 5 systemd.netdev [BOND]
+            # to https://www.kernel.org/doc/Documentation/networking/bonding.txt
+            # driver options.
+            driverOptionMapping = let
+              trans = f: optName: { valTransform = f; optNames = [optName]; };
+              simp  = trans id;
+              ms    = trans (v: v + "ms");
+              in {
+                Mode                       = simp "mode";
+                TransmitHashPolixy         = simp "xmit_hash_policy";
+                LACPTransmitRate           = simp "lacp_rate";
+                MIIMonitorSec              = ms "miimon";
+                UpDelaySec                 = ms "updelay";
+                DownDelaySec               = ms "downdelay";
+                LearnPacketIntervalSec     = simp "lp_interval";
+                AdSelect                   = simp "ad_select";
+                FailOverMACPolicy          = simp "fail_over_mac";
+                ARPValidate                = simp "arp_validate";
+                # apparently in ms for this value?! Upstream bug?
+                ARPIntervalSec             = simp "arp_interval";
+                ARPIPTargets               = simp "arp_ip_target";
+                ARPAllTargets              = simp "arp_all_targets";
+                PrimaryReselectPolicy      = simp "primary_reselect";
+                ResendIGMP                 = simp "resend_igmp";
+                PacketsPerSlave            = simp "packets_per_slave";
+                GratuitousARP = { valTransform = id;
+                                  optNames = [ "num_grat_arp" "num_unsol_na" ]; };
+                AllSlavesActive            = simp "all_slaves_active";
+                MinLinks                   = simp "min_links";
+              };
+
+            do = bond.driverOptions;
+            assertNoUnknownOption = let
+              knownOptions = flatten (mapAttrsToList (_: kOpts: kOpts.optNames)
+                                                     driverOptionMapping);
+              # options that apparently don’t exist in the networkd config
+              unknownOptions = [ "primary" ];
+              assertTrace = bool: msg: if bool then true else builtins.trace msg false;
+              in assert all (driverOpt: assertTrace
+                               (elem driverOpt (knownOptions ++ unknownOptions))
+                               "The bond.driverOption `${driverOpt}` cannot be mapped to the list of known networkd bond options. Please add it to the mapping above the assert or to `unknownOptions` should it not exist in networkd.")
+                            (mapAttrsToList (k: _: k) do); "";
+            # get those driverOptions that have been set
+            filterSystemdOptions = filterAttrs (sysDOpt: kOpts:
+                                     any (kOpt: do ? "${kOpt}") kOpts.optNames);
+            # build final set of systemd options to bond values
+            buildOptionSet = mapAttrs (_: kOpts: with kOpts;
+                               # we simply take the first set kernel bond option
+                               # (one option has multiple names, which is silly)
+                               head (map (optN: valTransform (do."${optN}"))
+                                 # only map those that exist
+                                 (filter (o: do ? "${o}") optNames)));
+            in seq assertNoUnknownOption
+                   (buildOptionSet (filterSystemdOptions driverOptionMapping));
+
         };
+
         networks = listToAttrs (flip map bond.interfaces (bi:
           nameValuePair "40-${bi}" (mkMerge [ (genericNetwork (mkOverride 999)) {
             DHCP = mkOverride 0 (dhcpStr false);

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -550,11 +550,28 @@ in
             description = "The interfaces to bond together";
           };
 
+          driverOptions = mkOption {
+            type = types.attrsOf types.str;
+            default = {};
+            example = literalExample {
+              interfaces = [ "eth0" "wlan0" ];
+              miimon = 100;
+              mode = "active-backup";
+            };
+            description = ''
+              Options for the bonding driver.
+              Documentation can be found in
+              <link xlink:href="https://www.kernel.org/doc/Documentation/networking/bonding.txt" />
+            '';
+
+          };
+
           lacp_rate = mkOption {
             default = null;
             example = "fast";
             type = types.nullOr types.str;
             description = ''
+              DEPRECATED, use `driverOptions`.
               Option specifying the rate in which we'll ask our link partner
               to transmit LACPDU packets in 802.3ad mode.
             '';
@@ -565,6 +582,7 @@ in
             example = 100;
             type = types.nullOr types.int;
             description = ''
+              DEPRECATED, use `driverOptions`.
               Miimon is the number of millisecond in between each round of polling
               by the device driver for failed links. By default polling is not
               enabled and the driver is trusted to properly detect and handle
@@ -577,6 +595,7 @@ in
             example = "active-backup";
             type = types.nullOr types.str;
             description = ''
+              DEPRECATED, use `driverOptions`.
               The mode which the bond will be running. The default mode for
               the bonding driver is balance-rr, optimizing for throughput.
               More information about valid modes can be found at
@@ -589,6 +608,7 @@ in
             example = "layer2+3";
             type = types.nullOr types.str;
             description = ''
+              DEPRECATED, use `driverOptions`.
               Selects the transmit hash policy to use for slave selection in
               balance-xor, 802.3ad, and tlb modes.
             '';

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -236,8 +236,8 @@ let
           firewall.allowPing = true;
           useDHCP = false;
           bonds.bond = {
-            mode = "balance-rr";
             interfaces = [ "eth1" "eth2" ];
+            driverOptions.mode = "balance-rr";
           };
           interfaces.eth1.ip4 = mkOverride 0 [ ];
           interfaces.eth2.ip4 = mkOverride 0 [ ];


### PR DESCRIPTION
Until now the four attributes available very selectively provided a small
subset, while copying upstream documentation.

We make driver options an arbitrary key-value set and point to kernel
documentation, which is always up-to-date. This way every option can be set.
The four already existing options are deprecated with a warning.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
- [x] ran & corrected vm-test

