### PR TITLE
mendeley: 1.16.3 -> 1.17.8, multiple improvements

### DIFF
--- a/pkgs/applications/office/mendeley/default.nix
+++ b/pkgs/applications/office/mendeley/default.nix
@@ -1,6 +1,30 @@
-{ fetchurl, stdenv, dpkg, makeWrapper, which
-, gcc, orc, xorg, qt4, zlib
-, ...}:
+{ fetchurl, stdenv, dpkg, which
+, alsaLib
+, desktop_file_utils
+, dbus
+, libcap
+, fontconfig
+, freetype
+, gcc
+, gconf
+, glib
+, icu
+, libxml2
+, libxslt
+, orc
+, nss
+, nspr
+, qt5
+, sqlite
+, xorg
+, xlibs
+, zlib
+# The provided wrapper does this, but since we don't use it
+# we emulate the behavior.  The downside is that this
+# will leave entries on your system after uninstalling mendeley.
+# (they can be removed by running '$out/bin/install-mendeley-link-handler.sh -u')
+, autorunLinkHandler ? true
+}:
 
 assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
 
@@ -12,20 +36,49 @@ let
     then "i386"
     else "amd64";
 
-  shortVersion = "1.16.3-stable";
+  shortVersion = "1.17.8-stable";
 
   version = "${shortVersion}_${arch}";
 
   url = "http://desktop-download.mendeley.com/download/apt/pool/main/m/mendeleydesktop/mendeleydesktop_${version}.deb";
   sha256 = if stdenv.system == arch32
-    then "14cxysn1l6s6z8awmqj1glm4146jif0852wiyhjg1dhhh25cvpbv"
-    else "1hdvawj8g4hpj36xy5ys27h1fa76xcdx8apsxa6hpg5xmxvcamqz";
+    then "0j2hi0kd3cjjs47fxdzilc3rh02kzkdhvh70yyv7j8n58lnyjnx7"
+    else "0pi1bis0jmy618c1jn6b61mn666w7546xzicbqv1g6c4l8s3wgm5";
 
   deps = [
+    qt5.qtbase
+    qt5.qtsvg
+    qt5.qtdeclarative
+    qt5.qtwebchannel
+    qt5.qtquickcontrols
+    qt5.qtwebkit
+    qt5.qtwebengine
+    alsaLib
+    dbus
+    freetype
+    fontconfig
     gcc.cc
+    gconf
+    glib
+    icu
+    libcap
+    libxml2
+    libxslt
+    nspr
+    nss
     orc
-    qt4
+    sqlite
     xorg.libX11
+    xlibs.xcbutilkeysyms
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXext
+    xorg.libXrender
+    xorg.libXi
+    xorg.libXcursor
+    xorg.libXtst
+    xorg.libXrandr
+    xorg.xcbutilimage
     zlib
   ];
 
@@ -39,19 +92,33 @@ stdenv.mkDerivation {
     sha256 = sha256;
   };
 
-  buildInputs = [ dpkg makeWrapper which ];
+  nativeBuildInputs = [ qt5.makeQtWrapper ];
+  buildInputs = [ dpkg which ] ++ deps;
 
   unpackPhase = "true";
 
   installPhase = ''
     dpkg-deb -x $src $out
-    mv $out/opt/mendeleydesktop/{bin,lib,plugins,share} $out
+    mv $out/opt/mendeleydesktop/{bin,lib,share} $out
 
     interpreter=$(patchelf --print-interpreter $(readlink -f $(which patchelf)))
-    patchelf --set-interpreter $interpreter $out/bin/mendeleydesktop
+    patchelf --set-interpreter $interpreter \
+             --set-rpath ${stdenv.lib.makeLibraryPath deps}:$out/lib \
+             $out/bin/mendeleydesktop
+    paxmark m $out/bin/mendeleydesktop
 
-    librarypath="${stdenv.lib.makeLibraryPath deps}:$out/lib:$out/lib/qt"
-    wrapProgram $out/bin/mendeleydesktop --prefix LD_LIBRARY_PATH : "$librarypath"
+    wrapQtProgram $out/bin/mendeleydesktop \
+      --add-flags "--unix-distro-build" \
+      ${stdenv.lib.optionalString autorunLinkHandler
+      ''--run "$out/bin/install-mendeley-link-handler.sh $out/bin/mendeleydesktop"''}
+
+    # Remove bundled qt bits
+    rm -rf $out/lib/qt
+    rm $out/bin/qt* $out/bin/Qt*
+
+    # Patch up link handler script
+    wrapProgram $out/bin/install-mendeley-link-handler.sh \
+      --prefix PATH ':' ${stdenv.lib.makeBinPath [ which gconf desktop_file_utils ] }
   '';
 
   dontStrip = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14381,7 +14381,10 @@ with pkgs;
 
   mcomix = callPackage ../applications/graphics/mcomix { };
 
-  mendeley = callPackage ../applications/office/mendeley { };
+  mendeley = callPackage ../applications/office/mendeley {
+    qt5 = qt56;
+    gconf = pkgs.gnome2.GConf;
+  };
 
   mercurial = callPackage ../applications/version-management/mercurial {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;


### PR DESCRIPTION
* don't use bundled qt
* fix link-handler script, autorun as 'normal'
* fix execution on grsec kernels

###### Motivation for this change

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

