### PR TITLE
dgsh-unstable: Init at 2017-02-05

### DIFF
--- a/pkgs/shells/dgsh/default.nix
+++ b/pkgs/shells/dgsh/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, pkgconfig,
+  libtool, check, bison, git, gperf,
+  perl, texinfo, help2man, gettext, ncurses
+}:
+
+stdenv.mkDerivation rec {
+  name = "dgsh-unstable-${version}";
+  version = "2017-02-05";
+
+  src = fetchFromGitHub {
+    owner = "dspinellis";
+    repo = "dgsh";
+    rev = "bc4fc2e8009c069ee4df5140c32a2fc15d0acdec";
+    sha256 = "0k3hmnarz56wphw45mabn5zcc427l5p77jldh1qqy89pxqy1wnql";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ autoconf automake pkgconfig libtool check
+    bison git gettext gperf perl texinfo help2man ncurses
+  ];
+
+  configurePhase = ''
+    cp -r ./unix-tools/coreutils/gnulib gnulib
+    perl -pi -e \
+      's#./bootstrap #./bootstrap --no-bootstrap-sync --skip-po --no-git --gnulib-srcdir='$PWD/gnulib' #g' \
+      unix-tools/Makefile
+    find . -name \*.diff | xargs rm -f
+    rm -rf unix-tools/*/gnulib
+    patchShebangs unix-tools/diffutils/man/help2man
+    export RSYNC=true # set to rsync binary, eventhough it is not used.
+    make PREFIX=$out config
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The Directed Graph Shell";
+    homepage = http://www.dmst.aueb.gr/dds/sw/dgsh;
+    license = with licenses; asl20;
+    maintainers = with maintainers; [ vrthra ];
+    platforms = with platforms; all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -490,6 +490,8 @@ with pkgs;
 
   djmount = callPackage ../tools/filesystems/djmount { };
 
+  dgsh = callPackage ../shells/dgsh { };
+
   elvish = callPackage ../shells/elvish { };
 
   encryptr = callPackage ../tools/security/encryptr {


### PR DESCRIPTION
Dgsh is the directed graph shell

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

