### PR TITLE
wp-cli: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/tools/wp-cli/default.nix
+++ b/pkgs/development/tools/wp-cli/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, php }:
 
 let
-  version = "1.0.0";
+  version = "1.1.0";
 
   bin  = "bin/wp";
   ini  = "etc/php/wp-cli.ini";
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url    = "https://github.com/wp-cli/wp-cli/releases/download/v${version}/${name}.phar";
-    sha256 = "06a80fz9na9arjdpmnislwr0121kkg11kxfqmac0axa9vkv9fjcp";
+    sha256 = "08b2lzc8fa9f5xldbdza6x3lg6jsp3wfwpyy187gxqw5pmqp11xc";
   };
 
   buildCommand = ''


### PR DESCRIPTION
###### Motivation for this change

Works fine here.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

