### PR TITLE
gajim: 0.16.6 -> 0.16.7

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -25,30 +25,22 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "gajim-${version}";
-  version = "0.16.6";
+  version = "0.16.7";
 
   src = fetchurl {
     name = "${name}.tar.bz2";
     url = "https://dev.gajim.org/gajim/gajim/repository/archive.tar.bz2?"
         + "ref=${name}";
-    sha256 = "1s0h4xll9490vh7ygmi4zsd1fa107f3s9ykhpq0snb04fllwhjq7";
+    sha256 = "18srrsswq09i54gcqqy0ylmrix1rrq43f0b8sz1lijr39h3ayw3j";
   };
 
   patches = let
     # An attribute set of revisions to apply from the upstream repository.
     cherries = {
-      misc-test-fixes = {
-        rev = "1f0d7387fd020df5dfc9a6349005ec7dedb7c008";
-        sha256 = "0nazpzyg50kl0k8z4dkn033933iz60g1i6nzhib1nmzhwwbnacc5";
-      };
-      jingle-fix = {
-        rev = "491d32a2ec13ed3a482e151e0b403eda7b4151b8";
-        sha256 = "1pfg1ysr0p6rcwmd8ikjs38av3c4gcxn8pxr6cnnj27n85gvi30g";
-      };
-      fix-connection-mock = {
-        rev = "46a19733d208fbd2404cbaeedd8c203d0b6557a4";
-        sha256 = "0l3s577pksnz16r4mqa1zmz4y165amsx2mclrm4vzlszy35rmy2b";
-      };
+      #example-fix = {
+      #  rev = "<replace-with-git-revsion>";
+      #  sha256 = "<replace-with-sha256>";
+      #};
     };
   in mapAttrsToList (name: { rev, sha256 }: fetchurl {
     name = "gajim-${name}.patch";


### PR DESCRIPTION
###### Motivation for this change

Made our patches obsolete.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

