### PR TITLE
lxappearance: 0.6.2 -> 0.6.3

### DIFF
--- a/pkgs/desktops/lxde/core/lxappearance/default.nix
+++ b/pkgs/desktops/lxde/core/lxappearance/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, intltool, pkgconfig, libX11, gtk2 }:
 
 stdenv.mkDerivation rec {
-  name = "lxappearance-0.6.2";
+  name = "lxappearance-0.6.3";
 
   src = fetchurl{
     url = "mirror://sourceforge/project/lxde/LXAppearance/${name}.tar.xz";
-    sha256 = "07r0xbi6504zjnbpan7zrn7gi4j0kbsqqfpj8v2x94gr05p16qj4";
+    sha256 = "0f4bjaamfxxdr9civvy55pa6vv9dx1hjs522gjbbgx7yp1cdh8kj";
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];
@@ -14,9 +14,9 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A lightweight program for configuring the theme and fonts of gtk applications";
+    homepage = "http://lxde.org/";
     maintainers = [ stdenv.lib.maintainers.hinton ];
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.gpl2;
-    homepage = "http://lxde.org/";
   };
 }


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).