### PR TITLE
test-driver: remove old statedir

### DIFF
--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -8,7 +8,7 @@ use POSIX qw(dup2);
 use FileHandle;
 use Cwd;
 use File::Basename;
-use File::Path qw(make_path);
+use File::Path qw(make_path remove_tree);
 use File::Slurp;
 
 
@@ -68,6 +68,7 @@ sub new {
         redirectSerial => $args->{redirectSerial} // 1,
     };
 
+    remove_tree $self->{stateDir}, { verbose => 1 };
     mkdir $self->{stateDir}, 0700;
 
     bless $self, $class;


### PR DESCRIPTION
###### Motivation for this change

Usually, test-driver run as part of ```nix-build``` process producing reports and screenshots.
In this case all files it created are located in a temporary build directory managed by ```nix-build```.

If ```test-driver``` run without ```nix-build``` ([example1](https://github.com/NixOS/nixpkgs/issues/22648#issuecomment-279197330) [example2](https://github.com/NixOS/nixpkgs/issues/21745)), the consequential runs share the same state.
E.g. ```/tmp/vm-state-client/client.qcow2``` is the disk of VM with name ```client```.
On the next run, if the .qcow2 file is found it is reused instead of being created from scratch, thus the test results depend on the .qcow2 file existing and the state stored in it from the previous run of the test.

I propose to clean up all files which may be left there from the previous run to ensure they will not be reused.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

