### PR TITLE
Dockerfile: Use a more recent nix/cleanup

### DIFF
--- a/maintainers/docker/Dockerfile
+++ b/maintainers/docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM busybox
 
-RUN dir=`mktemp -d` && trap 'rm -rf "$dir"' EXIT && \
-    wget -O- https://nixos.org/releases/nix/nix-1.7/nix-1.7-x86_64-linux.tar.bz2  | bzcat | tar x -C $dir && \
+RUN dir=$(mktemp -d) && trap 'rm -rf "$dir"' EXIT && \
+    wget -O- https://nixos.org/releases/nix/nix-1.11/nix-1.11-x86_64-linux.tar.bz2  | bzcat | tar x -C "$dir" && \
     mkdir -m 0755 /nix && USER=root sh $dir/*/install && \
-    echo ". /root/.nix-profile/etc/profile.d/nix.sh" >> /etc/profile
+    echo '. /root/.nix-profile/etc/profile.d/nix.sh' >> /etc/profile
 
 ADD . /root/nix/nixpkgs
 ONBUILD ENV NIX_PATH nixpkgs=/root/nix/nixpkgs:nixos=/root/nix/nixpkgs/nixos


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

