### PR TITLE
pygame: 1.9.1 -> 1.9.3

### DIFF
--- a/pkgs/development/python-modules/pygame/default.nix
+++ b/pkgs/development/python-modules/pygame/default.nix
@@ -1,28 +1,23 @@
 { stdenv, lib, fetchurl, buildPythonPackage, python, smpeg, libX11
-, SDL, SDL_image, SDL_mixer, SDL_ttf, libpng, libjpeg, portmidi, isPy3k,
+, SDL, SDL_image, SDL_mixer, SDL_ttf, libpng, libjpeg, portmidi, freetype
 }:
 
 buildPythonPackage rec {
   name = "pygame-${version}";
-  version = "1.9.1";
+  version = "1.9.3";
 
   src = fetchurl {
-    url = "http://www.pygame.org/ftp/pygame-1.9.1release.tar.gz";
-    sha256 = "0cyl0ww4fjlf289pjxa53q4klyn55ajvkgymw0qrdgp4593raq52";
+    url = "mirror://pypi/p/pygame/pygame-${version}.tar.gz";
+    sha256 = "1hlydiyygl444bq5m5g8n3jsxsgrdyxlm42ipmfbw36wkf0j243m";
   };
 
   buildInputs = [
     SDL SDL_image SDL_mixer SDL_ttf libpng libjpeg
-    smpeg portmidi libX11
+    portmidi libX11 freetype
   ];
-
-  # http://ubuntuforums.org/showthread.php?t=1960262
-  disabled = isPy3k;
 
   # Tests fail because of no audio device and display.
   doCheck = false;
-
-  patches = [ ./pygame-v4l.patch ];
 
   preConfigure = ''
     sed \


### PR DESCRIPTION
###### Motivation for this change
New upstream release; supports python 3.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`. In progress.
  * Renpy fails to build; will try updating it to the latest upstream release.
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).