### PR TITLE
docopt.cpp: init at 0.6.2

### DIFF
--- a/pkgs/development/libraries/docopt_cpp/default.nix
+++ b/pkgs/development/libraries/docopt_cpp/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake, python }:
+
+stdenv.mkDerivation rec {
+  version = "0.6.2";
+  name = "docopt.cpp-${version}";
+
+  src = fetchFromGitHub {
+    owner = "docopt";
+    repo = "docopt.cpp";
+    rev = "v${version}";
+    sha256 = "1rgkc8nsc2zz2lkyai0y68vrd6i6kbq63hm3vdza7ab6ghq0n1dd";
+  };
+
+  nativeBuildInputs = [ cmake python ];
+
+  cmakeFlags = ["-DWITH_TESTS=ON"];
+
+  doCheck = true;
+
+  checkPhase = "LD_LIBRARY_PATH=$(pwd) python ./run_tests";
+
+  meta = with stdenv.lib; {
+    description = "C++11 port of docopt";
+    homepage = https://github.com/docopt/docopt.cpp;
+    license = with licenses; [ mit boost ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ knedlsepp ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6296,6 +6296,8 @@ let
 
   dlib = callPackage ../development/libraries/dlib { };
 
+  docopt_cpp = callPackage ../development/libraries/docopt_cpp { };
+
   dotconf = callPackage ../development/libraries/dotconf { };
 
   dssi = callPackage ../development/libraries/dssi {};


### PR DESCRIPTION
###### Motivation for this change
docopt.cpp is an awesome alternative to Boost.Program_options.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

