### PR TITLE
fakeroot: add darwin support

### DIFF
--- a/pkgs/tools/system/fakeroot/default.nix
+++ b/pkgs/tools/system/fakeroot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, utillinux, libcap }:
+{ stdenv, fetchurl, fetchpatch, getopt, libcap }:
 
 stdenv.mkDerivation rec {
   version = "1.20.2";
@@ -9,7 +9,28 @@ stdenv.mkDerivation rec {
     sha256 = "0313xb2j6a4wihrw9gfd4rnyqw7zzv6wf3rfh2gglgnv356ic2kw";
   };
 
-  buildInputs = [ utillinux /* provides getopt */ libcap ];
+  # patchset from brew
+  patches = stdenv.lib.optionals stdenv.isDarwin [
+    (fetchpatch {
+      name = "0001-Implement-openat-2-wrapper-which-handles-optional-ar.patch";
+      url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=0001-Implement-openat-2-wrapper-which-handles-optional-ar.patch;att=1;bug=766649";
+      sha256 = "1m6ggrqwqy0in264sxqk912vniipiw629dxq7kibakvsswfk6bkk";
+    })
+    (fetchpatch {
+      name = "0002-OS-X-10.10-introduced-id_t-int-in-gs-etpriority.patch";
+      url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=0002-OS-X-10.10-introduced-id_t-int-in-gs-etpriority.patch;att=2;bug=766649";
+      sha256 = "0rhayp42x4i1a6yc4d28kpshmf7lrmaprq64zfrjpdn4kbs0rkln";
+    })
+    (fetchpatch {
+      name = "fakeroot-always-pass-mode.patch";
+      url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?att=2;bug=766649;filename=fakeroot-always-pass-mode.patch;msg=20";
+      sha256 = "0i3zaca1v449dm9m1cq6wq4dy6hc2y04l05m9gg8d4y4swld637p";
+    })
+    ];
+
+  buildInputs = [ getopt ]
+    ++ stdenv.lib.optional (!stdenv.isDarwin) libcap
+    ;
 
   postUnpack = ''
     for prog in getopt; do
@@ -22,7 +43,7 @@ stdenv.mkDerivation rec {
     description = "Give a fake root environment through LD_PRELOAD";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 
 }


### PR DESCRIPTION
replace utillinux with getopt

Fixes #22773

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

