### PR TITLE
pythonPackages.snakeviz: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/snakeviz/default.nix
+++ b/pkgs/development/python-modules/snakeviz/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, buildPythonPackage, tornado }:
+
+buildPythonPackage rec {
+  name = "snakeviz-${version}";
+  version = "0.4.1";
+
+  src = fetchurl {
+    url = "mirror://pypi/s/snakeviz/${name}.tar.gz";
+    sha256 = "18vsaw1wmf903fg21zkk6a9b49gj47g52jm5h52g4iygngjhpx79";
+  };
+
+  # Upstream doesn't run tests from setup.py
+  doCheck = false;
+  propagatedBuildInputs = [ tornado ];
+
+  meta = with stdenv.lib; {
+    description = "Browser based viewer for profiling data";
+    homepage = "https://jiffyclub.github.io/snakeviz";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ nixy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -32086,6 +32086,8 @@ EOF
 
   treq = callPackage ../development/python-modules/treq { };
 
+  snakeviz = callPackage ../development/python-modules/snakeviz { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

I had to package this for myself and sharing is caring.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

