### PR TITLE
ttfautohint: 1.3 -> 1.6

### DIFF
--- a/pkgs/tools/misc/ttfautohint/default.nix
+++ b/pkgs/tools/misc/ttfautohint/default.nix
@@ -1,15 +1,16 @@
 { stdenv, fetchurl, harfbuzz, pkgconfig, qt4 }:
 
 stdenv.mkDerivation rec {
-  version = "1.3";
+  version = "1.6";
   name = "ttfautohint-${version}";
   
   src = fetchurl {
     url = "mirror://savannah/freetype/${name}.tar.gz";
-    sha256 = "01719jgdzgf0m4fzkkij563iksr40c7wydv1yq8ygpxjj0vs17y3";
+    sha256 = "1r8vsznvh89ay35angxp3w1xljxjlpcv9wdjyn7m61n323vi6474";
   };
-
-  buildInputs = [ harfbuzz pkgconfig qt4 ];
+  
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ harfbuzz qt4 ];
 
   meta = with stdenv.lib; {
     description = "An automatic hinter for TrueType fonts";
@@ -21,7 +22,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.freetype.org/ttfautohint/;
     license = licenses.gpl2Plus; # or the FreeType License (BSD + advertising clause)
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = with maintainers; [ goibhniu ndowens ];
     platforms = platforms.linux;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

