### PR TITLE
purePackages.octave: 0.7 -> 0.9

### DIFF
--- a/pkgs/development/pure-modules/octave/default.nix
+++ b/pkgs/development/pure-modules/octave/default.nix
@@ -2,13 +2,15 @@
 
 stdenv.mkDerivation rec {
   baseName = "octave";
-  version = "0.7";
+  version = "0.9";
   name = "pure-${baseName}-${version}";
 
   src = fetchurl {
     url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
-    sha256 = "04c1q5cjcyc5sg15ny1hn43rkphja3virw4k110cahc3piwbpsqk";
+    sha256 = "001fc2188bb128d8865fff989e6adb5588645b26e09a9999fc4bdd3c62dd3550";
   };
+
+  CPPFLAGS = "-std=c++11";
 
   buildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure octave ];


### PR DESCRIPTION
###### Motivation for this change

Updates this package to the latest version, and also fixes a compile error (see #23253).

Although this package now builds, any Pure program that tries to use this package will segfault due to an upstream error in the Octave embedding API.  This error is not present in Octave 4.0, and is fixed in Octave 4.3 (unstable).  See https://groups.google.com/forum/#!topic/pure-lang/TRWnZkvHIqo for more info.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

