### PR TITLE
locate: fix security.wrappers

### DIFF
--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -104,13 +104,13 @@ in {
     users.extraGroups = mkIf isMLocate { mlocate = {}; };
 
     security.wrappers = mkIf isMLocate {
-      mlocate = {
+      locate = {
         group = "mlocate";
         owner = "root";
         permissions = "u+rx,g+x,o+x";
         setgid = true;
         setuid = false;
-        program = "locate";
+        source = "${cfg.locate}/bin/locate";
       };
     };
 


### PR DESCRIPTION
###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).