### PR TITLE
Generalize Fontconfig options

### DIFF
--- a/nixos/modules/config/fonts/fontconfig-ultimate.nix
+++ b/nixos/modules/config/fonts/fontconfig-ultimate.nix
@@ -8,61 +8,6 @@ let fcBool = x: if x then "<bool>true</bool>" else "<bool>false</bool>";
 
     latestVersion  = pkgs.fontconfig.configVersion;
 
-    # fontconfig ultimate main configuration file
-    # priority 52
-    fontconfigUltimateConf = pkgs.writeText "fc-52-fontconfig-ultimate.conf" ''
-      <?xml version="1.0"?>
-      <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
-      <fontconfig>
-
-        ${optionalString (!cfg.allowBitmaps) ''
-        <!-- Reject bitmap fonts -->
-        <selectfont>
-          <rejectfont>
-            <pattern>
-              <patelt name="scalable"><bool>false</bool></patelt>
-            </pattern>
-          </rejectfont>
-        </selectfont>
-        ''}
-
-        ${optionalString cfg.allowType1 ''
-        <!-- Reject Type 1 fonts -->
-        <selectfont>
-          <rejectfont>
-            <pattern>
-              <patelt name="fontformat">
-                <string>Type 1</string>
-              </patelt>
-            </pattern>
-          </rejectfont>
-        </selectfont>
-        ''}
-
-        <!-- Use embedded bitmaps in fonts like Calibri? -->
-        <match target="font">
-          <edit name="embeddedbitmap" mode="assign">
-            ${fcBool cfg.useEmbeddedBitmaps}
-          </edit>
-        </match>
-
-        <!-- Force autohint always -->
-        <match target="font">
-          <edit name="force_autohint" mode="assign">
-            ${fcBool cfg.forceAutohint}
-          </edit>
-        </match>
-
-        <!-- Render some monospace TTF fonts as bitmaps -->
-        <match target="pattern">
-          <edit name="bitmap_monospace" mode="assign">
-            ${fcBool cfg.renderMonoTTFAsBitmap}
-          </edit>
-        </match>
-
-      </fontconfig>
-    '';
-
     # The configuration to be included in /etc/font/
     confPkg = pkgs.runCommand "font-ultimate-conf" {} ''
       support_folder=$out/etc/fonts/conf.d
@@ -70,12 +15,6 @@ let fcBool = x: if x then "<bool>true</bool>" else "<bool>false</bool>";
 
       mkdir -p $support_folder
       mkdir -p $latest_folder
-
-      # 52-fontconfig-ultimate.conf
-      ln -s ${fontconfigUltimateConf} \
-            $support_folder/52-fontconfig-ultimate.conf
-      ln -s ${fontconfigUltimateConf} \
-            $latest_folder/52-fontconfig-ultimate.conf
 
       # fontconfig ultimate substitutions
       ${optionalString (cfg.substitutions != "none") ''
@@ -111,45 +50,6 @@ in
               module, fontconfig-ultimate also provides many font-specific
               rendering tweaks.
             '';
-          };
-
-          allowBitmaps = mkOption {
-            type = types.bool;
-            default = true;
-            description = ''
-              Allow bitmap fonts. Set to <literal>false</literal> to ban all
-              bitmap fonts.
-            '';
-          };
-
-          allowType1 = mkOption {
-            type = types.bool;
-            default = false;
-            description = ''
-              Allow Type-1 fonts. Default is <literal>false</literal> because of
-              poor rendering.
-            '';
-          };
-
-          useEmbeddedBitmaps = mkOption {
-            type = types.bool;
-            default = false;
-            description = ''Use embedded bitmaps in fonts like Calibri.'';
-          };
-
-          forceAutohint = mkOption {
-            type = types.bool;
-            default = false;
-            description = ''
-              Force use of the TrueType Autohinter. Useful for debugging or
-              free-software purists.
-            '';
-          };
-
-          renderMonoTTFAsBitmap = mkOption {
-            type = types.bool;
-            default = false;
-            description = ''Render some monospace TTF fonts as bitmaps.'';
           };
 
           substitutions = mkOption {

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -181,6 +181,13 @@ with lib;
     # KDE Plasma 5
     (mkRenamedOptionModule [ "services" "xserver" "desktopManager" "kde5" ] [ "services" "xserver" "desktopManager" "plasma5" ])
 
+    # Fontconfig
+    (mkRenamedOptionModule [ "config" "fonts" "fontconfig" "ultimate" "allowBitmaps" ] [ "config" "fonts" "fontconfig" "allowBitmaps" ])
+    (mkRenamedOptionModule [ "config" "fonts" "fontconfig" "ultimate" "allowType1" ] [ "config" "fonts" "fontconfig" "allowType1" ])
+    (mkRenamedOptionModule [ "config" "fonts" "fontconfig" "ultimate" "useEmbeddedBitmaps" ] [ "config" "fonts" "fontconfig" "useEmbeddedBitmaps" ])
+    (mkRenamedOptionModule [ "config" "fonts" "fontconfig" "ultimate" "forceAutohint" ] [ "config" "fonts" "fontconfig" "forceAutohint" ])
+    (mkRenamedOptionModule [ "config" "fonts" "fontconfig" "ultimate" "renderMonoTTFAsBitmap" ] [ "config" "fonts" "fontconfig" "renderMonoTTFAsBitmap" ])
+
     # Options that are obsolete and have no replacement.
     (mkRemovedOptionModule [ "boot" "initrd" "luks" "enable" ] "")
     (mkRemovedOptionModule [ "programs" "bash" "enable" ] "")

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -196,6 +196,11 @@ in
       };
 
       fonts.fonts = with pkgs; [ noto-fonts hack-font ];
+      fonts.fontconfig.defaultFonts = {
+        monospace = [ "Hack" "Noto Mono" ];
+        sansSerif = [ "Noto Sans" ];
+        serif = [ "Noto Serif" ];
+      };
 
       programs.ssh.askPassword = "${plasma5.ksshaskpass.out}/bin/ksshaskpass";
 

--- a/pkgs/desktops/plasma-5/startkde/startkde.sh
+++ b/pkgs/desktops/plasma-5/startkde/startkde.sh
@@ -14,6 +14,12 @@ if ! [ -e $HOME/.gtkrc-2.0 ] \
     cat >$HOME/.gtkrc-2.0 <<EOF
 # Default GTK+ 2 config for NixOS KDE 5
 include "/run/current-system/sw/share/themes/Breeze/gtk-2.0/gtkrc"
+style "user-font"
+{
+  font_name="Sans Serif Regular"
+}
+widget_class "*" style "user-font"
+gtk-font-name="Sans Serif Regular 10"
 gtk-theme-name="Breeze"
 gtk-icon-theme-name="breeze"
 gtk-fallback-icon-theme="hicolor"
@@ -28,6 +34,7 @@ if ! [ -e $HOME/.config/gtk-3.0/settings.ini ] \
        && [ -e /run/current-system/sw/share/themes/Breeze/gtk-3.0 ]; then
     cat >$HOME/.config/gtk-3.0/settings.ini <<EOF
 [Settings]
+gtk-font-name=Sans Serif Regular 10
 gtk-theme-name=Breeze
 gtk-icon-theme-name=breeze
 gtk-fallback-icon-theme=hicolor
@@ -79,9 +86,9 @@ kcheckrunning_result=$?
 if test $kcheckrunning_result -eq 0 ; then
     echo "KDE seems to be already running on this display."
     xmessage -geometry 500x100 "KDE seems to be already running on this display."
-	exit 1
+    exit 1
 elif test $kcheckrunning_result -eq 2 ; then
-	echo "\$DISPLAY is not set or cannot connect to the X server."
+    echo "\$DISPLAY is not set or cannot connect to the X server."
     exit 1
 fi
 
@@ -122,6 +129,7 @@ ksplashrc KSplash Theme ${THEME}.desktop
 ksplashrc KSplash Engine KSplashQML
 kdeglobals KScreen ScreenScaleFactors ''
 kcmfonts General forceFontDPI 0
+kcmfonts General dontChangeAASettings true
 EOF
 
 # preload the user's locale on first start
@@ -145,9 +153,14 @@ kdeglobalsfile=$configDir/kdeglobals
 test -f $kdeglobalsfile || {
 cat >$kdeglobalsfile <<EOF
 [General]
-XftAntialias=true
-XftHintStyle=hintmedium
-XftSubPixel=none
+fixed=Monospace,10,-1,5,50,0,0,0,0,0,Regular
+font=Sans Serif,10,-1,5,50,0,0,0,0,0,Regular
+menuFont=Sans Serif,10,-1,5,50,0,0,0,0,0,Regular
+smallestReadableFont=Sans Serif,8,-1,5,50,0,0,0,0,0,Regular
+toolBarFont=Sans Serif,8,-1,5,50,0,0,0,0,0,Regular
+
+[WM]
+activeFont=Noto Sans,12,-1,5,50,0,0,0,0,0,Bold
 EOF
 }
 


### PR DESCRIPTION
### Motivation

The `config.fonts.fontconfig.ultimate` module provides a number of options which do not actually require the `fontconfig-ultimate` patches; however, these options were still not available on NixOS without setting `config.fonts.fontconfig.ultimate.enable = true`.

The KDE Plasma desktop will now respect the default system-wide Fontconfig settings when it is first started. (Of course, the user may still choose to override the font choices in the System Settings module.)

### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

