### PR TITLE
Initial commit of HaLVM support

### DIFF
--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -82,5 +82,4 @@ stdenv.mkDerivation rec {
     maintainers = with stdenv.lib.maintainers; [ marcweber andres peti ];
     inherit (ghc.meta) license platforms;
   };
-
 }

--- a/pkgs/development/compilers/halvm/2.4.0.nix
+++ b/pkgs/development/compilers/halvm/2.4.0.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchgit, bootPkgs, perl, gmp, ncurses, binutils, autoconf, alex, happy, makeStaticLibraries
+, hscolour, xen, automake, gcc, git, zlib, libtool, enableIntegerSimple ? false
+}:
+
+stdenv.mkDerivation rec {
+  version = "2.4.0";
+  name = "HaLVM-${version}";
+  isHaLVM = true;
+  isGhcjs = false;
+  src = fetchgit {
+    rev = "6aa72c9b047fd8ddff857c994a5a895461fc3925";
+    url = "https://github.com/GaloisInc/HaLVM";
+    sha256 = "05cg4w6fw5ajmpmh8g2msprnygmr4isb3pphqhlddfqwyvqhl167";
+  };
+  prePatch = ''
+    sed -i '312 d' Makefile
+    sed -i '316,446 d' Makefile # Removes RPM packaging
+    sed -i '20 d' src/scripts/halvm-cabal.in
+    sed -ie 's|ld |${binutils}/bin/ld |g' src/scripts/ldkernel.in
+  '';
+  configureFlags = stdenv.lib.optional (!enableIntegerSimple) [ "--enable-gmp" ];
+  propagatedNativeBuildInputs = [ alex happy ];
+  buildInputs =
+   let haskellPkgs = [ alex happy bootPkgs.hscolour bootPkgs.cabal-install bootPkgs.haddock bootPkgs.hpc
+    ]; in [ bootPkgs.ghc
+            automake perl git binutils
+            autoconf xen zlib ncurses.dev
+            libtool gmp ] ++ haskellPkgs;
+  preConfigure = ''
+    autoconf
+    patchShebangs .
+  '';
+  hardeningDisable = ["all"];
+  postInstall = "$out/bin/halvm-ghc-pkg recache";
+  passthru = {
+    inherit bootPkgs;
+    cross.config = "halvm";
+    cc = "${gcc}/bin/gcc";
+    ld = "${binutils}/bin/ld";
+  };
+
+  meta = {
+    homepage = "http://github.com/GaloisInc/HaLVM";
+    description = "The Haskell Lightweight Virtual Machine (HaLVM): GHC running on Xen";
+    maintainers = with stdenv.lib.maintainers; [ dmjio ];
+    inherit (bootPkgs.ghc.meta) license platforms;
+  };
+}

--- a/pkgs/development/haskell-modules/configuration-halvm-2.4.0.nix
+++ b/pkgs/development/haskell-modules/configuration-halvm-2.4.0.nix
@@ -1,0 +1,59 @@
+{ pkgs }:
+
+with import ./lib.nix { inherit pkgs; };
+
+self: super: {
+
+  # Suitable LLVM version.
+  llvmPackages = pkgs.llvmPackages_35;
+
+  # Disable GHC 8.0.x core libraries.
+  array = null;
+  base = null;
+  binary = null;
+  bytestring = null;
+  Cabal = null;
+  containers = null;
+  deepseq = null;
+  directory = null;
+  filepath = null;
+  ghc-boot = null;
+  ghc-boot-th = null;
+  ghc-prim = null;
+  ghci = null;
+  haskeline = null;
+  hoopl = null;
+  hpc = null;
+  integer-gmp = null;
+  pretty = null;
+  process = null;
+  rts = null;
+  template-haskell = null;
+  terminfo = null;
+  time = null;
+  transformers = null;
+  unix = null;
+  xhtml = null;
+
+  # cabal-install can use the native Cabal library.
+  cabal-install = super.cabal-install.override { Cabal = null; };
+
+  # jailbreak-cabal can use the native Cabal library.
+  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = null; };
+
+  # https://github.com/bmillwood/applicative-quoters/issues/6
+  applicative-quoters = appendPatch super.applicative-quoters (pkgs.fetchpatch {
+    url = "https://patch-diff.githubusercontent.com/raw/bmillwood/applicative-quoters/pull/7.patch";
+    sha256 = "026vv2k3ks73jngwifszv8l59clg88pcdr4mz0wr0gamivkfa1zy";
+  });
+
+  # https://github.com/christian-marie/xxhash/issues/3
+  xxhash = doJailbreak super.xxhash;
+
+  # https://github.com/Deewiant/glob/issues/8
+  Glob = doJailbreak super.Glob;
+
+  # http://hub.darcs.net/dolio/vector-algorithms/issue/9#comment-20170112T145715
+  vector-algorithms = dontCheck super.vector-algorithms;
+
+}

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -8,7 +8,7 @@
 assert ghcLibdir != null -> (ghc.isGhcjs or false);
 
 # This wrapper works only with GHC 6.12 or later.
-assert lib.versionOlder "6.12" ghc.version || ghc.isGhcjs;
+assert lib.versionOlder "6.12" ghc.version || ghc.isGhcjs || ghc.isHaLVM;
 
 # It's probably a good idea to include the library "ghc-paths" in the
 # compiler environment, because we have a specially patched version of
@@ -33,13 +33,14 @@ assert lib.versionOlder "6.12" ghc.version || ghc.isGhcjs;
 
 let
   isGhcjs       = ghc.isGhcjs or false;
-  ghc761OrLater = isGhcjs || lib.versionOlder "7.6.1" ghc.version;
+  isHaLVM       = ghc.isHaLVM or false;
+  ghc761OrLater = isGhcjs || isHaLVM || lib.versionOlder "7.6.1" ghc.version;
   packageDBFlag = if ghc761OrLater then "--global-package-db" else "--global-conf";
-  ghcCommand'    = if isGhcjs then "ghcjs" else "ghc";
+  ghcCommand'   = if isGhcjs then "ghcjs" else "ghc";
   crossPrefix = if (ghc.cross or null) != null then "${ghc.cross.config}-" else "";
   ghcCommand = "${crossPrefix}${ghcCommand'}";
   ghcCommandCaps= lib.toUpper ghcCommand';
-  libDir        = "$out/lib/${ghcCommand}-${ghc.version}";
+  libDir        = if isHaLVM then "$out/lib/HaLVM-${ghc.version}" else "$out/lib/${ghcCommand}-${ghc.version}";
   docDir        = "$out/share/doc/ghc/html";
   packageCfgDir = "${libDir}/package.conf.d";
   paths         = lib.filter (x: x ? isHaskellLibrary) (lib.closePropagation packages);

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -79,6 +79,10 @@ in rec {
     ghcjsHEAD = packages.ghc802.callPackage ../development/compilers/ghcjs/head.nix {
       bootPkgs = packages.ghc802;
     };
+    ghcHaLVM240 = callPackage ../development/compilers/halvm/2.4.0.nix rec {
+      bootPkgs = packages.ghc802;
+      inherit (bootPkgs) hscolour alex happy;
+    };
 
     jhc = callPackage ../development/compilers/jhc {
       inherit (packages.ghc763) ghcWithPackages;
@@ -100,6 +104,7 @@ in rec {
       in pkgs.recurseIntoAttrs (integerSimpleGhcs // {
            ghcHEAD = integerSimpleGhcs.ghcHEAD.override { selfPkgs = packages.integer-simple.ghcHEAD; };
          });
+
   };
 
   packages = {
@@ -166,6 +171,10 @@ in rec {
     ghcjsHEAD = callPackage ../development/haskell-modules {
       ghc = compiler.ghcjsHEAD;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghcjs.nix { };
+    };
+    ghcHaLVM240 = callPackage ../development/haskell-modules {
+      ghc = compiler.ghcHaLVM240;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-halvm-2.4.0.nix { };
     };
 
     # The integer-simple attribute set contains package sets for all the GHC compilers


### PR DESCRIPTION
###### Motivation for this change
To provide Nix users easy access to the Haskell Lightweight Virtual Machine (`HaLVM`).

Still testing, but would like to get the PR review process started anyways. The `HaLVM` additions should be conformant to the existing `GHC` cross-compiler infrastructure.

**Example**: https://gist.github.com/dmjio/d6f18f8c4ac09b00d7df836bbf7f476f

**Todo**:
  - [x] - GMP must be statically linked `pkgs.gmp.override { withStatic = true; }`
  - [x] - Add `haddock`, `hpc`, `hsc2hs` to `/bin`

cc: @peti

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [x] Linux
   - OSX is N/A for `xen`
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

