### PR TITLE
nitrogen: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/tools/X11/nitrogen/default.nix
+++ b/pkgs/tools/X11/nitrogen/default.nix
@@ -1,23 +1,20 @@
 { stdenv, fetchurl, pkgconfig, glib, gtkmm2 }:
 
-let version = "1.6.0";
+let version = "1.6.1";
 in
 stdenv.mkDerivation rec {
   name = "nitrogen-${version}";
 
   src = fetchurl {
     url = "http://projects.l3ib.org/nitrogen/files/${name}.tar.gz";
-    sha256 = "1pil2qa3v7x56zh9xvba8v96abnf9qgglbsdlrlv0kfjlhzl4jhr";
+    sha256 = "0zc3fl1mbhq0iyndy4ysmy8vv5c7xwf54rbgamzfhfvsgdq160pl";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [ glib gtkmm2 ];
 
-  NIX_CXXFLAGS_COMPILE = "-std=c++11";
-
   patchPhase = ''
-    substituteInPlace data/Makefile.in --replace /usr/share $out/share
     patchShebangs data/icon-theme-installer
   '';
 


### PR DESCRIPTION
###### Changes

https://github.com/l3ib/nitrogen/releases/tag/1.6.1

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).