### PR TITLE
haproxy: Cleaning up and enable LUA and PCRE

### DIFF
--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -15,9 +15,15 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl zlib ];
 
   # TODO: make it work on bsd as well
-  preConfigure = ''
-    export makeFlags="TARGET=${if stdenv.isSunOS then "solaris" else if stdenv.isLinux then "linux2628" else "generic"} PREFIX=$out USE_OPENSSL=yes USE_ZLIB=yes ${stdenv.lib.optionalString stdenv.isDarwin "CC=cc USE_KQUEUE=1"}"
-  '';
+  makeFlags = [
+    "PREFIX=\${out}"
+    "TARGET=${if stdenv.isSunOS then "solaris" else if stdenv.isLinux then "linux2628" else "generic"}"
+  ];
+  buildFlags = [
+    "USE_OPENSSL=yes"
+    "USE_ZLIB=yes"
+    (stdenv.lib.optionalString stdenv.isDarwin "CC=cc USE_KQUEUE=1")
+  ];
 
   meta = {
     description = "Reliable, high performance TCP/HTTP load balancer";

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, fetchurl, lua5_3, openssl, zlib }:
+{ stdenv, pkgs, fetchurl, lua5_3, openssl, pcre, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "haproxy";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "ebb31550a5261091034f1b6ac7f4a8b9d79a8ce2a3ddcd7be5b5eb355c35ba65";
   };
 
-  buildInputs = [ lua5_3 openssl zlib ];
+  buildInputs = [ lua5_3 openssl pcre zlib ];
 
   # TODO: make it work on bsd as well
   makeFlags = [
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     "USE_LUA=yes"
     "LUA_LIB=${pkgs.lua5_3}/lib"
     "LUA_INC=${pkgs.lua5_3}/include"
+    "USE_PCRE=yes"
+    "USE_PCRE_JIT=yes"
     "USE_OPENSSL=yes"
     "USE_ZLIB=yes"
     (stdenv.lib.optionalString stdenv.isDarwin "CC=cc USE_KQUEUE=1")

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, fetchurl, openssl, zlib }:
+{ stdenv, pkgs, fetchurl, lua5_3, openssl, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "haproxy";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "ebb31550a5261091034f1b6ac7f4a8b9d79a8ce2a3ddcd7be5b5eb355c35ba65";
   };
 
-  buildInputs = [ openssl zlib ];
+  buildInputs = [ lua5_3 openssl zlib ];
 
   # TODO: make it work on bsd as well
   makeFlags = [
@@ -20,6 +20,9 @@ stdenv.mkDerivation rec {
     "TARGET=${if stdenv.isSunOS then "solaris" else if stdenv.isLinux then "linux2628" else "generic"}"
   ];
   buildFlags = [
+    "USE_LUA=yes"
+    "LUA_LIB=${pkgs.lua5_3}/lib"
+    "LUA_INC=${pkgs.lua5_3}/include"
     "USE_OPENSSL=yes"
     "USE_ZLIB=yes"
     (stdenv.lib.optionalString stdenv.isDarwin "CC=cc USE_KQUEUE=1")


### PR DESCRIPTION
###### Motivation for this change

This solves #23806.

By the way I also enabled PCRE. Quoting the haproxy README: "If your system supports PCRE (Perl Compatible Regular Expressions), then you really should build with libpcre which is between 2 and 10 times faster than other libc implementations."


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

