### PR TITLE
network-interfaces service: fix bindsTo deps for masters

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -49,7 +49,8 @@ in
         deviceDependency = dev:
           # Use systemd service if we manage device creation, else
           # trust udev when not in a container
-          if (hasAttr dev cfg.bridges) ||
+          if (hasAttr dev (filterAttrs (k: v: v.virtual) cfg.interfaces)) ||
+             (hasAttr dev cfg.bridges) ||
              (hasAttr dev cfg.bonds) ||
              (hasAttr dev cfg.macvlans) ||
              (hasAttr dev cfg.sits) ||

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -47,21 +47,17 @@ in
       let
 
         deviceDependency = dev:
-          if (config.boot.isContainer == false)
-          then
-            # Trust udev when not in the container
-            optional (dev != null) (subsystemDevice dev)
-          else
-            # When in the container, check whether the interface is built from other definitions
-            if (hasAttr dev cfg.bridges) ||
-               (hasAttr dev cfg.bonds) ||
-               (hasAttr dev cfg.macvlans) ||
-               (hasAttr dev cfg.sits) ||
-               (hasAttr dev cfg.vlans) ||
-               (hasAttr dev cfg.vswitches) ||
-               (hasAttr dev cfg.wlanInterfaces)
-            then [ "${dev}-netdev.service" ]
-            else [];
+          # Use systemd service if we manage device creation, else
+          # trust udev when not in a container
+          if (hasAttr dev cfg.bridges) ||
+             (hasAttr dev cfg.bonds) ||
+             (hasAttr dev cfg.macvlans) ||
+             (hasAttr dev cfg.sits) ||
+             (hasAttr dev cfg.vlans) ||
+             (hasAttr dev cfg.vswitches) ||
+             (hasAttr dev cfg.wlanInterfaces)
+          then [ "${dev}-netdev.service" ]
+          else optional (dev != null && !config.boot.isContainer) (subsystemDevice dev);
 
         networkLocalCommands = {
           after = [ "network-setup.service" ];
@@ -198,7 +194,7 @@ in
               user "${i.virtualOwner}"
             '';
             postStop = ''
-              ip link del ${i.name}
+              ip link del ${i.name} || true
             '';
           };
 
@@ -335,7 +331,7 @@ in
               ip link set "${n}" up
             '';
             postStop = ''
-              ip link delete "${n}"
+              ip link delete "${n}" || true
             '';
           });
 
@@ -363,7 +359,7 @@ in
               ip link set "${n}" up
             '';
             postStop = ''
-              ip link delete "${n}"
+              ip link delete "${n}" || true
             '';
           });
 
@@ -387,7 +383,7 @@ in
               ip link set "${n}" up
             '';
             postStop = ''
-              ip link delete "${n}"
+              ip link delete "${n}" || true
             '';
           });
 


### PR DESCRIPTION
###### Motivation for this change

Previously, netdev units for network interfaces defined in the nixos configurations would bindTo the systemd device unit of the interface if not in a container.

In situations where you switch to a new nixos configration with changes to network-setup.service (like nameservers) and have stacked interfaces like vlans on a bond, it would fail to propagate restarts to the netdevs correctly resulting in broken networking. The bond would be present but no vlan interfaces rendering the machine unreachable.

My fear is that the udev events fail to propagate correctly while a systemd transaction that is also restarting the triggered netdev service is running. This commit changes this behaviour so netdev services bindTo other netdev services if present and otherwise fall back to the previous behaviour.

We also noticed that stacked interfaces would sometimes seemingly be stopped in the wrong order. For instance in the above example, the bond interface would be deleted before the vlan interfaces resulting in the vlan interfaces not being present when their service is being stopped. This would cause the systemd transaction to fail and thus break networking. Their postStop hooks are now allowed to fail as we have reached the desired state.