### PR TITLE
aenum: Init at 1.4.7

### DIFF
--- a/pkgs/development/python-modules/aenum/default.nix
+++ b/pkgs/development/python-modules/aenum/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchPypi, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "aenum";
+  version = "1.4.7";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bvn2k53nz99fiwql5fkl0fh7xjw8ama9qzdjp36609mpk05ikl8";
+  };
+
+  meta = {
+    description = "Advanced Enumerations (compatible with Python's stdlib Enum), NamedTuples, and NamedConstants";
+    maintainer = with stdenv.lib.maintainers; [ vrthra ];
+    license = with stdenv.lib.licenses; [ bsd3 ];
+    homepage = https://bitbucket.org/stoneleaf/aenum;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -95,6 +95,8 @@ in {
     };
   };
 
+  aenum = callPackage ../development/python-modules/aenum { };
+
   agate = buildPythonPackage rec {
     name = "agate-1.2.2";
     disabled = isPy3k;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

