### PR TITLE
micropolis: fix build (patch changed)

### DIFF
--- a/pkgs/games/micropolis/default.nix
+++ b/pkgs/games/micropolis/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   patches =
     [ (fetchurl {
         url = http://rmdir.de/~michael/micropolis_git.patch;
-        sha256 = "0sjl61av7lab3a5vif1jpyicmdb2igvqq6nwaw0s3agg6dh69v1d";
+        sha256 = "10j0svcs576ip7v5mn99gvqx9ki8jfd5w5yvsxj57xh56dd0by2p";
       })
     ];
 


### PR DESCRIPTION
###### Motivation for this change
The patch file changed. The current patch applies, build succeeds and game is playable.

One less build failure for #23253 :)


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

