### PR TITLE
kde4, kdm: mark services as deprecated

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/kde4.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde4.nix
@@ -87,6 +87,9 @@ in
 
 
   config = mkIf (xcfg.enable && cfg.enable) {
+    warnings = [
+      "KDE4 is long unmaintained and will be removed. Please update to KDE5."
+    ];
 
     # If KDE 4 is enabled, make it the default desktop manager (unless
     # overridden by the user's configuration).

--- a/nixos/modules/services/x11/display-managers/kdm.nix
+++ b/nixos/modules/services/x11/display-managers/kdm.nix
@@ -35,7 +35,7 @@ let
       ${optionalString (cfg.setupScript != "")
       ''
         Setup=${cfg.setupScript}
-      ''} 
+      ''}
 
       [X-*-Greeter]
       HiddenUsers=root,${concatStringsSep "," dmcfg.hiddenUsers}
@@ -128,6 +128,9 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
+    warnings = [
+      "KDM is long unmaintained and will be removed. Please update to SDDM."
+    ];
 
     services.xserver.displayManager.slim.enable = false;
 


### PR DESCRIPTION
###### Motivation for this change

cc @ttuegel @domenkozar @globin 

https://github.com/NixOS/nixpkgs/issues/15866

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

