### PR TITLE
lilypond-unstable: init at 2.19.24

### DIFF
--- a/pkgs/misc/lilypond/unstable.nix
+++ b/pkgs/misc/lilypond/unstable.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, guile, rsync, lilypond }:
+
+with stdenv.lib;
+
+overrideDerivation lilypond (p: rec {
+  majorVersion = "2.19";
+  minorVersion = "24";
+  version="${majorVersion}.${minorVersion}";
+  name = "lilypond-${version}";
+
+  src = fetchurl {
+    url = "http://download.linuxaudio.org/lilypond/sources/v${majorVersion}/lilypond-${version}.tar.gz";
+    sha256 = "0wd57swrfc2nvkj10ipdbhq6gpnckiafg2b2kpd8aydsyp248iln";
+  };
+
+  configureFlags = [ "--disable-documentation" "--with-fonts-dir=${p.urwfonts}"];
+
+  buildInputs = p.buildInputs ++ [ rsync ];
+
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17569,6 +17569,7 @@ with pkgs;
   kops = callPackage ../applications/networking/cluster/kops { };
 
   lilypond = callPackage ../misc/lilypond { guile = guile_1_8; };
+  lilypond-unstable = callPackage ../misc/lilypond/unstable.nix { guile = guile_1_8; };
 
   mailcore2 = callPackage ../development/libraries/mailcore2 { };
 


### PR DESCRIPTION
###### Motivation for this change

In my personal projects I require some 2.19.x features.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

