### PR TITLE
mmex: v1.3.1 -> v1.3.3

### DIFF
--- a/pkgs/applications/office/mmex/default.nix
+++ b/pkgs/applications/office/mmex/default.nix
@@ -2,7 +2,7 @@
 
 
 let
-  version = "1.3.1";
+  version = "1.3.3";
 in
   stdenv.mkDerivation {
     name = "money-manager-ex-${version}";
@@ -10,7 +10,7 @@ in
     src = fetchgit {
       url = "https://github.com/moneymanagerex/moneymanagerex.git";
       rev = "refs/tags/v${version}";
-      sha256 = "1cmwmvlzg7r85qq23lbbmq2y91vhf9f5pblpja5ph98bsd218pc0";
+      sha256 = "0r4n93z3scv0i0zqflsxwv7j4yl8jy3gr0m4l30y1q8qv0zj9n74";
     };
 
     buildInputs = [ sqlite wxGTK30 gettext ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

