### PR TITLE
lmdb: split outputs, use shared library, etc.

### DIFF
--- a/pkgs/development/libraries/lmdb/default.nix
+++ b/pkgs/development/libraries/lmdb/default.nix
@@ -14,14 +14,28 @@ in stdenv.mkDerivation rec {
 
   postUnpack = "sourceRoot=\${sourceRoot}/libraries/liblmdb";
 
-  makeFlags = ["prefix=$(out)"]
-              ++ optional stdenv.cc.isClang "CC=clang";
+  outputs = [ "bin" "out" "dev" ];
+
+  makeFlags = [ "prefix=$(out)" "CC=cc" ];
 
   doCheck = true;
   checkPhase = "make test";
 
-  preInstall = ''
-    mkdir -p $out/{bin,lib,include}
+  postInstall = ''
+    moveToOutput bin "$bin"
+    moveToOutput "lib/*.a" REMOVE # until someone needs it
+  ''
+    # add lmdb.pc (dynamic only)
+    + ''
+    mkdir -p "$dev/lib/pkgconfig"
+    cat > "$dev/lib/pkgconfig/lmdb.pc" <<EOF
+    Name: lmdb
+    Description: ${meta.description}
+    Version: ${version}
+
+    Cflags: -I$dev/include
+    Libs: -L$out/lib -llmdb
+    EOF
   '';
 
   meta = with stdenv.lib; {
@@ -34,7 +48,7 @@ in stdenv.mkDerivation rec {
       limited to the size of the virtual address space.
     '';
     homepage = http://symas.com/mdb/;
-    maintainers = with maintainers; [ jb55 ];
+    maintainers = with maintainers; [ jb55 vcunat ];
     license = licenses.openldap;
     platforms = platforms.all;
   };

--- a/pkgs/servers/dns/knot-dns/default.nix
+++ b/pkgs/servers/dns/knot-dns/default.nix
@@ -16,14 +16,16 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    gnutls jansson liburcu libidn
+    gnutls jansson liburcu libidn lmdb
     nettle libedit
     libiconv
     # without sphinx &al. for developer documentation
   ]
     # Use embedded lmdb there for now, as detection is broken on Darwin somehow.
-    ++ stdenv.lib.optionals stdenv.isLinux [ libcap_ng systemd lmdb ]
+    ++ stdenv.lib.optionals stdenv.isLinux [ libcap_ng systemd ]
     ++ stdenv.lib.optional stdenv.isDarwin zlib; # perhaps due to gnutls
+
+  configureFlags = [ "--with-lmdb=${stdenv.lib.getLib lmdb}"/*not perfect*/ ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -23,8 +23,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig which makeWrapper hexdump ];
 
-  buildInputs = [ knot-dns luajit libuv gnutls ]
-    # TODO: lmdb needs lmdb.pc; embedded for now
+  buildInputs = [ knot-dns lmdb luajit libuv gnutls ]
     ## optional dependencies
     ++ optional doInstallCheck cmocka
     ++ optional stdenv.isLinux systemd # socket activation


### PR DESCRIPTION
/cc maintainer @jb55.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of *some* binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@copumpkin (maintainer): I see `pythonPackages.lmdb` uses some embedded version &ndash; is that intentional/deliberate?