### PR TITLE
networkmanager service: support changing the mac-address

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -24,10 +24,8 @@ let
 
     [connection]
     ipv6.ip6-privacy=2
-    ${optionalString (cfg.ethernet.macAddress != null)
-      ''ethernet.cloned-mac-address=${cfg.ethernet.macAddress}''}
-    ${optionalString (cfg.wifi.macAddress != null)
-      ''wifi.cloned-mac-address=${cfg.wifi.macAddress}''}
+    ethernet.cloned-mac-address=${cfg.ethernet.macAddress}
+    wifi.cloned-mac-address=${cfg.wifi.macAddress}
   '';
 
   /*
@@ -145,8 +143,8 @@ in {
       };
 
       ethernet.macAddress = mkOption {
-        type = types.nullOr (types.either types.str (types.enum ["permanent" "preserve" "random" "stable"]));
-        default = null;
+        type = types.either types.str (types.enum ["permanent" "preserve" "random" "stable"]);
+        default = "preserve";
         example = "00:11:22:33:44:55";
         description = ''
           "XX:XX:XX:XX:XX:XX": MAC address of the interface.
@@ -159,8 +157,8 @@ in {
       };
 
       wifi.macAddress = mkOption {
-        type = types.nullOr (types.either types.str (types.enum ["permanent" "preserve" "random" "stable"]));
-        default = null;
+        type = types.either types.str (types.enum ["permanent" "preserve" "random" "stable"]);
+        default = "preserve";
         example = "random";
         description = ''
           "XX:XX:XX:XX:XX:XX": MAC address of the interface.

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -261,6 +261,7 @@ in {
 
     systemd.services."network-manager" = {
       wantedBy = [ "network.target" ];
+      restartTriggers = [ configFile ];
 
       preStart = ''
         mkdir -m 700 -p /etc/NetworkManager/system-connections

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -24,6 +24,10 @@ let
 
     [connection]
     ipv6.ip6-privacy=2
+    ${optionalString (cfg.ethernet.macAddress != null)
+      ''ethernet.cloned-mac-address=${cfg.ethernet.macAddress}''}
+    ${optionalString (cfg.wifi.macAddress != null)
+      ''wifi.cloned-mac-address=${cfg.wifi.macAddress}''}
   '';
 
   /*
@@ -137,6 +141,34 @@ in {
         description = ''
           A list of name servers that should be inserted before
           the ones configured in NetworkManager or received by DHCP.
+        '';
+      };
+
+      ethernet.macAddress = mkOption {
+        type = types.nullOr (types.either types.str (types.enum ["permanent" "preserve" "random" "stable"]));
+        default = null;
+        example = "00:11:22:33:44:55";
+        description = ''
+          "XX:XX:XX:XX:XX:XX": MAC address of the interface.
+          <literal>permanent</literal>: use the permanent MAC address of the device.
+          <literal>preserve</literal>: don’t change the MAC address of the device upon activation.
+          <literal>random</literal>: generate a randomized value upon each connect.
+          <literal>stable</literal>: generate a stable, hashed MAC address.
+          See <link xlink:href="https://blogs.gnome.org/thaller/2016/08/26/mac-address-spoofing-in-networkmanager-1-4-0/">MAC Address Spoofing in NetworkManager 1.4.0 – Thomas Haller's Blog</link> for more information.
+        '';
+      };
+
+      wifi.macAddress = mkOption {
+        type = types.nullOr (types.either types.str (types.enum ["permanent" "preserve" "random" "stable"]));
+        default = null;
+        example = "random";
+        description = ''
+          "XX:XX:XX:XX:XX:XX": MAC address of the interface.
+          <literal>permanent</literal>: use the permanent MAC address of the device.
+          <literal>preserve</literal>: don’t change the MAC address of the device upon activation.
+          <literal>random</literal>: generate a randomized value upon each connect.
+          <literal>stable</literal>: generate a stable, hashed MAC address.
+          See <link xlink:href="https://blogs.gnome.org/thaller/2016/08/26/mac-address-spoofing-in-networkmanager-1-4-0/">MAC Address Spoofing in NetworkManager 1.4.0 – Thomas Haller's Blog</link> for more information.
         '';
       };
 

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -75,6 +75,19 @@ let
     "pre-down" = "pre-down.d/";
   };
 
+  macAddressOpt = mkOption {
+    type = types.either types.str (types.enum ["permanent" "preserve" "random" "stable"]);
+    default = "preserve";
+    example = "00:11:22:33:44:55";
+    description = ''
+      "XX:XX:XX:XX:XX:XX": MAC address of the interface.
+      <literal>permanent</literal>: use the permanent MAC address of the device.
+      <literal>preserve</literal>: don’t change the MAC address of the device upon activation.
+      <literal>random</literal>: generate a randomized value upon each connect.
+      <literal>stable</literal>: generate a stable, hashed MAC address.
+    '';
+  };
+
 in {
 
   ###### interface
@@ -142,33 +155,8 @@ in {
         '';
       };
 
-      ethernet.macAddress = mkOption {
-        type = types.either types.str (types.enum ["permanent" "preserve" "random" "stable"]);
-        default = "preserve";
-        example = "00:11:22:33:44:55";
-        description = ''
-          "XX:XX:XX:XX:XX:XX": MAC address of the interface.
-          <literal>permanent</literal>: use the permanent MAC address of the device.
-          <literal>preserve</literal>: don’t change the MAC address of the device upon activation.
-          <literal>random</literal>: generate a randomized value upon each connect.
-          <literal>stable</literal>: generate a stable, hashed MAC address.
-          See <link xlink:href="https://blogs.gnome.org/thaller/2016/08/26/mac-address-spoofing-in-networkmanager-1-4-0/">MAC Address Spoofing in NetworkManager 1.4.0 – Thomas Haller's Blog</link> for more information.
-        '';
-      };
-
-      wifi.macAddress = mkOption {
-        type = types.either types.str (types.enum ["permanent" "preserve" "random" "stable"]);
-        default = "preserve";
-        example = "random";
-        description = ''
-          "XX:XX:XX:XX:XX:XX": MAC address of the interface.
-          <literal>permanent</literal>: use the permanent MAC address of the device.
-          <literal>preserve</literal>: don’t change the MAC address of the device upon activation.
-          <literal>random</literal>: generate a randomized value upon each connect.
-          <literal>stable</literal>: generate a stable, hashed MAC address.
-          See <link xlink:href="https://blogs.gnome.org/thaller/2016/08/26/mac-address-spoofing-in-networkmanager-1-4-0/">MAC Address Spoofing in NetworkManager 1.4.0 – Thomas Haller's Blog</link> for more information.
-        '';
-      };
+      ethernet.macAddress = macAddressOpt;
+      wifi.macAddress = macAddressOpt;
 
       dispatcherScripts = mkOption {
         type = types.listOf (types.submodule {


### PR DESCRIPTION
###### Motivation for this change
Setting the MAC-address with `networking.interfaces.wlan0.macAddress` does not work when using `networking.networkmanager`.

###### Things done
This commit introduces these options: `networking.networkmanager.wifi.macAddress`
and `networking.networkmanager.ethernet.macAddress`

Which can be set to these possible values
  * "XX:XX:XX:XX:XX:XX": set the MAC address of the interface.
  * "permanent": use the permanent MAC address of the device.
  * "preserve": don’t change the MAC address of the device upon activation.
  * "random": generate a randomized value upon each connect.
  * "stable": generate a stable, hashed MAC address.

See https://blogs.gnome.org/thaller/2016/08/26/mac-address-spoofing-in-networkmanager-1-4-0/ for more information

###### Notes
The networkmanager service has to be restarted after changing these settings.
This can be done by calling:
```shell
systemctl restart network-manager.service
```

Is it possible to do this automatically?

---

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---