### PR TITLE
enca: 1.16 -> 1.19

### DIFF
--- a/pkgs/tools/text/enca/default.nix
+++ b/pkgs/tools/text/enca/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchurl, libiconv, recode }:
 
 stdenv.mkDerivation rec {
-  name = "enca-1.16";
+  name = "enca-${version}";
+  version = "1.19";
 
   src = fetchurl {
     url = "http://dl.cihar.com/enca/${name}.tar.xz";
-    sha256 = "0hg7ggldam66l9j53nlrvi2lv1k99r2qfk6dh23vg6mi05cph7bw";
+    sha256 = "1f78jmrggv3jymql8imm5m9yc8nqjw5l99mpwki2245l8357wj1s";
   };
 
   buildInputs = [ recode libiconv ];
 
-  meta = {
-    homepage = http://freecode.com/projects/enca;
+  meta = with stdenv.lib; {
     description = "Detects the encoding of text files and reencodes them";
 
     longDescription = ''
@@ -22,8 +22,7 @@ stdenv.mkDerivation rec {
         Unicode variants, independently on language.
     '';
 
-    license = stdenv.lib.licenses.gpl2;
-
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl2;
+   
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

