### PR TITLE
purescript: pin dependencies witih callHackage. Closes #23036.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -449,6 +449,18 @@ self: super: {
   apiary-session = dontCheck super.apiary-session;
   apiary-websockets = dontCheck super.apiary-websockets;
 
+  # See instructions provided by Peti in https://github.com/NixOS/nixpkgs/issues/23036
+  purescript = super.purescript.overrideScope (self: super: {
+    # TODO: Re-evaluate the following overrides after the 0.11 release.
+    aeson = self.aeson_0_11_3_0;
+    bower-json = self.bower-json_1_0_0_1;
+    optparse-applicative = self.optparse-applicative_0_13_1_0;
+    http-client = self.http-client_0_4_31_2;
+    http-client-tls = self.http-client-tls_0_2_4_1;
+    pipes = self.pipes_4_2_0;
+    websockets = self.websockets_0_9_8_2;
+  });
+
   # HsColour: Language/Unlambda.hs: hGetContents: invalid argument (invalid byte sequence)
   unlambda = dontHyperlinkSource super.unlambda;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2246,6 +2246,13 @@ extra-packages:
   - transformers == 0.4.3.*             # the latest version isn't supported by mtl yet
   - vector < 0.10.10                    # newer versions don't work with GHC 6.12.3
   - zlib < 0.6                          # newer versions break cabal-install
+  - aeson == 0.11.3.0                   # purescript 0.10.7
+  - bower-json == 1.0.0.1               # purescript 0.10.7
+  - optparse-applicative == 0.13.1.0    # purescript 0.10.7
+  - http-client == 0.4.31.2             # purescript 0.10.7
+  - http-client-tls == 0.2.4.1          # purescript 0.10.7
+  - pipes == 4.2.0                      # purescript 0.10.7
+  - websockets == 0.9.8.2               # purescript 0.10.7
 
 package-maintainers:
   peti:


### PR DESCRIPTION
###### Motivation for this change

Only tested on GHC 8.0.2 because of limited laptop computing power.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

