### PR TITLE
pythonPackages: use a more direct mirror

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -387,6 +387,9 @@ rec {
 
   # Python PyPI mirrors
   pypi = [
+    https://files.pythonhosted.org/packages/source/
+    # pypi.io is a more semantic link, but atm it’s referencing
+    # files.pythonhosted.org over two redirects
     https://pypi.io/packages/source/
   ];
 


### PR DESCRIPTION
The pypi.io domain is redirected two (!) times and lands on the URL added by
this commit.