### PR TITLE
gloox: 1.0.14 -> 1.0.20

### DIFF
--- a/pkgs/development/libraries/gloox/default.nix
+++ b/pkgs/development/libraries/gloox/default.nix
@@ -8,27 +8,29 @@ assert zlibSupport -> zlib != null;
 assert sslSupport -> openssl != null;
 assert idnSupport -> libidn != null;
 
+with stdenv.lib;
+
 let
-  version = "1.0.14";
+  version = "1.0.20";
 in
 stdenv.mkDerivation rec {
   name = "gloox-${version}";
 
   src = fetchurl {
     url = "http://camaya.net/download/gloox-${version}.tar.bz2";
-    sha256 = "0h9r4382qv0vqc91x1qz1nivxw1r2l874s1kl0bskzm9dyk742sj";
+    sha256 = "1a6yhs42wcdm8az3983m3lx4d9296bw0amz5v3b4012g1xn0hhq2";
   };
 
   buildInputs = [ ]
-    ++ stdenv.lib.optional zlibSupport zlib
-    ++ stdenv.lib.optional sslSupport openssl
-    ++ stdenv.lib.optional idnSupport libidn;
+    ++ optional zlibSupport zlib
+    ++ optional sslSupport openssl
+    ++ optional idnSupport libidn;
 
   meta = {
     description = "A portable high-level Jabber/XMPP library for C++";
-    homepage = "http://camaya.net/gloox";
-    license = stdenv.lib.licenses.gpl3;
-    maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
-    platforms = with stdenv.lib.platforms; unix;
+    homepage = http://camaya.net/gloox;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fuuzetsu ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

