### PR TITLE
exfat-nofuse: exclude 4.1 kernel build

### DIFF
--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -1,8 +1,11 @@
-{ stdenv, fetchFromGitHub, kernel }:
+{ stdenv, lib, fetchFromGitHub, kernel }:
 
 # Upstream build for kernel > 4.10 is currently broken
 # Reference: https://github.com/dorimanx/exfat-nofuse/issues/103
-assert stdenv.lib.versionOlder kernel.version "4.10";
+assert lib.versionOlder kernel.version "4.10";
+
+# Upstream build for kernel 4.1 is broken, 3.12 and below seems to be working
+assert lib.versionAtLeast kernel.version  "4.2" || lib.versionOlder kernel.version "4.0";
 
 stdenv.mkDerivation rec {
   name = "exfat-nofuse-${version}-${kernel.version}";
@@ -28,8 +31,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "exfat kernel module";
     homepage = https://github.com/dorimanx/exfat-nofuse;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ makefu ];
-    platforms = stdenv.lib.platforms.linux;
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ makefu ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

 Zero Hydra Failures for 17.03 #23253 
exfat-nofuse does not seem to build correctly on 4.1 kernel, this PR excludes this build version while keeping 3.12 and 3.10 builds intact

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

