### PR TITLE
lib: Add a function to filter sources by regular expressions.

### DIFF
--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -26,6 +26,12 @@ rec {
 
   cleanSource = builtins.filterSource cleanSourceFilter;
 
+  # Filter sources by a list of regular expressions.
+  #
+  # E.g. `src = sourceByRegex ./my-subproject [".*\.py$" "^database.sql$"]`
+  sourceByRegex = src: regexes: builtins.filterSource (path: type:
+    let relPath = lib.removePrefix (toString src + "/") (toString path);
+    in lib.any (re: builtins.match re relPath != null) regexes) src;
 
   # Get all files ending with the specified suffices from the given
   # directory or its descendants.  E.g. `sourceFilesBySuffices ./dir


### PR DESCRIPTION
Branch as discussed on the mailing list @basvandijk. Discussion points:

* If we following the one existing naming example `sourceFilesBySuffices` this should be called `sourceFilesByRegexes` but I find that quite untypeable.
* I can't figure out how to add or run tests in lib/tests.nix - any ideas?