### PR TITLE
mailpile: 0.4.1 -> 0.5.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/mailpile/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailpile/default.nix
@@ -1,21 +1,26 @@
-{ stdenv, fetchgit, python2Packages, gnupg1orig, openssl }:
+{ stdenv, fetchFromGitHub, python2Packages, gnupg1orig, openssl, git }:
 
 python2Packages.buildPythonApplication rec {
   name = "mailpile-${version}";
-  version = "0.5.2";
+  version = "0.5.x-git-master-20170301";
 
-  src = fetchgit {
-    url = "https://github.com/mailpile/Mailpile";
-    rev = "refs/tags/${version}";
-    sha256 = "1d2b776x9134sv67pylfkvf1dd4vs5pvgrngpmshrsjgsib13dx5";
+  src = fetchFromGitHub {
+    owner = "mailpile";
+    repo = "Mailpile";
+    rev = "523c9719c12303b7926b59913599ce50b601bc3f";
+    sha256 = "15g8va96cdab60zr17ndm8f2jw7x7l97j4ssz19mcjm60vqni0ih";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace setup.py --replace "data_files.append((dir" "data_files.append(('lib/${python2Packages.python.libPrefix}/site-packages/' + dir"
     patchShebangs scripts
   '';
+  PBR_VERSION=version;
+
+  buildInputs = with python2Packages; [ pbr git ];
 
   propagatedBuildInputs = with python2Packages; [
+    cryptography
     pillow jinja2 spambayes python2Packages.lxml
     pgpdump gnupg1orig
   ];

--- a/pkgs/applications/networking/mailreaders/mailpile/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailpile/default.nix
@@ -2,12 +2,12 @@
 
 python2Packages.buildPythonApplication rec {
   name = "mailpile-${version}";
-  version = "0.4.1";
+  version = "0.5.2";
 
   src = fetchgit {
-    url = "git://github.com/pagekite/Mailpile";
+    url = "git://github.com/mailpile/Mailpile";
     rev = "refs/tags/${version}";
-    sha256 = "118b5zwfwmzj38p0mkj3r1s09jxg8x38y0a42b21imzpmli5vpb5";
+    sha256 = "1d2b776x9134sv67pylfkvf1dd4vs5pvgrngpmshrsjgsib13dx5";
   };
 
   patchPhase = ''

--- a/pkgs/applications/networking/mailreaders/mailpile/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailpile/default.nix
@@ -1,21 +1,22 @@
-{ stdenv, fetchgit, python2Packages, gnupg1orig, makeWrapper, openssl }:
+{ stdenv, fetchgit, python2Packages, gnupg1orig, openssl }:
 
 python2Packages.buildPythonApplication rec {
   name = "mailpile-${version}";
   version = "0.5.2";
 
   src = fetchgit {
-    url = "git://github.com/mailpile/Mailpile";
+    url = "https://github.com/mailpile/Mailpile";
     rev = "refs/tags/${version}";
     sha256 = "1d2b776x9134sv67pylfkvf1dd4vs5pvgrngpmshrsjgsib13dx5";
   };
 
   patchPhase = ''
     substituteInPlace setup.py --replace "data_files.append((dir" "data_files.append(('lib/${python2Packages.python.libPrefix}/site-packages/' + dir"
+    patchShebangs scripts
   '';
 
   propagatedBuildInputs = with python2Packages; [
-    makeWrapper pillow jinja2 spambayes python2Packages.lxml
+    pillow jinja2 spambayes python2Packages.lxml
     pgpdump gnupg1orig
   ];
 


### PR DESCRIPTION
###### Motivation for this change

New version of mailpile is out, current version is waaaay to old.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

