### PR TITLE
fix #21745, preserve container connectivity when the bridge changes

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -239,6 +239,10 @@ let
                 ip link set "${i}" master "${n}"
                 ip link set "${i}" up
               '')}
+              # Save list of enslaved interfaces
+              echo "${flip concatMapStrings v.interfaces (i: ''
+                ${i}
+              '')}" > /run/${n}.interfaces
 
               # Enable stp on the interface
               ${optionalString v.rstp ''
@@ -250,7 +254,28 @@ let
             postStop = ''
               ip link set "${n}" down || true
               ip link del "${n}" || true
+              rm -f /run/${n}.interfaces
             '';
+            reload = ''
+              # Un-enslave child interfaces (old list of interfaces)
+              for interface in `cat /run/${n}.interfaces`; do
+                ip link set "$interface" nomaster up
+              done
+
+              # Enslave child interfaces (new list of interfaces)
+              ${flip concatMapStrings v.interfaces (i: ''
+                ip link set "${i}" master "${n}"
+                ip link set "${i}" up
+              '')}
+              # Save list of enslaved interfaces
+              echo "${flip concatMapStrings v.interfaces (i: ''
+                ${i}
+              '')}" > /run/${n}.interfaces
+
+              # (Un-)set stp on the bridge
+              echo ${if v.rstp then "2" else "0"} > /sys/class/net/${n}/bridge/stp_state
+            '';
+            reloadIfChanged = true;
           });
 
         createVswitchDevice = n: v: nameValuePair "${n}-netdev"

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -228,6 +228,7 @@ in rec {
   tests.containers-imperative = callTest tests/containers-imperative.nix {};
   tests.containers-extra_veth = callTest tests/containers-extra_veth.nix {};
   tests.containers-physical_interfaces = callTest tests/containers-physical_interfaces.nix {};
+  tests.containers-restart_networking = callTest tests/containers-restart_networking.nix {};
   tests.containers-tmpfs = callTest tests/containers-tmpfs.nix {};
   tests.containers-hosts = callTest tests/containers-hosts.nix {};
   tests.containers-macvlans = callTest tests/containers-macvlans.nix {};

--- a/nixos/tests/containers-restart_networking.nix
+++ b/nixos/tests/containers-restart_networking.nix
@@ -1,0 +1,114 @@
+# Test for NixOS' container support.
+
+let
+  client_base = rec {
+    networking.firewall.enable = false;
+
+    containers.webserver = {
+      autoStart = true;
+      privateNetwork = true;
+      hostBridge = "br0";
+      config = {
+        networking.firewall.enable = false;
+        networking.firewall.allowPing = true;
+        networking.interfaces.eth0.ip4 = [
+          { address = "192.168.1.122"; prefixLength = 24; }
+        ];
+      };
+    };
+  };
+in import ./make-test.nix ({ pkgs, lib, ...} :
+{
+  name = "containers-restart_networking";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ kampfschlaefer ];
+  };
+
+  nodes = {
+    client = { lib, pkgs, ... }: client_base // {
+      virtualisation.vlans = [ 1 ];
+
+      networking.bridges.br0 = {
+        interfaces = [];
+        rstp = false;
+      };
+      networking.interfaces = {
+        eth1.ip4 = lib.mkOverride 0 [ ];
+        br0.ip4 = [{ address = "192.168.1.1"; prefixLength = 24; }];
+      };
+
+    };
+    client_eth1 = { lib, pkgs, ... }: client_base // {
+      networking.bridges.br0 = {
+        interfaces = [ "eth1" ];
+        rstp = false;
+      };
+      networking.interfaces = {
+        eth1.ip4 = lib.mkOverride 0 [ ];
+        br0.ip4 = [{ address = "192.168.1.2"; prefixLength = 24; }];
+      };
+    };
+    client_eth1_rstp = { lib, pkgs, ... }: client_base // {
+      networking.bridges.br0 = {
+        interfaces = [ "eth1" ];
+        rstp = true;
+      };
+      networking.interfaces = {
+        eth1.ip4 = lib.mkOverride 0 [ ];
+        br0.ip4 = [{ address = "192.168.1.2"; prefixLength = 24; }];
+      };
+    };
+  };
+
+  testScript = {nodes, ...}: let
+    originalSystem = nodes.client.config.system.build.toplevel;
+    eth1_bridged = nodes.client_eth1.config.system.build.toplevel;
+    eth1_rstp = nodes.client_eth1_rstp.config.system.build.toplevel;
+  in ''
+    $client->start();
+
+    $client->waitForUnit("default.target");
+
+    subtest "initial state", sub {
+      $client->succeed("ping 192.168.1.122 -c 1 -n >&2");
+      $client->succeed("nixos-container run webserver -- ping -c 1 -n 192.168.1.1 >&2");
+
+      $client->fail("ip l show eth1 |grep \"master br0\" >&2");
+      $client->fail("grep eth1 /run/br0.interfaces >&2");
+    };
+
+    subtest "interfaces without stp", sub {
+      $client->succeed("${eth1_bridged}/bin/switch-to-configuration test >&2");
+
+      $client->succeed("ping 192.168.1.122 -c 1 -n >&2");
+      $client->succeed("nixos-container run webserver -- ping -c 1 -n 192.168.1.2 >&2");
+
+      $client->succeed("ip l show eth1 |grep \"master br0\" >&2");
+      $client->succeed("grep eth1 /run/br0.interfaces >&2");
+    };
+
+    # activating rstp needs another service, therefor the bridge will restart and the container will loose its connectivity
+    #subtest "interfaces with rstp", sub {
+    #  $client->succeed("${eth1_rstp}/bin/switch-to-configuration test >&2");
+    #  $client->execute("ip -4 a >&2");
+    #  $client->execute("ip l >&2");
+    #
+    #  $client->succeed("ping 192.168.1.122 -c 1 -n >&2");
+    #  $client->succeed("nixos-container run webserver -- ping -c 1 -n 192.168.1.2 >&2");
+    #
+    #  $client->succeed("ip l show eth1 |grep \"master br0\" >&2");
+    #  $client->succeed("grep eth1 /run/br0.interfaces >&2");
+    #};
+
+    subtest "back to no interfaces and no stp", sub {
+      $client->succeed("${originalSystem}/bin/switch-to-configuration test >&2");
+
+      $client->succeed("ping 192.168.1.122 -c 1 -n >&2");
+      $client->succeed("nixos-container run webserver -- ping -c 1 -n 192.168.1.1 >&2");
+
+      $client->fail("ip l show eth1 |grep \"master br0\" >&2");
+      $client->fail("grep eth1 /run/br0.interfaces >&2");
+    };
+  '';
+
+})


### PR DESCRIPTION
###### Motivation for this change

When a container has interfaces added to bridges on the host, there are changes to the host where the interface is removed from the bridge during switch-to-configuration as the bridge is stopped and restarted.

This tries to make the bridge only reload and preserve as much as possible.

I don't yet like the file in /run/<bridgename>.interfaces to remember which interfaces to remove when reloading. But we have to save this somewhere and not just remove all interfaces and re-add them as that would add removed devices. And we can't remove all enslaved devices and only add those configured as that would drop all containers from the bridge…

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [-] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [-] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

