### PR TITLE
c3d: init at 1.1.0

### DIFF
--- a/pkgs/applications/graphics/c3d/default.nix
+++ b/pkgs/applications/graphics/c3d/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchgit, cmake, itk }:
+
+stdenv.mkDerivation rec {
+  _name   = "c3d";
+  _version = "1.1.0";
+  name     = "${_name}-${_version}";
+
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/c3d/git";
+    rev = "3453f6133f0df831dcbb0d0cfbd8b26e121eb153";
+    sha256 = "1xgbk20w22jwvf7pa0n4lcbyx35fq56zzlslj0nvcclh6vx0b4z8";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ itk ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.itksnap.org/c3d;
+    description = "Medical imaging processing tool";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms = platforms.unix;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -697,6 +697,8 @@ with pkgs;
 
   burpsuite = callPackage ../tools/networking/burpsuite {};
 
+  c3d = callPackage ../applications/graphics/c3d {};
+
   cabal2nix = haskell.lib.overrideCabal haskellPackages.cabal2nix (drv: {
     isLibrary = false;
     enableSharedExecutables = false;


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

