### PR TITLE
inetutils: fix whois for canadian domains

### DIFF
--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "05n65k4ixl85dc6rxc51b1b732gnmm8xnqi424dy9f1nz7ppb3xy";
   };
 
+  patches = [ ./whois-Update-Canadian-TLD-server.patch ];
+
   buildInputs = [ ncurses /* for `talk' */ perl /* for `whois' */ ];
 
   configureFlags = "--with-ncurses-include-dir=${ncurses.dev}/include";

--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses }:
+{ stdenv, fetchurl, ncurses, perl }:
 
 stdenv.mkDerivation rec {
   name = "inetutils-1.9.4";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "05n65k4ixl85dc6rxc51b1b732gnmm8xnqi424dy9f1nz7ppb3xy";
   };
 
-  buildInputs = [ ncurses /* for `talk' */ ];
+  buildInputs = [ ncurses /* for `talk' */ perl /* for `whois' */ ];
 
   configureFlags = "--with-ncurses-include-dir=${ncurses.dev}/include";
 

--- a/pkgs/tools/networking/inetutils/whois-Update-Canadian-TLD-server.patch
+++ b/pkgs/tools/networking/inetutils/whois-Update-Canadian-TLD-server.patch
@@ -1,0 +1,43 @@
+From 73e2811a0512556fd5359acc4387f46c79a9884a Mon Sep 17 00:00:00 2001
+From: Mats Erik Andersson <gnu@gisladisker.se>
+Date: Thu, 2 Mar 2017 15:38:38 +0100
+Subject: [PATCH] whois: Update Canadian TLD server.
+Content-Type: text/plain; charset=utf-8
+
+---
+ ChangeLog           | 8 ++++++++
+ whois/tld_serv_list | 2 +-
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index c632d86..6b2a36b 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,11 @@
++2017-03-02  Mats Erik Andersson  <gnu@gisladisker.se>
++
++	whois: Update Canadian TLD server.
++	Old host name no longer exists.  Reported by Neil Mayhem:
++	http://lists.gnu.org/archive/html/bug-inetutils/2017-01/msg00000.html
++
++	* whois/tld_serv_list (.ca): New host 'whois.cira.ca'.
++
+ 2017-02-27  Mats Erik Andersson  <gnu@gisladisker.se>
+ 
+ 	telnetd: Portability of TTY termcap to Solaris systems.
+diff --git a/whois/tld_serv_list b/whois/tld_serv_list
+index 056efcf..91697b8 100644
+--- a/whois/tld_serv_list
++++ b/whois/tld_serv_list
+@@ -81,7 +81,7 @@
+ #.bw			# NIC? www.botsnet.bw
+ #.by	NONE		# NIC? http://unibel.by www.open.by
+ .bz	NONE		# http://www.psg.com/dns/bz/
+-.ca	whois.cdnnet.ca
++.ca	whois.cira.ca
+ .cc	whois.nic.cc
+ .cd	WEB http://www.nic.cd/database/cd/
+ #.cf	NONE		# NIC? http://www.socatel.intnet.cf
+-- 
+2.10.0
+


### PR DESCRIPTION
###### Motivation for this change

`whois` can't look up Canadian domains (`.ca` TLD).

Before:

```
$ whois google.ca
getaddrinfo: Name or service not known
```

After:

```
$ whois google.ca
Domain name:           google.ca
Domain status:         registered
...
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

