### PR TITLE
hieroglyph: init at 0.7.1

### DIFF
--- a/pkgs/development/python-modules/hieroglyph/default.nix
+++ b/pkgs/development/python-modules/hieroglyph/default.nix
@@ -1,0 +1,26 @@
+{ stdenv , fetchurl , buildPythonPackage , sphinx }:
+
+buildPythonPackage rec {
+  version = "0.7.1";
+  name = "hieroglyph-${version}";
+
+  src = fetchurl {
+    url = "mirror://pypi/h/hieroglyph/${name}.tar.gz";
+    sha256 = "0rswfk7x6zlj1z8388f153k3zn2h52k5h9b6p57pn7kqagsjilcb";
+  };
+
+  propagatedBuildInputs = [ sphinx ];
+
+  # all tests fail; don't know why:
+  # test_absolute_paths_made_relative (hieroglyph.tests.test_path_fixing.PostProcessImageTests) ... ERROR
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Generate HTML presentations from plain text sources";
+    homepage = https://github.com/nyergler/hieroglyph/;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ juliendehos ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -24675,6 +24675,8 @@ in {
     doCheck = false;
   };
 
+  hieroglyph = callPackage ../development/python-modules/hieroglyph { };
+
   sphinx_rtd_theme = buildPythonPackage (rec {
     name = "sphinx_rtd_theme-0.1.9";
 


### PR DESCRIPTION
###### Motivation for this change

Generate HTML presentations from plain text sources using python Sphinx.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
