### PR TITLE
range-v3: init at 2017-01-30

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -521,6 +521,7 @@
   womfoo = "Kranium Gikos Mendoza <kranium@gikos.net>";
   wscott = "Wayne Scott <wsc9tt@gmail.com>";
   wyvie = "Elijah Rum <elijahrum@gmail.com>";
+  xwvvvvwx = "David Terry <davidterry@posteo.de>";
   yarr = "Dmitry V. <savraz@gmail.com>";
   yochai = "Yochai <yochai@titat.info>";
   yorickvp = "Yorick van Pelt <yorickvanpelt@gmail.com>";

--- a/pkgs/development/libraries/range-v3/default.nix
+++ b/pkgs/development/libraries/range-v3/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "range-v3-${version}";
+  version = "2017-01-30";
+
+  src = fetchFromGitHub {
+    owner = "ericniebler";
+    repo = "range-v3";
+    rev = "bab29767cce120e11872d79a2537bc6f0be76963";
+    sha256 = "0kncpxms3f0nmn6jppp484244xq15d9298g3h3nlm1wvq8ib1jhi";
+  };
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/include
+    mv include/ $out/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Experimental range library for C++11/14/17";
+    homepage = https://github.com/ericniebler/range-v3;
+    license = licenses.boost;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/range-v3/default.nix
+++ b/pkgs/development/libraries/range-v3/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   name = "range-v3-${version}";

--- a/pkgs/development/libraries/range-v3/default.nix
+++ b/pkgs/development/libraries/range-v3/default.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/ericniebler/range-v3;
     license = licenses.boost;
     platforms = platforms.all;
+    maintainers = with maintainers; [ xwvvvvwx ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9337,6 +9337,8 @@ with pkgs;
 
   rabbitmq-c = callPackage ../development/libraries/rabbitmq-c {};
 
+  range-v3 = callPackage ../development/libraries/range-v3 {};
+
   rabbitmq-java-client = callPackage ../development/libraries/rabbitmq-java-client {};
 
   raul = callPackage ../development/libraries/audio/raul { };


### PR DESCRIPTION
###### Motivation for this change

Add the range-v3 c++ library

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

As a side note I decided not to run the test suite was that the correct choice? 