### PR TITLE
cl:1.2.1 -> 1.2.3

### DIFF
--- a/pkgs/development/libraries/cl/default.nix
+++ b/pkgs/development/libraries/cl/default.nix
@@ -1,19 +1,19 @@
-{stdenv, fetchurl, SDL, mesa, rebar, erlang, opencl-headers, ocl-icd }:
+{stdenv, fetchFromGitHub, SDL, mesa, rebar, erlang, opencl-headers, ocl-icd }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.1";
+  version = "1.2.3";
   name = "cl-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/tonyrog/cl/archive/${name}.tar.gz";
-    sha256 = "03jv280h9gqqqkm0mmkjr53srd2mzhvyy1biss77wpjrzq2z12c8";
+  src = fetchFromGitHub {
+    owner = "tonyrog";
+    repo = "cl";
+    rev = "cl-${version}";
+    sha256 = "1dk0k03z0ipxvrnn0kihph135hriw96jpnd31lbq44k6ckh6bm03";
   };
 
   buildInputs = [ erlang rebar opencl-headers ocl-icd ];
-  #propagatedBuildInputs = [ SDL mesa ];
-
+  
   buildPhase = ''
-    sed 's/git/"${version}"/' -i src/cl.app.src
     rebar compile
   '';
 
@@ -25,10 +25,10 @@ stdenv.mkDerivation rec {
     cp -ruv c_src doc ebin include priv src $DIR
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/tonyrog/cl;
     description = "OpenCL binding for Erlang";
-    license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.mit;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

