### PR TITLE
emboss: 6.0.1 -> 6.6.0

### DIFF
--- a/pkgs/applications/science/biology/emboss/default.nix
+++ b/pkgs/applications/science/biology/emboss/default.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl, readline, perl, libX11, libpng, libXt, zlib}:
 
 stdenv.mkDerivation {
-  name = "emboss-6.0.1";
+  name = "emboss-6.6.0";
   src = fetchurl {
-    url = ftp://emboss.open-bio.org/pub/EMBOSS/EMBOSS-6.0.1.tar.gz;
-    sha256 = "0g939k9wmpvmy55hqmbbzj6kj6agg4izymv492zqiawxm812jd9y";
+    url = "ftp://emboss.open-bio.org/pub/EMBOSS/EMBOSS-6.6.0.tar.gz";
+    sha256 = "7184a763d39ad96bb598bfd531628a34aa53e474db9e7cac4416c2a40ab10c6e";
   };
   # patch = fetchurl {
   #   url = ftp://emboss.open-bio.org/pub/EMBOSS/fixes/patches/patch-1-9.gz;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

