### PR TITLE
libibmad: 1.3.12 -> 1.3.13

### DIFF
--- a/pkgs/development/libraries/libibmad/default.nix
+++ b/pkgs/development/libraries/libibmad/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libibumad }:
 
 stdenv.mkDerivation rec {
-  name = "libibmad-1.3.12";
+  name = "libibmad-1.3.13";
 
   src = fetchurl {
     url = "https://www.openfabrics.org/downloads/management/${name}.tar.gz";
-    sha256 = "0ywkz0rskci414r6h6jd4iz4qjbj37ga2k91z1mlj9xrnl9bbgzi";
+    sha256 = "02sj8k2jpcbiq8s0l2lqk4vwji2dbb2lc730cv1yzv0zr0hxgk8p";
   };
 
   buildInputs = [ libibumad ];


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

