### PR TITLE
Fixups after new security wrapper

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -32,6 +32,9 @@ with lib;
 
     (mkRenamedOptionModule [ "services" "clamav" "updater" "config" ] [ "services" "clamav" "updater" "extraConfig" ])
 
+    (mkRemovedOptionModule [ "security" "setuidOwners" ] "Use security.wrappers instead")
+    (mkRemovedOptionModule [ "security" "setuidPrograms" ] "Use security.wrappers instead")
+
     # Old Grub-related options.
     (mkRenamedOptionModule [ "boot" "initrd" "extraKernelModules" ] [ "boot" "initrd" "kernelModules" ])
     (mkRenamedOptionModule [ "boot" "extraKernelParams" ] [ "boot" "kernelParams" ])

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 let
 
-  inherit (config.security) wrapperDir wrappers setuidPrograms;
+  inherit (config.security) wrapperDir wrappers;
 
   programs =
     (lib.mapAttrsToList

--- a/nixos/modules/virtualisation/virtualbox-host.nix
+++ b/nixos/modules/virtualisation/virtualbox-host.nix
@@ -69,13 +69,14 @@ in
     environment.systemPackages = [ virtualbox ];
 
     security.wrappers = let
-      mkSuid = program: {"${program}" = {
+      mkSuid = program: {
         source = "${virtualbox}/libexec/virtualbox/${program}";
         owner = "root";
         group = "vboxusers";
         setuid = true;
-      };};
-    in mkIf cfg.enableHardening (map mkSuid [
+      };
+    in mkIf cfg.enableHardening
+      (builtins.listToAttrs (map (x: { name = x; value = mkSuid x; }) [
       "VBoxHeadless"
       "VBoxNetAdpCtl"
       "VBoxNetDHCP"
@@ -83,7 +84,7 @@ in
       "VBoxSDL"
       "VBoxVolInfo"
       "VirtualBox"
-    ]);
+    ]));
 
     users.extraGroups.vboxusers.gid = config.ids.gids.vboxusers;
 


### PR DESCRIPTION
###### Motivation for this change
Needed to unbreak NixOS master branch.

###### Things done
WARNING: Not fully tested yet. Still building...

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

