### PR TITLE
gupnp-tools: 0.8.8 -> 0.8.13

### DIFF
--- a/pkgs/tools/networking/gupnp-tools/default.nix
+++ b/pkgs/tools/networking/gupnp-tools/default.nix
@@ -3,10 +3,10 @@
 stdenv.mkDerivation rec {
   name = "gupnp-tools-${version}";
   majorVersion = "0.8";
-  version = "${majorVersion}.8";
+  version = "${majorVersion}.13";
   src = fetchurl {
     url = "mirror://gnome/sources/gupnp-tools/${majorVersion}/gupnp-tools-${version}.tar.xz";
-    sha256 = "160dgh9pmlb85qfavwqz46lqawpshs8514bx2b57f9rbiny8kbij";
+    sha256 = "1vbr4iqi7nl7kq982agd3liw10gx67s95idd0pjy5h1jsnwyqgda";
   };
 
   buildInputs = [gupnp libuuid gssdp pkgconfig gtk3 intltool gupnp_av


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

