### PR TITLE
Nginx alias directive

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -158,7 +158,6 @@ let
           server_name ${serverName} ${concatStringsSep " " vhost.serverAliases};
           ${acmeLocation}
           ${optionalString (vhost.root != null) "root ${vhost.root};"}
-          ${optionalString (vhost.alias != null) "alias ${vhost.alias};"}
           ${optionalString (vhost.globalRedirect != null) ''
             return 301 http${optionalString ssl "s"}://${vhost.globalRedirect}$request_uri;
           ''}
@@ -380,10 +379,8 @@ in
   config = mkIf cfg.enable {
     # TODO: test user supplied config file pases syntax test
 
-    assertions = let hostOrAliasIsNull = l: l.root == null || l.alias == null; in [ {
-        assertion = all hostOrAliasIsNull (attrValues virtualHosts);
-        message = "Only one of nginx root or alias can be specified on a virtualHost.";
-      } {
+    assertions = let hostOrAliasIsNull = l: l.root == null || l.alias == null; in [
+      {
         assertion = all (host: all hostOrAliasIsNull (attrValues host.locations)) (attrValues virtualHosts);
         message = "Only one of nginx root or alias can be specified on a location.";
       }

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -380,6 +380,15 @@ in
   config = mkIf cfg.enable {
     # TODO: test user supplied config file pases syntax test
 
+    assertions = let hostOrAliasIsNull = l: l.root == null || l.alias == null; in [ {
+        assertion = all hostOrAliasIsNull (attrValues virtualHosts);
+        message = "Only one of nginx root or alias can be specified on a virtualHost.";
+      } {
+        assertion = all (host: all hostOrAliasIsNull (attrValues host.locations)) (attrValues virtualHosts);
+        message = "Only one of nginx root or alias can be specified on a location.";
+      }
+    ];
+
     systemd.services.nginx = {
       description = "Nginx Web Server";
       after = [ "network.target" ];

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -158,6 +158,7 @@ let
           server_name ${serverName} ${concatStringsSep " " vhost.serverAliases};
           ${acmeLocation}
           ${optionalString (vhost.root != null) "root ${vhost.root};"}
+          ${optionalString (vhost.alias != null) "alias ${vhost.alias};"}
           ${optionalString (vhost.globalRedirect != null) ''
             return 301 http${optionalString ssl "s"}://${vhost.globalRedirect}$request_uri;
           ''}
@@ -180,6 +181,7 @@ let
       ${optionalString (config.index != null) "index ${config.index};"}
       ${optionalString (config.tryFiles != null) "try_files ${config.tryFiles};"}
       ${optionalString (config.root != null) "root ${config.root};"}
+      ${optionalString (config.alias != null) "alias ${config.alias};"}
       ${config.extraConfig}
     }
   '') locations);

--- a/nixos/modules/services/web-servers/nginx/location-options.nix
+++ b/nixos/modules/services/web-servers/nginx/location-options.nix
@@ -45,6 +45,15 @@ with lib;
       '';
     };
 
+    alias = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/your/alias/directory";
+      description = ''
+        Alias directory for requests.
+      '';
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -89,6 +89,15 @@ with lib;
       '';
     };
 
+    alias = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/data/webserver/docs";
+      description = ''
+        The path of the web alias directory.
+      '';
+    };
+
     default = mkOption {
       type = types.bool;
       default = false;

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -89,15 +89,6 @@ with lib;
       '';
     };
 
-    alias = mkOption {
-      type = types.nullOr types.path;
-      default = null;
-      example = "/data/webserver/docs";
-      description = ''
-        The path of the web alias directory.
-      '';
-    };
-
     default = mkOption {
       type = types.bool;
       default = false;


### PR DESCRIPTION
###### Motivation for this change

While it's easy enough to add extraConfig = "alias = ${alias};", why not make it even easier?

For example, I'm using this to serve a robots.txt straight from pkgs.writeText; that's a really neat trick.  With the "root" directive, this doesn't work because nginx will look for ${robots.txt}/robots.txt; with alias, it serves the file path with no modification.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

