### PR TITLE
[RFC] version: Extend /etc/os-release

### DIFF
--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -106,9 +106,12 @@ in
         NAME=NixOS
         ID=nixos
         VERSION="${config.system.nixosVersion} (${config.system.nixosCodeName})"
+        VERSION_CODENAME=${toLower config.system.nixosCodeName}
         VERSION_ID="${config.system.nixosVersion}"
         PRETTY_NAME="NixOS ${config.system.nixosVersion} (${config.system.nixosCodeName})"
-        HOME_URL="http://nixos.org/"
+        HOME_URL="https://nixos.org/"
+        SUPPORT_URL="https://nixos.org/nixos/support.html"
+        BUG_REPORT_URL="https://github.com/NixOS/nixpkgs/issues"
       '';
 
   };


### PR DESCRIPTION
- Provide additional link for support and bug reporting.
- Use HTTPS links (related: "The IAB encourages all web servers to
employ TLS to protect their content, and use OCSP stapling to improve
the efficiency and privacy of revocation checking." [0].
- Add VERSION_CODENAME

[0]: https://www.iab.org/documents/correspondence-reports-documents/2017-2/iab-statement-on-ocsp-stapling/

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Imho we should always use HTTPS links when possible (the support and bug report URLs are optional).
`VERSION_CODENAME` could be helpful for #23175 (but it works fine without).