### PR TITLE
Add option to power up bluetooth controller

### DIFF
--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -1,8 +1,11 @@
 { config, lib, pkgs, ... }:
 
 with lib;
+
 let
   bluez-bluetooth = pkgs.bluez;
+  cfg = config.hardware.bluetooth;
+
 in
 
 {
@@ -11,33 +14,53 @@ in
 
   options = {
 
-    hardware.bluetooth.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Whether to enable support for Bluetooth.";
+    hardware.bluetooth.enable = mkEnableOption "support for Bluetooth.";
+
+    hardware.bluetooth.powerOnBoot = mkOption {
+      type    = types.bool;
+      default = true;
+      description = "Whether to power up the default Bluetooth controller on boot.";
     };
 
   };
 
   ###### implementation
 
-  config = mkIf config.hardware.bluetooth.enable {
+  config = mkIf cfg.enable {
 
     environment.systemPackages = [ bluez-bluetooth pkgs.openobex pkgs.obexftp ];
 
     services.udev.packages = [ bluez-bluetooth ];
-
     services.dbus.packages = [ bluez-bluetooth ];
+    systemd.packages       = [ bluez-bluetooth ];
 
-    systemd.packages = [ bluez-bluetooth ];
+    services.udev.extraRules = optionalString cfg.powerOnBoot ''
+      ACTION=="add", KERNEL=="hci[0-9]*", ENV{SYSTEMD_WANTS}="bluetooth-power@%k.service"
+    '';
 
-    systemd.services.bluetooth = {
-      wantedBy = [ "bluetooth.target" ];
-      aliases = [ "dbus-org.bluez.service" ];
+    systemd.services = {
+      bluetooth = {
+        wantedBy = [ "bluetooth.target" ];
+        aliases  = [ "dbus-org.bluez.service" ];
+      };
+
+      "bluetooth-power@" = mkIf cfg.powerOnBoot {
+        description = "Power up bluetooth controller";
+        after = [
+          "bluetooth.service"
+          "suspend.target"
+          "sys-subsystem-bluetooth-devices-%i.device"
+        ];
+        wantedBy = [ "suspend.target" ];
+
+        serviceConfig.Type      = "oneshot";
+        serviceConfig.ExecStart = "${pkgs.bluez.out}/bin/hciconfig %i up";
+      };
+
     };
 
-    systemd.user.services.obex = {
-      aliases = [ "dbus-org.bluez.obex.service" ];
+    systemd.user.services = {
+      obex.aliases = [ "dbus-org.bluez.obex.service" ];
     };
 
   };


### PR DESCRIPTION
###### Motivation for this change
I have been using a udev rule to automatically power up the default bluetooth controller however after the upgrade to systemd 232 this method stopped working due to a change in the systemd-udevd unit.
A possible fix (found [here](https://bbs.archlinux.org/viewtopic.php?id=220315)) is to add `AF_BLUETOOTH` to the `RestrictAddressFamilies` option. 

So I added this fix and also an handy option which implements the power up rule.

###### Things done
I tested this change and it's working ok.

---

