### PR TITLE
scala: put docs in correct subdirectory

### DIFF
--- a/pkgs/development/compilers/scala/default.nix
+++ b/pkgs/development/compilers/scala/default.nix
@@ -16,6 +16,10 @@ stdenv.mkDerivation rec {
     rm "bin/"*.bat
     mv * $out
 
+    # put docs in correct subdirectory
+    mkdir -p $out/share/doc
+    mv $out/doc $out/share/doc/scala
+
     for p in $(ls $out/bin/) ; do
       wrapProgram $out/bin/$p \
         --prefix PATH ":" ${coreutils}/bin \


### PR DESCRIPTION
###### Motivation for this change

Under NixOS, /run/current-system/sw/share/doc was getting the license file, etc. from scala. Have just moved them into a subdirectory.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

