### PR TITLE
patch ati-drivers for kernel 4.9

### DIFF
--- a/pkgs/os-specific/linux/ati-drivers/default.nix
+++ b/pkgs/os-specific/linux/ati-drivers/default.nix
@@ -80,7 +80,10 @@ stdenv.mkDerivation rec {
                  ./patches/kernel-4.6-page_cache_release-put_page.patch ]
   ++ optionals ( kernel != null &&
                  (lib.versionAtLeast kernel.version "4.7") )
-               [ ./patches/4.7-arch-cpu_has_pge-v2.patch ];
+               [ ./patches/4.7-arch-cpu_has_pge-v2.patch ]
+  ++ optionals ( kernel != null &&
+                 (lib.versionAtLeast kernel.version "4.9") )
+               [ ./patches/4.9-get_user_pages.patch ];
 
   buildInputs =
     [ xorg.libXrender xorg.libXext xorg.libX11 xorg.libXinerama xorg.libSM

--- a/pkgs/os-specific/linux/ati-drivers/patches/4.9-get_user_pages.patch
+++ b/pkgs/os-specific/linux/ati-drivers/patches/4.9-get_user_pages.patch
@@ -1,0 +1,28 @@
+commit b3e4353fc68a6a024dcb95e2d61aa0afd7370233
+Author: Matt McHenry <matt@mchenryfamily.org>
+Date:   Fri Feb 3 20:19:41 2017
+
+    patch for 4.9 only
+
+diff --git a/common/lib/modules/fglrx/build_mod/firegl_public.c b/common/lib/modules/fglrx/build_mod/firegl_public.c
+index 4ce095f..3b591e1 100755
+--- a/common/lib/modules/fglrx/build_mod/firegl_public.c
++++ b/common/lib/modules/fglrx/build_mod/firegl_public.c
+@@ -3224,7 +3224,7 @@ int ATI_API_CALL KCL_LockUserPages(unsigned long vaddr, unsigned long* page_list
+     int ret;
+ 
+     down_read(&current->mm->mmap_sem);
+-    ret = get_user_pages(vaddr, page_cnt, 1, 0, (struct page **)page_list, NULL);
++    ret = get_user_pages(vaddr, page_cnt, 1, (struct page **)page_list, NULL);
+     up_read(&current->mm->mmap_sem);
+ 
+     return ret;
+@@ -3242,7 +3242,7 @@ int ATI_API_CALL KCL_LockReadOnlyUserPages(unsigned long vaddr, unsigned long* p
+     int ret;
+ 
+     down_read(&current->mm->mmap_sem);
+-    ret = get_user_pages(vaddr, page_cnt, 0, 0, (struct page **)page_list, NULL);
++    ret = get_user_pages(vaddr, page_cnt, 0, (struct page **)page_list, NULL);
+     up_read(&current->mm->mmap_sem);
+ 
+     return ret;


### PR DESCRIPTION
uses patch from https://github.com/imageguy/fglrx-for-Fedora/blob/master/fglrx_kernel_4.9.diff

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

as usual, confirmed that minecraft and starcraft 2 are playable.  :)