### PR TITLE
wordpress: security upgrade: 4.7.2 -> 4.7.3 & other improvements

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/wordpress.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/wordpress.nix
@@ -4,11 +4,6 @@
 with lib;
 
 let
-
-  # Upgrading? We have a test! nix-build ./nixos/tests/wordpress.nix
-  version = "4.7.2";
-  fullversion = "${version}";
-
   # Our bare-bones wp-config.php file using the above settings
   wordpressConfig = pkgs.writeText "wp-config.php" ''
     <?php
@@ -71,12 +66,7 @@ let
   # The wordpress package itself
   wordpressRoot = pkgs.stdenv.mkDerivation rec {
     name = "wordpress";
-    src = pkgs.fetchFromGitHub {
-      owner = "WordPress";
-      repo = "WordPress";
-      rev = "${fullversion}";
-      sha256 = "0vph12708drf8ww0xd05hpdvbyy7n5gj9ca598lhdhy2i1j6wy32";
-    };
+    src = config.package;
     installPhase = ''
       mkdir -p $out
       # copy all the wordpress files we downloaded
@@ -122,6 +112,14 @@ in
   enablePHP = true;
 
   options = {
+    package = mkOption {
+      type = types.path;
+      default = pkgs.wordpress;
+      description = ''
+        Path to the wordpress sources.
+        Upgrading? We have a test! nix-build ./nixos/tests/wordpress.nix
+      '';
+    };
     dbHost = mkOption {
       default = "localhost";
       description = "The location of the database server.";

--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -10,14 +10,10 @@ import ./make-test.nix ({ pkgs, ... }:
     { web =
         { config, pkgs, ... }:
         {
-          services.mysql.enable = true;
-          services.mysql.package = pkgs.mysql;
-          services.mysql.initialScript = pkgs.writeText "start.sql" ''
-            CREATE DATABASE wordpress;
-	    CREATE USER 'wordpress'@'localhost' IDENTIFIED BY 'wordpress';
-            GRANT ALL on wordpress.* TO 'wordpress'@'localhost';
-          '';
-
+          services.mysql = {
+            enable = true;
+            package = pkgs.mysql;
+          };
           services.httpd = {
             enable = true;
             logPerVirtualHost = true;

--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -1,0 +1,12 @@
+  # Upgrading? We have a test! nix-build ./nixos/tests/wordpress.nix
+{ fetchFromGitHub, lib } : fetchFromGitHub {
+  owner = "WordPress";
+  repo = "WordPress";
+  rev = "4.7.3";
+  sha256 = "05gggm40065abylp6bdc0zn0q6ahcggyh4q6rk0ak242q8v5fm5b";
+  meta = {
+    homepage = https://wordpress.org;
+    description = "WordPress is open source software you can use to create a beautiful website, blog, or app.";
+    license = lib.licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18120,6 +18120,8 @@ with pkgs;
 
   wmutils-opt = callPackage ../tools/X11/wmutils-opt { };
 
+  wordpress = callPackage ../servers/web-apps/wordpress { };
+
   wraith = callPackage ../applications/networking/irc/wraith { };
 
   wxmupen64plus = callPackage ../misc/emulators/wxmupen64plus { };


### PR DESCRIPTION
* Upgrade WordPress to 4.7.3. See the [release notes](https://wordpress.org/news/2017/03/wordpress-4-7-3-security-and-maintenance-release/).

* Move the wordpress source derivation to the attribute `pkgs.wordpress`. This makes it easier to override.

* Also introduce the `package` option for the wordpress virtual host config which defaults to `pkgs.wordpress`. This enables multiple wordpress installations with different versions.

* Also fixed the test in `nixos/tests/wordpress.nix`.

Since this is a security update it should be cherry picked on `release-16.09` and `release-17.03`.


