### PR TITLE
FreeType 2.7.1 and Fontconfig defaults

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -49,6 +49,18 @@ following incompatible changes:</para>
       rest of the system on a stable release.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      Updated to FreeType 2.7.1, including a new TrueType engine.
+      The new engine replaces the Infinality engine which was the default in
+      NixOS. The default font rendering settings are now provided by
+      fontconfig-penultimate, replacing fontconfig-ultimate; the new defaults
+      are less invasive and provide rendering that is more consistent with
+      other systems and hopefully with each font designer's intent. Some
+      system-wide configuration has been removed from the Fontconfig NixOS
+      module where user Fontconfig settings are available.
+    </para>
+  </listitem>
 
 </itemizedlist>
 

--- a/nixos/modules/config/fonts/fontconfig-penultimate.nix
+++ b/nixos/modules/config/fonts/fontconfig-penultimate.nix
@@ -1,0 +1,57 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.fonts.fontconfig.penultimate;
+
+  latestVersion  = pkgs.fontconfig.configVersion;
+
+  # The configuration to be included in /etc/font/
+  confPkg = pkgs.runCommand "font-penultimate-conf" {} ''
+    support_folder=$out/etc/fonts/conf.d
+    latest_folder=$out/etc/fonts/${latestVersion}/conf.d
+
+    mkdir -p $support_folder
+    mkdir -p $latest_folder
+
+    # fontconfig ultimate various configuration files
+    ln -s ${pkgs.fontconfig-penultimate}/etc/fonts/conf.d/*.conf \
+          $support_folder
+    ln -s ${pkgs.fontconfig-penultimate}/etc/fonts/conf.d/*.conf \
+          $latest_folder
+  '';
+
+in
+{
+
+  options = {
+
+    fonts = {
+
+      fontconfig = {
+
+        penultimate = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Enable fontconfig-penultimate settings to supplement the
+              NixOS defaults by providing per-font rendering defaults and
+              metric aliases.
+            '';
+          };
+        };
+
+      };
+    };
+
+  };
+
+  config = mkIf (config.fonts.fontconfig.enable && cfg.enable) {
+
+    fonts.fontconfig.confPackages = [ confPkg ];
+
+  };
+
+}

--- a/nixos/modules/config/fonts/fontconfig-ultimate.nix
+++ b/nixos/modules/config/fonts/fontconfig-ultimate.nix
@@ -104,7 +104,7 @@ in
         ultimate = {
           enable = mkOption {
             type = types.bool;
-            default = true;
+            default = false;
             description = ''
               Enable fontconfig-ultimate settings (formerly known as
               Infinality). Besides the customizable settings in this NixOS
@@ -163,15 +163,6 @@ in
               <literal>none</literal> disables the substitutions.
             '';
           };
-
-          preset = mkOption {
-            type = types.enum ["ultimate1" "ultimate2" "ultimate3" "ultimate4" "ultimate5" "osx" "windowsxp"];
-            default = "ultimate3";
-            description = ''
-              FreeType rendering settings preset. Any of the presets may be
-              customized by setting environment variables.
-            '';
-          };
         };
       };
     };
@@ -181,7 +172,6 @@ in
   config = mkIf (config.fonts.fontconfig.enable && cfg.enable) {
 
     fonts.fontconfig.confPackages = [ confPkg ];
-    environment.variables."INFINALITY_FT" = cfg.preset;
 
   };
 

--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -75,23 +75,23 @@ let cfg = config.fonts.fontconfig;
       <fontconfig>
 
         <!-- Default rendering settings -->
-        <match target="font">
-          <edit mode="assign" name="hinting">
+        <match target="pattern">
+          <edit mode="append" name="hinting">
             ${fcBool cfg.hinting.enable}
           </edit>
-          <edit mode="assign" name="autohint">
+          <edit mode="append" name="autohint">
             ${fcBool cfg.hinting.autohint}
           </edit>
-          <edit mode="assign" name="hintstyle">
+          <edit mode="append" name="hintstyle">
             <const>hintslight</const>
           </edit>
-          <edit mode="assign" name="antialias">
+          <edit mode="append" name="antialias">
             ${fcBool cfg.antialias}
           </edit>
-          <edit mode="assign" name="rgba">
+          <edit mode="append" name="rgba">
             <const>${cfg.subpixel.rgba}</const>
           </edit>
-          <edit mode="assign" name="lcdfilter">
+          <edit mode="append" name="lcdfilter">
             <const>lcd${cfg.subpixel.lcdfilter}</const>
           </edit>
         </match>

--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -83,7 +83,7 @@ let cfg = config.fonts.fontconfig;
             ${fcBool cfg.hinting.autohint}
           </edit>
           <edit mode="assign" name="hintstyle">
-            <const>hint${cfg.hinting.style}</const>
+            <const>hintslight</const>
           </edit>
           <edit mode="assign" name="antialias">
             ${fcBool cfg.antialias}
@@ -233,7 +233,11 @@ in
         antialias = mkOption {
           type = types.bool;
           default = true;
-          description = "Enable font antialiasing.";
+          description = ''
+            Enable font antialiasing. At high resolution (> 200 DPI),
+            antialiasing has no visible effect; users of such displays may want
+            to disable this option.
+          '';
         };
 
         dpi = mkOption {
@@ -249,7 +253,7 @@ in
           type = types.lines;
           default = "";
           description = ''
-            System-wide customization file contents, has higher priority than 
+            System-wide customization file contents, has higher priority than
             <literal>defaultFonts</literal> settings.
           '';
         };
@@ -287,7 +291,12 @@ in
           enable = mkOption {
             type = types.bool;
             default = true;
-            description = "Enable TrueType hinting.";
+            description = ''
+              Enable font hinting. Hinting aligns glyphs to pixel boundaries to
+              improve rendering sharpness at low resolution. At high resolution
+              (> 200 dpi) hinting will do nothing (at best); users of such
+              displays may want to disable this option.
+            '';
           };
 
           autohint = mkOption {
@@ -297,16 +306,6 @@ in
               Enable the autohinter, which provides hinting for otherwise
               un-hinted fonts. The results are usually lower quality than
               correctly-hinted fonts.
-            '';
-          };
-
-          style = mkOption {
-            type = types.enum ["none" "slight" "medium" "full"];
-            default = "full";
-            description = ''
-              TrueType hinting style, one of <literal>none</literal>,
-              <literal>slight</literal>, <literal>medium</literal>, or
-              <literal>full</literal>.
             '';
           };
         };
@@ -327,7 +326,15 @@ in
             default = "rgb";
             type = types.enum ["rgb" "bgr" "vrgb" "vbgr" "none"];
             description = ''
-              Subpixel order.
+              Subpixel order. The overwhelming majority of displays are
+              <literal>rgb</literal> in their normal orientation. Select
+              <literal>vrgb</literal> for mounting such a display 90 degrees
+              clockwise from its normal orientation or <literal>vbgr</literal>
+              for mounting 90 degrees counter-clockwise. Select
+              <literal>bgr</literal> in the unlikely event of mounting 180
+              degrees from the normal orientation. Reverse these directions in
+              the improbable event that the display's native subpixel order is
+              <literal>bgr</literal>.
             '';
           };
 
@@ -335,7 +342,9 @@ in
             default = "default";
             type = types.enum ["none" "default" "light" "legacy"];
             description = ''
-              FreeType LCD filter.
+              FreeType LCD filter. At high resolution (> 200 DPI), LCD filtering
+              has no visible effect; users of such displays may want to select
+              <literal>none</literal>.
             '';
           };
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1,8 +1,9 @@
 [
   ./config/debug-info.nix
   ./config/fonts/corefonts.nix
-  ./config/fonts/fontconfig-ultimate.nix
   ./config/fonts/fontconfig.nix
+  ./config/fonts/fontconfig-penultimate.nix
+  ./config/fonts/fontconfig-ultimate.nix
   ./config/fonts/fontdir.nix
   ./config/fonts/fonts.nix
   ./config/fonts/ghostscript.nix

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -141,9 +141,6 @@ with lib;
     # Unity3D
     (mkRenamedOptionModule [ "programs" "unity3d" "enable" ] [ "security" "chromiumSuidSandbox" "enable" ])
 
-    # fontconfig-ultimate
-    (mkRenamedOptionModule [ "fonts" "fontconfig" "ultimate" "rendering" ] [ "fonts" "fontconfig" "ultimate" "preset" ])
-
     # murmur
     (mkRenamedOptionModule [ "services" "murmur" "welcome" ] [ "services" "murmur" "welcometext" ])
 
@@ -195,5 +192,6 @@ with lib;
       "See the 16.09 release notes for more information.")
     (mkRemovedOptionModule [ "services" "phpfpm" "phpIni" ] "")
     (mkRemovedOptionModule [ "services" "dovecot2" "package" ] "")
+    (mkRemovedOptionModule [ "fonts" "fontconfig" "hinting" "style" ] "")
   ];
 }

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -24,7 +24,7 @@ let
     Xft.lcdfilter: lcd${fontconfig.subpixel.lcdfilter}
     Xft.hinting: ${if fontconfig.hinting.enable then "1" else "0"}
     Xft.autohint: ${if fontconfig.hinting.autohint then "1" else "0"}
-    Xft.hintstyle: hint${fontconfig.hinting.style}
+    Xft.hintstyle: hintslight
   '';
 
   # file provided by services.xserver.displayManager.session.script

--- a/pkgs/data/fonts/fontconfig-penultimate/default.nix
+++ b/pkgs/data/fonts/fontconfig-penultimate/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchFromGitHub }:
+
+let version = "0.2"; in
+stdenv.mkDerivation {
+  name = "fontconfig-penultimate-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ttuegel";
+    repo = "fontconfig-penultimate";
+    rev = version;
+    sha256 = "106sjfmxdn2cachgsg0ky3wi676x6nd14y5fcl16n82kghi3d9yf";
+  };
+
+  installPhase = ''
+    mkdir -p $out/etc/fonts/conf.d
+    cp *.conf $out/etc/fonts/conf.d
+  '';
+}

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -19,13 +19,6 @@ stdenv.mkDerivation rec {
     sha1 = "c6f7b99986f93c9df78653c3e6a3b5043f65145e";
   };
 
-  infinality = fetchFromGitHub {
-    owner = "bohoomil";
-    repo = "fontconfig-ultimate";
-    rev = "730f5e77580677e86522c1f2119aa78803741759";
-    sha256 = "1hbrdpm6xcczs2c2iid7by8h7dsd0jcf7an88s150njyqnjzxjg7";
-  };
-
   patches = [
     # from https://bugs.freedesktop.org/show_bug.cgi?id=98165
     (fetchpatch {
@@ -34,10 +27,6 @@ stdenv.mkDerivation rec {
       sha256 = "03sfyaclzlglip4pvfjb4zj4dmm8mlphhxl30mb6giinkc74bfri";
     })
   ];
-
-  prePatch = ''
-    patches="$patches $(echo $infinality/*_cairo-iu/*.patch)"
-  '';
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev"; # very small

--- a/pkgs/development/libraries/fontconfig/2.10.nix
+++ b/pkgs/development/libraries/fontconfig/2.10.nix
@@ -8,13 +8,11 @@ stdenv.mkDerivation rec {
     sha256 = "0llraqw86jmw4vzv7inskp3xxm2gc64my08iwq5mzncgfdbfza4f";
   };
 
-  infinality_patch =
-    let subvers = "1";
-      in fetchurl {
-        url = http://www.infinality.net/fedora/linux/zips/fontconfig-infinality-1-20130104_1.tar.bz2;
-        sha256 = "1fm5xx0mx2243jrq5rxk4v0ajw2nawpj23399h710bx6hd1rviq7";
-      }
-    ;
+  patches = [
+    # FreeType 2.7 prefixes PCF font family names with the foundry name.
+    # The output of fc-list and fc-query change which breaks the tests.
+    ./test-pcf-family-names-freetype-2.7.patch
+  ];
 
   outputs = [ "bin" "dev" "lib" "out" ]; # $out contains all the config
 
@@ -43,10 +41,6 @@ stdenv.mkDerivation rec {
 
   # Don't try to write to /var/cache/fontconfig at install time.
   installFlags = "sysconfdir=$(out)/etc fc_cachedir=$(TMPDIR)/dummy RUN_FC_CACHE_TEST=false";
-
-  postInstall = ''
-    cd "$out/etc/fonts" && tar xvf ${infinality_patch}
-  '';
 
   passthru = {
     # Empty for backward compatibility, there was no versioning before 2.11

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -33,6 +33,10 @@ stdenv.mkDerivation rec {
       url = "https://cgit.freedesktop.org/fontconfig/patch/?id=1ab5258f7c";
       sha256 = "0x2a4qx51j3gqcp1kp4lisdzmhrkw1zw0r851d82ksgjlc0vkbaz";
     })
+
+    # FreeType 2.7 prefixes PCF font family names with the foundry name.
+    # The output of fc-list and fc-query change which breaks the tests.
+    ./test-pcf-family-names-freetype-2.7.patch
   ];
   # additionally required for the glibc-2.25 patch; avoid requiring gperf
   postPatch = ''

--- a/pkgs/development/libraries/fontconfig/test-pcf-family-names-freetype-2.7.patch
+++ b/pkgs/development/libraries/fontconfig/test-pcf-family-names-freetype-2.7.patch
@@ -1,0 +1,18 @@
+diff -Nuar fontconfig-2.10.2-orig/test/out.expected fontconfig-2.10.2/test/out.expected
+--- fontconfig-2.10.2-orig/test/out.expected	2017-03-06 06:45:50.876053093 -0600
++++ fontconfig-2.10.2/test/out.expected	2017-03-06 06:48:18.012514337 -0600
+@@ -1,8 +1,8 @@
+-Fixed:pixelsize=16
+-Fixed:pixelsize=6
++Misc Fixed:pixelsize=6
++Sony Fixed:pixelsize=16
+ =
+-Fixed:pixelsize=16
+-Fixed:pixelsize=6
++Misc Fixed:pixelsize=6
++Sony Fixed:pixelsize=16
+ =
+-Fixed:pixelsize=16
+-Fixed:pixelsize=6
++Misc Fixed:pixelsize=6
++Sony Fixed:pixelsize=16

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -1,63 +1,52 @@
-{ stdenv, fetchurl, fetchFromGitHub, pkgconfig, which, zlib, bzip2, libpng, gnumake
-, glib /* passthru only */
+{
+  stdenv, lib, fetchurl, copyPathsToStore,
+  pkgconfig, which,
+  zlib, bzip2, libpng, gnumake, glib,
 
-  # FreeType supports sub-pixel rendering.  This is patented by
-  # Microsoft, so it is disabled by default.  This option allows it to
-  # be enabled.  See http://www.freetype.org/patents.html.
-, useEncumberedCode ? true
-, useInfinality ? true
+  # FreeType supports LCD filtering (colloquially referred to as sub-pixel rendering).
+  # LCD filtering is also known as ClearType and covered by several Microsoft patents.
+  # This option allows it to be disabled. See http://www.freetype.org/patents.html.
+  useEncumberedCode ? true,
 }:
 
-assert useInfinality -> useEncumberedCode;
-
-let
-  version = "2.6.5";
-
-  infinality = fetchFromGitHub {
-    owner = "archfan";
-    repo = "infinality_bundle";
-    rev = "5c0949a477bf43d2ac4e57b4fc39bcc3331002ee";
-    sha256 = "17389aqm6rlxl4b5mv1fx4b22x2v2n60hfhixfxqxpd8ialsdi6l";
-  };
-
-in
 with { inherit (stdenv.lib) optional optionals optionalString; };
-stdenv.mkDerivation rec {
-  name = "freetype-${version}";
+
+let version = "2.7.1"; name = "freetype-" + version; in
+
+stdenv.mkDerivation {
+  inherit name;
+
+  meta = with stdenv.lib; {
+    description = "A font rendering engine";
+    longDescription = ''
+      FreeType is a portable and efficient library for rendering fonts. It
+      supports TrueType, Type 1, CFF fonts, and WOFF, PCF, FNT, BDF and PFR
+      fonts. It has a bytecode interpreter and has an automatic hinter called
+      autofit which can be used instead of hinting instructions included in
+      fonts.
+    '';
+    homepage = https://www.freetype.org/;
+    license = licenses.gpl2Plus; # or the FreeType License (BSD + advertising clause)
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ttuegel ];
+  };
 
   src = fetchurl {
     url = "mirror://savannah/freetype/${name}.tar.bz2";
-    sha256 = "1w5c87s4rpx9af5b3mk5cjd1yny3c4dq5p9iv3ixb3vr00a6w2p2";
+    sha256 = "121gm15ayfg3rglby8ifh8384mcjb9dhmx9j40zl7yszw72b4frs";
   };
-
-  patches = [
-    # Patch for validation of OpenType and GX/AAT tables.
-    (fetchurl {
-      name = "freetype-2.2.1-enable-valid.patch";
-      url = "http://pkgs.fedoraproject.org/cgit/rpms/freetype.git/plain/freetype-2.2.1-enable-valid.patch?id=9a81147af83b1166a5f301e379f85927cc610990";
-      sha256 = "0zkgqhws2s0j8ywksclf391iijhidb1a406zszd7xbdjn28kmj2l";
-    })
-  ] ++ optionals (!useInfinality && useEncumberedCode) [
-    # Patch to enable subpixel rendering.
-    # See https://www.freetype.org/freetype2/docs/reference/ft2-lcd_filtering.html.
-    (fetchurl {
-      name = "freetype-2.3.0-enable-spr.patch";
-      url = http://pkgs.fedoraproject.org/cgit/rpms/freetype.git/plain/freetype-2.3.0-enable-spr.patch?id=9a81147af83b1166a5f301e379f85927cc610990;
-      sha256 = "13ni9n5q3nla38wjmxd4f8cy29gp62kjx2l6y6nqhdyiqp8fz8nd";
-    })
-  ];
-
-  prePatch = optionalString useInfinality ''
-    patches="$patches $(ls ${infinality}/*_freetype2-iu/*-infinality-*.patch)"
-  '';
-
-  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [ zlib bzip2 libpng ]; # needed when linking against freetype
   # dependence on harfbuzz is looser than the reverse dependence
   nativeBuildInputs = [ pkgconfig which ]
     # FreeType requires GNU Make, which is not part of stdenv on FreeBSD.
     ++ optional (!stdenv.isLinux) gnumake;
+
+  patches =
+    [ ./enable-table-validation.patch ]
+    ++ optional useEncumberedCode ./enable-subpixel-rendering.patch;
+
+  outputs = [ "out" "dev" ];
 
   configureFlags = [ "--disable-static" "--bindir=$(dev)/bin" ];
 
@@ -75,20 +64,5 @@ stdenv.mkDerivation rec {
     # of gcc. I think it's due to the unwrapped gcc being in the PATH. I don't
     # know why it's on the PATH.
     configureFlags = "--disable-static CC_BUILD=gcc";
-  };
-
-  meta = with stdenv.lib; {
-    description = "A font rendering engine";
-    longDescription = ''
-      FreeType is a portable and efficient library for rendering fonts. It
-      supports TrueType, Type 1, CFF fonts, and WOFF, PCF, FNT, BDF and PFR
-      fonts. It has a bytecode interpreter and has an automatic hinter called
-      autofit which can be used instead of hinting instructions included in
-      fonts.
-    '';
-    homepage = https://www.freetype.org/;
-    license = licenses.gpl2Plus; # or the FreeType License (BSD + advertising clause)
-    #ToDo: encumbered = useEncumberedCode;
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/freetype/enable-subpixel-rendering.patch
+++ b/pkgs/development/libraries/freetype/enable-subpixel-rendering.patch
@@ -1,0 +1,13 @@
+Index: freetype-2.7.1/include/freetype/config/ftoption.h
+===================================================================
+--- freetype-2.7.1.orig/include/freetype/config/ftoption.h
++++ freetype-2.7.1/include/freetype/config/ftoption.h
+@@ -122,7 +122,7 @@ FT_BEGIN_HEADER
+   /* This is done to allow FreeType clients to run unmodified, forcing     */
+   /* them to display normal gray-level anti-aliased glyphs.                */
+   /*                                                                       */
+-/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
++#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING
+ 
+ 
+   /*************************************************************************/

--- a/pkgs/development/libraries/freetype/enable-table-validation.patch
+++ b/pkgs/development/libraries/freetype/enable-table-validation.patch
@@ -1,0 +1,22 @@
+Index: freetype-2.7.1/modules.cfg
+===================================================================
+--- freetype-2.7.1.orig/modules.cfg
++++ freetype-2.7.1/modules.cfg
+@@ -120,7 +120,7 @@ AUX_MODULES += cache
+ # TrueType GX/AAT table validation.  Needs ftgxval.c below.
+ #
+ # No FT_CONFIG_OPTION_PIC support.
+-# AUX_MODULES += gxvalid
++AUX_MODULES += gxvalid
+ 
+ # Support for streams compressed with gzip (files with suffix .gz).
+ #
+@@ -143,7 +143,7 @@ AUX_MODULES += bzip2
+ # OpenType table validation.  Needs ftotval.c below.
+ #
+ # No FT_CONFIG_OPTION_PIC support.
+-# AUX_MODULES += otvalid
++AUX_MODULES += otvalid
+ 
+ # Auxiliary PostScript driver component to share common code.
+ #

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7330,6 +7330,8 @@ with pkgs;
 
   fontconfig = callPackage ../development/libraries/fontconfig { };
 
+  fontconfig-penultimate = callPackage ../data/fonts/fontconfig-penultimate {};
+
   fontconfig-ultimate = callPackage ../development/libraries/fontconfig-ultimate {};
 
   folly = callPackage ../development/libraries/folly { };


### PR DESCRIPTION
###### Motivation for this change

Besides updating FreeType to the latest version 2.7.1, a number of changes are made to the patches we carry on FreeType and Cairo which I believe will reduce maintenance burden and improve security. To account for the new TrueType interpreter in FreeType 2.7, the defaults provided by fontconfig-ultimate (tuned for the Infinality interpreter) have been replaced by my own derivative thereof, fontconfig-penultimate. Along the way, I discovered that fontconfig-ultimate wasn't doing the right thing in several cases (probably because it isn't properly maintained). The new defaults are significantly simpler.

The commit message has most of the relevant details:

The Infinality bytecode interpreter is removed in favor of the new v40 TrueType
interpreter. In the past, the Infinality interpreter provided support for
ClearType-style hinting instructions while the default interpreter (then v35)
provided support only for original TrueType-style instructions. The v40
interpreter corrects this deficiency, so the Infinality interpreter is no longer
necessary.

To understand why the Infinality interpreter is no longer necessary, we should
understand how ClearType differs from TrueType and how the v40 interpreter
works. The following is a summary of information available on the FreeType
website [1] mixed with my own editorializing.

TrueType instructions use horizontal and vertical hints to improve glyph
rendering. Before TrueType, fonts were only vertically hinted; horizontal hints
improved rendering by snapping stems to pixel boundaries. Horizontal hinting is
a risk because it can significantly distort glyph shapes and kerning. Extensive
testing at different resolutions is needed to perfect the TrueType
hints. Microsoft invested significant effort to do this with its "Core fonts for
the Web" project, but few other typefaces have seen this level of attention.

With the advent of subpixel rendering, the effective horizontal resolution of
most displays increased significantly. ClearType eschews horizontal hinting in
favor of horizontal supersampling. Most fonts are designed for the Microsoft
bytecode interpreter, which implements a compatibility mode with
TrueType-style (horizontal and vertical) instructions. However, applying the
full horizontal hints to subpixel-rendered fonts leads to color fringes and
inconsistent stem widths. The Infinality interpreter implements several
techniques to mitigate these problems, going so far as to embed font- and
glyph-specific hacks in the interpreter. On the other hand, the v40 interpreter
ignores the horizontal hinting instructions so that glyphs render as they are
intended to on the Microsoft interpreter. Without the horizontal hints, the
problems of glyph and kerning distortion, color fringes, and inconsistent stem
widths--the problems the Infinality interpreter was created to solve--simply
don't occur in the first place.

There are also security concerns which motivate removing the Infinality patches.
Although there is an updated version of the Infinality interpreter for FreeType
2.7, the lack of a consistent upstream maintainer is a security concern. The
interpreter is a Turing-complete virtual machine which has had security
vulnerabilities in the past. While the default interpreter is used in billions
of devices and is maintained by an active developer, the Infinality interpreter
is neither scrutinized nor maintained. We will probably never know if there are
defects in the Infinality interpreter, and if they were discovered they would
likely never be fixed. I do not think that is an acceptable situtation for a
core library like FreeType.

Dropping the Infinality patches means that font rendering will be less
customizable. I think this is an acceptable trade-off. The Infinality
interpreter made many compromises to mitigate the problems with horizontal
hinting; the main purpose of customization is to tailor these compromises to the
user's preferences. The new interpreter does not have to make these compromises
because it renders fonts as their designers intended, so this level of
customization is not necessary.

The Infinality-associated patches are also removed from cairo. These patches
only set the default rendering options in case they aren't set though
Fontconfig. On NixOS, the rendering options are always set in Fontconfig, so
these patches never actually did anything for us!

The Fontconfig test suite is patched to account for a quirk in the way PCF fonts
are named.

The fontconfig option `hintstyle` is no longer configurable in NixOS. This
option selects the TrueType interpreter; the v40 interpreter is `hintslight` and
the older v35 interpreter is `hintmedium` or `hintfull` (which have actually
always been the same thing). The setting may still be changed through the
`localConf` option or by creating a user Fontconfig file.

Users with HiDPI displays should probably disable hinting and antialiasing: at
best they have no visible effect.

The fontconfig-ultimate settings are still available in NixOS, but they are no
longer the default. They still work, but their main purpose is to set rendering
quirks which are no longer necessary and may actually be
detrimental (e.g. setting `hintfull` for some fonts). Also, the vast array of
font substitutions provided is not an appropriate default; the default setting
should be to give the user the font they asked for.

[1]. https://www.freetype.org/freetype2/docs/subpixel-hinting.html

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I expect these changes to be controversial, so I will not merge immediately to allow for discussion.