### PR TITLE
dnsmasq: install launchd plist on darwin

### DIFF
--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -39,6 +39,11 @@ stdenv.mkDerivation rec {
   # module can create it in Nix-land?
   postInstall = ''
     install -Dm644 trust-anchors.conf $out/share/dnsmasq/trust-anchors.conf
+  '' + optionalString stdenv.isDarwin ''
+    install -Dm644 contrib/MacOSX-launchd/uk.org.thekelleys.dnsmasq.plist \
+      $out/Library/LaunchDaemons/uk.org.thekelleys.dnsmasq.plist
+    substituteInPlace $out/Library/LaunchDaemons/uk.org.thekelleys.dnsmasq.plist \
+      --replace "/usr/local/sbin" "$out/bin"
   '' + optionalString stdenv.isLinux ''
     install -Dm644 dbus/dnsmasq.conf $out/etc/dbus-1/system.d/dnsmasq.conf
     install -Dm755 contrib/lease-tools/dhcp_lease_time $out/bin/dhcp_lease_time


### PR DESCRIPTION
It's just a static file in the `contrib` folder of the project's source, added as an output in `System/Library/LaunchDaemons` (I copied this from a few other packages), with its path corrected.