### PR TITLE
fcitx: fix fcitx-qt5 attribute path

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/wrapper.nix
+++ b/pkgs/tools/inputmethods/fcitx/wrapper.nix
@@ -1,9 +1,9 @@
-{ stdenv, symlinkJoin, fcitx, fcitx-configtool, makeWrapper, plugins, qt55 }:
+{ stdenv, symlinkJoin, fcitx, fcitx-configtool, makeWrapper, plugins, libsForQt5 }:
 
 symlinkJoin {
   name = "fcitx-with-plugins-${fcitx.version}";
 
-  paths = [ fcitx fcitx-configtool qt55.fcitx-qt5 ] ++ plugins;
+  paths = [ fcitx fcitx-configtool libsForQt5.fcitx-qt5 ] ++ plugins;
 
   buildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #23395

`qt5.fcitx-qt5` path changed to `libsForQt5.fcitx-qt5`. This reflects this change in the fcitx wrapper.

Tested in a i3 nixos vm, with `mozc` and `chewing` engines on Qt5 applications.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

