### PR TITLE
quickder: 1.0-RC1 -> 1.0-RC2

### DIFF
--- a/pkgs/development/libraries/quickder/default.nix
+++ b/pkgs/development/libraries/quickder/default.nix
@@ -3,10 +3,10 @@
 stdenv.mkDerivation rec {
   pname = "quickder";
   name = "${pname}-${version}";
-  version = "1.0-RC1";
+  version = "1.0-RC2";
 
   src = fetchFromGitHub {
-    sha256 = "05gw5dqkw3l8kwwm0044zpxhcp7sxicx9wxbfyr49c91403p870w";
+    sha256 = "1nzk8x6qzpvli8bf74dc2qya63nlppqjrnkaxvjxr2dbqb8qcrqd";
     rev = "version-${version}";
     owner = "vanrein";
     repo = "quick-der";


### PR DESCRIPTION
###### Motivation for this change

Update to latest version of the library.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)[ 
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

