### PR TITLE
freeipa: init at 4.4.3

### DIFF
--- a/nixos/modules/config/ipa.nix
+++ b/nixos/modules/config/ipa.nix
@@ -1,0 +1,238 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.ipa;
+  sssd = config.services.sssd;
+  ntp = config.services.ntp;
+  krb5 = config.krb5;
+  ldap = config.users.ldap;
+  pyBool = x: if x then "True" else "False";
+
+  ldapConf = pkgs.writeText "ldap.conf" ''
+    # Turning this off breaks GSSAPI used with krb5 when rdns = false
+    SASL_NOCANON    on
+
+    URI ldaps://${cfg.server}
+    BASE ${cfg.basedn}
+    TLS_CACERT /etc/ipa/ca.crt
+  '';
+  nssDb = pkgs.runCommand "ipa-nssdb" { buildInputs = [ pkgs.nss.tools ]; } ''
+    set -x
+    mkdir -p $out
+    < /dev/urandom tr -dc '[:print:]' | head -c 40 > $out/pwdfile.txt ||:
+    chmod 600 $out/pwdfile.txt
+    certutil -d $out -N -f $out/pwdfile.txt
+    chmod 644 $out/*.db
+    certutil -d $out -A -f $out/pwdfile -n "${cfg.realm} IPA CA" -t CT,C,C -i ${cfg.certificate}
+  '';
+
+in {
+  options = {
+    ipa = {
+      enable = mkEnableOption "FreeIPA domain integration";
+
+      certificate = mkOption {
+        type = types.package;
+        description = ''
+          IPA server CA certificate.
+
+          Use `nix-prefetch-url http://$server/ipa/config/ca.crt` to
+          obtain the file and the hash.
+        '';
+      };
+
+      domain = mkOption {
+        type = types.str;
+        example = "in.corp.com";
+        description = "Domain of the IPA server.";
+      };
+
+      realm = mkOption {
+        type = types.str;
+        example = "IN.CORP.COM";
+        description = "Kerberos realm.";
+      };
+
+      server = mkOption {
+        type = types.str;
+        example = "ipa.in.corp.com";
+        description = "IPA Server hostname.";
+      };
+
+      basedn = mkOption {
+        type = types.str;
+        example = "dc=in,dc=corp,dc=com";
+        description = "Base DN to use when performing LDAP operations.";
+      };
+
+      offlinePasswords = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to store offline passwords when the server is down.";
+      };
+
+      adminUser = mkOption {
+        type = types.str;
+        default = "admin";
+        description = "IPA user with host joining privileges.";
+      };
+
+      dyndns = {
+        enable = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Whether to enable FreeIPA automatic hostname updates.";
+        };
+
+        interface = mkOption {
+          type = types.str;
+          example = "eth0";
+          default = "*";
+          description = "Network interface to perform hostname updates through.";
+        };
+      };
+
+      chromiumSupport = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to whitelist the FreeIPA domain in Chromium.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = sssd.enable;
+        message = "sssd must be enabled through `services.sssd.enable` for FreeIPA integration to work.";
+      }
+      {
+        assertion = ntp.enable;
+        message = "ntpd must be enabled through `services.ntp.enable` for FreeIPA integration to work.";
+      }
+      {
+        assertion = !krb5.enable;
+        message = "krb5 must be disabled through `krb5.enable` for FreeIPA integration to work.";
+      }
+      {
+        assertion = !ldap.enable;
+        message = "ldap must be disabled through `users.ldap.enable` for FreeIPA integration to work.";
+      }
+    ];
+
+    environment.systemPackages = with pkgs; [ freeipa freeipaKerberos freeipaCurl freeipaBind.dnsutils openldap ];
+
+    environment.etc = mkMerge [{
+      "ipa/default.conf".text = ''
+        [global]
+        basedn = ${cfg.basedn}
+        realm = ${cfg.realm}
+        domain = ${cfg.domain}
+        server = ${cfg.server}
+        host = ${config.networking.hostName}
+        xmlrpc_uri = https://${cfg.server}/ipa/xml
+        enable_ra = True
+      '';
+
+      "ipa/nssdb".source = nssDb;
+
+      "krb5.conf".text = ''
+        [libdefaults]
+         default_realm = ${cfg.realm}
+         dns_lookup_realm = false
+         dns_lookup_kdc = true
+         rdns = false
+         ticket_lifetime = 24h
+         forwardable = true
+         udp_preference_limit = 0
+
+        [realms]
+         ${cfg.realm} = {
+          kdc = ${cfg.server}:88
+          master_kdc = ${cfg.server}:88
+          admin_server = ${cfg.server}:749
+          default_domain = ${cfg.domain}
+          pkinit_anchors = FILE:/etc/ipa/ca.crt
+        }
+
+        [domain_realm]
+         .${cfg.domain} = ${cfg.realm}
+         ${cfg.domain} = ${cfg.realm}
+         ${cfg.server} = ${cfg.realm}
+
+        [dbmodules]
+          ${cfg.realm} = {
+            db_library = ${pkgs.freeipa}/lib/krb5/plugins/kdb/ipadb.so
+          }
+      '';
+
+      "opanldap/ldap.conf".source = ldapConf;
+    }
+    (mkIf cfg.chromiumSupport {
+      "chromium/policies/managed/freeipa.json".text = ''
+        { "AuthServerWhitelist": "*.${cfg.domain}" }
+      '';
+    })];
+
+    system.activationScripts.ipa = stringAfter [ "etc" ] ''
+      # libcurl requires a hard copy of the certificate
+      if ! ${pkgs.diffutils}/bin/diff ${cfg.certificate} /etc/ipa/ca.crt > /dev/null 2>&1; then
+        rm -f /etc/ipa/ca.crt
+        cp ${cfg.certificate} /etc/ipa/ca.crt
+      fi
+
+      # Perform ipa-join after all files in /etc are available
+      if [ ! -e /etc/krb5.keytab ]; then
+        echo "Joining IPA domain ${cfg.domain}"
+        ${pkgs.freeipaKerberos}/bin/kinit ${cfg.adminUser}@${cfg.realm} || exit 1
+        ${pkgs.freeipa}/bin/ipa-join || exit 1
+      fi
+    '';
+
+    services.sssd.config = ''
+      [domain/${cfg.domain}]
+      id_provider = ipa
+      auth_provider = ipa
+      access_provider = ipa
+      chpass_provider = ipa
+
+      ipa_domain = ${cfg.domain}
+      ipa_server = _srv_, ${cfg.server}
+      ipa_hostname = ${config.networking.hostName}
+
+      cache_credentials = True
+      krb5_store_password_if_offline = ${pyBool cfg.offlinePasswords}
+      ${optionalString ((toLower cfg.domain) != (toLower cfg.realm))
+        "krb5_realm = ${cfg.realm}"}
+
+      dyndns_update = ${pyBool cfg.dyndns.enable}
+      dyndns_iface = ${cfg.dyndns.interface}
+
+      ldap_tls_cacert = /etc/ipa/ca.crt
+
+      [sssd]
+      services = nss, sudo, pam, ssh
+      domains = ${cfg.domain}
+
+      [nss]
+      homedir_substring = /home
+
+      [pam]
+
+      [sudo]
+
+      [autofs]
+
+      [ssh]
+
+      [pac]
+
+      [ifp]
+    '';
+
+    services.ntp.servers = singleton cfg.server;
+    security.pki.certificateFiles = singleton cfg.certificate;
+
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -18,6 +18,8 @@
   ./config/i18n.nix
   ./config/iproute2.nix
   ./config/krb5/default.nix
+  ./config/ipa.nix
+  ./config/krb5.nix
   ./config/ldap.nix
   ./config/networking.nix
   ./config/no-x-libs.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -17,9 +17,8 @@
   ./config/gnu.nix
   ./config/i18n.nix
   ./config/iproute2.nix
-  ./config/krb5/default.nix
   ./config/ipa.nix
-  ./config/krb5.nix
+  ./config/krb5/default.nix
   ./config/ldap.nix
   ./config/networking.nix
   ./config/no-x-libs.nix

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -356,9 +356,12 @@ let
           # Modules in this block require having the password set in PAM_AUTHTOK.
           # pam_unix is marked as 'sufficient' on NixOS which means nothing will run
           # after it succeeds. Certain modules need to run after pam_unix
-          # prompts the user for password so we run it once with 'required' at an
+          # prompts the user for password so we run it once with 'optional' at an
           # earlier point and it will run again with 'sufficient' further down.
-          # We use try_first_pass the second time to avoid prompting password twice
+          # We use try_first_pass the second time to avoid prompting password twice.
+          # Alternative modules such as pam_sss may also terminate the auth
+          # process succesfully further down the line, using the first password
+          # passed in to pam_unix.
           (optionalString (cfg.unixAuth &&
           (config.security.pam.enableEcryptfs
             || cfg.pamMount
@@ -366,7 +369,7 @@ let
             || cfg.enableGnomeKeyring
             || cfg.googleAuthenticator.enable
             || cfg.duoSecurity.enable)) ''
-              auth required pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} likeauth
+              auth optional pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} likeauth
               ${optionalString config.security.pam.enableEcryptfs
                 "auth optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so unwrap"}
               ${optionalString cfg.pamMount

--- a/pkgs/development/compilers/lesscpy/default.nix
+++ b/pkgs/development/compilers/lesscpy/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, buildPythonApplication, fetchPypi, pytest, ply, six }:
+{ stdenv, pythonPackages }:
+
+with pythonPackages;
 
 buildPythonApplication rec {
   pname   = "lesscpy";

--- a/pkgs/development/compilers/lesscpy/default.nix
+++ b/pkgs/development/compilers/lesscpy/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest, ply, six }:
+{ stdenv, buildPythonApplication, fetchPypi, pytest, ply, six }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   pname   = "lesscpy";
   version = "0.13.0";
 

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, pkgconfig, perl, yacc, bootstrap_cmds
 , openssl, openldap, libedit, keyutils
+, libverto ? null
 
 # Extra Arguments
 , type ? ""
@@ -10,6 +11,7 @@
 
 let
   libOnly = type == "lib";
+  withSystemVerto = libverto != null;
 in
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -28,6 +30,7 @@ stdenv.mkDerivation rec {
     # krb5's ./configure does not allow passing --enable-shared and --enable-static at the same time.
     # See https://bbs.archlinux.org/viewtopic.php?pid=1576737#p1576737
     ++ optional staticOnly [ "--enable-static" "--disable-shared" ]
+    ++ optional withSystemVerto "--with-system-verto"
     ++ optional stdenv.isFreeBSD ''WARN_CFLAGS=""''
     ++ optionals (stdenv.buildPlatform != stdenv.hostPlatform)
        [ "krb5_cv_attr_constructor_destructor=yes,yes"
@@ -42,6 +45,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl ]
     ++ optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.libc != "bionic" && !(stdenv.hostPlatform.useLLVM or false)) [ keyutils ]
+    ++ optional withSystemVerto libverto
     ++ optionals (!libOnly) [ openldap libedit ];
 
   preConfigure = "cd ./src";

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, perl, yacc, bootstrap_cmds
-, openssl, openldap, libedit, keyutils
-, libverto ? null
+, openssl, openldap, libedit, keyutils, libverto
+, enableSystemVerto ? false
 
 # Extra Arguments
 , type ? ""
@@ -11,7 +11,6 @@
 
 let
   libOnly = type == "lib";
-  withSystemVerto = libverto != null;
 in
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -30,7 +29,7 @@ stdenv.mkDerivation rec {
     # krb5's ./configure does not allow passing --enable-shared and --enable-static at the same time.
     # See https://bbs.archlinux.org/viewtopic.php?pid=1576737#p1576737
     ++ optional staticOnly [ "--enable-static" "--disable-shared" ]
-    ++ optional withSystemVerto "--with-system-verto"
+    ++ optional enableSystemVerto "--with-system-verto"
     ++ optional stdenv.isFreeBSD ''WARN_CFLAGS=""''
     ++ optionals (stdenv.buildPlatform != stdenv.hostPlatform)
        [ "krb5_cv_attr_constructor_destructor=yes,yes"
@@ -45,7 +44,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl ]
     ++ optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.libc != "bionic" && !(stdenv.hostPlatform.useLLVM or false)) [ keyutils ]
-    ++ optional withSystemVerto libverto
+    ++ optional enableSystemVerto libverto
     ++ optionals (!libOnly) [ openldap libedit ];
 
   preConfigure = "cd ./src";

--- a/pkgs/development/libraries/libverto/default.nix
+++ b/pkgs/development/libraries/libverto/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, libev, libevent, tevent, talloc }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, glib, libev, libevent, tevent, talloc }:
 
 let
   name = "libverto-${version}";
@@ -8,13 +8,16 @@ stdenv.mkDerivation {
   inherit name;
   inherit version;
 
-  src = fetchurl {
-    url = "https://fedorahosted.org/releases/l/i/libverto/${name}.tar.gz";
-    sha256 = "17hwr55ga0rkm5cnyfiipyrk9n372x892ph9wzi88j2zhnisdv0p";
+  src = fetchFromGitHub {
+    owner = "latchset";
+    repo = "libverto";
+    rev = version;
+    sha256 = "1wis97l2f265bq6ps1b4yjblll7pa2xsckq3kjblv1djg71brmbr";
   };
 
   patches = [ ./libverto-0.2.6-exec-prefix.patch ];
-  
+
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ pkgconfig glib libev libevent tevent talloc ];
 
   meta = with stdenv.lib; {
@@ -28,7 +31,7 @@ stdenv.mkDerivation {
       async api which allows the library to expose asynchronous interfaces and
       offload the choice of the main loop to the application.
     '';
-    homepage = https://fedorahosted.org/libverto/;
+    homepage = https://github.com/latchset/libverto/;
     license = licenses.mit;
     maintainers = [ maintainers.e-user ];
   };

--- a/pkgs/development/libraries/libverto/default.nix
+++ b/pkgs/development/libraries/libverto/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, pkgconfig, glib, libev, libevent, tevent, talloc }:
+
+let
+  name = "libverto-${version}";
+  version = "0.2.6";
+in
+stdenv.mkDerivation {
+  inherit name;
+  inherit version;
+
+  src = fetchurl {
+    url = "https://fedorahosted.org/releases/l/i/libverto/${name}.tar.gz";
+    sha256 = "17hwr55ga0rkm5cnyfiipyrk9n372x892ph9wzi88j2zhnisdv0p";
+  };
+
+  patches = [ ./libverto-0.2.6-exec-prefix.patch ];
+  
+  buildInputs = [ pkgconfig glib libev libevent tevent talloc ];
+
+  meta = with stdenv.lib; {
+    description = "Main loop abstraction library";
+    longDescription = ''
+      libverto exists to solve an important problem: many applications and
+      libraries are unable to write asynchronous code because they are unable to
+      pick an event loop. This is particularly true of libraries who want to be
+      useful to many applications who use loops that do not integrate with one
+      another or which use home-grown loops. libverto provides a loop-neutral
+      async api which allows the library to expose asynchronous interfaces and
+      offload the choice of the main loop to the application.
+    '';
+    homepage = https://fedorahosted.org/libverto/;
+    license = licenses.mit;
+    maintainers = [ maintainers.e-user ];
+  };
+}

--- a/pkgs/development/libraries/libverto/libverto-0.2.6-exec-prefix.patch
+++ b/pkgs/development/libraries/libverto/libverto-0.2.6-exec-prefix.patch
@@ -1,0 +1,60 @@
+diff -ur libverto-0.2.6-exec-prefix/libverto-glib.pc.in libverto-0.2.6/libverto-glib.pc.in
+--- libverto-0.2.6-exec-prefix/libverto-glib.pc.in	2014-03-12 18:59:51.000000000 +0100
++++ libverto-0.2.6/libverto-glib.pc.in	2016-12-20 14:36:13.437952077 +0100
+@@ -1,7 +1,7 @@
+ prefix=@prefix@
++exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ includedir=@includedir@
+-exec_prefix=@exec_prefix@
+  
+ Name: libverto-glib
+ Description: Event loop abstraction interface (glib module)
+diff -ur libverto-0.2.6-exec-prefix/libverto-libevent.pc.in libverto-0.2.6/libverto-libevent.pc.in
+--- libverto-0.2.6-exec-prefix/libverto-libevent.pc.in	2014-03-12 18:59:51.000000000 +0100
++++ libverto-0.2.6/libverto-libevent.pc.in	2016-12-20 14:36:03.746964233 +0100
+@@ -1,7 +1,7 @@
+ prefix=@prefix@
++exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ includedir=@includedir@
+-exec_prefix=@exec_prefix@
+  
+ Name: libverto-libevent
+ Description: Event loop abstraction interface (libevent module)
+diff -ur libverto-0.2.6-exec-prefix/libverto-libev.pc.in libverto-0.2.6/libverto-libev.pc.in
+--- libverto-0.2.6-exec-prefix/libverto-libev.pc.in	2014-03-12 18:59:51.000000000 +0100
++++ libverto-0.2.6/libverto-libev.pc.in	2016-12-20 14:36:08.885957789 +0100
+@@ -1,7 +1,7 @@
+ prefix=@prefix@
++exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ includedir=@includedir@
+-exec_prefix=@exec_prefix@
+  
+ Name: libverto-libev
+ Description: Event loop abstraction interface (libev module)
+diff -ur libverto-0.2.6-exec-prefix/libverto.pc.in libverto-0.2.6/libverto.pc.in
+--- libverto-0.2.6-exec-prefix/libverto.pc.in	2014-03-12 18:59:51.000000000 +0100
++++ libverto-0.2.6/libverto.pc.in	2016-12-20 14:35:50.180981220 +0100
+@@ -1,7 +1,7 @@
+ prefix=@prefix@
++exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ includedir=@includedir@
+-exec_prefix=@exec_prefix@
+  
+ Name: libverto
+ Description: Event loop abstraction interface
+diff -ur libverto-0.2.6-exec-prefix/libverto-tevent.pc.in libverto-0.2.6/libverto-tevent.pc.in
+--- libverto-0.2.6-exec-prefix/libverto-tevent.pc.in	2014-03-12 18:59:51.000000000 +0100
++++ libverto-0.2.6/libverto-tevent.pc.in	2016-12-20 14:35:59.042970127 +0100
+@@ -1,7 +1,7 @@
+ prefix=@prefix@
++exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ includedir=@includedir@
+-exec_prefix=@exec_prefix@
+  
+ Name: libverto-tevent
+ Description: Event loop abstraction interface (tevent module)

--- a/pkgs/development/python-modules/lesscpy/default.nix
+++ b/pkgs/development/python-modules/lesscpy/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, ply, six }:
+
+buildPythonPackage rec {
+  pname   = "lesscpy";
+  version = "0.12.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1dcql1bgh70a9avbx9b8mq9gzdp76v8bszlik96x3rf6xxbjfmaw";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ ply six ];
+
+  doCheck = false; # Really weird test failures (`nix-build-python2.css not found`)
+
+  meta = with stdenv.lib; {
+    description = "Python LESS Compiler";
+    homepage    = https://github.com/lesscpy/lesscpy;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ e-user ];
+  };
+}

--- a/pkgs/development/python-modules/lesscpy/default.nix
+++ b/pkgs/development/python-modules/lesscpy/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname   = "lesscpy";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1dcql1bgh70a9avbx9b8mq9gzdp76v8bszlik96x3rf6xxbjfmaw";
+    sha256 = "1bbjag13kawnjdn7q4flfrkd0a21rgn9ycfqsgfdmg658jsx1ipk";
   };
 
   checkInputs = [ pytest ];

--- a/pkgs/development/python-modules/nss/default.nix
+++ b/pkgs/development/python-modules/nss/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   checkPhase = ''
     export PYTHONPATH=$(echo $(pwd)/build/lib.*):$PYTHONPATH
-    $PYTHON test/run_tests
+    python test/run_tests
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/nss/default.nix
+++ b/pkgs/development/python-modules/nss/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, buildPythonPackage, nss, nspr, six }:
+
+let
+  inherit (stdenv.lib) concatStringsSep replaceStrings;
+in
+buildPythonPackage rec {
+  name = "nss-${version}";
+  version = "1.0.0";
+  src = fetchurl {
+    url = "https://ftp.mozilla.org/pub/security/python-nss/releases/PYNSS_RELEASE_${replaceStrings ["."] ["_"] version}/src/python-${name}.tar.bz2";
+    sha1 = "8403f759a514726b9360b68f4d5e4f50bc422197";
+  };
+
+  buildInputs = [ nss nspr six nss ];
+  patchPhase = ''
+    sed -i -e "s/find_include_dir(\['nspr4', 'nspr'\]/find_include_dir(['.']/" setup.py
+    sed -i -e "s#include_roots = \[\]#include_roots = [${concatStringsSep ", " (map (pkg: "'" + pkg.dev + "/include'") [ nss nspr ])}]#" setup.py
+    for file in test/{setup_certs,test_pkcs12}.py; do
+      substituteInPlace $file \
+        --replace /usr/bin/certutil ${nss.tools}/bin/certutil \
+        --replace /usr/bin/modutil ${nss.tools}/bin/modutil \
+        --replace /usr/bin/pk12util ${nss.tools}/bin/pk12util
+    done
+  '';
+
+  checkPhase = ''
+    export PYTHONPATH=$(echo $(pwd)/build/lib.*):$PYTHONPATH
+    $PYTHON test/run_tests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Python binding for NSS";
+    homepage    = https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Python_binding_for_NSS;
+    license     = licenses.mpl20;
+    maintainers = with maintainers; [ e-user ];
+  };
+}

--- a/pkgs/development/python-modules/pki-core/default.nix
+++ b/pkgs/development/python-modules/pki-core/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildPythonPackage, sphinx, rpmextract, nss, requests2,
+{ stdenv, fetchurl, buildPythonPackage, sphinx, rpmextract, nss, requests,
   six }:
 
 buildPythonPackage rec {
@@ -22,14 +22,15 @@ buildPythonPackage rec {
 
   patchFlags = "-p1 -F 3";
 
-  buildInputs = [ sphinx rpmextract ];
-  propagatedBuildInputs = [ nss requests2 six ];
+  nativeBuildInputs = [ rpmextract ];
+  buildInputs = [ sphinx ];
+  propagatedBuildInputs = [ nss requests six ];
 
   unpackPhase = ''
     rpmextract $src
     tar -xf ${name}.tar.gz
     mv *.patch ${name}/
-    mkdir ${name}/specs 
+    mkdir ${name}/specs
     mv pki-core.spec ${name}/specs/
   '';
 

--- a/pkgs/development/python-modules/pki-core/default.nix
+++ b/pkgs/development/python-modules/pki-core/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, buildPythonPackage, sphinx, rpmextract, nss, requests2,
+  six }:
+
+buildPythonPackage rec {
+  name = "pki-core-${version}";
+  version = "10.3.5";
+
+  rpmFile = "${name}-7.fc25.src.rpm";
+
+  src = fetchurl {
+    url = "mirror://fedora/linux/releases/25/Everything/source/tree/Packages/p/${rpmFile}";
+    sha256 = "18kva88qqjfbkccaw1j889jfm95zk8a63xhy05ldj07yfqz38vsz";
+  };
+
+  patches = [
+    "pki-core-snapshot-1.patch"
+    "pki-core-snapshot-2.patch"
+    "pki-core-snapshot-3.patch"
+    "pki-core-snapshot-4.patch"
+    "pki-core-fedora-post-snapshot-1.patch"
+  ];
+
+  patchFlags = "-p1 -F 3";
+
+  buildInputs = [ sphinx rpmextract ];
+  propagatedBuildInputs = [ nss requests2 six ];
+
+  unpackPhase = ''
+    rpmextract $src
+    tar -xf ${name}.tar.gz
+    mv *.patch ${name}/
+    mkdir ${name}/specs 
+    mv pki-core.spec ${name}/specs/
+  '';
+
+  sourceRoot = name;
+
+  preBuild = ''
+    cd base/common/python
+    unset SOURCE_DATE_EPOCH
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Client library for Dogtag Certificate System";
+    homepage    = http://pki.fedoraproject.org/;
+    license     = licenses.lgpl3Plus;
+    maintainers = [ maintainers.e-user ];
+  };
+}

--- a/pkgs/development/python-modules/yubico/default.nix
+++ b/pkgs/development/python-modules/yubico/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, pyusb }:
+
+buildPythonPackage rec {
+  pname   = "python-yubico";
+  version = "1.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1gd3an1cdcq328nr1c9ijrsf32v0crv6dgq7knld8m9cadj517c7";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ pyusb ];
+
+  checkPhase =  ''
+    py.test -k "not usb"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Python code to talk to YubiKeys";
+    homepage    = https://github.com/Yubico/python-yubico;
+    license     = licenses.bsd2;
+    maintainers = with maintainers; [ e-user ];
+  };
+}

--- a/pkgs/os-specific/linux/freeipa/default.nix
+++ b/pkgs/os-specific/linux/freeipa/default.nix
@@ -1,0 +1,135 @@
+{ stdenv, fetchurl, writeText, pkgconfig, autoconf, automake, kerberos,
+  openldap, popt, sasl, curl, xmlrpc_c, ding-libs, p11_kit, gettext, nspr, nss,
+  dirsrv, svrcore, libuuid, talloc, tevent, samba, libunistring, libverto,
+  systemd, python2, bind, pyhbac, jre, rhino, lesscpy }:
+
+let
+  name = "freeipa-${version}";
+  version = "4.4.3";
+  ipa-client-install = ./ipa-client-install;
+  pathsPy = ./paths.py;
+  pythonPackages = python2.pkgs;
+
+  pythonInputs = with pythonPackages; [
+    six ldap dns netaddr netifaces gssapi nss pyasn1 pyhbac cffi lxml pki-core
+    dbus-python cryptography memcached qrcode pyusb yubico
+  ];
+in
+stdenv.mkDerivation rec {
+  inherit name;
+  inherit version;
+
+  src = fetchurl {
+    url = "http://freeipa.org/downloads/src/${name}.tar.gz";
+    sha1 = "cf1e078a6c1b52b81891e67b9b6b2a6d3436e98d";
+  };
+
+  nativeBuildInputs = [
+    pythonPackages.wrapPython jre rhino lesscpy automake autoconf gettext
+  ];
+
+  buildInputs = [
+    kerberos openldap popt sasl curl xmlrpc_c pkgconfig ding-libs p11_kit
+    python2 autoconf nspr nss dirsrv svrcore libuuid talloc tevent samba
+    libunistring libverto systemd bind
+  ] ++ pythonInputs;
+
+  postPatch = ''
+    export SUPPORTED_PLATFORM=nixos
+    export IPA_VERSION_IS_GIT_SNAPSHOT=no
+
+    for file in makeapi makeaci install/ui/util; do patchShebangs $file; done
+
+    substituteInPlace ipaserver/plugins/pwpolicy.py \
+      --replace klist ${kerberos}/bin/klist
+
+    substituteInPlace ipapython/p11helper.py \
+      --replace "ctypes.util.find_library('p11-kit')" \"${p11_kit}/lib/libp11-kit.so\"
+
+    for file in daemons/ipa-slapi-plugins/*/Makefile.*; do
+      substituteInPlace $file \
+        --replace "-I/usr/include/dirsrv" '$(DIRSRV_CFLAGS)'
+    done
+
+    for file in install/ui/util/build.sh install/ui/util/uglifyjs/uglify; do
+     substituteInPlace $file \
+        --replace /usr/share/java/js.jar ${rhino}/share/java/js.jar
+    done
+
+    substituteInPlace install/ui/util/make-css.sh \
+      --replace lesscpy ${lesscpy}/bin/lesscpy
+
+    for file in Makefile ipapython/Makefile ipalib/Makefile; do
+      substituteInPlace $file \
+        --replace "setup.py install --root" "setup.py install --prefix"
+    done
+
+    substituteInPlace client/ipa-join.c \
+      --replace /usr/sbin/ipa-getkeytab $out/bin/ipa-getkeytab
+
+    cp -r ipaplatform/{fedora,nixos}
+    substitute ${pathsPy} ipaplatform/nixos/paths.py \
+      --subst-var out \
+      --subst-var-by bind ${bind.dnsutils} \
+      --subst-var-by curl ${curl} \
+      --subst-var-by kerberos ${kerberos}
+  '';
+
+  PYTHON="${python2}/bin/python";
+
+  configurePhase = ''
+    for dir in asn1 client daemons install; do
+      pushd $dir
+      configurePhase
+      popd
+    done
+    pushd ipatests/man
+    autoreconf -i -f
+    configurePhase
+    popd
+  '';
+
+  preBuild = ''
+    make version-update
+    export SKIP_API_VERSION_CHECK=yes
+  '';
+
+  NIX_CFLAGS_COMPILE = "-I${dirsrv}/include/dirsrv";
+  pythonPath = pythonInputs;
+  prefix = "/";
+
+  # Building and installing the server fails with silent Rhino errors, skipping
+  # for now. Need a newer Rhino version.
+  #buildFlags = [ "client" "server" ];
+
+  buildFlags = [ "client" ];
+  installFlags = [ "DESTDIR=$(out)" ];
+  installTargets = "client-install";
+  checkFlags = [ "VERBOSE=yes" ];
+  checkTargets = [ "client-check" ];
+
+  postInstall = ''
+    cat ${ipa-client-install} > $out/sbin/ipa-client-install
+  '';
+
+  postFixup = ''
+    wrapPythonPrograms
+    rmdir -p --ignore-fail-on-non-empty \
+      $out/etc/ipa $out/var/lib/ipa-client/sysrestore
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Identity, Policy and Audit system";
+    longDescription = ''
+      IPA is an integrated solution to provide centrally managed Identity (users,
+      hosts, services), Authentication (SSO, 2FA), and Authorization
+      (host access control, SELinux user roles, services). The solution provides
+      features for further integration with Linux based clients (SUDO, automount)
+      and integration with Active Directory based infrastructures (Trusts).
+    '';
+    homepage = https://www.freeipa.org/;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.e-user ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/freeipa/default.nix
+++ b/pkgs/os-specific/linux/freeipa/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
       --subst-var-by kerberos ${kerberos}
   '';
 
-  PYTHON="${python2.intepreter}";
+  PYTHON="${python2}/bin/python";
 
   configurePhase = ''
     for dir in asn1 client daemons install; do

--- a/pkgs/os-specific/linux/freeipa/default.nix
+++ b/pkgs/os-specific/linux/freeipa/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, writeText, pkgconfig, autoconf, automake, kerberos,
-  openldap, popt, sasl, curl, xmlrpc_c, ding-libs, p11_kit, gettext, nspr, nss,
+  openldap, popt, sasl, curl, xmlrpc_c, ding-libs, p11-kit, gettext, nspr, nss,
   dirsrv, svrcore, libuuid, talloc, tevent, samba, libunistring, libverto,
   systemd, python2, bind, pyhbac, jre, rhino, lesscpy }:
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    kerberos openldap popt sasl curl xmlrpc_c pkgconfig ding-libs p11_kit
+    kerberos openldap popt sasl curl xmlrpc_c pkgconfig ding-libs p11-kit
     python2 autoconf nspr nss dirsrv svrcore libuuid talloc tevent samba
     libunistring libverto systemd bind
   ] ++ pythonInputs;
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       --replace klist ${kerberos}/bin/klist
 
     substituteInPlace ipapython/p11helper.py \
-      --replace "ctypes.util.find_library('p11-kit')" \"${p11_kit}/lib/libp11-kit.so\"
+      --replace "ctypes.util.find_library('p11-kit')" \"${p11-kit}/lib/libp11-kit.so\"
 
     for file in daemons/ipa-slapi-plugins/*/Makefile.*; do
       substituteInPlace $file \
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
       --subst-var-by kerberos ${kerberos}
   '';
 
-  PYTHON="${python2}/bin/python";
+  PYTHON="${python2.intepreter}";
 
   configurePhase = ''
     for dir in asn1 client daemons install; do

--- a/pkgs/os-specific/linux/freeipa/ipa-client-install
+++ b/pkgs/os-specific/linux/freeipa/ipa-client-install
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "ipa-client-install is not available on NixOS. Please see services.ipa.client, instead."
+
+exit 1

--- a/pkgs/os-specific/linux/freeipa/paths.py
+++ b/pkgs/os-specific/linux/freeipa/paths.py
@@ -1,0 +1,13 @@
+from ipaplatform.fedora.paths import FedoraPathNamespace
+
+class NixOSPathNamespace(FedoraPathNamespace):
+    SBIN_IPA_JOIN = "@out@/bin/ipa-join"
+    IPA_GETCERT = "@out@/bin/ipa-getcert"
+    IPA_RMKEYTAB = "@out@/bin/ipa-rmkeytab"
+    IPA_GETKEYTAB = "@out@/bin/ipa-getkeytab"
+    NSUPDATE = "@bind@/bin/nsupdate"
+    BIN_CURL = "@curl@/bin/curl"
+    KINIT = "@kerberos@/bin/kinit"
+    KDESTROY = "@kerberos@/bin/kdestroy"
+    
+paths = NixOSPathNamespace()

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -3,16 +3,14 @@
 , libcap, libtool, libxml2, openssl
 , enablePython ? config.bind.enablePython or false, python3 ? null
 , enableSeccomp ? false, libseccomp ? null, buildPackages
-, kerberos ? null
+, enableGSSAPI ? true, kerberos ? null
 }:
 
 assert enableSeccomp -> libseccomp != null;
 assert enablePython -> python3 != null;
+assert enableGSSAPI -> kerberos != null;
 
-let
-  version = "9.12.4-P1";
-  withGSSAPI = kerberos != null;
-in
+let version = "9.12.4-P1"; in
 
 stdenv.mkDerivation rec {
   name = "bind-${version}";
@@ -41,7 +39,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libtool libxml2 openssl ]
     ++ lib.optional stdenv.isLinux libcap
     ++ lib.optional enableSeccomp libseccomp
-    ++ stdenv.lib.optional withGSSAPI kerberos
+    ++ lib.optional enableGSSAPI kerberos
     ++ lib.optional enablePython (python3.withPackages (ps: with ps; [ ply ]));
 
   STD_CDEFINES = [ "-DDIG_SIGCHASE=1" ]; # support +sigchase
@@ -68,11 +66,9 @@ stdenv.mkDerivation rec {
     "--with-gost"
     "--without-eddsa"
     "--with-aes"
+    (if enableGSSAPI then "--with-gssapi=${kerberos}" else "--without-gssapi")
   ] ++ lib.optional stdenv.isLinux "--with-libcap=${libcap.dev}"
-    ++ lib.optional enableSeccomp "--enable-seccomp"
-    ++ (if withGSSAPI then ["--with-gssapi=${kerberos}"] else ["--without-gssapi"]);
-    "--without-python"
-  ]
+    ++ lib.optional enableSeccomp "--enable-seccomp";
 
   postInstall = ''
     moveToOutput bin/bind9-config $dev

--- a/pkgs/servers/ldap/389/default.nix
+++ b/pkgs/servers/ldap/389/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, perl, pam, nspr, nss, openldap
-, db, cyrus_sasl, svrcore, icu, net_snmp, kerberos, pcre, perlPackages
+, db, cyrus_sasl, svrcore, icu, net_snmp, kerberos, pcre, perlPackages, openssl
 }:
 let
   version = "1.3.5.19";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     perl pam nspr nss openldap db cyrus_sasl svrcore icu
-    net_snmp kerberos pcre
+    net_snmp kerberos pcre openssl
   ] ++ (with perlPackages; [ MozillaLdap NetAddrIP DBFile ]);
 
   # TODO: Fix bin/ds-logpipe.py, bin/logconv, bin/cl-dump

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10878,7 +10878,7 @@ in
 
   krb5 = callPackage ../development/libraries/kerberos/krb5.nix {
     inherit (buildPackages.darwin) bootstrap_cmds;
-    enableSystemVerto = true;
+    enableSystemVerto = !stdenv.isDarwin; # Circular dependency
   };
   krb5Full = krb5;
   libkrb5 = krb5.override { type = "lib"; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3916,6 +3916,8 @@ in
 
   lf = callPackage ../tools/misc/lf {};
 
+  lesscpy = pythonPackages.lesscpy;
+
   lhasa = callPackage ../tools/compression/lhasa {};
 
   libcpuid = callPackage ../tools/misc/libcpuid { };
@@ -10164,6 +10166,33 @@ in
 
   freeimage = callPackage ../development/libraries/freeimage { };
 
+  freeipaKerberos = krb5Full.override { inherit libverto; };
+
+  freeipaKerberosLib = freeipaKerberos.override { type = "lib"; };
+
+  freeipaCurl = curl.override {
+    gssSupport = true;
+    gss = krb5Full;
+  };
+
+  freeipaBind = bind.override { kerberos = freeipaKerberosLib; };
+
+  freeipaSamba = samba4.override {
+    enableLDAP = true;
+    kerberos = freeipaKerberosLib;
+  };
+
+  freeipa = callPackage ../os-specific/linux/freeipa {
+    kerberos = freeipaKerberos;
+    sasl = cyrus_sasl;
+    # ipa-join requires curl with krb5 GSSAPI delegation
+    curl = freeipaCurl;
+    pyhbac = sssd;
+    dirsrv = pkgs."389-ds-base";
+    samba = freeipaSamba;
+    bind = freeipaBind;
+  };
+
   freetts = callPackage ../development/libraries/freetts { };
 
   frog = res.languageMachines.frog;
@@ -11834,6 +11863,8 @@ in
   libvdpau-va-gl = callPackage ../development/libraries/libvdpau-va-gl { };
 
   libversion = callPackage ../development/libraries/libversion { };
+
+  libverto = callPackage ../development/libraries/libverto { };
 
   libvirt = callPackage ../development/libraries/libvirt { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3918,7 +3918,7 @@ in
 
   lf = callPackage ../tools/misc/lf {};
 
-  lesscpy = pythonPackages.lesscpy;
+  lesscpy = callPackage ../development/compilers/lesscpy { };
 
   lhasa = callPackage ../tools/compression/lhasa {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5528,8 +5528,6 @@ in {
 
   pki-core = callPackage ../development/python-modules/pki-core { };
 
-  lesscpy = callPackage ../development/python-modules/lesscpy { };
-
   yubico = callPackage ../development/python-modules/yubico { };
 
 });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5521,6 +5521,17 @@ in {
   flickrapi = callPackage ../development/python-modules/flickrapi { };
 
   aioesphomeapi = callPackage ../development/python-modules/aioesphomeapi { };
+
+  nss = callPackage ../development/python-modules/nss {
+    inherit (pkgs) nss nspr;
+  };
+
+  pki-core = callPackage ../development/python-modules/pki-core { };
+
+  lesscpy = callPackage ../development/python-modules/lesscpy { };
+
+  yubico = callPackage ../development/python-modules/yubico { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
libverto: init at 0.2.6
pythonPackages.nss: init at 1.0.0
pythonPackages.pki: init at 10.3.5
pythonPackages.lesscpy: init at 0.12.0
pythonPackages.python-yubico: init at 1.3.2

Changed bind to optionally build with Kerberos support.
Changed krb5 to build with system libverto by default.

###### Motivation for this change

This changeset contains all packages and other changes to turn NixOS into a fully capable, well-behaving [FreeIPA](http://www.freeipa.org/page/Main_Page) client and domain member. While only the client portion of FreeIPA is fully implemented, some of the work for building the server component has also been done to actually make the client build succeed.

FreeIPA needs several packages to be build with MIT Kerberos, which in turn needs to use a newer version of libverto than the one bundled with krb5. Because of transitive dependencies, Samba 4 also needs to be build with that same version of MIT Kerberos. The changeset takes a stance that krb5 should much rather always be built with system libverto, which will trigger a mass-rebuild but save time and space in the long run because no duplicate versions of krb5 dependents are needed.
Building with libverto is explicitly switched off for `fetchurl`'s curl derivation to prevent a circular dependency.

The usual way to join a host to IPA is via `freeipa-client-install`, which normally modifies and backs up many different files in `/etc`, which is not possible on NixOS, for obvious reasons. Therefore, I created a nix module that does the same job idiomatically. The only manual steps for a user is to prefetch the certificate from the server and specify the resulting hash in the configuration, as seen below. After activating the configuration, they need to join the domain and obtain the keytab file manually, for which multiple different methods exist, with the most common one presented in the build output.

A typical, a valid set of FreeIPA configuration looks like this:
```
{
  networking.hostName = "nixos.in.foo.com";

  ipa = {
    enable = true;
    domain = "in.foo.com";
    realm  = "IN.FOO.COM";
    server = "ipa.in.foo.com";
    basedn = "dc=in,dc=foo,dc=com";
    certificate = pkgs.fetchurl {
      url = http://ipa.in.foo.com/ipa/config/ca.crt;
      sha256 = "xxx";
    };
  };
  
  services.sssd.enable = true;
  services.ntp.enable = true;
  security.pam.services.login.makeHomeDir = true;  
  security.pam.services.su.makeHomeDir = true;
}
```

The easiest way to test this is to create and set up a FreeIPA instance in a Fedora VM or docker container and build a NixOS version via `nixos-container`, bind-mounting nixpkgs like so:
```
sudo nixos-container create ipa-test
sudo mkdir -p /nix/var/nix/profiles/per-container/ipa-test/per-user/root/channels/nixos
sudo mount --bind /path/to/nixpkgs /nix/var/nix/profiles/per-container/ipa-test/per-user/root/channels/nixos
sudo nixos-container start ipa-test
ln -s /path/to/nixpkgs /path/to/nixpkgs/nixpkgs # Yes, this is required!
sudo nixos-container root-login ipa-test
ipa-test> nix-prefetch-url http://ipa.in.foo.com/ipa/config/ca.crt
ipa-test> cat > /etc/nixos/configuration.nix <<'EOF'
{ config, lib, pkgs, ... }:

with lib;

{ boot.isContainer = true;
  networking.hostName = "ipa-test.in.foo.com";
  networking.useDHCP = false;

  ipa = {
    enable = true;
    domain = "in.foo.com";
    realm  = "IN.FOO.COM";
    server = "ipa.in.foo.com";
    basedn = "dc=in,dc=foo,dc=com";
    certificate = pkgs.fetchurl {
      url = http://ipa.in.foo.com/ipa/config/ca.crt;
      sha256 = "xxx";
    };
  };
  
  services.sssd.enable = true;
  services.ntp.enable = true;
  security.pam.services.login.makeHomeDir = true;  
  security.pam.services.su.makeHomeDir = true;
}
EOF

ipa-test> nixos-rebuild switch
```

I'm well aware this is not a trivial change but I believe the benefit makes up for it and I'm grateful for reviewers who feel like they could tackle this.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

