### PR TITLE
nixos: add programs.wireshark option

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -288,7 +288,6 @@
       kresd = 270;
       rpc = 271;
       geoip = 272;
-      #wireshark = 273; # unused
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -546,7 +545,6 @@
       kresd = 270;
       #rpc = 271; # unused
       #geoip = 272; # unused
-      wireshark = 273;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -288,6 +288,7 @@
       kresd = 270;
       rpc = 271;
       geoip = 272;
+      #wireshark = 273; # unused
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -545,6 +546,7 @@
       kresd = 270;
       #rpc = 271; # unused
       #geoip = 272; # unused
+      wireshark = 273;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -91,6 +91,7 @@
   ./programs/tmux.nix
   ./programs/venus.nix
   ./programs/vim.nix
+  ./programs/wireshark.nix
   ./programs/wvdial.nix
   ./programs/xfs_quota.nix
   ./programs/xonsh.nix

--- a/nixos/modules/programs/wireshark.nix
+++ b/nixos/modules/programs/wireshark.nix
@@ -3,27 +3,19 @@
 with lib;
 
 let
-
   cfg = config.programs.wireshark;
   wireshark = cfg.package;
-
-in
-
-{
-
+in {
   options = {
-
     programs.wireshark = {
-
       enable = mkOption {
         type = types.bool;
         default = false;
         description = ''
           Whether to add Wireshark to the global environment and configure a
-          setuid wrapper for 'dumpcap' for users in the 'wireshark' group.
+          setcap wrapper for 'dumpcap' for users in the 'wireshark' group.
         '';
       };
-
       package = mkOption {
         type = types.package;
         default = pkgs.wireshark-cli;
@@ -32,26 +24,19 @@ in
           Which Wireshark package to install in the global environment.
         '';
       };
-
     };
-
   };
 
   config = mkIf cfg.enable {
-
     environment.systemPackages = [ wireshark ];
-    
+    users.extraGroups.wireshark = {};
+
     security.wrappers.dumpcap = {
       source = "${wireshark}/bin/dumpcap";
+      capabilities = "cap_net_raw+p";
       owner = "root";
       group = "wireshark";
-      setuid = true;
-      setgid = false;
       permissions = "u+rx,g+x";
     };
-
-    users.extraGroups.wireshark.gid = config.ids.gids.wireshark;
-
   };
-
 }

--- a/nixos/modules/programs/wireshark.nix
+++ b/nixos/modules/programs/wireshark.nix
@@ -1,0 +1,57 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.wireshark;
+  wireshark = cfg.package;
+
+in
+
+{
+
+  options = {
+
+    programs.wireshark = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to add Wireshark to the global environment and configure a
+          setuid wrapper for 'dumpcap' for users in the 'wireshark' group.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.wireshark-cli;
+        defaultText = "pkgs.wireshark-cli";
+        description = ''
+          Which Wireshark package to install in the global environment.
+        '';
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ wireshark ];
+    
+    security.wrappers.dumpcap = {
+      source = "${wireshark}/bin/dumpcap";
+      owner = "root";
+      group = "wireshark";
+      setuid = true;
+      setgid = false;
+      permissions = "u+rx,g+x";
+    };
+
+    users.extraGroups.wireshark.gid = config.ids.gids.wireshark;
+
+  };
+
+}

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -28,6 +28,7 @@ let
     , source
     , owner  ? "nobody"
     , group  ? "nogroup"
+    , permissions ? "u+rx,g+x,o+x"
     , ...
     }:
     assert (lib.versionAtLeast (lib.getVersion config.boot.kernelPackages.kernel) "4.3");
@@ -45,7 +46,7 @@ let
       ${pkgs.libcap.out}/bin/setcap "cap_setpcap,${capabilities}" $wrapperDir/${program}
 
       # Set the executable bit
-      chmod u+rx,g+x,o+x $wrapperDir/${program}
+      chmod ${permissions} $wrapperDir/${program}
     '';
 
   ###### Activation script for the setuid wrappers


### PR DESCRIPTION
###### Motivation for this change
To be able to use Wireshark as an ordinary user, the 'dumpcap' program
must be installed setuid root. This module module simplifies such a
configuration to simply:

```
programs.wireshark.enable = true;
```

The setuid wrapper is available for users in the 'wireshark' group.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

