### PR TITLE
hydra-module: add cfg.package to hydra-evaluator path

### DIFF
--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -343,7 +343,7 @@ in
       { wantedBy = [ "multi-user.target" ];
         requires = [ "hydra-init.service" ];
         after = [ "hydra-init.service" "network.target" ];
-        path = [ pkgs.nettools ];
+        path = [ cfg.package pkgs.nettools ];
         environment = env;
         serviceConfig =
           { ExecStart = "@${cfg.package}/bin/hydra-evaluator hydra-evaluator";


### PR DESCRIPTION
This cherry-picks https://github.com/NixOS/nixpkgs/commit/37715d1f46653f331d9b5e52e5436fc6afc6d6c2 on `release-16.09`.