### PR TITLE
uriparser: 0.8.2 -> 0.8.4 + fixed build

### DIFF
--- a/pkgs/development/libraries/uriparser/default.nix
+++ b/pkgs/development/libraries/uriparser/default.nix
@@ -1,19 +1,27 @@
-{ stdenv, fetchurl, cpptest, pkgconfig, doxygen, graphviz }:
+{ stdenv, fetchurl, cpptest, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "uriparser-0.8.2";
+  name = "uriparser-${version}";
+  version = "0.8.4";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/uriparser/Sources/0.8.2/${name}.tar.bz2";
-    sha256 = "13sh7slys3y5gfscc40g2r3hkjjywjvxlcqr77ifjrazc6q6cvkd";
+    url = "mirror://sourceforge/project/uriparser/Sources/${version}/${name}.tar.bz2";
+    sha256 = "08vvcmg4mcpi2gyrq043c9mfcy3mbrw6lhp86698hx392fjcsz6f";
   };
-
-  buildInputs = [ cpptest pkgconfig doxygen graphviz ];
-
+  
+  configureFlags = "--disable-doc";
+  
+  buildInputs = [ cpptest pkgconfig ];
+  
   meta = with stdenv.lib; {
     homepage = http://uriparser.sourceforge.net/;
     description = "Strictly RFC 3986 compliant URI parsing library";
+    longDescription = ''
+      uriparser is a strictly RFC 3986 compliant URI parsing and handling library written in C.
+      API documentation is available on uriparser website.
+    '';
+    license = licenses.bsd3;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ bosu ];
-    license = stdenv.lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/libraries/uriparser/default.nix
+++ b/pkgs/development/libraries/uriparser/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cpptest, pkgconfig }:
+{ stdenv, fetchurl, cpptest, pkgconfig, doxygen, graphviz }:
 
 stdenv.mkDerivation rec {
   name = "uriparser-${version}";
@@ -9,9 +9,16 @@ stdenv.mkDerivation rec {
     sha256 = "08vvcmg4mcpi2gyrq043c9mfcy3mbrw6lhp86698hx392fjcsz6f";
   };
   
-  configureFlags = "--disable-doc";
   
-  buildInputs = [ cpptest pkgconfig ];
+  buildInputs = [ cpptest pkgconfig doxygen graphviz ];
+  
+  # There is actually no .map files to install in doc for v0.8.4
+  # (dot outputs only SVG and PNG in this release)
+  preBuild = ''
+    substituteInPlace doc/Makefile.am --replace " html/*.map" ""
+    substituteInPlace doc/Makefile.in --replace " html/*.map" ""
+  '';
+  
   
   meta = with stdenv.lib; {
     homepage = http://uriparser.sourceforge.net/;


### PR DESCRIPTION
###### Motivation for this change
Minor version bump + removed the creation of the HTML API documentation because :
1. it is available online on the website of the project
2. it requires `doxygen`, `graphviz` and `qhelpgenerator` which is part of the whole Qt framework...

This should be pushed to `release-17.03` as part of #23253

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

