### PR TITLE
Bazel: wrap to keep java available at runtime

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -75,8 +75,9 @@ stdenv.mkDerivation rec {
   doCheck = true;
   checkPhase = ''
     export TEST_TMPDIR=$(pwd)
-    ./output/bazel test --test_output=errors examples/cpp:hello-success_test
-    ./output/bazel test --test_output=errors examples/java-native/src/test/java/com/example/myproject:hello
+    ./output/bazel test --test_output=errors \
+        examples/cpp:hello-success_test \
+        examples/java-native/src/test/java/com/example/myproject:hello
   '';
 
   installPhase = ''

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jdk, zip, unzip, which, bash, binutils, coreutils }:
+{ stdenv, fetchurl, jdk, zip, unzip, which, bash, binutils, coreutils, makeWrapper }:
 
 stdenv.mkDerivation rec {
 
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
     unzip
     which
     binutils
+    makeWrapper
   ];
 
   # These must be propagated since the dependency is hidden in a compressed
@@ -83,6 +84,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     mv output/bazel $out/bin
+    wrapProgram "$out/bin/bazel" --prefix PATH : "${jdk}/bin"
   '';
 
   dontStrip = true;


### PR DESCRIPTION
###### Motivation for this change

Bazel can't start up unless javac is findable in $PATH or JAVA_HOME is set.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

