### PR TITLE
set elasticsearch classpath to nix store

### DIFF
--- a/pkgs/servers/search/elasticsearch/2.x.nix
+++ b/pkgs/servers/search/elasticsearch/2.x.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1qjq04sfqb35pf2xpvr8j5p27chfxpjp8ymrp1h5bfk5rbk9444q";
   };
 
-  patches = [ ./es-home-2.x.patch ];
+  patches = [ ./es-home-2.x.patch ./es-classpath-2.x.patch ];
 
   buildInputs = [ makeWrapper jre ] ++
     (if (!stdenv.isDarwin) then [utillinux] else [getopt]);
@@ -22,7 +22,9 @@ stdenv.mkDerivation rec {
 
     # don't want to have binary with name plugin
     mv $out/bin/plugin $out/bin/elasticsearch-plugin
-    wrapProgram $out/bin/elasticsearch ${if (!stdenv.isDarwin)
+    wrapProgram $out/bin/elasticsearch \
+      --prefix ES_CLASSPATH : "$out/lib/${name}.jar":"$out/lib/*" \
+      ${if (!stdenv.isDarwin)
         then ''--prefix PATH : "${utillinux}/bin/"''
         else ''--prefix PATH : "${getopt}/bin"''} \
       --set JAVA_HOME "${jre}"

--- a/pkgs/servers/search/elasticsearch/es-classpath-2.x.patch
+++ b/pkgs/servers/search/elasticsearch/es-classpath-2.x.patch
@@ -1,0 +1,38 @@
+diff -rupN a/bin/elasticsearch b/bin/elasticsearch
+--- a/bin/elasticsearch	2017-02-08 18:32:28.000298543 -0500
++++ b/bin/elasticsearch	2017-02-08 19:10:45.692916675 -0500
+@@ -81,12 +81,7 @@ ES_HOME=`cd "$ES_HOME"; pwd`
+ # If an include wasn't specified in the environment, then search for one...
+ if [ "x$ES_INCLUDE" = "x" ]; then
+     # Locations (in order) to use when searching for an include file.
+-    for include in /usr/share/elasticsearch/elasticsearch.in.sh \
+-                   /usr/local/share/elasticsearch/elasticsearch.in.sh \
+-                   /opt/elasticsearch/elasticsearch.in.sh \
+-                   ~/.elasticsearch.in.sh \
+-                   "$ES_HOME/bin/elasticsearch.in.sh" \
+-                   "`dirname "$0"`"/elasticsearch.in.sh; do
++    for include in "`dirname "$0"`"/elasticsearch.in.sh; do
+         if [ -r "$include" ]; then
+             . "$include"
+             break
+diff -rupN a/bin/elasticsearch.in.sh b/bin/elasticsearch.in.sh
+--- a/bin/elasticsearch.in.sh	2017-02-08 18:32:28.000298543 -0500
++++ b/bin/elasticsearch.in.sh	2017-02-08 18:33:46.816634599 -0500
+@@ -1,17 +1,5 @@
+ #!/bin/sh
+ 
+-# check in case a user was using this mechanism
+-if [ "x$ES_CLASSPATH" != "x" ]; then
+-    cat >&2 << EOF
+-Error: Don't modify the classpath with ES_CLASSPATH. Best is to add
+-additional elements via the plugin mechanism, or if code must really be
+-added to the main classpath, add jars to lib/ (unsupported).
+-EOF
+-    exit 1
+-fi
+-
+-ES_CLASSPATH="$ES_HOME/lib/elasticsearch-2.4.4.jar:$ES_HOME/lib/*"
+-
+ if [ "x$ES_MIN_MEM" = "x" ]; then
+     ES_MIN_MEM=256m
+ fi


### PR DESCRIPTION
###### Motivation for this change

Elasticsearch 2.4.4 currently ends up setting the classpath to "$ES_HOME/lib/...". But `ES_HOME` is a per-system directory. This patch points the classpath to the nix store instead. Currently, the existing behavior is completely broken on my system, and this PR fixes it.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

