### PR TITLE
btrfs-dedupe: add new package at the latest git revision.

### DIFF
--- a/pkgs/tools/filesystems/btrfs-dedupe/default.nix
+++ b/pkgs/tools/filesystems/btrfs-dedupe/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchgit, rustPlatform, lzo, zlib }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "btrfs-dedupe-${version}";
+  version = "1.0.3-git";
+
+  src = fetchgit {
+    url = "https://gitlab.wellbehavedsoftware.com/well-behaved-software/btrfs-dedupe.git";
+    rev = "72c6a301";
+    sha256 = "1qf3kyi7ir408d321pj2qffdnngam5g2zarb0952bm50aqcl3bh0";
+  };
+
+  depsSha256 = "04jlz7nzsmg86i73w75i8rmlbk635xrg8m1dfac8h17dwb29yj6a";
+
+  buildInputs = [ lzo zlib ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://gitlab.wellbehavedsoftware.com/well-behaved-software/btrfs-dedupe";
+    description = "BTRFS deduplication utility";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ikervagyok ];
+    broken = true;
+  };
+}

--- a/pkgs/tools/filesystems/btrfs-dedupe/default.nix
+++ b/pkgs/tools/filesystems/btrfs-dedupe/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchgit, rustPlatform, lzo, zlib }:
+{ stdenv, fetchurl, rustPlatform, lzo, zlib }:
 
 with rustPlatform;
 
 buildRustPackage rec {
   name = "btrfs-dedupe-${version}";
-  version = "1.0.3-git";
+  version = "1.1.0";
 
-  src = fetchgit {
-    url = "https://gitlab.wellbehavedsoftware.com/well-behaved-software/btrfs-dedupe.git";
-    rev = "72c6a301";
-    sha256 = "1qf3kyi7ir408d321pj2qffdnngam5g2zarb0952bm50aqcl3bh0";
+
+  src = fetchurl {
+    url = "https://gitlab.wellbehavedsoftware.com/well-behaved-software/btrfs-dedupe/repository/archive.tar.bz2?ref=72c6a301d20f935827b994db210bf0a1e121273a";
+    sha256 = "0qy1g4crhfgs2f5cmrsjv6qscg3r66gb8n6sxhimm9ksivhjyyjp";
   };
 
   depsSha256 = "04jlz7nzsmg86i73w75i8rmlbk635xrg8m1dfac8h17dwb29yj6a";
@@ -22,6 +22,5 @@ buildRustPackage rec {
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ ikervagyok ];
-    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -666,6 +666,8 @@ with pkgs;
   btrfs-progs = callPackage ../tools/filesystems/btrfs-progs { };
   btrfs-progs_4_4_1 = callPackage ../tools/filesystems/btrfs-progs/4.4.1.nix { };
 
+  btrfs-dedupe = callPackage ../tools/filesystems/btrfs-dedupe/default.nix {};
+
   btrbk = callPackage ../tools/backup/btrbk { };
 
   bwm_ng = callPackage ../tools/networking/bwm-ng { };


### PR DESCRIPTION
still marked broken, as i don't have experience with either rust nor btrfs-dedupe. also i have no throw-away partition atm, to test this - please test and remove the broken flag as soon as it is confirmed working

###### Things done
since i didn't find any direct cargo-to-nix transition, i took pijul
as a template. also, the `crates.io`-version is 1.2, this is 1.3
plus a few later patches.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

