### PR TITLE
opencc: 1.0.4 -> 1.0.5

### DIFF
--- a/pkgs/tools/text/opencc/default.nix
+++ b/pkgs/tools/text/opencc/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, cmake, python }:
 
 stdenv.mkDerivation {
-  name = "opencc-1.0.4";
+  name = "opencc-1.0.5";
   src = fetchurl {
-    url = "https://github.com/BYVoid/OpenCC/archive/ver.1.0.4.tar.gz";
-    sha256 = "0553b7461ebd379d118d45d7f40f8a6e272750115bdbc49267595a05ee3481ac";
+    url = "https://github.com/BYVoid/OpenCC/archive/ver.1.0.5.tar.gz";
+    sha256 = "1ce1649ba280cfc88bb76e740be5f54b29a9c034400c97a3ae211c37d7030705";
   };
 
   buildInputs = [ cmake python ];


### PR DESCRIPTION
###### Motivation for this change

Update the package.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

