### PR TITLE
nltk: init at 3.2.2

### DIFF
--- a/pkgs/development/python-modules/nltk.nix
+++ b/pkgs/development/python-modules/nltk.nix
@@ -1,0 +1,30 @@
+{ fetchurl, buildPythonPackage, isPy33, lib, six, pythonAtLeast, pythonOlder }:
+
+buildPythonPackage rec {
+  name = "nltk-${version}";
+  version = "3.2.2";
+
+  src = fetchurl {
+    url = "mirror://pypi/n/nltk/nltk-${version}.tar.gz";
+    sha256 = "13m8i393h5mhpyvh5rghxxpax3bscv8li3ynwfdiq0kh8wsdndqv";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  disabled = pythonOlder "2.7" || pythonOlder "3.4" && (pythonAtLeast "3.0");
+
+  # Tests require some data, the downloading of which is impure. It would
+  # probably make sense to make the data another derivation, but then feeding
+  # that into the tests (given that we need nltk itself to download the data,
+  # unless there's an easy way to download it without nltk's downloader) might
+  # be complicated. For now let's just disable the tests and hope for the
+  # best.
+  doCheck = false;
+
+  meta = {
+    description = "Natural Language Processing ToolKit";
+    homepage = http://nltk.org/;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lheckemann ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -283,6 +283,8 @@ in {
   # version of nixpart.
   nixpart0 = callPackage ../tools/filesystems/nixpart/0.4 { };
 
+  nltk = callPackage ../development/python-modules/nltk.nix { };
+
   pitz = callPackage ../applications/misc/pitz { };
 
   plantuml = callPackage ../tools/misc/plantuml { };


### PR DESCRIPTION
###### Motivation for this change
NLTK is a useful library for natural language processing.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `for py in 27 33 34 35 ; do nix-build -A python${py}Packages.nltk  ; done`
- [x] Tested execution of all binary files (none)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).