### PR TITLE
ranger: 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pythonPackages, w3m, file, less }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "ranger-1.8.0";
+  name = "ranger-1.8.1";
 
   meta = {
     description = "File manager with minimalistic curses interface";
@@ -12,7 +12,7 @@ pythonPackages.buildPythonApplication rec {
 
   src = fetchurl {
     url = "http://ranger.nongnu.org/${name}.tar.gz";
-    sha256 = "14j067n1azk6vc6cxlhi5w5bsn2wcz4hypvgxc0vjl9xp5n4f0nf";
+    sha256 = "1d11qw0mr9aj22a7nhr6p2c3yzf359xbffmjsjblq44bjpwzjcql";
   };
 
   checkInputs = with pythonPackages; [ pytest ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

