### PR TITLE
intecture-agent: init at 0.3.0

### DIFF
--- a/pkgs/tools/admin/intecture/agent.nix
+++ b/pkgs/tools/admin/intecture/agent.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitHub, rustPlatform
+, openssl, zeromq, czmq, pkgconfig, cmake, zlib }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "intecture-agent-${version}";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "intecture";
+    repo = "agent";
+    rev = version;
+    sha256 = "0b59ij9c7hv2p4jx96f3acbygw27wiv8cfzzg6sg73l6k244k6l6";
+  };
+
+  depsSha256 = "1f94j54pg94f2x2lmmyj8dlki8plq6vnppmf3hzk3kd0rp7fzban";
+
+  buildInputs = [ openssl zeromq czmq zlib ];
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  meta = with lib; {
+    description = "Authentication client/server for Intecture components";
+    homepage = https://intecture.io;
+    license = licenses.mpl20;
+    maintainers = [ maintainers.rushmorem ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2301,6 +2301,8 @@ with pkgs;
 
   innoextract = callPackage ../tools/archivers/innoextract { };
 
+  intecture-agent = callPackage ../tools/admin/intecture/agent.nix { };
+
   intecture-auth = callPackage ../tools/admin/intecture/auth.nix { };
 
   intecture-cli = callPackage ../tools/admin/intecture/cli.nix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

