### PR TITLE
antimicro: 2.22 -> 2.23

### DIFF
--- a/pkgs/tools/misc/antimicro/default.nix
+++ b/pkgs/tools/misc/antimicro/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "antimicro-${version}";
-  version = "2.22";
+  version = "2.23";
 
   src = fetchFromGitHub {
     owner = "AntiMicro";
     repo = "antimicro";
     rev = "${version}";
-    sha256 = "102fh9ysd2dmfc6b73bj88m064jhlglqrz2gd7k9jccadxpbp3mq";
+    sha256 = "1q40ayxwwyq85lc89cnj1cm2nar625h4vhh8dvmb2qcxczaggf4v";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

I noticed antimicro stopped working for my ps4 controller... latest release seems to have fixed it

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

