### PR TITLE
clips: init at 6.30

### DIFF
--- a/pkgs/development/interpreters/clips/default.nix
+++ b/pkgs/development/interpreters/clips/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "6.30";
+  name = "clips-${version}";
+  src = fetchurl {
+    url = "mirror://sourceforge/clipsrules/CLIPS/6.30/clips_core_source_630.tar.Z";
+    sha256 = "1r0m59l3mk9cwzq3nmyr5qxrlkzp3njls4hfv8ml85dmqh7n3ysy";
+  };
+  buildPhase = ''
+    make -C core -f ../makefiles/makefile.gcc
+  '';
+  installPhase = ''
+    install -D -t $out/bin core/clips
+  '';
+  meta = with stdenv.lib; {
+    description = "A Tool for Building Expert Systems";
+    homepage = "http://www.clipsrules.net/";
+    longDescription = ''
+      Developed at NASA's Johnson Space Center from 1985 to 1996,
+      CLIPS is a rule-based programming language useful for creating
+      expert systems and other programs where a heuristic solution is
+      easier to implement and maintain than an algorithmic solution.
+    '';
+    license = licenses.publicDomain;
+    maintainers = [maintainers.league];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5634,6 +5634,8 @@ with pkgs;
 
   ceptre = callPackage ../development/interpreters/ceptre { };
 
+  clips = callPackage ../development/interpreters/clips { };
+
   clisp = callPackage ../development/interpreters/clisp { };
   clisp-tip = callPackage ../development/interpreters/clisp/hg.nix { };
 


### PR DESCRIPTION

###### Motivation for this change

CLIPS is a language for building expert systems.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

