### PR TITLE
gplates: use boost 160

### DIFF
--- a/pkgs/applications/science/misc/gplates/default.nix
+++ b/pkgs/applications/science/misc/gplates/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, qt4, qwt6_qt4, mesa, glew, gdal_1_11, cgal
-, proj, boost159, cmake, python2, doxygen, graphviz, gmp }:
+, proj, boost, cmake, python2, doxygen, graphviz, gmp }:
 
 stdenv.mkDerivation rec {
   name = "gplates-${version}";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    qt4 qwt6_qt4 mesa glew gdal_1_11 cgal proj boost159 cmake python2
+    qt4 qwt6_qt4 mesa glew gdal_1_11 cgal proj boost cmake python2
     doxygen graphviz gmp
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17467,7 +17467,10 @@ with pkgs;
 
   fityk = callPackage ../applications/science/misc/fityk { };
 
-  gplates = callPackage ../applications/science/misc/gplates { };
+  gplates = callPackage ../applications/science/misc/gplates {
+    boost = boost160;
+    cgal = cgal.override { boost = boost160; };
+  };
 
   gravit = callPackage ../applications/science/astronomy/gravit { };
 


### PR DESCRIPTION

###### Motivation for this change

boost update 1.61 seems to have changed reference parameters for optional. I assume that's causing the break seen in hydra
https://hydra.nixos.org/build/49707856/nixlog/1
http://www.boost.org/doc/libs/1_61_0/libs/optional/doc/html/boost_ooptional/relnotes.html

Still needs to be tested, compiling takes hours. Is there some config for Travis to do that? 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

