### PR TITLE
vim_configurable: support managing plugins in "vim packages"

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -20,9 +20,9 @@ vim-with-plugins in PATH:
     # store your plugins in Vim packages
     vimrcConfig.packages.myVimPackage = with pkgs.vimPlugins; {
       # loaded on launch
-      start = [ youcompleteme fugitive ]
+      start = [ youcompleteme fugitive ];
       # manually loadable by calling `:packadd $plugin-name`
-      opt = [ phpCompletion elm-vim ]
+      opt = [ phpCompletion elm-vim ];
       # To automatically load a plugin when opening a filetype, add vimrc lines like:
       # autocmd FileType php :packadd phpCompletion
     };

--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -17,6 +17,17 @@ vim-with-plugins in PATH:
       set hidden
     '';
 
+    # store your plugins in Vim packages
+    vimrcConfig.packages.myVimPackage = with pkgs.vimPlugins; {
+      # loaded on launch
+      start = [ youcompleteme fugitive ]
+      # manually loadable by calling `:packadd $plugin-name`
+      opt = [ phpCompletion elm-vim ]
+      # To automatically load a plugin when opening a filetype, add vimrc lines like:
+      # autocmd FileType php :packadd phpCompletion
+    };
+
+    # plugins can also be managed by VAM
     vimrcConfig.vam.knownPlugins = pkgs.vimPlugins; # optional
     vimrcConfig.vam.pluginDictionaries = [
       # load always
@@ -154,6 +165,7 @@ let
     in lib.uniqList { inputList = recurseNames [] names; };
 
   vimrcFile = {
+    packages ? null,
     vam ? null,
     pathogen ? null,
     customRC ? ""
@@ -253,6 +265,31 @@ let
         call vam#Scripts(l, {})
       '');
 
+      nativeImpl = lib.optionalString (packages != null)
+      (let
+        link = (packageName: dir: pluginPath: "ln -sf ${pluginPath}/share/vim-plugins/* $out/pack/${packageName}/${dir}");
+        packageLinks = (packageName: {start ? [], opt ? []}:
+          ["mkdir -p $out/pack/${packageName}/start"]
+          ++ (builtins.map (link packageName "start") start)
+          ++ ["mkdir -p $out/pack/${packageName}/opt"]
+          ++ (builtins.map (link packageName "opt") opt)
+        );
+        packDir = (packages:
+          stdenv.mkDerivation rec {
+            name = "vim-pack-dir";
+            src = ./.;
+            installPhase = lib.concatStringsSep
+                             "\n"
+                             (lib.flatten (lib.mapAttrsToList packageLinks packages));
+          }
+        );
+      in
+      ''
+        set packpath-=~/.vim/after
+        set packpath+=${packDir packages}
+        set packpath+=~/.vim/after
+      '');
+
       # somebody else could provide these implementations
       vundleImpl = "";
 
@@ -267,6 +304,7 @@ let
   ${pathogenImpl}
   ${vundleImpl}
   ${neobundleImpl}
+  ${nativeImpl}
 
   filetype indent plugin on | syn on
 
@@ -383,6 +421,11 @@ rec {
   test_vim_with_vim_addon_nix_using_pathogen = vim_configurable.customize {
     name = "vim-with-vim-addon-nix-using-pathogen";
     vimrcConfig.pathogen.pluginNames = [ "vim-addon-nix" ];
+  };
+
+  test_vim_with_vim_addon_nix = vim_configurable.customize {
+    name = "vim-with-vim-addon-nix";
+    vimrcConfig.packages.myVimPackage.start = with vimPlugins; [ vim-addon-nix ];
   };
 
 }


### PR DESCRIPTION
Commit message:
> Version 8 of vim adds the concept of "vim packages": subdirectories of
any directory listed in vim's "packpath" option, containing one or more
vim plugins. Vim will automatically load plugins placed in a package's
"start" subdirectory, while those placed in an "opt" subdirectory can be
loaded manually.
>
> Correspondingly, vimrcConfig's packPath option accepts a set with
"start" and/or "opt" attributes containing lists of nix packages, which
are then combined into a vim package, which is then added to vim's
packpath.

I just tried to find the simplest thing that would work.  Feedback welcome.
  
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---