### PR TITLE
paperwork: fix locale path

### DIFF
--- a/pkgs/applications/office/paperwork/default.nix
+++ b/pkgs/applications/office/paperwork/default.nix
@@ -31,7 +31,7 @@ python3Packages.buildPythonApplication rec {
     }' src/paperwork/frontend/util/__init__.py
 
     sed -i -e '/^LOCALE_PATHS = \[/,/^\]$/ {
-      c LOCALE_PATHS = ["'"$out/share/locale"'"]
+      c LOCALE_PATHS = ["'"$out/share"'"]
     }' src/paperwork/paperwork.py
 
     sed -i -e 's/"icon"/"icon-name"/g' \


### PR DESCRIPTION
###### Motivation for this change

The path where paperwork was looking for localization files was wrong. This PR fixes this.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

