### PR TITLE
keybase: 1.0.18 -> 20170209.17b641d

### DIFF
--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -2,8 +2,7 @@
 
 buildGoPackage rec {
   name = "keybase-${version}";
-  version = "1.0.18";
-  rev = "v${version}";
+  version = "20170209.17b641d";
 
   goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/keybase" ];
@@ -13,8 +12,8 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "keybase";
     repo = "client";
-    inherit rev;
-    sha256 = "16n9fwx8v3jradp1l2564872akq6npib794jadfl5d122cll0n7h";
+    rev = "17b641de629a85ad77621d0efa3e2442661b5ee7";
+    sha256 = "0y6kiwj690yd0alvcyd74wx2wlbh110k1rdcvimszyb9gqig8p11";
   };
 
   buildFlags = [ "-tags production" ];


### PR DESCRIPTION
###### Motivation for this change
keybase is out of date.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm bumping kbfs's version simultaneously in #22601. Both programs seem to be actively developed over at [Keybase](https://github.com/keybase), but it seems that they've stopped making formal releases for keybase, and there were never any formal releases for kbfs. Instead they seem to be something like a rolling release (see [https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/index.html](here)). I picked the commits for keybase/kbfs based on (at the time of writing this) newest entry in that list.

This also fixes some warnings that were being generated due to a slight mismatch between the current versions (in nixpkgs) of keybase and kbfs. See  #22375.