### PR TITLE
monero: 0.10.1 -> 0.10.2.1

### DIFF
--- a/pkgs/applications/misc/monero/default.nix
+++ b/pkgs/applications/misc/monero/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, boost, miniupnpc, pkgconfig, unbound }:
+{ stdenv, fetchFromGitHub, cmake, boost, miniupnpc, openssl, pkgconfig, unbound }:
 
 let
-  version = "0.10.1";
+  version = "0.10.2.1";
 in
 stdenv.mkDerivation {
   name = "monero-${version}";
@@ -10,12 +10,12 @@ stdenv.mkDerivation {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    sha256 = "1zngskpgxz3vqq348h0mab2kv95z6g9ckvqkr77mx15m5z3qi6aw";
+    sha256 = "0jr57lih3smdg4abglfyfhxp69akiyqy889gcpdplwl05vfnhand";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
-  buildInputs = [ boost miniupnpc unbound ];
+  buildInputs = [ boost miniupnpc openssl unbound ];
 
   # these tests take a long time and don't
   # always complete in the build environment


### PR DESCRIPTION
###### Motivation for this change

bump to latest upstream

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).