### PR TITLE
Ensime

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -53,18 +53,24 @@ let
   rubyWrapper = ''--suffix PATH : \"${rubyEnv}/bin\" '' +
                 ''--suffix GEM_HOME : \"${rubyEnv}/${rubyEnv.ruby.gemPath}\" '';
 
+  pluginPythonPackages = builtins.concatLists
+    (map ({ pythonDependencies ? [], ...}: pythonDependencies)
+         (vimUtils.requiredPlugins configure));
   pythonEnv = pythonPackages.python.buildEnv.override {
     extraLibs = (
         if withPyGUI
           then [ pythonPackages.neovim_gui ]
           else [ pythonPackages.neovim ]
-      ) ++ extraPythonPackages;
+      ) ++ extraPythonPackages ++ pluginPythonPackages;
     ignoreCollisions = true;
   };
   pythonWrapper = ''--cmd \"let g:python_host_prog='$out/bin/nvim-python'\" '';
 
+  pluginPython3Packages = builtins.concatLists
+    (map ({ python3Dependencies ? [], ...}: python3Dependencies)
+         (vimUtils.requiredPlugins configure));
   python3Env = python3Packages.python.buildEnv.override {
-    extraLibs = [ python3Packages.neovim ] ++ extraPython3Packages;
+    extraLibs = [ python3Packages.neovim ] ++ extraPython3Packages ++ pluginPython3Packages;
     ignoreCollisions = true;
   };
   python3Wrapper = ''--cmd \"let g:python3_host_prog='$out/bin/nvim-python3'\" '';

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -345,6 +345,18 @@ rec {
 
   };
 
+  ensime-vim = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "ensime-vim-2017-02-06";
+    src = fetchgit {
+      url = "git://github.com/ensime/ensime-vim";
+      rev = "7b5f79c67a078c6e1e5f8c906d4227ce86d33df8";
+      sha256 = "04knizaa4gc1z22gxj41qybjl4ysqpv15rwi28h10l7gk9fb1b41";
+    };
+    dependencies = ["vimproc" "vimshell" "self" "forms"];
+
+    pythonDependencies = with pythonPackages; [ sexpdata websocket_client ];
+  };
+
   extradite = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "extradite-2015-09-22";
     src = fetchgit {
@@ -353,6 +365,17 @@ rec {
       sha256 = "0c89i0spvdm9vi65q15qcmsfmwa9rds2wmaq1kf6s7q7ywvs6w8i";
     };
     dependencies = [];
+
+  };
+
+  forms = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "forms-2012-11-28";
+    src = fetchgit {
+      url = "git://github.com/megaannum/forms";
+      rev = "b601e03fe0a3b8a43766231f4a6217e4492b4f75";
+      sha256 = "19kp1i5c6jmnpbsap9giayqbzlv7vh02mp4mjvicqj9n0nfyay74";
+    };
+    dependencies = ["self"];
 
   };
 
@@ -1164,6 +1187,17 @@ rec {
       export PY3=ON
       ./install.sh
     '';
+  };
+
+  self = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "self-2014-05-28";
+    src = fetchgit {
+      url = "git://github.com/megaannum/self";
+      rev = "2ed666b547eddee6ae1fcc63babca4ba0b66a59f";
+      sha256 = "1gcwn6i5i3msg7hrlzsnv1bs6pm4jz9cff8ppaz2xdj8xv9qy6fn";
+    };
+    dependencies = [];
+
   };
 
   shabadou-vim = buildVimPluginFrom2Nix { # created by nix#NixDerivation

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -4,6 +4,7 @@
 , xkb_switch, rustracerd, fzf
 , python3, boost, icu
 , ycmd
+, pythonPackages, python3Packages
 , Cocoa ? null
 }:
 

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -46,6 +46,7 @@
 "github:elmcast/elm-vim"
 "github:embear/vim-localvimrc"
 "github:enomsg/vim-haskellConcealPlus"
+"github:ensime/ensime-vim"
 "github:esneider/YUNOcommit.vim"
 "github:fatih/vim-go"
 "github:flazz/vim-colorschemes"


### PR DESCRIPTION
###### Motivation for this change

I'd like to be able to use [ensime](http://ensime.org/) from vim, hence the additional plugin.

However, using it requires a couple python packages to be available.  Initially I added them as extraPythonPackages in my config.nix, but it wasn't that much more work to add the logic to make neovim automatically pull them in, which is much more user-friendly.  Hopefully my additions are reasonable.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

