### PR TITLE
proselint: init at 0.8.0

### DIFF
--- a/pkgs/tools/text/proselint/default.nix
+++ b/pkgs/tools/text/proselint/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, buildPythonApplication, click, future, six }:
+
+buildPythonApplication rec {
+  name = "proselint-${version}";
+  version = "0.8.0";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/proselint/${name}.tar.gz";
+    sha256 = "1g8vx04gmv0agmggz1ml5vydfppqvl8dzjvqm6vqw5rzafa89m08";
+  };
+
+  propagatedBuildInputs = [ click future six ];
+
+  meta = with stdenv.lib; {
+    description = "A linter for prose";
+    homepage = http://proselint.com;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ alibabzo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18901,6 +18901,8 @@ in {
      };
   };
 
+  proselint = callPackage ../tools/text/proselint { };
+
   pylibconfig2 = buildPythonPackage rec {
     name = "pylibconfig2-${version}";
     version = "0.2.4";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

