### PR TITLE
libvirt and friends: fix 32 bit build by removing dependency on xen

### DIFF
--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -21,8 +21,8 @@ stdenv.mkDerivation rec {
     makeWrapper pkgconfig autoreconfHook ncurses cpio gperf perl
     cdrkit flex bison qemu pcre augeas libxml2 acl libcap libcap_ng libconfig
     systemd fuse yajl libvirt gmp readline file hivex libintlperl GetoptLong
-    SysVirt numactl xen
-  ];
+    SysVirt numactl
+  ] ++ stdenv.lib.optional (stdenv.system == "x86_64-linux") xen;
 
   configureFlags = "--disable-appliance --disable-daemon";
   patches = [ ./libguestfs-syms.patch ];

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -15,8 +15,8 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     pkgconfig libvirt glib libxml2 intltool libtool yajl nettle libgcrypt
-    python pygobject2 gobjectIntrospection libcap_ng numactl xen
-  ];
+    python pygobject2 gobjectIntrospection libcap_ng numactl
+  ] ++ stdenv.lib.optional (stdenv.system == "x86_64-linux") xen;
 
   meta = with stdenv.lib; {
     description = "Library for working with virtual machines";

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -25,10 +25,10 @@ stdenv.mkDerivation rec {
     libxslt xhtml1 perlPackages.XMLXPath curl libpcap
   ] ++ stdenv.lib.optionals stdenv.isLinux [
     libpciaccess devicemapper lvm2 utillinux systemd libcap_ng
-    libnl numad numactl xen zfs
+    libnl numad numactl zfs
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
      libiconv gmp
-  ];
+  ] ++ stdenv.lib.optional (stdenv.system == "x86_64-linux") xen;
 
   preConfigure = stdenv.lib.optionalString stdenv.isLinux ''
     PATH=${stdenv.lib.makeBinPath [ iproute iptables ebtables lvm2 systemd ]}:$PATH


### PR DESCRIPTION
###### Motivation for this change

```xen``` is declared as a [64-bit only package](https://github.com/NixOS/nixpkgs/blob/release-17.03/pkgs/applications/virtualization/xen/generic.nix#L185) and unconditional dependency on ```xen``` prevents ```libvirt``` to be built for ```i686-linux```.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

