### PR TITLE
gitlab: 8.16.3 -> 8.16.4

### DIFF
--- a/pkgs/applications/version-management/gitlab/default.nix
+++ b/pkgs/applications/version-management/gitlab/default.nix
@@ -22,7 +22,7 @@ in
 
 stdenv.mkDerivation rec {
   name = "gitlab-${version}";
-  version = "8.16.3";
+  version = "8.16.4";
 
   buildInputs = [ env ruby bundler tzdata git nodejs procps ];
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     owner = "gitlabhq";
     repo = "gitlabhq";
     rev = "v${version}";
-    sha256 = "0fdm92w97ggnpiqlpr5aia6x8j09v8id7n6pks134hq3pkdiz6mv";
+    sha256 = "118p3c9i9r2acc0yv5jzw9p7hql5pbp37k54qzrfgrs8vjjxi14i";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change
Bugfixes available (https://about.gitlab.com/2017/02/02/gitlab-8-dot-16-dot-4-released/) , especially https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/8730

###### Things done

- [x] updated our nixos based gitlab without issues
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

