### PR TITLE
Changes needed by Reflex Platform

### DIFF
--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
+{ stdenv, lib, fetchgit, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
 , autoconf, automake, happy, alex, python3, buildPlatform, targetPlatform
 , selfPkgs, cross ? null
 
@@ -105,7 +105,7 @@ in stdenv.mkDerivation (rec {
     "RANLIB=${stdenv.binutilsCross}/bin/${cross.config}-ranlib"
     "--target=${cross.config}"
     "--enable-bootstrap-with-devel-snapshot"
-  ];
+  ] ++ (lib.optional ("${cross.config}" == "aarch64-apple-darwin14") "--disable-large-address-space");
 
   buildInputs = commonBuildInputs ++ [ stdenv.ccCross stdenv.binutilsCross ];
 

--- a/pkgs/development/compilers/ghcjs/base.nix
+++ b/pkgs/development/compilers/ghcjs/base.nix
@@ -88,6 +88,10 @@
   ]
 
 , stage2 ? import ./stage2.nix
+
+, patches ? [ ./ghcjs.patch ]
+
+, ghcLibdir ? null
 }:
 let
   inherit (bootPkgs) ghc;
@@ -116,7 +120,7 @@ in mkDerivation (rec {
   testDepends = [
     HUnit test-framework test-framework-hunit
   ];
-  patches = [ ./ghcjs.patch ];
+  inherit patches;
   postPatch = ''
     substituteInPlace Setup.hs \
       --replace "/usr/bin/env" "${coreutils}/bin/env"
@@ -159,6 +163,7 @@ in mkDerivation (rec {
         --with-cabal ${cabal-install}/bin/cabal \
         --with-gmp-includes ${gmp.dev}/include \
         --with-gmp-libraries ${gmp.out}/lib
+      ${if isNull ghcLibdir then "" else ''echo "${ghcLibdir}" > "$out/lib/ghcjs-${version}/ghc_libdir"''}
   '';
   passthru = let
     ghcjsNodePkgs = callPackage ../../../top-level/node-packages.nix {

--- a/pkgs/development/compilers/ghcjs/ghcjsHEAD.patch
+++ b/pkgs/development/compilers/ghcjs/ghcjsHEAD.patch
@@ -1,0 +1,86 @@
+diff --git a/src-bin/Boot.hs b/src-bin/Boot.hs
+index 8e19b1d..03d3ac0 100644
+--- a/src-bin/Boot.hs
++++ b/src-bin/Boot.hs
+@@ -530,9 +530,7 @@ initPackageDB :: B ()
+ initPackageDB = do
+   msg info "creating package databases"
+   initDB "--global" <^> beLocations . blGlobalDB
+-  traverseOf_ _Just initUser <^> beLocations . blUserDBDir
+   where
+-    initUser dir = rm_f (dir </> "package.conf") >> initDB "--user" (dir </> "package.conf.d")
+     initDB dbName db = do
+       rm_rf db >> mkdir_p db
+       ghcjs_pkg_ ["init", toTextI db] `catchAny_` return ()
+@@ -556,29 +554,22 @@ installDevelopmentTree = subTop $ do
+   msgD info $ "preparing development boot tree"
+   checkpoint' "ghcjs-boot-git" "ghcjs-boot repository already cloned and prepared" $ do
+     testGit "ghcjs-boot" >>= \case
+-      Just False -> failWith "ghcjs-boot already exists and is not a git repository"
+-      Just True  -> do
+-        msg info "ghcjs-boot repository already exists but checkpoint not reached, cleaning first, then cloning"
+-        rm_rf "ghcjs-boot"
++      Just _ -> do
++        msg info "ghcjs-boot repository already exists; initializing ghcjs-boot"
+         initGhcjsBoot
+       Nothing    -> do
+         msgD info "cloning ghcjs-boot git repository"
+         initGhcjsBoot
+   checkpoint' "shims-git" "shims repository already cloned" $ do
+     testGit "shims" >>= \case
+-      Just False -> failWith "shims already exists and is not a git repository"
+-      Just True  -> do
+-        msgD info "shims repository already exists but checkpoint not reached, cleaning first, then cloning"
+-        rm_rf "shims"
+-        cloneGit shimsDescr "shims" bsrcShimsDevBranch bsrcShimsDev
++      Just _ -> do
++        msgD info "shims repository already exists; moving on"
+       Nothing    -> do
+         msgD info "cloning shims git repository"
+         cloneGit shimsDescr "shims" bsrcShimsDevBranch bsrcShimsDev
+   where
+     initGhcjsBoot = sub $ do
+-      cloneGit bootDescr "ghcjs-boot"  bsrcBootDevBranch bsrcBootDev
+       cd "ghcjs-boot"
+-      git_ ["submodule", "update", "--init", "--recursive"]
+       mapM_ patchPackage =<< allPackages
+       preparePrimops
+       buildGenPrim
+@@ -1167,14 +1158,14 @@ cabalInstallFlags parmakeGhcjs = do
+            , "--avoid-reinstalls"
+            , "--builddir",      "dist"
+            , "--with-compiler", ghcjs ^. pgmLocText
++           , "--with-gcc",      "@CC@"
+            , "--with-hc-pkg",   ghcjsPkg ^. pgmLocText
+-           , "--prefix",        toTextI instDir
++           , "--prefix",        "@PREFIX@"
++           , "--libdir",        "$prefix/lib/$compiler"
++           , "--libsubdir",     "$pkgid"
+            , bool haddock "--enable-documentation" "--disable-documentation"
+            , "--haddock-html"
+--- workaround for hoogle support being broken in haddock for GHC 7.10RC1
+-#if !(__GLASGOW_HASKELL__ >= 709)
+            , "--haddock-hoogle"
+-#endif
+            , "--haddock-hyperlink-source"
+ -- don't slow down Windows builds too much, on other platforms we get this more
+ -- or less for free, thanks to dynamic-too
+diff --git a/src/Compiler/Info.hs b/src/Compiler/Info.hs
+index 33a401f..e2405a7 100644
+--- a/src/Compiler/Info.hs
++++ b/src/Compiler/Info.hs
+@@ -48,13 +48,7 @@ compilerInfo nativeToo dflags = do
+ 
+ -- | the directory to use if started without -B flag
+ getDefaultTopDir :: IO FilePath
+-getDefaultTopDir = do
+-  appdir <- getAppUserDataDirectory "ghcjs"
+-  return (appdir </> subdir </> "ghcjs")
+-      where
+-        targetARCH = arch
+-        targetOS   = os
+-        subdir     = targetARCH ++ '-':targetOS ++ '-':getFullCompilerVersion
++getDefaultTopDir = return "@PREFIX@/lib/ghcjs-@VERSION@"
+ 
+ getDefaultLibDir :: IO FilePath
+ getDefaultLibDir = getDefaultTopDir

--- a/pkgs/development/compilers/ghcjs/head.nix
+++ b/pkgs/development/compilers/ghcjs/head.nix
@@ -47,4 +47,5 @@ bootPkgs.callPackage ./base.nix {
     "unix"
   ];
   stage2 = import ./head_stage2.nix;
+  patches = [ ./ghcjsHEAD.patch ];
 }

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -194,7 +194,7 @@ stdenv.mkDerivation ({
     runHook preSetupCompilerEnvironment
 
     echo "Build with ${ghc}."
-    export PATH="${ghc}/bin:$PATH"
+    export PATH="${if ghc.isGhcjs or false then ghcEnv else ghc}/bin:$PATH"
     ${optionalString (hasActiveLibrary && hyperlinkSource) "export PATH=${hscolour}/bin:$PATH"}
 
     packageConfDir="$TMPDIR/package.conf.d"


### PR DESCRIPTION
###### Motivation for this change

Trying to get Reflex-Platform to use latest nixpkgs. This is a start. I need to test this more too.

These changes are derived from https://github.com/NixOS/nixpkgs-channels/compare/nixos-unstable...ryantrinkle:ghcjs-update

Some semantic differences between the original and my changes:

  * The original modified `ghcjs/ghcjs.patch` which was being used for all variations of GHCJS. Instead of changing that, I found that the changes only apply to ghcjsHEAD (which is using the `ghc-8.0` branch) and not the default ghcjs package. So I made `patches` configurable and `ghcjsHEAD` uses a different patch file.
  * [Here](https://github.com/NixOS/nixpkgs-channels/compare/nixos-unstable...ryantrinkle:ghcjs-update#diff-290b63a2b3b2ea74530c5e12f9e17c4eR55), if `ghcLibdir` was `null`, then `${libDir}/ghc_libdir_override` would end up being written as an empty file. I changed this so that it does not run this code at all when `ghcLibdir == null`.

cc @ryantrinkle @ElvishJerricco


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

