### PR TITLE
htmlcxx: 0.85 -> 0.86

### DIFF
--- a/pkgs/development/libraries/htmlcxx/default.nix
+++ b/pkgs/development/libraries/htmlcxx/default.nix
@@ -2,19 +2,19 @@
 
 stdenv.mkDerivation rec {
   name = "htmlcxx-${version}";
-  version = "0.85";
+  version = "0.86";
 
   src = fetchurl {
     url = "mirror://sourceforge/htmlcxx/htmlcxx/${version}/${name}.tar.gz";
-    sha256 = "1rdsjrcjkf7mi3182lq4v5wn2wncw0ziczagaqnzi0nwmp2a00mb";
+    sha256 = "1hgmyiad3qgbpf2dvv2jygzj6jpz4dl3n8ds4nql68a4l9g2nm07";
   };
 
   patches = [ ./ptrdiff.patch ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://htmlcxx.sourceforge.net/;
-    description = "htmlcxx is a simple non-validating css1 and html parser for C++";
-    license = stdenv.lib.licenses.lgpl2;
-    platforms = stdenv.lib.platforms.linux;
+    description = "A simple non-validating css1 and html parser for C++";
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

