### PR TITLE
Update Qt 5 community releases automatically

### DIFF
--- a/pkgs/development/libraries/qt-5/5.7/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.7/fetch.sh
@@ -1,2 +1,3 @@
 WGET_ARGS=( http://download.qt.io/official_releases/qt/5.7/5.7.1/submodules/ \
+            http://download.qt.io/community_releases/5.7/5.7.1/ \
             -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-5/5.7/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.7/srcs.nix
@@ -2,14 +2,6 @@
 { fetchurl, mirror }:
 
 {
-  qtwebkit = {
-    version = "5.7.0";
-    src = fetchurl {
-      url = "${mirror}/community_releases/5.7/5.7.0/qtwebkit-opensource-src-5.7.0.tar.xz";
-      sha256 = "1prlpl3zslzpr1iv7m3irvxjxn3v8nlxh21v9k2kaq4fpwy2b8y7";
-      name = "qtwebkit-opensource-src-5.7.0.tar.xz";
-    };
-  };
   qt3d = {
     version = "5.7.1";
     src = fetchurl {
@@ -264,6 +256,22 @@
       url = "${mirror}/official_releases/qt/5.7/5.7.1/submodules/qtwebengine-opensource-src-5.7.1.tar.xz";
       sha256 = "0ayc3j17nampy7pg464nbi09wr2d3pfbpqql789m0av37lz8h091";
       name = "qtwebengine-opensource-src-5.7.1.tar.xz";
+    };
+  };
+  qtwebkit = {
+    version = "5.7.1";
+    src = fetchurl {
+      url = "${mirror}/community_releases/5.7/5.7.1/qtwebkit-opensource-src-5.7.1.tar.xz";
+      sha256 = "00szgcra6pf2myfjrdbsr1gmrxycpbjqlzkplna5yr1rjg4gfv54";
+      name = "qtwebkit-opensource-src-5.7.1.tar.xz";
+    };
+  };
+  qtwebkit-examples = {
+    version = "5.7.1";
+    src = fetchurl {
+      url = "${mirror}/community_releases/5.7/5.7.1/qtwebkit-examples-opensource-src-5.7.1.tar.xz";
+      sha256 = "09c2ni3nf7vdsw1y9yhpbal9zs8jgvi1wndnva6mgdbcnm8h23fm";
+      name = "qtwebkit-examples-opensource-src-5.7.1.tar.xz";
     };
   };
   qtwebsockets = {


### PR DESCRIPTION
### Motivation for this change

The file which was marked `DO NOT EDIT!` was edited. Please don't do that.

### Things done

The `fetch.sh` script was changed so that the community releases (WebKit) will be updated automatically with the rest of Qt.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

