### PR TITLE
haskell: ghc710x packages: fix dependent-map

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -191,6 +191,7 @@ self: super: {
   unordered-containers = dontCheck super.unordered-containers;
 
   # GHC versions prior to 8.x require additional build inputs.
+  dependent-map = addBuildDepend super.dependent-map self.semigroups;
   distributive = addBuildDepend super.distributive self.semigroups;
   mono-traversable = addBuildDepend super.mono-traversable self.semigroups;
   attoparsec = addBuildDepends super.attoparsec (with self; [semigroups fail]);


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

