### PR TITLE
Update grub to latest upstream release

### DIFF
--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromSavannah, autogen, flex, bison, python, autoconf, automake
+{ stdenv, fetchurl, fetchFromSavannah, autogen, flex, bison, python
 , gettext, ncurses, libusb, freetype, qemu, devicemapper
 , zfs ? null
 , efiSupport ? false
@@ -20,17 +20,11 @@ let
   canEfi = any (system: stdenv.system == system) (mapAttrsToList (name: _: name) efiSystems);
   inPCSystems = any (system: stdenv.system == system) (mapAttrsToList (name: _: name) pcSystems);
 
-  version = "2.x-2015-11-16";
+  version = "2.02-rc1";
 
   unifont_bdf = fetchurl {
     url = "http://unifoundry.com/unifont-5.1.20080820.bdf.gz";
     sha256 = "0s0qfff6n6282q28nwwblp5x295zd6n71kl43xj40vgvdqxv0fxx";
-  };
-
-  po_src = fetchurl {
-    name = "grub-2.02-beta2.tar.gz";
-    url = "http://alpha.gnu.org/gnu/grub/grub-2.02~beta2.tar.gz";
-    sha256 = "1lr9h3xcx0wwrnkxdnkfjwy08j7g7mdlmmbdip2db4zfgi69h0rm";
   };
 
 in (
@@ -41,13 +35,13 @@ assert zfsSupport -> zfs != null;
 stdenv.mkDerivation rec {
   name = "grub-${version}";
 
-  src = fetchFromSavannah {
-    repo = "grub";
-    rev = "50d6f38febe80d4d3088dae1ee639b341787ab71";
-    sha256 = "1pyn2qa8hwiabhgnzj86y4b69y4a37dh5n0j4csmm7xmgc13vvww";
+  src = fetchurl {
+    name = "grub-2.02-rc1.tar.xz";
+    url = "http://alpha.gnu.org/gnu/grub/grub-2.02~rc1.tar.xz";
+    sha256 = "0y02v19x9sb5jvj740f604vvi5j1rx8pily1jk0l64bdp7lkjlj4";
   };
 
-  nativeBuildInputs = [ autogen flex bison python autoconf automake ];
+  nativeBuildInputs = [ autogen flex bison python ];
   buildInputs = [ ncurses libusb freetype gettext devicemapper ]
     ++ optional doCheck qemu
     ++ optional zfsSupport zfs;
@@ -76,15 +70,9 @@ stdenv.mkDerivation rec {
            -e's/qemu-system-i386/qemu-system-x86_64 -nodefaults/g'
     '';
 
-  prePatch =
-    '' tar zxf ${po_src} grub-2.02~beta2/po
-       rm -rf po
-       mv grub-2.02~beta2/po po
-       sh autogen.sh
-       gunzip < "${unifont_bdf}" > "unifont.bdf"
-       sed -i "configure" \
-           -e "s|/usr/src/unifont.bdf|$PWD/unifont.bdf|g"
-    '';
+  prePatch = ''
+    gunzip < "${unifont_bdf}" > "unifont.bdf"
+  '';
 
   patches = [ ./fix-bash-completion.patch ];
 


### PR DESCRIPTION
There has been some upstream activity recently, let's update to the
latest upstream tag. Yes, it's -rc1 but that should be an improvement
over a year-and-a-half olf random git commit.

I guess it could be worth to get this to 17.03? cc @edolstra @globin.

I have tested this on one machine with ext4 rootfs and no separate boot. Also the installer tests I've tried pass. Would be nice to have a bit more testing, though.