### PR TITLE
service-runner: try to setuid when started as root

### DIFF
--- a/nixos/modules/testing/service-runner.nix
+++ b/nixos/modules/testing/service-runner.nix
@@ -9,6 +9,7 @@ let
       #! ${pkgs.perl}/bin/perl -w -I${pkgs.perlPackages.FileSlurp}/lib/perl5/site_perl
 
       use File::Slurp;
+      use POSIX;
 
       sub run {
           my ($cmd) = @_;
@@ -54,6 +55,19 @@ let
           my $res = run_wait $preStart;
           die "$0: ExecStartPre failed with status $res\n" if $res;
       };
+
+      if ($< eq 0) {
+        my $user = '${service.serviceConfig.User or ""}';
+        if ($user ne "") {
+          my $uid = getpwnam($user);
+          setuid($uid) if $uid;
+        }
+        my $group = '${service.serviceConfig.Group or ""}';
+        if ($group ne "") {
+          my $gid = getgrnam($group);
+          setgid($gid) if $gid;
+        }
+      }
 
       # Run the ExecStart program.
       my $cmd = '${service.serviceConfig.ExecStart}';


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

