### PR TITLE
glew: 1.13.0 -> 2.0.0

### DIFF
--- a/pkgs/development/libraries/glew/default.nix
+++ b/pkgs/development/libraries/glew/default.nix
@@ -3,11 +3,11 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "glew-1.13.0";
+  name = "glew-2.0.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/glew/${name}.tgz";
-    sha256 = "1iwb2a6wfhkzv6fa7zx2gz1lkwa0iwnd9ka1im5vdc44xm4dq9da";
+    sha256 = "0r37fg2s1f0jrvwh6c8cz5x6v4wqmhq42qm15cs9qs349q5c6wn5";
   };
 
   outputs = [ "bin" "out" "dev" "doc" ];
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     mkdir -pv $out/share/doc/glew
     mkdir -p $out/lib/pkgconfig
     cp glew*.pc $out/lib/pkgconfig
-    cp -r README.txt LICENSE.txt doc $out/share/doc/glew
+    cp -r README.md LICENSE.txt doc $out/share/doc/glew
     rm $out/lib/*.a
   '';
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

