### PR TITLE
libguestfs: 1.29.5 -> 1.36.3

### DIFF
--- a/pkgs/development/libraries/hivex/default.nix
+++ b/pkgs/development/libraries/hivex/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "hivex-${version}";
-  version = "1.3.11";
+  version = "1.3.14";
 
   src = fetchurl {
     url = "http://libguestfs.org/download/hivex/${name}.tar.gz";
-    sha256 = "0y3nqykwy58divxkv7gmsb067dasyfz3apbp437hl57rgrndyfn6";
+    sha256 = "0aqv28prjcmc66znw0wgaxjijg5mjm44bgn1iil8a4dlbsgv4p7b";
   };
 
   patches = [ ./hivex-syms.patch ];

--- a/pkgs/development/libraries/hivex/hivex-syms.patch
+++ b/pkgs/development/libraries/hivex/hivex-syms.patch
@@ -1,6 +1,6 @@
-diff -rupN hivex-1.3.11/lib/Makefile.am hivex-1.3.11-new/lib/Makefile.am
---- hivex-1.3.11/lib/Makefile.am	2013-09-10 13:04:12.000000000 +0200
-+++ hivex-1.3.11-new/lib/Makefile.am	2014-11-06 01:31:05.956106861 +0100
+diff -rupN hivex-1.3.14/lib/Makefile.am hivex-1.3.14-new/lib/Makefile.am
+--- hivex-1.3.14/lib/Makefile.am	2013-09-10 13:04:12.000000000 +0200
++++ hivex-1.3.14-new/lib/Makefile.am	2014-11-06 01:31:05.956106861 +0100
 @@ -40,8 +40,7 @@ libhivex_la_SOURCES = \
  
  libhivex_la_LIBADD =  ../gnulib/lib/libgnu.la $(LTLIBOBJS)

--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   name = "libguestfs-${version}";
-  version = "1.34.6";
+  version = "1.36.3";
 
   appliance = fetchurl {
     url = "http://libguestfs.org/download/binaries/appliance/appliance-1.36.1.tar.xz";
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
   };
 
   src = fetchurl {
-    url = "http://libguestfs.org/download/1.34-stable/libguestfs-${version}.tar.gz";
-    sha256 = "1bdn6jsxm7krl4bpzwx47lg1xlhp5wfzizy03vspkgcppgp2q36s";
+    url = "http://libguestfs.org/download/1.36-stable/libguestfs-${version}.tar.gz";
+    sha256 = "0dhb69b7svjgnrmbyvizdz5vsgsrr95ypz0qvp3kz83jyj6sa76m";
   };
 
   buildInputs = [

--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -1,32 +1,45 @@
 { stdenv, fetchurl, pkgconfig, autoreconfHook, makeWrapper
 , ncurses, cpio, gperf, perl, cdrkit, flex, bison, qemu, pcre, augeas, libxml2
 , acl, libcap, libcap_ng, libconfig, systemd, fuse, yajl, libvirt, hivex
-, gmp, readline, file, libintlperl, GetoptLong, SysVirt, numactl, xen, libapparmor }:
+, gmp, readline, file, libintlperl, GetoptLong, SysVirt, numactl, xen, libapparmor
+, getopt, perlPackages, ocamlPackages }:
 
 stdenv.mkDerivation rec {
   name = "libguestfs-${version}";
-  version = "1.29.5";
+  version = "1.34.4";
 
   appliance = fetchurl {
-    url = "http://libguestfs.org/download/binaries/appliance/appliance-1.26.0.tar.xz";
-    sha256 = "1kzvgmy845kclvr93y6rdpss2q0p8yfqg14r0i1pi5r4zc68yvj4";
+    url = "http://libguestfs.org/download/binaries/appliance/appliance-1.34.0.tar.xz";
+    sha256 = "0d7kg6ck9hwsqrxch69fhn49sbsjc8c40fr4753c35cq49f7xp6d";
   };
 
   src = fetchurl {
-    url = "http://libguestfs.org/download/1.29-development/libguestfs-${version}.tar.gz";
-    sha256 = "1il0p3irwcyfdm83935hj4bvxsx0kdfn8dvqmg2lbzap17jvzj8h";
+    url = "http://libguestfs.org/download/1.34-stable/libguestfs-${version}.tar.gz";
+    sha256 = "1ca9i9d03pnfm7qqixvl48d7n0hn4ldmzlh2wcws45441prdxw3z";
   };
 
   buildInputs = [
     makeWrapper pkgconfig autoreconfHook ncurses cpio gperf perl
     cdrkit flex bison qemu pcre augeas libxml2 acl libcap libcap_ng libconfig
     systemd fuse yajl libvirt gmp readline file hivex libintlperl GetoptLong
-    SysVirt numactl xen libapparmor
-  ];
+    SysVirt numactl xen libapparmor getopt perlPackages.ModuleBuild
+  ] ++ (with ocamlPackages; [ ocaml findlib ocamlbuild ocaml_libvirt ocaml_gettext ounit ]);
 
+  prePatch = ''
+    # build-time scripts
+    substituteInPlace run.in        --replace '#!/bin/bash' '#!/bin/sh'
+    substituteInPlace ocaml-link.sh --replace '#!/bin/bash' '#!/bin/sh'
+
+    # $(OCAMLLIB) is read-only "${ocamlPackages.ocaml}/lib/ocaml"
+    substituteInPlace ocaml/Makefile.am            --replace '$(DESTDIR)$(OCAMLLIB)' '$(out)/lib/ocaml'
+    substituteInPlace ocaml/Makefile.in            --replace '$(DESTDIR)$(OCAMLLIB)' '$(out)/lib/ocaml'
+    substituteInPlace v2v/test-harness/Makefile.am --replace '$(DESTDIR)$(OCAMLLIB)' '$(out)/lib/ocaml'
+    substituteInPlace v2v/test-harness/Makefile.in --replace '$(DESTDIR)$(OCAMLLIB)' '$(out)/lib/ocaml'
+  '';
   configureFlags = "--disable-appliance --disable-daemon";
   patches = [ ./libguestfs-syms.patch ];
   NIX_CFLAGS_COMPILE="-I${libxml2.dev}/include/libxml2/";
+  installFlags = "REALLY_INSTALL=yes";
 
   postInstall = ''
     for bin in $out/bin/*; do

--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -6,16 +6,16 @@
 
 stdenv.mkDerivation rec {
   name = "libguestfs-${version}";
-  version = "1.34.4";
+  version = "1.34.6";
 
   appliance = fetchurl {
-    url = "http://libguestfs.org/download/binaries/appliance/appliance-1.34.0.tar.xz";
-    sha256 = "0d7kg6ck9hwsqrxch69fhn49sbsjc8c40fr4753c35cq49f7xp6d";
+    url = "http://libguestfs.org/download/binaries/appliance/appliance-1.36.1.tar.xz";
+    sha256 = "1klvr13gpg615hgjvviwpxlj839lbwwsrq7x100qg5zmmjfhl125";
   };
 
   src = fetchurl {
     url = "http://libguestfs.org/download/1.34-stable/libguestfs-${version}.tar.gz";
-    sha256 = "1ca9i9d03pnfm7qqixvl48d7n0hn4ldmzlh2wcws45441prdxw3z";
+    sha256 = "1bdn6jsxm7krl4bpzwx47lg1xlhp5wfzizy03vspkgcppgp2q36s";
   };
 
   buildInputs = [

--- a/pkgs/development/libraries/libguestfs/libguestfs-syms.patch
+++ b/pkgs/development/libraries/libguestfs/libguestfs-syms.patch
@@ -1,7 +1,7 @@
-diff -rupN libguestfs-1.29.5/src/Makefile.am libguestfs-1.29.5-new/src/Makefile.am
---- libguestfs-1.29.5/src/Makefile.am	2014-11-05 16:43:08.000000000 +0100
-+++ libguestfs-1.29.5-new/src/Makefile.am	2014-11-05 20:07:45.760730596 +0100
-@@ -167,8 +167,7 @@ libguestfs_la_LIBADD = \
+diff -rupN libguestfs-1.34.4/src/Makefile.am libguestfs-1.34.4-new/src/Makefile.am
+--- libguestfs-1.34.4/src/Makefile.am	2017-02-22 07:49:07.322357165 +0000
++++ libguestfs-1.34.4-new/src/Makefile.am	2017-02-22 07:50:03.437454422 +0000
+@@ -172,8 +172,7 @@ libguestfs_la_LIBADD = \
  # Force libtool to name the library 'libguestfs.so.0.$(MAX_PROC_NR).0'.
  # Include the version script to limit which symbols are exported.
  libguestfs_la_LDFLAGS = \

--- a/pkgs/development/libraries/libguestfs/libguestfs-syms.patch
+++ b/pkgs/development/libraries/libguestfs/libguestfs-syms.patch
@@ -1,7 +1,7 @@
-diff -rupN libguestfs-1.34.4/src/Makefile.am libguestfs-1.34.4-new/src/Makefile.am
---- libguestfs-1.34.4/src/Makefile.am	2017-02-22 07:49:07.322357165 +0000
-+++ libguestfs-1.34.4-new/src/Makefile.am	2017-02-22 07:50:03.437454422 +0000
-@@ -172,8 +172,7 @@ libguestfs_la_LIBADD = \
+diff --git a/lib/Makefile.am b/lib/Makefile.am
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -168,8 +168,7 @@ libguestfs_la_LIBADD = \
  # Force libtool to name the library 'libguestfs.so.0.$(MAX_PROC_NR).0'.
  # Include the version script to limit which symbols are exported.
  libguestfs_la_LDFLAGS = \

--- a/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
@@ -1,19 +1,27 @@
-{ stdenv, fetchurl, libvirt, ocaml, findlib }:
+{ stdenv, fetchgit, libvirt, autoconf, ocaml, findlib }:
 
 stdenv.mkDerivation rec {
   name = "ocaml-libvirt-${version}";
-  version = "0.6.1.4";
+  version = "0.6.1.5"; # FIXME: libguestfs depends on not yet released 0.6.1.5, so the latest post-0.6.1.4 master from git is used
 
-  src = fetchurl {
-    url = "http://libvirt.org/sources/ocaml/ocaml-libvirt-${version}.tar.gz";
-    sha256 = "06q2y36ckb34n179bwczxkl82y3wrba65xb2acg8i04jpiyxadjd";
+  src = fetchgit {
+    url = "git://git.annexia.org/git/ocaml-libvirt.git";
+    rev = "8853f5a49587f00a7d2a5c8c7e52480a16bbdb02";
+    sha256 = "1lnsvyb6dll58blacc629nz1lzc20p7ayqn9pag1rrx5i54q9v24";
   };
 
   propagatedBuildInputs = [ libvirt ];
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ autoconf findlib ];
+
+  buildInputs = [ ocaml ];
 
   createFindlibDestdir = true;
+
+  preConfigure = ''
+    substituteInPlace configure.ac --replace 0.6.1.4 0.6.1.5
+    autoconf
+  '';
 
   buildPhase = if stdenv.cc.isClang then "make all opt CPPFLAGS=-Wno-error" else "make all opt";
 

--- a/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
@@ -2,12 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "ocaml-libvirt-${version}";
-  version = "0.6.1.5"; # FIXME: libguestfs depends on not yet released 0.6.1.5, so the latest post-0.6.1.4 master from git is used
+  rev = "3169af3";
+  version = "0.6.1.4-rev.${rev}"; # libguestfs-1.34 needs ocaml-libvirt newer than the latest release 0.6.1.4
 
   src = fetchgit {
     url = "git://git.annexia.org/git/ocaml-libvirt.git";
-    rev = "8853f5a49587f00a7d2a5c8c7e52480a16bbdb02";
-    sha256 = "1lnsvyb6dll58blacc629nz1lzc20p7ayqn9pag1rrx5i54q9v24";
+    rev = rev;
+    sha256 = "0z8p6q6k42rdrvy248siq922m1yszny1hfklf6djynvk2viyqdbg";
   };
 
   propagatedBuildInputs = [ libvirt ];
@@ -19,7 +20,6 @@ stdenv.mkDerivation rec {
   createFindlibDestdir = true;
 
   preConfigure = ''
-    substituteInPlace configure.ac --replace 0.6.1.4 0.6.1.5
     autoconf
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Newer version, stable branch, more utilities.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

