### PR TITLE
creduce: init at 2.6.0

### DIFF
--- a/pkgs/development/tools/misc/creduce/default.nix
+++ b/pkgs/development/tools/misc/creduce/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchurl, cmake
+, llvm, clang-unwrapped
+, flex
+, zlib
+, perl, ExporterLite, FileWhich, GetoptTabular, RegexpCommon, TermReadKey
+, utillinux
+}:
+
+assert stdenv.isLinux -> (utillinux != null);
+
+stdenv.mkDerivation rec {
+  name = "creduce-${version}";
+  version = "2.6.0";
+
+  src = fetchurl {
+    url = "http://embed.cs.utah.edu/creduce/${name}.tar.gz";
+    sha256 = "0pf5q0n8vkdcr1wrkxn2jzxv0xkrir13bwmqfw3jpbm3dh2c3b6d";
+  };
+
+  buildInputs = [
+    # Ensure stdenv's CC is on PATH before clang-unwrapped
+    stdenv.cc
+    # Actual deps:
+    cmake
+    llvm clang-unwrapped
+    flex zlib
+  ];
+
+  # On Linux, c-reduce's preferred way to reason about
+  # the cpu architecture/topology is to use 'lscpu',
+  # so let's make sure it knows where to find it:
+  patchPhase = stdenv.lib.optionalString stdenv.isLinux ''
+    substituteInPlace creduce/creduce_utils.pm --replace \
+      lscpu ${utillinux}/bin/lscpu
+  '';
+
+  perlDeps = [
+    perl ExporterLite FileWhich GetoptTabular RegexpCommon TermReadKey
+  ];
+
+  propagatedNativeBuildInputs = perlDeps;
+  propagatedUserEnvPkgs = perlDeps;
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A C program reducer";
+    homepage = "https://embed.cs.utah.edu/creduce";
+    # Officially, the license is: https://github.com/csmith-project/creduce/blob/master/COPYING
+    license = licenses.ncsa;
+    longDescription = ''
+      C-Reduce is a tool that takes a large C or C++ program that has a
+      property of interest (such as triggering a compiler bug) and
+      automatically produces a much smaller C/C++ program that has the same
+      property.  It is intended for use by people who discover and report
+      bugs in compilers and other tools that process C/C++ code.
+    '';
+    maintainers = [ maintainers.dtzWill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6263,6 +6263,13 @@ with pkgs;
 
   cppcheck = callPackage ../development/tools/analysis/cppcheck { };
 
+  creduce = callPackage ../development/tools/misc/creduce {
+    inherit (perlPackages) perl
+      ExporterLite FileWhich GetoptTabular RegexpCommon TermReadKey;
+    inherit (llvmPackages_39) llvm clang-unwrapped;
+    utillinux = if stdenv.isLinux then utillinuxMinimal else null;
+  };
+
   cscope = callPackage ../development/tools/misc/cscope { };
 
   csslint = callPackage ../development/web/csslint { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5611,6 +5611,14 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  GetoptTabular = buildPerlPackage rec {
+    name = "Getopt-Tabular-0.3";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/G/GW/GWARD/${name}.tar.gz";
+      sha256 = "0xskl9lcj07sdfx5dkma5wvhhgf5xlsq0khgh8kk34dm6dv0dpwv";
+    };
+  };
+
   GitPurePerl = buildPerlPackage {
     name = "Git-PurePerl-0.51";
     src = fetchurl {


### PR DESCRIPTION
Also includes perl dependency 'GetOpt::Tabular'.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

