### PR TITLE
pythonPackages.dateutil: 2.5.3 -> 2.6.0

### DIFF
--- a/pkgs/development/python-modules/dateutil/default.nix
+++ b/pkgs/development/python-modules/dateutil/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchurl, six }:
+buildPythonPackage rec {
+  name = "dateutil-${version}";
+  version = "2.6.0";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/python-dateutil/python-${name}.tar.gz";
+    sha256 = "1lhq0hxjc3cfha101q02ld5ijlpfyjn2w1yh7wvpiy367pgzi8k2";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    description = "Powerful extensions to the standard datetime module";
+    homepage = http://pypi.python.org/pypi/python-dateutil;
+    license = "BSD-style";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5938,23 +5938,7 @@ in {
     };
   };
 
-  dateutil = buildPythonPackage (rec {
-    name = "dateutil-${version}";
-    version = "2.5.3";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/python-dateutil/python-${name}.tar.gz";
-      sha256 = "1v9j9fmf8g911yg6k01xa2db6dx3wv73zkk7fncsj7vagjqgs20l";
-    };
-
-    propagatedBuildInputs = with self; [ self.six ];
-
-    meta = {
-      description = "Powerful extensions to the standard datetime module";
-      homepage = http://pypi.python.org/pypi/python-dateutil;
-      license = "BSD-style";
-    };
-  });
+  dateutil = callPackage ../development/python-modules/dateutil { };
 
   # csvkit 0.9.1 needs dateutil==2.2
   dateutil_2_2 = buildPythonPackage (rec {


### PR DESCRIPTION
###### Motivation for this change

`nix-build -A python35Packages.sympy` fails to build both before and after the update.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

