### PR TITLE
kde5: add hack font dependency

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/kde5.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde5.nix
@@ -209,7 +209,10 @@ in
             then { GDK_PIXBUF_MODULE_FILE = "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"; }
             else { });
 
-      fonts.fonts = [ (kde5.oxygen-fonts or pkgs.noto-fonts) ];
+      fonts.fonts = [
+        (kde5.oxygen-fonts or pkgs.noto-fonts)
+        pkgs.hack-font
+      ];
 
       programs.ssh.askPassword = "${kde5.ksshaskpass.out}/bin/ksshaskpass";
 


### PR DESCRIPTION
###### Motivation for this change

Hack is the recommended monospaced font for KDE.
See #22975

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is my first PR on a service, so I'm still trying to figure how I can test it.
If someone call tell me how to do it, I would be happy to test. I'll continue to search how to do this.

PS: as a new user, something I miss is a good documentation about how to contribute, especially for the testing part. There is a documentation about writing packages but not really about testing them.