### PR TITLE
lxc: fix glibc 2.25 incompatibility

### DIFF
--- a/pkgs/os-specific/linux/lxc/default.nix
+++ b/pkgs/os-specific/linux/lxc/default.nix
@@ -33,6 +33,14 @@ stdenv.mkDerivation rec {
 
   XML_CATALOG_FILES = "${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml";
 
+  # FIXME
+  # glibc 2.25 moved major()/minor() to <sys/sysmacros.h>.
+  # this commit should detect this: https://github.com/lxc/lxc/pull/1388/commits/af6824fce9c9536fbcabef8d5547f6c486f55fdf
+  # However autotools checks if mkdev is still defined in <sys/types.h> runs before
+  # checking if major()/minor() is defined there. The mkdev check succeeds with
+  # a warning and the check which should set MAJOR_IN_SYSMACROS is skipped.
+  NIX_CFLAGS_COMPILE = [ "-DMAJOR_IN_SYSMACROS" ];
+
   configureFlags = [
     "--localstatedir=/var"
     "--sysconfdir=/etc"


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

