### PR TITLE
Add vim plugins

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -786,6 +786,16 @@ rec {
     dependencies = [];
   };
 
+  vim-toml = buildVimPlugin {
+    name = "vim-toml";
+    src = fetchgit {
+      url = "https://github.com/cespare/vim-toml";
+      rev = "00ecc580aef1f7f80779af577b6e2b7a056f260f";
+      sha256 = "16jmk58619qg88s839d5rnhpjxcpdmfq1199d5z2l089x05cw1ad";
+    };
+    dependencies = [];
+  };
+
   vim-cpp-enhanced-highlight = buildVimPlugin {
     name = "vim-cpp-enhanced-highlight";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -786,6 +786,16 @@ rec {
     dependencies = [];
   };
 
+  vim-cpp-enhanced-highlight = buildVimPlugin {
+    name = "vim-cpp-enhanced-highlight";
+    src = fetchgit {
+      url = "https://github.com/octol/vim-cpp-enhanced-highlight";
+      rev = "42e8b05f200a22635ac4774fa6c1efd37b0484d6";
+      sha256 = "1sjfnbbgxngq590i51pmmpkp0npkqjsafkcwwc5a4bpprlyq4kbb";
+    };
+    dependencies = [];
+  };
+
   lightline-vim = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "lightline-vim-2017-02-12";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -776,6 +776,16 @@ rec {
 
   };
 
+  vim-trailing-whitespace = buildVimPlugin {
+    name = "vim-trailing-whitespace";
+    src = fetchgit {
+      url = "https://github.com/bronson/vim-trailing-whitespace";
+      rev = "733fb64337b6da4a51c85a43450cd620d8b617b5";
+      sha256 = "1469bd744lf8vk1nnw7kyq4ahpw84crp614mkpq88cs6rhvjhcyw";
+    };
+    dependencies = [];
+  };
+
   lightline-vim = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "lightline-vim-2017-02-12";
     src = fetchgit {
@@ -1730,7 +1740,7 @@ rec {
       sha256 = "0rl211rmnzwribzpqxfg99lsyln2x1i8ygyz8b9jy804fm5i24f3";
     };
     dependencies = [];
-    buildInputs = [ python3 ]; 
+    buildInputs = [ python3 ];
     buildPhase = ''
       pushd ./rplugin/python3/deoplete/ujson
       python3 setup.py build --build-base=$PWD/build --build-lib=$PWD/build

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -622,6 +622,16 @@ rec {
 
   };
 
+  vim-beancount = buildVimPlugin {
+    name = "vim-beancount";
+    src = fetchgit {
+      url = "https://github.com/nathangrigg/vim-beancount";
+      rev = "548424b59ac5902a07d53a2c984baeb3983c28ca";
+      sha256 = "0jdd2r6qg9kmv29hfwflr3m2wzqysg7aw1ssjw496bfzmwzyn6bx";
+    };
+    dependencies = [];
+  };
+
   vim-elixir = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "vim-elixir-2017-02-21";
     src = fetchgit {


### PR DESCRIPTION
###### Motivation for this change

Some vim plugins I had in my configuration.nix, but never put into nixpkgs.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

