### PR TITLE
miniupnpc: 1.9.20150430 -> 2.0.20161216

### DIFF
--- a/pkgs/tools/networking/miniupnpc/default.nix
+++ b/pkgs/tools/networking/miniupnpc/default.nix
@@ -1,23 +1,21 @@
 { stdenv, fetchurl }:
 
-let version = "1.9.20150430"; in
 stdenv.mkDerivation rec {
   name = "miniupnpc-${version}";
+  version = "2.0.20161216";
 
   src = fetchurl {
     url = "http://miniupnp.free.fr/files/download.php?file=${name}.tar.gz";
-    sha256 = "0ivnvzla0l2pzmy8s0j8ss0fnpsii7z9scvyl4a13g9k911hgmvn";
-    name = "${name}.tar.gz";
-  };
+    sha256 = "0gpxva9jkjvqwawff5y51r6bmsmdhixl3i5bmzlqsqpwsq449q81";
+   };
 
-  patches = stdenv.lib.optional stdenv.isFreeBSD ./freebsd.patch;
+   patches = stdenv.lib.optional stdenv.isFreeBSD ./freebsd.patch;
 
-  doCheck = !stdenv.isFreeBSD;
+   doCheck = !stdenv.isFreeBSD;
 
   installFlags = "PREFIX=$(out) INSTALLPREFIX=$(out)";
 
   meta = {
-    inherit version;
     homepage = http://miniupnp.free.fr/;
     description = "A client that implements the UPnP Internet Gateway Device (IGD) specification";
     platforms = with stdenv.lib.platforms; linux ++ freebsd;


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

