### PR TITLE
hakuneko: 1.4.1 -> 1.4.2

### DIFF
--- a/pkgs/tools/misc/hakuneko/default.nix
+++ b/pkgs/tools/misc/hakuneko/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "hakuneko-${version}";
-  version = "1.4.1";
+  version = "1.4.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/hakuneko/hakuneko_${version}_src.tar.gz";
-    sha256 = "d7e066e3157445f273ccf14172c05077759da036ffe700a28a409fde862b69a7";
+    sha256 = "76a63fa05e91b082cb5a70a8abacef005354e99978ff8b1369f7aa0af7615d52";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

