### PR TITLE
buildbot: fix .withPlugins to propagate inputs

### DIFF
--- a/pkgs/development/tools/build-managers/buildbot/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot/default.nix
@@ -2,11 +2,10 @@
 
 let
   withPlugins = plugins: runCommand "wrapped-${package.name}" {
-    buildInputs = [ makeWrapper ];
+    buildInputs = [ makeWrapper ] ++ plugins;
     passthru.withPlugins = moarPlugins: withPlugins (moarPlugins ++ plugins);
   } ''
-    makeWrapper ${package}/bin/buildbot $out/bin/buildbot \
-      --prefix PYTHONPATH : ${lib.makeSearchPathOutput "lib" pythonPackages.python.sitePackages plugins}
+    makeWrapper ${package}/bin/buildbot $out/bin/buildbot --prefix PYTHONPATH : $PYTHONPATH
   '';
 
   package = pythonPackages.buildPythonApplication (rec {


### PR DESCRIPTION
Before I was just grabbing the immediate dependencies. I _think_ this will do the right thing by using the pre-existing setup hook to avoid having to compute the transitive closure myself.

cc @FRidh @nand0p 