### PR TITLE
scanmem: 0.15.6 -> 0.16

### DIFF
--- a/pkgs/tools/misc/scanmem/default.nix
+++ b/pkgs/tools/misc/scanmem/default.nix
@@ -1,23 +1,27 @@
 { stdenv, autoconf, automake, intltool, libtool, fetchFromGitHub, readline }:
 
 stdenv.mkDerivation rec {
-  version = "0.15.6";
+  version = "0.16";
   name = "scanmem-${version}";
+ 
   src = fetchFromGitHub {
     owner  = "scanmem";
     repo   = "scanmem";
     rev    = "v${version}";
-    sha256 = "16cw76ji3mp0sj8q0sz5wndavk10n0si1sm6kr5zpiws4sw047ii";
+    sha256 = "131rx6cpnlz2x36r0ry80gqapmxpz2qc3h0040xhvp7ydmd4fyjd";
   };
-  buildInputs = [ autoconf automake intltool libtool readline ];
+
+  nativeBuildInputs = [ autoconf automake intltool libtool ];
+  buildInputs = [ readline ];
+  
   preConfigure = ''
     ./autogen.sh
   '';
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "https://github.com/scanmem/scanmem";
     description = "Memory scanner for finding and poking addresses in executing processes";
-    maintainers = [ stdenv.lib.maintainers.chattered  ];
-    platforms = with stdenv.lib.platforms; linux ++ darwin;
-    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ maintainers.chattered  ];
+    platforms = with platforms; linux ++ darwin;
+    license = licenses.gpl3;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

