### PR TITLE
logisim: use better jar wrapper, closes #23068

### DIFF
--- a/pkgs/applications/science/logic/logisim/default.nix
+++ b/pkgs/applications/science/logic/logisim/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre }:
+{ stdenv, fetchurl, jre, makeWrapper }:
 
 let version = "2.7.1"; in
 
@@ -11,17 +11,12 @@ stdenv.mkDerivation {
   };
   
   phases = [ "installPhase" ];
-  
+
+  nativeBuildInputs = [makeWrapper];
+
   installPhase = ''
     mkdir -pv $out/bin
-    cp -v $src $out/logisim.jar
-    
-    cat > $out/bin/logisim << EOF
-    #!${stdenv.shell}
-    ${jre}/bin/java -jar $out/logisim.jar
-    EOF
-    
-    chmod +x $out/bin/logisim
+    makeWrapper ${jre}/bin/java $out/bin/logisim --add-flags "-jar $src"
   '';
   
   meta = {


### PR DESCRIPTION
###### Motivation for this change

See #23068.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

