### PR TITLE
urbanterror: 4.2.023 -> 4.3.1

### DIFF
--- a/pkgs/games/urbanterror/default.nix
+++ b/pkgs/games/urbanterror/default.nix
@@ -1,25 +1,30 @@
 { stdenv, fetchurl, unzip, SDL, mesa, openal, curl, libXxf86vm }:
+
 stdenv.mkDerivation rec {
   name = "urbanterror-${version}";
-  version = "4.2.023";
+  version = "4.3.1";
+
   srcs =
     [ (fetchurl {
-         url = "http://mirror.urtstats.net/urbanterror/UrbanTerror42_full023.zip";
-         sha256 = "e287e2a17432b81551f5c16e431d752484ce9be10508e756542f653757a29090";
+         url = "http://cdn.fs1.urbanterror.info/urt/43/releases/zips/UrbanTerror431_full.zip";
+         sha256 = "1dfnyb2grf2fxxphwj7p2ff721j2l0gwrj76jzympr32sim5a6cw";
        })
       (fetchurl {
-         url = "https://github.com/Barbatos/ioq3-for-UrbanTerror-4/archive/release-4.2.023.tar.gz";
-         sha256 = "03zrrx5b96c1srf2p24ca7zygq84byvrmcgh42d8bh5ds579ziqp";
+         url = "https://github.com/Barbatos/ioq3-for-UrbanTerror-4/archive/release-4.3.1.zip";
+         sha256 = "1rbiqa1ki73649np3af96cilavkgv66a0b6p0a5x26cxvpgg128k";
        })
     ];
-  buildInputs = [ unzip SDL mesa openal curl libXxf86vm];
-  sourceRoot = "ioq3-for-UrbanTerror-4-release-4.2.023";
+
+  buildInputs = [ unzip SDL mesa openal curl libXxf86vm ];
+  sourceRoot = "ioq3-for-UrbanTerror-4-release-4.3.1";
+
   configurePhase = ''
     echo "USE_OPENAL = 1" > Makefile.local
     echo "USE_OPENAL_DLOPEN = 0" >> Makefile.local
     echo "USE_CURL = 1" >> Makefile.local
     echo "USE_CURL_DLOPEN = 0" >> Makefile.local
   '';
+
   installPhase = ''
     destDir="$out/opt/urbanterror"
     mkdir -p "$destDir"
@@ -28,7 +33,7 @@ stdenv.mkDerivation rec {
           "$destDir/Quake3-UrT"
     cp -v build/release-linux-*/Quake3-UrT-Ded.* \
           "$destDir/Quake3-UrT-Ded"
-    cp -rv ../UrbanTerror42/q3ut4 "$destDir"
+    cp -rv ../UrbanTerror43/q3ut4 "$destDir"
     cat << EOF > "$out/bin/urbanterror"
     #! ${stdenv.shell}
     cd "$destDir"
@@ -42,11 +47,15 @@ stdenv.mkDerivation rec {
     EOF
     chmod +x "$out/bin/urbanterror-ded"
   '';
+
   postFixup = ''
     p=$out/opt/urbanterror/Quake3-UrT
     cur_rpath=$(patchelf --print-rpath $p)
     patchelf --set-rpath $cur_rpath:${mesa}/lib $p
   '';
+
+  hardeningDisable = [ "format" ];
+
   meta = with stdenv.lib; {
     description = "A multiplayer tactical FPS on top of Quake 3 engine";
     longDescription = ''


### PR DESCRIPTION
Updated this package to the latest upstream and tested it online. Works very well, however, I had to disable the format security hardening option due to a compilation failure

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] (no dependencies) Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

