### PR TITLE
geogebra: 5-0-320-0 -> 5-0-328-0

### DIFF
--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "geogebra-${version}";
-  version = "5-0-320-0";
+  version = "5-0-328-0";
 
   preferLocalBuild = true;
 
   src = fetchurl {
     url = "http://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2";
-    sha256 = "039mrjwgkj3z51zq4xpchzr4msz5xgscgmp36dr1wms1kl42vibk";
+    sha256 = "1bzmnw5410fv9s29ji8f4naa6m6ykvv8h88mmxhiygr3rfsc7050";
   };
 
   srcIcon = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

geogebra removed old versions from their download server and the installation is broken again (see #22231)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

