### PR TITLE
s6-portable-utils: 2.0.5.3 -> 2.1.0.0

### DIFF
--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -1,16 +1,14 @@
-{ stdenv, fetchurl, skalibs }:
+{ stdenv, fetchFromGitHub, skalibs }:
 
-let
-
-  version = "2.0.5.3";
-
-in stdenv.mkDerivation rec {
-
+stdenv.mkDerivation rec {
   name = "s6-portable-utils-${version}";
+  version = "2.1.0.0";
 
-  src = fetchurl {
-    url = "http://www.skarnet.org/software/s6-portable-utils/${name}.tar.gz";
-    sha256 = "029fg9c37vwh9yagd69h8r192nrx4mfva8dwgpm1gxkdssrh3gi7";
+  src = fetchFromGitHub {
+    owner = "skarnet";
+    repo = "s6-portable-utils";
+    rev = "v${version}";
+    sha256 = "0k5pcwc45jw5l8ycz03wx2w4pds0wp4ll47d3i5i1j02i9v0rhc9";
   };
 
   dontDisableStatic = true;
@@ -23,12 +21,12 @@ in stdenv.mkDerivation rec {
   ]
   ++ (stdenv.lib.optional stdenv.isDarwin "--target=${stdenv.system}");
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.skarnet.org/software/s6-portable-utils/;
     description = "A set of tiny general Unix utilities optimized for simplicity and small size";
-    platforms = stdenv.lib.platforms.all;
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney ];
+    platforms = platforms.all;
+    license = licenses.isc;
+    maintainers = with maintainers; [ pmahoney ];
   };
 
 }

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -1,6 +1,9 @@
 { stdenv, fetchFromGitHub, skalibs, gcc }:
 
 with stdenv.lib;
+let
+  cross = "";
+in
 
 stdenv.mkDerivation rec {
   name = "s6-portable-utils-${version}";
@@ -17,7 +20,12 @@ stdenv.mkDerivation rec {
   
   nativeBuildInputs = []
     ++ optional stdenv.isDarwin gcc;
-    
+  
+  preConfigure = ''
+    substituteInPlace configure \
+      "${cross}" " "
+      '';
+
   configureFlags = [
     "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
     "--with-include=${skalibs}/include"
@@ -25,8 +33,7 @@ stdenv.mkDerivation rec {
     "--with-dynlib=${skalibs}/lib"
   ]
   ++ (optional stdenv.isDarwin "--target=${stdenv.system}")
-  ++ (optional stdenv.isDarwin "--with-gcc=${gcc}/bin");
-
+  ;
   meta = {
     homepage = http://www.skarnet.org/software/s6-portable-utils/;
     description = "A set of tiny general Unix utilities optimized for simplicity and small size";

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -21,19 +21,19 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = []
     ++ optional stdenv.isDarwin gcc;
   
-  preConfigure = ''
-    substituteInPlace configure \
-      "${cross}" " "
-      '';
+    #preConfigure = ''
+    #substituteInPlace configure \
+    # "${cross}" " "
+    # '';
 
-  configureFlags = [
-    "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs}/include"
-    "--with-lib=${skalibs}/lib"
-    "--with-dynlib=${skalibs}/lib"
-  ]
-  ++ (optional stdenv.isDarwin "--target=${stdenv.system}")
-  ;
+      # configureFlags = [
+        #"--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
+        #"--with-include=${skalibs}/include"
+        #"--with-lib=${skalibs}/lib"
+        #"--with-dynlib=${skalibs}/lib"
+        #]
+        #++ (optional stdenv.isDarwin "--target=${stdenv.system}")
+  
   meta = {
     homepage = http://www.skarnet.org/software/s6-portable-utils/;
     description = "A set of tiny general Unix utilities optimized for simplicity and small size";

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -1,5 +1,7 @@
 { stdenv, fetchFromGitHub, skalibs, gcc }:
 
+with stdenv.lib;
+
 stdenv.mkDerivation rec {
   name = "s6-portable-utils-${version}";
   version = "2.1.0.0";
@@ -13,8 +15,8 @@ stdenv.mkDerivation rec {
 
   dontDisableStatic = true;
   
-  # Darwin Support, optional isDarwin failed
-  nativeBuildInputs = [ gcc ];
+  nativeBuildInputs = []
+    ++ optional stdenv.isDarwin gcc;
     
   configureFlags = [
     "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
@@ -22,9 +24,10 @@ stdenv.mkDerivation rec {
     "--with-lib=${skalibs}/lib"
     "--with-dynlib=${skalibs}/lib"
   ]
-  ++ (stdenv.lib.optional stdenv.isDarwin "--target=${stdenv.system}");
+  ++ (optional stdenv.isDarwin "--target=${stdenv.system}")
+  ++ (optional stdenv.isDarwin "--with-gcc=${gcc}/bin");
 
-  meta = with stdenv.lib; {
+  meta = {
     homepage = http://www.skarnet.org/software/s6-portable-utils/;
     description = "A set of tiny general Unix utilities optimized for simplicity and small size";
     platforms = platforms.all;

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, skalibs }:
+{ stdenv, fetchFromGitHub, skalibs, gcc }:
 
 stdenv.mkDerivation rec {
   name = "s6-portable-utils-${version}";
@@ -12,7 +12,10 @@ stdenv.mkDerivation rec {
   };
 
   dontDisableStatic = true;
-
+  
+  # Darwin Support, optional isDarwin failed
+  nativeBuildInputs = [ gcc ];
+    
   configureFlags = [
     "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
     "--with-include=${skalibs}/include"

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -21,18 +21,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = []
     ++ optional stdenv.isDarwin gcc;
   
-    #preConfigure = ''
-    #substituteInPlace configure \
-    # "${cross}" " "
-    # '';
-
-      # configureFlags = [
-        #"--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
-        #"--with-include=${skalibs}/include"
-        #"--with-lib=${skalibs}/lib"
-        #"--with-dynlib=${skalibs}/lib"
-        #]
-        #++ (optional stdenv.isDarwin "--target=${stdenv.system}")
+  configureFlags = [
+    #"--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
+    #"--with-include=${skalibs}/include"
+     "--with-lib=${skalibs}/lib"
+     "--with-dynlib=${skalibs}/lib"
+        ];
+        
   
   meta = {
     homepage = http://www.skarnet.org/software/s6-portable-utils/;

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -1,9 +1,6 @@
 { stdenv, fetchFromGitHub, skalibs, gcc }:
 
 with stdenv.lib;
-let
-  cross = "";
-in
 
 stdenv.mkDerivation rec {
   name = "s6-portable-utils-${version}";
@@ -17,18 +14,18 @@ stdenv.mkDerivation rec {
   };
 
   dontDisableStatic = true;
-  
+
   nativeBuildInputs = []
-    ++ optional stdenv.isDarwin gcc;
-  
+  ++ optional stdenv.isDarwin gcc;
+
   configureFlags = [
-    #"--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
-    #"--with-include=${skalibs}/include"
-     "--with-lib=${skalibs}/lib"
-     "--with-dynlib=${skalibs}/lib"
-        ];
-        
-  
+    "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
+    "--with-include=${skalibs}/include"
+    "--with-lib=${skalibs}/lib"
+    "--with-dynlib=${skalibs}/lib"
+  ];
+
+
   meta = {
     homepage = http://www.skarnet.org/software/s6-portable-utils/;
     description = "A set of tiny general Unix utilities optimized for simplicity and small size";


### PR DESCRIPTION
###### Motivation for this change
Added gcc for darwin Support; Could not update PR #23425; Tried hard to do so, but my local branch the PR was using seems to be gone; Did a git fetch pull/#/head:branch; edited the file after checkout-ing the branch and didn't work

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

