### PR TITLE
pure: 0.64 -> 0.66

### DIFF
--- a/pkgs/development/interpreters/pure/default.nix
+++ b/pkgs/development/interpreters/pure/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   baseName="pure";
   project="pure-lang";
-  version="0.64";
+  version="0.66";
   name="${baseName}-${version}";
   extension="tar.gz";
 
   src = fetchurl {
     url="https://bitbucket.org/purelang/${project}/downloads/${name}.${extension}";
-    sha256="01vvix302gh5vsmnjf2g0rrif3hl1yik4izsx1wrvv1a6hlm5mgg";
+    sha256="42df6832476e8bee3a7ca179671284c1edd7bc82b71062fa0de62fd2117ee676";
   };
 
   buildInputs = [ bison flex makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Update Pure to the latest version. 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I've tested that all `purePackages` still compile in a `nix-shell --pure` environment, and that a rudimentary pure script that includes every library doesn't segfault.
---

