### PR TITLE
R/generate-shell: Use R from current tree, fix missing wget dep.

### DIFF
--- a/pkgs/development/r-modules/generate-shell.nix
+++ b/pkgs/development/r-modules/generate-shell.nix
@@ -1,10 +1,11 @@
-with import <nixpkgs> {};
+with import ../../.. {};
 
 stdenv.mkDerivation {
   name = "generate-r-packages-shell";
 
   buildCommand = "exit 1";
 
+  buildInputs = [ wget ];
   nativeBuildInputs = [ 
     (rWrapper.override {
       packages = with rPackages; [


### PR DESCRIPTION
Without this change, the 'R' version used might be the wrong
one which changes the package lists used.

Fixes #19530.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

