### PR TITLE
cdemu: bugfix updates

### DIFF
--- a/pkgs/misc/emulators/cdemu/analyzer.nix
+++ b/pkgs/misc/emulators/cdemu/analyzer.nix
@@ -1,12 +1,12 @@
-{ callPackage, gtk3, glib, libxml2, gnuplot, makeWrapper, stdenv, gnome3, gdk_pixbuf, librsvg }:
+{ callPackage, gtk3, glib, libxml2, gnuplot, makeWrapper, stdenv, gnome3, gdk_pixbuf, librsvg, intltool }:
 let pkg = import ./base.nix {
-  version = "3.0.0";
+  version = "3.0.1";
   pkgName = "image-analyzer";
-  pkgSha256 = "1rb3f7c08dxc02zrwrkfvq7qlzlmm0kd2ah1fhxj6ajiyshi8q4v";
+  pkgSha256 = "19x5hx991pl55ddm2wjd2ylm2hiz9yvzgrwmpnsqr9zqc4lja682";
 };
 in callPackage pkg {
   buildInputs = [ glib gtk3 libxml2 gnuplot (callPackage ./libmirage.nix {}) makeWrapper
-                  gnome3.defaultIconTheme gdk_pixbuf librsvg ];
+                  gnome3.defaultIconTheme gdk_pixbuf librsvg intltool ];
   drvParams = {
     postFixup = ''
       wrapProgram $out/bin/image-analyzer \

--- a/pkgs/misc/emulators/cdemu/client.nix
+++ b/pkgs/misc/emulators/cdemu/client.nix
@@ -1,8 +1,8 @@
 { callPackage, pythonPackages, intltool, makeWrapper }:
 let pkg = import ./base.nix {
-  version = "3.0.1";
+  version = "3.0.3";
   pkgName = "cdemu-client";
-  pkgSha256 = "1kg5m7npdxli93vihhp033hgkvikw5b6fm0qwgvlvdjby7njyyyg";
+  pkgSha256 = "1bfj7bc10z20isdg0h8sfdvnwbn6c49494mrmq6jwrfbqvby25x9";
 };
 in callPackage pkg {
   buildInputs = [ pythonPackages.python pythonPackages.dbus-python intltool makeWrapper ];

--- a/pkgs/misc/emulators/cdemu/daemon.nix
+++ b/pkgs/misc/emulators/cdemu/daemon.nix
@@ -1,8 +1,8 @@
 { callPackage, glib, libao }:
 let pkg = import ./base.nix {
-  version = "3.0.3";
+  version = "3.0.5";
   pkgName = "cdemu-daemon";
-  pkgSha256 = "00gi3x03l019nyqfxkph1rsldd7fwg0r0x95spwv5py5wyiqvp3m";
+  pkgSha256 = "1cc0yxf1y5dxinv7md1cqhdjsbqb69v9jygrdq5c20mrkqaajz1i";
 };
 in callPackage pkg {
   buildInputs = [ glib libao (callPackage ./libmirage.nix {}) ];

--- a/pkgs/misc/emulators/cdemu/gui.nix
+++ b/pkgs/misc/emulators/cdemu/gui.nix
@@ -1,9 +1,9 @@
 { callPackage, pythonPackages, gtk3, glib, libnotify, intltool, makeWrapper, gobjectIntrospection, gnome3, gdk_pixbuf, librsvg }:
 let
   pkg = import ./base.nix {
-    version = "3.0.1";
+    version = "3.0.2";
     pkgName = "gcdemu";
-    pkgSha256 = "1dlng1bvhns7f0ff5p89npsm2nznfqnaspr0alfh4fl0f11cvnfr";
+    pkgSha256 = "1kmcr2a0inaddx8wrjh3l1v5ymgwv3r6nv2w05lia51r1yzvb44p";
   };
   inherit (pythonPackages) python pygobject3;
 in callPackage pkg {

--- a/pkgs/misc/emulators/cdemu/libmirage.nix
+++ b/pkgs/misc/emulators/cdemu/libmirage.nix
@@ -1,8 +1,8 @@
 { callPackage, glib, libsndfile, zlib, bzip2, lzma, libsamplerate }:
 let pkg = import ./base.nix {
-  version = "3.0.4";
+  version = "3.0.5";
   pkgName = "libmirage";
-  pkgSha256 = "0grzdacl8hlj20amq88r98h8pd039ww0g4hl1a8lhly11h7kf1fc";
+  pkgSha256 = "01wfxlyviank7k3p27grl1r40rzm744rr80zr9lcjk3y8i5g8ni2";
 };
 in callPackage pkg {
   buildInputs = [ glib libsndfile zlib bzip2 lzma libsamplerate ];

--- a/pkgs/misc/emulators/cdemu/vhba.nix
+++ b/pkgs/misc/emulators/cdemu/vhba.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "vhba-${version}";
-  version = "20140928";
+  version = "20161009";
 
   src  = fetchurl {
     url = "mirror://sourceforge/cdemu/vhba-module-${version}.tar.bz2";
-    sha256 = "18jmpg2kpx87f32b8aprr1pxla9dlhf901rkj1sp3ammf94nxxa5";
+    sha256 = "1n9k3z8hppnl5b5vrn41b69wqwdpml6pm0rgc8vq3jqwss5js1nd";
   };
 
   makeFlags = [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" "INSTALL_MOD_PATH=$(out)" ];


### PR DESCRIPTION
image-analyzer: 3.0.0 -> 3.0.1
cdemu-client: 3.0.1 -> 3.0.3
cdemu-daemon: 3.0.3 -> 3.0.5
gcdemu: 3.0.1 -> 3.0.2
libmirage: 3.0.4 -> 3.0.5
vhba: 20140928 -> 20161009

###### Motivation for this change

Maintenance updates
