### PR TITLE
fix byobu, closes #14443

### DIFF
--- a/pkgs/development/libraries/newt/default.nix
+++ b/pkgs/development/libraries/newt/default.nix
@@ -1,18 +1,27 @@
-{ fetchurl, stdenv, slang, popt }:
+{ lib, fetchurl, stdenv, slang, popt
+, python ? null, pythonSupport ? true
+}:
 
 stdenv.mkDerivation rec {
-  name = "newt-0.52.15";
+  name = "newt-0.52.19";
 
   src = fetchurl {
     url = "https://fedorahosted.org/releases/n/e/newt/${name}.tar.gz";
-    sha256 = "0hg2l0siriq6qrz6mmzr6l7rpl40ay56c8cak87rb2ks7s952qbs";
+    sha256 = "101fzx5n711wj01rpkcixyfc1iklny8r9fdsgimaz5hrq9bdph08";
   };
+
+  postUnpack = ''
+    substituteInPlace $sourceRoot/configure \
+      --replace "/usr/include/python" "${python}/include/python"
+    substituteInPlace $sourceRoot/configure.ac \
+      --replace "/usr/include/python" "${python}/include/python"
+  '';
 
   patchPhase = ''
     sed -i -e s,/usr/bin/install,install, -e s,-I/usr/include/slang,, Makefile.in po/Makefile
   '';
 
-  buildInputs = [ slang popt ];
+  buildInputs = [ slang popt python ];
 
   NIX_LDFLAGS = "-lncurses";
 
@@ -20,12 +29,20 @@ stdenv.mkDerivation rec {
     makeFlags = "CROSS_COMPILE=${stdenv.cross.config}-";
   };
 
+  outputs = [ "out" ]
+   ++ lib.optional pythonSupport "py";
+
+  # Separate output for snack
+  postFixup = lib.optionalString pythonSupport ''
+   moveToOutput ${python.sitePackages} "$py"
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://fedorahosted.org/newt/;
     description = "Library for color text mode, widget based user interfaces";
 
     license = licenses.lgpl2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.viric ];
+    maintainers = with maintainers; [ viric ryantm ];
   };
 }

--- a/pkgs/tools/misc/byobu/default.nix
+++ b/pkgs/tools/misc/byobu/default.nix
@@ -1,36 +1,56 @@
-{ stdenv, fetchurl, ncurses, python, perl, textual-window-manager }:
+{ stdenv, fetchurl, makeWrapper, ncurses, python, perl, textual-window-manager,
+  gettext, vim, bc}:
 
-stdenv.mkDerivation rec {
-  version = "5.112";
+let
+  pythonEnv = python.withPackages(ps: [ps.snack]);
+in stdenv.mkDerivation rec {
+  version = "5.115";
   name = "byobu-" + version;
 
   src = fetchurl {
     url = "https://launchpad.net/byobu/trunk/${version}/+download/byobu_${version}.orig.tar.gz";
-    sha256 = "0avv1s8dh3z6rzkf1mn1375v3im1qc9c63w09yvwxdlcq5xznrsd";
+    sha256 = "0j2kfqwza2qq8hni87pjn2p722aan3m51wwn4h3vz904n7303g4y";
   };
 
   doCheck = true;
 
-  buildInputs = [ python perl ];
+  buildInputs = [ perl pythonEnv makeWrapper vim bc gettext];
+
   propagatedBuildInputs = [ textual-window-manager ];
+
+  postUnpack = ''
+    substituteInPlace $sourceRoot/usr/bin/byobu-select-profile.in \
+      --replace "/bin/true" "true" \
+      --replace "gettext" "${gettext}/bin/gettext"
+    substituteInPlace $sourceRoot/usr/bin/byobu-export.in \
+      --replace "gettext" "${gettext}/bin/gettext"
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/byobu-status-detail --prefix PATH ":" "${vim}/bin/"
+    wrapProgram $out/bin/byobu-ulevel --prefix PATH ":" "${bc}/bin/"
+    for i in $out/bin/*; do
+      wrapProgram "$i" --set BYOBU_PYTHON "${pythonEnv}/bin/python"
+    done
+  '';
 
   meta = {
     homepage = https://launchpad.net/byobu/;
     description = "Text-based window manager and terminal multiplexer";
 
     longDescription =
-      ''Byobu is a GPLv3 open source text-based window manager and terminal multiplexer. 
-        It was originally designed to provide elegant enhancements to the otherwise functional, 
-        plain, practical GNU Screen, for the Ubuntu server distribution. 
-        Byobu now includes an enhanced profiles, convenient keybindings, 
-        configuration utilities, and toggle-able system status notifications for both 
-        the GNU Screen window manager and the more modern Tmux terminal multiplexer, 
+      ''Byobu is a GPLv3 open source text-based window manager and terminal multiplexer.
+        It was originally designed to provide elegant enhancements to the otherwise functional,
+        plain, practical GNU Screen, for the Ubuntu server distribution.
+        Byobu now includes an enhanced profiles, convenient keybindings,
+        configuration utilities, and toggle-able system status notifications for both
+        the GNU Screen window manager and the more modern Tmux terminal multiplexer,
         and works on most Linux, BSD, and Mac distributions.
       '';
 
     license = stdenv.lib.licenses.gpl3;
 
     platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.qknight ];
+    maintainers = with stdenv.lib.maintainers; [ qknight ryantm ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15565,6 +15565,8 @@ in {
     };
   };
 
+  snack = (pkgs.newt.override{pythonSupport=true; python=python;}).py;
+
   sleekxmpp = buildPythonPackage rec {
     name = "sleekxmpp-${version}";
     version = "1.3.1";


### PR DESCRIPTION
###### Motivation for this change

byobu-config didn't work (issue #14443) ; byobu is out of date.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

