### PR TITLE
gtkspell:3.0.8 -> 3.0.9

### DIFF
--- a/pkgs/development/libraries/gtkspell/3.nix
+++ b/pkgs/development/libraries/gtkspell/3.nix
@@ -2,21 +2,22 @@
 
 stdenv.mkDerivation rec {
   name = "gtkspell-${version}";
-  version = "3.0.8";
+  version = "3.0.9";
 
   src = fetchurl {
-    url = "mirror://sourceforge/gtkspell/gtkspell3-${version}.tar.gz";
-    sha256 = "1zrz5pz4ryvcssk898liynmy2wyxgj95ak7mp2jv7x62yzihq6h1";
+    url = "mirror://sourceforge/gtkspell/gtkspell3-${version}.tar.xz";
+    sha256 = "09jdicmpipmj4v84gnkqwbmj4lh8v0i6pn967rb9jx4zg2ia9x54";
   };
 
-  buildInputs = [ aspell pkgconfig gtk3 enchant intltool ];
+  nativeBuildInputs = [ pkgconfig intltool ];
+  buildInputs = [ aspell gtk3 enchant ];
   propagatedBuildInputs = [ enchant ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "http://gtkspell.sourceforge.net/";
     description = "Word-processor-style highlighting GtkTextView widget";
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ fuuzetsu ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

