### PR TITLE
pdf2htmlEX: init at 0.14.6

### DIFF
--- a/pkgs/tools/typesetting/pdf2htmlEX/add-glib-cmake.patch
+++ b/pkgs/tools/typesetting/pdf2htmlEX/add-glib-cmake.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3fdabb0..378621a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -59,6 +59,12 @@ include_directories(${FONTFORGE_INCLUDE_DIRS})
+ link_directories(${FONTFORGE_LIBRARY_DIRS})
+ set(PDF2HTMLEX_LIBS ${PDF2HTMLEX_LIBS} ${FONTFORGE_LIBRARIES})
+ 
++# add glib dependency
++pkg_check_modules(GLIB REQUIRED glib-2.0)
++include_directories(${GLIB_INCLUDE_DIRS})
++link_directories(${GLIB_INCLUDE_DIRS})
++set(PDF2HTMLEX_LIBS ${PDF2HTMLEX_LIBS} ${GLIB_LIBRARIES})
++
+ # debug build flags (overwrite default cmake debug flags)
+ set(CMAKE_C_FLAGS_DEBUG "-ggdb -pg")
+ set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -pg")

--- a/pkgs/tools/typesetting/pdf2htmlEX/default.nix
+++ b/pkgs/tools/typesetting/pdf2htmlEX/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, poppler, xlibs, pcre, python, glib, fontforge-gtk, cairo, pango, openjdk8
+}:
+
+stdenv.mkDerivation rec {
+  name = "pdf2htmlEX-0.14.6";
+
+  src = fetchFromGitHub {
+    repo   = "pdf2htmlEX";
+    owner  = "coolwanglu";
+    rev    = "v0.14.6";
+    sha256 = "1nh0ab8f11fsyi4ldknlkmdzcfvm1dfh8b9bmprjgq6q0vjj7f78";
+  };
+
+  patches = [ ./add-glib-cmake.patch ];
+
+  cmakeFlags = [ "-DENABLE_SVG=ON" ];
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+  ];
+
+  buildInputs = [
+    xlibs.libpthreadstubs
+    xlibs.libXdmcp
+    pcre
+    python
+    glib
+    cairo
+    pango
+    (poppler.override { withData = true; })
+    fontforge-gtk
+    openjdk8
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Render PDF files to beautiful HTML";
+    homepage    = "https://github.com/coolwanglu/pdf2htmlEX";
+    license     = licenses.gpl3Plus;
+    maintainers = [ maintainers.taktoa ];
+    platforms   = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3320,6 +3320,8 @@ with pkgs;
 
   pdf2djvu = callPackage ../tools/typesetting/pdf2djvu { };
 
+  pdf2htmlEX = callPackage ../tools/typesetting/pdf2htmlEX { };
+
   pdf2odt = callPackage ../tools/typesetting/pdf2odt { };
 
   pdf2svg = callPackage ../tools/graphics/pdf2svg { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

