### PR TITLE
dhparams module: initialize

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -102,6 +102,7 @@
   ./security/audit.nix
   ./security/ca.nix
   ./security/chromium-suid-sandbox.nix
+  ./security/dhparams.nix
   ./security/duosec.nix
   ./security/grsecurity.nix
   ./security/hidepid.nix

--- a/nixos/modules/security/dhparams.nix
+++ b/nixos/modules/security/dhparams.nix
@@ -1,0 +1,90 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.security.dhparams;
+in
+{
+  options = {
+    security.dhparams = {
+      params = mkOption {
+        description =
+          ''
+            Diffie-Hellman parameters to generate.
+
+            The value is the size (in bits) of the DH params to generate. The
+            generated DH params path can be found in
+            <filename><replaceable>security.dhparams.path</replaceable>/<replaceable>name</replaceable>.pem</filename>.
+
+            Note: The name of the DH params is taken as being the name of the
+            service it serves: the params will be generated before the said
+            service is started.
+          '';
+        type = with types; attrsOf int;
+        default = {};
+        example = { nginx = 3072; };
+      };
+
+      path = mkOption {
+        description =
+          ''
+            Path to the directory in which Diffie-Hellman parameters will be
+            stored.
+          '';
+        type = types.str;
+        default = "/var/lib/dhparams";
+      };
+    };
+  };
+
+  config.systemd.services = {
+    dhparams-init = {
+      description = "Cleanup old Diffie-Hellman parameters";
+      wantedBy = [ "multi-user.target" ]; # Clean up even when no DH params is set
+      serviceConfig.Type = "oneshot";
+      script =
+        # Create directory
+        ''
+          if [ ! -d ${cfg.path} ]; then
+            mkdir -p ${cfg.path}
+          fi
+        '' +
+        # Remove old dhparams
+        ''
+          for file in ${cfg.path}/*; do
+            if [ ! -f "$file" ]; then
+              continue
+            fi
+        '' + concatStrings (mapAttrsToList (name: value:
+        ''
+            if [ "$file" == "${cfg.path}/${name}.pem" ] && \
+                ${pkgs.openssl}/bin/openssl dhparam -in "$file" -text | head -n 1 | grep "(${toString value} bit)" > /dev/null; then
+              continue
+            fi
+        ''
+        ) cfg.params) +
+        ''
+            rm $file
+          done
+
+          # TODO: Ideally this would be removing the *former* cfg.path, though this
+          # does not seem really important
+          rmdir -p --ignore-fail-on-non-empty ${cfg.path}
+        '';
+    };
+  } //
+    mapAttrs' (name: value: nameValuePair "dhparams-gen-${name}" {
+      description = "Generate Diffie-Hellman parameters for ${name} if they don't exist yet";
+      after = [ "dhparams-init.service" ];
+      before = [ "${name}.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig.Type = "oneshot";
+      script =
+        ''
+          mkdir -p ${cfg.path}
+          if [ ! -f ${cfg.path}/${name}.pem ]; then
+            ${pkgs.openssl}/bin/openssl dhparam -out ${cfg.path}/${name}.pem ${toString value}
+          fi
+        '';
+    }) cfg.params;
+}


### PR DESCRIPTION
###### Motivation for this change

Generating per-computer Diffie-Hellman parameters is both something advisable in security, and something that is slow and painful to do by hand.

This also fixes https://github.com/NixOS/nixpkgs/issues/22632

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

(Most checkboxes just don't apply to this module-only PR)

Hope this helps!
Leo