### PR TITLE
sha1collisiondetection: init -> unstable-2017-02-21

### DIFF
--- a/pkgs/tools/security/sha1collisiondetection/default.nix
+++ b/pkgs/tools/security/sha1collisiondetection/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, libtool }:
+
+stdenv.mkDerivation  rec {
+  pname = "sha1collisiondetection";
+  version = "2017-02-21";
+  name = "${pname}-unstable-${version}";
+
+  src = fetchFromGitHub {
+    owner = "cr-marcstevens";
+    repo = "${pname}";
+    rev = "40ccf5e3537ff6b2e5ceac5747f376a2ef430bec";
+    sha256 = "1k2qjarcx88ndc4yl8xnr1l3j74w1qacvyrhv4ms9hndy8lrsm0l";
+  };
+
+  patchPhase = ''substituteInPlace Makefile --replace "shell arch" "uname -m"'';
+
+  buildInputs = [ libtool ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib
+    cp bin/sha1dcsum bin/sha1dcsum_partialcoll $out/bin
+    cp bin/libdetectcoll.la $out/lib/
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Library and command line tool to detect SHA-1 collision";
+    longDescription = ''
+      This library and command line tool were designed as near drop-in
+      replacements for common SHA-1 libraries and sha1sum. They will
+      compute the SHA-1 hash of any given file and additionally will
+      detect cryptanalytic collision attacks against SHA-1 present in
+      each file. It is very fast and takes less than twice the amount
+      of time as regular SHA-1.
+      '';
+    platforms = platforms.all;
+    maintainers = with maintainers; [ leenaars ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/tools/security/sha1collisiondetection/default.nix
+++ b/pkgs/tools/security/sha1collisiondetection/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation  rec {
   pname = "sha1collisiondetection";
-  version = "2017-02-21";
-  name = "${pname}-unstable-${version}";
+  version = "1.0.1";
+  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "cr-marcstevens";
     repo = "${pname}";
-    rev = "40ccf5e3537ff6b2e5ceac5747f376a2ef430bec";
-    sha256 = "1k2qjarcx88ndc4yl8xnr1l3j74w1qacvyrhv4ms9hndy8lrsm0l";
+    rev = "development-v${version}";
+    sha256 = "2k2qjarcx88ndc4yl8xnr1l3j74w1qacvyrhv4ms9hndy8lrsm0l";
   };
 
   patchPhase = ''substituteInPlace Makefile --replace "shell arch" "uname -m"'';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3797,6 +3797,8 @@ with pkgs;
 
   sg3_utils = callPackage ../tools/system/sg3_utils { };
 
+  sha1collisiondetection = callPackage ../tools/security/sha1collisiondetection { };
+
   shadowsocks-libev = callPackage ../tools/networking/shadowsocks-libev { };
 
   sharutils = callPackage ../tools/archivers/sharutils { };


### PR DESCRIPTION
###### Motivation for this change

This creates a drop-in replacement for sha1sum, which can be used to detect collision attacks on SHA1.

(see:
http://www.cwi.nl/news/2017/cwi-and-google-announce-first-collision-industry-security-standard-sha-1)

There are currently over 8000 sha1 hashes still in use in nixpkgs itself.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

