### PR TITLE
trytond: init at 4.2.1

### DIFF
--- a/pkgs/applications/office/trytond/default.nix
+++ b/pkgs/applications/office/trytond/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, python2Packages
+, withPostgresql ? true }:
+
+with stdenv.lib;
+
+python2Packages.buildPythonApplication rec {
+  name = "trytond-${version}";
+  version = "4.2.1";
+  src = fetchurl {
+    url = "mirror://pypi/t/trytond/${name}.tar.gz";
+    sha256 = "1ijjpbsf3s0s7ksbi7xgzss4jgr14q5hqsyf6d68l8hwardrwpj7";
+  };
+
+  # Tells the tests which database to use
+  DB_NAME = ":memory:";
+
+  buildInputs = with python2Packages; [
+    mock
+  ];
+  propagatedBuildInputs = with python2Packages; ([
+    dateutil
+    lxml
+    polib
+    python-sql
+    relatorio
+    werkzeug
+    wrapt
+
+    # extra dependencies
+    bcrypt
+    pydot
+    python-Levenshtein
+    simplejson
+  ] ++ stdenv.lib.optional withPostgresql psycopg2);
+  meta = {
+    description = "The server of the Tryton application platform";
+    longDescription = ''
+      The server for Tryton, a three-tier high-level general purpose
+      application platform under the license GPL-3 written in Python and using
+      PostgreSQL as database engine.
+
+      It is the core base of a complete business solution providing
+      modularity, scalability and security.
+    '';
+    homepage = http://www.tryton.org/;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.johbo ];
+  };
+}

--- a/pkgs/development/python-modules/python-sql/default.nix
+++ b/pkgs/development/python-modules/python-sql/default.nix
@@ -1,0 +1,16 @@
+{ lib, fetchurl, buildPythonPackage }:
+
+buildPythonPackage rec {
+  name = "python-sql-${version}";
+  version = "0.8";
+  src = fetchurl {
+    url = "mirror://pypi/p/python-sql/${name}.tar.gz";
+    sha256 = "0xik939sxqfqqbpgcsnfjnws692bjip32khgwhq1ycphfy7df3h2";
+  };
+  meta = {
+    homepage = http://python-sql.tryton.org/;
+    description = "A library to write SQL queries in a pythonic way";
+    maintainers = with lib.maintainers; [ johbo ];
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/relatorio/default.nix
+++ b/pkgs/development/python-modules/relatorio/default.nix
@@ -1,0 +1,20 @@
+{ lib, fetchurl, buildPythonPackage, genshi, lxml }:
+
+buildPythonPackage rec {
+  name = "relatorio-${version}";
+  version = "0.6.4";
+  src = fetchurl {
+    url = "mirror://pypi/r/relatorio/${name}.tar.gz";
+    sha256 = "0lincq79mzgazwd9gh41dybjh9c3n87r83pl8nk3j79aihyfk84z";
+  };
+  propagatedBuildInputs = [
+    genshi
+    lxml
+  ];
+  meta = {
+    homepage = http://relatorio.tryton.org/;
+    description = "A templating library able to output odt and pdf files";
+    maintainers = with lib.maintainers; [ johbo ];
+    license = lib.licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4121,6 +4121,8 @@ with pkgs;
 
   tryton = callPackage ../applications/office/tryton { };
 
+  trytond = callPackage ../applications/office/trytond { };
+
   omapd = callPackage ../tools/security/omapd { };
 
   ttf2pt1 = callPackage ../tools/misc/ttf2pt1 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -332,6 +332,8 @@ in {
 
   pysideTools = callPackage ../development/python-modules/pyside/tools.nix { };
 
+  python-sql = callPackage ../development/python-modules/python-sql { };
+
   pytimeparse = buildPythonPackage rec {
     pname = "pytimeparse";
     version = "1.1.6";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -356,6 +356,8 @@ in {
 
   pyxml = if !isPy3k then callPackage ../development/python-modules/pyxml{ } else throw "pyxml not supported for interpreter ${python.executable}";
 
+  relatorio = callPackage ../development/python-modules/relatorio { };
+
   rhpl = if !isPy3k then callPackage ../development/python-modules/rhpl {} else throw "rhpl not supported for interpreter ${python.executable}";
 
   sip = callPackage ../development/python-modules/sip { };


### PR DESCRIPTION
###### Motivation for this change

Aims to make Tryton available on NixOS. The client is already available as the attribute `tryton`. This PR prepares the base of the server component.

At this stage it is still a minimal variant. Planned future work:

* Add support for the PostgreSQL database backend
* Add support to build trytond with a set of modules

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

