### PR TITLE
asterisk: 14.1.2 -> 14.2.1, add speex

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -83,8 +83,8 @@ in
   };
 
   asterisk-stable = common {
-    version = "14.1.2";
-    sha256 = "0w9s4334rwvpyxm169grmnb4k9yq0l2al73dyh4cb8769qcs0ij8";
+    version = "14.2.1";
+    sha256 = "193yhyjn0fwrd7hsmr3qwcx3k2pc6cq70v1mnfdwidix4cqm32xj";
     externals = {
       "externals_cache/pjproject-2.5.5.tar.bz2" = pjproject-255;
     };

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -1,7 +1,7 @@
 { stdenv, pkgs, lib, fetchurl, fetchgit,
   jansson, libxml2, libxslt, ncurses, openssl, sqlite,
   utillinux, dmidecode, libuuid, binutils, newt,
-  lua,
+  lua, speex,
   srtp, wget, curl,
   subversionClient
 }:
@@ -11,7 +11,7 @@ let
     inherit version;
     name = "asterisk-${version}";
 
-    buildInputs = [ jansson libxml2 libxslt ncurses openssl sqlite utillinux dmidecode libuuid binutils newt lua srtp wget curl subversionClient ];
+    buildInputs = [ jansson libxml2 libxslt ncurses openssl sqlite utillinux dmidecode libuuid binutils newt lua speex srtp wget curl subversionClient ];
 
     patches = [
       # We want the Makefile to install the default /var skeleton


### PR DESCRIPTION
###### Motivation for this change
- Update stable branch to 14.2.1
- Add speex codec (add speex-package to compile-environment, nothing else is needed)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

