### PR TITLE
doc: Add rust documentation

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -69,6 +69,10 @@ pkgs.stdenv.mkDerivation {
       outputFile = "languages-frameworks/r.xml";
     }
   + toDocbook {
+      inputFile = ./languages-frameworks/rust.md;
+      outputFile = "./languages-frameworks/rust.xml";
+    }
+  + toDocbook {
       inputFile = ./languages-frameworks/vim.md;
       outputFile = "./languages-frameworks/vim.xml";
     }

--- a/doc/languages-frameworks/index.xml
+++ b/doc/languages-frameworks/index.xml
@@ -27,6 +27,7 @@ such as Perl or Haskell.  These are described in this chapter.</para>
 <xi:include href="qt.xml" />
 <xi:include href="r.xml" /> <!-- generated from ../../pkgs/development/r-modules/README.md  -->
 <xi:include href="ruby.xml" />
+<xi:include href="rust.xml" />
 <xi:include href="texlive.xml" />
 <xi:include href="vim.xml" />
 

--- a/doc/languages-frameworks/rust.md
+++ b/doc/languages-frameworks/rust.md
@@ -17,7 +17,8 @@ into the `environment.systemPackages` or bring them into scope with
 `nix-shell -p rustStable.rustc -p rustStable.cargo`.
 
 There are also `rustBeta` and `rustNightly` package sets available.
-These are not updated very regulary. For daily builds see [Using the Rust nightlies overlay](#using-the-rust-nightlies-overlay)
+These are not updated very regulary. For daily builds see
+[Using the Rust nightlies overlay](#using-the-rust-nightlies-overlay)
 
 ## Packaging Rust applications
 
@@ -49,9 +50,13 @@ buildRustPackage rec {
 }
 ```
 
-`buildRustPackage` requires a `depsSha256` attribute which is computed over all crate sources of this package. Currently it is obtained by inserting a fake checksum into the expression and building the package once. The correct checksum can be then take from the failed build.
+`buildRustPackage` requires a `depsSha256` attribute which is computed over
+all crate sources of this package. Currently it is obtained by inserting a
+fake checksum into the expression and building the package once. The correct
+checksum can be then take from the failed build.
 
-To install creates with nix there is also an experimental project called [nixcrates](https://github.com/fractalide/nixcrates).
+To install creates with nix there is also an experimental project called
+[nixcrates](https://github.com/fractalide/nixcrates).
 
 ## Using the Rust nightlies overlay
 
@@ -82,4 +87,5 @@ To install the beta or nightly channel, "stable" should be substituted by
 use the function provided by this overlay to pull a version based on a
 build date.
 
-The overlay automatically update itself as it uses the same source as [rustup](https://www.rustup.rs/).
+The overlay automatically update itself as it uses the same source as
+[rustup](https://www.rustup.rs/).

--- a/doc/languages-frameworks/rust.md
+++ b/doc/languages-frameworks/rust.md
@@ -55,7 +55,7 @@ all crate sources of this package. Currently it is obtained by inserting a
 fake checksum into the expression and building the package once. The correct
 checksum can be then take from the failed build.
 
-To install creates with nix there is also an experimental project called
+To install crates with nix there is also an experimental project called
 [nixcrates](https://github.com/fractalide/nixcrates).
 
 ## Using the Rust nightlies overlay

--- a/doc/languages-frameworks/rust.md
+++ b/doc/languages-frameworks/rust.md
@@ -1,0 +1,73 @@
+---
+title: Rust
+author: Matthias Beyer
+date: 2017-03-05
+---
+
+# User's Guide to the Rust Infrastructure
+
+Rust is packaged with nixpkgs, although there are no rust crates packaged in
+nixpkgs.
+Therefor, one has to use `cargo` directly.
+
+To install the rust compiler and cargo, one has to put
+
+```
+rustStable.rustc
+rustStable.cargo
+```
+
+into the `environment.systemPackages` or bring them into scope with
+`nix-shell -p rustStable.rustc -p rustStable.cargo`.
+
+There are also `rustUnstable` and `rustNightly` package sets available,
+though, as nixpkgs does not update the nightlies very often, one should rather
+use an alternative approach for installing the nightly version of rust.
+
+## Using Rust nightlies (with an overlay)
+
+Mozilla provides an overlay for nixpkgs which can be used to bring a nightly
+version of Rust into scope.
+This overlay can _also_ be used to install recent unstable or stable versions
+of Rust, if desired.
+
+To use this overlay, clone
+[nixpkgs-mozilla](https://github.com/mozilla/nixpkgs-mozilla),
+and create a symbolic link to the file
+[rust-overlay.nix](https://github.com/mozilla/nixpkgs-mozilla/blob/master/rust-overlay.nix)
+in the `~/.config/nixpkgs/overlays` directory.
+
+    $ git clone https://github.com/mozilla/nixpkgs-mozilla.git
+    $ mkdir -p  ~/.config/nixpkgs/overlays
+    $ ln -s $(pwd)/nixpkgs-mozilla/rust-overlay.nix ~/.config/nixpkgs/overlays/rust-overlay.nix
+
+Once installed, one can install the latest versions with the following command:
+
+    $ nix-env -Ai nixos.rustChannels.stable.rust
+
+Or use this attribute to build a nix-shell environment which pull the
+latest version of rust for you when you enter it.
+
+To install the beta or nightly channel, "stable" should be substituted by
+"nightly" and "beta", or
+use the function provided by this overlay to pull a version based on a
+build date.
+
+### How does it work?
+
+This section explains how the overlay works.
+
+This overlay should auto-update it-self as if you were running rustup
+each time you go through the rustChannels attributes.  It works by
+using the fetchurl builtin function to pull the same file as rustup do
+through https.
+
+The `*.toml` manifest file is then parsed (yes,
+[in Nix](https://github.com/mozilla/nixpkgs-mozilla/blob/master/lib/parseTOML.nix)
+) to extract the sha256 and the location of all the packages indexed by the
+manifest file.  Then,
+[some logic](https://github.com/mozilla/nixpkgs-mozilla/blob/master/rust-overlay.nix)
+is used to convert the `*.toml` file into proper derivations which are used to
+pull the prebuilt binaries and to change the interpreter of the binaries using
+patchelf.
+

--- a/doc/languages-frameworks/rust.md
+++ b/doc/languages-frameworks/rust.md
@@ -24,6 +24,9 @@ There are also `rustUnstable` and `rustNightly` package sets available,
 though, as nixpkgs does not update the nightlies very often, one should rather
 use an alternative approach for installing the nightly version of rust.
 
+There is, however [nixcrates](https://github.com/fractalide/nixcrates)
+which might be used to install crates with nix.
+
 ## Using Rust nightlies (with an overlay)
 
 Mozilla provides an overlay for nixpkgs which can be used to bring a nightly

--- a/doc/languages-frameworks/rust.md
+++ b/doc/languages-frameworks/rust.md
@@ -60,8 +60,7 @@ To install crates with nix there is also an experimental project called
 
 ## Using the Rust nightlies overlay
 
-Mozilla provides an overlay for nixpkgs which can be used to bring a nightly
-version of Rust into scope.
+Mozilla provides an overlay for nixpkgs to bring a nightly version of Rust into scope.
 This overlay can _also_ be used to install recent unstable or stable versions
 of Rust, if desired.
 
@@ -75,12 +74,13 @@ in the `~/.config/nixpkgs/overlays` directory.
     $ mkdir -p  ~/.config/nixpkgs/overlays
     $ ln -s $(pwd)/nixpkgs-mozilla/rust-overlay.nix ~/.config/nixpkgs/overlays/rust-overlay.nix
 
-Once installed, one can install the latest versions with the following command:
+The latest version can be installed with the following command:
 
     $ nix-env -Ai nixos.rustChannels.stable.rust
 
-Or use this attribute to build a nix-shell environment which pull the
-latest version of rust for you when you enter it.
+Or using the attribute with nix-shell:
+
+    $ nix-shell -p nixos.rustChannels.stable.rust
 
 To install the beta or nightly channel, "stable" should be substituted by
 "nightly" and "beta", or

--- a/doc/languages-frameworks/rust.md
+++ b/doc/languages-frameworks/rust.md
@@ -83,9 +83,9 @@ Or using the attribute with nix-shell:
     $ nix-shell -p nixos.rustChannels.stable.rust
 
 To install the beta or nightly channel, "stable" should be substituted by
-"nightly" and "beta", or
+"nightly" or "beta", or
 use the function provided by this overlay to pull a version based on a
 build date.
 
-The overlay automatically update itself as it uses the same source as
+The overlay automatically updates itself as it uses the same source as
 [rustup](https://www.rustup.rs/).

--- a/doc/languages-frameworks/rust.md
+++ b/doc/languages-frameworks/rust.md
@@ -56,21 +56,4 @@ To install the beta or nightly channel, "stable" should be substituted by
 use the function provided by this overlay to pull a version based on a
 build date.
 
-### How does it work?
-
-This section explains how the overlay works.
-
-This overlay should auto-update it-self as if you were running rustup
-each time you go through the rustChannels attributes.  It works by
-using the fetchurl builtin function to pull the same file as rustup do
-through https.
-
-The `*.toml` manifest file is then parsed (yes,
-[in Nix](https://github.com/mozilla/nixpkgs-mozilla/blob/master/lib/parseTOML.nix)
-) to extract the sha256 and the location of all the packages indexed by the
-manifest file.  Then,
-[some logic](https://github.com/mozilla/nixpkgs-mozilla/blob/master/rust-overlay.nix)
-is used to convert the `*.toml` file into proper derivations which are used to
-pull the prebuilt binaries and to change the interpreter of the binaries using
-patchelf.
-
+The overlay automatically update itself as it uses the same source as [rustup](https://www.rustup.rs/).

--- a/doc/languages-frameworks/rust.md
+++ b/doc/languages-frameworks/rust.md
@@ -24,7 +24,7 @@ These are not updated very regulary. For daily builds see
 
 Rust applications are packaged by using the `buildRustPackage` helper from `rustPlatform`:
 
-``` from
+```
 with rustPlatform;
 
 buildRustPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Rust is/was not documented. Also: http://lists.science.uu.nl/pipermail/nix-dev/2017-March/022947.html by @nbp .

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

