### PR TITLE
keepassxc: 2.1.0 -> 2.1.2

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -1,17 +1,24 @@
-{ stdenv, fetchFromGitHub, cmake, libgcrypt, zlib, libmicrohttpd, libXtst, qtbase, qttools }:
+{ stdenv, fetchFromGitHub,
+  cmake, libgcrypt, zlib, libmicrohttpd, libXtst, qtbase, qttools, libgpgerror
+, withKeePassHTTP ? true
+}:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "keepassx-community-${version}";
-  version = "2.1.0";
+  version = "2.1.2";
 
   src = fetchFromGitHub {
     owner = "keepassxreboot";
     repo = "keepassxc";
     rev = "${version}";
-    sha256 = "0qwmi9f8ik3vkwl1kx7g3079h5ia4wl87y42nr5dal3ic1jc941p";
+    sha256 = "0ncc157xki1mzxfa41bgwjfsz5jq9sq750ka578lq61smyzh5lq6";
   };
 
-  buildInputs = [ cmake libgcrypt zlib qtbase qttools libXtst libmicrohttpd ];
+  cmakeFlags = optional (withKeePassHTTP) [ "-DWITH_XC_HTTP=ON" ];
+
+  buildInputs = [ cmake libgcrypt zlib qtbase qttools libXtst libmicrohttpd libgpgerror ];
 
   meta = {
     description = "Fork of the keepassX password-manager with additional http-interface to allow browser-integration an use with plugins such as PasslFox (https://github.com/pfn/passifox). See also keepassX2.";


### PR DESCRIPTION
###### Motivation for this change

also enable http plugin again. Readme mention using the protocol be a
security risk because it is unencrypted, but the connections stays local
(127.0.0.1) and the plugins has to explicitly enabled in settings
(disabled by default).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

