### PR TITLE
mkDerivation: Don't pass buildInputs to stdenv builder in nativeBuildInputs

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -264,18 +264,16 @@ let
           __ignoreNulls = true;
 
           # Inputs built by the cross compiler.
-          buildInputs = if crossConfig != null then buildInputs' else [];
-          propagatedBuildInputs = if crossConfig != null then propagatedBuildInputs' else [];
+          buildInputs = buildInputs';
+          propagatedBuildInputs = propagatedBuildInputs';
           # Inputs built by the usual native compiler.
           nativeBuildInputs = nativeBuildInputs'
-            ++ lib.optionals (crossConfig == null) buildInputs'
             ++ lib.optional
                 (result.isCygwin
                   || (crossConfig != null && lib.hasSuffix "mingw32" crossConfig))
                 ../../build-support/setup-hooks/win-dll-link.sh
             ;
-          propagatedNativeBuildInputs = propagatedNativeBuildInputs' ++
-            (if crossConfig == null then propagatedBuildInputs' else []);
+          propagatedNativeBuildInputs = propagatedNativeBuildInputs';
         } // ifDarwin {
           # TODO: remove lib.unique once nix has a list canonicalization primitive
           __sandboxProfile =


### PR DESCRIPTION
One way of solving the biggest problem described in #4855.

This does not rename anything and (at least doesn't intend to) change anything wrt. how the semantics of `buildInputs` and `nativeBuildInputs` work inside the builder script. But it does solve the problem of `foo.buildInputs` (or `echo $buildInputs` in a nix-shell) giving an unexpected result.

Needs a bit more testing, but in case this doesn't cause major breakage I'd propose this for 17.03. The reason for that being the new `overrideAttrs` function we merged earlier, which gets rid of another well-known `buildInputs` vs `nativeBuildInputs` wart when using `overrideDerivation`.

cc @edolstra 