### PR TITLE
mesa: allow overriding driver compilation

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch
+{ stdenv, fetchurl, fetchpatch, lib
 , pkgconfig, intltool, autoreconfHook, substituteAll
 , file, expat, libdrm, xorg, wayland, openssl
 , llvmPackages, libffi, libomxil-bellagio, libva
@@ -6,8 +6,10 @@
 , grsecEnabled ? false
 , enableRadv ? false
 , enableTextureFloats ? false # Texture floats are patented, see docs/patents.txt
+, galliumDrivers ? null
+, driDrivers ? null
+, vulkanDrivers ? null
 }:
-
 
 /** Packaging design:
   - The basic mesa ($out) contains headers and libraries (GLU is in mesa_glu now).
@@ -25,6 +27,40 @@ with stdenv.lib;
 if ! lists.elem stdenv.system platforms.mesaPlatforms then
   throw "unsupported platform for Mesa"
 else
+
+let
+  defaultGalliumDrivers =
+    if (stdenv.isArm || stdenv.isAarch64)
+    then ["nouveau" "freedreno" "vc4" "etnaviv"]
+    else ["i915" "ilo" "r300" "r600" "radeonsi" "nouveau"];
+  defaultDriDrivers =
+    if (stdenv.isArm || stdenv.isAarch64)
+    then ["nouveau"]
+    else ["i915" "i965" "nouveau" "radeon" "r200"];
+  defaultVulkanDrivers =
+    if (stdenv.isArm || stdenv.isAarch64)
+    then []
+    else ["intel"] ++ lib.optional enableRadv "radeon";
+in
+
+let gallium_ = galliumDrivers; dri_ = driDrivers; vulkan_ = vulkanDrivers; in
+
+let
+  galliumDrivers =
+    ["svga"]
+    ++ (if gallium_ == null
+          then defaultGalliumDrivers
+          else gallium_)
+    ++ ["swrast"];
+  driDrivers =
+    (if dri_ == null
+      then defaultDriDrivers
+      else dri_) ++ ["swrast"];
+  vulkanDrivers =
+    if vulkan_ == null
+    then defaultVulkanDrivers
+    else vulkan_;
+in
 
 let
   version = "17.0.0";
@@ -63,14 +99,17 @@ stdenv.mkDerivation {
     "--with-dri-driverdir=$(drivers)/lib/dri"
     "--with-dri-searchpath=${driverLink}/lib/dri"
     "--with-egl-platforms=x11,wayland,drm"
-  ] ++ (if stdenv.isArm || stdenv.isAarch64 then [
-      "--with-gallium-drivers=nouveau,freedreno,vc4,etnaviv,swrast"
-      "--with-dri-drivers=nouveau,swrast"
-  ] else [
-      "--with-gallium-drivers=svga,i915,ilo,r300,r600,radeonsi,nouveau,swrast"
-      "--with-dri-drivers=i915,i965,nouveau,radeon,r200,swrast"
-      ("--with-vulkan-drivers=intel" + optionalString enableRadv ",radeon")
-  ]) ++ [
+  ]
+  ++ (optional (galliumDrivers != [])
+      ("--with-gallium-drivers=" +
+        builtins.concatStringsSep "," galliumDrivers))
+  ++ (optional (driDrivers != [])
+      ("--with-dri-drivers=" +
+        builtins.concatStringsSep "," driDrivers))
+  ++ (optional (vulkanDrivers != [])
+      ("--with-vulkan-drivers=" +
+        builtins.concatStringsSep "," vulkanDrivers))
+  ++ [
     (enableFeature enableTextureFloats "texture-float")
     (enableFeature grsecEnabled "glx-rts")
     (enableFeature stdenv.isLinux "dri3")
@@ -143,7 +182,7 @@ stdenv.mkDerivation {
 
     # set the default search path for DRI drivers; used e.g. by X server
     substituteInPlace "$dev/lib/pkgconfig/dri.pc" --replace '$(drivers)' "${driverLink}"
-  '' + optionalString (!(stdenv.isArm || stdenv.isAarch64)) ''
+  '' + optionalString (builtins.elem "intel" vulkanDrivers) ''
     # move share/vulkan/icd.d/
     mv $out/share/ $drivers/
     # Update search path used by Vulkan (it's pointing to $out but


### PR DESCRIPTION
### Motivation

Mesa has encumbered features which are disabled by default. This is fine, because users need only enable them for the `mesa_drivers` package, which does not cause a mass-rebuild. But, the `mesa_drivers` package builds *all* the drivers Mesa provides; users building custom drivers probably only care about the drivers for their machine. This patch allows the user to build selected drivers by overriding the `driDrivers`, `galliumDrivers`, and `vulkanDrivers` attributes.

### Testing

I have been using this patch on my own for about a month on two different machines. By carefully tweaking the default driver sets, I have avoided a mass-rebuild of packages dependent on the Mesa library.

Future work may include disabling the driver build from the library, since it is presumably not needed. (Actually, the `svga` and `swrast` drivers are not optional, but even leaving those two drivers in the library build would speed it up significantly.)

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

