### PR TITLE
pnmixer: 0.7 -> 0.7.1-rc1

### DIFF
--- a/pkgs/tools/audio/pnmixer/default.nix
+++ b/pkgs/tools/audio/pnmixer/default.nix
@@ -1,23 +1,19 @@
-{ stdenv, fetchFromGitHub, pkgconfig, intltool, autoconf, automake, alsaLib, gtk3, glibc, libnotify, libX11 }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, gettext, alsaLib, gtk3, glib, libnotify, libX11 }:
 
 stdenv.mkDerivation rec {
   name = "pnmixer-${version}";
-  version = "0.7";
+  version = "0.7.1-rc1";
 
   src = fetchFromGitHub {
     owner = "nicklan";
     repo = "pnmixer";
     rev = "v${version}";
-    sha256 = "077l28qhr82ifqfwc2nqi5q1hmi6dyqqbhmjcsn27p4y433f3rpb";
+    sha256 = "0ns7s1jsc7fc3fvs9m3xwbv1fk1410cqc5w1cmia1mlzy94r3r6p";
   };
 
-  nativeBuildInputs = [ pkgconfig autoconf automake intltool ];
+  nativeBuildInputs = [ cmake pkgconfig gettext ];
 
-  buildInputs = [ alsaLib gtk3 glibc libnotify libX11 ];
-
-  preConfigure = ''
-    ./autogen.sh
-  '';
+  buildInputs = [ alsaLib gtk3 glib libnotify libX11 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/nicklan/pnmixer;


### PR DESCRIPTION
###### Motivation for this change

New release candidate with [improvements](https://github.com/nicklan/pnmixer/releases):



- Improvements:
  - Handle cards without mute switch by graying out the switch
  - Replace deprecated GtkTable with GtkGrid
- Translations:
  - Use modern 'gettext' instead of 'intltool'
  - New translations: Serbian
- Build infrastructure:
  - Switch from Autotools to CMake
  - Make the build reproducible
  - Simplify travis build and only build on debian:unstable

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).