### PR TITLE
herwig: disable i686-linux

### DIFF
--- a/pkgs/development/libraries/physics/herwig/default.nix
+++ b/pkgs/development/libraries/physics/herwig/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     description = "A multi-purpose particle physics event generator";
     license     = stdenv.lib.licenses.gpl2;
     homepage    = https://herwig.hepforge.org/;
-    platforms   = stdenv.lib.platforms.unix;
+    platforms   = [ "x86_64-darwin" "x86_64-linux" ];
     maintainers = with stdenv.lib.maintainers; [ veprbl ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

#23253
Disables i686-linux target as it fails to build. I would prefer to not apply this to master. The bug looks suspicious and, I think, I will look into it when I have time. This should be good enough for the release.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

