### PR TITLE
boost: 1.63.0 (not default)

### DIFF
--- a/pkgs/development/libraries/boost/1.63.nix
+++ b/pkgs/development/libraries/boost/1.63.nix
@@ -1,0 +1,12 @@
+{ stdenv, callPackage, fetchurl, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.63.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/boost/boost_1_63_0.tar.bz2";
+    # SHA256 from http://www.boost.org/users/history/version_1_63_0.html
+    sha256 = "beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0";
+  };
+
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6919,6 +6919,7 @@ with pkgs;
   boost159 = callPackage ../development/libraries/boost/1.59.nix { };
   boost160 = callPackage ../development/libraries/boost/1.60.nix { };
   boost162 = callPackage ../development/libraries/boost/1.62.nix { };
+  boost163 = callPackage ../development/libraries/boost/1.63.nix { };
   boost = boost162;
 
   boost_process = callPackage ../development/libraries/boost-process { };


### PR DESCRIPTION
###### Motivation for this change

Adding Boost 1.63.0 to the packages (not as a default version)

###### Things done

Built on Linux with python3. Works just fine for my python.boost development.

I might look into making it default boost but since I am new to nix, there is a learning curve.

@wkennington 
---

