### PR TITLE
iputils: 20151218 -> 20161105

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1703.xml
+++ b/nixos/doc/manual/release-notes/rl-1703.xml
@@ -217,6 +217,18 @@ following incompatible changes:</para>
     </para>
   </listitem>
 
+  <listitem>
+    <para>
+    Iputils no longer provide ping6 and traceroute6. The functionality of
+    these tools have been integrated into ping and traceroute respectively. To
+    enforce an address family the new flags <literal>-4</literal> and
+    <literal>-6</literal> have been added. One notable incompabtibility is that
+    specifying an interface (for link-local ipv6 for instance) is no longer done
+    with the <literal>-I</literal> flag, but by encoding the interface into the
+    address (<literal>ping fe80::1%eth0</literal>).
+    </para>
+  </listitem>
+
 </itemizedlist>
 
 

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -940,14 +940,8 @@ in
         source  = "${pkgs.iputils.out}/bin/ping";
         capabilities = "cap_net_raw+p";
       };
-
-      ping6 = {
-        source  = "${pkgs.iputils.out}/bin/ping6";
-        capabilities = "cap_net_raw+p";
-      };
     } else {
       ping.source = "${pkgs.iputils.out}/bin/ping";
-      "ping6".source = "${pkgs.iputils.out}/bin/ping6";
     };
 
     # Set the host and domain names in the activation script.  Don't

--- a/nixos/tests/cjdns.nix
+++ b/nixos/tests/cjdns.nix
@@ -109,14 +109,14 @@ import ./make-test.nix ({ pkgs, ...} : {
 
       # ping a few times each to let the routing table establish itself
 
-      $alice->succeed("ping6 -c 4 $carolIp6");
-      $bob->succeed("ping6 -c 4 $carolIp6");
+      $alice->succeed("ping -c 4 $carolIp6");
+      $bob->succeed("ping -c 4 $carolIp6");
 
-      $carol->succeed("ping6 -c 4 $aliceIp6");
-      $carol->succeed("ping6 -c 4 $bobIp6");
+      $carol->succeed("ping -c 4 $aliceIp6");
+      $carol->succeed("ping -c 4 $bobIp6");
 
-      $alice->succeed("ping6 -c 4 $bobIp6");
-      $bob->succeed("ping6 -c 4 $aliceIp6");
+      $alice->succeed("ping -c 4 $bobIp6");
+      $bob->succeed("ping -c 4 $aliceIp6");
 
       $alice->waitForUnit("httpd.service");
 

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -66,7 +66,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       "${containerIp6}" =~ /([^\/]+)\/([0-9+])/;
       my $ip6 = $1;
       chomp $ip6;
-      $machine->succeed("ping6 -n -c 1 $ip6");
+      $machine->succeed("ping -n -c 1 $ip6");
       $machine->succeed("curl --fail http://[$ip6]/ > /dev/null");
 
       # Stop the container.

--- a/nixos/tests/containers-extra_veth.nix
+++ b/nixos/tests/containers-extra_veth.nix
@@ -84,7 +84,7 @@ import ./make-test.nix ({ pkgs, ...} : {
 
       # Ping on main veth
       $machine->succeed("ping -n -c 1 192.168.0.100");
-      $machine->succeed("ping6 -n -c 1 fc00::2");
+      $machine->succeed("ping -n -c 1 fc00::2");
 
       # Ping on the first extra veth
       $machine->succeed("ping -n -c 1 192.168.1.100 >&2");

--- a/nixos/tests/containers-ipv6.nix
+++ b/nixos/tests/containers-ipv6.nix
@@ -47,7 +47,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       # multi-user.target, we should now be able to access it.
       my $ip = "${localIp}";
       chomp $ip;
-      $machine->succeed("ping6 -n -c 1 $ip");
+      $machine->succeed("ping -n -c 1 $ip");
       $machine->succeed("curl --fail http://[$ip]/ > /dev/null");
 
       # Stop the container.

--- a/nixos/tests/ipv6.nix
+++ b/nixos/tests/ipv6.nix
@@ -54,22 +54,22 @@ import ./make-test.nix ({ pkgs, ...} : {
       }
 
       subtest "loopback address", sub {
-          $client->succeed("ping6 -c 1 ::1 >&2");
-          $client->fail("ping6 -c 1 ::2 >&2");
+          $client->succeed("ping -c 1 ::1 >&2");
+          $client->fail("ping -c 1 ::2 >&2");
       };
 
       subtest "local link addressing", sub {
           my $clientIp = waitForAddress $client, "eth1", "link";
           my $serverIp = waitForAddress $server, "eth1", "link";
-          $client->succeed("ping6 -c 1 -I eth1 $clientIp >&2");
-          $client->succeed("ping6 -c 1 -I eth1 $serverIp >&2");
+          $client->succeed("ping -c 1 $clientIp%eth1 >&2");
+          $client->succeed("ping -c 1 $serverIp%eth1 >&2");
       };
 
       subtest "global addressing", sub {
           my $clientIp = waitForAddress $client, "eth1", "global";
           my $serverIp = waitForAddress $server, "eth1", "global";
-          $client->succeed("ping6 -c 1 $clientIp >&2");
-          $client->succeed("ping6 -c 1 $serverIp >&2");
+          $client->succeed("ping -c 1 $clientIp >&2");
+          $client->succeed("ping -c 1 $serverIp >&2");
           $client->succeed("curl --fail -g http://[$serverIp]");
           $client->fail("curl --fail -g http://[$clientIp]");
       };

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -166,24 +166,24 @@ let
           # Test vlan 1
           $client->waitUntilSucceeds("ping -c 1 192.168.1.1");
           $client->waitUntilSucceeds("ping -c 1 192.168.1.2");
-          $client->waitUntilSucceeds("ping6 -c 1 fd00:1234:5678:1::1");
-          $client->waitUntilSucceeds("ping6 -c 1 fd00:1234:5678:1::2");
+          $client->waitUntilSucceeds("ping -c 1 fd00:1234:5678:1::1");
+          $client->waitUntilSucceeds("ping -c 1 fd00:1234:5678:1::2");
 
           $router->waitUntilSucceeds("ping -c 1 192.168.1.1");
           $router->waitUntilSucceeds("ping -c 1 192.168.1.2");
-          $router->waitUntilSucceeds("ping6 -c 1 fd00:1234:5678:1::1");
-          $router->waitUntilSucceeds("ping6 -c 1 fd00:1234:5678:1::2");
+          $router->waitUntilSucceeds("ping -c 1 fd00:1234:5678:1::1");
+          $router->waitUntilSucceeds("ping -c 1 fd00:1234:5678:1::2");
 
           # Test vlan 2
           $client->waitUntilSucceeds("ping -c 1 192.168.2.1");
           $client->waitUntilSucceeds("ping -c 1 192.168.2.2");
-          $client->waitUntilSucceeds("ping6 -c 1 fd00:1234:5678:2::1");
-          $client->waitUntilSucceeds("ping6 -c 1 fd00:1234:5678:2::2");
+          $client->waitUntilSucceeds("ping -c 1 fd00:1234:5678:2::1");
+          $client->waitUntilSucceeds("ping -c 1 fd00:1234:5678:2::2");
 
           $router->waitUntilSucceeds("ping -c 1 192.168.2.1");
           $router->waitUntilSucceeds("ping -c 1 192.168.2.2");
-          $router->waitUntilSucceeds("ping6 -c 1 fd00:1234:5678:2::1");
-          $router->waitUntilSucceeds("ping6 -c 1 fd00:1234:5678:2::2");
+          $router->waitUntilSucceeds("ping -c 1 fd00:1234:5678:2::1");
+          $router->waitUntilSucceeds("ping -c 1 fd00:1234:5678:2::2");
         '';
     };
     dhcpOneIf = {
@@ -390,11 +390,11 @@ let
           $client2->succeed("ip addr >&2");
 
           # Test ipv6
-          $client1->waitUntilSucceeds("ping6 -c 1 fc00::1");
-          $client1->waitUntilSucceeds("ping6 -c 1 fc00::2");
+          $client1->waitUntilSucceeds("ping -c 1 fc00::1");
+          $client1->waitUntilSucceeds("ping -c 1 fc00::2");
 
-          $client2->waitUntilSucceeds("ping6 -c 1 fc00::1");
-          $client2->waitUntilSucceeds("ping6 -c 1 fc00::2");
+          $client2->waitUntilSucceeds("ping -c 1 fc00::1");
+          $client2->waitUntilSucceeds("ping -c 1 fc00::2");
         '';
     };
     vlan = let

--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -1,17 +1,20 @@
-{ stdenv, fetchurl, libsysfs, gnutls, openssl, libcap, sp, docbook_sgml_dtd_31
+{ stdenv, fetchurl
+, libsysfs, gnutls, openssl
+, libcap, sp, docbook_sgml_dtd_31
+, libidn, nettle
 , SGMLSpm, libgcrypt }:
 
 assert stdenv ? glibc;
 
 let
-  time = "20151218";
+  time = "20161105";
 in
 stdenv.mkDerivation rec {
   name = "iputils-${time}";
 
   src = fetchurl {
-    url = "http://www.skbuff.net/iputils/iputils-s${time}.tar.bz2";
-    sha256 = "189592jlkhxdgy8jc07m4bsl41ik9r6i6aaqb532prai37bmi7sl";
+    url = "https://github.com/iputils/iputils/archive/s${time}.tar.gz";
+    sha256 = "12mdmh4qbf5610csaw3rkzhpzf6djndi4jsl4gyr8wni0cphj4zq";
   };
 
   prePatch = ''
@@ -21,27 +24,24 @@ stdenv.mkDerivation rec {
   makeFlags = "USE_GNUTLS=no";
 
   buildInputs = [
-    libsysfs openssl libcap sp docbook_sgml_dtd_31 SGMLSpm libgcrypt
+    libsysfs openssl libcap sp docbook_sgml_dtd_31 SGMLSpm libgcrypt libidn nettle
   ];
 
   buildFlags = "man all ninfod";
 
   installPhase =
     ''
-      mkdir -p $out/sbin $out/bin
-      cp -p ping ping6 tracepath tracepath6 traceroute6 $out/bin/
-      cp -p clockdiff arping rdisc ninfod/ninfod $out/sbin/
+      mkdir -p $out/bin
+      cp -p ping tracepath clockdiff arping rdisc ninfod/ninfod $out/bin/
 
       mkdir -p $out/share/man/man8
-      cp -p doc/clockdiff.8 doc/arping.8 doc/ping.8 doc/rdisc.8 \
-        doc/tracepath.8 doc/ninfod.8 doc/traceroute6.8 \
+      cp -p \
+        doc/clockdiff.8 doc/arping.8 doc/ping.8 doc/rdisc.8 doc/tracepath.8 doc/ninfod.8 \
         $out/share/man/man8
-      ln -s $out/share/man/man8/{ping,ping6}.8
-      ln -s $out/share/man/man8/{tracepath,tracepath6}.8
     '';
 
   meta = {
-    homepage = http://www.skbuff.net/iputils/;
+    homepage = https://github.com/iputils/iputils;
     description = "A set of small useful utilities for Linux networking";
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/servers/monitoring/nagios/plugins/official-2.x.nix
+++ b/pkgs/servers/monitoring/nagios/plugins/official-2.x.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
   # configured on the build machine).
   preConfigure= "
     configureFlagsArray=(
-      --with-ping-command='/run/wrappers/bin/ping -n -U -w %d -c %d %s'
-      --with-ping6-command='/run/wrappers/bin/ping6 -n -U -w %d -c %d %s'
+      --with-ping-command='/run/wrappers/bin/ping -4 -n -U -w %d -c %d %s'
+      --with-ping6-command='/run/wrappers/bin/ping -6 -n -U -w %d -c %d %s'
     )
   ";
 


### PR DESCRIPTION
###### Motivation for this change

after the upgrade of iputils from 20151218 to 20161105
functionality of ping6 and tracepath6 was merged into ping and tracepath.

Ping is now mostly a drop-in replacment for ping6, except that selecting a
specific interface is done by encoding it into the address (ex.: fe80::1%eth0)
rather then specifing it with the `-I` flag.

Test check list:

- [x] nixos/modules/tasks/network-interfaces.nix
- [x] nixos/tests/cjdns.nix
- [x] nixos/tests/containers-bridge.nix
- [x] nixos/tests/containers-extra_veth.nix
- [x] nixos/tests/containers-ipv6.nix
- [x] nixos/tests/ipv6.nix
- [x] nixos/tests/networking.nix
- [x] pkgs/servers/monitoring/nagios/plugins/official-2.x.nix

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

