### PR TITLE
arx-libertatis: 2016-07-27 -> 2017-02-26

### DIFF
--- a/pkgs/games/arx-libertatis/default.nix
+++ b/pkgs/games/arx-libertatis/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, fetchgit, cmake, zlib, boost,
+{ stdenv, fetchFromGitHub, cmake, zlib, boost,
   openal, glm, freetype, mesa, glew, SDL2,
   dejavu_fonts, inkscape, optipng, imagemagick }:
 
 stdenv.mkDerivation rec {
   name = "arx-libertatis-${version}";
-  version = "2016-07-27";
+  version = "2017-02-26";
 
-  src = fetchgit {
-    url = "https://github.com/arx/ArxLibertatis";
-    rev = "e3aa6353f90886e7e9db2f4350ad9a232dd01c1e";
-    sha256 = "1hkkf0z607z8wxdikxq1ji120b3w7pxixq9qapdj1p54dzgbhgza";
+  src = fetchFromGitHub {
+    owner  = "arx";
+    repo   = "ArxLibertatis";
+    rev    = "0d2bb46025b2ad0fd5c8bcddd1cc04750282608d";
+    sha256 = "11z0ndhk802jr3w3z5gfqw064g98v99xin883q1qd36jw96s27p5";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
#23253 This update should fix the build failure on i686-linux.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files (also cast a couple spells around)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
I tested the build with `--argstr system i686-linux` because I don't have a 32bit system, is it ok?