### PR TITLE
QOwnNotes: init at 17.03.08

### DIFF
--- a/pkgs/applications/misc/qownnotes/default.nix
+++ b/pkgs/applications/misc/qownnotes/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchgit, qtbase, qtscript, qtxmlpatterns, qtquickcontrols
+, makeQtWrapper
+}:
+
+let
+  version = "17.03.08";
+in
+stdenv.mkDerivation {
+  name = "qownnotes-${version}";
+
+  # needs git submodules, so can't use fetchFromGitHub
+  src = fetchgit {
+    rev = "refs/tags/linux-b2844-162834";
+    url = "https://github.com/pbek/QOwnNotes";
+    sha256 = "1s38phw71mxwjpz0bk3apyrmf0jafd1ggh4f821rnshld8kapchr";
+  };
+
+  buildInputs = [ qtbase qtscript qtxmlpatterns qtquickcontrols ];
+  nativeBuildInputs = [ makeQtWrapper ];
+
+  configurePhase = ''
+    runHook preConfigure
+    cd src
+    qmake -makefile $qmakeFlags PREFIX=$out
+    runHook postConfigure
+  '';
+
+  # NIX_PROFILES may contain an older libqminimal.so remove system-path from NIX_PROFILES
+  postInstall = ''
+    wrapQtProgram "$out/bin/QOwnNotes" \
+       --set NIX_PROFILES "/nix/var/nix/profiles/default $HOME/.nix-profile"
+  '';
+
+  meta = with stdenv.lib;
+    { description = "An open source notepad with markdown support and todo list manager";
+      homepage = https://www.qownnotes.org/;
+      license = licenses.gpl2;
+      platforms = qtbase.meta.platforms;
+      maintainers = [ maintainers.vandenoever ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3654,6 +3654,8 @@ with pkgs;
 
   qjoypad = callPackage ../tools/misc/qjoypad { };
 
+  qownnotes = qt5.callPackage ../applications/misc/qownnotes { };
+
   qpdf = callPackage ../development/libraries/qpdf { };
 
   qprint = callPackage ../tools/text/qprint { };


### PR DESCRIPTION
QOwnNotes is a plain-text file notepad and todo-list manager with markdown support and ownCloud integration. http://www.qownnotes.org

###### Motivation for this change

Nice note taking application that integrates with NextCloud and OwnCloud.

###### Things done

- [ x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

