### PR TITLE
nixos: update default cases from KDM/KDE4 to SDDM/KDE5

### DIFF
--- a/nixos/doc/manual/configuration/modularity.xml
+++ b/nixos/doc/manual/configuration/modularity.xml
@@ -36,9 +36,8 @@ latter might look like this:
 { config, pkgs, ... }:
 
 { services.xserver.enable = true;
-  services.xserver.displayManager.kdm.enable = true;
-  services.xserver.desktopManager.kde4.enable = true;
-  environment.systemPackages = [ pkgs.kde4.kscreensaver ];
+  services.xserver.displayManager.sddm.enable = true;
+  services.xserver.desktopManager.kde5.enable = true;
 }
 </programlisting>
 

--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -25,7 +25,7 @@ Otherwise, you can only log into a plain undecorated
 <command>xterm</command> window.  Thus you should pick one or more of
 the following lines:
 <programlisting>
-services.xserver.desktopManager.kde4.enable = true;
+services.xserver.desktopManager.kde5.enable = true;
 services.xserver.desktopManager.xfce.enable = true;
 services.xserver.windowManager.xmonad.enable = true;
 services.xserver.windowManager.twm.enable = true;
@@ -35,9 +35,9 @@ services.xserver.windowManager.icewm.enable = true;
 
 <para>NixOS’s default <emphasis>display manager</emphasis> (the
 program that provides a graphical login prompt and manages the X
-server) is SLiM.  You can select KDE’s <command>kdm</command> instead:
+server) is SLiM.  You can select KDE’s <command>sddm</command> instead:
 <programlisting>
-services.xserver.displayManager.kdm.enable = true;
+services.xserver.displayManager.sddm.enable = true;
 </programlisting>
 </para>
 

--- a/nixos/doc/manual/configuration/xfce.xml
+++ b/nixos/doc/manual/configuration/xfce.xml
@@ -41,9 +41,9 @@
 		(DM is the program that provides a graphical login prompt
 		 and manages the X server.)
 	   	You can, for example, select KDE’s
-        <command>kdm</command> instead:
+        <command>sddm</command> instead:
         <programlisting>
-            services.xserver.displayManager.kdm.enable = true;
+            services.xserver.displayManager.sddm.enable = true;
         </programlisting>
     </para>
 

--- a/nixos/doc/manual/development/option-declarations.xml
+++ b/nixos/doc/manual/development/option-declarations.xml
@@ -65,22 +65,22 @@ options = {
 
 </para>
 
-<section xml:id="sec-option-declarations-eot"><title>Extensible Option 
+<section xml:id="sec-option-declarations-eot"><title>Extensible Option
     Types</title>
 
-  <para>Extensible option types is a feature that allow to extend certain types 
+  <para>Extensible option types is a feature that allow to extend certain types
     declaration through multiple module files.
-    This feature only work with a restricted set of types, namely 
+    This feature only work with a restricted set of types, namely
     <literal>enum</literal> and <literal>submodules</literal> and any composed
     forms of them.</para>
 
-  <para>Extensible option types can be used for <literal>enum</literal> options 
-    that affects multiple modules, or as an alternative to related 
+  <para>Extensible option types can be used for <literal>enum</literal> options
+    that affects multiple modules, or as an alternative to related
     <literal>enable</literal> options.</para>
 
   <para>As an example, we will take the case of display managers. There is a
     central display manager module for generic display manager options and a
-    module file per display manager backend (slim, kdm, gdm ...).
+    module file per display manager backend (slim, sddm, gdm ...).
   </para>
 
   <para>There are two approach to this module structure:
@@ -96,7 +96,7 @@ options = {
   </para>
 
   <para>Both approachs have problems.</para>
-    
+
   <para>Making backends independent can quickly become hard to manage. For
     display managers, there can be only one enabled at a time, but the type
     system can not enforce this restriction as there is no relation between
@@ -108,18 +108,18 @@ options = {
     central module will require to change the central module option every time
     a new backend is added or removed.</para>
 
-  <para>By using extensible option types, it is possible to create a placeholder 
-    option in the central module (<xref linkend='ex-option-declaration-eot-service' 
-      />), and to extend it in each backend module (<xref 
-      linkend='ex-option-declaration-eot-backend-slim' />, <xref 
-      linkend='ex-option-declaration-eot-backend-kdm' />).</para>
- 
+  <para>By using extensible option types, it is possible to create a placeholder
+    option in the central module (<xref linkend='ex-option-declaration-eot-service'
+      />), and to extend it in each backend module (<xref
+      linkend='ex-option-declaration-eot-backend-slim' />, <xref
+      linkend='ex-option-declaration-eot-backend-sddm' />).</para>
+
   <para>As a result, <literal>displayManager.enable</literal> option values can
   be added without changing the main service module file and the type system
   automatically enforce that there can only be a single display manager
   enabled.</para>
 
-<example xml:id='ex-option-declaration-eot-service'><title>Extensible type 
+<example xml:id='ex-option-declaration-eot-service'><title>Extensible type
     placeholder in the service module</title>
 <screen>
 services.xserver.displayManager.enable = mkOption {
@@ -127,29 +127,29 @@ services.xserver.displayManager.enable = mkOption {
   type = with types; nullOr (enum [ ]);
 };</screen></example>
 
-<example xml:id='ex-option-declaration-eot-backend-slim'><title>Extending 
-    <literal>services.xserver.displayManager.enable</literal> in the 
+<example xml:id='ex-option-declaration-eot-backend-slim'><title>Extending
+    <literal>services.xserver.displayManager.enable</literal> in the
     <literal>slim</literal> module</title>
 <screen>
 services.xserver.displayManager.enable = mkOption {
   type = with types; nullOr (enum [ "slim" ]);
 };</screen></example>
 
-<example xml:id='ex-option-declaration-eot-backend-kdm'><title>Extending 
-    <literal>services.foo.backend</literal> in the <literal>kdm</literal> 
+<example xml:id='ex-option-declaration-eot-backend-sdm'><title>Extending
+    <literal>services.foo.backend</literal> in the <literal>sdm</literal>
     module</title>
 <screen>
 services.xserver.displayManager.enable = mkOption {
-  type = with types; nullOr (enum [ "kdm" ]);
+  type = with types; nullOr (enum [ "sddm" ]);
 };</screen></example>
 
-<para>The placeholder declaration is a standard <literal>mkOption</literal> 
-  declaration, but it is important that extensible option declarations only use 
+<para>The placeholder declaration is a standard <literal>mkOption</literal>
+  declaration, but it is important that extensible option declarations only use
   the <literal>type</literal> argument.</para>
 
-<para>Extensible option types work with any of the composed variants of 
-  <literal>enum</literal> such as 
-  <literal>with types; nullOr (enum [ "foo" "bar" ])</literal> 
+<para>Extensible option types work with any of the composed variants of
+  <literal>enum</literal> such as
+  <literal>with types; nullOr (enum [ "foo" "bar" ])</literal>
   or <literal>with types; listOf (enum [ "foo" "bar" ])</literal>.</para>
 
 </section>

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -607,8 +607,8 @@ $bootLoaderConfig
   # services.xserver.xkbOptions = "eurosign:e";
 
   # Enable the KDE Desktop Environment.
-  # services.xserver.displayManager.kdm.enable = true;
-  # services.xserver.desktopManager.kde4.enable = true;
+  # services.xserver.displayManager.sddm.enable = true;
+  # services.xserver.desktopManager.kde5.enable = true;
 
   # Define a user account. Don't forget to set a password with ‘passwd’.
   # users.extraUsers.guest = {

--- a/nixos/modules/profiles/graphical.nix
+++ b/nixos/modules/profiles/graphical.nix
@@ -6,8 +6,8 @@
 {
   services.xserver = {
     enable = true;
-    displayManager.kdm.enable = true;
-    desktopManager.kde4.enable = true;
+    displayManager.sddm.enable = true;
+    desktopManager.kde5.enable = true;
     synaptics.enable = true; # for touchpad support on many laptops
   };
 

--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -22,7 +22,7 @@ in
   };
 
   ###### implementation
-  
+
   config = mkIf config.hardware.bluetooth.enable {
 
     environment.systemPackages = [ bluez-bluetooth pkgs.openobex pkgs.obexftp ];

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -1,5 +1,5 @@
 # This module declares the options to define a *display manager*, the
-# program responsible for handling X logins (such as xdm, kdm, gdb, or
+# program responsible for handling X logins (such as xdm, gdb, or
 # SLiM).  The display manager allows the user to select a *session
 # type*.  When the user logs in, the display manager starts the
 # *session script* ("xsession" below) to launch the selected session

--- a/nixos/modules/services/x11/terminal-server.nix
+++ b/nixos/modules/services/x11/terminal-server.nix
@@ -16,18 +16,8 @@ with lib;
     services.xserver.enable = true;
     services.xserver.videoDrivers = [];
 
-    # Enable KDM.  Any display manager will do as long as it supports XDMCP.
-    services.xserver.displayManager.kdm.enable = true;
-    services.xserver.displayManager.kdm.enableXDMCP = true;
-    services.xserver.displayManager.kdm.extraConfig =
-      ''
-        [General]
-        # We're headless, so don't bother starting an X server.
-        StaticServers=
-
-        [Xdmcp]
-        Xaccess=${pkgs.writeText "Xaccess" "localhost"}
-      '';
+    # Enable GDM.  Any display manager will do as long as it supports XDMCP.
+    services.xserver.displayManager.gdm.enable = true;
 
     systemd.sockets.terminal-server =
       { description = "Terminal Server Socket";

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -325,8 +325,8 @@ in rec {
 
     kde = makeClosure ({ pkgs, ... }:
       { services.xserver.enable = true;
-        services.xserver.displayManager.kdm.enable = true;
-        services.xserver.desktopManager.kde4.enable = true;
+        services.xserver.displayManager.sddm.enable = true;
+        services.xserver.desktopManager.kde5.enable = true;
       });
 
     xfce = makeClosure ({ pkgs, ... }:

--- a/nixos/tests/phabricator.nix
+++ b/nixos/tests/phabricator.nix
@@ -54,7 +54,7 @@ import ./make-test.nix ({ pkgs, ... }: {
     client =
       { config, pkgs, ... }:
       { imports = [ ./common/x11.nix ];
-        services.xserver.desktopManager.kde4.enable = true;
+        services.xserver.desktopManager.kde5.enable = true;
       };
   };
 

--- a/nixos/tests/trac.nix
+++ b/nixos/tests/trac.nix
@@ -45,7 +45,7 @@ import ./make-test.nix ({ pkgs, ... }: {
     client =
       { config, pkgs, ... }:
       { imports = [ ./common/x11.nix ];
-        services.xserver.desktopManager.kde4.enable = true;
+        services.xserver.desktopManager.kde5.enable = true;
       };
   };
 


### PR DESCRIPTION
###### Motivation for this change

KDE4 is now extremely out of support, and we should get rid of it.

This PR is completely untested. I'm not even sure _how_ to test it!

cc @domenkozar @globin @vcunat @ttuegel

https://github.com/NixOS/nixpkgs/issues/15866

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

