### PR TITLE
keras: depend on tensorflow

### DIFF
--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -7,10 +7,13 @@
 , pytest_xdist
 , six
 , Theano
+, tensorflow ? null
+, tensorflowWithCuda ? null
 , pyyaml
 }:
 
-buildPythonPackage rec {
+let tf = if tensorflowWithCuda != null then tensorflowWithCuda else tensorflow;
+in buildPythonPackage rec {
   pname = "Keras";
   version = "1.2.2";
   name = "${pname}-${version}";
@@ -28,7 +31,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    six Theano pyyaml
+    six Theano pyyaml tf
   ];
 
   # Couldn't get tests working


### PR DESCRIPTION
###### Motivation for this change
The Keras library has now a tensorflow backend. This patch exposes tensorflow to Keras.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

