### PR TITLE
chromium: fix .desktop file name

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -68,7 +68,7 @@ let
     bzip2 flac speex opusWithCustomModes
     libevent expat libjpeg snappy
     libpng libxml2 libxslt libcap
-    xdg_utils yasm minizip libwebp
+    yasm minizip libwebp
     libusb1 re2 zlib
   ];
 
@@ -114,6 +114,9 @@ let
         --replace \
           'return sandbox_binary;' \
           'return base::FilePath(GetDevelSandboxPath());'
+
+      sed -i -e 's@"\(#!\)\?.*xdg-@"\1${xdg_utils}/bin/xdg-@' \
+        chrome/browser/shell_integration_linux.cc
 
       sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${systemd.lib}/lib/\1!' \
         device/udev_linux/udev?_loader.cc

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -34,7 +34,7 @@ let
   };
 
   desktopItem = makeDesktopItem {
-    name = "chromium";
+    name = "chromium-browser";
     exec = "chromium %U";
     icon = "chromium";
     comment = "An open source web browser from Google";

--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -17,11 +17,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "xdg-utils-${version}";
-  version = "1.1.1";
+  version = "1.1.1-p24-ge63b408";
 
   src = fetchurl {
-    url = "https://portland.freedesktop.org/download/${name}.tar.gz";
-    sha256 = "09a1pk3ifsndc5qz2kcd1557i137gpgnv3d739pv22vfayi67pdh";
+    name = "${name}.tar.gz";
+    url = "http://cgit.freedesktop.org/xdg/xdg-utils/snapshot/e63b4088b5c60.tar.gz";
+    #url = "https://portland.freedesktop.org/download/${name}.tar.gz";
+    sha256 = "10vgxq72jphf7m14h1r46a05sx218ay604f5cnmiy99srn8hw032";
   };
 
   # just needed when built from git


### PR DESCRIPTION
The desktop file must be name "chromium-browser.desktop" because it is
used as-is when setting chromium as the default browser.

See https://cs.chromium.org/chromium/src/chrome/browser/shell_integration_linux.cc?l=657&rcl=34b92857a547538555be6a38e95f7e95ab9b6842

Fixes #4370 for chromium.

/cc @domenkozar for https://github.com/NixOS/nixpkgs/issues/4370#issuecomment-64034559