### PR TITLE
Qt 5: Use buildEnv for env, don't use it for packages

### DIFF
--- a/pkgs/applications/audio/qjackctl/default.nix
+++ b/pkgs/applications/audio/qjackctl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, alsaLib, libjack2, dbus, qt5 }:
+{ stdenv, fetchurl, alsaLib, libjack2, dbus, qtbase, qttools, qtx11extras }:
 
 stdenv.mkDerivation rec {
   version = "0.4.3";
@@ -12,14 +12,15 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    qt5.full
-    qt5.qtx11extras
+    qtbase
+    qtx11extras
+    qttools
     alsaLib
     libjack2
     dbus
   ];
 
-  configureFlags = "--enable-jack-version";
+  configureFlags = [ "--enable-jack-version" ];
 
   meta = with stdenv.lib; {
     description = "A Qt application to control the JACK sound server daemon";

--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, libgcrypt, qt5, zlib, libmicrohttpd, libXtst }:
+{ stdenv, fetchFromGitHub, cmake, libgcrypt, zlib, libmicrohttpd, libXtst, qtbase, qttools }:
 
 stdenv.mkDerivation rec {
   name = "keepassx-community-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0qwmi9f8ik3vkwl1kx7g3079h5ia4wl87y42nr5dal3ic1jc941p";
   };
 
-  buildInputs = [ cmake libgcrypt zlib qt5.full libXtst libmicrohttpd ];
+  buildInputs = [ cmake libgcrypt zlib qtbase qttools libXtst libmicrohttpd ];
 
   meta = {
     description = "Fork of the keepassX password-manager with additional http-interface to allow browser-integration an use with plugins such as PasslFox (https://github.com/pfn/passifox). See also keepassX2.";

--- a/pkgs/applications/office/cb2bib/default.nix
+++ b/pkgs/applications/office/cb2bib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, qt5Full, lzo, libX11 }:
+{ stdenv, fetchurl, qmakeHook, qtbase, qtwebkit, qtx11extras, lzo, libX11 }:
 
 stdenv.mkDerivation rec {
   name = pname + "-" + version;
@@ -8,10 +8,13 @@ stdenv.mkDerivation rec {
     url = "http://www.molspaces.com/dl/progs/${name}.tar.gz";
     sha256 = "0yz79v023w1229wzck3gij0iqah1xg8rg4a352q8idvg7bdmyfin";
   };
-  buildInputs = [ qt5Full lzo libX11 ];
-  QTDIR=qt5Full;
-  configurePhase =''
-    ./configure --prefix $out
+  buildInputs = [ qtbase qtwebkit qtx11extras lzo libX11 ];
+  nativeBuildInputs = [ qmakeHook ];
+
+  configurePhase = ''
+    runHook preConfigure
+    ./configure --prefix $out --qmakepath $QMAKE
+    runHook postConfigure
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/video/vokoscreen/default.nix
+++ b/pkgs/applications/video/vokoscreen/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit
-, pkgconfig, qt5, alsaLib, libv4l, xorg
+, pkgconfig, qtbase, qttools, qmakeHook, qtx11extras, alsaLib, libv4l, libXrandr
 , ffmpeg
 }:
 
@@ -12,13 +12,14 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    alsaLib.dev
-    libv4l.dev
+    alsaLib
+    libv4l
     pkgconfig
-    qt5.full
-    qt5.qmakeHook
-    qt5.qtx11extras
-    xorg.libXrandr.dev
+    qtbase
+    qttools
+    qmakeHook
+    qtx11extras
+    libXrandr
   ];
 
   patches = [

--- a/pkgs/development/libraries/qt-5/qt-env.nix
+++ b/pkgs/development/libraries/qt-5/qt-env.nix
@@ -1,28 +1,22 @@
-{ lib, runCommand, lndir, qtbase }: name: paths:
+{ lib, buildEnv, qtbase }: name: paths:
 
-runCommand name { qtbase = qtbase.dev; paths = lib.chooseDevOutputs paths;  } ''
+buildEnv {
+  inherit name;
+  paths = [ qtbase ] ++ paths;
 
-mkdir -p "$out/bin" "$out/mkspecs" "$out/include" "$out/lib" "$out/share"
+  pathsToLink = [ "/bin" "/mkspecs" "/include" "/lib" "/share" ];
+  extraOutputsToInstall = [ "dev" ];
 
-cp "$qtbase/bin/qmake" "$out/bin"
-cat >"$out/bin/qt.conf" <<EOF
-[Paths]
-Prefix = $out
-Plugins = lib/qt5/plugins
-Imports = lib/qt5/imports
-Qml2Imports = lib/qt5/qml
-Documentation = share/doc/qt5
-EOF
-
-for pkg in $paths $qtbase; do
-    if [[ -d "$pkg/mkspecs" ]]; then
-        ${lndir}/bin/lndir -silent "$pkg/mkspecs" "$out/mkspecs"
-
-        for dir in bin include lib share; do
-            if [[ -d "$pkg/$dir" ]]; then
-                ${lndir}/bin/lndir -silent "$pkg/$dir" "$out/$dir"
-            fi
-        done
-    fi
-done
-''
+  postBuild = ''
+    rm "$out/bin/qmake"
+    cp "${qtbase.dev}/bin/qmake" "$out/bin"
+    cat >"$out/bin/qt.conf" <<EOF
+    [Paths]
+    Prefix = $out
+    Plugins = lib/qt5/plugins
+    Imports = lib/qt5/imports
+    Qml2Imports = lib/qt5/qml
+    Documentation = share/doc/qt5
+    EOF
+  '';
+}

--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, qt5Full, jdk, zlib, file, makeWrapper, xorg, libpulseaudio, qt5 }:
+{ stdenv, fetchFromGitHub, cmake, jdk, zlib, file, makeWrapper, xorg, libpulseaudio, qtbase, quazip }:
 
 let
   libnbt = fetchFromGitHub {
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     rev = "895d8ab4699f1b50bf03532c967a91f5ecb62a50";
     sha256 = "179vc1iv57fx4g4h1wy8yvyvdm671jnvp6zi8pcr1n6azqhwklds";
   };
-  buildInputs = [ cmake qt5Full jdk zlib file makeWrapper ];
+  buildInputs = [ cmake qtbase jdk zlib file makeWrapper ];
 
   libpath = with xorg; [ libX11 libXext libXcursor libXrandr libXxf86vm libpulseaudio ];
   postUnpack = ''
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     cp -r ${libnbt} $sourceRoot/depends/libnbtplusplus
     chmod 755 -R $sourceRoot/depends/libnbtplusplus
     mkdir -pv $sourceRoot/build/
-    cp -v ${qt5.quazip.src} $sourceRoot/build/quazip-0.7.1.tar.gz
+    cp -v ${quazip.src} $sourceRoot/build/quazip-0.7.1.tar.gz
   '';
 
   patches = [ ./multimc.patch ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12627,9 +12627,7 @@ with pkgs;
 
   cava = callPackage ../applications/audio/cava { };
 
-  cb2bib = callPackage ../applications/office/cb2bib {
-    inherit (xorg) libX11;
-  };
+  cb2bib = qt5.callPackage ../applications/office/cb2bib { };
 
   cbatticon = callPackage ../applications/misc/cbatticon { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16133,7 +16133,7 @@ with pkgs;
 
   minecraft-server = callPackage ../games/minecraft-server { };
 
-  multimc = callPackage ../games/multimc { };
+  multimc = qt5.callPackage ../games/multimc { };
 
   minetest = callPackage ../games/minetest {
     libpng = libpng12;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17831,7 +17831,7 @@ with pkgs;
   vips = callPackage ../tools/graphics/vips { };
   nip2 = callPackage ../tools/graphics/nip2 { };
 
-  vokoscreen = callPackage ../applications/video/vokoscreen { };
+  vokoscreen = qt5.callPackage ../applications/video/vokoscreen { };
 
   wavegain = callPackage ../applications/audio/wavegain { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13142,7 +13142,7 @@ with pkgs;
 
   keepassx = callPackage ../applications/misc/keepassx { };
   keepassx2 = callPackage ../applications/misc/keepassx/2.0.nix { };
-  keepassx-community = callPackage ../applications/misc/keepassx/community.nix { };
+  keepassx-community = qt5.callPackage ../applications/misc/keepassx/community.nix { };
 
   inherit (gnome3) evince;
   evolution_data_server = gnome3.evolution_data_server;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14670,7 +14670,7 @@ with pkgs;
 
   qgroundcontrol = qt55.callPackage ../applications/science/robotics/qgroundcontrol { };
 
-  qjackctl = callPackage ../applications/audio/qjackctl { };
+  qjackctl = qt5.callPackage ../applications/audio/qjackctl { };
 
   qmidinet = callPackage ../applications/audio/qmidinet { };
 


### PR DESCRIPTION
###### Motivation for this change

With this Qt Creator can build projects when pointed at `qmake` from an env. Qt Quick Designer works too now. Packages shouldn't use this environment.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

