### PR TITLE
emscripten 1.37.1 -> 1.37.3

### DIFF
--- a/pkgs/development/compilers/emscripten-fastcomp/default.nix
+++ b/pkgs/development/compilers/emscripten-fastcomp/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, python, ... }:
 
 let
-  rev = "1.37.1";
+  rev = "1.37.3";
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in
 stdenv.mkDerivation rec {
@@ -10,14 +10,14 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "kripken";
     repo = "emscripten-fastcomp";
-    sha256 = "08jci6h73j4pcd6iq5r4zn8c6qpd6qxc7xivxh3iama9hghmxyk9";
+    sha256 = "0s5156g6576hm31628c2wbqwl9r6vn10z5ry59psl565zz3lpg8x";
     inherit rev;
   };
 
   srcFL = fetchFromGitHub {
     owner = "kripken";
     repo = "emscripten-fastcomp-clang";
-    sha256 = "053svm8vnsma61jzzr8n1224brmjw4pzvklh572bm1p7yg32chaw";
+    sha256 = "0jhk20wb7275n5m9niqkzmvrr8hh5v26glkmsfmng4p66cs7jkil";
     inherit rev;
   };
 

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, emscriptenfastcomp, python, nodejs, closurecompiler, jre }:
 
 let
-  rev = "1.37.1";
+  rev = "1.37.3";
   appdir = "share/emscripten";
 in
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "kripken";
     repo = "emscripten";
-    sha256 = "0xl8lv0ihxsnwnhma3i34pkbz0v1yyc93ac6mdqmzv6fx2wczm04";
+    sha256 = "0pkxm8nd2zv57f2xm0c3n4xsdh2scliyy3zx04xk2bpkvskyzl7x";
     inherit rev;
   };
 


### PR DESCRIPTION
###### Motivation for this change
[emscripten 1.37.3](https://github.com/kripken/emscripten/releases/tag/1.37.3) was released on Feb 16, 2017.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

