### PR TITLE
pythonPackages.configparser: fix with namespace packages

### DIFF
--- a/pkgs/development/python-modules/configparser/0001-namespace-fix.patch
+++ b/pkgs/development/python-modules/configparser/0001-namespace-fix.patch
@@ -1,0 +1,42 @@
+From daae1ae35e13bc8107dc97d9219dfb8e172d5d2a Mon Sep 17 00:00:00 2001
+From: Frederik Rietdijk <fridh@fridh.nl>
+Date: Tue, 14 Mar 2017 15:00:33 +0100
+Subject: [PATCH] namespace fix
+
+configparser broke other namespace packages
+https://github.com/NixOS/nixpkgs/issues/23855#issuecomment-286427428
+This patch seems to solve that issue.
+---
+ setup.py                  | 1 -
+ src/backports/__init__.py | 6 ------
+ 2 files changed, 7 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 3b07823..63ed25d 100644
+--- a/setup.py
++++ b/setup.py
+@@ -42,7 +42,6 @@ setup(
+     py_modules=modules,
+     package_dir={'': 'src'},
+     packages=find_packages('src'),
+-    namespace_packages=['backports'],
+     include_package_data=True,
+     zip_safe=False,
+     install_requires=requirements,
+diff --git a/src/backports/__init__.py b/src/backports/__init__.py
+index f84d25c..febdb2f 100644
+--- a/src/backports/__init__.py
++++ b/src/backports/__init__.py
+@@ -3,9 +3,3 @@
+ 
+ from pkgutil import extend_path
+ __path__ = extend_path(__path__, __name__)
+-
+-try:
+-    import pkg_resources
+-    pkg_resources.declare_namespace(__name__)
+-except ImportError:
+-    pass
+-- 
+2.11.1
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4172,6 +4172,12 @@ in {
     # No tests available
     doCheck = false;
 
+    # Fix issue when used together with other namespace packages
+    # https://github.com/NixOS/nixpkgs/issues/23855
+    patches = [
+      ./../development/python-modules/configparser/0001-namespace-fix.patch
+    ];
+
     meta = {
       maintainers = [ ];
       platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---