### PR TITLE
gogs: fix error on push

### DIFF
--- a/nixos/modules/services/misc/gogs.nix
+++ b/nixos/modules/services/misc/gogs.nix
@@ -208,6 +208,7 @@ in
         group = "gogs";
         home = cfg.stateDir;
         createHome = true;
+        shell = pkgs.bash;
       };
       extraGroups.gogs.gid = config.ids.gids.gogs;
     };


### PR DESCRIPTION
Pushing to gogs only works if the `gogs` user's shell is `bash`. For error and
solution, refer to [this SO thread](http://stackoverflow.com/a/22315659)

###### Motivation for this change
- couldn't push a repository to a gogs service I just enabled

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

