### PR TITLE
gnome-shell, gnome-tweak-tool: Don't propagate python

### DIFF
--- a/pkgs/desktops/gnome-3/3.22/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-shell/default.nix
@@ -7,7 +7,9 @@
 
 # http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/gnome-base/gnome-shell/gnome-shell-3.10.2.1.ebuild?revision=1.3&view=markup
 
-stdenv.mkDerivation rec {
+let
+  pythonEnv = python3Packages.python.withPackages ( ps: with ps; [ pygobject3 ] );
+in stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
   # Needed to find /etc/NetworkManager/VPN
@@ -23,9 +25,8 @@ stdenv.mkDerivation rec {
       defaultIconTheme sqlite gnome3.gnome-bluetooth
       libgweather # not declared at build time, but typelib is needed at runtime
       gnome3.gnome-clocks # schemas needed
-      at_spi2_core upower ibus gnome_desktop telepathy_logger gnome3.gnome_settings_daemon ];
-
-  propagatedBuildInputs = [ python3Packages.pygobject3 python3Packages.python gobjectIntrospection ];
+      at_spi2_core upower ibus gnome_desktop telepathy_logger gnome3.gnome_settings_daemon
+      pythonEnv gobjectIntrospection ];
 
   installFlags = [ "keysdir=$(out)/share/gnome-control-center/keybindings" ];
 
@@ -41,9 +42,6 @@ stdenv.mkDerivation rec {
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
       --prefix XDG_DATA_DIRS : "${gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS" \
       --suffix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-
-    wrapProgram "$out/bin/gnome-shell-extension-tool" \
-      --prefix PYTHONPATH : "${python3Packages.pygobject3}/${python3Packages.python.sitePackages}:$PYTHONPATH"
 
     wrapProgram "$out/libexec/gnome-shell-calendar-server" \
       --prefix XDG_DATA_DIRS : "${evolution_data_server}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"

--- a/pkgs/desktops/gnome-3/3.22/misc/gnome-tweak-tool/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/misc/gnome-tweak-tool/default.nix
@@ -4,22 +4,13 @@
 , gnome3, librsvg, gdk_pixbuf, file, libnotify, gobjectIntrospection, wrapGAppsHook }:
 
 let
-  python = python2Packages.python.withPackages ( ps: with ps; [ pygobject3 ] );
+  pythonEnv = python2Packages.python.withPackages ( ps: with ps; [ pygobject3 ] );
 in stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
   doCheck = true;
 
   propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
-
-  # Make sure that Python 2 is first in $PATH because gnome3.gnome_shell
-  # propagates python3Packages.python.  If we do not do this, autoconf will use
-  # Python 3 instead which gnome-tweak-tool does not support at this time.  See:
-  # https://github.com/NixOS/nixpkgs/issues/21851
-  # https://github.com/NixOS/nixpkgs/pull/22370
-  preConfigure = ''
-    PATH="${python}/bin:$PATH"
-  '';
 
   makeFlags = [ "DESTDIR=/" ];
 
@@ -28,11 +19,10 @@ in stdenv.mkDerivation rec {
                   gdk_pixbuf gnome3.defaultIconTheme librsvg
                   libnotify gnome3.gnome_shell
                   libsoup gnome3.gnome_settings_daemon gnome3.nautilus
-                  gnome3.gnome_desktop wrapGAppsHook ];
+                  gnome3.gnome_desktop wrapGAppsHook
+                  python2Packages.pygobject3.dev pythonEnv gobjectIntrospection ];
 
-  propagatedBuildInputs = [ python gobjectIntrospection ];
-
-  PYTHONPATH = "$out/${python.python.sitePackages}";
+  PYTHONPATH = "$out/${pythonEnv.python.sitePackages}";
 
   wrapPrefixVariables = [ "PYTHONPATH" ];
 


### PR DESCRIPTION
###### Motivation for this change
see https://github.com/NixOS/nixpkgs/issues/21851 for more details.

I don't think it is a good idea to propagate python in `gnome3.gnome-shell` because this leads to issues like in `gnome3.gnome-tweak-tools` (multiple python versions in build env).

The only reason I see for propagating is that `gnome-shell-extension-tool` didn't work in the past. My changes fixes `gnome-shell-extension-tool` without propagating python.

I've also removed the propagated python dependency in `gnome-tweak-tools` because... why not? It still works for me and it is IHMO less error prone.

Are there any downsides? If not we could also remove the `propagatedBuildInputs` in other (gnome specific) derivations.



###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

