### PR TITLE
Separate Qt 5 packages from dependent libraries

### DIFF
--- a/doc/languages-frameworks/qt.xml
+++ b/doc/languages-frameworks/qt.xml
@@ -2,67 +2,31 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          xml:id="sec-language-qt">
 
-<title>Qt</title>
+<title>Qt and KDE</title>
 
-<para>The information in this section applies to Qt 5.5 and later.</para>
-
-<para>Qt is an application development toolkit for C++. Although it is
-not a distinct programming language, there are special considerations
-for packaging Qt-based programs and libraries. A small set of tools
-and conventions has grown out of these considerations.</para>
+<para>Qt is a comprehensive desktop and mobile application development toolkit for C++. Legacy support is available for Qt 3 and Qt 4, but all current development uses Qt 5. The Qt 5 packages in Nixpkgs are updated frequently to take advantage of new features, but older versions are typically retained to support packages that may not be compatible with the latest version. When packaging applications and libraries for Nixpkgs, it is important to ensure that compatible versions of Qt 5 are used throughout; this consideration motivates the tools described below.</para>
 
 <section xml:id="ssec-qt-libraries"><title>Libraries</title>
 
-<para>Packages that provide libraries should be listed in
-<varname>qt5LibsFun</varname> so that the library is built with each
-Qt version. A set of packages is provided for each version of Qt; for
-example, <varname>qt5Libs</varname> always provides libraries built
-with the latest version, <varname>qt55Libs</varname> provides
-libraries built with Qt 5.5, and so on. To avoid version conflicts, no
-top-level attributes are created for these packages.</para>
+<para>Libraries that depend on Qt 5 should be built with each available version to avoid linking a dependent package against incompatible versions of Qt 5. (Although Qt 5 maintains backward ABI compatibility, linking against multiple versions at once is generally not possible; at best it will lead to runtime faults.) Packages that provide libraries should be added to the top-level function <varname>mkLibsForQt5</varname>, which is used to build a set of libraries for every Qt 5 version. The <varname>callPackage</varname> provided in this scope will ensure that only one Qt version will be used throughout the dependency tree. Dependencies should be imported unqualified, i.e. <literal>qtbase</literal> not <literal>qt5.qtbase</literal>, so that <varname>callPackage</varname> can do its work. <emphasis>Do not</emphasis> import a package set such as <literal>qt5</literal> or <literal>libsForQt5</literal> into your package; although it may work fine in the moment, it could well break at the next Qt update.</para>
+
+<para>If a library does not support a particular version of Qt 5, it is best to mark it as broken by setting its <literal>meta.broken</literal> attribute. A package may be marked broken for certain versions by testing the <literal>qtbase.version</literal> attribute, which will always give the current Qt 5 version.</para>
 
 </section>
 
-<section xml:id="ssec-qt-programs"><title>Programs</title>
+<section xml:id="ssec-qt-applications"><title>Applications</title>
 
-<para>Application packages do not need to be built with every Qt
-version. To ensure consistency between the package's dependencies,
-call the package with <literal>qt5Libs.callPackage</literal> instead
-of the usual <literal>callPackage</literal>. An older version may be
-selected in case of incompatibility. For example, to build with Qt
-5.5, call the package with
-<literal>qt55Libs.callPackage</literal>.</para>
+<para>Applications generally do not need to be built with every Qt version because they do not provide any libraries for dependent packages to link against. The primary consideration is merely ensuring that the application itself and its dependencies are linked against only one version of Qt. To call your application expression, use <literal>libsForQt5.callPackage</literal> instead of <literal>callPackage</literal>. Dependencies should be imported unqualified, i.e. <literal>qtbase</literal> not <literal>qt5.qtbase</literal>. <emphasis>Do not</emphasis> import a package set such as <literal>qt5</literal> or <literal>libsForQt5</literal> into your package; although it may work fine in the moment, it could well break at the next Qt update.</para>
 
-<para>Several environment variables must be set at runtime for Qt
-applications to function correctly, including:</para>
+<para>It is generally best to build an application package against the <varname>libsForQt5</varname> library set. In case a package does not build with the latest Qt version, it is possible to pick a set pinned to a particular version, e.g. <varname>libsForQt55</varname> for Qt 5.5, if that is the latest version the package supports.</para>
 
-<itemizedlist>
-  <listitem><para><envar>QT_PLUGIN_PATH</envar></para></listitem>
-  <listitem><para><envar>QML_IMPORT_PATH</envar></para></listitem>
-  <listitem><para><envar>QML2_IMPORT_PATH</envar></para></listitem>
-  <listitem><para><envar>XDG_DATA_DIRS</envar></para></listitem>
-</itemizedlist>
-
-<para>To ensure that these are set correctly, the program must be wrapped by
-invoking <literal>wrapQtProgram <replaceable>program</replaceable></literal>
-during installation (for example, during
-<literal>fixupPhase</literal>). <literal>wrapQtProgram</literal>
-accepts the same options as <literal>makeWrapper</literal>.
-</para>
+<para>Qt-based applications require that several paths be set at runtime. This is accomplished by wrapping the provided executables in a package with <literal>wrapQtProgram</literal> or <literal>makeQtWrapper</literal> during the <literal>postFixup</literal> phase. To use the wrapper generators, add <literal>makeQtWrapper</literal> to <literal>nativeBuildInputs</literal>. The wrapper generators support the same options as <literal>wrapProgram</literal> and <literal>makeWrapper</literal> respectively. It is usually only necessary to generate wrappers for programs intended to be invoked by the user.</para>
 
 </section>
 
 <section xml:id="ssec-qt-kde"><title>KDE</title>
 
-<para>Many of the considerations above also apply to KDE packages,
-especially the need to set the correct environment variables at
-runtime. To ensure that this is done, invoke <literal>wrapKDEProgram
-<replaceable>program</replaceable></literal> during
-installation. <literal>wrapKDEProgram</literal> also generates a
-<literal>ksycoca</literal> database so that required data and services
-can be found. Like its Qt counterpart,
-<literal>wrapKDEProgram</literal> accepts the same options as
-<literal>makeWrapper</literal>.</para>
+<para>The KDE Frameworks are a set of libraries for Qt 5 which form the basis of the Plasma desktop environment and the KDE Applications suite. Packaging a Frameworks-based library does not require any steps beyond those described above for general Qt-based libraries. Frameworks-based applications should not use <literal>makeQtWrapper</literal>; instead, use <literal>kdeWrapper</literal> to create the necessary wrappers: <literal>kdeWrapper { unwrapped = <replaceable>expr</replaceable>; targets = <replaceable>exes</replaceable>; }</literal>, where <replaceable>expr</replaceable> is the un-wrapped package expression and <replaceable>exes</replaceable> is a list of strings giving the relative paths to programs in the package which should be wrapped.</para>
 
 </section>
 

--- a/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
@@ -1,6 +1,11 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, qt5, kde5, lxqt, xorg,
-libstatgrab, lm_sensors, libpulseaudio, alsaLib, menu-cache,
-lxmenu-data }:
+{
+  stdenv, fetchFromGitHub, standardPatch,
+  cmake, pkgconfig, lxqt-build-tools,
+  qtbase, qttools, qtx11extras, qtsvg, libdbusmenu, kwindowsystem, solid,
+  kguiaddons, liblxqt, libqtxdg, lxqt-common, lxqt-globalkeys, libsysstat,
+  xorg, libstatgrab, lm_sensors, libpulseaudio, alsaLib, menu-cache,
+  lxmenu-data
+}:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -17,23 +22,23 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkgconfig
-    lxqt.lxqt-build-tools
+    lxqt-build-tools
   ];
 
   buildInputs = [
-    qt5.qtbase
-    qt5.qttools
-    qt5.qtx11extras
-    qt5.qtsvg
-    qt5.libdbusmenu
-    kde5.kwindowsystem
-    kde5.solid
-    kde5.kguiaddons
-    lxqt.liblxqt
-    lxqt.libqtxdg
-    lxqt.lxqt-common
-    lxqt.lxqt-globalkeys
-    lxqt.libsysstat
+    qtbase
+    qttools
+    qtx11extras
+    qtsvg
+    libdbusmenu
+    kwindowsystem
+    solid
+    kguiaddons
+    liblxqt
+    libqtxdg
+    lxqt-common
+    lxqt-globalkeys
+    libsysstat
     xorg.libpthreadstubs
     xorg.libXdmcp
     libstatgrab
@@ -46,7 +51,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DPULL_TRANSLATIONS=NO" ];
 
-  postPatch = lxqt.standardPatch;
+  postPatch = standardPatch;
 
   meta = with stdenv.lib; {
     description = "The LXQt desktop panel";

--- a/pkgs/desktops/lxqt/core/lxqt-policykit/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-policykit/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, qt5, kde5, lxqt }:
+{
+  stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools,
+  qtbase, qttools, qtx11extras, qtsvg, polkit-qt, kwindowsystem, liblxqt,
+  libqtxdg,
+}:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -15,18 +19,18 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkgconfig
-    lxqt.lxqt-build-tools
+    lxqt-build-tools
   ];
 
   buildInputs = [
-    qt5.qtbase
-    qt5.qttools
-    qt5.qtx11extras
-    qt5.qtsvg
-    qt5.polkit-qt
-    kde5.kwindowsystem
-    lxqt.liblxqt
-    lxqt.libqtxdg
+    qtbase
+    qttools
+    qtx11extras
+    qtsvg
+    polkit-qt
+    kwindowsystem
+    liblxqt
+    libqtxdg
   ];
 
   cmakeFlags = [ "-DPULL_TRANSLATIONS=NO" ];

--- a/pkgs/desktops/lxqt/core/lxqt-qtplugin/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-qtplugin/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchFromGitHub, cmake, qt5, lxqt }:
+{
+  stdenv, fetchFromGitHub, standardPatch,
+  cmake, lxqt-build-tools,
+  qtbase, qtx11extras, qttools, qtsvg, libdbusmenu, libqtxdg,
+}:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -14,21 +18,21 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    lxqt.lxqt-build-tools
+    lxqt-build-tools
   ];
 
   buildInputs = [
-    qt5.qtbase
-    qt5.qtx11extras
-    qt5.qttools
-    qt5.qtsvg
-    qt5.libdbusmenu
-    lxqt.libqtxdg
+    qtbase
+    qtx11extras
+    qttools
+    qtsvg
+    libdbusmenu
+    libqtxdg
   ];
 
   cmakeFlags = [ "-DPULL_TRANSLATIONS=NO" ];
 
-  postPatch = lxqt.standardPatch;
+  postPatch = standardPatch;
 
   meta = with stdenv.lib; {
     description = "LXQt Qt platform integration plugin";

--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -1,13 +1,11 @@
-{ pkgs, newScope, fetchFromGitHub }:
+{ pkgs, makeScope, libsForQt5, fetchFromGitHub }:
 
 let
-  callPackage = newScope self;
-
-  self = rec {
+  packages = self: with self; {
 
     # For compiling information, see:
     # - https://github.com/lxde/lxqt/wiki/Building-from-source
-  
+
     standardPatch = ''
       for file in $(find . -name CMakeLists.txt); do
         substituteInPlace $file \
@@ -128,4 +126,4 @@ let
 
   };
 
-in self
+in makeScope libsForQt5.newScope packages

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -51,9 +51,7 @@ let
 
       });
 
-    kdeFramework = let
-      broken = builtins.compareVersions self.qtbase.version "5.6.0" < 0;
-    in args:
+    kdeFramework = args:
       let
         inherit (args) name;
         inherit (srcs."${name}") src version;
@@ -67,7 +65,6 @@ let
           ];
           platforms = lib.platforms.linux;
           homepage = "http://www.kde.org";
-          inherit broken;
         } // (args.meta or {});
       });
 

--- a/pkgs/development/libraries/phonon/default.nix
+++ b/pkgs/development/libraries/phonon/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, cmake, mesa, pkgconfig, libpulseaudio
-, qt4 ? null, extra-cmake-modules, qtbase ? null, qttools ? null
+, qt4 ? null, ecm ? null, qtbase ? null, qttools ? null
 , withQt5 ? false
 , debug ? false }:
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     [ mesa libpulseaudio ]
     ++ (if withQt5 then [ qtbase qttools ] else [ qt4 ]);
 
-  nativeBuildInputs = [ cmake pkgconfig ] ++ optional withQt5 extra-cmake-modules;
+  nativeBuildInputs = [ cmake pkgconfig ] ++ optional withQt5 ecm;
 
   NIX_CFLAGS_COMPILE = "-fPIC";
 

--- a/pkgs/development/libraries/qt-5/5.7/default.nix
+++ b/pkgs/development/libraries/qt-5/5.7/default.nix
@@ -14,28 +14,30 @@ top-level attribute to `top-level/all-packages.nix`.
 
 */
 
-{ pkgs
+{
+  newScope,
+  stdenv, fetchurl, makeSetupHook, makeWrapper,
+  bison, cups ? null, harfbuzz, mesa, perl,
+  gstreamer, gst-plugins-base,
 
-# options
-, developerBuild ? false
-, decryptSslTraffic ? false
+  # options
+  developerBuild ? false,
+  decryptSslTraffic ? false,
 }:
-
-let inherit (pkgs) makeSetupHook makeWrapper stdenv; in
 
 with stdenv.lib;
 
 let
 
   mirror = "http://download.qt.io";
-  srcs = import ./srcs.nix { inherit (pkgs) fetchurl; inherit mirror; };
+  srcs = import ./srcs.nix { inherit fetchurl; inherit mirror; };
 
   qtSubmodule = args:
     let
       inherit (args) name;
       version = args.version or srcs."${name}".version;
       src = args.src or srcs."${name}".src;
-      inherit (pkgs.stdenv) mkDerivation;
+      inherit (stdenv) mkDerivation;
     in mkDerivation (args // {
       name = "${name}-${version}";
       inherit src;
@@ -43,7 +45,7 @@ let
       propagatedBuildInputs = args.qtInputs ++ (args.propagatedBuildInputs or []);
       nativeBuildInputs =
         (args.nativeBuildInputs or [])
-        ++ [ pkgs.perl self.qmakeHook ];
+        ++ [ perl self.qmakeHook ];
 
       NIX_QT_SUBMODULE = args.NIX_QT_SUBMODULE or true;
 
@@ -64,11 +66,7 @@ let
 
       qtbase = callPackage ./qtbase {
         inherit (srcs.qtbase) src version;
-        mesa = pkgs.mesa_noglu;
-        harfbuzz = pkgs.harfbuzz-icu;
-        cups = if stdenv.isLinux then pkgs.cups else null;
-        # GNOME dependencies are not used unless gtkStyle == true
-        bison = pkgs.bison2; # error: too few arguments to function 'int yylex(...
+        inherit bison cups harfbuzz mesa;
         inherit developerBuild decryptSslTraffic;
       };
 
@@ -79,7 +77,7 @@ let
       qtimageformats = callPackage ./qtimageformats.nix {};
       qtlocation = callPackage ./qtlocation.nix {};
       qtmultimedia = callPackage ./qtmultimedia.nix {
-        inherit (pkgs.gst_all_1) gstreamer gst-plugins-base;
+        inherit gstreamer gst-plugins-base;
       };
       qtquickcontrols = callPackage ./qtquickcontrols.nix {};
       qtquickcontrols2 = callPackage ./qtquickcontrols2.nix {};
@@ -117,6 +115,6 @@ let
 
     };
 
-   self = makeScope pkgs.newScope addPackages;
+   self = makeScope newScope addPackages;
 
 in self

--- a/pkgs/development/libraries/quazip/default.nix
+++ b/pkgs/development/libraries/quazip/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, zip, zlib, qt, qmakeHook }:
+{ fetchurl, stdenv, zip, zlib, qtbase, qmakeHook }:
 
 stdenv.mkDerivation rec {
   name = "quazip-0.7.1";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = "cd quazip";
 
-  buildInputs = [ zlib qt ];
+  buildInputs = [ zlib qtbase ];
   nativeBuildInputs = [ qmakeHook ];
 
   meta = {

--- a/pkgs/development/tools/profiling/heaptrack/default.nix
+++ b/pkgs/development/tools/profiling/heaptrack/default.nix
@@ -1,5 +1,8 @@
-{ stdenv, fetchFromGitHub, cmake, zlib, boost162, libunwind,
-  elfutils, qt5, kde5, sparsehash }:
+{
+  stdenv, fetchFromGitHub, cmake, ecm,
+  zlib, boost162, libunwind, elfutils, sparsehash,
+  qtbase, kio, kitemmodels, threadweaver, kconfigwidgets, kcoreaddons,
+}:
 
 stdenv.mkDerivation rec {
   name = "heaptrack-${version}";
@@ -12,9 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "0dqchd2r4khv9gzj4n0qjii2nqygkj5jclkji8jbvivx5qwsqznc";
   };
 
-  buildInputs = [ cmake zlib boost162 libunwind elfutils sparsehash
-                  qt5.ecm qt5.qtbase kde5.kio kde5.kitemmodels
-                  kde5.threadweaver kde5.kconfigwidgets kde5.kcoreaddons ];
+  nativeBuildInputs = [ cmake ecm ];
+  buildInputs = [
+    zlib boost162 libunwind elfutils sparsehash
+    qtbase kio kitemmodels threadweaver kconfigwidgets kcoreaddons
+  ];
 
   meta = with stdenv.lib; {
     description = "Heap memory profiler for Linux";

--- a/pkgs/tools/misc/colord-kde/0.5.nix
+++ b/pkgs/tools/misc/colord-kde/0.5.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl
-, extra-cmake-modules, ki18n
+, ecm, ki18n
 , kconfig, kconfigwidgets, kcoreaddons, kdbusaddons, kiconthemes, kcmutils
 , kio, knotifications, plasma-framework, kwidgetsaddons, kwindowsystem
 , kitemviews, lcms2, libXrandr, qtx11extras
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "0brdnpflm95vf4l41clrqxwvjrdwhs859n7401wxcykkmw4m0m3c";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules ki18n ];
+  nativeBuildInputs = [ ecm ki18n ];
 
   buildInputs = [
     kconfig kconfigwidgets kcoreaddons kdbusaddons kiconthemes

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -17,7 +17,7 @@ in
   ### Deprecated aliases - for backward compatibility
 
 doNotDisplayTwice rec {
-  accounts-qt = qt5.accounts-qt;  # added 2015-12-19
+  accounts-qt = libsForQt5.accounts-qt;  # added 2015-12-19
   adobeReader = adobe-reader;
   aircrackng = aircrack-ng; # added 2016-01-14
   arduino_core = arduino-core;  # added 2015-02-04
@@ -50,7 +50,7 @@ doNotDisplayTwice rec {
   gettextWithExpat = gettext; # 2016-02-19
   git-hub = gitAndTools.git-hub; # added 2016-04-29
   googleAuthenticator = google-authenticator; # added 2016-10-16
-  grantlee5 = qt5.grantlee;  # added 2015-12-19
+  grantlee5 = libsForQt5.grantlee;  # added 2015-12-19
   gupnptools = gupnp-tools;  # added 2015-12-19
   gnustep-make = gnustep.make; # added 2016-7-6
   htmlTidy = html-tidy;  # added 2014-12-06
@@ -62,7 +62,7 @@ doNotDisplayTwice rec {
   keepassx-reboot = keepassx-community; # added 2017-02-01
   keybase-go = keybase;  # added 2016-08-24
   letsencrypt = certbot; # added 2016-05-16
-  libdbusmenu_qt5 = qt5.libdbusmenu;  # added 2015-12-19
+  libdbusmenu_qt5 = libsForQt5.libdbusmenu;  # added 2015-12-19
   libcap_manpages = libcap.doc; # added 2016-04-29
   libcap_pam = if stdenv.isLinux then libcap.pam else null; # added 2016-04-29
   libcap_progs = libcap.out; # added 2016-04-29
@@ -74,7 +74,7 @@ doNotDisplayTwice rec {
   manpages = man-pages; # added 2015-12-06
   man_db = man-db; # added 2016-05
   midoriWrapper = midori; # added 2015-01
-  mlt-qt5 = qt5.mlt;  # added 2015-12-19
+  mlt-qt5 = libsForQt5.mlt;  # added 2015-12-19
   module_init_tools = kmod; # added 2016-04-22
   mssys = ms-sys; # added 2015-12-13
   multipath_tools = multipath-tools;  # added 2016-01-21
@@ -87,11 +87,11 @@ doNotDisplayTwice rec {
   owncloudclient = owncloud-client;  # added 2016-08
   pidgin-with-plugins = pidgin; # added 2016-06
   pidginlatexSF = pidginlatex; # added 2014-11-02
-  poppler_qt5 = qt5.poppler;  # added 2015-12-19
-  qca-qt5 = qt5.qca-qt5;  # added 2015-12-19
+  poppler_qt5 = libsForQt5.poppler;  # added 2015-12-19
+  qca-qt5 = libsForQt5.qca-qt5;  # added 2015-12-19
   QmidiNet = qmidinet;  # added 2016-05-22
   quake3game = ioquake3; # added 2016-01-14
-  qwt6 = qt5.qwt;  # added 2015-12-19
+  qwt6 = libsForQt5.qwt;  # added 2015-12-19
   rdiff_backup = rdiff-backup;  # added 2014-11-23
   rekonqWrapper = rekonq; # added 2015-01
   rssglx = rss-glx; #added 2015-03-25
@@ -108,7 +108,7 @@ doNotDisplayTwice rec {
   sqliteInteractive = sqlite-interactive;  # added 2014-12-06
   sshfsFuse = sshfs-fuse; # added 2016-09
   system_config_printer = system-config-printer;  # added 2016-01-03
-  telepathy_qt5 = qt5.telepathy;  # added 2015-12-19
+  telepathy_qt5 = libsForQt5.telepathy;  # added 2015-12-19
   tftp_hpa = tftp-hpa; # added 2015-04-03
   ucsFonts = ucs-fonts; # added 2016-07-15
   usb_modeswitch = usb-modeswitch; # added 2016-05-10

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -381,7 +381,7 @@ with pkgs;
 
   aj-snapshot  = callPackage ../applications/audio/aj-snapshot { };
 
-  albert = qt5.callPackage ../applications/misc/albert {};
+  albert = libsForQt5.callPackage ../applications/misc/albert {};
 
   amazon-glacier-cmd-interface = callPackage ../tools/backup/amazon-glacier-cmd-interface { };
 
@@ -420,7 +420,7 @@ with pkgs;
     withGui = false;
   };
 
-  apitrace = qt55.callPackage ../applications/graphics/apitrace {};
+  apitrace = libsForQt55.callPackage ../applications/graphics/apitrace {};
 
   argus = callPackage ../tools/networking/argus {};
 
@@ -746,7 +746,7 @@ with pkgs;
 
   clib = callPackage ../tools/package-management/clib { };
 
-  colord-kde = qt5.callPackage ../tools/misc/colord-kde/0.5.nix {};
+  colord-kde = libsForQt5.callPackage ../tools/misc/colord-kde/0.5.nix {};
 
   consul = callPackage ../servers/consul { };
 
@@ -1092,7 +1092,7 @@ with pkgs;
 
   davix = callPackage ../tools/networking/davix { };
 
-  cantata = qt5.callPackage ../applications/audio/cantata {
+  cantata = libsForQt5.callPackage ../applications/audio/cantata {
     ffmpeg = ffmpeg_2;
   };
 
@@ -1158,7 +1158,7 @@ with pkgs;
 
   citrix_receiver = callPackage ../applications/networking/remote/citrix-receiver { };
 
-  cmst = qt5.callPackage ../tools/networking/cmst { };
+  cmst = libsForQt5.callPackage ../tools/networking/cmst { };
 
   colord = callPackage ../tools/misc/colord { };
 
@@ -1289,7 +1289,7 @@ with pkgs;
 
   cloud-utils = callPackage ../tools/misc/cloud-utils { };
 
-  ckb = qt5.callPackage ../tools/misc/ckb { };
+  ckb = libsForQt5.callPackage ../tools/misc/ckb { };
 
   compass = callPackage ../development/tools/compass { };
 
@@ -1297,7 +1297,7 @@ with pkgs;
 
   convoy = callPackage ../tools/filesystems/convoy { };
 
-  cool-retro-term = qt55.callPackage ../applications/misc/cool-retro-term { };
+  cool-retro-term = libsForQt55.callPackage ../applications/misc/cool-retro-term { };
 
   coreutils = callPackage ../tools/misc/coreutils {
     aclSupport = stdenv.isLinux;
@@ -2198,7 +2198,7 @@ with pkgs;
 
   hecate = callPackage ../applications/editors/hecate { };
 
-  heaptrack = callPackage ../development/tools/profiling/heaptrack {};
+  heaptrack = libsForQt5.callPackage ../development/tools/profiling/heaptrack {};
 
   heimdall = callPackage ../tools/misc/heimdall { };
 
@@ -2248,11 +2248,11 @@ with pkgs;
 
   i2pd = callPackage ../tools/networking/i2pd {};
 
-  i-score = qt5.callPackage ../applications/audio/i-score { };
+  i-score = libsForQt5.callPackage ../applications/audio/i-score { };
 
   iasl = callPackage ../development/compilers/iasl { };
 
-  iannix = qt5.callPackage ../applications/audio/iannix { };
+  iannix = libsForQt5.callPackage ../applications/audio/iannix { };
 
   icecast = callPackage ../servers/icecast { };
 
@@ -2451,15 +2451,15 @@ with pkgs;
 
   kpcli = callPackage ../tools/security/kpcli { };
 
-  krename-qt5 = qt5.callPackage ../applications/misc/krename/kde5.nix { };
+  krename-qt5 = libsForQt5.callPackage ../applications/misc/krename/kde5.nix { };
 
-  kronometer = qt5.callPackage ../tools/misc/kronometer { };
+  kronometer = libsForQt5.callPackage ../tools/misc/kronometer { };
 
-  kdiff3-qt5 = qt5.callPackage ../tools/text/kdiff3/kde5.nix { };
+  kdiff3-qt5 = libsForQt5.callPackage ../tools/text/kdiff3/kde5.nix { };
 
-  peruse = qt5.callPackage ../tools/misc/peruse { };
+  peruse = libsForQt5.callPackage ../tools/misc/peruse { };
 
-  kst = qt5.callPackage ../tools/graphics/kst { gsl = gsl_1; };
+  kst = libsForQt5.callPackage ../tools/graphics/kst { gsl = gsl_1; };
 
   kytea = callPackage ../tools/text/kytea { };
 
@@ -2858,7 +2858,7 @@ with pkgs;
 
   mfoc = callPackage ../tools/security/mfoc { };
 
-  mgba = qt5.callPackage ../misc/emulators/mgba { };
+  mgba = libsForQt5.callPackage ../misc/emulators/mgba { };
 
   mimeo = callPackage ../tools/misc/mimeo { };
 
@@ -3403,7 +3403,7 @@ with pkgs;
     inherit qt4;
   };
 
-  pinentry_qt5 = qt5.callPackage ../tools/security/pinentry/qt5.nix {
+  pinentry_qt5 = libsForQt5.callPackage ../tools/security/pinentry/qt5.nix {
     libcap = if stdenv.isDarwin then null else libcap;
   };
 
@@ -3554,10 +3554,10 @@ with pkgs;
 
   qalculate-gtk = callPackage ../applications/science/math/qalculate-gtk { };
 
-  qastools = qt5.callPackage ../tools/audio/qastools { };
+  qastools = libsForQt5.callPackage ../tools/audio/qastools { };
 
-  qesteidutil = qt5.callPackage ../tools/security/qesteidutil { } ;
-  qdigidoc = qt5.callPackage ../tools/security/qdigidoc { } ;
+  qesteidutil = libsForQt5.callPackage ../tools/security/qesteidutil { } ;
+  qdigidoc = libsForQt5.callPackage ../tools/security/qdigidoc { } ;
   esteidfirefoxplugin = callPackage ../applications/networking/browsers/mozilla-plugins/esteidfirefoxplugin { };
 
 
@@ -3772,7 +3772,9 @@ with pkgs;
     quazip = quazip_qt4;
   };
 
-  quazip_qt4 = self.qt5.quazip.override { qt = qt4; qmakeHook = qmake4Hook; };
+  quazip_qt4 = libsForQt5.quazip.override {
+    qtbase = qt4; qmakeHook = qmake4Hook;
+  };
 
   scrot = callPackage ../tools/graphics/scrot { };
 
@@ -3814,7 +3816,7 @@ with pkgs;
 
   siege = callPackage ../tools/networking/siege {};
 
-  sigil = qt55.callPackage ../applications/editors/sigil { };
+  sigil = libsForQt55.callPackage ../applications/editors/sigil { };
 
   # aka., gpg-tools
   signing-party = callPackage ../tools/security/signing-party { };
@@ -3922,7 +3924,7 @@ with pkgs;
 
   su-exec = callPackage ../tools/security/su-exec {};
 
-  subsurface = qt5.callPackage ../applications/misc/subsurface { };
+  subsurface = libsForQt5.callPackage ../applications/misc/subsurface { };
 
   sudo = callPackage ../tools/security/sudo { };
 
@@ -4054,7 +4056,7 @@ with pkgs;
 
   thin-provisioning-tools = callPackage ../tools/misc/thin-provisioning-tools {  };
 
-  tiled = qt5.callPackage ../applications/editors/tiled { };
+  tiled = libsForQt5.callPackage ../applications/editors/tiled { };
 
   timemachine = callPackage ../applications/audio/timemachine { };
 
@@ -6272,7 +6274,7 @@ with pkgs;
   cmakeWithGui = cmakeCurses.override { useQt4 = true; };
 
   # Does not actually depend on Qt 5
-  extra-cmake-modules = qt5.ecmNoHooks;
+  extra-cmake-modules = libsForQt5.ecmNoHooks;
 
   coccinelle = callPackage ../development/tools/misc/coccinelle {
     ocamlPackages = ocamlPackages_4_01_0;
@@ -6649,7 +6651,7 @@ with pkgs;
 
   premake = premake4;
 
-  qtcreator = qt5.callPackage ../development/qtcreator { };
+  qtcreator = libsForQt5.callPackage ../development/qtcreator { };
 
   r10k = callPackage ../tools/system/r10k { };
 
@@ -9277,28 +9279,52 @@ with pkgs;
     developerBuild = true;
   });
 
-  qt55 =
-    let imported = import ../development/libraries/qt-5/5.5 { inherit pkgs; };
-        # Libraries that cannot be built with newer versions of Qt 5
-        qt55Only = self: with self; {
-          # Requires Qt Quick (deprecated in Qt 5.5, removed from Qt 5.6)
-          qmltermwidget = callPackage ../development/libraries/qmltermwidget { };
-        };
-    in recurseIntoAttrs (imported.override (super: self: qt5LibsFun self // qt55Only self));
+  qt55 = recurseIntoAttrs (import ../development/libraries/qt-5/5.5 {
+    inherit newScope;
+    inherit stdenv fetchurl makeSetupHook makeWrapper;
+    bison = bison2; # error: too few arguments to function 'int yylex(...
+    cups = if stdenv.isLinux then cups else null;
+    harfbuzz = harfbuzz-icu;
+    mesa = mesa_noglu;
+    inherit perl;
+    inherit (gnome2) libgnomeui GConf gnome_vfs;
+    inherit (gst_all_1) gstreamer gst-plugins-base;
+  });
 
-  qt56 =
-    let imported = import ../development/libraries/qt-5/5.6 { inherit pkgs; };
-    in recurseIntoAttrs (imported.override (super: qt5LibsFun));
+  libsForQt55 = lib.makeScope qt55.newScope mkLibsForQt5;
 
-  qt57 =
-    let imported = import ../development/libraries/qt-5/5.7 { inherit pkgs; };
-    in recurseIntoAttrs (imported.override (super: qt5LibsFun));
+  qt56 = recurseIntoAttrs (import ../development/libraries/qt-5/5.6 {
+    inherit newScope;
+    inherit stdenv fetchurl makeSetupHook makeWrapper;
+    bison = bison2; # error: too few arguments to function 'int yylex(...
+    cups = if stdenv.isLinux then cups else null;
+    harfbuzz = harfbuzz-icu;
+    mesa = mesa_noglu;
+    inherit perl;
+    inherit (gst_all_1) gstreamer gst-plugins-base;
+  });
+
+  libsForQt56 = lib.makeScope qt56.newScope mkLibsForQt5;
+
+  qt57 = recurseIntoAttrs (import ../development/libraries/qt-5/5.7 {
+    inherit newScope;
+    inherit stdenv fetchurl makeSetupHook makeWrapper;
+    bison = bison2; # error: too few arguments to function 'int yylex(...
+    cups = if stdenv.isLinux then cups else null;
+    harfbuzz = harfbuzz-icu;
+    mesa = mesa_noglu;
+    inherit perl;
+    inherit (gst_all_1) gstreamer gst-plugins-base;
+  });
+
+  libsForQt57 = lib.makeScope qt57.newScope mkLibsForQt5;
 
   qt5 = qt56;
+  libsForQt5 = libsForQt56;
 
-  qt5ct = qt5.callPackage ../tools/misc/qt5ct { };
+  qt5ct = libsForQt5.callPackage ../tools/misc/qt5ct { };
 
-  qt5LibsFun = self: with self;
+  mkLibsForQt5 = self: with self;
     let kdeFrameworks =
           import ../development/libraries/kde-frameworks { inherit pkgs; } self;
     in {
@@ -9356,6 +9382,8 @@ with pkgs;
 
     qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
 
+    qmltermwidget = callPackage ../development/libraries/qmltermwidget { };
+
     qscintilla = callPackage ../development/libraries/qscintilla {
       withQt5 = true;
     };
@@ -9366,9 +9394,7 @@ with pkgs;
 
     qtstyleplugins = callPackage ../development/libraries/qtstyleplugins { };
 
-    quazip = callPackage ../development/libraries/quazip {
-      qt = qtbase;
-    };
+    quazip = callPackage ../development/libraries/quazip { };
 
     qwt = callPackage ../development/libraries/qwt/6.nix { };
 
@@ -12450,7 +12476,7 @@ with pkgs;
 
   xlsx2csv = pythonPackages.xlsx2csv;
 
-  zeal = qt5.callPackage ../data/documentation/zeal { };
+  zeal = libsForQt5.callPackage ../data/documentation/zeal { };
 
 
   ### APPLICATIONS
@@ -12540,13 +12566,13 @@ with pkgs;
 
   antfs-cli = callPackage ../applications/misc/antfs-cli {};
 
-  antimony = qt5.callPackage ../applications/graphics/antimony {};
+  antimony = libsForQt5.callPackage ../applications/graphics/antimony {};
 
   antiword = callPackage ../applications/office/antiword {};
 
   ao = callPackage ../applications/graphics/ao {};
 
-  aqemu = qt5.callPackage ../applications/virtualization/aqemu { };
+  aqemu = libsForQt5.callPackage ../applications/virtualization/aqemu { };
 
   ardour = callPackage ../applications/audio/ardour {
     inherit (gnome2) libgnomecanvas libgnomecanvasmm;
@@ -12572,7 +12598,7 @@ with pkgs;
   astroid = callPackage ../applications/networking/mailreaders/astroid { };
 
   audacious = callPackage ../applications/audio/audacious { };
-  audaciousQt5 = qt5.callPackage ../applications/audio/audacious/qt-5.nix { };
+  audaciousQt5 = libsForQt5.callPackage ../applications/audio/audacious/qt-5.nix { };
 
   audacity = callPackage ../applications/audio/audacity { };
 
@@ -12634,7 +12660,7 @@ with pkgs;
   };
   awesome = awesome-4-0;
 
-  awesomebump = qt5.callPackage ../applications/graphics/awesomebump { };
+  awesomebump = libsForQt5.callPackage ../applications/graphics/awesomebump { };
 
   inherit (gnome3) baobab;
 
@@ -12705,7 +12731,7 @@ with pkgs;
 
   bluejeans = callPackage ../applications/networking/browsers/mozilla-plugins/bluejeans { };
 
-  bomi = qt5.callPackage ../applications/video/bomi {
+  bomi = libsForQt5.callPackage ../applications/video/bomi {
     youtube-dl = pythonPackages.youtube-dl;
     pulseSupport = config.pulseaudio or true;
     ffmpeg = ffmpeg_2;
@@ -12733,7 +12759,7 @@ with pkgs;
 
   calcurse = callPackage ../applications/misc/calcurse { };
 
-  calibre = qt5.callPackage ../applications/misc/calibre { };
+  calibre = libsForQt5.callPackage ../applications/misc/calibre { };
 
   camlistore = callPackage ../applications/misc/camlistore { };
 
@@ -12749,7 +12775,7 @@ with pkgs;
 
   cava = callPackage ../applications/audio/cava { };
 
-  cb2bib = qt5.callPackage ../applications/office/cb2bib { };
+  cb2bib = libsForQt5.callPackage ../applications/office/cb2bib { };
 
   cbatticon = callPackage ../applications/misc/cbatticon { };
 
@@ -12824,7 +12850,7 @@ with pkgs;
 
   cni = callPackage ../applications/networking/cluster/cni {};
 
-  communi = qt5.callPackage ../applications/networking/irc/communi { };
+  communi = libsForQt5.callPackage ../applications/networking/irc/communi { };
 
   compiz = callPackage ../applications/window-managers/compiz {
     inherit (gnome2) GConf ORBit2 metacity;
@@ -12871,7 +12897,7 @@ with pkgs;
   cutecom = callPackage ../tools/misc/cutecom { };
 
   cutegram =
-    let callpkg = qt55.callPackage;
+    let callpkg = libsForQt55.callPackage;
     in callpkg ../applications/networking/instant-messengers/telegram/cutegram rec {
       libqtelegram-aseman-edition = callpkg ../applications/networking/instant-messengers/telegram/libqtelegram-aseman-edition { };
       telegram-qml = callpkg ../applications/networking/instant-messengers/telegram/telegram-qml {
@@ -12921,9 +12947,9 @@ with pkgs;
     plugins = [];
   };
 
-  dfasma = qt5.callPackage ../applications/audio/dfasma { };
+  dfasma = libsForQt5.callPackage ../applications/audio/dfasma { };
 
-  dfilemanager = qt5.callPackage ../applications/misc/dfilemanager { };
+  dfilemanager = libsForQt5.callPackage ../applications/misc/dfilemanager { };
 
   dia = callPackage ../applications/graphics/dia {
     inherit (pkgs.gnome2) libart_lgpl libgnomeui;
@@ -13271,7 +13297,7 @@ with pkgs;
 
   keepassx = callPackage ../applications/misc/keepassx { };
   keepassx2 = callPackage ../applications/misc/keepassx/2.0.nix { };
-  keepassx-community = qt5.callPackage ../applications/misc/keepassx/community.nix { };
+  keepassx-community = libsForQt5.callPackage ../applications/misc/keepassx/community.nix { };
 
   inherit (gnome3) evince;
   evolution_data_server = gnome3.evolution_data_server;
@@ -13304,7 +13330,7 @@ with pkgs;
      inherit (darwin.apple_sdk.frameworks) CoreServices CoreAudio AudioUnit;
   };
 
-  fmit = qt5.callPackage ../applications/audio/fmit { };
+  fmit = libsForQt5.callPackage ../applications/audio/fmit { };
 
   fmsynth = callPackage ../applications/audio/fmsynth { };
 
@@ -13322,7 +13348,7 @@ with pkgs;
 
   fribid = callPackage ../applications/networking/browsers/mozilla-plugins/fribid { };
 
-  fritzing = qt5.callPackage ../applications/science/electronics/fritzing { };
+  fritzing = libsForQt5.callPackage ../applications/science/electronics/fritzing { };
 
   fvwm = callPackage ../applications/window-managers/fvwm { };
 
@@ -13353,7 +13379,7 @@ with pkgs;
 
   gnuradio-osmosdr = callPackage ../applications/misc/gnuradio-osmosdr { };
 
-  goldendict = qt55.callPackage ../applications/misc/goldendict { };
+  goldendict = libsForQt55.callPackage ../applications/misc/goldendict { };
 
   inherit (ocamlPackages) google-drive-ocamlfuse;
 
@@ -13461,7 +13487,7 @@ with pkgs;
     desktopName = "Firefox Beta";
   };
 
-  firestr = qt5.callPackage ../applications/networking/p2p/firestr
+  firestr = libsForQt5.callPackage ../applications/networking/p2p/firestr
     { boost = boost155;
     };
 
@@ -13612,7 +13638,7 @@ with pkgs;
 
   libquvi = callPackage ../applications/video/quvi/library.nix { };
 
-  linssid = qt5.callPackage ../applications/networking/linssid { };
+  linssid = libsForQt5.callPackage ../applications/networking/linssid { };
 
   manuskript = callPackage ../applications/editors/manuskript { };
 
@@ -13699,7 +13725,7 @@ with pkgs;
 
   gosmore = callPackage ../applications/misc/gosmore { };
 
-  gpsbabel = qt5.callPackage ../applications/misc/gpsbabel { };
+  gpsbabel = libsForQt5.callPackage ../applications/misc/gpsbabel { };
 
   gpscorrelate = callPackage ../applications/misc/gpscorrelate { };
 
@@ -13707,7 +13733,7 @@ with pkgs;
 
   gpsprune = callPackage ../applications/misc/gpsprune { };
 
-  gpxsee = qt5.callPackage ../applications/misc/gpxsee { };
+  gpxsee = libsForQt5.callPackage ../applications/misc/gpxsee { };
 
   gtk2fontsel = callPackage ../applications/misc/gtk2fontsel {
     inherit (gnome2) gtk;
@@ -13913,7 +13939,7 @@ with pkgs;
     lua = lua5_1;
   };
 
-  ipe = qt5.callPackage ../applications/graphics/ipe {
+  ipe = libsForQt5.callPackage ../applications/graphics/ipe {
     ghostscript = ghostscriptX;
     texlive = texlive.combine { inherit (texlive) scheme-small; };
   };
@@ -13977,9 +14003,9 @@ with pkgs;
     boost = boost155;
   };
 
-  k9copy = qt5.callPackage ../applications/video/k9copy {};
+  k9copy = libsForQt5.callPackage ../applications/video/k9copy {};
 
-  kdeconnect = qt5.callPackage ../applications/misc/kdeconnect { };
+  kdeconnect = libsForQt5.callPackage ../applications/misc/kdeconnect { };
 
   kdecoration-viewer = kde5.callPackage ../tools/misc/kdecoration-viewer {};
 
@@ -13995,9 +14021,9 @@ with pkgs;
 
   kermit = callPackage ../tools/misc/kermit { };
 
-  keyfinder = qt5.callPackage ../applications/audio/keyfinder { };
+  keyfinder = libsForQt5.callPackage ../applications/audio/keyfinder { };
 
-  keyfinder-cli = qt5.callPackage ../applications/audio/keyfinder-cli { };
+  keyfinder-cli = libsForQt5.callPackage ../applications/audio/keyfinder-cli { };
 
   keymon = callPackage ../applications/video/key-mon { };
 
@@ -14020,16 +14046,16 @@ with pkgs;
     stdenv = overrideCC stdenv gcc49;
   };
 
-  konversation = qt5.callPackage ../applications/networking/irc/konversation/1.6.nix { };
+  konversation = libsForQt5.callPackage ../applications/networking/irc/konversation/1.6.nix { };
 
-  krita = qt5.callPackage ../applications/graphics/krita {
+  krita = libsForQt5.callPackage ../applications/graphics/krita {
     vc = vc_0_7;
     openjpeg = openjpeg_1;
   };
 
   ksuperkey = callPackage ../tools/X11/ksuperkey { };
 
-  ktorrent = qt5.callPackage ../applications/networking/p2p/ktorrent/5.nix { };
+  ktorrent = libsForQt5.callPackage ../applications/networking/p2p/ktorrent/5.nix { };
 
   kubernetes = callPackage ../applications/networking/cluster/kubernetes {
     go = go_1_6;
@@ -14160,7 +14186,7 @@ with pkgs;
       webkit = webkitgtk2;
   };
 
-  luminanceHDR = qt55.callPackage ../applications/graphics/luminance-hdr { };
+  luminanceHDR = libsForQt55.callPackage ../applications/graphics/luminance-hdr { };
 
   lxdvdrip = callPackage ../applications/video/lxdvdrip { };
 
@@ -14179,7 +14205,7 @@ with pkgs;
 
   lynx = callPackage ../applications/networking/browsers/lynx { };
 
-  lyx = qt5.callPackage ../applications/misc/lyx { };
+  lyx = libsForQt5.callPackage ../applications/misc/lyx { };
 
   mail-notification = callPackage ../desktops/gnome-2/desktop/mail-notification {};
 
@@ -14410,7 +14436,7 @@ with pkgs;
       else null;
   };
 
-  musescore = qt55.callPackage ../applications/audio/musescore { };
+  musescore = libsForQt55.callPackage ../applications/audio/musescore { };
 
   mutt = callPackage ../applications/networking/mailreaders/mutt { };
   mutt-with-sidebar = callPackage ../applications/networking/mailreaders/mutt {
@@ -14454,11 +14480,11 @@ with pkgs;
 
   scudcloud = callPackage ../applications/networking/instant-messengers/scudcloud { };
 
-  shotcut = qt5.callPackage ../applications/video/shotcut { };
+  shotcut = libsForQt5.callPackage ../applications/video/shotcut { };
 
-  smplayer = qt5.callPackage ../applications/video/smplayer { };
+  smplayer = libsForQt5.callPackage ../applications/video/smplayer { };
 
-  smtube = qt55.callPackage ../applications/video/smtube {};
+  smtube = libsForQt55.callPackage ../applications/video/smtube {};
 
   sudolikeaboss = callPackage ../tools/security/sudolikeaboss { };
 
@@ -14561,7 +14587,7 @@ with pkgs;
 
   oblogout = callPackage ../tools/X11/oblogout { };
 
-  obs-studio = qt5.callPackage ../applications/video/obs-studio {
+  obs-studio = libsForQt5.callPackage ../applications/video/obs-studio {
     alsaSupport = stdenv.isLinux;
     pulseaudioSupport = config.pulseaudio or true;
   };
@@ -14661,9 +14687,9 @@ with pkgs;
 
   pflask = callPackage ../os-specific/linux/pflask {};
 
-  photoqt = qt5.callPackage ../applications/graphics/photoqt { };
+  photoqt = libsForQt5.callPackage ../applications/graphics/photoqt { };
 
-  phototonic = qt5.callPackage ../applications/graphics/phototonic { };
+  phototonic = libsForQt5.callPackage ../applications/graphics/phototonic { };
 
   phrasendrescher = callPackage ../tools/security/phrasendrescher { };
 
@@ -14793,7 +14819,7 @@ with pkgs;
 
   pythonmagick = callPackage ../applications/graphics/PythonMagick { };
 
-  qbittorrent = qt5.callPackage ../applications/networking/p2p/qbittorrent {
+  qbittorrent = libsForQt5.callPackage ../applications/networking/p2p/qbittorrent {
     boost = boost;
     libtorrentRasterbar = libtorrentRasterbar_1_0;
   };
@@ -14807,15 +14833,15 @@ with pkgs;
 
   qgis = callPackage ../applications/gis/qgis {};
 
-  qgroundcontrol = qt55.callPackage ../applications/science/robotics/qgroundcontrol { };
+  qgroundcontrol = libsForQt55.callPackage ../applications/science/robotics/qgroundcontrol { };
 
-  qjackctl = qt5.callPackage ../applications/audio/qjackctl { };
+  qjackctl = libsForQt5.callPackage ../applications/audio/qjackctl { };
 
   qmidinet = callPackage ../applications/audio/qmidinet { };
 
   qmidiroute = callPackage ../applications/audio/qmidiroute { };
 
-  qmmp = qt5.callPackage ../applications/audio/qmmp { };
+  qmmp = libsForQt5.callPackage ../applications/audio/qmmp { };
 
   qnotero = callPackage ../applications/office/qnotero { };
 
@@ -14827,15 +14853,15 @@ with pkgs;
     qt = qt4;
   };
 
-  qsyncthingtray = qt5.callPackage ../applications/misc/qsyncthingtray { };
+  qsyncthingtray = libsForQt5.callPackage ../applications/misc/qsyncthingtray { };
 
   qsynth = callPackage ../applications/audio/qsynth { };
 
   qtbitcointrader = callPackage ../applications/misc/qtbitcointrader { };
 
-  qtox = qt5.callPackage ../applications/networking/instant-messengers/qtox { };
+  qtox = libsForQt5.callPackage ../applications/networking/instant-messengers/qtox { };
 
-  qtpass = qt5.callPackage ../applications/misc/qtpass { };
+  qtpass = libsForQt5.callPackage ../applications/misc/qtpass { };
 
   qtpfsgui = callPackage ../applications/graphics/qtpfsgui { };
 
@@ -14843,7 +14869,7 @@ with pkgs;
 
   qtscrobbler = callPackage ../applications/audio/qtscrobbler { };
 
-  quassel = qt5.callPackage ../applications/networking/irc/quassel/qt-5.nix {
+  quassel = libsForQt5.callPackage ../applications/networking/irc/quassel/qt-5.nix {
     monolithic = true;
     daemon = false;
     client = false;
@@ -14869,7 +14895,7 @@ with pkgs;
 
   quirc = callPackage ../tools/graphics/quirc {};
 
-  quiterss = qt5.callPackage ../applications/networking/newsreaders/quiterss {};
+  quiterss = libsForQt5.callPackage ../applications/networking/newsreaders/quiterss {};
 
   quodlibet-without-gst-plugins = callPackage ../applications/audio/quodlibet { };
 
@@ -14878,7 +14904,7 @@ with pkgs;
     gst_plugins_bad = null;
   };
 
-  qutebrowser = qt5.callPackage ../applications/networking/browsers/qutebrowser {
+  qutebrowser = libsForQt5.callPackage ../applications/networking/browsers/qutebrowser {
     inherit (python3Packages) buildPythonApplication pyqt5 jinja2 pygments pyyaml pypeg2 cssutils;
     inherit (gst_all_1) gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav;
   };
@@ -14897,7 +14923,7 @@ with pkgs;
     demo = false;
   };
 
-  rapcad = qt55.callPackage ../applications/graphics/rapcad { boost = boost159; };
+  rapcad = libsForQt55.callPackage ../applications/graphics/rapcad { boost = boost159; };
 
   rapidsvn = callPackage ../applications/version-management/rapidsvn { };
 
@@ -14939,7 +14965,7 @@ with pkgs;
 
   retroshare06 = lowPrio (callPackage ../applications/networking/p2p/retroshare/0.6.nix { });
 
-  ricochet = qt55.callPackage ../applications/networking/instant-messengers/ricochet { };
+  ricochet = libsForQt55.callPackage ../applications/networking/instant-messengers/ricochet { };
 
   ripser = callPackage ../applications/science/math/ripser { };
 
@@ -15119,13 +15145,13 @@ with pkgs;
   bittorrentSync14 = callPackage ../applications/networking/bittorrentsync/1.4.x.nix { };
   bittorrentSync20 = callPackage ../applications/networking/bittorrentsync/2.0.x.nix { };
 
-  dropbox = qt5.callPackage ../applications/networking/dropbox { };
+  dropbox = libsForQt5.callPackage ../applications/networking/dropbox { };
 
   dropbox-cli = callPackage ../applications/networking/dropbox-cli { };
 
   insync = callPackage ../applications/networking/insync { };
 
-  lightdm = qt5.callPackage ../applications/display-managers/lightdm {
+  lightdm = libsForQt5.callPackage ../applications/display-managers/lightdm {
     qt4 = null;
     withQt5 = false;
   };
@@ -15146,11 +15172,11 @@ with pkgs;
 
   printrun = callPackage ../applications/misc/printrun { };
 
-  sddm = qt5.callPackage ../applications/display-managers/sddm {
+  sddm = libsForQt5.callPackage ../applications/display-managers/sddm {
     themes = [];  # extra themes, etc.
   };
 
-  skrooge2 = qt5.callPackage ../applications/office/skrooge/2.nix {};
+  skrooge2 = libsForQt5.callPackage ../applications/office/skrooge/2.nix {};
 
   slim = callPackage ../applications/display-managers/slim {
     libpng = libpng12;
@@ -15172,7 +15198,7 @@ with pkgs;
 
   sipp = callPackage ../development/tools/misc/sipp { };
 
-  sonic-visualiser = qt5.callPackage ../applications/audio/sonic-visualiser {
+  sonic-visualiser = libsForQt5.callPackage ../applications/audio/sonic-visualiser {
     inherit (pkgs.vamp) vampSDK;
   };
 
@@ -15287,7 +15313,7 @@ with pkgs;
     gconf = gnome2.GConf;
   };
 
-  teamspeak_client = qt55.callPackage ../applications/networking/instant-messengers/teamspeak/client.nix { };
+  teamspeak_client = libsForQt55.callPackage ../applications/networking/instant-messengers/teamspeak/client.nix { };
   teamspeak_server = callPackage ../applications/networking/instant-messengers/teamspeak/server.nix { };
 
   taskjuggler-2 = callPackage ../applications/misc/taskjuggler/2.x { };
@@ -15433,7 +15459,7 @@ with pkgs;
     boost = boost160;
   };
 
-  twmn = qt5.callPackage ../applications/misc/twmn { };
+  twmn = libsForQt5.callPackage ../applications/misc/twmn { };
 
   umurmur = callPackage ../applications/networking/umurmur { };
 
@@ -15511,7 +15537,7 @@ with pkgs;
 
   neovim = callPackage ../applications/editors/neovim { };
 
-  neovim-qt = qt5.callPackage ../applications/editors/neovim/qt.nix { };
+  neovim-qt = libsForQt5.callPackage ../applications/editors/neovim/qt.nix { };
 
   neovim-pygui = pythonPackages.neovim_gui;
 
@@ -15599,7 +15625,7 @@ with pkgs;
     gtk = gtk2;
   };
 
-  vlc_qt5 = qt5.vlc;
+  vlc_qt5 = libsForQt5.vlc;
 
   vmpk = callPackage ../applications/audio/vmpk { };
 
@@ -15804,7 +15830,7 @@ with pkgs;
   };
   xbmc-retroarch-advanced-launchers = kodi-retroarch-advanced-launchers;
 
-  xca = qt5.callPackage ../applications/misc/xca { };
+  xca = libsForQt5.callPackage ../applications/misc/xca { };
 
   xcalib = callPackage ../tools/X11/xcalib { };
 
@@ -16088,13 +16114,13 @@ with pkgs;
 
   chessdb = callPackage ../games/chessdb { };
 
-  chessx = qt5.callPackage ../games/chessx { };
+  chessx = libsForQt5.callPackage ../games/chessx { };
 
   chocolateDoom = callPackage ../games/chocolate-doom { };
 
   ckan = callPackage ../games/ckan { };
 
-  cockatrice = qt5.callPackage ../games/cockatrice {  };
+  cockatrice = libsForQt5.callPackage ../games/cockatrice {  };
 
   commandergenius = callPackage ../games/commandergenius { };
 
@@ -16173,7 +16199,7 @@ with pkgs;
 
   fish-fillets-ng = callPackage ../games/fish-fillets-ng {};
 
-  flightgear = qt5.callPackage ../games/flightgear { };
+  flightgear = libsForQt5.callPackage ../games/flightgear { };
 
   freecell-solver = callPackage ../games/freecell-solver { };
 
@@ -16286,7 +16312,7 @@ with pkgs;
 
   minecraft-server = callPackage ../games/minecraft-server { };
 
-  multimc = qt5.callPackage ../games/multimc { };
+  multimc = libsForQt5.callPackage ../games/multimc { };
 
   minetest = callPackage ../games/minetest {
     libpng = libpng12;
@@ -16296,7 +16322,7 @@ with pkgs;
 
   mrrescue = callPackage ../games/mrrescue { };
 
-  mudlet = qt5.callPackage ../games/mudlet {
+  mudlet = libsForQt5.callPackage ../games/mudlet {
     inherit (lua51Packages) luafilesystem lrexlib luazip luasqlite3;
   };
 
@@ -16439,7 +16465,7 @@ with pkgs;
 
   solarus = callPackage ../games/solarus { };
 
-  solarus-quest-editor = qt5.callPackage ../development/tools/solarus-quest-editor { };
+  solarus-quest-editor = libsForQt5.callPackage ../development/tools/solarus-quest-editor { };
 
   # You still can override by passing more arguments.
   space-orbit = callPackage ../games/space-orbit { };
@@ -16572,7 +16598,7 @@ with pkgs;
 
   warsow = callPackage ../games/warsow { };
 
-  warzone2100 = qt5.callPackage ../games/warzone2100 { };
+  warzone2100 = libsForQt5.callPackage ../games/warzone2100 { };
 
   wesnoth = callPackage ../games/wesnoth { };
 
@@ -16883,7 +16909,10 @@ with pkgs;
 
   lumina = callPackage ../desktops/lumina { };
 
-  lxqt = recurseIntoAttrs (callPackage ../desktops/lxqt { });
+  lxqt = recurseIntoAttrs (import ../desktops/lxqt {
+    inherit pkgs libsForQt5 fetchFromGitHub;
+    inherit (lib) makeScope;
+  });
 
   mate = recurseIntoAttrs (callPackage ../desktops/mate {
     callPackage = newScope pkgs.mate;
@@ -16925,15 +16954,15 @@ with pkgs;
       merged = self:
         {
           plasma = plasma self;
-          frameworks = qt5.kdeFrameworks;
+          frameworks = libsForQt5.kdeFrameworks;
           applications = applications self;
           kipi-plugins = self.callPackage ../applications/graphics/kipi-plugins/5.x.nix {};
         }
-        // qt5.kdeFrameworks
+        // libsForQt5.kdeFrameworks
         // plasma self
         // applications self;
     in
-      recurseIntoAttrs (lib.makeScope qt5.newScope merged);
+      recurseIntoAttrs (lib.makeScope libsForQt5.newScope merged);
 
   theme-vertex = callPackage ../misc/themes/vertex { };
 
@@ -17440,7 +17469,7 @@ with pkgs;
 
   yacas = callPackage ../applications/science/math/yacas { };
 
-  speedcrunch = qt5.callPackage ../applications/science/math/speedcrunch { };
+  speedcrunch = libsForQt5.callPackage ../applications/science/math/speedcrunch { };
 
   ### SCIENCE / MISC
 
@@ -17471,7 +17500,7 @@ with pkgs;
 
   spyder = pythonPackages.spyder;
 
-  stellarium = qt5.callPackage ../applications/science/astronomy/stellarium { };
+  stellarium = libsForQt5.callPackage ../applications/science/astronomy/stellarium { };
 
   tulip = callPackage ../applications/science/misc/tulip {
     cmake = cmake_2_8;
@@ -17533,7 +17562,7 @@ with pkgs;
 
   ### MISC
 
-  antimicro = qt5.callPackage ../tools/misc/antimicro { };
+  antimicro = libsForQt5.callPackage ../tools/misc/antimicro { };
 
   atari800 = callPackage ../misc/emulators/atari800 { };
 
@@ -17802,9 +17831,9 @@ with pkgs;
     pcre = pcre-cpp;
   });
 
-  redis-desktop-manager = qt55.callPackage ../applications/misc/redis-desktop-manager { };
+  redis-desktop-manager = libsForQt55.callPackage ../applications/misc/redis-desktop-manager { };
 
-  robomongo = qt5.callPackage ../applications/misc/robomongo { };
+  robomongo = libsForQt5.callPackage ../applications/misc/robomongo { };
 
   rucksack = callPackage ../development/tools/rucksack { };
 
@@ -18008,7 +18037,7 @@ with pkgs;
   vips = callPackage ../tools/graphics/vips { };
   nip2 = callPackage ../tools/graphics/nip2 { };
 
-  vokoscreen = qt5.callPackage ../applications/video/vokoscreen { };
+  vokoscreen = libsForQt5.callPackage ../applications/video/vokoscreen { };
 
   wavegain = callPackage ../applications/audio/wavegain { };
 
@@ -18171,7 +18200,7 @@ with pkgs;
 
   discord = callPackage ../applications/networking/instant-messengers/discord { };
 
-  golden-cheetah = qt5.callPackage ../applications/misc/golden-cheetah {};
+  golden-cheetah = libsForQt5.callPackage ../applications/misc/golden-cheetah {};
 
   linkchecker = callPackage ../tools/networking/linkchecker { };
 
@@ -18193,9 +18222,9 @@ with pkgs;
 
   zuki-themes = callPackage ../misc/themes/zuki { };
 
-  zoom-us = qt55.callPackage ../applications/networking/instant-messengers/zoom-us {};
+  zoom-us = libsForQt55.callPackage ../applications/networking/instant-messengers/zoom-us {};
 
-  tora = qt5.callPackage ../development/tools/tora {};
+  tora = libsForQt5.callPackage ../development/tools/tora {};
 
   xulrunner = firefox-unwrapped;
 


### PR DESCRIPTION
###### Motivation for this change

The `qt5` package set contained packages that are part of Qt 5, and packages which only depend on Qt 5. This is inappropriate for several reasons, foremost that it may lead to confusion with users.

The documentation for creating Qt and KDE packages was also out-of-date.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` N/A: only documentation packages changed
- [x] Tested execution of all binary files (usually in `./result/bin/`) N/A: only documentation packages changed
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

ATTN @gebner @romildo I had to make substantial changes to your packages to fix evaluation errors. Please do not import Qt 5-based package sets, but import individual packages instead. Please make sure you are using `wrapQtProgram` as necessary.