### PR TITLE
hyper: 0.8.3 -> 1.3.1

### DIFF
--- a/pkgs/applications/misc/hyper/default.nix
+++ b/pkgs/applications/misc/hyper/default.nix
@@ -11,11 +11,11 @@ let
   ];
 in
 stdenv.mkDerivation rec {
-  version = "0.8.3";
+  version = "1.3.1";
   name = "hyper-${version}";
   src = fetchurl {
-    url = "https://github.com/zeit/hyper/releases/download/${version}/hyper-${version}-amd64.deb";
-    sha256 = "1683gc0fhifn89l9h67yz02pk1xz7p5l3qpiyddr9w21qr9h3lhq";
+    url = "https://github.com/zeit/hyper/releases/download/${version}/hyper_${version}.deb";
+    sha256 = "1i1rnq10a9kid8lggrd1gp9g08v98la8idnyk4kx4vn0svqy7nvl";
   };
   buildInputs = [ dpkg ];
   unpackPhase = ''
@@ -26,9 +26,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out/bin"
     mv opt "$out/"
-    ln -s "$out/opt/Hyper/Hyper" "$out/bin/Hyper"
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}:\$ORIGIN" "$out/opt/Hyper/Hyper"
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}" "$out/opt/Hyper/resources/app/node_modules/child_pty/build/Release/exechelper"
+    ln -s "$out/opt/Hyper/hyper" "$out/bin/hyper"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}:\$ORIGIN" "$out/opt/Hyper/hyper"
     mv usr/* "$out/"
   '';
   dontPatchELF = true;


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

