### PR TITLE
spideroak: enable it to appear in the application menus

### DIFF
--- a/pkgs/applications/networking/spideroak/default.nix
+++ b/pkgs/applications/networking/spideroak/default.nix
@@ -40,6 +40,8 @@ in stdenv.mkDerivation {
     cp -r "./"* "$out"
     mkdir "$out/bin"
     rm "$out/usr/bin/SpiderOakONE"
+    rmdir $out/usr/bin || true
+    mv $out/usr/share $out/
 
     patchelf --set-interpreter ${stdenv.glibc.out}/lib/${interpreter} \
       "$out/opt/SpiderOakONE/lib/SpiderOakONE"
@@ -48,6 +50,8 @@ in stdenv.mkDerivation {
     makeWrapper $out/opt/SpiderOakONE/lib/SpiderOakONE $out/bin/spideroak --set LD_LIBRARY_PATH $RPATH \
       --set QT_PLUGIN_PATH $out/opt/SpiderOakONE/lib/plugins/ \
       --set SpiderOak_EXEC_SCRIPT $out/bin/spideroak
+
+    sed -i 's/^Exec=.*/Exec=spideroak/' $out/share/applications/SpiderOakONE.desktop
   '';
 
   buildInputs = [ patchelf makeWrapper ];


### PR DESCRIPTION
Put files in `$out/share` instead of `$out/usr/share`

###### Motivation for this change

On Gnome, at least, SpiderOakONE doesn't appear in the application menus and this also stops it from being used with the standard autostart mechanism in `~/.config/autostart`.

The main reason it doesn't appear is that the relevant files are in `$out/usr` instead of `$out`. However, the name of the executable is changed when the derivation creates a wrapper, so the `.desktop` file has to be changed to match.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

