### PR TITLE
xfce-timer-plugin: init at 1.6.0

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -91,6 +91,7 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   xfce4_notes_plugin            = callPackage ./panel-plugins/xfce4-notes-plugin.nix            { };
   xfce4-sensors-plugin          = callPackage ./panel-plugins/xfce4-sensors-plugin.nix          { };
   xfce4_systemload_plugin       = callPackage ./panel-plugins/xfce4-systemload-plugin.nix       { };
+  xfce4_timer_plugin            = callPackage ./panel-plugins/xfce4-timer-plugin.nix            { };
   xfce4_verve_plugin            = callPackage ./panel-plugins/xfce4-verve-plugin.nix            { };
   xfce4_xkb_plugin              = callPackage ./panel-plugins/xfce4-xkb-plugin.nix              { };
   xfce4_weather_plugin          = callPackage ./panel-plugins/xfce4-weather-plugin.nix          { };

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  p_name  = "xfce4-timer-plugin";
+  ver_maj = "1.6";
+  ver_min = "0";
+
+  src = fetchurl {
+    url = "mirror://xfce/src/panel-plugins/${p_name}/${ver_maj}/${name}.tar.bz2";
+    sha256 = "0z46gyw3ihcd1jf0m5z1dsc790xv1cpi8mk1dagj3i4v14gx5mrr";
+  };
+  name = "${p_name}-${ver_maj}.${ver_min}";
+
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf
+    gtk ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  hardeningDisable = [ "format" ];
+
+  meta = {
+    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    description = "Battery plugin for Xfce panel";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.matthiasbeyer ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

XFCE timer plugin for panel.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Pinging xfce ppl here: @vcunat @abbradar @obadz

Unfortunately this does not compile yet, and I do not see what the error is... if someone could give me a pointer, that'd be really nice!