### PR TITLE
spark: 1.6.0 -> 2.1.0

### DIFF
--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -1,22 +1,38 @@
 { stdenv, fetchzip, makeWrapper, jre, pythonPackages
 , mesosSupport ? true, mesos
+, version
 }:
+
+let
+  versionMap = {
+    "1.6.0" = {
+                hadoopVersion = "cdh4";
+                sparkSha256 = "19ycx1r8g82vkvzmn9wxkssmv2damrg72yfmrgzpc6xyh071g91c";
+              };
+    "2.1.0" = {
+                hadoopVersion = "hadoop2.4";
+                sparkSha256 = "0pbsmbjwijsfgbnm56kgwnmnlqkz3w010ma0d7vzlkdklj40vqn2";
+              };
+  };
+in
+
+with versionMap.${version};
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name    = "spark-${version}";
-  version = "1.6.0";
+
+  name = "spark-${version}";
 
   src = fetchzip {
-    url    = "mirror://apache/spark/${name}/${name}-bin-cdh4.tgz";
-    sha256 = "19ycx1r8g82vkvzmn9wxkssmv2damrg72yfmrgzpc6xyh071g91c";
+    url    = "mirror://apache/spark/${name}/${name}-bin-${hadoopVersion}.tgz";
+    sha256 = sparkSha256;
   };
 
   buildInputs = [ makeWrapper jre pythonPackages.python pythonPackages.numpy ]
     ++ optional mesosSupport mesos;
 
-  untarDir = "${name}-bin-cdh4";
+  untarDir = "${name}-bin-${hadoopVersion}";
   installPhase = ''
     mkdir -p $out/{lib/${untarDir}/conf,bin,/share/java}
     mv * $out/lib/${untarDir}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5931,7 +5931,9 @@ with pkgs;
 
   self = callPackage_i686 ../development/interpreters/self { };
 
-  spark = callPackage ../applications/networking/cluster/spark { };
+  spark = spark_21;
+  spark_16 = callPackage ../applications/networking/cluster/spark { version = "1.6.0"; };
+  spark_21 = callPackage ../applications/networking/cluster/spark { version = "2.1.0"; };
 
   spidermonkey_1_8_5 = callPackage ../development/interpreters/spidermonkey/1.8.5.nix { };
   spidermonkey_17 = callPackage ../development/interpreters/spidermonkey/17.nix { };


### PR DESCRIPTION
Tested in linux with:
nix-env -f . -i spark-1.6.0
nix-env -f . -i spark

cc @thoughtpolice @offlinehacker

###### Motivation for this change

Have nixpkgs provide a newer version of Spark.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

