### PR TITLE
Audacious: updates and name change Qt5 version

### DIFF
--- a/pkgs/applications/audio/audacious/default.nix
+++ b/pkgs/applications/audio/audacious/default.nix
@@ -8,16 +8,16 @@
 
 stdenv.mkDerivation rec {
   name = "audacious-${version}";
-  version = "3.8";
+  version = "3.8.2";
 
   src = fetchurl {
     url = "http://distfiles.audacious-media-player.org/audacious-${version}-gtk3.tar.bz2";
-    sha256 = "0rpdzf9pb52lcswxypwh4nq3qkjzliw42v39nm5rlwwxdq6bm99q";
+    sha256 = "1g08xprc9q0lyw3knq723j7xr7i15f8v1x1j3k5wvi8jv21bvijf";
   };
 
   pluginsSrc = fetchurl {
     url = "http://distfiles.audacious-media-player.org/audacious-plugins-${version}-gtk3.tar.bz2";
-    sha256 = "0j9svdqdjvj5spx1vfp0m63xh8xwk8naqsikdxfxbb68xk33rxb9";
+    sha256 = "1vqcxwqinlwb2l0kkrarg33sw1brjzrnq5jbhzrql6z6x95h4jbq";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/audio/audacious/qt-5.nix
+++ b/pkgs/applications/audio/audacious/qt-5.nix
@@ -10,23 +10,23 @@
 }:
 
 let
-  version = "3.8.1";
+  version = "3.8.2";
   sources = {
     "audacious-${version}" = fetchurl {
       url = "http://distfiles.audacious-media-player.org/audacious-${version}.tar.bz2";
-      sha256 = "1k9blmgqia0df18l39bd2bbcwmjfxak6bd286vcd9zzmjhqs4qdc";
+      sha256 = "14xyvmxdax0aj1gqcz8z23cjcavsysyh6b3lkiczkv4vrqf4gwdx";
     };
 
     "audacious-plugins-${version}" = fetchurl {
       url = "http://distfiles.audacious-media-player.org/audacious-plugins-${version}.tar.bz2";
-      sha256 = "0f16ivcp8nd83r781hnw1qgbs9hi2b2v22zwv7c3sw3jq1chb70h";
+      sha256 = "1m7xln93zc4qvb1fi83icyd5x2r6azqlvs5nigjz8az3l2kzrknp";
     };
   };
 in
 
 stdenv.mkDerivation {
   inherit version;
-  name = "audacious-${version}";
+  name = "audacious-qt5-${version}";
 
   sourceFiles = lib.attrValues sources;
   sourceRoots = lib.attrNames sources;


### PR DESCRIPTION
###### Motivation for this change

- package updates
- fixes https://github.com/NixOS/nixpkgs/issues/22673

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ttuegel 
