### PR TITLE
calibre: 2.76.0 -> 2.79.1

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.76.0";
+  version = "2.79.1";
   name = "calibre-${version}";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${name}.tar.xz";
-    sha256 = "1xfm586n6gm44mkyn25mbiyhj6w9ji9yl6fvmnr4zk1q6qcga3v8";
+    sha256 = "0slk3cili50a8kwwsk6syqqrcz0yx8yjvhm8gyggn2k2kpqjax15";
   };
 
   patches = [

--- a/pkgs/applications/misc/calibre/dont_build_unrar_plugin.patch
+++ b/pkgs/applications/misc/calibre/dont_build_unrar_plugin.patch
@@ -1,13 +1,8 @@
-Author: Dmitry Shachnev <mitya57@gmail.com>
-Description: do not build unrar extension as we strip unrar from the tarball
-Forwarded: not-needed
-Last-Update: 2013-04-04
-
-Index: calibre/setup/extensions.json
-===================================================================
---- calibre.orig/setup/extensions.json
-+++ calibre/setup/extensions.json
-@@ -211,14 +211,5 @@
+diff --git a/setup/extensions.json b/setup/extensions.json
+index 1f6d1fb..1273904 100644
+--- a/setup/extensions.json
++++ b/setup/extensions.json
+@@ -211,16 +211,5 @@
          "sources": "calibre/devices/mtp/unix/devices.c calibre/devices/mtp/unix/libmtp.c",
          "headers": "calibre/devices/mtp/unix/devices.h calibre/devices/mtp/unix/upstream/music-players.h calibre/devices/mtp/unix/upstream/device-flags.h",
          "libraries": "mtp"
@@ -18,15 +13,17 @@ Index: calibre/setup/extensions.json
 -        "inc_dirs": "unrar",
 -        "defines": "SILENT RARDLL UNRAR _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE",
 -        "windows_defines": "SILENT RARDLL UNRAR",
+-        "haiku_defines": "LITTLE_ENDIAN SILENT RARDLL UNRAR _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE _BSD_SOURCE",
+-        "haiku_libraries": "bsd",
 -        "optimize_level": 2,
 -        "windows_libraries": "User32 Advapi32 kernel32 Shell32"
      }
  ]
-Index: calibre/src/calibre/ebooks/metadata/archive.py
-===================================================================
---- calibre.orig/src/calibre/ebooks/metadata/archive.py	2014-02-02 10:42:14.510954007 +0100
-+++ calibre/src/calibre/ebooks/metadata/archive.py	2014-02-02 10:42:14.502954007 +0100
-@@ -42,7 +42,7 @@
+diff --git a/src/calibre/ebooks/metadata/archive.py b/src/calibre/ebooks/metadata/archive.py
+index 938ab24..1e095f8 100644
+--- a/src/calibre/ebooks/metadata/archive.py
++++ b/src/calibre/ebooks/metadata/archive.py
+@@ -44,7 +44,7 @@ class ArchiveExtract(FileTypePlugin):
      description = _('Extract common e-book formats from archives '
          '(zip/rar) files. Also try to autodetect if they are actually '
          'cbz/cbr files.')


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

