### PR TITLE
Sile: Init at 0.9.4

### DIFF
--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, makeWrapper, pkgconfig
+, harfbuzz, icu, lpeg, luaexpat, luazlib, luafilesystem
+, fontconfig, lua, libiconv
+}:
+
+with stdenv.lib;
+
+let
+
+  libs          = [lpeg luaexpat luazlib luafilesystem];
+  getPath       = lib : type : "${lib}/lib/lua/${lua.luaversion}/?.${type};${lib}/share/lua/${lua.luaversion}/?.${type}";
+  getLuaPath    = lib : getPath lib "lua";
+  getLuaCPath   = lib : getPath lib "so";
+  luaPath       = concatStringsSep ";" (map getLuaPath libs);
+  luaCPath      = concatStringsSep ";" (map getLuaCPath libs);
+  in
+
+  stdenv.mkDerivation rec {
+    name = "sile-${version}";
+    version = "0.9.4";
+    src = fetchurl {
+      url = "https://github.com/simoncozens/sile/releases/download/v${version}/${name}.tar.bz2";
+      sha256 = "1mald727hy9bi17rcaph8q400yn5xqkn5f2xf1408g94wmwncs8w";
+    };
+
+  nativeBuildInputs = [pkgconfig makeWrapper];
+  buildInputs = [ harfbuzz icu lua lpeg luaexpat luazlib luafilesystem fontconfig libiconv ];
+
+  LUA_PATH = luaPath;
+  LUA_CPATH = luaCPath;
+
+  postInstall = ''
+    wrapProgram $out/bin/sile \
+      --set LUA_PATH "${luaPath};" \
+      --set LUA_CPATH "${luaCPath};" \
+  '';
+
+  meta = {
+    description = "A typesetting system";
+    longDescription = ''
+      SILE is a typesetting system; its job is to produce beautiful printed documents.
+      Conceptually, SILE is similar to TeX—from which it borrows some concepts and even syntax and algorithms—but the similarities end there. Rather than being a derivative of the TeX family SILE is a new typesetting and layout engine written from the ground up using modern technologies and borrowing some ideas from graphical systems such as InDesign.
+    '';
+    homepage = "http://www.sile-typesetter.org";
+    platforms = stdenv.lib.platforms.unix;
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3781,6 +3781,10 @@ with pkgs;
 
   silc_server = callPackage ../servers/silc-server { };
 
+  sile = callPackage ../tools/typesetting/sile {
+  inherit (lua52Packages) lua luaexpat luazlib luafilesystem lpeg;
+  };
+
   silver-searcher = callPackage ../tools/text/silver-searcher { };
   ag = self.silver-searcher;
 


### PR DESCRIPTION
###### Motivation for this change

SILE is a nice tool for generating PDFs with layout and typesetting. Simpler than Tex and written in Lua.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

