### PR TITLE
kwallet: support GPG-encrypted wallets

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kwallet.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwallet.nix
@@ -1,6 +1,6 @@
 { kdeFramework, lib, extra-cmake-modules, kconfig, kconfigwidgets
 , kcoreaddons , kdbusaddons, kdoctools, ki18n, kiconthemes
-, knotifications , kservice, kwidgetsaddons, kwindowsystem, libgcrypt
+, knotifications , kservice, kwidgetsaddons, kwindowsystem, libgcrypt, gpgme
 }:
 
 kdeFramework {
@@ -9,6 +9,6 @@ kdeFramework {
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   propagatedBuildInputs = [
     kconfig kconfigwidgets kcoreaddons kdbusaddons ki18n kiconthemes
-    knotifications kservice kwidgetsaddons kwindowsystem libgcrypt
+    knotifications kservice kwidgetsaddons kwindowsystem libgcrypt gpgme
   ];
 }


### PR DESCRIPTION
###### Motivation for this change

I migrated to NixOS and could not open my KWallet wallets because they were gpg-encrypted and KWallet was not built with gpgme. (For an explanation see e.g. https://forum.kde.org/viewtopic.php?f=289&t=138507.)

KWallet compilation failed with gpgme-1.8.0 because gpgme had broken its cmake definitions in [b2c07bd4](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=commit;h=b2c07bd47bd608afa5cc819b60a7b5bb8c9dd96a), between 1.7.1 and 1.8.0, and have fixed them in [572c1aac](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=commit;h=572c1aac107125ce62230251713349348373db5a) and [2e661b9e](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=commit;h=2e661b9e1a9b50656a5c9646d7444a98477010c1), after 1.8.0.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).