### PR TITLE
lilypond-with-fonts: fix typos

### DIFF
--- a/pkgs/misc/lilypond/fonts.nix
+++ b/pkgs/misc/lilypond/fonts.nix
@@ -24,11 +24,11 @@ let
 
       installPhase = ''
         for f in {otf,supplementary-fonts}/**.{o,t}tf; do
-          install -Dt $out/otf -m755 otf/*
+          install -Dt $out/otf -m755 $f
         done
 
         for f in svg/**.{svg,woff}; do
-          install -Dt $out/svg -m755 svg/*
+          install -Dt $out/svg -m755 $f
         done
       '';
 


### PR DESCRIPTION
###### Motivation for this change

In development, I experimented with file globs, for loops and making the
supplementary fonts optional. As such, the original PR ended up with a
dysfunctional combination.

This commit fully adopts the for loop approach, which I prefer, since failing
matches, e.g. missing supplementary-fonts/, won't cause a failure.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

