### PR TITLE
hasklig: 0.9 -> 1.1

### DIFF
--- a/pkgs/data/fonts/hasklig/default.nix
+++ b/pkgs/data/fonts/hasklig/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "hasklig-${version}";
-  version = "0.9";
+  version = "1.1";
 
   src = fetchurl {
     url = "https://github.com/i-tu/Hasklig/releases/download/${version}/Hasklig-${version}.zip";
-    sha256 = "0rav55f6j1b8pqjgwvw52b92j2m630ampamlsiiym2xf684wnw2d";
+    sha256 = "1hwmdbygallw2kjk0v3a3dl7w6b21wii3acrl0w3ibn05g1cxv4q";
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

