### PR TITLE
bazel: Log test errors to stderr during checkPhase

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -54,8 +54,8 @@ stdenv.mkDerivation rec {
   doCheck = true;
   checkPhase = ''
     export TEST_TMPDIR=$(pwd)
-    ./output/bazel test examples/cpp:hello-success_test
-    ./output/bazel test examples/java-native/src/test/java/com/example/myproject:hello
+    ./output/bazel test --test_output=errors examples/cpp:hello-success_test
+    ./output/bazel test --test_output=errors examples/java-native/src/test/java/com/example/myproject:hello
   '';
 
   installPhase = ''


### PR DESCRIPTION
Otherwise it's difficult or impossible to retrieve them, particularly from a hydra build.

Related to #23074 
