### PR TITLE
add setup-hook to fix darwin frameworks

### DIFF
--- a/pkgs/build-support/setup-hooks/fix-darwin-frameworks.sh
+++ b/pkgs/build-support/setup-hooks/fix-darwin-frameworks.sh
@@ -1,0 +1,31 @@
+# On Mac OS X, frameworks are linked to the system CoreFoundation but
+# dynamic libraries built with nix use a pure version of CF this
+# causes segfaults for binaries that depend on it at runtime.  This
+# can be solved in two ways.
+# 1. Rewrite references to the pure CF using this setup hook, this
+# works for the simple case but this can still cause problems if other
+# dependencies (eg. python) use the pure CF.
+# 2. Create a wrapper for the binary that sets DYLD_FRAMEWORK_PATH to
+# /System/Library/Frameworks.  This will make everything load the
+# system's CoreFoundation framework while still keeping the
+# dependencies pure for other packages.
+
+fixupOutputHooks+=('fixDarwinFrameworksIn $prefix')
+
+fixDarwinFrameworks() {
+    local systemPrefix='/System/Library/Frameworks'
+
+    for fn in "$@"; do
+        if [ -L "$fn" ]; then continue; fi
+        echo "$fn: fixing dylib"
+
+        for framework in $(otool -L "$fn" | awk '/CoreFoundation\.framework/ {print $1}'); do
+          install_name_tool -change "$framework" "$systemPrefix/CoreFoundation.framework/Versions/A/CoreFoundation" "$fn" >&2
+        done
+    done
+}
+
+fixDarwinFrameworksIn() {
+    local dir="$1"
+    fixDarwinFrameworks $(find "$dir" -name "*.dylib")
+}

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -119,6 +119,9 @@ let
 
     propagatedBuildInputs = deps;
 
+    # don't use pure CF for dylibs that depend on frameworks
+    setupHook = ../../../build-support/setup-hooks/fix-darwin-frameworks.sh;
+
     # allows building the symlink tree
     __impureHostDeps = [ "/System/Library/Frameworks/${name}.framework" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -305,6 +305,8 @@ with pkgs;
 
   fixDarwinDylibNames = makeSetupHook { } ../build-support/setup-hooks/fix-darwin-dylib-names.sh;
 
+  fixDarwinFrameworks = makeSetupHook { } ../build-support/setup-hooks/fix-darwin-frameworks.sh;
+
   keepBuildTree = makeSetupHook { } ../build-support/setup-hooks/keep-build-tree.sh;
 
   enableGCOVInstrumentation = makeSetupHook { } ../build-support/setup-hooks/enable-coverage-instrumentation.sh;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8733,7 +8733,8 @@ with pkgs;
   libusb = callPackage ../development/libraries/libusb {};
 
   libusb1 = callPackage ../development/libraries/libusb1 {
-    inherit (darwin) libobjc IOKit;
+    inherit (darwin) libobjc;
+    inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
   libusbmuxd = callPackage ../development/libraries/libusbmuxd { };


### PR DESCRIPTION
###### Motivation for this change

Dynamic libraries built with nix use a pure version of CF, this can cause issues when it also depends on frameworks.

Fixes #22450, #20484

Packages that are fixed by this without setting `DYLD_LIBRARY_PATH` with a wrapper.

- [x] gnupg
- [x] graphviz
- [x] libnfc
- [x] libusb
- [x] racket
- [ ] python-pyqt (python depends on the pure CF)


###### Things done

- [x] Tested using without xcode
- Built on platform(s)
   - [x] macOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @copumpkin @pikajude @johbo