### PR TITLE
Support boot from USB disks with "uas" Linux module

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -280,7 +280,7 @@ in
         options = [ "allow_other" "cow" "nonempty" "chroot=/mnt-root" "max_files=32768" "hide_meta_files" "dirs=/nix/.rw-store=rw:/nix/.ro-store=ro" ];
       };
 
-    boot.initrd.availableKernelModules = [ "squashfs" "iso9660" "usb-storage" ];
+    boot.initrd.availableKernelModules = [ "squashfs" "iso9660" "usb-storage" "uas" ];
 
     boot.blacklistedKernelModules = [ "nouveau" ];
 


### PR DESCRIPTION
###### Motivation for this change

This allows booting from disks attached over USB 3, such as SATA/mSATA USB docks/enclosures.

###### Things done

Tested boot from iso_minimal on a USB disk that did not boot before.
