### PR TITLE
proxychains: build with -ldl

### DIFF
--- a/pkgs/tools/networking/proxychains/add-ldl.patch
+++ b/pkgs/tools/networking/proxychains/add-ldl.patch
@@ -1,0 +1,12 @@
+diff -Naur old-proxychains-proxychains-4.2.0/configure proxychains-proxychains-4.2.0/configure
+--- old-proxychains-proxychains-4.2.0/configure	2012-08-10 06:36:29.000000000 +0800
++++ proxychains-proxychains-4.2.0/configure	2017-03-01 01:01:54.851866688 +0800
+@@ -101,7 +101,7 @@
+ fi
+ 
+ if islinux ; then 
+-    echo LD_SET_SONAME=-ldl
++    echo LD_SET_SONAME=-ldl -Wl,-soname=>>config.mak
+ fi
+ 
+ if isbsd ; then 

--- a/pkgs/tools/networking/proxychains/default.nix
+++ b/pkgs/tools/networking/proxychains/default.nix
@@ -10,10 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "015skh3z1jmm8kxbm3nkqv1w56kcvabdmcbmpwzywxr4xnh3x3pc";
   };
 
-  postPatch = ''
-    # Temporary work-around; most likely fixed by next upstream release
-    sed -i Makefile -e '/-lpthread/a LDFLAGS+=-ldl'
-  '';
+  patches = [ ./add-ldl.patch ];
 
   meta = {
     description = "Proxifier for SOCKS proxies";


### PR DESCRIPTION
###### Motivation for this change

The `configure` script provided in the release archive of proxychains is broken, which leads to errors like this:

```
[proxychains] preloading /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so
wget: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
```

This patch modifies the `configure` script, adds `-ldl` to the built shared object file, and fixes the above issue.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

