### PR TITLE
openfortivpn: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/tools/networking/openfortivpn/default.nix
+++ b/pkgs/tools/networking/openfortivpn/default.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 let repo = "openfortivpn";
-    version = "1.2.0";
+    version = "1.3.0";
 
 in stdenv.mkDerivation {
   name = "${repo}-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "adrienverge";
     inherit repo;
     rev = "v${version}";
-    sha256 = "1a1l9f6zivfyxg9g2x7kzkvcyh84s7l6v0kimihhrd19zl0m41jn";
+    sha256 = "1jr2i0v82db7w9rdx5d64ph90b3hxi15yjy0abjg05wrpnbdyycp";
   };
 
   buildInputs = [ openssl ppp autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

Update openfortivpn from 1.2.0 to 1.3.0

###### Things done
- Built on platform(s)
   - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I tried this and I can connect to my company vpn just fine. There is one issue though: after closing the tunnel again there is some garbage appended to my `/etc/resolv.conf`:

```
^S^]AddTrust Exte<91>
```

The string `AddTrust` does not even seem to occur in the openfortivpn code base and googling for it does not seem to yield anything useful. Does anyone have an idea what this might be?

*Edit*: upstream ticket is [here](https://github.com/adrienverge/openfortivpn/issues/103)