### PR TITLE
nixos.cjdns: allow multiple cjdns networks and multiple UDP/ETH interfaces per network

### DIFF
--- a/nixos/modules/services/networking/cjdns.nix
+++ b/nixos/modules/services/networking/cjdns.nix
@@ -6,7 +6,9 @@ let
 
   pkg = pkgs.cjdns;
 
-  cfg = config.services.cjdns;
+  cfgs = config.services.cjdns.networks;
+
+  enabledCfgs = filterAttrs (name: cfg: cfg.enable) cfgs;
 
   connectToSubmodule =
   { options, ... }:
@@ -105,69 +107,16 @@ let
     };
   };
 
-  # Additional /etc/hosts entries for peers with an associated hostname
-  cjdnsExtraHosts = import (pkgs.runCommand "cjdns-hosts" {}
-    # Generate a builder that produces an output usable as a Nix string value
-    ''
-      exec >$out
-      echo \'\'
-      ${concatStringsSep "\n" (mapAttrsToList (k: v:
-          optionalString (v.hostname != "")
-            "echo $(${pkgs.cjdns}/bin/publictoip6 ${v.publicKey}) ${v.hostname}")
-          (foldl' (acc: iface: acc // iface.connectTo) {} (cfg.ETHInterfaces ++ cfg.UDPInterfaces)))}
-      echo \'\'
-    '');
-
-  parseModule = x:
-    (removeAttrs x [ "_module" ]) // { connectTo = mapAttrs (name: value: { inherit (value) password publicKey; }) x.connectTo; };
-
-  # would be nice to  merge 'cfg' with a //,
-  # but the json nesting is wacky.
-  cjdrouteConf = builtins.toJSON ( {
-    admin = {
-      bind = cfg.admin.bind;
-      password = "@CJDNS_ADMIN_PASSWORD@";
-    };
-    authorizedPasswords = map (p: { password = p; }) cfg.authorizedPasswords;
-    interfaces = {
-      ETHInterface = map parseModule cfg.ETHInterfaces;
-      UDPInterface = map parseModule cfg.UDPInterfaces;
-    };
-
-    privateKey = "@CJDNS_PRIVATE_KEY@";
-
-    resetAfterInactivitySeconds = 100;
-
-    router = {
-      interface = { type = "TUNInterface"; };
-      ipTunnel = {
-        allowedConnections = [];
-        outgoingConnections = [];
-      };
-    };
-
-    security = [ { exemptAngel = 1; setuser = "nobody"; } ];
-
-  });
-
-in
-
-{
-  options = {
-
-    services.cjdns = {
-
-      enable = mkOption {
+  cjdnsSubmodule =
+  { options, ... }:
+  { options =
+    { enable = mkOption {
         type = types.bool;
         default = false;
         description = ''
-          Whether to enable the cjdns network encryption
-          and routing engine. A file at /etc/cjdns.keys will
-          be created if it does not exist to contain a random
-          secret key that your IPv6 address will be derived from.
+          Whether to enable this cjdns network.
         '';
       };
-
       confFile = mkOption {
         type = types.nullOr types.path;
         default = null;
@@ -259,79 +208,169 @@ in
           incurs heavy eval-time costs.
         '';
       };
+    };
+  };
 
+  # Additional /etc/hosts entries for peers with an associated hostname
+  cjdnsExtraHosts = hosts: import (pkgs.runCommand "cjdns-hosts" {}
+    # Generate a builder that produces an output usable as a Nix string value
+    ''
+      exec >$out
+      echo \'\'
+      ${concatStringsSep "\n" (mapAttrsToList (k: v:
+            "echo $(${pkgs.cjdns}/bin/publictoip6 ${v.publicKey}) ${v.hostname}")
+          hosts)}
+      echo \'\'
+    '');
+
+  cfgsToAddHosts = filterAttrs (name: cfg: cfg.addExtraHosts) enabledCfgs;
+  interfacesToAddHosts = concatLists (mapAttrsToList (name: cfg: cfg.ETHInterfaces ++ cfg.UDPInterfaces) cfgsToAddHosts);
+  allExtraHosts = foldl' (acc: iface: acc // iface.connectTo) {} interfacesToAddHosts;
+  extraHosts = filterAttrs (k: v: v.hostname != "") allExtraHosts;
+
+  parseModule = x:
+    (removeAttrs x [ "_module" ]) // { connectTo = mapAttrs (name: value: { inherit (value) password publicKey; }) x.connectTo; };
+
+  # would be nice to merge 'cfg' with a //,
+  # but the json nesting is wacky.
+  cjdrouteConf = name: let opts = enabledCfgs.${name}; in builtins.toJSON ( {
+    admin = {
+      bind = opts.admin.bind;
+      password = "@CJDNS_ADMIN_PASSWORD@";
+    };
+    authorizedPasswords = map (p: { password = p; }) opts.authorizedPasswords;
+    interfaces = {
+      ETHInterface = map parseModule opts.ETHInterfaces;
+      UDPInterface = map parseModule opts.UDPInterfaces;
+    };
+
+    privateKey = "@CJDNS_PRIVATE_KEY@";
+
+    resetAfterInactivitySeconds = 100;
+
+    router = {
+      interface = { type = "TUNInterface"; tunDevice = name; };
+      ipTunnel = {
+        allowedConnections = [];
+        outgoingConnections = [];
+      };
+    };
+
+    security = [ { exemptAngel = 1; setuser = "nobody"; } ];
+
+  });
+
+in
+
+{
+  options = {
+
+    services.cjdns.networks = mkOption {
+      type = types.attrsOf ( types.submodule ( cjdnsSubmodule ) );
+      default = { };
+      example = {
+        hyper = {
+          ETHInterfaces = [
+            {
+              bind = "all";
+            }
+          ];
+          authorizedPasswords = [ "mtQYywL0XZ6JhXm6nprvQ4XKPuS2VFYb" ];
+        };
+      };
+      description = ''
+        cjdns network encryption and routing engine configuration.
+
+        For each defined attribute name, a TUN network interface will be created
+        with the specified name. Also, a file with path <literal>/etc/cjdns-&lt;name&gt;.keys</literal>
+        will be created if it does not exist to contain a random secret key that
+        your IPv6 address will be derived from.
+
+        A file with path <literal>/etc/cjdns-&lt;name&gt;.public</literal> will also
+        be created, containing the IPv6 address and public key of the specified
+        cjdns network.
+      '';
     };
 
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (enabledCfgs != []) {
 
     boot.kernelModules = [ "tun" ];
 
     # networking.firewall.allowedUDPPorts = ...
 
-    systemd.services.cjdns = {
-      description = "cjdns: routing engine designed for security, scalability, speed and ease of use";
-      wantedBy = [ "multi-user.target" "sleep.target"];
-      after = [ "network-online.target" ];
-      bindsTo = [ "network-online.target" ];
+    systemd.services = mapAttrs' (name: opts:
+      nameValuePair "cjdns-${name}" {
+        description = "cjdns: routing engine designed for security, scalability, speed and ease of use";
+        wantedBy = [ "multi-user.target" "sleep.target"];
+        after = [ "network-online.target" ];
+        bindsTo = [ "network-online.target" ];
 
-      preStart = if cfg.confFile != null then "" else ''
-        [ -e /etc/cjdns.keys ] && source /etc/cjdns.keys
+        preStart = if opts.confFile != null then "" else ''
+          [ -e /etc/cjdns-${name}.keys ] && source /etc/cjdns-${name}.keys
 
-        if [ -z "$CJDNS_PRIVATE_KEY" ]; then
-            shopt -s lastpipe
-            ${pkg}/bin/makekeys | { read private ipv6 public; }
+          if [ -z "$CJDNS_PRIVATE_KEY" ]; then
+              shopt -s lastpipe
+              ${pkg}/bin/makekeys | { read private ipv6 public; }
 
-            umask 0077
-            echo "CJDNS_PRIVATE_KEY=$private" >> /etc/cjdns.keys
-            echo -e "CJDNS_IPV6=$ipv6\nCJDNS_PUBLIC_KEY=$public" > /etc/cjdns.public
+              umask 0077
+              echo "CJDNS_PRIVATE_KEY=$private" >> /etc/cjdns-${name}.keys
+              echo -e "CJDNS_IPV6=$ipv6\nCJDNS_PUBLIC_KEY=$public" > /etc/cjdns-${name}.public
 
-            chmod 600 /etc/cjdns.keys
-            chmod 444 /etc/cjdns.public
-        fi
+              chmod 600 /etc/cjdns-${name}.keys
+              chmod 444 /etc/cjdns-${name}.public
+          fi
 
-        if [ -z "$CJDNS_ADMIN_PASSWORD" ]; then
-            echo "CJDNS_ADMIN_PASSWORD=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 96)" \
-                >> /etc/cjdns.keys
-        fi
-      '';
+          if [ -z "$CJDNS_ADMIN_PASSWORD" ]; then
+              echo "CJDNS_ADMIN_PASSWORD=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 96)" \
+                  >> /etc/cjdns-${name}.keys
+          fi
+        '';
 
-      script = (
-        if cfg.confFile != null then "${pkg}/bin/cjdroute < ${cfg.confFile}" else
-          ''
-            source /etc/cjdns.keys
-            echo '${cjdrouteConf}' | sed \
-                -e "s/@CJDNS_ADMIN_PASSWORD@/$CJDNS_ADMIN_PASSWORD/g" \
-                -e "s/@CJDNS_PRIVATE_KEY@/$CJDNS_PRIVATE_KEY/g" \
-                | ${pkg}/bin/cjdroute
-         ''
-      );
+        script = (
+          if opts.confFile != null then "${pkg}/bin/cjdroute < ${opts.confFile}" else
+            ''
+              source /etc/cjdns-${name}.keys
+              echo '${cjdrouteConf name}' | sed \
+                  -e "s/@CJDNS_ADMIN_PASSWORD@/$CJDNS_ADMIN_PASSWORD/g" \
+                  -e "s/@CJDNS_PRIVATE_KEY@/$CJDNS_PRIVATE_KEY/g" \
+                  | ${pkg}/bin/cjdroute
+            ''
+        );
 
-      serviceConfig = {
-        Type = "forking";
-        Restart = "always";
-        StartLimitInterval = 0;
-        RestartSec = 1;
-        CapabilityBoundingSet = "CAP_NET_ADMIN CAP_NET_RAW CAP_SETUID";
-        ProtectSystem = true;
-        MemoryDenyWriteExecute = true;
-        ProtectHome = true;
-        PrivateTmp = true;
-      };
-    };
-
-    networking.extraHosts = mkIf cfg.addExtraHosts cjdnsExtraHosts;
-
-    assertions = [
-      { assertion = (length cfg.ETHInterfaces) != 0 || (length cfg.UDPInterfaces) != 0 || cfg.confFile != null;
-        message = "No element in cjdns.ETHInterfaces or cjdns.UDPInterfaces is defined.";
+        serviceConfig = {
+          Type = "forking";
+          Restart = "always";
+          StartLimitInterval = 0;
+          RestartSec = 1;
+          CapabilityBoundingSet = "CAP_NET_ADMIN CAP_NET_RAW CAP_SETUID";
+          ProtectSystem = true;
+          MemoryDenyWriteExecute = true;
+          ProtectHome = true;
+          PrivateTmp = true;
+        };
       }
-      { assertion = config.networking.enableIPv6;
-        message = "networking.enableIPv6 must be enabled for CJDNS to work";
-      }
-    ];
+    ) enabledCfgs;
 
+    networking.extraHosts = mkIf (extraHosts != {}) (cjdnsExtraHosts extraHosts);
+
+    assertions =
+      let
+        mapAssertion = name: cfg:
+        { assertion = (length cfg.ETHInterfaces) != 0 || (length cfg.UDPInterfaces) != 0 || cfg.confFile != null;
+          message = "No cjdns.${name}.ETHInterfaces or cjdns.${name}.UDPInterfaces are defined";
+        };
+      in
+        (mapAttrsToList (name: cfg: mapAssertion name cfg) enabledCfgs) ++ [
+          { assertion =
+              let admins = mapAttrsToList (name: value: value.admin.bind) enabledCfgs; in
+              (length admins) == (length (unique admins));
+            message = "You cannot have two cjdns networks with the same admin bind address";
+          }
+          { assertion = config.networking.enableIPv6;
+            message = "networking.enableIPv6 must be enabled for CJDNS to work";
+          }
+        ];
   };
-
 }

--- a/nixos/tests/cjdns.nix
+++ b/nixos/tests/cjdns.nix
@@ -6,7 +6,7 @@ let
 
   basicConfig =
     { config, pkgs, ... }:
-    { services.cjdns.enable = true;
+    { services.cjdns.networks.test.enable = true;
 
       # Turning off DHCP isn't very realistic but makes
       # the sequence of address assignment less stochastic.
@@ -34,7 +34,11 @@ import ./make-test.nix ({ pkgs, ...} : {
         { config, ... }:
         { imports = [ basicConfig ];
 
-          services.cjdns.ETHInterface.bind = "eth1";
+          services.cjdns.networks.test.ETHInterfaces = [
+            {
+              bind = "eth1";
+            }
+          ];
 
           services.httpd.enable = true;
           services.httpd.adminAddr = "foo@example.org";
@@ -51,14 +55,14 @@ import ./make-test.nix ({ pkgs, ...} : {
 
           networking.interfaces.eth1.ipAddress = "192.168.0.2";
 
-          services.cjdns =
-            { UDPInterface =
+          services.cjdns.networks.test =
+            { UDPInterfaces = [
                 { bind = "0.0.0.0:1024";
                   connectTo."192.168.0.1:1024" =
                     { password = carolPassword;
                       publicKey = carolPubKey;
                     };
-                };
+                }];
             };
         };
 
@@ -71,17 +75,25 @@ import ./make-test.nix ({ pkgs, ...} : {
           in
           { imports = [ basicConfig ];
 
-          environment.etc."cjdns.keys".text = ''
+          environment.etc."cjdns-test.keys".text = ''
             CJDNS_PRIVATE_KEY=${carolKey}
             CJDNS_ADMIN_PASSWORD=FOOBAR
           '';
 
           networking.interfaces.eth1.ipAddress = "192.168.0.1";
 
-          services.cjdns =
+          services.cjdns.networks.test =
             { authorizedPasswords = [ carolPassword ];
-              ETHInterface.bind = "eth1";
-              UDPInterface.bind = "192.168.0.1:1024";
+              ETHInterfaces = [
+                {
+                  bind = "eth1";
+                }
+              ];
+              UDPInterfaces = [
+                {
+                  bind = "192.168.0.1:1024";
+                }
+              ];
             };
           networking.firewall.allowedUDPPorts = [ 1024 ];
         };
@@ -92,13 +104,13 @@ import ./make-test.nix ({ pkgs, ...} : {
     ''
       startAll;
 
-      $alice->waitForUnit("cjdns.service");
-      $bob->waitForUnit("cjdns.service");
-      $carol->waitForUnit("cjdns.service");
+      $alice->waitForUnit("cjdns-test.service");
+      $bob->waitForUnit("cjdns-test.service");
+      $carol->waitForUnit("cjdns-test.service");
 
       sub cjdnsIp {
           my ($machine) = @_;
-          my $ip = (split /[ \/]+/, $machine->succeed("ip -o -6 addr show dev tun0"))[3];
+          my $ip = (split /[ \/]+/, $machine->succeed("ip -o -6 addr show dev test"))[3];
           $machine->log("has ip $ip");
           return $ip;
       }


### PR DESCRIPTION
###### Motivation for this change

There are two big changes to the `cjdns` module:
1. Allow the definition of multiple UDP and ETH interfaces.
2. Allow the definition of multiple cjdns networks.

Both are breaking changes to existing `cjdns` configurations, and that's why I'm grouping both changes in the same PR (so that, if we go ahead with breaking configurations, we don't break them more often than necessary).

If you prefer, I can separate them into 2 separate PRs, instead of 2 separate commits in the same PR.

Both commit messages follow:

##### Accept multiple UDP and ETH interfaces

This can be useful for UDP interfaces if you want to listen on multiple
UDP ports, for example, if you want to have redundant paths to a node,
e.g. so that you are more likely to be able to bypass firewalls.

It is also useful for ethernet interfaces because if you have set
`bind = "all"` and `beacon = 0` in your ETHInterface, then (presumably
due to a bug) cjdns won't try to connect to any nodes.

In this case, you may want to define two separate ETHInterfaces, for
example, one binding to your actual ethernet device, and another one
binding to your wifi device.

**WARNING:** This is a breaking change for anyone who uses cjdns, since
UDPInterface is renamed to UDPInterfaces and it is now a list (same for
ETHInterface).

##### Allow multiple cjdns networks to coexist

This is useful in case you wish to be connected to one or more private
cjdns networks, and/or also be connected to a public network (e.g.
Hyperboria).

Each network will have a name assigned to it, and the TUN network
interface will be set to the name of the cjdns network (instead of being
named `tun0` or whatever number is available). This allows the interface
names to be predictable and easy to tell which one belongs to which
network, which facilitates firewall configuration.

The cjdns files that were automatically created with the secret keys
and the public parameters (`/etc/cjdns.keys` and `/etc/cjdns.public`) will
now be called `/etc/cjdns-<name>.keys` and `/etc/cjdns-<name>.public`.

**WARNING:** This is a breaking change for anyone who uses cjdns, since
cjdns networks now must be under an attribute name (which defines the
cjdns network name). For example, whereas before you had a cjdns network
defined liked this:

```
services.cjdns = {
  enable = true;
  UDPInterface = { ... };
};
```

... you must now define it like this:

```
services.cjdns.networks = {
  mynet = {
    enable = true;
    UDPInterfaces = [ {
      ...
    } ];
  };
};
```

... where `mynet` is some name you must assign to your cjdns network
(note that the name will also be used to name the network interface,
replacing the generic name `tun0`).

Also, you must copy your existing `/etc/cjdns.keys` and
`/etc/cjdns.public` files to `/etc/cjdns-mynet.keys` and
`/etc/cjdns-mynet.public`, respectively (replace `mynet` by your network
name), so that you can keep the same IPv6 address and private/public keys
you were using before.

Fixes #21813

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

