### PR TITLE
Update libcec

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -100,7 +100,7 @@ in stdenv.mkDerivation rec {
       ./bootstrap
     '';
 
-    configureFlags = [ ]
+    configureFlags = [ "--enable-libcec" ]
     ++ lib.optional (!sambaSupport) "--disable-samba"
     ++ lib.optional vdpauSupport "--enable-vdpau"
     ++ lib.optional pulseSupport "--enable-pulse"

--- a/pkgs/development/libraries/libcec/default.nix
+++ b/pkgs/development/libraries/libcec/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, cmake, pkgconfig, udev, libcec_platform }:
 
-let version = "3.1.0"; in
+let version = "4.0.2"; in
 
 stdenv.mkDerivation {
   name = "libcec-${version}";
 
   src = fetchurl {
     url = "https://github.com/Pulse-Eight/libcec/archive/libcec-${version}.tar.gz";
-    sha256 = "08gr4rhx7qh8ajkry9j0sqw11i74y802dla1wg4l4gxhl4hrs409";
+    sha256 = "09xsw9hfymzl9fi9r2r8n5cxk80fc00x9drsy1r59pgbycqxvf5q";
   };
 
   buildInputs = [ cmake pkgconfig udev libcec_platform ];


### PR DESCRIPTION
###### Motivation for this change

libcec was not working with Kodi because of a version mismatch. These patches update libcec to a working version and ensure that the build will fail if this happens again.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

