### PR TITLE
libsixel: 1.6.1 -> 1.7.3

### DIFF
--- a/pkgs/development/libraries/libsixel/default.nix
+++ b/pkgs/development/libraries/libsixel/default.nix
@@ -1,13 +1,13 @@
 {stdenv, fetchFromGitHub}:
 stdenv.mkDerivation rec {
-  version = "1.6.1";
+  version = "1.7.3";
   name = "libsixel-${version}";
 
   src = fetchFromGitHub {
     repo = "libsixel";
-    rev = "ef4374f80385edc48e0844cf324d7ef757688e44";
+    rev = "v${version}";
     owner = "saitoha";
-    sha256 = "08m5q2ppk235bzbwff1wg874vr1bh4080qdj26l39v8lw1xzlqcp";
+    sha256 = "1hzmypzzigmxl07vgc52wp4dgxkhya3gfk4yzaaxc8s630r6ixs8";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
package update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

