### PR TITLE
ostinato: fix build

### DIFF
--- a/pkgs/applications/networking/ostinato/default.nix
+++ b/pkgs/applications/networking/ostinato/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchgit, fetchurl, writeText
-, qt4, qmake4Hook, protobuf, libpcap
-, wireshark, gzip, diffutils, gawk
+{ stdenv, fetchFromGitHub, fetchurl, qmake4Hook, makeDesktopItem
+, qt4, protobuf, libpcap, wireshark, gzip, diffutils, gawk
 }:
 
 stdenv.mkDerivation rec {
-  name = "ostinato-2015-12-24";
-  src = fetchgit {
-    url = "https://github.com/pstavirs/ostinato.git";
-    rev = "414d89860de0987843295d149bcabeac7c6fd9e5";
-    sha256 = "1yif8z8ih027jdsgnxd82z9914wrqpkpi4xgxqv9lygnb2jjjrdx";
+  name    = "ostinato-${version}";
+  version = "0.8";
+
+  src = fetchFromGitHub  {
+    owner  = "pstavirs";
+    repo   = "ostinato";
+    rev    = "v${version}";
+    sha256 = "1b5a5gypcy9i03mj6md3lkrq05rqmdyhfykrr1z0sv8n3q48xca3";
   };
 
-  ostinato_png = fetchurl {
+  ostinatoIcon = fetchurl {
     url = "http://ostinato.org/images/site-logo.png";
     sha256 = "f5c067823f2934e4d358d76f65a343efd69ad783a7aeabd7ab4ce3cd03490d70";
   };
@@ -22,7 +24,27 @@ stdenv.mkDerivation rec {
 
   patches = [ ./drone_ini.patch ];
 
+  desktopItem = makeDesktopItem {
+    type          = "application";
+    name          = "ostinato";
+    desktopName   = "Ostinato";
+    genericName   = "Packet/Traffic Generator and Analyzer";
+    comment       = "Network packet and traffic generator and analyzer with a friendly GUI";
+    categories    = "Network";
+    terminal      = "false";
+    startupNotify = "true";
+    exec          = "$out/bin/ostinato";
+    icon          =  ostinatoIcon;
+    extraEntries  = ''
+      GenericName[it]=Generatore ed Analizzatore di pacchetti di rete
+      Comment[it]=Generatore ed Analizzatore di pacchetti di rete con interfaccia amichevole
+    '';
+  };
+
   postInstall = ''
+    mkdir -p $out/share/applications
+    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+
     cat > $out/bin/ostinato.ini <<EOF
     WiresharkPath=${wireshark}/bin/wireshark
     TsharkPath=${wireshark}/bin/tshark
@@ -30,34 +52,13 @@ stdenv.mkDerivation rec {
     DiffPath=${diffutils}/bin/diff
     AwkPath=${gawk}/bin/awk
     EOF
-
-    mkdir -p $out/share/pixmaps
-    cp ${ostinato_png} $out/share/pixmaps/ostinato.png
-
-    # Create a desktop item.
-    mkdir -p $out/share/applications
-    cat > $out/share/applications/ostinato.desktop <<EOF
-    [Desktop Entry]
-    Type=Application
-    Encoding=UTF-8
-    Name=Ostinato
-    GenericName=Packet/Traffic Generator and Analyzer
-    GenericName[it]=Generatore ed Analizzatore di pacchetti di rete
-    Comment=Network packet and traffic generator and analyzer with a friendly GUI
-    Comment[it]=Generatore ed Analizzatore di pacchetti di rete con interfaccia amichevole
-    Icon=$out/share/pixmaps/ostinato.png
-    Exec=$out/bin/ostinato
-    Terminal=false
-    Categories=Network;
-    StartupNotify=true
-    EOF
   '';
 
   meta = with stdenv.lib; {
     description = "A packet traffic generator and analyzer";
-    homepage = http://ostinato.org;
-    license = licenses.gpl3;
+    homepage    = http://ostinato.org;
+    license     = licenses.gpl3;
     maintainers = with maintainers; [ rick68 ];
-    platforms = platforms.linux;  # also OS X and cygwin
+    platforms   = with platforms; linux ++ darwin ++ cygwin;
   };
 }

--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, flex, bison }:
+{ stdenv, fetchurl, fetchpatch, flex, bison }:
 
 stdenv.mkDerivation rec {
   name = "libpcap-1.8.1";
@@ -20,6 +20,13 @@ stdenv.mkDerivation rec {
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace " -arch i386" ""
   '';
+
+  patches = [
+    (fetchpatch {
+      url    = "https://sources.debian.net/data/main/libp/libpcap/1.8.1-3/debian/patches/disable-remote.diff";
+      sha256 = "0dvjax9c0spvq8cdjnkbnm65wlzaml259yragf95kzg611vszfmj";
+    })
+  ];
 
   preInstall = ''mkdir -p $out/bin'';
 


### PR DESCRIPTION
###### Motivation for this change
With libpcap 1.8.1 programs that define `HAVE_REMOTE` macro fail to build. See debian bug [report](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=843384). These include package ostinato (and probably others) which is needed for release 17.03 (issue #23253).

I added the debian patch to libcap and update ostinato.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using (still running)
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

