### PR TITLE
riak_cs: added authv4 support and fixed advanced.conf

### DIFF
--- a/nixos/modules/services/databases/riak-cs.nix
+++ b/nixos/modules/services/databases/riak-cs.nix
@@ -86,6 +86,14 @@ in
         '';
       };
 
+      authV4Enabled = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Enable V4 signature authorization for clients to use when connecting.
+        '';
+      };
+
       dataDir = mkOption {
         type = types.path;
         default = "/var/db/riak-cs";
@@ -110,13 +118,6 @@ in
         '';
       };
 
-      extraAdvancedConfig = mkOption {
-        type = types.lines;
-        default = "";
-        description = ''
-          Additional text to be appended to <filename>advanced.config</filename>.
-        '';
-      };
     };
 
   };
@@ -142,7 +143,13 @@ in
     '';
 
     environment.etc."riak-cs/advanced.config".text = ''
-      ${cfg.extraAdvancedConfig}
+      [
+       {riak_cs,
+        [
+         {stanchion_ssl, ${if cfg.stanchionSsl then "true" else "false"}},
+         {auth_v4_enabled, ${if cfg.authV4Enabled then "true" else "false"}}
+        ]}
+      ].
     '';
 
     users.extraUsers.riak-cs = {


### PR DESCRIPTION
###### Motivation for this change
1. Auth V4 should be supported within the Riak CS package
2. `/etc/riak-cs/advanced.conf` should be auto-filled to disable possible breaks within the Riak CS launch. Error is thrown with empty `/etc/riak-cs/advanced.conf` file.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

