### PR TITLE
keepass-keeagent: init at 0.8.1

### DIFF
--- a/pkgs/applications/misc/keepass-plugins/keeagent/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keeagent/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildEnv, fetchzip, mono }:
+
+let
+  version = "0.8.1";
+  drv = stdenv.mkDerivation {
+    name = "keeagent-${version}";
+
+    src = fetchzip {
+        url = http://lechnology.com/wp-content/uploads/2016/07/KeeAgent_v0.8.1.zip;
+        sha256 = "16x1qrnzg0xkvi7w29wj3z0ldmql2vcbwxksbsmnidzmygwg98hk";
+        stripRoot = false;
+    };
+
+    meta = {
+      description = "KeePass plugin to allow other programs to access SSH keys stored in a KeePass database for authentication";
+      homepage    = http://lechnology.com/software/keeagent;
+      platforms   = with stdenv.lib.platforms; linux;
+      license     = stdenv.lib.licenses.gpl2;
+      maintainers = [ ];
+    };
+
+    pluginFilename = "KeeAgent.plgx";
+
+    installPhase = ''
+      mkdir -p $out/lib/dotnet/keepass/
+      cp $pluginFilename $out/lib/dotnet/keepass/$pluginFilename
+    '';
+  };
+in
+  # Mono is required to compile plugin at runtime, after loading.
+  buildEnv { name = drv.name; paths = [ mono drv ]; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13419,6 +13419,8 @@ with pkgs;
 
   keepass = callPackage ../applications/misc/keepass { };
 
+  keepass-keeagent = callPackage ../applications/misc/keepass-plugins/keeagent { };
+
   keepass-keefox = callPackage ../applications/misc/keepass-plugins/keefox { };
 
   keepass-keepasshttp = callPackage ../applications/misc/keepass-plugins/keepasshttp { };


### PR DESCRIPTION
Tested on top of channels/nixos-unstable

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

