### PR TITLE
httping 2.5: fetch over HTTPS + license info

### DIFF
--- a/pkgs/tools/networking/httping/default.nix
+++ b/pkgs/tools/networking/httping/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "2.5";
 
   src = fetchurl {
-    url = "http://www.vanheusden.com/httping/${name}.tgz";
+    url = "https://www.vanheusden.com/httping/${name}.tgz";
     sha256 = "1y7sbgkhgadmd93x1zafqc4yp26ssiv16ni5bbi9vmvvdl55m29y";
   };
 
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
       the transmission across the network also takes time! So it measures the
       latency of the webserver + network. It supports IPv6.
     '';
+    license = licenses.agpl3;
     maintainers = with maintainers; [ nckx rickynils ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
Follow-up to #23350 + #23369

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

