### PR TITLE
icewm: fix CFGDIR

### DIFF
--- a/pkgs/applications/window-managers/icewm/default.nix
+++ b/pkgs/applications/window-managers/icewm/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    export cmakeFlags="-DPREFIX=$out"
+    export cmakeFlags="-DPREFIX=$out -DCFGDIR=/etc/icewm"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

On non-NixOS Linuxes ```IceWM``` finds its config files in following directories: ```~/.icewm``` then ```/etc/icewm``` then ```${pkgs.icewm}/share/icewm```
On NixOS the second directory is ```${pkgs.icewm}/etc/icewm``` which is not exist nor writable.

This patch restores the usual sequence.

Why placing configs into ```/etc/icewm``` could be useful?
IceWM is often used with ```test-driver``` and it would allow to write in the tests something like 
```
environment.etc."icewm/preferences".text = ''
  NetworkStatusDevice="eth0 eth1"
'';
```
and have graphs of both network interfaces on the screenshots.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

