### PR TITLE
catdoc: 0.94.2 -> 0.95

### DIFF
--- a/pkgs/tools/text/catdoc/default.nix
+++ b/pkgs/tools/text/catdoc/default.nix
@@ -1,18 +1,20 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "catdoc-0.94.2";
+  name = "catdoc-${version}";
+  version = "0.95";
+
   src = fetchurl {
     url = "http://ftp.wagner.pp.ru/pub/catdoc/${name}.tar.gz";
-    sha256 = "0qnk8fw3wc40qa34yqz51g0knif2jd78a4717nvd3rb46q88pj83";
+    sha256 = "514a84180352b6bf367c1d2499819dfa82b60d8c45777432fa643a5ed7d80796";
   };
 
   configureFlags = "--disable-wordview";
 
   meta = with stdenv.lib; {
     description = "MS-Word/Excel/PowerPoint to text converter";
-    platforms = platforms.all;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ maintainers.urkud ];
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ urkud ndowens ];
+    meta.platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

