### PR TITLE
objconv: 2.16 -> 2.44

### DIFF
--- a/pkgs/development/tools/misc/objconv/default.nix
+++ b/pkgs/development/tools/misc/objconv/default.nix
@@ -1,26 +1,39 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchurl, unzip }:
 
 stdenv.mkDerivation rec {
   name = "objconv-${version}";
-  version = "2.16";
+  version = "2.44";
 
-  src = fetchFromGitHub {
-    owner  = "vertis";
-    repo   = "objconv";
-    rev    = "${version}";
-    sha256 = "1by2bbrampwv0qy8vn4hhs49rykczyj7q8g373ym38da3c95bym2";
+  src = fetchurl {
+    # Versioned archive of objconv sources maintained by orivej.
+    url = "https://archive.org/download/objconv/${name}.zip";
+    sha256 = "1dlnpv8qwz0rwivpbgk84kmsjz3vh1i149z44ha2dvg8afzyfhjl";
   };
 
-  buildPhase = "c++ -o objconv -O2 src/*.cpp";
+  nativeBuildInputs = [ unzip ];
 
-  installPhase = "mkdir -p $out/bin && mv objconv $out/bin";
+  outputs = [ "out" "doc" ];
+
+  unpackPhase = ''
+    mkdir -p "$name"
+    cd "$name"
+    unpackFile "$src"
+    unpackFile source.zip
+  '';
+
+  buildPhase = "c++ -o objconv -O2 *.cpp";
+
+  installPhase = ''
+    mkdir -p $out/bin $out/doc/objconv
+    mv objconv $out/bin
+    mv objconv-instructions.pdf $out/doc/objconv
+  '';
 
   meta = with stdenv.lib; {
-    description = "Used for converting object files between COFF/PE, OMF, ELF and Mach-O formats for all 32-bit and 64-bit x86 platforms.";
+    description = "Object and executable file converter, modifier and disassembler";
     homepage = http://www.agner.org/optimize/;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ vrthra ];
-    platforms = with platforms; unix;
+    maintainers = with maintainers; [ orivej vrthra ];
+    platforms = platforms.unix;
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change

objconv.zip at the [upstream](http://www.agner.org/optimize/) is not versioned, i.e. it changes after each release, and I have not found any third party versioned or actual mirrors, so I created a new one at archive.org ([details](https://archive.org/details/objconv/), [files](https://archive.org/download/objconv/)) and directed `fetchurl` at it.

Added `objconv.doc` output (not installed by default) with PDF documentation.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
