### PR TITLE
umockdev: init at 0.8.13

### DIFF
--- a/pkgs/development/libraries/umockdev/default.nix
+++ b/pkgs/development/libraries/umockdev/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, autoreconfHook
+, pkgconfig, glib, systemd, libgudev, vala  }:
+
+stdenv.mkDerivation rec {
+  name = "umockdev";
+  version = "0.8.13";
+
+  src = fetchFromGitHub {
+    owner = "martinpitt";
+    repo = "umockdev";
+    rev = version;
+    sha256 ="0bw2dpshlgbdwg5mhq4j22z474llpqix8pxii63r2bk5nhjc537k";
+  };
+
+  buildInputs = [ glib systemd libgudev vala ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  ### docs/gtk-doc.make not found
+  prePatch = ''
+    sed -i 's|include $(top_srcdir)/docs/gtk-doc.make||g' docs/reference/Makefile.am
+   sed -i 's|+=|=|g' docs/reference/Makefile.am
+   '';
+
+  preConfigure = ''
+    #  sed -i 's|gobject-2.0 >= 2.32.0 gio-2.0 >= 2.32.0 gio-unix-2.0 >= 2.32.0)|gobject-2.0 >= 2.32.0, gio-2.0 >= 2.32.0, gio-unix-2.0 >= 2.32.0)|g' configure
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Mock hardware devices for creating unit tests";
+    license = licenses.lgpl2;
+    maintainers = [ maintainers.ndowens ];
+  };
+}

--- a/pkgs/development/libraries/umockdev/default.nix
+++ b/pkgs/development/libraries/umockdev/default.nix
@@ -21,10 +21,6 @@ stdenv.mkDerivation rec {
    sed -i 's|+=|=|g' docs/reference/Makefile.am
    '';
 
-  preConfigure = ''
-    #  sed -i 's|gobject-2.0 >= 2.32.0 gio-2.0 >= 2.32.0 gio-unix-2.0 >= 2.32.0)|gobject-2.0 >= 2.32.0, gio-2.0 >= 2.32.0, gio-unix-2.0 >= 2.32.0)|g' configure
-    '';
-
   meta = with stdenv.lib; {
     description = "Mock hardware devices for creating unit tests";
     license = licenses.lgpl2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9873,6 +9873,8 @@ with pkgs;
 
   uid_wrapper = callPackage ../development/libraries/uid_wrapper { };
 
+  umockdev = callPackage ../development/libraries/umockdev {  };
+
   unibilium = callPackage ../development/libraries/unibilium { };
 
   unicap = callPackage ../development/libraries/unicap {};


### PR DESCRIPTION
###### Motivation for this change
New package for a required package that I am updating

###### Things done


- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

