### PR TITLE
amazon-init NixOS module: fix (I think) race condition with network

### DIFF
--- a/nixos/modules/virtualisation/amazon-init.nix
+++ b/nixos/modules/virtualisation/amazon-init.nix
@@ -1,20 +1,18 @@
-{ config, pkgs, modulesPath, ... }:
-
-# This attempts to pull a nix expression from this EC2 instance's user-data.
+{ config, pkgs, ... }:
 
 let
-  bootScript = pkgs.writeScript "bootscript.sh" ''
+  script = ''
     #!${pkgs.stdenv.shell} -eu
 
     echo "attempting to fetch configuration from EC2 user data..."
 
+    export HOME=/root
     export PATH=${pkgs.lib.makeBinPath [ config.nix.package pkgs.systemd pkgs.gnugrep pkgs.gnused config.system.build.nixos-rebuild]}:$PATH
     export NIX_PATH=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels
 
     userData=/etc/ec2-metadata/user-data
 
     if [ -s "$userData" ]; then
-
       # If the user-data looks like it could be a nix expression,
       # copy it over. Also, look for a magic three-hash comment and set
       # that as the channel.
@@ -43,7 +41,22 @@ let
     nixos-rebuild switch
   '';
 in {
-  boot.postBootCommands = ''
-    ${bootScript} &
-  '';
+  systemd.services.amazon-init = {
+    inherit script;
+    description = "Reconfigure the system from EC2 userdata on startup";
+
+    wantedBy = [ "sshd.service" ];
+    before = [ "sshd.service" ];
+    after = [ "network-online.target" ];
+    requires = [ "network-online.target" ];
+ 
+    restartIfChanged = false;
+    unitConfig.X-StopOnRemoval = false;
+
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+  };
 }
+


### PR DESCRIPTION
The initialization code is now a systemd service that explicitly waits for network-online, so the occasional failure I was seeing because the `nixos-rebuild` couldn't get anything from the binary
cache should stop. I hope!

cc @edolstra @rbvermaa 

I did notice that the test occasionally fails with this message:

```
wrong free space 2079145984 at (eval 15) line 53, <__ANONIO__> line 577.
```

which I was hoping you might have an idea about. Perhaps I need a `before = [ "sshd.service" ];` field?

###### Motivation for this change

#22830 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

