### PR TITLE
shaarli: add material theme package

### DIFF
--- a/pkgs/servers/web-apps/shaarli/material-theme.nix
+++ b/pkgs/servers/web-apps/shaarli/material-theme.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "shaarli-material-${version}";
-  version = "0.8.2";
+  version = "0.8.3";
 
   src = fetchFromGitHub {
     owner = "kalvn";
     repo = "Shaarli-Material";
     rev = "v${version}";
-    sha256 = "1gam080iwr8vd6k6liv0zmpb3zyw37a53nj1s4ywb4d2i68hjncd";
+    sha256 = "0ivq35183r5vyzvf47sgxwdxllmvhd5w9w75xgyp3kbw2na4yrmr";
   };
 
   patchPhase = ''
@@ -19,9 +19,6 @@ stdenv.mkDerivation rec {
         --replace '.min.js"'  '.min.js#"' \
         --replace '.png"'     '.png#"'
     done
-
-    substituteInPlace material/loginform.html \
-        --replace '"ban_canLogin()"' '"ban_canLogin($conf)"' # PHP 7.1 fix (https://github.com/shaarli/Shaarli/issues/711)
   '';
 
   installPhase = ''

--- a/pkgs/servers/web-apps/shaarli/material-theme.nix
+++ b/pkgs/servers/web-apps/shaarli/material-theme.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "shaarli-material-${version}";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "kalvn";
+    repo = "Shaarli-Material";
+    rev = "v${version}";
+    sha256 = "1gam080iwr8vd6k6liv0zmpb3zyw37a53nj1s4ywb4d2i68hjncd";
+  };
+
+  patchPhase = ''
+    for f in material/*.html
+    do
+      substituteInPlace $f \
+        --replace '.min.css"' '.min.css#"' \
+        --replace '.min.js"'  '.min.js#"' \
+        --replace '.png"'     '.png#"'
+    done
+
+    substituteInPlace material/loginform.html \
+        --replace '"ban_canLogin()"' '"ban_canLogin($conf)"' # PHP 7.1 fix (https://github.com/shaarli/Shaarli/issues/711)
+  '';
+
+  installPhase = ''
+    mv material/ $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A theme base on Google's Material Design for Shaarli, the superfast delicious clone";
+    license = licenses.mit;
+    homepage = https://github.com/kalvn/Shaarli-Material;
+    maintainers = with maintainers; [ schneefux ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10747,6 +10747,8 @@ in
 
   shaarli = callPackage ../servers/web-apps/shaarli { };
 
+  shaarli-material = callPackage ../servers/web-apps/shaarli/material-theme.nix { };
+
   axis2 = callPackage ../servers/http/tomcat/axis2 { };
 
   unifi = callPackage ../servers/unifi { };


### PR DESCRIPTION
###### Motivation for this change
Adds the material theme to shaarli. Usage is explained in #19491 and in the official documentation (change `raintpl_tpl` to the package path in the configuration file).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).