### PR TITLE
zathura-pdf-mupdf: 0.3.0 -> 0.3.2

### DIFF
--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -2,23 +2,17 @@
 , libjpeg, jbig2dec, openjpeg, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  version = "0.3.0";
+  version = "0.3.1";
   name = "zathura-pdf-mupdf-${version}";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/zathura-pdf-mupdf/download/${name}.tar.gz";
-    sha256 = "1j3j3wbp49walb19f0966qsnlqbd26wnsjpcxfbf021dav8vk327";
+    sha256 = "06zqn8z6a0hfsx3s1kzqvqzb73afgcl6z5r062sxv7kv570fvffr";
   };
 
   buildInputs = [ pkgconfig zathura_core gtk girara openssl mupdf libjpeg jbig2dec openjpeg ];
 
   makeFlags = [ "PREFIX=$(out)" "PLUGINDIR=$(out)/lib" ];
-
-  patches = [(fetchpatch {
-    name = "mupdf-1.9.patch";
-    url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/mupdf-1.9.patch?h=packages/zathura-pdf-mupdf&id=385ad96261b7297fdebbee6f4b22ec20dda8d65e";
-    sha256 = "185wgg0z4b0z5aybcnnyvbs50h43imn5xz3nqmya4rk4v5bwy49y";
-  })];
 
   meta = with lib; {
     homepage = http://pwmt.org/projects/zathura/;


### PR DESCRIPTION
(version compatible with mupdf 1.10a)

###### Motivation for this change

Current version was incompatible with updated library

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

