### PR TITLE
liberastika: init at 1.1.5

### DIFF
--- a/pkgs/data/fonts/liberastika/default.nix
+++ b/pkgs/data/fonts/liberastika/default.nix
@@ -1,0 +1,33 @@
+{stdenv, fetchurl, unzip}:
+
+stdenv.mkDerivation rec {
+  name = "liberastika-${version}";
+  version = "1.1.5";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/lib-ka/liberastika-ttf-${version}.zip";
+    sha256 = "0vg5ki120lb577ihvq8w0nxs8yacqzcvsmnsygksmn6281hyj0xj";
+  };
+
+  buildInputs = [ unzip ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp -v $(find . -name '*.ttf') $out/share/fonts/truetype
+
+    mkdir -p "$out/doc/${name}"
+    cp -v AUTHORS ChangeLog COPYING README "$out/doc/${name}" || true
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Liberation Sans fork with improved cyrillic support";
+    homepage = https://sourceforge.net/projects/lib-ka/;
+
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    hydraPlatforms = [];
+    maintainers = [ maintainers.volth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12140,6 +12140,8 @@ with pkgs;
   liberationsansnarrow = callPackage ../data/fonts/liberationsansnarrow { };
   liberationsansnarrow_binary = callPackage ../data/fonts/liberationsansnarrow/binary.nix { };
 
+  liberastika = callPackage ../data/fonts/liberastika { };
+
   libertine = callPackage ../data/fonts/libertine { };
 
   libre-baskerville = callPackage ../data/fonts/libre-baskerville { };


### PR DESCRIPTION
###### Motivation for this change

Liberation Sans fork with improved cyrillic support

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

