### PR TITLE
vint: init at 0.3.11

### DIFF
--- a/pkgs/development/tools/vim-vint/default.nix
+++ b/pkgs/development/tools/vim-vint/default.nix
@@ -1,0 +1,38 @@
+{ fetchFromGitHub, lib, python3Packages, stdenv }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  name = "vim-vint-${version}";
+  version = "0.3.11";
+
+  src = fetchFromGitHub {
+    owner = "kuniwak";
+    repo = "vint";
+    rev = "v${version}";
+    sha256 = "0xl166xs7sm404f1qz2s0xcry7fr1hgyvhqhyj1qj0dql9i3xx8v";
+  };
+
+  # For python 3.5 > version > 2.7 , a nested dependency (pythonPackages.hypothesis) fails.
+  disabled = ! pythonAtLeast "3.5";
+
+  # Prevent setup.py from adding dependencies in run-time and insisting on specific package versions
+  patchPhase = ''
+    substituteInPlace setup.py --replace "return requires" "return []"
+    '';
+  buildInputs = [ coverage pytest pytestcov ];
+  propagatedBuildInputs = [ ansicolor chardet pyyaml ] ;
+
+  # The acceptance tests check for stdout and location of binary files, which fails in nix-build.
+  checkPhase = ''
+    py.test -k "not acceptance"
+  '';
+
+  meta = with lib; {
+    description = "Fast and Highly Extensible Vim script Language Lint implemented by Python";
+    homepage = "https://github.com/Kuniwak/vint";
+    license = licenses.mit;
+    maintainers = with maintainers; [ andsild ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4215,6 +4215,8 @@ with pkgs;
     inherit (gnome3) gexiv2;
   };
 
+  vim-vint = callPackage ../development/tools/vim-vint { };
+
   vit = callPackage ../applications/misc/vit { };
 
   vnc2flv = callPackage ../tools/video/vnc2flv {};


### PR DESCRIPTION
###### Motivation for this change
New package

I tested using python35 and python36: `nix-env -f $NIXPKGS --option build-use-chroot true --option use-binary-caches false -i vim-vint`, `nix-shell -I nixpkgs=. --pure -p vim-vint`, and `nix-build -A vim-vint && ./result/bin/vint`

I made sure that the resulting executable worked on vimrc-files, e.g. `vint ~/.vimrc --color`
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

