### PR TITLE
callCabal2nix: take "name" parameter as a function argument

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -85,10 +85,7 @@ let
         callHackage = name: version: self.callPackage (hackage2nix name version);
 
         # Creates a Haskell package from a source package by calling cabal2nix on the source.
-        callCabal2nix = src: self.callPackage (haskellSrc2nix {
-          inherit src;
-          name = src.name or baseNameOf src;
-        });
+        callCabal2nix = name: src: self.callPackage (haskellSrc2nix { inherit src name; });
 
         ghcWithPackages = selectFrom: withPackages (selectFrom self);
 


### PR DESCRIPTION
The callCabal2nix function cannot reliably determine the appropriate "name" for
the package it's processing. Attempts to derive this information have led to
plenty of evaluation errors, and so I'd like to go for the obvious and reliable
solution now and let the caller specify that bit of information.

Here is an example that demonstrates how to use callCabal2nix.

    let
      pkgs = import <nixpkgs> {};
      src = pkgs.fetchFromGitHub {
        owner = "gtk2hs";
        repo = "gtk2hs";
        rev = "eee61d84edf1dd44f8d380d7d7cae2405de50124";
        sha256 = "12i53grimni0dyjqjydl120z5amcn668w4pfhl8dxscjh4a0l5nb";
      };
    in
      pkgs.haskellPackages.callCabal2nix "gtkhs-tools" "${src}/tools" {}