### PR TITLE
redshift-plasma-applet: init at 1.0.17

### DIFF
--- a/pkgs/applications/misc/redshift-plasma-applet/default.nix
+++ b/pkgs/applications/misc/redshift-plasma-applet/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, cmake, kde5, redshift, fetchFromGitHub, ... }:
+
+let version = "1.0.17"; in
+
+stdenv.mkDerivation {
+  name = "redshift-plasma-applet-${version}";
+
+  src = fetchFromGitHub {
+    owner = "kotelnik";
+    repo = "plasma-applet-redshift-control";
+    rev = "v${version}";
+    sha256 = "1lp1rb7i6c18lrgqxsglbvyvzh71qbm591abrbhw675ii0ca9hgj";
+  };
+
+  patchPhase = ''
+    substituteInPlace package/contents/ui/main.qml \
+      --replace "redshiftCommand: 'redshift'" \
+                "redshiftCommand: '${redshift}/bin/redshift'" \
+      --replace "redshiftOneTimeCommand: 'redshift -O " \
+                "redshiftOneTimeCommand: '${redshift}/bin/redshift -O "
+
+    substituteInPlace package/contents/ui/config/ConfigAdvanced.qml \
+      --replace "'redshift -V'" \
+                "'${redshift}/bin/redshift -V'"
+  '';
+
+  buildInputs = [
+    cmake
+    kde5.plasma-framework
+  ];
+
+
+  meta = with stdenv.lib; {
+    description = "KDE Plasma 5 widget for controlling Redshift";
+    homepage = https://github.com/kotelnik/plasma-applet-redshift-control;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ benley ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16766,6 +16766,8 @@ with pkgs;
     inherit (python3Packages) python pygobject3 pyxdg;
   };
 
+  redshift-plasma-applet = callPackage ../applications/misc/redshift-plasma-applet { };
+
   orion = callPackage ../misc/themes/orion {};
 
   albatross = callPackage ../misc/themes/albatross { };


### PR DESCRIPTION
###### Motivation for this change

Nice user-friendly KDE applet for controlling Redshift

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

