### PR TITLE
crack-attack: enable sound support in the crack-attack game.

### DIFF
--- a/pkgs/games/crack-attack/default.nix
+++ b/pkgs/games/crack-attack/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, gtk2, freeglut, SDL, mesa, libXi, libXmu}:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, gtk2, freeglut, SDL, SDL_mixer
+, mesa, libXi, libXmu}:
 
 stdenv.mkDerivation {
   name = "crack-attack-1.1.14";
@@ -8,9 +9,9 @@ stdenv.mkDerivation {
     sha256 = "1sakj9a2q05brpd7lkqxi8q30bccycdzd96ns00s6jbxrzjlijkm";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk2 freeglut SDL mesa libXi libXmu ];
-
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ gtk2 freeglut SDL SDL_mixer mesa libXi libXmu ];
+  configureFlags = [ "--enable-sound=yes" ];
   hardeningDisable = [ "format" ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

The crack-attack game can have sound if the user-supplied sound files are present in its configuration folder. However, this needs the `--enable-sound` configure option to be enabled. Note that the option on its own does not activate the sounds, the files must be added to the configuration folder (see the commit message for more info).

-----

The --enable-sound ./configure option enables the sound support in crack-attack.
This commit enables the --enable-sound option, and adds a dependency on SDL_mixer.
The following files still have to be supplied by the user, due to licencing issues upstream:

~/.crack-attack/music/game.ogg
~/.crack-attack/music/gameover.ogg
~/.crack-attack/music/prelude.ogg
~/.crack-attack/music/youwin.ogg
~/.crack-attack/sounds/block_awaking.wav
~/.crack-attack/sounds/block_dying.wav
~/.crack-attack/sounds/block_fallen.wav
~/.crack-attack/sounds/countdown.wav
~/.crack-attack/sounds/garbage_fallen.wav
~/.crack-attack/sounds/garbage_shattering.wav

The crack-attack game will detect when these sound files are present, and use them as background music and sound effects.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

