### PR TITLE
scudcloud: 1.38 -> 1.40

### DIFF
--- a/pkgs/applications/networking/instant-messengers/scudcloud/default.nix
+++ b/pkgs/applications/networking/instant-messengers/scudcloud/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchgit, python3Packages }:
 
 python3Packages.buildPythonPackage {
-  name = "scudcloud-1.38";
+  name = "scudcloud-1.40";
 
   # Branch 254-port-to-qt5
-  # https://github.com/raelgc/scudcloud/commit/6bcd877daea3d679cd5fd2c946c2d933940c48d9
+  # https://github.com/raelgc/scudcloud/commit/43ddc87f123a641b1fa78ace0bab159b05d34b65
   src = fetchgit {
       url = https://github.com/raelgc/scudcloud/;
-      rev = "6bcd877daea3d679cd5fd2c946c2d933940c48d9";
-      sha256 = "1884svz6m5vl06d0yac5zjb2phxwg6bjva72y15fw4larkjnh72s";
+      rev = "43ddc87f123a641b1fa78ace0bab159b05d34b65";
+      sha256 = "1lh9naf9xfrmj1pj7p8bd3fz7vy3gap6cvda4silk4b6ylyqa8vj";
   };
 
   propagatedBuildInputs = with python3Packages; [ pyqt5 dbus-python ];


### PR DESCRIPTION
###### Motivation for this change
Regular update.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

