### PR TITLE
slack: 2.3.4 -> 2.5.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -4,7 +4,7 @@
 
 let
 
-  version = "2.3.4";
+  version = "2.5.1";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -42,8 +42,8 @@ let
   src =
     if stdenv.system == "x86_64-linux" then
       fetchurl {
-        url = "https://slack-ssb-updates.global.ssl.fastly.net/linux_releases/slack-desktop-${version}-amd64.deb";
-        sha256 = "01kr7maj8f4yinyri7rs4pmzab9cvp48xfqw3ilirx4mvh8mr1fd";
+        url = "https://downloads.slack-edge.com/linux_releases/slack-desktop-${version}-amd64.deb";
+        sha256 = "1rrhgqmz0ajv2135bzykv3dq0mifzf5kiycgrisk2sfxn6nwyyvj";
       }
     else
       throw "Slack is not supported on ${stdenv.system}";

--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -59,7 +59,7 @@ in stdenv.mkDerivation {
     mkdir -p $out
     dpkg -x $src $out
     cp -av $out/usr/* $out
-    rm -rf $out/usr $out/share/lintian
+    rm -rf $out/etc $out/usr $out/share/lintian
 
     # Otherwise it looks "suspicious"
     chmod -R g-w $out


### PR DESCRIPTION
###### Motivation for this change

Update slack to latest version

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

