### PR TITLE
libdiscid: 0.6.1 -> 0.6.2

### DIFF
--- a/pkgs/development/libraries/libdiscid/default.nix
+++ b/pkgs/development/libraries/libdiscid/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, cmake, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "libdiscid-0.6.1";
+  name = "libdiscid-${version}";
+  version = "0.6.2";
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake ];
-
+  nativeBuildInputs = [ cmake pkgconfig ];
+  
   src = fetchurl {
     url = "http://ftp.musicbrainz.org/pub/musicbrainz/libdiscid/${name}.tar.gz";
-    sha256 = "1mbd5y9056638cffpfwc6772xwrsk18prv1djsr6jpfim38jpsxc";
+    sha256 = "1f9irlj3dpb5gyfdnb1m4skbjvx4d4hwiz2152f83m0d9jn47r7r";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

