### PR TITLE
sstp: 1.0.10 -> 1.0.11

### DIFF
--- a/pkgs/tools/networking/sstp/default.nix
+++ b/pkgs/tools/networking/sstp/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "sstp-client-${version}";
-  version = "1.0.10";
+  version = "1.0.11";
 
   src = fetchurl {
     url = "mirror://sourceforge/sstp-client/sstp-client/${version}/sstp-client-${version}.tar.gz";
-    sha256 = "096lw3a881hjqnffms3bl077pjyq77870kjaf83chhjcakc8942z";
+    sha256 = "087vp3n7nv001fsgbmkjpgl3a2vhbix22cflrqi5bv9h8181p18v";
   };
 
   patchPhase =


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

