### PR TITLE
epson-escpr: 1.6.8 -> 1.6.12

### DIFF
--- a/pkgs/misc/drivers/epson-escpr/default.nix
+++ b/pkgs/misc/drivers/epson-escpr/default.nix
@@ -1,15 +1,16 @@
 { stdenv, fetchurl, cups }:
 
 let
-  version = "1.6.8";
+  version = "1.6.12";
 in
   stdenv.mkDerivation {
 
     name = "epson-escpr-${version}";
   
     src = fetchurl {
-      url = "https://download3.ebz.epson.net/dsc/f/03/00/05/10/61/125006df4ffc84861395c1158a02f1f73e6f1753/epson-inkjet-printer-escpr-1.6.8-1lsb3.2.tar.gz";
-      sha256 = "02v8ljzw6xhfkz1x8m50mblcckgfbpa89fc902wcmi2sy8fihgh4";
+
+      url = "https://download3.ebz.epson.net/dsc/f/03/00/05/46/21/01534966894f35247dac8c8ef0a0a9c94d1c8b40/epson-inkjet-printer-escpr-1.6.12-1lsb3.2.tar.gz";
+      sha256 = "3773e74a0c4debf202eb9ad0aa31c6614a93d6170484ff660c14e99f8698cfda";
     }; 
 
     patches = [ ./cups-filter-ppd-dirs.patch ]; 
@@ -29,7 +30,14 @@ in
 	    enable = true;
 	    drivers = [ pkgs.epson-escpr ];
 	  };
-      '';
+
+  To setup a wireless printer, enable Avahi which provides
+  printer's hostname to CUPS and nss-mdns to make this
+  hostname resolvable:
+    services.avahi = {
+      enable = true;
+      nssmdns = true;
+    };'';
       license = licenses.gpl3Plus;
       maintainers = with maintainers; [ artuuge ];
       platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

Driver version update + Improve documentation (how to setup a wireless Epson printer).

###### Things done

Tested by switching to new configuration and actually printing a CUPS test page on my new L386 printer which was not (officially) supported by previous version of this driver.  

Configuration used (and possibly affected):
services.printing = {
    enable = true;
    drivers = [ pkgs.epson-escpr ];
  };

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

