### PR TITLE
cdi2iso: init at 0.1

### DIFF
--- a/pkgs/tools/cd-dvd/cdi2iso/default.nix
+++ b/pkgs/tools/cd-dvd/cdi2iso/default.nix
@@ -1,0 +1,24 @@
+{stdenv, fetchurl}:
+
+stdenv.mkDerivation rec {
+  name = "cdi2iso-${version}";
+  version = "0.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/cdi2iso.berlios/${name}-src.tar.gz";
+    sha256 = "0fj2fxhpr26z649m0ph71378c41ljflpyk89g87x8r1mc4rbq3kh";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    cp cdi2iso $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A very simple utility for converting DiscJuggler images to the standard ISO-9660 format";
+    homepage = https://sourceforge.net/projects/cdi2iso.berlios;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ hrdinka ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1092,6 +1092,8 @@ with pkgs;
 
   cdecl = callPackage ../development/tools/cdecl { };
 
+  cdi2iso = callPackage ../tools/cd-dvd/cdi2iso { };
+
   cdrdao = callPackage ../tools/cd-dvd/cdrdao { };
 
   cdrkit = callPackage ../tools/cd-dvd/cdrkit { };


### PR DESCRIPTION
###### Motivation for this change

This adds cdi2iso a very simple cli tool for converting cdi disk images to iso files.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

