### PR TITLE
Discount: 2.2.0 -> 2.2.2

### DIFF
--- a/pkgs/tools/text/discount/default.nix
+++ b/pkgs/tools/text/discount/default.nix
@@ -1,12 +1,14 @@
 {stdenv, fetchurl}:
+
 stdenv.mkDerivation rec {
-  version = "2.2.0";
+  version = "2.2.2";
   name = "discount-${version}";
 
   src = fetchurl {
     url = "http://www.pell.portland.or.us/~orc/Code/discount/discount-${version}.tar.bz2";
-    sha256 = "1wxrv86xr8cacwhzkyzmfxg58svfnn3swbpbk5hq621ckk19alxj";
+    sha256 = "0r4gjyk1ngx47zhb25q0gkjm3bz2m5x8ngrk6rim3y1y3rricygc";
   };
+
   patches = ./fix-configure-path.patch;
   configureScript = "./configure.sh";
 
@@ -14,7 +16,7 @@ stdenv.mkDerivation rec {
     description = "Implementation of Markdown markup language in C";
     homepage = "http://www.pell.portland.or.us/~orc/Code/discount/";
     license = licenses.bsd3;
-    maintainers = [ maintainers.shell ];
+    maintainers = with maintainers; [ shell ndowens ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

