### PR TITLE
luaPackages.luaposix: init at 33.4.0

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -151,6 +151,21 @@ let
     };
   };
 
+  luaposix = buildLuaPackage rec {
+    name = "posix-${version}";
+    version = "33.4.0";
+    src = fetchurl {
+      url = "https://github.com/luaposix/luaposix/archive/release-v${version}.tar.gz";
+      sha256 = "e66262f5b7fe1c32c65f17a5ef5ffb31c4d1877019b4870a5d373e2ab6526a21";
+    };
+    buildInputs = [ perl ];
+    meta = {
+      description = "Lua bindings for POSIX API";
+      homepage = "https://github.com/luaposix/luaposix";
+      hydraPlatforms = stdenv.lib.platforms.unix;
+    };
+  };
+
   lpty = buildLuaPackage rec {
     name = "lpty-${version}";
     version = "1.1.1";


### PR DESCRIPTION
###### Motivation for this change
Dependency for #20842

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

