### PR TITLE
assimp: 3.2 -> 3.3.1

### DIFF
--- a/pkgs/development/libraries/assimp/default.nix
+++ b/pkgs/development/libraries/assimp/default.nix
@@ -1,19 +1,17 @@
 { stdenv, fetchFromGitHub, unzip, cmake, boost, zlib }:
 
-let
-  version = "3.2";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "assimp-${version}";
+  version = "3.3.1";
 
   src = fetchFromGitHub{
     owner = "assimp";
     repo = "assimp";
     rev = "v${version}";
-    sha256 = "09fsksbq9a8gykwmw6gaicwh2ladrln1jc1xc5yk7w6x180cbb1x";
+    sha256 = "13y44fymj13h6alig0nqab91j2qch0yh9gq8yql2zz744ch2s5vc";
   };
 
-  buildInputs = [ unzip cmake boost zlib ];
+  buildInputs = [ cmake boost zlib ];
 
   meta = with stdenv.lib; {
     description = "A library to import various 3D model formats";


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

