### PR TITLE
mupdf: update mujs due to CVEs

### DIFF
--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -1,8 +1,15 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig
+{ stdenv, fetchgit, fetchurl, fetchpatch, pkgconfig
 , zlib, freetype, libjpeg, jbig2dec, openjpeg
 , libX11, libXcursor, libXrandr, libXinerama, libXext, harfbuzz, mesa }:
 
-stdenv.mkDerivation rec {
+let
+  mujs = fetchgit {
+    url    = "http://git.ghostscript.com/mujs.git";
+    rev    = "4006739a28367c708dea19aeb19b8a1a9326ce08";
+    sha256 = "0wvjl8lkh0ga6fkmxgjqq77yagncbv1bdy6hpnxq31x3mkwn1s51";
+  };
+
+in stdenv.mkDerivation rec {
   version = "1.9a";
   name = "mupdf-${version}";
 
@@ -33,12 +40,12 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "prefix=$(out)" ];
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ zlib libX11 libXcursor libXext harfbuzz mesa libXrandr libXinerama freetype libjpeg jbig2dec openjpeg ];
+  buildInputs = [ mujs zlib libX11 libXcursor libXext harfbuzz mesa libXrandr libXinerama freetype libjpeg jbig2dec openjpeg ];
   outputs = [ "bin" "dev" "out" "doc" ];
 
   preConfigure = ''
-    # Don't remove mujs because upstream version is incompatible
-    rm -rf thirdparty/{curl,freetype,glfw,harfbuzz,jbig2dec,jpeg,openjpeg,zlib}
+    rm -rf thirdparty/{curl,freetype,glfw,harfbuzz,jbig2dec,jpeg,mujs,openjpeg,zlib}
+    cp -r ${mujs} thirdparty/mujs
   '';
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

We update the JS runtime to the latest version in order to address:

CVE-2016-10132: Null pointer dereference in regexp because of a missing check after allocating memory allowing for DoS

CVE-2016-10133: Heap buffer overflow write in js_stackoverflow allowing for DoS or possible code execution

CVE-2016-10141: An integer overflow vulnerability triggered by a regular expression with nested repetition. A successful exploitation of this issue can lead to code execution or a denial of service (buffer overflow) condition


While mupdf launches and opens PDFs just fine, I haven't really tested PDFs with JS. I found some test files here: http://www.pdfscripting.com/public/Free-Sample-PDF-Files-with-scripts.cfm

But those all fail with javascript errors. At least they are failing with the same errors as the unpatched mupdf and are also broken in okular.

cc: @grahamc @joachifm @FRidh 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
