### PR TITLE
Python weasyprint and dependencies

### DIFF
--- a/pkgs/development/python-modules/pyphen/default.nix
+++ b/pkgs/development/python-modules/pyphen/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, fetchurl
+, buildPythonPackage
+}:
+
+let
+  pname = "Pyphen";
+  version = "0.9.4";
+in buildPythonPackage rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+    sha256 = "abfa9a0ab055341f6e250c1a6bef395c3a06f0e4cba216eeef37f617b32c0bd7";
+  };
+
+  # No tests included
+  doCheck = false;
+
+  meta = {
+    description = "Pure Python module to hyphenate text";
+    homepage = https://github.com/Kozea/Pyphen;
+    license = with lib.licenses; [ gpl2 lgpl21 mpl11 ];
+  };
+}

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, fetchurl
+, buildPythonPackage
+, cairosvg
+, cffi
+, cssselect
+, glib
+, html5lib
+, lxml
+, pango
+, pygobject2
+, Pyphen
+, tinycss
+, pytest
+, fontconfig
+}:
+
+let
+  pname = "WeasyPrint";
+  version = "0.34";
+in buildPythonPackage rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+    sha256 = "5afb18e90bb6da4c11ffc31730f30c7f6f40bc828d58376756e1dc8757e38e06";
+  };
+# Need to fix a couple more libraries!
+  postPatch = ''
+    substituteInPlace weasyprint/text.py --replace "libgobject-2.0.so" "${glib.out}/lib/libgobject-2.0.so"
+    substituteInPlace weasyprint/text.py --replace "libpango-1.0.so" "${pango.out}/lib/libpango-1.0.so"
+    substituteInPlace weasyprint/text.py --replace "libpangocairo-1.0.so" "${pango.out}/lib/libpangocairo-1.0.so"
+    substituteInPlace weasyprint/fonts.py --replace "libfontconfig.so.1" "${fontconfig.lib}/lib/libfontconfig.so.1"
+    substituteInPlace weasyprint/fonts.py --replace "libpangoft2-1.0.so" "${pango.out}/lib/libpangoft2-1.0.so"
+
+  '';
+
+  checkPhase = ''
+    py.test
+  '';
+
+  doCheck = false;
+
+
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ cairosvg Pyphen cffi cssselect lxml html5lib tinycss pygobject2 ];
+
+
+  meta = {
+    homepage = http://weasyprint.org/;
+    description = "Converts web documents to PDF";
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26571,6 +26571,8 @@ EOF
     };
   };
 
+  WeasyPrint = callPackage ../development/python-modules/weasyprint {};
+
   webassets = buildPythonPackage rec {
     name = "webassets-${version}";
     version = "0.12.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3415,15 +3415,18 @@ in {
 
 
   cairosvg = buildPythonPackage rec {
-    version = "1.0.18";
+    version = "2.0.1";
     name = "cairosvg-${version}";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/C/CairoSVG/CairoSVG-${version}.tar.gz";
-      sha256 = "01lpm38qp7xlnv8jv7qg48j44p5088dwfsrcllgs5fz355lrfds1";
+      sha256 = "99dc87de582f644f1f99f84d8f013ba79cc3c76e46cb74fd2b36ec7d6bc5c59d";
     };
 
-    propagatedBuildInputs = with self; [ cairocffi ];
+    # No tests.
+    doCheck = false;
+
+    propagatedBuildInputs = with self; [ cairocffi cssselect lxml pillow tinycss ];
 
     meta = {
       homepage = https://cairosvg.org;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18838,6 +18838,8 @@ in {
     };
   };
 
+  Pyphen = callPackage ../development/python-modules/pyphen {};
+
   pysftp = buildPythonPackage rec {
     name = "pysftp-${version}";
     version = "0.2.9";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5382,11 +5382,11 @@ in {
 
   tinycss = buildPythonPackage rec {
     name = "tinycss-${version}";
-    version = "0.3";
+    version = "0.4";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/t/tinycss/${name}.tar.gz";
-      sha256 = "1pichqra4wk86142hqgvy9s5x6c5k5zhy8l9qxr0620pqk8spbd4";
+      sha256 = "12306fb50e5e9e7eaeef84b802ed877488ba80e35c672867f548c0924a76716e";
     };
 
     buildInputs = with self; [ pytest ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

