### PR TITLE
Jailbreak extras to allow xmonad 0.13

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -862,4 +862,7 @@ self: super: {
 
   # https://github.com/Gabriel439/Haskell-DirStream-Library/issues/8
   dirstream = doJailbreak super.dirstream;
+
+  # https://github.com/xmonad/xmonad-extras/issues/3
+  xmonad-extras = doJailbreak super.xmonad-extras;
 }


### PR DESCRIPTION
###### Motivation for this change
xmonad-extras has too restrictive bounds to build with xmonad 0.13, but otherwise works fine

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

