### PR TITLE
lumail: init at 2.9

### DIFF
--- a/pkgs/applications/networking/mailreaders/lumail/default.nix
+++ b/pkgs/applications/networking/mailreaders/lumail/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, pkgconfig, lua5_2, file, ncurses, gmime, pcre-cpp
+, perl, perlPackages }:
+
+let
+  version = "2.9";
+in
+stdenv.mkDerivation {
+  name = "lumail-${version}";
+
+  src = fetchurl {
+    url = "https://lumail.org/download/lumail-${version}.tar.gz";
+    sha256 = "1rni5lbic36v4cd1r0l28542x0hlmfqkl6nac79gln491in2l2sc";
+  };
+
+  buildInputs = [
+    pkgconfig lua5_2 file ncurses gmime pcre-cpp
+    perl perlPackages.JSON perlPackages.NetIMAPClient
+  ];
+
+  preConfigure = ''
+    sed -e 's|"/etc/lumail2|LUMAIL_LUAPATH"/..|' -i src/lumail2.cc src/imap_proxy.cc
+
+    perlFlags=
+    for i in $(IFS=:; echo $PERL5LIB); do
+        perlFlags="$perlFlags -I$i"
+    done
+
+    sed -e "s|^#\!\(.*/perl.*\)$|#\!\1$perlFlags|" -i perl.d/imap-proxy
+  '';
+
+  makeFlags = [
+    "LVER=lua"
+    "PREFIX=$(out)"
+    "SYSCONFDIR=$(out)/etc"
+  ];
+
+  postInstall = ''
+    cp lumail2.user.lua $out/etc/lumail2/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Console-based email client";
+    homepage = https://lumail.org/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [orivej];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14089,6 +14089,8 @@ with pkgs;
     gtk = gtk2;
   };
 
+  lumail = callPackage ../applications/networking/mailreaders/lumail { };
+
   lv2bm = callPackage ../applications/audio/lv2bm { };
 
   lynx = callPackage ../applications/networking/browsers/lynx { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9640,6 +9640,19 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  NetIMAPClient = buildPerlPackage rec {
+    name = "Net-IMAP-Client-0.9505";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/G/GA/GANGLION/${name}.tar.gz";
+      sha256 = "d3f6a608b85e09a8080a67a9933837aae6f2cd0e8ee39df3380123dc5e3de912";
+    };
+    buildInputs = [TestPod TestPodCoverage];
+    propagatedBuildInputs = [ IOSocketSSL ListMoreUtils ];
+    meta = {
+      description = "Not so simple IMAP client library";
+    };
+  };
+
   NetIP = buildPerlPackage {
     name = "Net-IP-1.26";
     src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

This adds a console Mailbox and IMAP email client [Lumail](https://lumail.org/).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).