### PR TITLE
Hiawatha: Init at 10.5

### DIFF
--- a/pkgs/servers/http/hiawatha/default.nix
+++ b/pkgs/servers/http/hiawatha/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, cmake,
+libxslt, zlib, libxml2, openssl,
+enableSSL ? true,
+enableMonitor ? false,
+enableRproxy ? true,
+enableTomahawk ? false,
+enableXSLT ? true,
+enableToolkit ? true
+}:
+
+assert enableSSL -> openssl !=null;
+
+stdenv.mkDerivation rec {
+  name = "hiawatha-${version}";
+  version = "10.5";
+
+  src = fetchurl {
+    url = "https://github.com/hsleisink/hiawatha/archive/v${version}.tar.gz";
+    sha256 = "11nqdmmhq1glgsiza8pfh69wmpgwl51vb3xijmpcxv63a7ywp4fj";
+  };
+
+  buildInputs =  [ cmake libxslt zlib libxml2 ] ++ stdenv.lib.optional enableSSL openssl ;
+
+  cmakeFlags = [  
+    ( if enableSSL then "-DENABLE_TLS=on" else "-DENABLE_TLS=off" )
+    ( if enableMonitor then "-DENABLE_MONITOR=on" else "-DENABLE_MONITOR=off" )
+    ( if enableRproxy then "-DENABLE_RPROXY=on" else "-DENABLE_RPROXY=off" )
+    ( if enableTomahawk then "-DENABLE_TOMAHAWK=on" else "-DENABLE_TOMAHAWK=off" )
+    ( if enableXSLT then "-DENABLE_XSLT=on" else "-DENABLE_XSLT=off" )
+    ( if enableToolkit then "-DENABLE_TOOLKIT=on" else "-DENABLE_TOOLKIT=off" )
+
+  ];
+
+  meta = with stdenv.lib; {
+    description = "An advanced and secure webserver";
+    license = licenses.gpl2;
+    homepage = "https://www.hiawatha-webserver.org";
+    maintainer = [ maintainers.ndowens ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10413,6 +10413,8 @@ with pkgs;
 
   hbase = callPackage ../servers/hbase {};
 
+  hiawatha = callPackage ../servers/http/hiawatha {};
+  
   ircdHybrid = callPackage ../servers/irc/ircd-hybrid { };
 
   jboss = callPackage ../servers/http/jboss { };


### PR DESCRIPTION
###### Motivation for this change
Add Hiawatha server to repo

###### Things done

- [ x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

