### PR TITLE
skim: init at 1.4.28

### DIFF
--- a/pkgs/applications/misc/skim/default.nix
+++ b/pkgs/applications/misc/skim/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "skim-${version}";
-  version = "1.4.27";
+  version = "1.4.28";
 
   src = fetchurl {
     url = "https://downloads.sourceforge.net/skim-app/Skim/Skim-${version}/Skim-${version}.dmg";
-    sha256 = "173q24mvir14lqk6w2ixw66a5vj2ljcc4szaqdxfwna005vhbkm3";
+    sha256 = "1ip54gyd6aizmgvmhdclhfs0sr42kskhl4ivky4xyp9gq89p4fzw";
   };
 
   buildInputs = [ undmg ];

--- a/pkgs/applications/misc/skim/default.nix
+++ b/pkgs/applications/misc/skim/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, undmg }:
+
+stdenv.mkDerivation rec {
+  name = "skim-${version}";
+  version = "1.4.27";
+
+  src = fetchurl {
+    url = "https://downloads.sourceforge.net/skim-app/Skim/Skim-${version}/Skim-${version}.dmg";
+    sha256 = "173q24mvir14lqk6w2ixw66a5vj2ljcc4szaqdxfwna005vhbkm3";
+  };
+
+  buildInputs = [ undmg ];
+
+  installPhase = ''
+    local app=$out/Applications/Skim.app
+
+    mkdir -p $app
+    cp -R . $app
+    chmod a+x $app/Contents/MacOS/Skim
+  '';
+
+  meta = with stdenv.lib; {
+    description = "PDF reader and note-taker for OS X";
+    homepage = "http://skim-app.sourceforge.net";
+    repositories.svn = "https://svn.code.sf.net/p/skim-app/code/trunk";
+
+    license = licenses.bsd2;
+
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ yurrriq ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15821,6 +15821,8 @@ with pkgs;
     ];
   };
 
+  skim = callPackage ../applications/misc/skim { };
+
   skrooge = libsForQt5.callPackage ../applications/office/skrooge {};
 
   slim = callPackage ../applications/display-managers/slim {


### PR DESCRIPTION
###### Motivation for this change

[Skim](http://skim-app.sourceforge.net) is a great PDF reader for macOS, so why not have a Nix package for it?

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
