### PR TITLE
keybase-gui: init at 20170209.17b641d

### DIFF
--- a/pkgs/tools/security/keybase-gui/default.nix
+++ b/pkgs/tools/security/keybase-gui/default.nix
@@ -1,0 +1,91 @@
+{ stdenv, fetchurl, buildFHSUserEnv, writeTextFile, alsaLib, atk, cairo, cups
+, dbus, expat, fontconfig, freetype, gcc, gdk_pixbuf, glib, gnome2, gtk2, nspr
+, nss, pango, systemd, xorg, utillinuxMinimal }:
+
+let
+  libPath = stdenv.lib.makeLibraryPath [
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gcc.cc
+    gdk_pixbuf
+    glib
+    gnome2.GConf
+    gtk2
+    nspr
+    nss
+    pango
+    systemd
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+  ];
+in
+stdenv.mkDerivation rec {
+  name = "keybase-gui-${version}";
+  version = "1.0.18-20170209170023.17b641d";
+  src = fetchurl {
+    url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version}_amd64.deb";
+    sha256 = "01mr6hyzs208g3ankl4swikna66n85xzn7ig4k7p6hxmnnvplgb3";
+  };
+  phases = ["unpackPhase" "installPhase" "fixupPhase"];
+  unpackPhase = ''
+    ar xf $src
+    tar xf data.tar.xz
+  '';
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    mv opt/keybase $out/share/
+
+    cat > $out/bin/keybase-gui <<EOF
+    #!${stdenv.shell}
+
+    checkFailed() {
+      if [ "\$NIX_SKIP_KEYBASE_CHECKS" = "1" ]; then
+        return
+      fi
+      echo "Set NIX_SKIP_KEYBASE_CHECKS=1 if you want to skip this check." >&2
+      exit 1
+    }
+
+    if [ ! -S "\$XDG_RUNTIME_DIR/keybase/keybased.sock" ]; then
+      echo "Keybase service doesn't seem to be running." >&2
+      echo "You might need to run: keybase service" >&2
+      checkFailed
+    fi
+
+    ${utillinuxMinimal}/bin/mountpoint /keybase &>/dev/null
+    if [ "\$?" -ne "0" ]; then
+      echo "Keybase is not mounted to /keybase." >&2
+      echo "You might need to run: kbfsfuse /keybase" >&2
+      checkFailed
+    fi
+
+    exec $out/share/keybase/Keybase "\$@"
+    EOF
+    chmod +x $out/bin/keybase-gui
+  '';
+  postFixup = ''
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath "${libPath}:\$ORIGIN" "$out/share/keybase/Keybase"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.keybase.io/;
+    description = "The Keybase official GUI.";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ puffnfresh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2419,6 +2419,8 @@ with pkgs;
 
   kbfs = callPackage ../tools/security/kbfs { };
 
+  keybase-gui = callPackage ../tools/security/keybase-gui { };
+
   keychain = callPackage ../tools/misc/keychain { };
 
   keyfuzz = callPackage ../tools/inputmethods/keyfuzz { };


### PR DESCRIPTION
The GUI requires the keybase and kbfs packages to be installed and running with /keybase as the mount.

---

This depends upon #22600 and #22601.