### PR TITLE
evolution: Delete invalid option

### DIFF
--- a/pkgs/desktops/gnome-3/3.22/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/apps/evolution/default.nix
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
 
-  configureFlags = [ "--disable-spamassassin" "--disable-pst-import" "--disable-autoar"
+  configureFlags = [ "--disable-pst-import" "--disable-autoar"
                      "--disable-libcryptui" ];
 
   NIX_CFLAGS_COMPILE = "-I${nss.dev}/include/nss -I${glib.dev}/include/gio-unix-2.0";


### PR DESCRIPTION
###### Motivation for this change
The removed configureFlags entry is not a documented option according to `configure --help`.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

