### PR TITLE
wget: 1.18 -> 1.19

### DIFF
--- a/pkgs/tools/networking/wget/default.nix
+++ b/pkgs/tools/networking/wget/default.nix
@@ -3,11 +3,11 @@
 , libiconv, libpsl ? null, openssl ? null }:
 
 stdenv.mkDerivation rec {
-  name = "wget-1.18";
+  name = "wget-1.19";
 
   src = fetchurl {
     url = "mirror://gnu/wget/${name}.tar.xz";
-    sha256 = "1hcwx8ww3sxzdskkx3l7q70a7wd6569yrnjkw9pw013cf9smpddm";
+    sha256 = "1133c14g19ysv74j7am66jwgwrr0rdn0rdyxw7rikbnsyjxmf48g";
   };
 
   patches = [ ./remove-runtime-dep-on-openssl-headers.patch ];


### PR DESCRIPTION
See http://lists.gnu.org/archive/html/info-gnu/2017-02/msg00000.html
for release announcement.

`kiwix` fails to build both before and after this commit.

###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

