### PR TITLE
go2nix: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/development/tools/go2nix/default.nix
+++ b/pkgs/development/tools/go2nix/default.nix
@@ -3,7 +3,7 @@
 
 buildGoPackage rec {
   name = "go2nix-${version}";
-  version = "1.1.1";
+  version = "1.2.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/kamilchm/go2nix";
@@ -12,10 +12,12 @@ buildGoPackage rec {
     inherit rev;
     owner = "kamilchm";
     repo = "go2nix";
-    sha256 = "1idxgn9yf8shw4mq4d7rhf8fvb2s1lli4r4ck0h8ddf1s9q8p63s";
+    sha256 = "1hlanw56r1phj89sicpsfcz6sdjba9qjwhiblcsqka4wfqkai8pn";
   };
 
   goDeps = ./deps.nix;
+
+  outputs = [ "bin" "out" "man" ];
 
   buildInputs = [ go-bindata goimports makeWrapper ];
   preBuild = ''go generate ./...'';
@@ -24,6 +26,9 @@ buildGoPackage rec {
     wrapProgram $bin/bin/go2nix \
       --prefix PATH : ${nix-prefetch-git}/bin \
       --prefix PATH : ${git}/bin
+
+    mkdir -p $man/share/man/man1
+    cp $src/go2nix.1 $man/share/man/man1
   '';
 
   allowGoReference = true;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/kamilchm/go2nix/releases/tag/v1.2.0
https://github.com/kamilchm/go2nix/issues/53

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

