### PR TITLE
Qt 5.7 / qt-installer-framework: Init at 2.0.3

### DIFF
--- a/pkgs/development/libraries/qt-5/5.7/default.nix
+++ b/pkgs/development/libraries/qt-5/5.7/default.nix
@@ -77,6 +77,7 @@ let
       qtdoc = callPackage ./qtdoc.nix {};
       qtgraphicaleffects = callPackage ./qtgraphicaleffects.nix {};
       qtimageformats = callPackage ./qtimageformats.nix {};
+      qtinstaller = callPackage ./qtinstaller.nix { inherit mirror; };
       qtlocation = callPackage ./qtlocation.nix {};
       qtmultimedia = callPackage ./qtmultimedia.nix {
         inherit (pkgs.gst_all_1) gstreamer gst-plugins-base;

--- a/pkgs/development/libraries/qt-5/5.7/qtinstaller.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtinstaller.nix
@@ -1,0 +1,34 @@
+{ qtSubmodule, fetchurl, qtdeclarative , qttools, mirror }:
+
+qtSubmodule {
+  name = "qtinstaller";
+  qtInputs = [ qtdeclarative qttools ];
+  version = "2.0.3";
+  src = fetchurl {
+      url = "${mirror}/official_releases/qt-installer-framework/2.0.3/qt-installer-framework-opensource-2.0.3-src.tar.gz";
+      sha256 = "003gwjg02isw8qjyka377g1ahlisfyi44l6xfa4hvvdgqqq0hy2f";
+      name = "qt-installer-framework-opensource-src-2.0.3.tar.gz";
+  };
+
+  outputs = [ "out" "dev" "doc" ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib,share/qt-installer-framework}
+    cp -a bin/{archivegen,binarycreator,devtool,installerbase,repogen} $out/bin
+    cp -a lib/{libinstaller.so*,lib7z.a} $out/lib
+    cp -a examples $out/share/qt-installer-framework/
+  '';
+
+  postFixup = ''
+    moveToOutput "bin/archivegen" "$out"
+    moveToOutput "bin/binarycreator" "$out"
+    moveToOutput "bin/devtool" "$out"
+    moveToOutput "bin/installerbase" "$out"
+    moveToOutput "bin/repogen" "$out"
+    moveToOutput "share" "$doc"
+    moveToOutput "lib/libinstaller.so" "$out"
+    moveToOutput "lib/libinstaller.so.1" "$out"
+    moveToOutput "lib/libinstaller.so.1.0" "$out"
+    moveToOutput "lib/libinstaller.so.1.0.0" "$out"
+  '';
+}


### PR DESCRIPTION
###### Motivation for this change

The Qt installer framework provides tools to build and/or handle graphical installers, e.g. the foxit-reader installer.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

