### PR TITLE
nixos.pam.oath: Don't ignore 1st factor authentication

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -260,7 +260,7 @@ let
           # prompts the user for password so we run it once with 'required' at an
           # earlier point and it will run again with 'sufficient' further down.
           # We use try_first_pass the second time to avoid prompting password twice
-          (optionalString (cfg.unixAuth && (config.security.pam.enableEcryptfs || cfg.pamMount)) ''
+          (optionalString (cfg.oathAuth || (cfg.unixAuth && (config.security.pam.enableEcryptfs || cfg.pamMount))) ''
               auth required pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} likeauth
               ${optionalString config.security.pam.enableEcryptfs
                 "auth optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so unwrap"}


### PR DESCRIPTION
###### Motivation for this change

When setting `security.pam.services.sshd.oathAuth = true` in `configuration.nix`, instead of activating 2nd factor authentication, it seems that the OTP ends up replacing the password authentication, i.e., it ends up turning off 1st factor authentication. This has been better described in #14997.

With NixOS 16.09 plus this change, it seems that #14997 is fixed and the OTP now works properly as a 2nd factor. I wasn't able to login anymore by entering an incorrect password followed by a correct OTP.

Please note that I am not a security expert and I'm much less of a PAM expert, so I am not 100% sure that this is the correct way to fix this issue. That said, it seems to work for me.

It might be a good idea to backport this to 16.09.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

