### PR TITLE
glide: make sure to dispaly the correct version

### DIFF
--- a/pkgs/development/tools/glide/default.nix
+++ b/pkgs/development/tools/glide/default.nix
@@ -6,6 +6,11 @@ buildGoPackage rec {
 
   goPackagePath = "github.com/Masterminds/glide";
 
+   buildFlagsArray = ''
+   -ldflags=
+      -X main.version=${version}
+  '';
+
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "Masterminds";


### PR DESCRIPTION
###### Motivation for this change

It currently displays `0.12.0-dev` instead of the specified
version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

