### PR TITLE
smc: 6.3.0 -> 6.6.0

### DIFF
--- a/pkgs/tools/misc/smc/default.nix
+++ b/pkgs/tools/misc/smc/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, jre }:
 
 stdenv.mkDerivation rec {
-  name = "smc-6.3.0";
+  name = "smc-6.6.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/smc/smc/6_3_0/smc_6_3_0.tgz";
-    sha256 = "0arzi8kc4vycp1ccf0v87p08cdpylwhx4za2pzvp08vkfwi8zc7z";
+    url = "mirror://sourceforge/project/smc/smc/6_6_0/smc_6_6_0.tgz";
+    sha256 = "14lf286dslm7ymkr4my1xgjvwvqc9181mwkfr65ab49cxl0q85wz";
   };
 
   # Prebuilt Java package.


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

