### PR TITLE
cytoscape: fixed issue with startup script

### DIFF
--- a/pkgs/applications/science/misc/cytoscape/default.nix
+++ b/pkgs/applications/science/misc/cytoscape/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
     ln -s $out/share/cytoscape.sh $out/bin/cytoscape
 
-    wrapProgram $out/share/gen_vmoptions.sh \
+    wrapProgram $out/share/cytoscape.sh \
       --set JAVA_HOME "${jre}" \
       --set JAVA  "${jre}/bin/java"
 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/23347

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

