### PR TITLE
stanchion: added test

### DIFF
--- a/nixos/tests/stanchion.nix
+++ b/nixos/tests/stanchion.nix
@@ -1,0 +1,29 @@
+import ./make-test.nix {
+  name = "stanchion";
+
+  nodes = {
+    master =
+      { pkgs, config, ... }:
+
+      {
+        services.riak.enable = true;
+        services.riak.package = pkgs.riak;
+
+        services.stanchion.enable = true;
+        services.stanchion.riakHost = "127.0.0.1:8087";
+        services.stanchion.listener = "127.0.0.1:8085";
+      };
+  };
+
+  testScript = ''
+    startAll;
+
+    $master->waitForUnit("riak");
+    $master->sleep(20); # Hopefully this is long enough!!
+
+    $master->waitForUnit("stanchion");
+    $master->sleep(20);
+
+    $master->succeed("stanchion ping 2>&1");
+  '';
+}


### PR DESCRIPTION
###### Motivation for this change
Stanchion should have a test for itself.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

