### PR TITLE
kbfs: 1.0.2 -> 20170209.d1db463

### DIFF
--- a/pkgs/tools/security/kbfs/default.nix
+++ b/pkgs/tools/security/kbfs/default.nix
@@ -1,8 +1,8 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "kbfs-2016-11-18-git";
-  version = "1.0.2";
+  name = "kbfs-${version}";
+  version = "20170209.d1db463";
 
   goPackagePath = "github.com/keybase/kbfs";
   subPackages = [ "kbfsfuse" ];
@@ -12,8 +12,8 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "keybase";
     repo = "kbfs";
-    rev = "aac615d7c50e7512a51a133c14cb699d9941ba8c";
-    sha256 = "0vah6x37g2w1f7mb5x16f1815608mvv2d1mrpkpnhz2gz7qzz6bv";
+    rev = "d1db46315d9271f21ca2700a84ca19767e638296";
+    sha256 = "12i2m370r27mmn37s55krdkhr5k8kpl3x8y3gzg7w5zn2wiw8i1g";
   };
 
   buildFlags = [ "-tags production" ];


### PR DESCRIPTION
###### Motivation for this change
kbfs is out of date.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm bumping keybase's version simultaneously in #22600. Both programs seem to be actively developed over at [Keybase](https://github.com/keybase), but it seems that they've stopped making formal releases for keybase, and there were never any formal releases for kbfs. Instead they seem to be something like a rolling release (see [https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/index.html](here)). I picked the commits for keybase/kbfs based on (at the time of writing this) newest entry in that list.

This also fixes some warnings that were being generated due to a slight mismatch between the current versions (in nixpkgs) of keybase and kbfs. See  #22375.