### PR TITLE
scudcloud: 1.40 -> 1.44

### DIFF
--- a/pkgs/applications/networking/instant-messengers/scudcloud/default.nix
+++ b/pkgs/applications/networking/instant-messengers/scudcloud/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchgit, python3Packages }:
 
 python3Packages.buildPythonPackage {
-  name = "scudcloud-1.40";
+  name = "scudcloud-1.44";
 
   # Branch 254-port-to-qt5
-  # https://github.com/raelgc/scudcloud/commit/43ddc87f123a641b1fa78ace0bab159b05d34b65
+  # https://github.com/raelgc/scudcloud/commit/65c304416dfdd5f456fa6f7301432a953d5e12d0
   src = fetchgit {
       url = https://github.com/raelgc/scudcloud/;
-      rev = "43ddc87f123a641b1fa78ace0bab159b05d34b65";
-      sha256 = "1lh9naf9xfrmj1pj7p8bd3fz7vy3gap6cvda4silk4b6ylyqa8vj";
+      rev = "65c304416dfdd5f456fa6f7301432a953d5e12d0";
+      sha256 = "0h1055y88kldqw31ayqfx9zsksgxsyqd8h0hwnhj80yn3jcx0rp6";
   };
 
   propagatedBuildInputs = with python3Packages; [ pyqt5 dbus-python ];


### PR DESCRIPTION
###### Motivation for this change

AFAIU qt5 version was updated so older scudcloud was no longer working. This fixes the problem.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @jagajaga 

