### PR TITLE
microsoft_gsl: init at 2017-02-13

### DIFF
--- a/pkgs/development/libraries/microsoft_gsl/default.nix
+++ b/pkgs/development/libraries/microsoft_gsl/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchgit, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "microsoft_gsl-${version}";
+  version = "2017-02-13";
+
+  src = fetchgit {
+    url = "https://github.com/Microsoft/GSL.git";
+    rev = "3819df6e378ffccf0e29465afe99c3b324c2aa70";
+    sha256 = "03d17mnx6n175aakin313308q14wzvaa9pd0m1yfk6ckhha4qf35";
+  };
+
+  # build phase just runs the unit tests
+  buildInputs = [ cmake ];
+
+  installPhase = ''
+    mkdir -p $out/include
+    mv ../include/ $out/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Functions and types that are suggested for use by the C++ Core Guidelines";
+    homepage = https://github.com/Microsoft/GSL;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ xwvvvvwx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8821,6 +8821,8 @@ with pkgs;
 
   mhddfs = callPackage ../tools/filesystems/mhddfs { };
 
+  microsoft_gsl = callPackage ../development/libraries/microsoft_gsl { };
+
   minizip = callPackage ../development/libraries/minizip { };
 
   miro = callPackage ../applications/video/miro {


### PR DESCRIPTION
###### Motivation for this change

add the GSL lib from microsoft

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

