### PR TITLE
sqlite: 3.16.2 -> 3.17.0

### DIFF
--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -3,11 +3,11 @@
 assert interactive -> readline != null && ncurses != null;
 
 stdenv.mkDerivation {
-  name = "sqlite-3.16.2";
+  name = "sqlite-3.17.0";
 
   src = fetchurl {
-    url = "http://sqlite.org/2017/sqlite-autoconf-3160200.tar.gz";
-    sha256 = "059n4s9qd35qpbd4g29y9ay99a6f68ad7k65g430rxb6jcz0rk35";
+    url = "http://sqlite.org/2017/sqlite-autoconf-3170000.tar.gz";
+    sha256 = "0k472gq0p706jq4529p60znvw02hdf172qxgbdv59q0n7anqbr54";
   };
 
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
Firefox requires the latest sqlite to build:
```
checking for sqlite3 >= 3.17.0... Requested 'sqlite3 >= 3.17.0' but version of SQLite is 3.16.2
configure: error: Library requirements (sqlite3 >= 3.17.0) not met; consider adjusting the PKG_CONFIG_PATH environment variable if your libraries are in a nonstandard prefix so pkg-config can find them.
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

