### PR TITLE
xserver: check that selected layout exists

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -258,7 +258,7 @@ in
         type = types.str;
         default = "us";
         description = ''
-          Keyboard layout.
+          Keyboard layout, or multiple keyboard layouts separated by commas.
         '';
       };
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -578,6 +578,35 @@ in
 
     services.xserver.xkbDir = mkDefault "${pkgs.xkeyboard_config}/etc/X11/xkb";
 
+    system.extraDependencies = [
+      (pkgs.runCommand "xkb-layouts-exist" {
+            layouts=cfg.layout;
+        } ''
+        missing=()
+        while read -d , layout
+        do
+          [[ -f "${cfg.xkbDir}/symbols/$layout" ]] || missing+=($layout)
+        done <<< "$layouts,"
+        if [[ ''${#missing[@]} -eq 0 ]]
+        then
+          touch $out
+          exit 0
+        fi
+
+        cat >&2 <<EOF
+
+        Some of the selected keyboard layouts do not exist:
+
+          ''${missing[@]}
+
+        Set services.xserver.layout to the name of an existing keyboard
+        layout (check ${cfg.xkbDir}/symbols for options).
+
+        EOF
+        exit -1
+      '')
+    ];
+
     services.xserver.config =
       ''
         Section "ServerFlags"


### PR DESCRIPTION
###### Motivation for this change
#5638

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- [x] Built on NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).