### PR TITLE
NixOS: Plasma 5 tests and warnings

### DIFF
--- a/nixos/doc/manual/configuration/modularity.xml
+++ b/nixos/doc/manual/configuration/modularity.xml
@@ -37,7 +37,7 @@ latter might look like this:
 
 { services.xserver.enable = true;
   services.xserver.displayManager.sddm.enable = true;
-  services.xserver.desktopManager.kde5.enable = true;
+  services.xserver.desktopManager.plasma5.enable = true;
 }
 </programlisting>
 

--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -25,7 +25,7 @@ Otherwise, you can only log into a plain undecorated
 <command>xterm</command> window.  Thus you should pick one or more of
 the following lines:
 <programlisting>
-services.xserver.desktopManager.kde5.enable = true;
+services.xserver.desktopManager.plasma5.enable = true;
 services.xserver.desktopManager.xfce.enable = true;
 services.xserver.desktopManager.gnome3.enable = true;
 services.xserver.windowManager.xmonad.enable = true;

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
@@ -18,7 +18,7 @@ with lib;
       autoLogin = true;
     };
 
-    desktopManager.kde5 = {
+    desktopManager.plasma5 = {
       enable = true;
       enableQt4Support = false;
     };
@@ -66,7 +66,7 @@ with lib;
   in ''
     mkdir -p /root/Desktop
     ln -sfT ${desktopFile} /root/Desktop/nixos-manual.desktop
-    ln -sfT ${pkgs.kdeApplications.konsole}/share/applications/org.kde.konsole.desktop /root/Desktop/org.kde.konsole.desktop
+    ln -sfT ${pkgs.konsole}/share/applications/org.kde.konsole.desktop /root/Desktop/org.kde.konsole.desktop
     ln -sfT ${pkgs.gparted}/share/applications/gparted.desktop /root/Desktop/gparted.desktop
   '';
 

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -607,7 +607,7 @@ $bootLoaderConfig
 
   # Enable the KDE Desktop Environment.
   # services.xserver.displayManager.sddm.enable = true;
-  # services.xserver.desktopManager.kde5.enable = true;
+  # services.xserver.desktopManager.plasma5.enable = true;
 
   # Define a user account. Don't forget to set a password with ‘passwd’.
   # users.extraUsers.guest = {

--- a/nixos/modules/profiles/graphical.nix
+++ b/nixos/modules/profiles/graphical.nix
@@ -1,5 +1,5 @@
-# This module defines a NixOS configuration that contains X11 and
-# KDE 4.  It's used by the graphical installation CD.
+# This module defines a NixOS configuration with the Plasma 5 desktop.
+# It's used by the graphical installation CD.
 
 { config, pkgs, ... }:
 
@@ -7,7 +7,7 @@
   services.xserver = {
     enable = true;
     displayManager.sddm.enable = true;
-    desktopManager.kde5.enable = true;
+    desktopManager.plasma5.enable = true;
     synaptics.enable = true; # for touchpad support on many laptops
   };
 

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -72,7 +72,7 @@ in rec {
         (all nixos.tests.ecryptfs)
         (all nixos.tests.ipv6)
         (all nixos.tests.i3wm)
-        (all nixos.tests.kde5)
+        (all nixos.tests.plasma5)
         #(all nixos.tests.lightdm)
         (all nixos.tests.login)
         (all nixos.tests.misc)

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -255,7 +255,7 @@ in rec {
   tests.influxdb = callTest tests/influxdb.nix {};
   tests.ipv6 = callTest tests/ipv6.nix {};
   tests.jenkins = callTest tests/jenkins.nix {};
-  tests.kde5 = callTest tests/kde5.nix {};
+  tests.plasma5 = callTest tests/plasma5.nix {};
   tests.keymap = callSubTests tests/keymap.nix {};
   tests.initrdNetwork = callTest tests/initrd-network.nix {};
   tests.keystone = callTest tests/keystone.nix {};

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -327,7 +327,7 @@ in rec {
     kde = makeClosure ({ pkgs, ... }:
       { services.xserver.enable = true;
         services.xserver.displayManager.sddm.enable = true;
-        services.xserver.desktopManager.kde5.enable = true;
+        services.xserver.desktopManager.plasma5.enable = true;
       });
 
     xfce = makeClosure ({ pkgs, ... }:

--- a/nixos/tests/phabricator.nix
+++ b/nixos/tests/phabricator.nix
@@ -54,7 +54,7 @@ import ./make-test.nix ({ pkgs, ... }: {
     client =
       { config, pkgs, ... }:
       { imports = [ ./common/x11.nix ];
-        services.xserver.desktopManager.kde5.enable = true;
+        services.xserver.desktopManager.plasma5.enable = true;
       };
   };
 

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -1,7 +1,7 @@
 import ./make-test.nix ({ pkgs, ...} :
 
 {
-  name = "kde5";
+  name = "plasma5";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ttuegel ];
   };

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -17,7 +17,8 @@ import ./make-test.nix ({ pkgs, ...} :
         user = "alice";
       };
     };
-    services.xserver.desktopManager.kde5.enable = true;
+    services.xserver.desktopManager.plasma5.enable = true;
+    services.xserver.desktopManager.default = "plasma5";
     virtualisation.writableStore = false; # FIXME
   };
 

--- a/nixos/tests/trac.nix
+++ b/nixos/tests/trac.nix
@@ -45,7 +45,7 @@ import ./make-test.nix ({ pkgs, ... }: {
     client =
       { config, pkgs, ... }:
       { imports = [ ./common/x11.nix ];
-        services.xserver.desktopManager.kde5.enable = true;
+        services.xserver.desktopManager.plasma5.enable = true;
       };
   };
 


### PR DESCRIPTION
### Motivation for this change

- The Plasma test was not working since the KDE overhaul.
- Building the graphical ISO produced an avoidable warning.

### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

