### PR TITLE
SDL2_mixer: add optional fluidsynth support

### DIFF
--- a/pkgs/development/libraries/SDL2_mixer/default.nix
+++ b/pkgs/development/libraries/SDL2_mixer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, SDL2, libogg, libvorbis, enableNativeMidi ? false }:
+{ stdenv, lib, fetchurl, SDL2, libogg, libvorbis, smpeg, flac, enableNativeMidi ? false, fluidsynth ? null }:
 
 stdenv.mkDerivation rec {
   name = "SDL2_mixer-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0pv9jzjpcjlbiaybvwrb4avmv46qk7iqxlnqrd2dfj82c4mgc92s";
   };
 
-  propagatedBuildInputs = [ SDL2 libogg libvorbis ];
+  propagatedBuildInputs = [ SDL2 libogg libvorbis fluidsynth smpeg flac ];
 
   configureFlags = [ "--disable-music-ogg-shared" ] ++ lib.optional enableNativeMidi "--enable-music-native-midi-gpl";
 
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     description = "SDL multi-channel audio mixer library";
     platforms = platforms.linux;
     homepage = "https://www.libsdl.org/projects/SDL_mixer/";
+    maintainers = with maintainers; [ MP2E ];
     license = licenses.zlib;
   };
 }


### PR DESCRIPTION
also add flac support and mp3 support, and add myself as the maintainer,
since there is no current maintainer for this package

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

