### PR TITLE
awesome-4.0: Add optional hicolor-icon-theme for theme support

### DIFF
--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -4,27 +4,15 @@
 , compton, procps, iproute, coreutils, curl, alsaUtils, findutils, xterm
 , which, dbus, nettools, git, asciidoc, doxygen
 , xmlto, docbook_xml_dtd_45, docbook_xsl, findXMLCatalogs
-, libxkbcommon, xcbutilxrm
+, libxkbcommon, xcbutilxrm, hicolor_icon_theme
 }:
 
-let
-  version = "4.0";
-in with luaPackages;
-
-stdenv.mkDerivation rec {
+with luaPackages; stdenv.mkDerivation rec {
   name = "awesome-${version}";
-
+  version = "4.0";
   src = fetchurl {
     url    = "http://github.com/awesomeWM/awesome-releases/raw/master/${name}.tar.xz";
     sha256 = "0czkcz67sab63gf5m2p2pgg05yinjx60hfb9rfyzdkkg28q9f02w";
-  };
-
-  meta = with stdenv.lib; {
-    description = "Highly configurable, dynamic window manager for X";
-    homepage    = https://awesomewm.org/;
-    license     = licenses.gpl2Plus;
-    maintainers = with maintainers; [ lovek323 rasendubi ];
-    platforms   = platforms.linux;
   };
 
   nativeBuildInputs = [
@@ -36,33 +24,14 @@ stdenv.mkDerivation rec {
     pkgconfig
     xmlto docbook_xml_dtd_45 docbook_xsl findXMLCatalogs
   ];
-
-  buildInputs = [
-    cairo
-    dbus
-    gdk_pixbuf
-    gobjectIntrospection
-    git
-    lgi
-    libpthreadstubs
-    libstartup_notification
-    libxdg_basedir
-    lua
-    nettools
-    pango
-    xcb-util-cursor
-    xorg.libXau
-    xorg.libXdmcp
-    xorg.libxcb
-    xorg.libxshmfence
-    xorg.xcbutil
-    xorg.xcbutilimage
-    xorg.xcbutilkeysyms
-    xorg.xcbutilrenderutil
-    xorg.xcbutilwm
-    libxkbcommon
-    xcbutilxrm
-  ];
+  propagatedUserEnvPkgs = [ hicolor_icon_theme ];
+  buildInputs = [ cairo dbus gdk_pixbuf gobjectIntrospection
+                  git lgi libpthreadstubs libstartup_notification
+                  libxdg_basedir lua nettools pango xcb-util-cursor
+                  xorg.libXau xorg.libXdmcp xorg.libxcb xorg.libxshmfence
+                  xorg.xcbutil xorg.xcbutilimage xorg.xcbutilkeysyms
+                  xorg.xcbutilrenderutil xorg.xcbutilwm libxkbcommon
+                  xcbutilxrm ]; 
 
   #cmakeFlags = "-DGENERATE_MANPAGES=ON";
 
@@ -85,5 +54,13 @@ stdenv.mkDerivation rec {
 
   passthru = {
     inherit lua;
+  };
+
+  meta = with stdenv.lib; {
+    description = "Highly configurable, dynamic window manager for X";
+    homepage    = https://awesomewm.org/;
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ lovek323 rasendubi ndowens ];
+    platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Add hicolor_icon_theme optional dependency, so 4.0 themes such as https://github.com/copycat-killer/awesome-copycats will work

###### Things done

- [x ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

