### PR TITLE
tlspool: init at 20170123

### DIFF
--- a/pkgs/development/libraries/gnutls-kdh/3.5.nix
+++ b/pkgs/development/libraries/gnutls-kdh/3.5.nix
@@ -1,0 +1,12 @@
+{ callPackage, fetchFromGitHub, autoreconfHook, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "arpa2";
+    repo = "gnutls-kdh";
+    rev = "ff3bb36f70a746f28554641d466e124098dfcb25";
+    sha256 = "1rr3p4r145lnprxn8hqyyzh3qkj3idsbqp08g07ndrhqnxq0k0sw";
+  };
+})

--- a/pkgs/development/libraries/gnutls-kdh/generic.nix
+++ b/pkgs/development/libraries/gnutls-kdh/generic.nix
@@ -1,0 +1,92 @@
+{ lib, fetchurl, stdenv, zlib, lzo, libtasn1, nettle, pkgconfig, lzip
+, guileBindings, guile, perl, gmp, autogen, libidn, p11_kit, unbound, libiconv
+, tpmSupport ? true, trousers, nettools, bash, gperftools, gperf, gettext, automake
+, yacc, texinfo
+
+# Version dependent args
+, version, src, patches ? [], postPatch ? "", nativeBuildInputs ? []
+, ...}:
+
+assert guileBindings -> guile != null;
+let
+  # XXX: Gnulib's `test-select' fails on FreeBSD:
+  # http://hydra.nixos.org/build/2962084/nixlog/1/raw .
+  doCheck = !stdenv.isFreeBSD && !stdenv.isDarwin && lib.versionAtLeast version "3.4";
+in
+stdenv.mkDerivation {
+  name = "gnutls-kdh-${version}";
+
+  inherit src patches;
+
+  outputs = [ "bin" "dev" "out" ];
+
+  patchPhase = ''
+      # rm -fR ./po
+      # substituteInPlace configure "po/Makefile.in" " "
+      substituteInPlace doc/manpages/Makefile.in  --replace "gnutls_cipher_list.3" " "
+      substituteInPlace doc/manpages/Makefile.in  --replace "gnutls_cipher_self_test.3" " "
+      substituteInPlace doc/manpages/Makefile.in  --replace "gnutls_digest_self_test.3" " "
+      substituteInPlace doc/manpages/Makefile.in  --replace "gnutls_mac_self_test.3" " "
+      substituteInPlace doc/manpages/Makefile.in  --replace "gnutls_pk_self_test.3" " "
+      printf "all: ;\n\ninstall: ;" > "po/Makefile.in"
+      printf "all: ;\n\ninstall: ;" > "po/Makefile.in.in"
+      '';
+
+  postPatch = lib.optionalString (lib.versionAtLeast version "3.4") ''
+    sed '2iecho "name constraints tests skipped due to datefudge problems"\nexit 0' \
+      -i tests/cert-tests/name-constraints
+  '' + postPatch;
+
+  preConfigure = "patchShebangs .";
+  configureFlags =
+    lib.optional stdenv.isLinux "--with-default-trust-store-file=/etc/ssl/certs/ca-certificates.crt"
+  ++ [
+    "--disable-dependency-tracking"
+    "--enable-fast-install"
+  ] ++ lib.optional guileBindings
+    [ "--enable-guile" "--with-guile-site-dir=\${out}/share/guile/site" ];
+
+  # Build of the Guile bindings is not parallel-safe.  See
+  # <http://git.savannah.gnu.org/cgit/gnutls.git/commit/?id=330995a920037b6030ec0282b51dde3f8b493cad>
+  # for the actual fix.  Also an apparent race in the generation of
+  # systemkey-args.h.
+  enableParallelBuilding = false;
+
+  buildInputs = [ lzo lzip nettle libtasn1 libidn p11_kit zlib gmp
+  autogen gperftools gperf gettext automake yacc texinfo ]
+    ++ lib.optional doCheck nettools
+    ++ lib.optional (stdenv.isFreeBSD || stdenv.isDarwin) libiconv
+    ++ lib.optional (tpmSupport && stdenv.isLinux) trousers
+    ++ [ unbound ]
+    ++ lib.optional guileBindings guile;
+
+  nativeBuildInputs = [ perl pkgconfig ] ++ nativeBuildInputs;
+
+  #inherit doCheck;
+  doCheck = false;
+
+  # Fixup broken libtool and pkgconfig files
+  preFixup = lib.optionalString (!stdenv.isDarwin) ''
+    sed ${lib.optionalString tpmSupport "-e 's,-ltspi,-L${trousers}/lib -ltspi,'"} \
+        -e 's,-lz,-L${zlib.out}/lib -lz,' \
+        -e 's,-L${gmp.dev}/lib,-L${gmp.out}/lib,' \
+        -e 's,-lgmp,-L${gmp.out}/lib -lgmp,' \
+        -i $out/lib/*.la "$dev/lib/pkgconfig/gnutls.pc"
+  '';
+
+  meta = with lib; {
+    description = "GnuTLS with additional TLS-KDH ciphers: Kerberos + Diffie-Hellman";
+
+    longDescription = ''
+       The ARPA2 project aims to add security. This is an enhanced
+       version of GnuTLS,  a project that aims to develop a library which
+       provides a secure layer, over a reliable transport
+       layer. It adds TLS-KDH ciphers: Kerberos + Diffie-Hellman.
+    '';
+
+    homepage = http://www.gnu.org/software/gnutls://github.com/arpa2/gnutls-kdh;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/networking/tlspool/configvar-fix.patch
+++ b/pkgs/tools/networking/tlspool/configvar-fix.patch
@@ -1,0 +1,36 @@
+From 8561789ba70ae5d741992b143ee288b8e11a5e2b Mon Sep 17 00:00:00 2001
+From: joachim schiele <js@lastlog.de>
+Date: Wed, 1 Mar 2017 15:15:22 +0100
+Subject: [PATCH] fix to
+ https://github.com/arpa2/tlspool/issues/58#issuecomment-283333738
+
+---
+ tool/Makefile | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/tool/Makefile b/tool/Makefile
+index 9a15012..0f655e9 100644
+--- a/tool/Makefile
++++ b/tool/Makefile
+@@ -38,7 +38,6 @@ pgp11genkey_LIBS = $(P11KIT_LIBS) -lcrypto
+ 
+ configvar_CFLAGS = $(tlspool_CFLAGS)
+ configvar_LDFLAGS = $(tlspool_LDFLAGS)
+-configvar_LIBS = $(tlspool_LIBS)
+ 
+ P11KIT_CFLAGS = $(shell pkg-config --cflags p11-kit-1)
+ P11KIT_LIBS   = $(shell pkg-config --libs   p11-kit-1)
+@@ -96,8 +95,8 @@ have_db: have_db.c
+ pgp11_genkey: pgp11_genkey.c
+ 	gcc -std=gnu11 $(CFLAGS) $(pgp11genkey_CFLAGS) -o "$@" "$<" $(pgp11genkey_LIBS)
+ 
+-configvar: configvar.c $(configvar_LIBS)
+-	gcc -std=gnu11 $(CFLAGS) $(configvar_CFLAGS) $(configvar_LDFLAGS) $(configvar_CFLAGS) -o "$@" "$<" $(configvar_LIBS)
++configvar: configvar.c
++	gcc -std=gnu11 $(CFLAGS) $(configvar_CFLAGS) $(configvar_LDFLAGS) $(configvar_CFLAGS) -o "$@" "$<"
+ 
+ $(tlspool_LIBS):
+ 	$(MAKE) -C ../lib `basename $(tlspool_LIBS)`
+-- 
+2.12.0
+

--- a/pkgs/tools/networking/tlspool/default.nix
+++ b/pkgs/tools/networking/tlspool/default.nix
@@ -1,0 +1,60 @@
+{ pkgs, stdenv, fetchFromGitHub, unzip, libtool, pkgconfig, git, p11_kit,
+  libtasn1, db, openldap, libmemcached, cyrus_sasl, openssl, softhsm, bash,
+  python, libkrb5, quickder, unbound, ldns, gnupg, gnutls-kdh,
+  useSystemd ? true, systemd, swig
+}:
+
+let
+  pname = "tlspool";
+  version = "20170123";
+in
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  src = fetchFromGitHub { 
+    owner = "arpa2";
+    repo = "tlspool";
+    rev = "90cfa0758b02849114ba6373f280a4f2d3e534bf";
+    sha256 = "1qyq6da5bsgb8y9f3jhfrnhbvjns4k80lpkrydkvfx83bg494370";
+  };
+
+  propagatedBuildInputs = [ python softhsm openldap p11_kit.dev p11_kit.out gnupg ];
+  buildInputs = [ unbound pkgconfig unzip git libtasn1 db libmemcached cyrus_sasl openssl bash quickder
+                  libkrb5 ldns libtool swig pkgs.pythonPackages.pip gnutls-kdh ]
+                ++ stdenv.lib.optional useSystemd systemd;
+
+  phases = [ "unpackPhase" "patchPhase" "postPatchPhase" "buildPhase" "installPhase" ]; 
+
+  patches = [ ./fixing-rpath.patch ./configvar-fix.patch ];
+
+  postPatchPhase = ''
+    substituteInPlace etc/tlspool.conf \
+      --replace "dnssec_rootkey ../etc/root.key" "dnssec_rootkey $out/etc/root.key" \
+      --replace "pkcs11_path /usr/local/lib/softhsm/libsofthsm2.so" "pkcs11_path ${softhsm}/lib/softhsm/libsofthsm2.so"
+    substituteInPlace lib/Makefile \
+      --replace "DESTDIR=\$(DESTDIR) PREFIX=\$(PREFIX)" "DESTDIR=\$(DESTDIR) PREFIX=\$(PREFIX) SWIG=${swig}/bin/swig"
+  '';
+
+  buildPhase = ''
+    make clean
+    make DESTDIR=$out PREFIX=/ all
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib $out/sbin $out/man $out/etc/tlspool/ $out/include/${pname}/pulleyback
+    mkdir -p $out/${python.sitePackages}/tlspool
+    mkdir -p $out/bdb
+    make DESTDIR=$out PREFIX=/ install
+    cp -R etc/* $out/etc/tlspool/
+    cp include/tlspool/*.h $out/include/${pname}
+    cp pulleyback/*.h $out/include/${pname}/pulleyback/
+    cp src/*.h $out/include/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A supercharged TLS daemon that allows for easy, strong and consistent deployment";
+    license = licenses.bsd2;
+    homepage = https://www.tlspool.org;
+    maintainers = with maintainers; [ leenaars qknight ];
+  };
+}

--- a/pkgs/tools/networking/tlspool/fixing-rpath.patch
+++ b/pkgs/tools/networking/tlspool/fixing-rpath.patch
@@ -1,0 +1,36 @@
+From 8082f050794f771d1afb8e5c3d08862fc633922b Mon Sep 17 00:00:00 2001
+From: joachim schiele <js@lastlog.de>
+Date: Wed, 1 Mar 2017 13:12:19 +0100
+Subject: [PATCH] RPATH is back
+ https://github.com/arpa2/tlspool/issues/58#issuecomment-283318767
+
+---
+ tool/Makefile | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/tool/Makefile b/tool/Makefile
+index c1e6ce9..9a15012 100644
+--- a/tool/Makefile
++++ b/tool/Makefile
+@@ -18,9 +18,17 @@ LIBS =
+ 
+ PREFIX = /usr/local
+ 
++DIR := ${CURDIR}
++LIBDIR := ""
++ifndef DESTDIR
++       LIBDIR=$(DIR)/../lib/
++else
++       LIBDIR=$(DESTDIR)/lib
++endif
++
+ tlspool_CFLAGS =
+ tlspool_LIBS = ../lib/libtlspool.so
+-tlspool_LDFLAGS = -L ../lib -ltlspool
++tlspool_LDFLAGS = -L ../lib -ltlspool -Wl,-rpath,$(LIBDIR)
+ 
+ donai_CFLAGS = -DDONAI_ONLY_TEXTPROC
+ donai_SRC = ../src/donai.c
+-- 
+2.11.1
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4078,6 +4078,8 @@ with pkgs;
 
   tldr = callPackage ../tools/misc/tldr { };
 
+  tlspool = callPackage ../tools/networking/tlspool { };
+
   tmate = callPackage ../tools/misc/tmate { };
 
   tmpwatch = callPackage ../tools/misc/tmpwatch  { };
@@ -7577,6 +7579,11 @@ with pkgs;
 
   gnutls35 = callPackage ../development/libraries/gnutls/3.5.nix {
     guileBindings = config.gnutls.guile or false;
+  };
+
+  gnutls-kdh = callPackage ../development/libraries/gnutls-kdh/3.5.nix {
+    guileBindings = config.gnutls.guile or false;
+    gperf = gperf_3_0;
   };
 
   gpac = callPackage ../applications/video/gpac { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

