### PR TITLE
bins: fix permissions issue regenerating albums

### DIFF
--- a/pkgs/tools/graphics/bins/cp-dash-f.patch
+++ b/pkgs/tools/graphics/bins/cp-dash-f.patch
@@ -1,0 +1,11 @@
+--- a/bins	2016-05-18 20:45:49.513330005 -0400
++++ b/bins	2016-05-18 20:58:58.957830874 -0400
+@@ -1332,7 +1332,7 @@
+                 mkdir $destDir, 0755
+                     or die("\nCannot create $destDir: $?");
+             }
+-            system("cp", "-R", bsd_glob("$staticDir/*", GLOB_TILDE), "$destDir") == 0
++            system("cp", "-Rf", bsd_glob("$staticDir/*", GLOB_TILDE), "$destDir") == 0
+                 or die("\nCannot copy $staticDir directory content to $destDir: $?");
+         } else {
+             beVerboseN("  Cannot find any static template directory.", 4);

--- a/pkgs/tools/graphics/bins/default.nix
+++ b/pkgs/tools/graphics/bins/default.nix
@@ -23,7 +23,8 @@ stdenv.mkDerivation {
                                      DateTimeFormatDateParse ]; #TODO need Gtk (not Gtk2?) for bins-edit-gui
 
   patches = [ ./bins_edit-isa.patch
-              ./hashref.patch ];
+              ./hashref.patch
+              ./cp-dash-f.patch ];
 
   installPhase = ''
     export DESTDIR=$out;


### PR DESCRIPTION
since the template files in the nix store are read-only, they can't be
overwritten the second time the album is generated.  using cp's '-f'
option works around this.
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).