### PR TITLE
nvidia: support application profiles

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -49,6 +49,10 @@ in
         Option "RandRRotation" "on"
       '';
 
+    environment.etc."nvidia/nvidia-application-profiles-rc" = mkIf nvidia_x11.useProfiles {
+      source = "${nvidia_x11.bin}/share/nvidia/nvidia-application-profiles-${nvidia_x11.version}-rc";
+    };
+
     hardware.opengl.package = nvidiaPackage nvidia_x11 pkgs;
     hardware.opengl.package32 = nvidiaPackage nvidia_libs32 pkgs_i686;
 

--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -68,6 +68,12 @@ installPhase() {
             nuke-refs $i
             cp $i $bin/lib/modules/$kernelVersion/misc/
         done
+
+        # Install application profiles.
+        if [ "$useProfiles" = "1" ]; then
+            mkdir -p $bin/share/nvidia
+            cp -r nvidia-application-profiles-* $bin/share/nvidia
+        fi
     fi
 
     # All libs except GUI-only are installed now, so fixup them.

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -37,6 +37,7 @@ in
     settingsSha256 = "0q92xw4fr9p5nbhj1plynm50d32881861daxfwrisywszqijhmlf";
     persistencedSha256 = null;
     useGLVND = false;
+    useProfiles = false;
   };
 
   legacy_173 = callPackage ./legacy173.nix { };

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -4,6 +4,7 @@
 , settingsSha256
 , persistencedSha256
 , useGLVND ? true
+, useProfiles ? true
 , preferGtk2 ? false
 }:
 
@@ -41,7 +42,7 @@ let
         }
       else throw "nvidia-x11 does not support platform ${stdenv.system}";
 
-    inherit version useGLVND;
+    inherit version useGLVND useProfiles;
     inherit (stdenv) system;
 
     outputs = [ "out" ] ++ optional (!libsOnly) "bin";

--- a/pkgs/os-specific/linux/nvidia-x11/legacy173.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/legacy173.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation {
     settings = null;
     persistenced = null;
     useGLVND = false;
+    useProfiles = false;
   };
 
   meta = {

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation rec {
   makeFlags = [ "NV_USE_BUNDLED_LIBJANSSON=0" ];
   installFlags = [ "PREFIX=$(out)" ];
 
+  postPatch = lib.optionalString nvidia_x11.useProfiles ''
+    sed -i 's,/usr/share/nvidia/,${nvidia_x11.bin}/share/nvidia/,g' src/gtk+-2.x/ctkappprofile.c
+  '';
+
   preBuild = ''
     if [ -e src/libXNVCtrl/libXNVCtrl.a ]; then
       ( cd src/libXNVCtrl


### PR DESCRIPTION
###### Motivation for this change
 
Fix https://github.com/NixOS/nixpkgs/pull/22304#issuecomment-279132242.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

