### PR TITLE
pythonPackages.pepper: init at 0.5.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -383,6 +383,7 @@
   Phlogistique = "Noé Rubinstein <noe.rubinstein@gmail.com>";
   phreedom = "Evgeny Egorochkin <phreedom@yandex.ru>";
   phunehehe = "Hoang Xuan Phu <phunehehe@gmail.com>";
+  pierrer = "Pierre Radermecker <pierrer@pi3r.be>";
   pierron = "Nicolas B. Pierron <nixos@nbp.name>";
   piotr = "Piotr Pietraszkiewicz <ppietrasa@gmail.com>";
   pjbarnoy = "Perry Barnoy <pjbarnoy@gmail.com>";

--- a/pkgs/tools/admin/salt/pepper/default.nix
+++ b/pkgs/tools/admin/salt/pepper/default.nix
@@ -10,6 +10,8 @@ python2Packages.buildPythonApplication rec {
     url = "https://github.com/saltstack/pepper/releases/download/${version}/${name}.tar.gz";
     sha256 = "0gf4v5y1kp16i1na4c9qw7cgrpsh21p8ldv9r6b8gdwcxzadxbck";
   };
+  
+  doCheck = false; # no tests available
 
   meta = {
     description = "A CLI front-end to a running salt-api system";

--- a/pkgs/tools/admin/salt/pepper/default.nix
+++ b/pkgs/tools/admin/salt/pepper/default.nix
@@ -10,12 +10,13 @@ python2Packages.buildPythonApplication rec {
     url = "https://github.com/saltstack/pepper/releases/download/${version}/${name}.tar.gz";
     sha256 = "0gf4v5y1kp16i1na4c9qw7cgrpsh21p8ldv9r6b8gdwcxzadxbck";
   };
-  
+
   doCheck = false; # no tests available
 
-  meta = {
+  meta = with lib; {
     description = "A CLI front-end to a running salt-api system";
     homepage = https://github.com/saltstack/pepper;
-    license = lib.licenses.asl20;
+    maintainers = [ maintainers.pierrer ];
+    license = licenses.asl20;
   };
 }

--- a/pkgs/tools/admin/salt/pepper/default.nix
+++ b/pkgs/tools/admin/salt/pepper/default.nix
@@ -1,0 +1,19 @@
+{ lib
+, fetchurl
+, python2Packages
+}:
+
+python2Packages.buildPythonApplication rec {
+  name = "salt-pepper-${version}";
+  version = "0.5.0";
+  src = fetchurl {
+    url = "https://github.com/saltstack/pepper/releases/download/${version}/${name}.tar.gz";
+    sha256 = "0gf4v5y1kp16i1na4c9qw7cgrpsh21p8ldv9r6b8gdwcxzadxbck";
+  };
+
+  meta = {
+    description = "A CLI front-end to a running salt-api system";
+    homepage = https://github.com/saltstack/pepper;
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3314,6 +3314,8 @@ with pkgs;
 
   pell = callPackage ../applications/misc/pell { };
 
+  pepper = callPackage ../tools/admin/salt/pepper { };
+
   pick = callPackage ../tools/misc/pick { };
 
   pitivi = callPackage ../applications/video/pitivi {


### PR DESCRIPTION
###### Motivation for this change

Add missing `pepper` python package

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

