### PR TITLE
guitarix: remove webkit, add compile flags

### DIFF
--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, gettext, intltool, pkgconfig, python2
 , avahi, bluez, boost, eigen, fftw, glib, glib_networking
 , glibmm, gsettings_desktop_schemas, gtkmm2, libjack2
-, ladspaH, librdf, libsndfile, lilv, lv2, serd, sord, sratom
-, webkitgtk2, wrapGAppsHook, zita-convolver, zita-resampler
+, ladspaH, libav, librdf, libsndfile, lilv, lv2, serd, sord, sratom
+, wrapGAppsHook, zita-convolver, zita-resampler
 , optimizationSupport ? false # Enable support for native CPU extensions
 }:
 
@@ -23,8 +23,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     avahi bluez boost eigen fftw glib glibmm glib_networking.out
-    gsettings_desktop_schemas gtkmm2 libjack2 ladspaH librdf
-    libsndfile lilv lv2 serd sord sratom webkitgtk2 zita-convolver
+    gsettings_desktop_schemas gtkmm2 libjack2 ladspaH libav librdf
+    libsndfile lilv lv2 serd sord sratom zita-convolver
     zita-resampler
   ];
 
@@ -33,6 +33,9 @@ stdenv.mkDerivation rec {
     "--no-desktop-update"
     "--enable-nls"
     "--no-faust" # todo: find out why --faust doesn't work
+    "--install-roboto-font"
+    "--includeresampler"
+    "--convolver-ffmpeg"
   ] ++ optional optimizationSupport "--optimization";
 
   configurePhase = ''python2 waf configure --prefix=$out $configureFlags'';


### PR DESCRIPTION
as recomended by the author: https://sourceforge.net/p/guitarix/mailman/message/33688855/
[Please merge in 17.03](https://github.com/NixOS/nixpkgs/issues/23253), as the version with webkitgtk2 doesn't build.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

