### PR TITLE
timewarrior: patch to install all themes; use default install target.

### DIFF
--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -13,11 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  installPhase = ''
-    mkdir -p $out/{bin,share/man/man1}
-    cp -rv doc/man/*.1 $out/share/man/man1
-    cp src/timew $out/bin/
-  '';
+  patches = [ ./install-all-themes.patch ];
 
   meta = with stdenv.lib; {
     description = "A command-line time tracker";

--- a/pkgs/applications/misc/timewarrior/install-all-themes.patch
+++ b/pkgs/applications/misc/timewarrior/install-all-themes.patch
@@ -1,0 +1,27 @@
+From e4a14c61bff3a55de42718dc11b282c4d5342995 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Tue, 14 Mar 2017 07:51:02 -0500
+Subject: [PATCH] doc/themes: install all themes, not just 'dark.theme'.
+
+---
+ doc/themes/CMakeLists.txt | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/doc/themes/CMakeLists.txt b/doc/themes/CMakeLists.txt
+index a954576..3a3b453 100644
+--- a/doc/themes/CMakeLists.txt
++++ b/doc/themes/CMakeLists.txt
+@@ -2,5 +2,8 @@ cmake_minimum_required (VERSION 2.8)
+ 
+ message ("-- Configuring theme documentation")
+ 
+-install (FILES README     DESTINATION ${TIMEW_DOCDIR}/doc/themes)
+-install (FILES dark.theme DESTINATION ${TIMEW_DOCDIR}/doc/themes)
++install (FILES README           DESTINATION ${TIMEW_DOCDIR}/doc/themes)
++install (FILES dark.theme       DESTINATION ${TIMEW_DOCDIR}/doc/themes)
++install (FILES dark_blue.theme  DESTINATION ${TIMEW_DOCDIR}/doc/themes)
++install (FILES dark_green.theme DESTINATION ${TIMEW_DOCDIR}/doc/themes)
++install (FILES dark_red.theme   DESTINATION ${TIMEW_DOCDIR}/doc/themes)
+-- 
+2.12.0
+


### PR DESCRIPTION
###### Motivation for this change

Simpler install phase (presumably earlier timewarrior versions had a missing or broken install target),
fixes installation of docs which I discovered since they ship suggested themes as docs :).

Add patch to install all themes, not just 'dark.theme'.

Will be submitting patch upstream soon.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

