### PR TITLE
photivo: fix build with lensfun >= 0.3

### DIFF
--- a/pkgs/applications/graphics/photivo/default.nix
+++ b/pkgs/applications/graphics/photivo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchhg, cmake, qt4, fftw, graphicsmagick_q16,
+{ stdenv, fetchhg, fetchpatch, cmake, qt4, fftw, graphicsmagick_q16,
   lcms2, lensfun, pkgconfig, libjpeg, exiv2, liblqr1 }:
 
 stdenv.mkDerivation rec {
@@ -9,6 +9,16 @@ stdenv.mkDerivation rec {
     rev = "d687864489da";
     sha256 = "0f6y18k7db2ci6xn664zcwm1g1k04sdv7gg1yd5jk41bndjb7z8h";
   };
+
+  patches = [
+    # Patch fixing build with lensfun >= 0.3, taken from
+    # https://www.linuxquestions.org/questions/slackware-14/photivo-4175530230/#post5296578
+    (fetchpatch {
+      url = "https://www.linuxquestions.org/questions/attachment.php?attachmentid=17287&d=1420577220";
+      name = "lensfun-0.3.patch";
+      sha256 = "0ys45x4r4bjjlx0zpd5d56rgjz7k8gxili4r4k8zx3zfka4a3zwv";
+    })
+  ];
 
   postPatch = '' # kinda icky
     sed -e '/("@INSTALL@")/d' \


### PR DESCRIPTION
###### Motivation for this change

To fix photivo build in master and 17.03.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).