### PR TITLE
neovim-remote: move from python-packages to /neovim/neovim-remote.

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -138,6 +138,7 @@
   dtzWill = "Will Dietz <nix@wdtz.org>";
   e-user = "Alexander Kahl <nixos@sodosopa.io>";
   ebzzry = "Rommel Martinez <ebzzry@gmail.com>";
+  edanaher = "Evan Danaher <nixos@edanaher.net>";
   ederoyd46 = "Matthew Brown <matt@ederoyd.co.uk>";
   eduarrrd = "Eduard Bachmakov <e.bachmakov@gmail.com>";
   edwtjo = "Edward Tjörnhammar <ed@cflags.cc>";

--- a/pkgs/applications/editors/neovim/neovim-remote.nix
+++ b/pkgs/applications/editors/neovim/neovim-remote.nix
@@ -1,5 +1,7 @@
 { stdenv, fetchFromGitHub, pythonPackages }:
 
+with stdenv.lib;
+
 pythonPackages.buildPythonPackage rec {
   name = "neovim-remote-${version}";
   version = "v1.4.0";
@@ -13,4 +15,12 @@ pythonPackages.buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ pythonPackages.neovim ];
+
+  meta = {
+    description = "A tool that helps controlling nvim processes from a terminal";
+    homepage = https://github.com/mhinz/neovim-remote/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ edanaher ];
+    platforms = platforms.unix;
+  };
 }

--- a/pkgs/applications/editors/neovim/neovim-remote.nix
+++ b/pkgs/applications/editors/neovim/neovim-remote.nix
@@ -1,0 +1,16 @@
+{ stdenv, fetchFromGitHub, pythonPackages }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "neovim-remote-${version}";
+  version = "v1.4.0";
+  disabled = !pythonPackages.isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "mhinz";
+    repo = "neovim-remote";
+    rev = version;
+    sha256 = "0msvfh27f56xj5ki59ikzavxz863nal5scm57n43618m49qzg8iz";
+  };
+
+  propagatedBuildInputs = [ pythonPackages.neovim ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15385,6 +15385,8 @@ with pkgs;
 
   neovim-pygui = pythonPackages.neovim_gui;
 
+  neovim-remote = callPackage ../applications/editors/neovim/neovim-remote.nix { pythonPackages = python3Packages; };
+
   vis = callPackage ../applications/editors/vis {
     inherit (lua52Packages) lpeg;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -29771,23 +29771,6 @@ EOF
     '';
   };
 
-  neovim-remote = buildPythonPackage rec {
-    name = "neovim-remote-${version}";
-    version = "v1.4.0";
-    disabled = !isPy3k;
-
-    src = pkgs.fetchFromGitHub {
-      owner = "mhinz";
-      repo = "neovim-remote";
-      rev = version;
-      sha256 = "0msvfh27f56xj5ki59ikzavxz863nal5scm57n43618m49qzg8iz";
-    };
-
-    propagatedBuildInputs = [
-      self.neovim
-    ];
-  };
-
   ghp-import = buildPythonPackage rec {
     version = "0.4.1";
     name = "ghp-import-${version}";


### PR DESCRIPTION
###### Motivation for this change

As noted on #22405, neovim-remote doesn't belong in python-packages.  I'm not positive that it belongs under /neovim/, but that makes the most sense to me.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

