### PR TITLE
consul-template: 0.18.0 -> 0.18.1

### DIFF
--- a/pkgs/tools/system/consul-template/default.nix
+++ b/pkgs/tools/system/consul-template/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "consul-template-${version}";
-  version = "0.18.0";
+  version = "0.18.1";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/consul-template";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "hashicorp";
     repo = "consul-template";
-    sha256 = "1a1r7jwv0d4l8bcjal9chvr871hmw0ljbihgjqasp6gvjg0hfbx6";
+    sha256 = "0swyhc5smjbp5wql43qhpxrcbg47v89l5icb1s60gszhxizlkk7d";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

