### PR TITLE
qt58: init at 5.8.0

### DIFF
--- a/pkgs/development/libraries/qt-5/5.8/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/default.nix
@@ -1,0 +1,130 @@
+/*
+
+# New packages
+
+READ THIS FIRST
+
+This module is for official packages in Qt 5. All available packages are listed
+in `./srcs.nix`, although a few are not yet packaged in Nixpkgs (see below).
+
+IF YOUR PACKAGE IS NOT LISTED IN `./srcs.nix`, IT DOES NOT GO HERE.
+
+Many of the packages released upstream are not yet built in Nixpkgs due to lack
+of demand. To add a Nixpkgs build for an upstream package, copy one of the
+existing packages here and modify it as necessary.
+
+# Updates
+
+1. Update the URL in `./fetch.sh`.
+2. Run `./maintainers/scripts/fetch-kde-qt.sh pkgs/development/libraries/qt-5/$VERSION/`
+   from the top of the Nixpkgs tree.
+3. Use `nox-review wip` to check that everything builds.
+4. Commit the changes and open a pull request.
+
+*/
+
+{
+  newScope,
+  stdenv, fetchurl, makeSetupHook, makeWrapper,
+  bison, cups ? null, harfbuzz, mesa, perl,
+  gstreamer, gst-plugins-base,
+
+  # options
+  developerBuild ? false,
+  decryptSslTraffic ? false,
+}:
+
+with stdenv.lib;
+
+let
+
+  mirror = "http://download.qt.io";
+  srcs = import ./srcs.nix { inherit fetchurl; inherit mirror; };
+
+  qtSubmodule = args:
+    let
+      inherit (args) name;
+      version = args.version or srcs."${name}".version;
+      src = args.src or srcs."${name}".src;
+      inherit (stdenv) mkDerivation;
+    in mkDerivation (args // {
+      name = "${name}-${version}";
+      inherit src;
+
+      propagatedBuildInputs = args.qtInputs ++ (args.propagatedBuildInputs or []);
+      nativeBuildInputs =
+        (args.nativeBuildInputs or [])
+        ++ [ perl self.qmakeHook ];
+
+      NIX_QT_SUBMODULE = args.NIX_QT_SUBMODULE or true;
+
+      outputs = args.outputs or [ "out" "dev" ];
+      setOutputFlags = args.setOutputFlags or false;
+
+      setupHook = ../qtsubmodule-setup-hook.sh;
+
+      enableParallelBuilding = args.enableParallelBuilding or true;
+
+      meta = self.qtbase.meta // (args.meta or {});
+    });
+
+  addPackages = self: with self;
+    let
+      callPackage = self.newScope { inherit qtSubmodule srcs; };
+    in {
+
+      qtbase = callPackage ./qtbase {
+        inherit (srcs.qtbase) src version;
+        inherit bison cups harfbuzz mesa;
+        inherit developerBuild decryptSslTraffic;
+      };
+
+      qtconnectivity = callPackage ./qtconnectivity.nix {};
+      qtdeclarative = callPackage ./qtdeclarative {};
+      qtdoc = callPackage ./qtdoc.nix {};
+      qtgraphicaleffects = callPackage ./qtgraphicaleffects.nix {};
+      qtimageformats = callPackage ./qtimageformats.nix {};
+      qtlocation = callPackage ./qtlocation.nix {};
+      qtmultimedia = callPackage ./qtmultimedia.nix {
+        inherit gstreamer gst-plugins-base;
+      };
+      qtquick1 = null;
+      qtquickcontrols = callPackage ./qtquickcontrols.nix {};
+      qtquickcontrols2 = callPackage ./qtquickcontrols2.nix {};
+      qtscript = callPackage ./qtscript {};
+      qtsensors = callPackage ./qtsensors.nix {};
+      qtserialport = callPackage ./qtserialport {};
+      qtsvg = callPackage ./qtsvg.nix {};
+      qttools = callPackage ./qttools {};
+      qttranslations = callPackage ./qttranslations.nix {};
+      qtwayland = callPackage ./qtwayland.nix {};
+      qtwebchannel = callPackage ./qtwebchannel.nix {};
+      qtwebengine = callPackage ./qtwebengine {};
+      qtwebkit = callPackage ./qtwebkit {};
+      qtwebsockets = callPackage ./qtwebsockets.nix {};
+      qtx11extras = callPackage ./qtx11extras.nix {};
+      qtxmlpatterns = callPackage ./qtxmlpatterns.nix {};
+
+      env = callPackage ../qt-env.nix {};
+      full = env "qt-${qtbase.version}" [
+        qtconnectivity qtdeclarative qtdoc qtgraphicaleffects
+        qtimageformats qtlocation qtmultimedia qtquickcontrols qtscript
+        qtsensors qtserialport qtsvg qttools qttranslations qtwayland
+        qtwebsockets qtx11extras qtxmlpatterns
+      ];
+
+      makeQtWrapper =
+        makeSetupHook
+        { deps = [ makeWrapper ]; }
+        ../make-qt-wrapper.sh;
+
+      qmakeHook =
+        makeSetupHook
+        { deps = [ self.qtbase.dev ]; }
+        ../qmake-hook.sh;
+
+    };
+
+   self = makeScope newScope addPackages;
+
+in self

--- a/pkgs/development/libraries/qt-5/5.8/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.8/fetch.sh
@@ -1,0 +1,3 @@
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.8/5.8.0/submodules/ \
+            http://download.qt.io/community_releases/5.8/5.8.0-final/ \
+            -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/cmake-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/cmake-paths.patch
@@ -1,0 +1,385 @@
+Index: qtbase-opensource-src-5.7.0/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
++++ qtbase-opensource-src-5.7.0/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+@@ -9,30 +9,6 @@ if (CMAKE_VERSION VERSION_LESS 3.0.0)
+ endif()
+ !!ENDIF
+
+-!!IF !isEmpty(CMAKE_USR_MOVE_WORKAROUND)
+-!!IF !isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-set(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"$$[QT_INSTALL_PREFIX]\")
+-!!ELSE
+-get_filename_component(_IMPORT_PREFIX \"${CMAKE_CURRENT_LIST_FILE}\" PATH)
+-# Use original install prefix when loaded through a
+-# cross-prefix symbolic link such as /lib -> /usr/lib.
+-get_filename_component(_realCurr \"${_IMPORT_PREFIX}\" REALPATH)
+-get_filename_component(_realOrig \"$$CMAKE_INSTALL_LIBS_DIR/cmake/Qt5$${CMAKE_MODULE_NAME}\" REALPATH)
+-if(_realCurr STREQUAL _realOrig)
+-    get_filename_component(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"$$CMAKE_INSTALL_LIBS_DIR/$${CMAKE_RELATIVE_INSTALL_LIBS_DIR}\" ABSOLUTE)
+-else()
+-    get_filename_component(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"${CMAKE_CURRENT_LIST_DIR}/$${CMAKE_RELATIVE_INSTALL_DIR}\" ABSOLUTE)
+-endif()
+-unset(_realOrig)
+-unset(_realCurr)
+-unset(_IMPORT_PREFIX)
+-!!ENDIF
+-!!ELIF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-get_filename_component(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"${CMAKE_CURRENT_LIST_DIR}/$${CMAKE_RELATIVE_INSTALL_DIR}\" ABSOLUTE)
+-!!ELSE
+-set(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"$$[QT_INSTALL_PREFIX]\")
+-!!ENDIF
+-
+ !!IF !equals(TEMPLATE, aux)
+ # For backwards compatibility only. Use Qt5$${CMAKE_MODULE_NAME}_VERSION instead.
+ set(Qt5$${CMAKE_MODULE_NAME}_VERSION_STRING "$$eval(QT.$${MODULE}.MAJOR_VERSION).$$eval(QT.$${MODULE}.MINOR_VERSION).$$eval(QT.$${MODULE}.PATCH_VERSION)")
+@@ -59,7 +35,10 @@ macro(_populate_$${CMAKE_MODULE_NAME}_ta
+     set_property(TARGET Qt5::$${CMAKE_MODULE_NAME} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
+
+ !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
++    set(imported_location \"@NIX_OUT@/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
++    endif()
+ !!ELSE
+     set(imported_location \"$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
+ !!ENDIF
+@@ -74,45 +53,18 @@ macro(_populate_$${CMAKE_MODULE_NAME}_ta
+         \"IMPORTED_LINK_INTERFACE_LIBRARIES_${Configuration}\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}\"
+     )
+
+-!!IF !isEmpty(CMAKE_WINDOWS_BUILD)
+-!!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_implib \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
+-!!ELSE
+-    set(imported_implib \"IMPORTED_IMPLIB_${Configuration}\" \"$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
+-!!ENDIF
+-    _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_implib})
+-    if(NOT \"${IMPLIB_LOCATION}\" STREQUAL \"\")
+-        set_target_properties(Qt5::$${CMAKE_MODULE_NAME} PROPERTIES
+-        \"IMPORTED_IMPLIB_${Configuration}\" ${imported_implib}
+-        )
+-    endif()
+-!!ENDIF
+ endmacro()
+ !!ENDIF
+
+ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
+
+ !!IF !no_module_headers
+-!!IF !isEmpty(CMAKE_BUILD_IS_FRAMEWORK)
+-    set(_Qt5$${CMAKE_MODULE_NAME}_OWN_INCLUDE_DIRS
+-      \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}Qt$${CMAKE_MODULE_NAME}.framework\"
+-      \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}Qt$${CMAKE_MODULE_NAME}.framework/Headers\"
+-    )
+-!!IF isEmpty(CMAKE_NO_PRIVATE_INCLUDES)
+-    set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}Qt$${CMAKE_MODULE_NAME}.framework/Versions/$$section(VERSION, ., 0, 0)/Headers/$$VERSION/\"
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}Qt$${CMAKE_MODULE_NAME}.framework/Versions/$$section(VERSION, ., 0, 0)/Headers/$$VERSION/$${MODULE_INCNAME}\"
+-    )
+-!!ELSE
+-    set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS \"\")
+-!!ENDIF
+-!!ELSE
+ !!IF isEmpty(CMAKE_INCLUDE_DIR_IS_ABSOLUTE)
+-    set(_Qt5$${CMAKE_MODULE_NAME}_OWN_INCLUDE_DIRS \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$$CMAKE_INCLUDE_DIR\" \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}\")
++    set(_Qt5$${CMAKE_MODULE_NAME}_OWN_INCLUDE_DIRS \"@NIX_DEV@/$$CMAKE_INCLUDE_DIR\" \"@NIX_DEV@/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}\")
+ !!IF isEmpty(CMAKE_NO_PRIVATE_INCLUDES)
+     set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}/$$VERSION\"
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}/$$VERSION/$${MODULE_INCNAME}\"
++        \"@NIX_DEV@/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}/$$VERSION\"
++        \"@NIX_DEV@/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}/$$VERSION/$${MODULE_INCNAME}\"
+     )
+ !!ELSE
+     set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS \"\")
+@@ -128,7 +80,7 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME
+     set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS \"\")
+ !!ENDIF
+ !!ENDIF
+-!!ENDIF
++
+ !!IF !isEmpty(CMAKE_ADD_SOURCE_INCLUDE_DIRS)
+     include(\"${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake\" OPTIONAL)
+ !!ENDIF
+@@ -253,28 +205,19 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME
+
+ !!IF !isEmpty(CMAKE_FIND_OTHER_LIBRARY_BUILD)
+ !!IF isEmpty(CMAKE_DEBUG_TYPE)
+-!!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
+-!!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    if (EXISTS \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+-!!ELSE // CMAKE_LIB_DIR_IS_ABSOLUTE
+-    if (EXISTS \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+-!!ENDIF // CMAKE_LIB_DIR_IS_ABSOLUTE
+-        _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" \"\" )
+-!!ELSE // CMAKE_STATIC_WINDOWS_BUILD
+     if (EXISTS
+ !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_DLL_DIR}$${CMAKE_LIB_FILE_LOCATION_DEBUG}\"
++        \"@NIX_OUT@/$${CMAKE_DLL_DIR}$${CMAKE_LIB_FILE_LOCATION_DEBUG}\"
+ !!ELSE
+         \"$${CMAKE_LIB_FILE_LOCATION_DEBUG}\"
+ !!ENDIF
+       AND EXISTS
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
++        \"@NIX_DEV@/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+ !!ELSE
+         \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+ !!ENDIF
+         _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_LIB_FILE_LOCATION_DEBUG}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+-!!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
+     endif()
+ !!ENDIF // CMAKE_DEBUG_TYPE
+ !!ENDIF // CMAKE_FIND_OTHER_LIBRARY_BUILD
+@@ -282,36 +225,23 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME
+ !!ENDIF // CMAKE_RELEASE_TYPE
+
+ !!IF !isEmpty(CMAKE_DEBUG_TYPE)
+-!!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
+-    _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" \"\" )
+-!!ELSE
+     _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_LIB_FILE_LOCATION_DEBUG}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+-!!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
+
+ !!IF !isEmpty(CMAKE_FIND_OTHER_LIBRARY_BUILD)
+ !!IF isEmpty(CMAKE_RELEASE_TYPE)
+-!!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
+-!!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    if (EXISTS \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+-!!ELSE // CMAKE_LIB_DIR_IS_ABSOLUTE
+-    if (EXISTS \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+-!!ENDIF // CMAKE_LIB_DIR_IS_ABSOLUTE
+-        _populate_$${CMAKE_MODULE_NAME}_target_properties(RELEASE \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" \"\" )
+-!!ELSE // CMAKE_STATIC_WINDOWS_BUILD
+     if (EXISTS
+ !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_DLL_DIR}$${CMAKE_LIB_FILE_LOCATION_RELEASE}\"
++        \"@NIX_OUT@/$${CMAKE_DLL_DIR}$${CMAKE_LIB_FILE_LOCATION_RELEASE}\"
+ !!ELSE
+         \"$${CMAKE_LIB_FILE_LOCATION_RELEASE}\"
+ !!ENDIF
+       AND EXISTS
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
++        \"@NIX_DEV@/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+ !!ELSE
+         \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+ !!ENDIF
+         _populate_$${CMAKE_MODULE_NAME}_target_properties(RELEASE \"$${CMAKE_LIB_FILE_LOCATION_RELEASE}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+-!!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
+     endif()
+ !!ENDIF // CMAKE_RELEASE_TYPE
+ !!ENDIF // CMAKE_FIND_OTHER_LIBRARY_BUILD
+@@ -328,11 +258,7 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME
+     macro(_populate_$${CMAKE_MODULE_NAME}_plugin_properties Plugin Configuration PLUGIN_LOCATION)
+         set_property(TARGET Qt5::${Plugin} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
+
+-!!IF isEmpty(CMAKE_PLUGIN_DIR_IS_ABSOLUTE)
+-        set(imported_location \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_PLUGIN_DIR}${PLUGIN_LOCATION}\")
+-!!ELSE
+-        set(imported_location \"$${CMAKE_PLUGIN_DIR}${PLUGIN_LOCATION}\")
+-!!ENDIF
++        set(imported_location \"${PLUGIN_LOCATION}\")
+         _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_location})
+         set_target_properties(Qt5::${Plugin} PROPERTIES
+             \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
+Index: qtbase-opensource-src-5.7.0/src/gui/Qt5GuiConfigExtras.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/gui/Qt5GuiConfigExtras.cmake.in
++++ qtbase-opensource-src-5.7.0/src/gui/Qt5GuiConfigExtras.cmake.in
+@@ -2,7 +2,7 @@
+ !!IF !isEmpty(CMAKE_ANGLE_EGL_DLL_RELEASE)
+
+ !!IF isEmpty(CMAKE_INCLUDE_DIR_IS_ABSOLUTE)
+-set(Qt5Gui_EGL_INCLUDE_DIRS \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$$CMAKE_INCLUDE_DIR/QtANGLE\")
++set(Qt5Gui_EGL_INCLUDE_DIRS \"@NIX_DEV@/$$CMAKE_INCLUDE_DIR/QtANGLE\")
+ !!ELSE
+ set(Qt5Gui_EGL_INCLUDE_DIRS \"$$CMAKE_INCLUDE_DIR/QtANGLE\")
+ !!ENDIF
+@@ -17,13 +17,13 @@ macro(_populate_qt5gui_gl_target_propert
+     set_property(TARGET Qt5::${TargetName} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
+
+ !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Gui_install_prefix}/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
++    set(imported_location \"@NIX_OUT@/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
+ !!ENDIF
+
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_implib \"${_qt5Gui_install_prefix}/$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
++    set(imported_implib \"@NIX_DEV@/$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
+ !!ELSE
+     set(imported_implib \"$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.7.0/src/widgets/Qt5WidgetsConfigExtras.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/widgets/Qt5WidgetsConfigExtras.cmake.in
++++ qtbase-opensource-src-5.7.0/src/widgets/Qt5WidgetsConfigExtras.cmake.in
+@@ -3,7 +3,7 @@ if (NOT TARGET Qt5::uic)
+     add_executable(Qt5::uic IMPORTED)
+
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Widgets_install_prefix}/$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.7.0/src/corelib/Qt5CoreConfigExtras.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/Qt5CoreConfigExtras.cmake.in
++++ qtbase-opensource-src-5.7.0/src/corelib/Qt5CoreConfigExtras.cmake.in
+@@ -3,7 +3,7 @@ if (NOT TARGET Qt5::qmake)
+     add_executable(Qt5::qmake IMPORTED)
+
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -18,7 +18,7 @@ if (NOT TARGET Qt5::moc)
+     add_executable(Qt5::moc IMPORTED)
+
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -35,7 +35,7 @@ if (NOT TARGET Qt5::rcc)
+     add_executable(Qt5::rcc IMPORTED)
+
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -133,7 +133,7 @@ if (NOT TARGET Qt5::WinMain)
+ !!IF !isEmpty(CMAKE_RELEASE_TYPE)
+     set_property(TARGET Qt5::WinMain APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
+ !!ENDIF
+@@ -147,7 +147,7 @@ if (NOT TARGET Qt5::WinMain)
+     set_property(TARGET Qt5::WinMain APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.7.0/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
++++ qtbase-opensource-src-5.7.0/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
+@@ -1,6 +1,6 @@
+
+ !!IF isEmpty(CMAKE_INSTALL_DATA_DIR_IS_ABSOLUTE)
+-set(_qt5_corelib_extra_includes \"${_qt5Core_install_prefix}/$${CMAKE_INSTALL_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
++set(_qt5_corelib_extra_includes \"@NIX_DEV@/$${CMAKE_INSTALL_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
+ !!ELSE
+ set(_qt5_corelib_extra_includes \"$${CMAKE_INSTALL_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.7.0/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
++++ qtbase-opensource-src-5.7.0/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
+@@ -1,6 +1,6 @@
+
+ !!IF isEmpty(CMAKE_HOST_DATA_DIR_IS_ABSOLUTE)
+-set(_qt5_corelib_extra_includes \"${_qt5Core_install_prefix}/$${CMAKE_HOST_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
++set(_qt5_corelib_extra_includes \"@NIX_DEV@/$${CMAKE_HOST_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
+ !!ELSE
+ set(_qt5_corelib_extra_includes \"$${CMAKE_HOST_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.7.0/src/dbus/Qt5DBusConfigExtras.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/dbus/Qt5DBusConfigExtras.cmake.in
++++ qtbase-opensource-src-5.7.0/src/dbus/Qt5DBusConfigExtras.cmake.in
+@@ -3,7 +3,7 @@ if (NOT TARGET Qt5::qdbuscpp2xml)
+     add_executable(Qt5::qdbuscpp2xml IMPORTED)
+
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5DBus_install_prefix}/$${CMAKE_BIN_DIR}qdbuscpp2xml$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qdbuscpp2xml$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}qdbuscpp2xml$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -18,7 +18,7 @@ if (NOT TARGET Qt5::qdbusxml2cpp)
+     add_executable(Qt5::qdbusxml2cpp IMPORTED)
+
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5DBus_install_prefix}/$${CMAKE_BIN_DIR}qdbusxml2cpp$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qdbusxml2cpp$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}qdbusxml2cpp$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.7.0/mkspecs/features/create_cmake.prf
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/mkspecs/features/create_cmake.prf
++++ qtbase-opensource-src-5.7.0/mkspecs/features/create_cmake.prf
+@@ -136,28 +136,28 @@ contains(CONFIG, plugin) {
+
+     win32 {
+         isEmpty(CMAKE_STATIC_TYPE) {
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/$${TARGET}.dll
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/$${TARGET}d.dll
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/$${TARGET}.dll
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/$${TARGET}d.dll
+         } else:mingw {
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/lib$${TARGET}.a
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/lib$${TARGET}d.a
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}/$$PLUGIN_TYPE/lib$${TARGET}.a
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}d.a
+         } else {                         # MSVC static
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/$${TARGET}.lib
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/$${TARGET}d.lib
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/$${TARGET}.lib
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/$${TARGET}d.lib
+         }
+     } else {
+         mac {
+             isEmpty(CMAKE_STATIC_TYPE): CMAKE_PlUGIN_EXT = .dylib
+             else: CMAKE_PlUGIN_EXT = .a
+
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
+         } else {
+             isEmpty(CMAKE_STATIC_TYPE): CMAKE_PlUGIN_EXT = .so
+             else: CMAKE_PlUGIN_EXT = .a
+
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
+         }
+     }
+     cmake_target_file.input = $$PWD/data/cmake/Qt5PluginTarget.cmake.in
+Index: qtbase-opensource-src-5.7.0/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
++++ qtbase-opensource-src-5.7.0/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
+@@ -2,10 +2,10 @@
+ add_library(Qt5::$$CMAKE_PLUGIN_NAME MODULE IMPORTED)
+
+ !!IF !isEmpty(CMAKE_RELEASE_TYPE)
+-_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME RELEASE \"$${CMAKE_PLUGIN_LOCATION_RELEASE}\")
++_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME RELEASE \"@NIX_OUT@/$${CMAKE_PLUGIN_LOCATION_RELEASE}\")
+ !!ENDIF
+ !!IF !isEmpty(CMAKE_DEBUG_TYPE)
+-_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME DEBUG \"$${CMAKE_PLUGIN_LOCATION_DEBUG}\")
++_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME DEBUG \"@NIX_OUT@/$${CMAKE_PLUGIN_LOCATION_DEBUG}\")
+ !!ENDIF
+
+ list(APPEND Qt5$${CMAKE_MODULE_NAME}_PLUGINS Qt5::$$CMAKE_PLUGIN_NAME)

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/compose-search-path.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/compose-search-path.patch
@@ -1,0 +1,16 @@
+Index: qtbase-opensource-src-5.7.0/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
++++ qtbase-opensource-src-5.7.0/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
+@@ -257,10 +257,7 @@ void TableGenerator::initPossibleLocatio
+     // the QTCOMPOSE environment variable
+     if (qEnvironmentVariableIsSet("QTCOMPOSE"))
+         m_possibleLocations.append(QString::fromLocal8Bit(qgetenv("QTCOMPOSE")));
+-    m_possibleLocations.append(QStringLiteral("/usr/share/X11/locale"));
+-    m_possibleLocations.append(QStringLiteral("/usr/local/share/X11/locale"));
+-    m_possibleLocations.append(QStringLiteral("/usr/lib/X11/locale"));
+-    m_possibleLocations.append(QStringLiteral("/usr/local/lib/X11/locale"));
++    m_possibleLocations.append(QStringLiteral("${libX11}/share/X11/locale"));
+     m_possibleLocations.append(QStringLiteral(X11_PREFIX "/share/X11/locale"));
+     m_possibleLocations.append(QStringLiteral(X11_PREFIX "/lib/X11/locale"));
+ }

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/decrypt-ssl-traffic.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/decrypt-ssl-traffic.patch
@@ -1,0 +1,13 @@
+Index: qtbase-opensource-src-5.5.1/src/network/ssl/qsslsocket_openssl.cpp
+===================================================================
+--- qtbase-opensource-src-5.5.1.orig/src/network/ssl/qsslsocket_openssl.cpp
++++ qtbase-opensource-src-5.5.1/src/network/ssl/qsslsocket_openssl.cpp
+@@ -48,7 +48,7 @@
+ ****************************************************************************/
+
+ //#define QSSLSOCKET_DEBUG
+-//#define QT_DECRYPT_SSL_TRAFFIC
++#define QT_DECRYPT_SSL_TRAFFIC
+
+ #include "qssl_p.h"
+ #include "qsslsocket_openssl_p.h"

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/default.nix
@@ -1,0 +1,244 @@
+{
+  stdenv, lib, copyPathsToStore,
+  src, version,
+
+  coreutils, bison, flex, gdb, gperf, lndir, patchelf, perl, pkgconfig, python2,
+  ruby,
+
+  dbus, fontconfig, freetype, glib, gtk3, harfbuzz, icu, libX11, libXcomposite,
+  libXcursor, libXext, libXi, libXrender, libinput, libjpeg, libpng, libtiff,
+  libxcb, libxkbcommon, libxml2, libxslt, openssl, pcre16, sqlite, udev,
+  xcbutil, xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, xcbutilwm, xlibs,
+  zlib,
+
+  # optional dependencies
+  cups ? null, mysql ? null, postgresql ? null,
+
+  # options
+  mesaSupported, mesa,
+  buildExamples ? false,
+  buildTests ? false,
+  developerBuild ? false,
+  decryptSslTraffic ? false
+}:
+
+let
+  system-x86_64 = lib.elem stdenv.system lib.platforms.x86_64;
+in
+
+stdenv.mkDerivation {
+
+  name = "qtbase-${version}";
+  inherit src version;
+
+  outputs = [ "out" "dev" ];
+
+  patches =
+    copyPathsToStore (lib.readPathsFromFile ./. ./series)
+    ++ lib.optional decryptSslTraffic ./decrypt-ssl-traffic.patch
+    ++ lib.optional mesaSupported [ ./dlopen-gl.patch ./mkspecs-libgl.patch ];
+
+  postPatch =
+    ''
+      substituteInPlace configure --replace /bin/pwd pwd
+      substituteInPlace src/corelib/global/global.pri --replace /bin/ls ${coreutils}/bin/ls
+      sed -e 's@/\(usr\|opt\)/@/var/empty/@g' -i config.tests/*/*.test -i mkspecs/*/*.conf
+
+      sed -i 's/PATHS.*NO_DEFAULT_PATH//' "src/corelib/Qt5Config.cmake.in"
+      sed -i 's/PATHS.*NO_DEFAULT_PATH//' "src/corelib/Qt5CoreMacros.cmake"
+      sed -i 's/NO_DEFAULT_PATH//' "src/gui/Qt5GuiConfigExtras.cmake.in"
+      sed -i 's/PATHS.*NO_DEFAULT_PATH//' "mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in"
+
+      substituteInPlace src/network/kernel/qdnslookup_unix.cpp \
+        --replace "@glibc@" "${stdenv.cc.libc.out}"
+      substituteInPlace src/network/kernel/qhostinfo_unix.cpp \
+        --replace "@glibc@" "${stdenv.cc.libc.out}"
+
+      substituteInPlace src/plugins/platforms/xcb/qxcbcursor.cpp \
+        --replace "@libXcursor@" "${libXcursor.out}"
+
+      substituteInPlace src/network/ssl/qsslsocket_openssl_symbols.cpp \
+        --replace "@openssl@" "${openssl.out}"
+
+      substituteInPlace src/dbus/qdbus_symbols.cpp \
+        --replace "@dbus_libs@" "${dbus.lib}"
+
+      substituteInPlace \
+        src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp \
+        --replace "@libX11@" "${libX11.out}"
+    ''
+    + lib.optionalString mesaSupported ''
+      substituteInPlace \
+        src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp \
+        --replace "@mesa_lib@" "${mesa.out}"
+      substituteInPlace mkspecs/common/linux.conf \
+        --replace "@mesa_lib@" "${mesa.out}" \
+        --replace "@mesa_inc@" "${mesa.dev or mesa}"
+    '';
+
+
+  setOutputFlags = false;
+  preConfigure = ''
+    export LD_LIBRARY_PATH="$PWD/lib:$PWD/plugins/platforms:$LD_LIBRARY_PATH"
+    export MAKEFLAGS=-j$NIX_BUILD_CORES
+
+    configureFlags+="\
+        -plugindir $out/lib/qt5/plugins \
+        -importdir $out/lib/qt5/imports \
+        -qmldir $out/lib/qt5/qml \
+        -docdir $out/share/doc/qt5"
+  '';
+
+  prefixKey = "-prefix ";
+
+  # -no-eglfs, -no-directfb, -no-linuxfb and -no-kms because of the current minimalist mesa
+  # TODO Remove obsolete and useless flags once the build will be totally mastered
+  configureFlags = ''
+    -verbose
+    -confirm-license
+    -opensource
+
+    -release
+    -shared
+    ${lib.optionalString developerBuild "-developer-build"}
+    -accessibility
+    -rpath
+    -optimized-qmake
+    -strip
+    -no-reduce-relocations
+    -system-proxies
+    -pkg-config
+
+    -gui
+    -widgets
+    -opengl desktop
+    -qml-debug
+    -icu
+    -pch
+    -glib
+    -xcb
+    -qpa xcb
+    -${lib.optionalString (cups == null) "no-"}cups
+
+    -no-eglfs
+    -no-directfb
+    -no-linuxfb
+    -no-kms
+
+    ${lib.optionalString (!system-x86_64) "-no-sse2"}
+    -no-sse3
+    -no-ssse3
+    -no-sse4.1
+    -no-sse4.2
+    -no-avx
+    -no-avx2
+    -no-mips_dsp
+    -no-mips_dspr2
+
+    -system-zlib
+    -system-libpng
+    -system-libjpeg
+    -system-harfbuzz
+    -system-xcb
+    -system-xkbcommon
+    -system-pcre
+    -openssl-linked
+    -dbus-linked
+    -libinput
+    -gtk
+
+    -system-sqlite
+    -${if mysql != null then "plugin" else "no"}-sql-mysql
+    -${if postgresql != null then "plugin" else "no"}-sql-psql
+
+    -make libs
+    -make tools
+    -${lib.optionalString (buildExamples == false) "no"}make examples
+    -${lib.optionalString (buildTests == false) "no"}make tests
+    -v
+  '';
+
+  # PostgreSQL autodetection fails sporadically because Qt omits the "-lpq" flag
+  # if dependency paths contain the string "pq", which can occur in the hash.
+  # To prevent these failures, we need to override PostgreSQL detection.
+  PSQL_LIBS = lib.optionalString (postgresql != null) "-L${postgresql.lib}/lib -lpq";
+
+  propagatedBuildInputs = [
+    dbus glib libxml2 libxslt openssl pcre16 sqlite udev zlib
+
+    # Image formats
+    libjpeg libpng libtiff
+
+    # Text rendering
+    fontconfig freetype harfbuzz icu
+
+    # X11 libs
+    libX11 libXcomposite libXext libXi libXrender libxcb libxkbcommon xcbutil
+    xcbutilimage xcbutilkeysyms xcbutilrenderutil xcbutilwm
+  ]
+  ++ lib.optional mesaSupported mesa;
+
+  buildInputs =
+    [ gtk3 libinput ]
+    ++ lib.optional developerBuild gdb
+    ++ lib.optional (cups != null) cups
+    ++ lib.optional (mysql != null) mysql.lib
+    ++ lib.optional (postgresql != null) postgresql;
+
+  nativeBuildInputs =
+    [ bison flex gperf lndir patchelf perl pkgconfig python2 ];
+
+  # freetype-2.5.4 changed signedness of some struct fields
+  NIX_CFLAGS_COMPILE = "-Wno-error=sign-compare";
+
+  postInstall = ''
+    find "$out" -name "*.cmake" | while read file; do
+        substituteInPlace "$file" \
+            --subst-var-by NIX_OUT "$out" \
+            --subst-var-by NIX_DEV "$dev"
+    done
+  '';
+
+  preFixup = ''
+    # We cannot simply set these paths in configureFlags because libQtCore retains
+    # references to the paths it was built with.
+    moveToOutput "bin" "$dev"
+    moveToOutput "include" "$dev"
+    moveToOutput "mkspecs" "$dev"
+
+    # The destination directory must exist or moveToOutput will do nothing
+    mkdir -p "$dev/share"
+    moveToOutput "share/doc" "$dev"
+  '';
+
+  postFixup =
+    ''
+      # Don't retain build-time dependencies like gdb.
+      sed '/QMAKE_DEFAULT_.*DIRS/ d' -i $dev/mkspecs/qconfig.pri
+
+      # Move libtool archives and qmake projects
+      if [ "z''${!outputLib}" != "z''${!outputDev}" ]; then
+          pushd "''${!outputLib}"
+          find lib -name '*.a' -o -name '*.la' -o -name '*.prl' | \
+              while read -r file; do
+                  mkdir -p "''${!outputDev}/$(dirname "$file")"
+                  mv "''${!outputLib}/$file" "''${!outputDev}/$file"
+              done
+          popd
+      fi
+    '';
+
+  inherit lndir;
+  setupHook = ../../qtbase-setup-hook.sh;
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = http://www.qt.io;
+    description = "A cross-platform application framework for C++";
+    license = with licenses; [ fdl13 gpl2 lgpl21 lgpl3 ];
+    maintainers = with maintainers; [ bbenoist qknight ttuegel ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-dbus.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-dbus.patch
@@ -1,0 +1,13 @@
+Index: qtbase-opensource-src-5.7.0/src/dbus/qdbus_symbols.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/dbus/qdbus_symbols.cpp
++++ qtbase-opensource-src-5.7.0/src/dbus/qdbus_symbols.cpp
+@@ -97,7 +97,7 @@ bool qdbus_loadLibDBus()
+ #ifdef Q_OS_WIN
+         QLatin1String("dbus-1"),
+ #endif
+-        QLatin1String("libdbus-1")
++        QLatin1String("@dbus_libs@/lib/libdbus-1")
+     };
+
+     lib->unload();

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-gl.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-gl.patch
@@ -1,0 +1,17 @@
+Index: qtbase-opensource-src-5.5.1/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
+===================================================================
+--- qtbase-opensource-src-5.5.1.orig/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
++++ qtbase-opensource-src-5.5.1/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
+@@ -563,7 +563,12 @@ void (*QGLXContext::getProcAddress(const
+             {
+                 extern const QString qt_gl_library_name();
+ //                QLibrary lib(qt_gl_library_name());
++                // Check system library paths first
+                 QLibrary lib(QLatin1String("GL"));
++                if (!lib.load()) {
++                    // Fallback to Mesa driver
++                    lib.setFileName(QLatin1String("@mesa_lib@/lib/libGL"));
++                }
+                 glXGetProcAddressARB = (qt_glXGetProcAddressARB) lib.resolve("glXGetProcAddressARB");
+             }
+         }

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-gtkstyle.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-gtkstyle.patch
@@ -1,0 +1,50 @@
+Index: qtbase-opensource-src-5.5.1/src/widgets/styles/qgtk2painter.cpp
+===================================================================
+--- qtbase-opensource-src-5.5.1.orig/src/widgets/styles/qgtk2painter.cpp
++++ qtbase-opensource-src-5.5.1/src/widgets/styles/qgtk2painter.cpp
+@@ -96,7 +96,7 @@ static void initGtk()
+     static bool initialized = false;
+     if (!initialized) {
+         // enforce the "0" suffix, so we'll open libgtk-x11-2.0.so.0
+-        QLibrary libgtk(QLS("gtk-x11-2.0"), 0, 0);
++        QLibrary libgtk(QLS("@gtk@/lib/libgtk-x11-2.0"), 0, 0);
+
+         QGtk2PainterPrivate::gdk_pixmap_new = (Ptr_gdk_pixmap_new)libgtk.resolve("gdk_pixmap_new");
+         QGtk2PainterPrivate::gdk_pixbuf_get_from_drawable = (Ptr_gdk_pixbuf_get_from_drawable)libgtk.resolve("gdk_pixbuf_get_from_drawable");
+Index: qtbase-opensource-src-5.5.1/src/widgets/styles/qgtkstyle_p.cpp
+===================================================================
+--- qtbase-opensource-src-5.5.1.orig/src/widgets/styles/qgtkstyle_p.cpp
++++ qtbase-opensource-src-5.5.1/src/widgets/styles/qgtkstyle_p.cpp
+@@ -327,7 +327,7 @@ void QGtkStylePrivate::gtkWidgetSetFocus
+ void QGtkStylePrivate::resolveGtk() const
+ {
+     // enforce the "0" suffix, so we'll open libgtk-x11-2.0.so.0
+-    QLibrary libgtk(QLS("gtk-x11-2.0"), 0, 0);
++    QLibrary libgtk(QLS("@gtk@/lib/libgtk-x11-2.0"), 0, 0);
+
+     gtk_init = (Ptr_gtk_init)libgtk.resolve("gtk_init");
+     gtk_window_new = (Ptr_gtk_window_new)libgtk.resolve("gtk_window_new");
+@@ -425,8 +425,8 @@ void QGtkStylePrivate::resolveGtk() cons
+     pango_font_description_get_family = (Ptr_pango_font_description_get_family)libgtk.resolve("pango_font_description_get_family");
+     pango_font_description_get_style = (Ptr_pango_font_description_get_style)libgtk.resolve("pango_font_description_get_style");
+
+-    gnome_icon_lookup_sync = (Ptr_gnome_icon_lookup_sync)QLibrary::resolve(QLS("gnomeui-2"), 0, "gnome_icon_lookup_sync");
+-    gnome_vfs_init= (Ptr_gnome_vfs_init)QLibrary::resolve(QLS("gnomevfs-2"), 0, "gnome_vfs_init");
++    gnome_icon_lookup_sync = (Ptr_gnome_icon_lookup_sync)QLibrary::resolve(QLS("@libgnomeui@/lib/libgnomeui-2"), 0, "gnome_icon_lookup_sync");
++    gnome_vfs_init= (Ptr_gnome_vfs_init)QLibrary::resolve(QLS("@gnome_vfs@/lib/libgnomevfs-2"), 0, "gnome_vfs_init");
+ }
+
+ /* \internal
+@@ -594,9 +594,9 @@ void QGtkStylePrivate::cleanupGtkWidgets
+ static bool resolveGConf()
+ {
+     if (!QGtkStylePrivate::gconf_client_get_default) {
+-        QGtkStylePrivate::gconf_client_get_default = (Ptr_gconf_client_get_default)QLibrary::resolve(QLS("gconf-2"), 4, "gconf_client_get_default");
+-        QGtkStylePrivate::gconf_client_get_string =  (Ptr_gconf_client_get_string)QLibrary::resolve(QLS("gconf-2"), 4, "gconf_client_get_string");
+-        QGtkStylePrivate::gconf_client_get_bool =  (Ptr_gconf_client_get_bool)QLibrary::resolve(QLS("gconf-2"), 4, "gconf_client_get_bool");
++        QGtkStylePrivate::gconf_client_get_default = (Ptr_gconf_client_get_default)QLibrary::resolve(QLS("@gconf@/lib/libgconf-2"), 4, "gconf_client_get_default");
++        QGtkStylePrivate::gconf_client_get_string =  (Ptr_gconf_client_get_string)QLibrary::resolve(QLS("@gconf@/lib/libgconf-2"), 4, "gconf_client_get_string");
++        QGtkStylePrivate::gconf_client_get_bool =  (Ptr_gconf_client_get_bool)QLibrary::resolve(QLS("@gconf@/lib/libgconf-2"), 4, "gconf_client_get_bool");
+     }
+     return (QGtkStylePrivate::gconf_client_get_default !=0);
+ }

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-libXcursor.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-libXcursor.patch
@@ -1,0 +1,17 @@
+Index: qtbase-opensource-src-5.7.0/src/plugins/platforms/xcb/qxcbcursor.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/plugins/platforms/xcb/qxcbcursor.cpp
++++ qtbase-opensource-src-5.7.0/src/plugins/platforms/xcb/qxcbcursor.cpp
+@@ -309,10 +309,10 @@ QXcbCursor::QXcbCursor(QXcbConnection *c
+ #if defined(XCB_USE_XLIB) && !defined(QT_NO_LIBRARY)
+     static bool function_ptrs_not_initialized = true;
+     if (function_ptrs_not_initialized) {
+-        QLibrary xcursorLib(QLatin1String("Xcursor"), 1);
++        QLibrary xcursorLib(QLatin1String("@libXcursor@/lib/libXcursor"), 1);
+         bool xcursorFound = xcursorLib.load();
+         if (!xcursorFound) { // try without the version number
+-            xcursorLib.setFileName(QLatin1String("Xcursor"));
++            xcursorLib.setFileName(QLatin1String("@libXcursor@/lib/Xcursor"));
+             xcursorFound = xcursorLib.load();
+         }
+         if (xcursorFound) {

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-openssl.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-openssl.patch
@@ -1,0 +1,26 @@
+Index: qtbase-opensource-src-5.7.0/src/network/ssl/qsslsocket_openssl_symbols.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/network/ssl/qsslsocket_openssl_symbols.cpp
++++ qtbase-opensource-src-5.7.0/src/network/ssl/qsslsocket_openssl_symbols.cpp
+@@ -658,8 +658,8 @@ static QPair<QLibrary*, QLibrary*> loadO
+ #endif
+ #if defined(SHLIB_VERSION_NUMBER) && !defined(Q_OS_QNX) // on QNX, the libs are always libssl.so and libcrypto.so
+     // first attempt: the canonical name is libssl.so.<SHLIB_VERSION_NUMBER>
+-    libssl->setFileNameAndVersion(QLatin1String("ssl"), QLatin1String(SHLIB_VERSION_NUMBER));
+-    libcrypto->setFileNameAndVersion(QLatin1String("crypto"), QLatin1String(SHLIB_VERSION_NUMBER));
++    libssl->setFileNameAndVersion(QLatin1String("@openssl@/lib/libssl"), QLatin1String(SHLIB_VERSION_NUMBER));
++    libcrypto->setFileNameAndVersion(QLatin1String("@openssl@/lib/libcrypto"), QLatin1String(SHLIB_VERSION_NUMBER));
+     if (libcrypto->load() && libssl->load()) {
+         // libssl.so.<SHLIB_VERSION_NUMBER> and libcrypto.so.<SHLIB_VERSION_NUMBER> found
+         return pair;
+@@ -676,8 +676,8 @@ static QPair<QLibrary*, QLibrary*> loadO
+     //  OS X's /usr/lib/libssl.dylib, /usr/lib/libcrypto.dylib will be picked up in the third
+     //    attempt, _after_ <bundle>/Contents/Frameworks has been searched.
+     //  iOS does not ship a system libssl.dylib, libcrypto.dylib in the first place.
+-    libssl->setFileNameAndVersion(QLatin1String("ssl"), -1);
+-    libcrypto->setFileNameAndVersion(QLatin1String("crypto"), -1);
++    libssl->setFileNameAndVersion(QLatin1String("@openssl@/lib/libssl"), -1);
++    libcrypto->setFileNameAndVersion(QLatin1String("@openssl@/lib/libcrypto"), -1);
+     if (libcrypto->load() && libssl->load()) {
+         // libssl.so.0 and libcrypto.so.0 found
+         return pair;

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-resolv.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/dlopen-resolv.patch
@@ -1,0 +1,26 @@
+Index: qtbase-opensource-src-5.7.0/src/network/kernel/qdnslookup_unix.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/network/kernel/qdnslookup_unix.cpp
++++ qtbase-opensource-src-5.7.0/src/network/kernel/qdnslookup_unix.cpp
+@@ -85,7 +85,7 @@ static bool resolveLibraryInternal()
+     if (!lib.load())
+ #endif
+     {
+-        lib.setFileName(QLatin1String("resolv"));
++        lib.setFileName(QLatin1String("@glibc@/lib/resolv"));
+         if (!lib.load())
+             return false;
+     }
+Index: qtbase-opensource-src-5.7.0/src/network/kernel/qhostinfo_unix.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/network/kernel/qhostinfo_unix.cpp
++++ qtbase-opensource-src-5.7.0/src/network/kernel/qhostinfo_unix.cpp
+@@ -100,7 +100,7 @@ static bool resolveLibraryInternal()
+     if (!lib.load())
+ #endif
+     {
+-        lib.setFileName(QLatin1String("resolv"));
++        lib.setFileName(QLatin1String("@glibc@/lib/libresolv"));
+         if (!lib.load())
+             return false;
+     }

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/libressl.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/libressl.patch
@@ -1,0 +1,33 @@
+From 81494e67eccba04fc3fe554d76a9ca6fe7f2250e Mon Sep 17 00:00:00 2001
+From: hasufell <hasufell@gentoo.org>
+Date: Sat, 10 Oct 2015 01:15:01 +0200
+Subject: [PATCH] Fix compilation with libressl
+
+By additionally checking for defined(SSL_CTRL_SET_CURVES), which
+is defined in openssl, but not in libressl.
+---
+ src/network/ssl/qsslcontext_openssl.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+Index: qtbase-opensource-src-5.7.0/src/network/ssl/qsslcontext_openssl.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/network/ssl/qsslcontext_openssl.cpp
++++ qtbase-opensource-src-5.7.0/src/network/ssl/qsslcontext_openssl.cpp
+@@ -347,7 +347,7 @@ init_context:
+
+     const QVector<QSslEllipticCurve> qcurves = sslContext->sslConfiguration.ellipticCurves();
+     if (!qcurves.isEmpty()) {
+-#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(OPENSSL_NO_EC)
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L && defined(SSL_CTRL_SET_CURVES) && !defined(OPENSSL_NO_EC)
+         // Set the curves to be used
+         if (q_SSLeay() >= 0x10002000L) {
+             // SSL_CTX_ctrl wants a non-const pointer as last argument,
+@@ -360,7 +360,7 @@ init_context:
+                 sslContext->errorCode = QSslError::UnspecifiedError;
+             }
+         } else
+-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(OPENSSL_NO_EC)
++#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L && defined(SSL_CTRL_SET_CURVES) && !defined(OPENSSL_NO_EC)
+         {
+             // specific curves requested, but not possible to set -> error
+             sslContext->errorStr = msgErrorSettingEllipticCurves(QSslSocket::tr("OpenSSL version too old, need at least v1.0.2"));

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/mkspecs-libgl.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/mkspecs-libgl.patch
@@ -1,0 +1,15 @@
+Index: qtbase-opensource-src-5.5.1/mkspecs/common/linux.conf
+===================================================================
+--- qtbase-opensource-src-5.5.1.orig/mkspecs/common/linux.conf
++++ qtbase-opensource-src-5.5.1/mkspecs/common/linux.conf
+@@ -12,8 +12,8 @@ QMAKE_INCDIR            =
+ QMAKE_LIBDIR            =
+ QMAKE_INCDIR_X11        =
+ QMAKE_LIBDIR_X11        =
+-QMAKE_INCDIR_OPENGL     =
+-QMAKE_LIBDIR_OPENGL     =
++QMAKE_INCDIR_OPENGL     = @mesa_inc@/include
++QMAKE_LIBDIR_OPENGL     = @mesa_lib@/lib
+ QMAKE_INCDIR_OPENGL_ES2 = $$QMAKE_INCDIR_OPENGL
+ QMAKE_LIBDIR_OPENGL_ES2 = $$QMAKE_LIBDIR_OPENGL
+ QMAKE_INCDIR_EGL        =

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/nix-profiles-library-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/nix-profiles-library-paths.patch
@@ -1,0 +1,22 @@
+Index: qtbase-opensource-src-5.7.0/src/corelib/kernel/qcoreapplication.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/kernel/qcoreapplication.cpp
++++ qtbase-opensource-src-5.7.0/src/corelib/kernel/qcoreapplication.cpp
+@@ -2487,7 +2487,17 @@ QStringList QCoreApplication::libraryPat
+         QStringList *app_libpaths = new QStringList;
+         coreappdata()->app_libpaths.reset(app_libpaths);
+
++        // Add library paths derived from NIX_PROFILES.
++        const QByteArrayList profiles = qgetenv("NIX_PROFILES").split(' ');
++        const QString plugindir = QString::fromLatin1("/lib/qt5/plugins");
++        for (const QByteArray &profile: profiles) {
++            if (!profile.isEmpty()) {
++                app_libpaths->append(QFile::decodeName(profile) + plugindir);
++            }
++        }
++
+         const QByteArray libPathEnv = qgetenv("QT_PLUGIN_PATH");
++        qunsetenv("QT_PLUGIN_PATH"); // do not propagate to child processes
+         if (!libPathEnv.isEmpty()) {
+             QStringList paths = QFile::decodeName(libPathEnv).split(QDir::listSeparator(), QString::SkipEmptyParts);
+             for (QStringList::const_iterator it = paths.constBegin(); it != paths.constEnd(); ++it) {

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/series
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/series
@@ -1,0 +1,10 @@
+dlopen-resolv.patch
+tzdir.patch
+dlopen-libXcursor.patch
+dlopen-openssl.patch
+dlopen-dbus.patch
+xdg-config-dirs.patch
+nix-profiles-library-paths.patch
+compose-search-path.patch
+libressl.patch
+cmake-paths.patch

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/tzdir.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/tzdir.patch
@@ -1,0 +1,39 @@
+Index: qtbase-opensource-src-5.7.0/src/corelib/tools/qtimezoneprivate_tz.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/tools/qtimezoneprivate_tz.cpp
++++ qtbase-opensource-src-5.7.0/src/corelib/tools/qtimezoneprivate_tz.cpp
+@@ -68,7 +68,10 @@ typedef QHash<QByteArray, QTzTimeZone> Q
+ // Parse zone.tab table, assume lists all installed zones, if not will need to read directories
+ static QTzTimeZoneHash loadTzTimeZones()
+ {
+-    QString path = QStringLiteral("/usr/share/zoneinfo/zone.tab");
++    QString path = qgetenv("TZDIR");
++    path += "/zone.tab";
++    if (!QFile::exists(path))
++        path = QStringLiteral("/usr/share/zoneinfo/zone.tab");
+     if (!QFile::exists(path))
+         path = QStringLiteral("/usr/lib/zoneinfo/zone.tab");
+
+@@ -566,12 +569,18 @@ void QTzTimeZonePrivate::init(const QByt
+         if (!tzif.open(QIODevice::ReadOnly))
+             return;
+     } else {
+-        // Open named tz, try modern path first, if fails try legacy path
+-        tzif.setFileName(QLatin1String("/usr/share/zoneinfo/") + QString::fromLocal8Bit(ianaId));
++        // Try TZDIR first
++        QString zoneinfoDir = qgetenv("TZDIR");
++        zoneinfoDir += "/" + QString::fromLocal8Bit(ianaId);
++        tzif.setFileName(zoneinfoDir);
+         if (!tzif.open(QIODevice::ReadOnly)) {
+-            tzif.setFileName(QLatin1String("/usr/lib/zoneinfo/") + QString::fromLocal8Bit(ianaId));
+-            if (!tzif.open(QIODevice::ReadOnly))
+-                return;
++            // Open named tz, try modern path first, if fails try legacy path
++            tzif.setFileName(QLatin1String("/usr/share/zoneinfo/") + QString::fromLocal8Bit(ianaId));
++            if (!tzif.open(QIODevice::ReadOnly)) {
++                tzif.setFileName(QLatin1String("/usr/lib/zoneinfo/") + QString::fromLocal8Bit(ianaId));
++                if (!tzif.open(QIODevice::ReadOnly))
++                    return;
++            }
+         }
+     }

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/xdg-config-dirs.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/xdg-config-dirs.patch
@@ -1,0 +1,41 @@
+Index: qtbase-opensource-src-5.7.0/src/corelib/io/qsettings.cpp
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/io/qsettings.cpp
++++ qtbase-opensource-src-5.7.0/src/corelib/io/qsettings.cpp
+@@ -1161,6 +1161,23 @@ QConfFileSettingsPrivate::QConfFileSetti
+         confFiles[F_System | F_Application].reset(QConfFile::fromName(systemPath + appFile, false));
+     confFiles[F_System | F_Organization].reset(QConfFile::fromName(systemPath + orgFile, false));
+
++#if !defined(Q_OS_WIN)
++    // Add directories specified in $XDG_CONFIG_DIRS
++    const QString pathEnv = QString::fromLocal8Bit(getenv("XDG_CONFIG_DIRS"));
++    if (!pathEnv.isEmpty()) {
++        const QStringList pathEntries = pathEnv.split(QLatin1Char(':'), QString::SkipEmptyParts);
++        if (!pathEntries.isEmpty()) {
++            int j = 4; // This is the number of confFiles set above -- we need to start adding $XDG_CONFIG_DIRS after those.
++            for (int k = 0; k < pathEntries.size() && j < NumConfFiles - 1; ++k) {
++                const QString& path = pathEntries.at(k);
++                if (!application.isEmpty())
++                    confFiles[j++].reset(QConfFile::fromName(path + QDir::separator() + appFile, false));
++                confFiles[j++].reset(QConfFile::fromName(path + QDir::separator() + orgFile, false));
++            }
++        }
++    }
++#endif
++
+     for (i = 0; i < NumConfFiles; ++i) {
+         if (confFiles[i]) {
+             spec = i;
+Index: qtbase-opensource-src-5.7.0/src/corelib/io/qsettings_p.h
+===================================================================
+--- qtbase-opensource-src-5.7.0.orig/src/corelib/io/qsettings_p.h
++++ qtbase-opensource-src-5.7.0/src/corelib/io/qsettings_p.h
+@@ -246,7 +246,7 @@ public:
+         F_Organization = 0x1,
+         F_User = 0x0,
+         F_System = 0x2,
+-        NumConfFiles = 4
++        NumConfFiles = 40 // HACK: increase NumConfFiles from 4 to 40 in order to accommodate more paths in $XDG_CONFIG_DIRS -- ellis
+     };
+
+     QSettings::Format format;

--- a/pkgs/development/libraries/qt-5/5.8/qtconnectivity.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtconnectivity.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtconnectivity";
+  qtInputs = [ qtbase qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtdeclarative/default.nix
@@ -1,0 +1,8 @@
+{ qtSubmodule, lib, copyPathsToStore, python2, qtbase, qtsvg, qtxmlpatterns }:
+
+qtSubmodule {
+  name = "qtdeclarative";
+  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  qtInputs = [ qtbase qtsvg qtxmlpatterns ];
+  nativeBuildInputs = [ python2 ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtdeclarative/nix-profiles-import-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtdeclarative/nix-profiles-import-paths.patch
@@ -1,0 +1,20 @@
+Index: qtdeclarative-opensource-src-5.5.1/src/qml/qml/qqmlimport.cpp
+===================================================================
+--- qtdeclarative-opensource-src-5.5.1.orig/src/qml/qml/qqmlimport.cpp
++++ qtdeclarative-opensource-src-5.5.1/src/qml/qml/qqmlimport.cpp
+@@ -1549,6 +1549,15 @@ QQmlImportDatabase::QQmlImportDatabase(Q
+     QString installImportsPath =  QLibraryInfo::location(QLibraryInfo::Qml2ImportsPath);
+     addImportPath(installImportsPath);
+
++    // Add library paths derived from NIX_PROFILES.
++    const QByteArrayList profiles = qgetenv("NIX_PROFILES").split(' ');
++    const QString qmldir = QString::fromLatin1("/lib/qt5/qml");
++    Q_FOREACH (const QByteArray &profile, profiles) {
++        if (!profile.isEmpty()) {
++            addImportPath(QFile::decodeName(profile) + qmldir);
++        }
++    }
++
+     // env import paths
+     QByteArray envImportPath = qgetenv("QML2_IMPORT_PATH");
+     if (!envImportPath.isEmpty()) {

--- a/pkgs/development/libraries/qt-5/5.8/qtdeclarative/series
+++ b/pkgs/development/libraries/qt-5/5.8/qtdeclarative/series
@@ -1,0 +1,1 @@
+nix-profiles-import-paths.patch

--- a/pkgs/development/libraries/qt-5/5.8/qtdoc.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtdoc.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtdoc";
+  qtInputs = [ qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtgraphicaleffects.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtgraphicaleffects.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtgraphicaleffects";
+  qtInputs = [ qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtimageformats.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtimageformats.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase }:
+
+qtSubmodule {
+  name = "qtimageformats";
+  qtInputs = [ qtbase ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtlocation.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtlocation.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase, qtmultimedia }:
+
+qtSubmodule {
+  name = "qtlocation";
+  qtInputs = [ qtbase qtmultimedia ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtmultimedia.nix
@@ -1,0 +1,12 @@
+{ qtSubmodule, qtbase, qtdeclarative, pkgconfig
+, alsaLib, gstreamer, gst-plugins-base, libpulseaudio
+}:
+
+qtSubmodule {
+  name = "qtmultimedia";
+  qtInputs = [ qtbase qtdeclarative ];
+  buildInputs = [
+    pkgconfig alsaLib gstreamer gst-plugins-base libpulseaudio
+  ];
+  qmakeFlags = [ "GST_VERSION=1.0" ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtquickcontrols.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtquickcontrols.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtquickcontrols";
+  qtInputs = [ qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtquickcontrols2.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtquickcontrols2.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtquickcontrols2";
+  qtInputs = [ qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtscript/0001-glib-2.32.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtscript/0001-glib-2.32.patch
@@ -1,0 +1,24 @@
+From abd80356449bb36c8adcc5c9ca1df6b47715d265 Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:13:34 -0500
+Subject: [PATCH] glib-2.32
+
+---
+ src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h b/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h
+index 1f6d25e..087c3fb 100644
+--- a/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h
++++ b/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h
+@@ -81,7 +81,7 @@
+ #include <pthread.h>
+ #elif PLATFORM(GTK)
+ #include <wtf/gtk/GOwnPtr.h>
+-typedef struct _GMutex GMutex;
++typedef union _GMutex GMutex;
+ typedef struct _GCond GCond;
+ #endif
+
+--
+2.5.0

--- a/pkgs/development/libraries/qt-5/5.8/qtscript/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtscript/default.nix
@@ -1,0 +1,7 @@
+{ qtSubmodule, qtbase, qttools }:
+
+qtSubmodule {
+  name = "qtscript";
+  qtInputs = [ qtbase qttools ];
+  patches = [ ./0001-glib-2.32.patch ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtsensors.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtsensors.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtsensors";
+  qtInputs = [ qtbase qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtserialport/0001-dlopen-serialport-udev.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtserialport/0001-dlopen-serialport-udev.patch
@@ -1,0 +1,27 @@
+From d81c2c870b9bea8fb8e6b85baefb06542f568338 Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:16:02 -0500
+Subject: [PATCH] dlopen serialport udev
+
+---
+ src/serialport/qtudev_p.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/serialport/qtudev_p.h b/src/serialport/qtudev_p.h
+index 6f2cabd..81b9849 100644
+--- a/src/serialport/qtudev_p.h
++++ b/src/serialport/qtudev_p.h
+@@ -105,9 +105,9 @@ inline QFunctionPointer resolveSymbol(QLibrary *udevLibrary, const char *symbolN
+ inline bool resolveSymbols(QLibrary *udevLibrary)
+ {
+     if (!udevLibrary->isLoaded()) {
+-        udevLibrary->setFileNameAndVersion(QStringLiteral("udev"), 1);
++        udevLibrary->setFileNameAndVersion(QStringLiteral("@libudev@/lib/libudev"), 1);
+         if (!udevLibrary->load()) {
+-            udevLibrary->setFileNameAndVersion(QStringLiteral("udev"), 0);
++            udevLibrary->setFileNameAndVersion(QStringLiteral("@libudev@/lib/libudev"), 0);
+             if (!udevLibrary->load()) {
+                 qWarning("Failed to load the library: %s, supported version(s): %i and %i", qPrintable(udevLibrary->fileName()), 1, 0);
+                 return false;
+--
+2.5.0

--- a/pkgs/development/libraries/qt-5/5.8/qtserialport/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtserialport/default.nix
@@ -1,0 +1,12 @@
+{ qtSubmodule, qtbase, substituteAll, systemd }:
+
+qtSubmodule {
+  name = "qtserialport";
+  qtInputs = [ qtbase ];
+  patches = [
+    (substituteAll {
+      src = ./0001-dlopen-serialport-udev.patch;
+      libudev = systemd.lib;
+    })
+  ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtsvg.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtsvg.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase }:
+
+qtSubmodule {
+  name = "qtsvg";
+  qtInputs = [ qtbase ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qttools/cmake-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qttools/cmake-paths.patch
@@ -1,0 +1,86 @@
+diff -Naur qttools-opensource-src-5.7.1.orig/src/assistant/help/Qt5HelpConfigExtras.cmake.in qttools-opensource-src-5.7.1/src/assistant/help/Qt5HelpConfigExtras.cmake.in
+--- qttools-opensource-src-5.7.1.orig/src/assistant/help/Qt5HelpConfigExtras.cmake.in	2016-11-03 09:31:16.000000000 +0100
++++ qttools-opensource-src-5.7.1/src/assistant/help/Qt5HelpConfigExtras.cmake.in	2017-02-28 16:37:20.130457615 +0100
+@@ -2,11 +2,10 @@
+ if (NOT TARGET Qt5::qcollectiongenerator)
+     add_executable(Qt5::qcollectiongenerator IMPORTED)
+
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Help_install_prefix}/$${CMAKE_BIN_DIR}qcollectiongenerator$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}qcollectiongenerator$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
++    set(imported_location \"@NIX_OUT@/$${CMAKE_BIN_DIR}qcollectiongenerator$$CMAKE_BIN_SUFFIX\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qcollectiongenerator$$CMAKE_BIN_SUFFIX\")
++    endif()
+     _qt5_Help_check_file_exists(${imported_location})
+
+     set_target_properties(Qt5::qcollectiongenerator PROPERTIES
+@@ -17,11 +16,10 @@
+ if (NOT TARGET Qt5::qhelpgenerator)
+     add_executable(Qt5::qhelpgenerator IMPORTED)
+
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Help_install_prefix}/$${CMAKE_BIN_DIR}qhelpgenerator$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}qhelpgenerator$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
++    set(imported_location \"@NIX_OUT@/$${CMAKE_BIN_DIR}qhelpgenerator$$CMAKE_BIN_SUFFIX\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qhelpgenerator$$CMAKE_BIN_SUFFIX\")
++    endif()
+     _qt5_Help_check_file_exists(${imported_location})
+
+     set_target_properties(Qt5::qhelpgenerator PROPERTIES
+diff -Naur qttools-opensource-src-5.7.1.orig/src/linguist/Qt5LinguistToolsConfig.cmake.in qttools-opensource-src-5.7.1/src/linguist/Qt5LinguistToolsConfig.cmake.in
+--- qttools-opensource-src-5.7.1.orig/src/linguist/Qt5LinguistToolsConfig.cmake.in	2016-11-03 09:31:16.000000000 +0100
++++ qttools-opensource-src-5.7.1/src/linguist/Qt5LinguistToolsConfig.cmake.in	2017-02-28 16:35:40.470100681 +0100
+@@ -44,11 +44,10 @@
+ if (NOT TARGET Qt5::lrelease)
+     add_executable(Qt5::lrelease IMPORTED)
+
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5_linguisttools_install_prefix}/$${CMAKE_BIN_DIR}lrelease$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}lrelease$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
++    set(imported_location \"@NIX_OUT@/$${CMAKE_BIN_DIR}lrelease$$CMAKE_BIN_SUFFIX\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}lrelease$$CMAKE_BIN_SUFFIX\")
++    endif()
+     _qt5_LinguistTools_check_file_exists(${imported_location})
+
+     set_target_properties(Qt5::lrelease PROPERTIES
+@@ -59,11 +58,10 @@
+ if (NOT TARGET Qt5::lupdate)
+     add_executable(Qt5::lupdate IMPORTED)
+
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5_linguisttools_install_prefix}/$${CMAKE_BIN_DIR}lupdate$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}lupdate$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
++    set(imported_location \"@NIX_OUT@/$${CMAKE_BIN_DIR}lupdate$$CMAKE_BIN_SUFFIX\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}lupdate$$CMAKE_BIN_SUFFIX\")
++    endif()
+     _qt5_LinguistTools_check_file_exists(${imported_location})
+
+     set_target_properties(Qt5::lupdate PROPERTIES
+@@ -74,11 +72,10 @@
+ if (NOT TARGET Qt5::lconvert)
+     add_executable(Qt5::lconvert IMPORTED)
+
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5_linguisttools_install_prefix}/$${CMAKE_BIN_DIR}lconvert$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}lconvert$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
++    set(imported_location \"@NIX_OUT@/$${CMAKE_BIN_DIR}lconvert$$CMAKE_BIN_SUFFIX\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}lconvert$$CMAKE_BIN_SUFFIX\")
++    endif()
+     _qt5_LinguistTools_check_file_exists(${imported_location})
+
+     set_target_properties(Qt5::lconvert PROPERTIES

--- a/pkgs/development/libraries/qt-5/5.8/qttools/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qttools/default.nix
@@ -1,0 +1,11 @@
+{ qtSubmodule, lib, copyPathsToStore, qtbase }:
+
+qtSubmodule {
+  name = "qttools";
+  qtInputs = [ qtbase ];
+  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  postFixup = ''
+    moveToOutput "bin/qdbus" "$out"
+    moveToOutput "bin/qtpaths" "$out"
+  '';
+}

--- a/pkgs/development/libraries/qt-5/5.8/qttools/series
+++ b/pkgs/development/libraries/qt-5/5.8/qttools/series
@@ -1,0 +1,1 @@
+cmake-paths.patch

--- a/pkgs/development/libraries/qt-5/5.8/qttranslations.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qttranslations.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qttools }:
+
+qtSubmodule {
+  name = "qttranslations";
+  qtInputs = [ qttools ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtwayland.nix
@@ -1,0 +1,8 @@
+{ qtSubmodule, qtbase, qtquickcontrols, wayland, pkgconfig }:
+
+qtSubmodule {
+  name = "qtwayland";
+  qtInputs = [ qtbase qtquickcontrols ];
+  buildInputs = [ wayland ];
+  nativeBuildInputs = [ pkgconfig ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtwebchannel.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebchannel.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtwebchannel";
+  qtInputs = [ qtbase qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebengine/default.nix
@@ -1,0 +1,76 @@
+{ qtSubmodule, qtquickcontrols, qtlocation, qtwebchannel
+
+, xlibs, libXcursor, libXScrnSaver, libXrandr, libXtst
+, fontconfig, freetype, harfbuzz, icu, dbus
+, zlib, libjpeg, libpng, libtiff
+, alsaLib
+, libcap
+, pciutils
+
+, bison, flex, git, which, gperf
+, coreutils
+, pkgconfig, python2
+
+, stdenv # lib.optional, needsPax
+}:
+
+qtSubmodule {
+  name = "qtwebengine";
+  qtInputs = [ qtquickcontrols qtlocation qtwebchannel ];
+  buildInputs = [ bison flex git which gperf ];
+  nativeBuildInputs = [ pkgconfig python2 coreutils ];
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    export MAKEFLAGS=-j$NIX_BUILD_CORES
+    substituteInPlace ./src/3rdparty/chromium/build/common.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+    substituteInPlace ./src/3rdparty/chromium/v8/build/toolchain.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+    substituteInPlace ./src/3rdparty/chromium/v8/build/standalone.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+
+    # fix default SSL bundle location
+    sed -i -e 's,/cert.pem,/certs/ca-bundle.crt,' src/3rdparty/chromium/third_party/boringssl/src/crypto/x509/x509_def.c
+
+    # Fix library paths
+    sed -i \
+      -e "s,QLibraryInfo::location(QLibraryInfo::DataPath),QLatin1String(\"$out\"),g" \
+      -e "s,QLibraryInfo::location(QLibraryInfo::TranslationsPath),QLatin1String(\"$out/translations\"),g" \
+      -e "s,QLibraryInfo::location(QLibraryInfo::LibraryExecutablesPath),QLatin1String(\"$out/libexec\"),g" \
+      src/core/web_engine_library_info.cpp
+
+    configureFlags+="\
+        -plugindir $out/lib/qt5/plugins \
+        -importdir $out/lib/qt5/imports \
+        -qmldir $out/lib/qt5/qml \
+        -docdir $out/share/doc/qt5"
+  '';
+  propagatedBuildInputs = [
+    dbus zlib alsaLib
+
+    # Image formats
+    libjpeg libpng libtiff
+
+    # Text rendering
+    fontconfig freetype harfbuzz icu
+
+    # X11 libs
+    xlibs.xrandr libXScrnSaver libXcursor libXrandr xlibs.libpciaccess libXtst
+    xlibs.libXcomposite
+
+    libcap
+    pciutils
+  ];
+  patches = stdenv.lib.optional stdenv.needsPax ./qtwebengine-paxmark-mksnapshot.patch;
+  postInstall = ''
+    cat > $out/libexec/qt.conf <<EOF
+    [Paths]
+    Prefix = ..
+    EOF
+
+    paxmark m $out/libexec/QtWebEngineProcess
+  '';
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtwebengine/qtwebengine-paxmark-mksnapshot.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebengine/qtwebengine-paxmark-mksnapshot.patch
@@ -1,0 +1,46 @@
+--- qtwebengine-opensource-src-5.6.0-orig/src/3rdparty/chromium/v8/tools/gyp/v8.gyp	2016-03-04 01:48:36.000000000 +1100
++++ qtwebengine-opensource-src-5.6.0/src/3rdparty/chromium/v8/tools/gyp/v8.gyp	2016-05-01 19:15:44.052770543 +1000
+@@ -33,6 +33,7 @@
+     'embed_script%': "",
+     'v8_extra_library_files%': [],
+     'mksnapshot_exec': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)mksnapshot<(EXECUTABLE_SUFFIX)',
++    'mksnapshot_u_exec': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)mksnapshot_u<(EXECUTABLE_SUFFIX)',
+     'remove_v8base_debug_symbols%': 0,
+   },
+   'includes': ['../../build/toolchain.gypi', '../../build/features.gypi'],
+@@ -1913,7 +1914,7 @@
+         ]
+     },
+     {
+-      'target_name': 'mksnapshot',
++      'target_name': 'mksnapshot_u',
+       'type': 'executable',
+       'dependencies': ['v8_base', 'v8_nosnapshot', 'v8_libplatform'],
+       'include_dirs+': [
+@@ -1936,5 +1937,26 @@
+         }],
+       ],
+     },
++    {
++      'target_name': 'mksnapshot',
++      'type': 'executable',
++      'dependencies': ['mksnapshot_u'],
++      'actions': [
++        {
++          'action_name': 'paxmark_m_mksnapshot',
++          'inputs': [
++            '<(mksnapshot_u_exec)',
++          ],
++          'outputs': [
++            '<(mksnapshot_exec)',
++          ],
++          'action': [
++            'sh',
++            '-c',
++            'cp <(mksnapshot_u_exec) <(mksnapshot_exec) && paxctl -czexm <(mksnapshot_exec)',
++          ],
++        },
++      ],
++    },
+   ],
+ }

--- a/pkgs/development/libraries/qt-5/5.8/qtwebkit/0001-dlopen-webkit-nsplugin.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebkit/0001-dlopen-webkit-nsplugin.patch
@@ -1,0 +1,52 @@
+From 862ce7d357a3ec32683ac6ec7c0ebdc9346b44ba Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:18:54 -0500
+Subject: [PATCH 1/3] dlopen webkit nsplugin
+
+---
+ Source/WebCore/plugins/qt/PluginPackageQt.cpp                        | 2 +-
+ Source/WebCore/plugins/qt/PluginViewQt.cpp                           | 2 +-
+ Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Source/WebCore/plugins/qt/PluginPackageQt.cpp b/Source/WebCore/plugins/qt/PluginPackageQt.cpp
+index a923d49..2731d05 100644
+--- a/Source/WebCore/plugins/qt/PluginPackageQt.cpp
++++ b/Source/WebCore/plugins/qt/PluginPackageQt.cpp
+@@ -136,7 +136,7 @@ static void initializeGtk(QLibrary* module = 0)
+         }
+     }
+
+-    QLibrary library(QLatin1String("libgtk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gtk@/lib/libgtk-x11-2.0"), 0);
+     if (library.load()) {
+         typedef void *(*gtk_init_check_ptr)(int*, char***);
+         gtk_init_check_ptr gtkInitCheck = (gtk_init_check_ptr)library.resolve("gtk_init_check");
+diff --git a/Source/WebCore/plugins/qt/PluginViewQt.cpp b/Source/WebCore/plugins/qt/PluginViewQt.cpp
+index de06a2f..363bde5 100644
+--- a/Source/WebCore/plugins/qt/PluginViewQt.cpp
++++ b/Source/WebCore/plugins/qt/PluginViewQt.cpp
+@@ -697,7 +697,7 @@ static Display *getPluginDisplay()
+     // support gdk based plugins (like flash) that use a different X connection.
+     // The code below has the same effect as this one:
+     // Display *gdkDisplay = gdk_x11_display_get_xdisplay(gdk_display_get_default());
+-    QLibrary library(QLatin1String("libgdk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gdk_pixbuf@/lib/libgdk-x11-2.0"), 0);
+     if (!library.load())
+         return 0;
+
+diff --git a/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp b/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp
+index d734ff6..62a2197 100644
+--- a/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp
++++ b/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp
+@@ -64,7 +64,7 @@ static Display* getPluginDisplay()
+     // The code below has the same effect as this one:
+     // Display *gdkDisplay = gdk_x11_display_get_xdisplay(gdk_display_get_default());
+
+-    QLibrary library(QLatin1String("libgdk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gdk_pixbuf@/libgdk-x11-2.0"), 0);
+     if (!library.load())
+         return 0;
+
+--
+2.5.0

--- a/pkgs/development/libraries/qt-5/5.8/qtwebkit/0002-dlopen-webkit-gtk.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebkit/0002-dlopen-webkit-gtk.patch
@@ -1,0 +1,24 @@
+From 6a407d30357c2551abceac75c82f4a1688e47437 Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:19:16 -0500
+Subject: [PATCH 2/3] dlopen webkit gtk
+
+---
+ Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp b/Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp
+index 8de6521..0b25748 100644
+--- a/Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp
++++ b/Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp
+@@ -53,7 +53,7 @@ static void messageHandler(QtMsgType type, const QMessageLogContext&, const QStr
+
+ static bool initializeGtk()
+ {
+-    QLibrary gtkLibrary(QLatin1String("libgtk-x11-2.0"), 0);
++    QLibrary gtkLibrary(QLatin1String("@gtk@/lib/libgtk-x11-2.0"), 0);
+     if (!gtkLibrary.load())
+         return false;
+     typedef void* (*gtk_init_ptr)(void*, void*);
+--
+2.5.0

--- a/pkgs/development/libraries/qt-5/5.8/qtwebkit/0003-dlopen-webkit-udev.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebkit/0003-dlopen-webkit-udev.patch
@@ -1,0 +1,30 @@
+From 864020dd47c3b6d532d9f26b82185904cf9324f2 Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:19:29 -0500
+Subject: [PATCH 3/3] dlopen webkit udev
+
+---
+ Source/WebCore/platform/qt/GamepadsQt.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Source/WebCore/platform/qt/GamepadsQt.cpp b/Source/WebCore/platform/qt/GamepadsQt.cpp
+index 60ff317..da8ac69 100644
+--- a/Source/WebCore/platform/qt/GamepadsQt.cpp
++++ b/Source/WebCore/platform/qt/GamepadsQt.cpp
+@@ -111,12 +111,12 @@ private:
+     bool load()
+     {
+         m_libUdev.setLoadHints(QLibrary::ResolveAllSymbolsHint);
+-        m_libUdev.setFileNameAndVersion(QStringLiteral("udev"), 1);
++        m_libUdev.setFileNameAndVersion(QStringLiteral("@libudev@/lib/libudev"), 1);
+         m_loaded = m_libUdev.load();
+         if (resolveMethods())
+             return true;
+
+-        m_libUdev.setFileNameAndVersion(QStringLiteral("udev"), 0);
++        m_libUdev.setFileNameAndVersion(QStringLiteral("@libudev@/lib/libudev"), 0);
+         m_loaded = m_libUdev.load();
+         return resolveMethods();
+     }
+--
+2.5.0

--- a/pkgs/development/libraries/qt-5/5.8/qtwebkit/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebkit/default.nix
@@ -1,0 +1,35 @@
+{ qtSubmodule, stdenv, qtdeclarative, qtlocation, qtsensors
+, fontconfig, gdk_pixbuf, gtk2, libwebp, libxml2, libxslt
+, sqlite, systemd, glib, gst_all_1
+, bison2, flex, gdb, gperf, perl, pkgconfig, python2, ruby
+, substituteAll
+, flashplayerFix ? false
+}:
+
+with stdenv.lib;
+
+qtSubmodule {
+  name = "qtwebkit";
+  qtInputs = [ qtdeclarative qtlocation qtsensors ];
+  buildInputs = [ fontconfig libwebp libxml2 libxslt sqlite glib gst_all_1.gstreamer gst_all_1.gst-plugins-base ];
+  nativeBuildInputs = [
+    bison2 flex gdb gperf perl pkgconfig python2 ruby
+  ];
+  patches =
+    let dlopen-webkit-nsplugin = substituteAll {
+          src = ./0001-dlopen-webkit-nsplugin.patch;
+          gtk = gtk2.out;
+          gdk_pixbuf = gdk_pixbuf.out;
+        };
+        dlopen-webkit-gtk = substituteAll {
+          src = ./0002-dlopen-webkit-gtk.patch;
+          gtk = gtk2.out;
+        };
+        dlopen-webkit-udev = substituteAll {
+          src = ./0003-dlopen-webkit-udev.patch;
+          libudev = systemd.lib;
+        };
+    in optionals flashplayerFix [ dlopen-webkit-nsplugin dlopen-webkit-gtk ]
+    ++ [ dlopen-webkit-udev ];
+  meta.maintainers = with stdenv.lib.maintainers; [ abbradar ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtwebsockets.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebsockets.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtwebsockets";
+  qtInputs = [ qtbase qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtx11extras.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtx11extras.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase }:
+
+qtSubmodule {
+  name = "qtx11extras";
+  qtInputs = [ qtbase ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtxmlpatterns.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtxmlpatterns.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase }:
+
+qtSubmodule {
+  name = "qtxmlpatterns";
+  qtInputs = [ qtbase ];
+}

--- a/pkgs/development/libraries/qt-5/5.8/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.8/srcs.nix
@@ -1,0 +1,325 @@
+# DO NOT EDIT! This file is generated automatically by fetch-kde-qt.sh
+{ fetchurl, mirror }:
+
+{
+  qt3d = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qt3d-opensource-src-5.8.0.tar.xz";
+      sha256 = "1rca1k8lf0xy2x1w3kp9rnpi77bbrm8v7db302n9a8cjziv4a8is";
+      name = "qt3d-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtactiveqt = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtactiveqt-opensource-src-5.8.0.tar.xz";
+      sha256 = "1a9m87chmp2m3ljadryh9ggvwpvclmazz081h3p68n092dbl2ylj";
+      name = "qtactiveqt-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtandroidextras = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtandroidextras-opensource-src-5.8.0.tar.xz";
+      sha256 = "1wgbxi579fdnripp481qhcqma95hm4zcc16n4ljjpl0yzn1zx8qa";
+      name = "qtandroidextras-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtbase = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtbase-opensource-src-5.8.0.tar.xz";
+      sha256 = "01f07yjly7y24njl2h4hyknmi7pf8yd9gky23szcfkd40ap12wf1";
+      name = "qtbase-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtcanvas3d = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtcanvas3d-opensource-src-5.8.0.tar.xz";
+      sha256 = "18yaikbwk4d7sh09psi3kjn1mxjp4d2f3qchfzgq5x96yn8gfijl";
+      name = "qtcanvas3d-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtcharts = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtcharts-opensource-src-5.8.0.tar.xz";
+      sha256 = "11m5g1fxip6z2xk1z6g6h4rq7v282qbkxflan8hs87hadnzars03";
+      name = "qtcharts-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtconnectivity = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtconnectivity-opensource-src-5.8.0.tar.xz";
+      sha256 = "1w97na5s420y08dcydqinbqb0rd9h4pfdnjbwslr0qvzsvlh2bbv";
+      name = "qtconnectivity-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtdatavis3d = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtdatavis3d-opensource-src-5.8.0.tar.xz";
+      sha256 = "1n2vdf6n7pr9xrjwbvbar899q74shx6cy19x32adxfn2iilygwbp";
+      name = "qtdatavis3d-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtdeclarative = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtdeclarative-opensource-src-5.8.0.tar.xz";
+      sha256 = "0ilaf2sprpk9fg2j3905hxnhm0xbnm88ppk4zifp7n0jmnwix51j";
+      name = "qtdeclarative-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtdoc = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtdoc-opensource-src-5.8.0.tar.xz";
+      sha256 = "13jpml9hdcxvf8j2033x5liw26r3q8idpjmx2rij63w2956c84ii";
+      name = "qtdoc-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtgamepad = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtgamepad-opensource-src-5.8.0.tar.xz";
+      sha256 = "0dwcrq60h802z694h4108figlr3yvp8fpzhwjzbjm503v8yaxw5j";
+      name = "qtgamepad-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtgraphicaleffects = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtgraphicaleffects-opensource-src-5.8.0.tar.xz";
+      sha256 = "06frknb7m8bgg55rs7jjm61iziisy2ykzrrc5dy3vj0aad89najz";
+      name = "qtgraphicaleffects-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtimageformats = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtimageformats-opensource-src-5.8.0.tar.xz";
+      sha256 = "0vv0wh5q5sih294x661djzwvgdwy7r6xpnxsc111k5hwq7m5w13m";
+      name = "qtimageformats-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtlocation = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtlocation-opensource-src-5.8.0.tar.xz";
+      sha256 = "1fqssa8rhq83lnxjcdh4ijqck3lmqglpk8yax8x17w49v6gf78a8";
+      name = "qtlocation-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtmacextras = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtmacextras-opensource-src-5.8.0.tar.xz";
+      sha256 = "049lbxy6yxv7yii7zxibfbix0q2p8fn58dsbc33rn40gbs7rj9zf";
+      name = "qtmacextras-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtmultimedia = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtmultimedia-opensource-src-5.8.0.tar.xz";
+      sha256 = "01sakngvsqr90qhrxyghfqdpddpxwbjyzzhm34k0hlpr6i409g58";
+      name = "qtmultimedia-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtnetworkauth = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtnetworkauth-opensource-src-5.8.0.tar.xz";
+      sha256 = "1hz4lcm4cai56v0q7h1q6zc29ykkb2191iqmf8h7l5l9m71q2mb1";
+      name = "qtnetworkauth-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtpurchasing = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtpurchasing-opensource-src-5.8.0.tar.xz";
+      sha256 = "0mdkw73yx1csz9mf3wl0w1x1b8cv9j5px4nvakrknkjzaa9qgzdk";
+      name = "qtpurchasing-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtquickcontrols = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtquickcontrols-opensource-src-5.8.0.tar.xz";
+      sha256 = "09mkswxw7wa2l8xz9fbblxr1pbi86hggis55j4k8ifnrrw60vrq4";
+      name = "qtquickcontrols-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtquickcontrols2 = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtquickcontrols2-opensource-src-5.8.0.tar.xz";
+      sha256 = "06yy98x4vic2yrlpp83gf4kvl7kd93q62k178w0cy4sgqxp8d6dh";
+      name = "qtquickcontrols2-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtscript = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtscript-opensource-src-5.8.0.tar.xz";
+      sha256 = "1lssbsjf2p2ag02fjq6k6vk7vywhj4jsl286r2fqi78q5lfvjfi9";
+      name = "qtscript-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtscxml = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtscxml-opensource-src-5.8.0.tar.xz";
+      sha256 = "1i4xl24q4i32mbhyndrwaz0xj79d9n84s320gmkf5rwnfcwrvfxn";
+      name = "qtscxml-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtsensors = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtsensors-opensource-src-5.8.0.tar.xz";
+      sha256 = "15p7bp21yj4cdl5yfc9qnn4lhhiwiwx3b71lrb431kgqxhwhcp9s";
+      name = "qtsensors-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtserialbus = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtserialbus-opensource-src-5.8.0.tar.xz";
+      sha256 = "02n1b1wrvfg6c7z15c5c5gv9r5gd4pp58jrd1a8d8fg3ybcksd2q";
+      name = "qtserialbus-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtserialport = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtserialport-opensource-src-5.8.0.tar.xz";
+      sha256 = "1b86al3zn1pxyk0n59vh8bqxrpz2m0j33ygclaqbxl1sszg7ycaj";
+      name = "qtserialport-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtspeech = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtspeech-opensource-src-5.8.0.tar.xz";
+      sha256 = "0i2cx1b6ssj56p5blf7n16bbrq1g0hb27m3b5r6dh6py7mcq2spi";
+      name = "qtspeech-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtsvg = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtsvg-opensource-src-5.8.0.tar.xz";
+      sha256 = "12fwzbp28szqw1sk3flb8i6xnxgl94siwyy41ffdmd0s44f1jwwq";
+      name = "qtsvg-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qttools = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qttools-opensource-src-5.8.0.tar.xz";
+      sha256 = "10wx4vydj91yag30457c7azx4ihrwky42l7zzwkbmdlksdv8xv4m";
+      name = "qttools-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qttranslations = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qttranslations-opensource-src-5.8.0.tar.xz";
+      sha256 = "0bpwqclidji12f3f20hfpafr1b7b9wc7nhp4yhms1hhbqlpgfz1v";
+      name = "qttranslations-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtvirtualkeyboard = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtvirtualkeyboard-opensource-src-5.8.0.tar.xz";
+      sha256 = "0772yhb8w6rzxqgrdmvbw61vk2gagcs9zics56v3a2ckknrzbz9m";
+      name = "qtvirtualkeyboard-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwayland = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtwayland-opensource-src-5.8.0.tar.xz";
+      sha256 = "06ilh55vaxbkyv7irw0n11gxgc34ypx2qhqawxzy7kllzg9zcl7z";
+      name = "qtwayland-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwebchannel = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtwebchannel-opensource-src-5.8.0.tar.xz";
+      sha256 = "0jhbgp9rdp5lpwjrykxmg4lb60wk7gm3dldz5kp3b8ms2dab3xav";
+      name = "qtwebchannel-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwebengine = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtwebengine-opensource-src-5.8.0.tar.xz";
+      sha256 = "1gkrvb8wa04p91hras2pa7i26n1q5xgsiq5gfw3fc488cvqj4g92";
+      name = "qtwebengine-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwebkit = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/community_releases/5.8/5.8.0-final/qtwebkit-opensource-src-5.8.0.tar.xz";
+      sha256 = "1v0vj6slyh19mjrrpbqdzb47fr0f4xk7bc8803xjzybb11h8dbkr";
+      name = "qtwebkit-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwebkit-examples = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/community_releases/5.8/5.8.0-final/qtwebkit-examples-opensource-src-5.8.0.tar.xz";
+      sha256 = "18ar35mg32knm3r0wgqv1hmxl9pqhi1y0yhd3lbskca0f0csxiw4";
+      name = "qtwebkit-examples-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwebsockets = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtwebsockets-opensource-src-5.8.0.tar.xz";
+      sha256 = "1xa5p36grqxz3fa08amn7r3dy6k28g6y0gkc6jgj7lyhjzr0l4da";
+      name = "qtwebsockets-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwebview = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtwebview-opensource-src-5.8.0.tar.xz";
+      sha256 = "1lvzab6vjmpsl3rq73afhvjv6hkkgj19sl6sd03fgx0iikfd9n5p";
+      name = "qtwebview-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtwinextras = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtwinextras-opensource-src-5.8.0.tar.xz";
+      sha256 = "1761qaqbrsqqpznv2mrkc44fk4x3lc13x6s0z3ahjms6pna7pzr7";
+      name = "qtwinextras-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtx11extras = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtx11extras-opensource-src-5.8.0.tar.xz";
+      sha256 = "03i8lk9qcdf8h2k4f3rkqqkzbrlnyaspv9mgjkn4k61s2asz5mxy";
+      name = "qtx11extras-opensource-src-5.8.0.tar.xz";
+    };
+  };
+  qtxmlpatterns = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.8/5.8.0/submodules/qtxmlpatterns-opensource-src-5.8.0.tar.xz";
+      sha256 = "016s75j2cml7kc8scdm9a6pmxm8jhs424lml2h9znm1flmgadzvv";
+      name = "qtxmlpatterns-opensource-src-5.8.0.tar.xz";
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9357,6 +9357,19 @@ with pkgs;
 
   libsForQt57 = recurseIntoAttrs (lib.makeScope qt57.newScope mkLibsForQt5);
 
+  qt58 = recurseIntoAttrs (import ../development/libraries/qt-5/5.8 {
+    inherit newScope;
+    inherit stdenv fetchurl makeSetupHook makeWrapper;
+    bison = bison2; # error: too few arguments to function 'int yylex(...
+    cups = if stdenv.isLinux then cups else null;
+    harfbuzz = harfbuzz-icu;
+    mesa = mesa_noglu;
+    inherit perl;
+    inherit (gst_all_1) gstreamer gst-plugins-base;
+  });
+
+  libsForQt58 = recurseIntoAttrs (lib.makeScope qt58.newScope mkLibsForQt5);
+
   qt5 = qt57;
   libsForQt5 = libsForQt57;
 


### PR DESCRIPTION
Removed the -largefiles flag as it's no longer used, the configure scripts were rewritten for qt 5.8. This also means that the iconv flag was removed, as you can only pick icu or iconv now.

I made sure that the qtweb fixes recently introduced were pulled in, and also updated the instructions from 5.7 seeing as they were outdated (5.6 had the correct instructions)

Would like to run this through a full test with nox-review, but I keep hitting unrelated build issues in the tree.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

