### PR TITLE
avahi-daemon service: Add option to enable point-to-point interfaces.

### DIFF
--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -21,6 +21,7 @@ let
     use-ipv6=${if ipv6 then "yes" else "no"}
     ${optionalString (interfaces!=null) "allow-interfaces=${concatStringsSep "," interfaces}"}
     ${optionalString (domainName!=null) "domain-name=${domainName}"}
+    allow-point-to-point=${if allowPointToPoint then "yes" else "no"}
 
     [wide-area]
     enable-wide-area=${if wideArea then "yes" else "no"}
@@ -95,6 +96,15 @@ in
           List of network interfaces that should be used by the <command>avahi-daemon</command>.
           Other interfaces will be ignored. If <literal>null</literal> all local interfaces
           except loopback and point-to-point will be used.
+        '';
+      };
+
+      allowPointToPoint = mkOption {
+        default = false;
+        description= ''
+          Whether to use POINTTOPOINT interfaces. Might make mDNS unreliable due to usually large
+          latencies with such links and opens a potential security hole by allowing mDNS access from Internet
+          connections. Use with care and YMMV!
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change
I wanted to use mdns name resolving on my tinc vpn network link, but could not do this with the current NixOS avahi-daemon module. Even if the vpn interface is listed in `allow-interfaces`, avahi-daemon will not use the interface unless `alow-point-to-point-interfaces` is enabled.

###### Things done
https://nixos.org/wiki/Create_and_debug_nix_packages
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

