### PR TITLE
pythonPackages.lit: init at 0.5

### DIFF
--- a/pkgs/development/tools/misc/lit/default.nix
+++ b/pkgs/development/tools/misc/lit/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, python2Packages }:
+
+with python2Packages;
+buildPythonApplication rec {
+  pname = "lit";
+  version = "0.5";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3ea4251e78ebeb2e07be2feb33243d1f8931d956efc96ccc2b0846ced212b58c";
+  };
+
+  meta = {
+    description = "Portable tool for executing LLVM and Clang style test suites";
+    homepage = "http://llvm.org/docs/CommandGuide/lit.html";
+    license = licenses.ncsa;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6570,6 +6570,8 @@ with pkgs;
 
   libtool_2 = callPackage ../development/tools/misc/libtool/libtool2.nix { };
 
+  lit = callPackage ../development/tools/misc/lit { };
+
   lsof = callPackage ../development/tools/misc/lsof { };
 
   ltrace = callPackage ../development/tools/misc/ltrace { };


### PR DESCRIPTION
###### Motivation for this change

'lit' is handy for running test-suites of various LLVM projects.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

