### PR TITLE
buildRustPackage: fix deprecated use of registry.index config key

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-deps
+++ b/pkgs/build-support/rust/fetch-cargo-deps
@@ -11,8 +11,11 @@ fetchCargoDeps() {
     echo "Using rust registry from $rustRegistry"
 
     cat <<EOF > $out/config
-[registry]
-index = "file://$rustRegistry"
+[source.nix-store-rust-registry]
+registry = "file://$rustRegistry"
+
+[source.crates-io]
+replace-with = "nix-store-rust-registry"
 EOF
 
     export CARGO_HOME=$out


### PR DESCRIPTION
See
https://github.com/rust-lang/cargo/commit/8214bb953dee7f529747ce69ff81fe294259a6a0
for the cargo commit which deprecated the registry.index key, and
implements this as a replacement. This gets rid of the error message

warning: custom registry support via the `registry.index` configuration is being removed, this functionality will not work in the future

I tested by faking a depsSha256 for a package using buildRustPackage, rebuilding, and verifying that 
1) the warning goes away
2) it still doesn't talk to crates.io (i.e. I didn't break it)