### PR TITLE
[WIP] dateutil: 2.5.3 -> 2.6.0

### DIFF
--- a/pkgs/development/python-modules/cairocffi/dlopen-paths.osx.patch
+++ b/pkgs/development/python-modules/cairocffi/dlopen-paths.osx.patch
@@ -1,0 +1,45 @@
+commit 705dc9a55bd160625d9996e63fc7dc532d0ad0ab (modified)
+
+    Patch dlopen() to allow direct paths to all required libs
+    
+    This patch is OSX specific
+
+diff --git a/cairocffi/__init__.py b/cairocffi/__init__.py
+index 718aa7f..1a1dcff 100644
+--- a/cairocffi/__init__.py
++++ b/cairocffi/__init__.py
+@@ -27,20 +27,22 @@ VERSION = '0.7.2'
+ version = '1.10.0'
+ version_info = (1, 10, 0)
+ 
++# Use hardcoded soname, because ctypes.util use gcc/objdump which shouldn't be required for runtime
++_LIBS = {
++    'cairo': '@cairo@/lib/libcairo.2.dylib',
++    'glib-2.0': '@glib@/lib/libglib-2.0.0.dylib',
++    'gobject-2.0': '@glib@/lib/libgobject-2.0.0.dylib',
++    'gdk_pixbuf-2.0': '@gdk_pixbuf@/lib/libgdk_pixbuf-2.0.0.dylib',
++}
+ 
+-def dlopen(ffi, *names):
++def dlopen(ffi, name, *names):
+     """Try various names for the same library, for different platforms."""
+-    for name in names:
+-        for lib_name in [name, 'lib' + name]:
+-            try:
+-                path = ctypes.util.find_library(lib_name)
+-                if path:
+-                    lib = ffi.dlopen(path)
+-                    if lib:
+-                        return lib
+-            except OSError:
+-                pass
+-    raise OSError("dlopen() failed to load a library: %s" % ' / '.join(names))
++    path = _LIBS.get(name, None)
++    if path:
++        lib = ffi.dlopen(path)
++        if lib:
++            return lib
++    raise OSError("dlopen() failed to load a library: %s as %s" % (name, path))
+ 
+ 
+ cairo = dlopen(ffi, 'cairo', 'cairo-2')

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3483,9 +3483,10 @@ in {
           sha256 = "0gb570z3ivf1b0ixsk526n3h29m8c5rhjsiyam7rr3x80dp65cdl";
       })
 
-      ../development/python-modules/cairocffi/dlopen-paths.patch
       ../development/python-modules/cairocffi/fix_test_scaled_font.patch
-    ];
+    ] ++ ( if stdenv.isDarwin
+      then [ ../development/python-modules/cairocffi/dlopen-paths.osx.patch ]
+      else [ ../development/python-modules/cairocffi/dlopen-paths.patch ] );
 
     postPatch = ''
       # Hardcode cairo library path
@@ -3496,7 +3497,7 @@ in {
 
     meta = {
       homepage = https://github.com/SimonSapin/cairocffi;
-      license = "bsd";
+      license = licenses.bsd3;
       description = "cffi-based cairo bindings for Python";
     };
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5929,20 +5929,22 @@ in {
   };
 
   dateutil = buildPythonPackage (rec {
-    name = "dateutil-${version}";
     version = "2.5.3";
+    pname = "python-dateutil";
+    name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/python-dateutil/python-${name}.tar.gz";
+    src = fetchPypi {
+      inherit pname version;
       sha256 = "1v9j9fmf8g911yg6k01xa2db6dx3wv73zkk7fncsj7vagjqgs20l";
     };
 
-    propagatedBuildInputs = with self; [ self.six ];
+    propagatedBuildInputs = with self; [ six ];
 
     meta = {
       description = "Powerful extensions to the standard datetime module";
       homepage = http://pypi.python.org/pypi/python-dateutil;
-      license = "BSD-style";
+      maintainers = with maintainers; [ vrthra ];
+      license = licenses.bsd3;
     };
   });
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

