### PR TITLE
pythonPackages.libais: init at 0.16

### DIFF
--- a/pkgs/development/python-modules/libais/default.nix
+++ b/pkgs/development/python-modules/libais/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchurl,
+  six, pytest, pytestrunner, pytestcov, coverage
+}:
+buildPythonPackage rec {
+  name = "libais-${version}";
+  version = "0.16";
+
+  src = fetchurl {
+    url = "mirror://pypi/l/libais/${name}.tar.bz2";
+    sha256 = "14dsh5k32ryszwdn6p45wrqp4ska6cc9qpm6lk5c5d1p4rc7wnhq";
+  };
+
+  # data files missing
+  doCheck = false;
+
+  buildInputs = [ pytest pytestrunner pytestcov coverage ];
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/schwehr/libais;
+    description = "Library for decoding maritime Automatic Identification System messages";
+    license = licenses.asl20;
+    platforms = platforms.linux;  # It currently fails to build on darwin
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5678,6 +5678,8 @@ in {
 
   leather = callPackage ../development/python-modules/leather { };
 
+  libais = callPackage ../development/python-modules/libais { };
+
   libtmux = buildPythonPackage rec {
     name = "libtmux-${version}";
     version = "0.6.0";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

