### PR TITLE
nixos/users-groups: chown home on createHome

### DIFF
--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -177,7 +177,7 @@ foreach my $u (@{$spec->{users}}) {
     }
 
     # Create a home directory.
-    if ($u->{createHome} && ! -e $u->{home}) {
+    if ($u->{createHome}) {
         make_path($u->{home}, { mode => 0700 }) if ! -e $u->{home};
         chown $u->{uid}, $u->{gid}, $u->{home};
     }


### PR DESCRIPTION
###### Motivation for this change

Fixes #23619. This should work as documented and has valid use cases.

We should fix this in both 16.09 and 17.03.

###### Discussion

Should we also `chmod(700)` if the directory exists? In the docs it specifically says only the owner and group of the directory are modified but this could also be useful. Or should we expose an option to specify the mode?

It's a bit unfortunate that the semantics of `createHome` doesn't really match its name. I think `manageHome` would be more fitting but not sure if the breakage is worth it. This should obviously not make it into 17.03.

cc @arianvp @globin