### PR TITLE
nixos/manual/xserver: propose more alternatives

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -27,17 +27,21 @@ the following lines:
 <programlisting>
 services.xserver.desktopManager.kde5.enable = true;
 services.xserver.desktopManager.xfce.enable = true;
+services.xserver.desktopManager.gnome3.enable = true;
 services.xserver.windowManager.xmonad.enable = true;
 services.xserver.windowManager.twm.enable = true;
 services.xserver.windowManager.icewm.enable = true;
+services.xserver.windowManager.i3.enable = true;
 </programlisting>
 </para>
 
 <para>NixOS’s default <emphasis>display manager</emphasis> (the
 program that provides a graphical login prompt and manages the X
-server) is SLiM.  You can select KDE’s <command>sddm</command> instead:
+server) is SLiM. You can select an alternative one by picking one
+of the following lines:
 <programlisting>
 services.xserver.displayManager.sddm.enable = true;
+services.xserver.displayManager.lightdm.enable = true;
 </programlisting>
 </para>
 


### PR DESCRIPTION
It is very nice that the section on the X server of the NixOS manual proposes various alternatives but some are critically missing. This patch adds some of them. I did not list the GDM display manager because the option description discourages its use with anything else than Gnome3.