### PR TITLE
wgetpaste: 2.25 -> 2.28

### DIFF
--- a/pkgs/tools/text/wgetpaste/default.nix
+++ b/pkgs/tools/text/wgetpaste/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, wget, bash, coreutils }:
 
 stdenv.mkDerivation rec {
-  version = "2.25";
+  version = "2.28";
   name = "wgetpaste-${version}";
+
   src = fetchurl {
     url = "http://wgetpaste.zlin.dk/${name}.tar.bz2";
-    sha256 = "1x209j85mryp3hxmv1gfsbvw03k306k5fa65ky0zxx07cs70fzka";
+    sha256 = "1hh9svyypqcvdg5mjxyyfzpdzhylhf7s7xq5dzglnm4injx3i3ak";
   };
   # currently zsh-autocompletion support is not installed
 
@@ -23,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "Command-line interface to various pastebins";
     homepage = http://wgetpaste.zlin.dk/;
     license = stdenv.lib.licenses.publicDomain;
-    maintainers = with stdenv.lib.maintainers; [ qknight domenkozar ];
+    maintainers = with stdenv.lib.maintainers; [ qknight domenkozar ndowens ];
     platforms = stdenv.lib.platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [ x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

