### PR TITLE
musescore: add darwin-specific package

### DIFF
--- a/pkgs/applications/audio/musescore/darwin.nix
+++ b/pkgs/applications/audio/musescore/darwin.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, undmg }:
+
+let
+  major = "2";
+  minor = "0.3";
+  patch = "1";
+  appName = "MuseScore ${major}";
+in
+
+stdenv.mkDerivation rec {
+  name = "musescore-darwin-${version}";
+  version = "${major}.${minor}.${patch}";
+
+  src = fetchurl {
+    url =  "ftp://ftp.osuosl.org/pub/musescore/releases/MuseScore-${major}.${minor}/MuseScore-${version}.dmg";
+    sha256 = "0a9v2nc7sx2az7xpd9i7b84m7xk9zcydfpis5fj334r5yqds4rm1";
+  };
+
+  buildInputs = [ undmg ];
+  installPhase = ''
+    mkdir -p "$out/Applications/${appName}.app"
+    cp -R . "$out/Applications/${appName}.app"
+    chmod a+x "$out/Applications/${appName}.app/Contents/MacOS/mscore"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Music notation and composition software";
+    homepage = https://musescore.org/;
+    license = licenses.gpl2;
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ yurrriq ];
+    repositories.git = https://github.com/musescore/MuseScore;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14542,7 +14542,11 @@ with pkgs;
       else null;
   };
 
-  musescore = libsForQt55.callPackage ../applications/audio/musescore { };
+  musescore =
+    if stdenv.isDarwin then
+      callPackage ../applications/audio/musescore/darwin.nix { }
+    else
+      libsForQt55.callPackage ../applications/audio/musescore { };
 
   mutt = callPackage ../applications/networking/mailreaders/mutt { };
   mutt-with-sidebar = callPackage ../applications/networking/mailreaders/mutt {


### PR DESCRIPTION
###### Motivation for this change

The [existing package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/audio/musescore/default.nix) has: `platforms = platforms.linux` and I wanted a version that works on macOS. The added `musescore-darwin` package is basically a clone of the [Homebrew cask version](https://github.com/caskroom/homebrew-cask/blob/master/Casks/musescore.rb) and uses [the `.dmg` distributed by MuseScore](https://musescore.org/en/download).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
