### PR TITLE
qmetro: init at 0.7.1

### DIFF
--- a/pkgs/applications/misc/qmetro/default.nix
+++ b/pkgs/applications/misc/qmetro/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, qmake4Hook, unzip, qt4 }:
+
+stdenv.mkDerivation rec {
+  name = "${project}-${version}";
+  project = "qmetro";
+  version = "0.7.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${project}/${name}.zip";
+    sha256 = "1zdj87lzcr43gr2h05g17z31pd22n5kxdwbvx7rx656rmhv0sjq5";
+  };
+
+  nativeBuildInputs = [ qmake4Hook unzip ];
+
+  buildInputs = [ qt4 ];
+
+  postPatch = ''
+    sed -e 's#Exec=/usr/bin/qmetro#Exec=qmetro#' -i rc/qmetro.desktop
+    echo 'LIBS += -lz' >> qmetro.pro
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://sourceforge.net/projects/qmetro/;
+    description = "Worldwide transit maps viewer";
+    license = licenses.gpl3;
+
+    maintainter = with maintainers; [ orivej ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14998,6 +14998,8 @@ with pkgs;
 
   qjackctl = libsForQt5.callPackage ../applications/audio/qjackctl { };
 
+  qmetro = callPackage ../applications/misc/qmetro { };
+
   qmidinet = callPackage ../applications/audio/qmidinet { };
 
   qmidiroute = callPackage ../applications/audio/qmidiroute { };


### PR DESCRIPTION
###### Motivation for this change

qMetro displays transit [maps](http://translate.google.com/translate?sl=ru&tl=en&u=http://pmetro.su/Maps.html) and finds shortest paths between stations.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

