### PR TITLE
nixos/geoip-updater: run as user 'geoip' instead of 'nobody'

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -287,6 +287,7 @@
       pdns-recursor = 269;
       kresd = 270;
       rpc = 271;
+      geoip = 272;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -543,6 +544,7 @@
       gogs = 268;
       kresd = 270;
       #rpc = 271; # unused
+      #geoip = 272; # unused
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/services/misc/geoip-updater.nix
+++ b/nixos/modules/services/misc/geoip-updater.nix
@@ -251,6 +251,12 @@ in
       }
     ];
 
+    users.extraUsers.geoip = {
+      group = "root";
+      description = "GeoIP database updater";
+      uid = config.ids.uids.geoip;
+    };
+
     systemd.timers.geoip-updater =
       { description = "GeoIP Updater Timer";
         partOf = [ "geoip-updater.service" ];
@@ -267,11 +273,11 @@ in
       preStart = ''
         mkdir -p "${cfg.databaseDir}"
         chmod 755 "${cfg.databaseDir}"
-        chown nobody:root "${cfg.databaseDir}"
+        chown geoip:root "${cfg.databaseDir}"
       '';
       serviceConfig = {
         ExecStart = "${geoip-updater}/bin/geoip-updater";
-        User = "nobody";
+        User = "geoip";
         PermissionsStartOnly = true;
       };
     };
@@ -285,11 +291,11 @@ in
       preStart = ''
         mkdir -p "${cfg.databaseDir}"
         chmod 755 "${cfg.databaseDir}"
-        chown nobody:root "${cfg.databaseDir}"
+        chown geoip:root "${cfg.databaseDir}"
       '';
       serviceConfig = {
         ExecStart = "${geoip-updater}/bin/geoip-updater --skip-existing";
-        User = "nobody";
+        User = "geoip";
         PermissionsStartOnly = true;
         # So it won't be (needlessly) restarted:
         RemainAfterExit = true;


### PR DESCRIPTION
###### Motivation for this change

That way 'nobody' is prevented from messing with the databases.

Suggested by @abbradar.
CC @danbst 

WARNING: Not tested yet because master branch is broken.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

