### PR TITLE
attract-mode: init at 2.2.0

### DIFF
--- a/pkgs/misc/emulators/attract-mode/default.nix
+++ b/pkgs/misc/emulators/attract-mode/default.nix
@@ -1,0 +1,33 @@
+{ expat, fetchFromGitHub, ffmpeg, fontconfig, freetype, libarchive, libjpeg
+, mesa, openal, pkgconfig, sfml, stdenv, zlib
+}:
+
+stdenv.mkDerivation rec {
+  name = "attract-mode-${version}";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "mickelson";
+    repo = "attract";
+    rev = "v${version}";
+    sha256 = "1arkfj0q3n1qbq5jwmal0kixxph8lnmv3g9bli36inab4r8zzmp8";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  patchPhase = ''
+    sed -i "s|prefix=/usr/local|prefix=$out|" Makefile
+  '';
+
+  buildInputs = [
+    expat ffmpeg fontconfig freetype libarchive libjpeg mesa openal sfml zlib
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A frontend for arcade cabinets and media PCs";
+    homepage = http://attractmode.org;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ hrdinka ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17409,6 +17409,8 @@ with pkgs;
 
   areca = callPackage ../applications/backup/areca { };
 
+  attract-mode = callPackage ../misc/emulators/attract-mode { };
+
   beep = callPackage ../misc/beep { };
 
   blackbird = callPackage ../misc/themes/blackbird { };


### PR DESCRIPTION
###### Motivation for this change

This adds attract mode a graphical frontend for emulators to be used on arcade machines or multi media pcs.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

