### PR TITLE
pdnsd: fix darwin build

### DIFF
--- a/pkgs/tools/networking/pdnsd/default.nix
+++ b/pkgs/tools/networking/pdnsd/default.nix
@@ -14,11 +14,14 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--enable-ipv6" ];
 
-  meta = { 
+  # fix ipv6 on darwin
+  CPPFLAGS = "-D__APPLE_USE_RFC_3542";
+
+  meta = with stdenv.lib; {
     description = "Permanent DNS caching";
-    homepage = http://www.phys.uu.nl/~rombouts/pdnsd.html;
-    license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = with stdenv.lib.maintainers; [viric];
+    homepage = http://members.home.nl/p.a.rombouts/pdnsd;
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [viric];
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

