### PR TITLE
slock: added documentation to nixpkgs manual

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -382,6 +382,23 @@ it. Place the resulting <filename>package.nix</filename> file into
 
 </section>
 
+<section xml:id="sec-slock">
+
+<title>Slock</title>
+
+<para>
+    Slock requires root for accessing passwords and protecting itself from OOM killing (see also <link xlink:href="https://github.com/NixOS/nixpkgs/issues/9656">this issue</link> for more information). To fix this error, add slock to your system packages and change its uid by modifying your global configuration.nix like so
+    <programlisting>environment.systemPackages = with pkgs; [ slock ];
+security.wrappers = {
+    slock = {
+        source = "${pkgs.slock.out}/bin/slock";
+    };
+};
+    </programlisting>
+</para>
+
+</section>
+
 <section xml:id="sec-steam">
 
 <title>Steam</title>


### PR DESCRIPTION
###### Motivation for this change
Since `security.setuidPrograms` is deprecated, the wiki should be updated.
Slock wiki issue: https://github.com/NixOS/nixpkgs/issues/13286
Old wiki entry (which I mostly copied) https://nixos.org/wiki/Slock

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---