### PR TITLE
xiccd: 0.2.2 -> 0.2.4

### DIFF
--- a/pkgs/tools/misc/xiccd/default.nix
+++ b/pkgs/tools/misc/xiccd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "xiccd-${version}";
-  version = "0.2.2";
+  version = "0.2.4";
 
   src = fetchFromGitHub {
     owner = "agalakhov";
     repo = "xiccd";
     rev = "v${version}";
-    sha256 = "17p3vngmmjk52r5p8y41s19nwp7w25bgff68ffd50zdlicd33rsy";
+    sha256 = "0dhv913njzm80g5lwak5znmxllfa6rrkifwja8vk133lyxnarqra";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

