### PR TITLE
libgudev: 230 -> 231

### DIFF
--- a/pkgs/development/libraries/libgudev/default.nix
+++ b/pkgs/development/libraries/libgudev/default.nix
@@ -1,21 +1,20 @@
-{ lib, stdenv, fetchurl, pkgconfig, udev, glib }:
-
-let version = "230"; in
+{ stdenv, fetchurl, pkgconfig, udev, glib }:
 
 stdenv.mkDerivation rec {
   name = "libgudev-${version}";
+  version = "231";
 
   src = fetchurl {
     url = "https://download.gnome.org/sources/libgudev/${version}/${name}.tar.xz";
-    sha256 = "a2e77faced0c66d7498403adefcc0707105e03db71a2b2abd620025b86347c18";
+    sha256 = "15iz0qp57qy5pjrblsn36l0chlncqggqsg8h8i8c71499afzj7iv";
   };
 
   buildInputs = [ pkgconfig udev glib ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Projects/libgudev;
-    maintainers = [ lib.maintainers.eelco ];
-    platforms = lib.platforms.linux;
-    license = lib.licenses.lgpl2Plus;
+    maintainers = [ maintainers.eelco ];
+    platforms = platforms.linux;
+    license = licenses.lgpl2Plus;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done
Update 

work in progress
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

