### PR TITLE
pcsxr: remove name conflict with zlib 1.2.9

### DIFF
--- a/pkgs/misc/emulators/pcsxr/default.nix
+++ b/pkgs/misc/emulators/pcsxr/default.nix
@@ -45,6 +45,8 @@ stdenv.mkDerivation rec {
       url = "https://anonscm.debian.org/cgit/pkg-games/pcsxr.git/plain/debian/patches/08_reproducible.patch?h=debian/1.9.94-2";
       sha256 = "1cx9q59drsk9h6l31097lg4aanaj93ysdz5p88pg9c7wvxk1qz06";
     })
+
+    ./uncompress2.patch
   ];
 
   buildInputs = [

--- a/pkgs/misc/emulators/pcsxr/uncompress2.patch
+++ b/pkgs/misc/emulators/pcsxr/uncompress2.patch
@@ -1,0 +1,20 @@
+--- a/libpcsxcore/cdriso.c
++++ b/libpcsxcore/cdriso.c
+@@ -1219,7 +1219,7 @@
+ 	return ret;
+ }
+ 
+-static int uncompress2(void *out, unsigned long *out_size, void *in, unsigned long in_size)
++static int uncompress3(void *out, unsigned long *out_size, void *in, unsigned long in_size)
+ {
+ 	static z_stream z;
+ 	int ret = 0;
+@@ -1298,7 +1298,7 @@
+ 	if (is_compressed) {
+ 		cdbuffer_size_expect = sizeof(compr_img->buff_raw[0]) << compr_img->block_shift;
+ 		cdbuffer_size = cdbuffer_size_expect;
+-		ret = uncompress2(compr_img->buff_raw[0], &cdbuffer_size, compr_img->buff_compressed, size);
++		ret = uncompress3(compr_img->buff_raw[0], &cdbuffer_size, compr_img->buff_compressed, size);
+ 		if (ret != 0) {
+ 			SysPrintf("uncompress failed with %d for block %d, sector %d\n",
+ 					ret, block, sector);


### PR DESCRIPTION
###### Motivation for this change

zlib 1.2.9 added a uncompress2 function that conflicts

and https://github.com/NixOS/nixpkgs/issues/23253

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

