### PR TITLE
nginx service: add commonHttpConfig option

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -87,6 +87,8 @@ let
 
       server_tokens ${if cfg.serverTokens then "on" else "off"};
 
+      ${cfg.commonHttpConfig}
+
       ${vhosts}
 
       ${optionalString cfg.statusPage ''
@@ -272,6 +274,24 @@ in
           can be specified more than once and it's value will be
           concatenated (contrary to <option>config</option> which
           can be set only once).
+        '';
+      };
+
+      commonHttpConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          resolver 127.0.0.1 valid=5s;
+
+          log_format myformat '$remote_addr - $remote_user [$time_local] '
+                              '"$request" $status $body_bytes_sent '
+                              '"$http_referer" "$http_user_agent"';
+        '';
+        description = ''
+          With nginx you must provide common http context definitions before
+          they are used, e.g. log_format, resolver, etc. inside of server
+          or location contexts. Use this attribute to set these definitions
+          at the appropriate location.
         '';
       };
 

--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -1,0 +1,42 @@
+# verifies:
+#   1. nginx generates config file with shared http context definitions above
+#      generated virtual hosts config.
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "jenkins";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ mbbx6spp ];
+  };
+
+  nodes = {
+    webserver =
+      { config, pkgs, ... }:
+      { services.nginx.enable = true;
+        services.nginx.commonHttpConfig = ''
+        log_format ceeformat '@cee: {"status":"$status",'
+          '"request_time":$request_time,'
+          '"upstream_response_time":$upstream_response_time,'
+          '"pipe":"$pipe","bytes_sent":$bytes_sent,'
+          '"connection":"$connection",'
+          '"remote_addr":"$remote_addr",'
+          '"host":"$host",'
+          '"timestamp":"$time_iso8601",'
+          '"request":"$request",'
+          '"http_referer":"$http_referer",'
+          '"upstream_addr":"$upstream_addr"}';
+        '';
+        services.nginx.virtualHosts."0.my.test" = {
+          extraConfig = ''
+            access_log syslog:server=unix:/dev/log,facility=user,tag=mytag,severity=info ceeformat;
+          '';
+        };
+      };
+  };
+
+  testScript = ''
+    startAll;
+
+    $webserver->waitForUnit("nginx");
+    $webserver->waitForOpenPort("80");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

For users of the `nginx` module that use the declarative `virtualHosts` structure there must be a way to define common definitions like `log_format` before using them inside of the `server` or `location` context blocks of the generated virtual hosts that is also at the `http` context block scope. Currently the NixOS nginx module does not offer a solution that doesn't require me to manage raw config files for my virtual hosts (I get an `emerg` because when I try to append the http config via `appendHttpConfig` it shows up *after* the virtual host generated usage).

I added a `nginx` module VM test to very this works. See `nixos/tests/nginx.nix`.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

