### PR TITLE
bind: enable DIG_SIGCHASE (fix #10728)

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -35,6 +35,11 @@ stdenv.mkDerivation rec {
     "--without-python"
   ] ++ lib.optional (stdenv.isi686 || stdenv.isx86_64) "--enable-seccomp";
 
+  postConfigure = ''
+    STD_CDEFINES="-DDIG_SIGCHASE=1"
+    export STD_CDEFINES
+  '';
+
   postInstall = ''
     moveToOutput bin/bind9-config $dev
     moveToOutput bin/isc-config.sh $dev


### PR DESCRIPTION
###### Motivation for this change

See #10728

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

