### PR TITLE
Qt 5.7 fixes

### DIFF
--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     sed -i -e 's/install -s/install/' common.mak || die
   '';
 
+  NIX_CFLAGS_COMPILE = [ "-std=c++11" ]; # build with Qt 5.7
+
   IPEPREFIX="$$out";
   URWFONTDIR="${texlive}/texmf-dist/fonts/type1/urw/";
   LUA_PACKAGE = "lua";

--- a/pkgs/development/libraries/kde-frameworks/attica.nix
+++ b/pkgs/development/libraries/kde-frameworks/attica.nix
@@ -2,7 +2,10 @@
 
 kdeFramework {
   name = "attica";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/bluez-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/bluez-qt.nix
@@ -1,11 +1,14 @@
 { kdeFramework, lib
 , extra-cmake-modules
-, qtdeclarative
+, qtbase, qtdeclarative
 }:
 
 kdeFramework {
   name = "bluez-qt";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ qtdeclarative ];
   preConfigure = ''

--- a/pkgs/development/libraries/kde-frameworks/karchive.nix
+++ b/pkgs/development/libraries/kde-frameworks/karchive.nix
@@ -2,7 +2,10 @@
 
 kdeFramework {
   name = "karchive";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kcodecs.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcodecs.nix
@@ -2,7 +2,10 @@
 
 kdeFramework {
   name = "kcodecs";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   buildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kconfig.nix
+++ b/pkgs/development/libraries/kde-frameworks/kconfig.nix
@@ -2,7 +2,10 @@
 
 kdeFramework {
   name = "kconfig";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   buildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kcoreaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcoreaddons.nix
@@ -2,7 +2,10 @@
 
 kdeFramework {
   name = "kcoreaddons";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   buildInputs = [ qtbase ];
   propagatedBuildInputs = [ shared_mime_info ];

--- a/pkgs/development/libraries/kde-frameworks/kdbusaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdbusaddons.nix
@@ -1,8 +1,11 @@
-{ kdeFramework, lib, extra-cmake-modules, qttools, qtx11extras }:
+{ kdeFramework, lib, extra-cmake-modules, qtbase, qttools, qtx11extras }:
 
 kdeFramework {
   name = "kdbusaddons";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   propagatedBuildInputs = [ qtx11extras ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kdnssd.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdnssd.nix
@@ -5,7 +5,10 @@
 
 kdeFramework {
   name = "kdnssd";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   propagatedBuildInputs = [ avahi ];
   buildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kguiaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kguiaddons.nix
@@ -1,11 +1,15 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-, qtx11extras
+{
+  kdeFramework, lib,
+  extra-cmake-modules,
+  qtbase, qtx11extras,
 }:
 
 kdeFramework {
   name = "kguiaddons";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ qtx11extras ];
 }

--- a/pkgs/development/libraries/kde-frameworks/ki18n.nix
+++ b/pkgs/development/libraries/kde-frameworks/ki18n.nix
@@ -1,15 +1,16 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-, gettext
-, python
-, qtdeclarative
-, qtscript
+{
+  kdeFramework, lib,
+  extra-cmake-modules, gettext, python,
+  qtbase, qtdeclarative, qtscript,
 }:
 
 kdeFramework {
   name = "ki18n";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
-  propagatedBuildInputs = [ qtdeclarative qtscript ];
   propagatedNativeBuildInputs = [ gettext python ];
+  propagatedBuildInputs = [ qtdeclarative qtscript ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kidletime.nix
+++ b/pkgs/development/libraries/kde-frameworks/kidletime.nix
@@ -6,7 +6,10 @@
 
 kdeFramework {
   name = "kidletime";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ qtbase qtx11extras ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kitemmodels.nix
+++ b/pkgs/development/libraries/kde-frameworks/kitemmodels.nix
@@ -4,7 +4,10 @@
 
 kdeFramework {
   name = "kitemmodels";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kitemviews.nix
+++ b/pkgs/development/libraries/kde-frameworks/kitemviews.nix
@@ -4,7 +4,10 @@
 
 kdeFramework {
   name = "kitemviews";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   buildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kplotting.nix
+++ b/pkgs/development/libraries/kde-frameworks/kplotting.nix
@@ -4,7 +4,10 @@
 
 kdeFramework {
   name = "kplotting";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kwayland.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwayland.nix
@@ -1,15 +1,16 @@
-{ kdeFramework
-, extra-cmake-modules
-, qtbase, wayland
+{
+  kdeFramework, lib,
+  extra-cmake-modules,
+  qtbase, wayland
 }:
 
 kdeFramework {
   name = "kwayland";
-  nativeBuildInputs = [
-    extra-cmake-modules
-  ];
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
+  nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ];
-  propagatedBuildInputs = [
-    wayland
-  ];
+  propagatedBuildInputs = [ wayland ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kwidgetsaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwidgetsaddons.nix
@@ -4,7 +4,10 @@
 
 kdeFramework {
   name = "kwidgetsaddons";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   buildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kwindowsystem.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwindowsystem.nix
@@ -1,11 +1,15 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-, qttools, qtx11extras
+{
+  kdeFramework, lib,
+  extra-cmake-modules,
+  qtbase, qttools, qtx11extras
 }:
 
 kdeFramework {
   name = "kwindowsystem";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   propagatedBuildInputs = [ qtx11extras ];
 }

--- a/pkgs/development/libraries/kde-frameworks/modemmanager-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/modemmanager-qt.nix
@@ -5,7 +5,10 @@
 
 kdeFramework {
   name = "modemmanager-qt";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ];
   propagatedBuildInputs = [ modemmanager ];

--- a/pkgs/development/libraries/kde-frameworks/networkmanager-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/networkmanager-qt.nix
@@ -5,7 +5,10 @@
 
 kdeFramework {
   name = "networkmanager-qt";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ];
   propagatedBuildInputs = [ networkmanager ];

--- a/pkgs/development/libraries/kde-frameworks/solid.nix
+++ b/pkgs/development/libraries/kde-frameworks/solid.nix
@@ -1,12 +1,15 @@
 {
   kdeFramework, lib,
   bison, extra-cmake-modules, flex,
-  qtdeclarative, qttools
+  qtbase, qtdeclarative, qttools
 }:
 
 kdeFramework {
   name = "solid";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ bison extra-cmake-modules flex qttools ];
   propagatedBuildInputs = [ qtdeclarative ];
 }

--- a/pkgs/development/libraries/kde-frameworks/sonnet.nix
+++ b/pkgs/development/libraries/kde-frameworks/sonnet.nix
@@ -5,7 +5,10 @@
 
 kdeFramework {
   name = "sonnet";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   buildInputs = [ hunspell qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/syntax-highlighting.nix
+++ b/pkgs/development/libraries/kde-frameworks/syntax-highlighting.nix
@@ -4,7 +4,10 @@
 
 kdeFramework {
   name = "syntax-highlighting";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules perl qttools ];
   buildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/threadweaver.nix
+++ b/pkgs/development/libraries/kde-frameworks/threadweaver.nix
@@ -4,7 +4,10 @@
 
 kdeFramework {
   name = "threadweaver";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = {
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ];
 }

--- a/pkgs/tools/security/pinentry/qt5.nix
+++ b/pkgs/tools/security/pinentry/qt5.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     (mkEnable true "pinentry-qt")
   ];
 
+  NIX_CFLAGS_COMPILE = [ "-std=c++11" ];
+
   nativeBuildInputs = [ pkgconfig ];
 
   meta = {


### PR DESCRIPTION
### Motivation for this change

Hydra failures for my packages, see #23253.

### Things done

Mostly marking libraries broken. A few packages build with `-std=c++11`.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

