### PR TITLE
gede: init at 2.0.3

### DIFF
--- a/pkgs/development/tools/misc/gede/build.patch
+++ b/pkgs/development/tools/misc/gede/build.patch
@@ -1,0 +1,11 @@
+--- a/build.py	2017-01-16 21:12:43.000000000 +0100
++++ b/build.py	2017-02-26 22:03:11.394625315 +0100
+@@ -71,7 +71,7 @@
+         if do_build:
+             if not os.path.exists("Makefile"):
+                 print("Generating makefile")
+-                if subprocess.call(['qmake-qt4']):
++                if subprocess.call(['qmake']):
+                     exit(1)
+ 
+             print("Compiling (please wait)")

--- a/pkgs/development/tools/misc/gede/default.nix
+++ b/pkgs/development/tools/misc/gede/default.nix
@@ -1,0 +1,31 @@
+{stdenv, fetchurl, ctags, qt4, python}:
+
+stdenv.mkDerivation rec {
+
+  version = "2.0.3";
+  name = "gede-${version}";
+  src = fetchurl {
+    url = "http://gede.acidron.com/uploads/source/${name}.tar.xz";
+    sha256 = "1znlmkjgrmjl79q73xaa9ybp1xdc3k4h4ynv3jj5z8f92gjnj3kk";
+  };
+
+  buildInputs = [ ctags qt4 python ];
+  patches = [ ./build.patch ];
+
+  unpackPhase = ''
+    tar xf ${src}
+    cd ${name}
+  '';
+  configurePhase = "";
+  buildPhase = "";
+  installPhase = "./build.py install --prefix=$out";
+
+  meta = with stdenv.lib; {
+    description = "Graphical frontend (GUI) to GDB";
+    homepage = "http://gede.acidron.com";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ juliendehos ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6414,6 +6414,8 @@ with pkgs;
 
   funnelweb = callPackage ../development/tools/literate-programming/funnelweb { };
 
+  gede = callPackage ../development/tools/misc/gede { };
+
   pmd = callPackage ../development/tools/analysis/pmd { };
 
   jdepend = callPackage ../development/tools/analysis/jdepend { };


### PR DESCRIPTION
###### Motivation for this change

Init gede, a graphical frontent to GDB.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

