### PR TITLE
mkvtoolnix: 9.8.0 -> 9.9.0

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoconf, automake
 , drake, ruby, docbook_xsl, file, xdg_utils, gettext, expat, qt5, boost
-, libebml, zlib, libmatroska, libogg, libvorbis, flac
+, libebml, zlib, libmatroska, libogg, libvorbis, flac, libxslt
 , withGUI ? true
 }:
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "1jiz23s52l3gpl84yx4yw3w445jqzcimvnvibvrv3a21k29hyik1";
   };
 
-  nativeBuildInputs = [ pkgconfig autoconf automake gettext drake ruby docbook_xsl ];
+  nativeBuildInputs = [ pkgconfig autoconf automake gettext drake ruby docbook_xsl libxslt ];
 
   buildInputs = [
     expat file xdg_utils boost libebml zlib libmatroska libogg

--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoconf, automake
-, drake, ruby, file, xdg_utils, gettext, expat, qt5, boost
+, drake, ruby, docbook_xsl, file, xdg_utils, gettext, expat, qt5, boost
 , libebml, zlib, libmatroska, libogg, libvorbis, flac
 , withGUI ? true
 }:
@@ -10,16 +10,16 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "mkvtoolnix-${version}";
-  version = "9.8.0";
+  version = "9.9.0";
 
   src = fetchFromGitHub {
     owner = "mbunkus";
     repo = "mkvtoolnix";
     rev = "release-${version}";
-    sha256 = "1hnk92ksgg290q4kwdl8jqrz7vzlwki4f85bb6kgdgzpjkblw76n";
+    sha256 = "1jiz23s52l3gpl84yx4yw3w445jqzcimvnvibvrv3a21k29hyik1";
   };
 
-  nativeBuildInputs = [ pkgconfig autoconf automake gettext drake ruby ];
+  nativeBuildInputs = [ pkgconfig autoconf automake gettext drake ruby docbook_xsl ];
 
   buildInputs = [
     expat file xdg_utils boost libebml zlib libmatroska libogg
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
     "--disable-precompiled-headers"
     "--disable-static-qt"
     "--with-gettext"
+    "--with-docbook-xsl-root=${docbook_xsl}/share/xml/docbook-xsl"
     (enableFeature withGUI "qt")
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Update to version 9.9.0. See the [NEWS](https://mkvtoolnix.download/doc/NEWS.md).

Starting with version 9.9.0 the man pages and their translations are not pre-built and bundled with the source code. The tool "xsltproc" and the DocBook XSL stylesheets for man pages are now required dependencies to build them.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).