### PR TITLE
gss: don't build with shishi on darwin

### DIFF
--- a/pkgs/development/libraries/gss/default.nix
+++ b/pkgs/development/libraries/gss/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl
-
-# Optional Dependencies
-, shishi ? null
+, withShishi ? !stdenv.isDarwin, shishi ? null
 }:
+
+assert withShishi -> shishi != null;
 
 stdenv.mkDerivation rec {
   name = "gss-1.0.3";
@@ -12,16 +12,16 @@ stdenv.mkDerivation rec {
     sha256 = "1syyvh3k659xf1hdv9pilnnhbbhs6vfapayp4xgdcc8mfgf9v4gz";
   };
 
-  buildInputs = [ shishi ];
+  buildInputs = stdenv.lib.optional withShishi shishi;
 
   configureFlags = [
-    "--${if shishi != null then "enable" else "disable"}-kereberos5"
+    "--${if withShishi != null then "enable" else "disable"}-kereberos5"
   ];
 
   doCheck = true;
 
   # Fixup .la files
-  postInstall = stdenv.lib.optionalString (!stdenv.isDarwin && shishi != null) ''
+  postInstall = stdenv.lib.optionalString withShishi ''
     sed -i 's,\(-lshishi\),-L${shishi}/lib \1,' $out/lib/libgss.la
   '';
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

