### PR TITLE
exim: 4.88 -> 4.89

### DIFF
--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -1,11 +1,11 @@
 { coreutils, fetchurl, db, openssl, pcre, perl, pkgconfig, stdenv }:
 
 stdenv.mkDerivation rec {
-  name = "exim-4.88";
+  name = "exim-4.89";
 
   src = fetchurl {
-    url = "http://ftp.exim.org/pub/exim/exim4/${name}.tar.bz2";
-    sha256 = "0bca3wb45hl7h8m8bpvsmrmqa07jhbhqyigs9pl29hhzwgbmz78i";
+    url = "http://ftp.exim.org/pub/exim/exim4/${name}.tar.xz";
+    sha256 = "09lndv34jsxwglq5zsh9y4xaqj5g37g9ca4x0zb25fvvm4f0lj8c";
   };
 
   buildInputs = [ coreutils db openssl pcre perl pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

