### PR TITLE
gnupg21: Fix scdaemon for usb smartcards

### DIFF
--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -34,12 +34,12 @@ stdenv.mkDerivation rec {
     # TODO: Remove the following two patches on the next gnupg release after 2.1.18
     (fetchpatch {
       name = "scd-Backport-two-fixes-from-master";
-      url = "https://sources.debian.net/data/main/g/gnupg2/2.1.18-6/debian/patches/0028-scd-Backport-two-fixes-from-master.patch";
+      url = "https://anonscm.debian.org/git/pkg-gnupg/gnupg2.git/plain/debian/patches/0028-scd-Backport-two-fixes-from-master.patch?h=debian/2.1.18-6";
       sha256 = "01l2s4s7kp6j2f3qd371arq7pfphvncc9k1m63rqm0kyzy9jk20k";
     })
     (fetchpatch {
       name = "scd-Fix-use-case-of-PC-SC";
-      url = "https://sources.debian.net/data/main/g/gnupg2/2.1.18-6/debian/patches/0029-scd-Fix-use-case-of-PC-SC.patch";
+      url = "https://anonscm.debian.org/git/pkg-gnupg/gnupg2.git/plain/debian/patches/0029-scd-Fix-use-case-of-PC-SC.patch?h=debian/2.1.18-6";
       sha256 = "0lxqj614fialbqs2x0z13q5ikq2rc9xwphmkly179qs03d4mawsz";
     })
   ];

--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -1,5 +1,5 @@
-{ fetchurl, stdenv, pkgconfig, libgcrypt, libassuan, libksba, libiconv, npth
-, gettext, texinfo, pcsclite, sqlite
+{ fetchurl, fetchpatch, stdenv, pkgconfig, libgcrypt, libassuan, libksba
+, libiconv, npth, gettext, texinfo, pcsclite, sqlite
 
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
@@ -29,7 +29,20 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 
-  patches = [ ./fix-libusb-include-path.patch ];
+  patches = [
+    ./fix-libusb-include-path.patch
+    # TODO: Remove the following two patches on the next gnupg release after 2.1.18
+    (fetchpatch {
+      name = "scd-Backport-two-fixes-from-master";
+      url = "https://sources.debian.net/data/main/g/gnupg2/2.1.18-6/debian/patches/0028-scd-Backport-two-fixes-from-master.patch";
+      sha256 = "01l2s4s7kp6j2f3qd371arq7pfphvncc9k1m63rqm0kyzy9jk20k";
+    })
+    (fetchpatch {
+      name = "scd-Fix-use-case-of-PC-SC";
+      url = "https://sources.debian.net/data/main/g/gnupg2/2.1.18-6/debian/patches/0029-scd-Fix-use-case-of-PC-SC.patch";
+      sha256 = "0lxqj614fialbqs2x0z13q5ikq2rc9xwphmkly179qs03d4mawsz";
+    })
+  ];
   postPatch = stdenv.lib.optionalString stdenv.isLinux ''
     sed -i 's,"libpcsclite\.so[^"]*","${pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
   ''; #" fix Emacs syntax highlighting :-(


### PR DESCRIPTION
The use of smartcard functionality for yubikeys (and presumably other
usb smartcards) was broken in gnupg 2.1.18.  This has apparently already been
fixed in gnupg master, and debian backports the included patches for 2.1.18.

See also:
https://bugs.gnupg.org/gnupg/issue2933
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=852702
https://github.com/NixOS/nixpkgs/pull/21991

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

