### PR TITLE
nixos.chrony: add extraFlags config option

### DIFF
--- a/nixos/modules/services/networking/chrony.nix
+++ b/nixos/modules/services/networking/chrony.nix
@@ -30,6 +30,8 @@ let
     ${cfg.extraConfig}
   '';
 
+  chronyFlags = "-n -m -u chrony -f ${configFile} ${toString cfg.extraFlags}";
+
 in
 
 {
@@ -75,6 +77,13 @@ in
           Extra configuration directives that should be added to
           <literal>chrony.conf</literal>
         '';
+      };
+
+      extraFlags = mkOption {
+        default = [];
+        example = [ "-s" ];
+        type = types.listOf types.str;
+        description = "Extra flags passed to the chronyd command.";
       };
     };
 
@@ -123,7 +132,7 @@ in
           '';
 
         serviceConfig =
-          { ExecStart = "${pkgs.chrony}/bin/chronyd -n -m -u chrony -f ${configFile}";
+          { ExecStart = "${pkgs.chrony}/bin/chronyd ${chronyFlags}";
           };
       };
 

--- a/nixos/modules/services/networking/chrony.nix
+++ b/nixos/modules/services/networking/chrony.nix
@@ -23,7 +23,6 @@ let
     driftfile ${stateDir}/chrony.drift
 
     keyfile ${keyFile}
-    generatecommandkey
 
     ${optionalString (!config.time.hardwareClockInLocalTime) "rtconutc"}
 


### PR DESCRIPTION
###### Motivation for this change

Add `extraFlags` option to chrony's NixOS service.

Also remove deprecated (and no longer used) `generatecommandkey` config option.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

