### PR TITLE
display-manager: fix argument handling of sddm

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -32,8 +32,14 @@ let
     ''
       #! ${pkgs.bash}/bin/bash
 
-      # Handle being called by SDDM.
-      if test "''${1:0:1}" = / ; then eval exec $1 $2 ; fi
+      # SSDM splits "Exec" line in .desktop file by whitespace and pass script path as $1
+      if [[ "$0" = "$1" ]]; then
+        # remove superfluous $1 again
+        shift
+        # join arguments again and evaluate them in a shell context
+        # to interpret shell quoting
+        eval exec "$0" "$@"
+      fi
 
       ${optionalString cfg.displayManager.logToJournal ''
         if [ -z "$_DID_SYSTEMD_CAT" ]; then


### PR DESCRIPTION
###### Motivation for this change

previously session type was not correctly set.
Currently only tested with session type 'none + awesome wm' and ssdm.
Other combinations should be handled in the same way, but for
critical components like login manager, be better safe then sorry 
- so please test this with your setup.

TODO:

- [ ] run integration tests

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

