### PR TITLE
lxqt: fix qtsvg attribute

### DIFF
--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -71,7 +71,7 @@ let
       pkgs.lxmenu-data
       pkgs.menu-cache
       pkgs.openbox # default window manager
-      qt5.qtsvg # provides QT5 plugins for svg icons
+      pkgs.qt5.qtsvg # provides QT5 plugins for svg icons
     ];
 
     corePackages = [


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/23397.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).