### PR TITLE
audio-recorder: 1.7-5 -> 1.9.4

### DIFF
--- a/pkgs/applications/audio/audio-recorder/default.nix
+++ b/pkgs/applications/audio/audio-recorder/default.nix
@@ -1,24 +1,27 @@
 { stdenv, fetchurl, lib
-, pkgconfig, intltool, autoconf, makeWrapper
+, pkgconfig, intltool, autoconf, gnome3
 , glib, dbus, gtk3, libdbusmenu-gtk3, libappindicator-gtk3, gst_all_1
+, librsvg, wrapGAppsHook
 , pulseaudioSupport ? true, libpulseaudio ? null }:
 
 with lib;
 
 stdenv.mkDerivation rec {
   name = "audio-recorder-${version}";
-  version = "1.7-5";
+  version = "1.9.4";
 
   src = fetchurl {
-    name = "${name}-wily.tar.gz";
-    url = "${meta.homepage}/+archive/ubuntu/ppa/+files/audio-recorder_${version}%7Ewily.tar.gz";
-    sha256 = "1cdlqhfqw2mg51f068j2lhn8mzxggzsbl560l4pl4fxgmpjywpkj";
+    name = "${name}-zesty.tar.gz";
+    url = "${meta.homepage}/+archive/ubuntu/ppa/+files/audio-recorder_${version}%7Ezesty.tar.gz";
+    sha256 = "062bad38cz4fqzv418wza0x8sa4m5mqr3xsisrr1qgkqj9hg1f6x";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool autoconf makeWrapper ];
+  nativeBuildInputs = [ pkgconfig intltool autoconf wrapGAppsHook ];
+
+  patches = [ ./icon-names.diff ];
 
   buildInputs = with gst_all_1; [
-    glib dbus gtk3 libdbusmenu-gtk3 libappindicator-gtk3
+    glib dbus gtk3 librsvg libdbusmenu-gtk3 libappindicator-gtk3 gnome3.dconf
     gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav
   ] ++ optional pulseaudioSupport libpulseaudio;
 
@@ -30,10 +33,10 @@ stdenv.mkDerivation rec {
     intltoolize
   '';
 
-  postFixup = ''
-    wrapProgram $out/bin/audio-recorder \
-      --prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
-      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 ":" "$GST_PLUGIN_SYSTEM_PATH_1_0"
+  preFixup = ''
+    gappsWrapperArgs+=('--prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"'
+      '--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"'
+      '--prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"')
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/audio-recorder/icon-names.diff
+++ b/pkgs/applications/audio/audio-recorder/icon-names.diff
@@ -1,0 +1,51 @@
+diff -ru audio-recorder/src/main.c audio-recorder.new/src/main.c
+--- audio-recorder/src/main.c	2017-01-03 20:27:36.000000000 +0100
++++ audio-recorder.new/src/main.c	2017-01-30 20:19:44.019255096 +0100
+@@ -1099,7 +1099,7 @@
+     gtk_container_add(GTK_CONTAINER(frame2), g_win.timer_text);
+ 
+     // Timer [Save] button
+-    g_win.timer_save_button = gtk_button_new_from_icon_name("gtk-save", GTK_ICON_SIZE_BUTTON);
++    g_win.timer_save_button = gtk_button_new_from_icon_name("document-save", GTK_ICON_SIZE_BUTTON);
+     // Hide it
+     gtk_widget_hide(g_win.timer_save_button);
+     g_signal_connect(g_win.timer_save_button, "clicked", G_CALLBACK(win_timer_save_text_cb), NULL);
+@@ -1129,7 +1129,7 @@
+     // The [Info] button
+     GtkWidget *button0 = gtk_button_new();
+     gtk_widget_show(button0);
+-    GtkWidget *image = gtk_image_new_from_icon_name("gtk-info", GTK_ICON_SIZE_BUTTON);
++    GtkWidget *image = gtk_image_new_from_icon_name("dialog-information", GTK_ICON_SIZE_BUTTON);
+     gtk_widget_show(image);
+     gtk_button_set_always_show_image(GTK_BUTTON(button0), TRUE);
+     gtk_button_set_image(GTK_BUTTON(button0), image);
+@@ -1220,7 +1220,7 @@
+     // Add [Reload] button
+     button0 = gtk_button_new();
+     gtk_widget_show(button0);
+-    image = gtk_image_new_from_icon_name("gtk-refresh", GTK_ICON_SIZE_BUTTON);
++    image = gtk_image_new_from_icon_name("view-refresh", GTK_ICON_SIZE_BUTTON);
+     gtk_widget_show(image);
+     gtk_button_set_always_show_image(GTK_BUTTON(button0), TRUE);
+ 
+@@ -1297,7 +1297,7 @@
+     gtk_widget_show(hbox4);
+     gtk_box_pack_start(GTK_BOX(vbox0), hbox4, FALSE, TRUE, 0);
+ 
+-    button0 = gtk_button_new_from_icon_name("gtk-close", GTK_ICON_SIZE_BUTTON);
++    button0 = gtk_button_new_from_icon_name("window-close", GTK_ICON_SIZE_BUTTON);
+     gtk_button_set_always_show_image(GTK_BUTTON(button0), TRUE);
+     gtk_widget_show(button0);
+     gtk_box_pack_end(GTK_BOX(hbox4), button0, FALSE, FALSE, 0);
+diff -ru audio-recorder/src/settings.c audio-recorder.new/src/settings.c
+--- audio-recorder/src/settings.c	2017-01-02 10:47:27.000000000 +0100
++++ audio-recorder.new/src/settings.c	2017-01-30 20:23:04.621314105 +0100
+@@ -659,7 +659,7 @@
+     gtk_entry_set_invisible_char(GTK_ENTRY(file_name_pattern), 9679);
+ 
+     button0 = gtk_button_new();
+-    GtkWidget *image = gtk_image_new_from_icon_name("gtk-info", GTK_ICON_SIZE_BUTTON);
++    GtkWidget *image = gtk_image_new_from_icon_name("dialog-information", GTK_ICON_SIZE_BUTTON);
+     gtk_button_set_always_show_image(GTK_BUTTON(button0), TRUE);
+     gtk_button_set_image(GTK_BUTTON(button0), image);
+     g_signal_connect(button0, "clicked", G_CALLBACK(win_settings_show_filename_help), NULL);


### PR DESCRIPTION
###### Motivation for this change
Update of audio-recorder:
- Upstream fixes for GNOME 3.22
- Patches mis-named icon resources (Bug already filed upstream)
- Fixes the use of dconf and SVG icons

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

