### PR TITLE
highlight: Add support for darwin, suspecting needs gcc

### DIFF
--- a/pkgs/tools/text/highlight/default.nix
+++ b/pkgs/tools/text/highlight/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, getopt, lua, boost, pkgconfig }:
+{ stdenv, fetchurl, getopt, lua, boost, pkgconfig, gcc }:
 
 stdenv.mkDerivation rec {
   name = "highlight-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "8a14b49f5e0c07daa9f40b4ce674baa00bb20061079473a5d386656f6d236d05";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ] ++ stdenv.lib.optional stdenv.isDarwin  gcc ;
 
   buildInputs = [ getopt lua boost ];
 


### PR DESCRIPTION
###### Motivation for this change
Hoping this will fix Darwin build

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

