### PR TITLE
libxml2: add icu support

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -1,8 +1,11 @@
-{ stdenv, lib, fetchurl, zlib, xz, python2, findXMLCatalogs, libiconv, fetchpatch
-, pythonSupport ? (! stdenv ? cross) }:
+{ stdenv, lib, fetchurl, fetchpatch
+, zlib, xz, python2, findXMLCatalogs, libiconv
+, pythonSupport ? (! stdenv ? cross)
+, icuSupport ? false, icu ? null }:
 
 let
   python = python2;
+
 in stdenv.mkDerivation rec {
   name = "libxml2-${version}";
   version = "2.9.4";
@@ -37,9 +40,11 @@ in stdenv.mkDerivation rec {
     # RUNPATH for that, leading to undefined references for its users.
     ++ lib.optional stdenv.isFreeBSD xz;
 
-  propagatedBuildInputs = [ zlib findXMLCatalogs ];
+  propagatedBuildInputs = [ zlib findXMLCatalogs ] ++ lib.optional icuSupport icu;
 
-  configureFlags = lib.optional pythonSupport "--with-python=${python}"
+  configureFlags =
+       lib.optional pythonSupport "--with-python=${python}"
+    ++ lib.optional icuSupport    "--with-icu"
     ++ [ "--exec_prefix=$dev" ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Fixes #22623

Causes a massive rebuild.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

