### PR TITLE
osmctools: osmfilter: init at 1.4.0

### DIFF
--- a/pkgs/applications/misc/osmctools/default.nix
+++ b/pkgs/applications/misc/osmctools/default.nix
@@ -1,30 +1,46 @@
 { stdenv, fetchurl, zlib } :
 
+let
+
+  convert_src = fetchurl {
+    url = http://m.m.i24.cc/osmconvert.c;
+    sha256 = "1mvmb171c1jqxrm80jc7qicwk4kgg7yq694n7ci65g6i284r984x";
+    # version = 0.8.5
+  };
+
+  filter_src = fetchurl {
+    url = http://m.m.i24.cc/osmfilter.c;
+    sha256 = "0vm3bls9jb2cb5b11dn82sxnc22qzkf4ghmnkivycigrwa74i6xl";
+    # version = 1.4.0
+  };
+
+in
+
 stdenv.mkDerivation rec {
   name = "osmctools-${version}";
-  version = "0.8.5";
-
-  src = fetchurl {
-    url = http://m.m.i24.cc/osmconvert.c;
-    sha256 = "9da0940912d1bc62223b962483fd796f92c959c48749806aee5806164e5875d7";
-  };
+  version = "0.8.5plus1.4.0";
 
   buildInputs = [ zlib ];
 
   phases = [ "buildPhase" "installPhase" ];
 
   buildPhase = ''
-    cc $src -lz -O3 -o osmconvert
+    cc ${convert_src} -lz -O3 -o osmconvert
+    cc ${filter_src} -O3 -o osmfilter
   '';
 
   installPhase = ''
     mkdir -p $out/bin
     mv osmconvert $out/bin
+    mv osmfilter $out/bin
   '';
 
   meta = with stdenv.lib; {
-    description = "Converter between various Open Street Map file formats";
-    homepage = http://wiki.openstreetmap.org/wiki/Osmconvert;
+    description = "Command line tools for transforming Open Street Map files";
+    homepage = ''
+      http://wiki.openstreetmap.org/wiki/Osmconvert
+      https://wiki.openstreetmap.org/wiki/Osmfilter
+    '';
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

