### PR TITLE
redo-sh: init at 1.2.6

### DIFF
--- a/pkgs/development/tools/build-managers/redo-sh/default.nix
+++ b/pkgs/development/tools/build-managers/redo-sh/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.6";
+  name = "redo-sh-${version}";
+
+  src = fetchurl {
+    url = "http://news.dieweltistgarnichtso.net/bin/archives/redo-sh.tar.gz";
+    sha256 = "1cwrk4v22rb9410rzyb4py4ncg01n6850l80s74bk3sflbw974wp";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  sourceRoot = ".";
+  installPhase = ''
+    mkdir -p "$out/share"
+    mv man "$out/share"
+    mv bin "$out"
+    for p in $out/bin/*; do
+      wrapProgram "$p" --set PATH '$PATH:'"$out/bin"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Redo implementation in Bourne Shell";
+    homepage = "http://news.dieweltistgarnichtso.net/bin/redo-sh.html";
+    license  = licenses.agpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6657,6 +6657,8 @@ with pkgs;
 
   redo = callPackage ../development/tools/build-managers/redo { };
 
+  redo-sh = callPackage ../development/tools/build-managers/redo-sh { };
+
   reno = callPackage ../development/tools/reno { };
 
   re2c = callPackage ../development/tools/parsing/re2c { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Would be great if somebody could test `  redo`   extensively on macOS.