### PR TITLE
Qt 5.8 and Plasma 5.9

### DIFF
--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/plasma/5.8.6/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/plasma/5.9.3/ -A '*.tar.xz' )

--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -5,8 +5,9 @@
   kconfigwidgets, kcoreaddons, kcrash, kdeclarative, kdecoration, kglobalaccel,
   ki18n, kiconthemes, kidletime, kinit, kio, knewstuff, knotifications,
   kpackage, kscreenlocker, kservice, kwayland, kwidgetsaddons, kwindowsystem,
-  kxmlgui, libinput, libICE, libSM, plasma-framework, qtdeclarative,
-  qtmultimedia, qtscript, qtx11extras, udev, wayland, xcb-util-cursor, xwayland
+  kxmlgui, libICE, libSM, libinput, libxkbcommon, plasma-framework,
+  qtdeclarative, qtmultimedia, qtscript, qtx11extras, udev, wayland,
+  xcb-util-cursor, xwayland
 }:
 
 plasmaPackage {
@@ -19,9 +20,9 @@ plasmaPackage {
     breeze-qt5 epoxy kactivities kcmutils kcompletion kconfig kconfigwidgets
     kcoreaddons kcrash kdeclarative kdecoration kglobalaccel ki18n kiconthemes
     kidletime kinit kio knewstuff knotifications kpackage kscreenlocker kservice
-    kwayland kwidgetsaddons kwindowsystem kxmlgui libinput libICE libSM
-    plasma-framework qtdeclarative qtmultimedia qtscript qtx11extras udev
-    wayland xcb-util-cursor xwayland
+    kwayland kwidgetsaddons kwindowsystem kxmlgui libICE libSM libxkbcommon
+    libinput plasma-framework qtdeclarative qtmultimedia qtscript qtx11extras
+    udev wayland xcb-util-cursor xwayland
   ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
   postPatch = ''

--- a/pkgs/desktops/plasma-5/plasma-desktop/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-desktop/default.nix
@@ -6,8 +6,9 @@
   kglobalaccel, ki18n, kitemmodels, knewstuff, knotifications, knotifyconfig,
   kpeople, krunner, ksysguard, kwallet, kwin, libXcursor, libXft,
   libcanberra_kde, libpulseaudio, libxkbfile, phonon, plasma-framework,
-  plasma-workspace, qtdeclarative, qtquickcontrols, qtsvg, qtx11extras,
-  xf86inputevdev, xf86inputsynaptics, xinput, xkeyboard_config, xorgserver,
+  plasma-workspace, qtdeclarative, qtquickcontrols, qtquickcontrols2, qtsvg,
+  qtx11extras, xf86inputevdev, xf86inputsynaptics, xinput, xkeyboard_config,
+  xorgserver,
   utillinux
 }:
 
@@ -21,7 +22,7 @@ plasmaPackage rec {
     xf86inputsynaptics xkeyboard_config xinput baloo kactivities
     kactivities-stats kauth kdeclarative kdelibs4support kemoticons kglobalaccel
     ki18n kpeople krunner kwin plasma-framework plasma-workspace qtdeclarative
-    qtquickcontrols qtx11extras ksysguard
+    qtquickcontrols qtquickcontrols2 qtx11extras ksysguard
   ];
 
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);

--- a/pkgs/desktops/plasma-5/plasma-workspace/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-workspace/default.nix
@@ -7,8 +7,9 @@
   kdelibs4support, kdesu, kglobalaccel, kidletime, kjsembed, knewstuff,
   knotifyconfig, kpackage, krunner, ktexteditor, ktextwidgets, kwallet,
   kwayland, kwin, kxmlrpcclient, libkscreen, libksysguard, networkmanager-qt,
-  phonon, plasma-framework, qtgraphicaleffects, qtquickcontrols, qtscript,
-  qtx11extras, solid, isocodes, libdbusmenu, libSM, libXcursor, pam, wayland
+  phonon, plasma-framework, qtgraphicaleffects, qtquickcontrols,
+  qtquickcontrols2, qtscript, qtx11extras, solid, isocodes, libdbusmenu, libSM,
+  libXcursor, pam, wayland
 }:
 
 plasmaPackage {
@@ -20,8 +21,8 @@ plasmaPackage {
     kdelibs4support kdesu kglobalaccel kidletime kjsembed knewstuff
     knotifyconfig kpackage krunner ktexteditor ktextwidgets kwallet kwayland
     kwin kxmlrpcclient libkscreen libksysguard networkmanager-qt phonon
-    plasma-framework qtgraphicaleffects qtquickcontrols qtscript qtx11extras
-    solid isocodes libdbusmenu libSM libXcursor pam wayland
+    plasma-framework qtgraphicaleffects qtquickcontrols qtquickcontrols2
+    qtscript qtx11extras solid isocodes libdbusmenu libSM libXcursor pam wayland
   ];
 
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);

--- a/pkgs/desktops/plasma-5/srcs.nix
+++ b/pkgs/desktops/plasma-5/srcs.nix
@@ -3,323 +3,323 @@
 
 {
   bluedevil = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/bluedevil-5.8.6.tar.xz";
-      sha256 = "0qz9v5wrx72s3r1shi3m77931kl7sx7p89dk3h9w1hy61bx0azlj";
-      name = "bluedevil-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/bluedevil-5.9.3.tar.xz";
+      sha256 = "0cfk0khcd62ficsmpxhiqwfdgwzv771ndlf0s7b8ghqqyckq6bld";
+      name = "bluedevil-5.9.3.tar.xz";
     };
   };
   breeze = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/breeze-5.8.6.tar.xz";
-      sha256 = "16wxrmnlk359kapa6zj8hfcjjdffvmqc7ibzdxdd8xpdva01p7sm";
-      name = "breeze-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/breeze-5.9.3.tar.xz";
+      sha256 = "0f1h7ky9chsnbm8r85lwipc1sh7kb32jdaj3wl9qd7k0q4j115x0";
+      name = "breeze-5.9.3.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/breeze-grub-5.8.6.tar.xz";
-      sha256 = "1ywlczid32a8z4rrjxc6c3b8q3l02a3b7scbxyljgfv7xzggj1fm";
-      name = "breeze-grub-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/breeze-grub-5.9.3.tar.xz";
+      sha256 = "1hbvmyj1f5f8v0pc70w93ck27xw25m4x70vnbhgqi91y5dd1gh49";
+      name = "breeze-grub-5.9.3.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/breeze-gtk-5.8.6.tar.xz";
-      sha256 = "1ppxsf868d2v9kmdz18hnbdwwqbs0xhpn7pc3bdxxj4gk87dpxpl";
-      name = "breeze-gtk-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/breeze-gtk-5.9.3.tar.xz";
+      sha256 = "12qa4wllgr52ycdprlxq0h4pgykbbs0vbmmmiardpzlrplm0an26";
+      name = "breeze-gtk-5.9.3.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/breeze-plymouth-5.8.6.tar.xz";
-      sha256 = "0cdrl0ri4b5zbld8wb3hkmsncac6qn3mswvb7zp63br3jiqfg7v8";
-      name = "breeze-plymouth-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/breeze-plymouth-5.9.3.tar.xz";
+      sha256 = "0vz0hgx3hl03h4rkfrcaydaddljam3jbg6gd7n600a068p74s2mm";
+      name = "breeze-plymouth-5.9.3.tar.xz";
     };
   };
   discover = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/discover-5.8.6.tar.xz";
-      sha256 = "04smq3n0prs2bjq6sn5kd5mp4aay58nr2fg10yq39sgyp2qkls0r";
-      name = "discover-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/discover-5.9.3.tar.xz";
+      sha256 = "0xkf08k4jz5ym406bpnjf3xsx0il9wka4jp2k38bkl3sxh2s900f";
+      name = "discover-5.9.3.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kactivitymanagerd-5.8.6.tar.xz";
-      sha256 = "0cxpf3aj22ap6m24gm1ybjykwv10ryqhpd4bv6wr748ckj5zsgh4";
-      name = "kactivitymanagerd-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kactivitymanagerd-5.9.3.tar.xz";
+      sha256 = "0ywby3ijq4hjljy5qwd7rybpk2x4scairjffiy5n1jg7lq6sm44r";
+      name = "kactivitymanagerd-5.9.3.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kde-cli-tools-5.8.6.tar.xz";
-      sha256 = "08j6mpn6g4mrdwiljfm5rqvyfjgd3wd4kpwmpmvrprqrd755m0cs";
-      name = "kde-cli-tools-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kde-cli-tools-5.9.3.tar.xz";
+      sha256 = "1p9zjp9jmknyh82d6av3xhy461fsdppjxrxbmrlm9z6nsjyp0m0a";
+      name = "kde-cli-tools-5.9.3.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kdecoration-5.8.6.tar.xz";
-      sha256 = "0nbh0phgfzc5j1l1adnq3gn5fkazgk2pg2iiqjkfbax6a7r9wwny";
-      name = "kdecoration-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kdecoration-5.9.3.tar.xz";
+      sha256 = "1z37llaqf9mrb4aif75dfvbhr51rrgfpncv70v916jddcf90q4i9";
+      name = "kdecoration-5.9.3.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kde-gtk-config-5.8.6.tar.xz";
-      sha256 = "07in78awn7kqg47zbypj5lb2i9yibrmpzkljjy67wwcwax5zlm2d";
-      name = "kde-gtk-config-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kde-gtk-config-5.9.3.tar.xz";
+      sha256 = "1wxk3brwq105258ndx5l98n78q2h2idigkpp5s2xzmzw05m3gg6r";
+      name = "kde-gtk-config-5.9.3.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kdeplasma-addons-5.8.6.tar.xz";
-      sha256 = "0yvh2n736apbfzqc5kdf3b0a9jyvlzcaamall1paa8jb8cg706px";
-      name = "kdeplasma-addons-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kdeplasma-addons-5.9.3.tar.xz";
+      sha256 = "1k3fsrafrd72qymyi2ij36al7k92mnssz90kmmh830pszif16js3";
+      name = "kdeplasma-addons-5.9.3.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kgamma5-5.8.6.tar.xz";
-      sha256 = "1kk9bygihnggm4kmgxf1bbd0wc92ijmzvm9k5cmkm3v0pc975viz";
-      name = "kgamma5-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kgamma5-5.9.3.tar.xz";
+      sha256 = "02s3j1c5gjcv7b79448sizs6hdw91jysq9prkzznprw6jbb615v1";
+      name = "kgamma5-5.9.3.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/khotkeys-5.8.6.tar.xz";
-      sha256 = "0x6z025vzpccz0yql7nafcarq6rpw3p7d7wjffdck3lym8vkalxj";
-      name = "khotkeys-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/khotkeys-5.9.3.tar.xz";
+      sha256 = "0jv77rpx01cl15qf9vzndpks2q2lgq8dhjq4pg34zh8khr03snlf";
+      name = "khotkeys-5.9.3.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kinfocenter-5.8.6.tar.xz";
-      sha256 = "1d8h5h01dy7s1yaapamcz4dzf0pjdykf7jn8y34hc0djxww29k4b";
-      name = "kinfocenter-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kinfocenter-5.9.3.tar.xz";
+      sha256 = "14zaqrjf77008dc5c071hw75vd4dwvvmgkyz74vhs94i7bspzy6a";
+      name = "kinfocenter-5.9.3.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kmenuedit-5.8.6.tar.xz";
-      sha256 = "0zvircfmggc4vwz6520i67s1yfv34zkx8ydj1vfhaabpsn7nqn1w";
-      name = "kmenuedit-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kmenuedit-5.9.3.tar.xz";
+      sha256 = "1m7naiy6jq031psdx4jsxq7vsldn9j4girq820m24inh2ky105zk";
+      name = "kmenuedit-5.9.3.tar.xz";
     };
   };
   kscreen = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kscreen-5.8.6.tar.xz";
-      sha256 = "15k8pm1k2ylxqb3x4b75zi68firsxq56qfn39xddxnzncbsqp54r";
-      name = "kscreen-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kscreen-5.9.3.tar.xz";
+      sha256 = "1z3cihgjqrkg5h4y4gm1ah60r0vfpxrngry10fcc6343arbyk1bb";
+      name = "kscreen-5.9.3.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kscreenlocker-5.8.6.tar.xz";
-      sha256 = "1cql5wq4zh8sdwlgwibnyyx169g79948nhdqslw08ddw61f9llgd";
-      name = "kscreenlocker-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kscreenlocker-5.9.3.tar.xz";
+      sha256 = "0ccpgfp1gz07yiw98sqjlc097cac4z9qdcrwxm65bvqjj777by1a";
+      name = "kscreenlocker-5.9.3.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/ksshaskpass-5.8.6.tar.xz";
-      sha256 = "0y912dcvdx6gih0brnxnd3cysw0rj5pw7684xswaqz5i8iimw68g";
-      name = "ksshaskpass-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/ksshaskpass-5.9.3.tar.xz";
+      sha256 = "0jk6k5bn2aqjjl3li5qpmihk57d5hc197cpqjaj61a0bapab42hw";
+      name = "ksshaskpass-5.9.3.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/ksysguard-5.8.6.tar.xz";
-      sha256 = "0c0bxv5m0kziyqzwr6x46g4x2kahmq6n95kgcbihv74yvnn6v049";
-      name = "ksysguard-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/ksysguard-5.9.3.tar.xz";
+      sha256 = "0paypcwah41p2ygmfwzhw8mdfh47a6x0190yngxn8j0jhzfyllca";
+      name = "ksysguard-5.9.3.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kwallet-pam-5.8.6.tar.xz";
-      sha256 = "1ii1035w8xqvkbm0ckj5iq4qq7fnbix7vyvwmdjm8m4xm0rr7g33";
-      name = "kwallet-pam-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kwallet-pam-5.9.3.tar.xz";
+      sha256 = "1pmsfp6pn1r3crg5z5v7sz413v9qvn0j4n9l88zbw538lz2scpna";
+      name = "kwallet-pam-5.9.3.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kwayland-integration-5.8.6.tar.xz";
-      sha256 = "0bd8hnqr6sqlzk0qrymk6jdxnl2niamb1a08m8d27qdybm0ga56v";
-      name = "kwayland-integration-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kwayland-integration-5.9.3.tar.xz";
+      sha256 = "1r3cryv10lkvl1nrpq21w4kj9jd270m3p3dw07d888b891rgmzb7";
+      name = "kwayland-integration-5.9.3.tar.xz";
     };
   };
   kwin = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kwin-5.8.6.tar.xz";
-      sha256 = "1p9dgh6d25h41bgnx9jiyb9qg7jyc61kbzh9j9vy9j5kd97dsjg5";
-      name = "kwin-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kwin-5.9.3.tar.xz";
+      sha256 = "119cy472x5ssrr54v14pbs85gfrsjhz99ms8flb1xp38jb14xxhk";
+      name = "kwin-5.9.3.tar.xz";
     };
   };
   kwrited = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/kwrited-5.8.6.tar.xz";
-      sha256 = "08frbgzfzqhi4si3v024lx4dypxvm60mdz2xzyyx482iqjny97d5";
-      name = "kwrited-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/kwrited-5.9.3.tar.xz";
+      sha256 = "0liqspd4m6xly48vv85abnaxfvsjcbgg58843j9fpnzkk9nlj98q";
+      name = "kwrited-5.9.3.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/libkscreen-5.8.6.tar.xz";
-      sha256 = "0210lyvsk9wm7svj3bkaa9j0n57lfzs56jplasdqdia1450n7dmf";
-      name = "libkscreen-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/libkscreen-5.9.3.tar.xz";
+      sha256 = "1nxhbxmr0kmyp745bf3vd21xcjpv7jac9bdagraiqfcmwj4f86gb";
+      name = "libkscreen-5.9.3.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/libksysguard-5.8.6.tar.xz";
-      sha256 = "0i325hzl9zsknkr1dcdg64r4msrnvbb4b9rmjysygnpyll6n9bm8";
-      name = "libksysguard-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/libksysguard-5.9.3.tar.xz";
+      sha256 = "0fj7rycawarg7iydml0xw20nkyxlwa2nl5chxbbcs5mnmvpfv6ig";
+      name = "libksysguard-5.9.3.tar.xz";
     };
   };
   milou = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/milou-5.8.6.tar.xz";
-      sha256 = "00svi7f9pa1m6gxkkf8vngyf4jzv7k88pbcnlvik38zws17j4vbs";
-      name = "milou-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/milou-5.9.3.tar.xz";
+      sha256 = "1pmk9czmpz0mfqmkv7gl9wdlj8b7wwixv1zb43q24a471qby2xf3";
+      name = "milou-5.9.3.tar.xz";
     };
   };
   oxygen = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/oxygen-5.8.6.tar.xz";
-      sha256 = "1dspmzjmymnnv6blz2sfw0ynpqbw6cqzvhlnmzakf3xq8jd99k0m";
-      name = "oxygen-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/oxygen-5.9.3.tar.xz";
+      sha256 = "1v529wp9ll1hzb48xswigzf2r23k84f4cd7am2fnj73p3a0rg5ia";
+      name = "oxygen-5.9.3.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/plasma-desktop-5.8.6.tar.xz";
-      sha256 = "10qz1r777wr8wdr5lb7fph8ny8sxbm9vlq6njpn9rxxwr0nhlp6y";
-      name = "plasma-desktop-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/plasma-desktop-5.9.3.tar.xz";
+      sha256 = "0582n21nd15834mxc54pq1nx9a5z8ds3yz0x0lc5m35ps7abh7im";
+      name = "plasma-desktop-5.9.3.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/plasma-integration-5.8.6.tar.xz";
-      sha256 = "0v07i95xxv5rp0lis2xm0p66qicbigqjlx3sxyvcj3llf73jpcnc";
-      name = "plasma-integration-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/plasma-integration-5.9.3.tar.xz";
+      sha256 = "1yq3i0sqsn0m2y62npyad1nv17hgc0fm35cfq5fdjd96sr356znl";
+      name = "plasma-integration-5.9.3.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/plasma-nm-5.8.6.tar.xz";
-      sha256 = "162756r2rif415w8x6x67h8bwjvvmfv56s84p7a4k5zisyr1j678";
-      name = "plasma-nm-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/plasma-nm-5.9.3.tar.xz";
+      sha256 = "1i5djnbimkwcbjh6bi0cdw98qskli4jd1c8a8dbwqqh5pyqbrf66";
+      name = "plasma-nm-5.9.3.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/plasma-pa-5.8.6.tar.xz";
-      sha256 = "173w2ks2nm4sp96vj3pkax1d8asshd9y39m5cwq8mgzgpz6ldjp8";
-      name = "plasma-pa-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/plasma-pa-5.9.3.tar.xz";
+      sha256 = "0br83bnm6g7lzw4hwkppk8l6scbzblr3m3mi64a852lnxxvdwn01";
+      name = "plasma-pa-5.9.3.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/plasma-sdk-5.8.6.tar.xz";
-      sha256 = "1vadfwv23r33f5byaf3zj8m12a84r4qk24ak7qyq869m9gznyw8r";
-      name = "plasma-sdk-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/plasma-sdk-5.9.3.tar.xz";
+      sha256 = "104rhybchdjqnglzp3bpjv8052n2gi44bn58nyb6wz6gkzg3xzrb";
+      name = "plasma-sdk-5.9.3.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/plasma-tests-5.8.6.tar.xz";
-      sha256 = "0baqfn861jy7kmaqka79k6nkr7vivzymk8jy3glkh21rm4yl8gvh";
-      name = "plasma-tests-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/plasma-tests-5.9.3.tar.xz";
+      sha256 = "1wpbfna9yjvzc5fhgnw2hwnq04vzb3qfy42zrwbijy8sl6csgzzp";
+      name = "plasma-tests-5.9.3.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/plasma-workspace-5.8.6.tar.xz";
-      sha256 = "14h1lmyyb4rxnww7vyn9wnsi56v9ydhpbwmk9sv3zj1k9igqpasi";
-      name = "plasma-workspace-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/plasma-workspace-5.9.3.tar.xz";
+      sha256 = "0lnb36qnkw5z7w1y5ykiz6xfhc4h21dzlbhddipvd97bxycad6vg";
+      name = "plasma-workspace-5.9.3.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/plasma-workspace-wallpapers-5.8.6.tar.xz";
-      sha256 = "11s2sc37xni78fyb0yvnhlkw6ahhx4pkynqr06bmd9vq6c3133id";
-      name = "plasma-workspace-wallpapers-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/plasma-workspace-wallpapers-5.9.3.tar.xz";
+      sha256 = "1ikjj41nn5hn9r3glfhqsizawhkpw3cvybqq0ym4zky9lvbxzxb0";
+      name = "plasma-workspace-wallpapers-5.9.3.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.8.6";
+    version = "1-5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/polkit-kde-agent-1-5.8.6.tar.xz";
-      sha256 = "10bglbr7svm9bfl4a5kfyvj5zpyk46hsyh2rq9z9qy9ds76fh9w2";
-      name = "polkit-kde-agent-1-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/polkit-kde-agent-1-5.9.3.tar.xz";
+      sha256 = "0kfafag3bqp03aaa5dn7f8mkc174s80mwn98linl1dn12np2wv2q";
+      name = "polkit-kde-agent-1-5.9.3.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/powerdevil-5.8.6.tar.xz";
-      sha256 = "0cmyx267z917qqpndpzqzlgzx1hf54430644rhr7cf9iqqilvnv4";
-      name = "powerdevil-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/powerdevil-5.9.3.tar.xz";
+      sha256 = "1sphmngckfns5sx0n95njf39m02fg3q7bdafwrw8i4lv2svb1axj";
+      name = "powerdevil-5.9.3.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/sddm-kcm-5.8.6.tar.xz";
-      sha256 = "0xd8137pb0409vfiwv5n1vzzwa1vcvf3rgc36fid5hnlrdc15ilc";
-      name = "sddm-kcm-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/sddm-kcm-5.9.3.tar.xz";
+      sha256 = "142na2cnx5v459798fq6gx30k9v0i10myfyvgv562n1x79nbkyl0";
+      name = "sddm-kcm-5.9.3.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/systemsettings-5.8.6.tar.xz";
-      sha256 = "1zy037pb8w9xbzg316hbqfmfm39aylqngb5v08yn5hcnvxcll71v";
-      name = "systemsettings-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/systemsettings-5.9.3.tar.xz";
+      sha256 = "15ihvbkp91dz1z1z5dqgqyziiklzq2zkl3ns8dqzs3pbpki7jbqc";
+      name = "systemsettings-5.9.3.tar.xz";
     };
   };
   user-manager = {
-    version = "5.8.6";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.6/user-manager-5.8.6.tar.xz";
-      sha256 = "1z0aj5cvl5rxikbbvrvg0dq6y68jxm34ssf3gvhkd0jqlyqdl7ip";
-      name = "user-manager-5.8.6.tar.xz";
+      url = "${mirror}/stable/plasma/5.9.3/user-manager-5.9.3.tar.xz";
+      sha256 = "1s91zgh1rcqrpyh9fiklwqj2m78ify5fv83kh9zvyl4bapgyb0gn";
+      name = "user-manager-5.9.3.tar.xz";
     };
   };
 }

--- a/pkgs/desktops/plasma-5/startkde/default.nix
+++ b/pkgs/desktops/plasma-5/startkde/default.nix
@@ -1,8 +1,8 @@
 {
   stdenv, lib, runCommand, dbus, qttools, socat, gnugrep, gnused, kconfig,
   kinit, kservice, plasma-workspace, xmessage, xprop, xsetroot, qtbase,
-  qtdeclarative, qtgraphicaleffects, qtquickcontrols, qtscript, qtsvg,
-  qtx11extras, qtxmlpatterns
+  qtdeclarative, qtgraphicaleffects, qtquickcontrols, qtquickcontrols2,
+  qtscript, qtsvg, qtx11extras, qtxmlpatterns
 }:
 
 let
@@ -19,7 +19,7 @@ let
       ];
     libs = builtins.map (pkg: pkg.out or pkg)
       [
-        qtbase qtdeclarative qtgraphicaleffects qtquickcontrols
+        qtbase qtdeclarative qtgraphicaleffects qtquickcontrols qtquickcontrols2
         qtscript qtsvg qtx11extras qtxmlpatterns
       ];
   };

--- a/pkgs/desktops/plasma-5/systemsettings.nix
+++ b/pkgs/desktops/plasma-5/systemsettings.nix
@@ -1,7 +1,7 @@
 {
   plasmaPackage, extra-cmake-modules, kdoctools, makeQtWrapper,
   kcmutils, kconfig, kdbusaddons, khtml, ki18n, kiconthemes, kio, kitemviews,
-  kservice, kwindowsystem, kxmlgui, qtquickcontrols
+  kservice, kwindowsystem, kxmlgui, qtquickcontrols, qtquickcontrols2
 }:
 
 plasmaPackage {
@@ -9,6 +9,6 @@ plasmaPackage {
   nativeBuildInputs = [ extra-cmake-modules kdoctools makeQtWrapper ];
   propagatedBuildInputs = [
     kcmutils kconfig kdbusaddons khtml ki18n kiconthemes kio kitemviews kservice
-    kwindowsystem kxmlgui qtquickcontrols
+    kwindowsystem kxmlgui qtquickcontrols qtquickcontrols2
   ];
 }

--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     description = "A library to handle keyboard descriptions";
     homepage = http://xkbcommon.org;
     license = licenses.mit;
-    maintainers = with maintainers; [ garbas ];
+    maintainers = with maintainers; [ garbas ttuegel ];
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, yacc, flex, xkeyboard_config, libxcb, libX11 }:
 
 stdenv.mkDerivation rec {
-  name = "libxkbcommon-0.6.1";
+  name = "libxkbcommon-0.7.1";
 
   src = fetchurl {
     url = "http://xkbcommon.org/download/${name}.tar.xz";
-    sha256 = "0q47xa1szlxwgvwmhv4b7xwawnykz1hnc431d84nj8dlh2q8f22v";
+    sha256 = "ba59305d2e19e47c27ea065c2e0df96ebac6a3c6e97e28ae5620073b6084e68b";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/phonon/default.nix
+++ b/pkgs/development/libraries/phonon/default.nix
@@ -6,7 +6,7 @@
 with lib;
 
 let
-  v = "4.9.0";
+  v = "4.9.1";
 in
 
 assert withQt5 -> qtbase != null;
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://kde/stable/phonon/${v}/phonon-${v}.tar.xz";
-    sha256 = "1q5hvsk4sfcb91625wcmldy7kgjmfpmpmkgzi6mxkqdd307v8x5v";
+    sha256 = "177647r2jqfm32hqcz2nqfqv6v48hn5ab2vc31svba2wz23fkgk7";
   };
 
   buildInputs =

--- a/pkgs/development/libraries/qt-5/5.5/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.5/qtbase/default.nix
@@ -269,6 +269,9 @@ stdenv.mkDerivation {
               done
           popd
       fi
+
+      # fixup .pc file (where to find 'moc' etc.)
+      sed "s|^host_bins=.*|host_bins=$dev/bin|" -i "$dev/lib/pkgconfig/Qt5Core.pc"
     '';
 
   inherit lndir;

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/default.nix
@@ -267,6 +267,9 @@ stdenv.mkDerivation {
               done
           popd
       fi
+
+      # fixup .pc file (where to find 'moc' etc.)
+      sed "s|^host_bins=.*|host_bins=$dev/bin|" -i "$dev/lib/pkgconfig/Qt5Core.pc"
     '' + lib.optionalString stdenv.isDarwin ''
       fixDarwinDylibNames_rpath() {
         local flags=()

--- a/pkgs/development/libraries/qt-5/5.8/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/default.nix
@@ -1,0 +1,121 @@
+/*
+
+# Updates
+
+Before a major version update, make a copy of this directory. (We like to
+keep the old version around for a short time after major updates.) Add a
+top-level attribute to `top-level/all-packages.nix`.
+
+1. Update the URL in `maintainers/scripts/generate-qt.sh`.
+2. From the top of the Nixpkgs tree, run
+   `./maintainers/scripts/generate-qt.sh > pkgs/development/libraries/qt-5/$VERSION/srcs.nix`.
+3. Check that the new packages build correctly.
+4. Commit the changes and open a pull request.
+
+*/
+
+{
+  newScope,
+  stdenv, fetchurl, makeSetupHook, makeWrapper,
+  bison, cups ? null, harfbuzz, mesa, perl,
+  gstreamer, gst-plugins-base,
+
+  # options
+  developerBuild ? false,
+  decryptSslTraffic ? false,
+}:
+
+with stdenv.lib;
+
+let
+
+  mirror = "http://download.qt.io";
+  srcs = import ./srcs.nix { inherit fetchurl; inherit mirror; };
+
+  qtSubmodule = args:
+    let
+      inherit (args) name;
+      version = args.version or srcs."${name}".version;
+      src = args.src or srcs."${name}".src;
+      inherit (stdenv) mkDerivation;
+    in mkDerivation (args // {
+      name = "${name}-${version}";
+      inherit src;
+
+      propagatedBuildInputs = args.qtInputs ++ (args.propagatedBuildInputs or []);
+      nativeBuildInputs =
+        (args.nativeBuildInputs or [])
+        ++ [ perl self.qmakeHook ];
+
+      NIX_QT_SUBMODULE = args.NIX_QT_SUBMODULE or true;
+
+      outputs = args.outputs or [ "out" "dev" ];
+      setOutputFlags = args.setOutputFlags or false;
+
+      setupHook = ../qtsubmodule-setup-hook.sh;
+
+      enableParallelBuilding = args.enableParallelBuilding or true;
+
+      meta = self.qtbase.meta // (args.meta or {});
+    });
+
+  addPackages = self: with self;
+    let
+      callPackage = self.newScope { inherit qtSubmodule srcs; };
+    in {
+
+      qtbase = callPackage ./qtbase {
+        inherit (srcs.qtbase) src version;
+        inherit bison cups harfbuzz mesa;
+        inherit developerBuild decryptSslTraffic;
+      };
+
+      qtconnectivity = callPackage ./qtconnectivity.nix {};
+      qtdeclarative = callPackage ./qtdeclarative {};
+      qtdoc = callPackage ./qtdoc.nix {};
+      qtgraphicaleffects = callPackage ./qtgraphicaleffects.nix {};
+      qtimageformats = callPackage ./qtimageformats.nix {};
+      qtlocation = callPackage ./qtlocation.nix {};
+      qtmultimedia = callPackage ./qtmultimedia.nix {
+        inherit gstreamer gst-plugins-base;
+      };
+      qtquick1 = null;
+      qtquickcontrols = callPackage ./qtquickcontrols.nix {};
+      qtquickcontrols2 = callPackage ./qtquickcontrols2.nix {};
+      qtscript = callPackage ./qtscript {};
+      qtsensors = callPackage ./qtsensors.nix {};
+      qtserialport = callPackage ./qtserialport {};
+      qtsvg = callPackage ./qtsvg.nix {};
+      qttools = callPackage ./qttools {};
+      qttranslations = callPackage ./qttranslations.nix {};
+      qtwayland = callPackage ./qtwayland.nix {};
+      qtwebchannel = callPackage ./qtwebchannel.nix {};
+      qtwebengine = callPackage ./qtwebengine {};
+      qtwebkit = callPackage ./qtwebkit {};
+      qtwebsockets = callPackage ./qtwebsockets.nix {};
+      qtx11extras = callPackage ./qtx11extras.nix {};
+      qtxmlpatterns = callPackage ./qtxmlpatterns.nix {};
+
+      env = callPackage ../qt-env.nix {};
+      full = env "qt-${qtbase.version}" [
+        qtconnectivity qtdeclarative qtdoc qtgraphicaleffects
+        qtimageformats qtlocation qtmultimedia qtquickcontrols qtscript
+        qtsensors qtserialport qtsvg qttools qttranslations qtwayland
+        qtwebsockets qtx11extras qtxmlpatterns
+      ];
+
+      makeQtWrapper =
+        makeSetupHook
+        { deps = [ makeWrapper ]; }
+        ../make-qt-wrapper.sh;
+
+      qmakeHook =
+        makeSetupHook
+        { deps = [ self.qtbase.dev ]; }
+        ../qmake-hook.sh;
+
+    };
+
+   self = makeScope newScope addPackages;
+
+in self

--- a/pkgs/development/libraries/qt-5/5.8/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.8/fetch.sh
@@ -1,0 +1,3 @@
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.8/5.8.0/submodules/ \
+            http://download.qt.io/community_releases/5.8/5.8.0-final/ \
+            -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/cmake-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/cmake-paths.patch
@@ -1,0 +1,385 @@
+Index: qtbase-opensource-src-5.7.0/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
++++ qtbase-opensource-src-5.7.0/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+@@ -9,30 +9,6 @@ if (CMAKE_VERSION VERSION_LESS 3.0.0)
+ endif()
+ !!ENDIF
+ 
+-!!IF !isEmpty(CMAKE_USR_MOVE_WORKAROUND)
+-!!IF !isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-set(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"$$[QT_INSTALL_PREFIX]\")
+-!!ELSE
+-get_filename_component(_IMPORT_PREFIX \"${CMAKE_CURRENT_LIST_FILE}\" PATH)
+-# Use original install prefix when loaded through a
+-# cross-prefix symbolic link such as /lib -> /usr/lib.
+-get_filename_component(_realCurr \"${_IMPORT_PREFIX}\" REALPATH)
+-get_filename_component(_realOrig \"$$CMAKE_INSTALL_LIBS_DIR/cmake/Qt5$${CMAKE_MODULE_NAME}\" REALPATH)
+-if(_realCurr STREQUAL _realOrig)
+-    get_filename_component(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"$$CMAKE_INSTALL_LIBS_DIR/$${CMAKE_RELATIVE_INSTALL_LIBS_DIR}\" ABSOLUTE)
+-else()
+-    get_filename_component(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"${CMAKE_CURRENT_LIST_DIR}/$${CMAKE_RELATIVE_INSTALL_DIR}\" ABSOLUTE)
+-endif()
+-unset(_realOrig)
+-unset(_realCurr)
+-unset(_IMPORT_PREFIX)
+-!!ENDIF
+-!!ELIF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-get_filename_component(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"${CMAKE_CURRENT_LIST_DIR}/$${CMAKE_RELATIVE_INSTALL_DIR}\" ABSOLUTE)
+-!!ELSE
+-set(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"$$[QT_INSTALL_PREFIX]\")
+-!!ENDIF
+-
+ !!IF !equals(TEMPLATE, aux)
+ # For backwards compatibility only. Use Qt5$${CMAKE_MODULE_NAME}_VERSION instead.
+ set(Qt5$${CMAKE_MODULE_NAME}_VERSION_STRING "$$eval(QT.$${MODULE}.MAJOR_VERSION).$$eval(QT.$${MODULE}.MINOR_VERSION).$$eval(QT.$${MODULE}.PATCH_VERSION)")
+@@ -59,7 +35,10 @@ macro(_populate_$${CMAKE_MODULE_NAME}_ta
+     set_property(TARGET Qt5::$${CMAKE_MODULE_NAME} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
+ 
+ !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
++    set(imported_location \"@NIX_OUT@/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
++    endif()
+ !!ELSE
+     set(imported_location \"$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
+ !!ENDIF
+@@ -74,45 +53,18 @@ macro(_populate_$${CMAKE_MODULE_NAME}_ta
+         \"IMPORTED_LINK_INTERFACE_LIBRARIES_${Configuration}\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}\"
+     )
+ 
+-!!IF !isEmpty(CMAKE_WINDOWS_BUILD)
+-!!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_implib \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
+-!!ELSE
+-    set(imported_implib \"IMPORTED_IMPLIB_${Configuration}\" \"$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
+-!!ENDIF
+-    _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_implib})
+-    if(NOT \"${IMPLIB_LOCATION}\" STREQUAL \"\")
+-        set_target_properties(Qt5::$${CMAKE_MODULE_NAME} PROPERTIES
+-        \"IMPORTED_IMPLIB_${Configuration}\" ${imported_implib}
+-        )
+-    endif()
+-!!ENDIF
+ endmacro()
+ !!ENDIF
+ 
+ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
+ 
+ !!IF !no_module_headers
+-!!IF !isEmpty(CMAKE_BUILD_IS_FRAMEWORK)
+-    set(_Qt5$${CMAKE_MODULE_NAME}_OWN_INCLUDE_DIRS
+-      \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}Qt$${CMAKE_MODULE_NAME}.framework\"
+-      \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}Qt$${CMAKE_MODULE_NAME}.framework/Headers\"
+-    )
+-!!IF isEmpty(CMAKE_NO_PRIVATE_INCLUDES)
+-    set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}Qt$${CMAKE_MODULE_NAME}.framework/Versions/$$section(VERSION, ., 0, 0)/Headers/$$VERSION/\"
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}Qt$${CMAKE_MODULE_NAME}.framework/Versions/$$section(VERSION, ., 0, 0)/Headers/$$VERSION/$${MODULE_INCNAME}\"
+-    )
+-!!ELSE
+-    set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS \"\")
+-!!ENDIF
+-!!ELSE
+ !!IF isEmpty(CMAKE_INCLUDE_DIR_IS_ABSOLUTE)
+-    set(_Qt5$${CMAKE_MODULE_NAME}_OWN_INCLUDE_DIRS \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$$CMAKE_INCLUDE_DIR\" \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}\")
++    set(_Qt5$${CMAKE_MODULE_NAME}_OWN_INCLUDE_DIRS \"@NIX_DEV@/$$CMAKE_INCLUDE_DIR\" \"@NIX_DEV@/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}\")
+ !!IF isEmpty(CMAKE_NO_PRIVATE_INCLUDES)
+     set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}/$$VERSION\"
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}/$$VERSION/$${MODULE_INCNAME}\"
++        \"@NIX_DEV@/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}/$$VERSION\"
++        \"@NIX_DEV@/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}/$$VERSION/$${MODULE_INCNAME}\"
+     )
+ !!ELSE
+     set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS \"\")
+@@ -128,7 +80,7 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME
+     set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS \"\")
+ !!ENDIF
+ !!ENDIF
+-!!ENDIF
++
+ !!IF !isEmpty(CMAKE_ADD_SOURCE_INCLUDE_DIRS)
+     include(\"${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake\" OPTIONAL)
+ !!ENDIF
+@@ -253,28 +205,19 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME
+ 
+ !!IF !isEmpty(CMAKE_FIND_OTHER_LIBRARY_BUILD)
+ !!IF isEmpty(CMAKE_DEBUG_TYPE)
+-!!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
+-!!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    if (EXISTS \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+-!!ELSE // CMAKE_LIB_DIR_IS_ABSOLUTE
+-    if (EXISTS \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+-!!ENDIF // CMAKE_LIB_DIR_IS_ABSOLUTE
+-        _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" \"\" )
+-!!ELSE // CMAKE_STATIC_WINDOWS_BUILD
+     if (EXISTS
+ !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_DLL_DIR}$${CMAKE_LIB_FILE_LOCATION_DEBUG}\"
++        \"@NIX_OUT@/$${CMAKE_DLL_DIR}$${CMAKE_LIB_FILE_LOCATION_DEBUG}\"
+ !!ELSE
+         \"$${CMAKE_LIB_FILE_LOCATION_DEBUG}\"
+ !!ENDIF
+       AND EXISTS
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
++        \"@NIX_DEV@/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+ !!ELSE
+         \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+ !!ENDIF
+         _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_LIB_FILE_LOCATION_DEBUG}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+-!!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
+     endif()
+ !!ENDIF // CMAKE_DEBUG_TYPE
+ !!ENDIF // CMAKE_FIND_OTHER_LIBRARY_BUILD
+@@ -282,36 +225,23 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME
+ !!ENDIF // CMAKE_RELEASE_TYPE
+ 
+ !!IF !isEmpty(CMAKE_DEBUG_TYPE)
+-!!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
+-    _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" \"\" )
+-!!ELSE
+     _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_LIB_FILE_LOCATION_DEBUG}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+-!!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
+ 
+ !!IF !isEmpty(CMAKE_FIND_OTHER_LIBRARY_BUILD)
+ !!IF isEmpty(CMAKE_RELEASE_TYPE)
+-!!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
+-!!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    if (EXISTS \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+-!!ELSE // CMAKE_LIB_DIR_IS_ABSOLUTE
+-    if (EXISTS \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+-!!ENDIF // CMAKE_LIB_DIR_IS_ABSOLUTE
+-        _populate_$${CMAKE_MODULE_NAME}_target_properties(RELEASE \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" \"\" )
+-!!ELSE // CMAKE_STATIC_WINDOWS_BUILD
+     if (EXISTS
+ !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_DLL_DIR}$${CMAKE_LIB_FILE_LOCATION_RELEASE}\"
++        \"@NIX_OUT@/$${CMAKE_DLL_DIR}$${CMAKE_LIB_FILE_LOCATION_RELEASE}\"
+ !!ELSE
+         \"$${CMAKE_LIB_FILE_LOCATION_RELEASE}\"
+ !!ENDIF
+       AND EXISTS
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
++        \"@NIX_DEV@/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+ !!ELSE
+         \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+ !!ENDIF
+         _populate_$${CMAKE_MODULE_NAME}_target_properties(RELEASE \"$${CMAKE_LIB_FILE_LOCATION_RELEASE}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+-!!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
+     endif()
+ !!ENDIF // CMAKE_RELEASE_TYPE
+ !!ENDIF // CMAKE_FIND_OTHER_LIBRARY_BUILD
+@@ -328,11 +258,7 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME
+     macro(_populate_$${CMAKE_MODULE_NAME}_plugin_properties Plugin Configuration PLUGIN_LOCATION)
+         set_property(TARGET Qt5::${Plugin} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
+ 
+-!!IF isEmpty(CMAKE_PLUGIN_DIR_IS_ABSOLUTE)
+-        set(imported_location \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_PLUGIN_DIR}${PLUGIN_LOCATION}\")
+-!!ELSE
+-        set(imported_location \"$${CMAKE_PLUGIN_DIR}${PLUGIN_LOCATION}\")
+-!!ENDIF
++        set(imported_location \"${PLUGIN_LOCATION}\")
+         _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_location})
+         set_target_properties(Qt5::${Plugin} PROPERTIES
+             \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
+Index: qtbase-opensource-src-5.7.0/src/gui/Qt5GuiConfigExtras.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/gui/Qt5GuiConfigExtras.cmake.in
++++ qtbase-opensource-src-5.7.0/src/gui/Qt5GuiConfigExtras.cmake.in
+@@ -2,7 +2,7 @@
+ !!IF !isEmpty(CMAKE_ANGLE_EGL_DLL_RELEASE)
+ 
+ !!IF isEmpty(CMAKE_INCLUDE_DIR_IS_ABSOLUTE)
+-set(Qt5Gui_EGL_INCLUDE_DIRS \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$$CMAKE_INCLUDE_DIR/QtANGLE\")
++set(Qt5Gui_EGL_INCLUDE_DIRS \"@NIX_DEV@/$$CMAKE_INCLUDE_DIR/QtANGLE\")
+ !!ELSE
+ set(Qt5Gui_EGL_INCLUDE_DIRS \"$$CMAKE_INCLUDE_DIR/QtANGLE\")
+ !!ENDIF
+@@ -17,13 +17,13 @@ macro(_populate_qt5gui_gl_target_propert
+     set_property(TARGET Qt5::${TargetName} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
+ 
+ !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Gui_install_prefix}/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
++    set(imported_location \"@NIX_OUT@/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
+ !!ENDIF
+ 
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_implib \"${_qt5Gui_install_prefix}/$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
++    set(imported_implib \"@NIX_DEV@/$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
+ !!ELSE
+     set(imported_implib \"$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.7.0/src/widgets/Qt5WidgetsConfigExtras.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/widgets/Qt5WidgetsConfigExtras.cmake.in
++++ qtbase-opensource-src-5.7.0/src/widgets/Qt5WidgetsConfigExtras.cmake.in
+@@ -3,7 +3,7 @@ if (NOT TARGET Qt5::uic)
+     add_executable(Qt5::uic IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Widgets_install_prefix}/$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.7.0/src/corelib/Qt5CoreConfigExtras.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/Qt5CoreConfigExtras.cmake.in
++++ qtbase-opensource-src-5.7.0/src/corelib/Qt5CoreConfigExtras.cmake.in
+@@ -3,7 +3,7 @@ if (NOT TARGET Qt5::qmake)
+     add_executable(Qt5::qmake IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -18,7 +18,7 @@ if (NOT TARGET Qt5::moc)
+     add_executable(Qt5::moc IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -35,7 +35,7 @@ if (NOT TARGET Qt5::rcc)
+     add_executable(Qt5::rcc IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -133,7 +133,7 @@ if (NOT TARGET Qt5::WinMain)
+ !!IF !isEmpty(CMAKE_RELEASE_TYPE)
+     set_property(TARGET Qt5::WinMain APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
+ !!ENDIF
+@@ -147,7 +147,7 @@ if (NOT TARGET Qt5::WinMain)
+     set_property(TARGET Qt5::WinMain APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+ 
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.7.0/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
++++ qtbase-opensource-src-5.7.0/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
+@@ -1,6 +1,6 @@
+ 
+ !!IF isEmpty(CMAKE_INSTALL_DATA_DIR_IS_ABSOLUTE)
+-set(_qt5_corelib_extra_includes \"${_qt5Core_install_prefix}/$${CMAKE_INSTALL_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
++set(_qt5_corelib_extra_includes \"@NIX_DEV@/$${CMAKE_INSTALL_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
+ !!ELSE
+ set(_qt5_corelib_extra_includes \"$${CMAKE_INSTALL_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.7.0/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
++++ qtbase-opensource-src-5.7.0/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
+@@ -1,6 +1,6 @@
+ 
+ !!IF isEmpty(CMAKE_HOST_DATA_DIR_IS_ABSOLUTE)
+-set(_qt5_corelib_extra_includes \"${_qt5Core_install_prefix}/$${CMAKE_HOST_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
++set(_qt5_corelib_extra_includes \"@NIX_DEV@/$${CMAKE_HOST_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
+ !!ELSE
+ set(_qt5_corelib_extra_includes \"$${CMAKE_HOST_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.7.0/src/dbus/Qt5DBusConfigExtras.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/dbus/Qt5DBusConfigExtras.cmake.in
++++ qtbase-opensource-src-5.7.0/src/dbus/Qt5DBusConfigExtras.cmake.in
+@@ -3,7 +3,7 @@ if (NOT TARGET Qt5::qdbuscpp2xml)
+     add_executable(Qt5::qdbuscpp2xml IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5DBus_install_prefix}/$${CMAKE_BIN_DIR}qdbuscpp2xml$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qdbuscpp2xml$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}qdbuscpp2xml$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -18,7 +18,7 @@ if (NOT TARGET Qt5::qdbusxml2cpp)
+     add_executable(Qt5::qdbusxml2cpp IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5DBus_install_prefix}/$${CMAKE_BIN_DIR}qdbusxml2cpp$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qdbusxml2cpp$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}qdbusxml2cpp$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.7.0/mkspecs/features/create_cmake.prf
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/mkspecs/features/create_cmake.prf
++++ qtbase-opensource-src-5.7.0/mkspecs/features/create_cmake.prf
+@@ -136,28 +136,28 @@ contains(CONFIG, plugin) {
+ 
+     win32 {
+         isEmpty(CMAKE_STATIC_TYPE) {
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/$${TARGET}.dll
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/$${TARGET}d.dll
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/$${TARGET}.dll
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/$${TARGET}d.dll
+         } else:mingw {
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/lib$${TARGET}.a
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/lib$${TARGET}d.a
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}/$$PLUGIN_TYPE/lib$${TARGET}.a
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}d.a
+         } else {                         # MSVC static
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/$${TARGET}.lib
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/$${TARGET}d.lib
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/$${TARGET}.lib
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/$${TARGET}d.lib
+         }
+     } else {
+         mac {
+             isEmpty(CMAKE_STATIC_TYPE): CMAKE_PlUGIN_EXT = .dylib
+             else: CMAKE_PlUGIN_EXT = .a
+ 
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
+         } else {
+             isEmpty(CMAKE_STATIC_TYPE): CMAKE_PlUGIN_EXT = .so
+             else: CMAKE_PlUGIN_EXT = .a
+ 
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
+         }
+     }
+     cmake_target_file.input = $$PWD/data/cmake/Qt5PluginTarget.cmake.in
+Index: qtbase-opensource-src-5.7.0/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
++++ qtbase-opensource-src-5.7.0/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
+@@ -2,10 +2,10 @@
+ add_library(Qt5::$$CMAKE_PLUGIN_NAME MODULE IMPORTED)
+ 
+ !!IF !isEmpty(CMAKE_RELEASE_TYPE)
+-_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME RELEASE \"$${CMAKE_PLUGIN_LOCATION_RELEASE}\")
++_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME RELEASE \"@NIX_OUT@/$${CMAKE_PLUGIN_LOCATION_RELEASE}\")
+ !!ENDIF
+ !!IF !isEmpty(CMAKE_DEBUG_TYPE)
+-_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME DEBUG \"$${CMAKE_PLUGIN_LOCATION_DEBUG}\")
++_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME DEBUG \"@NIX_OUT@/$${CMAKE_PLUGIN_LOCATION_DEBUG}\")
+ !!ENDIF
+ 
+ list(APPEND Qt5$${CMAKE_MODULE_NAME}_PLUGINS Qt5::$$CMAKE_PLUGIN_NAME)

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/compose-search-path.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/compose-search-path.patch
@@ -1,0 +1,16 @@
+Index: qtbase-opensource-src-5.7.0/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
++++ qtbase-opensource-src-5.7.0/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
+@@ -257,10 +257,7 @@ void TableGenerator::initPossibleLocatio
+     // the QTCOMPOSE environment variable
+     if (qEnvironmentVariableIsSet("QTCOMPOSE"))
+         m_possibleLocations.append(QString::fromLocal8Bit(qgetenv("QTCOMPOSE")));
+-    m_possibleLocations.append(QStringLiteral("/usr/share/X11/locale"));
+-    m_possibleLocations.append(QStringLiteral("/usr/local/share/X11/locale"));
+-    m_possibleLocations.append(QStringLiteral("/usr/lib/X11/locale"));
+-    m_possibleLocations.append(QStringLiteral("/usr/local/lib/X11/locale"));
++    m_possibleLocations.append(QStringLiteral("${libX11}/share/X11/locale"));
+     m_possibleLocations.append(QStringLiteral(X11_PREFIX "/share/X11/locale"));
+     m_possibleLocations.append(QStringLiteral(X11_PREFIX "/lib/X11/locale"));
+ }

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/decrypt-ssl-traffic.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/decrypt-ssl-traffic.patch
@@ -1,0 +1,13 @@
+Index: qtbase-opensource-src-5.5.1/src/network/ssl/qsslsocket_openssl.cpp
+===================================================================
+--- qtbase-opensource-src-5.5.1.orig/src/network/ssl/qsslsocket_openssl.cpp
++++ qtbase-opensource-src-5.5.1/src/network/ssl/qsslsocket_openssl.cpp
+@@ -48,7 +48,7 @@
+ ****************************************************************************/
+ 
+ //#define QSSLSOCKET_DEBUG
+-//#define QT_DECRYPT_SSL_TRAFFIC
++#define QT_DECRYPT_SSL_TRAFFIC
+ 
+ #include "qssl_p.h"
+ #include "qsslsocket_openssl_p.h"

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/default.nix
@@ -1,0 +1,243 @@
+{
+  stdenv, lib, copyPathsToStore,
+  src, version,
+
+  coreutils, bison, flex, gdb, gperf, lndir, patchelf, perl, pkgconfig, python2,
+  ruby,
+
+  dbus, fontconfig, freetype, glib, gtk3, harfbuzz, icu, libX11, libXcomposite,
+  libXcursor, libXext, libXi, libXrender, libinput, libjpeg, libpng, libtiff,
+  libxcb, libxkbcommon, libxml2, libxslt, openssl, pcre16, sqlite, udev,
+  xcbutil, xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, xcbutilwm, xlibs,
+  zlib,
+
+  # optional dependencies
+  cups ? null, mysql ? null, postgresql ? null,
+
+  # options
+  mesaSupported, mesa,
+  buildExamples ? false,
+  buildTests ? false,
+  developerBuild ? false,
+  decryptSslTraffic ? false
+}:
+
+let
+  system-x86_64 = lib.elem stdenv.system lib.platforms.x86_64;
+in
+
+stdenv.mkDerivation {
+
+  name = "qtbase-${version}";
+  inherit src version;
+
+  outputs = [ "out" "dev" ];
+
+  patches =
+    copyPathsToStore (lib.readPathsFromFile ./. ./series)
+    ++ lib.optional decryptSslTraffic ./decrypt-ssl-traffic.patch
+    ++ lib.optional mesaSupported [ ./dlopen-gl.patch ./mkspecs-libgl.patch ];
+
+  postPatch =
+    ''
+      substituteInPlace configure --replace /bin/pwd pwd
+      substituteInPlace src/corelib/global/global.pri --replace /bin/ls ${coreutils}/bin/ls
+      sed -e 's@/\(usr\|opt\)/@/var/empty/@g' -i config.tests/*/*.test -i mkspecs/*/*.conf
+
+      sed -i 's/PATHS.*NO_DEFAULT_PATH//' "src/corelib/Qt5Config.cmake.in"
+      sed -i 's/PATHS.*NO_DEFAULT_PATH//' "src/corelib/Qt5CoreMacros.cmake"
+      sed -i 's/NO_DEFAULT_PATH//' "src/gui/Qt5GuiConfigExtras.cmake.in"
+      sed -i 's/PATHS.*NO_DEFAULT_PATH//' "mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in"
+
+      substituteInPlace src/network/kernel/qdnslookup_unix.cpp \
+        --replace "@glibc@" "${stdenv.cc.libc.out}"
+      substituteInPlace src/network/kernel/qhostinfo_unix.cpp \
+        --replace "@glibc@" "${stdenv.cc.libc.out}"
+
+      substituteInPlace src/plugins/platforms/xcb/qxcbcursor.cpp \
+        --replace "@libXcursor@" "${libXcursor.out}"
+
+      substituteInPlace src/network/ssl/qsslsocket_openssl_symbols.cpp \
+        --replace "@openssl@" "${openssl.out}"
+
+      substituteInPlace src/dbus/qdbus_symbols.cpp \
+        --replace "@dbus_libs@" "${dbus.lib}"
+
+      substituteInPlace \
+        src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp \
+        --replace "@libX11@" "${libX11.out}"
+    ''
+    + lib.optionalString mesaSupported ''
+      substituteInPlace \
+        src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp \
+        --replace "@mesa_lib@" "${mesa.out}"
+      substituteInPlace mkspecs/common/linux.conf \
+        --replace "@mesa_lib@" "${mesa.out}" \
+        --replace "@mesa_inc@" "${mesa.dev or mesa}"
+    '';
+
+
+  setOutputFlags = false;
+  preConfigure = ''
+    export LD_LIBRARY_PATH="$PWD/lib:$PWD/plugins/platforms:$LD_LIBRARY_PATH"
+    export MAKEFLAGS=-j$NIX_BUILD_CORES
+
+    configureFlags+="\
+        -plugindir $out/lib/qt5/plugins \
+        -importdir $out/lib/qt5/imports \
+        -qmldir $out/lib/qt5/qml \
+        -docdir $out/share/doc/qt5"
+  '';
+
+  prefixKey = "-prefix ";
+
+  # -no-eglfs, -no-directfb, -no-linuxfb and -no-kms because of the current minimalist mesa
+  # TODO Remove obsolete and useless flags once the build will be totally mastered
+  configureFlags = ''
+    -verbose
+    -confirm-license
+    -opensource
+
+    -release
+    -shared
+    ${lib.optionalString developerBuild "-developer-build"}
+    -accessibility
+    -rpath
+    -strip
+    -no-reduce-relocations
+    -system-proxies
+    -pkg-config
+
+    -gui
+    -widgets
+    -opengl desktop
+    -qml-debug
+    -icu
+    -pch
+    -glib
+    -xcb
+    -qpa xcb
+    -${lib.optionalString (cups == null) "no-"}cups
+
+    -no-eglfs
+    -no-directfb
+    -no-linuxfb
+    -no-kms
+
+    ${lib.optionalString (!system-x86_64) "-no-sse2"}
+    -no-sse3
+    -no-ssse3
+    -no-sse4.1
+    -no-sse4.2
+    -no-avx
+    -no-avx2
+    -no-mips_dsp
+    -no-mips_dspr2
+
+    -system-zlib
+    -system-libpng
+    -system-libjpeg
+    -system-harfbuzz
+    -system-xcb
+    -system-xkbcommon
+    -system-pcre
+    -openssl-linked
+    -dbus-linked
+    -libinput
+    -gtk
+
+    -system-sqlite
+    -${if mysql != null then "plugin" else "no"}-sql-mysql
+    -${if postgresql != null then "plugin" else "no"}-sql-psql
+
+    -make libs
+    -make tools
+    -${lib.optionalString (buildExamples == false) "no"}make examples
+    -${lib.optionalString (buildTests == false) "no"}make tests
+    -v
+  '';
+
+  # PostgreSQL autodetection fails sporadically because Qt omits the "-lpq" flag
+  # if dependency paths contain the string "pq", which can occur in the hash.
+  # To prevent these failures, we need to override PostgreSQL detection.
+  PSQL_LIBS = lib.optionalString (postgresql != null) "-L${postgresql.lib}/lib -lpq";
+
+  propagatedBuildInputs = [
+    dbus glib libxml2 libxslt openssl pcre16 sqlite udev zlib
+
+    # Image formats
+    libjpeg libpng libtiff
+
+    # Text rendering
+    fontconfig freetype harfbuzz icu
+
+    # X11 libs
+    libX11 libXcomposite libXext libXi libXrender libxcb libxkbcommon xcbutil
+    xcbutilimage xcbutilkeysyms xcbutilrenderutil xcbutilwm
+  ]
+  ++ lib.optional mesaSupported mesa;
+
+  buildInputs =
+    [ gtk3 libinput ]
+    ++ lib.optional developerBuild gdb
+    ++ lib.optional (cups != null) cups
+    ++ lib.optional (mysql != null) mysql.lib
+    ++ lib.optional (postgresql != null) postgresql;
+
+  nativeBuildInputs =
+    [ bison flex gperf lndir patchelf perl pkgconfig python2 ];
+
+  # freetype-2.5.4 changed signedness of some struct fields
+  NIX_CFLAGS_COMPILE = "-Wno-error=sign-compare";
+
+  postInstall = ''
+    find "$out" -name "*.cmake" | while read file; do
+        substituteInPlace "$file" \
+            --subst-var-by NIX_OUT "$out" \
+            --subst-var-by NIX_DEV "$dev"
+    done
+  '';
+
+  preFixup = ''
+    # We cannot simply set these paths in configureFlags because libQtCore retains
+    # references to the paths it was built with.
+    moveToOutput "bin" "$dev"
+    moveToOutput "include" "$dev"
+    moveToOutput "mkspecs" "$dev"
+
+    # The destination directory must exist or moveToOutput will do nothing
+    mkdir -p "$dev/share"
+    moveToOutput "share/doc" "$dev"
+  '';
+
+  postFixup =
+    ''
+      # Don't retain build-time dependencies like gdb.
+      sed '/QMAKE_DEFAULT_.*DIRS/ d' -i $dev/mkspecs/qconfig.pri
+
+      # Move libtool archives and qmake projects
+      if [ "z''${!outputLib}" != "z''${!outputDev}" ]; then
+          pushd "''${!outputLib}"
+          find lib -name '*.a' -o -name '*.la' -o -name '*.prl' | \
+              while read -r file; do
+                  mkdir -p "''${!outputDev}/$(dirname "$file")"
+                  mv "''${!outputLib}/$file" "''${!outputDev}/$file"
+              done
+          popd
+      fi
+    '';
+
+  inherit lndir;
+  setupHook = ../../qtbase-setup-hook.sh;
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = http://www.qt.io;
+    description = "A cross-platform application framework for C++";
+    license = with licenses; [ fdl13 gpl2 lgpl21 lgpl3 ];
+    maintainers = with maintainers; [ bbenoist qknight ttuegel ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/default.nix
@@ -225,10 +225,35 @@ stdenv.mkDerivation {
               done
           popd
       fi
+
+      # fixup .pc file (where to find 'moc' etc.)
+      sed "s|^host_bins=.*|host_bins=$dev/bin|" -i "$dev/lib/pkgconfig/Qt5Core.pc"
+    ''
+    # Don't move .prl files on darwin because they end up in
+    # "dev/lib/Foo.framework/Foo.prl" which interferes with subsequent
+    # use of lndir in the qtbase setup-hook. On Linux, the .prl files
+    # are in lib, and so do not cause a subsequent recreation of deep
+    # framework directory trees.
+    + lib.optionalString stdenv.isDarwin ''
+      fixDarwinDylibNames_rpath() {
+        local flags=()
+
+        for fn in "$@"; do
+          flags+=(-change "@rpath/$fn.framework/Versions/5/$fn" "$out/lib/$fn.framework/Versions/5/$fn")
+        done
+
+        for fn in "$@"; do
+          echo "$fn: fixing dylib"
+          install_name_tool -id "$out/lib/$fn.framework/Versions/5/$fn" "''${flags[@]}" "$out/lib/$fn.framework/Versions/5/$fn"
+        done
+      }
+      fixDarwinDylibNames_rpath "QtConcurrent" "QtPrintSupport" "QtCore" "QtSql" "QtDBus" "QtTest" "QtGui" "QtWidgets" "QtNetwork" "QtXml" "QtOpenGL"
     '';
 
   inherit lndir;
-  setupHook = ../../qtbase-setup-hook.sh;
+  setupHook = if stdenv.isDarwin
+              then ../../qtbase-setup-hook-darwin.sh
+              else ../../qtbase-setup-hook.sh;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-dbus.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-dbus.patch
@@ -1,0 +1,13 @@
+Index: qtbase-opensource-src-5.7.0/src/dbus/qdbus_symbols.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/dbus/qdbus_symbols.cpp
++++ qtbase-opensource-src-5.7.0/src/dbus/qdbus_symbols.cpp
+@@ -97,7 +97,7 @@ bool qdbus_loadLibDBus()
+ #ifdef Q_OS_WIN
+         QLatin1String("dbus-1"),
+ #endif
+-        QLatin1String("libdbus-1")
++        QLatin1String("@dbus_libs@/lib/libdbus-1")
+     };
+ 
+     lib->unload();

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-gl.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-gl.patch
@@ -1,0 +1,17 @@
+Index: qtbase-opensource-src-5.5.1/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
+===================================================================
+--- qtbase-opensource-src-5.5.1.orig/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
++++ qtbase-opensource-src-5.5.1/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
+@@ -563,7 +563,12 @@ void (*QGLXContext::getProcAddress(const
+             {
+                 extern const QString qt_gl_library_name();
+ //                QLibrary lib(qt_gl_library_name());
++                // Check system library paths first
+                 QLibrary lib(QLatin1String("GL"));
++                if (!lib.load()) {
++                    // Fallback to Mesa driver
++                    lib.setFileName(QLatin1String("@mesa_lib@/lib/libGL"));
++                }
+                 glXGetProcAddressARB = (qt_glXGetProcAddressARB) lib.resolve("glXGetProcAddressARB");
+             }
+         }

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-gtkstyle.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-gtkstyle.patch
@@ -1,0 +1,50 @@
+Index: qtbase-opensource-src-5.5.1/src/widgets/styles/qgtk2painter.cpp
+===================================================================
+--- qtbase-opensource-src-5.5.1.orig/src/widgets/styles/qgtk2painter.cpp
++++ qtbase-opensource-src-5.5.1/src/widgets/styles/qgtk2painter.cpp
+@@ -96,7 +96,7 @@ static void initGtk()
+     static bool initialized = false;
+     if (!initialized) {
+         // enforce the "0" suffix, so we'll open libgtk-x11-2.0.so.0
+-        QLibrary libgtk(QLS("gtk-x11-2.0"), 0, 0);
++        QLibrary libgtk(QLS("@gtk@/lib/libgtk-x11-2.0"), 0, 0);
+ 
+         QGtk2PainterPrivate::gdk_pixmap_new = (Ptr_gdk_pixmap_new)libgtk.resolve("gdk_pixmap_new");
+         QGtk2PainterPrivate::gdk_pixbuf_get_from_drawable = (Ptr_gdk_pixbuf_get_from_drawable)libgtk.resolve("gdk_pixbuf_get_from_drawable");
+Index: qtbase-opensource-src-5.5.1/src/widgets/styles/qgtkstyle_p.cpp
+===================================================================
+--- qtbase-opensource-src-5.5.1.orig/src/widgets/styles/qgtkstyle_p.cpp
++++ qtbase-opensource-src-5.5.1/src/widgets/styles/qgtkstyle_p.cpp
+@@ -327,7 +327,7 @@ void QGtkStylePrivate::gtkWidgetSetFocus
+ void QGtkStylePrivate::resolveGtk() const
+ {
+     // enforce the "0" suffix, so we'll open libgtk-x11-2.0.so.0
+-    QLibrary libgtk(QLS("gtk-x11-2.0"), 0, 0);
++    QLibrary libgtk(QLS("@gtk@/lib/libgtk-x11-2.0"), 0, 0);
+ 
+     gtk_init = (Ptr_gtk_init)libgtk.resolve("gtk_init");
+     gtk_window_new = (Ptr_gtk_window_new)libgtk.resolve("gtk_window_new");
+@@ -425,8 +425,8 @@ void QGtkStylePrivate::resolveGtk() cons
+     pango_font_description_get_family = (Ptr_pango_font_description_get_family)libgtk.resolve("pango_font_description_get_family");
+     pango_font_description_get_style = (Ptr_pango_font_description_get_style)libgtk.resolve("pango_font_description_get_style");
+ 
+-    gnome_icon_lookup_sync = (Ptr_gnome_icon_lookup_sync)QLibrary::resolve(QLS("gnomeui-2"), 0, "gnome_icon_lookup_sync");
+-    gnome_vfs_init= (Ptr_gnome_vfs_init)QLibrary::resolve(QLS("gnomevfs-2"), 0, "gnome_vfs_init");
++    gnome_icon_lookup_sync = (Ptr_gnome_icon_lookup_sync)QLibrary::resolve(QLS("@libgnomeui@/lib/libgnomeui-2"), 0, "gnome_icon_lookup_sync");
++    gnome_vfs_init= (Ptr_gnome_vfs_init)QLibrary::resolve(QLS("@gnome_vfs@/lib/libgnomevfs-2"), 0, "gnome_vfs_init");
+ }
+ 
+ /* \internal
+@@ -594,9 +594,9 @@ void QGtkStylePrivate::cleanupGtkWidgets
+ static bool resolveGConf()
+ {
+     if (!QGtkStylePrivate::gconf_client_get_default) {
+-        QGtkStylePrivate::gconf_client_get_default = (Ptr_gconf_client_get_default)QLibrary::resolve(QLS("gconf-2"), 4, "gconf_client_get_default");
+-        QGtkStylePrivate::gconf_client_get_string =  (Ptr_gconf_client_get_string)QLibrary::resolve(QLS("gconf-2"), 4, "gconf_client_get_string");
+-        QGtkStylePrivate::gconf_client_get_bool =  (Ptr_gconf_client_get_bool)QLibrary::resolve(QLS("gconf-2"), 4, "gconf_client_get_bool");
++        QGtkStylePrivate::gconf_client_get_default = (Ptr_gconf_client_get_default)QLibrary::resolve(QLS("@gconf@/lib/libgconf-2"), 4, "gconf_client_get_default");
++        QGtkStylePrivate::gconf_client_get_string =  (Ptr_gconf_client_get_string)QLibrary::resolve(QLS("@gconf@/lib/libgconf-2"), 4, "gconf_client_get_string");
++        QGtkStylePrivate::gconf_client_get_bool =  (Ptr_gconf_client_get_bool)QLibrary::resolve(QLS("@gconf@/lib/libgconf-2"), 4, "gconf_client_get_bool");
+     }
+     return (QGtkStylePrivate::gconf_client_get_default !=0);
+ }

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-libXcursor.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-libXcursor.patch
@@ -1,0 +1,17 @@
+Index: qtbase-opensource-src-5.7.0/src/plugins/platforms/xcb/qxcbcursor.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/plugins/platforms/xcb/qxcbcursor.cpp
++++ qtbase-opensource-src-5.7.0/src/plugins/platforms/xcb/qxcbcursor.cpp
+@@ -309,10 +309,10 @@ QXcbCursor::QXcbCursor(QXcbConnection *c
+ #if defined(XCB_USE_XLIB) && !defined(QT_NO_LIBRARY)
+     static bool function_ptrs_not_initialized = true;
+     if (function_ptrs_not_initialized) {
+-        QLibrary xcursorLib(QLatin1String("Xcursor"), 1);
++        QLibrary xcursorLib(QLatin1String("@libXcursor@/lib/libXcursor"), 1);
+         bool xcursorFound = xcursorLib.load();
+         if (!xcursorFound) { // try without the version number
+-            xcursorLib.setFileName(QLatin1String("Xcursor"));
++            xcursorLib.setFileName(QLatin1String("@libXcursor@/lib/Xcursor"));
+             xcursorFound = xcursorLib.load();
+         }
+         if (xcursorFound) {

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-openssl.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-openssl.patch
@@ -1,0 +1,26 @@
+Index: qtbase-opensource-src-5.7.0/src/network/ssl/qsslsocket_openssl_symbols.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/network/ssl/qsslsocket_openssl_symbols.cpp
++++ qtbase-opensource-src-5.7.0/src/network/ssl/qsslsocket_openssl_symbols.cpp
+@@ -658,8 +658,8 @@ static QPair<QLibrary*, QLibrary*> loadO
+ #endif
+ #if defined(SHLIB_VERSION_NUMBER) && !defined(Q_OS_QNX) // on QNX, the libs are always libssl.so and libcrypto.so
+     // first attempt: the canonical name is libssl.so.<SHLIB_VERSION_NUMBER>
+-    libssl->setFileNameAndVersion(QLatin1String("ssl"), QLatin1String(SHLIB_VERSION_NUMBER));
+-    libcrypto->setFileNameAndVersion(QLatin1String("crypto"), QLatin1String(SHLIB_VERSION_NUMBER));
++    libssl->setFileNameAndVersion(QLatin1String("@openssl@/lib/libssl"), QLatin1String(SHLIB_VERSION_NUMBER));
++    libcrypto->setFileNameAndVersion(QLatin1String("@openssl@/lib/libcrypto"), QLatin1String(SHLIB_VERSION_NUMBER));
+     if (libcrypto->load() && libssl->load()) {
+         // libssl.so.<SHLIB_VERSION_NUMBER> and libcrypto.so.<SHLIB_VERSION_NUMBER> found
+         return pair;
+@@ -676,8 +676,8 @@ static QPair<QLibrary*, QLibrary*> loadO
+     //  OS X's /usr/lib/libssl.dylib, /usr/lib/libcrypto.dylib will be picked up in the third
+     //    attempt, _after_ <bundle>/Contents/Frameworks has been searched.
+     //  iOS does not ship a system libssl.dylib, libcrypto.dylib in the first place.
+-    libssl->setFileNameAndVersion(QLatin1String("ssl"), -1);
+-    libcrypto->setFileNameAndVersion(QLatin1String("crypto"), -1);
++    libssl->setFileNameAndVersion(QLatin1String("@openssl@/lib/libssl"), -1);
++    libcrypto->setFileNameAndVersion(QLatin1String("@openssl@/lib/libcrypto"), -1);
+     if (libcrypto->load() && libssl->load()) {
+         // libssl.so.0 and libcrypto.so.0 found
+         return pair;

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-resolv.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-resolv.patch
@@ -1,0 +1,26 @@
+Index: qtbase-opensource-src-5.7.0/src/network/kernel/qdnslookup_unix.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/network/kernel/qdnslookup_unix.cpp
++++ qtbase-opensource-src-5.7.0/src/network/kernel/qdnslookup_unix.cpp
+@@ -85,7 +85,7 @@ static bool resolveLibraryInternal()
+     if (!lib.load())
+ #endif
+     {
+-        lib.setFileName(QLatin1String("resolv"));
++        lib.setFileName(QLatin1String("@glibc@/lib/resolv"));
+         if (!lib.load())
+             return false;
+     }
+Index: qtbase-opensource-src-5.7.0/src/network/kernel/qhostinfo_unix.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/network/kernel/qhostinfo_unix.cpp
++++ qtbase-opensource-src-5.7.0/src/network/kernel/qhostinfo_unix.cpp
+@@ -100,7 +100,7 @@ static bool resolveLibraryInternal()
+     if (!lib.load())
+ #endif
+     {
+-        lib.setFileName(QLatin1String("resolv"));
++        lib.setFileName(QLatin1String("@glibc@/lib/libresolv"));
+         if (!lib.load())
+             return false;
+     }

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/libressl.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/libressl.patch
@@ -1,0 +1,33 @@
+From 81494e67eccba04fc3fe554d76a9ca6fe7f2250e Mon Sep 17 00:00:00 2001
+From: hasufell <hasufell@gentoo.org>
+Date: Sat, 10 Oct 2015 01:15:01 +0200
+Subject: [PATCH] Fix compilation with libressl
+
+By additionally checking for defined(SSL_CTRL_SET_CURVES), which
+is defined in openssl, but not in libressl.
+---
+ src/network/ssl/qsslcontext_openssl.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+Index: qtbase-opensource-src-5.7.0/src/network/ssl/qsslcontext_openssl.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/network/ssl/qsslcontext_openssl.cpp
++++ qtbase-opensource-src-5.7.0/src/network/ssl/qsslcontext_openssl.cpp
+@@ -347,7 +347,7 @@ init_context:
+ 
+     const QVector<QSslEllipticCurve> qcurves = sslContext->sslConfiguration.ellipticCurves();
+     if (!qcurves.isEmpty()) {
+-#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(OPENSSL_NO_EC)
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L && defined(SSL_CTRL_SET_CURVES) && !defined(OPENSSL_NO_EC)
+         // Set the curves to be used
+         if (q_SSLeay() >= 0x10002000L) {
+             // SSL_CTX_ctrl wants a non-const pointer as last argument,
+@@ -360,7 +360,7 @@ init_context:
+                 sslContext->errorCode = QSslError::UnspecifiedError;
+             }
+         } else
+-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(OPENSSL_NO_EC)
++#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L && defined(SSL_CTRL_SET_CURVES) && !defined(OPENSSL_NO_EC)
+         {
+             // specific curves requested, but not possible to set -> error
+             sslContext->errorStr = msgErrorSettingEllipticCurves(QSslSocket::tr("OpenSSL version too old, need at least v1.0.2"));

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/mkspecs-libgl.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/mkspecs-libgl.patch
@@ -1,0 +1,15 @@
+Index: qtbase-opensource-src-5.5.1/mkspecs/common/linux.conf
+===================================================================
+--- qtbase-opensource-src-5.5.1.orig/mkspecs/common/linux.conf
++++ qtbase-opensource-src-5.5.1/mkspecs/common/linux.conf
+@@ -12,8 +12,8 @@ QMAKE_INCDIR            =
+ QMAKE_LIBDIR            =
+ QMAKE_INCDIR_X11        =
+ QMAKE_LIBDIR_X11        =
+-QMAKE_INCDIR_OPENGL     =
+-QMAKE_LIBDIR_OPENGL     =
++QMAKE_INCDIR_OPENGL     = @mesa_inc@/include
++QMAKE_LIBDIR_OPENGL     = @mesa_lib@/lib
+ QMAKE_INCDIR_OPENGL_ES2 = $$QMAKE_INCDIR_OPENGL
+ QMAKE_LIBDIR_OPENGL_ES2 = $$QMAKE_LIBDIR_OPENGL
+ QMAKE_INCDIR_EGL        =

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/nix-profiles-library-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/nix-profiles-library-paths.patch
@@ -1,0 +1,22 @@
+Index: qtbase-opensource-src-5.7.0/src/corelib/kernel/qcoreapplication.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/kernel/qcoreapplication.cpp
++++ qtbase-opensource-src-5.7.0/src/corelib/kernel/qcoreapplication.cpp
+@@ -2487,7 +2487,17 @@ QStringList QCoreApplication::libraryPat
+         QStringList *app_libpaths = new QStringList;
+         coreappdata()->app_libpaths.reset(app_libpaths);
+ 
++        // Add library paths derived from NIX_PROFILES.
++        const QByteArrayList profiles = qgetenv("NIX_PROFILES").split(' ');
++        const QString plugindir = QString::fromLatin1("/lib/qt5/plugins");
++        for (const QByteArray &profile: profiles) {
++            if (!profile.isEmpty()) {
++                app_libpaths->append(QFile::decodeName(profile) + plugindir);
++            }
++        }
++
+         const QByteArray libPathEnv = qgetenv("QT_PLUGIN_PATH");
++        qunsetenv("QT_PLUGIN_PATH"); // do not propagate to child processes
+         if (!libPathEnv.isEmpty()) {
+             QStringList paths = QFile::decodeName(libPathEnv).split(QDir::listSeparator(), QString::SkipEmptyParts);
+             for (QStringList::const_iterator it = paths.constBegin(); it != paths.constEnd(); ++it) {

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/series
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/series
@@ -1,0 +1,10 @@
+dlopen-resolv.patch
+tzdir.patch
+dlopen-libXcursor.patch
+dlopen-openssl.patch
+dlopen-dbus.patch
+xdg-config-dirs.patch
+nix-profiles-library-paths.patch
+compose-search-path.patch
+libressl.patch
+cmake-paths.patch

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/tzdir.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/tzdir.patch
@@ -1,0 +1,40 @@
+Index: qtbase-opensource-src-5.7.0/src/corelib/tools/qtimezoneprivate_tz.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/tools/qtimezoneprivate_tz.cpp
++++ qtbase-opensource-src-5.7.0/src/corelib/tools/qtimezoneprivate_tz.cpp
+@@ -68,7 +68,10 @@ typedef QHash<QByteArray, QTzTimeZone> Q
+ // Parse zone.tab table, assume lists all installed zones, if not will need to read directories
+ static QTzTimeZoneHash loadTzTimeZones()
+ {
+-    QString path = QStringLiteral("/usr/share/zoneinfo/zone.tab");
++    QString path = qgetenv("TZDIR");
++    path += "/zone.tab";
++    if (!QFile::exists(path))
++        path = QStringLiteral("/usr/share/zoneinfo/zone.tab");
+     if (!QFile::exists(path))
+         path = QStringLiteral("/usr/lib/zoneinfo/zone.tab");
+ 
+@@ -566,12 +569,18 @@ void QTzTimeZonePrivate::init(const QByt
+         if (!tzif.open(QIODevice::ReadOnly))
+             return;
+     } else {
+-        // Open named tz, try modern path first, if fails try legacy path
+-        tzif.setFileName(QLatin1String("/usr/share/zoneinfo/") + QString::fromLocal8Bit(ianaId));
++        // Try TZDIR first
++        QString zoneinfoDir = qgetenv("TZDIR");
++        zoneinfoDir += "/" + QString::fromLocal8Bit(ianaId);
++        tzif.setFileName(zoneinfoDir);
+         if (!tzif.open(QIODevice::ReadOnly)) {
+-            tzif.setFileName(QLatin1String("/usr/lib/zoneinfo/") + QString::fromLocal8Bit(ianaId));
+-            if (!tzif.open(QIODevice::ReadOnly))
+-                return;
++            // Open named tz, try modern path first, if fails try legacy path
++            tzif.setFileName(QLatin1String("/usr/share/zoneinfo/") + QString::fromLocal8Bit(ianaId));
++            if (!tzif.open(QIODevice::ReadOnly)) {
++                tzif.setFileName(QLatin1String("/usr/lib/zoneinfo/") + QString::fromLocal8Bit(ianaId));
++                if (!tzif.open(QIODevice::ReadOnly))
++                    return;
++            }
+         }
+     }
+ 

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/xdg-config-dirs.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/xdg-config-dirs.patch
@@ -1,0 +1,41 @@
+Index: qtbase-opensource-src-5.7.0/src/corelib/io/qsettings.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/io/qsettings.cpp
++++ qtbase-opensource-src-5.7.0/src/corelib/io/qsettings.cpp
+@@ -1161,6 +1161,23 @@ QConfFileSettingsPrivate::QConfFileSetti
+         confFiles[F_System | F_Application].reset(QConfFile::fromName(systemPath + appFile, false));
+     confFiles[F_System | F_Organization].reset(QConfFile::fromName(systemPath + orgFile, false));
+ 
++#if !defined(Q_OS_WIN)
++    // Add directories specified in $XDG_CONFIG_DIRS
++    const QString pathEnv = QString::fromLocal8Bit(getenv("XDG_CONFIG_DIRS"));
++    if (!pathEnv.isEmpty()) {
++        const QStringList pathEntries = pathEnv.split(QLatin1Char(':'), QString::SkipEmptyParts);
++        if (!pathEntries.isEmpty()) {
++            int j = 4; // This is the number of confFiles set above -- we need to start adding $XDG_CONFIG_DIRS after those.
++            for (int k = 0; k < pathEntries.size() && j < NumConfFiles - 1; ++k) {
++                const QString& path = pathEntries.at(k);
++                if (!application.isEmpty())
++                    confFiles[j++].reset(QConfFile::fromName(path + QDir::separator() + appFile, false));
++                confFiles[j++].reset(QConfFile::fromName(path + QDir::separator() + orgFile, false));
++            }
++        }
++    }
++#endif
++
+     for (i = 0; i < NumConfFiles; ++i) {
+         if (confFiles[i]) {
+             spec = i;
+Index: qtbase-opensource-src-5.7.0/src/corelib/io/qsettings_p.h
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/io/qsettings_p.h
++++ qtbase-opensource-src-5.7.0/src/corelib/io/qsettings_p.h
+@@ -246,7 +246,7 @@ public:
+         F_Organization = 0x1,
+         F_User = 0x0,
+         F_System = 0x2,
+-        NumConfFiles = 4
++        NumConfFiles = 40 // HACK: increase NumConfFiles from 4 to 40 in order to accommodate more paths in $XDG_CONFIG_DIRS -- ellis
+     };
+ 
+     QSettings::Format format;

--- a/pkgs/development/libraries/qt-5/5.8/qtconnectivity.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtconnectivity.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtconnectivity";
+  qtInputs = [ qtbase qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtdeclarative/default.nix
@@ -1,0 +1,8 @@
+{ qtSubmodule, lib, copyPathsToStore, python2, qtbase, qtsvg, qtxmlpatterns }:
+
+qtSubmodule {
+  name = "qtdeclarative";
+  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  qtInputs = [ qtbase qtsvg qtxmlpatterns ];
+  nativeBuildInputs = [ python2 ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtdeclarative/nix-profiles-import-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtdeclarative/nix-profiles-import-paths.patch
@@ -1,0 +1,20 @@
+Index: qtdeclarative-opensource-src-5.5.1/src/qml/qml/qqmlimport.cpp
+===================================================================
+--- qtdeclarative-opensource-src-5.5.1.orig/src/qml/qml/qqmlimport.cpp
++++ qtdeclarative-opensource-src-5.5.1/src/qml/qml/qqmlimport.cpp
+@@ -1549,6 +1549,15 @@ QQmlImportDatabase::QQmlImportDatabase(Q
+     QString installImportsPath =  QLibraryInfo::location(QLibraryInfo::Qml2ImportsPath);
+     addImportPath(installImportsPath);
+ 
++    // Add library paths derived from NIX_PROFILES.
++    const QByteArrayList profiles = qgetenv("NIX_PROFILES").split(' ');
++    const QString qmldir = QString::fromLatin1("/lib/qt5/qml");
++    Q_FOREACH (const QByteArray &profile, profiles) {
++        if (!profile.isEmpty()) {
++            addImportPath(QFile::decodeName(profile) + qmldir);
++        }
++    }
++
+     // env import paths
+     QByteArray envImportPath = qgetenv("QML2_IMPORT_PATH");
+     if (!envImportPath.isEmpty()) {

--- a/pkgs/development/libraries/qt-5/5.8/qtdeclarative/series
+++ b/pkgs/development/libraries/qt-5/5.8/qtdeclarative/series
@@ -1,0 +1,1 @@
+nix-profiles-import-paths.patch

--- a/pkgs/development/libraries/qt-5/5.8/qtdoc.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtdoc.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtdoc";
+  qtInputs = [ qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtgraphicaleffects.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtgraphicaleffects.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtgraphicaleffects";
+  qtInputs = [ qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtimageformats.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtimageformats.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase }:
+
+qtSubmodule {
+  name = "qtimageformats";
+  qtInputs = [ qtbase ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtlocation.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtlocation.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase, qtmultimedia }:
+
+qtSubmodule {
+  name = "qtlocation";
+  qtInputs = [ qtbase qtmultimedia ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtmultimedia.nix
@@ -1,0 +1,12 @@
+{ qtSubmodule, qtbase, qtdeclarative, pkgconfig
+, alsaLib, gstreamer, gst-plugins-base, libpulseaudio
+}:
+
+qtSubmodule {
+  name = "qtmultimedia";
+  qtInputs = [ qtbase qtdeclarative ];
+  buildInputs = [
+    pkgconfig alsaLib gstreamer gst-plugins-base libpulseaudio
+  ];
+  qmakeFlags = [ "GST_VERSION=1.0" ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtquickcontrols.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtquickcontrols.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtquickcontrols";
+  qtInputs = [ qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtquickcontrols2.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtquickcontrols2.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtquickcontrols2";
+  qtInputs = [ qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtscript/0001-glib-2.32.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtscript/0001-glib-2.32.patch
@@ -1,0 +1,25 @@
+From abd80356449bb36c8adcc5c9ca1df6b47715d265 Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:13:34 -0500
+Subject: [PATCH] glib-2.32
+
+---
+ src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h b/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h
+index 1f6d25e..087c3fb 100644
+--- a/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h
++++ b/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h
+@@ -81,7 +81,7 @@
+ #include <pthread.h>
+ #elif PLATFORM(GTK)
+ #include <wtf/gtk/GOwnPtr.h>
+-typedef struct _GMutex GMutex;
++typedef union _GMutex GMutex;
+ typedef struct _GCond GCond;
+ #endif
+ 
+-- 
+2.5.0
+

--- a/pkgs/development/libraries/qt-5/5.8/qtscript/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtscript/default.nix
@@ -1,0 +1,7 @@
+{ qtSubmodule, qtbase, qttools }:
+
+qtSubmodule {
+  name = "qtscript";
+  qtInputs = [ qtbase qttools ];
+  patches = [ ./0001-glib-2.32.patch ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtsensors.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtsensors.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtsensors";
+  qtInputs = [ qtbase qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtserialport/0001-dlopen-serialport-udev.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtserialport/0001-dlopen-serialport-udev.patch
@@ -1,0 +1,28 @@
+From d81c2c870b9bea8fb8e6b85baefb06542f568338 Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:16:02 -0500
+Subject: [PATCH] dlopen serialport udev
+
+---
+ src/serialport/qtudev_p.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/serialport/qtudev_p.h b/src/serialport/qtudev_p.h
+index 6f2cabd..81b9849 100644
+--- a/src/serialport/qtudev_p.h
++++ b/src/serialport/qtudev_p.h
+@@ -105,9 +105,9 @@ inline QFunctionPointer resolveSymbol(QLibrary *udevLibrary, const char *symbolN
+ inline bool resolveSymbols(QLibrary *udevLibrary)
+ {
+     if (!udevLibrary->isLoaded()) {
+-        udevLibrary->setFileNameAndVersion(QStringLiteral("udev"), 1);
++        udevLibrary->setFileNameAndVersion(QStringLiteral("@libudev@/lib/libudev"), 1);
+         if (!udevLibrary->load()) {
+-            udevLibrary->setFileNameAndVersion(QStringLiteral("udev"), 0);
++            udevLibrary->setFileNameAndVersion(QStringLiteral("@libudev@/lib/libudev"), 0);
+             if (!udevLibrary->load()) {
+                 qWarning("Failed to load the library: %s, supported version(s): %i and %i", qPrintable(udevLibrary->fileName()), 1, 0);
+                 return false;
+-- 
+2.5.0
+

--- a/pkgs/development/libraries/qt-5/5.8/qtserialport/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtserialport/default.nix
@@ -1,0 +1,12 @@
+{ qtSubmodule, qtbase, substituteAll, systemd }:
+
+qtSubmodule {
+  name = "qtserialport";
+  qtInputs = [ qtbase ];
+  patches = [
+    (substituteAll {
+      src = ./0001-dlopen-serialport-udev.patch;
+      libudev = systemd.lib;
+    })
+  ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtsvg.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtsvg.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase }:
+
+qtSubmodule {
+  name = "qtsvg";
+  qtInputs = [ qtbase ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qttools/cmake-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qttools/cmake-paths.patch
@@ -1,0 +1,72 @@
+Index: qttools-opensource-src-5.5.1/src/assistant/help/Qt5HelpConfigExtras.cmake.in
+===================================================================
+--- qttools-opensource-src-5.5.1.orig/src/assistant/help/Qt5HelpConfigExtras.cmake.in
++++ qttools-opensource-src-5.5.1/src/assistant/help/Qt5HelpConfigExtras.cmake.in
+@@ -2,11 +2,10 @@
+ if (NOT TARGET Qt5::qcollectiongenerator)
+     add_executable(Qt5::qcollectiongenerator IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Help_install_prefix}/$${CMAKE_BIN_DIR}qcollectiongenerator$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}qcollectiongenerator$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
++    set(imported_location \"@NIX_OUT@/$${CMAKE_BIN_DIR}qcollectiongenerator$$CMAKE_BIN_SUFFIX\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qcollectiongenerator$$CMAKE_BIN_SUFFIX\")
++    endif()
+     _qt5_Help_check_file_exists(${imported_location})
+ 
+     set_target_properties(Qt5::qcollectiongenerator PROPERTIES
+Index: qttools-opensource-src-5.5.1/src/linguist/Qt5LinguistToolsConfig.cmake.in
+===================================================================
+--- qttools-opensource-src-5.5.1.orig/src/linguist/Qt5LinguistToolsConfig.cmake.in
++++ qttools-opensource-src-5.5.1/src/linguist/Qt5LinguistToolsConfig.cmake.in
+@@ -44,11 +44,10 @@ endmacro()
+ if (NOT TARGET Qt5::lrelease)
+     add_executable(Qt5::lrelease IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5_linguisttools_install_prefix}/$${CMAKE_BIN_DIR}lrelease$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}lrelease$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
++    set(imported_location \"@NIX_OUT@/$${CMAKE_BIN_DIR}lrelease$$CMAKE_BIN_SUFFIX\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}lrelease$$CMAKE_BIN_SUFFIX\")
++    endif()
+     _qt5_LinguistTools_check_file_exists(${imported_location})
+ 
+     set_target_properties(Qt5::lrelease PROPERTIES
+@@ -59,11 +58,10 @@ endif()
+ if (NOT TARGET Qt5::lupdate)
+     add_executable(Qt5::lupdate IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5_linguisttools_install_prefix}/$${CMAKE_BIN_DIR}lupdate$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}lupdate$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
++    set(imported_location \"@NIX_OUT@/$${CMAKE_BIN_DIR}lupdate$$CMAKE_BIN_SUFFIX\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}lupdate$$CMAKE_BIN_SUFFIX\")
++    endif()
+     _qt5_LinguistTools_check_file_exists(${imported_location})
+ 
+     set_target_properties(Qt5::lupdate PROPERTIES
+@@ -74,11 +72,10 @@ endif()
+ if (NOT TARGET Qt5::lconvert)
+     add_executable(Qt5::lconvert IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5_linguisttools_install_prefix}/$${CMAKE_BIN_DIR}lconvert$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}lconvert$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
++    set(imported_location \"@NIX_OUT@/$${CMAKE_BIN_DIR}lconvert$$CMAKE_BIN_SUFFIX\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}lconvert$$CMAKE_BIN_SUFFIX\")
++    endif()
+     _qt5_LinguistTools_check_file_exists(${imported_location})
+ 
+     set_target_properties(Qt5::lconvert PROPERTIES

--- a/pkgs/development/libraries/qt-5/5.8/qttools/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qttools/default.nix
@@ -1,0 +1,11 @@
+{ qtSubmodule, lib, copyPathsToStore, qtbase }:
+
+qtSubmodule {
+  name = "qttools";
+  qtInputs = [ qtbase ];
+  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  postFixup = ''
+    moveToOutput "bin/qdbus" "$out"
+    moveToOutput "bin/qtpaths" "$out"
+  '';
+}

--- a/pkgs/development/libraries/qt-5/5.8/qttools/series
+++ b/pkgs/development/libraries/qt-5/5.8/qttools/series
@@ -1,0 +1,1 @@
+cmake-paths.patch

--- a/pkgs/development/libraries/qt-5/5.8/qttranslations.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qttranslations.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qttools }:
+
+qtSubmodule {
+  name = "qttranslations";
+  qtInputs = [ qttools ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtwayland.nix
@@ -1,0 +1,8 @@
+{ qtSubmodule, qtbase, qtquickcontrols, wayland, pkgconfig }:
+
+qtSubmodule {
+  name = "qtwayland";
+  qtInputs = [ qtbase qtquickcontrols ];
+  buildInputs = [ wayland ];
+  nativeBuildInputs = [ pkgconfig ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtwebchannel.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebchannel.nix
@@ -1,0 +1,7 @@
+{ qtSubmodule, qtbase, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtwebchannel";
+  qtInputs = [ qtbase qtdeclarative ];
+}
+

--- a/pkgs/development/libraries/qt-5/5.8/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebengine/default.nix
@@ -1,0 +1,69 @@
+{ qtSubmodule, qtquickcontrols, qtlocation, qtwebchannel
+
+, xlibs, libXcursor, libXScrnSaver, libXrandr, libXtst
+, fontconfig, freetype, harfbuzz, icu, dbus
+, zlib, libjpeg, libpng, libtiff
+, alsaLib
+, libcap
+, pciutils
+
+, bison, flex, git, which, gperf
+, coreutils
+, pkgconfig, python2
+
+, stdenv # lib.optional, needsPax
+}:
+
+qtSubmodule {
+  name = "qtwebengine";
+  qtInputs = [ qtquickcontrols qtlocation qtwebchannel ];
+  buildInputs = [ bison flex git which gperf ];
+  nativeBuildInputs = [ pkgconfig python2 coreutils ];
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    export MAKEFLAGS=-j$NIX_BUILD_CORES
+    substituteInPlace ./src/3rdparty/chromium/build/common.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+    substituteInPlace ./src/3rdparty/chromium/v8/build/toolchain.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+    substituteInPlace ./src/3rdparty/chromium/v8/build/standalone.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+
+    # fix default SSL bundle location
+    sed -i -e 's,/cert.pem,/certs/ca-bundle.crt,' src/3rdparty/chromium/third_party/boringssl/src/crypto/x509/x509_def.c
+
+    configureFlags+="\
+        -plugindir $out/lib/qt5/plugins \
+        -importdir $out/lib/qt5/imports \
+        -qmldir $out/lib/qt5/qml \
+        -docdir $out/share/doc/qt5"
+  '';
+  propagatedBuildInputs = [
+    dbus zlib alsaLib
+
+    # Image formats
+    libjpeg libpng libtiff
+
+    # Text rendering
+    fontconfig freetype harfbuzz icu
+
+    # X11 libs
+    xlibs.xrandr libXScrnSaver libXcursor libXrandr xlibs.libpciaccess libXtst
+    xlibs.libXcomposite
+
+    libcap
+    pciutils
+  ];
+  patches = stdenv.lib.optional stdenv.needsPax ./qtwebengine-paxmark-mksnapshot.patch;
+  postInstall = ''
+    cat > $out/libexec/qt.conf <<EOF
+    [Paths]
+    Prefix = ..
+    EOF
+
+    paxmark m $out/libexec/QtWebEngineProcess
+  '';
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtwebengine/qtwebengine-paxmark-mksnapshot.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebengine/qtwebengine-paxmark-mksnapshot.patch
@@ -1,0 +1,46 @@
+--- qtwebengine-opensource-src-5.6.0-orig/src/3rdparty/chromium/v8/tools/gyp/v8.gyp	2016-03-04 01:48:36.000000000 +1100
++++ qtwebengine-opensource-src-5.6.0/src/3rdparty/chromium/v8/tools/gyp/v8.gyp	2016-05-01 19:15:44.052770543 +1000
+@@ -33,6 +33,7 @@
+     'embed_script%': "",
+     'v8_extra_library_files%': [],
+     'mksnapshot_exec': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)mksnapshot<(EXECUTABLE_SUFFIX)',
++    'mksnapshot_u_exec': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)mksnapshot_u<(EXECUTABLE_SUFFIX)',
+     'remove_v8base_debug_symbols%': 0,
+   },
+   'includes': ['../../build/toolchain.gypi', '../../build/features.gypi'],
+@@ -1913,7 +1914,7 @@
+         ]
+     },
+     {
+-      'target_name': 'mksnapshot',
++      'target_name': 'mksnapshot_u',
+       'type': 'executable',
+       'dependencies': ['v8_base', 'v8_nosnapshot', 'v8_libplatform'],
+       'include_dirs+': [
+@@ -1936,5 +1937,26 @@
+         }],
+       ],
+     },
++    {
++      'target_name': 'mksnapshot',
++      'type': 'executable',
++      'dependencies': ['mksnapshot_u'],
++      'actions': [
++        {
++          'action_name': 'paxmark_m_mksnapshot',
++          'inputs': [
++            '<(mksnapshot_u_exec)',
++          ],
++          'outputs': [
++            '<(mksnapshot_exec)',
++          ],
++          'action': [
++            'sh',
++            '-c',
++            'cp <(mksnapshot_u_exec) <(mksnapshot_exec) && paxctl -czexm <(mksnapshot_exec)',
++          ],
++        },
++      ],
++    },
+   ],
+ }

--- a/pkgs/development/libraries/qt-5/5.8/qtwebkit/0001-dlopen-webkit-nsplugin.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebkit/0001-dlopen-webkit-nsplugin.patch
@@ -1,0 +1,53 @@
+From 862ce7d357a3ec32683ac6ec7c0ebdc9346b44ba Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:18:54 -0500
+Subject: [PATCH 1/3] dlopen webkit nsplugin
+
+---
+ Source/WebCore/plugins/qt/PluginPackageQt.cpp                        | 2 +-
+ Source/WebCore/plugins/qt/PluginViewQt.cpp                           | 2 +-
+ Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Source/WebCore/plugins/qt/PluginPackageQt.cpp b/Source/WebCore/plugins/qt/PluginPackageQt.cpp
+index a923d49..2731d05 100644
+--- a/Source/WebCore/plugins/qt/PluginPackageQt.cpp
++++ b/Source/WebCore/plugins/qt/PluginPackageQt.cpp
+@@ -136,7 +136,7 @@ static void initializeGtk(QLibrary* module = 0)
+         }
+     }
+ 
+-    QLibrary library(QLatin1String("libgtk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gtk@/lib/libgtk-x11-2.0"), 0);
+     if (library.load()) {
+         typedef void *(*gtk_init_check_ptr)(int*, char***);
+         gtk_init_check_ptr gtkInitCheck = (gtk_init_check_ptr)library.resolve("gtk_init_check");
+diff --git a/Source/WebCore/plugins/qt/PluginViewQt.cpp b/Source/WebCore/plugins/qt/PluginViewQt.cpp
+index de06a2f..363bde5 100644
+--- a/Source/WebCore/plugins/qt/PluginViewQt.cpp
++++ b/Source/WebCore/plugins/qt/PluginViewQt.cpp
+@@ -697,7 +697,7 @@ static Display *getPluginDisplay()
+     // support gdk based plugins (like flash) that use a different X connection.
+     // The code below has the same effect as this one:
+     // Display *gdkDisplay = gdk_x11_display_get_xdisplay(gdk_display_get_default());
+-    QLibrary library(QLatin1String("libgdk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gdk_pixbuf@/lib/libgdk-x11-2.0"), 0);
+     if (!library.load())
+         return 0;
+ 
+diff --git a/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp b/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp
+index d734ff6..62a2197 100644
+--- a/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp
++++ b/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp
+@@ -64,7 +64,7 @@ static Display* getPluginDisplay()
+     // The code below has the same effect as this one:
+     // Display *gdkDisplay = gdk_x11_display_get_xdisplay(gdk_display_get_default());
+ 
+-    QLibrary library(QLatin1String("libgdk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gdk_pixbuf@/libgdk-x11-2.0"), 0);
+     if (!library.load())
+         return 0;
+ 
+-- 
+2.5.0
+

--- a/pkgs/development/libraries/qt-5/5.8/qtwebkit/0002-dlopen-webkit-gtk.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebkit/0002-dlopen-webkit-gtk.patch
@@ -1,0 +1,25 @@
+From 6a407d30357c2551abceac75c82f4a1688e47437 Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:19:16 -0500
+Subject: [PATCH 2/3] dlopen webkit gtk
+
+---
+ Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp b/Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp
+index 8de6521..0b25748 100644
+--- a/Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp
++++ b/Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp
+@@ -53,7 +53,7 @@ static void messageHandler(QtMsgType type, const QMessageLogContext&, const QStr
+ 
+ static bool initializeGtk()
+ {
+-    QLibrary gtkLibrary(QLatin1String("libgtk-x11-2.0"), 0);
++    QLibrary gtkLibrary(QLatin1String("@gtk@/lib/libgtk-x11-2.0"), 0);
+     if (!gtkLibrary.load())
+         return false;
+     typedef void* (*gtk_init_ptr)(void*, void*);
+-- 
+2.5.0
+

--- a/pkgs/development/libraries/qt-5/5.8/qtwebkit/0003-dlopen-webkit-udev.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebkit/0003-dlopen-webkit-udev.patch
@@ -1,0 +1,31 @@
+From 864020dd47c3b6d532d9f26b82185904cf9324f2 Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:19:29 -0500
+Subject: [PATCH 3/3] dlopen webkit udev
+
+---
+ Source/WebCore/platform/qt/GamepadsQt.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Source/WebCore/platform/qt/GamepadsQt.cpp b/Source/WebCore/platform/qt/GamepadsQt.cpp
+index 60ff317..da8ac69 100644
+--- a/Source/WebCore/platform/qt/GamepadsQt.cpp
++++ b/Source/WebCore/platform/qt/GamepadsQt.cpp
+@@ -111,12 +111,12 @@ private:
+     bool load()
+     {
+         m_libUdev.setLoadHints(QLibrary::ResolveAllSymbolsHint);
+-        m_libUdev.setFileNameAndVersion(QStringLiteral("udev"), 1);
++        m_libUdev.setFileNameAndVersion(QStringLiteral("@libudev@/lib/libudev"), 1);
+         m_loaded = m_libUdev.load();
+         if (resolveMethods())
+             return true;
+ 
+-        m_libUdev.setFileNameAndVersion(QStringLiteral("udev"), 0);
++        m_libUdev.setFileNameAndVersion(QStringLiteral("@libudev@/lib/libudev"), 0);
+         m_loaded = m_libUdev.load();
+         return resolveMethods();
+     }
+-- 
+2.5.0
+

--- a/pkgs/development/libraries/qt-5/5.8/qtwebkit/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebkit/default.nix
@@ -1,0 +1,35 @@
+{ qtSubmodule, stdenv, qtdeclarative, qtlocation, qtsensors
+, fontconfig, gdk_pixbuf, gtk2, libwebp, libxml2, libxslt
+, sqlite, systemd, glib, gst_all_1
+, bison2, flex, gdb, gperf, perl, pkgconfig, python2, ruby
+, substituteAll
+, flashplayerFix ? false
+}:
+
+with stdenv.lib;
+
+qtSubmodule {
+  name = "qtwebkit";
+  qtInputs = [ qtdeclarative qtlocation qtsensors ];
+  buildInputs = [ fontconfig libwebp libxml2 libxslt sqlite glib gst_all_1.gstreamer gst_all_1.gst-plugins-base ];
+  nativeBuildInputs = [
+    bison2 flex gdb gperf perl pkgconfig python2 ruby
+  ];
+  patches =
+    let dlopen-webkit-nsplugin = substituteAll {
+          src = ./0001-dlopen-webkit-nsplugin.patch;
+          gtk = gtk2.out;
+          gdk_pixbuf = gdk_pixbuf.out;
+        };
+        dlopen-webkit-gtk = substituteAll {
+          src = ./0002-dlopen-webkit-gtk.patch;
+          gtk = gtk2.out;
+        };
+        dlopen-webkit-udev = substituteAll {
+          src = ./0003-dlopen-webkit-udev.patch;
+          libudev = systemd.lib;
+        };
+    in optionals flashplayerFix [ dlopen-webkit-nsplugin dlopen-webkit-gtk ]
+    ++ [ dlopen-webkit-udev ];
+  meta.maintainers = with stdenv.lib.maintainers; [ abbradar ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtwebsockets.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebsockets.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtwebsockets";
+  qtInputs = [ qtbase qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtx11extras.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtx11extras.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase }:
+
+qtSubmodule {
+  name = "qtx11extras";
+  qtInputs = [ qtbase ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtxmlpatterns.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtxmlpatterns.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase }:
+
+qtSubmodule {
+  name = "qtxmlpatterns";
+  qtInputs = [ qtbase ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.8/srcs.nix
@@ -1,0 +1,325 @@
+# DO NOT EDIT! This file is generated automatically by fetch-kde-qt.sh
+{ fetchurl, mirror }:
+
+{
+  qt3d = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qt3d-opensource-src-5.8.0.tar.xz";
+      sha256 = "1rca1k8lf0xy2x1w3kp9rnpi77bbrm8v7db302n9a8cjziv4a8is";
+      name = "qt3d-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtactiveqt = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtactiveqt-opensource-src-5.8.0.tar.xz";
+      sha256 = "1a9m87chmp2m3ljadryh9ggvwpvclmazz081h3p68n092dbl2ylj";
+      name = "qtactiveqt-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtandroidextras = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtandroidextras-opensource-src-5.8.0.tar.xz";
+      sha256 = "1wgbxi579fdnripp481qhcqma95hm4zcc16n4ljjpl0yzn1zx8qa";
+      name = "qtandroidextras-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtbase = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtbase-opensource-src-5.8.0.tar.xz";
+      sha256 = "01f07yjly7y24njl2h4hyknmi7pf8yd9gky23szcfkd40ap12wf1";
+      name = "qtbase-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtcanvas3d = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtcanvas3d-opensource-src-5.8.0.tar.xz";
+      sha256 = "18yaikbwk4d7sh09psi3kjn1mxjp4d2f3qchfzgq5x96yn8gfijl";
+      name = "qtcanvas3d-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtcharts = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtcharts-opensource-src-5.8.0.tar.xz";
+      sha256 = "11m5g1fxip6z2xk1z6g6h4rq7v282qbkxflan8hs87hadnzars03";
+      name = "qtcharts-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtconnectivity = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtconnectivity-opensource-src-5.8.0.tar.xz";
+      sha256 = "1w97na5s420y08dcydqinbqb0rd9h4pfdnjbwslr0qvzsvlh2bbv";
+      name = "qtconnectivity-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtdatavis3d = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtdatavis3d-opensource-src-5.8.0.tar.xz";
+      sha256 = "1n2vdf6n7pr9xrjwbvbar899q74shx6cy19x32adxfn2iilygwbp";
+      name = "qtdatavis3d-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtdeclarative = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtdeclarative-opensource-src-5.8.0.tar.xz";
+      sha256 = "0ilaf2sprpk9fg2j3905hxnhm0xbnm88ppk4zifp7n0jmnwix51j";
+      name = "qtdeclarative-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtdoc = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtdoc-opensource-src-5.8.0.tar.xz";
+      sha256 = "13jpml9hdcxvf8j2033x5liw26r3q8idpjmx2rij63w2956c84ii";
+      name = "qtdoc-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtgamepad = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtgamepad-opensource-src-5.8.0.tar.xz";
+      sha256 = "0dwcrq60h802z694h4108figlr3yvp8fpzhwjzbjm503v8yaxw5j";
+      name = "qtgamepad-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtgraphicaleffects = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtgraphicaleffects-opensource-src-5.8.0.tar.xz";
+      sha256 = "06frknb7m8bgg55rs7jjm61iziisy2ykzrrc5dy3vj0aad89najz";
+      name = "qtgraphicaleffects-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtimageformats = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtimageformats-opensource-src-5.8.0.tar.xz";
+      sha256 = "0vv0wh5q5sih294x661djzwvgdwy7r6xpnxsc111k5hwq7m5w13m";
+      name = "qtimageformats-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtlocation = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtlocation-opensource-src-5.8.0.tar.xz";
+      sha256 = "1fqssa8rhq83lnxjcdh4ijqck3lmqglpk8yax8x17w49v6gf78a8";
+      name = "qtlocation-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtmacextras = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtmacextras-opensource-src-5.8.0.tar.xz";
+      sha256 = "049lbxy6yxv7yii7zxibfbix0q2p8fn58dsbc33rn40gbs7rj9zf";
+      name = "qtmacextras-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtmultimedia = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtmultimedia-opensource-src-5.8.0.tar.xz";
+      sha256 = "01sakngvsqr90qhrxyghfqdpddpxwbjyzzhm34k0hlpr6i409g58";
+      name = "qtmultimedia-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtnetworkauth = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtnetworkauth-opensource-src-5.8.0.tar.xz";
+      sha256 = "1hz4lcm4cai56v0q7h1q6zc29ykkb2191iqmf8h7l5l9m71q2mb1";
+      name = "qtnetworkauth-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtpurchasing = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtpurchasing-opensource-src-5.8.0.tar.xz";
+      sha256 = "0mdkw73yx1csz9mf3wl0w1x1b8cv9j5px4nvakrknkjzaa9qgzdk";
+      name = "qtpurchasing-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtquickcontrols = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtquickcontrols-opensource-src-5.8.0.tar.xz";
+      sha256 = "09mkswxw7wa2l8xz9fbblxr1pbi86hggis55j4k8ifnrrw60vrq4";
+      name = "qtquickcontrols-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtquickcontrols2 = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtquickcontrols2-opensource-src-5.8.0.tar.xz";
+      sha256 = "06yy98x4vic2yrlpp83gf4kvl7kd93q62k178w0cy4sgqxp8d6dh";
+      name = "qtquickcontrols2-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtscript = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtscript-opensource-src-5.8.0.tar.xz";
+      sha256 = "1lssbsjf2p2ag02fjq6k6vk7vywhj4jsl286r2fqi78q5lfvjfi9";
+      name = "qtscript-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtscxml = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtscxml-opensource-src-5.8.0.tar.xz";
+      sha256 = "1i4xl24q4i32mbhyndrwaz0xj79d9n84s320gmkf5rwnfcwrvfxn";
+      name = "qtscxml-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtsensors = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtsensors-opensource-src-5.8.0.tar.xz";
+      sha256 = "15p7bp21yj4cdl5yfc9qnn4lhhiwiwx3b71lrb431kgqxhwhcp9s";
+      name = "qtsensors-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtserialbus = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtserialbus-opensource-src-5.8.0.tar.xz";
+      sha256 = "02n1b1wrvfg6c7z15c5c5gv9r5gd4pp58jrd1a8d8fg3ybcksd2q";
+      name = "qtserialbus-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtserialport = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtserialport-opensource-src-5.8.0.tar.xz";
+      sha256 = "1b86al3zn1pxyk0n59vh8bqxrpz2m0j33ygclaqbxl1sszg7ycaj";
+      name = "qtserialport-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtspeech = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtspeech-opensource-src-5.8.0.tar.xz";
+      sha256 = "0i2cx1b6ssj56p5blf7n16bbrq1g0hb27m3b5r6dh6py7mcq2spi";
+      name = "qtspeech-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtsvg = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtsvg-opensource-src-5.8.0.tar.xz";
+      sha256 = "12fwzbp28szqw1sk3flb8i6xnxgl94siwyy41ffdmd0s44f1jwwq";
+      name = "qtsvg-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qttools = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qttools-opensource-src-5.8.0.tar.xz";
+      sha256 = "10wx4vydj91yag30457c7azx4ihrwky42l7zzwkbmdlksdv8xv4m";
+      name = "qttools-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qttranslations = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qttranslations-opensource-src-5.8.0.tar.xz";
+      sha256 = "0bpwqclidji12f3f20hfpafr1b7b9wc7nhp4yhms1hhbqlpgfz1v";
+      name = "qttranslations-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtvirtualkeyboard = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtvirtualkeyboard-opensource-src-5.8.0.tar.xz";
+      sha256 = "0772yhb8w6rzxqgrdmvbw61vk2gagcs9zics56v3a2ckknrzbz9m";
+      name = "qtvirtualkeyboard-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwayland = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtwayland-opensource-src-5.8.0.tar.xz";
+      sha256 = "06ilh55vaxbkyv7irw0n11gxgc34ypx2qhqawxzy7kllzg9zcl7z";
+      name = "qtwayland-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwebchannel = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtwebchannel-opensource-src-5.8.0.tar.xz";
+      sha256 = "0jhbgp9rdp5lpwjrykxmg4lb60wk7gm3dldz5kp3b8ms2dab3xav";
+      name = "qtwebchannel-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwebengine = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtwebengine-opensource-src-5.8.0.tar.xz";
+      sha256 = "1gkrvb8wa04p91hras2pa7i26n1q5xgsiq5gfw3fc488cvqj4g92";
+      name = "qtwebengine-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwebkit = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/community_releases/5.8/5.8.0-final/qtwebkit-opensource-src-5.8.0.tar.xz";
+      sha256 = "1v0vj6slyh19mjrrpbqdzb47fr0f4xk7bc8803xjzybb11h8dbkr";
+      name = "qtwebkit-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwebkit-examples = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/community_releases/5.8/5.8.0-final/qtwebkit-examples-opensource-src-5.8.0.tar.xz";
+      sha256 = "18ar35mg32knm3r0wgqv1hmxl9pqhi1y0yhd3lbskca0f0csxiw4";
+      name = "qtwebkit-examples-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwebsockets = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtwebsockets-opensource-src-5.8.0.tar.xz";
+      sha256 = "1xa5p36grqxz3fa08amn7r3dy6k28g6y0gkc6jgj7lyhjzr0l4da";
+      name = "qtwebsockets-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwebview = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtwebview-opensource-src-5.8.0.tar.xz";
+      sha256 = "1lvzab6vjmpsl3rq73afhvjv6hkkgj19sl6sd03fgx0iikfd9n5p";
+      name = "qtwebview-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwinextras = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtwinextras-opensource-src-5.8.0.tar.xz";
+      sha256 = "1761qaqbrsqqpznv2mrkc44fk4x3lc13x6s0z3ahjms6pna7pzr7";
+      name = "qtwinextras-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtx11extras = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtx11extras-opensource-src-5.8.0.tar.xz";
+      sha256 = "03i8lk9qcdf8h2k4f3rkqqkzbrlnyaspv9mgjkn4k61s2asz5mxy";
+      name = "qtx11extras-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtxmlpatterns = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtxmlpatterns-opensource-src-5.8.0.tar.xz";
+      sha256 = "016s75j2cml7kc8scdm9a6pmxm8jhs424lml2h9znm1flmgadzvv";
+      name = "qtxmlpatterns-opensource-src-5.8.0.tar.xz";
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14320,7 +14320,7 @@ with pkgs;
 
   lynx = callPackage ../applications/networking/browsers/lynx { };
 
-  lyx = libsForQt5.callPackage ../applications/misc/lyx { };
+  lyx = libsForQt57.callPackage ../applications/misc/lyx { };
 
   mail-notification = callPackage ../desktops/gnome-2/desktop/mail-notification {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9347,8 +9347,21 @@ with pkgs;
 
   libsForQt57 = recurseIntoAttrs (lib.makeScope qt57.newScope mkLibsForQt5);
 
-  qt5 = qt57;
-  libsForQt5 = libsForQt57;
+  qt58 = recurseIntoAttrs (import ../development/libraries/qt-5/5.8 {
+    inherit newScope;
+    inherit stdenv fetchurl makeSetupHook makeWrapper;
+    bison = bison2; # error: too few arguments to function 'int yylex(...
+    cups = if stdenv.isLinux then cups else null;
+    harfbuzz = harfbuzz-icu;
+    mesa = mesa_noglu;
+    inherit perl;
+    inherit (gst_all_1) gstreamer gst-plugins-base;
+  });
+
+  libsForQt58 = recurseIntoAttrs (lib.makeScope qt58.newScope mkLibsForQt5);
+
+  qt5 = qt58;
+  libsForQt5 = libsForQt58;
 
   qt5ct = libsForQt5.callPackage ../tools/misc/qt5ct { };
 


### PR DESCRIPTION
### Motivation

Package updates:
- Qt 5 has been updated to 5.8.0 (new default).
- Plasma 5 has been updated from 5.8.6 to 5.9.3.
- libxkbcommon has been updated from 0.6.1 to 0.7.1 (needed by Plasma 5.9) (mass-rebuild).

### Testing

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Travis will not be able to rebuild all the dependent packages, but I am rebuilding locally and I will push additional package fixes as necessary.
