### PR TITLE
python-gflags: 2.0 -> 3.1.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12143,15 +12143,15 @@ in {
 
 
   gflags = buildPythonPackage rec {
-    name = "gflags-2.0";
+    name = "gflags-3.1.1";
 
     src = pkgs.fetchurl {
-      url = "http://python-gflags.googlecode.com/files/python-${name}.tar.gz";
-      sha256 = "1mkc7315bpmh39vbn0jq237jpw34zsrjr1sck98xi36bg8hnc41i";
+      url = "mirror://pypi/p/python-gflags/python-${name}.tar.gz";
+      sha256 = "0qvcizlz6r4511kl4jlg6fr34y1ka956dr2jj1q0qcklr94n9zxa";
     };
 
     meta = {
-      homepage = http://code.google.com/p/python-gflags/;
+      homepage = https://github.com/google/python-gflags;
       description = "A module for command line handling, similar to Google's gflags for C++";
     };
   };


### PR DESCRIPTION
###### Motivation for this change

So many bugfixes.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

