### PR TITLE
gpgme: fix build on macOS

### DIFF
--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -30,6 +30,9 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE =
     with stdenv; lib.optional (system == "i686-linux") "-D_FILE_OFFSET_BITS=64";
 
+  AM_CXXFLAGS =
+    with stdenv; lib.optional (isDarwin) "-D_POSIX_C_SOURCE=200809L";
+
   meta = with stdenv.lib; {
     homepage = "http://www.gnupg.org/related_software/gpgme";
     description = "Library for making GnuPG easier to use";


### PR DESCRIPTION
###### Motivation for this change
Fix build on macOS (it complained on `strdup` being undefined)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

