### PR TITLE
modules lib: type description in type error message

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -326,7 +326,7 @@ rec {
     # Type-check the remaining definitions, and merge them.
     mergedValue = foldl' (res: def:
       if type.check def.value then res
-      else throw "The option value `${showOption loc}' in `${def.file}' is not a ${type.name}.")
+      else throw "The option value `${showOption loc}' in `${def.file}' is not a ${type.description}.")
       (type.merge loc defsFinal) defsFinal;
 
     isDefined = defsFinal != [];

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -118,7 +118,7 @@ checkConfigOutput "true" "$@" ./define-module-check.nix
 # Check coerced value.
 checkConfigOutput "\"42\"" config.value ./declare-coerced-value.nix
 checkConfigOutput "\"24\"" config.value ./declare-coerced-value.nix ./define-value-string.nix
-checkConfigError 'The option value .* in .* is not a coercedTo.' config.value ./declare-coerced-value.nix ./define-value-list.nix
+checkConfigError 'The option value .* in .* is not a string or integer.' config.value ./declare-coerced-value.nix ./define-value-list.nix
 
 cat <<EOF
 ====== module tests ======


### PR DESCRIPTION
###### Motivation for this change

Better error messages.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

