### PR TITLE
jshon: 20140712 -> 20140712-nix1

### DIFF
--- a/pkgs/development/tools/parsing/jshon/default.nix
+++ b/pkgs/development/tools/parsing/jshon/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, fetchFromGitHub, jansson }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, jansson }:
 
 stdenv.mkDerivation rec {
-  name = "jshon-20140712";
+  name = "jshon-20140712-nix1";
 
   rev = "a61d7f2f85f4627bc3facdf951746f0fd62334b7";
   sha256 = "b0365e58553b9613a5636545c5bfd4ad05ab5024f192e1cb1d1824bae4e1a380";
@@ -12,14 +12,22 @@ stdenv.mkDerivation rec {
     repo = "jshon";
   };
 
+  patches = [
+    # Fix null termination in read_stream.
+    (fetchpatch {
+      url = https://github.com/mbrock/jshon/commit/32288dd186573ceb58164f30be1782d4580466d8.patch;
+      sha256 = "04rss2nprl9nqblc7smq0477n54hm801xgnnmvyzni313i1n6vhl";
+    })
+  ];
+
   buildInputs = [ jansson ];
 
-  patchPhase = 
+  patchPhase =
     ''
       substituteInPlace Makefile --replace "/usr/" "/"
     '';
 
-  preInstall = 
+  preInstall =
     ''
       export DESTDIR=$out
     '';


### PR DESCRIPTION
###### Motivation for this change

This fixes a somewhat critical (security?) bug.

We are trying to get it merged upstream but have had no response from
the ordinary maintainer in over a week.

(See <https://github.com/keenerd/jshon/issues/53>.)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

