### PR TITLE
Fix typo introduced by #22677

### DIFF
--- a/nixos/modules/services/networking/quassel.nix
+++ b/nixos/modules/services/networking/quassel.nix
@@ -25,12 +25,12 @@ in
 
       package = mkOption {
         type = types.package;
-        default = pkgs.quasselDaemon_qt5;
-        defaultText = "pkgs.quasselDaemon_qt5";
+        default = pkgs.quasselDaemon;
+        defaultText = "pkgs.quasselDaemon";
         description = ''
           The package of the quassel daemon.
         '';
-        example = literalExample "pkgs.quasselDaemon_qt5";
+        example = literalExample "pkgs.quasselDaemon";
       };
 
       interfaces = mkOption {


### PR DESCRIPTION
###### Motivation for this change

cc: @grahamc 

It looks like #22677 inadvertently introduced a reference to a non-existent package, `quasselDaemon_qt5`. A package `quasselDaemon` does indeed exist however, and is built using qt5, so this is probably what was intended.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

