### PR TITLE
gem: 2.6.8 -> 2.6.10

### DIFF
--- a/pkgs/development/interpreters/ruby/rubygems-src.nix
+++ b/pkgs/development/interpreters/ruby/rubygems-src.nix
@@ -1,6 +1,6 @@
 { fetchurl
-, version ? "2.6.8"
-, sha256 ? "1v6n6s8cq5l0xyf1fbm1w4752b9vdk3p130ar59ig72p9vqvkbl1"
+, version ? "2.6.10"
+, sha256 ? "364c0eee8e0c9e8ab4879c5035832e5a27f0c97292d2264af5ae0020585280f0"
 }:
 fetchurl {
   url = "http://production.cf.rubygems.org/rubygems/rubygems-${version}.tgz";


### PR DESCRIPTION
###### Motivation for this change

Gem 2.6.8 has few bugs which don't let certain gems to be built.

![screenshot from 2017-03-14 22-08-48](https://cloud.githubusercontent.com/assets/2529820/23923402/d49ea378-0906-11e7-8c8c-920322c3c2a7.png)

Reference:
[Gem 2.6.9 Release Notes](http://blog.rubygems.org/2017/01/20/2.6.9-released.html)
[Gem 2.6.10 Release Notes](http://blog.rubygems.org/2017/01/23/2.6.10-released.html)
[Github issue about the bug from screenshot](https://github.com/bundler/bundler/issues/5357)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

