### PR TITLE
gnupg: include systemd user units in output

### DIFF
--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -37,6 +37,14 @@ stdenv.mkDerivation rec {
   pinentryBinaryPath = pinentry.binaryPath or "bin/pinentry";
   configureFlags = optional guiSupport "--with-pinentry-pgm=${pinentry}/${pinentryBinaryPath}";
 
+  postInstall = ''
+    mkdir -p $out/lib/systemd/user
+    for f in doc/examples/systemd-user/*.{service,socket} ; do
+      substitute $f $out/lib/systemd/user/$(basename $f) \
+        --replace /usr/bin $out/bin
+    done
+  '';
+
   meta = with stdenv.lib; {
     homepage = http://gnupg.org;
     description = "A complete and free implementation of the OpenPGP standard";


### PR DESCRIPTION
###### Motivation for this change

In order for us to socket activate gpg-agent, we need the unit definitions from upstream. All this PR does is to include them in the output - nothing else changes.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

