### PR TITLE
quagga: 1.0.20161017 -> 1.2.0

### DIFF
--- a/pkgs/servers/quagga/default.nix
+++ b/pkgs/servers/quagga/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchurl, libcap, libnl, readline, net_snmp, less, perl, texinfo }:
+{ stdenv, fetchurl, libcap, libnl, readline, net_snmp, less, perl, texinfo,
+  pkgconfig, c-ares }:
 
 stdenv.mkDerivation rec {
   name = "quagga-${version}";
-  version = "1.0.20161017";
+  version = "1.2.0";
 
   src = fetchurl {
     url = "mirror://savannah/quagga/${name}.tar.gz";
-    sha256 = "0629f7bkyh0a3n90kkr202g2i44id09qzkl05y8z66blvd6p49lg";
+    sha256 = "1qyw675hrs3f67zprdbyw91wldmyihv97ibn1f99ypcp6x6n8hqh";
   };
 
   buildInputs =
-    [ readline net_snmp ]
+    [ readline net_snmp c-ares ]
     ++ stdenv.lib.optionals stdenv.isLinux [ libcap libnl ];
 
-  nativeBuildInputs = [ perl texinfo ];
+  nativeBuildInputs = [ pkgconfig perl texinfo ];
 
   configureFlags = [
     "--sysconfdir=/etc/quagga"


### PR DESCRIPTION
###### Motivation for this change

Update quagga to version 1.2.0. 
Fixes CVE-2017-5495

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

