### PR TITLE
armadillo: 7.200.2 -> 7.700.0

### DIFF
--- a/pkgs/development/libraries/armadillo/default.nix
+++ b/pkgs/development/libraries/armadillo/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, cmake, openblasCompat, superlu, hdf5-cpp }:
+{ stdenv, fetchurl, cmake, openblasCompat, superlu, hdf5 }:
 
 stdenv.mkDerivation rec {
-  version = "7.200.2";
+  version = "7.700.0";
   name = "armadillo-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/arma/armadillo-${version}.tar.xz";
-    sha256 = "1yvx75caks477jqwx5gspi6946jialddk00wdvg6dnh5wdi2xasm";
+    sha256 = "152x274hd3f59xgd27k9d3ikwb3w62v1v5hpw4lp1yzdyy8980pr";
   };
 
-  buildInputs = [ cmake openblasCompat superlu hdf5-cpp ];
+  buildInputs = [ cmake openblasCompat superlu hdf5 ];
 
   cmakeFlags = [ "-DDETECT_HDF5=ON" ];
 
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = http://arma.sourceforge.net;
     license = licenses.mpl20;
     platforms = platforms.unix;
-    maintainers = [ maintainers.juliendehos ];
+    maintainers = with maintainers; [ juliendehos knedlsepp ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The build broke when the new cmake was introduced. I addressed the issue upstream and the new version should work properly with the new cmake.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

