### PR TITLE
fix comments about nixos-hardware-scan

### DIFF
--- a/nixos/modules/installer/scan/detected.nix
+++ b/nixos/modules/installer/scan/detected.nix
@@ -1,4 +1,4 @@
-# List all devices which are detected by nixos-hardware-scan.
+# List all devices which are detected by nixos-generate-config.
 # Common devices are enabled by default.
 { config, lib, pkgs, ... }:
 

--- a/nixos/modules/installer/scan/not-detected.nix
+++ b/nixos/modules/installer/scan/not-detected.nix
@@ -1,4 +1,4 @@
-# List all devices which are _not_ detected by nixos-hardware-scan.
+# List all devices which are _not_ detected by nixos-generate-config.
 # Common devices are enabled by default.
 { config, lib, pkgs, ... }:
 

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -176,7 +176,7 @@ in
 
     boot.initrd.availableKernelModules =
       [ # Note: most of these (especially the SATA/PATA modules)
-        # shouldn't be included by default since nixos-hardware-scan
+        # shouldn't be included by default since nixos-generate-config
         # detects them, but I'm keeping them for now for backwards
         # compatibility.
 


### PR DESCRIPTION
It has been renamed to nixos-generate-config in 3ed4173