### PR TITLE
Git: Make the patchset more granular.

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -26,12 +26,12 @@ stdenv.mkDerivation {
   hardeningDisable = [ "format" ];
 
   patches = [
-    ./docbook2texi.patch
     ./symlinks-in-bin.patch
     ./git-sh-i18n.patch
     ./ssh-path.patch
     ./ssl-cert-file.patch
-  ];
+  ] ++ stdenv.lib.optionals withManual [ ./docbook2texi.patch ]
+    ++ stdenv.lib.optionals guiSupport [ ./ssh-path-gui.patch ];
 
   postPatch = ''
     for x in connect.c git-gui/lib/remote_add.tcl ; do

--- a/pkgs/applications/version-management/git-and-tools/git/ssh-path-gui.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/ssh-path-gui.patch
@@ -1,0 +1,13 @@
+diff --git a/git-gui/lib/remote_add.tcl b/git-gui/lib/remote_add.tcl
+index 50029d0..17b9594 100644
+--- a/git-gui/lib/remote_add.tcl
++++ b/git-gui/lib/remote_add.tcl
+@@ -139,7 +139,7 @@ method _add {} {
+ 		# Parse the location
+ 		if { [regexp {(?:git\+)?ssh://([^/]+)(/.+)} $location xx host path]
+ 		     || [regexp {([^:][^:]+):(.+)} $location xx host path]} {
+-			set ssh ssh
++			set ssh @ssh@
+ 			if {[info exists env(GIT_SSH)]} {
+ 				set ssh $env(GIT_SSH)
+ 			}

--- a/pkgs/applications/version-management/git-and-tools/git/ssh-path.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/ssh-path.patch
@@ -11,16 +11,3 @@ index fd7ffe1..20cd992 100644
  
  				ssh_dup = xstrdup(ssh);
  				base = basename(ssh_dup);
-diff --git a/git-gui/lib/remote_add.tcl b/git-gui/lib/remote_add.tcl
-index 50029d0..17b9594 100644
---- a/git-gui/lib/remote_add.tcl
-+++ b/git-gui/lib/remote_add.tcl
-@@ -139,7 +139,7 @@ method _add {} {
- 		# Parse the location
- 		if { [regexp {(?:git\+)?ssh://([^/]+)(/.+)} $location xx host path]
- 		     || [regexp {([^:][^:]+):(.+)} $location xx host path]} {
--			set ssh ssh
-+			set ssh @ssh@
- 			if {[info exists env(GIT_SSH)]} {
- 				set ssh $env(GIT_SSH)
- 			}


### PR DESCRIPTION
###### Motivation for this change
Splitting up the patch set for more granularity.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

