### PR TITLE
rhc: 1.36.4 -> 1.38.7

### DIFF
--- a/pkgs/development/tools/rhc/Gemfile
+++ b/pkgs/development/tools/rhc/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
+
+gem 'archive-tar-minitar', '>= 0.5.2.1', github: 'peterhoeg/archive-tar-minitar'
 gem 'rhc'

--- a/pkgs/development/tools/rhc/Gemfile.lock
+++ b/pkgs/development/tools/rhc/Gemfile.lock
@@ -1,27 +1,31 @@
+GIT
+  remote: git://github.com/peterhoeg/archive-tar-minitar.git
+  revision: dae32ca550a87dba32597115ae18805db4782ebe
+  specs:
+    archive-tar-minitar (0.5.2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    archive-tar-minitar (0.5.2)
     commander (4.2.1)
       highline (~> 1.6.11)
     highline (1.6.21)
     httpclient (2.6.0.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.2)
-    net-ssh-gateway (1.2.0)
-      net-ssh (>= 2.6.5)
+    net-ssh (4.0.1)
+    net-ssh-gateway (2.0.0)
+      net-ssh (>= 4.0.0)
     net-ssh-multi (1.2.1)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
     open4 (1.3.4)
-    rhc (1.36.4)
+    rhc (1.38.7)
       archive-tar-minitar
       commander (>= 4.0, < 4.3.0)
       highline (~> 1.6.11)
-      httpclient (>= 2.4.0)
+      httpclient (>= 2.4.0, < 2.7.0)
       net-scp (>= 1.1.2)
-      net-ssh (>= 2.0.11, < 2.9.3)
       net-ssh-multi (>= 1.2.0)
       open4
 
@@ -29,7 +33,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  archive-tar-minitar (>= 0.5.2.1)!
   rhc
 
 BUNDLED WITH
-   1.10.5
+   1.13.6

--- a/pkgs/development/tools/rhc/default.nix
+++ b/pkgs/development/tools/rhc/default.nix
@@ -1,10 +1,24 @@
-{ lib, bundlerEnv, ruby }:
+{ lib, bundlerEnv, ruby_2_2, stdenv, makeWrapper }:
 
-bundlerEnv {
-  name = "rhc-1.36.4";
+stdenv.mkDerivation rec {
+  name = "rhc-1.38.7";
 
-  inherit ruby;
-  gemdir = ./.;
+  env = bundlerEnv {
+    name = "rhc-1.38.7-gems";
+
+    ruby = ruby_2_2;
+
+    gemdir = ./.;
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper ${env}/bin/rhc $out/bin/rhc
+  '';
 
   meta = with lib; {
     homepage = https://github.com/openshift/rhc;

--- a/pkgs/development/tools/rhc/gemset.nix
+++ b/pkgs/development/tools/rhc/gemset.nix
@@ -1,95 +1,84 @@
 {
-  "archive-tar-minitar" = {
-    version = "0.5.2";
+  archive-tar-minitar = {
     source = {
-      type = "gem";
-      sha256 = "1j666713r3cc3wb0042x0wcmq2v11vwwy5pcaayy5f0lnd26iqig";
+      fetchSubmodules = false;
+      rev = "dae32ca550a87dba32597115ae18805db4782ebe";
+      sha256 = "0fvxacbcb52fm5dis451kdd7dv74z8p6nm4vnfqf7jg2aghcxdkd";
+      type = "git";
+      url = "git://github.com/peterhoeg/archive-tar-minitar.git";
     };
+    version = "0.5.2.1";
   };
-  "commander" = {
-    version = "4.2.1";
+  commander = {
     source = {
-      type = "gem";
+      remotes = ["https://rubygems.org"];
       sha256 = "1zwfhswnbhwv0zzj2b3s0qvpqijbbnmh7zvq6v0274rqbxyf1jwc";
-    };
-    dependencies = [
-      "highline"
-    ];
-  };
-  "highline" = {
-    version = "1.6.21";
-    source = {
       type = "gem";
+    };
+    version = "4.2.1";
+  };
+  highline = {
+    source = {
+      remotes = ["https://rubygems.org"];
       sha256 = "06bml1fjsnrhd956wqq5k3w8cyd09rv1vixdpa3zzkl6xs72jdn1";
-    };
-  };
-  "httpclient" = {
-    version = "2.6.0.1";
-    source = {
       type = "gem";
+    };
+    version = "1.6.21";
+  };
+  httpclient = {
+    source = {
+      remotes = ["https://rubygems.org"];
       sha256 = "0haz4s9xnzr73mkfpgabspj43bhfm9znmpmgdk74n6gih1xlrx1l";
-    };
-  };
-  "net-scp" = {
-    version = "1.2.1";
-    source = {
       type = "gem";
+    };
+    version = "2.6.0.1";
+  };
+  net-scp = {
+    source = {
+      remotes = ["https://rubygems.org"];
       sha256 = "0b0jqrcsp4bbi4n4mzyf70cp2ysyp6x07j8k8cqgxnvb4i3a134j";
-    };
-    dependencies = [
-      "net-ssh"
-    ];
-  };
-  "net-ssh" = {
-    version = "2.9.2";
-    source = {
       type = "gem";
-      sha256 = "1p0bj41zrmw5lhnxlm1pqb55zfz9y4p9fkrr9a79nrdmzrk1ph8r";
     };
-  };
-  "net-ssh-gateway" = {
-    version = "1.2.0";
-    source = {
-      type = "gem";
-      sha256 = "1nqkj4wnj26r81rp3g4jqk7bkd2nqzjil3c9xqwchi0fsbwv2niy";
-    };
-    dependencies = [
-      "net-ssh"
-    ];
-  };
-  "net-ssh-multi" = {
     version = "1.2.1";
+  };
+  net-ssh = {
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02xj3pcpqr32nlak0vsx71gd5z65jl3q1hwi2x157vabw1kgjanq";
       type = "gem";
+    };
+    version = "4.0.1";
+  };
+  net-ssh-gateway = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1l3v761y32aw0n8lm0c0m42lr4ay8cq6q4sc5yc68b9fwlfvb70x";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+  net-ssh-multi = {
+    source = {
+      remotes = ["https://rubygems.org"];
       sha256 = "13kxz9b6kgr9mcds44zpavbndxyi6pvyzyda6bhk1kfmb5c10m71";
-    };
-    dependencies = [
-      "net-ssh"
-      "net-ssh-gateway"
-    ];
-  };
-  "open4" = {
-    version = "1.3.4";
-    source = {
       type = "gem";
+    };
+    version = "1.2.1";
+  };
+  open4 = {
+    source = {
+      remotes = ["https://rubygems.org"];
       sha256 = "1cgls3f9dlrpil846q0w7h66vsc33jqn84nql4gcqkk221rh7px1";
-    };
-  };
-  "rhc" = {
-    version = "1.36.4";
-    source = {
       type = "gem";
-      sha256 = "1dkg39x3y3sxq71md5c8akq4y7ynjwcdy8ysm6d1k9b2rj0s5wdb";
     };
-    dependencies = [
-      "archive-tar-minitar"
-      "commander"
-      "highline"
-      "httpclient"
-      "net-scp"
-      "net-ssh"
-      "net-ssh-multi"
-      "open4"
-    ];
+    version = "1.3.4";
+  };
+  rhc = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yaq42szq81ph44q7ckzml9yrhz1pkjfik77rxvfzlf90l1g2ibk";
+      type = "gem";
+    };
+    version = "1.38.7";
   };
 }


### PR DESCRIPTION
Fix: CVE-2016-10173

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

