### PR TITLE
lilyterm-git: init at 2017-01-06

### DIFF
--- a/pkgs/applications/misc/lilyterm/default.nix
+++ b/pkgs/applications/misc/lilyterm/default.nix
@@ -1,17 +1,39 @@
-{ stdenv, fetchurl
+{ stdenv, fetchurl, fetchFromGitHub
 , pkgconfig
 , autoconf, automake, intltool, gettext
-, gtk, vte }:
+, gtk, vte
 
+# "stable" or "git"
+, flavour ? "stable"
+}:
+
+assert flavour == "stable" || flavour == "git";
+
+let
+  stuff =
+    if flavour == "stable"
+    then rec {
+        version = "0.9.9.4";
+        src = fetchurl {
+          url = "http://lilyterm.luna.com.tw/file/lilyterm-${version}.tar.gz";
+          sha256 = "0x2x59qsxq6d6xg5sd5lxbsbwsdvkwqlk17iw3h4amjg3m1jc9mp";
+        };
+      }
+    else {
+        version = "2017-01-06";
+        src = fetchFromGitHub {
+          owner = "Tetralet";
+          repo = "lilyterm";
+          rev = "20cce75d34fd24901c9828469d4881968183c389";
+          sha256 = "0am0y65674rfqy69q4qz8izb8cq0isylr4w5ychi40jxyp68rkv2";
+        };
+      };
+
+in
 stdenv.mkDerivation rec {
-
   name = "lilyterm-${version}";
-  version = "0.9.9.4";
 
-  src = fetchurl {
-    url = "http://lilyterm.luna.com.tw/file/${name}.tar.gz";
-    sha256 = "0x2x59qsxq6d6xg5sd5lxbsbwsdvkwqlk17iw3h4amjg3m1jc9mp";
-  };
+  inherit (stuff) src version;
 
   buildInputs = [ pkgconfig autoconf automake intltool gettext gtk vte ];
 
@@ -29,7 +51,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://lilyterm.luna.com.tw/;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ AndersonTorres profpatsch ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14181,6 +14181,11 @@ with pkgs;
   lilyterm = callPackage ../applications/misc/lilyterm {
     inherit (gnome2) vte;
     gtk = gtk2;
+    flavour = "stable";
+  };
+
+  lilyterm-git = lilyterm.override {
+    flavour = "git";
   };
 
   lumail = callPackage ../applications/networking/mailreaders/lumail { };


### PR DESCRIPTION
The latest stable release is quite old (2013-02) and many improvements have been
made in the meantime.

New version builds, old version evaluates to the same store path.