### PR TITLE
gwenview: add support for TIFF images

### DIFF
--- a/pkgs/desktops/kde-5/applications/gwenview.nix
+++ b/pkgs/desktops/kde-5/applications/gwenview.nix
@@ -2,7 +2,7 @@
   kdeApp, lib, kdeWrapper,
   ecm, kdoctools,
   baloo, exiv2, kactivities, kdelibs4support, kio, kipi-plugins, lcms2,
-  libkdcraw, libkipi, phonon, qtsvg, qtx11extras
+  libkdcraw, libkipi, phonon, qtimageformats, qtsvg, qtx11extras
 }:
 
 let
@@ -15,8 +15,8 @@ let
       };
       nativeBuildInputs = [ ecm kdoctools ];
       propagatedBuildInputs = [
-        baloo kactivities kdelibs4support kio qtx11extras exiv2 lcms2 libkdcraw
-        libkipi phonon qtsvg
+        baloo kactivities kdelibs4support kio exiv2 lcms2 libkdcraw
+        libkipi phonon qtimageformats qtsvg qtx11extras
       ];
     };
 in


### PR DESCRIPTION
###### Motivation for this change

gwenview didn't do TIFF. Now it does.

Cc: @ttuegel

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
