### PR TITLE
diskscan: init at 0.19

### DIFF
--- a/pkgs/tools/misc/diskscan/default.nix
+++ b/pkgs/tools/misc/diskscan/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, cmake, ncurses, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "diskscan-${version}";
+  version = "0.19";
+
+  src = fetchFromGitHub {
+    owner  = "baruch";
+    repo   = "diskscan";
+    rev    = "${version}";
+    sha256 = "0yqpaxfahbjr8hr9xw7nngncwigy7yncdwnyp5wy9s9wdp8mrjra";
+  };
+
+  buildInputs = [ ncurses zlib ];
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/baruch/diskscan;
+    description = "Scan HDD/SSD for failed and near failed sectors";
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ peterhoeg ];
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -812,6 +812,8 @@ with pkgs;
 
   discount = callPackage ../tools/text/discount { };
 
+  diskscan = callPackage ../tools/misc/diskscan { };
+
   disorderfs = callPackage ../tools/filesystems/disorderfs {
     asciidoc = asciidoc-full;
   };


### PR DESCRIPTION
###### Motivation for this change

I unfortunately needed this...

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
