### PR TITLE
netpbm: 10.70.0 -> 10.73.07

### DIFF
--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -1,13 +1,18 @@
-{ lib, stdenv, fetchurl, pkgconfig, libjpeg, libpng, flex, zlib, perl, libxml2
+{ lib, stdenv, fetchsvn, pkgconfig, libjpeg, libpng, flex, zlib, perl, libxml2
 , makeWrapper, libtiff
 , enableX11 ? false, libX11 }:
 
-stdenv.mkDerivation rec {
-  name = "netpbm-10.70.00";
+let
+  version = "10.73.07";
+  rev = 2885;
 
-  src = fetchurl {
-    url = "mirror://gentoo/distfiles/${name}.tar.xz";
-    sha256 = "14vxmzbwsy4rzrqjnzr4cvz1s0amacq69faps3v1j1kr05lcns0j";
+in stdenv.mkDerivation rec {
+  name = "netpbm-${version}";
+
+  src = fetchsvn {
+    url    = "http://svn.code.sf.net/p/netpbm/code/stable";
+    inherit rev;
+    sha256 = "004p95769800zh9a2zzm41k8l29c5wnnk6viz9b4fgb2g4gl3sn1";
   };
 
   postPatch = /* CVE-2005-2471, from Arch */ ''
@@ -52,10 +57,10 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://netpbm.sourceforge.net/;
     description = "Toolkit for manipulation of graphic images";
     license = "GPL,free";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

#22826 

netpbm comes in 3 flavours (in addition to master):

- advanced
- stable
- super_stable

The version we are currently carrying was released on the stable channel but is badly out of date.

Because this depends on libxml2 which has an issue pending, I'm not merging yet to avoid having to rebuild it twice.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

