### PR TITLE
bitcoin-xt: 0.11D -> 0.11F

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-xt.nix
+++ b/pkgs/applications/altcoins/bitcoin-xt.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, autoreconfHook, openssl, db48, boost
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, openssl, db48, boost
 , zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, curl
 , withGui }:
 
@@ -6,14 +6,17 @@ with stdenv.lib;
 stdenv.mkDerivation rec{
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-xt-" + version;
-  version = "0.11D";
+  version = "0.11F";
 
-  src = fetchurl {
-    url = "https://github.com/bitcoinxt/bitcoinxt/archive/v${version}.tar.gz";
-    sha256 = "09r2i88wzqaj6mh66l3ngyfkm1a0dhwm5ibalj6y55wbxm9bvd36";
+  src = fetchFromGitHub {
+    owner = "bitcoinxt";
+    repo = "bitcoinxt";
+    rev = "v${version}";
+    sha256 = "13s5k9mxmlbf49p5hc546x20y5dslfp6g9hi6nw5yja5bngbwr24";
   };
 
-  buildInputs = [ pkgconfig autoreconfHook openssl db48 boost zlib
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ openssl db48 boost zlib
                   miniupnpc utillinux protobuf curl ]
                   ++ optionals withGui [ qt4 qrencode ];
 


### PR DESCRIPTION
###### Motivation for this change
Updated 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

