### PR TITLE
connect: 1.104 -> 1.105

### DIFF
--- a/pkgs/tools/networking/connect/default.nix
+++ b/pkgs/tools/networking/connect/default.nix
@@ -1,15 +1,12 @@
 { stdenv, fetchurl }:
 
-let
-
-  version = "1.104";
-
-in stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "connect-${version}";
-  
+  version ="1.105";
+
   src = fetchurl {
     url = "https://bitbucket.org/gotoh/connect/get/${version}.tar.bz2";
-    sha256 = "0h7bfh1b2kcw5ddpbif57phdxpf8if0cm01pgwc6avp6dqxcsqp2";
+    sha256 = "00yld6yinc8s4xv3b8kbvzn2f4rja5dmp6ysv3n4847qn4k60dh7";
   };
 
   makeFlags = [ "CC=cc" ];      # gcc and/or clang compat


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

