### PR TITLE
super-user-spark: update, switch to haskellPackages LTS 8.x GHC 8.0.2

### DIFF
--- a/pkgs/applications/misc/super_user_spark/default.nix
+++ b/pkgs/applications/misc/super_user_spark/default.nix
@@ -1,27 +1,28 @@
-{ mkDerivation, aeson, aeson-pretty, base, binary, bytestring
-, directory, fetchgit, filepath, HTF, HUnit, mtl
-, optparse-applicative, parsec, process, shelly, stdenv, text
-, transformers, unix, zlib
+{ mkDerivation, fetchgit, aeson, aeson-pretty, base, bytestring, directory
+, filepath, hspec, hspec-core, HUnit, mtl, optparse-applicative
+, parsec, process, pureMD5, QuickCheck, shelly, stdenv, text
+, transformers, unix
 }:
 mkDerivation {
   pname = "super-user-spark";
-  version = "0.2.0.3";
+  version = "0.3.2.0-dev";
   src = fetchgit {
     url = "https://github.com/NorfairKing/super-user-spark";
-    sha256 = "1w9c2b1fxqxp2q5jxsvnrfqvyvpk8q70qqsgzshmghx0yylx9cns";
-    rev = "a7d132f7631649c3a093ede286e66f78e9793fba";
+    sha256 = "0akyc51bghzkk8j75n0i8v8rrsklidwvljhx3aibxfbkqp33372g";
+    rev = "ab8635682d67842b9e6d909cf3c618014e4157f2";
   };
-  isLibrary = false;
+  isLibrary = true;
   isExecutable = true;
-  executableHaskellDepends = [
-    aeson aeson-pretty base binary bytestring directory filepath HTF
-    mtl optparse-applicative parsec process shelly text transformers
-    unix zlib
+  libraryHaskellDepends = [
+    aeson aeson-pretty base bytestring directory filepath mtl
+    optparse-applicative parsec process pureMD5 shelly text
+    transformers unix
   ];
+  executableHaskellDepends = [ base ];
   testHaskellDepends = [
-    aeson aeson-pretty base binary bytestring directory filepath HTF
-    HUnit mtl optparse-applicative parsec process shelly text
-    transformers unix zlib
+    aeson aeson-pretty base bytestring directory filepath hspec
+    hspec-core HUnit mtl optparse-applicative parsec process pureMD5
+    QuickCheck shelly text transformers unix
   ];
   jailbreak = true;
   description = "Configure your dotfile deployment with a DSL";


### PR DESCRIPTION
###### Motivation for this change

This updates super-user-spark to support the recent change in nixpkgs
of the haskellPackages to LTS 8.x using GHC 8.0.2 [[mailinglist]].

It also includes some changes to the super-user-spark package,
upgraded to commit ab86356 [[github]].

This could go to the [17.03] milestone.

The updated derivation is obtained by running [scripts/cabal2nix] from the upstream repository and tweaking the result.

[mailinglist]: https://www.mail-archive.com/nix-dev@lists.science.uu.nl/msg31818.html
[github]: https://github.com/NorfairKing/super-user-spark/tree/ab8635682d67842b9e6d909cf3c618014e4157f2
[scripts/cabal2nix]: https://github.com/NorfairKing/super-user-spark/blob/master/scripts/cabal2nix
[17.03]: https://github.com/NixOS/nixpkgs/milestone/10


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

