### PR TITLE
idea.*: remove old versions

### DIFF
--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -146,18 +146,6 @@ in
     wmClass = "jetbrains-clion";
   };
 
-  idea14-community = buildIdea rec {
-    name = "idea-community-${version}";
-    version = "14.1.7";
-    description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
-    license = stdenv.lib.licenses.asl20;
-    src = fetchurl {
-      url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "1i4mdjm9dd6zvxlpdgd3bqg45ir0cfc9hl55cdc0hg5qwbz683fz";
-    };
-    wmClass = "jetbrains-idea-ce";
-  };
-
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
     version = "2016.3.4";

--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -218,18 +218,6 @@ in
     wmClass = "jetbrains-phpstorm";
   };
 
-  phpstorm10 = buildPhpStorm rec {
-    name = "phpstorm-${version}";
-    version = "10.0.4";
-    description = "Professional IDE for Web and PHP developers";
-    license = stdenv.lib.licenses.unfree;
-    src = fetchurl {
-      url = "https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz";
-      sha256 = "0fi042zvjpg5pn2mnhj3bbrdkl1b9vmhpf2l6ca4nr0rhjjv7dsm";
-    };
-    wmClass = "jetbrains-phpstorm";
-  };
-
   webstorm = buildWebStorm rec {
     name = "webstorm-${version}";
     version = "2016.3.3";

--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -146,18 +146,6 @@ in
     wmClass = "jetbrains-clion";
   };
 
-  clion1 = buildClion rec {
-    name = "clion-${version}";
-    version = "1.2.5";
-    description  = "C/C++ IDE. New. Intelligent. Cross-platform";
-    license = stdenv.lib.licenses.unfree;
-    src = fetchurl {
-      url = "https://download.jetbrains.com/cpp/${name}.tar.gz";
-      sha256 = "0ll1rcnnbd1if6x5rp3qw35lvp5zdzmvyg9n1lha89i34xiw36jp";
-    };
-    wmClass = "jetbrains-clion";
-  };
-
   idea14-community = buildIdea rec {
     name = "idea-community-${version}";
     version = "14.1.7";

--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -230,30 +230,6 @@ in
     wmClass = "jetbrains-rubymine";
   };
 
-  ruby-mine7 = buildRubyMine rec {
-    name = "ruby-mine-${version}";
-    version = "7.1.5";
-    description = "The Most Intelligent Ruby and Rails IDE";
-    license = stdenv.lib.licenses.unfree;
-    src = fetchurl {
-      url = "https://download.jetbrains.com/ruby/RubyMine-${version}.tar.gz";
-      sha256 = "04fcxj1xlap9mxmwf051s926p2darlj5kwl4lms2gy5d8b2lhd5l";
-    };
-    wmClass = "jetbrains-rubymine";
-  };
-
-  ruby-mine8 = buildRubyMine rec {
-    name = "ruby-mine-${version}";
-    version = "8.0.4";
-    description = "The Most Intelligent Ruby and Rails IDE";
-    license = stdenv.lib.licenses.unfree;
-    src = fetchurl {
-      url = "https://download.jetbrains.com/ruby/RubyMine-${version}.tar.gz";
-      sha256 = "0hipxib7377232w1jbf8h98bmh0djkllsrq3lq0w3fdxqglma43a";
-    };
-    wmClass = "jetbrains-rubymine";
-  };
-
   pycharm-community = buildPycharm rec {
     name = "pycharm-community-${version}";
     version = "2016.3.2";

--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -158,30 +158,6 @@ in
     wmClass = "jetbrains-idea-ce";
   };
 
-  idea14-ultimate = buildIdea rec {
-    name = "idea-ultimate-${version}";
-    version = "14.1.7";
-    description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
-    license = stdenv.lib.licenses.unfree;
-    src = fetchurl {
-      url = "https://download.jetbrains.com/idea/ideaIU-${version}.tar.gz";
-      sha256 = "1hhga1i2zbsipgq283gn19kv9n94inhr1bxh2yx19gz7yr4r49d2";
-    };
-    wmClass = "jetbrains-idea";
-  };
-
-  idea15-ultimate = buildIdea rec {
-    name = "idea-ultimate-${version}";
-    version = "15.0.6";
-    description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
-    license = stdenv.lib.licenses.unfree;
-    src = fetchurl {
-      url = "https://download.jetbrains.com/idea/ideaIU-${version}.tar.gz";
-      sha256 = "012aap2qn0jx4x34bdv9ivrsr86vvf683srb5vpj27hc4l6rw6ll";
-    };
-    wmClass = "jetbrains-idea";
-  };
-
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
     version = "2016.3.4";

--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -290,30 +290,6 @@ in
     wmClass = "jetbrains-webstorm";
   };
 
-  webstorm10 = buildWebStorm rec {
-    name = "webstorm-${version}";
-    version = "10.0.5";
-    description = "Professional IDE for Web and JavaScript development";
-    license = stdenv.lib.licenses.unfree;
-    src = fetchurl {
-      url = "https://download.jetbrains.com/webstorm/WebStorm-${version}.tar.gz";
-      sha256 = "0a5s6f99wyql5pgjl94pf4ljdbviik3b8dbr1s6b7c6jn1gk62ic";
-    };
-    wmClass = "jetbrains-webstorm";
-  };
-
-  webstorm11 = buildWebStorm rec {
-    name = "webstorm-${version}";
-    version = "11.0.4";
-    description = "Professional IDE for Web and JavaScript development";
-    license = stdenv.lib.licenses.unfree;
-    src = fetchurl {
-      url = "https://download.jetbrains.com/webstorm/WebStorm-${version}.tar.gz";
-      sha256 = "17agyqdyz6naxyx6p0y240ar93gja0ypw01nm2qmfzvh7ch03r24";
-    };
-    wmClass = "jetbrains-webstorm";
-  };
-
   datagrip = buildDataGrip rec {
     name = "datagrip-${version}";
     version = "2016.3.2";


### PR DESCRIPTION
###### Motivation for this change

Remove old version of JetBrains IDEs, no longer updated by JetBrains (and at least 3 majors versions has been released since this versions).

I splited #23081 to avoid confusion between version bump and clean-up.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

