### PR TITLE
crunch: enable darwin build

### DIFF
--- a/pkgs/tools/security/crunch/default.nix
+++ b/pkgs/tools/security/crunch/default.nix
@@ -11,11 +11,11 @@ stdenv.mkDerivation  rec {
 
   buildInputs = [ which ];
 
-  configurePhase = "true";
-
   preBuild = ''
-    sed 's/sudo //' -i Makefile
-    sed 's/-g root -o root//' -i Makefile
+    substituteInPlace Makefile \
+      --replace '-g root -o root' "" \
+      --replace '-g wheel -o root' "" \
+      --replace 'sudo ' ""
   '';
 
   makeFlags = "PREFIX=$(out)";
@@ -23,7 +23,7 @@ stdenv.mkDerivation  rec {
   meta = with stdenv.lib; {
     description = "Wordlist generator";
     homepage = https://sourceforge.net/projects/crunch-wordlist/;
-    platforms = platforms.linux;
-    maintainers = [ maintainers.lethalman ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ lethalman lnl7 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

