### PR TITLE
networkmanager_dmenu: init at unstable-2017-04-13

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -218,6 +218,7 @@
   jcumming = "Jack Cummings <jack@mudshark.org>";
   jdagilliland = "Jason Gilliland <jdagilliland@gmail.com>";
   jefdaj = "Jeffrey David Johnson <jefdaj@gmail.com>";
+  jensbin = "Jens Binkert <jensbin@protonmail.com>";
   jerith666 = "Matt McHenry <github@matt.mchenryfamily.org>";
   jfb = "James Felix Black <james@yamtime.com>";
   jgeerds = "Jascha Geerds <jascha@jgeerds.name>";

--- a/pkgs/tools/networking/networkmanager_dmenu/default.nix
+++ b/pkgs/tools/networking/networkmanager_dmenu/default.nix
@@ -1,35 +1,40 @@
 { stdenv, glib, fetchFromGitHub, networkmanager, python3Packages
-, gobjectIntrospection, dmenu, makeWrapper }:
+, gobjectIntrospection, dmenu }:
 
 let inherit (python3Packages) python pygobject3;
 in stdenv.mkDerivation rec {
-  name = "networkmanager_dmenu-${version}";
-  version = "git-20170301";
+  name = "networkmanager_dmenu-unstable-${version}";
+  version = "2017-04-13";
 
   src = fetchFromGitHub {
     owner = "firecat53";
     repo = "networkmanager-dmenu";
-    rev = "f631f34645cd581eb14cb2f3286fa02dcc60283f";
-    sha256 = "0f3rkyhhyy3ab0bnaasazx33b952gfl3g3b3sg8fl00n90l53d11";
+    rev = "fbc0704702b32c2efb30ba6b5c0ad6f054a71a18";
+    sha256 = "1584zrhla1njvkrbvb1rq66q06gs510f0l1ls3z7x7jmn322y6yr";
   };
 
-  buildInputs = [ glib python pygobject3 makeWrapper gobjectIntrospection networkmanager ];
+  buildInputs = [ glib python pygobject3 gobjectIntrospection networkmanager python3Packages.wrapPython ];
 
-  phases = "unpackPhase installPhase";
+  dontBuild = true;
 
   installPhase = ''
     mkdir -p $out/bin
     cp networkmanager_dmenu $out/bin/
-    wrapProgram $out/bin/networkmanager_dmenu \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${pygobject3})"
   '';
+
+  postFixup = ''
+    makeWrapperArgs="\
+      --prefix GI_TYPELIB_PATH : $GI_TYPELIB_PATH \
+      --prefix PYTHONPATH : \"$(toPythonPath $out):$(toPythonPath ${pygobject3})\""
+    wrapPythonPrograms
+  '';
+
 
   meta = with stdenv.lib; {
     description  = "Small script to manage NetworkManager connections with dmenu instead of nm-applet";
     homepage     = https://github.com/firecat53/networkmanager-dmenu;
     license      = stdenv.lib.licenses.mit;
-    maintainers  = [ ];
+    maintainers  = [ stdenv.lib.maintainers.jensbin ];
     platforms    = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/tools/networking/networkmanager_dmenu/default.nix
+++ b/pkgs/tools/networking/networkmanager_dmenu/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, glib, fetchFromGitHub, networkmanager, python3Packages
+, gobjectIntrospection, dmenu, makeWrapper }:
+
+let inherit (python3Packages) python pygobject3;
+in stdenv.mkDerivation rec {
+  name = "networkmanager_dmenu-${version}";
+  version = "git-20170301";
+
+  src = fetchFromGitHub {
+    owner = "firecat53";
+    repo = "networkmanager-dmenu";
+    rev = "f631f34645cd581eb14cb2f3286fa02dcc60283f";
+    sha256 = "0f3rkyhhyy3ab0bnaasazx33b952gfl3g3b3sg8fl00n90l53d11";
+  };
+
+  buildInputs = [ glib python pygobject3 makeWrapper gobjectIntrospection networkmanager ];
+
+  phases = "unpackPhase installPhase";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp networkmanager_dmenu $out/bin/
+    wrapProgram $out/bin/networkmanager_dmenu \
+      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
+      --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${pygobject3})"
+  '';
+
+  meta = with stdenv.lib; {
+    description  = "Small script to manage NetworkManager connections with dmenu instead of nm-applet";
+    homepage     = https://github.com/firecat53/networkmanager-dmenu;
+    license      = stdenv.lib.licenses.mit;
+    maintainers  = [ ];
+    platforms    = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3055,6 +3055,8 @@ with pkgs;
 
   networkmanagerapplet = newScope gnome2 ../tools/networking/network-manager-applet { };
 
+  networkmanager_dmenu = callPackage ../tools/networking/networkmanager_dmenu  { };
+
   newsbeuter = callPackage ../applications/networking/feedreaders/newsbeuter { };
 
   newsbeuter-dev = callPackage ../applications/networking/feedreaders/newsbeuter/dev.nix { };


### PR DESCRIPTION
###### Motivation for this change
networkmanager_dmenu let yoy control NetworkManager via dmenu. This wasn't available in the nixpkgs yet.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

