### PR TITLE
Revert "buildRustPackage: fix deprecated use of registry.index config…

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-deps
+++ b/pkgs/build-support/rust/fetch-cargo-deps
@@ -11,11 +11,8 @@ fetchCargoDeps() {
     echo "Using rust registry from $rustRegistry"
 
     cat <<EOF > $out/config
-[source.nix-store-rust-registry]
-registry = "file://$rustRegistry"
-
-[source.crates-io]
-replace-with = "nix-store-rust-registry"
+[registry]
+index = "file://$rustRegistry"
 EOF
 
     export CARGO_HOME=$out


### PR DESCRIPTION
This reverts commit e8aa8cc94be45103fcd32b5f0bfee4a55eae4080.

It's broken (https://github.com/NixOS/nixpkgs/issues/23282), and it's safe to revert while I figure out why it broke/how to do this correctly.