### PR TITLE
delve: 0.11.0-alpha -> 0.12.1

### DIFF
--- a/pkgs/development/tools/delve/default.nix
+++ b/pkgs/development/tools/delve/default.nix
@@ -2,16 +2,16 @@
 
 buildGoPackage rec {
   name = "delve-${version}";
-  version = "0.11.0-alpha";
+  version = "0.12.1";
 
   goPackagePath = "github.com/derekparker/delve";
-  excludedPackages = "_fixtures";
+  excludedPackages = "\\(_fixtures\\|scripts\\|service/test\\)";
 
   src = fetchFromGitHub {
     owner = "derekparker";
     repo = "delve";
     rev = "v${version}";
-    sha256 = "10axxlvqpa6gx6pz2djp8bb08b83rdj1pavay0nqdd2crsb6rvgd";
+    sha256 = "0vkyx9sd66yrqz9sa4pysmpjv6gdgpfk1icrbjk93h2ry15ma8d6";
   };
 
   meta = {


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Upgrade delve to its most recent release.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

