### PR TITLE
icu: 57.1 -> 58.2

### DIFF
--- a/pkgs/development/libraries/icu/default.nix
+++ b/pkgs/development/libraries/icu/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "icu4c";
-  version = "57.1";
+  version = "58.2";
 in
 stdenv.mkDerivation ({
   name = pname + "-" + version;
@@ -10,7 +10,7 @@ stdenv.mkDerivation ({
   src = fetchurl {
     url = "http://download.icu-project.org/files/${pname}/${version}/${pname}-"
       + (stdenv.lib.replaceChars ["."] ["_"] version) + "-src.tgz";
-    sha256 = "10cmkqigxh9f73y7q3p991q6j8pph0mrydgj11w1x6wlcp5ng37z";
+    sha256 = "036shcb3f8bm1lynhlsb4kpjm9s9c2vdiir01vg216rs2l8482ib";
   };
 
   outputs = [ "out" "dev" ];
@@ -35,26 +35,6 @@ stdenv.mkDerivation ({
   '';
 
   patches = [
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/i/icu/57.1-5/debian/patches/CVE-2014-6585.patch";
-      sha256 = "1s8kqax444pqf5chwxvgsx1n1dx7v74h34fqh08fyq57mcjnpj4d";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/i/icu/57.1-5/debian/patches/CVE-2015-4760.patch";
-      sha256 = "08gawyqbylk28i9pxv9vsw2drdpd6i97q0aml4nmv2xyb1ala0wp";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/i/icu/57.1-5/debian/patches/CVE-2016-0494.patch";
-      sha256 = "1741s8lpmnizjprzk3xb7zkm5fznzgk8hhlrs8a338c18nalvxay";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/i/icu/57.1-5/debian/patches/CVE-2016-6293.patch";
-      sha256 = "01h4xcss1vmsr60ijkv4lxsgvspwimyss61zp9nq4xd5i3kk1f4b";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/i/icu/57.1-5/debian/patches/CVE-2016-7415.patch";
-      sha256 = "01d070h8d7rkj55ac8isr64m999bv5znc8vnxa7aajglsfidzs2r";
-    })
   ];
 
   preConfigure = ''


### PR DESCRIPTION
Firefox requires new version of the icu to build:
```
checking for icu-i18n >= 58.1... Requested 'icu-i18n >= 58.1' but version of icu-i18n is 57.1
configure: error: Library requirements (icu-i18n >= 58.1) not met; consider adjusting the PKG_CONFIG_PATH environment variable if your libraries are in a nonstandard prefix so pkg-config can find them.
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

