### PR TITLE
gitflow: tweak for darwin

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitflow/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitflow/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub }:
+{ pkgs, stdenv, fetchFromGitHub }:
+
+with pkgs.lib;
 
 stdenv.mkDerivation rec {
   pname = "gitflow";
@@ -12,8 +14,15 @@ stdenv.mkDerivation rec {
     sha256 = "1i8bwi83qcqvi8zrkjn4mp2v8v7y11fd520wpg2jgy5hqyz34chg";
   };
 
+  buildInputs = optionals (stdenv.isDarwin) [ pkgs.makeWrapper ];
+
   preBuild = ''
     makeFlagsArray+=(prefix="$out")
+  '';
+
+  postInstall = optional (stdenv.isDarwin) ''
+    wrapProgram $out/bin/git-flow \
+      --set FLAGS_GETOPT_CMD ${pkgs.getopt}/bin/getopt
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
On Darwin, wrap the `git-flow` binary and set:

    FLAGS_GETOPT_CMD=${getopt}/bin/getopt

Without this change, I was getting the following error:

    flags:ERROR short flag required for (showcommands) on this platform

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

