### PR TITLE
groonga: 6.1.5 -> 7.0.0

### DIFF
--- a/pkgs/servers/search/groonga/default.nix
+++ b/pkgs/servers/search/groonga/default.nix
@@ -7,11 +7,11 @@
 stdenv.mkDerivation rec {
 
   name    = "groonga-${version}";
-  version = "6.1.5";
+  version = "7.0.0";
 
   src = fetchurl {
     url    = "http://packages.groonga.org/source/groonga/${name}.tar.gz";
-    sha256 = "0phh4qp7ky5rw8xgxv3gjzw2cadkjl604xrdyxxbpd30i354sh5x";
+    sha256 = "0c3vzw2ias0xpz1hwywlib1qqfjvvzwj1zggswd5l2cj87f1krfd";
   };
 
   buildInputs = with stdenv.lib;


### PR DESCRIPTION
###### Motivation for this change

Release notes: http://groonga.org/docs/news.html#release-7-0-0

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

