### PR TITLE
haskell: use GHCJS to build Setup.hs for GHCJS packages

### DIFF
--- a/pkgs/development/compilers/ghcjs/stage2.nix
+++ b/pkgs/development/compilers/ghcjs/stage2.nix
@@ -327,6 +327,7 @@
         version = "1.22.8.0";
         src = "${ghcjsBoot}/boot/cabal/Cabal";
         doCheck = false;
+        hyperlinkSource = false;
         libraryHaskellDepends = [
           array base binary bytestring containers deepseq directory filepath
           pretty process time unix

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -53,6 +53,14 @@ self: super:
   terminfo = self.terminfo_0_4_0_2;
   xhtml = self.xhtml_3000_2_1;
 
+  # Cabal isn't part of the stage1 packages which form the default package-db
+  # that GHCJS provides.
+  # Almost all packages require Cabal to build their Setup.hs,
+  # but usually they don't declare it explicitly as they don't need to for normal GHC.
+  # To account for that we add Cabal by default.
+  mkDerivation = args:
+    if args.pname == "Cabal" then super.mkDerivation args else super.mkDerivation (args //
+      { setupHaskellDepends = (args.setupHaskellDepends or []) ++ [ self.Cabal ]; });
 
 ## OTHER PACKAGES
 

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -15,6 +15,7 @@ let
       mkDerivationImpl = pkgs.callPackage ./generic-builder.nix {
         inherit stdenv;
         inherit (pkgs) fetchurl pkgconfig glibcLocales coreutils gnugrep gnused;
+        nodejs = pkgs.nodejs-slim;
         jailbreak-cabal = if (self.ghc.cross or null) != null
           then self.ghc.bootPkgs.jailbreak-cabal
           else self.jailbreak-cabal;

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -38,6 +38,9 @@ rec {
   addPkgconfigDepend = drv: x: addPkgconfigDepends drv [x];
   addPkgconfigDepends = drv: xs: overrideCabal drv (drv: { pkgconfigDepends = (drv.pkgconfigDepends or []) ++ xs; });
 
+  addSetupDepend = drv: x: addSetupDepends drv [x];
+  addSetupDepends = drv: xs: overrideCabal drv (drv: { setupHaskellDepends = (drv.setupHaskellDepends or []) ++ xs; });
+
   enableCabalFlag = drv: x: appendConfigureFlag (removeConfigureFlag drv "-f-${x}") "-f${x}";
   disableCabalFlag = drv: x: appendConfigureFlag (removeConfigureFlag drv "-f${x}") "-f-${x}";
 


### PR DESCRIPTION
One of the consequences of how GHCJS is compiled (first the stage1 packages, which do not include Cabal, then Cabal, and then all the stage2 packages with the previously compiled Cabal) is that the GHCJS native package-db does not include Cabal (unlike GHC). It follows that Cabal packages we want to compile with GHCJS need to depend explicitly on Cabal otherwise there will be no Cabal in the package-db to compile the Setup.hs. This wasn't a problem before since we used GHC to compile the Setup.hs which houses a Cabal in it's global package-db. I accounted for this by declaring Cabal as a Setup dependency for all sensible GHCJS packages. I guess that makes sense semantically, nonetheless I thought about different solutions, but I did not come up with something better.

With GHCJS and Cabal, executables from cabal packages are compiled to a bunch of .js files housed in folders like \<exe-name\>.jsexe. I provide nodejs wrappers automatically as \<exe-name\>, which seems to work fine. Tested with HSColour.

For testing #23611 should be applied, too, otherwise the Setup.hs compilations are of not much use and the `tasty-ant-xml` caveat mentioned there applies here as well.

The `optionalString` to `optional` refactoring is done, because otherwise each conditional flag that is added triggers a rebuild of everything (even if the flag is not activated) that depends on the builder, just because a whitespace is added into the build scripts when the flags are concatenated.

###### Motivation for this change
Currently we build the Setup.hs of cabal packages with GHC even if we use GHCJS for the actual compilation. This seems to work in general, but makes GHC as well as GHCJS a build time dependency for every cabal package compiled with GHCJS. There is also a bug in that we pass in [generic-builder.nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/generic-builder.nix#L240) a GHC or GHCJS package db to a command that is always GHC. GHC can not use a package-db from GHCJS, this becomes a problem if the cabal package has a dependency on a package that is also required for compiling Setup.hs, in that case the GHC native package gets shadowed.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

