### PR TITLE
cassandra: remove old branches 1.2 and 2.0

### DIFF
--- a/pkgs/servers/nosql/cassandra/1.2.nix
+++ b/pkgs/servers/nosql/cassandra/1.2.nix
@@ -1,6 +1,0 @@
-{ callPackage, ... } @ args:
-
-callPackage ./generic.nix (args // {
-  version = "1.2.19";
-  sha256 = "0zkq3ggpk8ra2siar43vmrn6lmvn902p1g2lrgb46ak1vii6w30w";
-})

--- a/pkgs/servers/nosql/cassandra/2.0.nix
+++ b/pkgs/servers/nosql/cassandra/2.0.nix
@@ -1,6 +1,0 @@
-{ callPackage, ... } @ args:
-
-callPackage ./generic.nix (args // {
-  version = "2.0.16";
-  sha256 = "1fpvgmakmxy1lnygccpc32q53pa36bwy0lqdvb6hsifkxymdw8y5";
-})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10402,8 +10402,6 @@ with pkgs;
 
   cadvisor = callPackage ../servers/monitoring/cadvisor { };
 
-  cassandra_1_2 = callPackage ../servers/nosql/cassandra/1.2.nix { };
-  cassandra_2_0 = callPackage ../servers/nosql/cassandra/2.0.nix { };
   cassandra_2_1 = callPackage ../servers/nosql/cassandra/2.1.nix { };
   cassandra_2_2 = callPackage ../servers/nosql/cassandra/2.2.nix { };
   cassandra_3_0 = callPackage ../servers/nosql/cassandra/3.0.nix { };


### PR DESCRIPTION
These versions of Cassandra do not appear to be supported upstream any longer: https://cassandra.apache.org/download/

Maintainer CC: @nckx  @rushmorem @cransom