### PR TITLE
kdiff3-qt5: init at 1.7.0

### DIFF
--- a/pkgs/tools/text/kdiff3/kde5.nix
+++ b/pkgs/tools/text/kdiff3/kde5.nix
@@ -1,0 +1,37 @@
+{
+  kdeDerivation, kdeWrapper, lib, fetchgit,
+  ecm, kdoctools, kconfig, kinit, kparts
+}:
+
+let
+  rev = "468652ce70b1214842cef0a021c81d056ec6aa01";
+
+  unwrapped = kdeDerivation rec {
+    name = "kdiff3-${version}";
+    version = "1.7.0-${lib.strings.substring 0 7 rev}";
+
+    src = fetchgit {
+      url = "https://gitlab.com/tfischer/kdiff3";
+      sha256 = "126xl7jbb26v2970ba1rw1d6clhd14p1f2avcwvj8wzqmniq5y5m";
+      inherit rev;
+    };
+
+    preConfigure = "cd kdiff3";
+
+    nativeBuildInputs = [ ecm kdoctools ];
+
+    propagatedBuildInputs = [ kconfig kinit kparts ];
+
+    meta = with lib; {
+      homepage = http://kdiff3.sourceforge.net/;
+      license = licenses.gpl2Plus;
+      description = "Compares and merges 2 or 3 files or directories";
+      maintainers = with maintainers; [ viric urkud peterhoeg ];
+      platforms = with platforms; linux;
+    };
+  };
+
+in kdeWrapper {
+  inherit unwrapped;
+  targets = [ "bin/kdiff3" ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2417,6 +2417,8 @@ with pkgs;
 
   kronometer = qt5.callPackage ../tools/misc/kronometer { };
 
+  kdiff3-qt5 = qt5.callPackage ../tools/text/kdiff3/kde5.nix { };
+
   peruse = qt5.callPackage ../tools/misc/peruse { };
 
   kst = qt5.callPackage ../tools/graphics/kst { gsl = gsl_1; };


### PR DESCRIPTION
###### Motivation for this change

Upstream hasn't made a formal release yet of the qt5 version which is why I'm
not replacing the existing kde4 version. The ```1.7.0``` tag is the most recently released version that then carries a number of patches to work with qt5. Upstream has told me that a formal release will be coming "soon".

Cc: @ttuegel 

###### Things done 

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

