### PR TITLE
wuzz: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/tools/networking/wuzz/default.nix
+++ b/pkgs/tools/networking/wuzz/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "wuzz-${version}";
-  version = "0.1.0";
+  version = "0.2.0";
   rev = "v${version}";
 
   goPackagePath = "https://github.com/asciimoo/wuzz";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "asciimoo";
     repo = "wuzz";
     inherit rev;
-    sha256 = "0n55y9dmx4rsccjscvbrgiq2g1qwqxj44lg90589i55b5f7r1ljd";
+    sha256 = "1fcr5jr0vn5w60bn08lkh2mi0hdarwp361h94in03139j7hhqrfs";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/tools/networking/wuzz/deps.nix
+++ b/pkgs/tools/networking/wuzz/deps.nix
@@ -4,8 +4,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/jroimartin/gocui";
-      rev = "7ac95c981b8a07b624ab197b3ad5813fdfbe4864";
-      sha256 = "1xr752gpjv32mnzzy5v367maczl7sn8frn258wqrs6gqf07sdmjp";
+      rev = "ed41d1bd2c217d4d1e312c2ee5d2f0c7793a99cc";
+      sha256 = "1h4jxhvkf43jsbn85w45fq2xsmcg08mc9g7pkxf880g6sqznrmcz";
     };
   }
   {
@@ -24,6 +24,69 @@
       url = "https://github.com/mattn/go-runewidth";
       rev = "14207d285c6c197daabb5c9793d63e7af9ab2d50";
       sha256 = "0y6yq9zd4kh7fimnc00r3h9pr2pwa5j85b3jcn5dyfamsnm2xdsv";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev = "b8bc1bf767474819792c23f32d8286a45736f1c6";
+      sha256 = "13ry4lylalkh4g2vny9cxwvryslzyzwp9r92z0b10idhdq3wad1q";
+    };
+  }
+  {
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "056c9bc7be7190eaa7715723883caffa5f8fa3e4";
+      sha256 = "0gkgkw04ndr5y7hrdy0r4v2drs5srwfcw2bs1gyas066hwl84xyw";
+    };
+  }
+  {
+    goPackagePath = "github.com/nwidger/jsoncolor";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nwidger/jsoncolor";
+      rev = "0192e84d44af834c3a90c8a17bf670483b91ad5a";
+      sha256 = "17mndgd1d233c22bd19xv4v2l2i5k8kz7y6n4n54a9i7fi9d10al";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "e8e01ee22a7d4a91b49646e39245fe08e69c7878";
+      sha256 = "1660g29qhshk6zxhpnc0f52m69jdqqdw2ccbkqw9y4kilnripfvl";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "30a891c33c7cde7b02a981314b4228ec99380cca";
+      sha256 = "03gsxn89pgkj4jkxm9avnj4f0ckvcskc6fj2lcd98l3akrz50ndg";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "d228849504861217f796da67fae4f6e347643f15";
+      sha256 = "0ch5sfcpmqczsh8kjbwpzdw31lacbkfyzvpzh4disnhhydbxjq0d";
+    };
+  }
+  {
+    goPackagePath = "github.com/asciimoo/wuzz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/asciimoo/wuzz";
+      rev = "f34c82a4386951022f8bfc011fe6a7362dd8286c";
+      sha256 = "1fcr5jr0vn5w60bn08lkh2mi0hdarwp361h94in03139j7hhqrfs";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

