### PR TITLE
moka-icon-theme: 2016-10-06 -> 2017-02-13

### DIFF
--- a/pkgs/data/icons/moka-icon-theme/default.nix
+++ b/pkgs/data/icons/moka-icon-theme/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${package-name}-${version}";
   package-name = "moka-icon-theme";
-  version = "2016-10-06";
+  version = "2017-02-13";
 
   src = fetchFromGitHub {
     owner = "snwh";
     repo = package-name;
-    rev = "50894ee9411721649019cd168b8ae2c85f4b5cf0";
-    sha256 = "1dlpsgqsn731ra5drkx72wljcgv1zydgldy4nn5bbia9s5w8mfgs";
+    rev = "5ac530d2394574bdbd5360de46391d0dfc7aa2ab";
+    sha256 = "1zw1jm03706086gnplkkrdlrcyhgwm9kp4qax57wwc1s27bhc90n";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).