### PR TITLE
augeas: 1.5.0 -> 1.7.0

### DIFF
--- a/pkgs/tools/system/augeas/default.nix
+++ b/pkgs/tools/system/augeas/default.nix
@@ -2,20 +2,20 @@
 
 stdenv.mkDerivation rec {
   name = "augeas-${version}";
-  version = "1.5.0";
+  version = "1.7.0";
 
   src = fetchurl {
     url = "http://download.augeas.net/${name}.tar.gz";
-    sha256 = "0gzpafrflkr0incq58vjkabfncrpc97d7mdgglkr57iyzvkbcfr2";
+    sha256 = "0qwpjz23z1x7dkf5k2y9f1cppryzhx4hpxprla6a4yvzs1smacdr";
   };
-
-  buildInputs = [ pkgconfig readline libxml2 ];
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ readline libxml2 ];
 
   meta = with stdenv.lib; {
     description = "Configuration editing tool";
     license = licenses.lgpl2;
     homepage = http://augeas.net/;
-    maintainers = with maintainers; [offline];
+    maintainers = with maintainers; [ offline ndowens ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

