### PR TITLE
gajim: use libasyncns as resolver

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -2,7 +2,7 @@
 , ldns, pythonPackages
 
 # Test requirements
-, xvfb_run, dnsutils
+, xvfb_run
 
 , enableJingle ? true, farstream ? null, gst_plugins_bad ? null
 ,                      libnice ? null
@@ -63,9 +63,8 @@ stdenv.mkDerivation rec {
         }$GST_PLUGIN_PATH"'"
     }' scripts/gajim.in
 
-    sed -i -e 's/return helpers.is_in_path('"'"'drill.*/return True/' \
-      src/features_window.py
-    sed -i -e "s|'drill'|'${ldns}/bin/drill'|" src/common/resolver.py
+    # requires network access
+    echo "" > test/integration/test_resolver.py
 
     # We want to run tests in installCheckPhase rather than checkPhase to test
     # whether the *installed* version of Gajim works rather than just whether it
@@ -83,19 +82,20 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook pythonPackages.wrapPython intltool pkgconfig
     # Test dependencies
-    xvfb_run dnsutils
+    xvfb_run
   ];
 
   autoreconfPhase = ''
     sed -e 's/which/type -P/;s,\./configure,:,' autogen.sh | bash
   '';
 
-  propagatedBuildInputs = [
-    pythonPackages.pygobject2 pythonPackages.pyGtkGlade
-    pythonPackages.pyasn1
-    pythonPackages.pyxdg
-    pythonPackages.nbxmpp
-    pythonPackages.pyopenssl pythonPackages.dbus-python
+  propagatedBuildInputs = with pythonPackages; [
+    libasyncns
+    pygobject2 pyGtkGlade
+    pyasn1
+    pyxdg
+    nbxmpp
+    pyopenssl dbus-python
   ] ++ optional enableE2E pythonPackages.pycrypto
     ++ optional enableRST pythonPackages.docutils
     ++ optional enableNotifications pythonPackages.notify

--- a/pkgs/development/python-modules/libasyncns.nix
+++ b/pkgs/development/python-modules/libasyncns.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchurl
+, libasyncns, pkgconfig }:
+
+buildPythonPackage rec {
+  name = "libasyncns-python-${version}";
+  version = "0.7.1";
+
+  src = fetchurl {
+    url = "https://launchpad.net/libasyncns-python/trunk/${version}/+download/libasyncns-python-${version}.tar.bz2";
+    sha256 = "1q4l71b2h9q756x4pjynp6kczr2d8c1jvbdp982hf7xzv7w5gxqg";
+  };
+
+  buildInputs = [ libasyncns ];
+  nativeBuildInputs = [ pkgconfig ];
+  doCheck = false; # requires network access
+
+  meta = with stdenv.lib; {
+    description = "libasyncns-python is a python binding for the asynchronous name service query library";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.mic92 ];
+    homepage = https://launchpad.net/libasyncns-python;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -28092,6 +28092,10 @@ EOF
     buildInputs = with self; [ pytest pkgs.glibcLocales ];
   };
 
+  libasyncns = callPackage ../development/python-modules/libasyncns.nix {
+    inherit (pkgs) libasyncns pkgconfig;
+  };
+
   pybrowserid = buildPythonPackage rec {
     name = "PyBrowserID-${version}";
     version = "0.9.2";


### PR DESCRIPTION

###### Motivation for this change

The provided fixup replacing drill did not have an effect. Using a library is cleaner then shell out to `dnsutils` 

###### Things done

- [ x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

