### PR TITLE
nkf: 2.1.3 -> 2.1.4

### DIFF
--- a/pkgs/tools/text/nkf/default.nix
+++ b/pkgs/tools/text/nkf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "nkf-${version}";
-  version = "2.1.3";
+  version = "2.1.4";
 
   src = fetchurl {
-    url = "mirror://sourceforgejp/nkf/59912/${name}.tar.gz";
-    sha256 = "8cb430ae69a1ad58b522eb4927b337b5b420bbaeb69df255919019dc64b72fc2";
+    url = "mirror://sourceforgejp/nkf/64158/${name}.tar.gz";
+    sha256 = "b4175070825deb3e98577186502a8408c05921b0c8ff52e772219f9d2ece89cb";
   };
 
   makeFlags = "prefix=\${out}";


### PR DESCRIPTION
###### Motivation for this change

Update.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

