### PR TITLE
Add nixos test for radicale

### DIFF
--- a/nixos/modules/services/networking/radicale.nix
+++ b/nixos/modules/services/networking/radicale.nix
@@ -57,4 +57,6 @@ in
       serviceConfig.Group = "radicale";
     };
   };
+
+  meta.maintainers = with lib.maintainers; [ aneeshusa ];
 }

--- a/nixos/tests/radicale.nix
+++ b/nixos/tests/radicale.nix
@@ -48,8 +48,9 @@ ht.save()
     '';
   };
 
-in import ./make-test.nix {
+in import ./make-test.nix ({ lib, ... }: {
   name = "radicale";
+  meta.maintainers = with lib.maintainers; [ aneeshusa ];
 
   # Test radicale with bcrypt-based htpasswd authentication
   nodes = {
@@ -76,4 +77,4 @@ in import ./make-test.nix {
       $machine->succeed('curl -s http://someuser:really_secret_password@127.0.0.1:${builtins.toString port}/someuser/calendar.ics/');
     }
   '';
-}
+})

--- a/nixos/tests/radicale.nix
+++ b/nixos/tests/radicale.nix
@@ -1,0 +1,70 @@
+let
+  port = 5232;
+  radicaleOverlay = self: super: {
+    radicale = super.radicale.overrideAttrs (oldAttrs: {
+      propagatedBuildInputs = with self.pythonPackages;
+        (oldAttrs.propagatedBuildInputs or []) ++ [
+          passlib
+        ];
+    });
+  };
+  common = { config, pkgs, ...}: {
+    services.radicale = {
+      enable = true;
+      config = let home = config.users.extraUsers.radicale.home; in ''
+        [server]
+        hosts = 127.0.0.1:${builtins.toString port}
+        daemon = False
+        [encoding]
+        [well-known]
+        [auth]
+        type = htpasswd
+        htpasswd_filename = /etc/radicale/htpasswd
+        htpasswd_encryption = bcrypt
+        [git]
+        [rights]
+        [storage]
+        type = filesystem
+        filesystem_folder = ${home}/collections
+        [logging]
+        [headers]
+      '';
+    };
+    # WARNING: DON'T DO THIS IN PRODUCTION!
+    # This puts secrets (albeit hashed) directly into the Nix store for ease of testing.
+    environment.etc."radicale/htpasswd".source = with pkgs; let
+      py = python.withPackages(ps: with ps; [ passlib ]);
+    in runCommand "htpasswd" {} ''
+        ${py}/bin/python -c "
+from passlib.apache import HtpasswdFile
+ht = HtpasswdFile(
+    '$out',
+    new=True,
+    default_scheme='bcrypt'
+)
+ht.set_password('someuser', 'really_secret_password')
+ht.save()
+"
+    '';
+  };
+
+in import ./make-test.nix {
+  name = "radicale";
+
+  # Test radicale with bcrypt-based htpasswd authentication
+  nodes = {
+    py2 = { config, pkgs, ... }@args: (common args) // {
+      nixpkgs.overlays = [
+        radicaleOverlay
+      ];
+    };
+  };
+
+  testScript = ''
+    for my $machine ($py2) {
+      $machine->waitForUnit('radicale.service');
+      $machine->waitForOpenPort(${builtins.toString port});
+      $machine->succeed('curl -s http://someuser:really_secret_password@127.0.0.1:${builtins.toString port}/someuser/calendar.ics/');
+    }
+  '';
+}

--- a/nixos/tests/radicale.nix
+++ b/nixos/tests/radicale.nix
@@ -58,10 +58,19 @@ in import ./make-test.nix {
         radicaleOverlay
       ];
     };
+    py3 = { config, pkgs, ... }@args: (common args) // {
+      nixpkgs.overlays = [
+        (self: super: {
+          python = self.python3;
+          pythonPackages = self.python3.pkgs;
+        })
+        radicaleOverlay
+      ];
+    };
   };
 
   testScript = ''
-    for my $machine ($py2) {
+    for my $machine ($py2, $py3) {
       $machine->waitForUnit('radicale.service');
       $machine->waitForOpenPort(${builtins.toString port});
       $machine->succeed('curl -s http://someuser:really_secret_password@127.0.0.1:${builtins.toString port}/someuser/calendar.ics/');

--- a/pkgs/development/python-modules/bcrypt.nix
+++ b/pkgs/development/python-modules/bcrypt.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, isPyPy, fetchurl
-, cffi, pycparser, mock, pytest, py }:
+, cffi, pycparser, mock, pytest, py, six }:
 
 with stdenv.lib;
 
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     sha256 = "1al54xafv1aharpb22yv5rjjc63fm60z3pn2shbiq48ah9f1fvil";
   };
   buildInputs = [ pycparser mock pytest py ];
-  propagatedBuildInputs = optional (!isPyPy) cffi;
+  propagatedBuildInputs = [ six ] ++ optional (!isPyPy) cffi;
 
   meta = {
     maintainers = with maintainers; [ domenkozar ];

--- a/pkgs/servers/radicale/default.nix
+++ b/pkgs/servers/radicale/default.nix
@@ -9,7 +9,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1c5lv8qca21mndkx350wxv34qypqh6gb4rhzms4anr642clq3jg2";
   };
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = stdenv.lib.optionals (!pythonPackages.isPy3k) [
     pythonPackages.flup
     pythonPackages.ldap
     pythonPackages.sqlalchemy

--- a/pkgs/servers/radicale/default.nix
+++ b/pkgs/servers/radicale/default.nix
@@ -29,6 +29,6 @@ pythonPackages.buildPythonApplication rec {
     '';
     license = licenses.gpl3Plus;
     platform = platforms.all;
-    maintainers = with maintainers; [ edwtjo pSub ];
+    maintainers = with maintainers; [ edwtjo pSub aneeshusa ];
   };
 }

--- a/pkgs/servers/radicale/default.nix
+++ b/pkgs/servers/radicale/default.nix
@@ -15,7 +15,7 @@ pythonPackages.buildPythonApplication rec {
     pythonPackages.sqlalchemy
   ];
 
-  doCheck = true;
+  doCheck = !pythonPackages.isPy3k;
 
   meta = with stdenv.lib; {
     homepage = http://www.radicale.org/;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8774,7 +8774,8 @@ in {
       sha256 = "1z27wdxs5rj5xhhqfzvzn3yg682irkxw6dcs5jj7mcf97psk8gd8";
     };
 
-    buildInputs = with self; [ nose pybcrypt];
+    buildInputs = with self; [ nose ];
+    propagatedBuildInputs = with self; [ bcrypt ];
 
     meta = {
       description = "A password hashing library for Python";


### PR DESCRIPTION
###### Motivation for this change

I attempted to run radicale on Python 3 and ran into some errors along the way. This PR has a few changes in separated commits:
- a new NixOS test for radicale
- fixes to enable building radicale on Python 3
- fixes for bcrypt
- package update for passlib

cc radicale maintainers @pSub @edwtjo 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

