### PR TITLE
Introduce concept of NixOS support states

### DIFF
--- a/.version-state.nix
+++ b/.version-state.nix
@@ -1,0 +1,4 @@
+# See nixos/doc/manual/development/releases.xml, subsection "After the final release time"
+{
+  state = "supported";
+}

--- a/nixos/doc/manual/development/releases.xml
+++ b/nixos/doc/manual/development/releases.xml
@@ -188,6 +188,23 @@
       </listitem>
     </itemizedlist>
   </section>
+  <section xml:id="after-final-release-time">
+    <title>After the final release time</title>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Mark the old stable as <literal>deprecated</literal> or <literal>unsupported</literal> by updating
+          the <literal>state</literal> field in the <literal>.version-state.nix</literal> file to
+          the desired state. It's recommended to also add a <literal>description</literal> field in that file
+          to give the user instructions on how to actually upgrade.
+        </para>
+        <para>
+          Whether or not the old stable should be marked deprecated or unsupported depends on
+          which commitments the security team is willing to make.
+        </para>
+      </listitem>
+    </itemizedlist>
+  </section>
 </section>
 
 <section xml:id="release-schedule">


### PR DESCRIPTION
Each NixOS branch will have a .version-state.nix file, which will have an attribute "state" that is either set to "supported", "deprecated" or "unsupported".

If the state is not equal to "supported", a warning will be generated during the building of a system configuration.

Optionally, it can include a "description" attribute that can be used to communicate extra information to the end user, such as how (s)he should upgrade to the newer release.

###### Motivation for this change
See #22096

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The warnings / state part as discussed in #22096