### PR TITLE
dropbox: 18.4.32 -> 19.4.13

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -23,11 +23,11 @@
 let
   # NOTE: When updating, please also update in current stable,
   # as older versions stop working
-  version = "18.4.32";
+  version = "19.4.13";
   sha256 =
     {
-      "x86_64-linux" = "0rm91gic6qwlvkclhwpw9mhsb1l9qdxqi7kyvn5ij6a978c70k5r";
-      "i686-linux"   = "0xzk4hxykacvrym8ls8q4zv2277adg6b5m7zmncmfwb6igx4ipap";
+      "x86_64-linux" = "06lgmjj204xpid35cqrp2msasg4s4w6lf1zpz1lnk3f9x6q10254";
+      "i686-linux"   = "1kdj3c5s8s4smd52p2mqbzjsk68a9cd5f8x92xgsx9zzdzjqmagl";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =


### PR DESCRIPTION
(cherry picked from commit b2e71c4224223f4ae3a618dc71237f7f61edbcfe)

###### Motivation for this change

Dropbox on NixOS is a royal pain in the rear due to:

1. Forced upgrades where anything but the latest version will simply stop working
2. No changelog when new versions are released

This user hostile approach by Dropbox means that dropbox stops working on NixOS from the time a new version is released and until the nixpkgs repository is updated.

There are several free and open source self-hosted alternatives to the Dropbox service. Please consider using one (or more) of these instead:

 - [Librevault](https://librevault.com)
 - [Nextcloud](https://nextcloud.com)
 - [ownCloud](https://owncloud.org)
 - [Syncthing](https://syncthing.net)

Note: This is not in any way an endorsement of any of the projects mentioned above.

Only tested on unstable.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
