### PR TITLE
[RFC] nixos-version: Add lsb_release compatibility

### DIFF
--- a/nixos/modules/installer/tools/nixos-version.sh
+++ b/nixos/modules/installer/tools/nixos-version.sh
@@ -1,14 +1,130 @@
 #! @shell@
 
-case "$1" in
-  -h|--help)
-    exec man nixos-version
-    exit 1
-    ;;
-  --hash|--revision)
-    echo "@nixosRevision@"
-    ;;
-  *)
-    echo "@nixosVersion@ (@nixosCodeName@)"
-    ;;
-esac
+show_help() {
+  cat << EOF
+Usage: nixos-version [options]
+
+Options:
+  -h, --help         show this help message and exit
+  -v, --version      show LSB modules this system supports
+  -i, --id           show distributor ID
+  -d, --description  show description of this distribution
+  -r, --release      show release number of this distribution
+  --revision, --hash show revision (abbreviated commit hash) of this distribution
+  -c, --codename     show code name of this distribution
+  -a, --all          show all of the above information
+  -s, --short        show requested information in short format
+EOF
+  exit 0
+}
+
+# Potential command-line options.
+version=0
+id=0
+description=0
+release=0
+revision=0
+codename=0
+all=0
+short=0
+
+# Process each argument, and set the appropriate flag if we recognize it.
+while [[ $# -ge 1 ]]; do
+  case $1 in
+    -v|--version)
+      version=1
+      ;;
+    -i|--id)
+      id=1
+      ;;
+    -d|--description)
+      description=1
+      ;;
+    -r|--release)
+      release=1
+      ;;
+    --revision|--hash)
+      revision=1
+      ;;
+    -c|--codename)
+      codename=1
+      ;;
+    -a|--all)
+      all=1
+      ;;
+    -s|--short)
+      short=1
+      ;;
+    -h|--help)
+      show_help
+      # TODO
+      #exec man nixos-version
+      ;;
+    *)
+      echo "nixos-version: unrecognized option '$1'"
+      echo "Type 'nixos-version -h' for a list of available options."
+      exit 1
+  esac
+  shift
+done
+
+#  Read our variables.
+if [[ -e /etc/os-release ]]; then
+  . /etc/os-release
+else
+  echo "/etc/os-release is not present.  Aborting" >&2
+  exit 1
+fi
+
+# TODO: Default?
+#echo "@nixosVersion@ (@nixosCodeName@)"
+if [[ "$all" = "1" ]] || [[ "$version" = "1" ]] || \
+   ([[ "$id" = "0" ]] && [[ "$description" = "0" ]] && \
+    [[ "$release" = "0" ]] && [[ "$codename" = "0" ]]); then
+  echo "No LSB modules are available."
+fi
+
+# Now output the data - The order of these was chosen to match
+# what the original lsb_release used, and while I suspect it doesn't
+# matter I kept it the same.
+if [[ "$all" = "1" ]] || [[ "$id" = "1" ]]; then
+  if [[ "$short" = "0" ]]; then
+    printf "Distributor ID:\t"
+  fi
+  echo $ID
+fi
+
+if [[ "$all" = "1" ]] || [[ "$description" = "1" ]]; then
+  if [[ "$short" = "0" ]]; then
+    printf "Description:\t"
+  fi
+  echo $PRETTY_NAME
+fi
+
+if [[ "$all" = "1" ]] || [[ "$release" = "1" ]]; then
+  if [[ "$short" = "0" ]]; then
+    printf "Release:\t"
+  fi
+  echo $VERSION_ID
+fi
+
+# TODO: For all (incompatible with lsb_release)?
+if [[ "$all" = "1" ]] || [[ "$revision" = "1" ]]; then
+  if [[ "$short" = "0" ]]; then
+    printf "Revision:\t"
+  fi
+  # TODO: echo "@nixosRevision@"?
+  # Revision comes from: VERSION="16.09.git.effc189 (Flounder)" -> effc189
+  echo $(echo $VERSION | awk '{print $1}' | rev | cut -d. -f1 | rev)
+fi
+
+if [[ "$all" = "1" ]] || [[ "$codename" = "1" ]]; then
+  if [[ "$short" = "0" ]]; then
+    printf "Codename:\t"
+  fi
+
+  # Codename comes from: VERSION="16.09.git.effc189 (Flounder)" -> Flounder
+  echo $(echo $VERSION | awk '{print $2}' | tr -d \(\))
+fi
+
+exit 0

--- a/nixos/modules/installer/tools/nixos-version.sh
+++ b/nixos/modules/installer/tools/nixos-version.sh
@@ -91,7 +91,7 @@ if [[ "$all" = "1" ]] || [[ "$id" = "1" ]]; then
   if [[ "$short" = "0" ]]; then
     printf "Distributor ID:\t"
   fi
-  echo $ID
+  echo $NAME
 fi
 
 if [[ "$all" = "1" ]] || [[ "$description" = "1" ]]; then
@@ -115,16 +115,14 @@ if [[ "$all" = "1" ]] || [[ "$revision" = "1" ]]; then
   fi
   # TODO: echo "@nixosRevision@"?
   # Revision comes from: VERSION="16.09.git.effc189 (Flounder)" -> effc189
-  echo $(echo $VERSION | awk '{print $1}' | rev | cut -d. -f1 | rev)
+  echo $(echo $VERSION_ID | rev | cut -d. -f1 | rev)
 fi
 
 if [[ "$all" = "1" ]] || [[ "$codename" = "1" ]]; then
   if [[ "$short" = "0" ]]; then
     printf "Codename:\t"
   fi
-
-  # Codename comes from: VERSION="16.09.git.effc189 (Flounder)" -> Flounder
-  echo $(echo $VERSION | awk '{print $2}' | tr -d \(\))
+  echo $(echo $VERSION_CODENAME)
 fi
 
 exit 0

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -58,7 +58,6 @@ let
   nixos-version = makeProg {
     name = "nixos-version";
     src = ./nixos-version.sh;
-    inherit (config.system) nixosVersion nixosCodeName nixosRevision;
   };
 
 in


### PR DESCRIPTION
###### Motivation for this change

See the discussion at #22729.

BUGS/TODOS:
- [ ] Update the man page
  - The current man page states that --hash or --revision shows the *full SHA1 hash of the Git commit* (~that changed~ (only if build from a git checkout), now it's the abbreviated commit hash)
- [x] The default is to print the following message: "No LSB modules are available." which is probably not desirable (changing the default to "nixos-version -r -s" would probably make sense, even tho it breaks full lsb_release compatibility).
  - **solved**: `lsb_release` and `nixos-version` now both keep their default output
- [ ] Rename or alias nixos-version to lsb_relase (#22729)
- [x] nixos-version currently doesn't support parameters like "-rs" (only "-r -s" - I consider that a bug)
  - **solved**: via [enhanced getopt](https://stackoverflow.com/a/29754866/2732828) (or something else if someone has a better idea :)
- [x] Verify `lsb_release` compatibility (I tried to stick to the [specification](http://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/lsbrelease.html) and the `lsb_release` binary from Debian (wheezy)).
- Make sure this doesn't beak too much (fix all references in nixpkgs, add something to the release notes for 17.9, nix-dev notice(?), etc.)

The script is based on [this](https://gist.github.com/skx/1f9e5240856c5976193a) great public-domain Gist from @skx (thanks :smile: - I hope it's ok that I mention you).

cc #22729 @grahamc @davidak @edolstra @eduarrrd 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

