### PR TITLE
cockatrice: 2015-09-24 -> 2017-01-20

### DIFF
--- a/pkgs/games/cockatrice/default.nix
+++ b/pkgs/games/cockatrice/default.nix
@@ -2,7 +2,7 @@
 }:
 
 stdenv.mkDerivation rec {
-    name = "${pname}-${version}";
+    name = "${pname}-unstable-${version}";
     pname = "cockatrice";
     version = "2017-01-20";
 

--- a/pkgs/games/cockatrice/default.nix
+++ b/pkgs/games/cockatrice/default.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation rec {
     name = "${pname}-${version}";
     pname = "cockatrice";
-    version = "2015-09-24";
+    version = "2017-01-20";
 
     src = fetchurl {
         url = "https://github.com/Cockatrice/Cockatrice/archive/${version}-Release.tar.gz";
-        sha256 = "068f93k3bg4cmdm0iyh2vfmk51nnzf3d6g6cvlm5q8dz1zk5nwzf";
+        sha256 = "1gbcn8vffqdagidlamx670jxymhzaw28r4c6aqg3pq0s6by1l65f";
     };
 
     buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Fixes build with QT 5.7.1 and Hydra failure in #23253

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

