### PR TITLE
ir.lv2: gtk -> gtk2

### DIFF
--- a/pkgs/applications/audio/ir.lv2/default.nix
+++ b/pkgs/applications/audio/ir.lv2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fftw, gtk, lv2, libsamplerate, libsndfile, pkgconfig, zita-convolver }:
+{ stdenv, fetchurl, fftw, gtk2, lv2, libsamplerate, libsndfile, pkgconfig, zita-convolver }:
 
 stdenv.mkDerivation rec {
   name = "ir.lv2-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "17a6h2mv9xv41jpbx6bdakkngin4kqzh2v67l4076ddq609k5a7v";
   };
 
-  buildInputs = [ fftw gtk lv2 libsamplerate libsndfile pkgconfig zita-convolver ];
+  buildInputs = [ fftw gtk2 lv2 libsamplerate libsndfile pkgconfig zita-convolver ];
 
   buildPhase = ''
     make


### PR DESCRIPTION
fixes the build on unstable

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

