### PR TITLE
bash-completion: 2.4 -> 2.5

### DIFF
--- a/pkgs/shells/bash-completion/default.nix
+++ b/pkgs/shells/bash-completion/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "bash-completion-${version}";
-  version = "2.4";
+  version = "2.5";
 
   src = fetchurl {
     url = "https://github.com/scop/bash-completion/releases/download/${version}/${name}.tar.xz";
-    sha256 = "1xlhd09sb2w3bw8qaypxgkr0782w082mcbx8zf7yzjgy0996pxy0";
+    sha256 = "1kwmii1z1ljx5i4z702ynsr8jgrq64bj9w9hl3n2aa2kcl659fdh";
   };
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

To bump the bash-completion version. Note, I haven't used this more than a few moment to try it out but seems to work fine.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).