### PR TITLE
bdf2psf: 1.152 -> 1.158

### DIFF
--- a/pkgs/tools/misc/bdf2psf/default.nix
+++ b/pkgs/tools/misc/bdf2psf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "bdf2psf-${version}";
-  version = "1.152";
+  version = "1.158";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/c/console-setup/bdf2psf_${version}_all.deb";
-    sha256 = "1hk5g0zhj78p74z0hdx3v29s5bpx0npabwdawaigwwxrrj03q9mw";
+    sha256 = "12zaj7hi5gzdh9r7rcyqnkwik1ljw1qzj6j7rw80bgw6fn611rs9";
   };
 
   buildInputs = [ dpkg ];


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

