### PR TITLE
security-wrapper: Wrap <para> tags in a <note> tag

### DIFF
--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -109,27 +109,29 @@ in
         };
       };
       description = ''
-        <para>This option allows the ownership and permissions on the
-        setuid wrappers for specific programs to be overridden from
-        the default (setuid root, but not setgid root).</para>
+        This option allows the ownership and permissions on the setuid
+        wrappers for specific programs to be overridden from the
+        default (setuid root, but not setgid root).
 
-        <para>Additionally, this option can set capabilities on a
-        wrapper program that propagates those capabilities down to the
-        wrapped, real program.</para>
+        <note>
+          <para>Additionally, this option can set capabilities on a
+          wrapper program that propagates those capabilities down to the
+          wrapped, real program.</para>
 
-        <para>The <literal>program</literal> attribute is the name of
-        the program to be wrapped. If no <literal>source</literal>
-        attribute is provided, specifying the absolute path to the
-        program, then the program will be searched for in the path
-        environment variable.</para>
+          <para>The <literal>program</literal> attribute is the name of
+          the program to be wrapped. If no <literal>source</literal>
+          attribute is provided, specifying the absolute path to the
+          program, then the program will be searched for in the path
+          environment variable.</para>
 
-        <para>NOTE: cap_setpcap, which is required for the wrapper
-        program to be able to raise caps into the Ambient set is NOT
-        raised to the Ambient set so that the real program cannot
-        modify its own capabilities!! This may be too restrictive for
-        cases in which the real program needs cap_setpcap but it at
-        least leans on the side security paranoid vs. too
-        relaxed.</para>
+          <para>NOTE: cap_setpcap, which is required for the wrapper
+          program to be able to raise caps into the Ambient set is NOT
+          raised to the Ambient set so that the real program cannot
+          modify its own capabilities!! This may be too restrictive for
+          cases in which the real program needs cap_setpcap but it at
+          least leans on the side security paranoid vs. too
+          relaxed.</para>
+        </note>
       '';
     };
 


### PR DESCRIPTION
This fixes a schema validation bug that breaks the build introduced in #16654 with [this commit](https://github.com/NixOS/nixpkgs/commit/69794e333a41f3d7d0de44da790c5d356c58e28b).

CC: @mrobbetts 

I tested this build on my EC2 machine and the docs build:

```
building path(s) ‘/nix/store/p6vxkpac1g2g1vvw04jivf05mprf220j-manual-olinkdb’
Writing /nix/store/p6vxkpac1g2g1vvw04jivf05mprf220j-manual-olinkdb/manual.db for book(book-nixos-manual)
./man-pages.xml validates
building path(s) ‘/nix/store/dyvfcm2vkkvp96i6qva0yks5ziz439jq-nixos-manpages’
building path(s) ‘/nix/store/cs6sjq4g1r71b18dikbls1ia366zndi8-nixos-manual’
./man-pages.xml validates
manual.xml validates
Writing options.html for appendix(ch-options)
Writing release-notes.html for appendix(ch-release-notes)
Writing index.html for book(book-nixos-manual)
building path(s) ‘/nix/store/2kip34gsi9g5b9mg3rwd84ybpx2s5pkf-nixos-help’
Note: Writing /nix/store/dyvfcm2vkkvp96i6qva0yks5ziz439jq-nixos-manpages/share/man/man5/configuration.nix.5
Note: Writing /nix/store/dyvfcm2vkkvp96i6qva0yks5ziz439jq-nixos-manpages/share/man/man8/nixos-build-vms.8
Note: Writing /nix/store/dyvfcm2vkkvp96i6qva0yks5ziz439jq-nixos-manpages/share/man/man8/nixos-generate-config.8
Note: Writing /nix/store/dyvfcm2vkkvp96i6qva0yks5ziz439jq-nixos-manpages/share/man/man8/nixos-install.8
Note: Writing /nix/store/dyvfcm2vkkvp96i6qva0yks5ziz439jq-nixos-manpages/share/man/man8/nixos-option.8
Note: Writing /nix/store/dyvfcm2vkkvp96i6qva0yks5ziz439jq-nixos-manpages/share/man/man8/nixos-rebuild.8
Note: Writing /nix/store/dyvfcm2vkkvp96i6qva0yks5ziz439jq-nixos-manpages/share/man/man8/nixos-version.8
```