### PR TITLE
haskell: envForPackages (hs: with hs; [A B]) should contain all dependencies of A and B, but not A, B themselves

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -310,6 +310,8 @@ stdenv.mkDerivation ({
       '';
     };
 
+    inherit haskellBuildInputs;
+    inherit systemBuildInputs;
   };
 
   meta = { inherit homepage license platforms; }


### PR DESCRIPTION
###### Motivation for this change
In our project we have packages A and B, such that B depends on package A. We would like to be able to get a shell environment where can incrementally work on both packages, but this currently doesn't seem possible. If we expose these variables, we can make our own environment that combines the two packages' dependencies.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

