### PR TITLE
wip: codelite: init at 10.0

### DIFF
--- a/pkgs/applications/editors/codelite/default.nix
+++ b/pkgs/applications/editors/codelite/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchFromGitHub, pkgconfig, wxGTK, gtk2, cmake, sqlite, which, libssh
+, flex, lldb, hunspell, llvmPackages, glib, pcre, bash
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  version = "10.0";
+  pname = "codelite";
+
+  src = fetchFromGitHub {
+    owner = "eranif";
+    repo = "${pname}";
+    rev = "${version}";
+    sha256 = "1n6n4wqdfl2g92b5swz3l394x0xjgim89x3jvwv1gsci7qm90akz";
+  };
+
+  buildInputs = [
+    pkgconfig wxGTK gtk2 cmake sqlite which libssh pcre
+    flex lldb hunspell llvmPackages.clang-unwrapped
+  ];
+
+  prePatch = ''
+    substituteInPlace ./Runtime/codelite_xterm --replace "/bin/bash" "${bash}/bin/bash"
+  '';
+
+  patches = [
+    ./glib.patch
+  ];
+
+  cmakeFlags = [
+    "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.dev}/include"
+    "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${gtk2.dev}/include"
+    "-DWITH_FLEX=TRUE"
+    "-DCMAKE_LIBRARY_PATH=${llvmPackages.clang-unwrapped}/lib"
+    "-DCMAKE_INCLUDE_PATH=${llvmPackages.clang-unwrapped}/include;${glib.dev}/include/glib-2.0/glib;${gtk2.out}/lib/gtk-2.0/include/"
+    "-DGLIB2_FIND_QUIETLY=FALSE"
+  ];
+
+  preConfigure = ''
+    substituteInPlace ./cmake/Modules/FindLibClang.cmake --replace "/bin/grep" "grep"
+    substituteInPlace ./cmake/Modules/FindGLIB2.cmake --replace "IF (NOT GLIB2_FIND_QUIETLY)" "IF (TRUE)"
+    cmakeFlags="$cmakeFlags -DCL_PREFIX=$out"
+  '';
+
+  meta = with stdenv.lib; {
+    maintainers = [ ];
+    platforms = platforms.all;
+    description = "An open source, free, cross platform IDE for the C/C++ programming languages which runs on all major Platforms ( OSX, Windows and Linux )";
+    homepage = https://codelite.org;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/applications/editors/codelite/glib.patch
+++ b/pkgs/applications/editors/codelite/glib.patch
@@ -1,0 +1,45 @@
+--- a/CMakeLists.txt	2017-02-15 01:15:44.920978809 -0200
++++ b/CMakeLists.txt	2017-02-15 01:15:44.920978809 -0200
+@@ -248,6 +248,23 @@
+         else (GTK2_FOUND)
+             message(FATAL_ERROR "Could not locate GTK.")
+         endif (GTK2_FOUND)
++        find_package(GLIB2)
++        if (GLIB2_FOUND)
++            include_directories(${GLIB2_INCLUDE_DIRS})
++#           add_${GLIB2_LIBRARIES}
++        else (GLIB2_FOUND)
++            message(FATAL_ERROR "Could not locate GLIB2.")
++        endif (GLIB2_FOUND)
++        find_path(GDK_I NAMES gdkconfig.h)
++        if(GDK_I)
++            include_directories(${GDK_I})
++        else(GDK_I)
++            message (FATAL_ERROR "gdk")
++        endif(GDK_I)
++        find_library(GTK_L libgdk-x11-2.0.so)
++        find_library(GDK_L libgdk-x11-2.0.so)
++        message (${GTK_L})
++        message (${GDK_L})
+     endif()
+ 
+ endif (UNIX AND NOT APPLE)
+--- a/codelitephp/CMakeLists.txt
++++ b/codelitephp/CMakeLists.txt
+@@ -103,4 +115,16 @@
+                      plugin 
+                      ${ADDITIONAL_LIBRARIES} 
+                      ${wxWidgets_LIBRARIES})
++find_library(GTK_L libgtk-x11-2.0)
++find_library(GDK_L libgdk-x11-2.0)
++if(GTK_L)
++  target_link_libraries(PHPUnitTests ${GTK_L})
++else(GTK_L)
++  message(FATAL_ERROR "GTK_L not found")
++endif(GTK_L)
++if(GDK_L)
++  target_link_libraries(PHPUnitTests ${GDK_L})
++else(GDK_L)
++  message(FATAL_ERROR "GDK_L not found")
++endif(GDK_L)
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12782,6 +12782,10 @@ with pkgs;
   codeblocks = callPackage ../applications/editors/codeblocks { };
   codeblocksFull = callPackage ../applications/editors/codeblocks { contribPlugins = true; };
 
+  codelite = callPackage ../applications/editors/codelite {
+    wxGTK = wxGTK30;
+  };
+
   comical = callPackage ../applications/graphics/comical { };
 
   conkeror-unwrapped = callPackage ../applications/networking/browsers/conkeror { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fails mid compilation with :

```

[  8%] Building CXX object CodeLite/CMakeFiles/libcodelite.dir/clBitmap.cpp.o
In file included from /nix/store/9kh6hb2yvk8fqa24cwnrch7ach9crl1m-glib-2.50.2-dev/include/glib-2.0/glib/galloca.h:32:0,
                 from /nix/store/9kh6hb2yvk8fqa24cwnrch7ach9crl1m-glib-2.50.2-dev/include/glib-2.0/glib.h:30,
                 from /nix/store/9kh6hb2yvk8fqa24cwnrch7ach9crl1m-glib-2.50.2-dev/include/glib-2.0/gobject/gbinding.h:28,
                 from /nix/store/9kh6hb2yvk8fqa24cwnrch7ach9crl1m-glib-2.50.2-dev/include/glib-2.0/glib-object.h:23,
                 from /nix/store/9kh6hb2yvk8fqa24cwnrch7ach9crl1m-glib-2.50.2-dev/include/glib-2.0/gio/gioenums.h:28,
                 from /nix/store/9kh6hb2yvk8fqa24cwnrch7ach9crl1m-glib-2.50.2-dev/include/glib-2.0/gio/giotypes.h:28,
                 from /nix/store/9kh6hb2yvk8fqa24cwnrch7ach9crl1m-glib-2.50.2-dev/include/glib-2.0/gio/gio.h:26,
                 from /nix/store/a1ljglvb7yi6j5p1vav1b6i7prjmfcfi-gtk+-2.24.31-dev/include/gtk-2.0/gdk/gdkapplaunchcontext.h:30,
                 from /nix/store/a1ljglvb7yi6j5p1vav1b6i7prjmfcfi-gtk+-2.24.31-dev/include/gtk-2.0/gdk/gdk.h:32,
                 from /nix/store/a1ljglvb7yi6j5p1vav1b6i7prjmfcfi-gtk+-2.24.31-dev/include/gtk-2.0/gtk/gtk.h:32,
                 from /tmp/nix-build-codelite-10.0.drv-0/codelite-10.0-src/CodeLite/clBitmap.cpp:6:
/nix/store/9kh6hb2yvk8fqa24cwnrch7ach9crl1m-glib-2.50.2-dev/include/glib-2.0/glib/gtypes.h:32:24: fatal error: glibconfig.h: No such file or directory

```

I assume the issue has something to do with cmake/Modules/FindGLIB2.cmake. The missing file seems to be at ${glib.out}/lib/glib-2.0/include/ . Is the include folder actually supposed to be there?

edit: ok, it compiles and installs now. Didn't do much testing yet.