### PR TITLE
buildRustPackage: fix fetch-cargo-deps when no Cargo dependencies

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-deps
+++ b/pkgs/build-support/rust/fetch-cargo-deps
@@ -97,6 +97,10 @@ EOF
                   "registry+file:///dev/null"
     mv Cargo.lock $out/
 
+    # If there are no Cargo dependencies create an empty dummy rust registry
+    if [[ -z "$(echo $out/registry/cache/*)" ]]; then
+      mkdir -p $out/registry/cache/DUMMY
+    fi
 
     # Let's replace $indexHash with something more deterministic
     mv $out/registry/cache/* $out/registry/cache/HASH


### PR DESCRIPTION
###### Motivation for this change

`buildRustPackage` fails for projects that declare no dependencies in `Cargo.toml`.

Try building this [example][example] project:

```
❯ nix-build release.nix -A build --arg nixpkgs '<nixpkgs>' --argstr system x86_64-linux
these derivations will be built:
  /nix/store/dw177b3in0rmfsx237jlzqimbjmcxrpk-ill-fetch.drv
  /nix/store/c4klqbmccg501naxznl48w24hpazgdc1-ill.drv
building path(s) ‘/nix/store/dy1dywfq2mh035z4v0phmx0kg7p066cw-ill-fetch’
unpacking sources
unpacking source archive /nix/store/q6b7iql14yafz8j2hqq3x4g6fzpdamxy-ill
source root is ill
installing
Fetching /tmp/nix-build-ill-fetch.drv-0/ill to /nix/store/dy1dywfq2mh035z4v0phmx0kg7p066cw-ill-fetch
Using rust registry from /nix/store/ri6jzyj02dw56zr5bk9yvaci6zr4g7vw-rustRegistry-2017-01-27-6a73a15
warning: custom registry support via the `registry.index` configuration is being removed, this functionality will not work in the future
mv: missing destination file operand after '/nix/store/dy1dywfq2mh035z4v0phmx0kg7p066cw-ill-fetch/registry/cache/HASH'
Try 'mv --help' for more information.
builder for ‘/nix/store/dw177b3in0rmfsx237jlzqimbjmcxrpk-ill-fetch.drv’ failed with exit code 1
cannot build derivation ‘/nix/store/c4klqbmccg501naxznl48w24hpazgdc1-ill.drv’: 1 dependencies couldn't be built
error: build of ‘/nix/store/c4klqbmccg501naxznl48w24hpazgdc1-ill.drv’ failed
```

[example]: http://bitbucket.org/dermetfan/ill

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).