### PR TITLE
openshot-qt: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/applications/video/openshot-qt/default.nix
+++ b/pkgs/applications/video/openshot-qt/default.nix
@@ -1,26 +1,24 @@
-{stdenv, fetchurl, fetchFromGitHub, callPackage, makeWrapper, doxygen
-, ffmpeg, python3Packages, libopenshot, qtbase, qtmultimedia }:
+{ stdenv, fetchFromGitHub
+, doxygen, python3Packages, ffmpeg, libopenshot
+, qtbase, qtmultimedia, makeQtWrapper }:
 
 with stdenv.lib;
-
 stdenv.mkDerivation rec {
   name = "openshot-qt-${version}";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "openshot-qt";
     rev = "v${version}";
-    sha256 = "1cyr5m1n6qcb9bzkhh3v6ka91a6x9c50dl5j0ilrc8vj0mb43g8c";
+    sha256 = "0dg4fkkci1rz49yrdd4fa1whv10c1pgm3cl4i49452ckqa7qg037";
   };
+    
+  buildInputs =
+  [ python3Packages.python ffmpeg libopenshot qtbase qtmultimedia ];
 
-  buildInputs = [doxygen python3Packages.python makeWrapper ffmpeg];
-
-  propagatedBuildInputs = [
-    qtbase
-    qtmultimedia
-    libopenshot
-  ];
+  nativeBuildInputs =
+  [ doxygen makeQtWrapper ];
 
   installPhase = ''
     mkdir -p $(toPythonPath $out)
@@ -29,17 +27,24 @@ stdenv.mkDerivation rec {
     echo "#/usr/bin/env sh" >$out/bin/openshot-qt
     echo "exec ${python3Packages.python.interpreter} $(toPythonPath $out)/launch.py" >>$out/bin/openshot-qt
     chmod +x $out/bin/openshot-qt
-    wrapProgram $out/bin/openshot-qt \
+    wrapQtProgram $out/bin/openshot-qt \
       --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${libopenshot}):$(toPythonPath ${python3Packages.pyqt5}):$(toPythonPath ${python3Packages.sip}):$(toPythonPath ${python3Packages.httplib2}):$(toPythonPath ${python3Packages.pyzmq}):$PYTHONPATH"
   '';
 
   doCheck = false;
 
   meta = {
-    homepage = "http://openshot.org/";
+    homepage = http://openshot.org/;
     description = "Free, open-source video editor";
-    license = licenses.gpl3Plus;
-    maintainers = [];
-    platforms = platforms.linux;
+    longDescription = ''
+      OpenShot Video Editor is a free, open-source video editor for Linux.
+      OpenShot can take your videos, photos, and music files and help you
+      create the film you have always dreamed of. Easily add sub-titles,
+      transitions, and effects, and then export your film to DVD, YouTube,
+      Vimeo, Xbox 360, and many other common formats.
+    '';
+    license = with licenses; gpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
@@ -1,8 +1,7 @@
-{stdenv, fetchurl, fetchFromGitHub, cmake, doxygen
-, libX11, libXft, libXrandr, libXinerama, libXext, libXcursor, alsaLib}:
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, doxygen, alsaLib
+, libX11, libXft, libXrandr, libXinerama, libXext, libXcursor }:
 
 with stdenv.lib;
-
 stdenv.mkDerivation rec {
   name = "libopenshot-audio-${version}";
   version = "0.1.2";
@@ -14,18 +13,24 @@ stdenv.mkDerivation rec {
     sha256 = "0dxyhnqkjc5y4hra8s17q9lafll6fx0pgibmmjznjm70whqcj8a6";
   };
 
-  buildInputs = [
-    cmake doxygen
-    libX11 libXft libXrandr libXinerama libXext libXcursor alsaLib
-  ];
+  nativeBuildInputs =
+  [ pkgconfig cmake doxygen ];
+
+  buildInputs =
+  [ alsaLib libX11 libXft libXrandr libXinerama libXext libXcursor ];
 
   doCheck = false;
 
   meta = {
-    homepage = "http://openshot.org/";
-    description = "Free, open-source video editor";
-    license = licenses.gpl3Plus;
-    maintainers = [];
-    platforms = platforms.linux;
+    homepage = http://openshot.org/;
+    description = "High-quality sound editing library";
+    longDescription = ''
+      OpenShot Audio Library (libopenshot-audio) is a program that allows the
+      high-quality editing and playback of audio, and is based on the amazing
+      JUCE library.
+    '';
+    license = with licenses; gpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -1,22 +1,20 @@
-{ stdenv, fetchurl, fetchFromGitHub, callPackage, cmake, doxygen
-, imagemagick, ffmpeg, qtbase, qtmultimedia, swig, python3, ruby, unittest-cpp
-, cppzmq, czmqpp
-}:
+{ stdenv, fetchFromGitHub
+, pkgconfig, cmake, doxygen
+, libopenshot-audio, imagemagick, ffmpeg
+, swig, python3, ruby
+, unittest-cpp, cppzmq, czmqpp
+, qtbase, qtmultimedia }:
 
 with stdenv.lib;
-
-let
-  libopenshot_audio = callPackage ./libopenshot-audio.nix {};
-in
 stdenv.mkDerivation rec {
   name = "libopenshot-${version}";
-  version = "0.1.2";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "libopenshot";
     rev = "v${version}";
-    sha256 = "00051ipb8y4z9j5m5smwm1ahv755k0glarwic8fv5b9fzryfbrdm";
+    sha256 = "0slszl6w96rhxhi6agw85dc4gmpab2qw03mq32g4qrirz68anz6f";
   };
 
   patchPhase = ''
@@ -27,22 +25,27 @@ stdenv.mkDerivation rec {
     export RUBY_VENDOR_ARCH_DIR=$out/lib/ruby/site-packages
   '';
 
-  buildInputs = [
-    cmake doxygen
-    imagemagick ffmpeg qtbase qtmultimedia swig python3 ruby
-    unittest-cpp cppzmq czmqpp
-  ];
+  nativeBuildInputs = [ pkgconfig cmake doxygen ];
 
-  LIBOPENSHOT_AUDIO_DIR = "${libopenshot_audio}";
+  buildInputs =
+  [ imagemagick ffmpeg swig python3 ruby unittest-cpp
+    cppzmq czmqpp qtbase qtmultimedia ];
+
+  LIBOPENSHOT_AUDIO_DIR = "${libopenshot-audio}";
   "UNITTEST++_INCLUDE_DIR" = "${unittest-cpp}/include/UnitTest++";
 
   doCheck = false;
 
   meta = {
-    homepage = "http://openshot.org/";
-    description = "Free, open-source video editor";
-    license = licenses.gpl3Plus;
-    maintainers = [];
-    platforms = platforms.linux;
+    homepage = http://openshot.org/;
+    description = "Free, open-source video editor library";
+    longDescription = ''
+      OpenShot Library (libopenshot) is an open-source project dedicated to
+      delivering high quality video editing, animation, and playback solutions
+      to the world. API currently supports C++, Python, and Ruby.
+    '';
+    license = with licenses; gpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5329,7 +5329,7 @@ with pkgs;
   jdk = jdk8;
   jre = jre8;
   jre_headless = jre8_headless;
-
+  
   openshot-qt = libsForQt56.callPackage ../applications/video/openshot-qt { };
 
   oraclejdk = pkgs.jdkdistro true false;
@@ -9517,7 +9517,9 @@ with pkgs;
 
     libktorrent = callPackage ../development/libraries/libktorrent { };
 
-    libopenshot = callPackage ../applications/video/openshot-qt/libopenshot.nix {};
+    libopenshot = callPackage ../applications/video/openshot-qt/libopenshot.nix { };
+
+    libopenshot-audio = callPackage ../applications/video/openshot-qt/libopenshot-audio.nix { };
 
     mlt = callPackage ../development/libraries/mlt/qt-5.nix {
       ffmpeg = ffmpeg_2;


### PR DESCRIPTION
Also, libopenshot: 0.1.2 -> 0.1.3

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

