### PR TITLE
buildbot: assorted cleanups

### DIFF
--- a/pkgs/development/tools/build-managers/buildbot/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot/default.nix
@@ -1,76 +1,83 @@
-{ stdenv, lib, fetchurl, coreutils, openssh, buildbot-worker, makeWrapper,
-  pythonPackages, gnused, plugins ? [] }:
+{ stdenv, lib, openssh, buildbot-worker, pythonPackages, runCommand, makeWrapper }:
 
-pythonPackages.buildPythonApplication (rec {
-  name = "${pname}-${version}";
-  pname = "buildbot";
-  version = "0.9.4";
-  src = fetchurl {
-    url = "mirror://pypi/b/${pname}/${name}.tar.gz";
-    sha256 = "0wklrn4fszac9wi8zw3vbsznwyff6y57cz0i81zvh46skb6n3086";
-  };
-
-  buildInputs = with pythonPackages; [
-    lz4
-    txrequests
-    pyjade
-    boto3
-    moto
-    txgithub
-    mock
-    setuptoolsTrial
-    isort
-    pylint
-    astroid
-    pyflakes
-    openssh
-    buildbot-worker
-    makeWrapper
-    treq
-  ];
-
-  propagatedBuildInputs = with pythonPackages; [
-
-    # core
-    twisted
-    jinja2
-    zope_interface
-    sqlalchemy
-    sqlalchemy_migrate
-    future
-    dateutil
-    txaio
-    autobahn
-    pyjwt
-
-    # tls
-    pyopenssl
-    service-identity
-    idna
-
-    # docs
-    sphinx
-    sphinxcontrib-blockdiag
-    sphinxcontrib-spelling
-    pyenchant
-    docutils
-    ramlfications
-    sphinx-jinja
-
-  ] ++ plugins;
-
-  postPatch = ''
-    ${gnused}/bin/sed -i 's|/usr/bin/tail|${coreutils}/bin/tail|' buildbot/scripts/logwatcher.py
+let
+  withPlugins = plugins: runCommand "wrapped-${package.name}" {
+    buildInputs = [ makeWrapper ];
+    passthru.withPlugins = moarPlugins: withPlugins (moarPlugins ++ plugins);
+  } ''
+    makeWrapper ${package}/bin/buildbot $out/bin/buildbot \
+      --prefix PYTHONPATH : ${lib.makeSearchPathOutput "lib" pythonPackages.python.sitePackages plugins}
   '';
 
-  postFixup = ''
-    makeWrapper $out/bin/.buildbot-wrapped $out/bin/buildbot --set PYTHONPATH "$PYTHONPATH"
-  '';
+  package = pythonPackages.buildPythonApplication (rec {
+    name = "${pname}-${version}";
+    pname = "buildbot";
+    version = "0.9.4";
 
-  meta = with stdenv.lib; {
-    homepage = http://buildbot.net/;
-    description = "Continuous integration system that automates the build/test cycle";
-    maintainers = with maintainers; [ nand0p ryansydnor ];
-    license = licenses.gpl2;
-  };
-})
+    src = pythonPackages.fetchPypi {
+      inherit pname version;
+      sha256 = "0wklrn4fszac9wi8zw3vbsznwyff6y57cz0i81zvh46skb6n3086";
+    };
+
+    buildInputs = with pythonPackages; [
+      lz4
+      txrequests
+      pyjade
+      boto3
+      moto
+      txgithub
+      mock
+      setuptoolsTrial
+      isort
+      pylint
+      astroid
+      pyflakes
+      openssh
+      buildbot-worker
+      treq
+    ];
+
+    propagatedBuildInputs = with pythonPackages; [
+
+      # core
+      twisted
+      jinja2
+      zope_interface
+      sqlalchemy
+      sqlalchemy_migrate
+      future
+      dateutil
+      txaio
+      autobahn
+      pyjwt
+
+      # tls
+      pyopenssl
+      service-identity
+      idna
+
+      # docs
+      sphinx
+      sphinxcontrib-blockdiag
+      sphinxcontrib-spelling
+      pyenchant
+      docutils
+      ramlfications
+      sphinx-jinja
+
+    ];
+
+    postPatch = ''
+      substituteInPlace buildbot/scripts/logwatcher.py --replace '/usr/bin/tail' "$(type -P tail)"
+    '';
+
+    passthru = { inherit withPlugins; };
+
+    meta = with stdenv.lib; {
+      homepage = http://buildbot.net/;
+      description = "Continuous integration system that automates the build/test cycle";
+      maintainers = with maintainers; [ nand0p ryansydnor ];
+      license = licenses.gpl2;
+    };
+  });
+in package

--- a/pkgs/development/tools/build-managers/buildbot/worker.nix
+++ b/pkgs/development/tools/build-managers/buildbot/worker.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, gnused, coreutils, pythonPackages }:
+{ stdenv, pythonPackages }:
 
 pythonPackages.buildPythonApplication (rec {
   name = "${pname}-${version}";
   pname = "buildbot-worker";
   version = "0.9.4";
 
-  src = fetchurl {
-    url = "mirror://pypi/b/${pname}/${name}.tar.gz";
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
     sha256 = "0rdrr8x7sn2nxl51p6h9ad42s3c28lb6sys84zrg0d7fm4zhv7hj";
   };
 
@@ -14,7 +14,7 @@ pythonPackages.buildPythonApplication (rec {
   propagatedBuildInputs = with pythonPackages; [ twisted future ];
 
   postPatch = ''
-    ${gnused}/bin/sed -i 's|/usr/bin/tail|${coreutils}/bin/tail|' buildbot_worker/scripts/logwatcher.py
+    substituteInPlace buildbot_worker/scripts/logwatcher.py --replace '/usr/bin/tail' "$(type -P tail)"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6220,12 +6220,8 @@ with pkgs;
   buildbot-plugins = callPackage ../development/tools/build-managers/buildbot/plugins.nix {
     pythonPackages = python2Packages;
   };
-  buildbot-ui = self.buildbot.override {
-    plugins = with self.buildbot-plugins; [ www ];
-  };
-  buildbot-full = self.buildbot.override {
-    plugins = with self.buildbot-plugins; [ www console-view waterfall-view ];
-  };
+  buildbot-ui = buildbot.withPlugins (with self.buildbot-plugins; [ www ]);
+  buildbot-full = buildbot.withPlugins (with self.buildbot-plugins; [ www console-view waterfall-view ]);
 
   buildkite-agent = callPackage ../development/tools/continuous-integration/buildkite-agent { };
 


### PR DESCRIPTION
Some changes to be more idiomatic and use stdenv building blocks more. I also added a `buildbot.withPlugins` instead of the current plugins mechanism, which forces an unnecessary rebuild of the package and reruns all the tests. This should be equivalent and more pleasant to use in practice.

cc @FRidh @nand0p 

###### Motivation for this change

I mostly got frustrated with waiting for buildbot tests to rerun every time I changed a dependency. When poking around I saw a few un-idiomatic things in the expression so I changed those too.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

