### PR TITLE
webkitgtk: 2.14.4 -> 2.14.5

### DIFF
--- a/pkgs/development/libraries/webkitgtk/2.14.nix
+++ b/pkgs/development/libraries/webkitgtk/2.14.nix
@@ -12,7 +12,7 @@ assert enableGeoLocation -> geoclue2 != null;
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "webkitgtk-${version}";
-  version = "2.14.4";
+  version = "2.14.5";
 
   meta = {
     description = "Web content rendering engine, GTK+ port";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://webkitgtk.org/releases/${name}.tar.xz";
-    sha256 = "1b73rcyfqjyg5rqw6f4760b2h1kixwva88clp2wl9vnl3psjvbni";
+    sha256 = "17rnjs7yl198bkghzcc2cgh30sb5i03irb6wag3xchwv7b1z3a1w";
   };
 
   # see if we can clean this up....


### PR DESCRIPTION
###### Motivation for this change

Stable upgrade. The recent [vulnerability roundup](https://github.com/NixOS/nixpkgs/issues/22826) mentions only pre-2.14.4, but browser engines should be regularly updated.

###### Things done
- Built on platform(s)
   - [x] NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

