### PR TITLE
caf: init at 0.15.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -71,6 +71,7 @@
   bjg = "Brian Gough <bjg@gnu.org>";
   bjornfor = "Bjørn Forsman <bjorn.forsman@gmail.com>";
   bluescreen303 = "Mathijs Kwik <mathijs@bluescreen303.nl>";
+  bobakker = "Bo Bakker <bobakk3r@gmail.com>";
   bobvanderlinden = "Bob van der Linden <bobvanderlinden@gmail.com>";
   bodil = "Bodil Stokke <nix@bodil.org>";
   boothead = "Ben Ford <ben@perurbis.com>";

--- a/pkgs/development/libraries/caf/default.nix
+++ b/pkgs/development/libraries/caf/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0202nsdriigdh6sxi1k3hddvmf1x54qpykbvf2ghfhzyh0m1q7j2";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "An open source implementation of the actor model in C++";

--- a/pkgs/development/libraries/caf/default.nix
+++ b/pkgs/development/libraries/caf/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     description = "An open source implementation of the actor model in C++";
     homepage = http://actor-framework.org/;
     license = stdenv.lib.licenses.bsd3;
-    platforms = stdenv.lib.platforms.all;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ bobakker ];
   };
 }

--- a/pkgs/development/libraries/caf/default.nix
+++ b/pkgs/development/libraries/caf/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "actor-framework-${version}";
+  version = "0.15.3";
+
+  src = fetchFromGitHub {
+    owner = "actor-framework";
+    repo = "actor-framework";
+    rev = "${version}";
+    sha256 = "0202nsdriigdh6sxi1k3hddvmf1x54qpykbvf2ghfhzyh0m1q7j2";
+  };
+
+  buildInputs = [ cmake ];
+
+  meta = {
+    description = "An open source implementation of the actor model in C++";
+    homepage = http://actor-framework.org/;
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7057,7 +7057,7 @@ with pkgs;
 
   certbot = callPackage ../tools/admin/certbot { };
 
-  caf = callPackage ../development/libraries/caf { };
+  caf = callPackage ../development/libraries/caf {};
 
   cgal = callPackage ../development/libraries/CGAL {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7057,6 +7057,8 @@ with pkgs;
 
   certbot = callPackage ../tools/admin/certbot { };
 
+  caf = callPackage ../development/libraries/caf { };
+
   cgal = callPackage ../development/libraries/CGAL {};
 
   cgui = callPackage ../development/libraries/cgui {};


### PR DESCRIPTION
###### Motivation for this change

Caf is a useful library for writing concurrent and distributed C++ programs.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (none)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

