### PR TITLE
WIP: Setuid interface

### DIFF
--- a/nixos/modules/security/setuid-wrappers.nix
+++ b/nixos/modules/security/setuid-wrappers.nix
@@ -80,7 +80,8 @@ in
 
     system.activationScripts.setuid =
       let
-        setuidPackages = flatten (p: p.setuid or []) environment.systemPackages;
+        withSource = pkg: map (setuid: { source = "${pkg}/bin/${setuid.program}"; } // setuid) (pkg.setuid or []);
+        setuidPackages = concatMap withSource environment.systemPackages;
         setuidPrograms =
           (map (x: { program = x; })
             config.security.setuidPrograms)

--- a/nixos/modules/security/setuid-wrappers.nix
+++ b/nixos/modules/security/setuid-wrappers.nix
@@ -81,16 +81,16 @@ in
     system.activationScripts.setuid =
       let
         setuidPrograms =
-          (map (x: { program = x; owner = "root"; group = "root"; setuid = true; })
+          (map (x: { program = x; })
             config.security.setuidPrograms)
           ++ config.security.setuidOwners;
 
         makeSetuidWrapper =
           { program
           , source ? ""
-          , owner ? "nobody"
-          , group ? "nogroup"
-          , setuid ? false
+          , owner ? "root"
+          , group ? "root"
+          , setuid ? true
           , setgid ? false
           , permissions ? "u+rx,g+x,o+x"
           }:

--- a/nixos/modules/security/setuid-wrappers.nix
+++ b/nixos/modules/security/setuid-wrappers.nix
@@ -80,10 +80,12 @@ in
 
     system.activationScripts.setuid =
       let
+        setuidPackages = flatten (p: p.setuid or []) environment.systemPackages;
         setuidPrograms =
           (map (x: { program = x; })
             config.security.setuidPrograms)
-          ++ config.security.setuidOwners;
+          ++ config.security.setuidOwners
+          ++ setuidPackages;
 
         makeSetuidWrapper =
           { program

--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -81,8 +81,6 @@ in
         ${cfg.extraConfig}
       '';
 
-    security.setuidPrograms = [ "sudo" "sudoedit" ];
-
     environment.systemPackages = [ sudo ];
 
     security.pam.services.sudo = { sshAgentAuth = true; };

--- a/pkgs/misc/screensavers/slock/default.nix
+++ b/pkgs/misc/screensavers/slock/default.nix
@@ -7,6 +7,13 @@ stdenv.mkDerivation rec {
   };
   buildInputs = [ xproto libX11 libXext libXrandr ];
   installFlags = "DESTDIR=\${out} PREFIX=";
+
+  passthru = {
+    setuid = [
+      { program = "slock"; }
+    ];
+  };
+
   meta = with stdenv.lib; {
     homepage = http://tools.suckless.org/slock;
     description = "Simple X display locker";

--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -30,6 +30,12 @@ stdenv.mkDerivation {
     sed -e "s@/etc/@$out/etc/@g" -i Makefile
   '';
 
+  passthru = {
+    setuid = [
+      { program = "firejail"; }
+    ]
+  };
+
   meta = {
     inherit (s) version;
     description = ''Namespace-based sandboxing tool for Linux'';

--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -50,6 +50,13 @@ stdenv.mkDerivation rec {
     rm -f $out/share/doc/sudo/ChangeLog
     '';
 
+  passthru = {
+    setuid = [
+      { program = "suid"; }
+      { program = "sudoedit"; }
+    ];
+  }
+
   meta = {
     description = "A command to run commands as root";
 


### PR DESCRIPTION
###### Motivation for this change

Inspired by the discussion at http://lists.science.uu.nl/pipermail/nix-dev/2017-February/022698.html I had a look and it seems that each setuid program needs to be specified by hand.

On other operating systems, the packages install their setuid themselves. I believe the package is also best placed to know which binaries he installs should setuid.

This is just a proof of concept for now, let me know what you think!

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

