### PR TITLE
concurrencykit: 0.4.5 -> 0.6.0

### DIFF
--- a/pkgs/development/libraries/concurrencykit/default.nix
+++ b/pkgs/development/libraries/concurrencykit/default.nix
@@ -2,22 +2,23 @@
 
 stdenv.mkDerivation rec {
   name    = "concurrencykit-${version}";
-  version = "0.4.5";
+  version = "0.6.0";
 
   src = fetchurl {
     url    = "http://concurrencykit.org/releases/ck-${version}.tar.gz";
-    sha256 = "0mh3z8ibiwidc6qvrv8bx9slgcycxwy06kfngfzfza6nihrymzl9";
+    sha256 = "1pv21p7sjwwmbs2xblpy1lqk53r2i212yrqyjlr5dr3rlv87vqnp";
   };
+  
+  #Deleting this line causes "Unknown option --disable-static"
+  configurePhase = "./configure --prefix=$out";
 
   enableParallelBuilding = true;
 
-  configurePhase = "./configure --prefix=$out";
-
-  meta = {
+  meta = with stdenv.lib; {
     description = "A library of safe, high-performance concurrent data structures";
-    homepage    = "http://concurrencykit.org";
-    license     = stdenv.lib.licenses.bsd2;
-    platforms   = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+    homepage    = http://concurrencykit.org;
+    license     = licenses.bsd2;
+    platforms   = platforms.unix;
+    maintainers = [ maintainers.thoughtpolice ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

