### PR TITLE
Fix/ngspice add XSPICE and CIDER support

### DIFF
--- a/pkgs/applications/science/electronics/ngspice/default.nix
+++ b/pkgs/applications/science/electronics/ngspice/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, readline, bison, libX11, libICE, libXaw, libXext}:
+{stdenv, fetchurl, readline, bison, flex, libX11, libICE, libXaw, libXext}:
 
 stdenv.mkDerivation {
   name = "ngspice-26";
@@ -8,9 +8,9 @@ stdenv.mkDerivation {
     sha256 = "51e230c8b720802d93747bc580c0a29d1fb530f3dd06f213b6a700ca9a4d0108";
   };
 
-  buildInputs = [ readline libX11 bison libICE libXaw libXext ];
+  buildInputs = [ readline libX11 flex bison libICE libXaw libXext ];
 
-  configureFlags = [ "--enable-x" "--with-x" "--with-readline" ];
+  configureFlags = [ "--enable-x" "--with-x" "--with-readline" "--enable-xspice" "--enable-cider" ];
 
   meta = with stdenv.lib; {
     description = "The Next Generation Spice (Electronic Circuit Simulator)";


### PR DESCRIPTION
###### Motivation for this change
ngspice in Nix didn't have XSPICE and CIDER compiled in. I added this support. The messy compare is due to an attempt to merge.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

