### PR TITLE
iana-etc: fixed source URL and homepage

### DIFF
--- a/pkgs/data/misc/iana-etc/default.nix
+++ b/pkgs/data/misc/iana-etc/default.nix
@@ -4,14 +4,14 @@ stdenv.mkDerivation rec {
   name = "iana-etc-2.30";
 
   src = fetchurl {
-    url = "http://sethwklein.net/projects/iana-etc/downloads/${name}.tar.bz2";
+    url = "http://sethwklein.net/${name}.tar.bz2";
     sha256 = "03gjlg5zlwsdk6qyw3v85l129rna5bpm4m7pzrp864h0n97qg9mr";
   };
 
   preInstall = "installFlags=\"PREFIX=$out\"";
 
   meta = {
-    homepage = http://sethwklein.net/projects/iana-etc/;
+    homepage = http://sethwklein.net/iana-etc;
     description = "IANA protocol and port number assignments (/etc/protocols and /etc/services)";
     platforms = stdenv.lib.platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change
It seems the homepage has moved years ago. The source URL was wrong.


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

