### PR TITLE
Perl::CGI: 4.31 -> 4.35

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1555,10 +1555,10 @@ let self = _self // overrides; _self = with self; {
   };
 
   CGI = buildPerlPackage rec {
-    name = "CGI-4.31";
+    name = "CGI-4.35";
     src = fetchurl {
       url = "mirror://cpan/authors/id/L/LE/LEEJO/${name}.tar.gz";
-      sha256 = "dee34f45525efb698d02c56ba2458a72acc34c4dcb05344706b587840b4e8c99";
+      sha256 = "07gwnlc7vq58fjwmfsrv0hfyirqqdrpjhf89caq34rjrkz2wsd0b";
     };
     buildInputs = [ TestDeep TestWarn ];
     propagatedBuildInputs = [ HTMLParser self."if" ];


### PR DESCRIPTION
###### Motivation for this change

fix #22784 

###### Things done

- Built on platform(s)
   - [x] NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

--> partially tested. Too much (226) packages

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/!\ shoud be tagged Mass-rebuild

~~~
nix-shell -p nox --run "nox-review wip"
Building in /run/user/1001/nox-review-w87pdg9t: perlPackages.NetAmazonS3 buildbot-ui rustc python27Packages.pytest-virtualenv pypi2nix openxpki python35Packages.pytest-shutil ntopng python27Packages.setuptoolsTrial python35Packages.setuptools-git kde5.akonadi-contacts perlPackages.RESTUtils perlPackages.TestWWWMechanizePSGI python27Packages.pytest-server-fixtures idea.idea14-community perlPackages.CGISession python27Packages.pyqt5 calibre scudcloud python27Packages.pyutil qarte gnuradio-gsm perlPackages.FinanceQuote python35Packages.setuptoolsTrial dolphinEmuMaster qgroundcontrol openmodelica nix-prefetch-scripts manuskript perlPackages.CatalystViewDownload python35Packages.powerline habitat-sh perlPackages.TestWWWMechanizeCatalyst mercurialFull inspectrum megaglest perlPackages.CatalystPluginCaptcha munin neko gitAndTools.gitSVN buildkite-agent heatseeker gqrx perlPackages.CatalystPluginSessionDynamicExpiry gnucash26 awesome rustracerd perlPackages.CatalystPluginSessionStoreFastMmap src perlPackages.TextTrim gogs tvheadend perlPackages.CatalystXScriptServerStarman snabb rustBeta.rustc perlPackages.CatalystPluginFormValidatorSimple perlPackages.CatalystPluginAuthorizationRoles perlPackages.CatalystPluginSessionStateCookie haxe clerk camlistore gitAndTools.stgit r10k tortoisehg python27Packages.hg-git qtpass go2nix gnuradio-nacl pbrt android-studio python35Packages.ramlfications rkt perlPackages.CGIPSGI utox stanchion bins ycmd rainicorn xprintidle-ng gitolite python35Packages.av gitAndTools.transcrypt gnuradio-rds perlPackages.CatalystAuthenticationCredentialHTTP rust-bindgen bup rustBeta.cargo bundix perlPackages.CGIFormBuilder cvs_fast_export perlPackages.FormValidatorSimple python27Packages.dulwich perlPackages.TaskCatalystTutorial rustPlatform.rustRegistry gnuradio-with-packages purple-facebook leo-editor gitAndTools.git-annex opentsdb perlPackages.TestWWWMechanizeCGI rustNightly.rustc perlPackages.TestWWWMechanize perlPackages.NetOpenIDConsumer gnuradio rofi-pass openshot-qt hxcpp python27Packages.setuptools-git perlPackages.W3CLinkChecker qt5.qtwebengine python27Packages.github-cli awesome-3-5 kde4.calligra python35Packages.pelican nix-prefetch-git python27Packages.powerline ripgrep hhvm altcoins.ethabi buildbot-worker matrix-synapse rustNightly.cargo gitAndTools.darcsToGit perlPackages.CatalystPluginFormValidator pfixtools perlPackages.TermProgressBarSimple nix-prefetch-hg tahoelafs loc cargo habitat perlPackages.CatalystAuthenticationStoreDBIxClass buildbot-full riak-cs qt5.full git-latexdiff perlPackages.HTMLMason perlPackages.RTClientREST perlPackages.HTMLTemplate python27Packages.pelican python35Packages.pyqt5 perlPackages.CatalystPluginCacheHTTP perlPackages.CatalystPluginSessionStoreFile reposurgeon python27Packages.klaus rustracer gitAndTools.gitFull mergerfs perlPackages.HTMLFormFu tokei factor-lang ios-cross-compile python27Packages.fedpkg nox python35Packages.limnoria perlPackages.CatalystAuthenticationStoreHtpasswd smokeping gitAndTools.tig popfile python27Packages.rpkg gnuradio-ais python27Packages.ramlfications pass xtitle mercurial perlPackages.CatalystControllerHTMLFormFu python27Packages.pytest-shutil kde5.kgpg foswiki simavr qutebrowser gitAndTools.diff-so-fancy gitAndTools.git-remote-hg gnucash idea.pycharm-community git-cola ikiwiki gitMinimal gitAndTools.svn2git libbladeRF perlPackages.DataFormValidator gnuradio-osmosdr rofi rustfmt frab perlPackages.TestMockObject gitAndTools.gitFastExport perlPackages.CatalystPluginSession rofi-menugen gibo gitlab git-up fpm qt57.qtwebengine rabbitvcs qsyncthingtray gitlab-workhorse perlPackages.CGIEmulatePSGI python27Packages.nxt-python vimPlugins.pluginnames2nix python35Packages.pytest-virtualenv cide perlPackages.TermProgressBarQuiet git python27Packages.zfec python27Packages.limnoria dotnetPackages.GitVersionTree buildbot vimPlugins.YouCompleteMe perlPackages.HTMLMasonPSGIHandler idea.idea-community python35Packages.github-cli perlPackages.CatalystControllerPOD perlPackages.CatalystPluginAuthentication hydra vulkan-loader perlPackages.HTTPServerSimpleMason opengrok altcoins.stellar-core cabal2nix rhc nix-exec python27Packages.av python35Packages.pytest-server-fixtures perlPackages.CGI luakit
~~~

---

