### PR TITLE
dhparams module: do not recursively remove all directories in the path

### DIFF
--- a/nixos/modules/security/dhparams.nix
+++ b/nixos/modules/security/dhparams.nix
@@ -19,6 +19,12 @@ in
             Note: The name of the DH params is taken as being the name of the
             service it serves: the params will be generated before the said
             service is started.
+
+            Warning: If you are removing all dhparams from this list, you have
+            to leave security.dhparams.enable for at least one activation in
+            order to have them be cleaned up. This also means if you rollback to
+            a version without any dhparams the existing ones won't be cleaned
+            up.
           '';
         type = with types; attrsOf int;
         default = {};
@@ -34,57 +40,68 @@ in
         type = types.str;
         default = "/var/lib/dhparams";
       };
+
+      enable = mkOption {
+        description =
+          ''
+            Whether to generate new DH params and clean up old DH params.
+          '';
+        default = false;
+        type = types.bool;
+      };
     };
   };
 
-  config.systemd.services = {
-    dhparams-init = {
-      description = "Cleanup old Diffie-Hellman parameters";
-      wantedBy = [ "multi-user.target" ]; # Clean up even when no DH params is set
-      serviceConfig.Type = "oneshot";
-      script =
-        # Create directory
-        ''
-          if [ ! -d ${cfg.path} ]; then
-            mkdir -p ${cfg.path}
-          fi
-        '' +
-        # Remove old dhparams
-        ''
-          for file in ${cfg.path}/*; do
-            if [ ! -f "$file" ]; then
-              continue
+  config = mkIf cfg.enable {
+    systemd.services = {
+      dhparams-init = {
+        description = "Cleanup old Diffie-Hellman parameters";
+        wantedBy = [ "multi-user.target" ]; # Clean up even when no DH params is set
+        serviceConfig.Type = "oneshot";
+        script =
+          # Create directory
+          ''
+            if [ ! -d ${cfg.path} ]; then
+              mkdir -p ${cfg.path}
             fi
-        '' + concatStrings (mapAttrsToList (name: value:
-        ''
-            if [ "$file" == "${cfg.path}/${name}.pem" ] && \
-                ${pkgs.openssl}/bin/openssl dhparam -in "$file" -text | head -n 1 | grep "(${toString value} bit)" > /dev/null; then
-              continue
-            fi
-        ''
-        ) cfg.params) +
-        ''
-            rm $file
-          done
+          '' +
+          # Remove old dhparams
+          ''
+            for file in ${cfg.path}/*; do
+              if [ ! -f "$file" ]; then
+                continue
+              fi
+          '' + concatStrings (mapAttrsToList (name: value:
+          ''
+              if [ "$file" == "${cfg.path}/${name}.pem" ] && \
+                  ${pkgs.openssl}/bin/openssl dhparam -in "$file" -text | head -n 1 | grep "(${toString value} bit)" > /dev/null; then
+                continue
+              fi
+          ''
+          ) cfg.params) +
+          ''
+              rm $file
+            done
 
-          # TODO: Ideally this would be removing the *former* cfg.path, though this
-          # does not seem really important
-          rmdir -p --ignore-fail-on-non-empty ${cfg.path}
-        '';
-    };
-  } //
-    mapAttrs' (name: value: nameValuePair "dhparams-gen-${name}" {
-      description = "Generate Diffie-Hellman parameters for ${name} if they don't exist yet";
-      after = [ "dhparams-init.service" ];
-      before = [ "${name}.service" ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig.Type = "oneshot";
-      script =
-        ''
-          mkdir -p ${cfg.path}
-          if [ ! -f ${cfg.path}/${name}.pem ]; then
-            ${pkgs.openssl}/bin/openssl dhparam -out ${cfg.path}/${name}.pem ${toString value}
-          fi
-        '';
-    }) cfg.params;
+            # TODO: Ideally this would be removing the *former* cfg.path, though this
+            # does not seem really important as changes to it are quite unlikely
+            rmdir --ignore-fail-on-non-empty ${cfg.path}
+          '';
+      };
+    } //
+      mapAttrs' (name: value: nameValuePair "dhparams-gen-${name}" {
+        description = "Generate Diffie-Hellman parameters for ${name} if they don't exist yet";
+        after = [ "dhparams-init.service" ];
+        before = [ "${name}.service" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig.Type = "oneshot";
+        script =
+          ''
+            mkdir -p ${cfg.path}
+            if [ ! -f ${cfg.path}/${name}.pem ]; then
+              ${pkgs.openssl}/bin/openssl dhparam -out ${cfg.path}/${name}.pem ${toString value}
+            fi
+          '';
+      }) cfg.params;
+  };
 }


### PR DESCRIPTION
This should fix https://github.com/NixOS/nixpkgs/issues/23508 .

I wanted to go with the solution advised (ie. remove the cleanup service), then noticed this would generate unsound behavior, like:
```nix
{
services.nginx = { enable = true; sshDhparam = "${security.dhparams.path}/nginx.pem"; };
# nginx fails to start

# Add the following
security.dhparams.params = { nginx = 3072; };
# nixos-rebuild, nginx successfully starts

# Remove the security.dhparams.params
# nixos-rebuild, nginx still successfully starts, even if the derivation is exactly the same as before adding the dhparams
}
```

So I think there is no choice but to leave this service even when no dhparams are being generated (it's literally a mkdir followed by a rmdir in this case, run only at startup, so not really costly imho). However, I removed the `-p` here, as anyway the default `path` is not really designed to be changed, and it may try to remove directories the user wanted to keep (even though no data could be lost as rmdir will refuse to remove non-empty directories).