### PR TITLE
restic: init at 0.5.0

### DIFF
--- a/pkgs/tools/backup/restic/default.nix
+++ b/pkgs/tools/backup/restic/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "restic-${version}";
+  version = "0.5.0";
+
+  goPackagePath = "github.com/restic/restic";
+
+  src = fetchFromGitHub {
+    owner = "restic";
+    repo = "restic";
+    rev = "v${version}";
+    sha256 = "0dj6zg4b00pwgs6nj7w5s0jxm6cfavd9kdcq0z4spypwdf211cgl";
+  };
+
+  buildPhase = ''
+    cd go/src/${goPackagePath}
+    go run build.go
+  '';
+
+  installPhase = ''
+    mkdir -p $bin/bin/
+    cp restic $bin/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://restic.github.io;
+    description = "A backup program that is fast, efficient and secure";
+    platforms = platforms.linux;
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10851,6 +10851,8 @@ with pkgs;
 
   redstore = callPackage ../servers/http/redstore { };
 
+  restic = callPackage ../tools/backup/restic { };
+
   restund = callPackage ../servers/restund {};
 
   rethinkdb = callPackage ../servers/nosql/rethinkdb {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

