### PR TITLE
gpsbabel: fix darwin build

### DIFF
--- a/pkgs/applications/misc/gpsbabel/clang-4.patch
+++ b/pkgs/applications/misc/gpsbabel/clang-4.patch
@@ -1,0 +1,22 @@
+diff --git a/bushnell.cc b/bushnell.cc
+index 8fa844d..40707c4 100644
+--- a/bushnell.cc
++++ b/bushnell.cc
+@@ -135,7 +135,7 @@ bushnell_get_icon_from_name(QString name)
+     name = "Waypoint";
+   }
+
+-  for (t = bushnell_icons; t->icon > 0; t++) {
++  for (t = bushnell_icons; t->icon != 0; t++) {
+     if (0 == name.compare(t->icon, Qt::CaseInsensitive)) {
+       return t->symbol;
+     }
+@@ -147,7 +147,7 @@ static const char*
+ bushnell_get_name_from_symbol(signed int s)
+ {
+   icon_mapping_t* t;
+-  for (t = bushnell_icons; t->icon > 0; t++) {
++  for (t = bushnell_icons; t->icon != 0; t++) {
+     if (s == t->symbol) {
+       return t->icon;
+     }

--- a/pkgs/applications/misc/gpsbabel/default.nix
+++ b/pkgs/applications/misc/gpsbabel/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    ./clang-4.patch
     (fetchpatch {
       url = https://sources.debian.net/data/main/g/gpsbabel/1.5.3-2/debian/patches/use_minizip;
       sha256 = "03fpsmlx1wc48d1j405zkzp8j64hcp0z72islf4mk1immql3ibcr";
@@ -44,8 +45,8 @@ stdenv.mkDerivation rec {
   ''
     # The raymarine and gtm tests fail on i686 despite -ffloat-store.
   + lib.optionalString stdenv.isi686 "rm -v testo.d/raymarine.test testo.d/gtm.test;"
-    # The tomtom asc test fails on darwin, see PR #23572.
-  + lib.optionalString stdenv.isDarwin "rm -v testo.d/tomtom_asc.test;";
+    # The gtm, kml and tomtom asc tests fail on darwin, see PR #23572.
+  + lib.optionalString stdenv.isDarwin "rm -v testo.d/gtm.test testo.d/kml.test testo.d/tomtom_asc.test";
 
   meta = with stdenv.lib; {
     description = "Convert, upload and download data from GPS and Map programs";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13985,7 +13985,9 @@ with pkgs;
 
   gosmore = callPackage ../applications/misc/gosmore { };
 
-  gpsbabel = libsForQt5.callPackage ../applications/misc/gpsbabel { };
+  gpsbabel = libsForQt5.callPackage ../applications/misc/gpsbabel {
+    inherit (darwin) IOKit;
+  };
 
   gpscorrelate = callPackage ../applications/misc/gpscorrelate { };
 


### PR DESCRIPTION
###### Motivation for this change

To hopefully fix [build on Darwin](https://hydra.nixos.org/build/49778334):
```
clang  -g -O2 -Wall -c   -I. -F/nix/store/v8lv37s2yi2sz6h2w8nbcim9mdd2g0fn-qt-4.8.7/lib  -DHAVE_CONFIG_H -DNEW_STRINGS mac/libusb/darwin.c -o mac/libusb/darwin.o
mac/libusb/darwin.c:62:10: fatal error: 'IOKit/IOCFBundle.h' file not found
#include <IOKit/IOCFBundle.h>
```

Note, I have no means to build on OSX so cannot say whether this PR actually fixes the issue.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).