### PR TITLE
astroid: fix crash due to missing icons

### DIFF
--- a/pkgs/applications/networking/mailreaders/astroid/default.nix
+++ b/pkgs/applications/networking/mailreaders/astroid/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     wrapProgram "$out/bin/astroid" \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:${gnome3.adwaita-icon-theme}/share"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
Astroid was unable to run in a pure environment because it couldn't find
the necessary icons.  This fixes that issue, and was tested with
`nix-shell --pure`

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

