### PR TITLE
qshowdiff: fix build

### DIFF
--- a/pkgs/tools/text/qshowdiff/default.nix
+++ b/pkgs/tools/text/qshowdiff/default.nix
@@ -1,14 +1,15 @@
-{stdenv, fetchurl, qt4, perl}:
+{stdenv, fetchurl, qt4, perl, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "qshowdiff-1.2";
-  
+  name = "qshowdiff-${version}";
+  version = "1.2";
+
   src = fetchurl {
-    url = "http://qshowdiff.danfis.cz/files/${name}.tar.gz";
-    sha256 = "0i3ssvax4xync9c53jaxribazvh8d8v148l3yiqsfjmqsggw9rh3";
+    url = "https://github.com/danfis/qshowdiff/archive/v${version}.tar.gz";
+    sha256 = "027959xbzvi5c2w9y1x122sr5i26k9mvp43banz2wln6gd860n1a";
   };
 
-  buildInputs = [ qt4 perl ];
+  buildInputs = [ qt4 perl pkgconfig ];
 
   configurePhase = ''
     mkdir -p $out/{bin,man/man1}


### PR DESCRIPTION
###### Motivation for this change

Fix build. Related to #23253

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

