### PR TITLE
init hostsblock (and kwakd)

### DIFF
--- a/pkgs/servers/kwakd/default.nix
+++ b/pkgs/servers/kwakd/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchFromGitHub, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "kwakd-${version}";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "fetchinson";
+    repo = "kwakd";
+    rev = "acdf0e1491204ae30622a60fde0bcae4769f78be";
+    sha256 = "1inf9ngrbxmkkdhqf1xday12nf0hxjxlx1810phkmivyyp6fl3nj";
+  };
+
+  postInstall = ''
+    serviceDir=$out/share/dbus-1/system-services
+    mkdir -p $serviceDir
+    cp kwakd.service $serviceDir/
+    substituteInPlace $serviceDir/kwakd.service \
+      --replace "kwakd -p 80" "$out/bin/kwakd -p 80"
+  '';
+
+  meta = with lib; {
+    description = "A super small webserver that serves blank pages";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.nicknovitski ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/hostsblock/default.nix
+++ b/pkgs/tools/misc/hostsblock/default.nix
@@ -1,0 +1,73 @@
+{ lib, coreutils, curl, fetchFromGitHub, unzip, p7zip, gnused, gnugrep, stdenv
+, blacklist ? [ "adwords.google.com" ]
+, whitelist ? [
+  ".dropbox.com"
+  " www.malwaredomainlists.com"
+  " www.arcamax.com"
+  " www.instructables.com"
+  " goo.gl"
+  " www.reddit.com"
+  " t.co"
+  " bit.ly"
+  " www.viddler.com"
+  " viddler.com"
+  " tinyurl.com"
+  " ompldr.org"
+  " www.ompldr.org"
+  "login.yahoo.com"
+  " l.yimg.com"
+  ".bp.blogspot.com"
+] }:
+
+stdenv.mkDerivation rec {
+  name = "hostsblock-${version}";
+  version = "20161213";
+
+  src = fetchFromGitHub {
+    owner = "gaenserich";
+    repo = "hostsblock";
+    rev = "91cacbdfbfb5e7ae9ba3babf8de41e135270c310";
+    sha256 = "1w91fbgf8v2nn0a6m8l6kd455km2j1lvpvqil4yxhrg018aigax0";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -Dm744 src/hostsblock.sh $out/bin/hostsblock
+    install -Dm744 src/hostsblock-urlcheck.sh $out/bin/hostsblock-urlcheck
+
+    mkdir -p $out/lib
+    install -Dm644 src/hostsblock-common.sh $out/lib/
+
+    mkdir -p $out/etc
+    install -Dm644 conf/hostsblock.conf $out/etc/
+    ${lib.concatMapStrings (d: "echo ${d} >> $out/etc/black.list\n") blacklist}
+    ${lib.concatMapStrings (d: "echo ${d} >> $out/etc/white.list\n") whitelist}
+    install -Dm644 conf/hosts.head $out/etc/
+
+    for f in $out/bin/* $out/lib/* $out/etc/hostsblock.conf; do
+      substituteInPlace $f --replace "/dev/shm" "/tmp"
+      substituteInPlace $f --replace "/usr/lib/" "$out/lib/"
+      substituteInPlace $f --replace "/etc/hostsblock/" "$out/etc/"
+      sed --in-place --regexp-extended "s|([\` ])curl |\1${curl}/bin/curl |g" $f
+      substituteInPlace $f --replace grep ${gnugrep}/bin/grep
+      substituteInPlace $f --replace " sed " " ${gnused}/bin/sed "
+      sed --in-place --regexp-extended "s|([^_])unzip |\1${unzip}/bin/unzip |" $f
+      sed --in-place --regexp-extended "s|7za([^,])|${p7zip}/bin/7za\1|g" $f
+    done
+
+    echo "postprocess(){ ${coreutils}/bin/true; }" >> $out/etc/hostsblock.conf
+
+    mkdir -p $out/share/dbus-1/system-services
+    install -Dm644 systemd/hostsblock.service $out/share/dbus-1/system-services
+    install -Dm644 systemd/hostsblock.timer $out/share/dbus-1/system-services
+  '';
+
+  meta = with lib; {
+    description = "An ad- and malware-blocking script for Linux";
+    website = http://gaenserich.github.io/hostsblock/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.nicknovitski ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -942,6 +942,8 @@ with pkgs;
 
   hexio = callPackage ../development/tools/hexio { };
 
+  hostsblock = callPackage ../tools/misc/hostsblock { };
+
   hr = callPackage ../applications/misc/hr { };
 
   interlock = callPackage ../servers/interlock {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -533,6 +533,8 @@ with pkgs;
 
   oracle-instantclient = callPackage ../development/libraries/oracle-instantclient { };
 
+  kwakd = callPackage ../servers/kwakd { };
+
   kwm = callPackage ../os-specific/darwin/kwm { };
 
   khd = callPackage ../os-specific/darwin/khd {


### PR DESCRIPTION
kwakd is very straightforward.

hostsblock is a pair of fancy bash scripts which overwrite `/etc/hosts` to block requests to ad networks, malware hosts, and whichever other sites you choose.  `bin/hostsblock` downloads and combines various online black-lists with your own black- and white-lists (which I exposed as package arguments), and `bin/hostsblock-urlcheck` just adds a domain you specify. 

The block in the install scripts with the varied calls to `sed` and `substituteInPlace` are patching dependency paths in the scripts without breaking them.  For instance, replacing `curl` but not `"$_v_curl"`.