### PR TITLE
irker: init at 2017-02-12

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -273,6 +273,7 @@
   ./services/misc/gogs.nix
   ./services/misc/gpsd.nix
   #./services/misc/ihaskell.nix
+  ./services/misc/irkerd.nix
   ./services/misc/leaps.nix
   ./services/misc/mantisbt.nix
   ./services/misc/mathics.nix

--- a/nixos/modules/services/misc/irkerd.nix
+++ b/nixos/modules/services/misc/irkerd.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.irkerd;
+  ports = [ 6659 ];
+in
+{
+  options.services.irkerd = {
+    enable = mkOption {
+      description = "Whether to enable irker, an IRC notification daemon.";
+      default = false;
+      type = types.bool;
+    };
+
+    openPorts = mkOption {
+      description = "Open ports in the firewall for irkerd";
+      default = false;
+      type = types.bool;
+    };
+
+    listenAddress = mkOption {
+      default = "localhost";
+      example = "0.0.0.0";
+      type = types.str;
+      description = ''
+        Specifies the bind address on which the irker daemon listens.
+        The default is localhost.
+
+        Irker authors strongly warn about the risks of running this on
+        a publicly accessible interface, so change this with caution.
+      '';
+    };
+
+    nick = mkOption {
+      default = "irker";
+      type = types.str;
+      description = "Nick to use for irker";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.irkerd = {
+      description = "Internet Relay Chat (IRC) notification daemon";
+      documentation = [ "man:irkerd(8)" "man:irkerhook(1)" "man:irk(1)" ];
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.irker}/bin/irkerd -H ${cfg.listenAddress} -n ${cfg.nick}";
+        User = "irkerd";
+      };
+    };
+
+    environment.systemPackages = [ pkgs.irker ];
+
+    users.users.irkerd = {
+      description = "Irker daemon user";
+      isSystemUser = true;
+      group = "irkerd";
+    };
+    users.groups.irkerd = {};
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openPorts ports;
+    networking.firewall.allowedUDPPorts = mkIf cfg.openPorts ports;
+  };
+}

--- a/pkgs/servers/irker/default.nix
+++ b/pkgs/servers/irker/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitLab, python, pkgconfig
+, xmlto, docbook2x, docbook_xsl, docbook_xml_dtd_412 }:
+
+stdenv.mkDerivation rec {
+  name = "irker-${version}";
+  version = "2017-02-12";
+
+  src = fetchFromGitLab {
+    owner = "esr";
+    repo = "irker";
+    rev = "dc0f65a7846a3922338e72d8c6140053fe914b54";
+    sha256 = "1hslwqa0gqsnl3l6hd5hxpn0wlachxd51infifhlwhyhd6iwgx8p";
+  };
+
+  nativeBuildInputs = [ pkgconfig xmlto docbook2x ];
+
+  buildInputs = [
+    python
+    # Needed for proxy support I believe, which I haven't tested.
+    # Probably needs to be propagated and some wrapPython magic
+    # python.pkgs.pysocks
+  ];
+
+  preBuild = ''
+    export XML_CATALOG_FILES='${docbook_xsl}/xml/xsl/docbook/catalog.xml ${docbook_xml_dtd_412}/xml/dtd/docbook/catalog.xml'
+  '';
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace '-o 0 -g 0' ""
+  '';
+
+  installFlags = [
+    "prefix=/"
+    "DESTDIR=$$out"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "IRC client that runs as a daemon accepting notification requests";
+    homepage = "https://gitlab.com/esr/irker";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2383,6 +2383,8 @@ with pkgs;
 
   ipxe = callPackage ../tools/misc/ipxe { };
 
+  irker = callPackage ../servers/irker { };
+
   ised = callPackage ../tools/misc/ised {};
 
   isl = isl_0_17;


### PR DESCRIPTION
* irker package
* NixOS module for irkerd service

###### Motivation for this change

IRC notification daemon for on-site installation with services like GitLab.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

