### PR TITLE
Sway: module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -542,6 +542,7 @@
   ./services/web-servers/apache-httpd/default.nix
   ./services/web-servers/caddy.nix
   ./services/web-servers/fcgiwrap.nix
+  ./services/web-servers/hiawatha.nix
   ./services/web-servers/jboss/default.nix
   ./services/web-servers/lighttpd/cgit.nix
   ./services/web-servers/lighttpd/default.nix
@@ -580,6 +581,7 @@
   ./services/x11/window-managers/bspwm.nix
   ./services/x11/window-managers/metacity.nix
   ./services/x11/window-managers/none.nix
+  ./services/x11/window-managers/sway.nix
   ./services/x11/window-managers/twm.nix
   ./services/x11/window-managers/windowlab.nix
   ./services/x11/window-managers/wmii.nix

--- a/nixos/modules/services/x11/window-managers/sway.nix
+++ b/nixos/modules/services/x11/window-managers/sway.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ...}:
+
+with lib;
+
+let
+  cfg = config.services.xserver.windowManager.sway;
+in
+
+{
+  ### Interface
+  options = {
+  services.xserver.windowManager.sway = {
+  enable = mkEnableOption "Sway window manager";
+
+  configFile = mkOption {
+    default = null;
+    type = with types; nullOr path;
+    description = ''
+                  Location of the Sway configuration file.
+		  '';
+      };
+  };
+};
+### Implementation
+
+config = mkIf cfg.enable {
+  services.xserver.windowManager.session = [{
+    name = "sway";
+    start = ''
+            ${pkgs.sway}/bin/sway ${optionalString (cfg.configFile != null)
+	      "-c \"${cfg.configFile}\""
+	      } &
+	      waitPID=$!
+	     '';
+	     }];
+	     environment.systemPackages = [ pkgs.sway ];
+	};
+
+	}


### PR DESCRIPTION
###### Motivation for this change

Adds service module for the swaywm 

###### Things done

- [x ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ n/a] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

