### PR TITLE
bs1770gain: 0.4.7 -> 0.4.12

### DIFF
--- a/pkgs/applications/audio/bs1770gain/default.nix
+++ b/pkgs/applications/audio/bs1770gain/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   name = "bs1770gain-${version}";
-  version = "0.4.7";
+  version = "0.4.12";
 
   src = fetchurl {
     url = "mirror://sourceforge/bs1770gain/${name}.tar.gz";
-    sha256 = "0dnypm7k4axc693g0z73n2mvycbzgc4lnj2am64xjzyg37my4qzz";
+    sha256 = "0n9skdap1vnl6w52fx0gsrjlk7w3xgdwi62ycyf96h29rx059z6a";
   };
 
   buildInputs = [ ffmpeg sox ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A audio/video loudness scanner implementing ITU-R BS.1770";
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
     homepage = "http://bs1770gain.sourceforge.net/";
-    platforms = stdenv.lib.platforms.all;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

