### PR TITLE
msgpack-tools: fix hydra build

### DIFF
--- a/pkgs/development/tools/msgpack-tools/default.nix
+++ b/pkgs/development/tools/msgpack-tools/default.nix
@@ -1,17 +1,39 @@
-{ stdenv, fetchFromGitHub, cmake }:
-
+{ stdenv, fetchurl, fetchFromGitHub, cmake, unzip }:
 stdenv.mkDerivation rec {
   name = "msgpack-tools-${version}";
-  version = "v0.6";
+  version = "0.6";
 
   src = fetchFromGitHub {
     owner = "ludocode";
     repo = "msgpack-tools";
-    rev = version;
+    rev = "v${version}";
     sha256 = "1ygjk25zlpqjckxgqmahnz999704zy2bd9id6hp5jych1szkjgs5";
   };
 
-  buildInputs = [ cmake ];
+  libb64 = fetchurl {
+    url = "mirror://sourceforge/libb64/libb64-1.2.1.zip";
+    sha256 = "1chlcc8qggzxnbpy5wrda533xyz38dk20w9wl4srrzawm45ny410";
+  };
+
+  rapidjson = fetchurl {
+    url = "https://github.com/miloyip/rapidjson/archive/99ba17bd66a85ec64a2f322b68c2b9c3b77a4391.tar.gz";
+    sha256 = "0jxgyy5n0lf9w36dycwwgz2wici4z9dnxlsn0z6m23zaa47g3wyw";
+  };
+
+  mpack = fetchurl {
+    url = "https://github.com/ludocode/mpack/archive/df17e83f0fa8571b9cd0d8ccf38144fa90e244d1.tar.gz";
+    sha256 = "1br8g3rf86h8z8wbqkd50aq40953862lgn0xk7cy68m07fhqc3pg";
+  };
+
+  postUnpack = ''
+    mkdir $sourceRoot/contrib
+    cp ${rapidjson} $sourceRoot/contrib/rapidjson-99ba17bd66a85ec64a2f322b68c2b9c3b77a4391.tar.gz
+    cp ${libb64} $sourceRoot/contrib/libb64-1.2.1.zip
+    cp ${mpack} $sourceRoot/contrib/mpack-df17e83f0fa8571b9cd0d8ccf38144fa90e244d1.tar.gz
+  '';
+
+
+  buildInputs = [ cmake unzip ];
 
   meta = with stdenv.lib; {
     description = "Command-line tools for converting between MessagePack and JSON";


### PR DESCRIPTION
###### Motivation for this change
At the moment msgpack-tools fails when built by hydra as the cmake list downloads additional sources. This needs to be fixed for #23253.
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

