### PR TITLE
nginx: enableACME should turn on SSL

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -119,7 +119,7 @@ let
   vhosts = concatStringsSep "\n" (mapAttrsToList (vhostName: vhost:
       let
         serverName = vhost.serverName;
-        ssl = vhost.enableSSL || vhost.forceSSL;
+        ssl = vhost.enableSSL || vhost.forceSSL || vhost.enableACME;
         port = if vhost.port != null then vhost.port else (if ssl then 443 else 80);
         listenString = toString port + optionalString ssl " ssl http2"
           + optionalString vhost.default " default_server";


### PR DESCRIPTION
Otherwise, why are you using it?

###### Motivation for this change

Besides the fact that I find it redundant to have to explicitly serve SSL when ACME is enabled (if you're getting an SSL certificate, you presumably want to use it), this should easily resolve #23711, since there won't be an weird configuration with ACME enabled but SSL disabled.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

