### PR TITLE
beast: mark as broken

### DIFF
--- a/pkgs/applications/audio/beast/default.nix
+++ b/pkgs/applications/audio/beast/default.nix
@@ -33,5 +33,6 @@ stdenv.mkDerivation rec {
     description = "A music composition and modular synthesis application";
     homepage = http://beast.gtk.org;
     license = with licenses; [ gpl2 lgpl21 ];
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This pkg has not built since I started using nixos 14.02.
[Please merge in 17.03](https://github.com/NixOS/nixpkgs/issues/23253).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

