### PR TITLE
awless: init at 0.0.13

### DIFF
--- a/pkgs/tools/virtualization/awless/default.nix
+++ b/pkgs/tools/virtualization/awless/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "awless-${version}";
+  version = "0.0.13";
+  rev = "${version}";
+
+  goPackagePath = "github.com/wallix/awless";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "wallix";
+    repo = "awless";
+    sha256 = "045n4r2mk40pjggsfcjlxni6q4arybs9x9raghqb9n8dyfg9v5kv";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/wallix/awless/;
+    description = "A Mighty CLI for AWS";
+    platforms = platforms.linux ++ platforms.darwin;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pradeepchhetri ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -460,6 +460,8 @@ with pkgs;
 
   azure-vhd-utils  = callPackage ../tools/misc/azure-vhd-utils { };
 
+  awless = callPackage ../tools/virtualization/awless { };
+
   ec2_api_tools = callPackage ../tools/virtualization/ec2-api-tools { };
 
   ec2_ami_tools = callPackage ../tools/virtualization/ec2-ami-tools { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

