### PR TITLE
habitat: 0.8.0 -> 0.30.2

### DIFF
--- a/pkgs/applications/networking/cluster/habitat/chroot-env.nix
+++ b/pkgs/applications/networking/cluster/habitat/chroot-env.nix
@@ -1,9 +1,0 @@
-# TODO: Drop once https://github.com/habitat-sh/habitat/issues/994
-#       is resolved.
-{ habitat, libsodium, libarchive, openssl, buildFHSUserEnv }:
-
-buildFHSUserEnv {
-    name = "habitat-sh";
-    targetPkgs = pkgs: [ habitat libsodium libarchive openssl ];
-    runScript = "bash";
-}

--- a/pkgs/applications/networking/cluster/habitat/default.nix
+++ b/pkgs/applications/networking/cluster/habitat/default.nix
@@ -5,22 +5,29 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "habitat-${version}";
-  version = "0.8.0";
+  version = "0.30.2";
 
   src = fetchFromGitHub {
     owner = "habitat-sh";
     repo = "habitat";
     rev = version;
-    sha256 = "1h9wv2v4hcv79jkkjf8j96lzxni9d51755zfflfr5s3ayaip7rzj";
+    sha256 = "0pqrm85pd9hqn5fwqjbyyrrfh4k7q9mi9qy9hm8yigk5l8mw44y1";
   };
 
-  sourceRoot = "habitat-${version}-src/components/hab";
-
-  depsSha256 = "1612jaw3zdrgrb56r755bb18l8szdmf1wi7p9lpv3d2gklqcb7l1";
+  depsSha256 = "1ahfm5agvabqqqgjsyjb95xxbc7mng1mdyclcakwp1m1qdkxx9py";
 
   buildInputs = [ libsodium libarchive openssl ];
 
   nativeBuildInputs = [ pkgconfig ];
+
+  cargoBuildFlags = ["--package hab"];
+
+  checkPhase = ''
+    runHook preCheck
+    echo "Running cargo test"
+    cargo test --package hab
+    runHook postCheck
+  '';
 
   meta = with lib; {
     description = "An application automation framework";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2436,7 +2436,6 @@ with pkgs;
   haveged = callPackage ../tools/security/haveged { };
 
   habitat = callPackage ../applications/networking/cluster/habitat { };
-  habitat-sh = callPackage ../applications/networking/cluster/habitat/chroot-env.nix { };
 
   hardlink = callPackage ../tools/system/hardlink { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

