### PR TITLE
postfix service: don't empty local_recipient_maps

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1703.xml
+++ b/nixos/doc/manual/release-notes/rl-1703.xml
@@ -46,6 +46,7 @@ following incompatible changes:</para>
       for what those parameters represent.
     </para>
   </listitem>
+
   <listitem>
     <para>
       <literal>ansible</literal> now defaults to ansible version 2 as version 1
@@ -54,6 +55,7 @@ following incompatible changes:</para>
       vulnerability</link> unpatched by upstream.
     </para>
   </listitem>
+
   <listitem>
     <para>
       <literal>gnome</literal> alias has been removed along with
@@ -116,7 +118,6 @@ following incompatible changes:</para>
   </listitem>
 
   <listitem>
-
     <para><literal>overridePackages</literal> function no longer exists.
     It is replaced by <link
     xlink:href="https://nixos.org/nixpkgs/manual/#sec-overlays-install">
@@ -150,6 +151,15 @@ following incompatible changes:</para>
       <literal>networking.firewall.autoLoadConntrackHelpers</literal> and
       tune <literal>networking.firewall.connectionTrackingModules</literal>
       to suit your needs.
+    </para>
+  </listitem>
+
+  <listitem>
+    <para>
+      <literal>local_recipient_maps</literal> is not set to empty value by
+      Postfix service. It's an insecure default as stated by Postfix
+      documentation. Those who want to retain this setting need to set it via
+      <literal>services.postfix.extraConfig</literal>.
     </para>
   </listitem>
 

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -79,8 +79,6 @@ let
       relay_domains = ${concatStringsSep ", " cfg.relayDomains}
     ''
     + ''
-      local_recipient_maps =
-
       relayhost = ${if cfg.lookupMX || cfg.relayHost == "" then
           cfg.relayHost
         else


### PR DESCRIPTION
###### Motivation for this change

From Postfix documentation:

> With this setting, the Postfix SMTP server will not reject mail with "User
> unknown in local recipient table". Don't do this on systems that receive mail
> directly from the Internet. With today's worms and viruses, Postfix will become
> a backscatter source: it accepts mail for non-existent recipients and then
> tries to return that mail as "undeliverable" to the often forged sender
> address.

However, I'm unsure that this is a right fix to do for everyone. Postfix can be configured in a multitude of ways: usually on my servers I set `local_recipient_maps` to a table with users, but perhaps for some other configurations this is not necessary.

Also this is a breaking change, but one that gives us more secure defaults.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

