### PR TITLE
haskell: support Haskell Program Coverage (HPC)

### DIFF
--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -8,6 +8,9 @@ rec {
     overrideScope = scope: overrideCabal (drv.overrideScope scope) f;
   };
 
+  doCoverage = drv: overrideCabal drv (drv: { doCoverage = true; });
+  dontCoverage = drv: overrideCabal drv (drv: { doCoverage = false; });
+
   doHaddock = drv: overrideCabal drv (drv: { doHaddock = true; });
   dontHaddock = drv: overrideCabal drv (drv: { doHaddock = false; });
 


### PR DESCRIPTION
@peti I would like to create [HPC](https://wiki.haskell.org/Haskell_program_coverage) reports for my Haskell packages. It would be handy to have built-in support for this in nixpkgs. This patch is a first attempt. 

I added a function to enable the generation of a HPC report. For example:

```nix
  pkgs.haskell.lib.doCoverage drv
```

will create a HPC report of the Haskell package `drv` in the directory: `$out/share/hpc`

Regarding the implementation, I could replace the:

```nix
optional doCoverage "--enable-coverage"
```

with the more consistent:

```nix
enableFeature doCoverage "coverage"
```

However that will produce the empty string by default which will generate a mass rebuild of the Haskell packages. Please let me know if you prefer the more consistent approach using `enableFeature`.