### PR TITLE
compilers/ghcjs/base.nix: Take ghcjsNodePkgs as argument

### DIFF
--- a/pkgs/development/compilers/ghcjs/base.nix
+++ b/pkgs/development/compilers/ghcjs/base.nix
@@ -39,6 +39,11 @@
 , coreutils
 , libiconv
 
+, ghcjsNodePkgs ? callPackage ../../../top-level/node-packages.nix {
+    generated = ./node-packages-generated.nix;
+    self = ghcjsNodePkgs;
+  }
+
 , version ? "0.2.0"
 , ghcjsSrc ? fetchFromGitHub {
     owner = "ghcjs";
@@ -160,12 +165,7 @@ in mkDerivation (rec {
         --with-gmp-includes ${gmp.dev}/include \
         --with-gmp-libraries ${gmp.out}/lib
   '';
-  passthru = let
-    ghcjsNodePkgs = callPackage ../../../top-level/node-packages.nix {
-      generated = ./node-packages-generated.nix;
-      self = ghcjsNodePkgs;
-    };
-  in {
+  passthru = {
     inherit bootPkgs;
     isCross = true;
     isGhcjs = true;


### PR DESCRIPTION
###### Motivation for this change

When using `pkgs/development/compilers/ghcjs/base.nix` from outside `nixpkgs`, the paths mentioned in `ghcjsNodePkgs` don't resolve correctly, so it's necessary to provide a mechanism for overriding those paths somehow, instead of hardcoding the paths as we currently do. Moreover, this allows for the customization of `ghcjsNodePkgs` itself, which, again, is useful when working on a custom GHCJS version outside the `nixpkgs` tree. 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
