### PR TITLE
pgjwt: init at 0.0.1

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -286,6 +286,7 @@ in rec {
   tests.openssh = callTest tests/openssh.nix {};
   #tests.panamax = hydraJob (import tests/panamax.nix { system = "x86_64-linux"; });
   tests.peerflix = callTest tests/peerflix.nix {};
+  tests.pgjwt = callTest tests/pgjwt.nix {};
   tests.postgresql = callTest tests/postgresql.nix {};
   tests.printing = callTest tests/printing.nix {};
   tests.proxy = callTest tests/proxy.nix {};

--- a/nixos/tests/pgjwt.nix
+++ b/nixos/tests/pgjwt.nix
@@ -1,0 +1,42 @@
+import ./make-test.nix ({ pkgs, ...} : 
+let
+  test = pkgs.writeText "test.sql" ''
+    CREATE EXTENSION pgcrypto;
+    CREATE EXTENSION pgjwt;
+    select sign('{"sub":"1234567890","name":"John Doe","admin":true}', 'secret');
+    select * from verify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ', 'secret');
+  '';
+in
+{
+  name = "pgjwt";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ spinus ];
+  };
+
+  nodes = {
+    master =
+      { pkgs, config, ... }:
+
+      {
+        services.postgresql = let mypg = pkgs.postgresql95; in {
+            enable = true;
+            package = mypg;
+            extraPlugins =[pkgs.pgjwt];
+            initialScript =  pkgs.writeText "postgresql-init.sql"
+          ''
+          CREATE ROLE postgres WITH superuser login createdb;
+          '';
+          };
+      };
+  };
+
+  testScript = ''
+    startAll;
+    $master->waitForUnit("postgresql");
+    $master->succeed("timeout 10 bash -c 'while ! psql postgres -c \"SELECT 1;\";do sleep 1;done;'");
+    $master->succeed("cat ${test} | psql postgres");
+    # I can't make original test working :[
+    # $master->succeed("${pkgs.perlPackages.TAPParserSourceHandlerpgTAP}/bin/pg_prove -d postgres ${pkgs.pgjwt.src}/test.sql");
+
+  '';
+})

--- a/pkgs/servers/sql/postgresql/pgjwt/default.nix
+++ b/pkgs/servers/sql/postgresql/pgjwt/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  name = "pgjwt-${version}";
+  version = "0.0.1";
+  src = fetchFromGitHub {
+    owner = "michelp";
+    repo = "pgjwt";
+    rev = "12a41eef15e6d3a22399e03178560d5174d496a3";
+    sha256 = "1dgx7kqkf9d7j5qj3xykx238xm8jg0s6c8h7zyl4lx8dmbz9sgsv";
+  };
+  buildPhase = "true";
+  installPhase = ''
+    mkdir -p $out/bin  # current postgresql extension mechanism in nixos requires bin directory
+    mkdir -p $out/share/extension
+    cp pg*sql *.control $out/share/extension
+  '';
+  meta = with stdenv.lib; {
+    description = "PostgreSQL implementation of JSON Web Tokens";
+    longDescription = ''
+      sign() and verify() functions to create and verify JSON Web Tokens.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [spinus];
+  };
+}

--- a/pkgs/servers/sql/postgresql/pgjwt/default.nix
+++ b/pkgs/servers/sql/postgresql/pgjwt/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     rev = "12a41eef15e6d3a22399e03178560d5174d496a3";
     sha256 = "1dgx7kqkf9d7j5qj3xykx238xm8jg0s6c8h7zyl4lx8dmbz9sgsv";
   };
-  buildPhase = "true";
+  dontBuild = true;
   installPhase = ''
     mkdir -p $out/bin  # current postgresql extension mechanism in nixos requires bin directory
     mkdir -p $out/share/extension

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2130,6 +2130,8 @@ with pkgs;
 
   pgf_graphics = callPackage ../tools/graphics/pgf { };
 
+  pgjwt = callPackage ../servers/sql/postgresql/pgjwt {};
+
   pigz = callPackage ../tools/compression/pigz { };
 
   pixz = callPackage ../tools/compression/pixz { };


### PR DESCRIPTION
###### Motivation for this change

Needed JWT token manipulation inside PostgreSQL (easier work with PostgREST).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

