### PR TITLE
earlyoom service: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -528,6 +528,7 @@
   ./services/system/cgmanager.nix
   ./services/system/cloud-init.nix
   ./services/system/dbus.nix
+  ./services/system/earlyoom.nix
   ./services/system/kerberos.nix
   ./services/system/nscd.nix
   ./services/system/uptimed.nix

--- a/nixos/modules/services/system/earlyoom.nix
+++ b/nixos/modules/services/system/earlyoom.nix
@@ -1,0 +1,96 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  ecfg = config.services.earlyoom;
+in
+{
+  options = {
+    services.earlyoom = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable early out of memory killing.
+        '';
+      };
+
+      freeMemThreshold = mkOption {
+        type = types.int;
+        default = 10;
+        description = ''
+          Minimum of availabe memory (in percent).
+          If the free memory falls below this threshold and the analog is true for
+          <option>services.earlyoom.freeSwapThreshold</option>
+          the killing begins.
+        '';
+      };
+
+      freeSwapThreshold = mkOption {
+        type = types.int;
+        default = 10;
+        description = ''
+          Minimum of availabe swap space (in percent).
+          If the available swap space falls below this threshold and the analog
+          is true for <option>services.earlyoom.freeMemThreshold</option>
+          the killing begins.
+        '';
+      };
+
+      useKernelOOMKiller= mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Use kernel OOM killer instead of own user-space implementation.
+        '';
+      };
+
+      ignoreOOMScoreAdjust = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Ignore oom_score_adjust values of processes.
+          User-space implementation only.
+        '';
+      };
+
+      enableDebugInfo = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable debugging messages.
+        '';
+      };
+    };
+  };
+
+  config = mkIf ecfg.enable {
+    assertions = [
+      { assertion = ecfg.freeMemThreshold > 0 && ecfg.freeMemThreshold <= 100;
+        message = "Needs to be a positive percentage"; }
+      { assertion = ecfg.freeSwapThreshold > 0 && ecfg.freeSwapThreshold <= 100;
+        message = "Needs to be a positive percentage"; }
+      { assertion = !ecfg.useKernelOOMKiller || !ecfg.ignoreOOMScoreAdjust;
+        message = "Both options in conjunction do not make sense"; }
+    ];
+
+    systemd.services.earlyoom = {
+      description = "Early OOM Daemon for Linux";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        StandardOutput = "null";
+        StandardError = "syslog";
+        ExecStart = ''
+          ${pkgs.earlyoom}/bin/earlyoom \
+          -m ${toString ecfg.freeMemThreshold} \
+          -s ${toString ecfg.freeSwapThreshold} \
+          ${optionalString ecfg.useKernelOOMKiller "-k"} \
+          ${optionalString ecfg.ignoreOOMScoreAdjust "-i"} \
+          ${optionalString ecfg.enableDebugInfo "-d"}
+        '';
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

