### PR TITLE
Fix/stlink update

### DIFF
--- a/pkgs/development/tools/misc/stlink/default.nix
+++ b/pkgs/development/tools/misc/stlink/default.nix
@@ -1,30 +1,33 @@
-{ stdenv, fetchurl, autoconf, automake, libtool, pkgconfig, libusb1 }:
+{ stdenv, fetchurl, cmake, libusb1 }:
 
-# IMPORTANT: You need permissions to access the stlink usb devices. Here are
-# example udev rules for stlink v1 and v2 so you don't need to have root
-# permissions (copied from <stlink>/49-stlink*.rules):
-#
-# SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3744", MODE:="0666", SYMLINK+="stlinkv1_%n"
-# SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3748", MODE:="0666", SYMLINK+="stlinkv2_%n"
+# IMPORTANT: You need permissions to access the stlink usb devices. 
+# Add services.udev.pkgs = [ pkgs.stlink ] to your configuration.nix
 
 let
-  version = "1.1.0";
+  version = "1.3.0";
 in
 stdenv.mkDerivation {
   name = "stlink-${version}";
 
   src = fetchurl {
     url = "https://github.com/texane/stlink/archive/${version}.tar.gz";
-    sha256 = "0b38a32ids9dpnz5h892l279fz8y1zzqk1qsnyhl1nm03p7xzi1s";
+    sha256 = "3e8cba21744d2c38a0557f6835a05189e1b98202931bb0183d22efc462c893dd";
   };
 
-  buildInputs = [ autoconf automake libtool pkgconfig libusb1 ];
-  preConfigure = "./autogen.sh";
+  buildInputs = [ cmake libusb1 ];
+  patchPhase = ''
+sed -i 's@/etc/udev/rules.d@$ENV{out}/etc/udev/rules.d@' CMakeLists.txt
+sed -i 's@/etc/modprobe.d@$ENV{out}/etc/modprobe.d@' CMakeLists.txt
+'';
+  preInstall = ''
+mkdir -p $out/etc/udev/rules.d
+mkdir -p $out/etc/modprobe.d
+'';
 
   meta = with stdenv.lib; {
     description = "In-circuit debug and programming for ST-Link devices";
     license = licenses.bsd3;
     platforms = platforms.linux;
-    maintainers = [ maintainers.bjornfor ];
+    maintainers = [ maintainers.bjornfor maintainers.rongcuid ];
   };
 }

--- a/pkgs/development/tools/misc/stlink/default.nix
+++ b/pkgs/development/tools/misc/stlink/default.nix
@@ -16,13 +16,13 @@ stdenv.mkDerivation {
 
   buildInputs = [ cmake libusb1 ];
   patchPhase = ''
-sed -i 's@/etc/udev/rules.d@$ENV{out}/etc/udev/rules.d@' CMakeLists.txt
-sed -i 's@/etc/modprobe.d@$ENV{out}/etc/modprobe.d@' CMakeLists.txt
-'';
+    sed -i 's@/etc/udev/rules.d@$ENV{out}/etc/udev/rules.d@' CMakeLists.txt
+    sed -i 's@/etc/modprobe.d@$ENV{out}/etc/modprobe.d@' CMakeLists.txt
+  '';
   preInstall = ''
-mkdir -p $out/etc/udev/rules.d
-mkdir -p $out/etc/modprobe.d
-'';
+    mkdir -p $out/etc/udev/rules.d
+    mkdir -p $out/etc/modprobe.d
+  '';
 
   meta = with stdenv.lib; {
     description = "In-circuit debug and programming for ST-Link devices";


### PR DESCRIPTION
###### Motivation for this change
To update STLink utility.

Note that I really don't know how to keep my branch up to date with master, since I based it on my current system version. Nowhere in docs did I find any information about how I merge changes from master back. I tried `-s ours`, `-Xtheirs`, `-Xours`, `rebase --onto`, and none of them work.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

