### PR TITLE
qt5ct: 0.24 -> 0.30

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -87,6 +87,7 @@
   ./programs/mtr.nix
   ./programs/nano.nix
   ./programs/oblogout.nix
+  ./programs/qt5ct.nix
   ./programs/screen.nix
   ./programs/shadow.nix
   ./programs/shell.nix

--- a/nixos/modules/programs/qt5ct.nix
+++ b/nixos/modules/programs/qt5ct.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  meta.maintainers = [ maintainers.romildo ];
+
+  ###### interface
+  options = {
+    programs.qt5ct = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Whether to enable the Qt5 Configuration Tool (qt5ct), a
+          program that allows users to configure Qt5 settings (theme,
+          font, icons, etc.) under desktop environments or window
+          manager without Qt integration.
+
+          Official home page: <link xlink:href="https://sourceforge.net/projects/qt5ct/">https://sourceforge.net/projects/qt5ct/</link>
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+  config = mkIf config.programs.qt5ct.enable {
+    environment.variables.QT_QPA_PLATFORMTHEME = "qt5ct";
+    environment.systemPackages = [ pkgs.qt5ct ];
+  };
+}

--- a/pkgs/tools/misc/qt5ct/default.nix
+++ b/pkgs/tools/misc/qt5ct/default.nix
@@ -2,18 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "qt5ct-${version}";
-  version = "0.24";
+  version = "0.30";
 
   src = fetchurl {
     url = "mirror://sourceforge/qt5ct/qt5ct-${version}.tar.bz2";
-    sha256 = "0k62nd945pbgkshycijzrgdyrwj5kcswk33slaj7hr7d6r7bmb6p";
+    sha256 = "1k0ywd440qvf84chadjb4fnkn8dkfl56cc3a6wqg6a59drslvng6";
   };
 
   buildInputs = [ qtbase qtsvg ];
   nativeBuildInputs = [ makeQtWrapper qmakeHook qttools ];
 
   preConfigure = ''
-    qmakeFlags="$qmakeFlags PLUGINDIR=$out/lib/qt5/plugins/platformthemes/"
+    qmakeFlags="$qmakeFlags PLUGINDIR=$out/lib/qt5/plugins"
   '';
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change

There are new releases.

[Changelog:](https://www.linux-apps.com/p/1131604/)

**0.30**

fixed crash on nonexistent style in qt5ct.conf
fixed issue with KDE color themes
updated documentation
updated Bulgarian translation
updated French translation

**0.29**

fixed libqt5ct-style.so installation path
updated Greek translation

**0.28**

added Qt 5.8 support
added qt5ct proxy-style plugin
added Serbian translation
updated Bulgarian translation
updated Italian translation
updated Russian translation
updated Dutch (Netherlands) translation
updated Czech translation
updated German translation
updated Chinese (Taiwan) translation

**0.27**

added D-Bus tray support
added feature to disable debug output
updated documentation

**0.26**

fixed stellarium compatibility
updated French translation
updated Greek translation

**0.25**

added environment variables verification
added Frensh translation
updated Slovak translation
updated Russian translation
updated Czech translation
updated German translation
updated Dutch (Netherlands) translation
updated Polish translation
updated Chinese (Taiwan) translation

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).