### PR TITLE
xfce: delay package selection for pulseaudio volume to nixos modules

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -5,6 +5,7 @@ with lib;
 let
 
   xcfg = config.services.xserver;
+  pcfg = config.hardware.pulseaudio;
   cfg = xcfg.desktopManager.xfce;
 
 in
@@ -89,7 +90,7 @@ in
         pkgs.xfce.xfce4icontheme
         pkgs.xfce.xfce4session
         pkgs.xfce.xfce4settings
-        pkgs.xfce.xfce4mixer
+       (pkgs.xfce.xfce4mixer.override { pulseaudioSupport = pcfg.enable; })
         pkgs.xfce.xfce4volumed
         pkgs.xfce.xfce4-screenshooter
         pkgs.xfce.xfconf

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -91,7 +91,7 @@ in
         pkgs.xfce.xfce4session
         pkgs.xfce.xfce4settings
        (pkgs.xfce.xfce4mixer.override { pulseaudioSupport = pcfg.enable; })
-        pkgs.xfce.xfce4volumed
+       (if pcfg.enable then pkgs.xfce.xfce4volumed_pulse else pkgs.xfce.xfce4volumed_gst)
         pkgs.xfce.xfce4-screenshooter
         pkgs.xfce.xfconf
         # This supplies some "abstract" icons such as

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -90,8 +90,8 @@ in
         pkgs.xfce.xfce4icontheme
         pkgs.xfce.xfce4session
         pkgs.xfce.xfce4settings
-       (pkgs.xfce.xfce4mixer.override { pulseaudioSupport = pcfg.enable; })
-       (if pcfg.enable then pkgs.xfce.xfce4volumed_pulse else pkgs.xfce.xfce4volumed_gst)
+       (if pcfg.enable then pkgs.xfce.xfce4mixer_pulse else pkgs.xfce.xfce4mixer)
+       (if pcfg.enable then pkgs.xfce.xfce4volumed_pulse else pkgs.xfce.xfce4volumed)
         pkgs.xfce.xfce4-screenshooter
         pkgs.xfce.xfconf
         # This supplies some "abstract" icons such as

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -58,17 +58,13 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   parole          = callPackage ./applications/parole.nix { };
   ristretto       = callPackage ./applications/ristretto.nix { };
   terminal        = xfce4terminal; # it has changed its name
-  xfce4mixer      = callPackage ./applications/xfce4-mixer.nix {
-    pulseaudioSupport = config.pulseaudio or false;
-  };
+  xfce4mixer      = callPackage ./applications/xfce4-mixer.nix { };
   xfce4notifyd    = callPackage ./applications/xfce4-notifyd.nix { };
   xfce4taskmanager= callPackage ./applications/xfce4-taskmanager.nix { };
   xfce4terminal   = callPackage ./applications/terminal.nix { };
   xfce4-screenshooter = callPackage ./applications/xfce4-screenshooter.nix { };
-  xfce4volumed    = let
-    gst = callPackage ./applications/xfce4-volumed.nix { };
-    pulse = callPackage ./applications/xfce4-volumed-pulse.nix { };
-  in if config.pulseaudio or false then pulse else gst;
+  xfce4volumed_gst = callPackage ./applications/xfce4-volumed.nix { };
+  xfce4volumed_pulse = callPackage ./applications/xfce4-volumed-pulse.nix { };
 
   #### ART                  from "mirror://xfce/src/art/${p_name}/${ver_maj}/${name}.tar.bz2"
 

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -59,11 +59,12 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   ristretto       = callPackage ./applications/ristretto.nix { };
   terminal        = xfce4terminal; # it has changed its name
   xfce4mixer      = callPackage ./applications/xfce4-mixer.nix { };
+  xfce4mixer_pulse = callPackage ./applications/xfce4-mixer.nix { pulseaudioSupport = true; };
   xfce4notifyd    = callPackage ./applications/xfce4-notifyd.nix { };
   xfce4taskmanager= callPackage ./applications/xfce4-taskmanager.nix { };
   xfce4terminal   = callPackage ./applications/terminal.nix { };
   xfce4-screenshooter = callPackage ./applications/xfce4-screenshooter.nix { };
-  xfce4volumed_gst = callPackage ./applications/xfce4-volumed.nix { };
+  xfce4volumed    = callPackage ./applications/xfce4-volumed.nix { };
   xfce4volumed_pulse = callPackage ./applications/xfce4-volumed-pulse.nix { };
 
   #### ART                  from "mirror://xfce/src/art/${p_name}/${ver_maj}/${name}.tar.bz2"


### PR DESCRIPTION
###### Motivation for this change

In XFCE, for some reasons, the current setup that selects whether to use `xfce4volumed` and `xfce4volume-pulse` and whether or not to enable pulseaudio support in `xfce4mixer` doesn't work at all. No matter what I set for `hardware.pulseaudio.enable`, no pulseaudio support is enabled. Selecting them in `./pkgs` also makes it hard to install pulseaudio-enabled package hard when system-wise pulseaudio is not enabled (or on non-NixOS). Thus I suggest delaying the selection logic to the corresponding NixOS modules.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

