### PR TITLE
virtualbox: 5.1.14 -> 5.1.16

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -18,10 +18,10 @@ let
   python = python2;
   buildType = "release";
 
-  extpack = "baddb7cc49224ecc1147f82d77fce2685ac39941ac9b0aac83c270dd6570ea85";
-  extpackRev = 112924;
-  main = "8267bb026717c6e55237eb798210767d9c703cfcdf01224d9bc26f7dac9f228a";
-  version = "5.1.14";
+  extpack = "02f73xxx8vk7g2ym26h6x9id088kff1256y9jbhmn0dz2qb72f58";
+  extpackRev = 113841;
+  main = "19wi4a5m5wvrxjkhmg14mgv0373adjpc6ln3h5wkrggkf8qiq1vq";
+  version = "5.1.16";
 
   # See https://github.com/NixOS/nixpkgs/issues/672 for details
   extensionPack = requireFile rec {

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "1b206b76050dccd3ed979307230f9ddea79551e1c0aba93faee77416733cdc8a";
+    sha256 = "1ayg524ghqz49xk9d7d4xzxl11w4hssjrcy9pmnksa7nslqpwcia";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/*/build";


### PR DESCRIPTION
###### Motivation for this change

This also makes the guest additions build with Linux 4.10
Unfortunatly this version still requires X.org ABI 1.18

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

