### PR TITLE
libhttpseverywhere: 0.2.3 -> 0.2.10

### DIFF
--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   major = "0.2";
-  minor = "3";
+  minor = "10";
   version = "${major}.${minor}";
 
   name = "libhttpseverywhere-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/libhttpseverywhere/${major}/libhttpseverywhere-${version}.tar.xz";
-    sha256 = "0ndk6yyfcd7iwwkv4rkivhd08k0x8v03gnp9dk1ms4bxb1l2i8l1";
+    sha256 = "235f5b7f96188d800470871774e31696fbde085b63f65bd71434af8e9e6ac8aa";
   };
 
   nativeBuildInputs = [ gnome3.vala valadoc  gobjectIntrospection meson ninja pkgconfig ];
@@ -23,8 +23,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     ninja
-    ninja devhelp
-  '';
+   '';
 
   installPhase = "ninja install";
 


### PR DESCRIPTION
###### Motivation for this change
Upgrade

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

