### PR TITLE
CONTRIBUTING.md: improve commit message guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,14 +14,22 @@ under the terms of [COPYING](../COPYING), which is an MIT-like license.
 
 * Format the commits in the following way:
 
-  `(pkg-name | service-name): (from -> to | init at version | refactor | etc)`
+  ```
+  (pkg-name | service-name): (from -> to | init at version | refactor | etc)
+  
+  (Motivation for change. Additional information.)
+  ```
 
   Examples:
 
   * nginx: init at 2.0.1
   * firefox: 3.0 -> 3.1.1
   * hydra service: add bazBaz option
+  
+    Dual baz behavior is needed to do foo.
   * nginx service: refactor config generation
+    
+    The old config generation system used impure shell scripts and could break in specific circumstances (see #1234).
 
 * `meta.description` should:
   * Be capitalized
@@ -29,6 +37,12 @@ under the terms of [COPYING](../COPYING), which is an MIT-like license.
   * Not have a dot at the end
 
 See the nixpkgs manual for more details on how to [Submit changes to nixpkgs](https://nixos.org/nixpkgs/manual/#chap-submitting-changes).
+
+## Writing good commit messages
+
+In addition to writing properly formatted commit messages, it's important to include relevant information so other developers can later understand *why* a change was made. While this information usually can be found by digging code, mailing list archives, pull request discussions or upstream changes, it may require a lot of work.
+
+For package version upgrades and such a one-line commit message is usually sufficient.
 
 ## Reviewing contributions
 


### PR DESCRIPTION
Add a brief request for expressing the motivation for a change. Change the example commit messages to match.

Resolves #19126.

###### Motivation for this change

Motivation for each change should exist in commit history in addition to this section in a PR. See discussion in #19126.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

