### PR TITLE
dwarfdump: init at 20161124

### DIFF
--- a/pkgs/development/libraries/libdwarf/default.nix
+++ b/pkgs/development/libraries/libdwarf/default.nix
@@ -1,30 +1,51 @@
 { stdenv, fetchurl, libelf }:
 
-stdenv.mkDerivation rec {
-  name = "libdwarf-20161124";
-
+let
+  version = "20161124";
   src = fetchurl {
-    url = "http://www.prevanders.net/${name}.tar.gz";
+    url = "http://www.prevanders.net/libdwarf-${version}.tar.gz";
     sha512 = "38e480bce5ae8273fd585ec1d8ba94dc3e865a0ef3fcfcf38b5d92fa1ce41f8b"
            + "8c95a7cf8a6e69e7c6f638a3cc56ebbfb37b6317047309725fa17e7929096799";
   };
-
-  configureFlags = [ "--enable-shared" "--disable-nonshared" ];
-
-  preConfigure = ''
-    cd libdwarf
-  '';
-  buildInputs = [ libelf ];
-
-  installPhase = ''
-    mkdir -p $out/lib $out/include
-    cp libdwarf.so.1 $out/lib
-    ln -s libdwarf.so.1 $out/lib/libdwarf.so
-    cp libdwarf.h dwarf.h $out/include
-  '';
-
   meta = {
     homepage = https://www.prevanders.net/dwarf.html;
     platforms = stdenv.lib.platforms.linux;
+  };
+
+in rec {
+  libdwarf = stdenv.mkDerivation rec {
+    name = "libdwarf-${version}";
+
+    configureFlags = [ "--enable-shared" "--disable-nonshared" ];
+
+    preConfigure = ''
+      cd libdwarf
+    '';
+    buildInputs = [ libelf ];
+
+    installPhase = ''
+      mkdir -p $out/lib $out/include
+      cp libdwarf.so.1 $out/lib
+      ln -s libdwarf.so.1 $out/lib/libdwarf.so
+      cp libdwarf.h dwarf.h $out/include
+    '';
+
+    inherit meta src;
+  };
+
+  dwarfdump = stdenv.mkDerivation rec {
+    name = "dwarfdump-${version}";
+
+    preConfigure = ''
+      cd dwarfdump
+    '';
+
+    buildInputs = [ libelf libdwarf ];
+
+    installPhase = ''
+      install -m755 -D dwarfdump $out/bin/dwarfdump
+    '';
+
+    inherit meta src;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8014,7 +8014,8 @@ with pkgs;
   libdvdread = callPackage ../development/libraries/libdvdread { };
   libdvdread_4_9_9 = callPackage ../development/libraries/libdvdread/4.9.9.nix { };
 
-  libdwarf = callPackage ../development/libraries/libdwarf { };
+  inherit (callPackage ../development/libraries/libdwarf { })
+    libdwarf dwarfdump;
 
   libeatmydata = callPackage ../development/libraries/libeatmydata { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

