### PR TITLE
nodejs: 7.2.1 -> 7.6.0

### DIFF
--- a/pkgs/development/web/nodejs/v7.nix
+++ b/pkgs/development/web/nodejs/v7.nix
@@ -10,11 +10,11 @@ let
   baseName = if enableNpm then "nodejs" else "nodejs-slim";
 in
   stdenv.mkDerivation (nodejs // rec {
-    version = "7.2.1";
+    version = "7.6.0";
     name = "${baseName}-${version}";
     src = fetchurl {
       url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
-      sha256 = "03fqv6k8y42ldnrz4iirhwg6wdyw8z95h9h40igiriicbnm072y0";
+      sha256 = "1adldbhza422951i9rk69x75apj9rdqlx1pm8ybb9w7zjqk09ybg";
     };
 
   })


### PR DESCRIPTION
###### Motivation for this change

NodeJS v7.6.0 contains some new, helpful features such as native support for `async`/`await` from the ES7 specification.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS (built by @lo1tuma, https://github.com/NixOS/nixpkgs/pull/23125#issuecomment-282156206)
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

