### PR TITLE
souper: 2017-01-05 -> 2017-03-07

### DIFF
--- a/pkgs/development/compilers/souper/cmake-fix.patch
+++ b/pkgs/development/compilers/souper/cmake-fix.patch
@@ -1,0 +1,14 @@
+--- souper-1be75fe6a96993b57dcba038798fe6d1c7d113eb-src/CMakeLists.txt.orig     2017-01-20 13:55:14.783632588 -0600
++++ souper-1be75fe6a96993b57dcba038798fe6d1c7d113eb-src/CMakeLists.txt  2017-01-20 13:55:20.505728456 -0600
+@@ -33,7 +33,10 @@
+   OUTPUT_VARIABLE LLVM_SYSTEM_LIBS
+   OUTPUT_STRIP_TRAILING_WHITESPACE
+ )
+-set(LLVM_LIBS "${LLVM_LIBS} ${LLVM_SYSTEM_LIBS}")
++
++if (LLVM_SYSTEM_LIBS)
++  set(LLVM_LIBS "${LLVM_LIBS} ${LLVM_SYSTEM_LIBS}")
++endif()
+
+ execute_process(
+   COMMAND ${LLVM_CONFIG_EXECUTABLE} --ldflags

--- a/pkgs/development/compilers/souper/default.nix
+++ b/pkgs/development/compilers/souper/default.nix
@@ -1,22 +1,22 @@
 { stdenv, fetchFromGitHub, cmake, makeWrapper
-, llvmPackages_39, hiredis, z3_opt, gtest
+, llvmPackages_4, hiredis, z3_opt, gtest
 }:
 
 let
   klee = fetchFromGitHub {
-    owner = "klee";
+    owner = "rsas";
     repo  = "klee";
-    rev   = "a743d7072d9ccf11f96e3df45f25ad07da6ad9d6";
-    sha256 = "0qwzs029vlba8xz362n4b00hdm2z3lzhzmvix1r8kpbfrvs8vv91";
+    rev   = "57cd3d43056b029d9da3c6b3c666c4153554c04f";
+    sha256 = "197wb7nbirlfpx2jr3afpjjhcj7slc4dxxi02j3kmazz9kcqaygz";
   };
 in stdenv.mkDerivation {
-  name = "souper-unstable-2017-01-05";
+  name = "souper-unstable-2017-03-07";
 
   src = fetchFromGitHub {
     owner  = "google";
     repo   = "souper";
-    rev    = "1be75fe6a96993b57dcba038798fe6d1c7d113eb";
-    sha256 = "0r8mjb88lwz9a3syx7gwsxlwfg0krffaml04ggaf3ad0cza2mvm8";
+    rev    = "5faed54ddc4a0e0e12647a0eac1da455a1067a47";
+    sha256 = "1v8ml94ryw5wdls9syvicx4sc9l34yaq8r7cf7is6x7y1q677rps";
   };
 
   nativeBuildInputs = [
@@ -25,11 +25,13 @@ in stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    llvmPackages_39.llvm
-    llvmPackages_39.clang-unwrapped
+    llvmPackages_4.llvm
+    llvmPackages_4.clang-unwrapped
     hiredis
     gtest
   ];
+
+  patches = [ ./cmake-fix.patch ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Update souper to latest, using LLVM 4 and their custom KLEE.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

