### PR TITLE
iso-codes: 3.56 -> 3.74

### DIFF
--- a/pkgs/development/libraries/iso-codes/default.nix
+++ b/pkgs/development/libraries/iso-codes/default.nix
@@ -1,24 +1,24 @@
-{stdenv, fetchurl, gettext, python, xz}:
+{stdenv, fetchurl, gettext, python3, xz}:
 
 stdenv.mkDerivation rec {
-  name = "iso-codes-3.56";
+  name = "iso-codes-3.74";
+
   src = fetchurl {
     url = "http://pkg-isocodes.alioth.debian.org/downloads/${name}.tar.xz";
-    sha256 = "0vnfygd03jg21i7r238n450wy2hp354f3ank0v3k34zchbjydl2m";
+    sha256 = "1vkaxkcx8h8lbg3z3jjfjs1x1rz1l01j6ll46ysza2gym37g7x11";
   };
   patchPhase = ''
     for i in `find . -name \*.py`
     do
-        sed -i -e "s|#!/usr/bin/env python|#!${python}/bin/python|" $i
+        sed -i -e "s|#!/usr/bin/env python|#!${python3}/bin/python|" $i
     done
   '';
-  buildInputs = [ gettext ];
-  nativeBuildInputs = [ xz ];
+  buildInputs = [ gettext python3 ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://pkg-isocodes.alioth.debian.org/;
     description = "Various ISO codes packaged as XML files";
-    maintainers = [ stdenv.lib.maintainers.urkud ];
-    platforms = stdenv.lib.platforms.all;
+    maintainers = [ maintainers.urkud ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

