### PR TITLE
Feat termdown at 1.11.0

### DIFF
--- a/pkgs/applications/misc/termdown/default.nix
+++ b/pkgs/applications/misc/termdown/default.nix
@@ -1,0 +1,27 @@
+{ pkgs, stdenv, fetchFromGitHub, buildPythonApplication,
+click, pyfiglet, dateutil}:
+
+with stdenv.lib;
+
+buildPythonApplication rec {
+
+  name    = "termdown-${version}";
+  version = "1.11.0";
+
+  src = fetchFromGitHub {
+      rev    = "d1e3504e02ad49013595112cb03fbf175822e58d";
+      sha256 = "1i6fxymg52q95n0cbm4imdxh6yvpj3q57yf7w9z5d9pr35cf1iq5";
+      repo   = "termdown";
+      owner  = "trehn";
+  };
+
+  propagatedBuildInputs = [ dateutil click pyfiglet ];
+
+  meta = with stdenv.lib; {
+     description     = "Starts a countdown to or from TIMESPEC";
+     longDescription = "Countdown timer and stopwatch in your terminal";
+     homepage        = https://github.com/trehn/termdown;
+     license         = licenses.gpl3;
+     platforms       = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15456,6 +15456,8 @@ with pkgs;
 
   telepathy_idle = callPackage ../applications/networking/instant-messengers/telepathy/idle {};
 
+  inherit (pythonPackages) termdown;
+
   terminal-notifier = callPackage ../applications/misc/terminal-notifier {};
 
   terminator = callPackage ../applications/misc/terminator {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20257,11 +20257,11 @@ in {
 
   pyfiglet = buildPythonPackage rec {
     name = "pyfiglet-${version}";
-    version = "0.7.2";
+    version = "0.7.5";
 
     src = pkgs.fetchurl {
       url    = "mirror://pypi/p/pyfiglet/${name}.tar.gz";
-      sha256 = "0v8a18wvaqnb1jksyv5dc5n6zj0vrkyhz0ivmm8gfwpa0ky6n68y";
+      sha256 = "04jy4182hn5xfs6jf432gxclfj1rhssd7bsf0b4gymrjzkhr8qa4";
     };
 
     doCheck = false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25935,6 +25935,8 @@ in {
     };
   };
 
+  termdown = callPackage ../applications/misc/termdown {};
+
   traits = buildPythonPackage rec {
     name = "traits-${version}";
     version = "4.5.0";


### PR DESCRIPTION
###### Motivation for this change
Init termdown 1.11.0

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

