### PR TITLE
pythonPackages.zeep: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/zeep/default.nix
+++ b/pkgs/development/python-modules/zeep/default.nix
@@ -1,0 +1,91 @@
+{ fetchPypi
+, lib
+, buildPythonPackage
+, python
+, isPy3k
+, appdirs
+, cached-property
+, defusedxml
+, isodate
+, lxml
+, pytz
+, requests_toolbelt
+, six
+# test dependencies
+, freezegun
+, mock
+, nose
+, pretend
+, pytest
+, pytestcov
+, requests-mock
+, testtools
+}:
+
+let
+  pname = "zeep";
+  version = "1.1.0";
+in buildPythonPackage {
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "83e82b6cb59e84bf4725add3771ed442bb099fad5959c887efe7c49a8a940ea5";
+  };
+
+  propagatedBuildInputs = [
+    appdirs
+    cached-property
+    defusedxml
+    isodate
+    lxml
+    pytz
+    requests_toolbelt
+    six
+  ];
+
+  # testtools dependency not supported for py3k
+  doCheck = !isPy3k;
+
+  buildInputs = if isPy3k then [] else [
+    freezegun
+    mock
+    nose
+    pretend
+    pytest
+    pytestcov
+    requests-mock
+  ];
+
+  patchPhase = ''
+    # remove overly strict bounds and lint requirements
+    sed -e "s/freezegun==.*'/freezegun'/" \
+        -e "s/pytest-cov==.*'/pytest-cov'/" \
+        -e "s/'isort.*//" \
+        -e "s/'flake8.*//" \
+        -i setup.py
+
+    # locale.preferredencoding() != 'utf-8'
+    sed -e "s/xsd', 'r')/xsd', 'r', encoding='utf-8')/" -i tests/*.py
+
+    # cache defaults to home directory, which doesn't exist
+    sed -e "s|SqliteCache()|SqliteCache(path='./zeeptest.db')|" \
+        -i tests/test_transports.py
+
+    # requires xmlsec python module
+    rm tests/test_wsse_signature.py
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m pytest tests
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    homepage = "http://docs.python-zeep.org";
+    license = licenses.mit;
+    description = "A modern/fast Python SOAP client based on lxml / requests";
+    maintainers = with maintainers; [ rvl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -32122,6 +32122,9 @@ EOF
   yenc = callPackage ../development/python-modules/yenc {
   };
 
+  zeep = callPackage ../development/python-modules/zeep {
+  };
+
   zeitgeist = if isPy3k then throw "zeitgeist not supported for interpreter ${python.executable}" else
     (pkgs.zeitgeist.override{python2Packages=self;}).py;
 


### PR DESCRIPTION
###### Motivation for this change

Handy library for accessing SOAP services with Python.

Works with both Python 2.7 and 3.5.

###### Tests

Tests won't work under Python 3.5 due to the testtools dependency. Under Python 2.7 some dependencies can be bumped by a few versions to make it install, but then the test runner wasn't finding the tests and it all seemed too hard to bother.

Tested build with
```
nix-shell -E 'with import ./. {}; (pkgs.python35.withPackages (ps: [ps.zeep])).env'
```
and then ran the example from the [home page](http://docs.python-zeep.org/en/master/).

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
