### PR TITLE
LLVM: Fix licensing metadata, closes #22679.

### DIFF
--- a/pkgs/development/compilers/llvm/3.4/clang.nix
+++ b/pkgs/development/compilers/llvm/3.4/clang.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
   meta = {
     description = "A c, c++, objective-c, and objective-c++ frontend for the llvm compiler";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/compilers/llvm/3.4/lld.nix
+++ b/pkgs/development/compilers/llvm/3.4/lld.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   meta = {
     description = "A set of modular code for creating linker tools";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/compilers/llvm/3.4/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.4/lldb.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
   meta = {
     description = "A next-generation high-performance debugger";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/compilers/llvm/3.4/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.4/llvm.nix
@@ -67,7 +67,7 @@ in stdenv.mkDerivation rec {
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     maintainers = with stdenv.lib.maintainers; [ lovek323 raskin viric ];
     platforms   = stdenv.lib.platforms.all;
   };

--- a/pkgs/development/compilers/llvm/3.4/polly.nix
+++ b/pkgs/development/compilers/llvm/3.4/polly.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   meta = {
     description = "A polyhedral optimizer for llvm";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/compilers/llvm/3.5/clang.nix
+++ b/pkgs/development/compilers/llvm/3.5/clang.nix
@@ -47,7 +47,7 @@ in stdenv.mkDerivation {
   meta = {
     description = "A c, c++, objective-c, and objective-c++ frontend for the llvm compiler";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/compilers/llvm/3.5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.5/libc++/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://libcxx.llvm.org/;
     description = "A new implementation of the C++ standard library, targeting C++11";
-    license = "BSD";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/compilers/llvm/3.5/libc++abi/default.nix
+++ b/pkgs/development/compilers/llvm/3.5/libc++abi/default.nix
@@ -52,7 +52,7 @@ in stdenv.mkDerivation {
   meta = {
     homepage = http://libcxxabi.llvm.org/;
     description = "A new implementation of low level support for a standard C++ library";
-    license = "BSD";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
     maintainers = with stdenv.lib.maintainers; [ vlstill ];
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/compilers/llvm/3.5/lld.nix
+++ b/pkgs/development/compilers/llvm/3.5/lld.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   meta = {
     description = "A set of modular code for creating linker tools";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/compilers/llvm/3.5/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.5/lldb.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
   meta = {
     description = "A next-generation high-performance debugger";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     platforms   = stdenv.lib.platforms.all;
     broken = true;
   };

--- a/pkgs/development/compilers/llvm/3.5/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.5/llvm.nix
@@ -72,7 +72,7 @@ in stdenv.mkDerivation rec {
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     maintainers = with stdenv.lib.maintainers; [ lovek323 raskin viric ];
     platforms   = stdenv.lib.platforms.all;
   };

--- a/pkgs/development/compilers/llvm/3.5/polly.nix
+++ b/pkgs/development/compilers/llvm/3.5/polly.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   meta = {
     description = "A polyhedral optimizer for llvm";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/compilers/llvm/3.7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/clang/default.nix
@@ -49,7 +49,7 @@ let
     meta = {
       description = "A c, c++, objective-c, and objective-c++ frontend for the llvm compiler";
       homepage    = http://llvm.org/;
-      license     = stdenv.lib.licenses.bsd3;
+      license     = stdenv.lib.licenses.ncsa;
       platforms   = stdenv.lib.platforms.all;
     };
   };

--- a/pkgs/development/compilers/llvm/3.7/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/libc++/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://libcxx.llvm.org/;
     description = "A new implementation of the C++ standard library, targeting C++11";
-    license = "BSD";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/compilers/llvm/3.7/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/3.7/libc++abi.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://libcxxabi.llvm.org/;
     description = "A new implementation of low level support for a standard C++ library";
-    license = "BSD";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
     maintainers = with stdenv.lib.maintainers; [ vlstill ];
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/compilers/llvm/3.7/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.7/lldb.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
   meta = {
     description = "A next-generation high-performance debugger";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/compilers/llvm/3.7/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.7/llvm.nix
@@ -83,7 +83,7 @@ in stdenv.mkDerivation rec {
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     maintainers = with stdenv.lib.maintainers; [ lovek323 raskin viric ];
     platforms   = stdenv.lib.platforms.all;
   };

--- a/pkgs/development/compilers/llvm/3.8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/clang/default.nix
@@ -60,7 +60,7 @@ let
     meta = {
       description = "A c, c++, objective-c, and objective-c++ frontend for the llvm compiler";
       homepage    = http://llvm.org/;
-      license     = stdenv.lib.licenses.bsd3;
+      license     = stdenv.lib.licenses.ncsa;
       platforms   = stdenv.lib.platforms.all;
     };
   };

--- a/pkgs/development/compilers/llvm/3.8/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/libc++/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://libcxx.llvm.org/;
     description = "A new implementation of the C++ standard library, targeting C++11";
-    license = "BSD";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/compilers/llvm/3.8/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/3.8/libc++abi.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://libcxxabi.llvm.org/;
     description = "A new implementation of low level support for a standard C++ library";
-    license = "BSD";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
     maintainers = with stdenv.lib.maintainers; [ vlstill ];
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/compilers/llvm/3.8/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.8/lldb.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
   meta = {
     description = "A next-generation high-performance debugger";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/compilers/llvm/3.8/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.8/llvm.nix
@@ -85,7 +85,7 @@ in stdenv.mkDerivation rec {
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     maintainers = with stdenv.lib.maintainers; [ lovek323 raskin viric ];
     platforms   = stdenv.lib.platforms.all;
   };

--- a/pkgs/development/compilers/llvm/3.9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/clang/default.nix
@@ -49,7 +49,7 @@ let
     meta = {
       description = "A c, c++, objective-c, and objective-c++ frontend for the llvm compiler";
       homepage    = http://llvm.org/;
-      license     = stdenv.lib.licenses.bsd3;
+      license     = stdenv.lib.licenses.ncsa;
       platforms   = stdenv.lib.platforms.all;
     };
   };

--- a/pkgs/development/compilers/llvm/3.9/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/libc++/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://libcxx.llvm.org/;
     description = "A new implementation of the C++ standard library, targeting C++11";
-    license = "BSD";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/compilers/llvm/3.9/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/3.9/libc++abi.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://libcxxabi.llvm.org/;
     description = "A new implementation of low level support for a standard C++ library";
-    license = "BSD";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
     maintainers = with stdenv.lib.maintainers; [ vlstill ];
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/compilers/llvm/3.9/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.9/lldb.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
   meta = {
     description = "A next-generation high-performance debugger";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -109,7 +109,7 @@ in stdenv.mkDerivation rec {
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";
     homepage    = http://llvm.org/;
-    license     = stdenv.lib.licenses.bsd3;
+    license     = stdenv.lib.licenses.ncsa;
     maintainers = with stdenv.lib.maintainers; [ lovek323 raskin viric ];
     platforms   = stdenv.lib.platforms.all;
   };


### PR DESCRIPTION
* All projects are available under NCSA license,
  other than dragonegg.
* "Runtime" projects are dual-licensed under
  both NCSA and MIT:
  libc++, libc++abi, compiler-rt
* I don't mention MIT for compiler-rt as
  we only build it as part of LLVM.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

