### PR TITLE
intecture-cli: init at 0.3.2

### DIFF
--- a/pkgs/tools/admin/intecture/cli.nix
+++ b/pkgs/tools/admin/intecture/cli.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub, rustPlatform
+, openssl, zeromq, czmq, pkgconfig, cmake, zlib }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "intecture-cli-${version}";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "intecture";
+    repo = "cli";
+    rev = version;
+    sha256 = "0f5pyrlkxzz4kdfzwambxzqr48g3n06f1pv163h06ggssqa51wbc";
+  };
+
+  depsSha256 = "0f3rhjs5addppva4cjx3ngpa5gz2i2n46hyc3zd4l7lhh8gaggix";
+
+  buildInputs = [ openssl zeromq czmq zlib ];
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  # Needed for tests
+  USER = "$(whoami)";
+
+  meta = with lib; {
+    description = "A developer friendly, language agnostic configuration management tool for server systems";
+    homepage = https://intecture.io;
+    license = licenses.mpl20;
+    maintainers = [ maintainers.rushmorem ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2301,6 +2301,8 @@ with pkgs;
 
   innoextract = callPackage ../tools/archivers/innoextract { };
 
+  intecture-cli = callPackage ../tools/admin/intecture/cli.nix { };
+
   ioping = callPackage ../tools/system/ioping { };
 
   iops = callPackage ../tools/system/iops { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

