### PR TITLE
undmg: 1.0.2 -> 1.0.3

### DIFF
--- a/pkgs/tools/archivers/undmg/default.nix
+++ b/pkgs/tools/archivers/undmg/default.nix
@@ -1,27 +1,28 @@
 { stdenv, fetchFromGitHub, zlib, bzip2 }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.2";
+  version = "1.0.3";
   name = "undmg-${version}";
 
   src = fetchFromGitHub {
     owner = "matthewbauer";
     repo = "undmg";
-    rev = "refs/tags/v${version}";
-    sha256 = "0w9vwvj9zbpsjkg251bwv9y10wjyjmh54q2piklz74w64rlbqblr";
-    name = "undmg-${version}";
+    rev = "v${version}";
+    sha256 = "1pxqw92h2w75d4jwiihwnkhnsfk09cddh3flgrqwh9r3ry14fgbb";
+    
   };
 
   buildInputs = [ zlib bzip2 ];
 
   setupHook = ./setup-hook.sh;
 
-  installFlags = "PREFIX=\${out}";
+  makeFlags = "PREFIX=$(out)";
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/matthewbauer/undmg;
     description = "Extract a DMG file";
-    license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ matthewbauer lnl7 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

