### PR TITLE
tldr: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/tools/misc/tldr/default.nix
+++ b/pkgs/tools/misc/tldr/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "tldr-${version}";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
-    sha256 = "1dyvmxdxm92bfs5i6cngk8isa65qp6xlpim4yizs5rnm0rynf9kr";
-    rev = "v${version}";
-    repo = "tldr-cpp-client";
     owner = "tldr-pages";
+    repo = "tldr-cpp-client";
+    rev = "v${version}";
+    sha256 = "10ylpiqc06p0qpma72vwksd7hd107s0vlx9c6s9rz4vc3i274lb6";
   };
 
   buildInputs = [ curl clang libzip ];


### PR DESCRIPTION
###### Motivation for this change
Package update

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

