### PR TITLE
kmod: 23 -> 24 and update kmod-blacklist-ubuntu to zesty

### DIFF
--- a/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
+++ b/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
@@ -1,13 +1,14 @@
 { stdenv, fetchurl, gnugrep, findutils }:
+
 let
-  version = "3ubuntu1"; # Saucy
-in
-stdenv.mkDerivation {
+  version = "22-1.1ubuntu1"; # Zesty
+
+in stdenv.mkDerivation {
   name = "kmod-blacklist-${version}";
 
   src = fetchurl {
-    url = "https://launchpad.net/ubuntu/+archive/primary/+files/kmod_9-${version}.debian.tar.gz";
-    sha256 = "0h6h0zw2490iqj9xa2sz4309jyfmcc50jdvkhxa1nw90npxglp67";
+    url = "https://launchpad.net/ubuntu/+archive/primary/+files/kmod_${version}.debian.tar.xz";
+    sha256 = "1k749g707ccb82l4xmrkp53khl71f57cpj9fzd1qyzrz147fjyhi";
   };
 
   installPhase = ''
@@ -25,9 +26,9 @@ stdenv.mkDerivation {
       --replace " xargs " " ${findutils}/bin/xargs "
   '';
 
-  meta = {
-    homepage = http://packages.ubuntu.com/source/saucy/kmod;
+  meta = with stdenv.lib; {
+    homepage = http://packages.ubuntu.com/source/zesty/kmod;
     description = "Linux kernel module blacklists from Ubuntu";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -6,11 +6,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "kmod-${version}";
-  version = "23";
+  version = "24";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/kernel/kmod/${name}.tar.xz";
-    sha256 = "0mc12sx06p8il1ym3hdmgxxb37apn9yv7xij26gddjdfkx8xa0yk";
+    sha256 = "15xkkkzvca9flvkm48gkh8y8f13vlm3sl7nz9ydc7b3jy4fqs2v1";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig libxslt ];


### PR DESCRIPTION
###### Motivation for this change

- kmod was out of date.
- kmod-blacklist-ubuntu was very out of date

Further to #23890.

I haven't tried this on stable.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

