### PR TITLE
ioping: 0.9 -> 1.0

### DIFF
--- a/pkgs/tools/system/ioping/default.nix
+++ b/pkgs/tools/system/ioping/default.nix
@@ -1,18 +1,21 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   name = "ioping-${version}";
-  version = "0.9";
-  src = fetchurl {
-    url = "https://github.com/koct9i/ioping/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "0pbp7b3304y9yyv2w41l3898h5q8w77hnnnq1vz8qz4qfl4467lm";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "koct9i";
+    repo = "ioping";
+    rev = "v${version}";
+    sha256 = "0yn7wgd6sd39zmr5l97zd6sq1ah7l49k1h7dhgx0nv96fa4r2y9h";
   };
 
   makeFlags = "PREFIX=$(out)";
 
   meta = with stdenv.lib; {
     description = "Disk I/O latency measuring tool";
-    maintainers = with maintainers; [ raskin ];
+    maintainers = with maintainers; [ raskin ndowens ];
     platforms = platforms.unix;
     license = licenses.gpl3Plus;
     homepage = https://github.com/koct9i/ioping;


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

