### PR TITLE
qjackctl: 0.4.3 -> 0.4.4, samplv1: 0.7.6 -> 0.8.0, drumkv1: 0.7.6 -> 0.8.0

### DIFF
--- a/pkgs/applications/audio/drumkv1/default.nix
+++ b/pkgs/applications/audio/drumkv1/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchurl, libjack2, alsaLib, libsndfile, liblo, lv2, qt5 }:
+{ stdenv, fetchurl, pkgconfig, libjack2, alsaLib, libsndfile, liblo, lv2, qt5 }:
 
 stdenv.mkDerivation rec {
   name = "drumkv1-${version}";
-  version = "0.7.6";
+  version = "0.8.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/drumkv1/${name}.tar.gz";
-    sha256 = "0cl1rbj26nsbvg9wzsh2j8xlx69xjxn29x46ypmy3939zbk81bi6";
+    sha256 = "1n2kd468kn71yp2asmamprvblmdlvh0zd8lsh3598dwi4b7aa3ga";
   };
 
   buildInputs = [ libjack2 alsaLib libsndfile liblo lv2 qt5.qtbase qt5.qttools ];
+
+  nativeBuildInputs = [ pkgconfig ];
 
   meta = with stdenv.lib; {
     description = "An old-school drum-kit sampler synthesizer with stereo fx";

--- a/pkgs/applications/audio/qjackctl/default.nix
+++ b/pkgs/applications/audio/qjackctl/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchurl, alsaLib, libjack2, dbus, qtbase, qttools, qtx11extras }:
+{ stdenv, fetchurl, pkgconfig, alsaLib, libjack2, dbus, qtbase, qttools, qtx11extras }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.3";
+  version = "0.4.4";
   name = "qjackctl-${version}";
 
   # some dependencies such as killall have to be installed additionally
 
   src = fetchurl {
     url = "mirror://sourceforge/qjackctl/${name}.tar.gz";
-    sha256 = "01wyyynxy21kim0gplzvfij7275a1jz68hdx837d2j1w5x2w7zbb";
+    sha256 = "19bbljb3iz5ss4s5fmra1dxabg2fnp61sa51d63zsm56xkvv47ak";
   };
 
   buildInputs = [
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     libjack2
     dbus
   ];
+
+  nativeBuildInputs = [ pkgconfig ];
 
   configureFlags = [ "--enable-jack-version" ];
 

--- a/pkgs/applications/audio/samplv1/default.nix
+++ b/pkgs/applications/audio/samplv1/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchurl, libjack2, alsaLib, liblo, libsndfile, lv2, qt5 }:
+{ stdenv, fetchurl, pkgconfig, libjack2, alsaLib, liblo, libsndfile, lv2, qt5 }:
 
 stdenv.mkDerivation rec {
   name = "samplv1-${version}";
-  version = "0.7.6";
+  version = "0.8.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/samplv1/${name}.tar.gz";
-    sha256 = "071j7mi2cwhx0ml5hq8izmjb0s4yhbkscqaxfdg56xfpfsqsa63l";
+    sha256 = "0j3hkmd9q0bw9b7nk9cssqywlrishkd1n790a9vq6gh3pdc5sf3r";
   };
 
   buildInputs = [ libjack2 alsaLib liblo libsndfile lv2 qt5.qtbase qt5.qttools];
+
+  nativeBuildInputs = [ pkgconfig ];
 
   meta = with stdenv.lib; {
     description = "An old-school all-digital polyphonic sampler synthesizer with stereo fx";


### PR DESCRIPTION
###### Motivation for this change

fixes some more breaking builds: https://github.com/NixOS/nixpkgs/issues/23253

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

