### PR TITLE
findutils: plug memory hole in find

### DIFF
--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -8,6 +8,12 @@ stdenv.mkDerivation rec {
     sha256 = "178nn4dl7wbcw499czikirnkniwnx36argdnqgz4ik9i6zvwkm6y";
   };
 
+  patches = [ (fetchurl {
+    # https://bugs.launchpad.net/ubuntu/+source/findutils/+bug/1364492
+    url = https://launchpadlibrarian.net/304000719/find_bug.patch;
+    sha256 = "0dpq2kxsl4lr5wqjqkdjsvskl06xnrrglz5z6w2k58kf7336gqad";
+  }) ];
+
   nativeBuildInputs = [ coreutils ];
 
   doCheck = !stdenv.isDarwin;


### PR DESCRIPTION
###### Motivation for this change

Running `update-locatedb.service` has been reproducibly making my computer unusable for some time now, with the `find` utility using memory north of 12G (RES) and growing. Thankfully, someone over at the [ubuntu bug tracker](https://bugs.launchpad.net/ubuntu/+source/findutils/+bug/1364492) has already developed a fix for this memory hole and I can confirm that with it `update-locatedb` now smoothly runs in the background, with find taking no more than a couple of megs, as it should be.

I'm now running this patch as part of my `services.locate.locate` findutils, though this PR applies it to the findutils in all-packages.nix and will result in a mass-rebuild.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

