### PR TITLE
epic5: init at 2.0.1

### DIFF
--- a/pkgs/applications/networking/irc/epic5/default.nix
+++ b/pkgs/applications/networking/irc/epic5/default.nix
@@ -1,0 +1,34 @@
+{stdenv, fetchurl, pkgs, openssl
+  , ncurses, libiconv, tcl }:
+
+stdenv.mkDerivation rec {
+  name = "epic5-${version}";
+  version = "2.0.1";
+
+  src = fetchurl {
+    url = "http://ftp.epicsol.org/pub/epic/EPIC5-PRODUCTION/${name}.tar.xz";
+    sha256 = "1ap73d5f4vccxjaaq249zh981z85106vvqmxfm4plvy76b40y9jm";
+    };
+
+   # Darwin needs libiconv, tcl; while Linux build don't
+ 
+   buildInputs = [ openssl ncurses ]  
+   ++ stdenv.lib.optionals 
+   stdenv.isDarwin [ libiconv tcl ];
+  
+  postConfigure = ''
+      substituteInPlace bsdinstall \
+      --replace /bin/cp cp \
+      --replace /bin/rm rm \
+      --replace /bin/chmod chmod \
+      '';
+  meta = with stdenv.lib; {
+    homepage = "http://epicsol.org/";
+    description = "a IRC client that offers a great ircII interface";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.ndowens ];
+  };
+}
+
+
+

--- a/pkgs/applications/networking/irc/epic5/default.nix
+++ b/pkgs/applications/networking/irc/epic5/default.nix
@@ -1,5 +1,4 @@
-{stdenv, fetchurl, pkgs, openssl
-  , ncurses, libiconv, tcl }:
+{ stdenv, fetchurl, openssl, ncurses, libiconv, tcl }:
 
 stdenv.mkDerivation rec {
   name = "epic5-${version}";
@@ -8,20 +7,21 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "http://ftp.epicsol.org/pub/epic/EPIC5-PRODUCTION/${name}.tar.xz";
     sha256 = "1ap73d5f4vccxjaaq249zh981z85106vvqmxfm4plvy76b40y9jm";
-    };
+  };
 
-   # Darwin needs libiconv, tcl; while Linux build don't
- 
-   buildInputs = [ openssl ncurses ]  
-   ++ stdenv.lib.optionals 
-   stdenv.isDarwin [ libiconv tcl ];
-  
+  # Darwin needs libiconv, tcl; while Linux build don't
+  buildInputs = [ openssl ncurses ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv tcl ];
+
+  configureFlags = [ "--disable-debug" "--with-ipv6" ];
+
   postConfigure = ''
-      substituteInPlace bsdinstall \
+    substituteInPlace bsdinstall \
       --replace /bin/cp cp \
       --replace /bin/rm rm \
-      --replace /bin/chmod chmod \
-      '';
+      --replace /bin/chmod chmod
+  '';
+
   meta = with stdenv.lib; {
     homepage = "http://epicsol.org/";
     description = "a IRC client that offers a great ircII interface";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13154,6 +13154,8 @@ with pkgs;
 
   inherit (gnome3) epiphany;
 
+  epic5 = callPackage ../applications/networking/irc/epic5 { };
+  
   eq10q = callPackage ../applications/audio/eq10q { };
 
   errbot = callPackage ../applications/networking/errbot {


### PR DESCRIPTION
###### Motivation for this change

Add Epic5 to nixpkg repo

###### Things done

- [ x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] Linux
- [x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

