### PR TITLE
Quote paths in makeWrapper

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -19,98 +19,100 @@
 #                                   are read first and used as VALS
 # --suffix-contents
 makeWrapper() {
-    local original=$1
-    local wrapper=$2
+    local original="$1"
+    local wrapper="$2"
     local params varName value command separator n fileNames
-    local argv0 flagsBefore flags extraFlagsArray
+    local argv0 flagsBefore flags
 
-    mkdir -p "$(dirname $wrapper)"
+    mkdir -p "$(dirname "$wrapper")"
 
-    echo "#! $SHELL -e" > $wrapper
+    echo "#! $SHELL -e" > "$wrapper"
 
     params=("$@")
     for ((n = 2; n < ${#params[*]}; n += 1)); do
-        p=${params[$n]}
+        p="${params[$n]}"
 
         if test "$p" = "--set"; then
-            varName=${params[$((n + 1))]}
-            value=${params[$((n + 2))]}
+            varName="${params[$((n + 1))]}"
+            value="${params[$((n + 2))]}"
             n=$((n + 2))
-            echo "export $varName=\"$value\"" >> $wrapper
+            echo "export $varName=\"$value\"" >> "$wrapper"
         fi
 
         if test "$p" = "--unset"; then
-            varName=${params[$((n + 1))]}
+            varName="${params[$((n + 1))]}"
             n=$((n + 1))
             echo "unset $varName" >> "$wrapper"
         fi
 
         if test "$p" = "--run"; then
-            command=${params[$((n + 1))]}
+            command="${params[$((n + 1))]}"
             n=$((n + 1))
-            echo "$command" >> $wrapper
+            echo "$command" >> "$wrapper"
         fi
 
         if test "$p" = "--suffix" -o "$p" = "--prefix"; then
-            varName=${params[$((n + 1))]}
-            separator=${params[$((n + 2))]}
-            value=${params[$((n + 3))]}
+            varName="${params[$((n + 1))]}"
+            separator="${params[$((n + 2))]}"
+            value="${params[$((n + 3))]}"
             n=$((n + 3))
             if test -n "$value"; then
                 if test "$p" = "--suffix"; then
-                    echo "export $varName=\$$varName\${$varName:+$separator}$value" >> $wrapper
+                    echo "export $varName=\$$varName\${$varName:+$separator}$value" >> "$wrapper"
                 else
-                    echo "export $varName=$value\${$varName:+$separator}\$$varName" >> $wrapper
+                    echo "export $varName=$value\${$varName:+$separator}\$$varName" >> "$wrapper"
                 fi
             fi
         fi
 
         if test "$p" = "--suffix-each"; then
-            varName=${params[$((n + 1))]}
-            separator=${params[$((n + 2))]}
-            values=${params[$((n + 3))]}
+            varName="${params[$((n + 1))]}"
+            separator="${params[$((n + 2))]}"
+            values="${params[$((n + 3))]}"
             n=$((n + 3))
             for value in $values; do
-                echo "export $varName=\$$varName\${$varName:+$separator}$value" >> $wrapper
+                echo "export $varName=\$$varName\${$varName:+$separator}$value" >> "$wrapper"
             done
         fi
 
         if test "$p" = "--suffix-contents" -o "$p" = "--prefix-contents"; then
-            varName=${params[$((n + 1))]}
-            separator=${params[$((n + 2))]}
-            fileNames=${params[$((n + 3))]}
+            varName="${params[$((n + 1))]}"
+            separator="${params[$((n + 2))]}"
+            fileNames="${params[$((n + 3))]}"
             n=$((n + 3))
             for fileName in $fileNames; do
                 if test "$p" = "--suffix-contents"; then
-                    echo "export $varName=\$$varName\${$varName:+$separator}$(cat $fileName)" >> $wrapper
+                    echo "export $varName=\$$varName\${$varName:+$separator}$(cat "$fileName")" >> "$wrapper"
                 else
-                    echo "export $varName=$(cat $fileName)\${$varName:+$separator}\$$varName" >> $wrapper
+                    echo "export $varName=$(cat "$fileName")\${$varName:+$separator}\$$varName" >> "$wrapper"
                 fi
             done
         fi
 
         if test "$p" = "--add-flags"; then
-            flags=${params[$((n + 1))]}
+            flags="${params[$((n + 1))]}"
             n=$((n + 1))
             flagsBefore="$flagsBefore $flags"
         fi
 
         if test "$p" = "--argv0"; then
-            argv0=${params[$((n + 1))]}
+            argv0="${params[$((n + 1))]}"
             n=$((n + 1))
         fi
     done
 
     # Note: extraFlagsArray is an array containing additional flags
     # that may be set by --run actions.
-    echo exec ${argv0:+-a $argv0} "$original" \
-         $flagsBefore '"${extraFlagsArray[@]}"' '"$@"' >> $wrapper
+    # Silence warning about unexpanded extraFlagsArray:
+    # shellcheck disable=SC2016
+    echo exec ${argv0:+-a \"$argv0\"} \""$original"\" \
+         "$flagsBefore" '"${extraFlagsArray[@]}"' '"$@"' >> "$wrapper"
 
-    chmod +x $wrapper
+    chmod +x "$wrapper"
 }
 
 addSuffix() {
-    suffix=$1
+    suffix="$1"
     shift
     for name in "$@"; do
         echo "$name$suffix"
@@ -128,7 +130,10 @@ filterExisting() {
 # Syntax: wrapProgram <PROGRAM> <MAKE-WRAPPER FLAGS...>
 wrapProgram() {
     local prog="$1"
-    local hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
-    mv $prog $hidden
-    makeWrapper $hidden $prog --argv0 '"$0"' "$@"
+    local hidden
+    hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
+    mv "$prog" "$hidden"
+    # Silence warning about unexpanded $0:
+    # shellcheck disable=SC2016
+    makeWrapper "$hidden" "$prog" --argv0 '$0' "$@"
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/pull/22962#commitcomment-21144939

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

With this `blink` builds correctly. cc @rnhmjoj