### PR TITLE
creduce: Use wrapper instead of propagatedUserEnvPkgs

### DIFF
--- a/pkgs/development/tools/misc/creduce/default.nix
+++ b/pkgs/development/tools/misc/creduce/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake
+{ stdenv, fetchurl, cmake, makeWrapper
 , llvm, clang-unwrapped
 , flex
 , zlib
@@ -21,9 +21,10 @@ stdenv.mkDerivation rec {
     # Ensure stdenv's CC is on PATH before clang-unwrapped
     stdenv.cc
     # Actual deps:
-    cmake
+    cmake makeWrapper
     llvm clang-unwrapped
     flex zlib
+    perl ExporterLite FileWhich GetoptTabular RegexpCommon TermReadKey
   ];
 
   # On Linux, c-reduce's preferred way to reason about
@@ -34,14 +35,12 @@ stdenv.mkDerivation rec {
       lscpu ${utillinux}/bin/lscpu
   '';
 
-  perlDeps = [
-    perl ExporterLite FileWhich GetoptTabular RegexpCommon TermReadKey
-  ];
-
-  propagatedNativeBuildInputs = perlDeps;
-  propagatedUserEnvPkgs = perlDeps;
 
   enableParallelBuilding = true;
+
+  postInstall = ''
+    wrapProgram $out/bin/creduce --prefix PERL5LIB : "$PERL5LIB"
+  '';
 
   meta = with stdenv.lib; {
     description = "A C program reducer";


### PR DESCRIPTION
Friendlier when installed,
fixes execution outside of NixOS.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

