### PR TITLE
eflite: init at 0.4.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -223,6 +223,7 @@
   jgeerds = "Jascha Geerds <jascha@jgeerds.name>";
   jgertm = "Tim Jaeger <jger.tm@gmail.com>";
   jgillich = "Jakob Gillich <jakob@gillich.me>";
+  jhhuh = "Ji-Haeng Huh <jhhuh.note@gmail.com>";
   jirkamarsik = "Jirka Marsik <jiri.marsik89@gmail.com>";
   joachifm = "Joachim Fasting <joachifm@fastmail.fm>";
   joamaki = "Jussi Maki <joamaki@gmail.com>";

--- a/pkgs/applications/audio/eflite/buf-overflow
+++ b/pkgs/applications/audio/eflite/buf-overflow
@@ -16,7 +16,7 @@ Fix buffer overflow
  
    if ((flags & 0xffff) > DEBUG) return;
 -  sprintf(logname, "%s/es.log", getenv("HOME"));
-+  sprintf(logname, sizeof(logname), "%s/es.log", getenv("HOME"));
++  snprintf(logname, sizeof(logname), "%s/es.log", getenv("HOME"));
    va_start(arg, text);
    vsnprintf(buf, 200, text, arg);
    va_end(arg);

--- a/pkgs/applications/audio/eflite/buf-overflow
+++ b/pkgs/applications/audio/eflite/buf-overflow
@@ -1,0 +1,22 @@
+Fix buffer overflow
+
+--- eflite-0.4.1.orig/es.c
++++ eflite-0.4.1/es.c
+@@ -329,7 +329,7 @@
+   char *p;
+ 
+   p = getenv("HOME");
+-  sprintf(buf, "%s/.es.conf", p);
++  snprintf(buf, sizeof(buf), "%s/.es.conf", p);
+   fp = fopen(buf, "r");
+   if (!fp) fp = fopen("/etc/es.conf", "r");
+   if (!fp) return 1;
+@@ -438,7 +438,7 @@
+   char logname[200];
+ 
+   if ((flags & 0xffff) > DEBUG) return;
+-  sprintf(logname, "%s/es.log", getenv("HOME"));
++  sprintf(logname, sizeof(logname), "%s/es.log", getenv("HOME"));
+   va_start(arg, text);
+   vsnprintf(buf, 200, text, arg);
+   va_end(arg);

--- a/pkgs/applications/audio/eflite/cvs-update
+++ b/pkgs/applications/audio/eflite/cvs-update
@@ -1,0 +1,98 @@
+--- eflite-0.4.1.orig/fs.c
++++ eflite-0.4.1/fs.c
+@@ -9,7 +9,7 @@
+  * GNU General Public License, as published by the Free Software
+  * Foundation.  Please see the file COPYING for details.
+  *
+- * $Id: fs.c,v 1.19 2007/01/18 23:58:42 mgorse Exp $
++ * $Id: fs.c,v 1.22 2008/03/05 15:21:43 mgorse Exp $
+  *
+  * Notes:
+  *
+@@ -505,19 +505,6 @@
+   }
+ }
+ 
+-
+-
+-static void play_audio_close(void *cancel)
+-{
+-  if (audiodev)
+-  {
+-	audio_drain(audiodev);
+-	close_audiodev();
+-	//	usleep(5000);
+-  }
+-}
+-
+-
+ static inline void determine_playlen(int speed, cst_wave *wptr, int type, int *pl, int *s)
+ {
+   int playlen, skip;
+@@ -573,12 +560,12 @@
+ 	type = ac[ac_head].type;
+ 	WAVE_UNLOCK;
+ 	pthread_testcancel();
+-	pthread_cleanup_push(play_audio_close, NULL);
+-
++	
+ 	es_log(2, "Opening audio device.");
+ 	/* We abuse the wave mutex here to avoid being canceled
+ 	 * while the audio device is being openned */
+ 	WAVE_LOCK;
++	assert(audiodev == NULL);
+ 	audiodev = audio_open(wptr->sample_rate, wptr->num_channels, CST_AUDIO_LINEAR16);
+ 	WAVE_UNLOCK;
+ 	if (audiodev == NULL)
+@@ -606,8 +593,8 @@
+ #ifdef DEBUG
+ 	  start_time = get_ticks_count();
+ #endif
+-	  pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+       audio_write(audiodev, wptr->samples + skip, playlen * 2);
++      pthread_testcancel();
+ 	  es_log(2, "Write took %.2f seconds.", get_ticks_count() - start_time);
+ 	}
+     es_log(2, "play: syncing.");
+@@ -617,16 +604,16 @@
+     audio_flush(audiodev);
+ 	pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+ 	es_log(2, "Flush took %.2f seconds.", get_ticks_count() - start_time);
+-    es_log(2, "play: Closing audio device");
+-	close_audiodev();
+-	pthread_cleanup_pop(0);
+-	  pthread_testcancel();
+-	  TEXT_LOCK;
++    	pthread_testcancel();
++
++	TEXT_LOCK;
+     time_left -= ((float)playlen) / wptr->sample_rate;
+ 	pthread_cond_signal(&text_condition);
+ 	TEXT_UNLOCK;
+ 
+ 	WAVE_LOCK;
++	es_log(2, "play: Closing audio device");
++	close_audiodev();
+     ac_destroy(&ac[ac_head]);
+ 	ac_head++;
+ 	if (ac_head == ac_tail)
+@@ -894,6 +881,7 @@
+ 	WAVE_LOCK_NI;
+ 	pthread_cond_signal(&wave_condition); // necessary because we inhibit cancellation while waiting
+ 	pthread_cancel(wave_thread);
++	if (audiodev != NULL) audio_drain(audiodev);
+ 	WAVE_UNLOCK_NI;
+   }
+ 
+@@ -917,7 +905,10 @@
+   }
+ 	
+   /* At this point, no thread is running */
+-  
++
++  // Make sure audio device is closed
++  close_audiodev();
++
+   /* Free any wave data */
+   es_log(2, "s_clear: freeing wave data: %d", ac_tail);
+   for (i = 0; i < ac_tail; i++)

--- a/pkgs/applications/audio/eflite/default.nix
+++ b/pkgs/applications/audio/eflite/default.nix
@@ -1,0 +1,31 @@
+{stdenv,fetchurl,flite,alsaLib}:
+
+stdenv.mkDerivation rec {
+  name = "eflite-${version}";
+  version = "0.4.1";
+  src = fetchurl {
+    url = "https://sourceforge.net/projects/eflite/files/eflite/${version}/${name}.tar.gz";
+    sha256 = "088p9w816s02s64grfs28gai3lnibzdjb9d1jwxzr8smbs2qbbci";
+  };
+  buildInputs = [ flite alsaLib ];
+  configureFlags = "flite_dir=${flite} --with-audio=alsa";
+  patches = [
+    ./buf-overflow
+    ./cvs-update
+    ./link
+  ]; # Patches are taken from debian.
+
+  meta = {
+    homepage = http://eflite.sourceforge.net;
+    description = "EFlite is a speech server for screen readers";
+    longDescription = ''
+      EFlite is a speech server for Emacspeak and other screen
+      readers that allows them to interface with Festival Lite,
+      a free text-to-speech engine developed at the CMU Speech
+      Center as an off-shoot of Festival.
+    ''; 
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ jhhuh ];
+  };
+}

--- a/pkgs/applications/audio/eflite/default.nix
+++ b/pkgs/applications/audio/eflite/default.nix
@@ -1,4 +1,4 @@
-{stdenv,fetchurl,flite,alsaLib}:
+{stdenv,fetchurl,flite,alsaLib,debug ? false}:
 
 stdenv.mkDerivation rec {
   name = "eflite-${version}";
@@ -13,8 +13,9 @@ stdenv.mkDerivation rec {
     ./buf-overflow
     ./cvs-update
     ./link
+    ./format.patch
   ]; # Patches are taken from debian.
-
+  CFLAGS = stdenv.lib.optionalString debug " -DDEBUG=2";
   meta = {
     homepage = http://eflite.sourceforge.net;
     description = "EFlite is a speech server for screen readers";

--- a/pkgs/applications/audio/eflite/default.nix
+++ b/pkgs/applications/audio/eflite/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "088p9w816s02s64grfs28gai3lnibzdjb9d1jwxzr8smbs2qbbci";
   };
   buildInputs = [ flite alsaLib ];
-  configureFlags = "flite_dir=${flite} --with-audio=alsa";
+  configureFlags = "flite_dir=${flite} --with-audio=alsa --with-vox=cmu_us_kal16";
   patches = [
     ./buf-overflow
     ./cvs-update

--- a/pkgs/applications/audio/eflite/format.patch
+++ b/pkgs/applications/audio/eflite/format.patch
@@ -1,0 +1,11 @@
+--- eflite-0.4.1.orig/es.c	2017-03-02 14:38:36.009731423 +0100
++++ eflite-0.4.1/es.c	2017-03-02 14:39:06.285894934 +0100
+@@ -449,7 +449,7 @@
+   fclose(fp);
+   if (flags & LOG_STDERR)
+   {
+-    fprintf(stderr, buf);
++    fputs(buf, stderr);
+     fprintf(stderr, "\n");
+   }
+ #endif

--- a/pkgs/applications/audio/eflite/link
+++ b/pkgs/applications/audio/eflite/link
@@ -1,13 +1,11 @@
-Link with shared libs
-
---- eflite-0.4.1.orig/Makefile.in
-+++ eflite-0.4.1/Makefile.in
-@@ -28,7 +28,7 @@
- #CFLAGS+= -DDEBUG=2
- 
- # For making releases
--FLITE_LIBS:=-L$(flite_dir)/lib -lflite_$(FL_VOX) -lflite_$(FL_LEX) -lflite_$(FL_LANG) -lflite
-+FLITE_LIBS:=-L$(flite_dir)/lib -lflite_$(subst cmu_us_kal16,cmu_us_kal,$(FL_VOX)) -lflite_$(FL_LEX) -lflite_$(FL_LANG) -lflite
- 
- eflite: fs.o es.o soccon.o sockopen.o tone.o
+--- eflite-0.4.1/Makefile.in	2007-01-19 01:01:09.000000000 +0100
++++ eflite-0.4.1-new/Makefile.in	2017-03-01 23:25:34.223615492 +0100
+@@ -34,7 +34,7 @@
  	$(CC) $(LDFLAGS) -o $@ $^ -lm $(LIBS) $(FLITE_LIBS) $(AUDIOLIBS)
+ 
+ fs.o: fs.c
+-	$(CC) $(CFLAGS) @AUDIODEFS@ -I. -I$(flite_include_dir) -DREGISTER_VOX=register_$(subst cmu_us_kal16,cmu_us_kal,$(FL_VOX)) -DSTANDALONE -DEFLITE -c -o $@ $<
++	$(CC) $(CFLAGS) @AUDIODEFS@ -I. -I$(flite_include_dir) -DREGISTER_VOX=register_$(FL_VOX) -DSTANDALONE -DEFLITE -c -o $@ $<
+ 
+ tone.o: tone.c
+ 	$(CC) $(CFLAGS) -I$(flite_include_dir) -DEFLITE -c -o $@ $<

--- a/pkgs/applications/audio/eflite/link
+++ b/pkgs/applications/audio/eflite/link
@@ -1,0 +1,13 @@
+Link with shared libs
+
+--- eflite-0.4.1.orig/Makefile.in
++++ eflite-0.4.1/Makefile.in
+@@ -28,7 +28,7 @@
+ #CFLAGS+= -DDEBUG=2
+ 
+ # For making releases
+-FLITE_LIBS:=-L$(flite_dir)/lib -lflite_$(FL_VOX) -lflite_$(FL_LEX) -lflite_$(FL_LANG) -lflite
++FLITE_LIBS:=-L$(flite_dir)/lib -lflite_$(subst cmu_us_kal16,cmu_us_kal,$(FL_VOX)) -lflite_$(FL_LEX) -lflite_$(FL_LANG) -lflite
+ 
+ eflite: fs.o es.o soccon.o sockopen.o tone.o
+ 	$(CC) $(LDFLAGS) -o $@ $^ -lm $(LIBS) $(FLITE_LIBS) $(AUDIOLIBS)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1573,6 +1573,8 @@ with pkgs;
 
   edk2 = callPackage ../development/compilers/edk2 { };
 
+  eflite = callPackage ../applications/audio/eflite {};
+
   eid-mw = callPackage ../tools/security/eid-mw { };
 
   eid-viewer = callPackage ../tools/security/eid-viewer { };


### PR DESCRIPTION
###### Motivation for this change
New package added. All the patches are from the corresponding debian package.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

