### PR TITLE
drumstick: 1.0.2 -> 1.1.0

### DIFF
--- a/pkgs/development/libraries/drumstick/default.nix
+++ b/pkgs/development/libraries/drumstick/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "drumstick-${version}";
-  version = "1.0.2";
+  version = "1.1.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/drumstick/${version}/${name}.tar.bz2";
-    sha256 = "0l47gy9yywrc860db5g3wdqg8yc8qdb2lqq6wvw1dfim5j0vbail";
+    sha256 = "13pkfqrav30bbcddgf1imd7jk6lpqbxkz1qv31718pdl446jq7df";
   };
 
   outputs = [ "out" "dev" "man" ];
@@ -28,8 +28,14 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  #Temporarily remove drumstick-piano; Gives segment fault. Submitted ticket
+  postInstall = ''
+    rm $out/bin/drumstick-vpiano
+    '';
+
+  nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [
-    alsaLib cmake doxygen fluidsynth pkgconfig qt5.qtbase qt5.qtsvg
+    alsaLib doxygen fluidsynth qt5.qtbase qt5.qtsvg
   ];
 
   meta = with stdenv.lib; {
@@ -37,6 +43,6 @@ stdenv.mkDerivation rec {
     description = "MIDI libraries for Qt5/C++";
     homepage = http://drumstick.sourceforge.net/;
     license = licenses.gpl2Plus;
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

