### PR TITLE
sqlite3_analyzer: 3.8.10.1 -> 3.17.0

### DIFF
--- a/pkgs/development/libraries/sqlite/sqlite3_analyzer.nix
+++ b/pkgs/development/libraries/sqlite/sqlite3_analyzer.nix
@@ -1,21 +1,14 @@
 { lib, stdenv, fetchurl, unzip, tcl }:
 
 stdenv.mkDerivation {
-  name = "sqlite3_analyzer-3.8.10.1";
+  name = "sqlite3_analyzer-3.17.0";
 
   src = fetchurl {
-    url = "https://www.sqlite.org/2015/sqlite-src-3081001.zip";
-    sha1 = "6z7w8y69jxr0xwxbhs8z3zf56zfs5x7z";
+    url = "https://www.sqlite.org/2017/sqlite-src-3170000.zip";
+    sha256 = "1hs8nzk2pjr4fhhrwcyqwpa24gd4ndp6f0japykg5wfadgp4nxc6";
   };
 
   buildInputs = [ unzip tcl ];
-
-  # A bug in the latest release of sqlite3 prevents bulding sqlite3_analyzer.
-  # Hopefully this work-around can be removed for future releases.
-  postConfigure = ''
-    substituteInPlace Makefile \
-      --replace '"#define SQLITE_ENABLE_DBSTAT_VTAB"' '"#define SQLITE_ENABLE_DBSTAT_VTAB 1"'
-  '';
 
   buildPhase = ''
     make sqlite3_analyzer


### PR DESCRIPTION
###### Motivation for this change

Update sqlite3_analyzer to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

