### PR TITLE
numdiff: 5.8.1 -> 5.9.0

### DIFF
--- a/pkgs/tools/text/numdiff/default.nix
+++ b/pkgs/tools/text/numdiff/default.nix
@@ -1,23 +1,23 @@
 { stdenv, fetchurl }:
 
-let
-  version = "5.8.1";
-in
-stdenv.mkDerivation {
+
+stdenv.mkDerivation rec {
   name = "numdiff-${version}";
+  version = "5.9.0";
+
   src = fetchurl {
     url = "mirror://savannah/numdiff/numdiff-${version}.tar.gz";
-    sha256 = "00zm9955gjsid0daa94sbw69klk0vrnrrh0ihijza99kysnvmblr";
+    sha256 = "1vzmjh8mhwwysn4x4m2vif7q2k8i19x8azq7pzmkwwj4g48lla47";
   };
-  meta = {
+  meta = with stdenv.lib; {
     description = ''
       A little program that can be used to compare putatively similar files
       line by line and field by field, ignoring small numeric differences
       or/and different numeric formats
     '';
     homepage = http://www.nongnu.org/numdiff/;
-    license = stdenv.lib.licenses.gpl3Plus;
-    maintainers = [ stdenv.lib.maintainers.bbenoist ];
-    platforms = stdenv.lib.platforms.gnu;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ bbenoist ndowens ];
+    platforms = platforms.gnu;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Package update

###### Things done

- [ x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

