### PR TITLE
wireguard: 0.0.20170213 -> 0.0.20170214

### DIFF
--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -6,11 +6,11 @@ assert kernel != null -> stdenv.lib.versionAtLeast kernel.version "3.18";
 let
   name = "wireguard-${version}";
 
-  version = "0.0.20170213";
+  version = "0.0.20170214";
 
   src = fetchurl {
     url    = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
-    sha256 = "256a7d41cf228f2a88e1b03b3911746dc827fe7be5b982c60080e7f81998cc6d";
+    sha256 = "1e4ee213d2a5ac672c952c59e9c64d6d7d5dc3e21c003aee30d75208237e8bf5";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Sorry to make another pull request and snapshot so soon. People quickly found an issue when using wg-quick with old bash, so this fixes it.