### PR TITLE
libcouchbase: 2.5.2 -> 2.7.2

### DIFF
--- a/pkgs/development/libraries/libcouchbase/default.nix
+++ b/pkgs/development/libraries/libcouchbase/default.nix
@@ -1,10 +1,14 @@
-{ stdenv, fetchurl, cmake, pkgconfig, libevent, openssl}:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, libevent, openssl}:
 
-stdenv.mkDerivation {
-  name = "libcouchbase-2.5.2";
-  src = fetchurl {
-    url = "https://github.com/couchbase/libcouchbase/archive/2.5.2.tar.gz";
-    sha256 = "0ka1hix38a2kdhxz6n8frssyznf78ra0irga9d8lr5683y73xw24";
+stdenv.mkDerivation rec {
+  name = "libcouchbase-${version}";
+  version = "2.7.2";
+
+  src = fetchFromGitHub {
+    owner = "couchbase";
+    repo ="libcouchbase";
+    rev = version;
+    sha256 = "1182r9z3cykkgx1vn36l0a50wvh5mr3yj89x0ynyjhfi3iwalrar";
   };
 
   cmakeFlags = "-DLCB_NO_MOCK=ON";
@@ -12,10 +16,10 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ libevent openssl];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "C client library for Couchbase";
     homepage = "https://github.com/couchbase/libcouchbase";
-    license = stdenv.lib.licenses.asl20;
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.asl20;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

