### PR TITLE
emem: 0.2.41 -> 0.2.42

### DIFF
--- a/pkgs/applications/misc/emem/default.nix
+++ b/pkgs/applications/misc/emem/default.nix
@@ -2,17 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "emem";
-  version = "0.2.41";
+  version = "0.2.42";
   name = "${pname}-${version}";
 
   inherit jdk;
 
   src = fetchurl {
     url = "https://github.com/ebzzry/${pname}/releases/download/v${version}/${pname}.jar";
-    sha256 = "0pg7m4fyrcbm8d5nj96xvvh1cvml501rw34hniqq384waifr2kqs";
+    sha256 = "0zm3sqgbiaj44nkgkjiifxwwyrcjs42nry6zmbg3dnnpd0v82v8j";
   };
-
-  buildInputs = [ ];
 
   phases = [ "buildPhase" "installPhase" ];
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

