### PR TITLE
geis: 2.2.16 -> 2.2.17

### DIFF
--- a/pkgs/development/libraries/geis/default.nix
+++ b/pkgs/development/libraries/geis/default.nix
@@ -16,11 +16,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "geis-${version}";
-  version = "2.2.16";
+  version = "2.2.17";
 
   src = fetchurl {
     url = "https://launchpad.net/geis/trunk/${version}/+download/${name}.tar.xz";
-    sha256 = "40a694092c79f325a2fbf8a9f301177bc91c364f4e637c2aa8963ad2a5aabbcf";
+    sha256 = "1svhbjibm448ybq6gnjjzj0ak42srhihssafj0w402aj71lgaq4a";
   };
 
   NIX_CFLAGS_COMPILE = "-Wno-error=pedantic";


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

