### PR TITLE
couchdb: add support for version 2.0.0

### DIFF
--- a/pkgs/servers/http/couchdb/2.0.0.nix
+++ b/pkgs/servers/http/couchdb/2.0.0.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl, erlang, icu, openssl, spidermonkey
+, coreutils, bash, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "couchdb-${version}";
+  version = "2.0.0";
+
+  src = fetchurl {
+    url = "mirror://apache/couchdb/source/${version}/apache-${name}.tar.gz";
+    sha256 = "1jkfx6g9anrgmkhrkcn50axcamragranwsciw1rhmi86rglkrbyc";
+  };
+
+  buildInputs = [ erlang icu openssl spidermonkey makeWrapper ];
+
+  patches = [ ./jsapi.patch ];
+  postPatch = ''
+    substituteInPlace src/couch/rebar.config.script --replace '-DHAVE_CURL -I/usr/local/include' "-DHAVE_CURL -I/usr/local/include $NIX_CFLAGS_COMPILE"
+
+    patch bin/rebar <<EOF
+    1c1
+    < #!/usr/bin/env escript
+    ---
+    > #!${coreutils}/bin/env escript
+    EOF
+
+  '';
+
+  # Configure a username.  The build system would use "couchdb" as
+  # default if none is provided.  Note that it is unclear where this
+  # username is actually used in the build, as any choice seems to be
+  # working.
+  configurePhase = ''
+    ./configure -u nobody
+  '';
+
+  buildPhase = ''
+    make release
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r rel/couchdb/* $out
+    wrapProgram $out/bin/couchdb --suffix PATH : ${bash}/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A database that uses JSON for documents, JavaScript for MapReduce queries, and regular HTTP for an API";
+    homepage = "http://couchdb.apache.org";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ garbas ];
+  };
+}

--- a/pkgs/servers/http/couchdb/jsapi.patch
+++ b/pkgs/servers/http/couchdb/jsapi.patch
@@ -1,0 +1,60 @@
+diff -ru couch_js/http.c couch_js-patched/http.c
+--- apache-couchdb-2.0.0/src/couch/priv/couch_js/http.c	2016-09-12 11:28:51.000000000 +0200
++++ apache-couchdb-2.0.0-patched/src/couch/priv/couch_js/http.c	2017-02-10 10:52:33.025854045 +0100
+@@ -15,7 +15,7 @@
+ #include <string.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+-#include <jsapi.h>
++#include <js/jsapi.h>
+ #include "config.h"
+ #include "utf8.h"
+ #include "util.h"
+diff -ru couch_js/main.c couch_js-patched/main.c
+--- apache-couchdb-2.0.0/src/couch/priv/couch_js/main.c	2016-09-12 11:28:51.000000000 +0200
++++ apache-couchdb-2.0.0-patched/src/couch/priv/couch_js/main.c	2017-02-10 10:52:33.001854154 +0100
+@@ -20,7 +20,7 @@
+ #include <unistd.h>
+ #endif
+ 
+-#include <jsapi.h>
++#include <js/jsapi.h>
+ #include "config.h"
+ #include "http.h"
+ #include "utf8.h"
+diff -ru couch_js/utf8.c couch_js-patched/utf8.c
+--- apache-couchdb-2.0.0/src/couch/priv/couch_js/utf8.c	2016-09-12 11:28:51.000000000 +0200
++++ apache-couchdb-2.0.0-patched/src/couch/priv/couch_js/utf8.c	2017-02-10 10:52:33.009854117 +0100
+@@ -10,7 +10,7 @@
+ // License for the specific language governing permissions and limitations under
+ // the License.
+ 
+-#include <jsapi.h>
++#include <js/jsapi.h>
+ #include "config.h"
+ 
+ static int
+diff -ru couch_js/util.c couch_js-patched/util.c
+--- apache-couchdb-2.0.0/src/couch/priv/couch_js/util.c	2016-09-12 11:28:51.000000000 +0200
++++ apache-couchdb-2.0.0-patched/src/couch/priv/couch_js/util.c	2017-02-10 10:52:33.017854081 +0100
+@@ -13,7 +13,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
+-#include <jsapi.h>
++#include <js/jsapi.h>
+ 
+ #include "help.h"
+ #include "util.h"
+diff -ru couch_js/util.h couch_js-patched/util.h
+--- apache-couchdb-2.0.0/src/couch/priv/couch_js/util.h	2016-09-12 11:28:51.000000000 +0200
++++ apache-couchdb-2.0.0-patched/src/couch/priv/couch_js/util.h	2017-02-10 10:52:32.988854212 +0100
+@@ -13,7 +13,7 @@
+ #ifndef COUCHJS_UTIL_H
+ #define COUCHJS_UTIL_H
+ 
+-#include <jsapi.h>
++#include <js/jsapi.h>
+ 
+ typedef struct {
+     int          no_eval;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10287,6 +10287,10 @@ with pkgs;
     erlang = erlangR16;
   };
 
+  couchdb2 = callPackage ../servers/http/couchdb/2.0.0.nix {
+    spidermonkey = spidermonkey_1_8_5;
+  };
+
   couchpotato = callPackage ../servers/couchpotato {};
 
   dico = callPackage ../servers/dico { };


### PR DESCRIPTION
###### Motivation for this change
Support 2.0.0 CouchDB release

Version 2.0.0 is installed as a separate package called "couchdb2".
When setting the config option "package" attribute to pkgs.couchdb2, a
corresponding service configuration will be generated.  If a previous
1.6 installation exists, the databases can still be found on the local
port (default: 5986) and can be replicated from there.

Note that single-node or cluster setup still needs to be configured
manually, as described in
http://docs.couchdb.org/en/2.0.0/install/index.html.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

