### PR TITLE
Use EnvironmentFile instead of Environment in systemd units. Closes #…

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -318,12 +318,18 @@ let
         ''
           [Service]
           ${let env = cfg.globalEnvironment // def.environment;
-            in concatMapStrings (n:
-              let s = optionalString (env."${n}" != null)
-                "Environment=${builtins.toJSON "${n}=${env.${n}}"}\n";
-              # systemd max line length is now 1MiB
-              # https://github.com/systemd/systemd/commit/e6dde451a51dc5aaa7f4d98d39b8fe735f73d2af
-              in if stringLength s >= 1048576 then throw "The value of the environment variable ‘${n}’ in systemd service ‘${name}.service’ is too long." else s) (attrNames env)}
+                # @ not allowed in writeText name
+                safeName = builtins.replaceStrings [ "@" ]  [ "_" ] name;
+                # NB that we use toJSON for correct escaping
+                # The systemd escaping rules might not be exactly the same
+                # but this is close enough.
+                envFileData = lib.concatStrings (lib.mapAttrsToList (key: value: "${key}=${builtins.toJSON value}\n") env);
+                envFile = pkgs.writeText "${safeName}-environment" envFileData;
+                envInline = lib.mapAttrsToList (key: value: "Environment=${builtins.toJSON "${key}=${value}"}\n") env;
+                tooLong = lib.any (s: stringLength s >= 2048) envInline;
+            in if tooLong
+               then "EnvironmentFile=${envFile}"
+               else lib.concatStrings envInline}
           ${if def.reloadIfChanged then ''
             X-ReloadIfChanged=true
           '' else if !def.restartIfChanged then ''

--- a/nixos/tests/systemd-spill-to-environmentfile.nix
+++ b/nixos/tests/systemd-spill-to-environmentfile.nix
@@ -1,0 +1,30 @@
+# Test that long environment variables spill over into an
+# EnvironmentFile.
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "systemd-spill-to-environmentfile";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ teh ];
+  };
+
+  machine = { config, pkgs, lib, ... }: {
+    imports = [ ../modules/profiles/minimal.nix ];
+    systemd.services.long-env-unit = {
+      wantedBy = [ "multi-user.target" ];
+      script = "true";
+      serviceConfig.Type = "oneshot";
+      serviceConfig.RemainAfterExit = true;
+      environment = {
+        SHORTVAR = "shortvar";
+        # exacly 1 MiB long
+        LONGVAR = lib.concatStrings (builtins.map (x: "longvar.") (lib.range 1 256));
+      };
+    };
+  };
+
+  testScript =
+    ''
+      startAll;
+      $machine->waitForUnit("long-env-unit.service");
+      $machine->shutdown;
+    '';
+})


### PR DESCRIPTION
…22829.

This is the simplest solution I could come up with.

We could also add an if-statement and only write environment files if the line would be longer than 2048, but then we'd introduce a potentially untested branch.
