### PR TITLE
phpPackages.memcached: add missing zlib build dependency

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -51,7 +51,7 @@ let
       "--with-libmemcached-dir=${pkgs.libmemcached}"
     ];
 
-    buildInputs = with pkgs; [ pkgconfig cyrus_sasl ];
+    buildInputs = with pkgs; [ pkgconfig cyrus_sasl zlib ];
   };
 
   # Not released yet
@@ -69,7 +69,7 @@ let
       "--with-libmemcached-dir=${pkgs.libmemcached}"
     ];
 
-    buildInputs = with pkgs; [ pkgconfig cyrus_sasl ];
+    buildInputs = with pkgs; [ pkgconfig cyrus_sasl zlib ];
   };
 
   # No support for PHP 7 yet (and probably never will be)


### PR DESCRIPTION
###### Motivation for this change

See Issue #22790 

The memcached extension builds now for php 5.6, 7.0 and 7.1 and tested execution of a simple script with each php version (http://php.net/manual/de/memcached.get.php).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

