### PR TITLE
upstart: wrap binaries and patch hard-coded paths

### DIFF
--- a/pkgs/os-specific/linux/upstart/check-config.nix
+++ b/pkgs/os-specific/linux/upstart/check-config.nix
@@ -1,0 +1,43 @@
+# Useful tool to check syntax of a config file. Upstart needs a dbus
+# session, so this script wraps one up and makes the operation not
+# require any prior state.
+#
+# See: http://mwhiteley.com/scripts/2012/12/11/dbus-init-checkconf.html
+{stdenv, coreutils, upstart, writeScript, dbus}:
+
+writeScript "upstart-check-config" ''
+  #!${stdenv.shell}
+
+  set -o errexit
+  set -o nounset
+
+  export PATH=${stdenv.lib.makeBinPath [dbus.out upstart coreutils]}:$PATH
+
+  if [[ $# -ne 1 ]]
+  then
+    echo "Usage: $0 upstart-conf-file" >&2
+    exit 1
+  fi
+  config=$1 && shift
+
+  dbus_pid_file=$(mktemp)
+  exec 4<> $dbus_pid_file
+
+  dbus_add_file=$(mktemp)
+  exec 6<> $dbus_add_file
+
+  dbus-daemon --fork --print-pid 4 --print-address 6 --session
+
+  function clean {
+    dbus_pid=$(cat $dbus_pid_file)
+    if [[ -n $dbus_pid ]]; then
+      kill $dbus_pid
+    fi
+    rm -f $dbus_pid_file $dbus_add_file
+  }
+  trap "{ clean; }" EXIT
+
+  export DBUS_SESSION_BUS_ADDRESS=$(cat $dbus_add_file)
+
+  init-checkconf $config
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11852,6 +11852,8 @@ with pkgs;
 
   upstart = callPackage ../os-specific/linux/upstart { };
 
+  upstart-check-config = callPackage ../os-specific/linux/upstart/check-config.nix {};
+
   usbutils = callPackage ../os-specific/linux/usbutils { };
 
   usermount = callPackage ../os-specific/linux/usermount { };


### PR DESCRIPTION
###### Motivation for this change

I wanted to be able to use `init-checkconf` to validate upstart config files during a nix build. Unfortunately, the `init-checkconf` binary wasn't usable due to `PATH` issues, hard-coded binary paths, and not having executable permissions. A few patches got things working though. In addition, `init-checkconf` requires a dbus session to be available; I adapted a script which makes this possible into a nix expression.

Unfortunately, since I'm not actually *running* upstart, it's pretty much impossible for me to actually check that all binaries work. However, since the only changes are to auxiliary scripts, I think this is pretty safe.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

