### PR TITLE
ttylog: 0.26 -> 0.29

### DIFF
--- a/pkgs/tools/misc/ttylog/default.nix
+++ b/pkgs/tools/misc/ttylog/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "ttylog-${version}";
-  version = "0.26";
+  version = "0.29";
 
   src = fetchFromGitHub {
     owner = "rocasa";
     repo = "ttylog";
-    rev = version;
-    sha256 = "1xvqch1dwpl2d89n9cjcxhqbpvm50fspj5yn883wbii6dpg62p84";
+    rev = "${version}";
+    sha256 = "035i9slmdgds5azwxqwp6skxykvaq3mq4jckvm49fng8jq09z7zr";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

