### PR TITLE
qt57.{qtdeclarative,qtscript,qttranslations}: fix darwin compat

### DIFF
--- a/pkgs/development/libraries/qt-5/qtbase-setup-hook-darwin.sh
+++ b/pkgs/development/libraries/qt-5/qtbase-setup-hook-darwin.sh
@@ -135,10 +135,14 @@ qt5LinkModuleDir() {
 
 qt5LinkDarwinModuleLibDir() {
   for fw in $(find "$1"/lib -maxdepth 1 -name '*.framework'); do
+    if [ ! -L "$fw" ]; then
       ln -s "$fw" "$NIX_QT5_TMP"/lib
+    fi
   done
   for file in $(find "$1"/lib -maxdepth 1 -type f); do
+    if [ ! -L "$file" ]; then
       ln -s "$file" "$NIX_QT5_TMP"/lib
+    fi
   done
   for dir in $(find "$1"/lib -maxdepth 1 -mindepth 1 -type d ! -name '*.framework'); do
       mkdir -p "$NIX_QT5_TMP"/lib/$(basename "$dir")
@@ -178,4 +182,3 @@ _qtFixCMakePaths() {
 if [ -n "$NIX_QT_SUBMODULE" ]; then
     postInstallHooks+=(_qtFixCMakePaths)
 fi
-


### PR DESCRIPTION
Fixes duplicate linkings issue for Qt-Frameworks provided by qtbase
during configurePhase.

###### Motivation for this change
Issues found during enable of qt57.qtbase darwin compatibility. Mentioned by @LnL7 [here](/NixOS/nixpkgs/pull/23764#issuecomment-285936924).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

