### PR TITLE
kcachegrind: init at 16.2.2

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -62,6 +62,7 @@ let
       kate = callPackage ./kate.nix {};
       kdenlive = callPackage ./kdenlive.nix {};
       kcalc = callPackage ./kcalc.nix {};
+      kcachegrind = callPackage ./kcachegrind.nix {};
       kcolorchooser = callPackage ./kcolorchooser.nix {};
       kcontacts = callPackage ./kcontacts.nix {};
       kdegraphics-mobipocket = callPackage ./kdegraphics-mobipocket.nix {};

--- a/pkgs/applications/kde/kcachegrind.nix
+++ b/pkgs/applications/kde/kcachegrind.nix
@@ -1,0 +1,27 @@
+{
+  kdeApp, lib, kdeWrapper,
+  cmake, automoc4,
+  kdelibs, perl, python, php
+}:
+
+kdeWrapper {
+  unwrapped = kdeApp {
+    name = "kcachegrind";
+    meta = {
+      license = with lib.licenses; [ gpl2 ];
+      maintainers = with lib.maintainers; [ orivej ];
+    };
+    nativeBuildInputs = [ cmake automoc4 ];
+    buildInputs = [ kdelibs perl python php ];
+    enableParallelBuilding = true;
+  };
+
+  targets = [
+    "bin/kcachegrind"
+    "bin/dprof2calltree"    # perl
+    "bin/hotshot2calltree"  # python
+    "bin/memprof2calltree"  # perl
+    "bin/op2calltree"       # perl
+    "bin/pprof2calltree"    # php
+  ];
+}


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).