### PR TITLE
haskell: ghcjs shims: dc034a0 -> b970152

### DIFF
--- a/pkgs/development/compilers/ghcjs/shims.nix
+++ b/pkgs/development/compilers/ghcjs/shims.nix
@@ -2,6 +2,6 @@
 fetchFromGitHub {
   owner = "ghcjs";
   repo = "shims";
-  rev = "dc034a035aa73db2c5be34145732090bd74c1b57";
-  sha256 = "18r8kf7g7d2n0rhwcgiz9gsgdmgln1nmwwyj347bpn4zh17qlkqa";
+  rev = "b97015229c58eeab7c1d0bb575794b14a9f6efca";
+  sha256 = "1p5adkqvmb1gsv9hnn3if0rdpnaq3v9a1zkfdy282yw05jaaaggz";
 }


### PR DESCRIPTION
`haskell.compiler.ghcjs` is currently broken due to `tasty-ant-xml`, where we are waiting for a newer version to be picked up by hackage2nix.
But `haskell.compiler.ghcjsHEAD` builds and of course I tested `ghcjs` with a fewer other local fixes.

###### Motivation for this change
There are some important fixes in there. I was bitten in particular by wrongly translated file permissions in the `base` shim, which is fixed now.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

