### PR TITLE
xe: 0.5 -> 0.6.1

### DIFF
--- a/pkgs/tools/system/xe/default.nix
+++ b/pkgs/tools/system/xe/default.nix
@@ -2,19 +2,22 @@
 
 stdenv.mkDerivation rec {
   name = "xe-${version}";
-  version = "0.5";
+  version = "0.6.1";
+  
   src = fetchFromGitHub {
     owner = "chneukirchen";
     repo = "xe";
     rev = "v${version}";
-    sha256 = "0rv9npgjb695slql39asyp6znv9r3a6jbcsrsa1cmhk82iy4bljc";
+    sha256 = "1dr3xlfq3zfdba1q96iags572lbk3z6s2179rs3pvsgkxn4m0qpf";
   };
+
   makeFlags = "PREFIX=$(out)";
+  
   meta = with lib; {
     description = "Simple xargs and apply replacement";
     homepage = "https://github.com/chneukirchen/xe";
     license = licenses.publicDomain;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ cstrahan ];
+    maintainers = with maintainers; [ cstrahan ndowens ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

