### PR TITLE
synthv1: 0.7.6 -> 0.8.0

### DIFF
--- a/pkgs/applications/audio/synthv1/default.nix
+++ b/pkgs/applications/audio/synthv1/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchurl, qt5, libjack2, alsaLib, liblo, lv2 }:
+{ stdenv, fetchurl, pkgconfig, qt5, libjack2, alsaLib, liblo, lv2 }:
 
 stdenv.mkDerivation rec {
   name = "synthv1-${version}";
-  version = "0.7.6";
+  version = "0.8.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/synthv1/${name}.tar.gz";
-    sha256 = "03vnmmiyq92p2gh4zax1vg2lx6y57bsxch936pzbiwx649x53wi9";
+    sha256 = "155pfyhr6d35ciw95pbxlqy7751cmij8j5d849rvblqbjzyzb5qx";
   };
 
   buildInputs = [ qt5.qtbase qt5.qttools libjack2 alsaLib liblo lv2 ];
+
+  nativeBuildInputs = [ pkgconfig ];
 
   meta = with stdenv.lib; {
     description = "An old-school 4-oscillator subtractive polyphonic synthesizer with stereo fx";


### PR DESCRIPTION
###### Motivation for this change
Fixes build.
[Please merge in 17.03.](https://github.com/NixOS/nixpkgs/issues/23253)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

