### PR TITLE
shotwell: 0.25.5 -> 0.25.90

### DIFF
--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -1,19 +1,19 @@
 { fetchurl, stdenv, m4, glibc, gtk3, libexif, libgphoto2, libsoup, libxml2, vala_0_28, sqlite
 , webkitgtk, pkgconfig, gnome3, gst_all_1, which, udev, libgudev, libraw, glib, json_glib
 , gettext, desktop_file_utils, lcms2, gdk_pixbuf, librsvg, wrapGAppsHook
-, gnome_doc_utils, hicolor_icon_theme, itstool }:
+, gnome_doc_utils, hicolor_icon_theme, itstool, libgdata }:
 
 # for dependencies see http://www.yorba.org/projects/shotwell/install/
 
 stdenv.mkDerivation rec {
   version = "${major}.${minor}";
   major = "0.25";
-  minor = "5";
+  minor = "90";
   name = "shotwell-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/shotwell/${major}/${name}.tar.xz";
-    sha256 = "10pv3v789hky8h7ladqzzmgvkmgy3c41n4xz0nnyjmpycwl26g29";
+    sha256 = "1xlywhwr27n2q7xid19zzgf6rmmiyf4jq62rxn2af2as8rpkf1pm";
   };
 
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/glib-2.0 -I${glib.out}/lib/glib-2.0/include";
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
                   which udev libgudev gnome3.gexiv2 hicolor_icon_theme
                   libraw json_glib gettext desktop_file_utils glib lcms2 gdk_pixbuf librsvg
                   wrapGAppsHook gnome_doc_utils gnome3.rest gnome3.gcr
-                  gnome3.defaultIconTheme itstool ];
+                  gnome3.defaultIconTheme itstool libgdata ];
 
   meta = with stdenv.lib; {
     description = "Popular photo organizer for the GNOME desktop";


### PR DESCRIPTION
###### Motivation for this change

Update shotwell to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

