### PR TITLE
hexcurse: 1.58 -> 1.60.0

### DIFF
--- a/pkgs/applications/editors/hexcurse/default.nix
+++ b/pkgs/applications/editors/hexcurse/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "hexcurse-${version}";
-  version = "1.58";
+  version = "1.60.0";
+
   src = fetchFromGitHub {
     owner = "LonnyGomes";
     repo = "hexcurse";
-    rev = "hexcurse-${version}";
-    sha256 = "0hm9mms2ija3wqba0mkk9i8fhb8q1pam6d6pjlingkzz6ygxnnp7";
+    rev = "v${version}";
+    sha256 = "17ckkxfzbqvvfdnh10if4aqdcq98q3vl6dn1v6f4lhr4ifnyjdlk";
   };
-  buildInputs = [
-    ncurses
-  ];
+  buildInputs = [ ncurses ];
+  
   meta = with lib; {
     description = "ncurses-based console hexeditor written in C";
     homepage = "https://github.com/LonnyGomes/hexcurse";


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

