### PR TITLE
Update dd agent

### DIFF
--- a/pkgs/tools/networking/dd-agent/default.nix
+++ b/pkgs/tools/networking/dd-agent/default.nix
@@ -1,7 +1,31 @@
-{ stdenv, fetchFromGitHub, python, pythonPackages, sysstat, unzip, tornado
-, makeWrapper }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, python, pythonPackages
+, sysstat, unzip, tornado, makeWrapper }:
+let
+  docker_1_10 = buildPythonPackage rec {
+    name = "docker-${version}";
+    version = "1.10.6";
 
-stdenv.mkDerivation rec {
+    src = fetchFromGitHub {
+      owner = "docker";
+      repo = "docker-py";
+      rev = version;
+      sha256 = "1awzpbrkh4fympqzddz5i3ml81b7f0i0nwkvbpmyxjjfqx6l0m4m";
+    };
+
+    propagatedBuildInputs = with pythonPackages; [
+      six
+      requests2
+      websocket_client
+      ipaddress
+      backports_ssl_match_hostname
+      docker_pycreds
+    ];
+
+    # due to flake8
+    doCheck = false;
+  };
+
+in stdenv.mkDerivation rec {
   version = "5.5.2";
   name = "dd-agent-${version}";
 
@@ -23,7 +47,9 @@ stdenv.mkDerivation rec {
     pythonPackages.simplejson
     pythonPackages.pyyaml
     pythonPackages.pymongo
-    pythonPackages.docker
+    pythonPackages.python-etcd
+    pythonPackages.consul
+    docker_1_10
   ];
   propagatedBuildInputs = [ python tornado ];
 

--- a/pkgs/tools/networking/dd-agent/default.nix
+++ b/pkgs/tools/networking/dd-agent/default.nix
@@ -26,14 +26,14 @@ let
   };
 
 in stdenv.mkDerivation rec {
-  version = "5.5.2";
+  version = "5.11.2";
   name = "dd-agent-${version}";
 
   src = fetchFromGitHub {
     owner  = "datadog";
     repo   = "dd-agent";
     rev    = version;
-    sha256 = "0ga7h3rdg6q2pi4dxxkird5nf6s6hc13mj1xd9awwpli48gyvxn7";
+    sha256 = "1iqxvgpsqibqw3vk79158l2pnb6y4pjhjp2d6724lm5rpz4825lx";
   };
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12810,7 +12810,7 @@ with pkgs;
 
   dbvisualizer = callPackage ../applications/misc/dbvisualizer {};
 
-  dd-agent = callPackage ../tools/networking/dd-agent { inherit (pythonPackages) tornado; };
+  dd-agent = callPackage ../tools/networking/dd-agent { inherit (pythonPackages) tornado buildPythonPackage; };
 
   deadbeef = callPackage ../applications/audio/deadbeef {
     pulseSupport = config.pulseaudio or true;


### PR DESCRIPTION
###### Motivation for this change

`dd-agent` is currently broken on master and 17.03. This happened when this PR was merged, this broke `dd-agent`'s dependency on `docker` python package in NixOS (it depends on 1.10.x, and 2.x changes symbols around): https://github.com/NixOS/nixpkgs/pull/22201/files

I also added missing python package dependencies in `dd-agent` for `python-etcd` and `consul`.

As a separate commit I also updated the `dd-agent` package sources from 5.5.2 -> 5.11.2 and create appropriate git logs as per contributing guide for each.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Output from `nox-review`:

```bash
<redacted>
Result in /run/user/1000/nox-review-0i73b82r
total 0
lrwxrwxrwx 1 spotter users 67 Mar  9 20:42 result -> /nix/store/1374i67agihx6n5c1374awvsr08l77rf-python2.7-docker-1.10.6
lrwxrwxrwx 1 spotter users 59 Mar  9 20:42 result-2 -> /nix/store/m2kbqm0l4xqy3bzvngacvraaj6l6978g-dd-agent-5.11.2
lrwxrwxrwx 1 spotter users 67 Mar  9 20:42 result-3 -> /nix/store/wpmiy1wckhmj12zg0m8idg01z5pkpwkf-python3.5-docker-1.10.6
```