### PR TITLE
graylog: update + module plugin support

### DIFF
--- a/nixos/modules/services/logging/graylog.nix
+++ b/nixos/modules/services/logging/graylog.nix
@@ -17,9 +17,16 @@ let
     elasticsearch_discovery_zen_ping_unicast_hosts = ${cfg.elasticsearchDiscoveryZenPingUnicastHosts}
     message_journal_dir = ${cfg.messageJournalDir}
     mongodb_uri = ${cfg.mongodbUri}
+    plugin_dir = /var/lib/graylog/plugins
 
     ${cfg.extraConfig}
   '';
+
+  glPlugins = pkgs.buildEnv {
+    name = "graylog-plugins";
+    paths = cfg.plugins;
+  };
+
 in
 
 {
@@ -121,6 +128,12 @@ in
         description = "Any other configuration options you might want to add";
       };
 
+      plugins = mkOption {
+        description = "Extra graylog plugins";
+        default = [ ];
+        type = types.listOf types.package;
+      };
+
     };
   };
 
@@ -146,6 +159,16 @@ in
       path = [ pkgs.openjdk8 pkgs.which pkgs.procps ];
       preStart = ''
         mkdir -p /var/lib/graylog -m 755
+
+        rm -rf /var/lib/graylog/plugins || true
+        mkdir -p /var/lib/graylog/plugins -m 755
+
+        for declarativeplugin in `ls ${glPlugins}/bin/`; do
+          ln -sf ${glPlugins}/bin/$declarativeplugin /var/lib/graylog/plugins/$declarativeplugin
+        done
+        for includedplugin in `ls ${cfg.package}/plugin/`; do
+          ln -s ${cfg.package}/plugin/$includedplugin /var/lib/graylog/plugins/$includedplugin || true
+        done
         chown -R ${cfg.user} /var/lib/graylog
 
         mkdir -p ${cfg.messageJournalDir} -m 755

--- a/pkgs/tools/misc/graylog/default.nix
+++ b/pkgs/tools/misc/graylog/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "2.1.2";
+  version = "2.2.1";
   name = "graylog-${version}";
 
   src = fetchurl {
     url = "https://packages.graylog2.org/releases/graylog/graylog-${version}.tgz";
-    sha256 = "0jwm1l3s00rh22gqvkg730h8xm4h1y1dr60m4s5xbz8qzdkk8rax";
+    sha256 = "19kwg6yn2bx9nk813d7z1mv5j375iy2qvpcvwm8hp242g13j5cy7";
   };
 
   dontBuild = true;

--- a/pkgs/tools/misc/graylog/plugins.nix
+++ b/pkgs/tools/misc/graylog/plugins.nix
@@ -1,0 +1,129 @@
+{ pkgs,  stdenv, fetchurl, fetchFromGitHub, unzip, graylog }:
+
+with pkgs.lib;
+
+let
+  glPlugin = a@{
+    pluginName,
+    version,
+    installPhase ? ''
+      mkdir -p $out/bin
+      cp $src $out/bin/${pluginName}-${version}.jar
+    '',
+    ...
+  }:
+    stdenv.mkDerivation (a // {
+      inherit installPhase;
+      unpackPhase = "true";
+      buildInputs = [ unzip ];
+      meta = a.meta // {
+        platforms = graylog.meta.platforms;
+        maintainers = (a.meta.maintainers or []) ++ [ maintainers.fadenb ];
+      };
+    });
+in {
+  auth_sso = glPlugin rec {
+    name = "graylog-auth-sso-${version}";
+    pluginName = "graylog-plugin-auth-sso";
+    version = "1.0.6";
+    src = fetchurl {
+      url = "https://github.com/Graylog2/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "0wvdf2rnjrhdw1vp7bc7008s45rggzq57lh8k6s3q35rppligaqd";
+    };
+    meta = {
+      homepage = "https://github.com/Graylog2/graylog-plugin-auth-sso";
+      description = "SSO support for Graylog through trusted HTTP headers set by load balancers or authentication proxies";
+    };
+  };
+  ipanonymizer = glPlugin rec {
+    name = "graylog-ipanonymizer-${version}";
+    pluginName = "graylog-plugin-ipanonymizer";
+    version = "1.1.2";
+    src = fetchurl {
+      url = "https://github.com/Graylog2/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "0hd66751hp97ddkn29s1cmjmc2h1nrp431bq7d2wq16iyxxlygri";
+    };
+    meta = {
+      homepage = "https://github.com/Graylog2/graylog-plugin-ipanonymizer";
+      description = "A graylog-server plugin that replaces the last octet of IP addresses in messages with xxx";
+    };
+  };
+  jabber = glPlugin rec {
+    name = "graylog-jabber-${version}";
+    pluginName = "graylog-plugin-jabber";
+    version = "1.2.1";
+    src = fetchurl {
+      url = "https://github.com/Graylog2/${pluginName}/releases/download/v${version}/${pluginName}-${version}.jar";
+      sha256 = "1r12hpjp2ggmhsapgrk829va94aw44qi2kqqkgf1fj9ih4k0c837";
+    };
+    meta = {
+      homepage = "https://github.com/Graylog2/graylog-plugin-jabber";
+      description = "Jabber Alarmcallback Plugin for Graylog";
+    };
+  };
+  netflow = glPlugin rec {
+    name = "graylog-netflow-${version}";
+    pluginName = "graylog-plugin-netflow";
+    version = "0.1.1";
+    src = fetchurl {
+      url = "https://github.com/Graylog2/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "1pdv12f9dca1rxf62ds51n79cjhkkyj0gjny8kj1cq64vlayc9x9";
+    };
+    meta = {
+      homepage = "https://github.com/Graylog2/graylog-plugin-netflow";
+      description = "Graylog NetFlow plugin";
+    };
+  };
+  redis = glPlugin rec {
+    name = "graylog-redis-${version}";
+    pluginName = "graylog-plugin-redis";
+    version = "0.1.0";
+    src = fetchurl {
+      url = "https://github.com/Graylog2/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "0hwz83m9gwx0fdapc63v3lr1q6acbphssqwp4qqzz78wg2w79xgi";
+    };
+    meta = {
+      homepage = "https://github.com/Graylog2/graylog-plugin-redis";
+      description = "Redis plugin for Graylog";
+    };
+  };
+  spaceweather = glPlugin rec {
+    name = "graylog-spaceweather-${version}";
+    pluginName = "graylog-plugin-spaceweather";
+    version = "1.0";
+    src = fetchurl {
+      url = "https://github.com/Graylog2/${pluginName}/releases/download/${version}/spaceweather-input.jar";
+      sha256 = "1mwqy3fhyy4zdwyrzvbr565xwf96xs9d3l70l0khmrm848xf8wz4";
+    };
+    meta = {
+      homepage = "https://github.com/Graylog2/graylog-plugin-spaceweather";
+      description = "Correlate proton density to the response time of your app and the ion temperature to your exception rate.";
+    };
+  };
+  threatintel = glPlugin rec {
+    name = "graylog-threatintel-${version}";
+    pluginName = "graylog-plugin-threatintel";
+    version = "0.9.2";
+    src = fetchurl {
+      url = "https://github.com/Graylog2/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "0d2cjcgjwfqp6b756n68zbslm1pq1z9dhn6iiskmv6jdpkffjw3l";
+    };
+    meta = {
+      homepage = "https://github.com/Graylog2/graylog-plugin-threatintel";
+      description = "Graylog Processing Pipeline functions to enrich log messages with IoC information from threat intelligence databases";
+    };
+  };
+  twitter = glPlugin rec {
+    name = "graylog-twitter-${version}";
+    pluginName = "graylog-plugin-twitter";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://github.com/Graylog2/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "1pi34swy9nzq35a823zzvqrjhb6wsg302z31vk2y656sw6ljjxyh";
+    };
+    meta = {
+      homepage = "https://github.com/Graylog2/graylog-plugin-twitter";
+      description = "Graylog input plugin that reads Twitter messages based on keywords in realtime";
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2008,6 +2008,9 @@ with pkgs;
   grails = callPackage ../development/web/grails { jdk = null; };
 
   graylog = callPackage ../tools/misc/graylog { };
+  graylogPlugins = recurseIntoAttrs (
+    callPackage ../tools/misc/graylog/plugins.nix { }
+  );
 
   gprof2dot = callPackage ../development/tools/profiling/gprof2dot {
     # Using pypy provides significant performance improvements (~2x)


### PR DESCRIPTION
###### Motivation for this change
This PR updates Graylog package to the current version and adds support for Graylog plugins in the module.

It is possible to add plugins in addition to those bundled with Graylog. Explicitely declared plugins take precedence over the bundled plugins to allow us to use e.g. a fixed plugin version before the next Graylog release.

###### Things done

- [x] Tested plugin support over several weeks in lab environment
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

