### PR TITLE
Update macOS frameworks from 10.9 to 10.10

### DIFF
--- a/pkgs/applications/virtualization/xhyve/default.nix
+++ b/pkgs/applications/virtualization/xhyve/default.nix
@@ -1,18 +1,24 @@
-{ stdenv, lib, fetchurl }:
+{ stdenv, lib, fetchurl, Hypervisor, vmnet, xpc, libobjc }:
 
 stdenv.mkDerivation rec {
-  name = "xhyve-${version}";
-  version = "0.2.0";
+  name    = "xhyve-${version}";
+  version = "1f1dbe305";
 
   src = fetchurl {
-    url = "https://github.com/mist64/xhyve/archive/v${version}.tar.gz";
-    sha256 = "0g1vknnh88kxc8aaqv3j9wqhq45mm9xxxbn1vcrypj3kk9991hrj";
+    url    = "https://github.com/mist64/xhyve/archive/1f1dbe3059904f885e4ab2b3328f4bb350ea5c37.tar.gz";
+    sha256 = "0hfix8yr90szlv2yyqb2rlq5qsrxyam8kg52sly0adja0cpwfjvx";
   };
 
+  buildInputs = [ Hypervisor vmnet xpc libobjc ];
+
   # Don't use git to determine version
-  buildFlags = ''
-    CFLAGS=-DVERSION=\"${version}\"
+  prePatch = ''
+    substituteInPlace Makefile \
+      --replace 'shell git describe --abbrev=6 --dirty --always --tags' "$version"
   '';
+
+
+  makeFlags = [ "CFLAGS+=-Wno-shift-sign-overflow" ''CFLAGS+=-DVERSION=\"${version}\"'' ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -1,17 +1,30 @@
-{ stdenv, fetchurl, xar, gzip, cpio, pkgs }:
+{ stdenv, fetchurl, xar, xz, cpio, pkgs, python }:
 
 let
+  # TODO: make this available to other packages and generalize the unpacking a bit
+  # from https://gist.github.com/pudquick/ff412bcb29c9c1fa4b8d
+  # This isn't needed until we get to SDK 10.11, but that presents other challenges
+  # unpbzx = fetchurl {
+  #   url    = "https://gist.githubusercontent.com/pudquick/ff412bcb29c9c1fa4b8d/raw/24b25538ea8df8d0634a2a6189aa581ccc6a5b4b/parse_pbzx2.py";
+  #   sha256 = "0jgp6qbfl36i0jlz7as5zk2w20z4ca8wlrhdw49lwsld6wi3rfhc";
+  # };
+
   # sadly needs to be exported because security_tool needs it
   sdk = stdenv.mkDerivation rec {
-    version = "10.9";
+    version = "10.10";
     name    = "MacOS_SDK-${version}";
 
+    # This URL comes from https://swscan.apple.com/content/catalogs/others/index-10.10.merged-1.sucatalog, which we found by:
+    #  1. Google: site:swscan.apple.com and look for a name that seems appropriate for your version
+    #  2. In the resulting file, search for a file called DevSDK ending in .pkg
+    #  3. ???
+    #  4. Profit
     src = fetchurl {
-      url    = "http://swcdn.apple.com/content/downloads/27/02/031-06182/xxog8vxu8i6af781ivf4uhy6yt1lslex34/DevSDK_OSX109.pkg";
-      sha256 = "16b7aplha5573yl1d44nl2yxzp0w2hafihbyh7930wrcvba69iy4";
+      url    = "http://swcdn.apple.com/content/downloads/22/52/031-45139/hcjjv7cm4n6yqk56ict73qqw15ikm5iaql/DevSDK_OSX1010.pkg";
+      sha256 = "08bxa93zw7r4vzs28j9giq2qyk3b68ky6jx1bb9850gflr3nvgq1";
     };
 
-    buildInputs = [ xar gzip cpio ];
+    buildInputs = [ xar xz cpio python ];
 
     phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
 
@@ -113,6 +126,7 @@ let
 
         popd >/dev/null
       }
+
 
       linkFramework "${name}.framework"
     '';

--- a/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
@@ -52,6 +52,7 @@ with frameworks; with libs; {
   GSS                     = [];
   GameController          = [];
   GameKit                 = [ Foundation ];
+  Hypervisor              = [];
   ICADevices              = [ Carbon CF IOBluetooth ];
   IMServicePlugIn         = [];
   IOBluetoothUI           = [ IOBluetooth ];
@@ -117,4 +118,6 @@ with frameworks; with libs; {
   OpenDirectory       = [];
   Quartz              = [ QuickLook QTKit ];
   QuartzCore          = [ ApplicationServices CF CoreVideo OpenCL ];
+
+  vmnet = [];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18148,7 +18148,11 @@ with pkgs;
 
   xcftools = callPackage ../tools/graphics/xcftools { };
 
-  xhyve = callPackage ../applications/virtualization/xhyve { };
+  xhyve = callPackage ../applications/virtualization/xhyve {
+    inherit (darwin.apple_sdk.frameworks) Hypervisor vmnet;
+    inherit (darwin.apple_sdk.libs) xpc;
+    inherit (darwin) libobjc;
+  };
 
   xinput_calibrator = callPackage ../tools/X11/xinput_calibrator { };
 


### PR DESCRIPTION
This is my second attempt to get Hypervisor.framework and friends into nixpkgs, as well as bumping all the framework headers. I haven't had time to figure out how to solve the issues with the 10.11 frameworks, but for now this seemed to work. Someday we'll get 10.11 and a more reliable CF but today is not that day 😄 

cc @LnL7 @acowley, especially if you can easily test a bunch of framework-using packages! I've tested `vim`, `mysql`, `emacs25Macport`, and `xhyve`, and they all seem to work with these changes.

Edit: err, `emacs25Macport` didn't work.