### PR TITLE
Haskell infrastructure: fix #9871 (overrideCabal)

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -6,12 +6,13 @@
 
 let
 
-  inherit (stdenv.lib) fix' extends;
+  inherit (stdenv.lib) fix' extends makeOverridable;
+  inherit (import ./lib.nix { inherit pkgs; }) overrideCabal;
 
   haskellPackages = self:
     let
 
-      mkDerivation = pkgs.callPackage ./generic-builder.nix {
+      mkDerivationImpl = pkgs.callPackage ./generic-builder.nix {
         inherit stdenv;
         inherit (pkgs) fetchurl pkgconfig glibcLocales coreutils gnugrep gnused;
         jailbreak-cabal = if (self.ghc.cross or null) != null
@@ -37,9 +38,7 @@ let
         });
       };
 
-      overrideCabal = drv: f: drv.override (args: args // {
-        mkDerivation = drv: args.mkDerivation (drv // f drv);
-      });
+      mkDerivation = makeOverridable mkDerivationImpl;
 
       callPackageWithScope = scope: drv: args: (stdenv.lib.callPackageWith scope drv args) // {
         overrideScope = f: callPackageWithScope (mkScope (fix' (extends f scope.__unfix__))) drv args;

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -3,7 +3,7 @@
 rec {
 
   overrideCabal = drv: f: (drv.override (args: args // {
-    mkDerivation = drv: args.mkDerivation (drv // f drv);
+    mkDerivation = drv: (args.mkDerivation drv).override f;
   })) // {
     overrideScope = scope: overrideCabal (drv.overrideScope scope) f;
   };


### PR DESCRIPTION
As per the recommendation by @Mathnerd314, this change seems to work with the testing I did.

It makes sense to me why it works, but I think it's in an important enough place that someone with much deeper knowledge of Haskell infrastructure in Nixpkgs should give it a really heavy review.  I only built a handful of packages.  I certainly didn't build all of haskellPackages to vet this change.

I think I followed all the contributor's guidelines.  If I didn't, I'm happy to rebase changes or supply more information.

I also consolidated all the overrideCabal definitions (there were two) into a single definition in haskell-modules/lib.nix.

###### Motivation for this change

This is documented in the associated issue.  overrideCabal has not allowed "un"-overriding of attributes that have been overidden.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

