### PR TITLE
lynx: 2.8.8rel.2 -> 2.8.9dev.11

### DIFF
--- a/pkgs/applications/networking/browsers/lynx/default.nix
+++ b/pkgs/applications/networking/browsers/lynx/default.nix
@@ -6,26 +6,25 @@ assert sslSupport -> openssl != null;
 
 stdenv.mkDerivation rec {
   name = "lynx-${version}";
-  version = "2.8.8rel.2";
-  
+  version = "2.8.9dev.11";
+
   src = fetchurl {
     url = "http://invisible-mirror.net/archives/lynx/tarballs/lynx${version}.tar.bz2";
-    sha256 = "1rxysl08acqll5b87368f04kckl8sggy1qhnq59gsxyny1ffg039";
+    sha256 = "1cqm1i7d209brkrpzaqqf2x951ra3l67dw8x9yg10vz7rpr9441a";
   };
-  
+
   configureFlags = []
     ++ stdenv.lib.optionals sslSupport [ "--with-ssl=${openssl.dev}" ];
-  
+
   buildInputs = [ ncurses gzip ];
-  nativeBuildInputs = [ ncurses ];
 
   crossAttrs = {
     configureFlags = configureFlags ++ [ "--enable-widec" ];
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://lynx.isc.org/;
     description = "A text-mode web browser";
-    platforms = stdenv.lib.platforms.unix;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
(cherry picked from commit a3bf71b76f28cb015a60805091b0367e16ab2408)

###### Motivation for this change

@grahamc, are you ok with simply updating the version (this is the version Fedora is using) despite being pre-release?

#23072

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
