### PR TITLE
wakatime: 6.0.1 -> 7.0.4

### DIFF
--- a/pkgs/tools/misc/wakatime/default.nix
+++ b/pkgs/tools/misc/wakatime/default.nix
@@ -5,10 +5,10 @@ with pythonPackages;
 buildPythonPackage rec {
   namePrefix = "";
   name = "wakatime-${version}";
-  version = "6.0.1";
+  version = "7.0.4";
 
   src = fetchFromGitHub {
-    sha256 = "0bkzchivkz39jiz78jy7zkpsg6fd94wd7nsmrnijvxb3dn35l7l2";
+    sha256 = "0ghrf0aqb89gjp4pb0398cszi6wzk8chqwd3l5xq6qcgvsq8srq3";
     rev = version;
     repo = "wakatime";
     owner = "wakatime";


### PR DESCRIPTION
###### Motivation for this change

Update to the latest version.

N.B. The `wakatime` CLI works on it's own, but for some reason doesn't seem to play nice with Emacs. So, per these [suggestions](https://github.com/wakatime/wakatime-mode/issues/12), I've configured [`wakatime-mode`](https://github.com/wakatime/wakatime-mode) as follows:

```elisp
(setq wakatime-cli-path "/run/current-system/sw/lib/python2.7/site-packages/wakatime/cli.py"
      wakatime-python-bin "/run/current-system/sw/bin/python2")
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
