### PR TITLE
nix service: try to downgrade schema

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -369,6 +369,25 @@ in
 
         unitConfig.RequiresMountsFor = "/nix/store";
 
+        preStart = ''
+          # Check that we can read the schema
+          if nix-store --query --hash ${nix} 2>&1 | grep -q 'current Nix store schema is version'; then
+            # Try to downgrade
+            /nix/var/nix/gcroots/nix-daemon/bin/nix-store --dump-db > /nix/var/nix/db.dump
+            mv /nix/var/nix/db /nix/var/nix/db.old
+            if ! cat /nix/var/nix/db.dump | ${nix}/bin/nix-store --load-db; then
+              rm -rf /nix/var/nix/db
+              mv /nix/var/nix/db.old /nix/var/nix/db
+              rm /nix/var/nix/db.dump
+              echo "Failed to downgrade database schema" >&2
+              exit 1
+            fi
+            rm /nix/var/nix/db.dump
+            rm -rf /nix/var/nix/db.old
+          fi
+          ln -sfn ${nix} /nix/var/nix/gcroots/nix-daemon
+        '';
+
         serviceConfig =
           { Nice = cfg.daemonNiceLevel;
             IOSchedulingPriority = cfg.daemonIONiceLevel;


### PR DESCRIPTION
###### Motivation for this change

Support downgrading Nix, for example `nixUnstable` to `nixStable`. This is a bit flaky now and I'm open to suggestions on how to make this better. Concurrent access is also a potential problem, although if it goes through daemon it is okay -- bad things will happen only if someone uses Nix with `NIX_REMOTE=` concurrently with this script. I've tested it by going to `nixUnstable` and back.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Prior discussion: https://github.com/NixOS/nixpkgs/issues/23107#issuecomment-282041214
cc @vcunat (potentially interested)