### PR TITLE
Allow directories with a default.nix to be imported as an overlay. Cl…

### DIFF
--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -45,7 +45,7 @@ in
       overlays = dir:
         let content = readDir dir; in
         map (n: import (dir + ("/" + n)))
-          (builtins.filter (n: builtins.match ".*\.nix" n != null)
+          (builtins.filter (n: builtins.match ".*\.nix" n != null || pathExists (dir + ("/" + n + "/default.nix")))
             (attrNames content));
     in
       if dirPath != "" then


### PR DESCRIPTION
* Tested locally
* See https://github.com/NixOS/nixpkgs/issues/23016
