### PR TITLE
tmate: 2.2.0 -> 2.2.1

### DIFF
--- a/pkgs/tools/misc/tmate/default.nix
+++ b/pkgs/tools/misc/tmate/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "tmate-${version}";
-  version = "2.2.0";
+  version = "2.2.1";
 
   src = fetchFromGitHub {
-    owner  = "nviennot";
+    owner  = "tmate-io";
     repo   = "tmate";
     rev    = version;
-    sha256 = "1w3a7na0yj1y0x24qckc7s2y9xfak5iv6vyqrd0iibn3b7dxarli";
+    sha256 = "0pfl9vrswzim9ydi1n652h3rax2zrmy6sqkp0r09yy3lw83h4y1r";
   };
 
   buildInputs = [ autoconf automake pkgconfig libtool zlib openssl libevent ncurses cmake ruby libmsgpack libssh ];


### PR DESCRIPTION
###### Motivation for this change

Minor upgrade

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

