### PR TITLE
pymol: init at 1.8.4

### DIFF
--- a/pkgs/applications/science/chemistry/pymol/default.nix
+++ b/pkgs/applications/science/chemistry/pymol/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, python27Packages, glew, freeglut, libpng, libxml2, tk, freetype }:
+
+let
+  version = "1.8.4.0";
+in
+python27Packages.buildPythonPackage {
+  name = "pymol-${version}";
+  src = fetchurl {
+    url = "mirror://sourceforge/project/pymol/pymol/1.8/pymol-v1.8.4.0.tar.bz2";
+    sha256 = "0yfj8g5yic9zz6f0bw2n8h6ifvgsn8qvhq84alixsi28wzppn55n";
+  };
+
+  buildInputs = [ python27Packages.numpy glew freeglut libpng libxml2.dev tk freetype ];
+  NIX_CFLAGS_COMPILE = "-I ${libxml2.dev}/include/libxml2";
+
+  installPhase = ''
+    python setup.py install --home=$out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Python-enhanced molecular graphics tool";
+    homepage = "https://www.pymol.org/";
+    license = licences.psfl;
+  };
+}

--- a/pkgs/applications/science/chemistry/pymol/default.nix
+++ b/pkgs/applications/science/chemistry/pymol/default.nix
@@ -3,14 +3,14 @@
 let
   version = "1.8.4.0";
 in
-python27Packages.buildPythonPackage {
+python27Packages.buildPythonApplication {
   name = "pymol-${version}";
   src = fetchurl {
     url = "mirror://sourceforge/project/pymol/pymol/1.8/pymol-v1.8.4.0.tar.bz2";
     sha256 = "0yfj8g5yic9zz6f0bw2n8h6ifvgsn8qvhq84alixsi28wzppn55n";
   };
 
-  buildInputs = [ python27Packages.numpy glew freeglut libpng libxml2.dev tk freetype ];
+  buildInputs = [ python27Packages.numpy glew freeglut libpng libxml2 tk freetype ];
   NIX_CFLAGS_COMPILE = "-I ${libxml2.dev}/include/libxml2";
 
   installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14748,6 +14748,8 @@ with pkgs;
 
   puremapping = callPackage ../applications/audio/pd-plugins/puremapping { };
 
+  pymol = callPackage ../applications/science/chemistry/pymol { };
+
   pybitmessage = callPackage ../applications/networking/instant-messengers/pybitmessage { };
 
   pythonmagick = callPackage ../applications/graphics/PythonMagick { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

