### PR TITLE
qtmultimedia-5.7: disable alsa on darwin

### DIFF
--- a/pkgs/development/libraries/qt-5/5.7/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtmultimedia.nix
@@ -1,4 +1,4 @@
-{ qtSubmodule, qtbase, qtdeclarative, pkgconfig
+{ stdenv, qtSubmodule, qtbase, qtdeclarative, pkgconfig
 , alsaLib, gstreamer, gst-plugins-base, libpulseaudio
 }:
 
@@ -6,7 +6,7 @@ qtSubmodule {
   name = "qtmultimedia";
   qtInputs = [ qtbase qtdeclarative ];
   buildInputs = [
-    pkgconfig alsaLib gstreamer gst-plugins-base libpulseaudio
-  ];
+    pkgconfig gstreamer gst-plugins-base libpulseaudio
+  ] ++ stdenv.lib.optional stdenv.isLinux alsaLib;
   qmakeFlags = [ "GST_VERSION=1.0" ];
 }


### PR DESCRIPTION
###### Motivation for this change

``error: Package ‘alsa-lib-1.1.2’ in ‘nixpkgs/pkgs/os-specific/linux/alsa-lib/default.nix:32’ is not supported on ‘x86_64-darwin’, refusing to evaluate.`` via qtmultimedia

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

