### PR TITLE
Plugins

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -399,6 +399,17 @@ rec {
 
   };
 
+  vim-indent-object = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "vim-indent-object-2015-08-11";
+    src = fetchgit {
+      url = "git://github.com/michaeljsmith/vim-indent-object";
+      rev = "1d3e4aac0117d57c3e1aaaa7e5a99f1d7553e01b";
+      sha256 = "1xxl5pwbz56qjfxw6l686m1qc4a3q0r7afa9r5gjhgd1jy67z7d7";
+    };
+    dependencies = [];
+
+  };
+
   vim-nix = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "vim-nix-2016-11-02";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -622,6 +622,17 @@ rec {
 
   };
 
+  argtextobj = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "argtextobj-vim-2010-10-17";
+    src = fetchgit {
+      url = "git://github.com/vim-scripts/argtextobj.vim";
+      rev = "f3fbe427f7b4ec436416a5816d714dc917dc530b";
+      sha256 = "1l4jh5hdmky1qj5z26jpnk49a6djjcvzyyr6pknrrgb8rzkiln48";
+    };
+    dependencies = [];
+
+  };
+
   vim-elixir = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "vim-elixir-2017-01-24";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -80,6 +80,7 @@
 "github:lyokha/vim-xkbswitch"
 "github:machakann/vim-highlightedyank"
 "github:mhinz/vim-startify"
+"github:michaeljsmith/vim-indent-object"
 "github:mkasa/lushtags"
 "github:mpickering/hlint-refactor-vim"
 "github:nathanaelkane/vim-indent-guides"

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -121,6 +121,7 @@
 "github:vim-scripts/Colour-Sampler-Pack"
 "github:vim-scripts/Rename"
 "github:vim-scripts/a.vim"
+"github:vim-scripts/argtextobj.vim"
 "github:vim-scripts/align"
 "github:vim-scripts/changeColorScheme.vim"
 "github:vim-scripts/random.vim"


### PR DESCRIPTION
###### Motivation for this change
Add two vim plugins : https://github.com/vim-scripts/argtextobj.vim and https://github.com/michaeljsmith/vim-indent-object

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

