### PR TITLE
obconf: add libSM to fix build

### DIFF
--- a/pkgs/tools/X11/obconf/default.nix
+++ b/pkgs/tools/X11/obconf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gtk2, libglade, openbox,
-  imlib2, libstartup_notification, makeWrapper }:
+  imlib2, libstartup_notification, makeWrapper, libSM }:
 
 stdenv.mkDerivation rec {
   name = "obconf-${version}";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    pkgconfig gtk2 libglade openbox imlib2 libstartup_notification makeWrapper
+    pkgconfig gtk2 libglade libSM openbox imlib2 libstartup_notification
+    makeWrapper
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

obconf didn't install

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

