### PR TITLE
libseccomp: 2.3.1  -> 2.3.2 + fixed scmp_sys_resolver

### DIFF
--- a/pkgs/development/libraries/libseccomp/default.nix
+++ b/pkgs/development/libraries/libseccomp/default.nix
@@ -1,26 +1,30 @@
-{ stdenv, fetchurl, getopt }:
-
-let version = "2.3.1"; in
+{ stdenv, fetchurl, getopt, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "libseccomp-${version}";
+  version = "2.3.2";
 
   src = fetchurl {
     url = "https://github.com/seccomp/libseccomp/releases/download/v${version}/libseccomp-${version}.tar.gz";
-    sha256 = "0asnlkzqms520r0dra08dzcz5hh6hs7lkajfw9wij3vrd0hxsnzz";
+    sha256 = "3ddc8c037956c0a5ac19664ece4194743f59e1ccd4adde848f4f0dae7f77bca1";
   };
 
-  buildInputs = [ getopt ];
+  buildInputs = [ getopt makeWrapper ];
 
   patchPhase = ''
     patchShebangs .
   '';
 
+  postInstall = ''
+    wrapProgram $out/bin/scmp_sys_resolver --prefix LD_LIBRARY_PATH ":" $out/lib
+  '';
+
   meta = with stdenv.lib; {
     description = "High level library for the Linux Kernel seccomp filter";
-    homepage    = "http://sourceforge.net/projects/libseccomp";
-    license     = licenses.lgpl2;
+    homepage    = "https://github.com/seccomp/libseccomp";
+    license     = licenses.lgpl21;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ thoughtpolice wkennington ];
   };
 }
+


### PR DESCRIPTION
###### Motivation for this change
- `libseccomp` is updated to 2.3.2
- `scmp_sys_resolver` is fixed (it could not find libseccomp.so.2 shared library before)

Up to now the `scmp_sys_resolver` command was not working because the bin could not find its shared lib :

>[demo@nixos:~/testbuild/libseccomp]$ scmp_sys_resolver 
>scmp_sys_resolver: error while loading shared libraries: libseccomp.so.2: cannot open shared object file: No such file or directory`

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

