### PR TITLE
nixos-generate-config.pl, all-hardware.nix: Add support for Hyper-V

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -208,9 +208,6 @@ foreach my $path (glob "/sys/bus/pci/devices/*") {
     pciCheck $path;
 }
 
-push @attrs, "services.xserver.videoDrivers = [ \"$videoDriver\" ];" if $videoDriver;
-
-
 # Idem for USB devices.
 
 sub usbCheck {
@@ -277,6 +274,12 @@ if ($virt eq "qemu" || $virt eq "kvm" || $virt eq "bochs") {
     push @imports, "<nixpkgs/nixos/modules/profiles/qemu-guest.nix>";
 }
 
+# Also for Hyper-V.
+if ($virt eq "microsoft") {
+    push @initrdAvailableKernelModules, "hv_storvsc";
+    $videoDriver = "fbdev";
+}
+
 
 # Pull in NixOS configuration for containers.
 if ($virt eq "systemd-nspawn") {
@@ -307,6 +310,7 @@ sub findStableDevPath {
     return $dev;
 }
 
+push @attrs, "services.xserver.videoDrivers = [ \"$videoDriver\" ];" if $videoDriver;
 
 # Generate the swapDevices option from the currently activated swap
 # devices.

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -42,6 +42,9 @@
       # Virtio (QEMU, KVM etc.) support.
       "virtio_net" "virtio_pci" "virtio_blk" "virtio_scsi" "virtio_balloon" "virtio_console"
 
+      # Hyper-V support.
+      "hv_storvsc"
+
       # Keyboards
       "usbhid" "hid_apple" "hid_logitech_dj" "hid_lenovo_tpkbd" "hid_roccat"
     ];


### PR DESCRIPTION
###### Motivation for this change

To Install to Hyper-V virtual machine using the minimal installation CD.

Hyper-V generation 2 VM requires the `hv_storvsc` module to boot. So this PR adds the module to the installation CD and `hardware-configuration.nix`.

The `modesetting` X11 video driver does not seem to work for Hyper-V, so this PR adds the `fbdev` video driver to `hardware-configuration.nix`.

Fixes #13971 and #9899.

Confirmed that I can boot from the minimal installation CD, install NixOS with X11, and start X11 in the installed NixOS. 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

