### PR TITLE
Backport "Make more visible which fetch approach is best"

### DIFF
--- a/doc/coding-conventions.xml
+++ b/doc/coding-conventions.xml
@@ -623,7 +623,7 @@ evaluate correctly.</para>
     from bad to good:
     <itemizedlist>
       <listitem>
-        <para>Uses <literal>git://</literal> which won't be proxied.
+        <para>Bad: Uses <literal>git://</literal> which won't be proxied.
 <programlisting>
 src = fetchgit {
   url = "git://github.com/NixOS/nix.git";
@@ -634,7 +634,7 @@ src = fetchgit {
         </para>
       </listitem>
       <listitem>
-        <para>This is ok, but an archive fetch will still be faster.
+        <para>Better: This is ok, but an archive fetch will still be faster.
 <programlisting>
 src = fetchgit {
   url = "https://github.com/NixOS/nix.git";
@@ -645,7 +645,7 @@ src = fetchgit {
         </para>
       </listitem>
       <listitem>
-        <para>Fetches a snapshot archive and you get the rev you want.
+        <para>Best: Fetches a snapshot archive and you get the rev you want.
 <programlisting>
 src = fetchFromGitHub {
   owner = "NixOS";


### PR DESCRIPTION
###### Motivation for this change

Backport [this PR](https://github.com/NixOS/nixpkgs/pull/22291) that applies a change to the docs.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

