### PR TITLE
go: Adding a derivation for the 1.8 Go compiler

### DIFF
--- a/pkgs/development/compilers/go/1.8.nix
+++ b/pkgs/development/compilers/go/1.8.nix
@@ -1,0 +1,170 @@
+{ stdenv, fetchFromGitHub, tzdata, iana_etc, go_bootstrap, runCommand, writeScriptBin
+, perl, which, pkgconfig, patch, fetchpatch
+, pcre, cacert
+, Security, Foundation, bash }:
+
+let
+
+  inherit (stdenv.lib) optional optionals optionalString;
+
+  clangHack = writeScriptBin "clang" ''
+    #!${stdenv.shell}
+    exec ${stdenv.cc}/bin/clang "$@" 2> >(sed '/ld: warning:.*ignoring unexpected dylib file/ d' 1>&2)
+  '';
+
+  goBootstrap = runCommand "go-bootstrap" {} ''
+    mkdir $out
+    cp -rf ${go_bootstrap}/* $out/
+    chmod -R u+w $out
+    find $out -name "*.c" -delete
+    cp -rf $out/bin/* $out/share/go/bin/
+  '';
+
+in
+
+stdenv.mkDerivation rec {
+  name = "go-${version}";
+  version = "1.8";
+
+  src = fetchFromGitHub {
+    owner = "golang";
+    repo = "go";
+    rev = "go${version}";
+    sha256 = "0plm11rqrqz7frwz0jjcm13x939yhny755ks1adxjzmsngln9prl";
+  };
+
+  # perl is used for testing go vet
+  nativeBuildInputs = [ perl which pkgconfig patch ];
+  buildInputs = [ pcre ]
+    ++ optionals stdenv.isLinux [ stdenv.glibc.out stdenv.glibc.static ];
+  propagatedBuildInputs = optionals stdenv.isDarwin [ Security Foundation ];
+
+  hardeningDisable = [ "all" ];
+
+  prePatch = ''
+    patchShebangs ./ # replace /bin/bash
+
+    # This source produces shell script at run time,
+    # and thus it is not corrected by patchShebangs.
+    substituteInPlace misc/cgo/testcarchive/carchive_test.go \
+      --replace '#!/usr/bin/env bash' '#!${stdenv.shell}'
+
+    # Disabling the 'os/http/net' tests (they want files not available in
+    # chroot builds)
+    rm src/net/{listen,parse}_test.go
+    rm src/syscall/exec_linux_test.go
+
+    # !!! substituteInPlace does not seems to be effective.
+    # The os test wants to read files in an existing path. Just don't let it be /usr/bin.
+    sed -i 's,/usr/bin,'"`pwd`", src/os/os_test.go
+    sed -i 's,/bin/pwd,'"`type -P pwd`", src/os/os_test.go
+    # Disable the unix socket test
+    sed -i '/TestShutdownUnix/areturn' src/net/net_test.go
+    # Disable the hostname test
+    sed -i '/TestHostname/areturn' src/os/os_test.go
+    # ParseInLocation fails the test
+    sed -i '/TestParseInSydney/areturn' src/time/format_test.go
+    # Remove the api check as it never worked
+    sed -i '/src\/cmd\/api\/run.go/ireturn nil' src/cmd/dist/test.go
+    # Remove the coverage test as we have removed this utility
+    sed -i '/TestCoverageWithCgo/areturn' src/cmd/go/go_test.go
+    # Remove the timezone naming test
+    sed -i '/TestLoadFixed/areturn' src/time/time_test.go
+
+    sed -i 's,/etc/protocols,${iana_etc}/etc/protocols,' src/net/lookup_unix.go
+    sed -i 's,/etc/services,${iana_etc}/etc/services,' src/net/port_unix.go
+
+    # Disable cgo lookup tests not works, they depend on resolver
+    rm src/net/cgo_unix_test.go
+
+  '' + optionalString stdenv.isLinux ''
+    sed -i 's,/usr/share/zoneinfo/,${tzdata}/share/zoneinfo/,' src/time/zoneinfo_unix.go
+  '' + optionalString stdenv.isDarwin ''
+
+    # Disabling `format_test.go` because it fails on Darwin for an
+    # unknown reason see: https://github.com/NixOS/nixpkgs/pull/23122#issuecomment-282188727
+    rm src/time/format_test.go
+
+    substituteInPlace src/race.bash --replace \
+      "sysctl machdep.cpu.extfeatures | grep -qv EM64T" true
+    sed -i 's,strings.Contains(.*sysctl.*,true {,' src/cmd/dist/util.go
+    sed -i 's,"/etc","'"$TMPDIR"'",' src/os/os_test.go
+    sed -i 's,/_go_os_test,'"$TMPDIR"'/_go_os_test,' src/os/path_test.go
+
+    sed -i '/TestChdirAndGetwd/areturn' src/os/os_test.go
+    sed -i '/TestRead0/areturn' src/os/os_test.go
+    sed -i '/TestNohup/areturn' src/os/signal/signal_test.go
+    sed -i '/TestCurrent/areturn' src/os/user/user_test.go
+    sed -i '/TestSystemRoots/areturn' src/crypto/x509/root_darwin_test.go
+
+    sed -i '/TestGoInstallRebuildsStalePackagesInOtherGOPATH/areturn' src/cmd/go/go_test.go
+    sed -i '/TestBuildDashIInstallsDependencies/areturn' src/cmd/go/go_test.go
+
+    sed -i '/TestDisasmExtld/areturn' src/cmd/objdump/objdump_test.go
+
+    sed -i 's/unrecognized/unknown/' src/cmd/link/internal/ld/lib.go
+    sed -i 's/unrecognized/unknown/' src/cmd/go/build.go
+
+    touch $TMPDIR/group $TMPDIR/hosts $TMPDIR/passwd
+
+    sed -i '1 a\exit 0' misc/cgo/errors/test.bash
+  '';
+
+  patches =
+    [ ./remove-tools-1.8.patch
+      ./cacert-1.8.patch
+      ./creds-test.patch
+      ./remove-test-pie-1.8.patch
+    ];
+
+  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  GOOS = if stdenv.isDarwin then "darwin" else "linux";
+  GOARCH = if stdenv.isDarwin then "amd64"
+           else if stdenv.system == "i686-linux" then "386"
+           else if stdenv.system == "x86_64-linux" then "amd64"
+           else if stdenv.isArm then "arm"
+           else throw "Unsupported system";
+  GOARM = optionalString (stdenv.system == "armv5tel-linux") "5";
+  GO386 = 387; # from Arch: don't assume sse2 on i686
+  CGO_ENABLED = 1;
+  GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";
+
+  # The go build actually checks for CC=*/clang and does something different, so we don't
+  # just want the generic `cc` here.
+  CC = if stdenv.isDarwin then "clang" else "cc";
+
+  configurePhase = ''
+    mkdir -p $out/share/go/bin
+    export GOROOT=$out/share/go
+    export GOBIN=$GOROOT/bin
+    export PATH=$GOBIN:$PATH
+  '';
+
+  postConfigure = optionalString stdenv.isDarwin ''
+    export PATH=${clangHack}/bin:$PATH
+  '';
+
+  installPhase = ''
+    cp -r . $GOROOT
+    ( cd $GOROOT/src && ./all.bash )
+  '';
+
+  preFixup = ''
+    rm -r $out/share/go/pkg/bootstrap
+    ln -s $out/share/go/bin $out/bin
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  disallowedReferences = [ go_bootstrap ];
+
+  meta = with stdenv.lib; {
+    branch = "1.8";
+    homepage = http://golang.org/;
+    description = "The Go Programming language";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cstrahan wkennington ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/compilers/go/cacert-1.8.patch
+++ b/pkgs/development/compilers/go/cacert-1.8.patch
@@ -1,0 +1,80 @@
+diff --git a/src/crypto/x509/root_cgo_darwin.go b/src/crypto/x509/root_cgo_darwin.go
+index a4b33c7..9700b75 100644
+--- a/src/crypto/x509/root_cgo_darwin.go
++++ b/src/crypto/x509/root_cgo_darwin.go
+@@ -151,11 +151,20 @@ int FetchPEMRoots(CFDataRef *pemRoots) {
+ import "C"
+ import (
+ 	"errors"
++	"io/ioutil"
++	"os"
+ 	"unsafe"
+ )
+ 
+ func loadSystemRoots() (*CertPool, error) {
+ 	roots := NewCertPool()
++	if file := os.Getenv("SSL_CERT_FILE"); file != "" {
++		data, err := ioutil.ReadFile(file)
++		if err == nil {
++			roots.AppendCertsFromPEM(data)
++			return roots, nil
++		}
++	}
+ 
+ 	var data C.CFDataRef = nil
+ 	err := C.FetchPEMRoots(&data)
+diff --git a/src/crypto/x509/root_darwin.go b/src/crypto/x509/root_darwin.go
+index 66cdb5e..bb28036 100644
+--- a/src/crypto/x509/root_darwin.go
++++ b/src/crypto/x509/root_darwin.go
+@@ -61,17 +61,25 @@ func execSecurityRoots() (*CertPool, error) {
+ 		println(fmt.Sprintf("crypto/x509: %d certs have a trust policy", len(hasPolicy)))
+ 	}
+
+-	cmd := exec.Command("/usr/bin/security", "find-certificate", "-a", "-p", "/System/Library/Keychains/SystemRootCertificates.keychain")
+-	data, err := cmd.Output()
+-	if err != nil {
+-		return nil, err
+-	}
+-
+ 	var (
+ 		mu          sync.Mutex
+ 		roots       = NewCertPool()
+ 		numVerified int // number of execs of 'security verify-cert', for debug stats
+ 	)
+
++	if file := os.Getenv("SSL_CERT_FILE"); file != "" {
++		data, err := ioutil.ReadFile(file)
++		if err == nil {
++			roots.AppendCertsFromPEM(data)
++			return roots, nil
++		}
++	}
++
++	cmd := exec.Command("/usr/bin/security", "find-certificate", "-a", "-p", "/System/Library/Keychains/SystemRootCertificates.keychain")
++	data, err := cmd.Output()
++	if err != nil {
++		return nil, err
++	}
++
+ 	blockCh := make(chan *pem.Block)
+ 	var wg sync.WaitGroup
+diff --git a/src/crypto/x509/root_unix.go b/src/crypto/x509/root_unix.go
+index 7bcb3d6..3986e1a 100644
+--- a/src/crypto/x509/root_unix.go
++++ b/src/crypto/x509/root_unix.go
+@@ -24,6 +24,14 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
+ 
+ func loadSystemRoots() (*CertPool, error) {
+ 	roots := NewCertPool()
++	if file := os.Getenv("SSL_CERT_FILE"); file != "" {
++		data, err := ioutil.ReadFile(file)
++		if err == nil {
++			roots.AppendCertsFromPEM(data)
++			return roots, nil
++		}
++	}
++
+ 	var firstErr error
+ 	for _, file := range certFiles {
+ 		data, err := ioutil.ReadFile(file)

--- a/pkgs/development/compilers/go/remove-test-pie-1.8.patch
+++ b/pkgs/development/compilers/go/remove-test-pie-1.8.patch
@@ -1,0 +1,23 @@
+diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
+index c51dcea..8fbec5e 100644
+--- a/src/cmd/dist/test.go
++++ b/src/cmd/dist/test.go
+@@ -461,17 +461,5 @@ func (t *tester) registerTests() {
+ 		})
+ 	}
+
+-	// Test internal linking of PIE binaries where it is supported.
+-	if t.goos == "linux" && t.goarch == "amd64" {
+-		t.tests = append(t.tests, distTest{
+-			name:    "pie_internal",
+-			heading: "internal linking of -buildmode=pie",
+-			fn: func(dt *distTest) error {
+-				t.addCmd(dt, "src", "go", "test", "reflect", "-short", "-buildmode=pie", "-ldflags=-linkmode=internal", t.timeout(60), t.tags(), t.runFlag(""))
+-				return nil
+-			},
+-		})
+-	}
+-
+ 	// sync tests
+ 	t.tests = append(t.tests, distTest{
+ 		name:    "sync_cpu",

--- a/pkgs/development/compilers/go/remove-tools-1.8.patch
+++ b/pkgs/development/compilers/go/remove-tools-1.8.patch
@@ -1,0 +1,35 @@
+diff --git a/src/go/build/build.go b/src/go/build/build.go
+index 9706b8b..f250751 100644
+--- a/src/go/build/build.go
++++ b/src/go/build/build.go
+@@ -1513,7 +1513,7 @@ func init() {
+ }
+ 
+ // ToolDir is the directory containing build tools.
+-var ToolDir = filepath.Join(runtime.GOROOT(), "pkg/tool/"+runtime.GOOS+"_"+runtime.GOARCH)
++var ToolDir = runtime.GOTOOLDIR()
+ 
+ // IsLocalImport reports whether the import path is
+ // a local import path, like ".", "..", "./foo", or "../foo".
+diff --git a/src/runtime/extern.go b/src/runtime/extern.go
+index 441dcd9..a50277e 100644
+--- a/src/runtime/extern.go
++++ b/src/runtime/extern.go
+@@ -230,6 +230,17 @@ func GOROOT() string {
+ 	return sys.DefaultGoroot
+ }
+ 
++// GOTOOLDIR returns the root of the Go tree.
++// It uses the GOTOOLDIR environment variable, if set,
++// or else the root used during the Go build.
++func GOTOOLDIR() string {
++	s := gogetenv("GOTOOLDIR")
++	if s != "" {
++		return s
++	}
++	return GOROOT() + "/pkg/tool/" + GOOS + "_" + GOARCH
++}
++
+ // Version returns the Go tree's version string.
+ // It is either the commit hash and date at the time of the build or,
+ // when possible, a release tag like "go1.3".

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5165,7 +5165,13 @@ with pkgs;
     stdenv = stdenvAdapters.overrideCC pkgs.stdenv pkgs.clang_38;
   });
 
-  go = go_1_7;
+  go_1_8 = callPackage ../development/compilers/go/1.8.nix ({
+    inherit (darwin.apple_sdk.frameworks) Security Foundation;
+  } // stdenv.lib.optionalAttrs stdenv.isDarwin {
+    stdenv = stdenvAdapters.overrideCC pkgs.stdenv pkgs.clang_38;
+  });
+
+  go = go_1_8;
 
   go-repo-root = callPackage ../development/tools/go-repo-root { };
 
@@ -10235,7 +10241,11 @@ with pkgs;
     go = go_1_7;
   };
 
-  buildGoPackage = buildGo17Package;
+  buildGo18Package = callPackage ../development/go-modules/generic {
+    go = go_1_8;
+  };
+
+  buildGoPackage = buildGo18Package;
 
   go2nix = callPackage ../development/tools/go2nix { };
 


### PR DESCRIPTION
###### Motivation for this change
Go 1.8 was recently released.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This should resolve issue #20082.

I haven't fully tested all packages that may depend on this (Real Life time constraints). If there are people using Go that are interested in this, I'd appreciate the help testing that this doesn't produce major breakage.

Maintainers: not sure if it's "correct" for me to `go = go_1_8` instead of keeping it at `go_1_7`? Maybe if I didn't retarget that attribute it would be more "okay" to not test as many packages as may depend on Go?