### PR TITLE
libdc1394: 2.2.3 -> 2.2.5

### DIFF
--- a/pkgs/development/libraries/libdc1394/default.nix
+++ b/pkgs/development/libraries/libdc1394/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, fetchurl, libraw1394, libusb1
-, CoreServices
-}:
+{ stdenv, fetchurl, libraw1394,
+libusb1, CoreServices }:
 
 stdenv.mkDerivation rec {
-  name = "libdc1394-2.2.3";
+  name = "libdc1394-${version}";
+  version = "2.2.5";
 
   src = fetchurl {
     url = "mirror://sourceforge/libdc1394/${name}.tar.gz";
-    sha256 = "1p9b4ciy97s04gmp7656cybr1zfd79hlw0ffhfb52m3zcn07h6aa";
+    sha256 = "0drk4sqvaym9glaraia25mj60rmwqbhy4j9h3x7gqpzfib8ch31m";
   };
 
   buildInputs = [ libusb1 ]
     ++ stdenv.lib.optional stdenv.isLinux libraw1394
     ++ stdenv.lib.optional stdenv.isDarwin CoreServices;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://sourceforge.net/projects/libdc1394/;
     description = "Capture and control API for IIDC compliant cameras";
-    license = stdenv.lib.licenses.lgpl21Plus;
-    maintainers = [ stdenv.lib.maintainers.viric ];
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.lgpl21Plus;
+    maintainers = [ maintainers.viric ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

