### PR TITLE
hydrogen: 0.9.6.1 -> 0.9.7

### DIFF
--- a/pkgs/applications/audio/hydrogen/default.nix
+++ b/pkgs/applications/audio/hydrogen/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, alsaLib, boost, cmake, glib, libjack2, libarchive
+{ stdenv, fetchurl, alsaLib, boost, cmake, glib, lash, libjack2, libarchive
 , liblrdf, libsndfile, pkgconfig, qt4 }:
 
 stdenv.mkDerivation rec {
-  version = "0.9.6.1";
+  version = "0.9.7";
   name = "hydrogen-${version}";
 
   src = fetchurl {
     url = "https://github.com/hydrogen-music/hydrogen/archive/${version}.tar.gz";
-    sha256 = "0vxnaqfmcv7hhk0cj67imdcqngspnck7f0wfmvhfgfqa7x1xznll";
+    sha256 = "1dy2jfkdw0nchars4xi4isrz66fqn53a9qk13bqza7lhmsg3s3qy";
   };
 
-  buildInputs = [ 
-    alsaLib boost cmake glib libjack2 libarchive liblrdf libsndfile pkgconfig qt4
+  buildInputs = [
+    alsaLib boost cmake glib lash libjack2 libarchive liblrdf libsndfile pkgconfig qt4
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

