### PR TITLE
zcash: reinit at 1.0.8

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -43,4 +43,10 @@ rec {
   primecoind = callPackage ./primecoin.nix { withGui = false; };
 
   stellar-core = callPackage ./stellar-core.nix { };
+
+  zcash = callPackage ./zcash {
+    withGui = false;
+    openssl = pkgs.openssl_1_1_0;
+    boost = pkgs.boost163;
+  };
 }

--- a/pkgs/applications/altcoins/zcash/default.nix
+++ b/pkgs/applications/altcoins/zcash/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, libsodium, fetchFromGitHub, wget, pkgconfig, autoreconfHook, openssl, db62, boost
+, zlib, gtest, gmock, miniupnpc, callPackage, gmp, qt4, utillinux, protobuf, qrencode, libevent
+, withGui }:
+
+let libsnark     = callPackage ./libsnark { inherit boost openssl; };
+    librustzcash = callPackage ./librustzcash {};
+in
+with stdenv.lib;
+stdenv.mkDerivation rec{
+
+  name = "zcash" + (toString (optional (!withGui) "d")) + "-" + version;
+  version = "1.0.8";
+
+  src = fetchFromGitHub {
+    owner = "zcash";
+    repo  = "zcash";
+    rev = "f630519d865ce22a6cf72a29785f2a876902f8e1";
+    sha256 = "1zjxg3dp0amjfs67469yp9b223v9hx29lkxid9wz2ivxj3paq7bv";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ pkgconfig gtest gmock gmp libsnark autoreconfHook openssl wget db62 boost zlib
+                  miniupnpc protobuf libevent libsodium librustzcash ]
+                  ++ optionals stdenv.isLinux [ utillinux ]
+                  ++ optionals withGui [ qt4 qrencode ];
+
+  configureFlags = [ "LIBSNARK_INCDIR=${libsnark}/include/libsnark"
+                     "--with-boost-libdir=${boost.out}/lib"
+                   ] ++ optionals withGui [ "--with-gui=qt4" ];
+
+  patchPhase = ''
+    sed -i"" '/^\[LIBSNARK_INCDIR/d'               configure.ac
+    sed -i"" 's,-lboost_system-mt,-lboost_system,' configure.ac
+    sed -i"" 's,-fvisibility=hidden,,g'            src/Makefile.am
+  '';
+
+  postInstall = ''
+    cp zcutil/fetch-params.sh $out/bin/zcash-fetch-params
+  '';
+
+  meta = {
+    description = "Peer-to-peer, anonymous electronic cash system";
+    homepage = "https://z.cash/";
+    maintainers = with maintainers; [ rht ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/zcash/librustzcash/default.nix
+++ b/pkgs/applications/altcoins/zcash/librustzcash/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "librustzcash-unstable-${version}";
+  version = "2017-03-17";
+
+  src = fetchFromGitHub {
+    owner = "zcash";
+    repo = "librustzcash";
+    rev = "91348647a86201a9482ad4ad68398152dc3d635e";
+    sha256 = "02l1f46frpvw1r6k1wfh77mrsnmsdvifqx0vnscxz4xgb9ia9d1c";
+  };
+
+  depsSha256 = "02qx8zdhmj7rmhqqq5q9428x9mlrjxxcnn4yhnygz9gfgvada2hx";
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp target/release/librustzcash.a $out/lib/
+    mkdir -p $out/include
+    cp include/librustzcash.h $out/include/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Rust-language assets for Zcash";
+    homepage = "https://github.com/zcash/librustzcash";
+    maintainers = with maintainers; [ rht ];
+    license = with licenses; [ mit asl20 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/zcash/libsnark/ate-pairing.nix
+++ b/pkgs/applications/altcoins/zcash/libsnark/ate-pairing.nix
@@ -1,0 +1,29 @@
+{ stdenv, xbyak, gmp, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "ate-pairing-unstable-${version}";
+  version = "2016-05-03";
+
+  src = fetchFromGitHub {
+    owner = "herumi";
+    repo  = "ate-pairing";
+    rev = "dcb9da999b1113f90b115bccb6f4b57ddf3a8452";
+    sha256 = "0jr6r1cma414k8mhsyp7n8hqaqxi7zklsp6820a095sbb3zajckh";
+  };
+
+  buildInputs = [ gmp xbyak ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r lib $out
+    cp -r include $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Optimal Ate Pairing over Barreto-Naehrig Curves";
+    homepage = "https://github.com/herumi/ate-pairing";
+    maintainers = with maintainers; [ rht ];
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/zcash/libsnark/default.nix
+++ b/pkgs/applications/altcoins/zcash/libsnark/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, libsodium, callPackage, boost, zlib, openssl, gmp, procps, fetchFromGitHub }:
+
+let atePairing = callPackage ./ate-pairing.nix { inherit xbyak; };
+    mie        = callPackage ./mie.nix { };
+    xbyak      = callPackage ./xbyak.nix {};
+in
+stdenv.mkDerivation rec{
+  name = "libsnark-unstable-${version}";
+  version = "2017-02-09";
+
+  src = fetchFromGitHub {
+    owner = "zcash";
+    repo  = "libsnark";
+    rev = "9ada3f84ab484c57b2247c2f41091fd6a0916573";
+    sha256 = "0vhslcb9rwqab9szavyn856z4h9w1syiamfcixqmj0s908zzlaaq";
+  };
+
+  buildInputs = [ libsodium atePairing mie xbyak zlib openssl boost gmp ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "CURVE=ALT_BN128"
+    "NO_SUPERCOP=1"
+    "STATIC=1"
+  ];
+
+  buildPhase = ''
+    CXXFLAGS="-fPIC -DBINARY_OUTPUT -DNO_PT_COMPRESSION=1" \
+    make lib \
+      CURVE=ALT_BN128 \
+      MULTICORE=1 \
+      STATIC=1 \
+      NO_PROCPS=1 \
+      NO_GTEST=1 \
+      FEATUREFLAGS=-DMONTGOMERY_OUTPUT \
+  '';
+
+  meta = with stdenv.lib; {
+    description = "a C++ library for zkSNARK proofs";
+    homepage = "https://github.com/zcash/libsnark";
+    maintainers = with maintainers; [ rht ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/zcash/libsnark/mie.nix
+++ b/pkgs/applications/altcoins/zcash/libsnark/mie.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "mie-unstable-${version}";
+  version = "2016-05-10";
+
+  src = fetchFromGitHub {
+    owner = "herumi";
+    repo  = "mie";
+    rev = "704b625b7770a8e1eab26ac65d1fed14c2fcf090";
+    sha256 = "144bpmgfs2m4qqv7a2mccgi1aq5jmlr25gnk78ryq09z8cyv88y2";
+  };
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r include $out
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/herumi/mie";
+    maintainers = with maintainers; [ rht ];
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/zcash/libsnark/xbyak.nix
+++ b/pkgs/applications/altcoins/zcash/libsnark/xbyak.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "xbyak-unstable-${version}";
+  version = "2016-05-03";
+
+  src = fetchFromGitHub {
+    owner = "herumi";
+    repo  = "xbyak";
+    rev = "b6133a02dd6b7116bea31d0e6b7142bf97f071aa";
+    sha256 = "1rc2nx8kj2lj13whxb9chhh79f4hmjjj4j1hpqsd0lbdb60jikrn";
+  };
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/include
+    cp -r xbyak $out/include
+  '';
+
+  meta = with stdenv.lib; {
+    description = "JIT assembler for x86, x64";
+    homepage = "https://github.com/herumi/xbyak";
+    maintainers = with maintainers; [ rht ];
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/db/db-6.2.nix
+++ b/pkgs/development/libraries/db/db-6.2.nix
@@ -1,0 +1,8 @@
+{ stdenv, fetchurl, ... } @ args:
+
+import ./generic.nix (args // rec {
+  version = "6.2.23";
+  sha256 = "1isxx4jfmnh913jzhp8hhfngbk6dsg46f4kjpvvc56maj64jqqa7";
+  license = stdenv.lib.licenses.agpl3;
+  extraPatches = [ ./clang-6.0.patch ];
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7499,6 +7499,7 @@ with pkgs;
   db53 = callPackage ../development/libraries/db/db-5.3.nix { };
   db6 = db60;
   db60 = callPackage ../development/libraries/db/db-6.0.nix { };
+  db62 = callPackage ../development/libraries/db/db-6.2.nix { };
 
   dbus = callPackage ../development/libraries/dbus { };
   dbus_cplusplus  = callPackage ../development/libraries/dbus-cplusplus { };


### PR DESCRIPTION
###### Motivation for this change

Based on @jb55's https://github.com/NixOS/nixpkgs/pull/19944.
With changes:
- zcash version 1.0.0 -> 1.0.8
- boost version 1.6.2 -> 1.6.3

To address https://github.com/NixOS/nixpkgs/pull/19944#discussion_r85650351: db still defaults to db60 so as not to break other packages that assume db is db60.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

