### PR TITLE
bluez also install gatttool

### DIFF
--- a/pkgs/development/avr/simulavr/default.nix
+++ b/pkgs/development/avr/simulavr/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, python, doxygen, tcl, tk, binutils }:
+
+stdenv.mkDerivation rec {
+  name = "simulavr";
+
+  src = fetchurl {
+    url = "http://download.savannah.nongnu.org/releases/simulavr/simulavr-1.0.0.tar.gz";
+    sha256 = "39d93faa3eeae2bee15f682dd6a48fb4d4366addd12a2abebb04c99f87809be7";
+  };
+
+  configureFlags = [
+    "--enable-python"
+    "--enable-doxygen-doc"
+    "--enable-tcl"
+    "--with-bfd=${binutils}/lib/libbfd.la"
+  ];
+  
+  buildInputs = [ python doxygen tcl tk binutils];
+
+  meta = {
+    description = "";
+    homepage    = http://www.nongnu.org/simulavr/;
+    license     = stdenv.lib.licenses.gpl2;
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/os-specific/linux/bluez/bluez5_28.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5_28.nix
@@ -51,6 +51,7 @@ in stdenv.mkDerivation rec {
   # FIXME: Move these into a separate package to prevent Bluez from
   # depending on Python etc.
   postInstall = ''
+    cp ./attrib/gatttool $out/bin/gatttool
     mkdir $out/test
     cp -a test $out
     pushd $out/test

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15082,6 +15082,10 @@ with pkgs;
 
   shutter = callPackage ../applications/graphics/shutter { };
 
+
+  simulavr = callPackage ../development/avr/simulavr { };
+
+
   simple-scan = callPackage ../applications/graphics/simple-scan { };
 
   siproxd = callPackage ../applications/networking/siproxd { };


### PR DESCRIPTION
###### Motivation for this change
bluez does not install gatttool by default, although it does build it. 

https://bugzilla.redhat.com/show_bug.cgi?id=1141909

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [yes] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

