### PR TITLE
intel-ocl: init at r4.0-59481

### DIFF
--- a/pkgs/os-specific/linux/intel-ocl/default.nix
+++ b/pkgs/os-specific/linux/intel-ocl/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchzip, rpmextract, ncurses5, numactl, zlib }:
+
+stdenv.mkDerivation rec {
+  version = "r4.0-59481";
+  name = "intel-ocl-${version}";
+
+  src = fetchzip {
+    url = "https://software.intel.com/sites/default/files/managed/48/96/SRB4_linux64.zip";
+    sha256 = "1q69g28i6l7p13hnsk82g2qhdf2chwh4f0wvzac6xml67hna3v34";
+    stripRoot = false;
+  };
+
+  buildInputs = [ rpmextract ];
+
+  sourceRoot = ".";
+
+  libPath = stdenv.lib.makeLibraryPath [
+    stdenv.cc.cc.lib
+    ncurses5
+    numactl
+    zlib
+  ];
+
+  postUnpack = ''
+    # Extract the RPMs contained within the source ZIP.
+    rpmextract SRB4_linux64.zip/intel-opencl-${version}.x86_64.rpm
+    rpmextract SRB4_linux64.zip/intel-opencl-cpu-${version}.x86_64.rpm
+  '';
+
+  patchPhase = ''
+    # Remove libOpenCL.so, since we use ocl-icd's libOpenCL.so instead and this would cause a clash.
+    rm opt/intel/opencl/libOpenCL.so*
+
+    # Patch shared libraries.
+    for lib in opt/intel/opencl/*.so; do
+      patchelf --set-rpath "${libPath}:$out/lib/intel-ocl" $lib || true
+    done
+  '';
+
+  buildPhase = ''
+    # Create ICD file, which just contains the path of the corresponding shared library.
+    echo "$out/lib/intel-ocl/libintelocl.so" > intel.icd
+  '';
+
+  installPhase = ''
+    install -D -m 0755 opt/intel/opencl/*.so* -t $out/lib/intel-ocl
+    install -D -m 0644 opt/intel/opencl/*.{o,rtl,bin} -t $out/lib/intel-ocl
+    install -D -m 0644 opt/intel/opencl/{LICENSE,NOTICES} -t $out/share/doc/intel-ocl
+    install -D -m 0644 intel.icd -t $out/etc/OpenCL/vendors
+  '';
+
+  dontStrip = true;
+
+  meta = {
+    description = "Official OpenCL runtime for Intel CPUs";
+    homepage    = https://software.intel.com/en-us/articles/opencl-drivers;
+    license     = stdenv.lib.licenses.unfree;
+    platforms   = [ "x86_64-linux" ];
+    maintainers = [ stdenv.lib.maintainers.kierdavis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11080,6 +11080,8 @@ with pkgs;
 
   intel2200BGFirmware = callPackage ../os-specific/linux/firmware/intel2200BGFirmware { };
 
+  intel-ocl = callPackage ../os-specific/linux/intel-ocl { };
+
   iomelt = callPackage ../os-specific/linux/iomelt { };
 
   iotop = callPackage ../os-specific/linux/iotop { };


### PR DESCRIPTION
###### Motivation for this change

Makes the official (nonfree) Intel OpenCL runtime available for use by OpenCL-enabled programs.

I'm not 100% certain that this doesn't already exist in nixpkgs, but no existing package with "ICD" in the name provides an ICD file like this one does.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I may attempt to put together a section in the NixOS manual on OpenCL sometime; for now, I'll dump the documentation here:

The libraries in this package are not intended to be accessed directly, but by an ICD loader such as `ocl-icd`. To use this package, `ocl-icd` needs to be aware of the location of the ICD file contained in this package at `etc/OpenCL/vendors/intel.icd`. On NixOS, it is recommended to do this by adding this package to the OpenGL driver in `configuration.nix`:

```nix
{
  hardware.opengl.extraPackages = [ pkgs.intel-ocl ];
}
```

This creates a symlink to the ICD file in `/run/opengl-driver/etc/OpenGL/vendors`, which is `ocl-icd`'s default search directory.

Alternatively, the `OPENCL_VENDOR_PATH` environment variable can be used to override `ocl-icd`'s search path. For example, `hashcat3` could be started as follows:

```sh
mkdir icds
ln -s /nix/store/mx26nqd8a1dr0a5a04p1q3zqq6cmw3by-intel-ocl-r4.0-59481/etc/OpenCL/vendors/intel.icd icds/intel.icd
# ICDs for other hardware types can be added as well, e.g.
ln -s /nix/store/cbvfqhv1g244shk0rfa6x5rvg3gz6w1s-nvidia-x11-375.26-4.4.45/etc/OpenCL/vendors/nvidia.icd icds/nvidia.icd
OPENCL_VENDOR_PATH=./icds hashcat
```
