### PR TITLE
kdenlive: phonon-backend-vlc -> phonon-backend-gstreamer

### DIFF
--- a/pkgs/applications/kde/kdenlive.nix
+++ b/pkgs/applications/kde/kdenlive.nix
@@ -27,7 +27,7 @@
 , libv4l
 , kfilemetadata
 , ffmpeg
-, phonon-backend-vlc
+, phonon-backend-gstreamer
 , qtquickcontrols
 }:
 
@@ -65,7 +65,7 @@ unwrapped = kdeApp {
     kwindowsystem
     kfilemetadata
     plasma-framework
-    phonon-backend-vlc
+    phonon-backend-gstreamer
     qtquickcontrols
   ];
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/23399 
[Please merge in 17.03](https://github.com/NixOS/nixpkgs/issues/23253).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

