### PR TITLE
jemalloc: 4.3.1 -> 4.5.0

### DIFF
--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -2,17 +2,20 @@
 
 stdenv.mkDerivation rec {
   name = "jemalloc-${version}";
-  version = "4.3.1";
+  version = "4.5.0";
 
   src = fetchurl {
     url = "https://github.com/jemalloc/jemalloc/releases/download/${version}/${name}.tar.bz2";
-    sha256 = "12r71i8nm3vwz21fc16rwbb0pwcg5s05n1qg3rwl2s85v0x1ifzp";
+    sha256 = "9409d85664b4f135b77518b0b118c549009dc10f6cba14557d170476611f6780";
   };
 
   # By default, jemalloc puts a je_ prefix onto all its symbols on OSX, which
   # then stops downstream builds (mariadb in particular) from detecting it. This
   # option should remove the prefix and give us a working jemalloc.
   configureFlags = stdenv.lib.optional stdenv.isDarwin "--with-jemalloc-prefix=";
+
+  doCheck = true;
+
 
   meta = with stdenv.lib; {
     homepage = http://jemalloc.net;


### PR DESCRIPTION
###### Motivation for this change
Package update.
This PR is targeted at staging because a mass-rebuild is expected.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

