### PR TITLE
speedread: init at git-2016-09-21

### DIFF
--- a/pkgs/applications/misc/speedread/default.nix
+++ b/pkgs/applications/misc/speedread/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, perl }:
+
+stdenv.mkDerivation rec {
+  version = "git-2016-09-21";
+  name = "speedread-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "pasky";
+    repo   = "speedread";
+    rev    = "93acfd61a1bf4482537ce5d71b9164b8446cb6bd";
+    sha256 = "1h94jx3v18fdlc64lfmj2g5x63fjyqb8c56k5lihl7bva0xgdkxd";
+  };
+
+  buildInputs = [ perl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv speedread $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple terminal-based open source Spritz-alike";
+    longDescription = ''
+      Speedread is a command line filter that shows input text as a
+      per-word rapid serial visual presentation aligned on optimal
+      reading points. This allows reading text at a much more rapid
+      pace than usual as the eye can stay fixed on a single place.
+    '';
+    homepage = src.meta.homepage;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.oxij ];
+  };
+}

--- a/pkgs/applications/misc/speedread/default.nix
+++ b/pkgs/applications/misc/speedread/default.nix
@@ -1,8 +1,7 @@
 { stdenv, fetchFromGitHub, perl }:
 
 stdenv.mkDerivation rec {
-  version = "git-2016-09-21";
-  name = "speedread-${version}";
+  name = "speedread-unstable-2016-09-21";
 
   src = fetchFromGitHub {
     owner  = "pasky";
@@ -14,8 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ perl ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    mv speedread $out/bin
+    install -m755 -D speedread $out/bin/speedread
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14605,6 +14605,8 @@ with pkgs;
 
   sudolikeaboss = callPackage ../tools/security/sudolikeaboss { };
 
+  speedread = callPackage ../applications/misc/speedread { };
+
   sup = callPackage ../applications/networking/mailreaders/sup {
     ruby = ruby_2_3.override { cursesSupport = true; };
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

