### PR TITLE
citrix-receiver: 13.4.0 -> 13.5.0

### DIFF
--- a/pkgs/applications/networking/remote/citrix-receiver/default.nix
+++ b/pkgs/applications/networking/remote/citrix-receiver/default.nix
@@ -24,17 +24,17 @@
 
 stdenv.mkDerivation rec {
   name = "citrix-receiver-${version}";
-  version = "13.4.0";
+  version = "13.5.0";
   homepage = https://www.citrix.com/downloads/citrix-receiver/linux/receiver-for-linux-latest.html;
 
   prefixWithBitness = if stdenv.is64bit then "linuxx64" else "linuxx86";
 
   src = requireFile rec {
-    name = "${prefixWithBitness}-${version}.10109380.tar.gz";
+    name = "${prefixWithBitness}-${version}.10185126.tar.gz";
     sha256 =
       if stdenv.is64bit
-      then "133brs0sq6d0mgr19rc6ig1n9ahm3ryi23v5nrgqfh0hgxqcrrjb"
-      else "0r7jfl5yqv1s2npy8l9gsn0gbb82f6raa092ppkc8xy5pni5sh7l";
+      then "1r24mhkpcc0z95n597p07fz92pd1b8qqzp2z6w07rmb9wb8mpd4x"
+      else "0pwxshlryzhkl86cj9ryybm54alhzjx0gpp67fnvdn5r64wy1nd1";
     message = ''
       In order to use Citrix Receiver, you need to comply with the Citrix EULA and download
       the ${if stdenv.is64bit then "64-bit" else "32-bit"} binaries, .tar.gz from:


### PR DESCRIPTION
###### Motivation for this change

This unfree package requires the user to download a tarball manually and insert it into the store with `nix-prefetch-url file:///...`. However, the release that the current version of the Nix pkg is built from is no longer easy to find on the download site. This change updates the derivation to use the current upstream release.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

