### PR TITLE
angband: Fix build by enabling stats frontend.

### DIFF
--- a/pkgs/games/angband/default.nix
+++ b/pkgs/games/angband/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ ncurses5 ];
+  configureFlags = [ "--enable-stats" ];
   installFlags = "bindir=$(out)/bin";
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Angband currently fails to build from source, since the C source generated in the absence of any frontend modules fails -pedantic (which is forced by its ./configure).
I work around this by enabling the stats frontend, which has the side effect of providing slightly more features. This change does not introduce any additional dependencies.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

