### PR TITLE
scummvm: 1.8.0 -> 1.9.0

### DIFF
--- a/pkgs/games/scummvm/default.nix
+++ b/pkgs/games/scummvm/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, SDL, zlib, libmpeg2, libmad, libogg, libvorbis, flac, alsaLib, mesa }:
 
 stdenv.mkDerivation rec {
-  name = "scummvm-1.8.0";
+  name = "scummvm-1.9.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/scummvm/${name}.tar.bz2";
-    sha256 = "0f3zgvz886lk9ps0v333aq74vx6grlx68hg14gfaxcvj55g73v01";
+    url = "http://scummvm.org/frs/scummvm/1.9.0/scummvm-1.9.0.tar.bz2";
+    sha256 = "813d7d8a76e3d05b45001d37451368711dadc32899ecf907df1cc7abfb1754d2";
   };
   
   buildInputs = [ SDL zlib libmpeg2 libmad libogg libvorbis flac alsaLib mesa ];

--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, libuuid }:
 
 stdenv.mkDerivation rec {
-  name = "e2fsprogs-1.43.3";
+  name = "e2fsprogs-1.43.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/e2fsprogs/${name}.tar.gz";
-    sha256 = "09wrn60rlqdgjkmm09yv32zxdjba2pd4ya3704bhywyln2xz33nf";
+    sha256 = "a648a90a513f1b25113c7f981af978b8a19f832b3a32bd10707af3ff682ba66d";
   };
 
   outputs = [ "bin" "dev" "out" "man" ];

--- a/pkgs/tools/networking/fping/default.nix
+++ b/pkgs/tools/networking/fping/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "fping-3.15";
+  name = "fping-3.16";
 
   src = fetchurl {
     url = "http://www.fping.org/dist/${name}.tar.gz";
-    sha256 = "072jhm9wpz1bvwnwgvz24ijw0xwwnn3z3zan4mgr5s5y6ml8z54n";
+    sha256 = "2f753094e4df3cdb1d99be1687c0fb7d2f14c0d526ebf03158c8c5519bc78f54";
   };
 
   configureFlags = [ "--enable-ipv6" "--enable-ipv4" ];


### PR DESCRIPTION
###### Motivation for this change

* new releases are apparently no longer hosted on sourceforge

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

