### PR TITLE
afio: init at 2.5.1

### DIFF
--- a/pkgs/tools/archivers/afio/afio-2.5.1-install.patch
+++ b/pkgs/tools/archivers/afio/afio-2.5.1-install.patch
@@ -1,0 +1,48 @@
+--- p1/Makefile.orig	2017-02-14 21:40:20.404249126 +0100
++++ p1/Makefile	2017-02-19 23:38:43.880414077 +0100
+@@ -66,37 +66,42 @@
+ # systems the large file compile environment itself might be buggy or beta.
+ #LARGEFILEFLAGS=
+ LARGEFILEFLAGS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+ 
+ # even more warnings flags..
+ MW=
+ #MW=-Wtraditional -Wcast-qual -Wcast-align -Wconversion -pedantic -Wlong-long -Wimplicit -Wuninitialized -W -Wshadow -Wsign-compare -Wstrict-prototypes -Wmissing-declarations
+ 
+ CFLAGS1 = -Wall -Wstrict-prototypes -s -O2 -fomit-frame-pointer ${LARGEFILEFLAGS} ${MW}
+ 
+-CC=gcc
++#CC=gcc
+ 
+ CFLAGS = ${CFLAGS1} $1 $2 $3 $4 $5 $6 $7 $8 $9 $a $b $c $d $e ${e2} $f $g $I
+ LDFLAGS =
+ 
+ afio : afio.o compfile.o exten.o match.o $M
+ 	${CC} ${LDFLAGS} afio.o compfile.o exten.o match.o $M -o afio
+ 
+ clean:
+ 	rm -f *.o afio 
+ 	rm -f regtest/cmpstat regtest/makesparse
+ 	rm -f regtest/statsize regtest/statsize64
+ 	cd regtest; /bin/sh regtest.clean
+ 
++ifndef DESTDIR
++install:
++	$(error Please specify install prefix as $$DESTDIR)
++else
+ install: afio
+-	cp afio /usr/local/bin
+-	cp afio.1 /usr/share/man/man1
++	install -Dm755 afio $(DESTDIR)/bin/afio
++	install -Dm644 afio.1 $(DESTDIR)/share/man/man1/afio.1
++endif
+ 
+ # generate default list of -E extensions from manpage
+ # note: on sun, I had to change awk command below to nawk or gawk
+ # to get it to work.
+ exten_default.h : afio.1
+ 		awk -f exten_make.awk afio.1 >exten_default.h
+ 
+ 
+ afio.o : afio.h patchlevel.h
+ compfile.o : afio.h

--- a/pkgs/tools/archivers/afio/default.nix
+++ b/pkgs/tools/archivers/afio/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl } :
+
+stdenv.mkDerivation rec {
+  version = "2.5.1";
+  name = "afio-${version}";
+
+  src = fetchurl {
+    url = "http://members.chello.nl/~k.holtman/${name}.tgz";
+    sha256 = "363457a5d6ee422d9b704ef56d26369ca5ee671d7209cfe799cab6e30bf2b99a";
+  };
+
+  /*
+   * A patch to simplify the installation and for removing the
+   * hard coded dependency on GCC.
+   */
+  patches = [ ./afio-2.5.1-install.patch ];
+
+  installFlags = "DESTDIR=$(out)";
+
+  meta = {
+    homepage = http://members.chello.nl/~k.holtman/afio.html;
+    description = "Fault tolerant cpio archiver targeting backups";
+    platforms = stdenv.lib.platforms.all;
+    /*
+     * Licensing is complicated due to the age of the code base, but
+     * generally free. See the file ``afio_license_issues_v5.txt`` for
+     * a comprehensive discussion.
+     */
+    license = stdenv.lib.licenses.free;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -359,6 +359,8 @@ with pkgs;
 
   aescrypt = callPackage ../tools/misc/aescrypt { };
 
+  afio = callPackage ../tools/archivers/afio { };
+
   afl = callPackage ../tools/security/afl { };
 
   afpfs-ng = callPackage ../tools/filesystems/afpfs-ng/default.nix { };


### PR DESCRIPTION
Signed-off-by: Philipp Gesang <phg@phi-gamma.net>

###### Motivation for this change

Add useful package.

###### Things done

- [x ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

