### PR TITLE
slack: added missing libxkbfile dependency

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -26,6 +26,7 @@ let
     stdenv.cc.cc
     systemd
 
+    xorg.libxkbfile
     xorg.libX11
     xorg.libXcomposite
     xorg.libXcursor


### PR DESCRIPTION
###### Motivation for this change
Slack 2.5.1 was not able to render due to `libxkbfile` missing (as seen in the logs while troubleshooting)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [x] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

