### PR TITLE
hydra-eval-failures.py: Remove Python 2 specific syntax

### DIFF
--- a/maintainers/scripts/hydra-eval-failures.py
+++ b/maintainers/scripts/hydra-eval-failures.py
@@ -74,13 +74,13 @@ def cli(jobset):
     # TODO: dependency failed without propagated builds
     for tr in d('img[alt="Failed"]').parents('tr'):
         a = pq(tr)('a')[1]
-        print "- [ ] [{}]({})".format(a.text, a.get('href'))
+        print("- [ ] [{}]({})".format(a.text, a.get('href')))
 
         sys.stdout.flush()
 
         maintainers = get_maintainers(a.text)
         if maintainers:
-            print "  - maintainers: {}".format(", ".join(map(lambda u: '@' + u, maintainers)))
+            print("  - maintainers: {}".format(", ".join(map(lambda u: '@' + u, maintainers))))
         # TODO: print last three persons that touched this file
         # TODO: pinpoint the diff that broke this build, or maybe it's transient or maybe it never worked?
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

