### PR TITLE
emacs25Macport: use newer icons

### DIFF
--- a/pkgs/applications/editors/emacs/macport-25.1.nix
+++ b/pkgs/applications/editors/emacs/macport-25.1.nix
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
     sha256 = "1zwxh7zsvwcg221mpjh0dhpdas3j9mc5q92pprf8yljl7clqvg62";
   };
 
+  hiresSrc = fetchurl {
+    url = "ftp://ftp.math.s.chiba-u.ac.jp/emacs/emacs-hires-icons-2.0.tar.gz";
+    sha256 = "1ari8n3y1d4hdl9npg3c3hk27x7cfkwfgyhgzn1vlqkrdah4z434";
+  };
+
   enableParallelBuilding = true;
 
   buildInputs = [ ncurses libxml2 gnutls pkgconfig texinfo gettext autoconf automake];
@@ -32,12 +37,18 @@ stdenv.mkDerivation rec {
     mv $sourceRoot $name
     tar xzf $macportSrc
     mv $name $sourceRoot
+
+    # extract retina image resources
+    tar xzfv $hiresSrc --strip 1 -C $sourceRoot
   '';
 
   postPatch = ''
     patch -p1 < patch-mac
     substituteInPlace lisp/international/mule-cmds.el \
       --replace /usr/share/locale ${gettext}/share/locale
+
+    # use newer emacs icon
+    cp nextstep/Cocoa/Emacs.base/Contents/Resources/Emacs.icns mac/Emacs.app/Contents/Resources/Emacs.icns
   '';
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

This gives emacs25Macport the newer purple icon from the Cocoa port instead of the wildebeest one from the Mac port. I prefer the purple one, but perhaps not everyone agrees?

The [homebrew formula](https://github.com/railwaycat/homebrew-emacsmacport) has a bunch of options to specify all of the different icons you could want. We can certainly add options if this is contentius, but to me it seems like over kill.

I'm not sure why @mituharu has kept the wildebeest icon for so long. Perhaps to make it easier to differentiate the Mac port from the Cocoa port?

Also, I can update emacs24Macport if anyone is interested. emacs24 has been removed from nixpkgs, however, so it's probably going to get removed as well.

Note: I have not tested this on a non-retina macOS setup. Could someone with one verify that this does not break anything in their setup?
