### PR TITLE
csound: 6.04 -> 6.08.1

### DIFF
--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, libsndfile, flex, bison, boost, boost-build
+{ stdenv, fetchurl, cmake, libsndfile, flex, bison, boost
 , alsaLib ? null
 , libpulseaudio ? null
 , tcltk ? null

--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, libsndfile, flex, bison
+{ stdenv, fetchurl, cmake, libsndfile, flex, bison, boost, boost-build
 , alsaLib ? null
 , libpulseaudio ? null
 , tcltk ? null
@@ -12,18 +12,18 @@
 }:
 
 stdenv.mkDerivation {
-  name = "csound-6.04";
+  name = "csound-6.08.1";
 
   enableParallelBuilding = true;
 
   hardeningDisable = [ "format" ];
 
   src = fetchurl {
-    url = mirror://sourceforge/csound/Csound6.04.tar.gz;
-    sha256 = "1030w38lxdwjz1irr32m9cl0paqmgr02lab2m7f7j1yihwxj1w0g";
+    url = https://github.com/csound/csound/archive/6.08.1.tar.gz;
+    sha256 = "153c6c06573dd0c6989f45df1cb32ae48fb2ea942428900c0097ecc1476b82b7";
   };
 
-  buildInputs = [ cmake libsndfile flex bison alsaLib libpulseaudio tcltk ];
+  buildInputs = [ cmake libsndfile flex bison alsaLib libpulseaudio tcltk boost ];
 
   meta = {
     description = "Sound design, audio synthesis, and signal processing system, providing facilities for music composition and performance on all major operating systems and platforms";


### PR DESCRIPTION
###### Motivation for this change
Very old version, so it's a bump.

(my first nixpks pull request, didn't do any fancy testing).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

