### PR TITLE
ANTs: init at 2.1.0 (0gyys1lf) and update ITK accordingly

### DIFF
--- a/pkgs/applications/graphics/seg3d/default.nix
+++ b/pkgs/applications/graphics/seg3d/default.nix
@@ -48,4 +48,8 @@ stdenv.mkDerivation {
   '';
 
   buildInputs = [ cmake wxGTK itk mesa libXft libXext libXi zlib libXmu libuuid ];
+
+  meta = {
+    broken = true;
+  };
 }

--- a/pkgs/applications/science/biology/ants/default.nix
+++ b/pkgs/applications/science/biology/ants/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake, itk, vtk }:
+
+stdenv.mkDerivation rec {
+  _name    = "ANTs";
+  _version = "2.1.0";
+  name  = "${_name}-${_version}";
+
+  src = fetchFromGitHub {
+    owner  = "stnava";
+    repo   = "ANTs";
+    rev    = "4e02aa76621698e3513330dd9e863e22917e14b7";
+    sha256 = "0gyys1lf69bl3569cskxc8r5llwcr0dsyzvlby5skhfpsyw0dh8r";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ itk vtk ];
+
+  cmakeFlags = [ "-DANTS_SUPERBUILD=FALSE" "-DUSE_VTK=TRUE" ];
+
+  checkPhase = "ctest";
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/stnava/ANTs;
+    description = "Advanced normalization toolkit for medical image registration and other processing";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms = platforms.unix;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/libraries/itk/default.nix
+++ b/pkgs/development/libraries/itk/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, cmake, libX11, libuuid, xz}:
+{ stdenv, fetchurl, cmake, libX11, libuuid, xz, vtk }:
 
 stdenv.mkDerivation rec {
   name = "itk-4.10.0";
@@ -12,12 +12,15 @@ stdenv.mkDerivation rec {
     "-DBUILD_TESTING=OFF"
     "-DBUILD_EXAMPLES=OFF"
     "-DBUILD_SHARED_LIBS=ON"
+    "-DModule_ITKIOMINC=ON"
+    "-DModule_ITKVtkGlue=ON"
+    "-DModule_ITKReview=ON"
   ];
 
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ cmake xz ];
-  buildInputs = [ libX11 libuuid ];
+  buildInputs = [ libX11 libuuid vtk ];
 
   meta = {
     description = "Insight Segmentation and Registration Toolkit";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16930,6 +16930,8 @@ with pkgs;
 
   alliance = callPackage ../applications/science/electronics/alliance { };
 
+  ants = callPackage ../applications/science/biology/ants { };
+
   archimedes = callPackage ../applications/science/electronics/archimedes {
     stdenv = overrideCC stdenv gcc49;
   };


### PR DESCRIPTION
###### Motivation for this change

added ANTs and built ITK with appropriate VTK-related options.  Also enabled MINC support.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

