### PR TITLE
qemu-vm: Make it possible to adjust RAM allocation at runtime

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -74,7 +74,7 @@ let
       # Start QEMU.
       exec ${qemu}/bin/qemu-kvm \
           -name ${vmName} \
-          -m ${toString config.virtualisation.memorySize} \
+          -m ''${QEMU_RAM:-${toString config.virtualisation.memorySize}} \
           ${optionalString (pkgs.stdenv.system == "x86_64-linux") "-cpu kvm64"} \
           ${concatStringsSep " " config.virtualisation.qemu.networkingOptions} \
           -virtfs local,path=/nix/store,security_model=none,mount_tag=store \


### PR DESCRIPTION
This is handy with things like `nixos-rebuild build-vm`, where there isn't a good way to expose the memorySize parameter to the user.