### PR TITLE
fcron-module: Add fcron user. Fixes #23320

### DIFF
--- a/nixos/modules/services/scheduling/fcron.nix
+++ b/nixos/modules/services/scheduling/fcron.nix
@@ -105,6 +105,10 @@ in
       ];
 
     environment.systemPackages = [ pkgs.fcron ];
+    users.extraUsers.fcron = {
+      isSystemUser = true;
+      description = "fcron";};
+    users.groups = { fcron = { }; };
 
     security.wrappers.fcrontab.source = "${pkgs.fcron.out}/bin/fcrontab";
     systemd.services.fcron = {


### PR DESCRIPTION
###### Motivation for this change
Add fcron user

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

