### PR TITLE
nitpick: Init at 1.1

### DIFF
--- a/pkgs/applications/version-management/nitpick/default.nix
+++ b/pkgs/applications/version-management/nitpick/default.nix
@@ -1,21 +1,21 @@
 { fetchFromGitHub
-, python
-, wrapPython
+, buildPythonPackage
 , stdenv
 }:
 
-stdenv.mkDerivation rec {
-  name = "nitpick-${version}";
+buildPythonPackage rec {
+  pname = "nitpick";
   version = "1.1";
+  name = "${pname}-${version}";
+
+  format = "other";
+  
   src = fetchFromGitHub {
     owner = "travisb-ca";
-    repo = "nitpick";
+    repo = pname;
     rev = version;
     sha256 = "11gn6nc6ypwivy20bx1r0rm2giblwx6jv485zk875a9pdbcwbrf6";
   };
-
-  buildInputs = [ python ];
-  nativeBuildInputs = [ wrapPython ];
 
   installPhase = ''
     mkdir -p $out/share/src
@@ -23,12 +23,6 @@ stdenv.mkDerivation rec {
   
     mkdir -p $out/bin
     ln -s $out/share/src/nitpick.py $out/bin/nitpick
-  '';
-
-  postFixup = ''
-    buildPythonPath "$out"
-
-    patchPythonScript "$out/share/src/nitpick.py"
   '';
 
   meta = {

--- a/pkgs/applications/version-management/nitpick/default.nix
+++ b/pkgs/applications/version-management/nitpick/default.nix
@@ -37,6 +37,5 @@ buildPythonPackage rec {
     homepage = http://travisbrown.ca/projects/nitpick/docs/nitpick.html;
     license = with stdenv.lib.licenses; gpl2;
     maintainers = [];
-    platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/applications/version-management/nitpick/default.nix
+++ b/pkgs/applications/version-management/nitpick/default.nix
@@ -1,6 +1,7 @@
 { fetchFromGitHub
 , buildPythonPackage
 , stdenv
+, isPy27
 }:
 
 buildPythonPackage rec {
@@ -9,6 +10,7 @@ buildPythonPackage rec {
   name = "${pname}-${version}";
 
   format = "other";
+  disabled = !isPy27;
   
   src = fetchFromGitHub {
     owner = "travisb-ca";

--- a/pkgs/applications/version-management/nitpick/default.nix
+++ b/pkgs/applications/version-management/nitpick/default.nix
@@ -1,0 +1,46 @@
+{ fetchFromGitHub
+, python
+, wrapPython
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  name = "nitpick-${version}";
+  version = "1.1";
+  src = fetchFromGitHub {
+    owner = "travisb-ca";
+    repo = "nitpick";
+    rev = version;
+    sha256 = "11gn6nc6ypwivy20bx1r0rm2giblwx6jv485zk875a9pdbcwbrf6";
+  };
+
+  buildInputs = [ python ];
+  nativeBuildInputs = [ wrapPython ];
+
+  installPhase = ''
+    mkdir -p $out/share/src
+    install -m 755 -t $out/share/src nitpick.py
+  
+    mkdir -p $out/bin
+    ln -s $out/share/src/nitpick.py $out/bin/nitpick
+  '';
+
+  postFixup = ''
+    buildPythonPath "$out"
+
+    patchPythonScript "$out/share/src/nitpick.py"
+  '';
+
+  meta = {
+    description = "A distributed issue tracker";
+    longDescription = ''
+      Nitpick is a distributed issue tracker. It helps keep track of which nits you
+      should pick. It's intended to be used with source code such that the issues can
+      follow the code via whatever VCS or distribution mechanism.
+    '';
+    homepage = http://travisbrown.ca/projects/nitpick/docs/nitpick.html;
+    license = with stdenv.lib.licenses; gpl2;
+    maintainers = [];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14475,6 +14475,11 @@ with pkgs;
 
   ympd = callPackage ../applications/audio/ympd { };
 
+  nitpick = callPackage ../applications/version-management/nitpick {
+    python = python27;
+    inherit (python27Packages) wrapPython;
+  };
+
   nload = callPackage ../applications/networking/nload { };
 
   normalize = callPackage ../applications/audio/normalize { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14475,11 +14475,6 @@ with pkgs;
 
   ympd = callPackage ../applications/audio/ympd { };
 
-  nitpick = callPackage ../applications/version-management/nitpick {
-    python = python27;
-    inherit (python27Packages) wrapPython;
-  };
-
   nload = callPackage ../applications/networking/nload { };
 
   normalize = callPackage ../applications/audio/normalize { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -32105,6 +32105,8 @@ EOF
 
   snakeviz = callPackage ../development/python-modules/snakeviz { };
 
+  nitpick = callPackage ../applications/version-management/nitpick { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).