### PR TITLE
bitcoin-classic: 0.11.2.cl1.b1 -> 1.2.1

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-classic.nix
+++ b/pkgs/applications/altcoins/bitcoin-classic.nix
@@ -1,20 +1,24 @@
-{ stdenv, fetchurl, pkgconfig, autoreconfHook, openssl, db48, boost
-, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, openssl, db48, boost
+, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, libevent
 , withGui }:
 
 with stdenv.lib;
+
 stdenv.mkDerivation rec {
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-classic-" + version;
-  version = "0.11.2.cl1.b1";
+  version = "1.2.1";
 
-  src = fetchurl {
-    url = "https://github.com/bitcoinclassic/bitcoinclassic/archive/v${version}.tar.gz";
-    sha256 = "1szsnx5aijk3hx7qkqzbqsr0basg8ydwp20mh3bhnf4ljryy2049";
+  src = fetchFromGitHub {
+    owner = "bitcoinclassic";
+    repo = "bitcoinclassic";
+    rev = "v${version}";
+    sha256 = "0ykblw6mb8bh2pa50iqgc5f07mmsz4m3yajsphqgiv5n2fwmkzng";
   };
 
-  buildInputs = [ pkgconfig autoreconfHook openssl db48 boost zlib
-                  miniupnpc utillinux protobuf ]
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ openssl db48 boost zlib
+                  miniupnpc utillinux protobuf libevent ]
                   ++ optionals withGui [ qt4 qrencode ];
 
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
@@ -35,7 +39,7 @@ stdenv.mkDerivation rec {
       continue to release updates that are in line with Satoshi’s whitepaper &
       vision, and are agreed upon by the community.
     '';
-    homepage = "https://bitcoinclassic.com/";
+    homepage = https://bitcoinclassic.com/;
     maintainers = with maintainers; [ jefdaj ];
     license = licenses.mit;
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

