### PR TITLE
numix-gtk-theme: 2016-11-19 -> 2017-02-15

### DIFF
--- a/pkgs/misc/themes/numix/default.nix
+++ b/pkgs/misc/themes/numix/default.nix
@@ -3,14 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2016-11-19";
+  version = "2017-02-15";
   name = "numix-gtk-theme-${version}";
 
   src = fetchFromGitHub {
     repo = "numix-gtk-theme";
     owner = "numixproject";
-    rev = "0e4a840bd1ec434ba660418caaa59ada05d8660e";
-    sha256 = "09nacjwrl5k3dgji2smdv6q5v23qjzfayic044bnjfm5d3p3yf6n";
+    rev = "f25d7e04353543e03fd155f4d9dfa80fc6b551f2";
+    sha256 = "0n57airi1kgg754099sdq40bb0mbp4my385fvslnsjv5d4h8jhvq";
   };
 
   nativeBuildInputs = [ sass glib libxml2 gdk_pixbuf ];


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).