### PR TITLE
closurecompiler: 20160208 -> 20170218

### DIFF
--- a/pkgs/development/compilers/closure/default.nix
+++ b/pkgs/development/compilers/closure/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "closure-compiler-${version}";
-  version = "20160208";
+  version = "20170218";
 
   src = fetchurl {
     url = "http://dl.google.com/closure-compiler/compiler-${version}.tar.gz";
-    sha256 = "19v9z8lfxfmhc4cl9fys7vnaslqiznjy1jpk5mcv468p7vysg46p";
+    sha256 = "06snabmpy07x4xm8d1xgq5dfzbjli10xkxk3nx9jms39zkj493cd";
   };
 
   phases = [ "installPhase" ];
@@ -16,9 +16,9 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/share/java $out/bin
     tar -xzf $src
-    cp -r compiler.jar $out/share/java/
+    cp -r closure-compiler-v${version}.jar $out/share/java/
     echo "#!${bash}/bin/bash" > $out/bin/closure-compiler
-    echo "${jre}/bin/java -jar $out/share/java/compiler.jar \"\$@\"" >> $out/bin/closure-compiler
+    echo "${jre}/bin/java -jar $out/share/java/closure-compiler-v${version}.jar \"\$@\"" >> $out/bin/closure-compiler
     chmod +x $out/bin/closure-compiler
   '';
 


### PR DESCRIPTION
###### Motivation for this change

[closure-compiler v20170218](https://github.com/google/closure-compiler/releases/tag/v20170218) was released on Feb. 18, 2017.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

