### PR TITLE
logcheck: 1.3.17 -> 1.3.18

### DIFF
--- a/pkgs/tools/system/logcheck/default.nix
+++ b/pkgs/tools/system/logcheck/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, lockfileProgs, perl, mimeConstruct }:
 
 stdenv.mkDerivation rec {
-  _name   = "logcheck";
-  version = "1.3.17";
-  name    = "${_name}-${version}";
+  name = "logcheck-${version}";
+  version = "1.3.18";
+  _name    = "logcheck_${version}";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/l/${_name}/${_name}_${version}.tar.xz";
-    sha256 = "0fphzaljc9ddv1x6l3zdf9cbarqgzpdqaqwm3plmarcc7qrgrly2";
+    url = "mirror://debian/pool/main/l/logcheck/${_name}.tar.xz";
+    sha256 = "1x4skb5nmv2xj8cygj8pq1rd1ws4m2fsibw54yslgdyjri4r2yq7";
   };
 
   preConfigure = ''
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     "SHAREDIR=share/logtail/detectrotate"
  ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Mails anomalies in the system logfiles to the administrator";
     longDescription = ''
       Mails anomalies in the system logfiles to the administrator.
@@ -37,9 +37,8 @@ stdenv.mkDerivation rec {
       Logcheck was part of the Abacus Project of security tools, but this version has been rewritten.
     '';
     homepage = http://logcheck.org;
-    license = stdenv.lib.licenses.gpl2;
-
-    maintainers = [ stdenv.lib.maintainers.bluescreen303 ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.bluescreen303 ];
+    
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

