### PR TITLE
epic5: changed rm, cp, chmod to use pkgs.coreutils

### DIFF
--- a/pkgs/applications/networking/irc/epic5/default.nix
+++ b/pkgs/applications/networking/irc/epic5/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, ncurses, libiconv, tcl }:
+{ stdenv, fetchurl, openssl, ncurses, libiconv, tcl, coreutils }:
 
 stdenv.mkDerivation rec {
   name = "epic5-${version}";
@@ -17,14 +17,14 @@ stdenv.mkDerivation rec {
 
   postConfigure = ''
     substituteInPlace bsdinstall \
-      --replace /bin/cp cp \
-      --replace /bin/rm rm \
-      --replace /bin/chmod chmod
+      --replace /bin/cp ${coreutils}/bin/cp \
+      --replace /bin/rm ${coreutils}/bin/rm \
+      --replace /bin/chmod ${coreutils}/bin/chmod \
   '';
 
   meta = with stdenv.lib; {
-    homepage = "http://epicsol.org/";
-    description = "a IRC client that offers a great ircII interface";
+    homepage = "http://epicsol.org";
+    description = "A IRC client that offers a great ircII interface";
     license = licenses.bsd3;
     maintainers = [ maintainers.ndowens ];
   };


### PR DESCRIPTION
###### Motivation for this change
Capitalized in description and used pkgs.coreutils instead of using plain cp, chmod, rm

###### Things done

- [x ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] Linux
- [x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

