### PR TITLE
sage: fix build at 6.8

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, m4, perl, gfortran, texlive, ffmpeg, tk
-, imagemagick, liblapack, python, openssl, libpng
+{ stdenv, fetchurl, m4, perl, gfortran, texlive, ffmpeg, tk, gnused_422
+, imagemagick, liblapack, python, openssl, libpng 
 , which
 }:
 
@@ -9,10 +9,11 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "http://old.files.sagemath.org/src-old/${name}.tar.gz";
     sha256 = "102mrzzi215g1xn5zgcv501x9sghwg758jagx2jixvg1rj2jijj9";
+
   };
 
-  buildInputs = [ m4 perl gfortran texlive.combined.scheme-basic ffmpeg tk imagemagick liblapack
-                  python openssl libpng which];
+  buildInputs = [ m4 perl gfortran texlive.combined.scheme-basic ffmpeg gnused_422 tk imagemagick liblapack
+                  python openssl libpng which ];
 
   patches = [ ./spkg-singular.patch ./spkg-python.patch ./spkg-git.patch ];
 


### PR DESCRIPTION
###### Motivation for this change
Sed on master failed to build for at least several weeks. https://groups.google.com/forum/#!topic/sage-devel/sqXwBseqiRA
Adding older version of `gnused` fixes it.
Also tested by @itegulov.
Related issue: https://github.com/NixOS/nixpkgs/issues/23304

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @jagajaga 