### PR TITLE
Fix `pkgs.haskellPackages.gtk` build.  Fixes #23184

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -689,6 +689,10 @@ self: super: {
   # Tools that use gtk2hs-buildtools now depend on them in a custom-setup stanza
   cairo = addBuildTool super.cairo self.gtk2hs-buildtools;
   pango = disableHardening (addBuildTool super.pango self.gtk2hs-buildtools) ["fortify"];
+  gtk =
+    if pkgs.stdenv.isDarwin
+    then appendConfigureFlag super.gtk "-fhave-quartz-gtk"
+    else super.gtk;
 
   # https://github.com/commercialhaskell/stack/issues/3001
   stack = doJailbreak super.stack;


### PR DESCRIPTION
###### Motivation for this change

Haskell's `gtk` package [doesn't build on `master`](http://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.gtk.x86_64-darwin) because Haskell's `gtk` package
requires the `have-quartz-gtk` flag to be built on OS X when using the Quartz backend

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested by building the following file:

```nix
let
  pkgs = import /path/to/my/local/nixpkgs {};

in
  pkgs.haskellPackages.gtk
```

The test fails before this change and succeeds after

---

