### PR TITLE
findutils: updatedb now uses writable database outside of /nix/store by default

### DIFF
--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "info" ];
 
+  configureFlags = [ "--localstatedir=/var/cache" ];
+
   crossAttrs = {
     # http://osdir.com/ml/bug-findutils-gnu/2009-08/msg00026.html
     configureFlags = [ "gl_cv_func_wcwidth_works=yes" ];


### PR DESCRIPTION
###### Motivation for this change

updatedb could only be run by providing the --output parameter,
because it would use a path inside the nix store as it's database.
The default for --output is now /var/cache/locatedb (the same
as in the NixOS locate service)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

