### PR TITLE
picard: 1.32. -> 1.4

### DIFF
--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -1,7 +1,7 @@
 { stdenv, python2Packages, fetchurl, gettext, chromaprint }:
 
 let
-  version = "1.3.2";
+  version = "1.4";
   pythonPackages = python2Packages;
 in pythonPackages.buildPythonApplication {
   name = "picard-${version}";
@@ -9,7 +9,7 @@ in pythonPackages.buildPythonApplication {
 
   src = fetchurl {
     url = "http://ftp.musicbrainz.org/pub/musicbrainz/picard/picard-${version}.tar.gz";
-    sha256 = "0821xb7gyg0rhch8s3qkzmak90wjpcxkv9a364yv6bmqc12j6a77";
+    sha256 = "0gi7f1h7jcg7n18cx8iw38sd868viv3w377xmi7cq98f1g76d4h6";
   };
 
   buildInputs = [ gettext ];


### PR DESCRIPTION
- [x] Tested execution of all binary files (usually in `./result/bin/`)

cc @ehmry 