### PR TITLE
zstdmt: init at 0.3

### DIFF
--- a/pkgs/tools/compression/zstdmt/default.nix
+++ b/pkgs/tools/compression/zstdmt/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, zstd, lz4 }:
+
+stdenv.mkDerivation rec {
+  name = "zstdmt-${version}";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    sha256 = "17i44kjc612sbs7diim9ih007zp7z9zs3q3yacd6dzlqya5vsp0w";
+    rev = "v${version}";
+    repo = "zstdmt";
+    owner = "mcmilk";
+  };
+
+  sourceRoot = "zstdmt-v${version}-src/unix";
+
+  buildInputs = [
+    zstd lz4
+  ];
+
+  buildPhase = ''
+    make zstdmt lz4mt
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    mv zstdmt lz4mt $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Multithreading Library for LZ4, LZ5 and ZStandard";
+    homepage = https://github.com/mcmilk/zstdmt;
+    license = with licenses; [ bsd2 ];
+
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4610,6 +4610,7 @@ with pkgs;
   zsh-autosuggestions = callPackage ../shells/zsh-autosuggestions { };
 
   zstd = callPackage ../tools/compression/zstd { };
+  zstdmt = callPackage ../tools/compression/zstdmt { };
 
   zsync = callPackage ../tools/compression/zsync { };
 


### PR DESCRIPTION
###### Motivation for this change
Multithreaded zstd & lz4

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

