### PR TITLE
google-cloud-sdk: support x86_64-darwin

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -3,7 +3,7 @@
 with python27Packages;
 
 # other systems not supported yet
-assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
+assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux" || stdenv.system == "x86_64-darwin";
 
 stdenv.mkDerivation rec {
   name = "google-cloud-sdk-${version}";
@@ -14,6 +14,11 @@ stdenv.mkDerivation rec {
       fetchurl {
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-linux-x86.tar.gz";
         sha256 = "1z2v4bg743qkdlmyyy0z2j5s0g10vbc1643gxrhyz491sk6sp616";
+      }
+    else if stdenv.system == "x86_64-darwin" then
+      fetchurl {
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-darwin-x86_64.tar.gz";
+        sha256 = "efbe2074da5a544c09b6bf87a8ca045dc429ac38dfcd5380561987769491d5ba";
       }
     else
       fetchurl {
@@ -58,6 +63,6 @@ stdenv.mkDerivation rec {
     license = licenses.free;
     homepage = "https://cloud.google.com/sdk/";
     maintainers = with maintainers; [stephenmw zimbatm];
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I'd like to use *gcloud* command on macOS.

###### Things done

Though I've tested with `build-use-sandbox = true` environment, installation stops with an error:

> error: while setting up the build environment: changing into ‘/private/var/folders/nm/l0vy_ycj3pn0xzchk6hfyt140000gn/T/nix-build-python2.7-crcmod-1.7.drv-0’: No such file or directory

This problem seems to be NixOS/nix#759

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] macOS
   - [x] No changes for other platforms
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

