### PR TITLE
epic5: init at 2.0.1

### DIFF
--- a/pkgs/applications/misc/worker/default.nix
+++ b/pkgs/applications/misc/worker/default.nix
@@ -4,12 +4,12 @@ stdenv.mkDerivation rec {
   name = "worker";
   version = "3.8.5";
 
- src = fetchurl {
-   url = "http://www.boomerangsworld.de/cms/worker/downloads/${name}-${version}.tar.gz";
-   sha256 = "1xy02jdf60wg2jycinl6682xg4zvphdj80f8xgs26ip45iqgkmvw";
-};
+  src = fetchurl {
+    url = "http://www.boomerangsworld.de/cms/worker/downloads/${name}-${version}.tar.gz";
+    sha256 = "1xy02jdf60wg2jycinl6682xg4zvphdj80f8xgs26ip45iqgkmvw";
+  };
 
-buildInputs = with pkgs; [ xorg.libX11 ];
+  buildInputs = with pkgs; [ xorg.libX11 ];
 
   meta = with stdenv.lib; {
     description = "a two-pane file manager with advanced file manipulation features";

--- a/pkgs/applications/networking/irc/epic5/default.nix
+++ b/pkgs/applications/networking/irc/epic5/default.nix
@@ -1,0 +1,29 @@
+{stdenv, fetchurl, pkgs, openssl
+  , ncurses, libiconv, tcl }:
+
+stdenv.mkDerivation rec {
+  name = "epic5-${version}";
+  version = "2.0.1";
+
+  src = fetchurl {
+    url = "http://ftp.epicsol.org/pub/epic/EPIC5-PRODUCTION/${name}.tar.xz";
+    sha256 = "1ap73d5f4vccxjaaq249zh981z85106vvqmxfm4plvy76b40y9jm";
+    };
+
+  buildInputs =  [ openssl ncurses libiconv tcl ];
+  postConfigure = ''
+      substituteInPlace bsdinstall \
+      --replace /bin/cp cp \
+      --replace /bin/rm rm \
+      --replace /bin/chmod chmod \
+      '';
+  meta = with stdenv.lib; {
+    homepage = "http://epicsol.org/";
+    description = "a IRC client that offers a great ircII interface";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.ndowens ];
+  };
+}
+
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13154,6 +13154,8 @@ with pkgs;
 
   inherit (gnome3) epiphany;
 
+  epic5 = callPackage  ../applications/networking/irc/epic5 { };
+
   eq10q = callPackage ../applications/audio/eq10q { };
 
   errbot = callPackage ../applications/networking/errbot {


### PR DESCRIPTION
###### Motivation for this change
Add Epic5 to nixpkgs

###### Things done

- [ x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

