### PR TITLE
zmq: v4.2.0 -> v4.2.2

### DIFF
--- a/pkgs/development/libraries/zeromq/4.x.nix
+++ b/pkgs/development/libraries/zeromq/4.x.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "zeromq-${version}";
-  version = "4.2.0";
+  version = "4.2.2";
 
   src = fetchurl {
     url = "https://github.com/zeromq/libzmq/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "05y1s0938x5w838z79b4f9w6bspz9anldjx9dzvk32cpxvq3pf2k";
+    sha256 = "0syzwsiqblimfjb32fr6hswhdvp3cmbk0pgm7ayxaigmkv5g88sv";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

