### PR TITLE
exfat-nofuse: init at 2017-01-03

### DIFF
--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  name = "exfat-nofuse-${version}-${kernel.version}";
+  version = "2017-01-03";
+
+  src = fetchFromGitHub {
+    owner = "dorimanx";
+    repo = "exfat-nofuse";
+    rev = "8d291f5";
+    sha256 = "0lg1mykglayswli2aliw8chsbr4g629v9chki5975avh43jn47w9";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  makeFlags = [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    install -m644 -b -D exfat.ko $out/lib/modules/${kernel.modDirVersion}/kernel/fs/exfat/exfat.ko
+  '';
+
+  meta = {
+    description = "exfat kernel module";
+    homepage = https://github.com/dorimanx/exfat-nofuse;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ makefu ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11245,6 +11245,8 @@ in
 
     dpdk = callPackage ../os-specific/linux/dpdk { };
 
+    exfat-nofuse = callPackage ../os-specific/linux/exfat { };
+
     pktgen = callPackage ../os-specific/linux/pktgen { };
 
     odp-dpdk = callPackage ../os-specific/linux/odp-dpdk { };


### PR DESCRIPTION
###### Motivation for this change

Include the exfat kernel module because i had issues with certain file systems ("ERROR: unsupported FAT count: 2.").
The native kernel module does not have this issue.

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested modprobe modules `modprobe exfat`
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).