### PR TITLE
sweethome3d: version compatible with master and 16.09

### DIFF
--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -1,8 +1,6 @@
 { lib, stdenv, fetchurl, fetchcvs, makeWrapper, makeDesktopItem, jdk, jre, ant
-, gtk3, gsettings_desktop_schemas, p7zip }:
-
+, gtk3, gsettings_desktop_schemas, p7zip, xorg }:
 let
-
   getDesktopFileName = drvName: (builtins.parseDrvName drvName).name;
 
   # TODO: Should we move this to `lib`? Seems like its would be useful in many cases.
@@ -28,6 +26,15 @@ let
       genericName = "Computer Aided (Interior) Design";
       categories = "Application;Graphics;2DGraphics;3DGraphics;";
     };
+
+    libXxf86vm = xorg.libXxf86vm;
+
+    patchPhase = ''
+      patchelf --set-rpath ${libXxf86vm}/lib lib/java3d-1.6/linux/amd64/libnativewindow_awt.so
+      patchelf --set-rpath ${libXxf86vm}/lib lib/java3d-1.6/linux/amd64/libnativewindow_x11.so
+      patchelf --set-rpath ${libXxf86vm}/lib lib/java3d-1.6/linux/i586/libnativewindow_awt.so
+      patchelf --set-rpath ${libXxf86vm}/lib lib/java3d-1.6/linux/i586/libnativewindow_x11.so
+    '';
 
     buildInputs = [ ant jdk jre makeWrapper p7zip gtk3 gsettings_desktop_schemas ];
 


### PR DESCRIPTION
###### Motivation for this change
As described in https://github.com/NixOS/nixpkgs/pull/22750, current version doesn't work on 16.09. This one should work on both 16.09 and master.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

