### PR TITLE
travis: send emails iff commit caused the build to start failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,8 @@ matrix:
 env:
     global:
         - GITHUB_TOKEN=5edaaf1017f691ed34e7f80878f8f5fbd071603f
+
+notifications:
+    email:
+        on_success: never
+        on_failure: change


### PR DESCRIPTION
This setting should ensure that email notifications are sent
*only* when the commit caused the build to start failing.  That
is, no more "the build is still failing" spam.

As an alternative we could consider disabling email
notifications outright and possibly enable IRC notifications
instead.

I believe this fixes https://github.com/NixOS/nixpkgs/issues/23887