### PR TITLE
aqemu: init at 0.9.2

### DIFF
--- a/pkgs/applications/virtualization/aqemu/default.nix
+++ b/pkgs/applications/virtualization/aqemu/default.nix
@@ -1,0 +1,26 @@
+{ cmake, fetchFromGitHub, libvncserver, qemu, qtbase, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  name = "aqemu-${version}";
+  version = "0.9.2";
+
+  src = fetchFromGitHub {
+    owner = "tobimensch";
+    repo = "aqemu";
+    rev = "v${version}";
+    sha256 = "1h1mcw8x0jir5p39bs8ka0lcisiyi4jq61fsccgb9hsvl1i8fvk5";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libvncserver qtbase qemu ];
+
+  meta = with stdenv.lib; {
+    description = "A virtual machine manager GUI for qemu";
+    homepage = https://github.com/tobimensch/aqemu;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ hrdinka ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12450,6 +12450,8 @@ with pkgs;
 
   ao = callPackage ../applications/graphics/ao {};
 
+  aqemu = qt5.callPackage ../applications/virtualization/aqemu { };
+
   ardour = callPackage ../applications/audio/ardour {
     inherit (gnome2) libgnomecanvas libgnomecanvasmm;
     inherit (vamp) vampSDK;


### PR DESCRIPTION
###### Motivation for this change

This adds aqemu a virtual machine management GUI for qemu similar to VirtualBox.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

