### PR TITLE
par2cmdline: 0.6.11 -> 0.6.13

### DIFF
--- a/pkgs/tools/networking/par2cmdline/default.nix
+++ b/pkgs/tools/networking/par2cmdline/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0jxixkc8vid933nph2mvhgz58my42kwjlzbir38hml2xrzq00d8f";
   };
 
-  buildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/BlackIkeEagle/par2cmdline;

--- a/pkgs/tools/networking/par2cmdline/default.nix
+++ b/pkgs/tools/networking/par2cmdline/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchzip, autoreconfHook }:
+{ stdenv, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name    = "par2cmdline-${version}";
-  version = "0.6.11";
+  version = "0.6.13";
 
-  src = fetchzip {
-    url = "https://github.com/BlackIkeEagle/par2cmdline/archive/v${version}.tar.gz";
-    sha256 = "0maywssv468ia7rf8jyq4axwahgli3nfykl7x3zip503psywjj8a";
+  src = fetchFromGitHub {
+    owner = "Parchive";
+    repo = "par2cmdline";
+    rev = "v${version}";
+    sha256 = "0jxixkc8vid933nph2mvhgz58my42kwjlzbir38hml2xrzq00d8f";
   };
 
   buildInputs = [ autoreconfHook ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/BlackIkeEagle/par2cmdline;
     description = "PAR 2.0 compatible file verification and repair tool";
     longDescription = ''
@@ -19,8 +21,8 @@ stdenv.mkDerivation rec {
       damage in data files and repair them if necessary. It can be used with
       any kind of file.
     '';
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = [ stdenv.lib.maintainers.muflax ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.muflax ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

