### PR TITLE
mate-common: update 1.16 -> 1.17

### DIFF
--- a/pkgs/desktops/mate/mate-common/default.nix
+++ b/pkgs/desktops/mate/mate-common/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   name = "mate-common-${version}";
   version = "${major-ver}.${minor-ver}";
-  major-ver = "1.16";
+  major-ver = "1.17";
   minor-ver = "0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "02pj5ry3c7p5sd2mp9dsshy0ij0xgv00bxr4vvmnm027hv2silrl";
+    sha256 = "06pvbi2kk39ysd9dfi6ljkncm53hn02n7dygax6ig4p9qd750sdc";
   };
 
   meta = {

--- a/pkgs/desktops/mate/mate-icon-theme/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   name = "mate-icon-theme-${version}";
   version = "${major-ver}.${minor-ver}";
-  major-ver = "1.16";
+  major-ver = "1.17";
   minor-ver = "0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "1zldw22p1i76iss8car39pmfagpfxxlfk1fdhvr4x5r6gf36gv7d";
+    sha256 = "1kxpckaksaz5g3c4jjkh4pdm9yhbjda5835am3wg2iyy2p7rjn8n";
   };
 
   nativeBuildInputs = [ pkgconfig intltool iconnamingutils ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

