### PR TITLE
exfat-nofuse: build only for kernels < 4.10

### DIFF
--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchFromGitHub, kernel }:
 
+# Upstream build for kernel > 4.10 is currently broken
+# Reference: https://github.com/dorimanx/exfat-nofuse/issues/103
+assert stdenv.lib.versionOlder kernel.version "4.10";
+
 stdenv.mkDerivation rec {
   name = "exfat-nofuse-${version}-${kernel.version}";
   version = "2017-01-03";


### PR DESCRIPTION
###### Motivation for this change

Zero Hydra Failures for 17.03 #23253 
exfat-nofuse is currently broken for 4.10, ref: https://github.com/dorimanx/exfat-nofuse/issues/103 


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

