### PR TITLE
libnfc: Add missing dependency on readline

### DIFF
--- a/pkgs/development/libraries/libnfc/default.nix
+++ b/pkgs/development/libraries/libnfc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libusb }:
+{ stdenv, fetchurl, libusb, readline }:
 
 stdenv.mkDerivation rec {
   name = "libnfc-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0wj0iwwcpmpalyk61aa7yc6i4p9hgdajkrgnlswgk0vnwbc78pll";
   };
 
-  buildInputs = [ libusb ];
+  buildInputs = [ libusb readline ];
 
   meta = with stdenv.lib; {
     description = "Open source library libnfc for Near Field Communication";


### PR DESCRIPTION
###### Motivation for this change

Fix build, actually.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

