### PR TITLE
amtterm: 1.4 -> 1.6-1

### DIFF
--- a/pkgs/tools/system/amtterm/default.nix
+++ b/pkgs/tools/system/amtterm/default.nix
@@ -1,15 +1,16 @@
 { fetchurl, stdenv, makeWrapper, perl, perlPackages }:
 
-let version = "1.4"; in
-stdenv.mkDerivation {
-  name = "amtterm-"+version;
 
+stdenv.mkDerivation rec {
+  name = "amtterm-${version}";
+  version = "1.6-1";
+  
   buildInputs = with perlPackages; [ perl SOAPLite ];
   nativeBuildInputs = [ makeWrapper ];
 
   src = fetchurl {
-    url = "https://www.kraxel.org/cgit/amtterm/snapshot/amtterm-a75e48e010e92dc5540e2142efc445ccb0ab1a42.tar.gz";
-    sha256 = "0i4ny5dyf3fy3sd65zw9v4xxw3rc3qyn8r8y8gwwgankj6iqkqp4";
+    url = "https://www.kraxel.org/cgit/amtterm/snapshot/${name}.tar.gz";
+    sha256 = "1jxcsqkag2bxmrnr4m6g88sln1j2d9liqlna57fj8kkc85316vlc";
   };
 
   makeFlags = [ "prefix=$(out)" ];


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

