### PR TITLE
Add Mozilla sops package

### DIFF
--- a/pkgs/tools/security/sops/default.nix
+++ b/pkgs/tools/security/sops/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "sops-${version}";
+  version = "2.0.8";
+
+  goPackagePath = "go.mozilla.org/sops";
+
+  src = fetchFromGitHub {
+    rev = version;
+    owner = "mozilla";
+    repo = "sops";
+    sha256 = "0kawnp24i3r981hz6apfwhgp71002vjq7ir54arq0zkssmykms1c";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Mozilla sops (Secrets OPerationS) is an editor of encrypted files";
+    homepage = https://github.com/mozilla/sops;
+    license = licenses.mpl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15228,6 +15228,8 @@ with pkgs;
 
   sooperlooper = callPackage ../applications/audio/sooperlooper { };
 
+  sops = callPackage ../tools/security/sops { };
+
   sorcer = callPackage ../applications/audio/sorcer { };
 
   sound-juicer = callPackage ../applications/audio/sound-juicer { };


### PR DESCRIPTION
###### Motivation for this change
Adding mozilla sops (go) package. Would appreciate it if someone more golang-savvy than me could take a look at this.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

