### PR TITLE
hostapd-2.6: libressl patches.

### DIFF
--- a/pkgs/os-specific/linux/hostapd/default.nix
+++ b/pkgs/os-specific/linux/hostapd/default.nix
@@ -10,6 +10,21 @@ stdenv.mkDerivation rec {
     sha256 = "0z8ilypad82q3l6q6kbv6hczvhjn8k63j8051x5yqfyjq686nlh1";
   };
 
+  patches = [
+    (fetchurl {
+      url = "http://w1.fi/cgit/hostap/patch/?id=0d42179e1246f996d334c8bd18deca469fdb1add";
+      sha256 = "0w5n3ypwavq5zlyfxpcyvbaf96g59xkwbw9xwpjyzb7h5j264615";
+    })
+    (fetchurl {
+      url = "http://w1.fi/cgit/hostap/patch/?id=df426738fb212d62b132d9bb447f0128194e00ab";
+      sha256 = "0ps2prjijlcgv1i97xb5ypw840dhkc7ja1aw8zhlbrap7pbgi1mm";
+    })
+    (fetchurl {
+      url = "http://w1.fi/cgit/hostap/patch/?id=b70d508c50e8e2d2b8fb96ae44ae10f84cf0c1ae";
+      sha256 = "0pslmsbay2cy1k07w1mdcr0b8w059jkrqrr9zi1aljvkm3vbwhj1";
+    })
+  ];
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libnl openssl sqlite ];
 


### PR DESCRIPTION
###### Motivation for this change
Since updating to v2.6, `hostapd` has not been willing to build against `libressl`.

I have cherry-picked the `libressl` support commits from the upstream `hostapd` repo:
http://w1.fi/cgit/hostap/commit/?id=0d42179e1246f996d334c8bd18deca469fdb1add
http://w1.fi/cgit/hostap/commit/?id=df426738fb212d62b132d9bb447f0128194e00ab
http://w1.fi/cgit/hostap/commit/?id=b70d508c50e8e2d2b8fb96ae44ae10f84cf0c1ae

and added them to the patches list. This allows the build to complete, and the resulting build seems to work perfectly.

###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
