### PR TITLE
httping: 2.4 -> 2.5

### DIFF
--- a/pkgs/tools/networking/httping/default.nix
+++ b/pkgs/tools/networking/httping/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "httping-${version}";
-  version = "2.4";
+  version = "2.5";
 
   src = fetchurl {
-    url = "http://www.vanheusden.com/httping/${name}.tgz";
-    sha256 = "1110r3gpsj9xmybdw7w4zkhj3zmn5mnv2nq0ijbvrywbn019zdfs";
+    url = "https://www.vanheusden.com/httping/${name}.tgz";
+    sha256 = "3e895a0a6d7bd79de25a255a1376d4da88eb09c34efdd0476ab5a907e75bfaf8";
   };
 
   buildInputs = [ fftw ncurses openssl ];
@@ -27,7 +27,8 @@ stdenv.mkDerivation rec {
       the transmission across the network also takes time! So it measures the
       latency of the webserver + network. It supports IPv6.
     '';
+    license     = licenses.agpl3;
     maintainers = with maintainers; [ nckx rickynils ];
-    platforms = platforms.linux;
+    platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Package update.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

