### PR TITLE
clog-cli: init at 0.9.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -341,6 +341,7 @@
   notthemessiah = "Brian Cohen <brian.cohen.88@gmail.com>";
   np = "Nicolas Pouillard <np.nix@nicolaspouillard.fr>";
   nslqqq = "Nikita Mikhailov <nslqqq@gmail.com>";
+  nthorne = "Niklas Thörne <notrupertthorne@gmail.com>";
   obadz = "obadz <obadz-nixos@obadz.com>";
   ocharles = "Oliver Charles <ollie@ocharles.org.uk>";
   odi = "Oliver Dunkl <oliver.dunkl@gmail.com>";

--- a/pkgs/development/tools/clog-cli/default.nix
+++ b/pkgs/development/tools/clog-cli/default.nix
@@ -20,5 +20,6 @@ buildRustPackage rec {
     homepage = https://github.com/clog-tool/clog-cli;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.linux;
+    maintainers = [stdenv.lib.maintainers.nthorne];
   };
 }

--- a/pkgs/development/tools/clog-cli/default.nix
+++ b/pkgs/development/tools/clog-cli/default.nix
@@ -1,0 +1,24 @@
+{ fetchFromGitHub, rustPlatform, stdenv }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "clog-cli-${version}";
+  version = "0.9.2";
+
+  src = fetchFromGitHub {
+    owner = "clog-tool";
+    repo = "clog-cli";
+    rev = "${version}";
+    sha256 = "00sfbchyf50z6mb5dq1837hlrki88rrf043idy6qd1r90488jsbv";
+  };
+
+  depsSha256 = "0czv190r6xhbw33l0jhlri6rgspxb8f6dakcamh52qr3z9m0xs2x";
+
+  meta = {
+    description = "Generate changelogs from local git metadata";
+    homepage = https://github.com/clog-tool/clog-cli;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -726,6 +726,8 @@ with pkgs;
 
   cli-visualizer = callPackage ../applications/misc/cli-visualizer { };
 
+  clog-cli = callPackage ../development/tools/clog-cli { };
+
   cloud-init = callPackage ../tools/virtualization/cloud-init { };
 
   clib = callPackage ../tools/package-management/clib { };


### PR DESCRIPTION
###### Motivation for this change

To introduce the clog-cli changelog generation tool.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

