### PR TITLE
hr: init at 1.2

### DIFF
--- a/pkgs/applications/misc/hr/default.nix
+++ b/pkgs/applications/misc/hr/default.nix
@@ -11,20 +11,18 @@ stdenv.mkDerivation rec {
     sha256 = "162vkip2772jl59lschpinimpg4ssiyg7fq0va5cx4d7wldpqmks";
   };
 
-  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+  dontBuild = true;
+  installFlags = [ "PREFIX=$(out)" "MANPREFIX=$(out)/share" ];
 
-  installPhase = ''
+  preInstall = ''
     mkdir -p $out/{bin,share}
-    sed -i "s,PREFIX=.*,PREFIX=$out," Makefile
-    sed -i "s,MANPREFIX=.*,MANPREFIX=$out/share," Makefile
-    make install
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/LuRsT/hr;
     description = "A horizontal bar for your terminal";
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
-    platforms = with stdenv.lib.platforms; unix;
+    license = licenses.mit;
+    maintainers = [ maintainers.matthiasbeyer ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/hr/default.nix
+++ b/pkgs/applications/misc/hr/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "hr-${version}";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "LuRsT";
+    repo = "hr";
+    rev = version;
+    sha256 = "162vkip2772jl59lschpinimpg4ssiyg7fq0va5cx4d7wldpqmks";
+  };
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    sed -i "s,PREFIX=.*,PREFIX=$out," Makefile
+    sed -i "s,MANPREFIX=.*,MANPREFIX=$out/share," Makefile
+    make install
+  '';
+
+  meta = {
+    homepage = https://github.com/LuRsT/hr;
+    description = "A horizontal bar for your terminal";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    platforms = with stdenv.lib.platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -924,6 +924,8 @@ with pkgs;
 
   hexio = callPackage ../development/tools/hexio { };
 
+  hr = callPackage ../applications/misc/hr { };
+
   interlock = callPackage ../servers/interlock {};
 
   kapacitor = callPackage ../servers/monitoring/kapacitor { };


### PR DESCRIPTION
###### Motivation for this change

New package

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

