### PR TITLE
physlock: fix issue #21935

### DIFF
--- a/nixos/modules/services/security/physlock.nix
+++ b/nixos/modules/services/security/physlock.nix
@@ -26,17 +26,7 @@ in
           This will switch to a new virtual terminal, turn off console
           switching and disable SysRq mechanism (when
           <option>services.physlock.disableSysRq</option> is set)
-          until the root or <option>services.physlock.user</option>
-          password is given.
-        '';
-      };
-
-      user = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = ''
-          User whose password will be used to unlock the screen on par
-          with the root password.
+          until the root or user password is given.
         '';
       };
 
@@ -105,7 +95,7 @@ in
               ++ cfg.lockOn.extraTargets;
       serviceConfig.Type = "forking";
       script = ''
-        ${pkgs.physlock}/bin/physlock -d${optionalString cfg.disableSysRq "s"}${optionalString (cfg.user != null) " -u ${cfg.user}"}
+        ${pkgs.physlock}/bin/physlock -d${optionalString cfg.disableSysRq "s"}
       '';
     };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

