### PR TITLE
ocaml-angstrom: init at 0.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/angstrom/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, ocaml, cstruct, result, findlib, ocaml_oasis }:
+
+stdenv.mkDerivation rec {
+  version = "0.3.0";
+  name = "ocaml-angstrom-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "inhabitedtype";
+    repo   = "angstrom";
+    rev    = "${version}";
+    sha256 = "1x9pvy5vw98ns4pspj7i10pmgqyngn4v4cdlz5pbvwbrpwpn090q";
+  };
+
+  createFindlibDestdir = true;
+
+  buildInputs = [ ocaml ocaml_oasis findlib ];
+  propagatedBuildInputs = [ result cstruct ];
+
+  meta = {
+    homepage = https://github.com/inhabitedtype/angstrom;
+    description = "OCaml parser combinators built for speed and memory efficiency";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -18,6 +18,8 @@ let
 
     alcotest = callPackage ../development/ocaml-modules/alcotest {};
 
+    angstrom = callPackage ../development/ocaml-modules/angstrom { };
+
     ansiterminal = callPackage ../development/ocaml-modules/ansiterminal { };
 
     apron = callPackage ../development/ocaml-modules/apron { };


### PR DESCRIPTION



###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

