### PR TITLE
Fix sessions with sddm.

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -32,6 +32,9 @@ let
     ''
       #! ${pkgs.bash}/bin/bash
 
+      # Handle being called by SDDM.
+      if test "''${1:0:1}" = / ; then eval exec $1 $2 ; fi
+
       ${optionalString cfg.displayManager.logToJournal ''
         if [ -z "$_DID_SYSTEMD_CAT" ]; then
           _DID_SYSTEMD_CAT=1 exec ${config.systemd.package}/bin/systemd-cat -t xsession -- "$0" "$@"


### PR DESCRIPTION
###### Motivation for this change

From email:

> The sddm must be handled separately (as with kdm) in the xsession start
> script because it treats the Exec line in the .desktop file as a
> parameter and not a command, and due to the in the current master
> branch sddm cannot start a session.  The attached patch fixes this.