### PR TITLE
eclipse: add aliases for "latest" versions

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -14,6 +14,8 @@ rec {
 
   ### Eclipse CPP
 
+  eclipse-cpp = eclipse-cpp-46; # always point to latest
+
   eclipse-cpp-46 = buildEclipse {
     name = "eclipse-cpp-4.6.0";
     description = "Eclipse IDE for C/C++ Developers, Neon release";
@@ -50,6 +52,8 @@ rec {
 
   ### Eclipse Modeling
 
+  eclipse-modeling = eclipse-modeling-46; # always point to latest
+
   eclipse-modeling-46 = buildEclipse {
     name = "eclipse-modeling-4.6";
     description = "Eclipse Modeling Tools";
@@ -85,7 +89,7 @@ rec {
 
   ### Eclipse Platform
 
-  eclipse-platform = eclipse-platform-46;
+  eclipse-platform = eclipse-platform-46; # always point to latest
 
   eclipse-platform-46 = buildEclipse {
     name = "eclipse-platform-4.6.2";
@@ -104,6 +108,8 @@ rec {
 
   ### Eclipse Scala SDK
 
+  eclipse-scala-sdk = eclipse-scala-sdk-441; # always point to latest
+
   eclipse-scala-sdk-441 = buildEclipse {
     name = "eclipse-scala-sdk-4.4.1";
     description = "Eclipse IDE for Scala Developers";
@@ -121,6 +127,8 @@ rec {
   };
 
   ### Eclipse SDK
+
+  eclipse-sdk = eclipse-sdk-46; # always point to latest
 
   eclipse-sdk-46 = buildEclipse {
     name = "eclipse-sdk-4.6.2";


### PR DESCRIPTION
###### Motivation for this change

Add aliases like "eclipse-cpp = eclipse-cpp-46" so that user
configurations can point to "eclipse-cpp" and have it not regularly
break as nixpkgs is updated.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

