### PR TITLE
rustNightlyBin: 2017-01-26 -> 2017-03-16

### DIFF
--- a/pkgs/development/compilers/rust/nightlyBin.nix
+++ b/pkgs/development/compilers/rust/nightlyBin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, cacert, zlib, buildRustPackage }:
+{ stdenv, fetchurl, makeWrapper, cacert, zlib, buildRustPackage, curl }:
 
 let
   inherit (stdenv.lib) optionalString;
@@ -9,7 +9,7 @@ let
 
   bootstrapHash =
     if stdenv.system == "x86_64-linux"
-    then "1v7jvwigb29m15wilzcrk5jmlpaccpzbkhlzf7z5qw08320gvc91"
+    then "1d5h34dkm1r1ff562szygn9xk2qll1pjryvypl0lazzanxdh5gv5"
     else throw "missing bootstrap hash for platform ${stdenv.system}";
 
   needsPatchelf = stdenv.isLinux;
@@ -19,7 +19,7 @@ let
      sha256 = bootstrapHash;
   };
 
-  version = "2017-01-26";
+  version = "2017-03-16";
 in
 
 rec {
@@ -69,7 +69,7 @@ rec {
       license = [ licenses.mit licenses.asl20 ];
     };
 
-    buildInputs = [ makeWrapper ];
+    buildInputs = [ makeWrapper curl ];
     phases = ["unpackPhase" "installPhase"];
 
     installPhase = ''
@@ -78,6 +78,7 @@ rec {
 
       ${optionalString needsPatchelf ''
         patchelf \
+          --set-rpath "${stdenv.lib.makeLibraryPath [ curl zlib ]}" \
           --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
           "$out/bin/cargo"
       ''}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

