### PR TITLE
PyZufall: init at 0.13.2

### DIFF
--- a/pkgs/development/python-modules/pyzufall/default.nix
+++ b/pkgs/development/python-modules/pyzufall/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, python, buildPythonPackage, nose, future, coverage }:
+
+buildPythonPackage rec {
+  pname = "PyZufall";
+  version = "0.13.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+    sha256 = "1jffhi20m82fdf78bjhncbdxkfzcskrlipxlrqq9741xdvrn14b5";
+  };
+
+  # disable tests due to problem with nose
+  # https://github.com/nose-devs/nose/issues/1037
+  doCheck = false;
+
+  buildInputs = [ nose coverage ];
+  propagatedBuildInputs = [ future ];
+
+  checkPhase = ''
+    ${python.interpreter} setup.py nosetests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://pyzufall.readthedocs.io/de/latest/";
+    description = "Library for generating random data and sentences in german language";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ davidak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -360,6 +360,8 @@ in {
 
   relatorio = callPackage ../development/python-modules/relatorio { };
 
+  pyzufall = callPackage ../development/python-modules/pyzufall { };
+
   rhpl = if !isPy3k then callPackage ../development/python-modules/rhpl {} else throw "rhpl not supported for interpreter ${python.executable}";
 
   sip = callPackage ../development/python-modules/sip { };


### PR DESCRIPTION
###### Motivation for this change

I want to use it on a server running NixOS and maybe it's useful for more Nix users :)

The `description` is in german since the library outputs random german words and sentences.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

