### PR TITLE
corebird: missing dependencies (glib_networking)

### DIFF
--- a/pkgs/applications/networking/corebird/default.nix
+++ b/pkgs/applications/networking/corebird/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, gtk3, json_glib, sqlite, libsoup, gettext, vala_0_32
-, automake, autoconf, libtool, pkgconfig, gnome3, gst_all_1, wrapGAppsHook }:
+, automake, autoconf, libtool, pkgconfig, gnome3, gst_all_1, wrapGAppsHook
+, glib_networking }:
 
 stdenv.mkDerivation rec {
   version = "1.3.3";
@@ -19,7 +20,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ automake autoconf libtool pkgconfig wrapGAppsHook ];
 
   buildInputs = [
-    gtk3 json_glib sqlite libsoup gettext vala_0_32 gnome3.rest
+    gtk3 json_glib sqlite libsoup gettext vala_0_32 gnome3.rest glib_networking
   ] ++ (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav ]);
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
Corebird has a missing dependencies which leads to `TLS/SSL support not available; install glib-networking` error messages.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

