### PR TITLE
haskellPackages: fix dangling references

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-6.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-6.12.x.nix
@@ -43,9 +43,9 @@ self: super: {
   # These packages are core libraries in GHC 7.10.x, but not here.
   binary = self.binary_0_8_4_1;
   deepseq = self.deepseq_1_3_0_1;
-  haskeline = self.haskeline_0_7_2_1;
+  haskeline = self.haskeline_0_7_3_1;
   hoopl = self.hoopl_3_10_2_0;
-  terminfo = self.terminfo_0_4_0_1;
+  terminfo = self.terminfo_0_4_0_2;
   transformers = self.transformers_0_4_3_0;
   xhtml = self.xhtml_3000_2_1;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.0.x.nix
@@ -37,9 +37,9 @@ self: super: {
   # These packages are core libraries in GHC 7.10.x, but not here.
   binary = self.binary_0_7_6_1;
   deepseq = self.deepseq_1_3_0_1;
-  haskeline = self.haskeline_0_7_2_1;
+  haskeline = self.haskeline_0_7_3_1;
   hoopl = self.hoopl_3_10_2_0;
-  terminfo = self.terminfo_0_4_0_1;
+  terminfo = self.terminfo_0_4_0_2;
   transformers = self.transformers_0_4_3_0;
   xhtml = self.xhtml_3000_2_1;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.2.x.nix
@@ -36,8 +36,8 @@ self: super: {
 
   # These packages are core libraries in GHC 7.10.x, but not here.
   deepseq = self.deepseq_1_3_0_1;
-  haskeline = self.haskeline_0_7_2_1;
-  terminfo = self.terminfo_0_4_0_1;
+  haskeline = self.haskeline_0_7_3_1;
+  terminfo = self.terminfo_0_4_0_2;
   transformers = self.transformers_0_4_3_0;
   xhtml = self.xhtml_3000_2_1;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.4.x.nix
@@ -35,8 +35,8 @@ self: super: {
   unix = null;
 
   # These packages are core libraries in GHC 7.10.x, but not here.
-  haskeline = self.haskeline_0_7_2_1;
-  terminfo = self.terminfo_0_4_0_1;
+  haskeline = self.haskeline_0_7_3_1;
+  terminfo = self.terminfo_0_4_0_2;
   transformers = self.transformers_0_4_3_0;
   xhtml = self.xhtml_3000_2_1;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.6.x.nix
@@ -34,8 +34,8 @@ self: super: {
   unix = null;
 
   # These packages are core libraries in GHC 7.10.x, but not here.
-  haskeline = self.haskeline_0_7_2_1;
-  terminfo = self.terminfo_0_4_0_1;
+  haskeline = self.haskeline_0_7_3_1;
+  terminfo = self.terminfo_0_4_0_2;
   transformers = self.transformers_0_4_3_0;
   xhtml = self.xhtml_3000_2_1;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
@@ -65,7 +65,7 @@ self: super: {
     mkDerivation = drv: super.mkDerivation (drv // { doCheck = false; });
     mtl = super.mtl_2_2_1;
     transformers = super.transformers_0_4_3_0;
-    haskeline = self.haskeline_0_7_2_1;
+    haskeline = self.haskeline_0_7_3_1;
     transformers-compat = disableCabalFlag super.transformers-compat "three";
   })) (drv: {});
 

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -47,10 +47,10 @@ self: super:
 
   # These packages are core libraries in GHC 7.10.x, but not here.
   bin-package-db = null;
-  haskeline = self.haskeline_0_7_2_1;
+  haskeline = self.haskeline_0_7_3_1;
   hoopl = self.hoopl_3_10_2_1;
   hpc = self.hpc_0_6_0_2;
-  terminfo = self.terminfo_0_4_0_1;
+  terminfo = self.terminfo_0_4_0_2;
   xhtml = self.xhtml_3000_2_1;
 
 


### PR DESCRIPTION
haskeline_0_7_2_1 -> haskline_0_7_3_1
terminfo_0_4_0_1 -> terminfo_0_4_0_2

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

