### PR TITLE
callCabal2nix: Don't rebuild unchanged cabal file

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -84,7 +84,14 @@ let
         callHackage = name: version: self.callPackage (hackage2nix name version);
 
         # Creates a Haskell package from a source package by calling cabal2nix on the source.
-        callCabal2nix = name: src: self.callPackage (haskellSrc2nix { inherit src name; });
+        callCabal2nix = name: src: args:
+	  let
+	    # Filter out files other than the cabal file. This ensures
+	    # that we don't create new derivations even when the cabal
+	    # file hasn't changed.
+	    justCabal = builtins.filterSource (path: type: pkgs.lib.hasSuffix ".cabal" path) src;
+	    drv = self.callPackage (haskellSrc2nix { inherit name; src = justCabal; }) args;
+	  in overrideCabal drv (drv': { inherit src; }); # Restore the desired src.
 
         ghcWithPackages = selectFrom: withPackages (selectFrom self);
 


### PR DESCRIPTION
It can be quite annoying that callCabal2nix will build a new derivation if anything in the source has changed, even if the cabal file hasn't. In particular, you can trick Stack and Intero to work with a Nix based setup by using Stack's Nix integration and throwing away the `ghc` it gives you, but Intero freaks out when it sees `building path(s) ...` unexpectedly.

This patch uses `cabal2nix` on a filtered source that only includes the cabal file, then restores the `src` in the resulting derivation. This way the `cabal2nix-<name>` derivations will be cached between builds where non-cabal-files were changed.