### PR TITLE
pythonPackage.pycassa: init at 1.11.2

### DIFF
--- a/pkgs/development/python-modules/pycassa/default.nix
+++ b/pkgs/development/python-modules/pycassa/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchurl, thrift, isPy3k }:
+
+buildPythonPackage rec {
+  version = "1.11.2";
+  name = "pycassa-${version}";
+  src = fetchurl {
+    url = "mirror://pypi/p/pycassa/${name}.tar.gz";
+    sha256 = "1nsqjzgn6v0rya60dihvbnrnq1zwaxl2qwf0sr08q9qlkr334hr6";
+  };
+
+  disabled = isPy3k;
+
+  # Tests are not executed since they require a cassandra up and
+  # running
+  doCheck = false;
+
+  propagatedBuildInputs = [ thrift ];
+
+  meta = {
+    description = "pycassa is a python client library for Apache Cassandra";
+    homepage = http://github.com/pycassa/pycassa;
+    license = stdenv.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8948,6 +8948,8 @@ in {
     };
   };
 
+  pycassa = callPackage ../development/python-modules/pycassa { };
+
    pybluez = buildPythonPackage rec {
     version = "unstable-20160819";
     pname = "pybluez";


### PR DESCRIPTION
###### Motivation for this change
to have it

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

