### PR TITLE
Pip tools

### DIFF
--- a/pkgs/development/python-modules/first/default.nix
+++ b/pkgs/development/python-modules/first/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+let
+  pname = "first";
+  version = "2.0.1";
+in
+buildPythonPackage {
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0pn9hl2y0pz61la1xhkdz6vl9i2dg3nh0ksizcf0f9ybh8sxxcrv";
+  };
+
+  doCheck = false; # no tests
+
+  meta = with stdenv.lib; {
+    description = "The function you always missed in Python";
+    homepage = https://github.com/hynek/first/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ zimbatm ];
+  };
+}

--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, buildPythonPackage, pip, pytest, click, six, first, glibcLocales }:
+buildPythonPackage rec {
+  pname = "pip-tools";
+  version = "1.8.1rc3";
+  name = "pip-tools-${version}";
+
+  src = fetchFromGitHub {
+    owner = "jazzband";
+    repo = "pip-tools";
+    rev = version;
+    sha256 = "09rbgzj71bfp1x1jfr1zx3vax4qjbw5l6vcd3fqvshsdvg9lcnpx";
+  };
+
+  LC_ALL = "en_US.UTF-8";
+  buildInputs = [ pytest glibcLocales ];
+  propagatedBuildInputs = [ pip click six first ];
+
+  checkPhase = ''
+    export HOME=$(mktemp -d)
+    py.test -k "not test_realistic_complex_sub_dependencies" # requires network
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Keeps your pinned dependencies fresh";
+    homepage = https://github.com/jazzband/pip-tools/;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ zimbatm ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18874,6 +18874,10 @@ in {
     };
   };
 
+  pip-tools = callPackage ../development/python-modules/pip-tools {
+    glibcLocales = pkgs.glibcLocales;
+  };
+
   pika = buildPythonPackage rec {
     name = "pika-${version}";
     version = "0.10.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -29044,6 +29044,8 @@ EOF
     };
   };
 
+  first = callPackage ../development/python-modules/first {};
+
   flaskbabel = buildPythonPackage rec {
     name = "Flask-Babel-0.11.1";
 


### PR DESCRIPTION
###### Motivation for this change

Pip tools allow to produce better frozen requirements.txt. Hopefully also usable by nix because it contains hashes.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

