### PR TITLE
Dvdstyler: init at 3.0.3

### DIFF
--- a/pkgs/applications/video/dvdstyler/default.nix
+++ b/pkgs/applications/video/dvdstyler/default.nix
@@ -1,0 +1,85 @@
+{ stdenv, fetchurl, pkgconfig
+, flex, bison, gettext
+, xineUI, wxSVG
+, fontconfig
+, xmlto, docbook5, zip
+, cdrtools, dvdauthor, dvdplusrwtools
+, dvdisasterSupport ? true, dvdisaster ? null
+, thumbnailSupport ? true, libgnomeui ? null
+, udevSupport ? true, libudev ? null
+, dbusSupport ? true, dbus ? null
+, makeWrapper }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+
+  name = "dvdstyler-${version}";
+  srcName = "DVDStyler-${version}";
+  version = "3.0.3";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/dvdstyler/dvdstyler/${version}/${srcName}.tar.bz2";
+    sha256 = "1j432kszmwmsd3nz398h5514dbm5vsrn4rr3iil72ckjj1h3i00q";
+  };
+
+  nativeBuildInputs = 
+  [ pkgconfig ];
+
+  packagesToBinPath =
+  [ cdrtools dvdauthor dvdplusrwtools ];
+
+  buildInputs =
+  [ flex bison gettext xineUI
+    wxSVG fontconfig xmlto
+    docbook5 zip makeWrapper ]
+  ++ packagesToBinPath
+  ++ optionals dvdisasterSupport [ dvdisaster ]
+  ++ optionals udevSupport [ libudev ]
+  ++ optionals dbusSupport [ dbus ]
+  ++ optionals thumbnailSupport [ libgnomeui ];
+
+  binPath = makeBinPath packagesToBinPath;
+
+  postInstall = ''
+    wrapProgram $out/bin/dvdstyler \
+      --prefix PATH ":" "${binPath}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A DVD authoring software";
+    longDescription = ''
+    DVDStyler is a cross-platform free DVD authoring application for the
+    creation of professional-looking DVDs. It allows not only burning of video
+    files on DVD that can be played practically on any standalone DVD player,
+    but also creation of individually designed DVD menus. It is Open Source
+    Software and is completely free.
+
+    Some of its features include:
+    -  create and burn DVD video with interactive menus
+    - design your own DVD menu or select one from the list of ready to use menu
+      templates
+    - create photo slideshow
+    - add multiple subtitle and audio tracks
+    - support of AVI, MOV, MP4, MPEG, OGG, WMV and other file formats
+    - support of MPEG-2, MPEG-4, DivX, Xvid, MP2, MP3, AC-3 and other audio and
+      video formats
+    - support of multi-core processor
+    - use MPEG and VOB files without reencoding
+    - put files with different audio/video format on one DVD (support of
+      titleset)
+    - user-friendly interface with support of drag & drop
+    - flexible menu creation on the basis of scalable vector graphic
+    - import of image file for background
+    - place buttons, text, images and other graphic objects anywhere on the menu
+      screen
+    - change the font/color and other parameters of buttons and graphic objects
+    - scale any button or graphic object
+    - copy any menu object or whole menu
+    - customize navigation using DVD scripting
+    '';
+    homepage = http://www.dvdstyler.org/;
+    license = with licenses; gpl2;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/development/libraries/wxSVG/default.nix
+++ b/pkgs/development/libraries/wxSVG/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl
+, pkgconfig, wxGTK
+, ffmpeg, libexif
+, cairo, pango }:
+
+stdenv.mkDerivation rec {
+
+  name = "wxSVG-${version}";
+  srcName = "wxsvg-${version}";
+  version = "1.5.11";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/wxsvg/wxsvg/${version}/${srcName}.tar.bz2";
+    sha256 = "0m3ff8mjiq4hvy8rmxyc9fkpf24xwxhvr3a6jmvr2q5zc41xhz7x";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  propagatedBuildInputs = [ wxGTK ffmpeg libexif ];
+
+  buildInputs = [ cairo pango ];
+
+  meta = with stdenv.lib; {
+    description = "A SVG manipulation library built with wxWidgets";
+    longDescription = ''
+    wxSVG is C++ library to create, manipulate and render
+    Scalable Vector Graphics (SVG) files with the wxWidgets toolkit.
+    '';
+    homepage = http://wxsvg.sourceforge.net/;
+    license = licenses.gpl;
+    maintainers = [ maintainers.AndersonTorres ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/wxSVG/default.nix
+++ b/pkgs/development/libraries/wxSVG/default.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
     Scalable Vector Graphics (SVG) files with the wxWidgets toolkit.
     '';
     homepage = http://wxsvg.sourceforge.net/;
-    license = licenses.gpl;
-    maintainers = [ maintainers.AndersonTorres ];
-    platforms = platforms.linux;
+    license = with licenses; gpl2;
+    maintainers = with  maintainers [ AndersonTorres ];
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10023,6 +10023,10 @@ with pkgs;
     inherit (darwin.stubs) setfile rez derez;
   };
 
+  wxSVG = callPackage ../development/libraries/wxSVG {
+    wxGTK = wxGTK30;
+  };
+
   wtk = callPackage ../development/libraries/wtk { };
 
   x264 = callPackage ../development/libraries/x264 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13101,6 +13101,10 @@ with pkgs;
 
   dvd-slideshow = callPackage ../applications/video/dvd-slideshow { };
 
+  dvdstyler = callPackage ../applications/video/dvdstyler {
+    inherit (gnome2) libgnomeui;
+  };
+
   dwb-unwrapped = callPackage ../applications/networking/browsers/dwb { dconf = gnome3.dconf; };
   dwb = wrapFirefox dwb-unwrapped { desktopName = "dwb"; };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

