### PR TITLE
meson: 0.35.0 -> 0.39.0

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -1,11 +1,11 @@
 { lib, python3Packages, fetchurl }:
 python3Packages.buildPythonPackage rec {
-  version = "0.35.0";
+  version = "0.39.0";
   name = "meson-${version}";
 
   src = fetchurl {
     url = "mirror://pypi/m/meson/${name}.tar.gz";
-    sha256 = "0w4vian55cwcv2m5qzn73aznf9a0y24cszqb7dkpahrb9yrg25l3";
+    sha256 = "eac71036ae0e7c692873880fd32c55ca28e99f56630d118ca9c78fbd986c6c97";
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Simple update from 0.35.0 to 0.39.0.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

