### PR TITLE
bash-completion: call readlink without errors on Darwin

### DIFF
--- a/pkgs/shells/bash-completion/default.nix
+++ b/pkgs/shells/bash-completion/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i -e 's/readlink -f/readlink/g' bash_completion completions/*
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://github.com/scop/bash-completion;
     description = "Programmable completion for the bash shell";


### PR DESCRIPTION
###### Motivation for this change

I use nix on a mac.  When I tried to source the completions, I get a blizzard of errors about invoking readlink with the `-f` option.  Presumably this breaks some completions, though the error messages themselves are worth fixing.  I assume they hasn't been reported in the past because you have to go a bit out of your way to use the package outside of nixos.

I don't pretend to fully get what readlink is doing here; I just stole the solution from the matching homebrew package.

###### Things done

- Built on platform(s)
   - [x] macOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

