### PR TITLE
git-repo: bump to version 1.23

### DIFF
--- a/pkgs/applications/version-management/git-repo/default.nix
+++ b/pkgs/applications/version-management/git-repo/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, python }:
 
 stdenv.mkDerivation {
-  name = "git-repo-1.22";
+  name = "git-repo-1.23";
   src = fetchurl {
     # I could not find a versioned url for the 1.21 version. In case
     # the sha mismatches, check the homepage for new version and sha.
     url = "http://commondatastorage.googleapis.com/git-repo-downloads/repo";
-    sha1 = "da0514e484f74648a890c0467d61ca415379f791";
+    sha1 = "xnv7mbiqfcz7sy5wlqi6i7v9dmpn97dc";
   };
 
   unpackPhase = "true";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

