### PR TITLE
evolution:configure script refers to /usr/bin/file

### DIFF
--- a/pkgs/desktops/gnome-3/3.22/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/apps/evolution/default.nix
@@ -15,6 +15,10 @@ in stdenv.mkDerivation rec {
                             gnome3.evolution_data_server ];
 
   propagatedBuildInputs = [ gnome3.gtkhtml ];
+  
+  postPatch = ''
+    substituteInPlace ./configure --replace "/usr/bin/file" "${file}/bin/file" 
+  '';
 
   buildInputs = [ gtk3 glib intltool itstool libxml2 libtool
                   gdk_pixbuf gnome3.defaultIconTheme librsvg db icu

--- a/pkgs/desktops/gnome-3/3.22/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/apps/evolution/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, intltool, fetchurl, libxml2, webkitgtk, highlight
+{ stdenv, file, intltool, fetchurl, libxml2, webkitgtk, highlight
 , pkgconfig, gtk3, glib, libnotify, gtkspell3
 , wrapGAppsHook, itstool, shared_mime_info, libical, db, gcr, sqlite
 , gnome3, librsvg, gdk_pixbuf, libsecret, nss, nspr, icu, libtool


### PR DESCRIPTION
Replace /usr/bin/file with "${file}/bin/file"

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

