### PR TITLE
mhddfs: fix-format-security

### DIFF
--- a/pkgs/tools/filesystems/mhddfs/default.nix
+++ b/pkgs/tools/filesystems/mhddfs/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ fuse pkgconfig attr uthash ];
 
+  patches = [
+    ./fix-format-security-error.patch
+  ];
+
   installPhase = ''
     mkdir -p $out/bin
     cp mhddfs $out/bin/

--- a/pkgs/tools/filesystems/mhddfs/fix-format-security-error.patch
+++ b/pkgs/tools/filesystems/mhddfs/fix-format-security-error.patch
@@ -1,0 +1,12 @@
+--- mhddfs-0.1.39/src/usage.c.old	2017-02-28 15:00:25.435438622 +0100
++++ mhddfs-0.1.39/src/usage.c	2017-02-28 15:00:33.847454958 +0100
+@@ -43,7 +43,7 @@
+ 		"\n"
+ 		" see fusermount(1) for information about other options\n"
+ 		"";
+-	fprintf(to, usage);
++	fprintf(to,"%s", usage);
+ 	if (to==stdout) exit(0);
+ 	exit(-1);
+ }
+

--- a/pkgs/tools/filesystems/mhddfs/fix-format-security-error.patch
+++ b/pkgs/tools/filesystems/mhddfs/fix-format-security-error.patch
@@ -5,7 +5,7 @@
  		" see fusermount(1) for information about other options\n"
  		"";
 -	fprintf(to, usage);
-+	fprintf(to,"%s", usage);
++	fputs(usage, to);
  	if (to==stdout) exit(0);
  	exit(-1);
  }


### PR DESCRIPTION
###### Motivation for this change

Zero Hydra Failures for 17.03 (#23253)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

