### PR TITLE
haskell: ghc710 packages cleanup

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -182,6 +182,10 @@ self: super: {
   # https://github.com/well-typed/hackage-security/issues/158
   hackage-security = dontHaddock (dontCheck super.hackage-security);
 
+  # Breaks a dependency cycle between QuickCheck and semigroups
+  hashable = dontCheck super.hashable;
+  unordered-containers = dontCheck super.unordered-containers;
+
   # GHC versions prior to 8.x require additional build inputs.
   distributive = addBuildDepend super.distributive self.semigroups;
   mono-traversable = addBuildDepend super.mono-traversable self.semigroups;

--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -187,9 +187,7 @@ self: super: {
   mono-traversable = addBuildDepend super.mono-traversable self.semigroups;
   attoparsec = addBuildDepends super.attoparsec (with self; [semigroups fail]);
   Glob = addBuildDepends super.Glob (with self; [semigroups]);
-  Glob_0_7_10 = addBuildDepends super.Glob_0_7_10 (with self; [semigroups]);
   aeson = disableCabalFlag (addBuildDepend super.aeson self.semigroups) "old-locale";
-  aeson_0_11_2_0 = disableCabalFlag (addBuildDepend super.aeson_0_11_2_0 self.semigroups) "old-locale";
   bytes = addBuildDepend super.bytes self.doctest;
   case-insensitive = addBuildDepend super.case-insensitive self.semigroups;
   hoauth2 = overrideCabal super.hoauth2 (drv: { testDepends = (drv.testDepends or []) ++ [ self.wai self.warp ]; });
@@ -197,13 +195,11 @@ self: super: {
   intervals = addBuildDepends super.intervals (with self; [doctest QuickCheck]);
   lens = addBuildDepends super.lens (with self; [doctest generic-deriving nats simple-reflect]);
   semigroups = addBuildDepends super.semigroups (with self; [hashable tagged text unordered-containers]);
-  semigroups_0_18_1 = addBuildDepends super.semigroups (with self; [hashable tagged text unordered-containers]);
   texmath = addBuildDepend super.texmath self.network-uri;
   yesod-auth-oauth2 = overrideCabal super.yesod-auth-oauth2 (drv: { testDepends = (drv.testDepends or []) ++ [ self.load-env self.yesod ]; });
   # cereal must have `fail` in pre-ghc-8.0.x versions
   # also tests require bytestring>=0.10.8.1
   cereal = dontCheck (addBuildDepend super.cereal self.fail);
-  cereal_0_5_2_0 = dontCheck (addBuildDepend super.cereal_0_5_2_0 self.fail);
 
   # Moved out from common as no longer the case for GHC8
   ghc-mod = super.ghc-mod.override { cabal-helper = self.cabal-helper_0_6_3_1; };

--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -194,6 +194,7 @@ self: super: {
   hslogger = addBuildDepend super.hslogger self.HUnit;
   intervals = addBuildDepends super.intervals (with self; [doctest QuickCheck]);
   lens = addBuildDepends super.lens (with self; [doctest generic-deriving nats simple-reflect]);
+  QuickCheck = addBuildDepend super.QuickCheck self.semigroups;
   semigroups = addBuildDepends super.semigroups (with self; [hashable tagged text unordered-containers]);
   texmath = addBuildDepend super.texmath self.network-uri;
   yesod-auth-oauth2 = overrideCabal super.yesod-auth-oauth2 (drv: { testDepends = (drv.testDepends or []) ++ [ self.load-env self.yesod ]; });

--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -198,6 +198,7 @@ self: super: {
   hslogger = addBuildDepend super.hslogger self.HUnit;
   intervals = addBuildDepends super.intervals (with self; [doctest QuickCheck]);
   lens = addBuildDepends super.lens (with self; [doctest generic-deriving nats simple-reflect]);
+  optparse-applicative = addBuildDepend super.optparse-applicative self.semigroups;
   QuickCheck = addBuildDepend super.QuickCheck self.semigroups;
   semigroups = addBuildDepends super.semigroups (with self; [hashable tagged text unordered-containers]);
   texmath = addBuildDepend super.texmath self.network-uri;


### PR DESCRIPTION
###### Motivation for this change

Dependency cycle between semigroups and QuickCheck:
The specific cycle is part of the commit message. I simply disabled the test suites for hashable and unordered-containers altogether. I'm not sure if there is a better way.

Removing obsolete packages from configuration:
There are a few references to specific versions of packages in ```configuration-ghc-7.10.x.nix```. Many (most?) of them are not included in ```hackage-packages.nix``` and fail to evaluate. I deleted those which where only referenced by themselves. That seemed reasonable, but there are more occurrences e.g. in ghc-mod which also don't evaluate. I'm not sure what the general process is in regards to this.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

