### PR TITLE
hexio: unstable -> 1.0-RC1

### DIFF
--- a/pkgs/development/tools/hexio/default.nix
+++ b/pkgs/development/tools/hexio/default.nix
@@ -1,18 +1,19 @@
-{ stdenv, fetchFromGitHub, fetchurl, python, pcsclite, pth, glibc }:
+{ stdenv, fetchFromGitHub, fetchurl, python, pcsclite, pth }:
 
 stdenv.mkDerivation rec {
   pname = "hexio";
   name = "${pname}-${version}";
-  version = "201605";
+  version = "1.0-RC1";
 
   src = fetchFromGitHub {
     sha256 = "08jxkdi0gjsi8s793f9kdlad0a58a0xpsaayrsnpn9bpmm5cgihq";
-    rev = "f6f963bd0fcd2808977e0ad82dcb3100691cdd7c";
+    rev = "version-${version}";
     owner = "vanrein";
     repo = "hexio";
   };
 
-  buildInputs = [ python pcsclite pth glibc ];
+  propagatedBuildInputs = [ python ];
+  buildInputs = [ pcsclite pth ];
 
   patchPhase = ''
     substituteInPlace Makefile \


### PR DESCRIPTION
###### Motivation for this change

New version of the tool.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

