### PR TITLE
nix-update-source: init at 0.3.0

### DIFF
--- a/pkgs/tools/package-management/nix-update-source/default.nix
+++ b/pkgs/tools/package-management/nix-update-source/default.nix
@@ -1,0 +1,46 @@
+{ lib, pkgs, fetchFromGitHub, python3Packages, nix-prefetch-scripts }:
+python3Packages.buildPythonApplication rec {
+  version = "0.4.0";
+  name = "nix-update-source-${version}";
+  src = fetchFromGitHub {
+    owner = "timbertson";
+    repo = "nix-update-source";
+    rev = "version-0.4.0";
+    sha256 = "0gz0f7nx1q697s16ya7q84q1cj020n547k2ffb99ds2r40nckr2g";
+  };
+  propagatedBuildInputs = [ nix-prefetch-scripts ];
+  passthru = {
+    # NOTE: `fetch` should not be used within nixpkgs because it
+    # uses a non-idiomatic structure. It is provided for use by
+    # out-of-tree nix derivations.
+    fetch = path:
+      let
+        fetchers = {
+          # whitelist of allowed fetchers
+          inherit (pkgs) fetchgit fetchurl fetchFromGitHub;
+        };
+        json = lib.importJSON path;
+        fetchFn = builtins.getAttr json.fetch.fn fetchers;
+        src = fetchFn json.fetch.args;
+      in
+      json // json.fetch // { inherit src; };
+    updateScript = ''
+      set -e
+      echo
+      cd ${toString ./.}
+      ${pkgs.nix-update-source}/bin/nix-update-source \
+        --prompt version \
+        --replace-attr version \
+        --set owner timbertson \
+        --set repo nix-update-source \
+        --set type fetchFromGitHub \
+        --set rev 'version-{version}' \
+        --modify-nix default.nix
+    '';
+  };
+  meta = {
+    description = "Utility to automate updating of nix derivation sources";
+    maintainers = with lib.maintainers; [ timbertson ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17635,6 +17635,8 @@ with pkgs;
     nix-prefetch-zip
     nix-prefetch-scripts;
 
+  nix-update-source = callPackage ../tools/package-management/nix-update-source {};
+
   nix-template-rpm = callPackage ../build-support/templaterpm { inherit (pythonPackages) python toposort; };
 
   nix-repl = callPackage ../tools/package-management/nix-repl { };


### PR DESCRIPTION
@edolstra this one will need a review from you since it builds on https://github.com/NixOS/nixpkgs/pull/21734 (which was reverted)

Reintroduce `nix-update-source` at version 0.3.0. This version includes support for modifying a nix file inline[*] instead of using a separate JSON file. This PR also includes a `passthru.updateScript` for nix-update-source itself, as an example of JSON-less usage.

The version retains support for importing JSON files, since that's still useful for non-`nixpkgs` sources which prefer that method. But there's a comment warning people not to use it nixpkgs proper. I'm hoping this is an acceptable compromise.

[*]: it has little actual knowledge of nix syntax, because I don't have a real nix parser available - it relies on the nix file being formatted like a typical derivation

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

