### PR TITLE
endless-sky: 0.9.4 -> 0.9.6

### DIFF
--- a/pkgs/games/endless-sky/default.nix
+++ b/pkgs/games/endless-sky/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchFromGitHub
-, SDL2, libpng, libjpeg, glew, openal, scons
+, SDL2, libpng, libjpeg, glew, openal, scons, libmad
 }:
 
 let
-  version = "0.9.4";
+  version = "0.9.6";
 
 in
 stdenv.mkDerivation rec {
@@ -13,13 +13,13 @@ stdenv.mkDerivation rec {
     owner = "endless-sky";
     repo = "endless-sky";
     rev = "v${version}";
-    sha256 = "1mirdcpap0a280j472lhmhqg605b7glvdr4l93qcapk8an8d46m7";
+    sha256 = "166wr861w415kynim0yx3x7c16x66f5367hv2mfzhpyp244jzccx";
   };
 
   enableParallelBuilding = true;
 
   buildInputs = [
-    SDL2 libpng libjpeg glew openal scons
+    SDL2 libpng libjpeg glew openal scons libmad
   ];
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change
New upstream stable release.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Package has no dependents
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).