### PR TITLE
msmtp: 1.6.4 -> 1.6.6 and make it nix friendly

### DIFF
--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, openssl, pkgconfig, gnutls, gsasl, libidn, Security }:
 
 stdenv.mkDerivation rec {
-  version = "1.6.4";
+  version = "1.6.6";
   name = "msmtp-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/msmtp/${name}.tar.xz";
-    sha256 = "1kfihblm769s4hv8iah5mqynqd6hfwlyz5rcg2v423a4llic0jcv";
+    sha256 = "0ppvww0sb09bnsrpqnvlrn8vx231r24xn2iiwpy020mxc8gxn5fs";
   };
 
   buildInputs = [ openssl pkgconfig gnutls gsasl libidn ]

--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -1,30 +1,49 @@
-{ stdenv, fetchurl, openssl, pkgconfig, gnutls, gsasl, libidn, Security }:
+{ stdenv, lib, fetchurl, autoreconfHook, pkgconfig
+, openssl, netcat, gnutls, gsasl, libidn, Security, systemd }:
 
-stdenv.mkDerivation rec {
-  version = "1.6.6";
+let
+  tester = "n"; # {x| |p|P|n|s}
+  journal = if stdenv.isLinux then "y" else "n";
+
+in stdenv.mkDerivation rec {
   name = "msmtp-${version}";
+  version = "1.6.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/msmtp/${name}.tar.xz";
     sha256 = "0ppvww0sb09bnsrpqnvlrn8vx231r24xn2iiwpy020mxc8gxn5fs";
   };
 
-  buildInputs = [ openssl pkgconfig gnutls gsasl libidn ]
+  patches = [
+    ./paths.patch
+  ];
+
+  buildInputs = [ openssl gnutls gsasl libidn ]
     ++ stdenv.lib.optional stdenv.isDarwin Security;
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   configureFlags =
     stdenv.lib.optional stdenv.isDarwin [ "--with-macosx-keyring" ];
 
   postInstall = ''
-    cp scripts/msmtpq/msmtp-queue scripts/msmtpq/msmtpq $prefix/bin/
-    chmod +x $prefix/bin/msmtp-queue $prefix/bin/msmtpq
+    substitute scripts/msmtpq/msmtpq $out/bin/msmtpq \
+      --replace @msmtp@      $out/bin/msmtp \
+      --replace @nc@         ${netcat}/bin/nc \
+      --replace @journal@    ${journal} \
+      ${lib.optionalString (journal == "y") "--replace @systemdcat@ ${systemd}/bin/systemd-cat" } \
+      --replace @test@       ${tester}
+
+    substitute scripts/msmtpq/msmtp-queue $out/bin/msmtp-queue \
+      --replace @msmtpq@ $out/bin/msmtpq
+
+    chmod +x $out/bin/*
   '';
 
-  meta = {
-      description = "Simple and easy to use SMTP client with excellent sendmail compatibility";
-      homepage = "http://msmtp.sourceforge.net/";
-      license = stdenv.lib.licenses.gpl3;
-      maintainers = [ stdenv.lib.maintainers.garbas ];
-      platforms = stdenv.lib.platforms.unix;
-    };
+  meta = with stdenv.lib; {
+    description = "Simple and easy to use SMTP client with excellent sendmail compatibility";
+    homepage = "http://msmtp.sourceforge.net/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ garbas peterhoeg ];
+    platforms = platforms.unix;
+  };
 }

--- a/pkgs/applications/networking/msmtp/paths.patch
+++ b/pkgs/applications/networking/msmtp/paths.patch
@@ -1,0 +1,96 @@
+diff --git a/scripts/msmtpq/msmtp-queue b/scripts/msmtpq/msmtp-queue
+index 1dc220d..d834241 100755
+--- a/scripts/msmtpq/msmtp-queue
++++ b/scripts/msmtpq/msmtp-queue
+@@ -27,4 +27,4 @@
+ ## change the below line to be
+ ##   exec /path/to/msmtpq --q-mgmt
+ 
+-exec msmtpq --q-mgmt "$1"
++exec @msmtpq@ --q-mgmt "$1"
+diff --git a/scripts/msmtpq/msmtpq b/scripts/msmtpq/msmtpq
+index bdb4fb8..1363a67 100755
+--- a/scripts/msmtpq/msmtpq
++++ b/scripts/msmtpq/msmtpq
+@@ -59,7 +59,7 @@ err() { dsp '' "$@" '' ; exit 1 ; }
+ ##   enter the location of the msmtp executable  (no quotes !!)
+ ##   e.g. ( MSMTP=/path/to/msmtp )
+ ##   and uncomment the test for its existence
+-MSMTP=msmtp
++MSMTP=@msmtp@
+ #[ -x "$MSMTP" ] || \
+ #  log -e 1 "msmtpq : can't find the msmtp executable [ $MSMTP ]"   # if not found - complain ; quit
+ ##
+@@ -70,9 +70,8 @@ MSMTP=msmtp
+ ##            ( chmod 0700 msmtp.queue )
+ ##
+ ## the queue dir - modify this to reflect where you'd like it to be  (no quotes !!)
+-Q=~/.msmtp.queue
+-[ -d "$Q" ] || \
+-  err '' "msmtpq : can't find msmtp queue directory [ $Q ]" ''     # if not present - complain ; quit
++Q=${MSMTP_QUEUE:-~/.msmtp.queue}
++test -d "$Q" || mkdir -p "$Q"
+ ##
+ ## set the queue log file var to the location of the msmtp queue log file
+ ##   where it is or where you'd like it to be
+@@ -84,7 +83,10 @@ Q=~/.msmtp.queue
+ ##     (doing so would be inadvisable under most conditions, however)
+ ##
+ ## the queue log file - modify (or comment out) to taste  (but no quotes !!)
+-LOG=~/log/msmtp.queue.log
++LOG=${MSMTP_LOG:-~/log/msmtp.queue.log}
++test -d "$(dirname $LOG)" || mkdir -p "$(dirname $LOG)"
++
++JOURNAL=@journal@
+ ## ======================================================================================
+ 
+ ## msmtpq can use the following environment variables :
+@@ -108,7 +110,7 @@ LOG=~/log/msmtp.queue.log
+ ##
+ #EMAIL_CONN_NOTEST=y                 # deprecated ; use below var
+ #EMAIL_CONN_TEST={x| |p|P|n|s}       # see settings above for EMAIL_CONN_TEST
+-EMAIL_CONN_TEST=n
++EMAIL_CONN_TEST=@test@
+ #EMAIL_QUEUE_QUIET=t
+ ## ======================================================================================
+ 
+@@ -138,6 +140,7 @@ on_exit() {                          # unlock the queue on exit if the lock was
+ ## display msg to user, as well
+ ##
+ log() {
++  local NAME=msmtpq
+   local ARG RC PFX="$('date' +'%Y %d %b %H:%M:%S')"
+                                      # time stamp prefix - "2008 13 Mar 03:59:45 "
+   if [ "$1" = '-e' ] ; then          # there's an error exit code
+@@ -154,10 +157,19 @@ log() {
+     done
+   fi
+ 
++  if [ "$JOURNAL" == "y" ] ; then
++    for ARG ; do
++      [ -n "$ARG" ] && \
++        echo "$PFX : $ARG" | @systemdcat@ -t $NAME -p info
++    done
++  fi
++
+   if [ -n "$RC" ] ; then             # an error ; leave w/error return
+     [ -n "$LKD" ] && lock_queue -u   # unlock here (if locked)
+     [ -n "$LOG" ] && \
+       echo "    exit code = $RC" >> "$LOG" # logging ok ; send exit code to log
++    [ "$JOURNAL" == "y" ] && \
++      echo "exit code= $RC" | @systemdcat@ -t $NAME -p emerg
+     exit $RC                         # exit w/return code
+   fi
+ }
+@@ -207,10 +219,7 @@ connect_test() {
+     ping -qnc1 -w4 8.8.8.8 >/dev/null 2>&1 || return 1
+ 
+   elif [ "$EMAIL_CONN_TEST" = 'n' ] ; then                     # use netcat (nc) test
+-    # must, of course, have netcat (nc) installed
+-    which nc >/dev/null 2>&1 || \
+-      log -e 1 "msmtpq : can't find netcat executable [ nc ]"  # if not found - complain ; quit
+-    'nc' -vz www.debian.org 80 >/dev/null 2>&1 || return 1
++    @nc@ -vz www.debian.org 80 >/dev/null 2>&1 || return 1
+ 
+   elif [ "$EMAIL_CONN_TEST" = 's' ] ; then                     # use sh sockets test
+     # note that this does not work on debian systems


### PR DESCRIPTION
###### Motivation for this change

I'm not changing any functionality (apart from adding support for logging to the journal), but simply making ```msmtpq``` behave better by fixing paths to ```/nix/store```.

Works as daily driver here.

Cc: @garbas 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

