### PR TITLE
geogebra: 5-0-328-0 -> 5-0-331-0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -277,6 +277,7 @@
   luispedro = "Luis Pedro Coelho <luis@luispedro.org>";
   lukego = "Luke Gorrie <luke@snabb.co>";
   lw = "Sergey Sofeychuk <lw@fmap.me>";
+  ma27 = "Maximilian Bosch <maximilian@mbosch.me>";
   madjar = "Georges Dubus <georges.dubus@compiletoi.net>";
   magnetophon = "Bart Brouns <bart@magnetophon.nl>";
   mahe = "Matthias Herrmann <matthias.mh.herrmann@gmail.com>";

--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
       calculus in one easy-to-use package.
     '';
     homepage = https://www.geogebra.org/;
+    maintainers = with maintainers; [ ma27 ];
     license = with licenses; [ gpl3 cc-by-nc-sa-30 geogebra ];
     platforms = platforms.all;
     hydraPlatforms = [];

--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "geogebra-${version}";
-  version = "5-0-328-0";
+  version = "5-0-331-0";
 
   preferLocalBuild = true;
 
   src = fetchurl {
     url = "http://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2";
-    sha256 = "1bzmnw5410fv9s29ji8f4naa6m6ykvv8h88mmxhiygr3rfsc7050";
+    sha256 = "135g2xqafgs1gv98vqq2jpfwyi1aflyiynx1gmsgs23jxbr218v2";
   };
 
   srcIcon = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

GeoGebra needs an update (again) to prevent any failing builds when `5-0-328-0` is removed from the download server.
Furthermore I added myself as maintainer for the Geogebra package as no maintainers were listed.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

