### PR TITLE
quicktun: 2.2.4 -> 2.2.5

### DIFF
--- a/pkgs/tools/networking/quicktun/default.nix
+++ b/pkgs/tools/networking/quicktun/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "quicktun-${version}";
-  version = "2.2.4";
+  version = "2.2.5";
 
   src = fetchFromGitHub {
     owner = "UCIS";
     repo = "QuickTun";
-    rev = "980fe1b8c718d6df82af1d57b56140c0e541dbe0";
-    sha256 = "0m7gvlgs1mhyw3c8s2dg05j7r7hz8kjpb0sk245m61ir9dmwlf8i";
+    rev = "2d0c6a9cda8c21f921a5d1197aeee92e9568ca39";
+    sha256 = "1ydvwasj84qljfbzh6lmhyzjc20yw24a0v2mykp8afsm97zzlqgx";
   };
 
   buildInputs = [ libsodium ];


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

