### PR TITLE
ocproxy: 1.50 -> 1.60

### DIFF
--- a/pkgs/tools/networking/ocproxy/default.nix
+++ b/pkgs/tools/networking/ocproxy/default.nix
@@ -1,17 +1,18 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libevent }:
 
 stdenv.mkDerivation rec {
-  version = "1.50";
+  version = "1.60";
   name = "ocproxy-${version}";
 
   src = fetchFromGitHub {
     owner = "cernekee";
     repo = "ocproxy";
     rev = "v${version}";
-    sha256 = "136vlk2svgls5paf17xi1zahcahgcnmi2p55khh7zpqaar4lzw6s";
+    sha256 = "03323nnhb4y9nzwva04mq7xg03dvdrgp689g89f69jqc261skcqx";
   };
-
-  buildInputs = [ autoconf automake libevent ];
+  
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libevent ];
 
   preConfigure = ''
     patchShebangs autogen.sh


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

