### PR TITLE
unshield: 1.3 -> 1.4.2

### DIFF
--- a/pkgs/tools/archivers/unshield/default.nix
+++ b/pkgs/tools/archivers/unshield/default.nix
@@ -1,30 +1,23 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, zlib, openssl }:
+{ stdenv, fetchFromGitHub, cmake, zlib, openssl }:
 
 stdenv.mkDerivation rec {
   name = "unshield-${version}";
-  version = "1.3";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "twogood";
     repo = "unshield";
     rev = version;
-    sha256 = "0cg84jr0ymvi8bmm3lx5hshhgm33vnr1rma1mfyqkc065c7gi9ja";
+    sha256 = "07lmh8vmrbqy4kd6zl5yc1ar3bg33w5cymlzwfijy6arg77hjgq9";
   };
 
-  patches = [
-    # Fix build in separate directory
-    (fetchpatch {
-      url = "https://github.com/twogood/unshield/commit/07ce8d82f0f60b9048265410fa8063298ab520c4.patch";
-      sha256 = "160pbk2r98lv3vd0qxsxm6647qn5mddj37jzfmccdja4dpxhxz2z";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib openssl ];
 
   meta = with stdenv.lib; {
     description = "Tool and library to extract CAB files from InstallShield installers";
-    homepage = https://github.com/twogood/unshield;
+    homepage = "https://github.com/twogood/unshield";
     license = licenses.mit;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

