### PR TITLE
marathon: 1.3.6 -> 1.4.1

### DIFF
--- a/pkgs/applications/networking/cluster/marathon/default.nix
+++ b/pkgs/applications/networking/cluster/marathon/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "marathon-${version}";
-  version = "1.3.6";
+  version = "1.4.1";
 
   src = fetchurl {
     url = "https://downloads.mesosphere.com/marathon/v${version}/marathon-${version}.tgz";
-    sha256 = "12a6ah6qsx1ap6y7sps4vwkq8lyc08k1qnak2mnsa04ifrx9z0dy";
+    sha256 = "1wpzsvvmk19qrwzwj7k12rngry1qriiqnjzq2q2pbpv5w0zb1fz5";
   };
 
   buildInputs = [ makeWrapper jdk mesos ];
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     homepage = https://mesosphere.github.io/marathon;
     description = "Cluster-wide init and control system for services in cgroups or Docker containers";
     license = licenses.asl20;
-    maintainers = with maintainers; [ rushmorem kamilchm kevincox ];
+    maintainers = with maintainers; [ rushmorem kamilchm kevincox pradeepchhetri ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

