### PR TITLE
granite: 0.3.0 -> 0.4.0.1

### DIFF
--- a/pkgs/development/libraries/granite/default.nix
+++ b/pkgs/development/libraries/granite/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, perl, cmake, vala_0_23, pkgconfig, gobjectIntrospection, glib, gtk3, gnome3, gettext }:
+{ stdenv, fetchurl, perl, cmake, vala, pkgconfig, gobjectIntrospection, glib, gtk3, gnome3, gettext }:
 
 stdenv.mkDerivation rec {
-  majorVersion = "0.3";
-  minorVersion = "0";
+  majorVersion = "0.4";
+  minorVersion = "0.1";
   name = "granite-${majorVersion}.${minorVersion}";
   src = fetchurl {
-    url = "https://code.launchpad.net/granite/${majorVersion}/${majorVersion}/+download/${name}.tar.gz";
-    sha256 = "1laa109dz7kbd8zxddqw2p1b67yzva7cc5h3smqkj8a9jzbhv5fz";
+    url = "https://launchpad.net/granite/${majorVersion}/${majorVersion}.${minorVersion}/+download/${name}.tar.xz";
+    sha256 = "1pf4jkz3xyn1sqv70063im80ayb5kdsqwqwx11dc7vgypsl458cm";
   };
   cmakeFlags = "-DINTROSPECTION_GIRDIR=share/gir-1.0/ -DINTROSPECTION_TYPELIBDIR=lib/girepository-1.0";
-  buildInputs = [perl cmake vala_0_23 pkgconfig gobjectIntrospection glib gtk3 gnome3.libgee gettext];
+  buildInputs = [perl cmake vala pkgconfig gobjectIntrospection glib gtk3 gnome3.libgee gettext];
   meta = {
     description = "An extension to GTK+ used by elementary OS";
     longDescription = "An extension to GTK+ that provides several useful widgets and classes to ease application development. Designed for elementary OS.";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

