### PR TITLE
Add subl symlink for Sublime Text 3

### DIFF
--- a/pkgs/applications/editors/sublime3/default.nix
+++ b/pkgs/applications/editors/sublime3/default.nix
@@ -66,6 +66,7 @@ in stdenv.mkDerivation {
   phases = [ "installPhase" ];
   installPhase = ''
     mkdir -p $out/bin
+    ln -s ${sublime}/sublime_text $out/bin/subl
     ln -s ${sublime}/sublime_text $out/bin/sublime
     ln -s ${sublime}/sublime_text $out/bin/sublime3
     mkdir -p $out/share/applications


### PR DESCRIPTION
###### Motivation for this change

[ST3 distribution comes with `subl` in it](http://stackoverflow.com/a/25577833/242684) ([on Linux too](https://launchpad.net/~webupd8team/+archive/ubuntu/sublime-text-3/+files/sublime-text-installer_3126-2~webupd8~1.tar.gz)).

###### Things done

Done none of the below, the change is too minor.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

