### PR TITLE
brscan4: 0.4.3-4 -> 0.4.4-2

### DIFF
--- a/pkgs/applications/graphics/sane/backends/brscan4/default.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan4/default.nix
@@ -10,11 +10,19 @@ let
   udevRules = callPackage ./udev_rules_type1.nix {};
 
 in stdenv.mkDerivation rec {
-  name = "brscan4-0.4.3-3";
-  src = fetchurl {
-    url = "http://download.brother.com/welcome/dlf006645/${name}.amd64.deb";
-    sha256 = "1nccyjl0b195pn6ya4q0zijb075q8r31v9z9a0hfzipfyvcj57n2";
-  };
+  name = "brscan4-0.4.4-2";
+  src = 
+    if stdenv.system == "i686-linux" then
+      fetchurl {
+        url = "http://download.brother.com/welcome/dlf006646/${name}.i386.deb";
+        sha256 = "1rd6qmg49lvack8rg9kkqs3vxfvvqf2x45h93pkrhk8a4aj5c8ll";
+      }
+    else if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "http://download.brother.com/welcome/dlf006645/${name}.amd64.deb";
+        sha256 = "1r3cq1k2a2bghibkckmk00x7y59ic31gv7jcsw7380szf1j3la59";
+      }
+    else throw "${name} is not supported on ${stdenv.system} (only i686-linux and x86_64 linux are supported)";
 
   unpackPhase = ''
     ar x $src
@@ -36,12 +44,12 @@ in stdenv.mkDerivation rec {
     done
   '';
 
-  installPhase = ''
+  installPhase = with stdenv.lib; ''
     PATH_TO_BRSCAN4="opt/brother/scanner/brscan4"
     mkdir -p $out/$PATH_TO_BRSCAN4
     cp -rp $PATH_TO_BRSCAN4/* $out/$PATH_TO_BRSCAN4
     mkdir -p $out/lib/sane
-    cp -rp usr/lib64/sane/* $out/lib/sane
+    cp -rp usr/lib${optionalString stdenv.is64bit "64"}/sane/* $out/lib/sane
 
     # Symbolic links were absolute. Fix them so that they point to $out.
     pushd "$out/lib/sane" > /dev/null


### PR DESCRIPTION
Also add missing linux32 support.

###### Motivation for this change

Update to latest (link to previous version broken on x86_64) and add linux32 support.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

