### PR TITLE
renderdoc: init at version 0.34pre

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -213,6 +213,7 @@
   ivan-tkatchev = "Ivan Tkatchev <tkatchev@gmail.com>";
   j-keck = "Jürgen Keck <jhyphenkeck@gmail.com>";
   jagajaga = "Arseniy Seroka <ars.seroka@gmail.com>";
+  jansol = "Jan Solanti <jan.solanti@paivola.fi>";
   javaguirre = "Javier Aguirre <contacto@javaguirre.net>";
   jb55 = "William Casarin <bill@casarin.me>";
   jbedo = "Justin Bedő <cu@cua0.org>";

--- a/pkgs/applications/graphics/renderdoc/default.nix
+++ b/pkgs/applications/graphics/renderdoc/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchFromGitHub, cmake, qtbase, qtx11extras
+, pkgconfig, xorg, makeQtWrapper, vulkan-loader
+}:
+
+stdenv.mkDerivation rec {
+  name = "renderdoc-${version}";
+  version = "0.34pre";
+
+  src = fetchFromGitHub {
+    owner = "baldurk";
+    repo = "renderdoc";
+    rev = "5e2717daec53e5b51517d3231fb6120bebbe6b7a";
+    sha256 = "1zpvjvsj5c441kyjpmd2d2r0ykb190rbq474nkmp1jk72cggnpq0";
+  };
+
+  buildInputs = [
+    qtbase xorg.libpthreadstubs xorg.libXdmcp qtx11extras vulkan-loader
+  ];
+  nativeBuildInputs = [ cmake makeQtWrapper pkgconfig ];
+
+  cmakeFlags = [
+    "-DBUILD_VERSION_HASH=${src.rev}-distro-nix"
+    # TODO: use this instead of preConfigure once placeholders land
+    #"-DVULKAN_LAYER_FOLDER=${placeholder out}/share/vulkan/implicit_layer.d/"
+  ];
+  preConfigure = ''
+    cmakeFlags+=" -DVULKAN_LAYER_FOLDER=$out/share/vulkan/implicit_layer.d/"
+  '';
+  preFixup = ''
+    mkdir $out/bin/.bin
+    mv $out/bin/qrenderdoc $out/bin/.bin/qrenderdoc
+    ln -s $out/bin/.bin/qrenderdoc $out/bin/qrenderdoc
+    wrapQtProgram $out/bin/qrenderdoc --suffix LD_LIBRARY_PATH : $out/lib --suffix LD_LIBRARY_PATH : ${vulkan-loader}/lib
+    mv $out/bin/renderdoccmd $out/bin/.bin/renderdoccmd
+    ln -s $out/bin/.bin/renderdoccmd $out/bin/renderdoccmd
+    wrapProgram $out/bin/renderdoccmd --suffix LD_LIBRARY_PATH : $out/lib --suffix LD_LIBRARY_PATH : ${vulkan-loader}/lib
+  '';
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A single-frame graphics debugger";
+    homepage = https://renderdoc.org/;
+    license = licenses.mit;
+    longDescription = ''
+      RenderDoc is a free MIT licensed stand-alone graphics debugger that
+      allows quick and easy single-frame capture and detailed introspection
+      of any application using Vulkan, D3D11, OpenGL or D3D12 across
+      Windows 7 - 10, Linux or Android.
+    '';
+    maintainers = maintainers.jansol;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/graphics/renderdoc/default.nix
+++ b/pkgs/applications/graphics/renderdoc/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
       of any application using Vulkan, D3D11, OpenGL or D3D12 across
       Windows 7 - 10, Linux or Android.
     '';
-    maintainers = maintainers.jansol;
+    maintainers = [maintainers.jansol];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3685,6 +3685,8 @@ with pkgs;
 
   renameutils = callPackage ../tools/misc/renameutils { };
 
+  renderdoc = libsForQt5.callPackage ../applications/graphics/renderdoc { };
+
   replace = callPackage ../tools/text/replace { };
 
   reckon = callPackage ../tools/text/reckon { };


### PR DESCRIPTION
Initialising a few commits after the latest release due to some upstream
improvements to the build system.

###### Motivation for this change

It was missing. It's also a great app needed by multiple people, including me.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

