### PR TITLE
garmin-uploader: init at version 1.0.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7155,6 +7155,26 @@ in {
     };
   };
 
+  garmin-uploader = buildPythonApplication rec {
+    name = "garmin-uploader-${version}";
+    version = "1.0.1";
+
+    meta = {
+      homepage = "https://github.com/La0/garmin-uploader";
+      description = "A tool to upload FIT, GPX, and TCX files to the Garmin Connect web site";
+      license = licenses.gpl2;
+    };
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/La0/garmin-uploader/archive/${version}.tar.gz";
+      sha256 = "1x8vqlx01m86kcj1lvr2g93qyrrgmj7227fwd8xm2d4bphrwxal6";
+    };
+
+    buildInputs = [ self.pytestrunner ];
+    propagatedBuildInputs = with self; [ requests2 six ];
+  };
+
+
   gateone = buildPythonPackage rec {
     name = "gateone-1.2-0d57c3";
     disabled = ! isPy27;


### PR DESCRIPTION
###### Motivation for this change

Add garmin-uploader (`gupload`) to nixpkgs.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

