### PR TITLE
stanchion: remove ssl option

### DIFF
--- a/nixos/modules/services/databases/stanchion.nix
+++ b/nixos/modules/services/databases/stanchion.nix
@@ -76,14 +76,6 @@ in
         '';
       };
 
-      stanchionSsl = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Tell stanchion to use SSL.
-        '';
-      };
-
       distributedCookie = mkOption {
         type = types.str;
         default = "riak";
@@ -147,8 +139,6 @@ in
       nodename = ${cfg.nodeName}
 
       distributed_cookie = ${cfg.distributedCookie}
-
-      stanchion_ssl=${if cfg.stanchionSsl then "on" else "off"}
 
       ${cfg.extraConfig}
     '';


### PR DESCRIPTION
###### Motivation for this change
`stanchion_ssl` no longer is an available option within stanchion's configuration file. Therefore, we should remove this, as it prevents the launch of `stanchion`

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

