### PR TITLE
squirrel-sql: init at 3.7.1

### DIFF
--- a/pkgs/development/tools/database/squirrel-sql/default.nix
+++ b/pkgs/development/tools/database/squirrel-sql/default.nix
@@ -1,0 +1,69 @@
+# To enable specific database drivers, override this derivation and pass the
+# driver packages in the drivers argument (e.g. mysql_jdbc, postgresql_jdbc).
+{ stdenv, fetchurl, makeDesktopItem, makeWrapper, unzip
+, jre
+, drivers ? []
+}:
+let
+  version = "3.7.1";
+in stdenv.mkDerivation rec {
+  name = "squirrel-sql-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/squirrel-sql/1-stable/${version}-plainzip/squirrelsql-${version}-standard.zip";
+    sha256 = "1v141ply57k5krwbnnmz4mbs9hs8rbys0bkjz69gvxlqjizyiq23";
+  };
+
+  buildInputs = [
+    jre makeWrapper stdenv unzip
+  ];
+
+  unpackPhase = ''
+    unzip ${src}
+  '';
+
+  buildPhase = ''
+    cd squirrelsql-${version}-standard
+    chmod +x squirrel-sql.sh
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/squirrel-sql
+    cp -r . $out/share/squirrel-sql
+
+    mkdir -p $out/bin
+    cp=""
+    for pkg in ${builtins.concatStringsSep " " drivers}; do
+      if test -n "$cp"; then
+        cp="$cp:"
+      fi
+      cp="$cp"$(echo $pkg/share/java/*.jar | tr ' ' :)
+    done
+    makeWrapper $out/share/squirrel-sql/squirrel-sql.sh $out/bin/squirrel-sql \
+      --set CLASSPATH "$cp" \
+      --set JAVA_HOME "${jre}"
+
+    mkdir -p $out/share/icons/hicolor/32x32/apps
+    ln -s $out/share/squirrel-sql/icons/acorn.png \
+      $out/share/icons/hicolor/32x32/apps/squirrel-sql.png
+    ln -s ${desktopItem}/share/applications $out/share
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = "squirrel-sql";
+    exec = "squirrel-sql";
+    comment = meta.description;
+    desktopName = "SQuirreL SQL";
+    genericName = "SQL Client";
+    categories = "Development;";
+    icon = "squirrel-sql";
+  };
+
+  meta = {
+    description = "Universal SQL Client";
+    homepage = http://squirrel-sql.sourceforge.net/;
+    license = stdenv.lib.licenses.lgpl21;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ khumba ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5443,6 +5443,10 @@ with pkgs;
 
   squeak = callPackage ../development/compilers/squeak { };
 
+  squirrel-sql = callPackage ../development/tools/database/squirrel-sql {
+    drivers = [ mysql_jdbc postgresql_jdbc ];
+  };
+
   stalin = callPackage ../development/compilers/stalin { };
 
   metaBuildEnv = callPackage ../development/compilers/meta-environment/meta-build-env { };


### PR DESCRIPTION
###### Motivation for this change

SQuirreL SQL is a powerful SQL client, and it would be great to have it available in Nixpkgs.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

