### PR TITLE
sc-im: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/applications/misc/sc-im/default.nix
+++ b/pkgs/applications/misc/sc-im/default.nix
@@ -1,23 +1,25 @@
-{ stdenv, fetchFromGitHub, yacc, ncurses, libxml2, pkgconfig }:
+{ stdenv, fetchFromGitHub, yacc, ncurses, libxml2, libzip, libxls, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.0";
+  version = "0.5.0";
   name = "sc-im-${version}";
 
   src = fetchFromGitHub {
     owner = "andmarti1424";
     repo = "sc-im";
     rev = "v${version}";
-    sha256 = "1v1cfmfqs5997bqlirp6p7smc3qrinq8dvsi33sk09r33zkzyar0";
+    sha256 = "1vdn9p9srvdksxznrn65pfigwrd7brlq8bac3pjfqsvf8gjnzq61";
   };
 
-  buildInputs = [ yacc ncurses libxml2 pkgconfig ];
+  buildInputs = [ yacc ncurses libxml2 libzip libxls pkgconfig ];
 
   buildPhase = ''
     cd src
 
-    sed -i "s,prefix=/usr,prefix=$out," Makefile
-    sed -i "s,-I/usr/include/libxml2,-I$libxml2," Makefile
+    sed -e "\|^prefix  = /usr/local|   s|/usr/local|$out|" \
+        -e "\|^#LDLIBS += -lxlsreader| s|^#||            " \
+        -e "\|^#CFLAGS += -DXLS|       s|^#||            " \
+        -i Makefile
 
     make
     export DESTDIR=$out


### PR DESCRIPTION
###### Motivation for this change

- Bump version to 0.5.0
- Enable support for reading '.xls' and '.xlsx' files.

The support for reading Excel files depends on:
  - libxml2, which was already a build input.
  - libzip
  - libxls

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
   

---

