### PR TITLE
cups-dymo: init at 1.4.0.5

### DIFF
--- a/pkgs/misc/cups/drivers/dymo/default.nix
+++ b/pkgs/misc/cups/drivers/dymo/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchurl, cups, ... }:
+
+stdenv.mkDerivation rec {
+  name = "cups-dymo-${version}";
+  version = "1.4.0.5";
+
+  # exposed version and 'real' version may differ
+  # in this case the download states '1.4.0' but the real version is '1.4.0.5'
+  # this has the potential to break future builds
+  dl-name = "dymo-cups-drivers-1.4.0";
+
+  src = fetchurl {
+    url = "http://download.dymo.com/dymo/Software/Download%20Drivers/Linux/Download/${dl-name}.tar.gz";
+    sha256 = "0wagsrz3q7yrkzb5ws0m5faq68rqnqfap9p98sgk5jl6x7krf1y6";
+  };
+
+  buildInputs = [ cups ];
+  makeFlags = [ "cupsfilterdir=$(out)/lib/cups/filter" "cupsmodeldir=$(out)/share/cups/model" ];
+
+  meta = {
+    description = "CUPS Linux drivers and SDK for DYMO printers";
+    homepage = "http://www.dymo.com/";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ makefu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17474,6 +17474,8 @@ with pkgs;
 
   cups-kyocera = callPackage ../misc/cups/drivers/kyocera {};
 
+  cups-dymo = callPackage ../misc/cups/drivers/dymo {};
+
   crashplan = callPackage ../applications/backup/crashplan { };
 
   e17gtk = callPackage ../misc/themes/e17gtk { };


### PR DESCRIPTION
###### Motivation for this change

Adds DYMO drivers to CUPS

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

