### PR TITLE
dateutils: init at 0.4.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -358,6 +358,7 @@
   paholg = "Paho Lurie-Gregg <paho@paholg.com>";
   pakhfn = "Fedor Pakhomov <pakhfn@gmail.com>";
   palo = "Ingolf Wanger <palipalo9@googlemail.com>";
+  paperdigits = "Mica Semrick <mica@silentumbrella.com>";
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
   pawelpacana = "Paweł Pacana <pawel.pacana@gmail.com>";
   periklis = "theopompos@gmail.com";

--- a/pkgs/tools/misc/dateutils/default.nix
+++ b/pkgs/tools/misc/dateutils/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "0.4.1";
+  name = "dateutils-${version}";
+
+  src =fetchurl {
+    url = "https://bitbucket.org/hroptatyr/dateutils/downloads/${name}.tar.xz";
+    sha256 = "0y2jsmvilljbid14lzmk3kgvasn4h7hr6y3wwbr3lkgwfn4y9k3c";
+ 	};
+
+  meta = with stdenv.lib; {
+    description = "A bunch of tools that revolve around fiddling with dates and times in the command line";
+    homepage = http://www.fresse.org/dateutils/;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.paperdigits ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -783,6 +783,8 @@ with pkgs;
 
   datefudge = callPackage ../tools/system/datefudge { };
 
+  dateutils = callPackage ../tools/misc/dateutils { };
+
   ddate = callPackage ../tools/misc/ddate { };
 
   dehydrated = callPackage ../tools/admin/dehydrated { };


### PR DESCRIPTION
###### Motivation for this change

Package a nice CLI app for computing dates. Particularly useful for finding relative dates.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

