### PR TITLE
prometheus-bind-exporter: init at 20161221

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -428,6 +428,7 @@
   rongcuid = "Rongcui Dong <rongcuid@outlook.com>";
   ronny = "Ronny Pfannschmidt <nixos@ronnypfannschmidt.de>";
   rszibele = "Richard Szibele <richard_szibele@hotmail.com>";
+  rtreffer = "Rene Treffer <treffer+nixos@measite.de>";
   rushmorem = "Rushmore Mushambi <rushmore@webenchanter.com>";
   rvl = "Rodney Lorrimar <dev+nix@rodney.id.au>";
   rvlander = "Gaëtan André <rvlander@gaetanandre.eu>";

--- a/pkgs/servers/monitoring/prometheus/bind-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/bind-exporter.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "bind_exporter-${version}";
+  version = "20161221-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "4e1717c7cd5f31c47d0c37274464cbaabdd462ba";
+
+  goPackagePath = "github.com/digitalocean/bind_exporter";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "digitalocean";
+    repo = "bind_exporter";
+    sha256 = "1nd6pc1z627w4x55vd42zfhlqxxjmfsa9lyn0g6qq19k4l85v1qm";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Prometheus exporter for bind9 server";
+    homepage = https://github.com/digitalocean/bind_exporter;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rtreffer ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10640,6 +10640,7 @@ with pkgs;
   prom2json = callPackage ../servers/monitoring/prometheus/prom2json.nix { };
   prometheus = callPackage ../servers/monitoring/prometheus { };
   prometheus-alertmanager = callPackage ../servers/monitoring/prometheus/alertmanager.nix { };
+  prometheus-bind-exporter = callPackage ../servers/monitoring/prometheus/bind-exporter.nix { };
   prometheus-blackbox-exporter = callPackage ../servers/monitoring/prometheus/blackbox-exporter.nix { };
   prometheus-collectd-exporter = callPackage ../servers/monitoring/prometheus/collectd-exporter.nix { };
   prometheus-haproxy-exporter = callPackage ../servers/monitoring/prometheus/haproxy-exporter.nix { };


### PR DESCRIPTION
This exporter provides many bind9 metrics for prometheus.

###### Motivation for this change

bind_exporter is not available in NixOS :-)
Package is packaged in the same way as e.g. node_exporter, but with a hash instead of a tag (bind_exporter has only a repo and no real versioning yet)

###### Things done

Tested with `nix-build -A nixpkgs.tarball nixos/release-combined.nix`

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`): *installed it to my .nix profile*
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

