### PR TITLE
tty-clock: 0.1 -> 2.3

### DIFF
--- a/pkgs/tools/misc/tty-clock/default.nix
+++ b/pkgs/tools/misc/tty-clock/default.nix
@@ -1,21 +1,20 @@
-{ stdenv, fetchFromGitHub, ncurses }:
+{ stdenv, fetchFromGitHub, ncurses, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "tty-clock-${version}";
-  version = "0.1";
+  version = "2.3";
 
   src = fetchFromGitHub {
     owner = "xorg62";
     repo = "tty-clock";
-    rev = "v0.1";
-    sha256 = "14h70ky5y9nb3mzhlshdgq5n47hg3g6msnwbqd7nnmjzrw1nmarl";
+    rev = "v${version}";
+    sha256 = "16v3pmva13skpfjja96zacjpxrwzs1nb1iqmrp2qzvdbcm9061pp";
   };
-
+  
+  nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ncurses ];
 
-  preInstall = ''
-    sed -i 's@/usr/local/@$(out)/@' Makefile
-  '';
+  makeFlags = "PREFIX=$(out)";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/xorg62/tty-clock;


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

