### PR TITLE
VoiceOfFaust: fix pitchTracker

### DIFF
--- a/pkgs/applications/audio/magnetophonDSP/VoiceOfFaust/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/VoiceOfFaust/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     sed -i "s@pd -nodac@${pitchTracker}/bin/pd -nodac@g" launchers/synthWrapper
-    sed -i "s@../PureData/OscSendVoc.pd@$out/PureData/OscSendVoc.pd@g" launchers/synthWrapper
+    sed -i "s@../PureData/OscSendVoc.pd@$out/PureData/OscSendVoc.pd@g" launchers/pitchTracker
   '';
 
   buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change
This program doesn't work properly without this fix..
Please merge in 17.03.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

