### PR TITLE
haskellPackages: fix issue #23794

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -29,7 +29,7 @@
 
 with import ./lib.nix { inherit pkgs; };
 
-self: super: builtins.intersectAttrs super {
+self: super: {
 
   # Apply NixOS-specific patches.
   ghc-paths = appendPatch super.ghc-paths ./patches/ghc-paths-nix.patch;


### PR DESCRIPTION
Running `nix-env -f "<nixpkgs>" -qaP -A haskellPackages` on MacOs result in:

```
error: attribute ‘llvm-general-darwin’ missing, at /nix/store/.../haskell-modules/configuration-nix.nix:231:10
```

###### Motivation for this change

Fix for https://github.com/NixOS/nixpkgs/issues/23794


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

