### PR TITLE
diamond: init at 0.8.36

### DIFF
--- a/pkgs/applications/science/biology/diamond/default.nix
+++ b/pkgs/applications/science/biology/diamond/default.nix
@@ -39,6 +39,3 @@ stdenv.mkDerivation rec {
 		    maintainers = [ maintainers.metabar ];
   		};
 }
-
-
-

--- a/pkgs/applications/science/biology/diamond/default.nix
+++ b/pkgs/applications/science/biology/diamond/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, cmake, gcc, zlib }:
+
+stdenv.mkDerivation rec {
+	  name = "diamond-0.8.36";
+	
+	  src = fetchurl {
+	    url = "https://github.com/bbuchfink/diamond/archive/v0.8.36.tar.gz";
+	    sha256 = "092smzzjcg51n3x4h84k52ijpz9m40ri838j9k2i463ribc3c8rh";
+	    };
+	
+	  patches = [
+	  		      ./diamond-0.8.36-no-warning.patch
+	  	   	    ];
+	  		
+	  nativeBuildInputs = [ cmake ];
+	  buildInputs = [ zlib ];
+	  	 
+	  meta = with stdenv.lib; {
+		    description = "Accelerated BLAST compatible local sequence aligner";
+		    longDescription = ''
+			    A sequence aligner for protein and translated DNA 
+			    searches and functions as a drop-in replacement for the NCBI BLAST 
+			    software tools. It is suitable for protein-protein search as well as 
+			    DNA-protein search on short reads and longer sequences including contigs 
+			    and assemblies, providing a speedup of BLAST ranging up to x20,000.
+			    
+			    DIAMOND is developed by Benjamin Buchfink. Feel free to contact him for support (Email Twitter).
+			
+					If you use DIAMOND in published research, please cite 
+					B. Buchfink, Xie C., D. Huson, 
+					"Fast and sensitive protein alignment using DIAMOND", 
+					Nature Methods 12, 59-60 (2015).
+		      '';
+		    homepage = https://github.com/bbuchfink/diamond;
+		    license = {
+		    			fullName = "University of Tuebingen, Benjamin Buchfink";
+		    			url = https://raw.githubusercontent.com/bbuchfink/diamond/master/src/COPYING;
+		  			  };
+		    maintainers = [ maintainers.metabar ];
+  		};
+}
+
+
+

--- a/pkgs/applications/science/biology/diamond/default.nix
+++ b/pkgs/applications/science/biology/diamond/default.nix
@@ -1,41 +1,41 @@
 { stdenv, fetchurl, cmake, gcc, zlib }:
 
 stdenv.mkDerivation rec {
-	  name = "diamond-0.8.36";
-	
-	  src = fetchurl {
-	    url = "https://github.com/bbuchfink/diamond/archive/v0.8.36.tar.gz";
-	    sha256 = "092smzzjcg51n3x4h84k52ijpz9m40ri838j9k2i463ribc3c8rh";
-	    };
-	
-	  patches = [
-	  		      ./diamond-0.8.36-no-warning.patch
-	  	   	    ];
-	  		
-	  nativeBuildInputs = [ cmake ];
-	  buildInputs = [ zlib ];
-	  	 
-	  meta = with stdenv.lib; {
-		    description = "Accelerated BLAST compatible local sequence aligner";
-		    longDescription = ''
-			    A sequence aligner for protein and translated DNA 
-			    searches and functions as a drop-in replacement for the NCBI BLAST 
-			    software tools. It is suitable for protein-protein search as well as 
-			    DNA-protein search on short reads and longer sequences including contigs 
-			    and assemblies, providing a speedup of BLAST ranging up to x20,000.
-			    
-			    DIAMOND is developed by Benjamin Buchfink. Feel free to contact him for support (Email Twitter).
-			
-					If you use DIAMOND in published research, please cite 
-					B. Buchfink, Xie C., D. Huson, 
-					"Fast and sensitive protein alignment using DIAMOND", 
-					Nature Methods 12, 59-60 (2015).
-		      '';
-		    homepage = https://github.com/bbuchfink/diamond;
-		    license = {
-		    			fullName = "University of Tuebingen, Benjamin Buchfink";
-		    			url = https://raw.githubusercontent.com/bbuchfink/diamond/master/src/COPYING;
-		  			  };
-		    maintainers = [ maintainers.metabar ];
-  		};
+      name = "diamond-0.8.36";
+    
+      src = fetchurl {
+        url = "https://github.com/bbuchfink/diamond/archive/v0.8.36.tar.gz";
+        sha256 = "092smzzjcg51n3x4h84k52ijpz9m40ri838j9k2i463ribc3c8rh";
+        };
+    
+      patches = [
+                    ./diamond-0.8.36-no-warning.patch
+                     ];
+              
+      nativeBuildInputs = [ cmake ];
+      buildInputs = [ zlib ];
+           
+      meta = with stdenv.lib; {
+            description = "Accelerated BLAST compatible local sequence aligner";
+            longDescription = ''
+                A sequence aligner for protein and translated DNA 
+                searches and functions as a drop-in replacement for the NCBI BLAST 
+                software tools. It is suitable for protein-protein search as well as 
+                DNA-protein search on short reads and longer sequences including contigs 
+                and assemblies, providing a speedup of BLAST ranging up to x20,000.
+                
+                DIAMOND is developed by Benjamin Buchfink. Feel free to contact him for support (Email Twitter).
+            
+                    If you use DIAMOND in published research, please cite 
+                    B. Buchfink, Xie C., D. Huson, 
+                    "Fast and sensitive protein alignment using DIAMOND", 
+                    Nature Methods 12, 59-60 (2015).
+              '';
+            homepage = https://github.com/bbuchfink/diamond;
+            license = {
+                        fullName = "University of Tuebingen, Benjamin Buchfink";
+                        url = https://raw.githubusercontent.com/bbuchfink/diamond/master/src/COPYING;
+                        };
+            maintainers = [ maintainers.metabar ];
+          };
 }

--- a/pkgs/applications/science/biology/diamond/diamond-0.8.36-no-warning.patch
+++ b/pkgs/applications/science/biology/diamond/diamond-0.8.36-no-warning.patch
@@ -1,0 +1,20 @@
+diff -u -r diamond-0.8.36/src/dp/scalar_traceback.h diamond-0.8.36-patched/src/dp/scalar_traceback.h
+--- diamond-0.8.36/src/dp/scalar_traceback.h	2017-02-06 16:32:05.000000000 +0100
++++ diamond-0.8.36-patched/src/dp/scalar_traceback.h	2017-02-23 15:13:24.000000000 +0100
+@@ -19,6 +19,7 @@
+ #ifndef SCALAR_TRACEBACK_H_
+ #define SCALAR_TRACEBACK_H_
+ 
++#include <cmath>
+ #include <exception>
+ #include "../basic/score_matrix.h"
+ 
+@@ -31,7 +32,7 @@
+ template<>
+ inline bool almost_equal<float>(float x, float y)
+ {
+-	return abs(x - y) < 0.001f;
++	return std::abs(x - y) < 0.001f;
+ }
+ 
+ template<typename _score>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17186,6 +17186,8 @@ with pkgs;
 
   bcftools = callPackage ../applications/science/biology/bcftools { };
 
+  diamond = callPackage ../applications/science/biology/diamond { };
+
   ecopcr = callPackage ../applications/science/biology/ecopcr { };
 
   emboss = callPackage ../applications/science/biology/emboss { };


### PR DESCRIPTION
###### Motivation for this change

This is a new package, DIAMOND, a bioinformatics tool to perform that implements an accelerated BLAST compatible local sequence aligner.

B. Buchfink, Xie C., D. Huson, Fast and sensitive protein alignment using DIAMOND, Nature Methods 12, 59-60 (2015).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

