### PR TITLE
ansicolor: init at 0.2.4

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -152,6 +152,23 @@ in {
     };
   };
 
+  ansicolor = buildPythonPackage rec {
+    name = "ansicolor-${version}";
+    version = "0.2.4";
+
+    src = pkgs.fetchurl{
+      url = "mirror://pypi/a/ansicolor/${name}.tar.gz";
+      sha256 = "0zlkk9706xn5yshwzdn8xsfkim8iv44zsl6qjwg2f4gn62rqky1h";
+    };
+
+    meta = {
+      homepage = "https://github.com/numerodix/ansicolor/";
+      description = "A library to produce ansi color output and colored highlighting and diffing";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ andsild ];
+    };
+  };
+
   # packages defined elsewhere
 
   blivet = callPackage ../development/python-modules/blivet { };


### PR DESCRIPTION
###### Motivation for this change
New library, not previously in nixpkgs
Needed dependency for vim-vint, [which I'll post a PR for after this one goes through](https://github.com/andsild/nixpkgs/commit/004f7acbb0ca757995cb21adc6bd0002980c4570). I have verified that vim-vint, which depends on ansicolor, works on my local computer.



~~The tests for ansicolor do not work in the nix installer. I'm not sure how to fix it and I didn't get a response on the IRC channel. Hoping someone here can help me or point me to the right direction. Otherwise, seems like a lot pythonpackages in nixpkgs suppress tests anyway?~~

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

