### PR TITLE
bluefish: 2.2.9 -> 2.2.10

### DIFF
--- a/pkgs/applications/editors/bluefish/default.nix
+++ b/pkgs/applications/editors/bluefish/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "bluefish-2.2.9";
+  name = "bluefish-2.2.10";
 
   src = fetchurl {
     url = "mirror://sourceforge/bluefish/${name}.tar.bz2";
-    sha256 = "1l7pg6h485yj84i34jr09y8qzc1yr4ih6w5jdhmnrg156db7nwav";
+    sha256 = "1ciygj79q6i3ga5x1j8aivc05nh6rhhnm7hrq8q8xd9vd4ms3v5g";
   };
 
   nativeBuildInputs = [ intltool pkgconfig wrapGAppsHook ];


### PR DESCRIPTION
###### Motivation for this change

Update bluefish to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

