### PR TITLE
wlc: 0.0.5 -> 0.0.8

### DIFF
--- a/pkgs/development/libraries/wlc/default.nix
+++ b/pkgs/development/libraries/wlc/default.nix
@@ -1,16 +1,17 @@
-{ lib, stdenv, fetchurl, fetchgit, cmake, pkgconfig, fetchFromGitHub
+{ lib, stdenv, fetchgit, cmake, pkgconfig
 , glibc, wayland, pixman, libxkbcommon, libinput, libxcb, xcbutilwm, xcbutilimage, mesa, libdrm, udev, systemd, dbus_libs
 , libpthreadstubs, libX11, libXau, libXdmcp, libXext, libXdamage, libxshmfence, libXxf86vm
+, wayland-protocols
 }:
 
 stdenv.mkDerivation rec {
   name = "wlc-${version}";
-  version = "0.0.5";
+  version = "0.0.8";
 
   src = fetchgit {
     url = "https://github.com/Cloudef/wlc";
     rev = "refs/tags/v${version}";
-    sha256 = "0pg95n488fjlkc8n8x1h2dh4mxb7qln6mrq906lwwqv94aks9b43";
+    sha256 = "1lkxbqnxfmbk9j9k8wq2fl5z0a9ihzalad3x1pp8w2riz41j3by6";
     fetchSubmodules = true;
    };
 
@@ -18,7 +19,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     wayland pixman libxkbcommon libinput libxcb xcbutilwm xcbutilimage mesa libdrm udev
-    libX11 libXdamage systemd dbus_libs
+    libX11 libXdamage systemd dbus_libs wayland-protocols
   ];
 
 


### PR DESCRIPTION
###### Motivation for this change

The upstream repo includes wayland-protocols as submodule.
But if it isn't specifically configured, the submodule isn't used, hence the nixpkgs version as a dependency.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

