### PR TITLE
Fix mattermost systemd unit

### DIFF
--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -201,7 +201,7 @@ in
           Group = cfg.group;
           ExecStart = "${pkgs.mattermost}/bin/mattermost-platform";
           WorkingDirectory = "${cfg.statePath}";
-          PrivateTmp = true;
+          PrivateTmp = false; # psql looks for unix domain socket in /tmp
           Restart = "always";
           RestartSec = "10";
           LimitNOFILE = "49152";

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -201,7 +201,8 @@ in
           Group = cfg.group;
           ExecStart = "${pkgs.mattermost}/bin/mattermost-platform";
           WorkingDirectory = "${cfg.statePath}";
-          PrivateTmp = false; # psql looks for unix domain socket in /tmp
+          PrivateTmp = true;
+          JoinsNamespaceOf = mkIf cfg.localDatabaseCreate "postgresql.service";
           Restart = "always";
           RestartSec = "10";
           LimitNOFILE = "49152";


### PR DESCRIPTION
Fixes #22860

###### Motivation for this change
The preStart hook of the service file tries to set up a postgres database using the `psql` command.
`psql` connects to Postgres through a unix domain socket that is in `/tmp` .    However, because we have `PrivateTmp=true` , `psql` can never find this domain socket.   Hence the change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

