### PR TITLE
Disable orgmode-parse tests in configuration-common.nix

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -340,6 +340,7 @@ self: super: {
   opaleye = dontCheck super.opaleye;
   openpgp = dontCheck super.openpgp;
   optional = dontCheck super.optional;
+  orgmode-parse = dontCheck super.orgmode-parse;
   os-release = dontCheck super.os-release;
   persistent-redis = dontCheck super.persistent-redis;
   pipes-extra = dontCheck super.pipes-extra;


### PR DESCRIPTION
###### Motivation for this change

Orgmode-parse doesn't pass the build. I didn't manage to figure it out given a limited amount of time. The project passes tests if launched with stack (locally), ghc/lts in repo seems to match with ones in nixpkgs. So I've just disabled tests for now.

