### PR TITLE
highlight: 3.28 -> 3.35

### DIFF
--- a/pkgs/tools/text/highlight/default.nix
+++ b/pkgs/tools/text/highlight/default.nix
@@ -2,19 +2,23 @@
 
 stdenv.mkDerivation rec {
   name = "highlight-${version}";
-  version = "3.28";
+  version = "3.35";
 
   src = fetchurl {
     url = "http://www.andre-simon.de/zip/${name}.tar.bz2";
-    sha256 = "1kg73isgz3czb1k6ccajqzifahr3zs9ci8168k0dlj31j1nlndin";
+    sha256 = "8a14b49f5e0c07daa9f40b4ce674baa00bb20061079473a5d386656f6d236d05";
   };
 
-  buildInputs = [ getopt lua boost pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ getopt lua boost ];
 
   preConfigure = ''makeFlags="PREFIX=$out conf_dir=$out/etc/highlight/"'';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Source code highlighting tool";
-    platforms = stdenv.lib.platforms.unix;
+    homepage = "http://www.andre-simon.de/doku/highlight/en/highlight.php";
+    platforms = platforms.unix;
+    maintainers = maintainers.ndowens;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

