### PR TITLE
gtk-vnc: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/tools/admin/gtk-vnc/default.nix
+++ b/pkgs/tools/admin/gtk-vnc/default.nix
@@ -8,11 +8,11 @@ let
   inherit (pythonPackages) pygobject3 python;
 in stdenv.mkDerivation rec {
   name = "gtk-vnc-${version}";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gtk-vnc/0.6/${name}.tar.xz";
-    sha256 = "9559348805e64d130dae569fee466930175dbe150d2649bb868b5c095f130433";
+    url = "mirror://gnome/sources/gtk-vnc/${stdenv.lib.strings.substring 0 3 version}/${name}.tar.xz";
+    sha256 = "0gj8dpy3sj4dp810gy67spzh5f0jd8aqg69clcwqjcskj1yawbiw";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Vulnerability Roundup, aka "Weekly playtime with @grahamc"

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
