### PR TITLE
fetchSvn: Add support for --ignore-keywords flag

### DIFF
--- a/pkgs/build-support/fetchsvn/builder.sh
+++ b/pkgs/build-support/fetchsvn/builder.sh
@@ -22,7 +22,8 @@ fi;
 # server's certificate.  This is perfectly safe: we don't care
 # whether the server is being spoofed --- only the cryptographic
 # hash of the output matters. Pass in extra p's to handle redirects.
-printf 'p\np\np\n' | svn export --trust-server-cert --non-interactive ${ignoreExternals:+--ignore-externals} \
+printf 'p\np\np\n' | svn export --trust-server-cert --non-interactive \
+    ${ignoreExternals:+--ignore-externals} ${ignoreKeywords:+--ignore-keywords} \
     -r "$rev" "$url" "$out"
 
 stopNest

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -1,5 +1,6 @@
 {stdenv, subversion, sshSupport ? false, openssh ? null}:
-{url, rev ? "HEAD", md5 ? "", sha256 ? "", ignoreExternals ? false, name ? null}:
+{url, rev ? "HEAD", md5 ? "", sha256 ? "",
+ ignoreExternals ? false, ignoreKeywords ? false, name ? null}:
 
 let
   repoName = with stdenv.lib;
@@ -31,7 +32,7 @@ stdenv.mkDerivation {
   outputHashMode = "recursive";
   outputHash = if sha256 == "" then md5 else sha256;
   
-  inherit url rev sshSupport openssh ignoreExternals;
+  inherit url rev sshSupport openssh ignoreExternals ignoreKeywords;
 
   impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
   preferLocalBuild = true;


### PR DESCRIPTION
###### Motivation for this change

This is a flag that disables subversion keyword substitution.
Keyword substitution inserts metadata into the files being checked
out, and is therefore somewhat at odds with build reproducibility.

In particular, it can become a problem if you're trying to switch
between svn and a git export of the same thing (keyword substitutions
are normally not exported into git).

###### Things done

Used fetchGit and fetchSvn to fetch openttd. They produced different sha256 hashes initially, but they produce the same sha256 hash when I use ignoreKeywords

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (says: Nothing changed)
- [x] (vacuously) Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

