### PR TITLE
nixos: tests: firefox: make more comprehensive

### DIFF
--- a/nixos/tests/firefox.nix
+++ b/nixos/tests/firefox.nix
@@ -8,15 +8,21 @@ import ./make-test.nix ({ pkgs, ... }: {
     { config, pkgs, ... }:
 
     { imports = [ ./common/x11.nix ];
-      environment.systemPackages = [ pkgs.firefox ];
+      environment.systemPackages = [ pkgs.firefox pkgs.xdotool ];
     };
 
   testScript =
     ''
       $machine->waitForX;
-      $machine->execute("firefox file://${pkgs.valgrind.doc}/share/doc/valgrind/html/index.html &");
+      $machine->execute("xterm -e 'firefox file://${pkgs.valgrind.doc}/share/doc/valgrind/html/index.html' &");
       $machine->waitForWindow(qr/Valgrind/);
       $machine->sleep(40); # wait until Firefox has finished loading the page
+      $machine->execute("xdotool key space"); # do I want to make Firefox the
+                             # default browser? I just want to close the dialog
+      $machine->sleep(2); # wait until Firefox hides the default browser window
+      $machine->execute("xdotool key F12");
+      $machine->sleep(10); # wait until Firefox draws the developer tool panel
+      $machine->succeed("xwininfo -root -tree | grep Valgrind");
       $machine->screenshot("screen");
     '';
 


### PR DESCRIPTION
Run Firefox inside an XTerm, it doesn't crash mysteriously this way.
Also try opening developer tools and checking that Firefox doesn't
crash in the process.

###### Motivation for this change

In #23917 there is a Firefox crash that happens all the time but cannot be reproduced manually. The workaround for this crash makes the build that crashes on every keypress pass the test, so I added a check that developer tools can be opened.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Opened the resulting screenshot

---

