### PR TITLE
Add service for glances

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -333,6 +333,7 @@
   ./services/monitoring/collectd.nix
   ./services/monitoring/das_watchdog.nix
   ./services/monitoring/dd-agent/dd-agent.nix
+  ./services/monitoring/glances.nix
   ./services/monitoring/grafana.nix
   ./services/monitoring/graphite.nix
   ./services/monitoring/hdaps.nix

--- a/nixos/modules/services/monitoring/glances.nix
+++ b/nixos/modules/services/monitoring/glances.nix
@@ -28,6 +28,38 @@ let
         else cfg.conf;
     };
 
+  mkPkgDep = cfg: pkg: if cfg then pkg else null;
+
+  pyPkgs = pkgs.pythonPackages;
+
+  package = pkgs.glances.overrideAttrs (attrs: {
+    # attrs.withBatinfoPkg
+    attrs.withBernhardPkg = mkPkgDep cfg.export-riemann pyPkgs.bernhard;
+    # attrs.withBottlePkg
+    attrs.withCassandra-driverPkg = mkPkgDep cfg.export-cassandra pyPkgs.cassandra-driver;
+    attrs.withCouchdbPkg = mkPkgDep cfg.export-couchdb pyPkgs.couchdb;
+    attrs.withDockerPkg = mkPkgDep !cfg.disable-docker pyPkgs.docker;
+    attrs.withElasticsearchPkg = mkPkgDep cfg.export-elasticsearch pyPkgs.elasicsearch;
+    attrs.withHddtempPkg = mkPkgDep !cfg.disable-hddtemp pyPkgs.hddtemp;
+    attrs.withInfluxdbPkg = mkPkgDep cfg.export-influxdb pyPkgs.influxdb;
+    attrs.withMatplotlibPkg = mkPkgDep cfg.enable-history pyPkgs.matplotlib;
+    # attrs.withNetifacesPkg
+    # attrs.withNvidia-ml-pyPkg
+    # attrs.withPikaPkg
+    attrs.withPotsdbPkg = mkPkgDep cfg.export-opentsdb pyPkgs.potsdb;
+    attrs.withPy3sensorsPkg = mkPkgDep !cfg.disable-left-sidebar pyPkgs.py3sensors;
+    attrs.withPy-cpuinfoPkg = mkPkgDep !cfg.disable-quicklook pyPkgs.py-cpuinfo;
+    attrs.withPymdstatPkg = mkPkgDep !cfg.disable-raid pyPkgs.pymdstat;
+    # attrs.withPysnmpPkg
+    # attrs.withPystachePkg
+    # attrs.withPyzmqPkg
+    # attrs.withRequestsPkg
+    # attrs.withScandirPkg
+    attrs.withStatsdPkg = mkPkgDep cfg.export-statsd pyPkgs.statsd;
+    # attrs.withWifiPkg
+    attrs.withZeroconfPkg = mkPkgDep cfg.export-zeromq pyPkgs.zmq;
+  });
+
   # Building the commandline flags for glances here
   glancesCommands = ""
     + "--config ${mkConfig cfg}"
@@ -472,7 +504,7 @@ in
 
   config = mkIf cfg.enable {
 
-    environment.systemPackages = [ pkgs.pythonPackages.glances ];
+    environment.systemPackages = [ package ];
 
     systemd.services.glances = {
       description = "Glances monitoring service";

--- a/nixos/modules/services/monitoring/glances.nix
+++ b/nixos/modules/services/monitoring/glances.nix
@@ -33,8 +33,8 @@ let
     + "--config ${mkConfig cfg}"
     + "${mkNamedFlag cfg "listenAddress" "bind"}"
     + "${mkFlag cfg "port"}"
-    + "${mkFlag cfg "username"}"
-    + "${mkFlag cfg "password"}"
+    # + "${mkFlag cfg "username"}"
+    # + "${mkFlag cfg "password"}"
     + "${mkFlag cfg "disable-alert"}"
     + "${mkFlag cfg "disable-amps"}"
     + "${mkFlag cfg "disable-cpu"}"
@@ -120,17 +120,19 @@ in
         description = "Port to listen on.";
       };
 
-      username = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = "Username";
-      };
+      # The "username" option does not work as I would expect it to
+      # username = mkOption {
+      #   type = types.nullOr types.str;
+      #   default = null;
+      #   description = "Username";
+      # };
 
-      password = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = "Password";
-      };
+      # The "password" option does not work as I would expect it to
+      # password = mkOption {
+      #   type = types.nullOr types.str;
+      #   default = null;
+      #   description = "Password";
+      # };
 
       conf = mkOption {
         type = types.str;

--- a/nixos/modules/services/monitoring/glances.nix
+++ b/nixos/modules/services/monitoring/glances.nix
@@ -1,0 +1,487 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.glances;
+
+  mkFlag = cfg: flagname: (mkNamedFlag cfg flagname flagname);
+
+  mkNamedFlag = cfg: flagname: destname:
+    let
+      flg = cfg."${flagname}";
+    in
+    if (isBool flg && flg == true) || (!isBool flg && !isNull flg) then
+      " --${destname}" +
+      (
+        if !isBool flg then " ${toString flg}"
+        else ""
+      )
+    else
+      "";
+
+  mkConfig = cfg:
+    pkgs.writeTextFile {
+      name = "glances.conf";
+      text =
+        if !(isNull cfg.confFile) then builtins.readFile cfg.confFile
+        else cfg.conf;
+    };
+
+  # Building the commandline flags for glances here
+  glancesCommands = ""
+    + "--config ${mkConfig cfg}"
+    + "${mkNamedFlag cfg "listenAddress" "bind"}"
+    + "${mkFlag cfg "port"}"
+    + "${mkFlag cfg "username"}"
+    + "${mkFlag cfg "password"}"
+    + "${mkFlag cfg "disable-alert"}"
+    + "${mkFlag cfg "disable-amps"}"
+    + "${mkFlag cfg "disable-cpu"}"
+    + "${mkFlag cfg "disable-diskio"}"
+    + "${mkFlag cfg "disable-docker"}"
+    + "${mkFlag cfg "disable-folders"}"
+    + "${mkFlag cfg "disable-fs"}"
+    + "${mkFlag cfg "disable-hddtemp"}"
+    + "${mkFlag cfg "disable-ip"}"
+    + "${mkFlag cfg "disable-irq"}"
+    + "${mkFlag cfg "disable-load"}"
+    + "${mkFlag cfg "disable-mem"}"
+    + "${mkFlag cfg "disable-memswap"}"
+    + "${mkFlag cfg "disable-network"}"
+    + "${mkFlag cfg "disable-now"}"
+    + "${mkFlag cfg "disable-ports"}"
+    + "${mkFlag cfg "disable-process"}"
+    + "${mkFlag cfg "disable-raid"}"
+    + "${mkFlag cfg "disable-sensors"}"
+    + "${mkFlag cfg "disable-wifi"}"
+    + "${mkFlag cfg "disable-irix"}"
+    + "${mkFlag cfg "percpu"}"
+    + "${mkFlag cfg "disable-left-sidebar"}"
+    + "${mkFlag cfg "disable-quicklook"}"
+    + "${mkFlag cfg "full-quicklook"}"
+    + "${mkFlag cfg "disable-top"}"
+    + "${mkFlag cfg "meangpu"}"
+    + "${mkFlag cfg "enable-history"}"
+    + "${mkFlag cfg "disable-bold"}"
+    + "${mkFlag cfg "disable-bg"}"
+    + "${mkFlag cfg "enable-process-extended"}"
+    + "${mkFlag cfg "export-cassandra"}"
+    + "${mkFlag cfg "export-couchdb"}"
+    + "${mkFlag cfg "export-elasticsearch"}"
+    + "${mkFlag cfg "export-influxdb"}"
+    + "${mkFlag cfg "export-opentsdb"}"
+    + "${mkFlag cfg "export-rabbitmq"}"
+    + "${mkFlag cfg "export-statsd"}"
+    + "${mkFlag cfg "export-riemann"}"
+    + "${mkFlag cfg "export-zeromq"}"
+    + "${mkFlag cfg "disable-autodiscover"}"
+    + "${mkFlag cfg "time"}"
+    + "${mkFlag cfg "cached-time"}"
+    + "${mkFlag cfg "process-filter"}"
+    + "${mkFlag cfg "process-short-name"}"
+    + "${mkFlag cfg "hide-kernel-threads"}"
+    + "${mkFlag cfg "tree"}"
+    + "${mkFlag cfg "byte"}"
+    + "${mkFlag cfg "diskio-show-ramfs"}"
+    + "${mkFlag cfg "diskio-iops"}"
+    + "${mkFlag cfg "fahrenheit"}"
+    + "${mkFlag cfg "fs-free-space"}"
+    + "${mkFlag cfg "disable-check-update"}"
+    ;
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.glances = {
+
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Whether to enable the glances server service.
+        '';
+      };
+
+      listenAddress = mkOption {
+        type = types.str;
+        default = "";
+        example = "0.0.0.0";
+        description = "bind server to the given IPv4/IPv6 address or hostname";
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 61209;
+        description = "Port to listen on.";
+      };
+
+      username = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Username";
+      };
+
+      password = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Password";
+      };
+
+      conf = mkOption {
+        type = types.str;
+        default = "";
+        description = "Extra configuration";
+      };
+
+      confFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "Configuration file. Overrides 'conf' option if set.";
+      };
+
+      disable-alert = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable alert/log module";
+      };
+
+      disable-amps = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable application monitoring process module";
+      };
+
+      disable-cpu = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable CPU module";
+      };
+
+      disable-diskio = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable disk I/O module";
+      };
+
+      disable-docker = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable Docker module";
+      };
+
+      disable-folders = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable folders module";
+      };
+
+      disable-fs = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable file system module";
+      };
+
+      disable-hddtemp = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable HD temperature module";
+      };
+
+      disable-ip = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable IP module";
+      };
+
+      disable-irq = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable IRQ module";
+      };
+
+      disable-load = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable load module";
+      };
+
+      disable-mem = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable memory module";
+      };
+
+      disable-memswap = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable memory swap module";
+      };
+
+      disable-network = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable network module";
+      };
+
+      disable-now = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable current time module";
+      };
+
+      disable-ports = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable Ports module";
+      };
+
+      disable-process = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable process module";
+      };
+
+      disable-raid = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable RAID module";
+      };
+
+      disable-sensors = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable sensors module";
+      };
+
+      disable-wifi = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable Wifi module";
+      };
+
+      disable-irix = mkOption {
+        type = types.bool;
+        description = "task's CPU usage will be divided by the total number of CPUs";
+        default = false;
+      };
+
+      percpu = mkOption {
+        type = types.bool;
+        default = false;
+        description = "start Glances in per CPU mode";
+      };
+
+      disable-left-sidebar = mkOption {
+        type = types.bool;
+        description = "disable network, disk I/O, FS and sensors modules (py3sensors lib needed)";
+        default = false;
+      };
+
+      disable-quicklook = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable quick look module";
+      };
+
+      full-quicklook = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable all but quick look and load";
+      };
+
+      disable-top = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable top menu (QuickLook, CPU, MEM, SWAP and LOAD)";
+      };
+
+      meangpu = mkOption {
+        type = types.bool;
+        default = false;
+        description = "start Glances in mean GPU mode";
+      };
+
+      enable-history = mkOption {
+        type = types.bool;
+        default = false;
+        description = "enable the history mode (matplotlib lib needed)";
+      };
+
+      disable-bold = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable bold mode in the terminal";
+      };
+
+      disable-bg = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable background colors in the terminal";
+      };
+
+      enable-process-extended = mkOption {
+        type = types.bool;
+        default = false;
+        description = "enable extended stats on top process";
+      };
+
+      export-cassandra = mkOption {
+        type = types.bool;
+        description = "export stats to a Cassandra/Scylla server (cassandra lib needed)";
+        default = false;
+      };
+
+      export-couchdb = mkOption {
+        type = types.bool;
+        default = false;
+        description = "export stats to a CouchDB server (couchdb lib needed)";
+      };
+
+      export-elasticsearch = mkOption {
+        type = types.bool;
+        description = "export stats to an Elasticsearch server (elasticsearch lib needed)";
+        default = false;
+      };
+
+      export-influxdb = mkOption {
+        type = types.bool;
+        description = "export stats to an InfluxDB server (influxdb lib needed)";
+        default = false;
+      };
+
+      export-opentsdb = mkOption {
+        type = types.bool;
+        default = false;
+        description = "export stats to an OpenTSDB server (potsdb lib needed)";
+      };
+
+      export-rabbitmq = mkOption {
+        type = types.bool;
+        default = false;
+        description = "export stats to RabbitMQ broker (pika lib needed)";
+      };
+
+      export-statsd = mkOption {
+        type = types.bool;
+        default = false;
+        description = "export stats to a StatsD server (statsd lib needed)";
+      };
+
+      export-riemann = mkOption {
+        type = types.bool;
+        default = false;
+        description = "export stats to Riemann server (bernhard lib needed)";
+      };
+
+      export-zeromq = mkOption {
+        type = types.bool;
+        default = false;
+        description = "export stats to a ZeroMQ server (zmq lib needed)";
+      };
+
+      disable-autodiscover = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable autodiscover feature";
+      };
+
+      time = mkOption {
+        type = types.int;
+        default = 3;
+        description = "set refresh time in seconds [default: 3 sec]";
+      };
+
+      cached-time = mkOption {
+        type = types.int;
+        default = 1;
+        description = "set the server cache time [default: 1 sec]";
+      };
+
+      process-filter = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "set the process filter pattern (regular expression).";
+      };
+
+      process-short-name = mkOption {
+        type = types.bool;
+        default = false;
+        description = "force short name for processes name";
+      };
+
+      hide-kernel-threads = mkOption {
+        type = types.bool;
+        default = false;
+        description = "hide kernel threads in process list";
+      };
+
+      tree = mkOption {
+        type = types.bool;
+        default = false;
+        description = "display processes as a tree";
+      };
+
+      byte = mkOption {
+        type = types.bool;
+        default = false;
+        description = "display network rate in byte per second";
+      };
+
+      diskio-show-ramfs = mkOption {
+        type = types.bool;
+        default = false;
+        description = "show RAM FS in the DiskIO plugin";
+      };
+
+      diskio-iops = mkOption {
+        type = types.bool;
+        default = false;
+        description = "show I/O per second in the DiskIO plugin";
+      };
+
+      fahrenheit = mkOption {
+        type = types.bool;
+        default = false;
+        description = "display temperature in Fahrenheit (default is Celsius)";
+      };
+
+      fs-free-space = mkOption {
+        type = types.bool;
+        default = false;
+        description = "display FS free space instead of used";
+      };
+
+      disable-check-update = mkOption {
+        type = types.bool;
+        default = false;
+        description = "disable online Glances version ckeck";
+      };
+
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ pkgs.pythonPackages.glances ];
+
+    systemd.services.glances = {
+      description = "Glances monitoring service";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.pythonPackages.glances}/bin/glances --server ${glancesCommands}";
+      };
+      unitConfig.Documentation = "man:glances(1)";
+    };
+
+  };
+
+}
+

--- a/pkgs/tools/system/glances/default.nix
+++ b/pkgs/tools/system/glances/default.nix
@@ -1,4 +1,30 @@
-{ pythonPackages }:
+{ lib, pythonPackages
+, withBatinfoPkg ? null
+, withBernhardPkg ? null
+, withBottlePkg ? null
+, withCassandra-driverPkg ? null
+, withCouchdbPkg ? null
+, withDockerPkg ? null
+, withElasticsearchPkg ? null
+, withHddtempPkg ? null
+, withInfluxdbPkg ? null
+, withMatplotlibPkg ? null
+, withNetifacesPkg ? null
+, withNvidia-ml-pyPkg ? null
+, withPikaPkg ? null
+, withPotsdbPkg ? null
+, withPy3sensorsPkg ? null
+, withPy-cpuinfoPkg ? null
+, withPymdstatPkg ? null
+, withPysnmpPkg ? null
+, withPystachePkg ? null
+, withPyzmqPkg ? null
+, withRequestsPkg ? null
+, withScandirPkg ? null
+, withStatsdPkg ? null
+, withWifiPkg ? null
+, withZeroconfPkg ? null
+}:
 
 pythonPackages.buildPythonPackage rec {
   name = "glances-${version}";
@@ -15,7 +41,35 @@ pythonPackages.buildPythonPackage rec {
   doCheck = false;
 
   buildInputs = with pythonPackages; [ unittest2 ];
-  propagatedBuildInputs = with pythonPackages; [ psutil setuptools bottle batinfo pkgs.hddtemp pysnmp ];
+  propagatedBuildInputs = with pythonPackages; [
+    psutil setuptools bottle batinfo pkgs.hddtemp pysnmp
+  ]
+  ++ (if isNull withBatinfoPkg then [] else [withBatinfoPkg] )
+  ++ (if isNull withBernhardPkg then [] else [withBernhardPkg] )
+  ++ (if isNull withBottlePkg then [] else [withBottlePkg] )
+  ++ (if isNull withCassandra-driverPkg then [] else [withCassandr]a)
+  ++ (if isNull withCouchdbPkg then [] else [withCouchdbPkg] )
+  ++ (if isNull withDockerPkg then [] else [withDockerPkg] )
+  ++ (if isNull withElasticsearchPkg then [] else [withElasticsearchPkg] )
+  ++ (if isNull withHddtempPkg then [] else [withHddtempPkg] )
+  ++ (if isNull withInfluxdbPkg then [] else [withInfluxdbPkg] )
+  ++ (if isNull withMatplotlibPkg then [] else [withMatplotlibPkg] )
+  ++ (if isNull withNetifacesPkg then [] else [withNetifacesPkg] )
+  ++ (if isNull withNvidia-ml-pyPkg then [] else [withNvidi]a)
+  ++ (if isNull withPikaPkg then [] else [withPikaPkg] )
+  ++ (if isNull withPotsdbPkg then [] else [withPotsdbPkg] )
+  ++ (if isNull withPy3sensorsPkg then [] else [withPy3sensorsPkg] )
+  ++ (if isNull withPy-cpuinfoPkg then [] else [withP]y)
+  ++ (if isNull withPymdstatPkg then [] else [withPymdstatPkg] )
+  ++ (if isNull withPysnmpPkg then [] else [withPysnmpPkg] )
+  ++ (if isNull withPystachePkg then [] else [withPystachePkg] )
+  ++ (if isNull withPyzmqPkg then [] else [withPyzmqPkg] )
+  ++ (if isNull withRequestsPkg then [] else [withRequestsPkg] )
+  ++ (if isNull withScandirPkg then [] else [withScandirPkg] )
+  ++ (if isNull withStatsdPkg then [] else [withStatsdPkg] )
+  ++ (if isNull withWifiPkg then [] else [withWifiPkg] )
+  ++ (if isNull withZeroconfPkg then [] else [withZeroconfPkg] )
+  ;
 
   preConfigure = ''
     sed -i 's/data_files\.append((conf_path/data_files.append(("etc\/glances"/' setup.py;

--- a/pkgs/tools/system/glances/default.nix
+++ b/pkgs/tools/system/glances/default.nix
@@ -1,0 +1,31 @@
+{ pythonPackages }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "glances-${version}";
+  version = "2.8.2";
+  disabled = isPyPy;
+
+  src = pkgs.fetchFromGitHub {
+    owner = "nicolargo";
+    repo = "glances";
+    rev = "v${version}";
+    sha256 = "1jwaq9k6q8wn197wadiwid7d8aik24rhsypmcl5q0jviwkhhiri9";
+  };
+
+  doCheck = false;
+
+  buildInputs = with pythonPackages; [ unittest2 ];
+  propagatedBuildInputs = with pythonPackages; [ psutil setuptools bottle batinfo pkgs.hddtemp pysnmp ];
+
+  preConfigure = ''
+    sed -i 's/data_files\.append((conf_path/data_files.append(("etc\/glances"/' setup.py;
+  '';
+
+  meta = {
+    homepage = "http://nicolargo.github.io/glances/";
+    description = "Cross-platform curses-based monitoring tool";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ koral ];
+  };
+};
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -970,6 +970,8 @@ with pkgs;
 
   gist = callPackage ../tools/text/gist { };
 
+  glances = callPackage ../tools/system/glances { };
+
   glide = callPackage ../development/tools/glide { };
 
   glock = callPackage ../development/tools/glock { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12066,34 +12066,7 @@ in {
     };
   };
 
-  glances = buildPythonPackage rec {
-    name = "glances-${version}";
-    version = "2.9.1";
-    disabled = isPyPy;
-
-    src = pkgs.fetchFromGitHub {
-      owner = "nicolargo";
-      repo = "glances";
-      rev = "v${version}";
-      sha256 = "13pnim8zxqbw5b1jkl1ggqn2rg5kfwhznw42ckizrhg73ngy9yyp";
-    };
-
-    doCheck = false;
-
-    buildInputs = with self; [ unittest2 ];
-    propagatedBuildInputs = with self; [ psutil setuptools bottle batinfo pkgs.hddtemp pysnmp ];
-
-    preConfigure = ''
-      sed -i 's/data_files\.append((conf_path/data_files.append(("etc\/glances"/' setup.py;
-    '';
-
-    meta = {
-      homepage = "http://nicolargo.github.io/glances/";
-      description = "Cross-platform curses-based monitoring tool";
-      license = licenses.lgpl3;
-      maintainers = with maintainers; [ koral ];
-    };
-  };
+  glances = pkgs.glances;
 
   github3_py = buildPythonPackage rec {
     name = "github3.py-${version}";


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I rudimentarily tested the service on my local device.

The `username` and `password` do not work as expected, will shortly push a commit to disable these options.