### PR TITLE
Mypy

### DIFF
--- a/pkgs/development/python-modules/typed-ast/default.nix
+++ b/pkgs/development/python-modules/typed-ast/default.nix
@@ -1,0 +1,16 @@
+{ buildPythonPackage, fetchzip, isPy3k, lib, pythonOlder }:
+buildPythonPackage rec {
+  name = "typed-ast-${version}";
+  version = "1.0.1";
+  src = fetchzip {
+    url = "mirror://pypi/t/typed-ast/${name}.zip";
+    sha256 = "1q69czr9ghnbd81hay71kgynn6mqi5nsgand9yw6dyw5bim5l154";
+  };
+  # Only works with Python 3.3 and newer;
+  disabled = !isPy3k && !(pythonOlder "3.3");
+  meta = {
+    homepage = "https://pypi.python.org/pypi/typed-ast";
+    description = "a fork of Python 2 and 3 ast modules with type comment support";
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/development/tools/mypy/default.nix
+++ b/pkgs/development/tools/mypy/default.nix
@@ -1,18 +1,17 @@
 { stdenv, fetchurl, python35Packages }:
-
 python35Packages.buildPythonApplication rec {
-  name = "mypy-lang-${version}";
-  version = "0.4.5";
+  name = "mypy-${version}";
+  version = "0.501";
 
   # Tests not included in pip package.
   doCheck = false;
 
   src = fetchurl {
-    url = "mirror://pypi/m/mypy-lang/${name}.tar.gz";
-    sha256 = "0x1n6r5in57zv4s75r22smpqxrz7xxp84fnrhkwzbpjnafa3y81f";
+    url = "mirror://pypi/m/mypy/${name}.tar.gz";
+    sha256 = "164g3dq2vzxa53n9lgvmbapg41qiwcxk1w9mvzmnqksvql5vm60h";
   };
 
-  propagatedBuildInputs = with python35Packages; [ lxml ];
+  propagatedBuildInputs = with python35Packages; [ lxml typed-ast ];
 
   meta = with stdenv.lib; {
     description = "Optional static typing for Python";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6909,7 +6909,7 @@ with pkgs;
 
   grabserial = callPackage ../development/tools/grabserial { };
 
-  mypy-lang = callPackage ../development/tools/mypy-lang { };
+  mypy = callPackage ../development/tools/mypy { };
 
 
   ### DEVELOPMENT / LIBRARIES

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -32038,6 +32038,8 @@ EOF
     };
   };
 
+  typed-ast = callPackage ../development/python-modules/typed-ast { };
+
   stripe = buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "stripe";


### PR DESCRIPTION
###### Motivation for this change

mypy has changed its name and versioning scheme

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

