### PR TITLE
fpm: fix vulnerable dependency (for 16.09)

### DIFF
--- a/pkgs/tools/package-management/fpm/Gemfile
+++ b/pkgs/tools/package-management/fpm/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
+
+gem 'archive-tar-minitar', '>= 0.5.2.1', github: 'peterhoeg/archive-tar-minitar'
 gem 'fpm'

--- a/pkgs/tools/package-management/fpm/Gemfile.lock
+++ b/pkgs/tools/package-management/fpm/Gemfile.lock
@@ -1,7 +1,12 @@
+GIT
+  remote: git://github.com/peterhoeg/archive-tar-minitar.git
+  revision: dae32ca550a87dba32597115ae18805db4782ebe
+  specs:
+    archive-tar-minitar (0.5.2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    archive-tar-minitar (0.5.2)
     arr-pm (0.0.10)
       cabin (> 0)
     backports (3.6.8)
@@ -40,6 +45,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  archive-tar-minitar (>= 0.5.2.1)!
   fpm
 
 BUNDLED WITH

--- a/pkgs/tools/package-management/fpm/gemset.nix
+++ b/pkgs/tools/package-management/fpm/gemset.nix
@@ -1,11 +1,13 @@
 {
   archive-tar-minitar = {
     source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1j666713r3cc3wb0042x0wcmq2v11vwwy5pcaayy5f0lnd26iqig";
-      type = "gem";
+      fetchSubmodules = false;
+      rev = "dae32ca550a87dba32597115ae18805db4782ebe";
+      sha256 = "0fvxacbcb52fm5dis451kdd7dv74z8p6nm4vnfqf7jg2aghcxdkd";
+      type = "git";
+      url = "git://github.com/peterhoeg/archive-tar-minitar.git";
     };
-    version = "0.5.2";
+    version = "0.5.2.1";
   };
   arr-pm = {
     source = {


### PR DESCRIPTION
###### Motivation for this change

Further to #22374, thanks @joachifm

Only tested on unstable.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
