### PR TITLE
Update isync-git, with several other improvements

### DIFF
--- a/pkgs/tools/networking/isync/unstable.nix
+++ b/pkgs/tools/networking/isync/unstable.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   rev = "46e792";
 
   src = fetchgit {
-    url = "git://git.code.sf.net/p/isync/isync";
+    url = "https://git.code.sf.net/p/isync/isync";
     inherit rev;
     sha256 = "02bm5m3bwpfns7qdwfybyl4fwa146n55v67pdchkhxaqpa4ddws1";
   };

--- a/pkgs/tools/networking/isync/unstable.nix
+++ b/pkgs/tools/networking/isync/unstable.nix
@@ -1,4 +1,4 @@
-{ fetchgit, stdenv, openssl, pkgconfig, db, cyrus_sasl
+{ fetchgit, stdenv, openssl, pkgconfig, db, cyrus_sasl, zlib
 , autoconf, automake }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0i21cgmgm8acvd7xwdk9pll3kl6cxj9s1hakqzbwks8j4ncygwkj";
   };
 
-  buildInputs = [ openssl pkgconfig db cyrus_sasl autoconf automake ];
+  buildInputs = [ openssl pkgconfig db cyrus_sasl zlib autoconf automake ];
 
   preConfigure = ''
     touch ChangeLog

--- a/pkgs/tools/networking/isync/unstable.nix
+++ b/pkgs/tools/networking/isync/unstable.nix
@@ -22,8 +22,7 @@ stdenv.mkDerivation rec {
     homepage = http://isync.sourceforge.net/;
     description = "Free IMAP and MailDir mailbox synchronizer";
     license = licenses.gpl2Plus;
-
-    maintainers = with maintainers; [ the-kenny ];
+    maintainers = with maintainers; [ the-kenny ttuegel ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/networking/isync/unstable.nix
+++ b/pkgs/tools/networking/isync/unstable.nix
@@ -2,13 +2,13 @@
 , autoconf, automake }:
 
 stdenv.mkDerivation rec {
-  name = "isync-git-2015-11-08";
-  rev = "46e792";
+  name = "isync-git-20161218";
+  rev = "77acc268123b8233843ca9bc3dcf90669efde08f";
 
   src = fetchgit {
     url = "https://git.code.sf.net/p/isync/isync";
     inherit rev;
-    sha256 = "02bm5m3bwpfns7qdwfybyl4fwa146n55v67pdchkhxaqpa4ddws1";
+    sha256 = "0i21cgmgm8acvd7xwdk9pll3kl6cxj9s1hakqzbwks8j4ncygwkj";
   };
 
   buildInputs = [ openssl pkgconfig db cyrus_sasl autoconf automake ];


### PR DESCRIPTION
###### Motivation for this change

Although there has not been an isync release in several years, development continues upstream at a moderate pace, so it is important that we keep our Git-based version up-to-date.

Besides updating the package, I:
- added myself to the maintainers
- changed the `src` to download over HTTPS, and
- added zlib support

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (*Not Applicable*)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

