### PR TITLE
httplab: init at 0.1.0

### DIFF
--- a/pkgs/tools/networking/httplab/default.nix
+++ b/pkgs/tools/networking/httplab/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "httplab-${version}";
+  version = "0.1.0";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/gchaincl/httplab";
+
+  src = fetchFromGitHub {
+    owner = "gchaincl";
+    repo = "httplab";
+    inherit rev;
+    sha256 = "19d0aasaxayvw25m9n2gahyq590dwym7k0fng8pqvrgc2mpl0ncw";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/gchaincl/httplab;
+    description = "Interactive WebServer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pradeepchhetri ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2144,6 +2144,8 @@ with pkgs;
 
   gzrt = callPackage ../tools/compression/gzrt { };
 
+  httplab = callPackage ../tools/networking/httplab { };
+
   partclone = callPackage ../tools/backup/partclone { };
 
   partimage = callPackage ../tools/backup/partimage { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

