### PR TITLE
kytea: 0.4.6 -> 0.4.7; source was still pointing to version 0.4.6

### DIFF
--- a/pkgs/tools/text/kytea/default.nix
+++ b/pkgs/tools/text/kytea/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec {
   version = "0.4.7";
 
   src = fetchurl {
-    url    = "http://www.phontron.com/kytea/download/kytea-0.4.6.tar.gz";
-    sha256 = "0n6d88j0qda4dmy6mcj0cyin46n05m5phvjiah9i4ip54h8vs9s3";
+    url    = "http://www.phontron.com/kytea/download/${name}.tar.gz";
+    sha256 = "0ilzzwn5vpvm65bnbyb9f5rxyxy3jmbafw9w0lgl5iad1ka36jjk";
   };
 
   meta = with stdenv.lib; {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
     license = licenses.asl20;
 
-    maintainers = [ maintainers.ericsagnes ];
+    maintainers = with maintainers; [ ericsagnes ndowens ];
     platforms = platforms.linux;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Source was pointing to 0.4.6 even though version stated 0.4.7

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

