### PR TITLE
prometheus-fritzbox-exporter: init at 1.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -328,6 +328,7 @@
   ./services/monitoring/prometheus/default.nix
   ./services/monitoring/prometheus/alertmanager.nix
   ./services/monitoring/prometheus/blackbox-exporter.nix
+  ./services/monitoring/prometheus/fritzbox-exporter.nix
   ./services/monitoring/prometheus/json-exporter.nix
   ./services/monitoring/prometheus/nginx-exporter.nix
   ./services/monitoring/prometheus/node-exporter.nix

--- a/nixos/modules/services/monitoring/prometheus/fritzbox-exporter.nix
+++ b/nixos/modules/services/monitoring/prometheus/fritzbox-exporter.nix
@@ -1,0 +1,76 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.fritzboxExporter;
+in {
+  options = {
+    services.prometheus.fritzboxExporter = {
+      enable = mkEnableOption "prometheus fritzbox exporter";
+
+      port = mkOption {
+        type = types.int;
+        default = 9133;
+        description = ''
+          Port to listen on.
+        '';
+      };
+
+      gatewayAddress = mkOption {
+        type = types.str;
+        default = "fritz.box";
+        description = ''
+          The hostname or IP of the FRITZ!Box.
+        '';
+      };
+
+      gatewayPort = mkOption {
+        type = types.int;
+        default = 49000;
+        description = ''
+          The port of the FRITZ!Box UPnP service.
+        '';
+      };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Extra commandline options when launching the fritzbox exporter.
+        '';
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Open port in firewall for incoming connections.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = optional cfg.openFirewall cfg.port;
+
+    systemd.services.prometheus-fritzbox-exporter = {
+      description = "Prometheus exporter for FRITZ!Box via UPnP";
+      unitConfig.Documentation = "https://github.com/ndecker/fritzbox_exporter";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        User = "nobody";
+        Restart = "always";
+        PrivateTmp = true;
+        WorkingDirectory = /tmp;
+        ExecStart = ''
+          ${pkgs.prometheus-fritzbox-exporter}/bin/fritzbox_exporter \
+            -listen-address :${toString cfg.port} \
+            -gateway-address ${cfg.gatewayAddress} \
+            -gateway-port ${toString cfg.gatewayPort} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
+    };
+  };
+}

--- a/pkgs/servers/monitoring/prometheus/fritzbox-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/fritzbox-exporter.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "fritzbox-exporter-${version}";
+  version = "1.0";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/ndecker/fritzbox_exporter";
+
+  src= fetchFromGitHub {
+    inherit rev;
+    owner = "ndecker";
+    repo = "fritzbox_exporter";
+    sha256 = "1qk3dgxxz3cnz52jzz0yvfkrkk4s5kdhc26nbfgdpn0ifzqj0awr";
+  };
+
+  meta = with stdenv.lib; {
+    description = "FRITZ!Box UPnP statistics exporter for prometheus";
+    homepage = https://github.com/ndecker/fritzbox_exporter;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bachp ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10780,6 +10780,7 @@ with pkgs;
   prometheus-bind-exporter = callPackage ../servers/monitoring/prometheus/bind-exporter.nix { };
   prometheus-blackbox-exporter = callPackage ../servers/monitoring/prometheus/blackbox-exporter.nix { };
   prometheus-collectd-exporter = callPackage ../servers/monitoring/prometheus/collectd-exporter.nix { };
+  prometheus-fritzbox-exporter = callPackage ../servers/monitoring/prometheus/fritzbox-exporter.nix { };
   prometheus-haproxy-exporter = callPackage ../servers/monitoring/prometheus/haproxy-exporter.nix { };
   prometheus-json-exporter = callPackage ../servers/monitoring/prometheus/json-exporter.nix { };
   prometheus-mesos-exporter = callPackage ../servers/monitoring/prometheus/mesos-exporter.nix { };


### PR DESCRIPTION
###### Motivation for this change

Allows to monitor fritzbox devices via prometheus.
The default module should work by just enabling it in most cases.
/cc @ndecker

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

