### PR TITLE
JBoss AS: list known vulnerability

### DIFF
--- a/nixos/modules/services/web-servers/jboss/default.nix
+++ b/nixos/modules/services/web-servers/jboss/default.nix
@@ -25,7 +25,7 @@ in
 
       enable = mkOption {
         default = false;
-        description = "Whether to enable jboss";
+        description = "Whether to enable JBoss. WARNING : this package is outdated and is known to have vulnerabilities.";
       };
 
       tempDir = mkOption {

--- a/pkgs/servers/http/jboss/default.nix
+++ b/pkgs/servers/http/jboss/default.nix
@@ -22,5 +22,8 @@ stdenv.mkDerivation {
     license = licenses.lgpl21;
     maintainers = [ maintainers.sander ];
     platforms = platforms.unix;
+    knownVulnerabilities = [
+      "CVE-2015-7501: remote code execution in apache-commons-collections: InvokerTransformer during deserialisation"
+    ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
CVE-2015-7501
and add a warning in JBoss module

This is following issue #23637
There won't be a fix or an update because we already have the latest JBoss 7.x and the project was then entirely renamed to [WildFly](http://wildfly.org/).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

