### PR TITLE
tox clients and libraries updates

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/tox-prpl/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/tox-prpl/default.nix
@@ -1,29 +1,27 @@
 { stdenv, fetchFromGitHub, libtoxcore, pidgin, autoreconfHook, libsodium }:
 
-let
-  version = "dd181722ea";
-  date = "20141202";
-in
 stdenv.mkDerivation rec {
-  name = "tox-prpl-${date}-${version}";
+  name = "tox-prpl-${version}";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
-    owner = "jin-eld";
-    repo = "tox-prpl";
-    rev = "${version}";
-    sha256 = "0wzyvg11h4ym28zqd24p35lza3siwm2519ga0yhk98rv458zks0v";
+    owner  = "jin-eld";
+    repo   = "tox-prpl";
+    rev    = "v${version}";
+    sha256 = "0ms367l2f7x83k407c93bmhpyc820f1css61fh2gx4jq13cxqq3p";
   };
 
   NIX_LDFLAGS = "-lssp -lsodium";
 
   postInstall = "mv $out/lib/purple-2 $out/lib/pidgin";
 
-  buildInputs = [ libtoxcore pidgin autoreconfHook libsodium ];
+  buildInputs = [ libtoxcore pidgin libsodium ];
+  nativeBuildInputs = [ autoreconfHook ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://tox.dhs.org/;
     description = "Tox plugin for Pidgin / libpurple";
-    license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/qtox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/qtox/default.nix
@@ -1,46 +1,31 @@
-{ stdenv, fetchFromGitHub, pkgconfig, libtoxcore-dev, openal, opencv,
-  libsodium, libXScrnSaver, glib, gdk_pixbuf, gtk2, cairo,
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, openal, opencv,
+  libtoxcore, libsodium, libXScrnSaver, glib, gdk_pixbuf, gtk2, cairo, xorg,
   pango, atk, qrencode, ffmpeg, filter-audio, makeQtWrapper,
-  qtbase, qtsvg, qttools, qmakeHook, qttranslations, sqlcipher }:
-
-let
-  version = "1.5.0";
-  revision = "v${version}";
-in
+  qtbase, qtsvg, qttools, qttranslations, sqlcipher,
+  libvpx, libopus }:
 
 stdenv.mkDerivation rec {
   name = "qtox-${version}";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
-      owner = "tux3";
-      repo = "qTox";
-      rev = revision;
-      sha256 = "1na2qqzbdbjfw8kymxw5jfglslmw18fz3vpw805pqg4d5y7f7vsi";
+    owner  = "tux3";
+    repo   = "qTox";
+    rev    = "v${version}";
+    sha256 = "073kwfaw5n7vvcpwrpdbw5mlswbbwjipx7yy4a95r9z0gjljqnhq";
   };
 
-  buildInputs =
-    [
-      libtoxcore-dev openal opencv libsodium filter-audio
-      qtbase qttools qtsvg libXScrnSaver glib gtk2 cairo
-      pango atk qrencode ffmpeg qttranslations makeQtWrapper
-      sqlcipher
-    ];
+  buildInputs = [
+    libtoxcore openal opencv libsodium filter-audio
+    qtbase qttools qtsvg libXScrnSaver glib gtk2 cairo
+    pango atk qrencode ffmpeg qttranslations
+    sqlcipher
+    libopus libvpx
+  ] ++ (with xorg; [
+    libpthreadstubs libXdmcp
+  ]);
 
-  nativeBuildInputs = [ pkgconfig qmakeHook ];
-
-  preConfigure = ''
-    # patch .pro file for proper set of the git hash
-    sed -i '/git rev-parse/d' qtox.pro
-    sed -i 's/$$quote($$GIT_VERSION)/${revision}/' qtox.pro
-    # since .pro have hardcoded paths, we need to explicitly set paths here
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags glib-2.0)"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags gdk-pixbuf-2.0)"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags gtk+-2.0)"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags cairo)"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags pango)"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags atk)"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags sqlcipher)"
-  '';
+  nativeBuildInputs = [ cmake makeQtWrapper pkgconfig ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/networking/instant-messengers/toxic/default.nix
+++ b/pkgs/applications/networking/instant-messengers/toxic/default.nix
@@ -1,26 +1,27 @@
 { stdenv, fetchFromGitHub, libsodium, ncurses, curl
-, libtoxcore-dev, openal, libvpx, freealut, libconfig, pkgconfig
-, libqrencode }:
+, libtoxcore, openal, libvpx, freealut, libconfig, pkgconfig, libopus
+, libqrencode, gdk_pixbuf, libnotify }:
 
 stdenv.mkDerivation rec {
-  name = "toxic-dev-20160728";
+  name = "toxic-${version}";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
-    owner = "Tox";
-    repo = "toxic";
-    rev = "cb21672600206423c844306a84f8b122e534c348";
-    sha256 = "1nq1xnbyjfrk8jrjvk5sli1bm3i9r8b4m8f4xgmiz68mx1r3fn5k";
+    owner  = "Tox";
+    repo   = "toxic";
+    rev    = "v${version}";
+    sha256 = "1kws6bx5va1wc0k6pqihrla91vicxk4zqghvxiylgfbjr1jnkvwc";
   };
 
-  makeFlags = [ "PREFIX=$(out)" ];
-  installFlags = [ "PREFIX=$(out)" ];
+  makeFlags = [ "PREFIX=$(out)"];
+  installFlags = [ "PREFIX=$(out)"];
 
-  nativeBuildInputs = [ pkgconfig libconfig ];
   buildInputs = [
-    libtoxcore-dev libsodium ncurses curl
+    libtoxcore libsodium ncurses curl gdk_pixbuf libnotify
   ] ++ stdenv.lib.optionals (!stdenv.isArm) [
-    openal libvpx freealut libqrencode
+    openal libopus libvpx freealut libqrencode
   ];
+  nativeBuildInputs = [ pkgconfig libconfig ];
 
   meta = with stdenv.lib; {
     description = "Reference CLI for Tox";

--- a/pkgs/applications/networking/instant-messengers/utox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/utox/default.nix
@@ -1,20 +1,26 @@
-{ stdenv, fetchFromGitHub, pkgconfig, libtoxcore-dev, filter-audio, dbus, libvpx, libX11, openal, freetype, libv4l
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, libtoxcore, filter-audio, dbus, libvpx, libX11, openal, freetype, libv4l
 , libXrender, fontconfig, libXext, libXft, utillinux, git, libsodium }:
 
 stdenv.mkDerivation rec {
   name = "utox-${version}";
-  version = "0.9.8";
+  version = "0.12.2";
 
   src = fetchFromGitHub {
-    owner = "GrayHatter";
-    repo = "uTox";
-    rev = "v${version}";
-    sha256 = "0ahwdwqhi1gmvw80jihc1ba4cqqnx8ifjnzazxidfdky4ikzccmn";
+    owner  = "uTox";
+    repo   = "uTox";
+    rev    = "v${version}";
+    sha256 = "1y26dpx0qc01mhv2f325ymyc3r7ihayrr10rp25p1bs24010azwn";
   };
 
-  buildInputs = [ pkgconfig libtoxcore-dev dbus libvpx libX11 openal freetype
-                  libv4l libXrender fontconfig libXext libXft filter-audio
-                  git libsodium ];
+  buildInputs = [
+    libtoxcore dbus libvpx libX11 openal freetype
+    libv4l libXrender fontconfig libXext libXft filter-audio
+    libsodium
+  ];
+
+  nativeBuildInputs = [
+    cmake git pkgconfig
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/libraries/libtoxcore/default.nix
+++ b/pkgs/development/libraries/libtoxcore/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, cmake, libsodium, ncurses, libopus, libmsgpack
+, libvpx, check, libconfig, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "libtoxcore-${version}";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner  = "TokTok";
+    repo   = "c-toxcore";
+    rev    = "v${version}";
+    sha256 = "0a00gjar6ibaqa2cm81867nk7chsd141v360268v7ym2mxwa0ya6";
+  };
+
+  cmakeFlags = [
+    "-DBUILD_NTOX=ON"
+    "-DDHT_BOOTSTRAP=ON"
+    "-DBOOTSTRAP_DAEMON=ON"
+  ];
+
+  buildInputs = [
+    libsodium libmsgpack ncurses
+  ] ++ stdenv.lib.optionals (!stdenv.isArm) [
+    libopus
+    libvpx
+  ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+  checkInputs = [ check ];
+
+  checkPhase = "ctest";
+
+  # for some reason the tests are not running - it says "No tests found!!"
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "P2P FOSS instant messaging application aimed to replace Skype with crypto";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/libtoxcore/new-api.nix
+++ b/pkgs/development/libraries/libtoxcore/new-api.nix
@@ -2,7 +2,7 @@
 , libvpx, check, libconfig, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "tox-core-dev-20160727";
+  name = "tox-core-new-20160727";
 
   src = fetchFromGitHub {
     owner  = "irungentoo";

--- a/pkgs/development/libraries/libtoxcore/old-api.nix
+++ b/pkgs/development/libraries/libtoxcore/old-api.nix
@@ -4,9 +4,9 @@
 let
   version = "4c220e336330213b151a0c20307d0a1fce04ac9e";
   date = "20150126";
-in
-stdenv.mkDerivation rec {
-  name = "tox-core-${date}-${builtins.substring 0 7 version}";
+
+in stdenv.mkDerivation rec {
+  name = "tox-core-old-${date}-${builtins.substring 0 7 version}";
 
   src = fetchFromGitHub {
     owner  = "irungentoo";

--- a/pkgs/tools/networking/toxvpn/default.nix
+++ b/pkgs/tools/networking/toxvpn/default.nix
@@ -1,31 +1,23 @@
-{ stdenv, fetchFromGitHub, libtoxcore, cmake, jsoncpp, lib, stdenvAdapters, libsodium, systemd, enableDebugging, libcap }:
+{ stdenv, fetchFromGitHub, cmake, lib
+, libtoxcore, jsoncpp, libsodium, systemd, libcap }:
 
 with lib;
 
-let
-  libtoxcoreLocked = stdenv.lib.overrideDerivation libtoxcore (oldAttrs: {
-    name = "libtoxcore-2016-09-07";
-    src = fetchFromGitHub {
-      owner  = "TokTok";
-      repo   = "toxcore";
-      rev    = "3521898b0cbf398d882496f6382f6c4ea1c23bc1";
-      sha256 = "1jvf0v9cqwd4ssj1iarhgsr05qg48v7yvmbnn3k01jy0lqci8iaq";
-    };
-  });
-
-in stdenv.mkDerivation {
-  name = "toxvpn-2016-09-09";
+stdenv.mkDerivation rec {
+  name = "toxvpn-${version}";
+  version = "20161230";
 
   src = fetchFromGitHub {
     owner  = "cleverca22";
     repo   = "toxvpn";
-    rev    = "6e188f26fff8bddc1014ee3cc7a7423f9f344a09";
-    sha256 = "1bshc6pzk7z7q7g17cwx9gmlcyzn4szqvdiy0ihbk2xmx9k31c6p";
+    rev    = "4b7498a5fae680484cb5779ac01fb08ad3089bdd";
+    sha256 = "0bazdspiym9xyzms7pd6i1f2gph13rnf764nm3jc27fbfwmc98rp";
   };
 
-  buildInputs = [ cmake libtoxcoreLocked jsoncpp libsodium libcap ] ++ optional (systemd != null) systemd;
+  buildInputs = [ libtoxcore jsoncpp libsodium libcap ] ++ optional stdenv.isLinux systemd;
+  nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = optional (systemd != null) [ "-DSYSTEMD=1" ];
+  cmakeFlags = optional stdenv.isLinux [ "-DSYSTEMD=1" ];
 
   meta = with stdenv.lib; {
     description = "A powerful tool that allows one to make tunneled point to point connections over Tox";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14826,7 +14826,9 @@ with pkgs;
 
   ratmen = callPackage ../tools/X11/ratmen {};
 
-  ratox = callPackage ../applications/networking/instant-messengers/ratox { };
+  ratox = callPackage ../applications/networking/instant-messengers/ratox {
+    libtoxcore = libtoxcore-old;
+  };
 
   ratpoison = callPackage ../applications/window-managers/ratpoison { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14640,7 +14640,9 @@ with pkgs;
 
   telegram-purple = callPackage ../applications/networking/instant-messengers/pidgin-plugins/telegram-purple { };
 
-  toxprpl = callPackage ../applications/networking/instant-messengers/pidgin-plugins/tox-prpl { };
+  toxprpl = callPackage ../applications/networking/instant-messengers/pidgin-plugins/tox-prpl {
+    libtoxcore = libtoxcore-new;
+  };
 
   pidgin-opensteamworks = callPackage ../applications/networking/instant-messengers/pidgin-plugins/pidgin-opensteamworks { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8581,9 +8581,11 @@ with pkgs;
 
   libtorrentRasterbar_1_0 = callPackage ../development/libraries/libtorrent-rasterbar/1.0.nix { };
 
-  libtoxcore = callPackage ../development/libraries/libtoxcore/old-api { };
+  libtoxcore-old = callPackage ../development/libraries/libtoxcore/old-api.nix { };
 
-  libtoxcore-dev = callPackage ../development/libraries/libtoxcore/new-api { };
+  libtoxcore-new = callPackage ../development/libraries/libtoxcore/new-api.nix { };
+
+  libtoxcore = callPackage ../development/libraries/libtoxcore { };
 
   libtap = callPackage ../development/libraries/libtap { };
 


### PR DESCRIPTION
###### Motivation for this change

As I'm sick and tired of skype, I needed qtox to work properly.

As a young project there's been quite a bit of churn and it turns out a number of changes have been made to the libraries.

We currently have 3 versions of libtoxcore:

1) libtoxcore-old - the old API of the old library
2) libtoxcore-new - the new API of the old library
3) libtoxcore - the new library that everybody either has moved to or is in the process of moving to

All the tox clients have now been updated and those that can use the proper libtoxcore do (spoiler, we only have one user each of -old and -new).

All this came about because I wanted the latest qtox... Oh well.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Cc: @grahamc @globin