### PR TITLE
syslog-ng: 3.6.2 -> 3.9.1

### DIFF
--- a/pkgs/development/libraries/libivykis/default.nix
+++ b/pkgs/development/libraries/libivykis/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "libivykis-${version}";
 
-  version = "0.40";
+  version = "0.41";
 
   src = fetchurl {
     url = "mirror://sourceforge/libivykis/${version}/ivykis-${version}.tar.gz";
-    sha256 = "1rn32dijv0pn9y2mbdg1n7al4h4i5pwwhhihr9pyakwyb6qgmqxj";
+    sha256 = "1igk3svf36i5xgb6ipc507xpj6zjm4xi9j1j2cdqaachllwlb4rc";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/tools/system/syslog-ng-incubator/default.nix
+++ b/pkgs/tools/system/syslog-ng-incubator/default.nix
@@ -1,25 +1,25 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, glib, syslogng
-, eventlog, perl, python, yacc, riemann_c_client, libivykis, protobufc
+, eventlog, perl, python, yacc, protobufc, libivykis
 }:
 
 stdenv.mkDerivation rec {
   name = "syslog-ng-incubator-${version}";
-  version = "141106-54179c5";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "balabit";
     repo = "syslog-ng-incubator";
-    rev = "54179c5f733487fe97ee856bc27130d0b09f3d5a";
-    sha256 = "1y099f7pdan1441ycycd67igcwbla2m2cgnxjfvdw76llvi35sam";
+    rev = name;
+    sha256 = "00j123ya0xfj1jicaqnk1liffx07mhhf0r406pabxjjj97gy8nlk";
   };
 
+  nativeBuildInputs = [ pkgconfig autoreconfHook yacc ];
+
   buildInputs = [
-    autoreconfHook pkgconfig glib syslogng eventlog perl python
-    yacc riemann_c_client libivykis protobufc
+    glib syslogng eventlog perl python protobufc libivykis
   ];
 
   configureFlags = [
-    "--without-ivykis"
     "--with-module-dir=$(out)/lib/syslog-ng"
   ];
 
@@ -29,5 +29,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = [ maintainers.rickynils ];
     platforms = platforms.linux;
+    broken = true; # does not work with our new syslog-ng version yet
   };
 }

--- a/pkgs/tools/system/syslog-ng/default.nix
+++ b/pkgs/tools/system/syslog-ng/default.nix
@@ -1,17 +1,40 @@
-{ stdenv, fetchurl, eventlog, pkgconfig, glib, python, systemd, perl
-, riemann_c_client, protobufc, pcre, yacc }:
+{ stdenv, fetchgit, autoconf, autoconf-archive, automake, libtool, flex, openssl
+, eventlog, pkgconfig, glib, python, systemd, perl
+, riemann_c_client, protobufc, pcre, yacc, which }:
 
 stdenv.mkDerivation rec {
   name = "syslog-ng-${version}";
+  version = "3.9.1";
 
-  version = "3.6.2";
-
-  src = fetchurl {
-    url = "http://www.balabit.com/downloads/files?path=/syslog-ng/sources/${version}/source/syslog-ng_${version}.tar.gz";
-    sha256 = "0qc21mwajk6xrra3gqy2nvaza5gq62psamq4ayphj7lqabdglizg";
+  src = fetchgit {
+    url = "https://github.com/balabit/syslog-ng.git";
+    rev = "59aa4e5d9396d293aae021746214b97d7fe0a8ee"; # tag: syslog-ng-3.9.1
+    sha256 = "15lalqf6dmpm4nr1pp0f2p0a6wbckkrh1k83vhp9ws0by5m8m66r";
   };
 
-  buildInputs = [ eventlog pkgconfig glib python systemd perl riemann_c_client protobufc yacc pcre ];
+  buildInputs = [
+    autoconf
+    autoconf-archive
+    automake
+    libtool
+    which
+    flex
+    openssl
+    eventlog
+    pkgconfig
+    glib
+    python
+    systemd
+    perl
+    riemann_c_client
+    protobufc
+    yacc
+    pcre
+  ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
 
   configureFlags = [
     "--enable-dynamic-linking"

--- a/pkgs/tools/system/syslog-ng/default.nix
+++ b/pkgs/tools/system/syslog-ng/default.nix
@@ -1,52 +1,62 @@
-{ stdenv, fetchgit, autoconf, autoconf-archive, automake, libtool, flex, openssl
+{ stdenv, fetchurl, openssl, libcap, curl, which
 , eventlog, pkgconfig, glib, python, systemd, perl
-, riemann_c_client, protobufc, pcre, yacc, which }:
+, riemann_c_client, protobufc, pcre, libnet
+, json_c, libuuid, libivykis, mongoc, rabbitmq-c }:
+
+let
+  pname = "syslog-ng";
+in
 
 stdenv.mkDerivation rec {
-  name = "syslog-ng-${version}";
+  name = "${pname}-${version}";
   version = "3.9.1";
 
-  src = fetchgit {
-    url = "https://github.com/balabit/syslog-ng.git";
-    rev = "59aa4e5d9396d293aae021746214b97d7fe0a8ee"; # tag: syslog-ng-3.9.1
-    sha256 = "15lalqf6dmpm4nr1pp0f2p0a6wbckkrh1k83vhp9ws0by5m8m66r";
+  src = fetchurl {
+    url = "https://github.com/balabit/${pname}/releases/download/${name}/${name}.tar.gz";
+    sha256 = "05qaqw115py5iz55vmc0j1xcwcpr8wa9vpmbixhr1rqaamm8ay2n";
   };
 
+  nativeBuildInputs = [ pkgconfig which ];
+
   buildInputs = [
-    autoconf
-    autoconf-archive
-    automake
-    libtool
-    which
-    flex
+    libcap
+    curl
     openssl
     eventlog
-    pkgconfig
     glib
+    perl
     python
     systemd
-    perl
     riemann_c_client
     protobufc
-    yacc
     pcre
+    libnet
+    json_c
+    libuuid
+    libivykis
+    mongoc
+    rabbitmq-c
   ];
-
-  preConfigure = ''
-    ./autogen.sh
-  '';
 
   configureFlags = [
+    "--enable-manpages"
     "--enable-dynamic-linking"
     "--enable-systemd"
+    "--with-ivykis=system"
+    "--with-librabbitmq-client=system"
+    "--with-mongoc=system"
+    "--with-jsonc=system"
+    "--with-systemd-journal=system"
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
   ];
+
+  outputs = [ "out" "man" ];
 
   meta = with stdenv.lib; {
     homepage = "http://www.balabit.com/network-security/syslog-ng/";
     description = "Next-generation syslogd with advanced networking and filtering capabilities";
     license = licenses.gpl2;
-    maintainers = [ maintainers.rickynils ];
+    maintainers = with maintainers; [ rickynils  fpletz ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
@fpletz this fixes https://github.com/NixOS/nixpkgs/issues/20153.

Since syslog-ng is currently broken on 16.09 this should be cherry-picked on `release-16.09`.

I tested it with the following configuration:

```nix
{
  services.syslog-ng = {
    enable = true;
    extraConfig = ''
      source s_network_tcp {
        network (
          ip("0.0.0.0")
          port(601)
          transport("tcp")
        );
      };
     
      destination d_devlog {
        unix-dgram(
          /dev/log
          flags(syslog-protocol)
        );
      };
     
      log {
        source(s_network_tcp);
        destination(d_devlog);
      };
    '';
  };
}
```

If I then log a message using:

```
logger --server=localhost --tcp "Hello World"
```

I see the following in my `journalctl`:

```
Feb 13 18:07:15 bas.van.dijk.lumi syslog-ng[13387]: 1 2017-02-13T18:07:15+01:00 localhost 1 - - - 2017-02-13T18:07:15.046465+01:00 bas.van.dijk.lumi bas.van.dijk - - [timeQuality tzKnown="1" isSynced="1" syncAccuracy="229387"] Hello World
```