### PR TITLE
libzip: 1.1.2 -> 1.2.0

### DIFF
--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libzip-${version}";
-  version = "1.1.2";
+  version = "1.2.0";
 
   src = fetchurl {
     url = "http://www.nih.at/libzip/${name}.tar.gz";
-    sha256 = "08b26qbfxq6z5xf36y1d8insm5valv83dhj933iag6man04prb2r";
+    sha256 = "17vxj2ffsxwh8lkc6801ppmwj15jp8q58rin76znxfbx88789ybc";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change

Update libzip to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

