### PR TITLE
pfixtools: patch for unbound API change

### DIFF
--- a/pkgs/servers/mail/postfix/pfixtools.nix
+++ b/pkgs/servers/mail/postfix/pfixtools.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, git, gperf, pcre, unbound, libev, tokyocabinet, pkgconfig, bash, libsrs2 }:
+{ stdenv, lib, fetchurl, fetchFromGitHub, git, gperf, pcre, unbound, libev, tokyocabinet, pkgconfig, bash, libsrs2 }:
 
 let
   version = "0.9";
@@ -19,6 +19,12 @@ let
     sha256 = "14fxldp29j4vmfmhfgwwi37pj8cz0flm1aykkxlbgakz92d4pm35";
   };
 
+  # from https://github.com/Fruneau/pfixtools/pull/21
+  unboundPatch = fetchurl {
+    url = https://github.com/cpages/pfixtools/commit/bf269dda3c81bb9eaa244b3015d426de38c85ccf.patch;
+    sha256 = "1c50qsmpqg5j49k992hvhsf5ya5ml7ybg7hhm10y90dslkkgh4in";
+  };
+
 in
 
 stdenv.mkDerivation {
@@ -27,6 +33,10 @@ stdenv.mkDerivation {
   src = pfixtoolsSrc;
 
   buildInputs = [git gperf pcre unbound libev tokyocabinet pkgconfig bash libsrs2];
+
+  patches = [
+    unboundPatch
+  ];
 
   postUnpack = ''
     cp -Rp ${libCommonSrc}/* ${srcRoot}/common;


### PR DESCRIPTION
this is a stop-gap, applying the work-in-progress patch from
https://github.com/Fruneau/pfixtools/pull/21, while we await its
acceptance upstream.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @cpages 