### PR TITLE
qsyncthingtray: 0.5.5rc2 -> 0.5.7

### DIFF
--- a/pkgs/applications/misc/qsyncthingtray/default.nix
+++ b/pkgs/applications/misc/qsyncthingtray/default.nix
@@ -3,14 +3,14 @@
 , qmakeHook }:
 
 stdenv.mkDerivation rec {
-  version = "0.5.5rc2";
+  version = "0.5.7";
   name = "qsyncthingtray-${version}";
 
   src = fetchFromGitHub {
     owner = "sieren";
     repo = "QSyncthingTray";
     rev = "${version}";
-    sha256 = "1x7j7ylgm4ih06m7gb5ls3c9bdjwbra675489caq2f04kgw4yxq2";
+    sha256 = "0crrdpdmlc4ahkvp5znzc4zhfwsdih655q1kfjf0g231mmynxhvq";
   };
 
   buildInputs = [ qtbase qtwebengine ];
@@ -20,10 +20,6 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/bin
     cp binary/QSyncthingTray $out/bin
-    cat > $out/bin/qt.conf <<EOF
-    [Paths]
-    Prefix = ${qtwebengine.out}
-    EOF
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Update to the latest version before 17.03 branches off.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

