### PR TITLE
edward: init at 1.2.2

### DIFF
--- a/pkgs/development/python-modules/edward/default.nix
+++ b/pkgs/development/python-modules/edward/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy27, pythonAtLeast
+, Keras, numpy, scipy, six, tensorflow }:
+
+buildPythonPackage rec {
+  pname = "edward";
+  version = "1.2.2";
+  name  = "${pname}-${version}";
+
+  disabled = !(isPy27 || pythonAtLeast "3.4");
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0h9i15l7mczwx8jvabjbvxjjidr13x81h6vylb1p8r308w01r2as";
+  };
+
+  # disabled for now due to Tensorflow trying to create files in $HOME:
+  doCheck = false;
+
+  propagatedBuildInputs = [ Keras numpy scipy six tensorflow ];
+
+  meta = with stdenv.lib; {
+    description = "Probabilistic programming language using Tensorflow";
+    homepage = https://github.com/blei-lab/edward;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6672,6 +6672,8 @@ in {
     };
   };
 
+  edward = callPackage ../development/python-modules/edward { };
+
   elasticsearch = buildPythonPackage (rec {
     name = "elasticsearch-1.9.0";
 


### PR DESCRIPTION
Didn't add support for tensorflow with CUDA yet.

Tests currently don't work due to tensorflow weirdness.

Didn't add all optional dependencies.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [N/A] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

