### PR TITLE
rnv: init at 1.7.11

### DIFF
--- a/pkgs/tools/text/xml/rnv/default.nix
+++ b/pkgs/tools/text/xml/rnv/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, expat }:
+
+stdenv.mkDerivation {
+  name = "rnv-${version}";
+  version = "1.7.11";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/rnv/rnv-${version}.tar.xz";
+    sha256 = "1rlxrkkkp8b5j6lyvnd9z1d85grmwwmdggkxq6yl226nwkqj1faa";
+  };
+
+  buildInputs = [ expat ];
+
+  meta = with stdenv.lib; {
+    description = "Relax NG Compact Syntax validator";
+    homepage = http://www.davidashen.net/rnv.html;
+    license = licenses.bsd3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3686,6 +3686,8 @@ with pkgs;
 
   rng_tools = callPackage ../tools/security/rng-tools { };
 
+  rnv = callPackage ../tools/text/xml/rnv { };
+
   rq = callPackage ../development/tools/rq {
     v8 = v8_static;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

