### PR TITLE
neo4j: increase file limit, per warning emitted at startup.

### DIFF
--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -130,6 +130,7 @@ in {
         ExecStart = "${cfg.package}/bin/neo4j console";
         User = "neo4j";
         PermissionsStartOnly = true;
+        LimitNOFILE = 40000;
       };
       preStart = ''
         mkdir -m 0700 -p ${cfg.dataDir}/{data/graph.db,conf,logs}


### PR DESCRIPTION
###### Motivation for this change

Neo4j complains at startup if this limit is < 40k, so bump it to 40k as it recommends.

(I actually tried to address this when updating Neo4j earlier, but didn't stumble on this simple setting until saw it used elsewhere! :))

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

