### PR TITLE
exosip: 4.0.0 -> 4.1.0

### DIFF
--- a/pkgs/development/libraries/exosip/default.nix
+++ b/pkgs/development/libraries/exosip/default.nix
@@ -1,18 +1,20 @@
 {stdenv, fetchurl, libosip, openssl, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  version = "4.0.0";
-  src = fetchurl {
+ name = "libexosip2-${version}";
+ version = "4.1.0";
+ 
+ src = fetchurl {
     url = "mirror://savannah/exosip/libeXosip2-${version}.tar.gz";
-    sha256 = "1rdjr3x7s992w004cqf4xji1522an9rpzsr9wvyhp685khmahrsj";
+    sha256 = "17cna8kpc8nk1si419vgr6r42k2lda0rdk50vlxrw8rzg0xp2xrw";
   };
-  name = "libexosip2-${version}";
-
+ 
+  nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libosip openssl pkgconfig ];
       
-  meta = {
-    license = stdenv.lib.licenses.gpl2Plus;
+  meta = with stdenv.lib; {
+    license = licenses.gpl2Plus;
     description = "Library that hides the complexity of using the SIP protocol";
-    platforms = stdenv.lib.platforms.linux;
+    platforms =platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

