### PR TITLE
cmus: enable opus support (re #23051)

### DIFF
--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -31,9 +31,8 @@
 , wavpackSupport ? true, wavpack ? null
 , opusSupport ? true, opusfile ? null
 
-# can't make these work, something is broken
-, aacSupport ? true, faad2 ? null
-, mp4Support ? true, mp4v2 ? null
+, aacSupport ? false, faad2 ? null # already handled by ffmpeg
+, mp4Support ? false, mp4v2 ? null # ffmpeg does support mp4 better
 
 # not in nixpkgs
 #, vtxSupport ? true, libayemu ? null

--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -32,8 +32,8 @@
 , opusSupport ? true, opusfile ? null
 
 # can't make these work, something is broken
-#, mp4Support ? true, mp4v2 ? null
 , aacSupport ? true, faad2 ? null
+, mp4Support ? true, mp4v2 ? null
 
 # not in nixpkgs
 #, vtxSupport ? true, libayemu ? null
@@ -84,7 +84,7 @@ let
     (mkFlag wavpackSupport "CONFIG_WAVPACK=y" wavpack)
     (mkFlag opusSupport   "CONFIG_OPUS=y"    opusfile)
 
-    #(mkFlag mp4Support    "CONFIG_MP4=y"     mp4v2)
+    (mkFlag mp4Support    "CONFIG_MP4=y"     mp4v2)
     (mkFlag aacSupport    "CONFIG_AAC=y"     faad2)
 
     #(mkFlag vtxSupport    "CONFIG_VTX=y"     libayemu)

--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -29,11 +29,11 @@
 , tremorSupport ? false, tremor ? null
 , vorbisSupport ? true, libvorbis ? null
 , wavpackSupport ? true, wavpack ? null
+, opusSupport ? true, opusfile ? null
 
 # can't make these work, something is broken
 #, aacSupport ? true, faac ? null
 #, mp4Support ? true, mp4v2 ? null
-#, opusSupport ? true, opusfile ? null
 
 # not in nixpkgs
 #, vtxSupport ? true, libayemu ? null
@@ -82,8 +82,8 @@ let
     (mkFlag tremorSupport  "CONFIG_TREMOR=y"  tremor)
     (mkFlag vorbisSupport  "CONFIG_VORBIS=y"  libvorbis)
     (mkFlag wavpackSupport "CONFIG_WAVPACK=y" wavpack)
+    (mkFlag opusSupport   "CONFIG_OPUS=y"    opusfile)
 
-    #(mkFlag opusSupport   "CONFIG_OPUS=y"    opusfile)
     #(mkFlag mp4Support    "CONFIG_MP4=y"     mp4v2)
     #(mkFlag aacSupport    "CONFIG_AAC=y"     faac)
 

--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -32,8 +32,8 @@
 , opusSupport ? true, opusfile ? null
 
 # can't make these work, something is broken
-#, aacSupport ? true, faac ? null
 #, mp4Support ? true, mp4v2 ? null
+, aacSupport ? true, faad2 ? null
 
 # not in nixpkgs
 #, vtxSupport ? true, libayemu ? null
@@ -85,7 +85,7 @@ let
     (mkFlag opusSupport   "CONFIG_OPUS=y"    opusfile)
 
     #(mkFlag mp4Support    "CONFIG_MP4=y"     mp4v2)
-    #(mkFlag aacSupport    "CONFIG_AAC=y"     faac)
+    (mkFlag aacSupport    "CONFIG_AAC=y"     faad2)
 
     #(mkFlag vtxSupport    "CONFIG_VTX=y"     libayemu)
   ];

--- a/pkgs/development/libraries/mp4v2/default.nix
+++ b/pkgs/development/libraries/mp4v2/default.nix
@@ -1,18 +1,17 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "mp4v2-1.9.1p4";
+  name = "mp4v2-2.0.0";
 
   src = fetchurl {
-    url = "http://mp4v2.googlecode.com/files/${name}.tar.bz2";
-    sha256 = "1d73qbi0faqad3bpmjfr4kk0mfmqpl1f43ysrx4gq9i3mfp1qf2w";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mp4v2/${name}.tar.bz2";
+    sha256 = "0f438bimimsvxjbdp4vsr8hjw2nwggmhaxgcw07g2z361fkbj683";
   };
 
   # From Handbrake
   # mp4v2 doesn't seem to be actively maintained any more :-/
   patches = [
-    ./A00-nero-vobsub.patch ./A01-divide-zero.patch ./A02-meaningful-4gb-warning.patch
-    ./P00-mingw-dllimport.patch
+    ./A02-meaningful-4gb-warning.patch
   ];
   # `faac' expects `mp4.h'.
   postInstall = "ln -s mp4v2/mp4v2.h $out/include/mp4.h";


### PR DESCRIPTION
###### Motivation for this change

Opus support was enabled since it didn't work in the past; I found it to be working when I gave it a try now.

###### Things done

- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @oxij