### PR TITLE
idutils: disable tests on darwin

### DIFF
--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -106,6 +106,7 @@ stdenv.mkDerivation rec {
     description = "An offline reader for Web content";
     homepage = http://kiwix.org;
     license = licenses.gpl3;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ robbinch ];
   };
 }

--- a/pkgs/tools/misc/idutils/default.nix
+++ b/pkgs/tools/misc/idutils/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = stdenv.lib.optional stdenv.isLinux emacs;
 
-  doCheck = true;
+  doCheck = !stdenv.isDarwin;
 
   patches = [ ./nix-mapping.patch ];
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

