### PR TITLE
haskellPackages.callCabal2nix: provide fallback name

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -87,7 +87,7 @@ let
         # Creates a Haskell package from a source package by calling cabal2nix on the source.
         callCabal2nix = src: self.callPackage (haskellSrc2nix {
           inherit src;
-          name = src.name;
+          name = src.name or baseNameOf src;
         });
 
         ghcWithPackages = selectFrom: withPackages (selectFrom self);


### PR DESCRIPTION
@peti I realized just after my last patch that `callCabal2nix` did not accept paths (e.g. `callCabal2nix ./. {}` is an error). This is too limiting. Sorry I didn't catch it earlier.

Do you have any other recommendations while I'm revisiting this?