### PR TITLE
psi-plus: init at 0.16.572.639

### DIFF
--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub
+, which, pkgconfig
+, qt4, libidn, qca2, libXScrnSaver, enchant
+}:
+
+stdenv.mkDerivation rec {
+  name = "psi-plus-${version}";
+  version = "0.16.575.639";
+
+  src = fetchFromGitHub {
+    owner = "psi-plus";
+    repo = "psi-plus-snapshots";
+    rev = "${version}";
+    sha256 = "0mn24y3y4qybw81rjy0hr46y7y96dvwdl6kk61kizwj32z1in8cg";
+  };
+
+  resources = fetchFromGitHub {
+    owner = "psi-plus";
+    repo = "resources";
+    rev = "8f5038380e1be884b04b5a1ad3cc3385e793f668";
+    sha256 = "1b8a2aixg966fzjwp9hz51rc31imyvpx014mp2fsm47k8na4470d";
+  };
+
+  postUnpack = ''
+    cp -a "${resources}/iconsets" "$sourceRoot"
+  '';
+
+  nativeBuildInputs = [ which pkgconfig ];
+
+  buildInputs = [ qt4 libidn qca2 libXScrnSaver enchant ];
+
+  NIX_CFLAGS_COMPILE="-I${qca2}/include/QtCrypto";
+
+  NIX_LDFLAGS="-lqca";
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "XMPP (Jabber) client";
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub
-, which, pkgconfig
-, qt5, libidn, qca2-qt5, libXScrnSaver, enchant
+{ stdenv, fetchFromGitHub, cmake
+, qt5, libidn, qca2-qt5, libXScrnSaver, hunspell
+, libgcrypt, libotr, html-tidy, libgpgerror
 }:
 
 stdenv.mkDerivation rec {
@@ -25,11 +25,16 @@ stdenv.mkDerivation rec {
     cp -a "${resources}/iconsets" "$sourceRoot"
   '';
 
-  nativeBuildInputs = [ which pkgconfig ];
+  cmakeFlags = [
+    "-DENABLE_PLUGINS=ON"
+  ];
+
+  nativeBuildInputs = [ cmake ];
 
   buildInputs = [
-    qt5.qtbase qt5.qtmultimedia qt5.qtx11extras
-    libidn qca2-qt5 libXScrnSaver enchant
+    qt5.qtbase qt5.qtmultimedia qt5.qtx11extras qt5.qttools qt5.qtwebkit
+    libidn qca2-qt5 libXScrnSaver hunspell
+    libgcrypt libotr html-tidy libgpgerror
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , which, pkgconfig
-, qt4, libidn, qca2, libXScrnSaver, enchant
+, qt5, libidn, qca2-qt5, libXScrnSaver, enchant
 }:
 
 stdenv.mkDerivation rec {
@@ -27,11 +27,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ which pkgconfig ];
 
-  buildInputs = [ qt4 libidn qca2 libXScrnSaver enchant ];
-
-  NIX_CFLAGS_COMPILE="-I${qca2}/include/QtCrypto";
-
-  NIX_LDFLAGS="-lqca";
+  buildInputs = [
+    qt5.qtbase qt5.qtmultimedia qt5.qtx11extras
+    libidn qca2-qt5 libXScrnSaver enchant
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15031,6 +15031,8 @@ with pkgs;
 
   psi = kde4.callPackage ../applications/networking/instant-messengers/psi { };
 
+  psi-plus = callPackage ../applications/networking/instant-messengers/psi-plus { };
+
   psol = callPackage ../development/libraries/psol/default.nix { };
 
   pstree = callPackage ../applications/misc/pstree { };


### PR DESCRIPTION
###### Motivation for this change

Psi+ is a great Jabber client, successor of Psi.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

