### PR TITLE
renpy: mark as broken

### DIFF
--- a/pkgs/development/interpreters/renpy/default.nix
+++ b/pkgs/development/interpreters/renpy/default.nix
@@ -12,6 +12,9 @@ stdenv.mkDerivation {
     homepage = "http://renpy.org/";
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.linux;
+    # This is an ancient version, last updated in 2014 (3d59f42ce); it fails to
+    # build with the most recent pygame version, and fails to run with 1.9.1.
+    broken = true;
   };
 
   src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
 - Pygame was updated to 1.9.3 and this broke the build;
 - Before pygame 1.9.1, the build succeeded but the result failed to run;
 - Version is ancient, last updated in 2014 by 3d59f42ce
 - Updating to latest upstream is non-trivial.

See also #23981.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Package has no dependents
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).