### PR TITLE
iana-etc: 2.30 -> 20170321

### DIFF
--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -529,7 +529,7 @@
   <note>
   <para>
   If you see errors similar to <literal>getProtocolByName: does not exist (no such protocol name: tcp)</literal>
-  you may need to add <literal>pkgs.iana_etc</literal> to <varname>contents</varname>.
+  you may need to add <literal>pkgs.iana-etc</literal> to <varname>contents</varname>.
   </para>
   </note>
 

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -178,10 +178,10 @@ in
 
     environment.etc =
       { # /etc/services: TCP/UDP port assignments.
-        "services".source = pkgs.iana_etc + "/etc/services";
+        "services".source = pkgs.iana-etc + "/etc/services";
 
         # /etc/protocols: IP protocol numbers.
-        "protocols".source  = pkgs.iana_etc + "/etc/protocols";
+        "protocols".source  = pkgs.iana-etc + "/etc/protocols";
 
         # /etc/rpc: RPC program numbers.
         "rpc".source = pkgs.glibc.out + "/etc/rpc";

--- a/pkgs/data/misc/iana-etc/builder.sh
+++ b/pkgs/data/misc/iana-etc/builder.sh
@@ -1,0 +1,89 @@
+source $stdenv/setup
+
+# Curl flags :
+# progress-bar is lighter on the screen
+# retry 3 times
+# fail silently (no output at all) on server errors ; an error code is still returned
+# use only TLSv1.0, TLSv1.1 or TLSv1.2
+# use the collections of trusted CAs from ${cacert}
+# write output to a local file named like the remote file we get
+# TODO: for security it would be possible to pin IANA certificate with --pinnedpubkey
+curl="curl \
+  --progress-bar \
+  --retry 3 \
+  --fail \
+  --tlsv1 \
+  --cacert $cacert/etc/ssl/certs/ca-bundle.crt \
+  -O"
+
+
+# Fetch protocols-numbers.xml over HTTPS
+$curl "https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xml"
+protoxml="protocol-numbers.xml"
+
+# Fetch service-names-port-numbers.xml over HTTPS
+$curl "https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xml"
+svcxml="service-names-port-numbers.xml"
+
+
+# Make sure protocol-numbers.xml is readable and is the file we expect
+if [ ! -r $protoxml ] \
+  || [ "$(head -n 1 $protoxml)" != "<?xml version='1.0' encoding='UTF-8'?>" ] \
+  || [ "$(awk -F'[<>]' '/registry xmlns/{print $2; exit}' $protoxml)" != 'registry xmlns="http://www.iana.org/assignments" id="protocol-numbers"' ]
+then
+  echo 'ERROR: protocol-numbers.xml does not match the expected structure'
+  exit 1
+fi
+
+# Same checks on service-names-port-numbers.xml
+if [ ! -r $svcxml ] \
+  || [ "$(head -n 1 $svcxml)" != "<?xml version='1.0' encoding='UTF-8'?>" ] \
+  || [ "$(awk -F'[<>]' '/registry xmlns/{print $2; exit}' $svcxml)" != 'registry xmlns="http://www.iana.org/assignments" id="service-names-port-numbers"' ]
+then
+  echo 'ERROR: service-names-port-numbers.xml does not match the expected structure'
+  exit 1
+fi
+
+
+# Create final directory in Nix store
+mkdir -pv $out/etc
+
+# Process /etc/protocols from IANA protocol-numbers.xml and install it
+gawk '
+BEGIN {
+  print "# See also protocols(5) and IANA official page :"
+  print "# https://www.iana.org/assignments/protocol-numbers \n#"
+  FS="[<>]"
+}
+{
+  if (/<updated/) { print "# Last updated: " $3 "\n" ; next }
+  if (/<record/) { v=n=0 }
+  if (/<value/) v=$3
+  if (/<name/ && !($3~/ /)) n=$3
+  if (/<\/record/ && (v || n=="HOPOPT") && n) printf "%-16s %3i %s\n", tolower(n),v,n
+  if (/<people/) exit
+}
+' $protoxml > $out/etc/protocols
+
+# Process /etc/services from IANA service-names-port-numbers.xml and install it
+gawk '
+BEGIN {
+  print "# See also services(5) and IANA official page :"
+  print "# https://www.iana.org/assignments/service-names-port-numbers \n#"
+  FS="[<>]"
+}
+{
+  if (/<updated/) { print "# Last updated: " $3 "\n" ; next }
+  if (/<record/) { n=u=p=c=0 }
+  if (/<name/ && !/\(/) n=$3
+  if (/<number/) u=$3
+  if (/<protocol/) p=$3
+  if (/Unassigned/ || /Reserved/ || /historic/) c=1
+  if (/<\/record/ && n && u && p && !c) printf "%-16s %5i/%s\n", n,u,p
+  if (/<people/) exit
+}
+' $svcxml > $out/etc/services
+
+
+# Some cleanup before leaving
+rm *.xml

--- a/pkgs/data/misc/iana-etc/default.nix
+++ b/pkgs/data/misc/iana-etc/default.nix
@@ -1,17 +1,18 @@
-{stdenv, fetchurl}:
+{ stdenv, cacert, curl }:
+
 
 stdenv.mkDerivation rec {
-  name = "iana-etc-2.30";
 
-  src = fetchurl {
-    url = "http://sethwklein.net/${name}.tar.bz2";
-    sha256 = "03gjlg5zlwsdk6qyw3v85l129rna5bpm4m7pzrp864h0n97qg9mr";
-  };
-
-  preInstall = "installFlags=\"PREFIX=$out\"";
-
+  name = "iana-etc-${version}";
+  version = "20170321";
+  
+  phases = [ "buildPhase" ];
+  buildInputs = [ cacert curl ];
+  builder = ./builder.sh;
+  
+  
   meta = {
-    homepage = http://sethwklein.net/iana-etc;
+    homepage = https://www.iana.org/;
     description = "IANA protocol and port number assignments (/etc/protocols and /etc/services)";
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/compilers/go/1.4.nix
+++ b/pkgs/development/compilers/go/1.4.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchpatch, tzdata, iana_etc, libcCross
+{ stdenv, lib, fetchurl, fetchpatch, tzdata, iana-etc, libcCross
 , pkgconfig
 , pcre
 , Security }:
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     # ParseInLocation fails the test
     sed -i '/TestParseInSydney/areturn' src/time/format_test.go
 
-    sed -i 's,/etc/protocols,${iana_etc}/etc/protocols,' src/net/lookup_unix.go
+    sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
   '' + lib.optionalString stdenv.isLinux ''
     sed -i 's,/usr/share/zoneinfo/,${tzdata}/share/zoneinfo/,' src/time/zoneinfo_unix.go
 

--- a/pkgs/development/compilers/go/1.6.nix
+++ b/pkgs/development/compilers/go/1.6.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, tzdata, iana_etc, go_bootstrap, runCommand
+{ stdenv, lib, fetchurl, tzdata, iana-etc, go_bootstrap, runCommand
 , perl, which, pkgconfig, patch, fetchpatch
 , pcre
 , Security, Foundation, bash }:
@@ -75,8 +75,8 @@ stdenv.mkDerivation rec {
     # Remove the timezone naming test
     sed -i '/TestLoadFixed/areturn' src/time/time_test.go
 
-    sed -i 's,/etc/protocols,${iana_etc}/etc/protocols,' src/net/lookup_unix.go
-    sed -i 's,/etc/services,${iana_etc}/etc/services,' src/net/port_unix.go
+    sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
+    sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go
   '' + lib.optionalString stdenv.isLinux ''
     sed -i 's,/usr/share/zoneinfo/,${tzdata}/share/zoneinfo/,' src/time/zoneinfo_unix.go
   '' + lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/go/1.7.nix
+++ b/pkgs/development/compilers/go/1.7.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, tzdata, iana_etc, go_bootstrap, runCommand, writeScriptBin
+{ stdenv, fetchFromGitHub, tzdata, iana-etc, go_bootstrap, runCommand, writeScriptBin
 , perl, which, pkgconfig, patch, fetchpatch
 , pcre, cacert
 , Security, Foundation, bash }:
@@ -69,8 +69,8 @@ stdenv.mkDerivation rec {
     # Remove the timezone naming test
     sed -i '/TestLoadFixed/areturn' src/time/time_test.go
 
-    sed -i 's,/etc/protocols,${iana_etc}/etc/protocols,' src/net/lookup_unix.go
-    sed -i 's,/etc/services,${iana_etc}/etc/services,' src/net/port_unix.go
+    sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
+    sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go
 
     # Disable cgo lookup tests not works, they depend on resolver
     rm src/net/cgo_unix_test.go

--- a/pkgs/development/compilers/go/1.8.nix
+++ b/pkgs/development/compilers/go/1.8.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, tzdata, iana_etc, go_bootstrap, runCommand, writeScriptBin
+{ stdenv, fetchFromGitHub, tzdata, iana-etc, go_bootstrap, runCommand, writeScriptBin
 , perl, which, pkgconfig, patch, fetchpatch
 , pcre, cacert
 , Security, Foundation, bash }:
@@ -71,8 +71,8 @@ stdenv.mkDerivation rec {
     # Remove the timezone naming test
     sed -i '/TestLoadFixed/areturn' src/time/time_test.go
 
-    sed -i 's,/etc/protocols,${iana_etc}/etc/protocols,' src/net/lookup_unix.go
-    sed -i 's,/etc/services,${iana_etc}/etc/services,' src/net/port_unix.go
+    sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
+    sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go
 
     # Disable cgo lookup tests not works, they depend on resolver
     rm src/net/cgo_unix_test.go

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -61,6 +61,7 @@ doNotDisplayTwice rec {
   gupnptools = gupnp-tools;  # added 2015-12-19
   gnustep-make = gnustep.make; # added 2016-7-6
   htmlTidy = html-tidy;  # added 2014-12-06
+  iana_etc = iana-etc;  # added 2017-03-08
   inherit (haskell.compiler) jhc uhc;   # 2015-05-15
   inotifyTools = inotify-tools;
   joseki = apache-jena-fuseki; # added 2016-02-28

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12593,7 +12593,7 @@ with pkgs;
   inherit (callPackages ../data/fonts/gdouros { })
     symbola aegyptus akkadian anatolian maya unidings musica analecta;
 
-  iana_etc = callPackage ../data/misc/iana-etc { };
+  iana-etc = callPackage ../data/misc/iana-etc { };
 
   poppler_data = callPackage ../data/misc/poppler-data { };
 

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -68,7 +68,7 @@ with import ./release-lib.nix { inherit supportedSystems; };
   hdparm = linux;
   hello = all;
   host = linux;
-  iana_etc = linux;
+  iana-etc = linux;
   icewm = linux;
   idutils = all;
   inetutils = linux;


### PR DESCRIPTION
###### Motivation for this change
- Move away from an outdated package and fetch content directly from IANA
- Align the attribute name with the package name for clarity

Some time ago I push a quick PR to fix the source of the old `iana-etc` package : see #23167 
When looking at it I realised NixOS relied on an outdated package that does not seem maintained anymore. The last version is from 2008-MAR-05.
Present `/etc/services` and `/etc/protocols` content is just as old as this package and probably incomplete/outdated.

This PR propose to fetch the information directly from IANA.
Truth be told, this is heavily inspired by what Arch does.

As an added bonus, this PR rename the attribute name to `iana-etc` instead of iana_etc. For clarity it seems proper to align attr and pkg name.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

