### PR TITLE
openblas: disable static libs

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -98,6 +98,7 @@ stdenv.mkDerivation {
       ''PREFIX="''$(out)"''
       "NUM_THREADS=64"
       "INTERFACE64=${if blas64 then "1" else "0"}"
+      "NO_STATIC=1"
     ]
     ++ mapAttrsToList (var: val: var + "=" + val) config;
 


### PR DESCRIPTION
Disable static on openblas. This should save about 57M from closure sizes.

###### Motivation for this change

openblas adds quite a bit to some bundles in [nix-bundle](https://github.com/matthewbauer/nix-bundle). Hopefully this helps.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Here are the sizes:

```
$ du -shL /nix/store/*-openblas-0.2.19
(old) 92M     /nix/store/...-openblas-0.2.19
(new) 35M     /nix/store/...-openblas-0.2.19
```
---
