### PR TITLE
sound-of-sorting: 0.6.5 -> 20150721

### DIFF
--- a/pkgs/misc/sound-of-sorting/default.nix
+++ b/pkgs/misc/sound-of-sorting/default.nix
@@ -1,28 +1,29 @@
-{ stdenv, fetchurl
-, SDL2, wxGTK
-}:
+{ stdenv, fetchgit
+, SDL2, wxGTK }:
 
 stdenv.mkDerivation rec {
 
   name = "sound-of-sorting-${version}";
-  version = "0.6.5";
+  version = "20150721";
 
-  src = fetchurl {
-    url = "https://github.com/bingmann/sound-of-sorting/archive/${name}.tar.gz";
-    sha256 = "1524bhmy5067z9bjc15hvqslw43adgpdn4272iymq09ahja4x76b";
+  src = fetchgit {
+    url = "https://github.com/bingmann/sound-of-sorting.git";
+    rev = "05db428c796a7006d63efdbe314f976e0aa881d6";
+    sha256 = "0m2f1dym3hcar7784sjzkbf940b28r02ajhkjgyyw7715psifb8l";
+    fetchSubmodules = true;
   };
 
   buildInputs = with stdenv.lib;
   [ wxGTK SDL2 ];
 
   preConfigure = ''
-    export SDL_CONFIG=${SDL2}/bin/sdl2-config
+    export SDL_CONFIG=${SDL2.dev}/bin/sdl2-config
   '';
 
   meta = with stdenv.lib;{
     description = "Audibilization and Visualization of Sorting Algorithms";
     homepage = http://panthema.net/2013/sound-of-sorting/;
-    license = licenses.gpl3;
-    maintainers = [ maintainers.AndersonTorres ];
+    license = with licenses; gpl3;
+    maintainers = with maintainers; [ AndersonTorres ];
   };
 }

--- a/pkgs/misc/sound-of-sorting/default.nix
+++ b/pkgs/misc/sound-of-sorting/default.nix
@@ -4,7 +4,7 @@
 stdenv.mkDerivation rec {
 
   name = "sound-of-sorting-${version}";
-  version = "20150721";
+  version = "unstable-2015-07-21";
 
   src = fetchgit {
     url = "https://github.com/bingmann/sound-of-sorting.git";


### PR DESCRIPTION
###### Motivation for this change

Update to git - the stable version doesn't compile
Fixes ZHF #23253

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

