### PR TITLE
Add trytond module dependencies

### DIFF
--- a/pkgs/development/python-modules/flake8-blind-except/default.nix
+++ b/pkgs/development/python-modules/flake8-blind-except/default.nix
@@ -1,0 +1,16 @@
+{ lib, fetchurl, buildPythonPackage }:
+
+buildPythonPackage rec {
+  name = "flake8-blind-except-${version}";
+  version = "0.1.1";
+  src = fetchurl {
+    url = "mirror://pypi/f/flake8-blind-except/${name}.tar.gz";
+    sha256 = "16g58mkr3fcn2vlfhp3rlahj93qswc7jd5qrqp748mc26dk3b8xc";
+  };
+  meta = {
+    homepage = https://github.com/elijahandrews/flake8-blind-except;
+    description = "A flake8 extension that checks for blind except: statements";
+    maintainers = with lib.maintainers; [ johbo ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/flake8-debugger/default.nix
+++ b/pkgs/development/python-modules/flake8-debugger/default.nix
@@ -1,0 +1,18 @@
+{ lib, fetchurl, buildPythonPackage, flake8, nose }:
+
+buildPythonPackage rec {
+  name = "flake8-debugger-${version}";
+  version = "1.4.0";
+  src = fetchurl {
+    url = "mirror://pypi/f/flake8-debugger/${name}.tar.gz";
+    sha256 = "0chjfa6wvnqjnx778qzahhwvjx1j0rc8ax0ipp5bn70gf47lj62r";
+  };
+  buildInputs = [ nose ];
+  propagatedBuildInputs = [ flake8 ];
+  meta = {
+    homepage = https://github.com/jbkahn/flake8-debugger;
+    description = "ipdb/pdb statement checker plugin for flake8";
+    maintainers = with lib.maintainers; [ johbo ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/python-stdnum/default.nix
+++ b/pkgs/development/python-modules/python-stdnum/default.nix
@@ -1,0 +1,18 @@
+{ lib, fetchurl, buildPythonPackage, isPy3k }:
+
+buildPythonPackage rec {
+  name = "python-stdnum-${version}";
+  version = "1.5";
+  # Failing tests and dependency issue on Py3k
+  disabled = isPy3k;
+  src = fetchurl {
+    url = "mirror://pypi/p/python-stdnum/${name}.tar.gz";
+    sha256 = "0zkkpjy4gc161dkyxjmingjw48glljlqqrl4fh2k5idf0frkvzhh";
+  };
+  meta = {
+    homepage = "http://arthurdejong.org/python-stdnum/";
+    description = "Python module to handle standardized numbers and codes";
+    maintainers = with lib.maintainers; [ johbo ];
+    license = lib.licenses.lgpl2Plus;
+  };
+}

--- a/pkgs/development/python-modules/pywebdav/default.nix
+++ b/pkgs/development/python-modules/pywebdav/default.nix
@@ -1,0 +1,17 @@
+{ lib, fetchurl, buildPythonPackage, isPy3k }:
+
+buildPythonPackage rec {
+  name = "PyWebDAV-${version}";
+  version = "0.9.8";
+  disabled = isPy3k;
+  src = fetchurl {
+    url = "mirror://pypi/p/pywebdav/${name}.tar.gz";
+    sha256 = "1v10vg79h85milnq8w7yd75qq5z6297ywkn9b2kxajldzwqxn3ji";
+  };
+  meta = {
+    homepage = http://code.google.com/p/pywebdav/;
+    description = "WebDAV library including a standalone server for python";
+    maintainers = with lib.maintainers; [ johbo ];
+    license = lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/development/python-modules/simpleeval/default.nix
+++ b/pkgs/development/python-modules/simpleeval/default.nix
@@ -1,0 +1,16 @@
+{ lib, fetchurl, buildPythonPackage }:
+
+buildPythonPackage rec {
+  name = "simpleeval-${version}";
+  version = "0.9.5";
+  src = fetchurl {
+    url = "mirror://pypi/s/simpleeval/${name}.tar.gz";
+    sha256 = "0sda13bqg9l4j17iczmfanxbzsg6fm9aw8i3crzsjfxx51rwj1i3";
+  };
+  meta = {
+    homepage = "https://github.com/danthedeckie/simpleeval";
+    description = "A simple, safe single expression evaluator library";
+    maintainers = with lib.maintainers; [ johbo ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -360,6 +360,8 @@ in {
 
   rhpl = if !isPy3k then callPackage ../development/python-modules/rhpl {} else throw "rhpl not supported for interpreter ${python.executable}";
 
+  simpleeval = callPackage ../development/python-modules/simpleeval { };
+
   sip = callPackage ../development/python-modules/sip { };
 
   tables = callPackage ../development/python-modules/tables {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -354,6 +354,8 @@ in {
     };
   };
 
+  PyWebDAV = callPackage ../development/python-modules/pywebdav { };
+
   pyxml = if !isPy3k then callPackage ../development/python-modules/pyxml{ } else throw "pyxml not supported for interpreter ${python.executable}";
 
   relatorio = callPackage ../development/python-modules/relatorio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27591,6 +27591,10 @@ EOF
 
     propagatedBuildInputs = with self; [ zope_i18nmessageid zope_schema ];
 
+    # Trouble with implicit namespace packages on Python3
+    # see https://github.com/pypa/setuptools/issues/912
+    doCheck = !isPy3k;
+
     meta = {
         maintainers = with maintainers; [ goibhniu ];
     };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11337,6 +11337,8 @@ in {
     };
   };
 
+  flake8-blind-except = callPackage ../development/python-modules/flake8-blind-except { };
+
   flake8-debugger = callPackage ../development/python-modules/flake8-debugger { };
 
   flaky = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11337,6 +11337,8 @@ in {
     };
   };
 
+  flake8-debugger = callPackage ../development/python-modules/flake8-debugger { };
+
   flaky = buildPythonPackage rec {
     name = "flaky-${version}";
     version = "3.1.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -334,6 +334,8 @@ in {
 
   python-sql = callPackage ../development/python-modules/python-sql { };
 
+  python-stdnum = callPackage ../development/python-modules/python-stdnum { };
+
   pytimeparse = buildPythonPackage rec {
     pname = "pytimeparse";
     version = "1.1.6";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22181,12 +22181,12 @@ in {
   requests_oauthlib = callPackage ../development/python-modules/requests-oauthlib.nix { };
 
   requests_toolbelt = buildPythonPackage rec {
-    version = "0.6.2";
+    version = "0.7.1";
     name = "requests-toolbelt-${version}";
 
     src = pkgs.fetchurl {
       url = "https://github.com/sigmavirus24/requests-toolbelt/archive/${version}.tar.gz";
-      sha256 = "0ds1b2qx0nx9bqj1sqgr4lmanb4hpchmylp1hml1l0p71qi5ha0r";
+      sha256 = "16grklnbgcfwqj3f39gw7fc9afi7xlp9gm7x8w6mi81dzhdxf50y";
     };
 
     propagatedBuildInputs = with self; [ requests2 ];


### PR DESCRIPTION
###### Motivation for this change

I am working on adding support for the modules of trytond. This PR contains a first chunk of dependencies needed to install them.

Details about the modules which are available in the project: http://doc.tryton.org/4.2/modules/index.html

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

