### PR TITLE
add ocsigen_start

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec
 
   createFindlibDestdir = true;
 
+  setupHook = [ ./setup-hook.sh ];
+
   meta = {
     homepage = http://ocsigen.org/eliom/;
     description = "Ocaml Framework for programming Web sites and client/server Web applications";

--- a/pkgs/development/ocaml-modules/eliom/setup-hook.sh
+++ b/pkgs/development/ocaml-modules/eliom/setup-hook.sh
@@ -1,0 +1,5 @@
+addOcsigenDistilleryTemplate() {
+    addToSearchPathWithCustomDelimiter : ELIOM_DISTILLERY_PATH $1/eliom-distillery-templates
+}
+
+envHooks+=(addOcsigenDistilleryTemplate)

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, buildOcaml, ocsigen-toolkit, eliom, ocaml_pcre, pgocaml, macaque, safepass, yojson, ojquery, magick, ocsigen_deriving, ocsigen_server }:
+
+buildOcaml rec
+{
+  name = "ocsigen-start";
+  version = "1.0.0";
+
+  buildInputs = [ eliom ];
+  propagatedBuildInputs = [ pgocaml macaque safepass ocaml_pcre ocsigen-toolkit yojson ojquery ocsigen_deriving ocsigen_server magick ];
+
+  patches = [ ./templates-dir.patch ];
+
+  postPatch = ''
+  substituteInPlace "src/os_db.ml" --replace "citext" "text"
+  '';
+  
+  src = fetchurl {
+    url = "https://github.com/ocsigen/${name}/archive/${version}.tar.gz";
+    sha256 = "0npc2iq39ixci6ly0fssklv07zqi5cfa1adad4hm8dbzjawkqqll";
+  };
+
+  createFindlibDestdir = true;
+
+  meta = {
+    homepage = http://ocsigen.org/ocsigen-start;
+    description = "Eliom application skeleton";
+    longDescription =''
+     An Eliom application skeleton, ready to use to build your own application with users, (pre)registration, notifications, etc.
+      '';
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = [ stdenv.lib.maintainers.gal_bolle ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/ocsigen-start/templates-dir.patch
+++ b/pkgs/development/ocaml-modules/ocsigen-start/templates-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/install.sh b/scripts/install.sh
+index f88ae11..d6aae70 100755
+--- a/scripts/install.sh
++++ b/scripts/install.sh
+@@ -11,9 +11,9 @@ fi
+ 
+ TPL_DIR=$1
+ TPL_NAME=$2
+-DEST0=$DESTDIR/$(eliom-distillery -dir)
++DEST0=$out/eliom-distillery-templates
+ DEST=$DEST0/$TPL_NAME
+ 
+ mkdir -p $DEST0

--- a/pkgs/development/tools/ocaml/ocsigen-i18n/default.nix
+++ b/pkgs/development/tools/ocaml/ocsigen-i18n/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, buildOcaml }:
+
+buildOcaml rec
+{
+  name = "ocsigen-i18n";
+  version = "3.1.0";
+
+  minimumSupportedOcamlVersion = "4.03";
+
+  buildInputs = [ ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    make bindir=$out/bin install
+    '';
+
+  src = fetchurl {
+    url = "https://github.com/besport/${name}/archive/${version}.tar.gz";
+    sha256 = "0cw0mmr67wx03j4279z7ldxwb01smkqz9rbklx5lafrj5sf99178";
+  };
+
+  meta = {
+    homepage = https://github.com/besport/ocsigen-i18n;
+    description = "I18n made easy for web sites written with eliom";
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = [ stdenv.lib.maintainers.gal_bolle ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5462,6 +5462,8 @@ with pkgs;
 
   ocaml-top = callPackage ../development/tools/ocaml/ocaml-top { };
 
+  ocsigen-i18n = ocamlPackages_4_03.callPackage ../development/tools/ocaml/ocsigen-i18n { };
+
   opa = callPackage ../development/compilers/opa {
     nodejs = nodejs-4_x;
     ocamlPackages = ocamlPackages_4_02;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -384,6 +384,8 @@ let
 
     ocsigen_server = callPackage ../development/ocaml-modules/ocsigen-server { };
 
+    ocsigen-start = callPackage ../development/ocaml-modules/ocsigen-start { };
+
     ocsigen-toolkit = callPackage ../development/ocaml-modules/ocsigen-toolkit { };
 
     ojquery = callPackage ../development/ocaml-modules/ojquery { };


### PR DESCRIPTION
###### Motivation for this change

This updates to the latest versions of the ocsigen project. This allows nix users to follow their "recommended workflow".

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

