### PR TITLE
olm: init at 2.2.1

### DIFF
--- a/pkgs/development/libraries/olm/default.nix
+++ b/pkgs/development/libraries/olm/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "olm-${version}";
+  version = "2.2.1";
+
+  meta = {
+    description = "Implements double cryptographic ratchet and Megolm ratchet";
+    license = stdenv.lib.licenses.asl20;
+    homepage = "https://matrix.org/git/olm/about";
+  };
+
+  src = fetchurl {
+    url = "https://matrix.org/git/olm/snapshot/${name}.tar.gz";
+    sha256 = "1spgsjmsw8afm2hg1mrq9c7cli3p17wl0ns7qbzn0h6ksh193709";
+  };
+
+  doCheck = true;
+  checkTarget = "test";
+
+  installFlags = "PREFIX=$(out)";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8945,6 +8945,8 @@ with pkgs;
 
   ogrepaged = callPackage ../development/libraries/ogrepaged { };
 
+  olm = callPackage ../development/libraries/olm { };
+
   oniguruma = callPackage ../development/libraries/oniguruma { };
 
   openal = self.openalSoft;


### PR DESCRIPTION
###### Motivation for this change

The olm cryptographic library is needed for some https://matrix.org clients

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

