### PR TITLE
pythonPackages.django-raster: 0.3 -> 0.3.1

### DIFF
--- a/pkgs/development/python-modules/django-raster/default.nix
+++ b/pkgs/development/python-modules/django-raster/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchurl,
+  numpy, django_colorful, pillow, psycopg2,
+  pyparsing, django, celery
+}:
+buildPythonPackage rec {
+  name = "django-raster-${version}";
+  version = "0.3.1";
+
+  src = fetchurl {
+    url = "mirror://pypi/d/django-raster/${name}.tar.gz";
+    sha256 = "1hsrkvybak1adn9d9qdw7hx3rcxsbzas4ixwll6vrjkrizgfihk3";
+  };
+
+  # Tests require a postgresql + postgis server
+  doCheck = false;
+
+  propagatedBuildInputs = [ numpy django_colorful pillow psycopg2
+                            pyparsing django celery ];
+
+  meta = with stdenv.lib; {
+    description = "Basic raster data integration for Django";
+    homepage = https://github.com/geodesign/django-raster;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10632,24 +10632,7 @@ in {
 
   djangorestframework = callPackage ../development/python-modules/djangorestframework { };
 
-  django_raster = buildPythonPackage rec {
-    name = "django-raster-${version}";
-    version = "0.3";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/django-raster/${name}.tar.gz";
-      sha256 = "0vn11y07wag7yvjzrk7m99xs3cqyaaaklwcsik9zbvw0kwp2khni";
-    };
-
-    propagatedBuildInputs = with self ; [ numpy django_colorful pillow psycopg2
-                                          pyparsing django celery_3 ];
-
-    meta = {
-      description = "Basic raster data integration for Django";
-      homepage = https://github.com/geodesign/django-raster;
-      license = licenses.mit;
-    };
-  };
+  django-raster = callPackage ../development/python-modules/django-raster { };
 
   django_redis = buildPythonPackage rec {
     name = "django-redis-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3630,31 +3630,6 @@ in {
     };
   };
 
-  celery_3 = buildPythonPackage rec {
-    name = "celery-${version}";
-    version = "3.1.23";
-
-    disabled = (pythonOlder "2.6") || isPy35;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/celery/${name}.tar.gz";
-      sha256 = "0614ppp18vmiwdk0rxvz0wn62d7svanwdnx7jgqxpy9pb20rqd8s";
-    };
-
-    buildInputs = with self; [ mock nose unittest2 ];
-    propagatedBuildInputs = with self; [ kombu_3 billiard_33 pytz anyjson amqp_1 ];
-
-    checkPhase = ''
-      nosetests $out/${python.sitePackages}/celery/tests/
-    '';
-
-    meta = {
-      homepage = https://github.com/celery/celery/;
-      description = "Distributed task queue";
-      license = licenses.bsd3;
-    };
-  };
-
   celery = buildPythonPackage rec {
     name = "celery-${version}";
     version = "4.0.2";


### PR DESCRIPTION
###### Motivation for this change

`django-raster-0.3.1` fixes the celery-4 compatibility. This allows to drop completely the old celery-3 branch.

This should probably be incorporated into 17.03 to drop completely `celery_3` (which was only used by `django_raster`)

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

