### PR TITLE
libreoffice: build -fresh as well

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -266,6 +266,5 @@ in stdenv.mkDerivation rec {
     license = licenses.lgpl3;
     maintainers = with maintainers; [ viric raskin ];
     platforms = platforms.linux;
-    hydraPlatforms = [];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Building libreoffice takes a lot of time. ~~The way I understand it, ```lowPrio``` makes hydra not build libreoffice-fresh (only -still).~~

I can fully appreciate not having hydra every new bleeding edge thing, but this is not actually the case here - fresh is just the latest released version so it makes sense to have it available.

Do this for 17.03 @globin ?

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
