### PR TITLE
envconsul: init at 0.6.2

### DIFF
--- a/pkgs/tools/system/envconsul/default.nix
+++ b/pkgs/tools/system/envconsul/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "envconsul-${version}";
+  version = "0.6.2";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/hashicorp/envconsul";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "hashicorp";
+    repo = "envconsul";
+    sha256 = "176jbicyg7vwd0kgawz859gq7ldrxyw1gx55wig7azakiidkl731";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/hashicorp/envconsul/;
+    description = "Read and set environmental variables for processes from Consul";
+    platforms = platforms.linux ++ platforms.darwin;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ pradeepchhetri ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -856,6 +856,8 @@ with pkgs;
 
   ent = callPackage ../tools/misc/ent { };
 
+  envconsul = callPackage ../tools/system/envconsul { };
+
   f3 = callPackage ../tools/filesystems/f3 { };
 
   facter = callPackage ../tools/system/facter {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

