### PR TITLE
kcachegrind: init at 2017-02-25

### DIFF
--- a/pkgs/development/tools/analysis/kcachegrind/default.nix
+++ b/pkgs/development/tools/analysis/kcachegrind/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, extra-cmake-modules, kdeFrameworks, php }:
+# php is for pprof2calltree
+
+stdenv.mkDerivation rec {
+  name = "kcachegrind-${version}";
+
+  version = "2017-02-25";
+
+  src = fetchFromGitHub {
+    owner = "KDE";
+    repo = "kcachegrind";
+    rev = "3c0f3423e58f65f93bf062b319a346dcea11daff";
+    sha256 = "0qpvrkiir5yclsqxmwsbs8s6dkl9msx3nynnskrx2vf4nikxp2i1";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules ];
+
+  buildInputs = with kdeFrameworks; [
+    karchive kcoreaddons kdoctools ki18n kio kwidgetsaddons kxmlgui
+  ] ++ [ php ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    license = with licenses; [ gpl2 ];
+    maintainers = with maintainers; [ orivej ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6550,6 +6550,8 @@ with pkgs;
 
   jenkins-job-builder = pythonPackages.jenkins-job-builder;
 
+  kcachegrind = callPackage ../development/tools/analysis/kcachegrind { };
+
   kconfig-frontends = callPackage ../development/tools/misc/kconfig-frontends {
     gperf = gperf_3_0;
   };


### PR DESCRIPTION
###### Motivation for this change

This adds [KCachegrind](https://github.com/KDE/kcachegrind/). There is another [branch](https://github.com/KDE/kcachegrind/tree/Applications/16.12) of KCachegrind in KDE Applications Bundle, but it requires KDE 4 (unlike the master branch that requires KDE 5) and is not available in Nixpkgs.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).