### PR TITLE
google-play-music-desktop-player: init at 4.2.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -474,6 +474,7 @@
   sternenseemann = "Lukas Epple <post@lukasepple.de>";
   stesie = "Stefan Siegl <stesie@brokenpipe.de>";
   steveej = "Stefan Junker <mail@stefanjunker.de>";
+  SuprDewd = "Bjarki Ágúst Guðmundsson <suprdewd@gmail.com>";
   swarren83 = "Shawn Warren <shawn.w.warren@gmail.com>";
   swistak35 = "Rafał Łasocha <me@swistak35.com>";
   szczyp = "Szczyp <qb@szczyp.com>";

--- a/pkgs/applications/audio/google-play-music-desktop-player/default.nix
+++ b/pkgs/applications/audio/google-play-music-desktop-player/default.nix
@@ -1,0 +1,79 @@
+{ stdenv, alsaLib, atk, cairo, cups, dbus, dpkg, expat, fontconfig, freetype
+, fetchurl, GConf, gdk_pixbuf, glib, gtk2, libpulseaudio, makeWrapper, nspr
+, nss, pango, udev, xorg
+}:
+
+let
+  version = "4.2.0";
+
+  deps = [
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    GConf
+    gdk_pixbuf
+    glib
+    gtk2
+    libpulseaudio
+    nspr
+    nss
+    pango
+    stdenv.cc.cc
+    udev
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXScrnSaver
+    xorg.libXtst
+  ];
+
+in
+
+stdenv.mkDerivation {
+  name = "google-play-music-desktop-player-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v${version}/google-play-music-desktop-player_${version}_amd64.deb";
+    sha256 = "0n59b73jc6b86p5063xz7n0z48wy9mzqcx0l34av2hqkx6wcb2h8";
+  };
+
+  dontBuild = true;
+  buildInputs = [ dpkg makeWrapper ];
+
+  unpackPhase = ''
+    dpkg -x $src .
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r ./usr/share $out
+    cp -r ./usr/bin $out
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+             "$out/share/google-play-music-desktop-player/Google Play Music Desktop Player"
+
+    wrapProgram $out/bin/google-play-music-desktop-player \
+      --prefix LD_LIBRARY_PATH : "$out/share/google-play-music-desktop-player" \
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath deps}"
+  '';
+
+  meta = {
+    homepage = https://www.googleplaymusicdesktopplayer.com/;
+    description = "A beautiful cross platform Desktop Player for Google Play Music";
+    license = stdenv.lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = stdenv.lib.maintainers.SuprDewd;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13805,6 +13805,10 @@ with pkgs;
 
   googleearth = callPackage_i686 ../applications/misc/googleearth { };
 
+  google-play-music-desktop-player = callPackage ../applications/audio/google-play-music-desktop-player {
+    inherit (gnome2) GConf;
+  };
+
   google_talk_plugin = callPackage ../applications/networking/browsers/mozilla-plugins/google-talk-plugin {
     libpng = libpng12;
   };


### PR DESCRIPTION
###### Motivation for this change
Lack of a good desktop player for Google Play Music.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

