### PR TITLE
terragrunt: 0.10.0 -> 0.10.1

### DIFF
--- a/pkgs/applications/networking/cluster/terragrunt/default.nix
+++ b/pkgs/applications/networking/cluster/terragrunt/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "terragrunt-${version}";
-  version = "0.10.0";
+  version = "0.10.1";
 
   goPackagePath = "github.com/gruntwork-io/terragrunt";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     rev    = "v${version}";
     owner  = "gruntwork-io";
     repo   = "terragrunt";
-    sha256 = "1cdhl7rqd2jslvp1ia1gph1lg0sjzsnvj7dj6lg85jfdcffafygj";
+    sha256 = "04q9wm8dnbm1pcy9i3c7ral49k3z10a7gx7h6h4bsvjy1sdf58vz";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/applications/networking/cluster/terragrunt/deps.nix
+++ b/pkgs/applications/networking/cluster/terragrunt/deps.nix
@@ -5,8 +5,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/aws/aws-sdk-go";
-      rev = "63102d196e0996a2910839857c3584f62be907cc";
-      sha256 = "0n207g4bf5fjq23f63nkhh14shj7kjdrr4qn6h28d7x2vqfb9pss";
+      rev = "f85f603a3e5b4d0eb9516dddb33778918f3b45c6";
+      sha256 = "10frgavkbsqpfninrlgwh64qjx9rwyjzbdfrikciv75v1gljh6zv";
     };
   }
   {
@@ -95,8 +95,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/urfave/cli";
-      rev = "347a9884a87374d000eec7e6445a34487c1f4a2b";
-      sha256 = "0wii48b2g5dyp6bknnlgs3ln93qxz5jvi96420wnpkkz51nrcmbp";
+      rev = "2526b57c56f30b50466c96c4133b1a4ad0f0191f";
+      sha256 = "03vvr1wq4pw2fixxsbr1d623hwqxf93d07p8vjml6iyd6k97b15p";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change

Fixes a fairly significant bug in 0.10.0

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

