### PR TITLE
nixos: Add a menu launcher for the NixOS manual

### DIFF
--- a/nixos/modules/services/misc/nixos-manual.nix
+++ b/nixos/modules/services/misc/nixos-manual.nix
@@ -41,7 +41,7 @@ let
 
   entry = "${manual.manual}/share/doc/nixos/index.html";
 
-  help = pkgs.writeScriptBin "nixos-help"
+  helpScript = pkgs.writeScriptBin "nixos-help"
     ''
       #! ${pkgs.stdenv.shell} -e
       browser="$BROWSER"
@@ -58,6 +58,15 @@ let
       exec "$browser" ${entry}
     '';
 
+  desktopItem = pkgs.makeDesktopItem {
+    name = "nixos-manual";
+    desktopName = "NixOS Manual";
+    genericName = "View NixOS documentation in a web browser";
+    # TODO: find a better icon (Nix logo + help overlay?)
+    icon = "system-help";
+    exec = "${helpScript}/bin/nixos-help";
+    categories = "System";
+  };
 in
 
 {
@@ -105,7 +114,8 @@ in
     system.build.manual = manual;
 
     environment.systemPackages =
-      [ manual.manual help ]
+      [ manual.manual helpScript ]
+      ++ optional config.services.xserver.enable desktopItem
       ++ optional config.programs.man.enable manual.manpages;
 
     boot.extraTTYs = mkIf cfg.showManual ["tty${toString cfg.ttyNumber}"];


### PR DESCRIPTION
This adds a clickable app launcher in most desktop environments to open the current system's generated documentation set.