### PR TITLE
pygments: 2.1.3 -> 2.2.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -28950,7 +28950,8 @@ EOF
         --replace 'pyyaml==3.11' 'pyyaml' \
         --replace 'lxml==3.7.1' 'lxml' \
         --replace 'pyopenssl==16.2.0' 'pyopenssl' \
-        --replace 'requests[socks]==2.12.4' 'requests[socks]'
+        --replace 'requests[socks]==2.12.4' 'requests[socks]' \
+        --replace 'pygments==2.1.3' 'pygments>=2.1,<3.0'
     '';
 
     propagatedBuildInputs = with self; [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20321,12 +20321,12 @@ in {
   };
 
   pygments = buildPythonPackage rec {
-    version = "2.1.3";
+    version = "2.2.0";
     name = "Pygments-${version}";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/P/Pygments/${name}.tar.gz";
-      sha256 = "10axnp2wpjnq9g8wg53fx0c70dfxqrz498jyz8mrdx9a3flwir48";
+      sha256 = "1k78qdvir1yb1c634nkv6rbga8wv4289xarghmsbbvzhvr311bnv";
     };
 
     propagatedBuildInputs = with self; [ docutils ];


### PR DESCRIPTION
###### Motivation for this change

A new version has been released.

[Changes:](http://pygments.org/docs/changelog/)

**Version 2.2.0**

(release Jan 22, 2017)

-    Added lexers:
     -   AMPL
     -   TypoScript (#1173)
     -   Varnish config (PR#554)
     -   Clean (PR#503)
     -   WDiff (PR#513)
     -   Flatline (PR#551)
     -   Silver (PR#537)
     -   HSAIL (PR#518)
     -   JSGF (PR#546)
     -   NCAR command language (PR#536)
     -   Extempore (PR#530)
     -   Cap’n Proto (PR#595)
     -   Whiley (PR#573)
     -   Monte (PR#592)
     -   Crystal (PR#576)
     -   Snowball (PR#589)
     -   CapDL (PR#579)
     -   NuSMV (PR#564)
     -   SAS, Stata (PR#593)
-    Added the ability to load lexer and formatter classes directly from files with the -x command line option and the lexers.load_lexer_from_file() and formatters.load_formatter_from_file() functions. (PR#559)
-    Added lexers.find_lexer_class_by_name(). (#1203)
-    Added new token types and lexing for magic methods and variables in Python and PHP.
-    Added a new token type for string affixes and lexing for them in Python, C++ and Postgresql lexers.
-    Added a new token type for heredoc (and similar) string delimiters and lexing for them in C++, Perl, PHP, Postgresql and Ruby lexers.
-    Styles can now define colors with ANSI colors for use in the 256-color terminal formatter. (PR#531)
-    Improved the CSS lexer. (#1083, #1130)
-    Added “Rainbow Dash” style. (PR#623)
-    Delay loading pkg_resources, which takes a long while to import. (PR#690)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).