### PR TITLE
emby: 3.1.5 -> 3.2.4

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
-  version = "3.1.5";
+  version = "3.2.4";
 
   src = fetchurl {
     url = "https://github.com/MediaBrowser/Emby/releases/download/${version}/Emby.Mono.zip";
-    sha256 = "0s0m456rxdrj58zbaby6mdgc1ndc3zx2c07n94hn3hdlgralgwaa";
+    sha256 = "0a14wr2yal9q5vlwadyki9w35bn4f3r7r5w3zynp4f7460lfapmf";
   };
 
   buildInputs = with pkgs; [


### PR DESCRIPTION
###### Motivation for this change
New version available.
Changelogs:
https://github.com/MediaBrowser/Emby/releases/tag/3.2.0
https://github.com/MediaBrowser/Emby/releases/tag/3.2.1
https://github.com/MediaBrowser/Emby/releases/tag/3.2.3
https://github.com/MediaBrowser/Emby/releases/tag/3.2.4


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

