### PR TITLE
KDE 5 packaging instructions

### DIFF
--- a/pkgs/desktops/kde-5/applications/default.nix
+++ b/pkgs/desktops/kde-5/applications/default.nix
@@ -1,11 +1,27 @@
 /*
 
+# New packages
+
+READ THIS FIRST
+
+This module is for official packages in the KDE Applications Bundle. All
+available packages are listed in `./srcs.nix`, although some are not yet
+packaged in Nixpkgs (see below).
+
+IF YOUR PACKAGE IS NOT LISTED IN `./srcs.nix`, IT DOES NOT GO HERE.
+
+Many of the packages released upstream are not yet built in Nixpkgs due to lack
+of demand. To add a Nixpkgs build for an upstream package, copy one of the
+existing packages here and modify it as necessary. A simple example package that
+still shows most of the available features is in `./gwenview.nix`.
+
 # Updates
 
-1. Update the URL in `maintainers/scripts/generate-kde-applications.sh` and
-   run that script from the top of the Nixpkgs tree.
-2. Check that the new packages build correctly.
-3. Commit the changes and open a pull request.
+1. Update the URL in `./fetch.sh`.
+2. Run `./maintainers/scripts/fetch-kde-qt.sh pkgs/desktops/kde-5/applications`
+   from the top of the Nixpkgs tree.
+3. Invoke `nix-build -A kde5` and ensure that everything builds.
+4. Commit the changes and open a pull request.
 
 */
 
@@ -71,11 +87,6 @@ let
     spectacle = callPackage ./spectacle.nix {};
 
     l10n = pkgs.recurseIntoAttrs (import ./l10n.nix { inherit callPackage lib pkgs; });
-
-    # External packages
-    kipi-plugins = callPackage ../../../applications/graphics/kipi-plugins/5.x.nix {};
-    ktorrent = callPackage ../../../applications/networking/p2p/ktorrent/5.nix { };
-    libktorrent = callPackage ../../../development/libraries/libktorrent/5.nix { };
   };
 
 in packages

--- a/pkgs/desktops/kde-5/plasma/default.nix
+++ b/pkgs/desktops/kde-5/plasma/default.nix
@@ -1,11 +1,26 @@
 /*
 
+# New packages
+
+READ THIS FIRST
+
+This module is for official packages in KDE Plasma 5. All available packages are
+listed in `./srcs.nix`, although a few are not yet packaged in Nixpkgs (see
+below).
+
+IF YOUR PACKAGE IS NOT LISTED IN `./srcs.nix`, IT DOES NOT GO HERE.
+
+Many of the packages released upstream are not yet built in Nixpkgs due to lack
+of demand. To add a Nixpkgs build for an upstream package, copy one of the
+existing packages here and modify it as necessary.
+
 # Updates
 
-1. Update the URL in `maintainers/scripts/generate-kde-plasma.sh` and run
-   that script from the top of the Nixpkgs tree.
-2. Check that the new packages build correctly.
-3. Commit the changes and open a pull request.
+1. Update the URL in `./fetch.sh`.
+2. Run `./maintainers/scripts/fetch-kde-qt.sh pkgs/desktops/kde-5/plasma`
+   from the top of the Nixpkgs tree.
+3. Invoke `nix-build -A kde5` and ensure that everything builds.
+4. Commit the changes and open a pull request.
 
 */
 

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -1,11 +1,26 @@
 /*
 
+# New packages
+
+READ THIS FIRST
+
+This module is for official packages in KDE Frameworks 5. All available packages
+are listed in `./srcs.nix`, although a few are not yet packaged in Nixpkgs (see
+below).
+
+IF YOUR PACKAGE IS NOT LISTED IN `./srcs.nix`, IT DOES NOT GO HERE.
+
+Many of the packages released upstream are not yet built in Nixpkgs due to lack
+of demand. To add a Nixpkgs build for an upstream package, copy one of the
+existing packages here and modify it as necessary.
+
 # Updates
 
-1. Update the URL in `maintainers/scripts/generate-kde-frameworks.sh` and
-   run that script from the top of the Nixpkgs tree.
-2. Check that the new packages build correctly.
-3. Commit the changes and open a pull request.
+1. Update the URL in `./fetch.sh`.
+2. Run `./maintainers/scripts/fetch-kde-qt.sh pkgs/development/libraries/kde-frameworks`
+   from the top of the Nixpkgs tree.
+3. Invoke `nix-build -A kde5` and ensure that everything builds.
+4. Commit the changes and open a pull request.
 
 */
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9279,6 +9279,8 @@ with pkgs;
 
     libkeyfinder = callPackage ../development/libraries/libkeyfinder { };
 
+    libktorrent = callPackage ../development/libraries/libktorrent/5.nix { };
+
     mlt = callPackage ../development/libraries/mlt/qt-5.nix {
       ffmpeg = ffmpeg_2;
     };
@@ -13947,6 +13949,8 @@ with pkgs;
 
   ksuperkey = callPackage ../tools/X11/ksuperkey { };
 
+  ktorrent = qt5.callPackage ../applications/networking/p2p/ktorrent/5.nix { };
+
   kubernetes = callPackage ../applications/networking/cluster/kubernetes {
     go = go_1_6;
   };
@@ -16845,9 +16849,12 @@ with pkgs;
       plasma = import ../desktops/kde-5/plasma { inherit pkgs; };
       applications = import ../desktops/kde-5/applications { inherit pkgs; };
       merged = self:
-        { plasma = plasma self;
+        {
+          plasma = plasma self;
           frameworks = qt5.kdeFrameworks;
-          applications = applications self; }
+          applications = applications self;
+          kipi-plugins = self.callPackage ../applications/graphics/kipi-plugins/5.x.nix {};
+        }
         // qt5.kdeFrameworks
         // plasma self
         // applications self;


### PR DESCRIPTION
### Problem

The instructions for adding and updating KDE 5 packages were significantly out-of-date. Consequently, there were mistakes in several package updates or additions.

### Solution

1. The instructions are made current.
2. The mistaken package updates and additions are corrected.

### Testing

~~I have verified, using `nox-review`, that these changes do not cause any rebuilds.~~

This change makes additional versions of `libktorrent` available, verified with `nox-review`.

Builds:
- [x] NixOS with sandboxing
- [x] macOS (Travis)
- [ ] Other Linux