### PR TITLE
Redo DBus configuration

### DIFF
--- a/nixos/modules/services/system/dbus-session-local.conf.in
+++ b/nixos/modules/services/system/dbus-session-local.conf.in
@@ -1,5 +1,0 @@
-<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
- "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
-<busconfig>
-  @extra@
-</busconfig>

--- a/nixos/modules/services/system/dbus-system-local.conf.in
+++ b/nixos/modules/services/system/dbus-system-local.conf.in
@@ -1,6 +1,0 @@
-<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
- "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
-<busconfig>
-  <servicehelper>@servicehelper@</servicehelper>
-  @extra@
-</busconfig>

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -10,32 +10,10 @@ let
 
   homeDir = "/run/dbus";
 
-  systemExtraxml = concatStrings (flip concatMap cfg.packages (d: [
-    "<servicedir>${d}/share/dbus-1/system-services</servicedir>"
-    "<includedir>${d}/etc/dbus-1/system.d</includedir>"
-  ]));
-
-  sessionExtraxml = concatStrings (flip concatMap cfg.packages (d: [
-    "<servicedir>${d}/share/dbus-1/services</servicedir>"
-    "<includedir>${d}/etc/dbus-1/session.d</includedir>"
-  ]));
-
-  configDir = pkgs.runCommand "dbus-conf"
-    { preferLocalBuild = true;
-      allowSubstitutes = false;
-    }
-    ''
-      mkdir -p $out
-
-      sed '${./dbus-system-local.conf.in}' \
-        -e 's,@servicehelper@,${config.security.wrapperDir}/dbus-daemon-launch-helper,g' \
-        -e 's,@extra@,${systemExtraxml},' \
-        > "$out/system-local.conf"
-
-      sed '${./dbus-session-local.conf.in}' \
-        -e 's,@extra@,${sessionExtraxml},' \
-        > "$out/session-local.conf"
-    '';
+  configDir = pkgs.makeDBusConf {
+    suidHelper = "${config.security.wrapperDir}/dbus-daemon-launch-helper";
+    serviceDirectories = cfg.packages;
+  };
 
 in
 

--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -50,7 +50,8 @@ self = stdenv.mkDerivation {
       "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
       "--with-systemduserunitdir=$(out)/etc/systemd/user"
       "--enable-user-session"
-      "--libexecdir=$(out)/libexec" # we don't need dbus-daemon-launch-helper
+      "--datadir=/etc"
+      "--libexecdir=$(out)/libexec"
     ] ++ lib.optional (!x11Support) "--without-x";
 
     # Enable X11 autolaunch support in libdbus. This doesn't actually depend on X11
@@ -63,7 +64,12 @@ self = stdenv.mkDerivation {
 
     doCheck = true;
 
-    installFlags = [ "sysconfdir=$(out)/etc" ];
+    installFlags = [ "sysconfdir=$(out)/etc" "datadir=$(out)/share" ];
+
+    postInstall = ''
+      mkdir -p $doc/share/xml/dbus
+      cp doc/*.dtd $doc/share/xml/dbus
+    '';
 
     # it's executed from $lib by absolute path
     postFixup = ''

--- a/pkgs/development/libraries/dbus/make-dbus-conf.nix
+++ b/pkgs/development/libraries/dbus/make-dbus-conf.nix
@@ -1,0 +1,27 @@
+{ runCommand, libxslt, dbus, serviceDirectories ? [], suidHelper ? "/var/setuid-wrappers/dbus-daemon-launch-helper" }:
+
+/* DBus has two configuration parsers -- normal and "trivial", which is used
+ * for suid helper. Unfortunately the latter doesn't support <include>
+ * directive. That means that we can't just place our configuration to
+ * *-local.conf -- it needs to be in the main configuration file.
+ */
+runCommand "dbus-1"
+  {
+    buildInputs = [ libxslt ];
+    inherit serviceDirectories suidHelper;
+  }
+  ''
+    mkdir -p $out
+
+    xsltproc \
+      --stringparam serviceDirectories "$serviceDirectories" \
+      --stringparam suidHelper "$suidHelper" \
+      --path ${dbus.doc}/share/xml/dbus \
+      ${./make-system-conf.xsl} ${dbus}/share/dbus-1/system.conf \
+      > $out/system.conf
+    xsltproc \
+      --stringparam serviceDirectories "$serviceDirectories" \
+      --path ${dbus.doc}/share/xml/dbus \
+      ${./make-session-conf.xsl} ${dbus}/share/dbus-1/session.conf \
+      > $out/session.conf
+  ''

--- a/pkgs/development/libraries/dbus/make-session-conf.xsl
+++ b/pkgs/development/libraries/dbus/make-session-conf.xsl
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+
+<!--
+  This script copies the original system.conf from the dbus
+  distribution, but sets paths from $serviceDirectories parameter
+  and suid helper from $suidHelper parameter.
+-->
+
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:str="http://exslt.org/strings"
+                extension-element-prefixes="str"
+                >
+
+  <xsl:output method='xml' encoding="UTF-8" doctype-system="busconfig.dtd" />
+
+  <xsl:param name="serviceDirectories" />
+
+  <xsl:template match="/busconfig">
+    <busconfig>
+      <xsl:copy-of select="child::node()[name() != 'include' and name() != 'standard_session_servicedirs' and name() != 'servicedir' and name() != 'includedir']" />
+
+      <xsl:for-each select="str:tokenize($serviceDirectories)">
+        <servicedir><xsl:value-of select="." />/share/dbus-1/services</servicedir>
+        <includedir><xsl:value-of select="." />/etc/dbus-1/session.d</includedir>
+      </xsl:for-each>
+    </busconfig>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/pkgs/development/libraries/dbus/make-system-conf.xsl
+++ b/pkgs/development/libraries/dbus/make-system-conf.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+
+<!--
+  This script copies the original system.conf from the dbus
+  distribution, but sets paths from $serviceDirectories parameter
+  and suid helper from $suidHelper parameter.
+-->
+
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:str="http://exslt.org/strings"
+                extension-element-prefixes="str"
+                >
+
+  <xsl:output method='xml' encoding="UTF-8" doctype-system="busconfig.dtd" />
+
+  <xsl:param name="serviceDirectories" />
+  <xsl:param name="suidHelper" />
+
+  <xsl:template match="/busconfig">
+    <busconfig>
+      <xsl:copy-of select="child::node()[name() != 'include' and name() != 'standard_system_servicedirs' and name() != 'servicehelper' and name() != 'servicedir' and name() != 'includedir']" />
+
+      <!-- set suid helper -->
+      <servicehelper><xsl:value-of select="$suidHelper" /></servicehelper>
+
+      <xsl:for-each select="str:tokenize($serviceDirectories)">
+        <servicedir><xsl:value-of select="." />/share/dbus-1/system-services</servicedir>
+        <includedir><xsl:value-of select="." />/etc/dbus-1/system.d</includedir>
+      </xsl:for-each>
+    </busconfig>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7094,6 +7094,11 @@ with pkgs;
   dbus_libs = dbus;
   dbus_daemon = dbus.daemon;
 
+  makeDBusConf = { suidHelper, serviceDirectories }:
+    callPackage ../development/libraries/dbus/make-dbus-conf.nix {
+      inherit suidHelper serviceDirectories;
+    };
+
   dee = callPackage ../development/libraries/dee { };
 
   dhex = callPackage ../applications/editors/dhex { };


### PR DESCRIPTION
###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/pull/22354#issuecomment-279516720. We now don't use any extra configuration files. Instead we embed our configuration into the main config using XSLT. See the issue and description in commits on why this is necessary.

With this `blueman` starts correctly for me in a virtual machine.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @layus (was interested in previous DBus changes)

XSLT solution is heavily ~~copied from~~inspired by `makeFontsConf`  -- thanks to original authors!