### PR TITLE
nodejs: 7.7.1 -> 7.7.2

### DIFF
--- a/pkgs/development/web/nodejs/v7.nix
+++ b/pkgs/development/web/nodejs/v7.nix
@@ -10,11 +10,11 @@ let
   baseName = if enableNpm then "nodejs" else "nodejs-slim";
 in
   stdenv.mkDerivation (nodejs // rec {
-    version = "7.7.1";
+    version = "7.7.2";
     name = "${baseName}-${version}";
     src = fetchurl {
       url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
-      sha256 = "04bn7c2hvhs6dqjz3khrlqyspljbxiw7y7g4fkjkn8k7lwmchpwn";
+      sha256 = "117mqhvnvipyaq02knq75ikbk1swrw42b0kw6iijqb6k8j78si77";
     };
 
   })


### PR DESCRIPTION
###### Motivation for this change

[NodeJS 7.7.2](https://nodejs.org/en/blog/release/v7.7.2/) was released on March 8, 2017.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

