### PR TITLE
antfs-cli and openant: init at unstable-2017-02-11

### DIFF
--- a/pkgs/applications/misc/antfs-cli/default.nix
+++ b/pkgs/applications/misc/antfs-cli/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "antfs-cli-unstable-2017-02-11";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Tigge/antfs-cli";
+    description = "Extracts FIT files from ANT-FS based sport watches";
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+
+  src = fetchFromGitHub {
+    owner = "Tigge";
+    repo = "antfs-cli";
+    rev = "85a6cc6fe6fc0ec38399f5aa30fb39177c565b52";
+    sha256 = "0v8y64kldfbs809j1g9d75dd1vxq7mfxnp4b45pz8anpxhjf64fy";
+  };
+
+  propagatedBuildInputs = [ pythonPackages.openant ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12457,6 +12457,8 @@ with pkgs;
     };
   };
 
+  antfs-cli = callPackage ../applications/misc/antfs-cli {};
+
   antimony = qt5.callPackage ../applications/graphics/antimony {};
 
   antiword = callPackage ../applications/office/antiword {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4659,6 +4659,37 @@ in {
     };
   };
 
+  openant = buildPythonPackage rec {
+    name = "openant-unstable-2017-02-11";
+
+    meta = with stdenv.lib; {
+      homepage = "https://github.com/Tigge/openant";
+      description = "ANT and ANT-FS Python Library";
+      license = licenses.mit;
+      platforms = platforms.linux;
+    };
+
+    src = pkgs.fetchFromGitHub {
+      owner = "Tigge";
+      repo = "openant";
+      rev = "ed89281e37f65d768641e87356cef38877952397";
+      sha256 = "1g81l9arqdy09ijswn3sp4d6i3z18d44lzyb78bwnvdb14q22k19";
+    };
+
+    # Removes some setup.py hacks intended to install udev rules.
+    # We do the job ourselves in postInstall below.
+    postPatch = ''
+      sed -i -e '/cmdclass=.*/d' setup.py
+    '';
+
+    postInstall = ''
+      install -dm755 "$out/etc/udev/rules.d"
+      install -m644 resources/ant-usb-sticks.rules "$out/etc/udev/rules.d/99-ant-usb-sticks.rules"
+    '';
+
+    propagatedBuildInputs = with self; [ pyusb ];
+  };
+
   opencv = pkgs.opencv.override {
     enablePython = true;
     pythonPackages = self;


### PR DESCRIPTION
###### Motivation for this change

Adds `antfs-cli` and the `openant` library it depends on to nixpkgs.

These packages seem to not have had any formal release and their version numbers haven't been updated in a long time, so I decided to package them as a Git snapshot rather than aiming for a particular (non-existent) release.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

