### PR TITLE
ecopcr: init at version 0.7.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -296,6 +296,7 @@
   mdaiter = "Matthew S. Daiter <mdaiter8121@gmail.com>";
   meditans = "Carlo Nucera <meditans@gmail.com>";
   meisternu = "Matt Miemiec <meister@krutt.org>";
+  metabar = "Celine Mercier <softs@metabarcoding.org>";
   mguentner = "Maximilian Güntner <code@klandest.in>";
   mic92 = "Jörg Thalheim <joerg@higgsboson.tk>";
   michaelpj = "Michael Peyton Jones <michaelpj@gmail.com>";

--- a/pkgs/applications/science/biology/ecopcr/default.nix
+++ b/pkgs/applications/science/biology/ecopcr/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, gcc, zlib, python27 }:
+
+stdenv.mkDerivation rec {
+  name = "ecoPCR-0.8.0";
+
+  src = fetchurl {
+    url = "https://git.metabarcoding.org/obitools/ecopcr/uploads/6f37991b325c8c171df7e79e6ae8d080/ecopcr-0.8.0.tar.gz";
+    sha256 = "10c58hj25z78jh0g3zcbx4890yd2qrvaaanyx8mn9p49mmyf5pk6";
+  };
+
+  sourceRoot = "ecoPCR/src";
+
+  buildInputs = [ gcc zlib ];
+
+  installPhase = ''
+	mkdir -p $out/bin
+	cp -v ecoPCR $out/bin
+	cp -v ecogrep $out/bin
+	cp -v ecofind $out/bin
+	cp -v ../tools/ecoPCRFormat.py $out/bin/ecoPCRFormat
+	chmod a+x $out/bin/ecoPCRFormat
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Electronic PCR software tool";
+    longDescription = ''
+      ecoPCR is an electronic PCR software developed by the LECA. It
+      helps you estimate Barcode primers quality. In conjunction with
+      OBITools, you can postprocess ecoPCR output to compute barcode
+      coverage and barcode specificity. New barcode primers can be
+      developed using the ecoPrimers software.
+    '';
+    homepage = https://git.metabarcoding.org/obitools/ecopcr/wikis/home;
+    license = licenses.cecill20;
+    maintainers = [ maintainers.metabar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16812,6 +16812,8 @@ with pkgs;
 
   bcftools = callPackage ../applications/science/biology/bcftools { };
 
+  ecopcr = callPackage ../applications/science/biology/ecopcr { };
+
   emboss = callPackage ../applications/science/biology/emboss { };
 
   htslib = callPackage ../development/libraries/science/biology/htslib { };


### PR DESCRIPTION
###### Motivation for this change

This is a new package, ecoPCR, a bioinformatics tool to perform electronic PCR, developed by the Laboratoire d'Ecologie Alpine in Grenoble, France.
Ficetola, G.F., Coissac, E., Zundel, S., Riaz, T., Shehzad, W., Bessière, J., Taberlet, P. and Pompanon, F., 2010. An in silico approach for the evaluation of DNA barcodes. BMC genomics, 11(1), p.434.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

