### PR TITLE
opengrok: 0.12.1 (broken) -> 0.12.5

### DIFF
--- a/pkgs/development/tools/misc/opengrok/default.nix
+++ b/pkgs/development/tools/misc/opengrok/default.nix
@@ -1,11 +1,22 @@
 { fetchurl, stdenv, jre, ctags, makeWrapper, coreutils, git }:
 
 stdenv.mkDerivation rec {
-  name = "opengrok-0.12.1";
+  name = "opengrok-${version}";
+  version = "0.12.5";
 
+  # 0.12.5 is the latest distributed as a .tar.gz file.
+  # Newer are distribued as .zip so a source build is required.
+
+  # if builded from source
+  #src = fetchurl {
+  #  url = "https://github.com/OpenGrok/OpenGrok/archive/${version}.tar.gz";
+  #  sha256 = "01r7ipnj915rnyxyqrnmjfagkip23q5lx9g787qb7qrnbvgfi118";
+  #};
+
+  # binary distribution
   src = fetchurl {
-    url = "http://java.net/projects/opengrok/downloads/download/${name}.tar.gz";
-    sha256 = "0ihaqgf1z2gsjmy2q96m0s07dpnh92j3ss3myiqjdsh9957fwg79";
+    url = https://github.com/OpenGrok/OpenGrok/files/213268/opengrok-0.12.1.5.tar.gz;
+    sha256 = "c3ce079f6ed1526c475cb4b9a7aa901f75507318c93b436d6c14eba4098e4ead";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

fix #22779

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
