### PR TITLE
intecture-auth: init at 0.1.0

### DIFF
--- a/pkgs/tools/admin/intecture/auth.nix
+++ b/pkgs/tools/admin/intecture/auth.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitHub, rustPlatform
+, openssl, zeromq, czmq, pkgconfig, cmake, zlib }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "intecture-auth-${version}";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "intecture";
+    repo = "auth";
+    rev = version;
+    sha256 = "1p3jahha8k139f22ijg050cl8akfzxda4gzvijpqv869hmhc70py";
+  };
+
+  depsSha256 = "0mki57yzb29y9fhh16xvpi5gfp6c14r5q3f45f3v8sdj95rjahz1";
+
+  buildInputs = [ openssl zeromq czmq zlib ];
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  meta = with lib; {
+    description = "Authentication client/server for Intecture components";
+    homepage = https://intecture.io;
+    license = licenses.mpl20;
+    maintainers = [ maintainers.rushmorem ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2301,6 +2301,8 @@ with pkgs;
 
   innoextract = callPackage ../tools/archivers/innoextract { };
 
+  intecture-auth = callPackage ../tools/admin/intecture/auth.nix { };
+
   intecture-cli = callPackage ../tools/admin/intecture/cli.nix { };
 
   ioping = callPackage ../tools/system/ioping { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

