### PR TITLE
kdevplatform: Add patch to fix build with newer KF5.

### DIFF
--- a/pkgs/applications/editors/kdevelop5/kdevplatform-projectconfigskeleton.patch
+++ b/pkgs/applications/editors/kdevelop5/kdevplatform-projectconfigskeleton.patch
@@ -1,0 +1,55 @@
+From e84645d1694bdad7f179cd41babce723fe07aa63 Mon Sep 17 00:00:00 2001
+From: Kevin Funk <kfunk@kde.org>
+Date: Mon, 5 Dec 2016 15:20:53 +0100
+Subject: Hotfix for restoring build with newer KConfig
+
+https://phabricator.kde.org/D3386 is a SIC change, handle that
+---
+ project/projectconfigskeleton.cpp |  4 ++++
+ project/projectconfigskeleton.h   | 14 +++++---------
+ 2 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/project/projectconfigskeleton.cpp b/project/projectconfigskeleton.cpp
+index 0e06149..c4c9767 100644
+--- a/project/projectconfigskeleton.cpp
++++ b/project/projectconfigskeleton.cpp
+@@ -46,6 +46,10 @@ ProjectConfigSkeleton::ProjectConfigSkeleton( const QString & configname )
+ ProjectConfigSkeleton::ProjectConfigSkeleton( KSharedConfigPtr config )
+         : KConfigSkeleton( config ), d( new ProjectConfigSkeletonPrivate )
+ {
++    // FIXME: Check if that does the right thing.
++    // https://phabricator.kde.org/D3386 broke source compat in kconfig, thus requiring us to make this ctor public
++    Q_ASSERT(config);
++    d->m_developerTempFile = config->name();
+ }
+ 
+ void ProjectConfigSkeleton::setDeveloperTempFile( const QString& cfg )
+diff --git a/project/projectconfigskeleton.h b/project/projectconfigskeleton.h
+index ed17ed0..c8314df 100644
+--- a/project/projectconfigskeleton.h
++++ b/project/projectconfigskeleton.h
+@@ -55,16 +55,12 @@ public:
+ 
+     Path projectFile() const;
+     Path developerFile() const;
++
++protected:
++    explicit ProjectConfigSkeleton( KSharedConfigPtr config );
++
+ private:
+-    /**
+-     * There's no way in KDE4 API to find out the file that the config object
+-     * was created from, so we can't apply defaults when using this
+-     * constructors. Thus I'm making this private, so we can find out when
+-     * this constructor is used and see if we need to add appropriate API to
+-     * kdelibs
+-     */
+-     explicit ProjectConfigSkeleton( KSharedConfigPtr config );
+-     struct ProjectConfigSkeletonPrivate * const d;
++    struct ProjectConfigSkeletonPrivate * const d;
+ };
+ 
+ }
+-- 
+cgit v0.11.2
+

--- a/pkgs/applications/editors/kdevelop5/kdevplatform.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevplatform.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
     sha256 = "643d1145e1948af221f9ae148d0a10809f3d89af4b97ff0d6c4d571004f46bd4";
   };
 
+  patches = [ ./kdevplatform-projectconfigskeleton.patch ];
+
   nativeBuildInputs = [ cmake gettext pkgconfig extra-cmake-modules makeQtWrapper ];
 
   propagatedBuildInputs = [ ];


### PR DESCRIPTION
###### Motivation for this change

Fixes build error: https://hydra.nixos.org/build/47765317/nixlog/1

Patch is from:
https://cgit.kde.org/kdevplatform.git/commit/?h=5.0&id=e84645d1694bdad7f179cd41babce723fe07aa63

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

