### PR TITLE
matrix-synapse: 0.18.7-rc2 -> 0.19.0

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -11,26 +11,26 @@ let
   };
   matrix-synapse-ldap3 = pythonPackages.buildPythonApplication rec {
     name = "matrix-synapse-ldap3-${version}";
-    version = "0.1.1";
+    version = "0.1.2";
 
     src = fetchFromGitHub {
       owner = "matrix-org";
       repo = "matrix-synapse-ldap3";
-      rev = "564eb3f109ce7f1082c47d5f8efaa792d90467f1";
-      sha256 = "1mkjlvy7a3rq405m59ihkh1wq7pa4l03fp8hgwwyjnbmz25bqmbk";
+      rev = "v${version}";
+      sha256 = "16pivz1lhs1c3z84rxxy8khyvn0hqxwxaz552br1y9ri0maa0aq8";
     };
 
     propagatedBuildInputs = with pythonPackages; [ service-identity ldap3 twisted ];
   };
 in pythonPackages.buildPythonApplication rec {
   name = "matrix-synapse-${version}";
-  version = "0.18.7-rc2";
+  version = "0.19.0";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "synapse";
     rev = "v${version}";
-    sha256 = "13rx77xfcci7q8xpxxgnh84h6md53akjcy9glwn20vm9vpka3vvj";
+    sha256 = "02zbyfnkc8a0bmaz3ylcwc8010cy0c1vrr7k2yywv5wd3ril4cp6";
   };
 
   patches = [ ./matrix-synapse.patch ];


### PR DESCRIPTION
###### Motivation for this change
Performance and E2E encryption support improvements!

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

