### PR TITLE
top-level: Hack around Nix's --arg logic not handling unnamed params

### DIFF
--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -18,6 +18,11 @@ in
   # so we do it now.
   localSystem ? builtins.intersectAttrs { system = null; platform = null; } args
 
+, # These are needed only because nix's `--arg` command-line logic doesn't work
+  # with unnamed parameters allowed by ...
+  system ? localSystem.system
+, platform ? localSystem.platform
+
 , # Fallback: The contents of the configuration file found at $NIXPKGS_CONFIG or
   # $HOME/.config/nixpkgs/config.nix.
   config ? let


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/commit/8cd4c31d6b8c6432986edf0ec5d00d2fe1c12854#commitcomment-20815520

###### Things done

`nix-instantiate` locally.