### PR TITLE
ndpi: init at 1.8

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -478,6 +478,7 @@
   sztupi = "Attila Sztupak <attila.sztupak@gmail.com>";
   taeer = "Taeer Bar-Yam <taeer@necsi.edu>";
   tailhook = "Paul Colomiets <paul@colomiets.name>";
+  takikawa = "Asumu Takikawa <asumu@igalia.com>";
   taktoa = "Remy Goldschmidt <taktoa@gmail.com>";
   tavyc = "Octavian Cerna <octavian.cerna@gmail.com>";
   teh = "Tom Hunger <tehunger@gmail.com>";

--- a/pkgs/development/libraries/ndpi/default.nix
+++ b/pkgs/development/libraries/ndpi/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, which, autoconf, automake, libtool, libpcap }:
+
+let version = "1.8"; in
+
+stdenv.mkDerivation rec {
+  name = "ndpi-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ntop";
+    repo = "nDPI";
+    rev = "${version}";
+    sha256 = "0kxp9dv4d1nmr2cxv6zsfy2j14wyb0q6am0qyxg0npjb08p7njf4";
+  };
+
+  configureScript = "./autogen.sh";
+
+  nativeBuildInputs = [which autoconf automake libtool];
+  buildInputs = [libpcap];
+
+  meta = with stdenv.lib; {
+    description = "A library for deep-packet inspection";
+    longDescription = ''
+      nDPI is a library for deep-packet inspection based on OpenDPI.
+    '';
+    homepage = http://www.ntop.org/products/deep-packet-inspection/ndpi/;
+    license = with licenses; lgpl3;
+    maintainers = with maintainers; [ takikawa ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8935,6 +8935,8 @@ with pkgs;
 
   nanomsg = callPackage ../development/libraries/nanomsg { };
 
+  ndpi = callPackage ../development/libraries/ndpi { };
+
   notify-sharp = callPackage ../development/libraries/notify-sharp { };
 
   ncurses5 = callPackage ../development/libraries/ncurses { abiVersion = "5"; };


### PR DESCRIPTION
###### Motivation for this change

This adds the [nDPI](https://github.com/ntop/nDPI) library for deep-packet inspection.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

