### PR TITLE
sweethome3d: 5.2 -> 5.4

### DIFF
--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -6,9 +6,8 @@ let
   getDesktopFileName = drvName: (builtins.parseDrvName drvName).name;
 
   # TODO: Should we move this to `lib`? Seems like its would be useful in many cases.
-  extensionOf = filePath: 
-    lib.concatStringsSep "." (lib.tail (lib.splitString "." 
-      (builtins.baseNameOf filePath)));
+  extensionOf = filePath:
+    lib.concatStringsSep "." (lib.tail (lib.splitString "." (builtins.baseNameOf filePath)));
 
   installIcons = iconName: icons: lib.concatStringsSep "\n" (lib.mapAttrsToList (size: iconFile: ''
     mkdir -p "$out/share/icons/hicolor/${size}/apps"
@@ -68,14 +67,14 @@ let
 in rec {
 
   application = mkSweetHome3D rec {
-    version = "5.2";
+    version = "5.4";
     module = "SweetHome3D";
     name = stdenv.lib.toLower module + "-application-" + version;
     description = "Design and visualize your future home";
     license = stdenv.lib.licenses.gpl2Plus;
     src = fetchcvs {
       cvsRoot = ":pserver:anonymous@sweethome3d.cvs.sourceforge.net:/cvsroot/sweethome3d";
-      sha256 = "0vws3lj5lgix5fz2hpqvz6p79py5gbfpkhmqpfb1knx1a12310bb";
+      sha256 = "09sk4svmaiw8dabcya3407iq5yjwxbss8pik1rzalrlds2428vyw";
       module = module;
       tag = "V_" + d2u version;
     };

--- a/pkgs/applications/misc/sweethome3d/editors.nix
+++ b/pkgs/applications/misc/sweethome3d/editors.nix
@@ -30,6 +30,7 @@ let
 
     patchPhase = ''
       sed -i -e 's,../SweetHome3D,${application.src},g' build.xml
+      sed -i -e 's,lib/macosx/java3d-1.6/jogl-all.jar,lib/java3d-1.6/jogl-all.jar,g' build.xml
     '';
 
     buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Newer version. Also, in the current version the functions "create image" and "create video" are broken and lead to a JVM crash. In 5.4 this seems to be fixed.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

