### PR TITLE
paper-icon-theme: 2016-11-05 -> 2017-02-13

### DIFF
--- a/pkgs/data/icons/paper-icon-theme/default.nix
+++ b/pkgs/data/icons/paper-icon-theme/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${package-name}-${version}";
   package-name = "paper-icon-theme";
-  version = "2016-11-05";
+  version = "2017-02-13";
 
   src = fetchFromGitHub {
     owner = "snwh";
     repo = package-name;
-    rev = "2a1f25a47fe8fb92e9d4db5537bbddb539586602";
-    sha256 = "0v956wrfraaj5qznz86q7s3zi55xd3gxmg7pzcfsw2ghgfv13swd";
+    rev = "fcaf8bb2aacdd1bb7dcde3d45ef92d0751567e8e";
+    sha256 = "1l1w99411jrv4l7jr5dvwszghrncsir23c7lpc26gh2f0ydf3d0d";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).