### PR TITLE
vapoursynth: disable OCR by default

### DIFF
--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -1,7 +1,11 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoreconfHook,
-  glibc, zimg, imagemagick, libass, tesseract, yasm,
-  python3
+  glibc, zimg, imagemagick, libass, yasm, python3,
+  ocrSupport ? false, tesseract
 }:
+
+assert ocrSupport -> tesseract != null;
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "vapoursynth-${version}";
@@ -18,14 +22,15 @@ stdenv.mkDerivation rec {
     pkgconfig autoreconfHook
     zimg imagemagick libass glibc tesseract yasm
     (python3.withPackages (ps: with ps; [ sphinx cython ]))
-  ];
+  ] ++ optional ocrSupport tesseract;
 
   configureFlags = [
     "--enable-imwri"
     "--disable-static"
+    (optionalString (!ocrSupport) "--disable-ocr")
   ];
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "A video processing framework with the future in mind";
     homepage    = http://www.vapoursynth.com/;
     license     = licenses.lgpl21;


### PR DESCRIPTION
###### Motivation for this change
Vapoursynth uses tesseract for the `ocr.Recognize()` function.
By disabling the OCR support the closure size of vapoursynth gets reduced by 1.2GB, so building mpv with vapoursynth enabled now increase the size by "only" 92MB.

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

