### PR TITLE
xen: update domU config for pvgrub2

### DIFF
--- a/nixos/modules/virtualisation/xen-domU.nix
+++ b/nixos/modules/virtualisation/xen-domU.nix
@@ -3,11 +3,8 @@
 { config, pkgs, ... }:
 
 {
-  # We're being booted using pv-grub, which means that we need to
-  # generate a GRUB 1 menu without actually installing GRUB.
-  boot.loader.grub.version = 1;
+  boot.loader.grub.version = 2;
   boot.loader.grub.device = "nodev";
-  boot.loader.grub.extraPerEntryConfig = "root (hd0)";
 
   boot.initrd.kernelModules =
     [ "xen-blkfront" "xen-tpmfront" "xen-kbdfront" "xen-fbfront"


### PR DESCRIPTION
fix #22709

Recent pvgrub (from Grub built with “--with-platform=xen”) understands
the Grub2 configuration format. Grub legacy configuration (menu.lst) is
ignored.

###### Motivation for this change

See the related report https://github.com/NixOS/nixpkgs/issues/22709

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

