### PR TITLE
modules/filesystems: disallow non-empty fstab fields

### DIFF
--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -5,6 +5,11 @@ with utils;
 
 let
 
+  addCheckDesc = desc: elemType: check: types.addCheck elemType check
+    // { description = "${elemType.description} (with check: ${desc})"; };
+  nonEmptyStr = addCheckDesc "non-empty" types.str
+    (x: x != "" && ! (all (c: c == " " || c == "\t") (stringToCharacters x)));
+
   fileSystems' = toposort fsBefore (attrValues config.fileSystems);
 
   fileSystems = if fileSystems' ? "result"
@@ -26,21 +31,21 @@ let
 
       mountPoint = mkOption {
         example = "/mnt/usb";
-        type = types.str;
+        type = nonEmptyStr;
         description = "Location of the mounted the file system.";
       };
 
       device = mkOption {
         default = null;
         example = "/dev/sda";
-        type = types.nullOr types.str;
+        type = types.nullOr nonEmptyStr;
         description = "Location of the device.";
       };
 
       fsType = mkOption {
         default = "auto";
         example = "ext3";
-        type = types.str;
+        type = nonEmptyStr;
         description = "Type of the file system.";
       };
 
@@ -48,7 +53,7 @@ let
         default = [ "defaults" ];
         example = [ "data=journal" ];
         description = "Options used to mount the file system.";
-        type = types.listOf types.str;
+        type = types.listOf nonEmptyStr;
       };
 
     };
@@ -67,7 +72,7 @@ let
       label = mkOption {
         default = null;
         example = "root-partition";
-        type = types.nullOr types.str;
+        type = types.nullOr nonEmptyStr;
         description = "Label of the device (if any).";
       };
 


### PR DESCRIPTION
It was possible to pass empty strings / strings with only separator characters;
this lead to broken fstab formatting.