### PR TITLE
minikube: switch to build from source & mostly fix on Darwin

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -1,47 +1,77 @@
-{ stdenv, lib, fetchurl, makeWrapper, docker-machine-kvm, kubernetes, libvirt, qemu }:
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchurl, go-bindata, kubernetes, libvirt, qemu, docker-machine-kvm, makeWrapper }:
 
 let
-  arch = if stdenv.isLinux
-         then "linux-amd64"
-         else "darwin-amd64";
-  checksum = if stdenv.isLinux
-             then "0cdcabsx5l4jbpyj3zzyz5bnzks6wl64bmzdsnk41x92ar5y5yal"
-             else "12f3b7s5lwpvzx4wj6i6h62n4zjshqf206fxxwpwx9kpsdaw6xdi";
+  binPath = [ kubernetes ]
+    ++ stdenv.lib.optionals stdenv.isLinux [ libvirt qemu docker-machine-kvm ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [];
 
-# TODO: compile from source
-
-in stdenv.mkDerivation rec {
-  pname = "minikube";
+  # Normally, minikube bundles localkube in its own binary via go-bindata. Unfortunately, it needs to make that localkube
+  # a static linux binary, and our Linux nixpkgs go compiler doesn't seem to work when asking for a cgo binary that's static
+  # (presumably because we don't have some static system libraries it wants), and cross-compiling cgo on Darwin is a nightmare.
+  #
+  # Note that minikube can download (and cache) versions of localkube it needs on demand. Unfortunately, minikube's knowledge
+  # of where it can download versions of localkube seems to rely on a json file that doesn't get updated as often as we'd like,
+  # so for example it doesn't know about v1.5.3 even though there's a perfectly good version of localkube hosted there. So
+  # instead, we download localkube ourselves and shove it into the minikube binary. The versions URL that minikube uses is
+  # currently https://storage.googleapis.com/minikube/k8s_releases.json. Note that we can't use 1.5.3 with minikube 0.17.1
+  # expects to be able to pass it a command-line argument that it doesn't understand. v1.5.4 and higher should be fine. There
+  # doesn't seem to ae any official release of localkube for 1.5.4 yet so I'm temporarily grabbing a version built from the
+  # minikube CI server.
+  localkube-binary = fetchurl {
+    url    = "https://storage.googleapis.com/minikube-builds/1216/localkube";
+    # url    = "https://storage.googleapis.com/minikube/k8sReleases/v${kubernetes.version}/localkube-linux-amd64";
+    sha256 = "1vqrsak7n045ci6af3rpgs2qwjnrqk8k7c3ax6wzli4m8vhsiv57";
+  };
+in buildGoPackage rec {
+  pname   = "minikube";
+  name    = "${pname}-${version}";
   version = "0.17.1";
-  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://storage.googleapis.com/minikube/releases/v${version}/minikube-${arch}";
-    sha256 = "${checksum}";
+  goPackagePath = "k8s.io/minikube";
+
+  src = fetchFromGitHub {
+    owner  = "kubernetes";
+    repo   = "minikube";
+    rev    = "v${version}";
+    sha256 = "1m61yipn0p3cfavjddhrg1rcmr0hv6k3zxvqqd9fisl79g0sdfsr";
   };
 
-  phases = [ "installPhase" "fixupPhase" ];
+  # kubernetes is here only to shut up a loud warning when generating the completions below. minikube checks very eagerly
+  # that kubectl is on the $PATH, even if it doesn't use it at all to generate the completions
+  buildInputs = [ go-bindata makeWrapper kubernetes ];
+  subPackages = [ "cmd/minikube" ];
 
-  buildInputs = [ makeWrapper ];
+  preBuild = ''
+    pushd go/src/${goPackagePath} >/dev/null
 
-  binPath = lib.makeBinPath [ docker-machine-kvm kubernetes libvirt qemu ];
+    mkdir -p out
+    cp ${localkube-binary} out/localkube
 
-  installPhase = ''
-    install -Dm755 ${src} $out/bin/${pname}
+    go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets ./out/localkube deploy/addons/...
+
+    ISO_VERSION=$(grep "^ISO_VERSION" Makefile | sed "s/^.*\s//")
+    ISO_BUCKET=$(grep "^ISO_BUCKET" Makefile | sed "s/^.*\s//")
+
+    export buildFlagsArray="-ldflags=\
+      -X k8s.io/minikube/pkg/version.version=v${version} \
+      -X k8s.io/minikube/pkg/version.isoVersion=$ISO_VERSION \
+      -X k8s.io/minikube/pkg/version.isoPath=$ISO_BUCKET"
+
+    popd >/dev/null
   '';
 
-  fixupPhase = ''
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$out/bin/minikube"
-
-    wrapProgram $out/bin/${pname} \
-      --prefix PATH : ${binPath}
+  postInstall = ''
+    mkdir -p $bin/share/bash-completion/completions/
+    MINIKUBE_WANTUPDATENOTIFICATION=false HOME=$PWD $bin/bin/minikube completion bash > $bin/share/bash-completion/completions/minikube
   '';
+
+  postFixup = "wrapProgram $bin/bin/${pname} --prefix PATH : ${stdenv.lib.makeBinPath binPath}";
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/kubernetes/minikube;
+    homepage    = https://github.com/kubernetes/minikube;
     description = "A tool that makes it easy to run Kubernetes locally";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ ebzzry ];
-    platforms = with platforms; linux ++ darwin;
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ ebzzry copumpkin ];
+    platforms   = with platforms; unix;
   };
 }


### PR DESCRIPTION
Linux behavior should be largely unchanged but Darwin now mostly works. I was unable to spin it up against the VMWare Fusion driver but I think it'll work with the xhyve one. I'll probably make another couple of changes after I get the xhyve driver working on Darwin. Would appreciate someone giving it a go on Linux.

cc @ebzzry @peterhoeg

###### Motivation for this change

Source builds are cooler than binaries 😄 also, it's nice when things work on Darwin.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

