### PR TITLE
ja2-stracciatella: init 0.15.1

### DIFF
--- a/pkgs/games/ja2-stracciatella/default.nix
+++ b/pkgs/games/ja2-stracciatella/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchFromGitHub, SDL }:
+
+stdenv.mkDerivation rec {
+  version = "0.15.1";
+  name = "ja2-stracciatella-${version}";
+  src = fetchFromGitHub {
+    owner = "ja2-stracciatella";
+    repo = "ja2-stracciatella";
+    rev = "v${version}";
+    sha256 = "0r7j6k7412b3qfb1rnh80s55zhnriw0v03zn5bp3spcqjxh4xhv1";
+  };
+  enableParallelBuilding = true;
+  buildInputs = [ SDL ];
+  meta = {
+    description = "Jagged Alliance 2, with community fixes";
+    license = "SFI Source Code license agreement";
+    homepage = "https://ja2-stracciatella.github.io/";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16163,6 +16163,8 @@ with pkgs;
     lua = lua5;
   };
 
+  ja2-stracciatella = callPackage ../games/ja2-stracciatella { };
+
   klavaro = callPackage ../games/klavaro {};
 
   kobodeluxe = callPackage ../games/kobodeluxe { };


### PR DESCRIPTION
This is the open-source version of the venerable Jagged Alliance 2.

Stracciatella means almost vanilla. This version is only changed for
fixes, stability improvements and to host mods.

The original data files are non-free and have to be provided by the user.

###### Motivation for this change
More linux games 8-)

###### Things done
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS (should run there too)
   - [x] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

