### PR TITLE
qbittorrent: 3.3.7 -> 3.3.10

### DIFF
--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -10,11 +10,11 @@ assert guiSupport -> (dbus_libs != null);
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "qbittorrent-${version}";
-  version = "3.3.7";
+  version = "3.3.10";
 
   src = fetchurl {
     url = "mirror://sourceforge/qbittorrent/${name}.tar.xz";
-    sha256 = "0h2ccqmjnm0x0qjvd0vz5hk7dy9qbqhiqvxywqjhip7sj1585p3j";
+    sha256 = "1lm8y5k9363gajbw0k9jb1cb7zg0lz5rw2ja0kd36h68rpm7qr9c";
   };
 
   nativeBuildInputs = [ pkgconfig which ];
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     description = "Free Software alternative to µtorrent";
     homepage    = http://www.qbittorrent.org/;
     license     = licenses.gpl2;
-    maintainers = with maintainers; [ viric ];
     platforms   = platforms.linux;
+    maintainers = with maintainers; [ viric ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to new version.

[See changes.](https://www.qbittorrent.org/news.php)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).