### PR TITLE
Revert "sqlitebrowser: 3.8.0 -> 3.9.1"

### DIFF
--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, qt4, sqlite, cmake }:
 
 stdenv.mkDerivation rec {
-  version = "3.9.1";
+  version = "3.8.0";
   name = "sqlitebrowser-${version}";
 
   src = fetchFromGitHub {
     repo   = "sqlitebrowser";
     owner  = "sqlitebrowser";
     rev    = "v${version}";
-    sha256 = "1s7f2d7wx2i68x60z7wdws3il6m83k5n5w5wyjvr0mz0mih0s150";
+    sha256 = "009yaamf6f654dl796f1gmj3rb34d55w87snsfgk33gpy6x19ccp";
   };
 
   buildInputs = [ qt4 sqlite cmake ];


### PR DESCRIPTION
This reverts commit f9d7d29fa939eeba39d5aa497b9703e60a016eab.

###### Motivation for this change

Build for this package failed after the update: http://hydra.nixos.org/build/48993006/nixlog/1

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Cannot build, as I'm not at my workstation and the notebook I'm using would take years to build this.
