### PR TITLE
nodePackages: regenerate package set with node2nix -6

### DIFF
--- a/pkgs/development/node-packages/composition-v6.nix
+++ b/pkgs/development/node-packages/composition-v6.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-5_x"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-6_x"}:
 
 let
   nodeEnv = import ./node-env.nix {

--- a/pkgs/development/node-packages/generate.sh
+++ b/pkgs/development/node-packages/generate.sh
@@ -2,5 +2,4 @@
 
 rm -f node-env.nix
 node2nix -i node-packages.json -o node-packages-v4.nix -c composition-v4.nix
-# node2nix doesn't explicitely support node v6 so far
-node2nix -5 -i node-packages.json -o node-packages-v6.nix -c composition-v6.nix
+node2nix --nodejs-6 -i node-packages.json -o node-packages-v6.nix -c composition-v6.nix


### PR DESCRIPTION
I noticed the outdated note in `node-packages/generate.sh` about explicit node v6 support, and thought it might be worth updating it to use the new `-6` option.