### PR TITLE
updating networkmanager and friends

### DIFF
--- a/pkgs/tools/networking/network-manager-applet/default.nix
+++ b/pkgs/tools/networking/network-manager-applet/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url    = "mirror://gnome/sources/${pname}/${networkmanager.major}/${name}.tar.xz";
-    sha256 = "431b7b4876638c6a537c8bf9c91a9250532b3d960b22b056df554695a81e4499";
+    sha256 = "09ijxicsqf39y6h8kwbfjyljfbqkkx4vrpyfn6gfg1h9mvp4cf39";
   };
 
   configureFlags = [ "--sysconfdir=/etc" ];

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -8,11 +8,11 @@ stdenv.mkDerivation rec {
   name    = "network-manager-${version}";
   pname   = "NetworkManager";
   major   = "1.4";
-  version = "${major}.2";
+  version = "${major}.4";
 
   src = fetchurl {
     url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
-    sha256 = "a864e347ddf6da8dabd40e0185b8c10a655d4a94b45cbaa2b3bb4b5e8360d204";
+    sha256 = "029k2f1arx1m5hppmr778i9yg34jj68nmji3i89qs06c33rpi4w2";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/tools/networking/network-manager/openconnect.nix
+++ b/pkgs/tools/networking/network-manager/openconnect.nix
@@ -5,11 +5,11 @@ stdenv.mkDerivation rec {
   name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname   = "NetworkManager-openconnect";
   major   = "1.2";
-  version = "${major}.2";
+  version = "${major}.4";
 
   src = fetchurl {
     url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
-    sha256 = "522979593e21b4e884112816708db9eb66148b3491580dacfad53472b94aafec";
+    sha256 = "15j98wwspv6mcmy91w30as5qc1bzsnhlk060xhjy4qrvd37y0xx1";
   };
 
   buildInputs = [ openconnect networkmanager libsecret ]

--- a/pkgs/tools/networking/network-manager/openvpn.nix
+++ b/pkgs/tools/networking/network-manager/openvpn.nix
@@ -5,11 +5,11 @@ stdenv.mkDerivation rec {
   name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname   = "NetworkManager-openvpn";
   major   = "1.2";
-  version = "${major}.6";
+  version = "${major}.8";
 
   src = fetchurl {
     url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
-    sha256 = "2373e2bb0a8a876cb2997cd8b0e3d6e10012d9bef3705ea3ac21f6394b3f1fb0";
+    sha256 = "0m06sg2rnz764psvpsrx0pvll11nfn9hypgbp3s6vna8y83l02ry";
   };
 
   buildInputs = [ openvpn networkmanager libsecret ]

--- a/pkgs/tools/networking/network-manager/strongswan.nix
+++ b/pkgs/tools/networking/network-manager/strongswan.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation rec {
   name    = "${pname}-${version}";
   pname   = "NetworkManager-strongswan";
-  version = "1.4.0";
+  version = "1.4.1";
 
   src = fetchurl {
     url    = "https://download.strongswan.org/NetworkManager/${name}.tar.bz2";
-    sha256 = "0qfnylg949lkyw1nmyggz2ipgmy154ic5q5ljjcwcgi14r90ys02";
+    sha256 = "0r5j8cr4x01d2cdy970990292n7p9v617cw103kdczw646xwcxs8";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

With the recent upgrade of openvpn, my vpn (which is setup via) networkmanager ui stopped working. 

User action is needed as described [here](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=848024#59).

    > openvpn 2.4 breaks backward compatibility by removing the option.
    > There is nothing that nm-openvpn can do about it except requiring
    > users to fix their configuration.
    > 
    > E.g. the Gnome plugin of nm-openvpn for nm-connection-editor has a
    > "Server Certificate Check" combobox. Affected users have to move away
    > from the "Verify subject partially (legacy mode)" setting.

Anyway before realizing this I updated the networkmanager and friends, just in case :)


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

