### PR TITLE
znc: 1.6.4 -> 1.6.5

### DIFF
--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -9,14 +9,16 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "znc-${version}";
-  version = "1.6.4";
+  version = "1.6.5";
 
   src = fetchurl {
-    url = "http://znc.in/releases/${name}.tar.gz";
-    sha256 = "070d6b1i3jy66m4ci4ypxkg4pbwqbzbzss1y1ycgq2w62zmrf423";
+    url = "http://znc.in/releases/archive/${name}.tar.gz";
+    sha256 = "1jia6kq6bp8yxfj02d5vj9vqb4pylqcldspyjj6iz82kkka2a0ig";
   };
 
-  buildInputs = [ openssl pkgconfig ]
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ openssl ]
     ++ optional withPerl perl
     ++ optional withPython python3
     ++ optional withTcl tcl


### PR DESCRIPTION
###### Motivation for this change

Use stable archive url, not sure if I should should port this to stable or just update the url there.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

