### PR TITLE
nixbot: typo

### DIFF
--- a/pkgs/tools/misc/nixbot/default.nix
+++ b/pkgs/tools/misc/nixbot/default.nix
@@ -17,7 +17,7 @@ python3Packages.buildPythonApplication rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    desciption = "Github bot for reviewing/testing pull requests with the help of Hydra";
+    description = "Github bot for reviewing/testing pull requests with the help of Hydra";
     maintainers = with maintainers; [ domenkozar fpletz globin ];
     license = licenses.asl20;
     homepage = https://github.com/domenkozar/nixbot;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

