### PR TITLE
terragrunt: 0.9.9 -> 0.10.0

### DIFF
--- a/pkgs/applications/networking/cluster/terragrunt/default.nix
+++ b/pkgs/applications/networking/cluster/terragrunt/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "terragrunt-${version}";
-  version = "0.9.9";
+  version = "0.10.0";
 
   goPackagePath = "github.com/gruntwork-io/terragrunt";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     rev    = "v${version}";
     owner  = "gruntwork-io";
     repo   = "terragrunt";
-    sha256 = "08rygmcjlcdj4g575cpx2lfdq69r450ri5q2dngvnhbvzk8nvnr0";
+    sha256 = "1cdhl7rqd2jslvp1ia1gph1lg0sjzsnvj7dj6lg85jfdcffafygj";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/applications/networking/cluster/terragrunt/deps.nix
+++ b/pkgs/applications/networking/cluster/terragrunt/deps.nix
@@ -5,8 +5,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/aws/aws-sdk-go";
-      rev = "4590e9b51cd6698144a025a75608fa7a90752d5d";
-      sha256 = "13hczsimaanfmbhj8aki8zib7fi161f7p7cjm7z9x8hwwa9q4nld";
+      rev = "63102d196e0996a2910839857c3584f62be907cc";
+      sha256 = "0n207g4bf5fjq23f63nkhh14shj7kjdrr4qn6h28d7x2vqfb9pss";
     };
   }
   {
@@ -32,8 +32,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/hashicorp/go-getter";
-      rev = "cc80f38c726badeae53775d179755e1c4953d6cf";
-      sha256 = "1xbflbgg3gfh3zy5ibfzxv4gbzg62rkzr4l2i9igvz8m7sxgyy1f";
+      rev = "c3d66e76678dce180a7b452653472f949aedfbcd";
+      sha256 = "0ykpkiszcwp3hnvnnyl95zdrsziwrzr989ynyvbfkgpnkqfdhfy7";
     };
   }
   {


### PR DESCRIPTION
###### Motivation for this change

Upstream upgrade.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

