### PR TITLE
opusfile: enable on darwin

### DIFF
--- a/pkgs/applications/audio/opusfile/default.nix
+++ b/pkgs/applications/audio/opusfile/default.nix
@@ -13,11 +13,11 @@ stdenv.mkDerivation rec {
   patches = [ ./include-multistream.patch ];
   configureFlags = [ "--disable-examples" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "High-level API for decoding and seeking in .opus files";
     homepage = http://www.opus-codec.org/;
-    license = stdenv.lib.licenses.bsd3;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
+    license = licenses.bsd3;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ fuuzetsu ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes `cmus` on darwin.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] macOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

