### PR TITLE
eclipse: don't use webkitgtk2, fix dependency passing

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, makeDesktopItem, makeWrapper
 , freetype, fontconfig, libX11, libXext, libXrender, zlib
-, glib, libXtst, jdk
+, glib, gtk2, libXtst, jdk
 , webkitgtk2 ? null  # for internal web browser
 , buildEnv, writeText, runCommand
 , callPackage
@@ -10,7 +10,7 @@ assert stdenv ? glibc;
 
 rec {
 
-  buildEclipse = callPackage ./build-eclipse.nix { };
+  buildEclipse = import ./build-eclipse.nix { inherit stdenv makeDesktopItem freetype fontconfig libX11 libXrender zlib jdk glib gtk2 libXtst webkitgtk2 makeWrapper; };
 
   ### Eclipse CPP
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13110,7 +13110,7 @@ with pkgs;
 
   eaglemode = callPackage ../applications/misc/eaglemode { };
 
-  eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse { });
+  eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse { webkitgtk2 = null; });
 
   ecs-agent = callPackage ../applications/virtualization/ecs-agent { };
 


### PR DESCRIPTION
###### Motivation for this change

Made eclipse 'import' the builder instead of using 'callPackage' so it uses the dependencies it is passed.
Told eclipse to not use webkitgtk2 by default.

This fixes the issue of eclipse trying to use webkitgtk2 and failing because it has vulnerabilities.

This should be ported to 17.03

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

