### PR TITLE
wireguard: 0.0.20170214 -> 0.0.20170223

### DIFF
--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -6,11 +6,11 @@ assert kernel != null -> stdenv.lib.versionAtLeast kernel.version "3.18";
 let
   name = "wireguard-${version}";
 
-  version = "0.0.20170214";
+  version = "0.0.20170223";
 
   src = fetchurl {
     url    = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
-    sha256 = "1e4ee213d2a5ac672c952c59e9c64d6d7d5dc3e21c003aee30d75208237e8bf5";
+    sha256 = "6d2c8cd29c4f9fb404546a4749ec050739a26b4a49b5864f1dec531377c3c50d";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Simple version bump.

Release notes: https://lists.zx2c4.com/pipermail/wireguard/2017-February/001068.html