### PR TITLE
racket: disable on darwin

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -28,6 +28,8 @@ let
     sqlite
   ];
 
+  x86_64-noDarwin = builtins.filter (x: x != "x86_64-darwin") stdenv.lib.platforms.x86_64;
+
 in
 
 stdenv.mkDerivation rec {
@@ -80,6 +82,6 @@ stdenv.mkDerivation rec {
     homepage = http://racket-lang.org/;
     license = licenses.lgpl3;
     maintainers = with maintainers; [ kkallio henrytill vrthra ];
-    platforms = platforms.x86_64;
+    platforms = x86_64-noDarwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Darwin builds of Racket are segfaulting for unknown reasons:
https://hydra.nixos.org/build/49778947

I don't have the capacity to troubleshoot this issue ATM. Anyone with the capacity is more than welcome to try to fix the build, but until such a person steps forward, I am proposing that we simply disable builds on Darwin.

Aside from updating the `meta.platforms` attribute, I have kept other bits of Darwin-specific code intact so that they will not be lost to the sands of time.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

