### PR TITLE
tomboy: init at 1.15.7

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -461,6 +461,7 @@
   SShrike = "Severen Redwood <severen@shrike.me>";
   stephenmw = "Stephen Weinberg <stephen@q5comm.com>";
   sternenseemann = "Lukas Epple <post@lukasepple.de>";
+  stesie = "Stefan Siegl <stesie@brokenpipe.de>";
   steveej = "Stefan Junker <mail@stefanjunker.de>";
   swarren83 = "Shawn Warren <shawn.w.warren@gmail.com>";
   swistak35 = "Rafał Łasocha <me@swistak35.com>";

--- a/pkgs/applications/misc/tomboy/default.nix
+++ b/pkgs/applications/misc/tomboy/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, itstool, intltool, pkgconfig
+, libxml2, gnome2, atk, gtk2, glib
+, mono, mono-addins, dbus-sharp-2_0, dbus-sharp-glib-2_0, gnome-sharp, gtk-sharp-2_0
+, makeWrapper, lib}:
+
+let
+  version = "1.15.7";
+in
+
+stdenv.mkDerivation {
+  name = "tomboy-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/tomboy-notes/tomboy/releases/download/${version}/tomboy-${version}.tar.xz";
+    sha256 = "1i6sv6w2ms2x0nkgxq11agljiyg0yl4x2rzmcyvs2hxyf574hd1y";
+  };
+
+  buildInputs = [ itstool intltool pkgconfig
+    libxml2 gnome2.GConf atk gtk2
+    mono mono-addins dbus-sharp-2_0 dbus-sharp-glib-2_0 gnome-sharp gtk-sharp-2_0
+    makeWrapper ];
+
+  postInstall = ''
+    makeWrapper "${mono}/bin/mono" "$out/bin/tomboy" \
+      --add-flags "$out/lib/tomboy/Tomboy.exe" \
+      --prefix MONO_GAC_PREFIX : ${dbus-sharp-2_0} \
+      --prefix MONO_GAC_PREFIX : ${dbus-sharp-glib-2_0} \
+      --prefix MONO_GAC_PREFIX : ${gtk-sharp-2_0} \
+      --prefix MONO_GAC_PREFIX : ${gnome-sharp} \
+      --prefix MONO_GAC_PREFIX : ${mono-addins} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ glib gtk-sharp-2_0 gtk-sharp-2_0.gtk gnome2.GConf ]}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://wiki.gnome.org/Apps/Tomboy";
+    description = "A simple note-taking application with synchronization";
+    platforms = platforms.linux;
+    license = stdenv.lib.licenses.lgpl2;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18041,6 +18041,8 @@ with pkgs;
 
   tomb = callPackage ../os-specific/linux/tomb {};
 
+  tomboy = callPackage ../applications/misc/tomboy {};
+
   imatix_gsl = callPackage ../development/tools/imatix_gsl {};
 
   iterm2 = callPackage ../applications/misc/iterm2 {};


### PR DESCRIPTION
###### Motivation for this change

I was missing Tomboy from nix repo, hence adding it, as it is a useful note-taking application that allows for note formatting and synchronization.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I declared it `platforms = platforms.linux` instead of maybe all; as it is based on mono it theoretically should work fine on e.g. macOS, but I don't have the hardware at hand, so cannot test...
