### PR TITLE
pythonPackages.matplotlib: fix build on macOS

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -7,6 +7,7 @@
 , enableTk ? false, tcl ? null, tk ? null, tkinter ? null, libX11 ? null
 , enableQt ? false, pyqt4
 , libcxx
+, Cocoa
 }:
 
 assert enableGhostscript -> ghostscript != null;
@@ -32,7 +33,8 @@ buildPythonPackage rec {
   XDG_RUNTIME_DIR = "/tmp";
 
   buildInputs = [ python which sphinx stdenv ]
-    ++ stdenv.lib.optional enableGhostscript ghostscript;
+    ++ stdenv.lib.optional enableGhostscript ghostscript
+    ++ stdenv.lib.optional stdenv.isDarwin [ Cocoa ];
 
   propagatedBuildInputs =
     [ cycler dateutil nose numpy pyparsing tornado freetype

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14281,6 +14281,7 @@ in {
   matplotlib = callPackage ../development/python-modules/matplotlib/default.nix {
     stdenv = if stdenv.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
     enableGhostscript = true;
+    inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
   };
 
 


### PR DESCRIPTION
###### Motivation for this change

since #22003 i cannot build this package on mac os-

```
building 'matplotlib.backends._macosx' extension
clang -I. -I/nix/store/gdfw5cmrc78qka1a985iawdqb3ampral-python-2.7.13/include/python2.7 -c src/_macosx.m -o build/temp.macosx-10.10-x86_64-2.7/src/_macosx.o
src/_macosx.m:1:10: fatal error: 'Cocoa/Cocoa.h' file not found
#include <Cocoa/Cocoa.h>
         ^
1 error generated.
error: command 'clang' failed with exit status 1
builder for ‘/nix/store/cjhdsgcj02yip5bdyxnrgpcfljq9rdgb-python2.7-matplotlib-2.0.0.drv’ failed with exit code 1
error: build of ‘/nix/store/cjhdsgcj02yip5bdyxnrgpcfljq9rdgb-python2.7-matplotlib-2.0.0.drv’ failed
```

this change re-adds Cocoa and package now builds on macos

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
