### PR TITLE
jimtcl: 0.76 -> 0.77

### DIFF
--- a/pkgs/development/interpreters/jimtcl/default.nix
+++ b/pkgs/development/interpreters/jimtcl/default.nix
@@ -1,20 +1,25 @@
-{ stdenv, fetchFromGitHub, sqlite, readline, asciidoc, SDL, SDL_gfx }:
+{ stdenv, lib, fetchFromGitHub, pkgconfig, sqlite, readline, asciidoc, SDL, SDL_gfx }:
 
-stdenv.mkDerivation {
-  name = "jimtcl-0.76";
+let
+  makeSDLFlags = map (p: "-I${lib.getDev p}/include/SDL");
+
+in stdenv.mkDerivation {
+  name = "jimtcl-0.77";
 
   src = fetchFromGitHub {
     owner = "msteveb";
     repo = "jimtcl";
-    rev = "51f65c6d38fbf86e1f0b036ad336761fd2ab7fa0";
-    sha256 = "00ldal1w9ysyfmx28xdcaz81vaazr1fqixxb2abk438yfpp1i9hq";
+    rev = "0.77";
+    sha256 = "06d9gdgvi6cwd6pjg3xig0kkjqm6kgq3am8yq1xnksyz2n09f0kp";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     sqlite readline asciidoc SDL SDL_gfx
   ];
 
-  NIX_CFLAGS_COMPILE = [ "-I${SDL.dev}/include/SDL" ];
+  buildInputs = [ pkgconfig ];
+
+  NIX_CFLAGS_COMPILE = makeSDLFlags [ SDL SDL_gfx ];
 
   configureFlags = [
     "--with-ext=oo"


### PR DESCRIPTION
###### Motivation for this change
Package update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

