### PR TITLE
qmidinet: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/applications/audio/qmidinet/default.nix
+++ b/pkgs/applications/audio/qmidinet/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchurl, qt5, alsaLib, libjack2 }:
+{ stdenv, fetchurl, pkgconfig, qt5, alsaLib, libjack2 }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.1";
+  version = "0.4.2";
   name = "qmidinet-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/qmidinet/${name}.tar.gz";
-    sha256 = "1hh06g19lfh6r673avfvy0l2mq999mxk2jnv396226swj97lv7yz";
+    sha256 = "1sdnd189db44xhl9p8pd8h4bsy8s0bn1y64lrdq7nb21mwg8ymcs";
   };
 
   hardeningDisable = [ "format" ];
 
   buildInputs = [  qt5.qtbase qt5.qttools alsaLib libjack2 ];
+
+  nativeBuildInputs = [ pkgconfig ];
 
   meta = with stdenv.lib; {
     description = "A MIDI network gateway application that sends and receives MIDI data (ALSA Sequencer and/or JACK MIDI) over the network";


### PR DESCRIPTION
###### Motivation for this change
Makes it build again.
[Zero Hydra Failures for 17.03](https://github.com/NixOS/nixpkgs/issues/23253)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

