### PR TITLE
okteta: init at 16.12.1 (kf5 version)

### DIFF
--- a/pkgs/desktops/kde-5/applications/default.nix
+++ b/pkgs/desktops/kde-5/applications/default.nix
@@ -64,6 +64,7 @@ let
     libkipi = callPackage ./libkipi.nix {};
     libkomparediff2 = callPackage ./libkomparediff2.nix {};
     marble = callPackage ./marble.nix {};
+    okteta = callPackage ./okteta.nix {};
     okular = callPackage ./okular.nix {};
     print-manager = callPackage ./print-manager.nix {};
     spectacle = callPackage ./spectacle.nix {};

--- a/pkgs/desktops/kde-5/applications/okteta.nix
+++ b/pkgs/desktops/kde-5/applications/okteta.nix
@@ -1,0 +1,26 @@
+{
+  kdeApp, lib, kdeWrapper,
+  ecm, kdoctools,
+  kconfig, kinit,
+  kcmutils, kconfigwidgets, knewstuff, kparts, qca-qt5
+}:
+
+let
+  unwrapped =
+    kdeApp {
+      name = "okteta";
+      meta = {
+        license = with lib.licenses; [ gpl2 ];
+        maintainers = with lib.maintainers; [ peterhoeg ];
+      };
+      nativeBuildInputs = [ ecm kdoctools ];
+      propagatedBuildInputs = [
+        kconfig kinit
+        kcmutils kconfigwidgets knewstuff kparts qca-qt5
+      ];
+    };
+
+in kdeWrapper {
+  inherit unwrapped;
+  targets = [ "bin/okteta" ];
+}


### PR DESCRIPTION
###### Motivation for this change

It is already part of KDE Applications - might as well make it available.

Cc: @ttuegel 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

