### PR TITLE
xfce4-mailwatch-plugin: init at 1.2.0

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -32,9 +32,9 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   thunar          = callPackage ./core/thunar.nix { };
   thunarx-2-dev   = thunar-build; # Plugins need only the `thunarx-2` part of the package. Awaiting multiple outputs.
   thunar_volman   = callPackage ./core/thunar-volman.nix { }; # ToDo: probably inside Thunar now
-  thunar-archive-plugin 
+  thunar-archive-plugin
                   = callPackage ./thunar-plugins/archive { };
-  thunar-dropbox-plugin 
+  thunar-dropbox-plugin
                   = callPackage ./thunar-plugins/dropbox { };
   tumbler         = callPackage ./core/tumbler.nix { };
   xfce4panel      = callPackage ./core/xfce4-panel.nix { }; # ToDo: impure plugins from /run/current-system/sw/lib/xfce4
@@ -89,6 +89,7 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   xfce4-hardware-monitor-plugin = callPackage ./panel-plugins/xfce4-hardware-monitor-plugin.nix { };
   xfce4_netload_plugin          = callPackage ./panel-plugins/xfce4-netload-plugin.nix          { };
   xfce4_notes_plugin            = callPackage ./panel-plugins/xfce4-notes-plugin.nix            { };
+  xfce4_mailwatch_plugin        = callPackage ./panel-plugins/xfce4-mailwatch-plugin.nix        { };
   xfce4-sensors-plugin          = callPackage ./panel-plugins/xfce4-sensors-plugin.nix          { };
   xfce4_systemload_plugin       = callPackage ./panel-plugins/xfce4-systemload-plugin.nix       { };
   xfce4_verve_plugin            = callPackage ./panel-plugins/xfce4-verve-plugin.nix            { };

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui,
-libxfcegui4, xfconf, gtk, exo}:
+libxfcegui4, xfconf, gtk, exo, gnutls, libgcrypt }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   buildInputs = [ pkgconfig intltool libxfce4util libxfce4ui xfce4panel
-    libxfcegui4 xfconf gtk exo ];
+    libxfcegui4 xfconf gtk exo gnutls libgcrypt ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui,
+libxfcegui4, xfconf, gtk, exo}:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  p_name  = "xfce4-mailwatch-plugin";
+  ver_maj = "1.2";
+  ver_min = "0";
+
+  src = fetchurl {
+    url = "mirror://xfce/src/panel-plugins/${p_name}/${ver_maj}/${name}.tar.bz2";
+    sha256 = "1bfw3smwivr9mzdyq768biqrl4aq94zqi3xjzq6kqnd8561cqjk2";
+  };
+  name = "${p_name}-${ver_maj}.${ver_min}";
+
+  buildInputs = [ pkgconfig intltool libxfce4util libxfce4ui xfce4panel
+    libxfcegui4 xfconf gtk exo ];
+
+  meta = {
+    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    description = "Mailwatch plugin for Xfce panel";
+    platforms = platforms.linux;
+    maintainers = [ maintainers.matthiasbeyer ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Mailwatch plugin for xfce panel.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Pinging xfce ppl here: @vcunat @abbradar @obadz