### PR TITLE
Align attrname with pkgname of some packages

### DIFF
--- a/pkgs/applications/audio/banshee/default.nix
+++ b/pkgs/applications/audio/banshee/default.nix
@@ -1,5 +1,5 @@
 { pkgs, stdenv, lib, fetchurl, intltool, pkgconfig, gstreamer, gst_plugins_base
-, gst_plugins_good, gst_plugins_bad, gst_plugins_ugly, gst-ffmpeg, glib
+, gst-plugins-good, gst_plugins_bad, gst_plugins_ugly, gst-ffmpeg, glib
 , mono, mono-addins, dbus-sharp-1_0, dbus-sharp-glib-1_0, notify-sharp, gtk-sharp-2_0
 , boo, gdata-sharp, taglib-sharp, sqlite, gnome-sharp, gconf, gtk-sharp-beans, gio-sharp
 , libmtp, libgpod, mono-zeroconf }:
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool ];
   buildInputs = [
-    gtk-sharp-2_0.gtk gstreamer gst_plugins_base gst_plugins_good
+    gtk-sharp-2_0.gtk gstreamer gst_plugins_base gst-plugins-good
     gst_plugins_bad gst_plugins_ugly gst-ffmpeg
     mono dbus-sharp-1_0 dbus-sharp-glib-1_0 mono-addins notify-sharp
     gtk-sharp-2_0 boo gdata-sharp taglib-sharp sqlite gnome-sharp gconf gtk-sharp-beans

--- a/pkgs/applications/audio/banshee/default.nix
+++ b/pkgs/applications/audio/banshee/default.nix
@@ -1,5 +1,5 @@
 { pkgs, stdenv, lib, fetchurl, intltool, pkgconfig, gstreamer, gst_plugins_base
-, gst_plugins_good, gst_plugins_bad, gst_plugins_ugly, gst_ffmpeg, glib
+, gst_plugins_good, gst_plugins_bad, gst_plugins_ugly, gst-ffmpeg, glib
 , mono, mono-addins, dbus-sharp-1_0, dbus-sharp-glib-1_0, notify-sharp, gtk-sharp-2_0
 , boo, gdata-sharp, taglib-sharp, sqlite, gnome-sharp, gconf, gtk-sharp-beans, gio-sharp
 , libmtp, libgpod, mono-zeroconf }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool ];
   buildInputs = [
     gtk-sharp-2_0.gtk gstreamer gst_plugins_base gst_plugins_good
-    gst_plugins_bad gst_plugins_ugly gst_ffmpeg
+    gst_plugins_bad gst_plugins_ugly gst-ffmpeg
     mono dbus-sharp-1_0 dbus-sharp-glib-1_0 mono-addins notify-sharp
     gtk-sharp-2_0 boo gdata-sharp taglib-sharp sqlite gnome-sharp gconf gtk-sharp-beans
     gio-sharp libmtp libgpod mono-zeroconf

--- a/pkgs/applications/audio/banshee/default.nix
+++ b/pkgs/applications/audio/banshee/default.nix
@@ -1,5 +1,5 @@
 { pkgs, stdenv, lib, fetchurl, intltool, pkgconfig, gstreamer, gst_plugins_base
-, gst-plugins-good, gst_plugins_bad, gst_plugins_ugly, gst-ffmpeg, glib
+, gst-plugins-good, gst-plugins-bad, gst_plugins_ugly, gst-ffmpeg, glib
 , mono, mono-addins, dbus-sharp-1_0, dbus-sharp-glib-1_0, notify-sharp, gtk-sharp-2_0
 , boo, gdata-sharp, taglib-sharp, sqlite, gnome-sharp, gconf, gtk-sharp-beans, gio-sharp
 , libmtp, libgpod, mono-zeroconf }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool ];
   buildInputs = [
     gtk-sharp-2_0.gtk gstreamer gst_plugins_base gst-plugins-good
-    gst_plugins_bad gst_plugins_ugly gst-ffmpeg
+    gst-plugins-bad gst_plugins_ugly gst-ffmpeg
     mono dbus-sharp-1_0 dbus-sharp-glib-1_0 mono-addins notify-sharp
     gtk-sharp-2_0 boo gdata-sharp taglib-sharp sqlite gnome-sharp gconf gtk-sharp-beans
     gio-sharp libmtp libgpod mono-zeroconf

--- a/pkgs/applications/audio/banshee/default.nix
+++ b/pkgs/applications/audio/banshee/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, lib, fetchurl, intltool, pkgconfig, gstreamer, gst_plugins_base
+{ pkgs, stdenv, lib, fetchurl, intltool, pkgconfig, gstreamer, gst-plugins-base
 , gst-plugins-good, gst-plugins-bad, gst-plugins-ugly, gst-ffmpeg, glib
 , mono, mono-addins, dbus-sharp-1_0, dbus-sharp-glib-1_0, notify-sharp, gtk-sharp-2_0
 , boo, gdata-sharp, taglib-sharp, sqlite, gnome-sharp, gconf, gtk-sharp-beans, gio-sharp
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool ];
   buildInputs = [
-    gtk-sharp-2_0.gtk gstreamer gst_plugins_base gst-plugins-good
+    gtk-sharp-2_0.gtk gstreamer gst-plugins-base gst-plugins-good
     gst-plugins-bad gst-plugins-ugly gst-ffmpeg
     mono dbus-sharp-1_0 dbus-sharp-glib-1_0 mono-addins notify-sharp
     gtk-sharp-2_0 boo gdata-sharp taglib-sharp sqlite gnome-sharp gconf gtk-sharp-beans

--- a/pkgs/applications/audio/banshee/default.nix
+++ b/pkgs/applications/audio/banshee/default.nix
@@ -1,5 +1,5 @@
 { pkgs, stdenv, lib, fetchurl, intltool, pkgconfig, gstreamer, gst_plugins_base
-, gst-plugins-good, gst-plugins-bad, gst_plugins_ugly, gst-ffmpeg, glib
+, gst-plugins-good, gst-plugins-bad, gst-plugins-ugly, gst-ffmpeg, glib
 , mono, mono-addins, dbus-sharp-1_0, dbus-sharp-glib-1_0, notify-sharp, gtk-sharp-2_0
 , boo, gdata-sharp, taglib-sharp, sqlite, gnome-sharp, gconf, gtk-sharp-beans, gio-sharp
 , libmtp, libgpod, mono-zeroconf }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool ];
   buildInputs = [
     gtk-sharp-2_0.gtk gstreamer gst_plugins_base gst-plugins-good
-    gst-plugins-bad gst_plugins_ugly gst-ffmpeg
+    gst-plugins-bad gst-plugins-ugly gst-ffmpeg
     mono dbus-sharp-1_0 dbus-sharp-glib-1_0 mono-addins notify-sharp
     gtk-sharp-2_0 boo gdata-sharp taglib-sharp sqlite gnome-sharp gconf gtk-sharp-beans
     gio-sharp libmtp libgpod mono-zeroconf

--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, boost, cmake, gettext, gstreamer, gst_plugins_base
+{ stdenv, fetchurl, boost, cmake, gettext, gstreamer, gst-plugins-base
 , liblastfm, qt4, taglib, fftw, glew, qjson, sqlite, libgpod, libplist
 , usbmuxd, libmtp, gvfs, libcdio, libspotify, protobuf, qca2, pkgconfig
 , sparsehash, config, makeWrapper, runCommand, gst_plugins }:
@@ -27,7 +27,7 @@ let
     fftw
     gettext
     glew
-    gst_plugins_base
+    gst-plugins-base
     gstreamer
     gvfs
     libcdio

--- a/pkgs/applications/audio/morituri/default.nix
+++ b/pkgs/applications/audio/morituri/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, pythonPackages, cdparanoia, cdrdao
-, gst_python, gst_plugins_base, gst_plugins_good
+, gst-python, gst_plugins_base, gst_plugins_good
 , utillinux, makeWrapper, substituteAll, autoreconfHook }:
 
 let
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
   };
 
   pythonPath = with pythonPackages; [
-    pygobject2 gst_python musicbrainzngs
+    pygobject2 gst-python musicbrainzngs
     pycdio pyxdg setuptools
     CDDB
   ];

--- a/pkgs/applications/audio/morituri/default.nix
+++ b/pkgs/applications/audio/morituri/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, pythonPackages, cdparanoia, cdrdao
-, gst-python, gst_plugins_base, gst-plugins-good
+, gst-python, gst-plugins-base, gst-plugins-good
 , utillinux, makeWrapper, substituteAll, autoreconfHook }:
 
 let
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [
     python cdparanoia cdrdao utillinux makeWrapper
-    gst_plugins_base gst-plugins-good
+    gst-plugins-base gst-plugins-good
   ] ++ pythonPath;
 
   patches = [

--- a/pkgs/applications/audio/morituri/default.nix
+++ b/pkgs/applications/audio/morituri/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, pythonPackages, cdparanoia, cdrdao
-, gst-python, gst_plugins_base, gst_plugins_good
+, gst-python, gst_plugins_base, gst-plugins-good
 , utillinux, makeWrapper, substituteAll, autoreconfHook }:
 
 let
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [
     python cdparanoia cdrdao utillinux makeWrapper
-    gst_plugins_base gst_plugins_good
+    gst_plugins_base gst-plugins-good
   ] ++ pythonPath;
 
   patches = [

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchurl, python2Packages, intltool
 , gst-python, withGstPlugins ? false, gst_plugins_base ? null
-, gst_plugins_good ? null, gst_plugins_ugly ? null, gst_plugins_bad ? null }:
+, gst-plugins-good ? null, gst_plugins_ugly ? null, gst_plugins_bad ? null }:
 
 assert withGstPlugins -> gst_plugins_base != null
-                         || gst_plugins_good != null
+                         || gst-plugins-good != null
                          || gst_plugins_ugly != null
                          || gst_plugins_bad != null;
 
@@ -44,7 +44,7 @@ in buildPythonApplication {
   patches = [ ./quodlibet-package-plugins.patch ];
 
   buildInputs = stdenv.lib.optionals withGstPlugins [
-    gst_plugins_base gst_plugins_good gst_plugins_ugly gst_plugins_bad
+    gst_plugins_base gst-plugins-good gst_plugins_ugly gst_plugins_bad
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, python2Packages, intltool
 , gst-python, withGstPlugins ? false, gst_plugins_base ? null
-, gst-plugins-good ? null, gst_plugins_ugly ? null, gst-plugins-bad ? null }:
+, gst-plugins-good ? null, gst-plugins-ugly ? null, gst-plugins-bad ? null }:
 
 assert withGstPlugins -> gst_plugins_base != null
                          || gst-plugins-good != null
-                         || gst_plugins_ugly != null
+                         || gst-plugins-ugly != null
                          || gst-plugins-bad != null;
 
 let
@@ -44,7 +44,7 @@ in buildPythonApplication {
   patches = [ ./quodlibet-package-plugins.patch ];
 
   buildInputs = stdenv.lib.optionals withGstPlugins [
-    gst_plugins_base gst-plugins-good gst_plugins_ugly gst-plugins-bad
+    gst_plugins_base gst-plugins-good gst-plugins-ugly gst-plugins-bad
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, python2Packages, intltool
 , gst-python, withGstPlugins ? false, gst_plugins_base ? null
-, gst-plugins-good ? null, gst_plugins_ugly ? null, gst_plugins_bad ? null }:
+, gst-plugins-good ? null, gst_plugins_ugly ? null, gst-plugins-bad ? null }:
 
 assert withGstPlugins -> gst_plugins_base != null
                          || gst-plugins-good != null
                          || gst_plugins_ugly != null
-                         || gst_plugins_bad != null;
+                         || gst-plugins-bad != null;
 
 let
   version = "2.6.3";
@@ -44,7 +44,7 @@ in buildPythonApplication {
   patches = [ ./quodlibet-package-plugins.patch ];
 
   buildInputs = stdenv.lib.optionals withGstPlugins [
-    gst_plugins_base gst-plugins-good gst_plugins_ugly gst_plugins_bad
+    gst_plugins_base gst-plugins-good gst_plugins_ugly gst-plugins-bad
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, python2Packages, intltool
-, gst-python, withGstPlugins ? false, gst_plugins_base ? null
+, gst-python, withGstPlugins ? false, gst-plugins-base ? null
 , gst-plugins-good ? null, gst-plugins-ugly ? null, gst-plugins-bad ? null }:
 
-assert withGstPlugins -> gst_plugins_base != null
+assert withGstPlugins -> gst-plugins-base != null
                          || gst-plugins-good != null
                          || gst-plugins-ugly != null
                          || gst-plugins-bad != null;
@@ -44,7 +44,7 @@ in buildPythonApplication {
   patches = [ ./quodlibet-package-plugins.patch ];
 
   buildInputs = stdenv.lib.optionals withGstPlugins [
-    gst_plugins_base gst-plugins-good gst-plugins-ugly gst-plugins-bad
+    gst-plugins-base gst-plugins-good gst-plugins-ugly gst-plugins-bad
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python2Packages, intltool
-, gst_python, withGstPlugins ? false, gst_plugins_base ? null
+, gst-python, withGstPlugins ? false, gst_plugins_base ? null
 , gst_plugins_good ? null, gst_plugins_ugly ? null, gst_plugins_bad ? null }:
 
 assert withGstPlugins -> gst_plugins_base != null
@@ -48,7 +48,7 @@ in buildPythonApplication {
   ];
 
   propagatedBuildInputs = [
-    mutagen pygtk pygobject2 dbus-python gst_python intltool
+    mutagen pygtk pygobject2 dbus-python gst-python intltool
   ];
 
   postInstall = stdenv.lib.optionalString withGstPlugins ''

--- a/pkgs/applications/audio/transcribe/default.nix
+++ b/pkgs/applications/audio/transcribe/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip, lib, makeWrapper, alsaLib, atk, cairo, gdk_pixbuf
-, glib, gst_ffmpeg, gst_plugins_bad, gst_plugins_base
+, glib, gst-ffmpeg, gst_plugins_bad, gst_plugins_base
 , gst_plugins_good, gst_plugins_ugly, gstreamer, gtk2, libSM, libX11
 , libpng12, pango, zlib }:
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [ gst_plugins_base gst_plugins_good
-    gst_plugins_bad gst_plugins_ugly gst_ffmpeg ];
+    gst_plugins_bad gst_plugins_ugly gst-ffmpeg ];
 
   dontPatchELF = true;
 

--- a/pkgs/applications/audio/transcribe/default.nix
+++ b/pkgs/applications/audio/transcribe/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchzip, lib, makeWrapper, alsaLib, atk, cairo, gdk_pixbuf
 , glib, gst-ffmpeg, gst-plugins-bad, gst_plugins_base
-, gst-plugins-good, gst_plugins_ugly, gstreamer, gtk2, libSM, libX11
+, gst-plugins-good, gst-plugins-ugly, gstreamer, gtk2, libSM, libX11
 , libpng12, pango, zlib }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [ gst_plugins_base gst-plugins-good
-    gst-plugins-bad gst_plugins_ugly gst-ffmpeg ];
+    gst-plugins-bad gst-plugins-ugly gst-ffmpeg ];
 
   dontPatchELF = true;
 

--- a/pkgs/applications/audio/transcribe/default.nix
+++ b/pkgs/applications/audio/transcribe/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip, lib, makeWrapper, alsaLib, atk, cairo, gdk_pixbuf
-, glib, gst-ffmpeg, gst_plugins_bad, gst_plugins_base
+, glib, gst-ffmpeg, gst-plugins-bad, gst_plugins_base
 , gst-plugins-good, gst_plugins_ugly, gstreamer, gtk2, libSM, libX11
 , libpng12, pango, zlib }:
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [ gst_plugins_base gst-plugins-good
-    gst_plugins_bad gst_plugins_ugly gst-ffmpeg ];
+    gst-plugins-bad gst_plugins_ugly gst-ffmpeg ];
 
   dontPatchELF = true;
 

--- a/pkgs/applications/audio/transcribe/default.nix
+++ b/pkgs/applications/audio/transcribe/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip, lib, makeWrapper, alsaLib, atk, cairo, gdk_pixbuf
-, glib, gst-ffmpeg, gst-plugins-bad, gst_plugins_base
+, glib, gst-ffmpeg, gst-plugins-bad, gst-plugins-base
 , gst-plugins-good, gst-plugins-ugly, gstreamer, gtk2, libSM, libX11
 , libpng12, pango, zlib }:
 
@@ -21,14 +21,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [ gst_plugins_base gst-plugins-good
+  buildInputs = [ gst-plugins-base gst-plugins-good
     gst-plugins-bad gst-plugins-ugly gst-ffmpeg ];
 
   dontPatchELF = true;
 
   libPath = lib.makeLibraryPath [
     stdenv.cc.cc glib gtk2 atk pango cairo gdk_pixbuf alsaLib
-    libX11 libSM libpng12 gstreamer gst_plugins_base zlib
+    libX11 libSM libpng12 gstreamer gst-plugins-base zlib
   ];
 
   installPhase = ''

--- a/pkgs/applications/audio/transcribe/default.nix
+++ b/pkgs/applications/audio/transcribe/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchzip, lib, makeWrapper, alsaLib, atk, cairo, gdk_pixbuf
 , glib, gst-ffmpeg, gst_plugins_bad, gst_plugins_base
-, gst_plugins_good, gst_plugins_ugly, gstreamer, gtk2, libSM, libX11
+, gst-plugins-good, gst_plugins_ugly, gstreamer, gtk2, libSM, libX11
 , libpng12, pango, zlib }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [ gst_plugins_base gst_plugins_good
+  buildInputs = [ gst_plugins_base gst-plugins-good
     gst_plugins_bad gst_plugins_ugly gst-ffmpeg ];
 
   dontPatchELF = true;

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -12,7 +12,7 @@
 , gdk_pixbuf
 , glib
 , glibc
-, gst_plugins_base
+, gst-plugins-base
 , gstreamer
 , gtk2
 , gtk3
@@ -94,7 +94,7 @@ stdenv.mkDerivation {
       gdk_pixbuf
       glib
       glibc
-      gst_plugins_base
+      gst-plugins-base
       gstreamer
       gtk2
       gtk3

--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -3,7 +3,7 @@
 , freetype, fontconfig, file, alsaLib, nspr, nss, libnotify
 , yasm, mesa, sqlite, unzip, makeWrapper
 , hunspell, libevent, libstartup_notification, libvpx
-, cairo, gstreamer, gst_plugins_base, icu, libpng, jemalloc, libpulseaudio
+, cairo, gstreamer, gst-plugins-base, icu, libpng, jemalloc, libpulseaudio
 , autoconf213, which
 , writeScript, xidel, common-updater-scripts, coreutils, gnused, gnugrep, curl
 , enableGTK3 ? false
@@ -42,7 +42,7 @@ common = { pname, version, sha512, updateScript }: stdenv.mkDerivation rec {
       libpulseaudio # only headers are needed
     ]
     ++ lib.optional enableGTK3 gtk3
-    ++ lib.optionals (!passthru.ffmpegSupport) [ gstreamer gst_plugins_base ];
+    ++ lib.optionals (!passthru.ffmpegSupport) [ gstreamer gst-plugins-base ];
 
   nativeBuildInputs = [ autoconf213 which gnused ];
 

--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, makeDesktopItem
 , pkgconfig, autoconf213, alsaLib, bzip2, cairo
 , dbus, dbus_glib, file, fontconfig, freetype
-, gstreamer, gst_plugins_base, gst_all_1
+, gstreamer, gst-plugins-base, gst_all_1
 , gtk2, hunspell, icu, libevent, libjpeg, libnotify
 , libstartup_notification, libvpx, makeWrapper, mesa 
 , nspr, nss, pango, perl, python, libpulseaudio, sqlite 
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     alsaLib bzip2 cairo dbus dbus_glib file fontconfig freetype
-    gst_plugins_base gstreamer gst_all_1.gst-plugins-base gtk2
+    gst-plugins-base gstreamer gst_all_1.gst-plugins-base gtk2
     hunspell icu libevent libjpeg libnotify libstartup_notification
     libvpx makeWrapper mesa nspr nss pango perl pkgconfig python
     libpulseaudio sqlite unzip which yasm zip zlib

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -3,7 +3,7 @@
 , alsaLib, dbus_libs, cups, libexif, ffmpeg, systemd
 , freetype, fontconfig, libXft, libXrender, libxcb, expat, libXau, libXdmcp
 , libuuid, xz
-, gstreamer, gst_plugins_base, libxml2
+, gstreamer, gst-plugins-base, libxml2
 , glib, gtk2, pango, gdk_pixbuf, cairo, atk, gnome3
 , nss, nspr
 , patchelf
@@ -41,7 +41,7 @@ in stdenv.mkDerivation rec {
       libXi libXft libXcursor libXfixes libXScrnSaver libXcomposite libXdamage libXtst libXrandr
       atk alsaLib dbus_libs cups gtk2 gdk_pixbuf libexif ffmpeg systemd
       freetype fontconfig libXrender libuuid expat glib nss nspr
-      gstreamer libxml2 gst_plugins_base pango cairo gnome3.gconf
+      gstreamer libxml2 gst-plugins-base pango cairo gnome3.gconf
       patchelf
     ];
 

--- a/pkgs/applications/networking/instant-messengers/baresip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/baresip/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchurl, zlib, openssl, libre, librem, pkgconfig
 , cairo, mpg123, gstreamer, gst-ffmpeg, gst_plugins_base, gst_plugins_bad
-, gst_plugins_good, alsaLib, SDL, libv4l, celt, libsndfile, srtp, ffmpeg
+, gst-plugins-good, alsaLib, SDL, libv4l, celt, libsndfile, srtp, ffmpeg
 , gsm, speex, portaudio, spandsp, libuuid, ccache
 }:
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0dhlgjkqn7jkd1pmdyid41c829clzmi5kczjdwxzh5ygn95lydjc";
   };
   buildInputs = [zlib openssl libre librem pkgconfig
-    cairo mpg123 gstreamer gst-ffmpeg gst_plugins_base gst_plugins_bad gst_plugins_good
+    cairo mpg123 gstreamer gst-ffmpeg gst_plugins_base gst_plugins_bad gst-plugins-good
     alsaLib SDL libv4l celt libsndfile srtp ffmpeg gsm speex portaudio spandsp libuuid
     ccache
     ];

--- a/pkgs/applications/networking/instant-messengers/baresip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/baresip/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, zlib, openssl, libre, librem, pkgconfig
-, cairo, mpg123, gstreamer, gst-ffmpeg, gst_plugins_base, gst-plugins-bad
+, cairo, mpg123, gstreamer, gst-ffmpeg, gst-plugins-base, gst-plugins-bad
 , gst-plugins-good, alsaLib, SDL, libv4l, celt, libsndfile, srtp, ffmpeg
 , gsm, speex, portaudio, spandsp, libuuid, ccache
 }:
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0dhlgjkqn7jkd1pmdyid41c829clzmi5kczjdwxzh5ygn95lydjc";
   };
   buildInputs = [zlib openssl libre librem pkgconfig
-    cairo mpg123 gstreamer gst-ffmpeg gst_plugins_base gst-plugins-bad gst-plugins-good
+    cairo mpg123 gstreamer gst-ffmpeg gst-plugins-base gst-plugins-bad gst-plugins-good
     alsaLib SDL libv4l celt libsndfile srtp ffmpeg gsm speex portaudio spandsp libuuid
     ccache
     ];

--- a/pkgs/applications/networking/instant-messengers/baresip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/baresip/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, zlib, openssl, libre, librem, pkgconfig
-, cairo, mpg123, gstreamer, gst-ffmpeg, gst_plugins_base, gst_plugins_bad
+, cairo, mpg123, gstreamer, gst-ffmpeg, gst_plugins_base, gst-plugins-bad
 , gst-plugins-good, alsaLib, SDL, libv4l, celt, libsndfile, srtp, ffmpeg
 , gsm, speex, portaudio, spandsp, libuuid, ccache
 }:
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0dhlgjkqn7jkd1pmdyid41c829clzmi5kczjdwxzh5ygn95lydjc";
   };
   buildInputs = [zlib openssl libre librem pkgconfig
-    cairo mpg123 gstreamer gst-ffmpeg gst_plugins_base gst_plugins_bad gst-plugins-good
+    cairo mpg123 gstreamer gst-ffmpeg gst_plugins_base gst-plugins-bad gst-plugins-good
     alsaLib SDL libv4l celt libsndfile srtp ffmpeg gsm speex portaudio spandsp libuuid
     ccache
     ];

--- a/pkgs/applications/networking/instant-messengers/baresip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/baresip/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, zlib, openssl, libre, librem, pkgconfig
-, cairo, mpg123, gstreamer, gst_ffmpeg, gst_plugins_base, gst_plugins_bad
+, cairo, mpg123, gstreamer, gst-ffmpeg, gst_plugins_base, gst_plugins_bad
 , gst_plugins_good, alsaLib, SDL, libv4l, celt, libsndfile, srtp, ffmpeg
 , gsm, speex, portaudio, spandsp, libuuid, ccache
 }:
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0dhlgjkqn7jkd1pmdyid41c829clzmi5kczjdwxzh5ygn95lydjc";
   };
   buildInputs = [zlib openssl libre librem pkgconfig
-    cairo mpg123 gstreamer gst_ffmpeg gst_plugins_base gst_plugins_bad gst_plugins_good
+    cairo mpg123 gstreamer gst-ffmpeg gst_plugins_base gst_plugins_bad gst_plugins_good
     alsaLib SDL libv4l celt libsndfile srtp ffmpeg gsm speex portaudio spandsp libuuid
     ccache
     ];

--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -4,7 +4,7 @@
 # Test requirements
 , xvfb_run
 
-, enableJingle ? true, farstream ? null, gst_plugins_bad ? null
+, enableJingle ? true, farstream ? null, gst-plugins-bad ? null
 ,                      libnice ? null
 , enableE2E ? true
 , enableRST ? true
@@ -14,7 +14,7 @@
 , extraPythonPackages ? pkgs: []
 }:
 
-assert enableJingle -> farstream != null && gst_plugins_bad != null
+assert enableJingle -> farstream != null && gst-plugins-bad != null
                     && libnice != null;
 assert enableE2E -> pythonPackages.pycrypto != null;
 assert enableRST -> pythonPackages.docutils != null;
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     python libX11
-  ] ++ optionals enableJingle [ farstream gst_plugins_bad libnice ];
+  ] ++ optionals enableJingle [ farstream gst-plugins-bad libnice ];
 
   nativeBuildInputs = [
     autoreconfHook pythonPackages.wrapPython intltool pkgconfig

--- a/pkgs/applications/networking/instant-messengers/telepathy/kde/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/kde/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchgit, automoc4, cmake, gettext, perl, pkgconfig
 , telepathy_qt, kdelibs4, kde_workspace, dbus_glib, dbus_libs, farstream
-, qt_gstreamer1, telepathy_glib, telepathy_logger
+, qt-gstreamer1, telepathy_glib, telepathy_logger
 , qjson, flex, bison, qca2 }:
 
 let
@@ -21,10 +21,10 @@ let
 
   extraBuildInputs = {
     auth_handler = [ qjson qca2 ];
-    call_ui = [ qt_gstreamer1 telepathy_glib farstream ];
+    call_ui = [ qt-gstreamer1 telepathy_glib farstream ];
     contact_applet = [ kde_workspace ];
-    telepathy_logger_qt = [ telepathy_logger qt_gstreamer1 ];
-    text_ui = [ qt_gstreamer1 telepathy_logger qjson ];
+    telepathy_logger_qt = [ telepathy_logger qt-gstreamer1 ];
+    text_ui = [ qt-gstreamer1 telepathy_logger qjson ];
     common_internals = [ telepathy_qt ];
   };
 

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -2,7 +2,7 @@
 , fetchurl
 , gcc
 , glib
-, gst_plugins_base
+, gst-plugins-base
 , gstreamer
 , icu
 , libpulseaudio
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
       alsaLib
       gcc.cc
       glib
-      gst_plugins_base
+      gst-plugins-base
       gstreamer
       icu
       libpulseaudio

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -13,7 +13,7 @@
 , gdk_pixbuf
 , glib
 , glibc
-, gst_plugins_base
+, gst-plugins-base
 , gstreamer
 , gtk2
 , kerberos
@@ -91,7 +91,7 @@ stdenv.mkDerivation {
       gdk_pixbuf
       glib
       glibc
-      gst_plugins_base
+      gst-plugins-base
       gstreamer
       gtk2
       kerberos

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -3,7 +3,7 @@
 , freetype, fontconfig, file, alsaLib, nspr, nss, libnotify
 , yasm, mesa, sqlite, unzip, makeWrapper
 , hunspell, libevent, libstartup_notification, libvpx
-, cairo, gstreamer, gst_plugins_base, icu
+, cairo, gstreamer, gst-plugins-base, icu
 , writeScript, xidel, common-updater-scripts, coreutils, gnused, gnugrep, curl
 , debugBuild ? false
 , # If you want the resulting program to call itself "Thunderbird"

--- a/pkgs/applications/science/robotics/qgroundcontrol/default.nix
+++ b/pkgs/applications/science/robotics/qgroundcontrol/default.nix
@@ -2,7 +2,7 @@
   , qtbase, qtlocation, qtserialport, qtdeclarative, qtconnectivity, qtxmlpatterns
   , qtsvg, qtquick1, qtquickcontrols, qtgraphicaleffects, qmakeHook
   , makeQtWrapper, lndir
-  , gst_all_1, qt_gstreamer1, pkgconfig, glibc
+  , gst_all_1, qt-gstreamer1, pkgconfig, glibc
   , version ? "2.9.4"
 }:
 

--- a/pkgs/applications/video/miro/default.nix
+++ b/pkgs/applications/video/miro/default.nix
@@ -2,7 +2,7 @@
 , pythonPackages, pyrex096, ffmpeg, boost, glib, gtk2, webkitgtk2, libsoup
 , taglib, sqlite
 , libtorrentRasterbar, glib_networking, gsettings_desktop_schemas
-, gst-python, gst_plugins_base, gst-plugins-good, gst-ffmpeg
+, gst-python, gst-plugins-base, gst-plugins-good, gst-ffmpeg
 , enableBonjour ? false, avahi ? null
 }:
 
@@ -77,7 +77,7 @@ in buildPythonApplication rec {
   propagatedBuildInputs = with pythonPackages; [
     pygobject2 pygtk pycurl mutagen pycairo dbus-python
     pywebkitgtk] ++ [ libtorrentRasterbar
-    gst-python gst_plugins_base gst-plugins-good gst-ffmpeg
+    gst-python gst-plugins-base gst-plugins-good gst-ffmpeg
   ] ++ optional enableBonjour avahi;
 
   meta = {

--- a/pkgs/applications/video/miro/default.nix
+++ b/pkgs/applications/video/miro/default.nix
@@ -2,7 +2,7 @@
 , pythonPackages, pyrex096, ffmpeg, boost, glib, gtk2, webkitgtk2, libsoup
 , taglib, sqlite
 , libtorrentRasterbar, glib_networking, gsettings_desktop_schemas
-, gst-python, gst_plugins_base, gst_plugins_good, gst_ffmpeg
+, gst-python, gst_plugins_base, gst_plugins_good, gst-ffmpeg
 , enableBonjour ? false, avahi ? null
 }:
 
@@ -77,7 +77,7 @@ in buildPythonApplication rec {
   propagatedBuildInputs = with pythonPackages; [
     pygobject2 pygtk pycurl mutagen pycairo dbus-python
     pywebkitgtk] ++ [ libtorrentRasterbar
-    gst-python gst_plugins_base gst_plugins_good gst_ffmpeg
+    gst-python gst_plugins_base gst_plugins_good gst-ffmpeg
   ] ++ optional enableBonjour avahi;
 
   meta = {

--- a/pkgs/applications/video/miro/default.nix
+++ b/pkgs/applications/video/miro/default.nix
@@ -2,7 +2,7 @@
 , pythonPackages, pyrex096, ffmpeg, boost, glib, gtk2, webkitgtk2, libsoup
 , taglib, sqlite
 , libtorrentRasterbar, glib_networking, gsettings_desktop_schemas
-, gst_python, gst_plugins_base, gst_plugins_good, gst_ffmpeg
+, gst-python, gst_plugins_base, gst_plugins_good, gst_ffmpeg
 , enableBonjour ? false, avahi ? null
 }:
 
@@ -77,7 +77,7 @@ in buildPythonApplication rec {
   propagatedBuildInputs = with pythonPackages; [
     pygobject2 pygtk pycurl mutagen pycairo dbus-python
     pywebkitgtk] ++ [ libtorrentRasterbar
-    gst_python gst_plugins_base gst_plugins_good gst_ffmpeg
+    gst-python gst_plugins_base gst_plugins_good gst_ffmpeg
   ] ++ optional enableBonjour avahi;
 
   meta = {

--- a/pkgs/applications/video/miro/default.nix
+++ b/pkgs/applications/video/miro/default.nix
@@ -2,7 +2,7 @@
 , pythonPackages, pyrex096, ffmpeg, boost, glib, gtk2, webkitgtk2, libsoup
 , taglib, sqlite
 , libtorrentRasterbar, glib_networking, gsettings_desktop_schemas
-, gst-python, gst_plugins_base, gst_plugins_good, gst-ffmpeg
+, gst-python, gst_plugins_base, gst-plugins-good, gst-ffmpeg
 , enableBonjour ? false, avahi ? null
 }:
 
@@ -77,7 +77,7 @@ in buildPythonApplication rec {
   propagatedBuildInputs = with pythonPackages; [
     pygobject2 pygtk pycurl mutagen pycairo dbus-python
     pywebkitgtk] ++ [ libtorrentRasterbar
-    gst-python gst_plugins_base gst_plugins_good gst-ffmpeg
+    gst-python gst_plugins_base gst-plugins-good gst-ffmpeg
   ] ++ optional enableBonjour avahi;
 
   meta = {

--- a/pkgs/desktops/gnome-3/3.22/misc/pomodoro/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/misc/pomodoro/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, which, automake113x, intltool, pkgconfig, libtool, makeWrapper,
-  dbus_glib, libcanberra_gtk2, gst_all_1, vala_0_32, gnome3, gtk3, gst_plugins_base,
+  dbus_glib, libcanberra_gtk2, gst_all_1, vala_0_32, gnome3, gtk3, gst-plugins-base,
   glib, gobjectIntrospection, telepathy_glib
 }:
 

--- a/pkgs/desktops/xfce/applications/xfce4-mixer.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-mixer.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, intltool, makeWrapper
 , glib, gstreamer, gst_plugins_base, gtk
 , libxfce4util, libxfce4ui, xfce4panel, xfconf, libunique ? null
-, pulseaudioSupport ? false, gst_plugins_good
+, pulseaudioSupport ? false, gst-plugins-good
 }:
 
 let
@@ -10,7 +10,7 @@ let
   gst_plugins_minimal = gst_plugins_base.override {
     minimalDeps = true;
   };
-  gst_plugins_pulse = gst_plugins_good.override {
+  gst_plugins_pulse = gst-plugins-good.override {
     minimalDeps = true;
   };
   gst_plugins = [ gst_plugins_minimal ] ++ stdenv.lib.optional pulseaudioSupport gst_plugins_pulse;

--- a/pkgs/desktops/xfce/applications/xfce4-mixer.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-mixer.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, makeWrapper
-, glib, gstreamer, gst_plugins_base, gtk
+, glib, gstreamer, gst-plugins-base, gtk
 , libxfce4util, libxfce4ui, xfce4panel, xfconf, libunique ? null
 , pulseaudioSupport ? false, gst-plugins-good
 }:
@@ -7,7 +7,7 @@
 let
   # The usual Gstreamer plugins package has a zillion dependencies
   # that we don't need for a simple mixer, so build a minimal package.
-  gst_plugins_minimal = gst_plugins_base.override {
+  gst_plugins_minimal = gst-plugins-base.override {
     minimalDeps = true;
   };
   gst_plugins_pulse = gst-plugins-good.override {

--- a/pkgs/desktops/xfce/applications/xfce4-volumed.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-volumed.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkgconfig, makeWrapper
-, gstreamer, gtk2, gst_plugins_base, libnotify
+, gstreamer, gtk2, gst-plugins-base, libnotify
 , keybinder, xfconf
 }:
 
 let
   # The usual Gstreamer plugins package has a zillion dependencies
   # that we don't need for a simple mixer, so build a minimal package.
-  gst_plugins_minimal = gst_plugins_base.override {
+  gst_plugins_minimal = gst-plugins-base.override {
     minimalDeps = true;
   };
 

--- a/pkgs/development/libraries/farsight2/default.nix
+++ b/pkgs/development/libraries/farsight2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libnice, pkgconfig, python2Packages, gstreamer, gst_plugins_base
+{ stdenv, fetchurl, libnice, pkgconfig, python2Packages, gstreamer, gst-plugins-base
 , gst-python, gupnp_igd }:
 
 let
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  propagatedBuildInputs = [ gstreamer gst_plugins_base ];
+  propagatedBuildInputs = [ gstreamer gst-plugins-base ];
 
   meta = {
     homepage = http://farsight.freedesktop.org/wiki/;

--- a/pkgs/development/libraries/farsight2/default.nix
+++ b/pkgs/development/libraries/farsight2/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, libnice, pkgconfig, python2Packages, gstreamer, gst_plugins_base
-, gst_python, gupnp_igd }:
+, gst-python, gupnp_igd }:
 
 let
   inherit (python2Packages) python pygobject2;
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
     sha256 = "16qz4x14rdycm4nrn5wx6k2y22fzrazsbmihrxdwafx9cyf23kjm";
   };
 
-  buildInputs = [ libnice python pygobject2 gst_python gupnp_igd ];
+  buildInputs = [ libnice python pygobject2 gst-python gupnp_igd ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/libraries/gstreamer/legacy/gnonlin/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gnonlin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gst_plugins_base, gstreamer }:
+{ stdenv, fetchurl, pkgconfig, gst-plugins-base, gstreamer }:
 
 stdenv.mkDerivation rec {
   name = "gnonlin-0.10.17";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0dc9kvr6i7sh91cyhzlbx2bchwg84rfa4679ccppzjf0y65dv8p4";
   };
 
-  buildInputs = [ gst_plugins_base gstreamer pkgconfig ];
+  buildInputs = [ gst-plugins-base gstreamer pkgconfig ];
 
   meta = {
     homepage = "http://gstreamer.freedesktop.org/modules/gnonlin.html";

--- a/pkgs/development/libraries/gstreamer/legacy/gst-ffmpeg/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-ffmpeg/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, gst_plugins_base, bzip2, yasm, orc
+{ fetchurl, stdenv, pkgconfig, gst-plugins-base, bzip2, yasm, orc
 , useInternalFfmpeg ? false, ffmpeg ? null }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   configureFlags = stdenv.lib.optionalString (!useInternalFfmpeg) "--with-system-ffmpeg";
 
   buildInputs =
-    [ pkgconfig bzip2 gst_plugins_base orc ]
+    [ pkgconfig bzip2 gst-plugins-base orc ]
     ++ (if useInternalFfmpeg then [ yasm ] else [ ffmpeg ]);
 
   meta = {

--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-bad/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, glib, gstreamer, gst_plugins_base
+{ fetchurl, stdenv, pkgconfig, glib, gstreamer, gst-plugins-base
 , libdvdnav, libdvdread, orc }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ pkgconfig glib gstreamer gst_plugins_base libdvdnav libdvdread orc ];
+    [ pkgconfig glib gstreamer gst-plugins-base libdvdnav libdvdread orc ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-good/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-good/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, lib, pkgconfig, gst_plugins_base, aalib, cairo
+{ fetchurl, stdenv, lib, pkgconfig, gst-plugins-base, aalib, cairo
 , flac, libjpeg, zlib, speex, libpng, libdv, libcaca, libvpx
 , libiec61883, libavc1394, taglib, libpulseaudio, gdk_pixbuf, orc
 , glib, gstreamer, bzip2, libsoup, libshout, ncurses, libintlOrEmpty
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--enable-experimental" "--disable-oss" ];
 
   buildInputs =
-    [ pkgconfig glib gstreamer gst_plugins_base ]
+    [ pkgconfig glib gstreamer gst-plugins-base ]
     ++ lib.optional stdenv.isLinux libpulseaudio
     ++ libintlOrEmpty
     ++ lib.optionals (!minimalDeps)

--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-ugly/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, glib, gstreamer, gst_plugins_base
+{ fetchurl, stdenv, pkgconfig, glib, gstreamer, gst-plugins-base
 , libmad, libdvdread, libmpeg2, libcdio, a52dec, x264, orc, lame, libintlOrEmpty }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ pkgconfig glib gstreamer gst_plugins_base libmad libdvdread a52dec x264 orc lame ] ++ libintlOrEmpty;
+    [ pkgconfig glib gstreamer gst-plugins-base libmad libdvdread a52dec x264 orc lame ] ++ libintlOrEmpty;
 
   NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
 

--- a/pkgs/development/libraries/gstreamer/legacy/gst-python/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-python/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, python2Packages, gstreamer, gst_plugins_base
+{ fetchurl, stdenv, pkgconfig, python2Packages, gstreamer, gst-plugins-base
 }:
 
 let
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
   patches = [ ./disable-testFake.patch ];
 
   buildInputs =
-    [ pkgconfig gst_plugins_base pygobject2 ]
+    [ pkgconfig gst-plugins-base pygobject2 ]
     ;
 
   propagatedBuildInputs = [ gstreamer python ];

--- a/pkgs/development/libraries/gstreamer/legacy/gstreamermm/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gstreamermm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glibmm, gstreamer, gst_plugins_base, libsigcxx, libxmlxx, pkgconfig }:
+{ stdenv, fetchurl, glibmm, gstreamer, gst-plugins-base, libsigcxx, libxmlxx, pkgconfig }:
 
 let
   ver_maj = "0.10";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   doCheck = false; # Tests require pulseaudio in /homeless-shelter
 
   propagatedBuildInputs = [
-    glibmm gstreamer gst_plugins_base libsigcxx libxmlxx
+    glibmm gstreamer gst-plugins-base libsigcxx libxmlxx
   ];
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/gstreamer/legacy/qt-gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/qt-gstreamer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gstreamer, gst_plugins_base, boost, glib, qt4, cmake
+{ stdenv, fetchurl, gstreamer, gst-plugins-base, boost, glib, qt4, cmake
 , automoc4, flex, bison, pkgconfig }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1pqg9sxzk8sdrf7pazb5v21hasqai9i4l203gbdqz29w2ll1ybsl";
   };
 
-  buildInputs = [ gstreamer gst_plugins_base glib qt4 ];
+  buildInputs = [ gstreamer gst-plugins-base glib qt4 ];
   propagatedBuildInputs = [ boost ];
   nativeBuildInputs = [ cmake automoc4 flex bison pkgconfig ];
 

--- a/pkgs/development/libraries/libcanberra/default.nix
+++ b/pkgs/development/libraries/libcanberra/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libtool, gtk ? null, libcap
-, alsaLib, libpulseaudio, gstreamer, gst_plugins_base, libvorbis }:
+, alsaLib, libpulseaudio, gstreamer, gst-plugins-base, libvorbis }:
 
 stdenv.mkDerivation rec {
   name = "libcanberra-0.30";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pkgconfig libtool alsaLib libpulseaudio libvorbis gtk libcap
-    /*gstreamer gst_plugins_base*/      # ToDo: gstreamer not found (why?), add (g)udev?
+    /*gstreamer gst-plugins-base*/      # ToDo: gstreamer not found (why?), add (g)udev?
   ];
 
   configureFlags = "--disable-oss";

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -3,7 +3,7 @@
 , libXfixes, libXrandr, libSM, freetype, fontconfig, zlib, libjpeg, libpng
 , libmng, which, mesaSupported, mesa, mesa_glu, openssl, dbus, cups, pkgconfig
 , libtiff, glib, icu, mysql, postgresql, sqlite, perl, coreutils, libXi
-, buildMultimedia ? stdenv.isLinux, alsaLib, gstreamer, gst_plugins_base
+, buildMultimedia ? stdenv.isLinux, alsaLib, gstreamer, gst-plugins-base
 , buildWebkit ? (stdenv.isLinux || stdenv.isDarwin)
 , flashplayerFix ? false, gdk_pixbuf
 , gtkStyle ? false, libgnomeui, gtk2, GConf, gnome_vfs
@@ -138,7 +138,7 @@ stdenv.mkDerivation rec {
         # Qt doesn't directly need GLU (just GL), but many apps use, it's small and doesn't remain a runtime-dep if not used
     ++ optional mesaSupported mesa_glu
     ++ optional ((buildWebkit || buildMultimedia) && stdenv.isLinux ) alsaLib
-    ++ optionals (buildWebkit || buildMultimedia) [ gstreamer gst_plugins_base ];
+    ++ optionals (buildWebkit || buildMultimedia) [ gstreamer gst-plugins-base ];
 
   # The following libraries are only used in plugins
   buildInputs =

--- a/pkgs/development/libraries/wxGTK-2.8/default.nix
+++ b/pkgs/development/libraries/wxGTK-2.8/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gtk2, libXinerama, libSM, libXxf86vm, xf86vidmodeproto
-, gstreamer, gst_plugins_base, GConf, libX11, cairo
+, gstreamer, gst-plugins-base, GConf, libX11, cairo
 , withMesa ? true, mesa ? null, compat24 ? false, compat26 ? true, unicode ? true,
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "1l1w4i113csv3bd5r8ybyj0qpxdq83lj6jrc5p7cc10mkwyiagqz";
   };
 
-  buildInputs = [ gtk2 libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer gst_plugins_base GConf libX11 cairo ]
+  buildInputs = [ gtk2 libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer gst-plugins-base GConf libX11 cairo ]
     ++ optional withMesa mesa;
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/wxGTK-2.9/default.nix
+++ b/pkgs/development/libraries/wxGTK-2.9/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gtk2, libXinerama, libSM, libXxf86vm, xf86vidmodeproto
-, gstreamer, gst_plugins_base, GConf, setfile
+, gstreamer, gst-plugins-base, GConf, setfile
 , withMesa ? true, mesa ? null, compat24 ? false, compat26 ? true, unicode ? true
 , Carbon ? null, Cocoa ? null, Kernel ? null, QuickTime ? null, AGL ? null
 }:
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
 
   buildInputs =
     [ gtk2 libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer
-      gst_plugins_base GConf ]
+      gst-plugins-base GConf ]
     ++ optional withMesa mesa
     ++ optionals stdenv.isDarwin [ setfile Carbon Cocoa Kernel QuickTime ];
 

--- a/pkgs/development/libraries/wxGTK-3.0/default.nix
+++ b/pkgs/development/libraries/wxGTK-3.0/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, gtk2, libXinerama, libSM, libXxf86vm
-, xf86vidmodeproto , gstreamer, gst_plugins_base, GConf, setfile
+, xf86vidmodeproto , gstreamer, gst-plugins-base, GConf, setfile
 , withMesa ? true, mesa ? null, compat24 ? false, compat26 ? true, unicode ? true
 , withWebKit ? false, webkitgtk2 ? null
 , AGL ? null, Carbon ? null, Cocoa ? null, Kernel ? null, QTKit ? null
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   buildInputs =
     [ gtk2 libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer
-      gst_plugins_base GConf ]
+      gst-plugins-base GConf ]
     ++ optional withMesa mesa
     ++ optional withWebKit webkitgtk2
     ++ optionals stdenv.isDarwin [ setfile Carbon Cocoa Kernel QTKit ];

--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -78,7 +78,7 @@ let
     SDL2_ttf
     SDL2_mixer
     gstreamer
-    gst_plugins_base
+    gst-plugins-base
   ] ++ lib.optional (!newStdcpp) gcc48.cc;
 
   overridePkgs = with pkgs; [

--- a/pkgs/os-specific/linux/bluez/bluez5.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
       readline libsndfile udev libical
       # Disables GStreamer; not clear what it gains us other than a
       # zillion extra dependencies.
-      # gstreamer gst_plugins_base
+      # gstreamer gst-plugins-base
     ];
 
   outputs = [ "out" "dev" "test" ];

--- a/pkgs/os-specific/linux/bluez/bluez5_28.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5_28.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
       readline libsndfile udev libical
       # Disables GStreamer; not clear what it gains us other than a
       # zillion extra dependencies.
-      # gstreamer gst_plugins_base 
+      # gstreamer gst-plugins-base 
     ];
 
   preConfigure = ''

--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
       readline libsndfile
       # Disables GStreamer; not clear what it gains us other than a
       # zillion extra dependencies.
-      # gstreamer gst_plugins_base 
+      # gstreamer gst-plugins-base 
     ];
 
   configureFlags = [

--- a/pkgs/tools/networking/uget/default.nix
+++ b/pkgs/tools/networking/uget/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, openssl, curl, libnotify, gstreamer,
-  gst_plugins_base, gst_plugins_good, gnome3, makeWrapper, aria2 ? null }:
+  gst_plugins_base, gst-plugins-good, gnome3, makeWrapper, aria2 ? null }:
 
 stdenv.mkDerivation rec {
   name = "uget-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool makeWrapper ];
   
   buildInputs = [
-    openssl curl libnotify gstreamer gst_plugins_base gst_plugins_good
+    openssl curl libnotify gstreamer gst_plugins_base gst-plugins-good
     gnome3.gtk gnome3.dconf
   ]
   ++ (stdenv.lib.optional (aria2 != null) aria2);

--- a/pkgs/tools/networking/uget/default.nix
+++ b/pkgs/tools/networking/uget/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, openssl, curl, libnotify, gstreamer,
-  gst_plugins_base, gst-plugins-good, gnome3, makeWrapper, aria2 ? null }:
+  gst-plugins-base, gst-plugins-good, gnome3, makeWrapper, aria2 ? null }:
 
 stdenv.mkDerivation rec {
   name = "uget-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool makeWrapper ];
   
   buildInputs = [
-    openssl curl libnotify gstreamer gst_plugins_base gst-plugins-good
+    openssl curl libnotify gstreamer gst-plugins-base gst-plugins-good
     gnome3.gtk gnome3.dconf
   ]
   ++ (stdenv.lib.optional (aria2 != null) aria2);

--- a/pkgs/tools/security/tor/torbrowser.nix
+++ b/pkgs/tools/security/tor/torbrowser.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeDesktopItem
 , libXrender, libX11, libXext, libXt, alsaLib, dbus, dbus_glib, glib, gtk2
 , atk, pango, freetype, fontconfig, gdk_pixbuf, cairo, zlib
-, gstreamer, gst_plugins_base, gst_plugins_good, gst_ffmpeg, gmp, ffmpeg
+, gstreamer, gst_plugins_base, gst_plugins_good, gst-ffmpeg, gmp, ffmpeg
 , libpulseaudio
 , mediaSupport ? false
 }:
@@ -16,7 +16,7 @@ let
   ]);
 
   # Ignored if !mediaSupport
-  gstPlugins = [ gstreamer gst_plugins_base gst_plugins_good gst_ffmpeg ];
+  gstPlugins = [ gstreamer gst_plugins_base gst_plugins_good gst-ffmpeg ];
 
   gstPluginsPath = stdenv.lib.concatMapStringsSep ":" (x:
     "${x}/lib/gstreamer-0.10") gstPlugins;

--- a/pkgs/tools/security/tor/torbrowser.nix
+++ b/pkgs/tools/security/tor/torbrowser.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeDesktopItem
 , libXrender, libX11, libXext, libXt, alsaLib, dbus, dbus_glib, glib, gtk2
 , atk, pango, freetype, fontconfig, gdk_pixbuf, cairo, zlib
-, gstreamer, gst_plugins_base, gst_plugins_good, gst-ffmpeg, gmp, ffmpeg
+, gstreamer, gst_plugins_base, gst-plugins-good, gst-ffmpeg, gmp, ffmpeg
 , libpulseaudio
 , mediaSupport ? false
 }:
@@ -16,7 +16,7 @@ let
   ]);
 
   # Ignored if !mediaSupport
-  gstPlugins = [ gstreamer gst_plugins_base gst_plugins_good gst-ffmpeg ];
+  gstPlugins = [ gstreamer gst_plugins_base gst-plugins-good gst-ffmpeg ];
 
   gstPluginsPath = stdenv.lib.concatMapStringsSep ":" (x:
     "${x}/lib/gstreamer-0.10") gstPlugins;

--- a/pkgs/tools/security/tor/torbrowser.nix
+++ b/pkgs/tools/security/tor/torbrowser.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeDesktopItem
 , libXrender, libX11, libXext, libXt, alsaLib, dbus, dbus_glib, glib, gtk2
 , atk, pango, freetype, fontconfig, gdk_pixbuf, cairo, zlib
-, gstreamer, gst_plugins_base, gst-plugins-good, gst-ffmpeg, gmp, ffmpeg
+, gstreamer, gst-plugins-base, gst-plugins-good, gst-ffmpeg, gmp, ffmpeg
 , libpulseaudio
 , mediaSupport ? false
 }:
@@ -11,12 +11,12 @@ let
     stdenv.cc.cc zlib glib alsaLib dbus dbus_glib gtk2 atk pango freetype
     fontconfig gdk_pixbuf cairo libXrender libX11 libXext libXt
   ] ++ stdenv.lib.optionals mediaSupport [
-    gstreamer gst_plugins_base gmp ffmpeg
+    gstreamer gst-plugins-base gmp ffmpeg
     libpulseaudio
   ]);
 
   # Ignored if !mediaSupport
-  gstPlugins = [ gstreamer gst_plugins_base gst-plugins-good gst-ffmpeg ];
+  gstPlugins = [ gstreamer gst-plugins-base gst-plugins-good gst-ffmpeg ];
 
   gstPluginsPath = stdenv.lib.concatMapStringsSep ":" (x:
     "${x}/lib/gstreamer-0.10") gstPlugins;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -54,6 +54,7 @@ doNotDisplayTwice rec {
   grantlee5 = qt5.grantlee;  # added 2015-12-19
   gst_ffmpeg = gst-ffmpeg;  # added 2017-02
   gst_plugins_good = gst-plugins-good;  # added 2017-02
+  gst_plugins_bad = gst-plugins-bad;  # added 2017-02
   gst_python = gst-python;  # added 2017-02
   gupnptools = gupnp-tools;  # added 2015-12-19
   gnustep-make = gnustep.make; # added 2016-7-6

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -98,6 +98,7 @@ doNotDisplayTwice rec {
   poppler_qt5 = qt5.poppler;  # added 2015-12-19
   qca-qt5 = qt5.qca-qt5;  # added 2015-12-19
   QmidiNet = qmidinet;  # added 2016-05-22
+  qt_gstreamer = qt-gstreamer;  # added 2017-02
   quake3game = ioquake3; # added 2016-01-14
   qwt6 = qt5.qwt;  # added 2015-12-19
   rdiff_backup = rdiff-backup;  # added 2014-11-23

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -52,6 +52,7 @@ doNotDisplayTwice rec {
   git-hub = gitAndTools.git-hub; # added 2016-04-29
   googleAuthenticator = google-authenticator; # added 2016-10-16
   grantlee5 = qt5.grantlee;  # added 2015-12-19
+  gst_python = gst-python;  # added 2017-02
   gupnptools = gupnp-tools;  # added 2015-12-19
   gnustep-make = gnustep.make; # added 2016-7-6
   htmlTidy = html-tidy;  # added 2014-12-06

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -99,6 +99,7 @@ doNotDisplayTwice rec {
   qca-qt5 = qt5.qca-qt5;  # added 2015-12-19
   QmidiNet = qmidinet;  # added 2016-05-22
   qt_gstreamer = qt-gstreamer;  # added 2017-02
+  qt_gstreamer1 = qt-gstreamer1;  # added 2017-02
   quake3game = ioquake3; # added 2016-01-14
   qwt6 = qt5.qwt;  # added 2015-12-19
   rdiff_backup = rdiff-backup;  # added 2014-11-23

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -53,6 +53,7 @@ doNotDisplayTwice rec {
   googleAuthenticator = google-authenticator; # added 2016-10-16
   grantlee5 = qt5.grantlee;  # added 2015-12-19
   gst_ffmpeg = gst-ffmpeg;  # added 2017-02
+  gst_plugins_base = gst-plugins-base;  # added 2017-02
   gst_plugins_good = gst-plugins-good;  # added 2017-02
   gst_plugins_bad = gst-plugins-bad;  # added 2017-02
   gst_plugins_ugly = gst-plugins-ugly;  # added 2017-02

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -55,6 +55,7 @@ doNotDisplayTwice rec {
   gst_ffmpeg = gst-ffmpeg;  # added 2017-02
   gst_plugins_good = gst-plugins-good;  # added 2017-02
   gst_plugins_bad = gst-plugins-bad;  # added 2017-02
+  gst_plugins_ugly = gst-plugins-ugly;  # added 2017-02
   gst_python = gst-python;  # added 2017-02
   gupnptools = gupnp-tools;  # added 2015-12-19
   gnustep-make = gnustep.make; # added 2016-7-6

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -53,6 +53,7 @@ doNotDisplayTwice rec {
   googleAuthenticator = google-authenticator; # added 2016-10-16
   grantlee5 = qt5.grantlee;  # added 2015-12-19
   gst_ffmpeg = gst-ffmpeg;  # added 2017-02
+  gst_plugins_good = gst-plugins-good;  # added 2017-02
   gst_python = gst-python;  # added 2017-02
   gupnptools = gupnp-tools;  # added 2015-12-19
   gnustep-make = gnustep.make; # added 2016-7-6

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -52,6 +52,7 @@ doNotDisplayTwice rec {
   git-hub = gitAndTools.git-hub; # added 2016-04-29
   googleAuthenticator = google-authenticator; # added 2016-10-16
   grantlee5 = qt5.grantlee;  # added 2015-12-19
+  gst_ffmpeg = gst-ffmpeg;  # added 2017-02
   gst_python = gst-python;  # added 2017-02
   gupnptools = gupnp-tools;  # added 2015-12-19
   gnustep-make = gnustep.make; # added 2016-7-6

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7516,14 +7516,14 @@ with pkgs;
   gst_all = {
     inherit (pkgs) gstreamer gnonlin gst-python qt_gstreamer;
     gstPluginsBase = pkgs.gst_plugins_base;
-    gstPluginsBad = pkgs.gst_plugins_bad;
+    gstPluginsBad = pkgs.gst-plugins-bad;
     gstPluginsGood = pkgs.gst-plugins-good;
     gstPluginsUgly = pkgs.gst_plugins_ugly;
     gstFfmpeg = pkgs.gst-ffmpeg;
 
     # aliases with the dashed naming, same as in gst_all_1
     gst-plugins-base = pkgs.gst_plugins_base;
-    gst-plugins-bad = pkgs.gst_plugins_bad;
+    gst-plugins-bad = pkgs.gst-plugins-bad;
     gst-plugins-good = pkgs.gst-plugins-good;
     gst-plugins-ugly = pkgs.gst_plugins_ugly;
     gst-ffmpeg = pkgs.gst-ffmpeg;
@@ -7539,7 +7539,7 @@ with pkgs;
 
   gst-plugins-good = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-good {};
 
-  gst_plugins_bad = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-bad {};
+  gst-plugins-bad = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-bad {};
 
   gst_plugins_ugly = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-ugly {};
 
@@ -14915,7 +14915,7 @@ with pkgs;
 
   quodlibet = callPackage ../applications/audio/quodlibet {
     withGstPlugins = true;
-    gst_plugins_bad = null;
+    gst-plugins-bad = null;
   };
 
   qutebrowser = qt5.callPackage ../applications/networking/browsers/qutebrowser {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7561,7 +7561,7 @@ with pkgs;
 
   qt-gstreamer = callPackage ../development/libraries/gstreamer/legacy/qt-gstreamer {};
 
-  qt_gstreamer1 = callPackage ../development/libraries/gstreamer/qt-gstreamer { boost = boost155;};
+  qt-gstreamer1 = callPackage ../development/libraries/gstreamer/qt-gstreamer { boost = boost155;};
 
   gnet = callPackage ../development/libraries/gnet { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7514,7 +7514,7 @@ with pkgs;
   });
 
   gst_all = {
-    inherit (pkgs) gstreamer gnonlin gst-python qt_gstreamer;
+    inherit (pkgs) gstreamer gnonlin gst-python qt-gstreamer;
     gstPluginsBase = pkgs.gst_plugins_base;
     gstPluginsBad = pkgs.gst-plugins-bad;
     gstPluginsGood = pkgs.gst-plugins-good;
@@ -7559,7 +7559,7 @@ with pkgs;
 
   qt-mobility = callPackage ../development/libraries/qt-mobility {};
 
-  qt_gstreamer = callPackage ../development/libraries/gstreamer/legacy/qt-gstreamer {};
+  qt-gstreamer = callPackage ../development/libraries/gstreamer/legacy/qt-gstreamer {};
 
   qt_gstreamer1 = callPackage ../development/libraries/gstreamer/qt-gstreamer { boost = boost155;};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7514,7 +7514,7 @@ with pkgs;
   });
 
   gst_all = {
-    inherit (pkgs) gstreamer gnonlin gst_python qt_gstreamer;
+    inherit (pkgs) gstreamer gnonlin gst-python qt_gstreamer;
     gstPluginsBase = pkgs.gst_plugins_base;
     gstPluginsBad = pkgs.gst_plugins_bad;
     gstPluginsGood = pkgs.gst_plugins_good;
@@ -7526,8 +7526,7 @@ with pkgs;
     gst-plugins-bad = pkgs.gst_plugins_bad;
     gst-plugins-good = pkgs.gst_plugins_good;
     gst-plugins-ugly = pkgs.gst_plugins_ugly;
-    gst-ffmpeg = pkgs.gst_ffmpeg;
-    gst-python = pkgs.gst_python;
+    gst-ffmpeg = pkgs.gst-ffmpeg;
   };
 
   gstreamer = callPackage ../development/libraries/gstreamer/legacy/gstreamer {
@@ -7548,7 +7547,7 @@ with pkgs;
     ffmpeg = ffmpeg_0;
   };
 
-  gst_python = callPackage ../development/libraries/gstreamer/legacy/gst-python {};
+  gst-python = callPackage ../development/libraries/gstreamer/legacy/gst-python {};
 
   gstreamermm = callPackage ../development/libraries/gstreamer/legacy/gstreamermm { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1149,7 +1149,7 @@ with pkgs;
 
   clementine = callPackage ../applications/audio/clementine {
     boost = boost155;
-    gst_plugins = [ gst_plugins_base gst_plugins_good gst_plugins_ugly gst-ffmpeg ];
+    gst_plugins = [ gst_plugins_base gst-plugins-good gst_plugins_ugly gst-ffmpeg ];
   };
 
   clementineFree = clementine.free;
@@ -7517,14 +7517,14 @@ with pkgs;
     inherit (pkgs) gstreamer gnonlin gst-python qt_gstreamer;
     gstPluginsBase = pkgs.gst_plugins_base;
     gstPluginsBad = pkgs.gst_plugins_bad;
-    gstPluginsGood = pkgs.gst_plugins_good;
+    gstPluginsGood = pkgs.gst-plugins-good;
     gstPluginsUgly = pkgs.gst_plugins_ugly;
     gstFfmpeg = pkgs.gst-ffmpeg;
 
     # aliases with the dashed naming, same as in gst_all_1
     gst-plugins-base = pkgs.gst_plugins_base;
     gst-plugins-bad = pkgs.gst_plugins_bad;
-    gst-plugins-good = pkgs.gst_plugins_good;
+    gst-plugins-good = pkgs.gst-plugins-good;
     gst-plugins-ugly = pkgs.gst_plugins_ugly;
     gst-ffmpeg = pkgs.gst-ffmpeg;
   };
@@ -7537,7 +7537,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };
 
-  gst_plugins_good = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-good {};
+  gst-plugins-good = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-good {};
 
   gst_plugins_bad = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-bad {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1149,7 +1149,7 @@ with pkgs;
 
   clementine = callPackage ../applications/audio/clementine {
     boost = boost155;
-    gst_plugins = [ gst_plugins_base gst-plugins-good gst_plugins_ugly gst-ffmpeg ];
+    gst_plugins = [ gst_plugins_base gst-plugins-good gst-plugins-ugly gst-ffmpeg ];
   };
 
   clementineFree = clementine.free;
@@ -7518,14 +7518,14 @@ with pkgs;
     gstPluginsBase = pkgs.gst_plugins_base;
     gstPluginsBad = pkgs.gst-plugins-bad;
     gstPluginsGood = pkgs.gst-plugins-good;
-    gstPluginsUgly = pkgs.gst_plugins_ugly;
+    gstPluginsUgly = pkgs.gst-plugins-ugly;
     gstFfmpeg = pkgs.gst-ffmpeg;
 
     # aliases with the dashed naming, same as in gst_all_1
     gst-plugins-base = pkgs.gst_plugins_base;
     gst-plugins-bad = pkgs.gst-plugins-bad;
     gst-plugins-good = pkgs.gst-plugins-good;
-    gst-plugins-ugly = pkgs.gst_plugins_ugly;
+    gst-plugins-ugly = pkgs.gst-plugins-ugly;
     gst-ffmpeg = pkgs.gst-ffmpeg;
   };
 
@@ -7541,7 +7541,7 @@ with pkgs;
 
   gst-plugins-bad = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-bad {};
 
-  gst_plugins_ugly = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-ugly {};
+  gst-plugins-ugly = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-ugly {};
 
   gst-ffmpeg = callPackage ../development/libraries/gstreamer/legacy/gst-ffmpeg {
     ffmpeg = ffmpeg_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1149,7 +1149,7 @@ with pkgs;
 
   clementine = callPackage ../applications/audio/clementine {
     boost = boost155;
-    gst_plugins = [ gst_plugins_base gst_plugins_good gst_plugins_ugly gst_ffmpeg ];
+    gst_plugins = [ gst_plugins_base gst_plugins_good gst_plugins_ugly gst-ffmpeg ];
   };
 
   clementineFree = clementine.free;
@@ -7519,7 +7519,7 @@ with pkgs;
     gstPluginsBad = pkgs.gst_plugins_bad;
     gstPluginsGood = pkgs.gst_plugins_good;
     gstPluginsUgly = pkgs.gst_plugins_ugly;
-    gstFfmpeg = pkgs.gst_ffmpeg;
+    gstFfmpeg = pkgs.gst-ffmpeg;
 
     # aliases with the dashed naming, same as in gst_all_1
     gst-plugins-base = pkgs.gst_plugins_base;
@@ -7543,7 +7543,7 @@ with pkgs;
 
   gst_plugins_ugly = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-ugly {};
 
-  gst_ffmpeg = callPackage ../development/libraries/gstreamer/legacy/gst-ffmpeg {
+  gst-ffmpeg = callPackage ../development/libraries/gstreamer/legacy/gst-ffmpeg {
     ffmpeg = ffmpeg_0;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1149,7 +1149,7 @@ with pkgs;
 
   clementine = callPackage ../applications/audio/clementine {
     boost = boost155;
-    gst_plugins = [ gst_plugins_base gst-plugins-good gst-plugins-ugly gst-ffmpeg ];
+    gst_plugins = [ gst-plugins-base gst-plugins-good gst-plugins-ugly gst-ffmpeg ];
   };
 
   clementineFree = clementine.free;
@@ -7515,14 +7515,14 @@ with pkgs;
 
   gst_all = {
     inherit (pkgs) gstreamer gnonlin gst-python qt-gstreamer;
-    gstPluginsBase = pkgs.gst_plugins_base;
+    gstPluginsBase = pkgs.gst-plugins-base;
     gstPluginsBad = pkgs.gst-plugins-bad;
     gstPluginsGood = pkgs.gst-plugins-good;
     gstPluginsUgly = pkgs.gst-plugins-ugly;
     gstFfmpeg = pkgs.gst-ffmpeg;
 
     # aliases with the dashed naming, same as in gst_all_1
-    gst-plugins-base = pkgs.gst_plugins_base;
+    gst-plugins-base = pkgs.gst-plugins-base;
     gst-plugins-bad = pkgs.gst-plugins-bad;
     gst-plugins-good = pkgs.gst-plugins-good;
     gst-plugins-ugly = pkgs.gst-plugins-ugly;
@@ -7533,7 +7533,7 @@ with pkgs;
     bison = bison2;
   };
 
-  gst_plugins_base = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-base {
+  gst-plugins-base = callPackage ../development/libraries/gstreamer/legacy/gst-plugins-base {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Align attribute names with package names for some packages I happened to bump into. It's easier to work with nix cli when attr and pkg names match.

It's just a mass replace + adding backwards compatibility aliases. There shouldn't be any hash changes / mass rebuilds.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

