### PR TITLE
nixos/bluetooth: add extraConfig option

### DIFF
--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -14,12 +14,26 @@ in
 
   options = {
 
-    hardware.bluetooth.enable = mkEnableOption "support for Bluetooth.";
+    hardware.bluetooth = {
+      enable = mkEnableOption "support for Bluetooth.";
 
-    hardware.bluetooth.powerOnBoot = mkOption {
-      type    = types.bool;
-      default = true;
-      description = "Whether to power up the default Bluetooth controller on boot.";
+      powerOnBoot = mkOption {
+        type    = types.bool;
+        default = true;
+        description = "Whether to power up the default Bluetooth controller on boot.";
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          [General]
+          ControllerMode = bredr
+        '';
+        description = ''
+          Set additional configuration for system-wide bluetooth (/etc/bluetooth/main.conf).
+        '';
+      };
     };
 
   };
@@ -29,6 +43,11 @@ in
   config = mkIf cfg.enable {
 
     environment.systemPackages = [ bluez-bluetooth pkgs.openobex pkgs.obexftp ];
+
+    environment.etc = singleton {
+      source = pkgs.writeText "main.conf" cfg.extraConfig;
+      target = "bluetooth/main.conf";
+    };
 
     services.udev.packages = [ bluez-bluetooth ];
     services.dbus.packages = [ bluez-bluetooth ];

--- a/pkgs/os-specific/linux/bluez/bluez5.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5.nix
@@ -73,6 +73,10 @@ stdenv.mkDerivation rec {
     mkdir $out/sbin
     ln -s ../libexec/bluetooth/bluetoothd $out/sbin/bluetoothd
     ln -s ../libexec/bluetooth/obexd $out/sbin/obexd
+
+    # Add extra configuration
+    mkdir $out/etc/bluetooth
+    ln -s /etc/bluetooth/main.conf $out/etc/bluetooth/main.conf
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
I had the same problem as in issue #20377, and added /etc/bluetooth/main.conf in the bluetooth module. Looking around this looks like a kosher solution (e.g. programs.spacefm does something similar), but feedback or other suggestions are more than welcome, as this is my first attempt at a feature contribution.

###### Things done
Tested locally, and my Bose QC 35 works.


---

