### PR TITLE
suil: 0.8.2 -> 0.8.4

### DIFF
--- a/pkgs/applications/audio/ingen/default.nix
+++ b/pkgs/applications/audio/ingen/default.nix
@@ -5,12 +5,12 @@
 
 stdenv.mkDerivation  rec {
   name = "ingen-unstable-${rev}";
-  rev = "2016-10-29";
+  rev = "2017-01-18";
 
   src = fetchgit {
     url = "http://git.drobilla.net/cgit.cgi/ingen.git";
-    rev = "fd147d0b888090bfb897505852c1f25dbdf77e18";
-    sha256 = "1qmg79962my82c43vyrv5sxbqci9c7gc2s9bwaaqd0fcf08xcz1z";
+    rev = "02ae3e9d8bf3f6a5e844706721aad8c0ac9f4340";
+    sha256 = "15s8nrzn68hc2s6iw0zshbz3lfnsq0mr6gflq05xm911b7xbp74k";
   };
 
   buildInputs = [

--- a/pkgs/development/libraries/audio/suil/default.nix
+++ b/pkgs/development/libraries/audio/suil/default.nix
@@ -1,15 +1,24 @@
-{ stdenv, fetchurl, gtk2, lv2, pkgconfig, python, serd, sord, sratom, qt4 }:
+{ stdenv, lib, fetchurl, gtk2, lv2, pkgconfig, python, serd, sord, sratom
+, withQt4 ? true, qt4 ? null
+, withQt5 ? false, qt5 ? null }:
+
+# I haven't found an XOR operator in nix...
+assert withQt4 || withQt5;
+assert !(withQt4 && withQt5);
 
 stdenv.mkDerivation rec {
-  name = "suil-${version}";
-  version = "0.8.2";
+  pname = "suil";
+  version = "0.8.4";
+  name = "${pname}-qt${if withQt4 then "4" else "5"}-${version}";
 
   src = fetchurl {
-    url = "http://download.drobilla.net/${name}.tar.bz2";
-    sha256 = "1s3adyiw7sa5gfvm5wasa61qa23629kprxyv6w8hbxdiwp0hhxkq";
+    url = "http://download.drobilla.net/${pname}-${version}.tar.bz2";
+    sha256 = "1kji3lhha26qr6xm9j8ic5c40zbrrb5qnwm2qxzmsfxgmrz29wkf";
   };
 
-  buildInputs = [ gtk2 lv2 pkgconfig python qt4 serd sord sratom ];
+  buildInputs = [ gtk2 lv2 pkgconfig python serd sord sratom ]
+    ++ (lib.optionals withQt4 [ qt4 ])
+    ++ (lib.optionals withQt5 (with qt5; [ qtbase qttools ]));
 
   configurePhase = "python waf configure --prefix=$out";
 
@@ -21,7 +30,7 @@ stdenv.mkDerivation rec {
     homepage = http://drobilla.net/software/suil;
     description = "A lightweight C library for loading and wrapping LV2 plugin UIs";
     license = licenses.mit;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = with maintainers; [ goibhniu ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9550,7 +9550,17 @@ with pkgs;
 
   subtitleeditor = callPackage ../applications/video/subtitleeditor { };
 
-  suil = callPackage ../development/libraries/audio/suil { };
+  suil-qt4 = callPackage ../development/libraries/audio/suil {
+    withQt4 = true;
+    withQt5 = false;
+  };
+
+  suil-qt5 = callPackage ../development/libraries/audio/suil {
+    withQt4 = false;
+    withQt5 = true;
+  };
+
+  suil = suil-qt4;
 
   sutils = callPackage ../tools/misc/sutils { };
 


### PR DESCRIPTION
###### Motivation for this change

In addition to the version upgrade, we now build specific qt4 and qt5 versions.

The library is used to bridge gtk and qt applications, but in the previous incarnation it was fixed to qt4. 

This PR also has a commit that makes ```ingen``` compile against this version which makes ```nox-review wip``` work.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
