### PR TITLE
pythonPackages.wrapPython: fix for paths with spaces

### DIFF
--- a/pkgs/development/interpreters/python/wrap.sh
+++ b/pkgs/development/interpreters/python/wrap.sh
@@ -47,7 +47,7 @@ wrapPythonProgramsIn() {
     buildPythonPath "$pythonPath"
 
     # Find all regular files in the output directory that are executable.
-    for f in $(find "$dir" -type f -perm -0100); do
+    find "$dir" -type f -perm -0100 -print0 | while read -d "" f; do
         # Rewrite "#! .../env python" to "#! /nix/store/.../python".
         # Strip suffix, like "3" or "2.7m" -- we don't have any choice on which
         # Python to use besides one with this hook anyway.


### PR DESCRIPTION
###### Motivation for this change

Fix the bug. Affected example: `octoprint`.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Not sure if this should be marked as a mass rebuild/done against staging.