### PR TITLE
xdgmenumaker: 1.1 -> 1.4

### DIFF
--- a/pkgs/applications/misc/xdgmenumaker/default.nix
+++ b/pkgs/applications/misc/xdgmenumaker/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "xdgmenumaker-${version}";
-  version = "1.1";
+  version = "1.4";
 
   src = fetchFromGitHub {
     owner = "gapan";
     repo = "xdgmenumaker";
     rev = version;
-    sha256 = "11mqafpgfnz0h0d6fxd1xsfsjxzg1abvwqgwy9jmm5xhcjx3c3l7";
+    sha256 = "0i909dk9chdsc7njp5llgm5xlag4lr0nkxkwl1g5lf8cvdjrawh2";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).