### PR TITLE
libdap: 3.15.1 -> 3.18.3

### DIFF
--- a/pkgs/development/libraries/libdap/default.nix
+++ b/pkgs/development/libraries/libdap/default.nix
@@ -1,21 +1,21 @@
 { stdenv, fetchurl, bison, libuuid, curl, libxml2, flex }:
 
 stdenv.mkDerivation rec {
-  version = "3.15.1";
+  version = "3.18.3";
   name = "libdap-${version}";
 
   buildInputs = [ bison libuuid curl libxml2 flex ];
 
   src = fetchurl {
     url = "http://www.opendap.org/pub/source/${name}.tar.gz";
-    sha256 = "6ee13cc69ae0b5e7552ddfd17013ebb385859bba66f42a2cfba3b3be7aa4ef0f";
+    sha256 = "0azjf4gjqvp1fdf1wb3s98x52zfy4viq1m3j9lggaidldfinmv8c";
   };
 
-  meta = { 
+  meta = with stdenv.lib; {
     description = "A C++ SDK which contains an implementation of DAP";
     homepage = http://www.opendap.org/download/libdap;
-    license = stdenv.lib.licenses.lgpl2;
-    maintainers = [ stdenv.lib.maintainers.bzizou ];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.lgpl2;
+    maintainers = [ maintainers.bzizou ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

