### PR TITLE
thunderbird, thunderbird-bin: 45.7.1 -> 45.8.0 [Critical security fix]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -38,6 +38,7 @@
 , coreutils
 , gnused
 , gnugrep
+, gnupg
 }:
 
 assert stdenv.isLinux;
@@ -148,7 +149,7 @@ stdenv.mkDerivation {
     '';
 
   passthru.updateScript = import ./../../browsers/firefox-bin/update.nix {
-    inherit name writeScript xidel coreutils gnused gnugrep curl;
+    inherit name writeScript xidel coreutils gnused gnugrep curl gnupg;
     baseName = "thunderbird";
     basePath = "pkgs/applications/networking/mailreaders/thunderbird-bin";
     baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/sources.nix
@@ -1,585 +1,585 @@
 {
-  version = "45.7.1";
+  version = "45.8.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/ar/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/ar/thunderbird-45.8.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "e1c0092e9068c5b687443c66e51d0a66821b509d554ae49563ceb5ca7f9f1429b47b084d39d9b8c7726aad79d61ad09b3b256118560b77ae9a179152d4914147";
+      sha512 = "b56803f7047547e0ffbe7491062e82a82b19dabf8d4a7483834720166b0fb913f4a0252bebb5653abfaaf526998a5af0c31ff8a62ad8f5ec7d9736a6d581a7d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/ast/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/ast/thunderbird-45.8.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "0dfa480291f654fcd3af50711b3634202b81e9661a037a98d1e32e7b51bdc0395331fa99d8806a49873f23a02be95a383bfbdf001f905eac42d9b132d1e170ee";
+      sha512 = "c49d973c8b138743ea8fa0bca75f2de01ce1d051b15b5d9e6516ad7a8e489028d2198ba460abcb62a06f0738994f00885d0e26e98b5f3311dddb258622ef6f36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/be/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/be/thunderbird-45.8.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "fd705a8bdbe5bb6e8c7e120495021b538f75ca8d5c485d9d224392808c5397e149004c2262e2dbf982d5248a7ab036ed82980665be7628cf87e789b5d4ed4e19";
+      sha512 = "8e5463a97d93c70fd9fb3b5cda89ad916c7ae2abc89974536dbe2af0633e696c839a97e8dfbf35bb3c1efc7ccf1c588c5ab3e595a0cea519596ac2c112f8012f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/bg/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/bg/thunderbird-45.8.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "f6ceb36dfd93e10b29a8d5322604c1fe17d1ef96113e79bd3c5a0f9912b4a77f8a182f676919ad5a58c15ef9555fc2ab07d8c2f375654057cdf2efc0be9a1ea1";
+      sha512 = "912056b19247376e3f8f4f8da493391c9e094abe2723091cf22c83017fcaefa3402e3465db99ea2a4413ea3fdecb9eb6170e8091a2ce3bc191061e9697daf0cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/bn-BD/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/bn-BD/thunderbird-45.8.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "d3dfebeb5d6a301449130c94c7cbdea50e8c29c2571b408d89b3a632a164056605bc0e15dc2957f677d639ca9712088d94c62d26c0b2ade4faadb159978519c8";
+      sha512 = "a221336fae5a44312b1fbf8027c9a6088152f96cf2e5ff55239c0256f6b824c92eddba4442b5efa9e4ae1ed81b3a7114d85fa08a785eb73a20aa0f2b86f73107";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/br/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/br/thunderbird-45.8.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "1de73392b72d595504314e36c2c8cda7ee781a246dab443ba8f1cf46027c40a85a1e7a8626bfc46901940a08d89de69c2779a0702e5271da3f703aa299ae4767";
+      sha512 = "ba3d2a59ef9347cb1c23716bd308f62cdcf1399ea6a2c35ede563fa2af48e49a8ca9954f986f55e41c80647cceb218d664ebed0c7053e3ef4a0ea12395bd01d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/ca/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/ca/thunderbird-45.8.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "e481f63846a437dd1326820f455ec7c50ae56e638bc771814c4a53b5fcd7b397e0b6d7886965f4ebc94c15d33eeabb947c65a72ddad8ebd6a0549ec5df94be73";
+      sha512 = "f64e2eaa1208fbcc8be61e28ceedc113101fd6a9d7b2ac23299f36913b7c696b7a3fbb83934c4ea2ca8d23d632891a22e48ce3001425fea54f7669599da136cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/cs/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/cs/thunderbird-45.8.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "148114a531d1dd467fa59690836dee75e2640dca5b448175424d56224867676990561693e12faef7ea53b0e0a87cb039a5f7b35432901703f135cfb99f48e53f";
+      sha512 = "130c73d25b581988fc14f734d39bdea4d777258ba35f56f421b234a79a00cc4f322912977af0feab0b3d4ac72e3fd3d13eb26465da7b2d81d8ccbf05a42b8c0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/cy/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/cy/thunderbird-45.8.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "6ee390cc87fc717cb1e413e5e2b46eb1f7335f617877f9c190075f808f9e0f7d21f59a41a651f2bce14323a46994c499056c6ba3308dfc28a2733f125e200a0e";
+      sha512 = "a3894db9cef7368ee824ea7015b62d378a7e8733b86eaa5fa59645fea4fe9bd9bcb1752ed12678d6ac052b42060d2a3282f23c25c4451362a0c941001352a352";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/da/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/da/thunderbird-45.8.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "1246c3338ec1c66ec0631cd3dd2e2ddfa2f55eaac2ebf36d6fc78a58cdafe15b5bb02c542447fa7aeac56eb9dce2501951b998c605844ce37fe8bb4868c100c7";
+      sha512 = "ae037f835dd51fc4b140ca0165f75ff26a305715a8536929d46c487d4db1e77cb10f101faea6a612579b021db597b63045deaaa7db1cea2b3d4160d8ef423a4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/de/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/de/thunderbird-45.8.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "ba651c2f07eceb4c20a9997bd518c322b025467e3474a56c17e1c35ea9dab7c3ac08295f573cdb7c4967e531dfcaa76facf4185ecc12a66436690817c73c0454";
+      sha512 = "71255dfb152f4f204399b6ecaa837a468bce5582fb9f358a1d7bdd073e2aecd41a7302a0096f1429d20bd67a92d012172308e8df9aebde141bb7da828b158cd5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/dsb/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/dsb/thunderbird-45.8.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "5fcbb029e59b50e3c8762acdcb561f3541a1056bd467f2830b316ef39b9f55f88797693ef4c281d8411c678bfbe86abde74483f0b9418e185fe80463487da489";
+      sha512 = "39f02422d754637044fe4c75c9d677c43ff6a87229893c3eb637ff6b9c8adf541833aa929b70f2b783aa1fcf998e112645809c6256070fa746c4c95885c9232e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/el/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/el/thunderbird-45.8.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "36fa1fe8d3b52ee95275acfcda8eeda175f9ff5d44b7fcd0e33df2a27fd4c815d79b647265e9c32bfdcd9f1900bc98195bee6de5e580abb452ca47003a438b40";
+      sha512 = "3cf4cce1398e945a3cb41e5432aa0c2ed1fa386e8e553816b1478a12e1248ac709de8d21a938e6c3cd801fffb58fe6e10776b8b96bb295b5fa016492f70031e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/en-GB/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/en-GB/thunderbird-45.8.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "15973247dab22789b8c63f5617fd1d85aa2a889e78d1bfd8ade002d769bf81857cf7d84c6302c168c5923ccdd08ea561df4fca1f17f0fe3337608af161c6e86e";
+      sha512 = "609ebe7d015af9dfd3b88ebfb04d67691314ac91d3df7cff91df3f20ba7fb12db5f44dff5c773b4b7c858cc4bc5817119fcfabff03ec550ce250a5289aaea9ab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/en-US/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/en-US/thunderbird-45.8.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "4acce7404bad1bef72d1ba0630a6d9e7678716121b5520d399c3e47096a5b82c03b797a3680428d1c8447121d403de227d7f327001a27092db8df438f1d88d18";
+      sha512 = "4294c93adb8f38617b2898c91d0362b3ab327158e1810d2304f2481bdc4e0e06e1fd2a2d6748cb491cc6c732a039fa3dd83dac801b12ec7be2d7c8cf7e986286";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/es-AR/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/es-AR/thunderbird-45.8.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "68e7e8b134d6b3a6b44ecf9deaaa4fe58a2ba2324621722300eb39c74f6d4801edb7532ff81a2a22f473b55d227caefce4e5460b9527fee2bc7e9b765b4a66e9";
+      sha512 = "ded0d52934a5b74e4eff172037c1abe9c15cb522897daee5173739f4a149c1891309a366d3aded2f1306c447970e72b1a2930a9adce07d57287f7f5f0e8eec73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/es-ES/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/es-ES/thunderbird-45.8.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "80517102d930a0613254f5f2ebbccfadc27606664e957b217e899b2d519f1a7fd189caa17756ae9849f870b97ed8a589c327d3239d2312368a94583434a31bf9";
+      sha512 = "523c9b931d9ef8319c5a30463035d84946d97b07a9714b2357637f9992a3dcda4536a29933a29340d4e4951ff2bc540d587ab290a16033bfc510ac911c32d3e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/et/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/et/thunderbird-45.8.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "3399aaf7a8eb812b4ed4c56e8e6619c9e7018e552bc810f9a20773854cdaaa3a4382754fafde2809bb945885059c1613e3832071bdc55d32816aac49e38acc9e";
+      sha512 = "376e5cd8f50c4b10c4f71b6410528965f256b69c17f3d0d103efe6bdd28ed96d0fc47dcfb709dce617757c3cec603c5a16ac675ae12e17b093db3d1184c8ebfb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/eu/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/eu/thunderbird-45.8.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "4b7ace6485b3d9f14a924a9827226c3337f4b95107b94e51925524aea6eff2d446868f7a7f350c22ef7dec0c3c04c0fbb79f9eac9c1db0070195ce402559b3c6";
+      sha512 = "8dba4439fadb14028903eb552ad08c62b0a63559ff5332fd2d5434179fe28a75d754b6769d1a171d7e580ec6d86fdfcad8ae6230c14c4e9aa981944013dc5b86";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/fi/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/fi/thunderbird-45.8.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "42330fa494ff9e09ddddaa5828fd6e984f4e016d45f90638a72d958f1d0d52458c4d66492c4bf3a9a57fad32ebb24ecd4d43efc51795f738f50d7385b3090015";
+      sha512 = "40d579d59beae9070cf548f340d5b36d67d0456bb0f9569330dcaf4667d6cef71be1be4d32ffbb49446c8921486153e50d5c33ad87746f605e4d3a79b4b74a69";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/fr/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/fr/thunderbird-45.8.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "53696b4b77c2dfc4eeb03059429dbf38dc31910664ef7638ce291adee5d9e0bcfb1b8a19524a96fed02594b664d125e9c4791aac674c03e9dbb272544f429cb1";
+      sha512 = "80b489cb98c0a39c641c0d49cb750cd737594e6de1c9b0559208535a41f95855afbbaf987ab0cfedf5fb5b2fa1589d538b7eada05114d7259d3789fa399e20e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/fy-NL/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/fy-NL/thunderbird-45.8.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "2c8a487a2a77451d2d4c239a16cdf114e1d9ef37d7c0a1f2dd2e3e9ba6270004e39fc38828b363805ac530b2f6cd3016594dfcccf2db37525f9700866d6a513f";
+      sha512 = "6bd13607375c513be19ae9f86e806ca94d4acb087700fdf85842cd2a7eecab66735b9ca5130b013d09dcaab12134d894bb991774727d67ff71ef2cef4b0f9b49";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/ga-IE/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/ga-IE/thunderbird-45.8.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "127d0cfc24b8e3e00aedee39aa400af198c7e48239fce97dde27416ac517108957d5f18735e5106eaba0433321f406ca9c82d774a83f1e58dc297b80e55a33dd";
+      sha512 = "de4744accb4332e8509a1cb439f29d773d67f42d3964e11df83e790e6f720063b3368d3a120f746829d61741abb18baaf1f2afd9dc3bffde1ae2a118025d7973";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/gd/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/gd/thunderbird-45.8.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "48dca91d52b3f71a76c3a08003247bcfe498342b3e2e6158f58087251a9248959d17a7c91437475892a5b5124d9a76a1f0cc99c118e34c763ae4227fc4776dd9";
+      sha512 = "98f73337263ea57e609bab9f8f0537c15c385448c48b84185d9c8cde8550d2d2fb6adc31735c7a45eff5d1872047f7137e168b977a5686401c1f0aa21a38effb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/gl/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/gl/thunderbird-45.8.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "92993f4090d641ee6573ec08c9ed25d3126e0e9796568aaa77296e859fd70069ce0f63f017fc08a3e01d65dd9864063f8ec089ee8e43197d511358b53259fb76";
+      sha512 = "b255dcc44f33c9b8d74ba664350cb6423245a146134e64292f7bd0850ddeafedfd691d8c5e4db51c019df92283b094a8d152441512aef33971ac8959a2904656";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/he/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/he/thunderbird-45.8.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "c7e78d6aa2920fa81820b54a3f1047d42089e65fcc424ff663ef287cf581aec7b11fec33c309c88ae5986c9a78d3967dbc3cccd6efadbacfb145e36d2409e514";
+      sha512 = "4c8406c16bae204a1aeb075dd061eb3a70585e439c29f585fed4bb7ee3c1d599f8fb2f12f2ad9d0521550729d7ad1a0b097349a3a318be89a37d10b749fa4fc1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/hr/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/hr/thunderbird-45.8.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "0160db00133e4564b9ca0ddcb2771abd343bd3cef1bfc09303805bc0aaa01a5cbeeb6a23effd2e8256ae5457a2fddc149156d1702705531c728134845945dc56";
+      sha512 = "e855a5753de07b4f4435356571178149c0eb26d9b0b81bbd41de89e88bcf30c3d970514c3548a389cf719917f29899185e1bed9d18c4b467f2d31e00d271623b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/hsb/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/hsb/thunderbird-45.8.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "012f4544e60f7a917ffd49fd6668da548e6e44ce666a86f61cc0e36e53806db16496824bd20b253d079e27d5601ddb6cc1ee290c600e116c922bb842a2232294";
+      sha512 = "8afc5a73b43ae6b43595028213ff6e21da813f9e9a93aad498e583c4ad5fcc2c5eb90ecdf911a32a68710c36a742ca1a0cc89b987789aaeb9995716783e0fff3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/hu/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/hu/thunderbird-45.8.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "ff13587b1098f0d503c6f3b81c2a9f3c075d192517e0dee6d9fe324927a6dce8686d989a34c3d36cff7a8e2bd6a074aee5fc96f7527ec3fd78cc0c96f4279b2c";
+      sha512 = "da48fd9398349c6dd583391413add0b789d1500dd1481758a62121052bedaa739406011b5a3747fca810c74140c98498eb8c49a092ff3f184627bbc3469df90c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/hy-AM/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/hy-AM/thunderbird-45.8.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "84f3ca15346c821dcb9efdcfbc2b599a68b608cf8dc28145e0aac80babcf3b82da456a0816f2e31ed47b19c47f3afa9a265f864de6662fdd4fa8586d520ea025";
+      sha512 = "588c3670d7748453e273f515255c29e5644e521f9710d1f87360a2031334f9353adba4e219b0f90c3c028102e5e02a0ffe07071a6fddea2bd2a1d972c04e1537";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/id/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/id/thunderbird-45.8.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "2310cca9ced00d10b932eb6d27797b53e427f997671b836a5d03bc3f263fd469ea3dc5a2ba35a71da6b73e4dec83c60fc31203329562d6250ec573a38c55f115";
+      sha512 = "a9acd62a369249370f7c6b70bb48aaa8af06de2439b328d92ddd3092cb95fd59df679a451f42173e6901d0e9fce9159e295331479d5128fc50ca7a2c93129bbb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/is/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/is/thunderbird-45.8.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "710f180201035cde81d8e07cbc7e9e83289a160f6679393d2dd70c48c92f5b3568c0f7290e18613945abee052433f31c2b3b11019cb95cb8f6b23f04e985741d";
+      sha512 = "76aee81433e6d8f2f7906d754069a5aab3ff8caa2b3d503a730eefcc42ddc1ea2018049419015dd4725344dbb54d821633f10f1d0c0139ee62c230f7643c5ee9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/it/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/it/thunderbird-45.8.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "d5596d86c425f2d1251947a6d66558d87ec22a20490db23c267c514b98ddb9acebc30180c6c29a242ead4bf079fb8e9bc35414210c1d294dc735923f0ab29d3d";
+      sha512 = "c7912a63ab9141a32e8f9040522900b10bb56360fd387b8b47af860814fa1541ab7ec1c59eb6376b7aacc2a22faa046d05c4a1ae81ef12bf553fdf546cfc403a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/ja/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/ja/thunderbird-45.8.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "954e41ec6842e4ea40c84354a3499085d5fa754c0a8fe581fd0e1ddafb84c218b0afc6b84d6b89448573372ca8170563f4732eb0e00388d5daf918fc9eccab5b";
+      sha512 = "03f414eba62f4188bb7a368653f89f0b8d48e850751cab0fb6d706912787aa098a32934bd5c7b3026e466b23df4cc6780f6b88f1f252943b2d56b53f1ea62cb6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/ko/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/ko/thunderbird-45.8.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "3b48ec21a87f4763e95a045f273b3077cc0f73f0cd79d0fd341bab93308ca6aa122aa1b6fe60cd9857e2af30f8b868a1ce56ca5e2418235b9207c33339abe66b";
+      sha512 = "d9c1cfba0ab167b4f3e16eb8ee37ca3acfd94477df51a2526975602882b93a4c86e7936f76263bddfc904900146b0ed570c641f4cd1d48904bd5b9f09aef91ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/lt/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/lt/thunderbird-45.8.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "e314d8aebc993a9471610d885736e50a174905cdd862eacb3cc08516fda8538cd86afbe62744a7a28947f289cd9d3847436ac4be6966097c4e2d81f74bb3aa19";
+      sha512 = "5f28db94768ba285feb1a239cfd909a588a975dea16ade7793e4e1f71f8dcee1685e7370ba23cb50b253d8252a51a38a90375e8224653bfeb37e2a1e8d969d34";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/nb-NO/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/nb-NO/thunderbird-45.8.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "2d14dad1eedc2b5043adca4d8ae9ddfa7bd7c4d9c246fb5abaf552f2bd1a27cd7d64638291a82391ceb84ba83c6c4f22f9ae09c7efc1c2530cfe986654b8b27e";
+      sha512 = "e3078466c4a5aa5a2743c7224c279c908be05730a79bc541031efa48605e0b74fb4244e087f3cf526bab6c67c40da585815f11999ff29d6a3d0867614aa11e17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/nl/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/nl/thunderbird-45.8.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "fcde3900e201175fb9071b553f26dc49cad67888137df2e6ca4c7a85ffcf85aa23ca331bd4e5a3430b20615b2dbfae1ca4fe59833cd9d303f7ea6f8b73f42f64";
+      sha512 = "7e2bc54b6d72fa495ef99e132dc4e476bc233c88c1652fc625ed66b504b901fcef53b4968d63d7d468e734903b38ef897282c2122e4bfca5b492e2f4d44b51b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/nn-NO/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/nn-NO/thunderbird-45.8.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "a3e41f8fe0486a691c413104fe89009db9e4709821bac4a7062a78a6a30b083fed5a522c6d5b7c004e0e9b2131aa4bdbae85e8dae3300d2f81fd875981d79b44";
+      sha512 = "99a733996460fe3a425d7ac9d37d292ef9fdd0d1bb22aac251f592bd57f4ab2228040443ed132987cf17d971b3bb2232ba9e70aa2b6b702d73967ed55a1b3b41";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/pa-IN/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/pa-IN/thunderbird-45.8.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "841cf7f21b436d1194c4082ec0fd0067bed7ae625299b8f07f535708005ea3a7c217f4a6d3acd8b392e620ebdd15447f62f969c4e0c8e40e69f77c3b89402517";
+      sha512 = "d43dc96e3620c8ee1257243e725743e72c64f39123d2e4648eb5a31e45175b9b01b066b85ee9cc3d9765151bc2aee32f73b50579619968ff95918189d45358ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/pl/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/pl/thunderbird-45.8.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "026002b4161801b9ba44442ac2b54f0897b6fd3dea3c6819a16c5b886c829308558917470e87eba1e7bfa9adf6d5a33dcce4645f24cec8b8cf7ef4773d924e65";
+      sha512 = "32f034261425fc41ad9b2c252aa456b1526526816d9ed66e92c49fbf8fb4b077405e2ead3256dac568e1470e29971ff84466854115f57f792a254f0723278054";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/pt-BR/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/pt-BR/thunderbird-45.8.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "7b78eed009541c2b5e99fac1c6267f42511feab8cd26b8c6cd758c8cc4fade84195da5b4ed1dd44ba078c3ae6a3d2aeed0bdd04e37a48f585938765a7e14021e";
+      sha512 = "65f85f596241f812a548a90a1ebf3cd24733e590cbedd600ca8d1164d3d3f5db9fb9a0e152ea05025039203f192168f60fd28a03121c31cdcf14449505d57c0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/pt-PT/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/pt-PT/thunderbird-45.8.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "15f5f46ad34ab5506d462c68ae5a2c0ab1548b8588ac877863ca73c97166d10ed26a6af32c9f0f57bb94da7b0c025813585a17e52dd3238b49344995905bb705";
+      sha512 = "fab114396e6cbee135441392dfe6baa179640174edd19ec4d1854a4adb6d3310a38e162209bea0ac532e2734a9ad4c5abc1926e0a4ca2052c62697f99c374135";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/rm/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/rm/thunderbird-45.8.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "d0e70c192fdd0cc440f81173b13a09e6916355c2f65292c234e1da288e9a54ff1696e20c3a04f3a18fdb664d0fd76d8c477c7b19b0368a1d5dd889a5bfdf8f49";
+      sha512 = "e03da559d75887e2418119cc946bb9ae2f11027dc2109035e533da46c859f3dcaf8fec294a6bdcb10d164866bc5c3652ccb6b8276c58a91311c2bba63117f1fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/ro/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/ro/thunderbird-45.8.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "0bd336fa6f8e1f22e8d9f8e10071518a91922d9f8b75d4e462cda1ff9a7e6a744a4d8b4412dd3d1f5617553cea67bf73599b5023dd205437ff3aa26854916e24";
+      sha512 = "f7bed7908706485e0cb26a663bdd6b0fd8ad8ad5e687a21e1c137c39d01427e3edce5ce58602bcd18a185445badefa519ecd841367f88f169591aabdf570b940";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/ru/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/ru/thunderbird-45.8.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "61a02467ee16e6a14b535be1b4a3ce2fa3a6bc6a61c2804e234242758361182df976f7edd0c8080637f3403436b018946c28668da09ecb9322c0eaa5fe395ba1";
+      sha512 = "7775b9054e95d373d188e496287b2cbea1ddcd12c51681123642fbc181cff258d47b900b3dbf046f3de7d75e80eef5f343a50577a9db05ab2b56867a18f3c912";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/si/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/si/thunderbird-45.8.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "823e069b47f42c35c194bbfae832f71203e78f14057223bc569d8a18bc631d2d5bfdc3dfe5cb18c0bbae561b39023cb43dc26bf841a0e20e53bf336128bc1210";
+      sha512 = "3e19c7e5b62b6d0bd3598ce6bfd23631abe381f7af91275aa8e424ff2950433fd5e58e912ad13c726185e528046d3bdccdb6b3e1fa540fc0cb69b18d37caa095";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/sk/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/sk/thunderbird-45.8.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "c3bf6785424419f7a1240c2069abafcd1275dfdf8908fe2e80dbd395176328e7c8c0c2cad9ce7ef46a605bae9e153e6c98fa696145fe7a186e30c7a2b147dde2";
+      sha512 = "35a5b23cffb7a80aaab378ac17195b727b7776a0c91e1616fe9a66708adc08d6041efa55dd5b291eee823a5420b092671a34f930276521f0d757e3b5568e7861";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/sl/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/sl/thunderbird-45.8.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "bbf63ca0e0992c5102b047c5e41dd9a2dd04d38bcbb983393345a54679ddf100496082804d17c088f6dbb76bcaf1d9be39f0e45d1e1cb0abc33fef98a79bde7c";
+      sha512 = "a7b27babbcd47b4bca6e0686aefa175fab17c4ab0d7f18793a0a3755fcaf04cd85e9bf8ddaec442ab83bafede0ad9f8211add33b6cad845f7c827e3af0982f76";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/sq/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/sq/thunderbird-45.8.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "68f2977a84aa0a1fc94b19a3504733cb4168d5835244482e775b0200cc0e17a548cb3f4e29d81edffb9172d3faced2a8d459709ddb90e1957c6c05ff792ce05d";
+      sha512 = "796d3cd98d39fbad987387f92d23c10f4176f2e612c1fa939bbbcf86eb3de5798a9c9add31549dcae001041d0318de2186e00200190f467ebfc85e5c95797cb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/sr/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/sr/thunderbird-45.8.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "d0de9ea4f4cfb619d37b957b4260477522ae1c2df9af19e6001672f7f693015c09e8e74ff0278d0107abbb0483de0c9f6d251efaa3d9175947beb8c156145ae8";
+      sha512 = "8b296aaf9314a8b0381e567ff87e8ed261ebb976c0f63d3636d03fe2e416475dad8c500058e58793a7945ae620268854f99c97b93da0ab73a40f67d801b34af9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/sv-SE/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/sv-SE/thunderbird-45.8.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "db4af37830a458808b9450b414b7e25aede621c602b344cfbb62f00fb610747ee48fe3a7aceb1a58c0b1fc397415ea7a9e0888e0cbd7116922f2bc28d09c6426";
+      sha512 = "59e0eb3a4e1cc65fc34369b0854d7029bfe108b3cc3550bde26628d88d82c0031bbf13ed8564c7508b2acae5ffc9a912f1cbb991bc5cecf2a210bcdb181e2a05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/ta-LK/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/ta-LK/thunderbird-45.8.0.tar.bz2";
       locale = "ta-LK";
       arch = "linux-x86_64";
-      sha512 = "1db6844293dce004878176cb76df68e7c7b3fd1147b4e78bf647d155d1a7efe01e5126c088c96d26f78dd2c9de98e0703b7eedef1f2de1584a0cb835f9123c1b";
+      sha512 = "86719203c04b90e2d359ede21ef3bca7e2190b131a78ba4ccf6a7d9644bcb2971b541cb3c6432e6a12952a3a589769851277a257aeec594b6208918c17d76b32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/tr/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/tr/thunderbird-45.8.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "f05b1f63839a9d38431b9c1bce8a2f31ad242edc4df5b327f9f0a562dca1f94a9f3947ba55a517cca5dab9a96fc44b938496bf72086f1dd8d1399aa3170167a1";
+      sha512 = "5b7fa2e0881dceeb0ac371a0d84209cb9e9c414ee617766ff898b50c2b21956919410be26cc0b1e30997931519fcc491c63c6e30144a2c57af8b7b8f61cd192d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/uk/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/uk/thunderbird-45.8.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "303d6b4ea136dba2217301f6c42bd91e45ff635ffa1ab38ec0633d963a1bafc1625475bbd24383e5b9dcf233a19ab0a712e70891614e14207b651c4e65016456";
+      sha512 = "8be8b331dce88d3244007066036741af4794559237811ab8d45dffe3e850383de636bb75a510d4a0500a2a78aa86d06768073a5626f5bf2676eb4d8e355eddcd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/vi/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/vi/thunderbird-45.8.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "3f712c97073ff191bf2e16d61877711ca4faac204e85b2394015d53a4f600a3c0fa352787ccddf863379ebefce4020b3526f957f2556620e4632bcb20204421c";
+      sha512 = "60ff68fc5190679b4faf2e80f89b8061348f24c0426f632fc2e523be2d47b0477b2ca122fe4c9a77e8baa91d5c55ef0204fba74f65a1d7e77727abb9846c93df";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/zh-CN/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/zh-CN/thunderbird-45.8.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "d986a5e9a60512ca4d398fc4fb503aa7980947eee68dfcd5c4a73bcc8b324c20c6a3be66855eece6d0d77019e6b22d8ae220058948488d197063f55a291a8865";
+      sha512 = "a7da3633bb13627a81681e2539472291e0ffbef2921ae59c7fa541b0115f761295221501ea7b4e71975ba89dff559aa0f4ae1be196983854021bef823cd7c40d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-x86_64/zh-TW/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-x86_64/zh-TW/thunderbird-45.8.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "7dee7ced1c48aa6019eb80c66d2c68af9b5afe89ba3c147bd83e78532fab84fbdba8afce934ef8bb55a82837b84475797cad25710001e22fa522823bc60d6a96";
+      sha512 = "dc16cdd23ad53baa7b0863aa889a9222a14ae8e81794efad08dfffc4a6282655fcce3ff64187ce149c06d808a0010af8a084bafc59e253f094d501ee6bebbbef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/ar/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/ar/thunderbird-45.8.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "0453a451bc0ef3704cf54121f7781f11c2a35c29fa407b36a1159bdb462daf35ac13da1cb0deca19b5b9456a4bc68c8bcfa12384dde82441a8e69c5376875d5a";
+      sha512 = "21c08dc4ae1655ddf62ab03ab68ff0d5fc3efd6c8cd3ccc6d757b0b684365a3316b4cf4fac5a51b21be27a5e3067fbc875bdac1a8bca5cceab6e048c10f0f177";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/ast/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/ast/thunderbird-45.8.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "4bc10c64922604b95dfb310f0415a8e49552378c51025511265e7f1e7f2cf7bd8f9e9c6b3e45f8806f2df9fd02db451014cae4de7c2e5ce57e48dc1288cb30b3";
+      sha512 = "3669b524e5d5800f9ef3c1c6b5f874c29ba6fbb336cebbfc9a88f857e73f9bf90ccdb0fa2f1723d4e883947e71dc0333391b9021166b5acf2e39ca3d7bf02ff1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/be/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/be/thunderbird-45.8.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "0fb8f8d0a2c7ea4455c0ff90b85e4ef6b0b6f8ccd08f9f9d4852743ebc1f6a6277011be82be979142097fe8cba853d244afad30749aaa423bd9ffcde9fc3a00a";
+      sha512 = "f49f90f1998a5b7dec1e3a862b8f76bc11445d99f66cc6503675fc6629a028624e55dac5245da777b6e3acffcba24305ed199674343cb610861da9c7671c342f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/bg/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/bg/thunderbird-45.8.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "6d586700050d399e4058eb03931bc6915ec56a9270462a7a60846f66b884aea9627526b87b14a654166e30b8a1d43412ba8acfcb12ba4af8d3fd4fd15d4d7cbb";
+      sha512 = "b46e78338269dc6c65f0eb2bcd2cb4a0dffd5c100b4b1905582c8189f79abc975f55c7edf06e1f0edbb641de86f3b6aba1ca9028d11f4fa08ea8bd1c276e41f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/bn-BD/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/bn-BD/thunderbird-45.8.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "1cfa845129724a098cb913b3bcaf7174ab125321b35f58279ec9c11c04f7f991b37bb9000eeea4003cf033f6f0089992ebd0d7ebf1d6f8b4d7c558eb8c850d99";
+      sha512 = "d349c503a13ae9b951af173a43f4f8dcbd5cab43d5a6219fe5b00e1d37efa7a0ceeeda36576f31f51bac615d6e4307611496e8036af4f9fc40dd3dfb495a6b6c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/br/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/br/thunderbird-45.8.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "951631129aff5cbfc2695e1a5dddd88e855d57716ce335a15ae069b7bb4572d082495ddad9caea202c5d36f46f599cdcb8f028def63252f7888fb2ba24f4437f";
+      sha512 = "4afebf7eab2f7205a8760f04e566ba8d54bc2974cbd132262eedeaf880d29aaaba48ebd731bb8dd7ca537e6cc3fe444c1ae4168e3e08b7e17c55e70f763fbadb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/ca/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/ca/thunderbird-45.8.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "cae03ff18fb33f6d097836e5e7f5884f64e7c594eaaf77cb3a0e1f46214b878ef2de51c750bf1f849f5cfddc68da21c3fb72927ddf6824a89ae51e44378123fc";
+      sha512 = "6b5e9abc4fc05ed580d35baeb6c7b1462daef2352f751e318b9a7bf16d032d8a8240f83d54fa17d02a9a967e7477a36808587a9183df4274f10b59059c55fede";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/cs/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/cs/thunderbird-45.8.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "ea9ec870c91cc2eaab758a3585e20779d24734e62c285f1f591646f9aba92e33c6a7966b0b1e484f28ba0a2f40d74f918dc899c87518f052b793fb5d1cc867ce";
+      sha512 = "1410e7bb8ffc8a4c515b1c023ffa6eedc960632c05e5e7f4675aee9e972877dfc73d09ef14deb1c308bfcc1a6333e62b24af582410854b62acf4d889c7d54158";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/cy/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/cy/thunderbird-45.8.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "082d8f2fa527a75b8a388f84085a709cde9d9c455aaa2615f35bad0eb6962de0af163d515e0481edcbba29fb858095aebb05c0a3f25f33e1e14f7136b83a73d9";
+      sha512 = "28b50a2fb0703f80fc9fb91d1add2305e71f2ddac99cfd086c8559f29b5a420e9e5e3d370f0b84a32f5c358661566b070844ccd0b33447ed4c5a427eec03cfa0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/da/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/da/thunderbird-45.8.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "9ccb84b78ec7fbef596b64e76fae50bbc8af63eb0c0d37c6f81e1353f3afc242c0e3be9495d4b0125fc0500e0b4569df3e00d5e302f93f7007bcdf3089cf0c22";
+      sha512 = "c38cffe6416ca50c78651d24d5466d6e06b2cbaa66062eb13381c4402d39a7bd55aae10cbe3400ba0fe5983309f2d70d3058a46054911399a057679b09b451be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/de/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/de/thunderbird-45.8.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "a493f5e2c4c787f7c8f15d1d2da6f457a52af3deee161d3d9c031525eff48d2aeb294b6745e3ada079026f727db06baaca943d0711aeedb8df5bcd37c3f13286";
+      sha512 = "101ee34b890f1f3f9bc3eedf4936b8ef1fc9edd2f5af79b9c8375326d430585fc564a76a0bbc81bb119ce9a638af60055d578b5e6f1f760100171696351f13c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/dsb/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/dsb/thunderbird-45.8.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "4d1e7a0bf3f55d913aaa47c37ed5529c59240168f2a53faa4367d3c47e900e136d25446b2b4e465d05b3857fdf3671e9bc7f98be6fe7b42c1ec926d0216d6022";
+      sha512 = "a6dd564baa36402d082d5bc2b5bc6002a5abd66b9bd545a0962fc844f4800390e527b9deaa6ca4f197d98265bd85e7d52624e32be17b2efc96b136d4a0108109";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/el/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/el/thunderbird-45.8.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "145bf4a0db9b2fd3b16637fed966d6c0f0d184eeb7ce373024609b869219720f73feb0c10b13c761a4214a88d68ceeee234ac50694ac16599a92e2fe6ea61e4a";
+      sha512 = "d5611f341f3322adeb5e94f9dc83dc0de26d6dbaaaa45a904fb9add1770f77b86db57693aa3c89f69c1aeb27e98793475c900643b78a70284911a63791048069";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/en-GB/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/en-GB/thunderbird-45.8.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "1d3deeccfbba4a871a54eb4ad6077be1cf2e6fc7adb0ad0c04b3638db3b7fb3cbf66b55737befaef034d0b1671e9a53bdadc8d9ee7b3b9eb33a7c64e53ce5b2e";
+      sha512 = "b8c71ccef1793589f5cbbac8e12ad1aef833131a51a0029c75b08e26f28b3d5dfa821a84654efffae1e41c23cf5575cfb1b55de29e9c29b1a5adc1632581129f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/en-US/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/en-US/thunderbird-45.8.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "b1340885d6c92da79ad99f9f491ca1f15429aca73759d4e5055c212f33af96f7a7d4446eec6bc37ffcff4371213051188d7211c021da50f25b85fcf445ca58dc";
+      sha512 = "dbc77f7814b3a085fdf54536d77db69ad893b0230ca1930fb5fbf916cc09e421cdf8987e7f75d726f1fe31f3c7ed0afc584da1d1b1636a2750e9e0454a6de45f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/es-AR/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/es-AR/thunderbird-45.8.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "307473247bbcf0064380b4d9f9bb12ea796c32dfc012af2d4246466aab880dc040a92f06e0917acdf2f930a9df0cc0fce39b17e4ff710ea2311f4b2250b90f53";
+      sha512 = "f161bccff6692a9652568530faa89012e2a7438814fc87f816cbbf93d40425133ef24250a6d1b9990bc772e9ce86d778f905d844166527ab6020687bbede4688";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/es-ES/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/es-ES/thunderbird-45.8.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "3245ee600a95e1f59e8e7aabb521be96d88c1e59ae5cd29cc78825ed2c8c2abd1135dce1c2272d1eef2716717719947ca4b223359e1c56df406569b55226de61";
+      sha512 = "51ca5165f83366f0fd73fa900640b35d572656d123d14663b737e140c1903a816ca8e2980c2c121b1e0a512e9211ceef745c34d3fd8c04b21cbec84b868b468a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/et/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/et/thunderbird-45.8.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "b1cd90842d3888e555799cef84bd2e8d3eeb0c73abd4af9bab2a9db2b24ee90770f39d1376e63df567f8ab63778f6cde305ea8ba2a070aad36d6809a676a2344";
+      sha512 = "a8524b1a72353ddf3d2b883b3936606b9eb3f1898aea05530c38d7d57fd03ad9c36085996fe3442f085ddf668e2fc909a704939c370ba1d2d0684253a10fa965";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/eu/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/eu/thunderbird-45.8.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "6278435a0f46cbd40514780beacda014c8528a79bb5d9be1366b0dd46dc71aa1f7a387311511e8d04cea3e78dd84157b97307df5bb69797b6d39cd299be18a33";
+      sha512 = "6c3f12ccd7dd48258ff5972163da3617f3038f4f670223617f1b7734181234eaef5be4762156650c0398c4791fc82cfb397149f62e14bc6c873d279eaca92fb3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/fi/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/fi/thunderbird-45.8.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "000fbb4519ed626af2dfaec3d588f4ce567212b8a01c4aeae34b1f9e8ec6086ad45b90b57412fe830b8e236606d686e05c807e60bc2078df1364fd9f58d06d0e";
+      sha512 = "2d417c63a5c5d5203bea96f88a51ac4b501dee7575bb43fcda3ea523e76e65dacaf16c3f6ad772b25a242aa8016fb36c4f3a04c86431ade23389a97b7cac25cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/fr/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/fr/thunderbird-45.8.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "5120e880f297f8899ee6067660d65cf1ffd66d3ae6c16a888ab5e5e1b32f48a58aefef9a7023b1a8860987a5ca6399d69fd6df8e12838c00c305c3854c18582f";
+      sha512 = "2c64e8a21306b6129a87333ff1c29ebba10f708d67636042bf6daf40bf01e5ef954038afae8d0d76c42d83ed0c8074525b13b60791f0d0e21108053c9b81822e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/fy-NL/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/fy-NL/thunderbird-45.8.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "2e3b2a7cdcd4e5bcae6e46f86c5a4956f164ec37f4cb657ac18c1233c5b36b8c0f041e6930ea15adbcd8269662f9315e2822a9ed43be38a5fae8b7c747812035";
+      sha512 = "fe444a91350d3c30e6254e526f5a506aedaebc92ed9632df6a4d2ee5c8f18246601bc8b853eadd54c0b02c2647cae21514a0c1767ff506bb3fd048aa431d5b7a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/ga-IE/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/ga-IE/thunderbird-45.8.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "b4567af9057eaffe812feb43fa195474094fe1c0d804eb79a9dc936b93662cdfafd1c1f4bba51adda57abed677473fe2bd5e5ce9523659c931035b617a1e3ad7";
+      sha512 = "73979022d045433b27f71a7278d518b2ee42a7250b166327bfd2f94c2f747acf2d14a9ea55e254f6ade0ccc3ffdc898f61e8dfaa9c7e2b8450fdee195db97b5b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/gd/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/gd/thunderbird-45.8.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "1200cfb333861d2bd5013cfa5c764f202b7a2febadff5f4c8c0bc648f744af19362b07147e720c06046d4ceae7fac186c5bc33c1b637104241493f960a5c307c";
+      sha512 = "e856393fe16f57ecbcdc796dd027d8f426f9c1b39fd51c4bcea8ceb82934087ab71d87e7c04ae67b12de6d063994ee4eb607cca9889c7e500272600f80d65f6c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/gl/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/gl/thunderbird-45.8.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "10ec0d042e14c80d65af5ce7a271844553e4bfb96f349a16d94c5caed3c33fa35fb2065ec99b2ae1dfb7b1e47059f6f3ce730d6d293efdd380862fe18b03c877";
+      sha512 = "c1e8ae50ce6495e9706ff1ef4fb790c53be407eaa738e86f2a788feaa16e5e903386f59bc986497d2ae9e5dff8489007a16c0f2b8b9c37456d180794dfa82642";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/he/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/he/thunderbird-45.8.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "7d7edbf3fd840fcf80c3d3491fcf9cbeed923b597840bdc16e7e43097cd5843554030e2690ff178f10ad97b0f447760bd06da87b4cae545dfb32c3b0f4668b68";
+      sha512 = "6caf34bd52e21809eb80ed88b104ed1a47a1c29abdc3b3f4059fb183a0b844449936362a1839d888e4d224ee987890982d37d27c32102cfe8029bea1371847cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/hr/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/hr/thunderbird-45.8.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "28a2e3e0dcabecced0a9b66a5e11434fcbabe11257508eb481513e56a82d13c5bf36e79d8174fcd0080b0b310df4ada6f92f3d24fb67658d40db66823d18e0a6";
+      sha512 = "230f0bd3eddf99811d8fc60e988772ed107b75981beceec053d861f977e1e3c5261c0ea51475410aeff50efd0a4e378b5e666cdd4b2bfd76ad0ae465142a28a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/hsb/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/hsb/thunderbird-45.8.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "760c99978bc2a326fa5e5d8f9b4a6fc9420a8a3c95251b42dc3db26bb399942a5fdd08f3eff3eaea9f3bc96ca85b0523abdae3f72b7400f8bed136e906a8e79f";
+      sha512 = "389b0fab729562e09c17d7ca251675ed4d333f4a79932b5ef2ffeda9d3e683adb95b7f4e4cb192fcf9416826a8aa470b7f8ae4211165b50d7a5a21fe39ba199a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/hu/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/hu/thunderbird-45.8.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "4118ae0a62d7c8c6e68f7468040361091f98197c8135ba88ba9165ff3c807ae3ec8ac7e587224e9f45cb49290abe7c85aa11518714440db0f797f426fb73b5d5";
+      sha512 = "2d0ec213b7cf3f875518841e0c08bc6b4134173606098cd0515e93206bf2419377041d44a2737c98b17a198998b80453763e695cabedc283ebbdfb42a60abd70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/hy-AM/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/hy-AM/thunderbird-45.8.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "664dade424cdca68158c98e531dc0b46ee5482f728b4f172684061da029c7dac76d80bcaa4c0228ff929a19e6bf11fd08890b3ed71fa6e23f442dba174de84da";
+      sha512 = "f77164c2fc3a083e13a11417f77454a885fd4ac77a0b7695c0d2bf8169b54afcd06c32e7c78cb6bbb4ac447a3d690a423344cdab59bc6fdfe83d82bac5d0be0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/id/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/id/thunderbird-45.8.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "58e48787ec26d8cfaa7be233055d95982d073ae8a1a01e4556d239e18598939ab6077f0aaa4b14051c6460730f89c1710a6dbb54ce5aaaa75967418f324073ab";
+      sha512 = "24c383b106de72a3741d7333aa4ec53c091d41ab3638c91f5f88f8d2952d25e77223e95a728611bdfd1cbe2d4418447e588069c286f90ffec0d12c7f245c07fd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/is/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/is/thunderbird-45.8.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "77e95822a92855c41ed557574ab3f0e464d8be21146139a1cbff243ae76b035ae0912e92c07513d4c5fc9d522a2da1a738dc7ab790f9327ecc6d94c0d577a124";
+      sha512 = "bae6f4fa377bb76ffd8d5257f525ce43f151f44f07eaeb5c4109a3440965c36a622c41d6577113bf111335d51d211e18b1c9decac6d9c1dea6303f90b7368f94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/it/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/it/thunderbird-45.8.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "835a2059b02ffd019fefa2988bc2f05f456e5fc8b05badc7f5477a6958ba8fac1bc3539cc66ce6eca73fe86b4c70a172b609fa365e83593ff97405e9bbb533cd";
+      sha512 = "6b6082972ea030e2564bffaf4e9349d33800b840c0b185bb646c53d0578a1b6360a3d85cdf1dbc534a648d34138f1c8cd26d1c0297c99795e93b93b145a100c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/ja/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/ja/thunderbird-45.8.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "11b6f0d2326bb89a6cf6d8452d2312eb8f7af616a0fcd43dd2b2263f52397c1c0a0a3ad7ceb67dd09b81a624adb95ed8a905bd7c9dba5f1d2a94114776257ff6";
+      sha512 = "66c8808d49986675e9049e77328cf7b1d2fad163b193b8442ca39be1b605bce0180e29b239141509cfec6302f053eaf2197513d5d482beb6c498f6a0ae8bbd9b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/ko/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/ko/thunderbird-45.8.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "69f804d87a17072803b6e081dedcea57d633036299eaee9599b7df83604dd599234236b5b5b647da25c066633ee481e196fe9b219bc3da29d07b6dd55fdbf4f1";
+      sha512 = "bdb8a9d6172b6f56d29b29043c484547c9a9dc7bd1477bd8ac4aaa4bf07c0ceffe2ae1560458acefefad66e4487d62746f60b6ec56d5d91603937b0c339d5625";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/lt/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/lt/thunderbird-45.8.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "4534bc70c43b108e59d7e7c15cb53e32f54c20e0ad21a5c0e1d309b3fec32db870ab8cb268d59b8964c526c28382cd89753ccc978e34d0aedd5c87eeeb525a5e";
+      sha512 = "dd70d123787ef85ee1c596346bf4c40a99907c2ece2116f7fb4536cb078d162f9afe0f92b466b713d6b75bf92960de32a3b3dedd861946da5b2e946187d4ebc5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/nb-NO/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/nb-NO/thunderbird-45.8.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "13d4f6b638d6005ec854cac82b16c02dc347d0cd1eb804a056c106fb1031c11982973abbfbd319f4925264a1095cce8bede670f68c2efc9bd4be49ceb6b2f2a3";
+      sha512 = "caf4d3d27db952fce1f34d5c641194d555c2443b86fbecdf68869cafeed0d532d7379212f4338401743e6e26531dd98111f75bddc5e2a3af42a3a7731ec3039b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/nl/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/nl/thunderbird-45.8.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "b6e49ff5a473dee02bb749481924fdbb345be2d532119dde93f80396a29da726b0450e2f2ee522454c8dcef74b09dfcb57474264873b873beeaa6edc81853fb2";
+      sha512 = "dd5071174889bdda282c496c4aa05158887fffc652d4c557320fab2c11e16b0cbb7e5121ef20b423d703dfbf9da52983ff288b9377ecedabfdba496f9c99eb6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/nn-NO/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/nn-NO/thunderbird-45.8.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "3992cb6ca869e9470bb30042ba3c8d1710511a2170504a5a65cafa4a9091492903509ddd366c29f5e9e7ada9ac657416972002a297a57550a418031a7ed6ee0f";
+      sha512 = "edd6a1384ed0060398cffb4598a7014aa13cfe83891a4cd4972db2ed6eaae5068703944a6e14b033409eaf6b6426838a0a3d708b9d83eb08907f39469fde4435";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/pa-IN/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/pa-IN/thunderbird-45.8.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "6aca05743fe7383490cd94281fe1d0c64451832e128b8b3da5d2643bf59f05cdcfe2130ba5218f7e314ac7c55b126ad62d4d24f987b215bfe767a17d6a8eeeed";
+      sha512 = "9e6227d28dc844621d1d9ac6c5536505dea0cc1d1b3d161bedf13b75a3255c5c681ce5b38bb510150f8db1add7f149119a8b5ce5b98c5f4dfe2427db6ad58581";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/pl/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/pl/thunderbird-45.8.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "0b8969b08e11792c547d666843799459e27d3732f4e56ab64d7624df4360e6cf65fc2cce538ffd0a287f239cf6c57ebe7aad68bd397c0f56a85dcc499f35e4a5";
+      sha512 = "8da6ec38d37df6202b751f112031e590777e587e23437cb7a4dcfeb958b27928e2f01cbd1682daa96c143df756b3c8f31f7516ca8cb30a884db2dc03f130f960";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/pt-BR/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/pt-BR/thunderbird-45.8.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "4a921106175214b7fd029e27e19f4442a50076d08c2bf6f6ad4b27c1c37730d2f90ac4bd058363395777d336e5170bdd48276f71b0d253375d32daac9af66412";
+      sha512 = "00a7ffd7509d538b9fe3e801d5c2ad069edd62665a7ce045381213b78226646b1cfe6356b5c873904277330b674608711e15f18dcf4664218b9c61048cf88e40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/pt-PT/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/pt-PT/thunderbird-45.8.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "f64a4396570349d2f520f8eeca157a012e028cba1e3cf592f5e11807997b4501a2af829dd4920ffac5fee8c50bd691d037aa86bbe9396305352ed4710e854e25";
+      sha512 = "f12f544c9eb3a33f861791af9afcc987b72607c2456d7f741046ef9ad36f12552d4e9cf2682ac3f8adc108dc9d36c9fc1b013714b50ae894f72cbe367914f14b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/rm/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/rm/thunderbird-45.8.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "540d6db390cbe93dbb607f84286e445da5234b01c55846f3d3a91cc61d30d1d32f0216fbfefc0ab0d7a60c5369a63aaab385c73362adf1a0595db57282dad01e";
+      sha512 = "9a8497f13a459d5dde822edeb9516d98beed220d75735a2f620c69b1f5e75e68987420aac6bb2a77775b6b34c2e0daa277c15d1491a6a02bb0f9658a40a16526";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/ro/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/ro/thunderbird-45.8.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "37cede489bb3082efa853f310dec5293baa411abcf15e9f193a760768cfc2b9f7be952bb6225bf901a0097bc19e77d9133c0e6dfed880c6e33cef250e80ff0f1";
+      sha512 = "2c9c650647079eb754e471757cae6b5844ae8e19bf01ce25d91a73832483507f90e604caf11305760cab719fe4f830cace5b9313b7e2a6f07a92427f35441c55";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/ru/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/ru/thunderbird-45.8.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "b091376e3937712f5f92ac789dbe39b90e1b486b4409325341dadb06d4a4a3ff4fa9438d8da2fb5b7923beab4ec6b568d6be309cd22a68c277c822614205734d";
+      sha512 = "4cbbe88691fd265b4d98aab61c5763f6baea168ea4cae222425973023174f765e7fa6b97fdef959ac0788a632f742715eb7e565113344147d43c228ece7f08ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/si/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/si/thunderbird-45.8.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "bb53ecebf56785d7ede52b7a0afed0a01e6248d537ccd8bcd236a837fed86b3f390cf9493f1c2d6d6d58c0d349cd6cfef2a59996fd7766ee77f25dc1af75faca";
+      sha512 = "a270a871187dc95d05cb79d9f4df7947aa58b875c2b0c588c2646f806e7e0eaeb1a62f69d38e78d40399f1c588f043b26d06c0d77cedc9949d8e3d8b026ad4a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/sk/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/sk/thunderbird-45.8.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "c13c32cf17b0291bf049c2790fce2066e8b07aa2f30fb7bbecaf8cb88b4660bbf07506cb04e5aa8b756a35371d25c5a793b54d0134a81027946d35109e7714a9";
+      sha512 = "8cfd22b92789766c179dbb70739fcf68907c4b215e70d164c83e50f67f2c834f515176e30788ba1fcd58717fdf5642c9e1ef05640a06470146ee942737744c83";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/sl/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/sl/thunderbird-45.8.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "be0d2a0e501f074329b815f61c1ce04337499c7a88f58e3526e762b47c82ccd975c22063a363a338e22bfc12ad3403107751f66376b1d269101b660e391e7437";
+      sha512 = "fbf54d81b006625f526ab496e9ec7acf9698f7c95415d61aa4bd91896db07bce9d13c835ec944f164678fca9f49be16b69d6e8b728914ec84a5a8d733d3941b4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/sq/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/sq/thunderbird-45.8.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "1aadc162591de3467af622c3e1fc7655885d7831d2faa470a5f53b2fb12a42dfbd44f3a942dc4089a28235942ba0e46749810a88adbb396e1417f7ed0fc07586";
+      sha512 = "f8dee08b3a4e049392f7c407e9403b972c755493fe638e7917181b8281a86d70f2d1113e69b785be756774bb9aef4cb493084bc8d0d12bda0f928f4cd468f569";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/sr/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/sr/thunderbird-45.8.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "aab1299fb2e2b022bfaaa6403461bd2f5ed70d5fea77ea29936fea465984cc57bfa1ed5be1e8968138e757118d1caa3eb664388fddb04d0008abe932035c818e";
+      sha512 = "8c8fba2fc92d91f086679b6ba451eed1af4fef5c56747260f9907300f057aab354d7f8ebc411fa25821bc006a551f26e0ddf29b344846a30dc493cfef30c7375";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/sv-SE/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/sv-SE/thunderbird-45.8.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "11ce9c1b444adb242e826d4e1e8ab88e2272ac6b77f68f9d2a860c75e421c7b69f1841d0a4fef0b9b4d3a636678f0d57d5abb985f5fda6b5afd6cfb319f39b14";
+      sha512 = "caf3911023d48fc48f4834be424c01cb22bd7383582c8bfc15468401a1558351659e93955103625872b5ea3351570bf216b34e93bff9bf535eccd1789f493bca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/ta-LK/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/ta-LK/thunderbird-45.8.0.tar.bz2";
       locale = "ta-LK";
       arch = "linux-i686";
-      sha512 = "e46dff7831a6805917d2982347e4899aea9c726bcbf1e0b081c8ead225d585df1d0e9c485729d28483fd7ea8e0e5a47598fa9146f0138ed8ed65162c8191a381";
+      sha512 = "99a0db9f4e7d9f05e8398f76f0dcce418d0230b8a325a1289b690a87a43febd0c17f52248bb6070ad7bd2dc60d6e877a78f1c4a23c8888b105160f131b31ec1c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/tr/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/tr/thunderbird-45.8.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "158e4d49beae2af88c9aeddf5933e58a73541d0acc960d3965159662dd18ec876fd9a598b7bdba31261f8eeccf1595eb5e66ace3656658b3557c1482b7a4263f";
+      sha512 = "79379c3dc58d330949aa5a0338fb38e6334ca47c964842bf090a9431e5b7267f871aaa519dd35262ed9d6e042188e998e95eb7a63c77b3592db09a81bdd95267";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/uk/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/uk/thunderbird-45.8.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "0d298daa6b416b60b696d57ae7508f56749f1fdc7f8d4ca3514fc106b91567fcc3bf41881cce398d431c0aa0b6bb9d5913d25abcded8e68628fe54fae3cbec25";
+      sha512 = "a2f0efb561fd84e5881bb93145f86f9445eb6cb3ce5ce0e209fc896c797e9a554d180ed1009f369bc12790b8d03d09d429dd3d52fda4ce48d7642009c1a9920a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/vi/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/vi/thunderbird-45.8.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "f3e21ff0bf5b0b57bf6a3d1564ec0194c4c4b8987e0db89c84662e091131601526cd1b109e113fa8738d6b16d61220df1ef6c09acfd46c154de7e86dd9aa744b";
+      sha512 = "14a7352ac3254aa0a748e98e208f48ee0b764853b37889077f651ed1d1a401d98c35dd6cd09bb5b25a7f8c5d5c3a7b02319ddf4dcdaa7a5440aa5caae9f09a32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/zh-CN/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/zh-CN/thunderbird-45.8.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "ad624ccf882b3703de853d67b9fb2d53fa4a69a20353638dc108750b35b486f2333307e7fb947e39a76f32cc204459347fe9c52e5c6c60c8b9210d9f7ca68632";
+      sha512 = "5b991ccc4daafe744f1fffdc51882bdc72d5fadd1e570e0ff3670f7d7201a67151797a26f0222fe8cfa0ddefff45f0741da6c04d924367705347858cc028a945";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.7.1/linux-i686/zh-TW/thunderbird-45.7.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/45.8.0/linux-i686/zh-TW/thunderbird-45.8.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "877e9fbfd4421fecb01d94142ae753c7b90b7a1430a01dfdfbf916e4505a1b647fc3f75d896558437e7d5c4ae3a0aefe0892881f4bec7ce9ab672d7b44c337b3";
+      sha512 = "231abcab55934962d3b8dec164ddf48b8b7bfc0e8cd70251479351d8be5d2605e2bb823bbf6c3002bba6c431461b0bfd570f101f31b5adf7c70804610262b856";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -14,7 +14,7 @@
   enableOfficialBranding ? false
 }:
 
-let version = "45.7.1"; in
+let version = "45.8.0"; in
 let verName = "${version}"; in
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${verName}/source/thunderbird-${verName}.source.tar.xz";
-    sha512 = "aa1231169cfe243a257e6b9088281b85d0cf75207e3b9ebeda7792567a86f6098fb5c74dc397e3eeeb1925d221d2fb1b17df8762afd115eff9ad4d1370a49e56";
+    sha512 = "f8ba08d874fb1a09ac9ba5d4d1f46cefe801783ba4bf82eee682ac2ecc4e231d07033a80e036ad04bda7780c093fb7bc3122a23dc6e19c12f18fb7168dc78deb";
   };
 
   patches = [ ./gcc6.patch ];


### PR DESCRIPTION
###### Motivation for this change

- Critical security fixes

https://www.mozilla.org/en-US/thunderbird/45.8.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2017-07/

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
