### PR TITLE
Precision strike

### DIFF
--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -1,11 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, go, pkgs }:
+{ stdenv, lib, fetchFromGitHub, go, pkgs, removeReferencesTo }:
 
-let
-  removeExpr = ref: ''
-    sed -i "s,${ref},$(echo "${ref}" | sed "s,$NIX_STORE/[^-]*,$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee,"),g" \
-  '';
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   version = "0.14.24";
   name = "syncthing-${version}";
 
@@ -16,7 +11,7 @@ in stdenv.mkDerivation rec {
     sha256 = "15jjk49ibry7crc3sw5zg09zsm5ir0ph5c0f3acas66wd02rnvl1";
   };
 
-  buildInputs = [ go ];
+  buildInputs = [ go removeReferencesTo ];
 
   buildPhase = ''
     mkdir -p src/github.com/syncthing
@@ -48,7 +43,7 @@ in stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    find $out/bin -type f -exec ${removeExpr go} '{}' '+'
+    find $out/bin -type f -exec remove-references-to -t ${go} '{}' '+'
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/build-support/remove-references-to/default.nix
+++ b/pkgs/build-support/remove-references-to/default.nix
@@ -1,0 +1,34 @@
+# The program `remove-references-to' created by this derivation replaces all
+# references to the given Nix store paths in the specified files by a
+# non-existent path (/nix/store/eeee...).  This is useful for getting rid of
+# dependencies that you know are not actually needed at runtime.
+
+{ stdenv, writeScriptBin }:
+
+writeScriptBin "remove-references-to" ''
+#! ${stdenv.shell} -e
+
+# References to remove
+targets=()
+while getopts t: o; do
+    case "$o" in
+        t) storeId=$(echo "$OPTARG" | sed -n "s|^$NIX_STORE/\\([a-z0-9]\{32\}\\)-.*|\1|p")
+           if [ -z "$storeId" ]; then
+               echo "-t argument must be a Nix store path"
+               exit 1
+           fi
+           targets+=("$storeId")
+    esac
+done
+shift $(($OPTIND-1))
+
+# Files to remove the references from
+regions=()
+for i in "$@"; do
+    test ! -L "$i" -a -f "$i" && regions+=("$i")
+done
+
+for target in "''${targets[@]}" ; do
+    sed -i -e "s|$NIX_STORE/$target-|$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-|g" "''${regions[@]}"
+done
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -291,6 +291,8 @@ with pkgs;
 
   nukeReferences = callPackage ../build-support/nuke-references/default.nix { };
 
+  removeReferencesTo = callPackage ../build-support/remove-references-to/default.nix { };
+
   vmTools = callPackage ../build-support/vm/default.nix { };
 
   releaseTools = callPackage ../build-support/release/default.nix { };


### PR DESCRIPTION
###### Motivation for this change
#21852 It would be nice to allow removing specific references rather than all references besides the ones specifically listed.

Also includes a sample usage for syncthing. I think this should be used in more places (e.g. buildGoPackage, perhaps some places that currently use nuke-refs), but was hoping to get some feedback on the idea, the implementation and the name (chosen by analogy to “nuke”).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).