### PR TITLE
bfg-repo-cleaner: init at 1.12.15

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -87,6 +87,7 @@
   cfouche = "Chaddaï Fouché <chaddai.fouche@gmail.com>";
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";
   chattered = "Phil Scott <me@philscotted.com>";
+  changlinli = "Changlin Li <mail@changlinli.com>";
   choochootrain = "Hurshal Patel <hurshal@imap.cc>";
   chris-martin = "Chris Martin <ch.martin@gmail.com>";
   chrisjefferson = "Christopher Jefferson <chris@bubblescope.net>";

--- a/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, jre, makeWrapper }:
+
+let
+  version = "1.12.15";
+  jarName = "bfg-${version}.jar";
+  mavenUrl = "http://central.maven.org/maven2/com/madgag/bfg/${version}/${jarName}";
+in
+  stdenv.mkDerivation {
+    inherit version jarName;
+
+    name = "bfg-repo-cleaner";
+
+    src = fetchurl {
+      url = mavenUrl;
+      sha256 = "17dh25jambkk55khknlhy8wa9s1i1xmh9hdgj72j1lzyl0ag42ik";
+    };
+
+    buildInputs = [ jre makeWrapper ];
+
+    phases = "installPhase";
+
+    installPhase = ''
+      mkdir -p $out/share/java
+      mkdir -p $out/bin
+      cp $src $out/share/java/$jarName
+      makeWrapper "${jre}/bin/java" $out/bin/bfg --add-flags "-cp $out/share/java/$jarName com.madgag.git.bfg.cli.Main"
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = "https://rtyley.github.io/bfg-repo-cleaner/";
+      # Descriptions taken with minor modification from the homepage of bfg-repo-cleaner
+      description = "Removes large or troublesome blobs in a git repository like git-filter-branch does, but faster";
+      longDescription = ''
+        The BFG is a simpler, faster alternative to git-filter-branch for
+        cleansing bad data out of your Git repository history, in particular removing
+        crazy big files and removing passwords, credentials, and other private data.
+
+        The git-filter-branch command is enormously powerful and can do things
+        that the BFG can't - but the BFG is much better for the tasks above, because
+        it's faster (10-720x), simpler (dedicated to just removing things), and
+        beautiful (can use Scala instead of bash to script customizations).
+      '';
+      license = licenses.gpl3;
+      maintainers = [ maintainers.changlinli ];
+      platforms = platforms.unix;
+      downloadPage = "https://mvnrepository.com/artifact/com.madgag/bfg/${version}";
+    };
+
+  }

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -22,6 +22,8 @@ in
 rec {
   # Try to keep this generally alphabetized
 
+  bfg-repo-cleaner = callPackage ./bfg-repo-cleaner { };
+
   bitbucket-server-cli = callPackage ./bitbucket-server-cli { };
 
   darcsToGit = callPackage ./darcs-to-git { };


### PR DESCRIPTION
###### Motivation for this change

Packaging up the BFG repo cleaner for Git (a nice little git-history-rewrite tool that's a fast way of removing unwanted data from git history).

Tested by building `nix-build -A gitAndTools.bfg-repo-cleaner <my local nixpkgs>/default.nix` and deleting a file from the history one of my git repos.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

