### PR TITLE
wolfssl: 3.9.10b -> 3.10.3

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "wolfssl-${version}";
-  version = "3.9.10b";
+  version = "3.10.3";
 
   src = fetchFromGitHub {
     owner = "wolfSSL";
     repo = "wolfssl";
     rev = "v${version}";
-    sha256 = "1hx543kxi4fpxww0y2c05kaav99zmnxm81rq7v7d87qzmvw2g4gx";
+    sha256 = "05j3sg4vdzir89qy6y566wyfpqaz3mn53fiqg7ia4r7wjwhzbzrw";
   };
 
   outputs = [ "out" "dev" "doc" "lib" ];


### PR DESCRIPTION
###### Motivation for this change

Sync with latest upstream.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (see note below)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

No package currently depends on wolfssl, so for testing I recompiled curl against wolfssl using the following shell.nix:

```nix
with import <nixpkgs> {};
let
  curlwolfssl = (curl.override {
    openssl = wolfssl;
  }).overrideDerivation (oldAttrs: {
    configureFlags = oldAttrs.configureFlags ++ [
      "--with-cyassl=${wolfssl}"
    ];
  });
in
{
  my-env = stdenv.mkDerivation {
    name = "my-env";
    buildInputs = [
      curlwolfssl
    ];
  };
}
```

I tested the resulting curl binary and compared its output against my local curl binary provided by Fedora:

```
curl -2 https://nixos.org
curl https://nixos.org > 1.txt
/usr/bin/curl https://nixos.org > 2.txt
diff 1.txt 2.txt
```

The first line gives an error message "curl: (35) CyaSSL does not support SSLv2" confirming that CyaSSL - which is the old name for wolfssl still referred to by curl - is indeed used. Diff of output of local curl and this new curl shows identical outputs as expected.