### PR TITLE
Various python

### DIFF
--- a/pkgs/development/python-modules/tables/default.nix
+++ b/pkgs/development/python-modules/tables/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchurl, python, buildPythonPackage
-, cython, bzip2, lzo, numpy, numexpr, hdf5 }:
+, cython, bzip2, lzo, numpy, numexpr, hdf5, six }:
 
 buildPythonPackage rec {
-  version = "3.2.2";
+  version = "3.3.0";
   name = "tables-${version}";
 
   src = fetchurl {
     url = "mirror://pypi/t/tables/${name}.tar.gz";
-    sha256 = "3564b351a71ec1737b503b001eb7ceae1f65d5d6e3ffe1ea75aafba10f37fa84";
+    sha256 = "0b4211s0zzdmh74k49ss0m9lc2ql2iazq2aa95ams6h45vqcr0w3";
   };
 
   buildInputs = [ hdf5 cython bzip2 lzo ];
-  propagatedBuildInputs = [ numpy numexpr ];
+  propagatedBuildInputs = [ numpy numexpr six ];
 
   # The setup script complains about missing run-paths, but they are
   # actually set.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -28965,14 +28965,14 @@ EOF
 
   Logbook = buildPythonPackage rec {
     name = "Logbook-${version}";
-    version = "0.11.3";
+    version = "1.0.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/L/Logbook/${name}.tar.gz";
-      sha256 = "0bchn00jj0y4dmrmqsm29ffcx37g79jcxjihadmgz2aj0z6dbsrc";
+      sha256 = "0whqbx5p0zkf7gmb5ssnsnhm4kn4drd4x7fbhdi8dnxklqajbnl7";
     };
 
-    buildInputs = [ self.pytest ];
+    buildInputs = [ self.pytest ] ++ optionals (!isPy3k) [ self.mock ];
 
     checkPhase = ''
       find tests -name \*.pyc -delete

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -431,15 +431,19 @@ in {
   };
 
   altair = buildPythonPackage rec {
-    name = "altair-1.0.0";
+    name = "altair-1.2.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/a/altair/${name}.tar.gz";
-      sha256 = "024drhmiw8w3dl7dbal0pvnlfd3sv4n1rqywv2jb488b3fzm704r";
+      sha256 = "05c47dm20p7m0017p2h38il721rxag1q0457dj7whp0k8rc7qd1n";
     };
+    buildInputs = [ self.pytest ];
 
+    checkPhase = ''
+      export LANG=en_US.UTF-8
+      py.test altair --doctest-modules
+    '';
     propagatedBuildInputs = with self; [ vega pandas ipython traitlets ];
-
     meta = {
       description = "A declarative statistical visualization library for Python.";
       homepage = https://github.com/altair-viz/altair;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -456,6 +456,7 @@ in {
       sha256 = "08k92afnk0bivm07h1l5nh26xl2rfp7qn03aq17q1hr3fs5r6cdm";
     };
 
+    buildInputs = [ self.pytest ];
     propagatedBuildInputs = with self; [ jupyter_core pandas ];
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

Don't merge just yet, running nox-review fails locally so I want to try the `pr` option.

```
error: while querying the derivation named ‘tex4ht-1.0.2009_06_11_1038’:
while evaluating the attribute ‘buildPhase’ of the derivation ‘tex4ht-1.0.2009_06_11_1038’ at /home/tom/.nox/nixpkgs/pkgs/tools/typesetting/tex/tex4ht/default.nix:4:3:
cannot coerce null to a string, at /home/tom/.nox/nixpkgs/pkgs/tools/typesetting/tex/tex4ht/default.nix:15:16
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

