### PR TITLE
release(-lib).nix: add nixpkgsArgs parameter

### DIFF
--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -1,17 +1,15 @@
 { supportedSystems
 , packageSet ? (import ../..)
 , scrubJobs ? true
+, # Attributes passed to nixpkgs. Don't build packages marked as unfree.
+  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
 
 with import ../../lib;
 
 rec {
 
-  # Ensure that we don't build packages marked as unfree.
-  allPackages = args: packageSet (args // {
-    config.allowUnfree = false;
-    config.inHydra = true;
-  });
+  allPackages = args: packageSet (args // nixpkgsArgs);
 
   pkgs = pkgsFor "x86_64-linux";
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -15,9 +15,11 @@
   supportedSystems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" ]
 , # Strip most of attributes when evaluating to spare memory usage
   scrubJobs ? true
+, # Attributes passed to nixpkgs. Don't build packages marked as unfree.
+  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
 
-with import ./release-lib.nix { inherit supportedSystems scrubJobs; };
+with import ./release-lib.nix { inherit supportedSystems scrubJobs nixpkgsArgs; };
 
 let
 


### PR DESCRIPTION
###### Motivation for this change
This allows customizing the nixpkgs arguments by the caller. My use case
is creating a personal nixpkgs channel containing some unfree packages.

The default is still to not build unfree packages, so for nixpkgs this
is no functional change.

This is a more flexible version of https://github.com/NixOS/nixpkgs/pull/23243

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

