### PR TITLE
mnemosyne: move generated locale files to correct location

### DIFF
--- a/pkgs/games/mnemosyne/default.nix
+++ b/pkgs/games/mnemosyne/default.nix
@@ -20,6 +20,11 @@ in pythonPackages.buildPythonApplication rec {
     substituteInPlace setup.py --replace /usr $out
     find . -type f -exec grep -H sys.exec_prefix {} ';' | cut -d: -f1 | xargs sed -i s,sys.exec_prefix,\"$out\",
   '';
+  postInstall = ''
+    mkdir -p $out/share
+    mv $out/lib/python2.7/site-packages/$out/share/locale $out/share
+    rm -r $out/lib/python2.7/site-packages/nix
+  '';
   meta = {
     homepage = http://mnemosyne-proj.org/;
     description = "Spaced-repetition software";


### PR DESCRIPTION
It feels like a bit of a hack to move them after the install rather
than generating them in the correct spot in the first place, but this
fixes #12763.

###### Motivation for this change

Allows users to access the Mnemosyne settings window without errors and also allows them to change the locale.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) is always set to true in my config)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- **N/A** Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

