### PR TITLE
flpsed: ghostscript patch, fixes, new url

### DIFF
--- a/pkgs/applications/editors/flpsed/default.nix
+++ b/pkgs/applications/editors/flpsed/default.nix
@@ -1,20 +1,27 @@
 {stdenv, fetchurl, fltk13, ghostscript}:
 
-stdenv.mkDerivation {
-  name = "flpsed-0.7.3";
+stdenv.mkDerivation rec {
+  name = "flpsed-${version}";
+  version = "0.7.3";
 
   src = fetchurl {
-    url = "http://www.ecademix.com/JohannesHofmann/flpsed-0.7.3.tar.gz";
+    url = "http://www.flpsed.org/${name}.tar.gz";
     sha256 = "0vngqxanykicabhfdznisv82k5ypkxwg0s93ms9ribvhpm8vf2xp";
   };
 
-  buildInputs = [ fltk13 ghostscript ];
+  buildInputs = [ fltk13 ];
 
-  meta = {
+  postPatch = ''
+    # replace the execvp call to ghostscript
+    sed -e '/exec_gs/ {n; s|"gs"|"${stdenv.lib.getBin ghostscript}/bin/gs"|}' \
+        -i src/GsWidget.cxx
+  '';
+
+  meta = with stdenv.lib; {
     description = "WYSIWYG PostScript annotator";
     homepage = "http://http://flpsed.org/flpsed.html";
-    license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.mesaPlatforms;
-    maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
+    license = licenses.gpl3;
+    platforms = platforms.mesaPlatforms;
+    maintainers = with maintainers; [ fuuzetsu ];
   };
 }


### PR DESCRIPTION
gs was called at runtime, fix the execvp call.
The url changed to its own domain.
A little face-lift for the package code.

The program still does not work really well for me, but at least a little better now.

@Fuuzetsu, does the menu work for you in this version?