### PR TITLE
coinmp: 1.7.6 -> 1.8.3

### DIFF
--- a/pkgs/development/libraries/CoinMP/default.nix
+++ b/pkgs/development/libraries/CoinMP/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "CoinMP-${version}";
-  version = "1.7.6";
+  version = "1.8.3";
 
   src = fetchurl {
     url = "http://www.coin-or.org/download/source/CoinMP/${name}.tgz";
-    sha256 = "0gqi2vqkg35gazzzv8asnhihchnbjcd6bzjfzqhmj7wy1dw9iiw6";
+    sha256 = "1xr2iwbbhm6l9hwiry5c10pz46xfih8bvzrzwp0nkzf76vdnb9m1";
   };
 
   hardeningDisable = [ "format" ];


### PR DESCRIPTION
###### Motivation for this change
Update. 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

