### PR TITLE
linode-cli: init at 1.4.7

### DIFF
--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, buildPerlPackage, perlPackages, makeWrapper}:
+
+buildPerlPackage rec {
+  name = "linode-cli-${version}";
+  version = "1.4.7";
+
+  src = fetchFromGitHub {
+    owner = "linode";
+    repo = "cli";
+    rev = "v${version}";
+    sha256 = "1wiz067wgxi4z4rz4n9p7dlvx5z4hkl2nxpfvhikl6dri4m2nkkp";
+  };
+
+  buildInputs = [ makeWrapper ];
+  propagatedBuildInputs = with perlPackages; [
+    JSON
+    LWPUserAgent
+    MozillaCA
+    TryTiny
+    WebServiceLinode
+  ];
+
+  # Wrap perl scripts so they can find libraries
+  postInstall = ''
+    for n in "$out/bin"/*; do
+      wrapProgram "$n" --prefix PERL5LIB : "$PERL5LIB"
+    done
+  '';
+
+  # Has no tests
+  doCheck = false;
+
+  # Has no "doc" or "devdoc" outputs
+  outputs = [ "out" ];
+
+  meta = with stdenv.lib; {
+    description = "Command-line interface to the Linode platform";
+    homepage = "https://github.com/linode/cli";
+    license = with licenses; [ artistic2 gpl2 ];
+    maintainers = with maintainers; [ nixy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18652,4 +18652,5 @@ with pkgs;
 
   xib2nib = callPackage ../development/tools/xib2nib {};
 
+  linode-cli = callPackage ../tools/virtualization/linode-cli { };
 }

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15513,4 +15513,19 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  WebServiceLinode = buildPerlModule rec {
+    name = "WebService-Linode-0.28";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MI/MIKEGRB/${name}.tar.gz";
+      sha256 = "66a315016999c0d2043caae86e664dad10c6613708f33a2f56aae8030326c509";
+    };
+    buildInputs = [ ModuleBuildTiny ];
+    propagatedBuildInputs = [ JSON LWP LWPProtocolhttps ];
+    meta = {
+      homepage = https://github.com/mikegrb/WebService-Linode;
+      description = "Perl Interface to the Linode.com API";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
 }; in self


### PR DESCRIPTION
###### Motivation for this change

Want to make the Linode-CLI available through Nix, because Nix is the best :) 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

