### PR TITLE
krfb: expose kde 5 version

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -76,6 +76,7 @@ let
       kmix = callPackage ./kmix.nix {};
       kompare = callPackage ./kompare.nix {};
       konsole = callPackage ./konsole.nix {};
+      krfb = callPackage ./krfb.nix {};
       kwalletmanager = callPackage ./kwalletmanager.nix {};
       libkdcraw = callPackage ./libkdcraw.nix {};
       libkexiv2 = callPackage ./libkexiv2.nix {};

--- a/pkgs/applications/kde/krfb.nix
+++ b/pkgs/applications/kde/krfb.nix
@@ -1,0 +1,22 @@
+{
+  kdeApp, lib, kdeWrapper,
+  extra-cmake-modules, kdoctools,
+  kdelibs4support, kdnssd, libvncserver, libXtst
+}:
+
+let
+  unwrapped =
+    kdeApp {
+      name = "krfb";
+      meta = {
+        license = with lib.licenses; [ gpl2 fdl12 ];
+        maintainers = with lib.maintainers; [ jerith666 ];
+      };
+      nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+      propagatedBuildInputs = [ kdelibs4support kdnssd libvncserver libXtst ];
+    };
+in
+kdeWrapper {
+  inherit unwrapped;
+  targets = [ "bin/krfb" ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14101,7 +14101,7 @@ with pkgs;
 
   inherit (kdeApplications)
     akonadi ark dolphin ffmpegthumbs filelight gwenview kate
-    kdenlive kcalc kcolorchooser kcontacts kgpg khelpcenter kig konsole marble
+    kdenlive kcalc kcolorchooser kcontacts kgpg khelpcenter kig konsole krfb marble
     okteta okular spectacle;
 
   kdeconnect = libsForQt5.callPackage ../applications/misc/kdeconnect { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).