### PR TITLE
drbd: fix output file location

### DIFF
--- a/pkgs/os-specific/linux/drbd/default.nix
+++ b/pkgs/os-specific/linux/drbd/default.nix
@@ -19,17 +19,17 @@ stdenv.mkDerivation rec {
   preConfigure =
     ''
       export PATH=${systemd.udev.bin}/sbin:$PATH
-      substituteInPlace user/Makefile.in --replace /sbin/ $out/sbin/
+      substituteInPlace user/Makefile.in \
+        --replace /sbin '$(sbindir)'
       substituteInPlace user/legacy/Makefile.in \
-        --replace /sbin/ $out/sbin/ \
-        --replace '$(DESTDIR)/lib/drbd' $out/lib/drbd
+        --replace '$(DESTDIR)/lib/drbd' '$(DESTDIR)$(LIBDIR)'
       substituteInPlace user/drbdadm_usage_cnt.c --replace /lib/drbd $out/lib/drbd
       substituteInPlace scripts/drbd.rules --replace /sbin/drbdadm $out/sbin/drbdadm
     '';
 
   makeFlags = "SHELL=${stdenv.shell}";
 
-  installFlags = "localstatedir=$(TMPDIR)/var sysconfdir=$(out)/etc INITDIR=$(out)/etc/init.d DESTDIR=$(out)";
+  installFlags = "localstatedir=$(TMPDIR)/var sysconfdir=$(out)/etc INITDIR=$(out)/etc/init.d";
 
   meta = {
     homepage = http://www.drbd.org/;


### PR DESCRIPTION
drbd was installing files into $out/nix/store/... due to the usage of DESTDIR
(setting both DESTDIR + prefix to $out will cause files to be installed into $out/$out/...)

I'm unfortunately not very familar with this package, so I don't know how to properly test my changes.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

