### PR TITLE
valgrind: enable darwin build

### DIFF
--- a/pkgs/development/tools/analysis/valgrind/valgrind-bzero.patch
+++ b/pkgs/development/tools/analysis/valgrind/valgrind-bzero.patch
@@ -1,0 +1,37 @@
+Index: coregrind/m_main.c
+===================================================================
+--- a/coregrind/m_main.c (revision 16102)
++++ b/coregrind/m_main.c (revision 16103)
+@@ -3489,6 +3489,10 @@
+     // skip check
+   return VG_(memset)(s,c,n);
+ }
++void __bzero(void* s, UWord n);
++void __bzero(void* s, UWord n) {
++    (void)VG_(memset)(s,0,n);
++}
+ void bzero(void *s, SizeT n);
+ void bzero(void *s, SizeT n) {
+     VG_(memset)(s,0,n);
+@@ -4058,20 +4062,7 @@
+ 
+ #endif
+ 
+-#if defined(VGO_darwin) && DARWIN_VERS == DARWIN_10_10
+ 
+-/* This might also be needed for > DARWIN_10_10, but I have no way
+-   to test for that.  Hence '==' rather than '>=' in the version
+-   test above. */
+-void __bzero ( void* s, UWord n );
+-void __bzero ( void* s, UWord n )
+-{
+-   (void) VG_(memset)( s, 0, n );
+-}
+-
+-#endif
+-
+-
+ /*--------------------------------------------------------------------*/
+ /*--- end                                                          ---*/
+ /*--------------------------------------------------------------------*/
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6862,7 +6862,10 @@ with pkgs;
 
   gdb-multitarget = lowPrio (gdb.override { multitarget = true; });
 
-  valgrind = callPackage ../development/tools/analysis/valgrind { };
+  valgrind = callPackage ../development/tools/analysis/valgrind {
+    inherit (darwin) xnu bootstrap_cmds cctools;
+    llvm = llvm_39;
+   };
 
   valkyrie = callPackage ../development/tools/analysis/valkyrie { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

