### PR TITLE
cloud-init: 0.7.6 -> 0.7.9 + module improvements

### DIFF
--- a/nixos/modules/services/system/cloud-init.nix
+++ b/nixos/modules/services/system/cloud-init.nix
@@ -47,8 +47,6 @@ in
            - write-files
            - growpart
            - resizefs
-           - set_hostname
-           - update_hostname
            - update_etc_hosts
            - ca-certs
            - rsyslog

--- a/pkgs/tools/virtualization/cloud-init/add-nixos-support.patch
+++ b/pkgs/tools/virtualization/cloud-init/add-nixos-support.patch
@@ -1,0 +1,113 @@
+diff -ruN cloud-init-0.7.6.orig/cloudinit/distros/__init__.py cloud-init-0.7.6/cloudinit/distros/__init__.py
+--- cloud-init-0.7.6.orig/cloudinit/distros/__init__.py	2014-10-10 15:26:25.000000000 +0000
++++ cloud-init-0.7.6/cloudinit/distros/__init__.py	2016-06-08 07:51:45.230357099 +0000
+@@ -43,6 +43,7 @@
+     'freebsd': ['freebsd'],
+     'suse': ['sles'],
+     'arch': ['arch'],
++    'nixos': ['nixos'],
+ }
+ 
+ LOG = logging.getLogger(__name__)
+diff -ruN cloud-init-0.7.6.orig/cloudinit/distros/nixos.py cloud-init-0.7.6/cloudinit/distros/nixos.py
+--- cloud-init-0.7.6.orig/cloudinit/distros/nixos.py	1970-01-01 00:00:00.000000000 +0000
++++ cloud-init-0.7.6/cloudinit/distros/nixos.py	2016-06-08 07:50:58.602616595 +0000
+@@ -0,0 +1,98 @@
++# vi: ts=4 expandtab
++#
++#    Copyright (C) 2012 Canonical Ltd.
++#    Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
++#    Copyright (C) 2012 Yahoo! Inc.
++#
++#    Author: Scott Moser <scott.moser@canonical.com>
++#    Author: Juerg Haefliger <juerg.haefliger@hp.com>
++#    Author: Joshua Harlow <harlowja@yahoo-inc.com>
++#
++#    This program is free software: you can redistribute it and/or modify
++#    it under the terms of the GNU General Public License version 3, as
++#    published by the Free Software Foundation.
++#
++#    This program is distributed in the hope that it will be useful,
++#    but WITHOUT ANY WARRANTY; without even the implied warranty of
++#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++#    GNU General Public License for more details.
++#
++#    You should have received a copy of the GNU General Public License
++#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
++
++from cloudinit import distros
++from cloudinit import helpers
++from cloudinit import log as logging
++from cloudinit import util
++
++from cloudinit.distros.parsers.hostname import HostnameConf
++
++LOG = logging.getLogger(__name__)
++
++class Distro(distros.Distro):
++
++    def __init__(self, name, cfg, paths):
++        distros.Distro.__init__(self, name, cfg, paths)
++        # This will be used to restrict certain
++        # calls from repeatly happening (when they
++        # should only happen say once per instance...)
++        self._runner = helpers.Runners(paths)
++        self.osfamily = 'nixos'
++
++    def _select_hostname(self, hostname, fqdn):
++        # Prefer the short hostname over the long
++        # fully qualified domain name
++        if not hostname:
++            return fqdn
++        return hostname
++
++    def _write_hostname(self, your_hostname, out_fn):
++        conf = None
++        try:
++            # Try to update the previous one
++            # so lets see if we can read it first.
++            conf = self._read_hostname_conf(out_fn)
++        except IOError:
++            pass
++        if not conf:
++            conf = HostnameConf('')
++        conf.set_hostname(your_hostname)
++        util.write_file(out_fn, str(conf), 0644)
++
++    def _read_system_hostname(self):
++        sys_hostname = self._read_hostname(self.hostname_conf_fn)
++        return (self.hostname_conf_fn, sys_hostname)
++
++    def _read_hostname_conf(self, filename):
++        conf = HostnameConf(util.load_file(filename))
++        conf.parse()
++        return conf
++
++    def _read_hostname(self, filename, default=None):
++        hostname = None
++        try:
++            conf = self._read_hostname_conf(filename)
++            hostname = conf.hostname
++        except IOError:
++            pass
++        if not hostname:
++            return default
++        return hostname
++
++    def _write_network(self, settings):
++        raise NotImplementedError()
++
++    def apply_locale(self, locale, out_fn=None):
++        raise NotImplementedError()
++
++    def install_packages(self, pkglist):
++        raise NotImplementedError()
++
++    def package_command(self, command, args=None, pkgs=None):
++        raise NotImplementedError()
++
++    def set_timezone(self, tz):
++        raise NotImplementedError()
++
++    def update_package_sources(self):
++        raise NotImplementedError()

--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -1,6 +1,6 @@
-{ lib, pythonPackages, fetchurl }:
+{ lib, pythonPackages, fetchurl, kmod, systemd }:
 
-let version = "0.7.6";
+let version = "0.7.9";
 
 in pythonPackages.buildPythonApplication rec {
   name = "cloud-init-${version}";
@@ -8,9 +8,10 @@ in pythonPackages.buildPythonApplication rec {
 
   src = fetchurl {
     url = "https://launchpad.net/cloud-init/trunk/${version}/+download/cloud-init-${version}.tar.gz";
-    sha256 = "1mry5zdkfaq952kn1i06wiggc66cqgfp6qgnlpk0mr7nnwpd53wy";
+    sha256 = "0wnl76pdcj754pl99wxx76hkir1s61x0bg0lh27sdgdxy45vivbn";
   };
 
+  patches = [ ./add-nixos-support.patch ];
   patchPhase = ''
     patchShebangs ./tools
 
@@ -19,15 +20,17 @@ in pythonPackages.buildPythonApplication rec {
       --replace /etc $out/etc \
       --replace /lib/systemd $out/lib/systemd \
       --replace 'self.init_system = ""' 'self.init_system = "systemd"'
+
+    patchPhase
     '';
 
   propagatedBuildInputs = with pythonPackages; [ cheetah jinja2 prettytable
-    oauth pyserial configobj pyyaml argparse requests jsonpatch ];
+    oauthlib pyserial configobj pyyaml argparse requests jsonpatch ];
 
   meta = {
     homepage = http://cloudinit.readthedocs.org;
     description = "Provides configuration and customization of cloud instance";
-    maintainers = [ lib.maintainers.madjar ];
+    maintainers = [ lib.maintainers.madjar lib.maintainers.phile314 ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -20,8 +20,6 @@ in pythonPackages.buildPythonApplication rec {
       --replace /etc $out/etc \
       --replace /lib/systemd $out/lib/systemd \
       --replace 'self.init_system = ""' 'self.init_system = "systemd"'
-
-    patchPhase
     '';
 
   propagatedBuildInputs = with pythonPackages; [ cheetah jinja2 prettytable

--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -20,6 +20,8 @@ in pythonPackages.buildPythonApplication rec {
       --replace /etc $out/etc \
       --replace /lib/systemd $out/lib/systemd \
       --replace 'self.init_system = ""' 'self.init_system = "systemd"'
+
+    patchPhase
     '';
 
   propagatedBuildInputs = with pythonPackages; [ cheetah jinja2 prettytable

--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -1,4 +1,4 @@
-{ lib, pythonPackages, fetchurl, kmod, systemd }:
+{ lib, pythonPackages, fetchurl, kmod, systemd, cloud-utils }:
 
 let version = "0.7.9";
 
@@ -20,6 +20,9 @@ in pythonPackages.buildPythonApplication rec {
       --replace /etc $out/etc \
       --replace /lib/systemd $out/lib/systemd \
       --replace 'self.init_system = ""' 'self.init_system = "systemd"'
+
+    substituteInPlace cloudinit/config/cc_growpart.py \
+      --replace 'util.subp(["growpart"' 'util.subp(["${cloud-utils}/bin/growpart"'
     '';
 
   propagatedBuildInputs = with pythonPackages; [ cheetah jinja2 prettytable

--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -12,7 +12,7 @@ in pythonPackages.buildPythonApplication rec {
   };
 
   patches = [ ./add-nixos-support.patch ];
-  patchPhase = ''
+  prePatch = ''
     patchShebangs ./tools
 
     substituteInPlace setup.py \
@@ -20,8 +20,6 @@ in pythonPackages.buildPythonApplication rec {
       --replace /etc $out/etc \
       --replace /lib/systemd $out/lib/systemd \
       --replace 'self.init_system = ""' 'self.init_system = "systemd"'
-
-    patchPhase
     '';
 
   propagatedBuildInputs = with pythonPackages; [ cheetah jinja2 prettytable


### PR DESCRIPTION
###### Motivation for this change

Update cloud-init version and make the configuration an option. Also properly wait for online network. Based upon earlier work by @alexandergall .

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

