### PR TITLE
retroarch: libretro-mednafen-* -> libretro-beetle-*

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -62,6 +62,45 @@ in
     buildPhase = "make";
   };
 
+  beetle-pce-fast = (mkLibRetroCore rec {
+    core = "mednafen-pce-fast";
+    src = fetchRetro {
+      repo = "beetle-pce-fast-libretro";
+      rev = "6e2eaf75da2eb3dfcf2fd64413f471c8c90cf885";
+      sha256 = "0m946108wzawg0c4xvqpv6yzfmjngz6lji5hn4swgk0z5f2bj5a5";
+    };
+    description = "Port of Mednafen's PC Engine core to libretro";
+  }).override {
+    buildPhase = "make";
+    name = "beetle-pce-fast";
+  };
+
+  beetle-psx = (mkLibRetroCore rec {
+    core = "mednafen-psx";
+    src = fetchRetro {
+      repo = "beetle-psx-libretro";
+      rev = "20c9b0eb0062b8768cc40aca0e2b2d626f1002a2";
+      sha256 = "192xzvdbjjqlxrnxxn45hmrr6yjpxw3gapkbax6nhrabnxhva43k";
+    };
+    description = "Port of Mednafen's PSX Engine core to libretro";
+  }).override {
+    buildPhase = "make";
+    name = "beetle-psx";
+  };
+
+  beetle-saturn = (mkLibRetroCore rec {
+    core = "mednafen-saturn";
+    src = fetchRetro {
+      repo = "beetle-saturn-libretro";
+      rev = "bb5d0c126feb25cf980f5cc1fc57d6a5a6f6e7ab";
+      sha256 = "0bnsdy27378b71y6aa65k4jxxy2xw6ky2ici3z53hkky2jnnjq0b";
+    };
+    description = "Port of Mednafen's Saturn core to libretro";
+  }).override {
+    buildPhase = "make";
+    name = "beetle-saturn";
+  };
+
   bsnes-mercury = let bname = "bsnes-mercury"; in (mkLibRetroCore rec {
     core = bname + "-accuracy";
     src = fetchRetro {
@@ -144,42 +183,6 @@ in
     description = "Port of MAME to libretro";
 
     extraBuildInputs = [ alsaLib portaudio python27 ];
-  };
-
-  mednafen-pce-fast = (mkLibRetroCore rec {
-    core = "mednafen-pce-fast";
-    src = fetchRetro {
-      repo = "beetle-pce-fast-libretro";
-      rev = "6e2eaf75da2eb3dfcf2fd64413f471c8c90cf885";
-      sha256 = "0m946108wzawg0c4xvqpv6yzfmjngz6lji5hn4swgk0z5f2bj5a5";
-    };
-    description = "Port of Mednafen's PC Engine core to libretro";
-  }).override {
-    buildPhase = "make";
-  };
-
-  mednafen-psx = (mkLibRetroCore rec {
-    core = "mednafen-psx";
-    src = fetchRetro {
-      repo = "beetle-psx-libretro";
-      rev = "20c9b0eb0062b8768cc40aca0e2b2d626f1002a2";
-      sha256 = "192xzvdbjjqlxrnxxn45hmrr6yjpxw3gapkbax6nhrabnxhva43k";
-    };
-    description = "Port of Mednafen's PSX Engine core to libretro";
-  }).override {
-    buildPhase = "make";
-  };
-
-  mednafen-saturn = (mkLibRetroCore rec {
-    core = "mednafen-saturn";
-    src = fetchRetro {
-      repo = "beetle-saturn-libretro";
-      rev = "bb5d0c126feb25cf980f5cc1fc57d6a5a6f6e7ab";
-      sha256 = "0bnsdy27378b71y6aa65k4jxxy2xw6ky2ici3z53hkky2jnnjq0b";
-    };
-    description = "Port of Mednafen's Saturn core to libretro";
-  }).override {
-    buildPhase = "make";
   };
 
   mgba = mkLibRetroCore rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15719,6 +15719,9 @@ with pkgs;
     in with libretro;
       ([ ]
       ++ optional (cfg.enable4do or false) _4do
+      ++ optional (cfg.enableBeetlePCEFast or false) beetle-pce-fast
+      ++ optional (cfg.enableBeetlePSX or false) beetle-psx
+      ++ optional (cfg.enableBeetleSaturn or false) beetle-saturn
       ++ optional (cfg.enableBsnesMercury or false) bsnes-mercury
       ++ optional (cfg.enableDesmume or false) desmume
       ++ optional (cfg.enableFBA or false) fba
@@ -15726,9 +15729,6 @@ with pkgs;
       ++ optional (cfg.enableGambatte or false) gambatte
       ++ optional (cfg.enableGenesisPlusGX or false) genesis-plus-gx
       ++ optional (cfg.enableMAME or false) mame
-      ++ optional (cfg.enableMednafenPCEFast or false) mednafen-pce-fast
-      ++ optional (cfg.enableMednafenPSX or false) mednafen-psx
-      ++ optional (cfg.enableMednafenSaturn or false) mednafen-saturn
       ++ optional (cfg.enableMGBA or false) mgba
       ++ optional (cfg.enableMupen64Plus or false) mupen64plus
       ++ optional (cfg.enableNestopia or false) nestopia
@@ -15743,6 +15743,14 @@ with pkgs;
       ++ optional (cfg.enableStella or false) stella
       ++ optional (cfg.enableVbaNext or false) vba-next
       ++ optional (cfg.enableVbaM or false) vba-m
+
+      # added on 2017-02-25 due #23163
+      ++ optional (cfg.enableMednafenPCEFast or false)
+          (throw "nix config option enableMednafenPCEFast has been renamed to enableBeetlePCEFast")
+      ++ optional (cfg.enableMednafenPSX or false)
+          (throw "nix config option enableMednafenPSX has been renamed to enableBeetlePSX")
+      ++ optional (cfg.enableMednafenSaturn or false)
+          (throw "nix config option enableMednafenSaturn has been renamed to enableBeetleSaturn")
       );
 
   wrapRetroArch = { retroarch }: callPackage ../misc/emulators/retroarch/wrapper.nix {


### PR DESCRIPTION
Renames all mednafen-* libretro ports to beetle-* due #23163.

Alle derivation products (executables & libraries) are still called mednafen-* (that's what libretro's makefiles produce). That's why the core variables are still named that way (and why it has been named like that initially). However all package attributes & names are changed. I've added exceptions for old nix config files, I guess that this should be sufficient to inform our users about the change. Only users who aren't using the the config interface and have installed the packages explicitly won't get updates when installed by name or an error when installed by attribute. I don't believe that an alias is necessary.

@mednafen thanks for the clarification. Libretro's repos do use both names interchangeably without explaining why the alternate exists.

Closes #23163.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---