### PR TITLE
khd: 2.0.0 -> 2.1.1

### DIFF
--- a/pkgs/os-specific/darwin/khd/default.nix
+++ b/pkgs/os-specific/darwin/khd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "khd-${version}";
-  version = "2.0.0";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "koekeishiya";
     repo = "khd";
     rev = "v${version}";
-    sha256 = "02v2bq095h1ylx700kayakg7f9p43vrz6p9ry3g7lq37s6apgm8h";
+    sha256 = "1ijfrlnwdf8hk259j3jfxj6zizvqzj57458rflza626z5dnhmbpr";
   };
 
   buildInputs = [ Carbon Cocoa ];
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A simple modal hototkey daemon for OSX";
+    description = "A simple modal hotkey daemon for OSX";
     homepage = https://github.com/koekeishiya/khd;
     downloadPage = https://github.com/koekeishiya/khd/releases;
     platforms = platforms.darwin;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] macOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

