### PR TITLE
mtr: 0.86 -> 0.87

### DIFF
--- a/pkgs/tools/networking/mtr/default.nix
+++ b/pkgs/tools/networking/mtr/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ncurses, autoconf
+{stdenv, fetchurl, autoreconfHook, pkgconfig, ncurses
 , withGtk ? false, gtk2 ? null}:
 
 assert withGtk -> gtk2 != null;
@@ -6,24 +6,27 @@ assert withGtk -> gtk2 != null;
 with stdenv.lib;
 stdenv.mkDerivation rec {
   baseName="mtr";
-  version="0.86";
+  version="0.87";
   name="${baseName}-${version}";
-  
+
   src = fetchurl {
     url="ftp://ftp.bitwizard.nl/${baseName}/${name}.tar.gz";
-    sha256 = "01lcy89q3i9g4kz4liy6m7kcq1zyvmbc63rqidgw67341f94inf5";
+    sha256 = "17zi99n8bdqrwrnbfyjn327jz4gxx287wrq3vk459c933p34ff8r";
   };
 
   configureFlags = optionalString (!withGtk) "--without-gtk";
 
-  buildInputs = [ autoconf ncurses ] ++ optional withGtk gtk2;
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ ncurses ] ++ optional withGtk gtk2;
+
+  enableParallelBuilding = true;
 
   meta = {
     homepage = http://www.bitwizard.nl/mtr/;
     description = "A network diagnostics tool";
-    maintainers = [ maintainers.koral maintainers.raskin ];
+    maintainers = with maintainers; [ koral orivej raskin ];
     platforms = platforms.unix;
     license = licenses.gpl2;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

This not only bumps version but also fixes support for the override `withGtk = true`. This package ships `configure` that simply assumes that GTK is not available, this is why it has to be regenerated with `autoreconf`.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
