### PR TITLE
libretro: add reicast core

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -248,6 +248,19 @@ in
     buildPhase = "make";
   };
 
+  reicast = (mkLibRetroCore rec {
+    core = "reicast";
+    src = fetchRetro {
+      repo = core + "-emulator";
+      rev = "ed47c72cf2e124d9d753285fd61d12ea8e071d0d";
+      sha256 = "05dw7qjnprf1lw3ps0sb7sp73hsh1a27rxbwjqd26j85zr84g3r9";
+    };
+    description = "Reicast libretro port";
+    extraBuildInputs = [ mesa ];
+  }).override {
+    buildPhase = "make";
+  };
+
   scummvm = (mkLibRetroCore rec {
     core = "scummvm";
     src = fetchRetro {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15599,6 +15599,7 @@ with pkgs;
       ++ optional (cfg.enablePrboom or false) prboom
       ++ optional (cfg.enablePPSSPP or false) ppsspp
       ++ optional (cfg.enableQuickNES or false) quicknes
+      ++ optional (cfg.enableReicast or false) reicast
       ++ optional (cfg.enableScummVM or false) scummvm
       ++ optional (cfg.enableSnes9x or false) snes9x
       ++ optional (cfg.enableSnes9xNext or false) snes9x-next


### PR DESCRIPTION
###### Motivation for this change

This adds the Reicast (Dreamcast) retroarch port as a core to libretro.

CC @edwtjo, @MP2E

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

