### PR TITLE
f2fs module: add crc32 dependency to initrd kernel modules, closes #2…

### DIFF
--- a/nixos/modules/tasks/filesystems/f2fs.nix
+++ b/nixos/modules/tasks/filesystems/f2fs.nix
@@ -10,7 +10,7 @@ in
 
     system.fsPackages = [ pkgs.f2fs-tools ];
 
-    boot.initrd.availableKernelModules = mkIf inInitrd [ "f2fs" ];
+    boot.initrd.availableKernelModules = mkIf inInitrd [ "f2fs" "crc32" ];
 
     boot.initrd.extraUtilsCommands = mkIf inInitrd ''
       copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/fsck.f2fs


### PR DESCRIPTION
…3093

f2fs.fsck depends on crc32 module being present in the initrd system,
otherwise, if f2fs is used as the root disk, the system is unbootable.

###### Things done
- Built on platform(s)
   - [x] NixOS
---

