### PR TITLE
worker: init at 3.8.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -336,6 +336,7 @@
   Nate-Devv = "Nathan Moore <natedevv@gmail.com>";
   nathan-gs = "Nathan Bijnens <nathan@nathan.gs>";
   nckx = "Tobias Geerinckx-Rice <tobias.geerinckx.rice@gmail.com>";
+  ndowens = "Nathan Owens <ndowens04@gmail.com>";
   nequissimus = "Tim Steinbach <tim@nequissimus.com>";
   nfjinjing = "Jinjing Wang <nfjinjing@gmail.com>";
   nhooyr = "Anmol Sethi <anmol@aubble.com>";

--- a/pkgs/applications/misc/worker/default.nix
+++ b/pkgs/applications/misc/worker/default.nix
@@ -4,12 +4,12 @@ stdenv.mkDerivation rec {
   name = "worker";
   version = "3.8.5";
 
- src = fetchurl {
-   url = "http://www.boomerangsworld.de/cms/worker/downloads/${name}-${version}.tar.gz";
-   sha256 = "1xy02jdf60wg2jycinl6682xg4zvphdj80f8xgs26ip45iqgkmvw";
-};
+  src = fetchurl {
+    url = "http://www.boomerangsworld.de/cms/worker/downloads/${name}-${version}.tar.gz";
+    sha256 = "1xy02jdf60wg2jycinl6682xg4zvphdj80f8xgs26ip45iqgkmvw";
+  };
 
-buildInputs = with pkgs; [ xorg.libX11 ];
+  buildInputs = with pkgs; [ xorg.libX11 ];
 
   meta = with stdenv.lib; {
     description = "a two-pane file manager with advanced file manipulation features";

--- a/pkgs/applications/misc/worker/default.nix
+++ b/pkgs/applications/misc/worker/default.nix
@@ -1,0 +1,20 @@
+{pkgs, stdenv, xorg, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "worker";
+  version = "3.8.5";
+
+ src = fetchurl {
+   url = "http://www.boomerangsworld.de/cms/worker/downloads/${name}-${version}.tar.gz";
+   sha256 = "1xy02jdf60wg2jycinl6682xg4zvphdj80f8xgs26ip45iqgkmvw";
+};
+
+buildInputs = with pkgs; [ xorg.libX11 ];
+
+  meta = with stdenv.lib; {
+    description = "a two-pane file manager with advanced file manipulation features";
+    homepage = "http://www.boomerangsworld.de/cms/worker/index.html";
+    license =  licenses.gpl2;
+    maintainers = [ maintainers.ndowens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15588,6 +15588,8 @@ with pkgs;
   wmii_hg = callPackage ../applications/window-managers/wmii-hg { };
 
   wordnet = callPackage ../applications/misc/wordnet { };
+  
+  worker = callPackage ../applications/misc/worker { };
 
   workrave = callPackage ../applications/misc/workrave {
     inherit (gnome2) GConf gconfmm;


### PR DESCRIPTION
###### Motivation for this change


###### Things done
Add worker FM to repo
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

