### PR TITLE
beets: enable gstreamer support

### DIFF
--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, writeScript, glibcLocales
-, pythonPackages, imagemagick
+, pythonPackages, imagemagick, gobjectIntrospection, gst_all_1
 
 , enableAcousticbrainz ? true
 , enableAcoustid       ? true
@@ -93,6 +93,9 @@ in pythonPackages.buildPythonApplication rec {
     pythonPackages.pathlib
     pythonPackages.pyyaml
     pythonPackages.unidecode
+    pythonPackages.gst-python
+    pythonPackages.pygobject3
+    gobjectIntrospection
   ] ++ optional enableAcoustid     pythonPackages.pyacoustid
     ++ optional (enableFetchart
               || enableEmbyupdate
@@ -119,7 +122,11 @@ in pythonPackages.buildPythonApplication rec {
     nose
     rarfile
     responses
-  ];
+  ] ++ (with gst_all_1; [
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-ugly
+  ]);
 
   patches = [
     ./replaygain-default-bs1770gain.patch
@@ -197,6 +204,8 @@ in pythonPackages.buildPythonApplication rec {
 
     runHook postInstallCheck
   '';
+
+  makeWrapperArgs = [ "--set GI_TYPELIB_PATH \"$GI_TYPELIB_PATH\"" "--set GST_PLUGIN_SYSTEM_PATH_1_0 \"$GST_PLUGIN_SYSTEM_PATH_1_0\"" ];
 
   meta = {
     description = "Music tagger and library organizer";


### PR DESCRIPTION
###### Motivation for this change

So this was suggested as [long ago as October, 2015](https://github.com/NixOS/nixpkgs/issues/10376#issuecomment-147734898).

Despite being fairly ignorant of the nix Python support, I decided that I really wanted this; this change brings in what I believe are the necessary components---I have, at least, successfully run `beet replaygain` and `beet bpd`---but it may not do it in the best way; I'm happy to consider input on that front.

I can at least state that all three changes are necessary---leave any one of them out and gstreamer support doesn't work.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

