### PR TITLE
bazel: 0.3.2 -> 0.4.4

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchFromGitHub, buildFHSUserEnv, writeScript, jdk, zip, unzip,
+{ stdenv, fetchurl, buildFHSUserEnv, writeScript, jdk, zip, unzip,
   which, makeWrapper, binutils }:
 
 let
 
-  version = "0.3.2";
+  version = "0.4.4";
 
   meta = with stdenv.lib; {
     homepage = http://github.com/bazelbuild/bazel/;
@@ -22,14 +22,16 @@ let
   };
 
   bazelBinary = stdenv.mkDerivation rec {
+
     name = "bazel-${version}";
 
-    src = fetchFromGitHub {
-      owner = "bazelbuild";
-      repo = "bazel";
-      rev = version;
-      sha256 = "085cjz0qhm4a12jmhkjd9w3ic4a67035j01q111h387iklvgn6xg";
+    src = fetchurl {
+      url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
+      sha256 = "1fwfahkqi680zyxmdriqj603lpacyh6cg6ff25bn9bkilbfj2anm";
     };
+
+    sourceRoot = ".";
+
     patches = [ ./java_stub_template.patch ];
 
     packagesNotFromEnv = [


### PR DESCRIPTION
###### Motivation for this change

Wanted to build tensorflow locally; needed a newer version of bazel.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

