### PR TITLE
release(-lib).nix: optionally allow building unfree packages

### DIFF
--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -1,15 +1,16 @@
 { supportedSystems
 , packageSet ? (import ../..)
 , scrubJobs ? true
+, # Don't build packages marked as unfree
+  allowUnfree ? false
 }:
 
 with import ../../lib;
 
 rec {
 
-  # Ensure that we don't build packages marked as unfree.
   allPackages = args: packageSet (args // {
-    config.allowUnfree = false;
+    config.allowUnfree = allowUnfree;
     config.inHydra = true;
   });
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -15,9 +15,11 @@
   supportedSystems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" ]
 , # Strip most of attributes when evaluating to spare memory usage
   scrubJobs ? true
+, # Don't build packages marked as unfree
+  allowUnfree ? false
 }:
 
-with import ./release-lib.nix { inherit supportedSystems scrubJobs; };
+with import ./release-lib.nix { inherit supportedSystems scrubJobs allowUnfree; };
 
 let
 


### PR DESCRIPTION
I'd like to create a personal nixpkgs channel containing some unfree
packages. This adds 'allowUnfree' parameter so that more of the release
infrastructure can be reused.

The default is still to not build unfree packages, so for nixpkgs this
is no functional change.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

