### PR TITLE
emem: 0.2.35 -> 0.2.38

### DIFF
--- a/pkgs/applications/misc/emem/default.nix
+++ b/pkgs/applications/misc/emem/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "emem";
-  version = "0.2.35";
+  version = "0.2.38";
   name = "${pname}-${version}";
 
   inherit jdk;
 
   src = fetchurl {
     url = "https://github.com/ebzzry/${pname}/releases/download/v${version}/${pname}.jar";
-    sha256 = "0y1jwfmqmmff3kh82j07p9j0l2hc7dxhy8vij4lz8wrv6pnxng7f";
+    sha256 = "088kzc5fm92kwn5vqxw78qxrhd3sary1y1l02n2mgjiiicv31hc4";
   };
 
   buildInputs = [ ];
@@ -17,8 +17,7 @@ stdenv.mkDerivation rec {
   phases = [ "buildPhase" "installPhase" ];
 
   buildPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/java
+    mkdir -p $out/bin $out/share/java
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
- new features and bug fixes

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

