### PR TITLE
ustr: Remove unhelpful 'buildTargets' value.

### DIFF
--- a/pkgs/development/libraries/ustr/default.nix
+++ b/pkgs/development/libraries/ustr/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
     sed -i 's,\(USTR_CONF_HAVE_STDINT_H\) 0,\1 1,g' ustr-import.in
   '';
 
-  buildTargets = [ "all-shared" ];
-
   preBuild = ''
     makeFlagsArray+=("prefix=$out")
     makeFlagsArray+=("LDCONFIG=echo")


### PR DESCRIPTION
mkDerivation doesn't do anything with this,
and while it does become an environment variable
AFAICT that was never the intention and isn't helpful here.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
