### PR TITLE
inkscape: 0.92.0 -> 0.92.1

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -5,17 +5,23 @@
 , libvisio, libcdr, libexif, automake114x, cmake
 }:
 
-let 
+let
   python2Env = python2.withPackages(ps: with ps; [ numpy lxml ]);
 in
 
 stdenv.mkDerivation rec {
-  name = "inkscape-0.92.0";
+  name = "inkscape-0.92.1";
 
   src = fetchurl {
-    url = "https://inkscape.org/gallery/item/10552/${name}.tar.bz2";
-    sha256 = "0mmssxnxsvb3bpm7ck5pqvwyacrz1nkyacs571jx8j04l1cw3d5q";
+    url = "https://media.inkscape.org/dl/resources/file/${name}.tar_XlpI7qT.bz2";
+    sha256 = "01chr3vh728dkg7l7lilwgmh5nrp784khdhjgpqjbq9dh2zhax15";
   };
+
+  unpackPhase = ''
+    cp $src ${name}.tar.bz2
+    tar xvjf ${name}.tar.bz2 > /dev/null
+    cd ${name}
+  '';
 
   postPatch = ''
     patchShebangs share/extensions


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

