### PR TITLE
nixos: nix snowflake logo for the nixos manual launcher

### DIFF
--- a/nixos/modules/services/misc/nixos-manual.nix
+++ b/nixos/modules/services/misc/nixos-manual.nix
@@ -62,8 +62,7 @@ let
     name = "nixos-manual";
     desktopName = "NixOS Manual";
     genericName = "View NixOS documentation in a web browser";
-    # TODO: find a better icon (Nix logo + help overlay?)
-    icon = "system-help";
+    icon = "nix-snowflake";
     exec = "${helpScript}/bin/nixos-help";
     categories = "System";
   };
@@ -115,7 +114,7 @@ in
 
     environment.systemPackages =
       [ manual.manual helpScript ]
-      ++ optional config.services.xserver.enable desktopItem
+      ++ optionals config.services.xserver.enable [desktopItem pkgs.nixos-icons]
       ++ optional config.programs.man.enable manual.manpages;
 
     boot.extraTTYs = mkIf cfg.showManual ["tty${toString cfg.ttyNumber}"];

--- a/pkgs/data/misc/nixos-artwork/icons.nix
+++ b/pkgs/data/misc/nixos-artwork/icons.nix
@@ -1,0 +1,13 @@
+{ stdenv, fetchFromGitHub, imagemagick }:
+
+stdenv.mkDerivation {
+  name = "nixos-icons-2017-03-16";
+  srcs = fetchFromGitHub {
+    owner = "nixos";
+    repo = "nixos-artwork";
+    rev = "783ca1249fc4cfe523ad4e541f37e2229891bc8b";
+    sha256 = "0wp08b1gh2chs1xri43wziznyjcplx0clpsrb13wzyscv290ay5a";
+  };
+  makeFlags = [ "DESTDIR=$(out)" "prefix=" ];
+  buildInputs = [ imagemagick ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17830,6 +17830,7 @@ with pkgs;
   nix-serve = callPackage ../tools/package-management/nix-serve { };
 
   nixos-artwork = callPackage ../data/misc/nixos-artwork { };
+  nixos-icons = callPackage ../data/misc/nixos-artwork/icons.nix { };
 
   nixos-container = callPackage ../tools/virtualization/nixos-container { };
 


### PR DESCRIPTION
The existing nixos-artwork derivation is pretty specific to that gnome wallpaper, and the Makefile in the artwork repo only builds the icons, so I figured having this one be separate would be simpler than combining them.