### PR TITLE
styx and themes: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/applications/misc/styx/default.nix
+++ b/pkgs/applications/misc/styx/default.nix
@@ -1,20 +1,22 @@
 { stdenv, fetchFromGitHub, caddy, asciidoctor
-, file, lessc, sass, multimarkdown }:
+, file, lessc, sass, multimarkdown, linkchecker
+, perlPackages, python27 }:
 
 stdenv.mkDerivation rec {
   name    = "styx-${version}";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner  = "styx-static";
     repo   = "styx";
     rev    = "v${version}";
-    sha256 = "0v36i40cwrajsd02xjfdldih5g493m28lhzgjg1gd3pwk2yd6rm1";
+    sha256 = "1dl6zmic8bv17f3ib8by66c2fj7izlnv9dh2cfa2m0ipkxk930vk";
   };
 
   setSourceRoot = "cd styx-*/src; export sourceRoot=`pwd`";
 
   server = "${caddy.bin}/bin/caddy";
+  linkcheck = "${linkchecker}/bin/linkchecker";
 
   nativeBuildInputs = [ asciidoctor ];
 
@@ -24,6 +26,8 @@ stdenv.mkDerivation rec {
     sass
     asciidoctor
     multimarkdown
+    perlPackages.ImageExifTool
+    (python27.withPackages (ps: [ ps.parsimonious ]))
   ];
 
   outputs = [ "out" "lib" ];
@@ -34,16 +38,20 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/share/styx
     cp -r scaffold $out/share/styx
-    cp    builder.nix $out/share/styx
+    cp -r nix $out/share/styx
 
     mkdir -p $out/share/doc/styx
     asciidoctor doc/index.adoc       -o $out/share/doc/styx/index.html
     asciidoctor doc/styx-themes.adoc -o $out/share/doc/styx/styx-themes.html
+    asciidoctor doc/library.adoc     -o $out/share/doc/styx/library.html
+    cp -r doc/highlight $out/share/doc/styx/
     cp -r doc/imgs $out/share/doc/styx/
+    cp -r tools $out/share
 
     substituteAllInPlace $out/bin/styx
     substituteAllInPlace $out/share/doc/styx/index.html
     substituteAllInPlace $out/share/doc/styx/styx-themes.html
+    substituteAllInPlace $out/share/doc/styx/library.html
 
     mkdir $lib
     cp -r lib/* $lib

--- a/pkgs/applications/misc/styx/themes.nix
+++ b/pkgs/applications/misc/styx/themes.nix
@@ -26,12 +26,12 @@ let
 
 in
 {
-  agency = mkThemeDrv {
+  agency = mkThemeDrv rec {
     themeName = "agency";
-    version   = "2017-01-17";
+    version   = "0.6.0";
     src = {
-      rev    = "3201f65841c9e7f97cc0ab0264cafb01b1620ed7";
-      sha256 = "1b3547lzmhs1lmr9gln1yvh5xrsg92m8ngrjwf0ny91y81x04da6";
+      rev    = "v${version}";
+      sha256 = "1i9bajzgmxd3ffvgic6wwnqijsgkfr2mfdijkgw9yf3bxcdq5cb6";
     };
     meta = {
       license = stdenv.lib.licenses.asl20;
@@ -44,24 +44,24 @@ in
     };
   };
 
-  generic-templates = mkThemeDrv {
+  generic-templates = mkThemeDrv rec {
     themeName = "generic-templates";
-    version   = "2017-01-18";
+    version   = "0.6.0";
     src = {
-      rev    = "af7cd527584322d8731a306a137a1794b18ad71a";
-      sha256 = "18zk4qihi8iw5dxkm9sf6cjai1mf22l6q1ykkrgaxjd5709is0li";
+      rev    = "v${version}";
+      sha256 = "0wr2687pffczn0sns1xvqxr2gpf5v9j64zbj6q9f7km6bq0zpiiy";
     };
     meta = {
       license = stdenv.lib.licenses.mit;
     };
   };
 
-  hyde = mkThemeDrv {
+  hyde = mkThemeDrv rec {
     themeName = "hyde";
-    version   = "2017-01-17";
+    version   = "0.6.0";
     src = {
-      rev    = "22caf4edc738f399bb1013d8e968d111c7fa2a59";
-      sha256 = "1a2j3m941vc2pyb1dz341ww5l3xblg527szfrfqh588lmsrkdqb6";
+      rev    = "v${version}";
+      sha256 = "0yca76p297ymxd049fkcpw8bca5b9yvv36707z31jbijriy50zxb";
     };
     meta = {
       license = stdenv.lib.licenses.mit;
@@ -72,12 +72,12 @@ in
     };
   };
 
-  orbit = mkThemeDrv {
+  orbit = mkThemeDrv rec {
     themeName = "orbit";
-    version   = "2017-01-17";
+    version   = "0.6.0";
     src = {
-      rev    = "b5896e25561f05e026b34d04ad95a647ddfc3d03";
-      sha256 = "11p11f2d0swgjil5hfx153yw13p7pcp6fwx1bnvxrlfmmx9x2yj5";
+      rev    = "v${version}";
+      sha256 = "0qdx1r7dcycr5hzl9ix70pl4xf0426ghpi1lgh61zdpdhcch0xfi";
     };
     meta = {
       license = stdenv.lib.licenses.cc-by-30;
@@ -87,12 +87,12 @@ in
     };
   };
 
-  showcase = mkThemeDrv {
+  showcase = mkThemeDrv rec {
     themeName = "showcase";
-    version   = "2017-01-17";
+    version   = "0.6.0";
     src = {
-      rev    = "1b4b9d4af29c05aaadfd58233f0e3f61fac726af";
-      sha256 = "0mwd1ycwvlv15y431336wwlv8mdv0ikz1aymh3yxhjyxqllc2snk";
+      rev    = "v${version}";
+      sha256 = "1jfhw49yag8l1zr69l01y1p4p88waig3xv3b6c3mfxc8jrchp7pb";
     };
     meta = {
       license = stdenv.lib.licenses.mit;


### PR DESCRIPTION
###### Motivation for this change

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

