### PR TITLE
KDE Applications: 16.12.2 -> 16.12.3

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/applications/16.12.2/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/applications/16.12.3/ -A '*.tar.xz' )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -3,2227 +3,2227 @@
 
 {
   akonadi = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/akonadi-16.12.2.tar.xz";
-      sha256 = "1csaa69n65d3cnkajzk5702vxskfaiajvxw724s17a5y6sgk0h5z";
-      name = "akonadi-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/akonadi-16.12.3.tar.xz";
+      sha256 = "00sbchj3yjbqdjckrciv2c7j9i7kc5yqvyvbmjlxacbkq80a4j7w";
+      name = "akonadi-16.12.3.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/akonadi-calendar-16.12.2.tar.xz";
-      sha256 = "1qfkwmh82l5ahzjpsla9gwwk2kqxv773ddq8f5h52qlxx56agc6k";
-      name = "akonadi-calendar-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/akonadi-calendar-16.12.3.tar.xz";
+      sha256 = "0kv636a8x75fcagw8hjnrwnxzvqnnm42hfw68ywfics0pn0pl50g";
+      name = "akonadi-calendar-16.12.3.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/akonadi-calendar-tools-16.12.2.tar.xz";
-      sha256 = "1isjvsas6fnz2v2a8yl6ggkimfknr56a3zydwhq59lzcm15hn0hj";
-      name = "akonadi-calendar-tools-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/akonadi-calendar-tools-16.12.3.tar.xz";
+      sha256 = "157kmcl77pj32ysbwr1xw365p5pgk69w5j8397axly6dmdl71x47";
+      name = "akonadi-calendar-tools-16.12.3.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/akonadiconsole-16.12.2.tar.xz";
-      sha256 = "188qb2lc6d0xhvq8n5y7ax13a6wz3agg1mx3j2kphwn8f53grgzb";
-      name = "akonadiconsole-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/akonadiconsole-16.12.3.tar.xz";
+      sha256 = "195amn610y5ydg665ag45xb0l1wyplbdlrwagzc7yvswp12rlcv3";
+      name = "akonadiconsole-16.12.3.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/akonadi-contacts-16.12.2.tar.xz";
-      sha256 = "1ixd1qzakxhq9qlfr6l8igii2ny8fi8hxasdadq9cyr5jl20rpgp";
-      name = "akonadi-contacts-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/akonadi-contacts-16.12.3.tar.xz";
+      sha256 = "1205g4z5rz02j8swrmhncm06d8m727z63d526djygz5svz15sd2l";
+      name = "akonadi-contacts-16.12.3.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/akonadi-import-wizard-16.12.2.tar.xz";
-      sha256 = "0xdmcs8l0lqqx2f2yabp1xx60h1jcz05q7lk6zzapzc0xqa8pqnq";
-      name = "akonadi-import-wizard-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/akonadi-import-wizard-16.12.3.tar.xz";
+      sha256 = "0dnpiqcmphm2x76f21acrwhg7ah5ih0hnhxdy1d6pm3ng2p1irfq";
+      name = "akonadi-import-wizard-16.12.3.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/akonadi-mime-16.12.2.tar.xz";
-      sha256 = "0w88splvk1ci6l590kybb8dgddhk8q0mqag1xxliws534kl9bd0s";
-      name = "akonadi-mime-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/akonadi-mime-16.12.3.tar.xz";
+      sha256 = "1xay3rlygdhf9lp356wjb92wnmxdpaxgm3prxnfxcdg5ql6xcg07";
+      name = "akonadi-mime-16.12.3.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/akonadi-notes-16.12.2.tar.xz";
-      sha256 = "181d4sv6vqrx0iy5fwdpd28h78i0jy4bj51jxbdn7fqmx1mavbkl";
-      name = "akonadi-notes-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/akonadi-notes-16.12.3.tar.xz";
+      sha256 = "0405nkz9ri9qlclgvwycvdx1gsms2pm1fn6xhvyrj2v4s8brb3r7";
+      name = "akonadi-notes-16.12.3.tar.xz";
     };
   };
   akonadi-search = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/akonadi-search-16.12.2.tar.xz";
-      sha256 = "1jfcpjn45cxxnfg9y15fjkig6nfj6w8ggq3a7339kdhb79lkh1p5";
-      name = "akonadi-search-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/akonadi-search-16.12.3.tar.xz";
+      sha256 = "0wf22rmfz471iw6zxl7yz279fkks2pj5jfw4bs5185kr3xw2q7zp";
+      name = "akonadi-search-16.12.3.tar.xz";
     };
   };
   akregator = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/akregator-16.12.2.tar.xz";
-      sha256 = "0yyjpl6kajy0ip60m6vf0jnm217m5ax34a5y14k1wj7civ4fz9il";
-      name = "akregator-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/akregator-16.12.3.tar.xz";
+      sha256 = "1v6jg35ha6wrjgwfvrvy1qwl1700dmk40d0fwy1irkpdlgg79128";
+      name = "akregator-16.12.3.tar.xz";
     };
   };
   analitza = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/analitza-16.12.2.tar.xz";
-      sha256 = "1jii70a2nppfzqlzwrjvawfq2cfjqrcsj0mbpgahb8zphcfs5xhy";
-      name = "analitza-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/analitza-16.12.3.tar.xz";
+      sha256 = "0ap3sf8bw9f58pzw3zy6w60apd4ccc47zs3v61x4kp1g81rn265w";
+      name = "analitza-16.12.3.tar.xz";
     };
   };
   ark = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ark-16.12.2.tar.xz";
-      sha256 = "07jp25jqnfcx48x7w0wwyldk56czyx2341yf2k73p3fy67rldlr3";
-      name = "ark-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ark-16.12.3.tar.xz";
+      sha256 = "0q1bxrsb03pwsvxqlbnzfmahlj300l336pdrm82vin89m294ird0";
+      name = "ark-16.12.3.tar.xz";
     };
   };
   artikulate = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/artikulate-16.12.2.tar.xz";
-      sha256 = "11065zl5gdc1q7rvzmjvbz33k9xhdph7ynqwnv628c6a0478xwc5";
-      name = "artikulate-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/artikulate-16.12.3.tar.xz";
+      sha256 = "113k6c0yrir61j258gn9n6k7fifa6g9g8wxf3zq18jy3liwdl97s";
+      name = "artikulate-16.12.3.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/audiocd-kio-16.12.2.tar.xz";
-      sha256 = "184grq1nfpv9sfcsk6kcx6bdnbh938jc3qr6n00gnnj509347xga";
-      name = "audiocd-kio-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/audiocd-kio-16.12.3.tar.xz";
+      sha256 = "0bmmi2rxx368nss8ciwj32dspc1ailc0shm06ynmhw3slrplnx1y";
+      name = "audiocd-kio-16.12.3.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/baloo-widgets-16.12.2.tar.xz";
-      sha256 = "000v5s33j6qsdbxqf856si0z5dmh9dan41kf2lrzc017hj6pr34x";
-      name = "baloo-widgets-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/baloo-widgets-16.12.3.tar.xz";
+      sha256 = "0h75zhdiylyjifdk9ikw9gpwla3p87knndc2svkci90ga7ynggvl";
+      name = "baloo-widgets-16.12.3.tar.xz";
     };
   };
   blinken = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/blinken-16.12.2.tar.xz";
-      sha256 = "1wcl8199wg74cv9hyrhcpqkf1awpf3q960jzgfv0z0c28xywb76x";
-      name = "blinken-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/blinken-16.12.3.tar.xz";
+      sha256 = "1z50ack1iqh194vn487nhdkrbn1camswy4a3g2ayxv3qfgmxdcga";
+      name = "blinken-16.12.3.tar.xz";
     };
   };
   blogilo = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/blogilo-16.12.2.tar.xz";
-      sha256 = "0j5mz8nfndr0g99l84s7n3gxrj6y4jbql1srnyl0yspmcjwmnc09";
-      name = "blogilo-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/blogilo-16.12.3.tar.xz";
+      sha256 = "14yl52m8x7b8bj2b7pkhabwg7rrmmhnkjq4z7mrxbnsndqmsi10f";
+      name = "blogilo-16.12.3.tar.xz";
     };
   };
   bomber = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/bomber-16.12.2.tar.xz";
-      sha256 = "1fy17y5grir6kbr7xzclslrxyip4favhag6wasg9ah60r6k15cqc";
-      name = "bomber-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/bomber-16.12.3.tar.xz";
+      sha256 = "1h4s6amjzazr3ywcqw8d14a0fi1arzxka0g6i9ii85s904k23r41";
+      name = "bomber-16.12.3.tar.xz";
     };
   };
   bovo = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/bovo-16.12.2.tar.xz";
-      sha256 = "0dszbxisq172x5jv10w62wg3kcs1f8wdxgw9pjq423j3jq8rw9zq";
-      name = "bovo-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/bovo-16.12.3.tar.xz";
+      sha256 = "1pr67gf47xmw21sv1im7k0dz18bhjfpbkhd7j5gaifj66h65sfy6";
+      name = "bovo-16.12.3.tar.xz";
     };
   };
   calendarsupport = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/calendarsupport-16.12.2.tar.xz";
-      sha256 = "065h09kq6h2hr4lg34lqckw0g91zkhxpviagdgymx7qpdy36l2sb";
-      name = "calendarsupport-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/calendarsupport-16.12.3.tar.xz";
+      sha256 = "0r30z2wzyms7m7s8y0livsfy5pj82g988bs6amaj2571hz55d8y0";
+      name = "calendarsupport-16.12.3.tar.xz";
     };
   };
   cantor = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/cantor-16.12.2.tar.xz";
-      sha256 = "055sxyl2x2mipnidrsgkmbjy4vw64pf5k0fql64p7pjhknn3i6x4";
-      name = "cantor-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/cantor-16.12.3.tar.xz";
+      sha256 = "1nzg9sfnv8afpa84x51whbw1qh8gfwqnkr5zyai7817kkc97g1l8";
+      name = "cantor-16.12.3.tar.xz";
     };
   };
   cervisia = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/cervisia-16.12.2.tar.xz";
-      sha256 = "1fdnvdp27wa8pni4vq501ajdln6dmg2kc0468x1c375g734npabx";
-      name = "cervisia-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/cervisia-16.12.3.tar.xz";
+      sha256 = "14r55ngvz4rci1h3iqdwbfcyxmm2b04c5smkv9x0bqxq4zz2yfvk";
+      name = "cervisia-16.12.3.tar.xz";
     };
   };
   dolphin = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/dolphin-16.12.2.tar.xz";
-      sha256 = "1xqkrkhpcxcrrk3msd7fkhqikwrx2mjd0c4cna2iwd0s4h7ahmy6";
-      name = "dolphin-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/dolphin-16.12.3.tar.xz";
+      sha256 = "0y35ljbjib4pvyngdgbq1yx3rfmy94crpa7v1zzwfav94lm3kwb2";
+      name = "dolphin-16.12.3.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/dolphin-plugins-16.12.2.tar.xz";
-      sha256 = "07i4w95b20db51bzg0rnx6m3dgk2bz5nwivz6zngfiiksmb39dj3";
-      name = "dolphin-plugins-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/dolphin-plugins-16.12.3.tar.xz";
+      sha256 = "18azlmzw33praz4z6lamamj79gyxbbdgz7lp1cimxyddhmacc2x9";
+      name = "dolphin-plugins-16.12.3.tar.xz";
     };
   };
   dragon = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/dragon-16.12.2.tar.xz";
-      sha256 = "07iip379kpwy8yfiwacykkgzj7bfw2nz3vij61q68lr64k5sg4kk";
-      name = "dragon-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/dragon-16.12.3.tar.xz";
+      sha256 = "1652cl6sa9d71c685xpwqv5hgz3spxg2hynwcnn8xybn5hv9ar4r";
+      name = "dragon-16.12.3.tar.xz";
     };
   };
   eventviews = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/eventviews-16.12.2.tar.xz";
-      sha256 = "1hl0adi0ss533mnncyih3y9075i90accklbk8068dvxb7la9b7zd";
-      name = "eventviews-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/eventviews-16.12.3.tar.xz";
+      sha256 = "0z8jznvw2nhszrlll7458gb4r0585ivkbq9dqplkw2mdrv7vxz5c";
+      name = "eventviews-16.12.3.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ffmpegthumbs-16.12.2.tar.xz";
-      sha256 = "0p1fqxqcgz3k910acacr86pa66yl5d65wxf93nlg4627dfhmrbkc";
-      name = "ffmpegthumbs-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ffmpegthumbs-16.12.3.tar.xz";
+      sha256 = "1scyyd85rs21rv3ghcxv7pw3aa2nl703gi4dpikbsd7wjmxixzq9";
+      name = "ffmpegthumbs-16.12.3.tar.xz";
     };
   };
   filelight = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/filelight-16.12.2.tar.xz";
-      sha256 = "0ynqnagyrn61gzvi0rl38200yxbxa2zpch3cl917wff527kjd7cw";
-      name = "filelight-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/filelight-16.12.3.tar.xz";
+      sha256 = "13gcx1w9zq3i9fy32m3ypjyqcd9vrkqyr0j4cbqfvhpzv2chk3is";
+      name = "filelight-16.12.3.tar.xz";
     };
   };
   granatier = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/granatier-16.12.2.tar.xz";
-      sha256 = "01b0nvfj5v2spaml003bpd4f5snncxsilfplwgb06kf8wwsb9mzd";
-      name = "granatier-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/granatier-16.12.3.tar.xz";
+      sha256 = "17vpz6jz2vvpvsrhvllglacrwg0sxy15aqnm8n6d73sk9zlv9n76";
+      name = "granatier-16.12.3.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/grantlee-editor-16.12.2.tar.xz";
-      sha256 = "16r1f7vwsqfngv3kld4wqmvxn4pnxgcpiaaxa2z9szsjfrz10bp9";
-      name = "grantlee-editor-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/grantlee-editor-16.12.3.tar.xz";
+      sha256 = "007q6cb5f3vzw6dwm2y2b5m3dhb5mws5b6083ssm8rydycyi9pzi";
+      name = "grantlee-editor-16.12.3.tar.xz";
     };
   };
   grantleetheme = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/grantleetheme-16.12.2.tar.xz";
-      sha256 = "09qr7icbkq4my594xkjkydkfwx8sixbc73i3gxjnki64w549gan2";
-      name = "grantleetheme-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/grantleetheme-16.12.3.tar.xz";
+      sha256 = "19mka62p75qnv6r9ib70y25jjj3bpziz0xqihfkb6jvafrgy8p8k";
+      name = "grantleetheme-16.12.3.tar.xz";
     };
   };
   gwenview = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/gwenview-16.12.2.tar.xz";
-      sha256 = "1ldflh10b34r9xy8a8yh72jcjdxs3ylhyjhs97xcg381q4dyg1dr";
-      name = "gwenview-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/gwenview-16.12.3.tar.xz";
+      sha256 = "069fblw9g9h6r9gy05nj2n93jpnsx610jncwl6403q01rwlbrgbr";
+      name = "gwenview-16.12.3.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/incidenceeditor-16.12.2.tar.xz";
-      sha256 = "0z8ysrdkxfkn71anlzifd0dxh6fysl924jh4wjsphb4dnb417rym";
-      name = "incidenceeditor-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/incidenceeditor-16.12.3.tar.xz";
+      sha256 = "11jplw3fngnyvpjkhqwv1gzzwxxcm4v93h09f68hs015apncjvpp";
+      name = "incidenceeditor-16.12.3.tar.xz";
     };
   };
   jovie = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/jovie-16.12.2.tar.xz";
-      sha256 = "19ifp3p02ayka2zqnwfq381mjqpxhm0hydf1yx9lh2p8n6j9s4gy";
-      name = "jovie-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/jovie-16.12.3.tar.xz";
+      sha256 = "190c4g587x4wxbfksf0mszq5qv1pzny6bkd3w2pwwsj222bl0fxa";
+      name = "jovie-16.12.3.tar.xz";
     };
   };
   juk = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/juk-16.12.2.tar.xz";
-      sha256 = "1453s0zxagqmx91f3x7fqrb6xdlgzr2sqj6hcj2pgl6jaz2x3n1c";
-      name = "juk-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/juk-16.12.3.tar.xz";
+      sha256 = "1ssgia5sknam2hnjflzglv0khxbwyyvzm4w1wmxw04rbjzs4gi4h";
+      name = "juk-16.12.3.tar.xz";
     };
   };
   kaccessible = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kaccessible-16.12.2.tar.xz";
-      sha256 = "1ibh2nw4bdnj1ll8qp3d3vkwvzdkv2k53n98p9282w3jhckpiq5r";
-      name = "kaccessible-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kaccessible-16.12.3.tar.xz";
+      sha256 = "162a4pw61b3rhq5mf7zdhgyyhbrxhr9fjw7bidicw7aljiy2cwb9";
+      name = "kaccessible-16.12.3.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kaccounts-integration-16.12.2.tar.xz";
-      sha256 = "0nx9wlh7arjqz0wf2zyaj3fwzm7sn38hn00m74mj7zvxr1pwcypv";
-      name = "kaccounts-integration-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kaccounts-integration-16.12.3.tar.xz";
+      sha256 = "0w8h33sysf590xyg4bvf2a2z39kzc0wn6mxv31mrf68b6ks7b9h2";
+      name = "kaccounts-integration-16.12.3.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kaccounts-providers-16.12.2.tar.xz";
-      sha256 = "0dln1l44bzaw782qjc57w2hgydbqzn4g7xh8d93qq52yz8ph875g";
-      name = "kaccounts-providers-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kaccounts-providers-16.12.3.tar.xz";
+      sha256 = "0iqqwfjadsf7nhrqvpzypazipris4ljhf6daprxwxqa2bfigr5j2";
+      name = "kaccounts-providers-16.12.3.tar.xz";
     };
   };
   kaddressbook = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kaddressbook-16.12.2.tar.xz";
-      sha256 = "023mfnin8si234yczhhfm3nk083w8bixg1b3gr8bzc1x92ka93m2";
-      name = "kaddressbook-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kaddressbook-16.12.3.tar.xz";
+      sha256 = "1a86asy0pw8ivyg7aaw2mais4xbplabp5aljzcyb2rykij6482rh";
+      name = "kaddressbook-16.12.3.tar.xz";
     };
   };
   kajongg = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kajongg-16.12.2.tar.xz";
-      sha256 = "0909hzwj8yf6sv97r2rgzbp8l7ixlxxy8nwy8dcv471dznlvqznn";
-      name = "kajongg-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kajongg-16.12.3.tar.xz";
+      sha256 = "0xwwkl2npls0aq4435xlcvssm8pmfhramjgxv70mnjapr0dlpk5c";
+      name = "kajongg-16.12.3.tar.xz";
     };
   };
   kalarm = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kalarm-16.12.2.tar.xz";
-      sha256 = "1znp4lym95jz93wwn1nrw9q8nkbwg7x489iccndrv4pl93jfsnqk";
-      name = "kalarm-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kalarm-16.12.3.tar.xz";
+      sha256 = "1n3h252cvqib1bx4ryq3xgj2mkqr38wvhiyj2vkkll4pf5lphpqz";
+      name = "kalarm-16.12.3.tar.xz";
     };
   };
   kalarmcal = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kalarmcal-16.12.2.tar.xz";
-      sha256 = "06rx33hdwz940cggr5rg6g1gh84yzz6vrnvk5lrgr8vxqgrssp3s";
-      name = "kalarmcal-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kalarmcal-16.12.3.tar.xz";
+      sha256 = "064sihcsbdi1w6viv5gq6sw2m8r7x3nn1hl2aji1109pf5913vbr";
+      name = "kalarmcal-16.12.3.tar.xz";
     };
   };
   kalgebra = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kalgebra-16.12.2.tar.xz";
-      sha256 = "02yykjrsa01r697bk4jsly7762hvml7f67gy33vgywhh8lz3h3cd";
-      name = "kalgebra-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kalgebra-16.12.3.tar.xz";
+      sha256 = "0qhini5gm41dlyham4zzqgz6r11s2rfwwphb81xvwp1bgn8q2rqb";
+      name = "kalgebra-16.12.3.tar.xz";
     };
   };
   kalzium = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kalzium-16.12.2.tar.xz";
-      sha256 = "043prql6bwg2ka6y0inh8h46y7d5060b0h2inw0lhm49vizgkmsh";
-      name = "kalzium-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kalzium-16.12.3.tar.xz";
+      sha256 = "0rlfjqfb1vpr0cdcx429nvrbkr7kc1m4ps3z3pphkajq4vlrql8i";
+      name = "kalzium-16.12.3.tar.xz";
     };
   };
   kamera = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kamera-16.12.2.tar.xz";
-      sha256 = "1kxmjpk0vdj9s3kxgcp2vw8dpx4r69j3jwifyvzrh06sg9z0bnqd";
-      name = "kamera-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kamera-16.12.3.tar.xz";
+      sha256 = "04p19qv5ssf5wlpfqzhqsi8281pzcdjkd0jy177f9r7qgqq4lkgr";
+      name = "kamera-16.12.3.tar.xz";
     };
   };
   kanagram = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kanagram-16.12.2.tar.xz";
-      sha256 = "09d20x0z066pgkwp25ig49v78k89nyxs769a3zjmq1y490nm34y1";
-      name = "kanagram-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kanagram-16.12.3.tar.xz";
+      sha256 = "183hkxxwf7h335gmfvi2lppsyhpv80lvlg1fg4whq79f1d2lrw47";
+      name = "kanagram-16.12.3.tar.xz";
     };
   };
   kapman = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kapman-16.12.2.tar.xz";
-      sha256 = "0g9swdgz8sd49q3sw2107b50ww978nppzp1b7bkv7ygiz49p28bq";
-      name = "kapman-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kapman-16.12.3.tar.xz";
+      sha256 = "1if3dzn1qy2pr42zcmzpq7f38spkxh492gl12vndckzah67cmz4g";
+      name = "kapman-16.12.3.tar.xz";
     };
   };
   kapptemplate = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kapptemplate-16.12.2.tar.xz";
-      sha256 = "1agpq16wxbzd7crgbj1cj60alqv090dkvxi2szg054bmks82j6rc";
-      name = "kapptemplate-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kapptemplate-16.12.3.tar.xz";
+      sha256 = "036npdxyh9rx0aaiwvdjqrb39f8bqglqbl3iddb1vh7w9p1h158n";
+      name = "kapptemplate-16.12.3.tar.xz";
     };
   };
   kate = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kate-16.12.2.tar.xz";
-      sha256 = "1hkqzidd2cfp3wg7pq47ymsw1dh26qwn4cybnxw23d95ss85wx2p";
-      name = "kate-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kate-16.12.3.tar.xz";
+      sha256 = "1fbrdlf64bdj71g692fkk7fiym0nm9vvbki2q105carrhl4w9s0r";
+      name = "kate-16.12.3.tar.xz";
     };
   };
   katomic = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/katomic-16.12.2.tar.xz";
-      sha256 = "1sgi8npzq3p7qwv3c4q8ji83gp33zxb0i19dx2i6rb45lir3lj68";
-      name = "katomic-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/katomic-16.12.3.tar.xz";
+      sha256 = "14dnfjww1fzgz3nbg45ck5yqbxdyvp0la9qs4n5cjy1ym52k5pjm";
+      name = "katomic-16.12.3.tar.xz";
     };
   };
   kblackbox = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kblackbox-16.12.2.tar.xz";
-      sha256 = "1cv5kqyqspiz0aaamnyq37s683m2iw27ma6yf3blm5f9g1r43n2k";
-      name = "kblackbox-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kblackbox-16.12.3.tar.xz";
+      sha256 = "0i359pq65swrzsb7vdk0m00vjrj2xgvbgxin8ly2cijqlmfd3iv8";
+      name = "kblackbox-16.12.3.tar.xz";
     };
   };
   kblocks = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kblocks-16.12.2.tar.xz";
-      sha256 = "1xd5pxpi97nmrp4xglhm2qfpz8ksv8vyq4wrv25qbgvfc8jis790";
-      name = "kblocks-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kblocks-16.12.3.tar.xz";
+      sha256 = "09kdbwya4xl84vzayhz286lmfb6a0mmp9i40hzldfl59as4d67kw";
+      name = "kblocks-16.12.3.tar.xz";
     };
   };
   kblog = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kblog-16.12.2.tar.xz";
-      sha256 = "001mqvahsmf4amxqmz2ah5chlgpp2zi8g4pcg83qb9d65cvr6877";
-      name = "kblog-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kblog-16.12.3.tar.xz";
+      sha256 = "0q1qswg7dgy0jvk9kaz6cps6sfddsmv0lp5r3nhk751l497bbl3x";
+      name = "kblog-16.12.3.tar.xz";
     };
   };
   kbounce = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kbounce-16.12.2.tar.xz";
-      sha256 = "1gsrafcjk55lbxi2mx382hj2lahlgnn3pv13ldi7zh6ms4sms1wm";
-      name = "kbounce-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kbounce-16.12.3.tar.xz";
+      sha256 = "0cwvsbw0a60a2csxqvpkm3znbcd1whsl80v63ljyc3gyik7wxil0";
+      name = "kbounce-16.12.3.tar.xz";
     };
   };
   kbreakout = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kbreakout-16.12.2.tar.xz";
-      sha256 = "0lwwz17ynhdi6qw76yih8an6p890w8gwh1khsr8casc1wlm04s0y";
-      name = "kbreakout-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kbreakout-16.12.3.tar.xz";
+      sha256 = "0zszxxw7r7ggxhc47pngsi7bl57mnhbzkb0bhvy5rcyamgi90v39";
+      name = "kbreakout-16.12.3.tar.xz";
     };
   };
   kbruch = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kbruch-16.12.2.tar.xz";
-      sha256 = "1n119nkm0385pv8pngsbwxd56v6y6pwh0rshbk0ryd7974i2z4mi";
-      name = "kbruch-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kbruch-16.12.3.tar.xz";
+      sha256 = "12zmp9ix8q9mf3a4xpbsr0y9h4g1srwx48604x1phdwwdhgx0gsj";
+      name = "kbruch-16.12.3.tar.xz";
     };
   };
   kcachegrind = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kcachegrind-16.12.2.tar.xz";
-      sha256 = "0wcizav1z3n31n7qcc05mx42vl2rv71c7haaa8vn0ma39rj4iaqv";
-      name = "kcachegrind-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kcachegrind-16.12.3.tar.xz";
+      sha256 = "109y94nz96izzsjjdpj9c6g344rcr86srp5w0433mssbyvym4x7q";
+      name = "kcachegrind-16.12.3.tar.xz";
     };
   };
   kcalc = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kcalc-16.12.2.tar.xz";
-      sha256 = "07lyssmkq34ym1w3ajm1vf4f57xv2h8y2zb039vj7gdx609syaq0";
-      name = "kcalc-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kcalc-16.12.3.tar.xz";
+      sha256 = "06kfz1d5i01h31v277y04pqnx08yv0050rlb6phv72cx6div4mgp";
+      name = "kcalc-16.12.3.tar.xz";
     };
   };
   kcalcore = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kcalcore-16.12.2.tar.xz";
-      sha256 = "1lq5shp8jwy490qx0rnc0sd67976r7j3sblzw0j5hn95k8n23hzd";
-      name = "kcalcore-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kcalcore-16.12.3.tar.xz";
+      sha256 = "09i43vs6jpjmmk52df6pzclh0jn8shn3wfnaivw2wlirwa60d901";
+      name = "kcalcore-16.12.3.tar.xz";
     };
   };
   kcalutils = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kcalutils-16.12.2.tar.xz";
-      sha256 = "1sf5f8mwjdi2d8lpkrprnqc9jkj72p6mdz3pbczmixgfy7d7y4ci";
-      name = "kcalutils-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kcalutils-16.12.3.tar.xz";
+      sha256 = "0449029fa1w496fmb81csb5amk801n11ish450drqw34lp9qla4n";
+      name = "kcalutils-16.12.3.tar.xz";
     };
   };
   kcharselect = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kcharselect-16.12.2.tar.xz";
-      sha256 = "0a5cmc6n9h8h64in68qdi8bmqx341fvm8vf98vcqn5sivwwnflhc";
-      name = "kcharselect-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kcharselect-16.12.3.tar.xz";
+      sha256 = "1iwqqds9fy970ykgq1xbpbrzpdacy1h4bw87h1jingi42z1jkw2n";
+      name = "kcharselect-16.12.3.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kcolorchooser-16.12.2.tar.xz";
-      sha256 = "07psjid00bjw0s6xx2hq96f8cj2axdsr7lqvgrclksa07lphzcvm";
-      name = "kcolorchooser-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kcolorchooser-16.12.3.tar.xz";
+      sha256 = "13nkvxl3z2l3m6zs057ipxgqfgsw7gma1rs66maqhzl30k3hrcyb";
+      name = "kcolorchooser-16.12.3.tar.xz";
     };
   };
   kcontacts = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kcontacts-16.12.2.tar.xz";
-      sha256 = "18z7894xh1ifkg177xxy41n61djcy07m8a39favbpab0ya1xk81l";
-      name = "kcontacts-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kcontacts-16.12.3.tar.xz";
+      sha256 = "1479g32c9532pjgmfpy38vycii1sxk1nzv27z7wbgpxch6735szx";
+      name = "kcontacts-16.12.3.tar.xz";
     };
   };
   kcron = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kcron-16.12.2.tar.xz";
-      sha256 = "1z72wcrr8ggw89ivq70v98zwg1hw3sn5l5czpq00scqpaf8664g2";
-      name = "kcron-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kcron-16.12.3.tar.xz";
+      sha256 = "0whxc9h7qn0fwcca9sq6qy0j4hfb8xlkdypnb6gspl687ws799xz";
+      name = "kcron-16.12.3.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdebugsettings-16.12.2.tar.xz";
-      sha256 = "1zbmvn9c1sjjxiskivl0s4mpmh52hqj7921v2bac7bvqd2hkc5cv";
-      name = "kdebugsettings-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdebugsettings-16.12.3.tar.xz";
+      sha256 = "0mkhklv4dynz23w8w9yh5qspdlfp3hi6fyiijyfwj358rqgbf3p5";
+      name = "kdebugsettings-16.12.3.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-dev-scripts-16.12.2.tar.xz";
-      sha256 = "0l4sbzpnczixavyppc3swb09jna44rb61awwgh37ngsz97iza3sx";
-      name = "kde-dev-scripts-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-dev-scripts-16.12.3.tar.xz";
+      sha256 = "0kiddn0wg90p98zgnpq3x2hcfw8xczn98nyd21zbkzz357v14pya";
+      name = "kde-dev-scripts-16.12.3.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-dev-utils-16.12.2.tar.xz";
-      sha256 = "0fhf9w5v355jsrr25yhj612gi0qh8kvrbfdfplns04q7viycn44f";
-      name = "kde-dev-utils-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-dev-utils-16.12.3.tar.xz";
+      sha256 = "0svbl7yd5vz285gaymxy5mz0ll6fviamrbd6fjhj7rc4qx1gjgin";
+      name = "kde-dev-utils-16.12.3.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdeedu-data-16.12.2.tar.xz";
-      sha256 = "05jhqasi5h5dl4xlydx6jmn1i81qd8q8bzimhc2f9bwakkhqf73b";
-      name = "kdeedu-data-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdeedu-data-16.12.3.tar.xz";
+      sha256 = "0vqzamp5fc2d0i9qn6986f3a1s1fdbrlzrsnimpdfcas5xngbv5m";
+      name = "kdeedu-data-16.12.3.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdegraphics-mobipocket-16.12.2.tar.xz";
-      sha256 = "07mpm55ipdqq6absvhcsrbc3c9xmb3b5bnl5k852mqpp0v36ijs8";
-      name = "kdegraphics-mobipocket-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdegraphics-mobipocket-16.12.3.tar.xz";
+      sha256 = "06zqny8idaw7s85h7iprbwdp7y1qspfp7yh5klwav12p72nn54w2";
+      name = "kdegraphics-mobipocket-16.12.3.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdegraphics-thumbnailers-16.12.2.tar.xz";
-      sha256 = "0asv8wjr5nm5i6zylvhn8qgxvpr79yg681rc6mg1liimimwzxia3";
-      name = "kdegraphics-thumbnailers-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdegraphics-thumbnailers-16.12.3.tar.xz";
+      sha256 = "01q2czzqq240cbp9yg7mji2q15kmiwn1aqs6iii00i56yy2mwaxq";
+      name = "kdegraphics-thumbnailers-16.12.3.tar.xz";
     };
   };
   kde-l10n-ar = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-ar-16.12.2.tar.xz";
-      sha256 = "0an0r2l4vc2sdi4lc2p7iks9gnwasgvxnq81vf3qb40q290x4fim";
-      name = "kde-l10n-ar-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ar-16.12.3.tar.xz";
+      sha256 = "1a6in9zq0a4a1v7mijm7gdrprkb5djp4qzyrbrwwlyzpk0sjs153";
+      name = "kde-l10n-ar-16.12.3.tar.xz";
     };
   };
   kde-l10n-ast = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-ast-16.12.2.tar.xz";
-      sha256 = "0fjpypz9w1ic9w75gpp1c71l43x3j8nm37h1bgbqkyik3spxin2l";
-      name = "kde-l10n-ast-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ast-16.12.3.tar.xz";
+      sha256 = "05di4xbm8viam0lz6gsyl8zip01dan5bb3h1ib7n7ri4rd49gb13";
+      name = "kde-l10n-ast-16.12.3.tar.xz";
     };
   };
   kde-l10n-bg = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-bg-16.12.2.tar.xz";
-      sha256 = "1iwcs8nz2rfi0b05ypl6mydiw02c64hscy3zlz998nww65x3nks0";
-      name = "kde-l10n-bg-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-bg-16.12.3.tar.xz";
+      sha256 = "1clqz50ri2zpsaqvlwq01jc44d2w4abpwaqd37jcvcpjg836kj32";
+      name = "kde-l10n-bg-16.12.3.tar.xz";
     };
   };
   kde-l10n-bs = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-bs-16.12.2.tar.xz";
-      sha256 = "0kps4paygx10l2nijwd946wns6sxlgn2771fzv1cmn5h1smffhkn";
-      name = "kde-l10n-bs-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-bs-16.12.3.tar.xz";
+      sha256 = "1lfpq4lixamh08vmmj8ai8pzdybs1anlg8vfb6lnxj3dpplxxjdv";
+      name = "kde-l10n-bs-16.12.3.tar.xz";
     };
   };
   kde-l10n-ca = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-ca-16.12.2.tar.xz";
-      sha256 = "0r6yccw7fdi2dsz9qf9rccgdmznkc66z5c51asdhrmyzq4x7c7r2";
-      name = "kde-l10n-ca-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ca-16.12.3.tar.xz";
+      sha256 = "1h3d7gdpixiqn4gyk1z9lj5k4bhf4719w1rcfzcajrpwrmvdfvms";
+      name = "kde-l10n-ca-16.12.3.tar.xz";
     };
   };
   kde-l10n-ca_valencia = {
-    version = "ca_valencia-16.12.2";
+    version = "ca_valencia-16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-ca@valencia-16.12.2.tar.xz";
-      sha256 = "15wpsjzk9z61rpai8dzpzi5j9w57nmhm7fx4b6i5hsr9c4ypmi01";
-      name = "kde-l10n-ca_valencia-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ca@valencia-16.12.3.tar.xz";
+      sha256 = "00g1124n84lq380srykcr4yigqr5w9xivssj27jf1ak40vyanln0";
+      name = "kde-l10n-ca_valencia-16.12.3.tar.xz";
     };
   };
   kde-l10n-cs = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-cs-16.12.2.tar.xz";
-      sha256 = "1z6a3rl7p0wmq6zs8fap052dp5hvlpzxf4xvjxk9c75wl2m9nvlg";
-      name = "kde-l10n-cs-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-cs-16.12.3.tar.xz";
+      sha256 = "0nvl0lbg1pw1r73ggycfqjvlga6lg7gyin4bigyjcq41k9y6xf91";
+      name = "kde-l10n-cs-16.12.3.tar.xz";
     };
   };
   kde-l10n-da = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-da-16.12.2.tar.xz";
-      sha256 = "0zi7h0cvzza1ly88821fsl2bnr2vn524rrdqsfc9yj3z1jbpnn2h";
-      name = "kde-l10n-da-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-da-16.12.3.tar.xz";
+      sha256 = "1bsv0z0q5fqgn2jkgazm3aazi6s9crz23acwx9p2w7fc7h98bqpq";
+      name = "kde-l10n-da-16.12.3.tar.xz";
     };
   };
   kde-l10n-de = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-de-16.12.2.tar.xz";
-      sha256 = "0s1c22ad1r0qxpkc878gxz2wqkb52qrn1k753kqpn9105p5l92fh";
-      name = "kde-l10n-de-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-de-16.12.3.tar.xz";
+      sha256 = "0ym6f1n86rvbwdk0xlx2ajfv4l70kw3qir8z82d2jf5dhgz9h2k6";
+      name = "kde-l10n-de-16.12.3.tar.xz";
     };
   };
   kde-l10n-el = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-el-16.12.2.tar.xz";
-      sha256 = "02d4j12yr4v9apa3iziza611v6cgjf6725wgd41g00pj41p61kcq";
-      name = "kde-l10n-el-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-el-16.12.3.tar.xz";
+      sha256 = "1dd51kh52rq9y3r2iz985ib2bpi109vf2xv2abkm8ddsfmb1mq6c";
+      name = "kde-l10n-el-16.12.3.tar.xz";
     };
   };
   kde-l10n-en_GB = {
-    version = "en_GB-16.12.2";
+    version = "en_GB-16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-en_GB-16.12.2.tar.xz";
-      sha256 = "09h3zsq5qhzyagl8xysv74g2iv26739y02xgbwv5dahv0iln99rs";
-      name = "kde-l10n-en_GB-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-en_GB-16.12.3.tar.xz";
+      sha256 = "0yc6fk5ak0442gv1gxwwz2zz13s9d1ihlfkvl8aqi6zky5b6c91n";
+      name = "kde-l10n-en_GB-16.12.3.tar.xz";
     };
   };
   kde-l10n-eo = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-eo-16.12.2.tar.xz";
-      sha256 = "1isqdnnj1g9jxagns3yq611pfd6nbanji9a8igfgm55djj5hx527";
-      name = "kde-l10n-eo-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-eo-16.12.3.tar.xz";
+      sha256 = "0p43p1as9s2x4145k59li39fvg77c38mjnlb16zhb5bg5c0r1401";
+      name = "kde-l10n-eo-16.12.3.tar.xz";
     };
   };
   kde-l10n-es = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-es-16.12.2.tar.xz";
-      sha256 = "0h3c5an1i072rk9mkc9mc6k3bvlk37slhgl6qy3rs2l77mhhnpyi";
-      name = "kde-l10n-es-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-es-16.12.3.tar.xz";
+      sha256 = "194svk1axicbijy4ywsrn1q27pzrm3g139i63388qh3lzv8654p1";
+      name = "kde-l10n-es-16.12.3.tar.xz";
     };
   };
   kde-l10n-et = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-et-16.12.2.tar.xz";
-      sha256 = "0dpkxwpl17pgimx94v67wq90fzdayp6p3wcz7y0g8b0hn3bsbidj";
-      name = "kde-l10n-et-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-et-16.12.3.tar.xz";
+      sha256 = "1q0mrc517jr5hicklhzvs6vw5vwgvb2gj3fi93a9iqxbw1a794pk";
+      name = "kde-l10n-et-16.12.3.tar.xz";
     };
   };
   kde-l10n-eu = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-eu-16.12.2.tar.xz";
-      sha256 = "0q7l5s502ayr2vfa4ysvk4c6k5i8y5ci6yb34mm3lpwlain3bssb";
-      name = "kde-l10n-eu-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-eu-16.12.3.tar.xz";
+      sha256 = "0dgwklynwwksdm0dxk8dm53y0v92kfin6vgwpn2scc97fns16r08";
+      name = "kde-l10n-eu-16.12.3.tar.xz";
     };
   };
   kde-l10n-fa = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-fa-16.12.2.tar.xz";
-      sha256 = "03qvv814kvddf24fjvg55pbxaq58kc936b5qwbddxjr05n1dy964";
-      name = "kde-l10n-fa-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-fa-16.12.3.tar.xz";
+      sha256 = "1ywipqg2dv3dapp3m7sfhap4izhabb4srk3gpl2kd2wx0abnwmdb";
+      name = "kde-l10n-fa-16.12.3.tar.xz";
     };
   };
   kde-l10n-fi = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-fi-16.12.2.tar.xz";
-      sha256 = "0902bbyi10vpn0qn0xn46p8fy98kaa4cvlgnn4cb2dgp8q3kni8j";
-      name = "kde-l10n-fi-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-fi-16.12.3.tar.xz";
+      sha256 = "11grklvacq70mq4fj0772v8xqmp1b1pl7gff8gvy692rva5qhv29";
+      name = "kde-l10n-fi-16.12.3.tar.xz";
     };
   };
   kde-l10n-fr = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-fr-16.12.2.tar.xz";
-      sha256 = "0zjlryvyq8z2llrba4hp3awz5hq74b6z21wp2x86g4k6y154i0as";
-      name = "kde-l10n-fr-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-fr-16.12.3.tar.xz";
+      sha256 = "0qx849ilp1597nxrx6cmgnmm202all14y8pcyd19gp70wdra8wcm";
+      name = "kde-l10n-fr-16.12.3.tar.xz";
     };
   };
   kde-l10n-ga = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-ga-16.12.2.tar.xz";
-      sha256 = "1gwd4r28qv5sh4r008nq5mdzzb8cwq8dg17r19l3syydxxhjlf86";
-      name = "kde-l10n-ga-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ga-16.12.3.tar.xz";
+      sha256 = "06w92m84bxqs06gyi45x1jmzh99ip7vnnzjq7ixx7ny9k6m0as1m";
+      name = "kde-l10n-ga-16.12.3.tar.xz";
     };
   };
   kde-l10n-gl = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-gl-16.12.2.tar.xz";
-      sha256 = "1jka29dh5aqdzgmqc9rf3lmrq4mm4vahhsk2klhp12ajzp9dgg70";
-      name = "kde-l10n-gl-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-gl-16.12.3.tar.xz";
+      sha256 = "1k6jydmqbmxfkimxqn8qhd136zdjz4z7d5mk0n80607n91y7n3kv";
+      name = "kde-l10n-gl-16.12.3.tar.xz";
     };
   };
   kde-l10n-he = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-he-16.12.2.tar.xz";
-      sha256 = "0g87g0mpa3i59fk4fm5hk2z54s07cy9niy2kal50fbm5lnr7czfk";
-      name = "kde-l10n-he-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-he-16.12.3.tar.xz";
+      sha256 = "1ry1wd9ng5xwpi402p1rqbsrb0ma7bgkmx53yygzc5mpszarga6y";
+      name = "kde-l10n-he-16.12.3.tar.xz";
     };
   };
   kde-l10n-hi = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-hi-16.12.2.tar.xz";
-      sha256 = "05q608wic0ssx0d14n39s786k8xw86hc560ywfs3k89v973nba5b";
-      name = "kde-l10n-hi-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-hi-16.12.3.tar.xz";
+      sha256 = "1qwjiarqi8c3b15nc2nqrxvb6pcrb232qcx6nz0f9day2d0zxdwk";
+      name = "kde-l10n-hi-16.12.3.tar.xz";
     };
   };
   kde-l10n-hr = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-hr-16.12.2.tar.xz";
-      sha256 = "0sm7ba6x3hgw1ml6qm00g9dfi56w2kx3pk37944l3r4jx2wdqs4f";
-      name = "kde-l10n-hr-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-hr-16.12.3.tar.xz";
+      sha256 = "0y3pvdy1pkhraahsfkwhkar6004ll19gd6rhhhzgaw0irmw1yxp1";
+      name = "kde-l10n-hr-16.12.3.tar.xz";
     };
   };
   kde-l10n-hu = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-hu-16.12.2.tar.xz";
-      sha256 = "1qcdqm6wjcgd5br99mm93lwlaxk5dvrliyj1ff4bxfxx0cabhx2g";
-      name = "kde-l10n-hu-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-hu-16.12.3.tar.xz";
+      sha256 = "001pl0l0cj4f2j7c6fjv9jv4wnkk2zb428y8szqm78zg85ms9wpz";
+      name = "kde-l10n-hu-16.12.3.tar.xz";
     };
   };
   kde-l10n-ia = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-ia-16.12.2.tar.xz";
-      sha256 = "0r1fryhi4czgbl1r228zry0msk11s075y15i4flznwdps99s5q8c";
-      name = "kde-l10n-ia-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ia-16.12.3.tar.xz";
+      sha256 = "09p9r6xzirr6cwcjdg10db62g3d4z0ksl6caf45rz0i2k5zn4r6r";
+      name = "kde-l10n-ia-16.12.3.tar.xz";
     };
   };
   kde-l10n-id = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-id-16.12.2.tar.xz";
-      sha256 = "1lz51bilx8dziiff65l91pknif9w7390q3l9amdlcjq86cj44khz";
-      name = "kde-l10n-id-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-id-16.12.3.tar.xz";
+      sha256 = "1kanlr401ljaaqijhdvv52lvrn90m9b0l6i2jly8mdnnnwp896ra";
+      name = "kde-l10n-id-16.12.3.tar.xz";
     };
   };
   kde-l10n-is = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-is-16.12.2.tar.xz";
-      sha256 = "08bqhxppib360ywzmphjqx5yalzr3bgwpqkff79rl5ffq9dd4psv";
-      name = "kde-l10n-is-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-is-16.12.3.tar.xz";
+      sha256 = "10a9sxjnv9xb9wy04b9pfwpj4xg22x0ami37jhwggpskl9sj736v";
+      name = "kde-l10n-is-16.12.3.tar.xz";
     };
   };
   kde-l10n-it = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-it-16.12.2.tar.xz";
-      sha256 = "12k9vqdr2nrcqh535crylxrmznndx7bkwz68vrdvqidlabd0ci7m";
-      name = "kde-l10n-it-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-it-16.12.3.tar.xz";
+      sha256 = "0f771kli3zw6dgwdxgk19kiy6gwv9yj3f2cgiyxaiak8yawa9ary";
+      name = "kde-l10n-it-16.12.3.tar.xz";
     };
   };
   kde-l10n-ja = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-ja-16.12.2.tar.xz";
-      sha256 = "0i9hc66qlnq0yij9d3754m5wa2wkra95wcdbp6xwk82ws7lkckai";
-      name = "kde-l10n-ja-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ja-16.12.3.tar.xz";
+      sha256 = "1p0arv340i34gdlkdbjw234c9a4jqy8z417f0p19pn6ic3i5i6yv";
+      name = "kde-l10n-ja-16.12.3.tar.xz";
     };
   };
   kde-l10n-kk = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-kk-16.12.2.tar.xz";
-      sha256 = "1h9scz1z046szxf54702w3wzlsvzr8016rx9fwg7z5fc1vpkhxxn";
-      name = "kde-l10n-kk-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-kk-16.12.3.tar.xz";
+      sha256 = "1ik3abczhxkm2b8i22akz12q5lm7rsc7i4qdz6ml1sn4kd0949i5";
+      name = "kde-l10n-kk-16.12.3.tar.xz";
     };
   };
   kde-l10n-km = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-km-16.12.2.tar.xz";
-      sha256 = "09vw686y9qdx09cz58d11ldqz5bsnch1sx2dsbxvp1drypb1nhxk";
-      name = "kde-l10n-km-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-km-16.12.3.tar.xz";
+      sha256 = "1lwpfkv87i6km9pxrm78cqnnb1jnysaij0lmgvz2d0bs6dldaxrs";
+      name = "kde-l10n-km-16.12.3.tar.xz";
     };
   };
   kde-l10n-ko = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-ko-16.12.2.tar.xz";
-      sha256 = "1q9kla2djqsvkj773wybxb1lds50v0lg3jkfpnrg2pvm49jl2c9g";
-      name = "kde-l10n-ko-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ko-16.12.3.tar.xz";
+      sha256 = "0c0hkprngxyxj2sf05s5i0y04i5f4vgqis1mgq500l03q0x16b4y";
+      name = "kde-l10n-ko-16.12.3.tar.xz";
     };
   };
   kde-l10n-lt = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-lt-16.12.2.tar.xz";
-      sha256 = "1i6nzmqm1sl895x7hnsk9snw2ci8cbdvswdfbvllqivcd8l4vmg5";
-      name = "kde-l10n-lt-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-lt-16.12.3.tar.xz";
+      sha256 = "04d2l2qisbpzxppxchfrxnijc8706pq3s9pgmyyy6c0v26gsgz77";
+      name = "kde-l10n-lt-16.12.3.tar.xz";
     };
   };
   kde-l10n-lv = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-lv-16.12.2.tar.xz";
-      sha256 = "0why1sa09pd7pwwa57c27y969ijgmjsmni8x7n9gxx5w0317kq9d";
-      name = "kde-l10n-lv-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-lv-16.12.3.tar.xz";
+      sha256 = "1af13p7ri4x3dhwlv30gf7za7dgsr1kx3khzlgdg4hcgi2s4aq12";
+      name = "kde-l10n-lv-16.12.3.tar.xz";
     };
   };
   kde-l10n-mr = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-mr-16.12.2.tar.xz";
-      sha256 = "0wkncbs5di9vlcfqbc8g4msp6kp926049jlkj4jhvgj1in434ay8";
-      name = "kde-l10n-mr-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-mr-16.12.3.tar.xz";
+      sha256 = "16g8ln11x9qpda4wgzwvvij77bdpsdd6vsh7ysik8fc87km4qkax";
+      name = "kde-l10n-mr-16.12.3.tar.xz";
     };
   };
   kde-l10n-nb = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-nb-16.12.2.tar.xz";
-      sha256 = "0p9yq33jzh83c1471072p94mrx8jazrinb987ifrl5lk8m54k34z";
-      name = "kde-l10n-nb-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-nb-16.12.3.tar.xz";
+      sha256 = "091wm8z6ibw8by220j89xdf0vpk7dp341hph2dhz17ykdzck3cdf";
+      name = "kde-l10n-nb-16.12.3.tar.xz";
     };
   };
   kde-l10n-nds = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-nds-16.12.2.tar.xz";
-      sha256 = "1yb7axm4k1rlfp41s9q8ql7l2mjbyrf7ry1ww7c1rprcb93gm7f8";
-      name = "kde-l10n-nds-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-nds-16.12.3.tar.xz";
+      sha256 = "052nw25rd3vq0fkixcwmn1iwaxnfwcg7iarf78c276w6vzrbvvcc";
+      name = "kde-l10n-nds-16.12.3.tar.xz";
     };
   };
   kde-l10n-nl = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-nl-16.12.2.tar.xz";
-      sha256 = "04d75kfxxijb4a7xk5saxz5vbrwfsl2nx0i4x3d4i2k06wzysvch";
-      name = "kde-l10n-nl-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-nl-16.12.3.tar.xz";
+      sha256 = "0axlpjq70142blccsfqbh7zs7l8k31mkc30lr79d03975dp2ivzi";
+      name = "kde-l10n-nl-16.12.3.tar.xz";
     };
   };
   kde-l10n-nn = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-nn-16.12.2.tar.xz";
-      sha256 = "09vmvvmakcybgy6zl51xj05wflq88xkbjmns4wv42jf0fn4kipif";
-      name = "kde-l10n-nn-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-nn-16.12.3.tar.xz";
+      sha256 = "0ql8pvj47kwvdaj2gsjlc4rxb7mpl9nv4fraavffinv4xzrh0v18";
+      name = "kde-l10n-nn-16.12.3.tar.xz";
     };
   };
   kde-l10n-pa = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-pa-16.12.2.tar.xz";
-      sha256 = "0nv9pch0s24aamcz8lgbs26kp343kyw0rnz4a7myzcrb8g8sm0d3";
-      name = "kde-l10n-pa-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-pa-16.12.3.tar.xz";
+      sha256 = "0r2snb5bkvha8yj692g1y8xwdwcnav06w3qliz1v7jiyb6hv8ncm";
+      name = "kde-l10n-pa-16.12.3.tar.xz";
     };
   };
   kde-l10n-pl = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-pl-16.12.2.tar.xz";
-      sha256 = "1bxhcqwmcfl2srfrn50ib57890m3m6w4x9vwn24qxwapb9s6nzav";
-      name = "kde-l10n-pl-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-pl-16.12.3.tar.xz";
+      sha256 = "1bp8br37wfn3xlxl4hzr45sv41w2i562rgjcj25ngn27y7cqvwq5";
+      name = "kde-l10n-pl-16.12.3.tar.xz";
     };
   };
   kde-l10n-pt = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-pt-16.12.2.tar.xz";
-      sha256 = "02x96cdvrbdcmrhnn4pamsdnr8m530p047avh82xvjvqywsnqf7z";
-      name = "kde-l10n-pt-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-pt-16.12.3.tar.xz";
+      sha256 = "1f3ray689q3w4yr20j0bj8vvwyb1qzi608ip0p6n4nzjkq3ycqh6";
+      name = "kde-l10n-pt-16.12.3.tar.xz";
     };
   };
   kde-l10n-pt_BR = {
-    version = "pt_BR-16.12.2";
+    version = "pt_BR-16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-pt_BR-16.12.2.tar.xz";
-      sha256 = "17155laifayfb5c2hznlpnmaa8kwxzlmk7yb2skrf92fzzqx2379";
-      name = "kde-l10n-pt_BR-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-pt_BR-16.12.3.tar.xz";
+      sha256 = "06h0dp54n8brv7kcfdbxy3yxk6c5b1ncbd9fzmflr8bpivifj66s";
+      name = "kde-l10n-pt_BR-16.12.3.tar.xz";
     };
   };
   kde-l10n-ro = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-ro-16.12.2.tar.xz";
-      sha256 = "1zsng3m031cbyz1jl5lv1fjg5vb3ig3pk0gaamvxbs6fxaz14ss3";
-      name = "kde-l10n-ro-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ro-16.12.3.tar.xz";
+      sha256 = "17kbkh50jf8zb9p3kl2malddvq08ybg881x1w5gmw514k3d3hwxh";
+      name = "kde-l10n-ro-16.12.3.tar.xz";
     };
   };
   kde-l10n-ru = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-ru-16.12.2.tar.xz";
-      sha256 = "1shs2j4kqqf2b8jz2691yi45f5bpsr9nx2i5j67mmn94dnds4ps6";
-      name = "kde-l10n-ru-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ru-16.12.3.tar.xz";
+      sha256 = "12ghgwy84i6nmlgi8wmvhxn7d9mvanhyd6pqyd302r5x0zxd8rza";
+      name = "kde-l10n-ru-16.12.3.tar.xz";
     };
   };
   kde-l10n-sk = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-sk-16.12.2.tar.xz";
-      sha256 = "1397sxczn9jdxbab3d9296w15swc40a8ypa3f4yhckqm4nmr8xn1";
-      name = "kde-l10n-sk-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-sk-16.12.3.tar.xz";
+      sha256 = "0hc1cm2npsw2w9mx09kn9jxvaqpjhv6snhwdi2mybpbs9qmgnzcn";
+      name = "kde-l10n-sk-16.12.3.tar.xz";
     };
   };
   kde-l10n-sl = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-sl-16.12.2.tar.xz";
-      sha256 = "1z14sbdk5zdshn36wija4hkj7l825i336bz92rq42f8by4mha0h4";
-      name = "kde-l10n-sl-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-sl-16.12.3.tar.xz";
+      sha256 = "02d0fg40pvlr6wnxg425n3fpqpizvdppznyp8nnxbzb9ia583aw0";
+      name = "kde-l10n-sl-16.12.3.tar.xz";
     };
   };
   kde-l10n-sr = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-sr-16.12.2.tar.xz";
-      sha256 = "12v6whnydgxxpx9vl3pimnxqny22kfiv51i1r9dk6vfqik18kxzy";
-      name = "kde-l10n-sr-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-sr-16.12.3.tar.xz";
+      sha256 = "1yq44dykajcz4n10zrad85lji30phr9cm5dnmx4s08404qwh68cz";
+      name = "kde-l10n-sr-16.12.3.tar.xz";
     };
   };
   kde-l10n-sv = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-sv-16.12.2.tar.xz";
-      sha256 = "10dzz39779lbb5mcnnmhwm86pkwc2g5qyiqg5jzpf0mg1zbl9y3w";
-      name = "kde-l10n-sv-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-sv-16.12.3.tar.xz";
+      sha256 = "1q8ags96jwjrihi8ai8139c3s9nfy7v7lss9ci3xl786hyggdlrb";
+      name = "kde-l10n-sv-16.12.3.tar.xz";
     };
   };
   kde-l10n-tr = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-tr-16.12.2.tar.xz";
-      sha256 = "0m4rgz7ha2i9bladavc5g3n94kai82ilx8akd2jcxz6q3wb75r0r";
-      name = "kde-l10n-tr-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-tr-16.12.3.tar.xz";
+      sha256 = "1l24d0abhhlbam0wfz52495nvjy1blfid9h31233hkykb782gi0n";
+      name = "kde-l10n-tr-16.12.3.tar.xz";
     };
   };
   kde-l10n-ug = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-ug-16.12.2.tar.xz";
-      sha256 = "1kjdiy92pi5vdxbfy61ckq8j9pc8kmrccfqnlm7yqvh8p5i28p2x";
-      name = "kde-l10n-ug-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ug-16.12.3.tar.xz";
+      sha256 = "0sb4136wjyg9g1fvhcgqv97wpv82ia37aknd8xcvjnp5n2jl80nn";
+      name = "kde-l10n-ug-16.12.3.tar.xz";
     };
   };
   kde-l10n-uk = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-uk-16.12.2.tar.xz";
-      sha256 = "1nhclnwy5lgkzhs6lm8dkhh4957v78rv2d9ss13a1jn2salz5kfv";
-      name = "kde-l10n-uk-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-uk-16.12.3.tar.xz";
+      sha256 = "073pqvxbpibwd1bv0vh4rijgkhg061g2gaaaqnckaakw677g2bmz";
+      name = "kde-l10n-uk-16.12.3.tar.xz";
     };
   };
   kde-l10n-wa = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-wa-16.12.2.tar.xz";
-      sha256 = "12f2kvks21hj5gjqjys7fa295148j0ndhxbzs5jysl0zq9y4909j";
-      name = "kde-l10n-wa-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-wa-16.12.3.tar.xz";
+      sha256 = "14qms294pz7hf4ramhscif9n6jfk5ixfwww558ypi0lwnzc17mrf";
+      name = "kde-l10n-wa-16.12.3.tar.xz";
     };
   };
   kde-l10n-zh_CN = {
-    version = "zh_CN-16.12.2";
+    version = "zh_CN-16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-zh_CN-16.12.2.tar.xz";
-      sha256 = "1v21kap5lyzgygqv02jjx9yrfnkjkk0qrd85l0pjhqjyycs5r97w";
-      name = "kde-l10n-zh_CN-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-zh_CN-16.12.3.tar.xz";
+      sha256 = "01q92gc13wjpd2gzvn1sipgl5xs86mwq8y0583glsx7s2wfp3g41";
+      name = "kde-l10n-zh_CN-16.12.3.tar.xz";
     };
   };
   kde-l10n-zh_TW = {
-    version = "zh_TW-16.12.2";
+    version = "zh_TW-16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-l10n/kde-l10n-zh_TW-16.12.2.tar.xz";
-      sha256 = "049q9d9ykhxk0dkmm4aw7fx1aa39s5cslk4011335jmg1msmrfna";
-      name = "kde-l10n-zh_TW-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-zh_TW-16.12.3.tar.xz";
+      sha256 = "0a9xnxlbr5469k1ij7hc8wa5p38r3yqq1d9fxmmpqyj111v63g3h";
+      name = "kde-l10n-zh_TW-16.12.3.tar.xz";
     };
   };
   kdelibs = {
-    version = "4.14.29";
+    version = "4.14.30";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdelibs-4.14.29.tar.xz";
-      sha256 = "0xvw0cscvz8arclgfhrrbgdg94mz4h9y33nyndlsw67qrbg8slqv";
-      name = "kdelibs-4.14.29.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdelibs-4.14.30.tar.xz";
+      sha256 = "0v8r70d55c4jhfhnh8lj41584qggc2lb4f6jwm4yl9qc6bpw77x3";
+      name = "kdelibs-4.14.30.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdenetwork-filesharing-16.12.2.tar.xz";
-      sha256 = "0q43c2xim5ibxyib1xz1wfz6bigkmk97bkvy9wrlk869c0qvrcn5";
-      name = "kdenetwork-filesharing-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdenetwork-filesharing-16.12.3.tar.xz";
+      sha256 = "0345wq7ayahfd2jlpgfs18c7nrdp9gn9yxig2x75pspqmb5pgxh7";
+      name = "kdenetwork-filesharing-16.12.3.tar.xz";
     };
   };
   kdenlive = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdenlive-16.12.2.tar.xz";
-      sha256 = "116lk641qlx8jkiaxm54g6svc6adg0bilhf634cyc8c46991a8z7";
-      name = "kdenlive-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdenlive-16.12.3.tar.xz";
+      sha256 = "1z7afrx00yaracf6cv9p8r14gqampabya8li6ws1ihzdgfamlkd0";
+      name = "kdenlive-16.12.3.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdepim-addons-16.12.2.tar.xz";
-      sha256 = "1gi87bbdkj8cwinhicr5r6qxysc5rmylj8gajn0qh99rsyxy52dn";
-      name = "kdepim-addons-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdepim-addons-16.12.3.tar.xz";
+      sha256 = "1hqm7vi7fy7s17djayq9q7l3dxdnzk2ii78mjdg90aac9cxdxgmm";
+      name = "kdepim-addons-16.12.3.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdepim-apps-libs-16.12.2.tar.xz";
-      sha256 = "07imq7nb1aqan8pbapvqg9mkzj18pj1v9xah9lpi6k64rhh0bkw9";
-      name = "kdepim-apps-libs-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdepim-apps-libs-16.12.3.tar.xz";
+      sha256 = "1q4ksp377piqxbs843nxafzssz80ayjii90iz86r2z2rd3lyrjzw";
+      name = "kdepim-apps-libs-16.12.3.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdepim-runtime-16.12.2.tar.xz";
-      sha256 = "0wd04zhc7nq2qf8iyjqf036bjs5by0zl0c58hl8r579b7gp5xljz";
-      name = "kdepim-runtime-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdepim-runtime-16.12.3.tar.xz";
+      sha256 = "0j5c3y8bqnffcrx4g7ilq7id46h11d1hiw81l7x4mg1p0zw07bg1";
+      name = "kdepim-runtime-16.12.3.tar.xz";
     };
   };
   kde-runtime = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kde-runtime-16.12.2.tar.xz";
-      sha256 = "1bsnb7inxqv652vq9izwdj02gi15xxf34my51kdq2xk9dn2kmj8x";
-      name = "kde-runtime-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kde-runtime-16.12.3.tar.xz";
+      sha256 = "1sqp827l30adiqrp12djx3xk6mlz2lb46hmxnbnzv52mv2whcr3y";
+      name = "kde-runtime-16.12.3.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdesdk-kioslaves-16.12.2.tar.xz";
-      sha256 = "18wd4lb3v2br40xclsig718r8mqs5hgl7xw13pq5bfqk5kx11md1";
-      name = "kdesdk-kioslaves-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdesdk-kioslaves-16.12.3.tar.xz";
+      sha256 = "17zqp43a1266616h3g6yccjmfgwni6lr8lz4rrvfda275vvwbshj";
+      name = "kdesdk-kioslaves-16.12.3.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdesdk-thumbnailers-16.12.2.tar.xz";
-      sha256 = "1jjchrbpyxjzs4zv68av53zhnlj46705261p0ad7x9ayb1mdrr24";
-      name = "kdesdk-thumbnailers-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdesdk-thumbnailers-16.12.3.tar.xz";
+      sha256 = "0p2s6pyq16jmjv29r8n9ygvsh1dxgz9zk90mk138cxxhbx9nks9h";
+      name = "kdesdk-thumbnailers-16.12.3.tar.xz";
     };
   };
   kdf = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdf-16.12.2.tar.xz";
-      sha256 = "0zkwqqrcna2f9j4g798lhdi2v5j9p6r3zqkhf7clh4nk2c6f766k";
-      name = "kdf-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdf-16.12.3.tar.xz";
+      sha256 = "1502ib1hlc5xxsphspxwj8jvjm7qig0zdwckvm3nmh7hf4474sc5";
+      name = "kdf-16.12.3.tar.xz";
     };
   };
   kdialog = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdialog-16.12.2.tar.xz";
-      sha256 = "0jrp06zbdj5c3nigdard0a7whb3lg8j2lgnf3dp2gf7iqj8gb189";
-      name = "kdialog-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdialog-16.12.3.tar.xz";
+      sha256 = "161barz5x9jrdk2p5hqc2vk1rqfwn8nlhdmc1vjqnhvww786ghmh";
+      name = "kdialog-16.12.3.tar.xz";
     };
   };
   kdiamond = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kdiamond-16.12.2.tar.xz";
-      sha256 = "1bflb2lbhahwmcqzck0xbr39rcbyaw4fzjaalbsdf9n5mk5ixmxs";
-      name = "kdiamond-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kdiamond-16.12.3.tar.xz";
+      sha256 = "0qdh9ngrz5ph0kly27c58sxhwamqm3wq566337yhdqjizzcin4pf";
+      name = "kdiamond-16.12.3.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/keditbookmarks-16.12.2.tar.xz";
-      sha256 = "16a2sq92r6nq7ksp905xp9v3fv8ynhfp9hslq4a46v71an06yh4p";
-      name = "keditbookmarks-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/keditbookmarks-16.12.3.tar.xz";
+      sha256 = "0dn3jb5lsjj2c6pbrbn4cik68fqqk99ljl45vbal9cc27lmrfa2n";
+      name = "keditbookmarks-16.12.3.tar.xz";
     };
   };
   kfilereplace = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kfilereplace-16.12.2.tar.xz";
-      sha256 = "086x9k71s2bc80863vlfryblg0cyw1qhk20vwhxmq81xkxsah6ky";
-      name = "kfilereplace-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kfilereplace-16.12.3.tar.xz";
+      sha256 = "0gym9bmkyjwg97khy6xxiaidjp6wi98fzmk7wa97wbdqc0qvswja";
+      name = "kfilereplace-16.12.3.tar.xz";
     };
   };
   kfind = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kfind-16.12.2.tar.xz";
-      sha256 = "0jpn75d331qiyhqswflkad5nc5r6c21q1d8236k2qvcm80xp10bm";
-      name = "kfind-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kfind-16.12.3.tar.xz";
+      sha256 = "1d7rn3xri4dgv97s6jw3n4cbsg73zyrbcm3ligxgj37ziggrhgsj";
+      name = "kfind-16.12.3.tar.xz";
     };
   };
   kfloppy = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kfloppy-16.12.2.tar.xz";
-      sha256 = "1q1fh16msixpn59y0yglmjbib6a5c9pb3hpmcd5vsiy2ilpgffbm";
-      name = "kfloppy-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kfloppy-16.12.3.tar.xz";
+      sha256 = "07mgrpjqd2kdz5gmg8ylmvdb4mis328b7qlchszdx0l1z30kqkzp";
+      name = "kfloppy-16.12.3.tar.xz";
     };
   };
   kfourinline = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kfourinline-16.12.2.tar.xz";
-      sha256 = "1df3si16d4ra3x3v9m4kiknlflx1ac10fq3vydcsn4yi89rhx2ix";
-      name = "kfourinline-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kfourinline-16.12.3.tar.xz";
+      sha256 = "087c00sggx5i1g8i2rjvvwlys15bisgx9fm2nl8f30h2ba3im4sg";
+      name = "kfourinline-16.12.3.tar.xz";
     };
   };
   kgeography = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kgeography-16.12.2.tar.xz";
-      sha256 = "1sw7blr264p88702718m5ch9qdzyd5krpf5qjvfhypx0fgzr40b6";
-      name = "kgeography-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kgeography-16.12.3.tar.xz";
+      sha256 = "1rnk00nj29zimpw36vhm0yrwlmpmxwv9wzxnhr7n2jq5qhbqsp5g";
+      name = "kgeography-16.12.3.tar.xz";
     };
   };
   kget = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kget-16.12.2.tar.xz";
-      sha256 = "1qiwcbdvr9g7cgqm4i3gcc6aw60d36n2m8a7faqa28srrw8f55lj";
-      name = "kget-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kget-16.12.3.tar.xz";
+      sha256 = "0h8nklsl6gddwzgjig5cwp463s96ffn5688zjlsyx4hphnvbj8kb";
+      name = "kget-16.12.3.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kgoldrunner-16.12.2.tar.xz";
-      sha256 = "0sa7yf3656f8mib785xdv7q86gsslx1hwy69vqrnrfwg24vzx3gy";
-      name = "kgoldrunner-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kgoldrunner-16.12.3.tar.xz";
+      sha256 = "028kz5x8a3jb3zp3vfxajmszrqk859hdln9175pp6zj78b278xz4";
+      name = "kgoldrunner-16.12.3.tar.xz";
     };
   };
   kgpg = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kgpg-16.12.2.tar.xz";
-      sha256 = "082fvxpawhsvfn6c1y32rvgp2qcim6lnk1gpp92cgn6k70dcx4lr";
-      name = "kgpg-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kgpg-16.12.3.tar.xz";
+      sha256 = "0abh15j2p0vinskd8f1yvjkyi1a70k0wf1sdldrfdwpdgq1pqsxw";
+      name = "kgpg-16.12.3.tar.xz";
     };
   };
   khangman = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/khangman-16.12.2.tar.xz";
-      sha256 = "1v57za5bqhppc1fy2xd7d1x1fvanwxgl3xzckfz1k7kbx1kcpn1s";
-      name = "khangman-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/khangman-16.12.3.tar.xz";
+      sha256 = "03ffigr9a6n3aj1a7lxcw9wgf1pafdjwqjnwnny2ric5vn6lpq1z";
+      name = "khangman-16.12.3.tar.xz";
     };
   };
   khelpcenter = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/khelpcenter-16.12.2.tar.xz";
-      sha256 = "1cij7v57zs14ynvmplcgn14m30hdc554kvrsbjgb695kmcvm1jv9";
-      name = "khelpcenter-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/khelpcenter-16.12.3.tar.xz";
+      sha256 = "100xcjjjbszhbwgydbylk9m9lrxikjyazmhaq2rvv2mfzsbijjm7";
+      name = "khelpcenter-16.12.3.tar.xz";
     };
   };
   kholidays = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kholidays-16.12.2.tar.xz";
-      sha256 = "0pybdq2asx10sxf4kz1p85yfs66dhccz2xvf95n8hky7833kqs1n";
-      name = "kholidays-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kholidays-16.12.3.tar.xz";
+      sha256 = "09iwkqpnmn3h7yfin4y9izb2sdk6hrm8rfq106cnz7j8i31q93ad";
+      name = "kholidays-16.12.3.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kidentitymanagement-16.12.2.tar.xz";
-      sha256 = "0wv7b3rfysbsj87xgp5ymy5glh9p12i9x8ffv483nm8xqyzwaa9p";
-      name = "kidentitymanagement-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kidentitymanagement-16.12.3.tar.xz";
+      sha256 = "1b23cwdhc7rv260kmn4akff3jfa21hk49p0kp8p0mf6nw6qahbvp";
+      name = "kidentitymanagement-16.12.3.tar.xz";
     };
   };
   kig = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kig-16.12.2.tar.xz";
-      sha256 = "0v261pb1l7cnjkqcqfg3885wxa2hb2bgdk0a1dcwrg4q6fr9kw1g";
-      name = "kig-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kig-16.12.3.tar.xz";
+      sha256 = "0fnlgxwcnspaqzv4y40xm0kq3xwwd4r5abh7ssbd6iqsbzgm6ghw";
+      name = "kig-16.12.3.tar.xz";
     };
   };
   kigo = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kigo-16.12.2.tar.xz";
-      sha256 = "19sns6w32pm12634xqxx53hgpmrb4ggzx2idcx3ldknbixhmqm7c";
-      name = "kigo-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kigo-16.12.3.tar.xz";
+      sha256 = "08rdz91jzz79884xhg87cwy57q1jk2414shyxxy9r0pb4wdcdbhn";
+      name = "kigo-16.12.3.tar.xz";
     };
   };
   killbots = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/killbots-16.12.2.tar.xz";
-      sha256 = "1cc2ddmp7a21yn0aavbh887j4xmzm2a6xlyq71b3msraw3p5vbmy";
-      name = "killbots-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/killbots-16.12.3.tar.xz";
+      sha256 = "0lwniwm8cbnwpqhfis38x5qvkz53626v9bn00amml57zj8x3hjnd";
+      name = "killbots-16.12.3.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kimagemapeditor-16.12.2.tar.xz";
-      sha256 = "0n82v73da8hnan2c96g2lxy826dg6xhln28wwr8iib89zd5gmbi6";
-      name = "kimagemapeditor-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kimagemapeditor-16.12.3.tar.xz";
+      sha256 = "0362zcj6by3kydr5v3sr7l6k9kkyfcy16879f93d1qqkjfi11cic";
+      name = "kimagemapeditor-16.12.3.tar.xz";
     };
   };
   kimap = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kimap-16.12.2.tar.xz";
-      sha256 = "04shglmr8rv5r16qb3n9x7vwrsm55121rkj9pz1y7l40kybajl87";
-      name = "kimap-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kimap-16.12.3.tar.xz";
+      sha256 = "1jlva17hy500jpb5mg6m3vrcy6mqikcy8m1pgy68d2ip0m93rb5f";
+      name = "kimap-16.12.3.tar.xz";
     };
   };
   kio-extras = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kio-extras-16.12.2.tar.xz";
-      sha256 = "0bfjmggyl7x7nmkqq10pmcc2507yfkbv5c5v86225g9mk02frmhp";
-      name = "kio-extras-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kio-extras-16.12.3.tar.xz";
+      sha256 = "1mfpllrmc88khlpg3yd4sghs8igg8dh0x568jw46vv90qgdb9xss";
+      name = "kio-extras-16.12.3.tar.xz";
     };
   };
   kiriki = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kiriki-16.12.2.tar.xz";
-      sha256 = "1fgdw7f4fqdfzsryvd8crdv60j2s2g3cvbibv3g91xkcq6p155wk";
-      name = "kiriki-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kiriki-16.12.3.tar.xz";
+      sha256 = "142p2zv1826iclaa2zrfyzfdwnflh3sq2xymca4di5anrmcwmm2m";
+      name = "kiriki-16.12.3.tar.xz";
     };
   };
   kiten = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kiten-16.12.2.tar.xz";
-      sha256 = "1ya1wwgh1x4iap3vs947ln949hjc499aiylg24666ab7vcqkbhh8";
-      name = "kiten-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kiten-16.12.3.tar.xz";
+      sha256 = "0skwgv3v79p5z1livjbdsg7i18ky8vc49z53dmgsgbziqvs0s2y4";
+      name = "kiten-16.12.3.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kjumpingcube-16.12.2.tar.xz";
-      sha256 = "0flx7sxqac763i2nsvyjzjv9aii27hnv51k0yhqcp6pnsjy1fbhh";
-      name = "kjumpingcube-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kjumpingcube-16.12.3.tar.xz";
+      sha256 = "1fii1arzpsdhnnb5yladhpsb0g6icald5si0fwnl47wg3gshaqiz";
+      name = "kjumpingcube-16.12.3.tar.xz";
     };
   };
   kldap = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kldap-16.12.2.tar.xz";
-      sha256 = "06ql2d7l22c19gnw6wigym3qpqw22arsmwpnnwz9i76l3wq32s3x";
-      name = "kldap-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kldap-16.12.3.tar.xz";
+      sha256 = "0a7pm9dzcvyyznqs4apwdl6dpg87qhxcr3a06grjwxhqvfdl52na";
+      name = "kldap-16.12.3.tar.xz";
     };
   };
   kleopatra = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kleopatra-16.12.2.tar.xz";
-      sha256 = "1kh75qjas4x4aqvshdgcryqdrp475lx60gksjfh34ygz03avdssl";
-      name = "kleopatra-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kleopatra-16.12.3.tar.xz";
+      sha256 = "1ja26gzdj8h5f8w1061scl40p6ahba3ci4hp91n2vp3rrz9m96wa";
+      name = "kleopatra-16.12.3.tar.xz";
     };
   };
   klettres = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/klettres-16.12.2.tar.xz";
-      sha256 = "116igb1gbl3dfh5rm4mp0n8krm0d9kpgns63sh355g02wf0cbz3f";
-      name = "klettres-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/klettres-16.12.3.tar.xz";
+      sha256 = "0m3k3zyrw7rwm6ad75c86bap80v2y5k938mdhqjaciglqc9pk83h";
+      name = "klettres-16.12.3.tar.xz";
     };
   };
   klickety = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/klickety-16.12.2.tar.xz";
-      sha256 = "00fqfnxh8bb069q3a5jszggnwq0z45najd6qg3z9gqb2i6bb4w93";
-      name = "klickety-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/klickety-16.12.3.tar.xz";
+      sha256 = "0mim86wxcljs192q9y6a6i326sic350jd89m1vx3p78dwpj35q42";
+      name = "klickety-16.12.3.tar.xz";
     };
   };
   klines = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/klines-16.12.2.tar.xz";
-      sha256 = "1pr5pvxd6fnybkjqxig9zjiq04d7g6igw24p2j6kfz91ihaf4g6q";
-      name = "klines-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/klines-16.12.3.tar.xz";
+      sha256 = "03ran5hyl8p9vfi82m2pkzng9hn5ipx1plgq9bz25c53z5fg63di";
+      name = "klines-16.12.3.tar.xz";
     };
   };
   klinkstatus = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/klinkstatus-16.12.2.tar.xz";
-      sha256 = "07wmaphs56x0jwgbkdynahwa0hrr3rakkbbfa4w046dga5z6dz60";
-      name = "klinkstatus-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/klinkstatus-16.12.3.tar.xz";
+      sha256 = "0kmjh0398k6fpz6lgz6d5rb79xl6wpgd4j56zacpha9046cfnmsk";
+      name = "klinkstatus-16.12.3.tar.xz";
     };
   };
   kmag = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kmag-16.12.2.tar.xz";
-      sha256 = "02vjwfh926jvhxn1sw603ijdrayk4jxrw9rl7kv48q00kgk5sr23";
-      name = "kmag-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kmag-16.12.3.tar.xz";
+      sha256 = "1llv9vd1557h4lz2sdd1wjlqb9wzrk9jxn4731iac2b5wdwpihii";
+      name = "kmag-16.12.3.tar.xz";
     };
   };
   kmahjongg = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kmahjongg-16.12.2.tar.xz";
-      sha256 = "1rbcbak87jyf6bc8k44xvpcihagwh4i3v20af14hvm52gdvzdhij";
-      name = "kmahjongg-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kmahjongg-16.12.3.tar.xz";
+      sha256 = "0xy3w5kxn69l0dagly5qd9dqzkpikflmrjbv1b45psafdmj3125r";
+      name = "kmahjongg-16.12.3.tar.xz";
     };
   };
   kmail = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kmail-16.12.2.tar.xz";
-      sha256 = "0a3r6pwm3dvvmljp5grl1mgymp3fb1l3hb8issdqlk4s805q0pql";
-      name = "kmail-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kmail-16.12.3.tar.xz";
+      sha256 = "1kyhc952k78yg2wa9cgxvqa6qrrgc08dly7fin7as8cxfh49i0b0";
+      name = "kmail-16.12.3.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kmail-account-wizard-16.12.2.tar.xz";
-      sha256 = "1vm4lx5jwk5kqf3zdfm3zyzhap1dalslwj03gxmif6hh65d2s7h5";
-      name = "kmail-account-wizard-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kmail-account-wizard-16.12.3.tar.xz";
+      sha256 = "0w94v2c38sl0qnyr38yzlfj6pxixaziw5kb4fkawv26c18fi42pl";
+      name = "kmail-account-wizard-16.12.3.tar.xz";
     };
   };
   kmailtransport = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kmailtransport-16.12.2.tar.xz";
-      sha256 = "0g2f25l4l8jlj4d5dcdlbz8rgy4xvm6if2i3qm4naqh35kb4rycn";
-      name = "kmailtransport-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kmailtransport-16.12.3.tar.xz";
+      sha256 = "1dkw7niymhnf0jncflvqyldw28c9j0q6j598flb5ksds0n30iasy";
+      name = "kmailtransport-16.12.3.tar.xz";
     };
   };
   kmbox = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kmbox-16.12.2.tar.xz";
-      sha256 = "1j30kvvlnfbky5x19gxjsbrshrdys6ajdbhpd9fy46jjh2dv3y6j";
-      name = "kmbox-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kmbox-16.12.3.tar.xz";
+      sha256 = "0khvf4kqf9i425fjczl1miqsz0pxbyryxy32bf9knr3k5kmwbn24";
+      name = "kmbox-16.12.3.tar.xz";
     };
   };
   kmime = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kmime-16.12.2.tar.xz";
-      sha256 = "0sl34qahgvxaw9xi56d0l2a2iim9bpiv8ysf3spsc1m2ribf3400";
-      name = "kmime-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kmime-16.12.3.tar.xz";
+      sha256 = "0gzbh0g075ml5x0qy4zd1cg1qygdsnssl5ahk9pcgc0fik4p9j20";
+      name = "kmime-16.12.3.tar.xz";
     };
   };
   kmines = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kmines-16.12.2.tar.xz";
-      sha256 = "1324j3myr1wds3f6nzw186d1rc2aakxv0mqsx89bdvnky6zq2v5q";
-      name = "kmines-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kmines-16.12.3.tar.xz";
+      sha256 = "0dz6yx7y0jpxhmyjrfyf6rrkiayn4mpyr4n1iszs11gac1bqppvn";
+      name = "kmines-16.12.3.tar.xz";
     };
   };
   kmix = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kmix-16.12.2.tar.xz";
-      sha256 = "1s8di3jbgcaamfxfmmwxlajixia9m2ngl4qc1z7rq6a14fk3w5hz";
-      name = "kmix-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kmix-16.12.3.tar.xz";
+      sha256 = "1mq4kna3z62269m43qy42knq4byrvirk0mk5yp56n51im1bmdyj4";
+      name = "kmix-16.12.3.tar.xz";
     };
   };
   kmousetool = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kmousetool-16.12.2.tar.xz";
-      sha256 = "128hp75zyyariflx03ilmvw09jngfy9ylykb73gg7xw2zqnjjw4i";
-      name = "kmousetool-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kmousetool-16.12.3.tar.xz";
+      sha256 = "1678sjj96f22sn60ccyj6hqi2vghkf4facnx8l15x4xx05yq1vgg";
+      name = "kmousetool-16.12.3.tar.xz";
     };
   };
   kmouth = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kmouth-16.12.2.tar.xz";
-      sha256 = "0gk8rdlpwh304k7g85i80rfdjnvj4fcd1nlj89zmq2qh5s9jmqzg";
-      name = "kmouth-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kmouth-16.12.3.tar.xz";
+      sha256 = "1afvjds1kfb8zvv3ma8c6svan6zlbd1w9a164vxwp7gl3ycjyj52";
+      name = "kmouth-16.12.3.tar.xz";
     };
   };
   kmplot = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kmplot-16.12.2.tar.xz";
-      sha256 = "0lwx0d1gv6k3nm0nxry6bl282j3vjc0p7rssbvhi5qsc7z9lc8s3";
-      name = "kmplot-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kmplot-16.12.3.tar.xz";
+      sha256 = "02vh4diqs4688p2xlia437jywx89yhpaf8ipprdq92q034glybyz";
+      name = "kmplot-16.12.3.tar.xz";
     };
   };
   knavalbattle = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/knavalbattle-16.12.2.tar.xz";
-      sha256 = "065hyrdqaj0g7kpgxdyjbf2msdxb6w6m2y50bw23p4w69y7fdxgn";
-      name = "knavalbattle-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/knavalbattle-16.12.3.tar.xz";
+      sha256 = "0164z9h1689bz600p17p8fq552g8pq73l81nj4f5csklhnsiykkg";
+      name = "knavalbattle-16.12.3.tar.xz";
     };
   };
   knetwalk = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/knetwalk-16.12.2.tar.xz";
-      sha256 = "1rhmgr2qk8h04y87dviy0yhrv5dg8za5v00csmia3s1jyvz0fbwp";
-      name = "knetwalk-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/knetwalk-16.12.3.tar.xz";
+      sha256 = "1mavc0rn41y3vgzf0ikwvk3kh4fszylh7h4briw9k0kqx2cxh5vk";
+      name = "knetwalk-16.12.3.tar.xz";
     };
   };
   knotes = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/knotes-16.12.2.tar.xz";
-      sha256 = "12bdrw4ikw014phbq9w4q5y9lgjnazhvri7j13ld5r6806bxls04";
-      name = "knotes-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/knotes-16.12.3.tar.xz";
+      sha256 = "1yyx98zn7a3hbiyr16fcbylbm5v8lyg22v8gwf7xpnbx5jb4hpb8";
+      name = "knotes-16.12.3.tar.xz";
     };
   };
   kolf = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kolf-16.12.2.tar.xz";
-      sha256 = "1v9lhir520n7kcc061z3zcc8wxswhnmjv7yifbqvviazl1n0p0vx";
-      name = "kolf-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kolf-16.12.3.tar.xz";
+      sha256 = "136iyf8clr2r8qkjcm0nqcq0sjr5xry9gbxjhz128lc0nywsxpd5";
+      name = "kolf-16.12.3.tar.xz";
     };
   };
   kollision = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kollision-16.12.2.tar.xz";
-      sha256 = "1dklg0ns3abfxbfr7xrnzkcxxng3v7avzj4bjvsmsbq3lzy3pb8c";
-      name = "kollision-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kollision-16.12.3.tar.xz";
+      sha256 = "0kwnqqm9gs6ac7ags9x82ykmp3vccp3kdd3js26a1kz1zkip32il";
+      name = "kollision-16.12.3.tar.xz";
     };
   };
   kolourpaint = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kolourpaint-16.12.2.tar.xz";
-      sha256 = "1himisb1f68pgaz15qam73qv9acqqh8i1jnk9wbsqjyj6z67wvnj";
-      name = "kolourpaint-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kolourpaint-16.12.3.tar.xz";
+      sha256 = "1yg3xnbbzvhcgb7i92bya41gq4z0135njcc77848khndpgkxvczb";
+      name = "kolourpaint-16.12.3.tar.xz";
     };
   };
   kommander = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kommander-16.12.2.tar.xz";
-      sha256 = "140sz82gm5p8f8mhr2kdfy24fr6jjs0l53jcqr9hwdw6vlrm399w";
-      name = "kommander-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kommander-16.12.3.tar.xz";
+      sha256 = "1wlks0alw82ra3g63d8k8nj9sq899hjv1r2kshk7c4vdk7arn1fg";
+      name = "kommander-16.12.3.tar.xz";
     };
   };
   kompare = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kompare-16.12.2.tar.xz";
-      sha256 = "1dd4k3rq8wlzsvl5nv5mrd0ddxgwlriik3vxj8xx3b4nqk720lh6";
-      name = "kompare-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kompare-16.12.3.tar.xz";
+      sha256 = "18z6424xidpx5kmbjiasvhagh2b1a9pxizc0dsvba47v9xcavsaw";
+      name = "kompare-16.12.3.tar.xz";
     };
   };
   konqueror = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/konqueror-16.12.2.tar.xz";
-      sha256 = "0md9glzr1br2n5dsfmmv6gxsfhv6jl0r4fa1qgw4d2j2kpm94zw7";
-      name = "konqueror-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/konqueror-16.12.3.tar.xz";
+      sha256 = "1pwv2mj9xrn6aymhkqmwd89d5i3v2jixp07dz0by62rcpfhm89p5";
+      name = "konqueror-16.12.3.tar.xz";
     };
   };
   konquest = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/konquest-16.12.2.tar.xz";
-      sha256 = "0k58adqr20k9wrwbaf1s6lqqgcma08wqnv66zrxbgacgsgx3pnzi";
-      name = "konquest-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/konquest-16.12.3.tar.xz";
+      sha256 = "1fhz9pwi2dmmcjg10vp36m8d759zikg6nqpjdp41dg95lkyf5vkf";
+      name = "konquest-16.12.3.tar.xz";
     };
   };
   konsole = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/konsole-16.12.2.tar.xz";
-      sha256 = "1mwfv2hznmd1qml8hq1z81jv9y8jn1ybc69dqgnf1n6ygmz14676";
-      name = "konsole-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/konsole-16.12.3.tar.xz";
+      sha256 = "10k7ryvsssbskpxk04iqx2mrp2a91291r8nzvg1780lrhql5rdj7";
+      name = "konsole-16.12.3.tar.xz";
     };
   };
   kontact = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kontact-16.12.2.tar.xz";
-      sha256 = "1rfqb5a4brbvkhv905lcvc40r0as8zwdm2h67jc96cix358cpshv";
-      name = "kontact-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kontact-16.12.3.tar.xz";
+      sha256 = "0wj4w9ak6dm330s393hjb79w16gs5kij5gz9swf3pxwg21xbd4ps";
+      name = "kontact-16.12.3.tar.xz";
     };
   };
   kontactinterface = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kontactinterface-16.12.2.tar.xz";
-      sha256 = "0z6mjg8sy18jhkfmk9s098851gdqbh03031l92yqzsgsfph9nk77";
-      name = "kontactinterface-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kontactinterface-16.12.3.tar.xz";
+      sha256 = "0n5hvx3xp01krwwd2szgh1s6nn5spfns1ivc36i1gdbhkf871k98";
+      name = "kontactinterface-16.12.3.tar.xz";
     };
   };
   kopete = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kopete-16.12.2.tar.xz";
-      sha256 = "0bf0bffcsyhrj70yb4l5g6n0jr38i5zkcl4hsfi9hac43xvp62ib";
-      name = "kopete-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kopete-16.12.3.tar.xz";
+      sha256 = "1dkn4d13knf0lcj4241fmjcj51ypg9frzsf0pl02mr08rd2rxgk1";
+      name = "kopete-16.12.3.tar.xz";
     };
   };
   korganizer = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/korganizer-16.12.2.tar.xz";
-      sha256 = "1211rhxvx42lndqv6n23mj6ibhfp09vvmzz59k1j0l9z8y1zyr2g";
-      name = "korganizer-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/korganizer-16.12.3.tar.xz";
+      sha256 = "1724l321gzjwha8yhrans4lhzs39fs98xi7wbd5msfflzyg3l6ga";
+      name = "korganizer-16.12.3.tar.xz";
     };
   };
   kpat = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kpat-16.12.2.tar.xz";
-      sha256 = "1yc16yfsq18m5xxm9b17zba3ppw7j5hq82z0ln8sw2yisz59mylr";
-      name = "kpat-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kpat-16.12.3.tar.xz";
+      sha256 = "04qvv7q7rlsiyff2isy18h2fbz2lnljal5spq5qg9zl6v8hx6qzm";
+      name = "kpat-16.12.3.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kpimtextedit-16.12.2.tar.xz";
-      sha256 = "0xspr7hip57j8n3mp71x8s908vlj7acl27jwyc33yi4xvlyfcgfy";
-      name = "kpimtextedit-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kpimtextedit-16.12.3.tar.xz";
+      sha256 = "06iz9l8z708kdivzibqkgdrbvw7kfd2lr2grf3v9l6gfl3qs1kbw";
+      name = "kpimtextedit-16.12.3.tar.xz";
     };
   };
   kppp = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kppp-16.12.2.tar.xz";
-      sha256 = "1gvb3sgxg1ysdrv18rf5kh6znvwlkp673yld6ghj3dcif8w6xq0n";
-      name = "kppp-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kppp-16.12.3.tar.xz";
+      sha256 = "0lqv95zfzcik8k95a39s6whjsnq6g15amnxlzy898liyxkr499bc";
+      name = "kppp-16.12.3.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kqtquickcharts-16.12.2.tar.xz";
-      sha256 = "1gh3alqlmj2icd2jblncps4k6kklckbpqv18wplybgaz4h0pi4pi";
-      name = "kqtquickcharts-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kqtquickcharts-16.12.3.tar.xz";
+      sha256 = "1xzn9vxiqam8pk4zj8qcq55v9g52d9qkddbdv25pml8s0yhlsgqf";
+      name = "kqtquickcharts-16.12.3.tar.xz";
     };
   };
   krdc = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/krdc-16.12.2.tar.xz";
-      sha256 = "1ql2mkx7xc2y0vkxjk3i5scxa6ws5mwz39zynmyx7rmxp9f8frsf";
-      name = "krdc-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/krdc-16.12.3.tar.xz";
+      sha256 = "0visx3371ym78n9aqkln2akvvf0rphyxg5hxvc2981pgpdry20zq";
+      name = "krdc-16.12.3.tar.xz";
     };
   };
   kremotecontrol = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kremotecontrol-16.12.2.tar.xz";
-      sha256 = "1c1xx458lchn9b3c9h27zb13m2y6b01sb0g6lf6bpx4skbdwdwma";
-      name = "kremotecontrol-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kremotecontrol-16.12.3.tar.xz";
+      sha256 = "0xcs8gvb7ack0xqdp99x04lyv6hbqgxa5nq44pxl7czzc0la5nbk";
+      name = "kremotecontrol-16.12.3.tar.xz";
     };
   };
   kreversi = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kreversi-16.12.2.tar.xz";
-      sha256 = "18zfy3dzi9rgwhgvci93iv0gkmvac30rbj4xwpvzr3bc8zwz76df";
-      name = "kreversi-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kreversi-16.12.3.tar.xz";
+      sha256 = "1qi6y263c8qp0bv9vmjk4rxq55mc0v1kn56yvivc5sfg9p4bqs9b";
+      name = "kreversi-16.12.3.tar.xz";
     };
   };
   krfb = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/krfb-16.12.2.tar.xz";
-      sha256 = "1sqij11a6pbivf2xbcglxzkfrpqvzcqxb4d85jxrhbp2wljx0xvy";
-      name = "krfb-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/krfb-16.12.3.tar.xz";
+      sha256 = "1ijz0zdlkxb9mldgd5a5k7aa2ikmmg023mafmxrjwymsig7ya4hv";
+      name = "krfb-16.12.3.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kross-interpreters-16.12.2.tar.xz";
-      sha256 = "1cw84z2wdh1kb7fgwmmljmc5d57skh6hlm0p6kzlqdbqknnva8ad";
-      name = "kross-interpreters-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kross-interpreters-16.12.3.tar.xz";
+      sha256 = "0z1n42imbhsx0qmx479sklnihwvbd5l5pigbpbpm80rgwda2ib57";
+      name = "kross-interpreters-16.12.3.tar.xz";
     };
   };
   kruler = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kruler-16.12.2.tar.xz";
-      sha256 = "11i7k53kpfampbkzzabp0v97pb22h7sb2i0r6qdx78kyhmkgdrvp";
-      name = "kruler-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kruler-16.12.3.tar.xz";
+      sha256 = "08w7pb7wyaqnhwvqczxzbrbnm8930wzkl8y4lpimp5mqzb94i8qx";
+      name = "kruler-16.12.3.tar.xz";
     };
   };
   ksaneplugin = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ksaneplugin-16.12.2.tar.xz";
-      sha256 = "0ljk7cf4ns39xszn6g1vk8av3dkkgwzj4ry4n56305mqyjgqx258";
-      name = "ksaneplugin-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ksaneplugin-16.12.3.tar.xz";
+      sha256 = "1z0ziapcjmi7fqfnb0zsbjgd1q05np1s7smj1k8cd8c6f169yrld";
+      name = "ksaneplugin-16.12.3.tar.xz";
     };
   };
   kscd = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kscd-16.12.2.tar.xz";
-      sha256 = "1w1gcfwp1r18pjfp526pdb837kpd8zj08g1jrjcb3bmvh600apm0";
-      name = "kscd-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kscd-16.12.3.tar.xz";
+      sha256 = "1mpba78m4hs8541n4ydz7vswq1chi0fmmlfw2kqnrzarcandyga0";
+      name = "kscd-16.12.3.tar.xz";
     };
   };
   kshisen = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kshisen-16.12.2.tar.xz";
-      sha256 = "0sw78qwlpimlhqzlz5migbngrhj7w6gdbqx12q7949paa03ash1b";
-      name = "kshisen-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kshisen-16.12.3.tar.xz";
+      sha256 = "17szjblrp172rvyl98x5a0g9yg29b85bmwkzk7pqnjbn387kgy9r";
+      name = "kshisen-16.12.3.tar.xz";
     };
   };
   ksirk = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ksirk-16.12.2.tar.xz";
-      sha256 = "0f9k476wbwx0maf0wsicgipqyv7gccm7ydwvns399iamb6xkiqnn";
-      name = "ksirk-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ksirk-16.12.3.tar.xz";
+      sha256 = "1akfskyfhffh71w2hknw9vvap2a2sq0irmkxij9xcdmlvpfwnkn5";
+      name = "ksirk-16.12.3.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ksnakeduel-16.12.2.tar.xz";
-      sha256 = "0lhwz1b1v1dir7k1vbkcwb73x7f3h7prb3zv4f8wlh32dj1yg983";
-      name = "ksnakeduel-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ksnakeduel-16.12.3.tar.xz";
+      sha256 = "1797kac3prchq5254dby41k04i8i7hgf2a9cb8s71n7hrsj62dyn";
+      name = "ksnakeduel-16.12.3.tar.xz";
     };
   };
   kspaceduel = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kspaceduel-16.12.2.tar.xz";
-      sha256 = "0h6m8xnmxx0q2r863ikck0kpyscd8s4iidcjiqz7wqgbsw1dadqb";
-      name = "kspaceduel-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kspaceduel-16.12.3.tar.xz";
+      sha256 = "0ipx1sxhv207nlw7rcp7155l76z39x7j1b5y3qwxcgd7s69wb82k";
+      name = "kspaceduel-16.12.3.tar.xz";
     };
   };
   ksquares = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ksquares-16.12.2.tar.xz";
-      sha256 = "14x1d9300wdhrnri5f5n5i31bs83hcbxs5w9cai1m8mlql99vvfy";
-      name = "ksquares-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ksquares-16.12.3.tar.xz";
+      sha256 = "0abd19hf1rvlzkxc4kvdljs5yk39pay81n3n9n0w6qyr764r4qn9";
+      name = "ksquares-16.12.3.tar.xz";
     };
   };
   kstars = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kstars-16.12.2.tar.xz";
-      sha256 = "0acbirhr970fh53hfsbfw9jn4jqlww9zf80jfyg2drixi9d70mpp";
-      name = "kstars-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kstars-16.12.3.tar.xz";
+      sha256 = "0lcrn7r1nw85c0w6dg03mwf5lnsahmww60y6vwzfh2r53nbm9c1y";
+      name = "kstars-16.12.3.tar.xz";
     };
   };
   ksudoku = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ksudoku-16.12.2.tar.xz";
-      sha256 = "1nvk8l6n7sja19s2kazf6xhzqwi9mrjxvz5i0i9nmpwmksii6lbg";
-      name = "ksudoku-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ksudoku-16.12.3.tar.xz";
+      sha256 = "00hi8x09fj5ahj0ah9rsci2dscrdl8x9mrlcacjrwgwm503y95gk";
+      name = "ksudoku-16.12.3.tar.xz";
     };
   };
   ksystemlog = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ksystemlog-16.12.2.tar.xz";
-      sha256 = "13q2h3yhlpjy8hiiz6vdx5xwniysbmz5agvvn28a469710601154";
-      name = "ksystemlog-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ksystemlog-16.12.3.tar.xz";
+      sha256 = "0xd6pp02k84a1r6gy10x0br33g4awpbhx45j7n69l1s96szj4aki";
+      name = "ksystemlog-16.12.3.tar.xz";
     };
   };
   kteatime = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kteatime-16.12.2.tar.xz";
-      sha256 = "0m163a11hp90rqf5170iqapmvn4ym6m2n42da2p1jgyim4877613";
-      name = "kteatime-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kteatime-16.12.3.tar.xz";
+      sha256 = "0wqzw9sa4zkgkwndvyas47x5wc4gcya3pmdcvg7wf7wl8j5k7vdy";
+      name = "kteatime-16.12.3.tar.xz";
     };
   };
   ktimer = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktimer-16.12.2.tar.xz";
-      sha256 = "1l9xwfg3701h1f16ifh74c5hv7j7z0f332izcvfpiccps7gplhvz";
-      name = "ktimer-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktimer-16.12.3.tar.xz";
+      sha256 = "0hpskwa8g88fz39b0y7sjl574s82d6smla1bhs8mdjlabv0sln6z";
+      name = "ktimer-16.12.3.tar.xz";
     };
   };
   ktnef = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktnef-16.12.2.tar.xz";
-      sha256 = "0id9shripwahgb258hgfpmxyg0z9x2dqpxgyrvb47d44rrcf9dxg";
-      name = "ktnef-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktnef-16.12.3.tar.xz";
+      sha256 = "0v38h7bwjwab1656w3c2h1by5925f616idnvflgp123v1cs6jy1n";
+      name = "ktnef-16.12.3.tar.xz";
     };
   };
   ktouch = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktouch-16.12.2.tar.xz";
-      sha256 = "08c0g35ypsndh8pj1nbxn8gnzis10a5cxkz175x4asi5lcpw3kc1";
-      name = "ktouch-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktouch-16.12.3.tar.xz";
+      sha256 = "17gkvzczfgmip18y3jbjisz4z8m5hwbgkqn4qynabp6dqihwhzgg";
+      name = "ktouch-16.12.3.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktp-accounts-kcm-16.12.2.tar.xz";
-      sha256 = "1p3pqvkyhwcqcwgpyfghhii3d5shbfpm8i9vap8vc43clvj9sfah";
-      name = "ktp-accounts-kcm-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktp-accounts-kcm-16.12.3.tar.xz";
+      sha256 = "0pr191i9fmz66wlv8krmy1pba7igd1qwa0akb4kdzkm4bx3z8wq3";
+      name = "ktp-accounts-kcm-16.12.3.tar.xz";
     };
   };
   ktp-approver = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktp-approver-16.12.2.tar.xz";
-      sha256 = "1ky4wg8qk4n2qyh5009zz6487pf31jb8w8zmjmck9fypc9rhzw2j";
-      name = "ktp-approver-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktp-approver-16.12.3.tar.xz";
+      sha256 = "08aj2j9bjdyigl4cx65v5fjsdayid07mx0mq72iy6l17d8z4b39a";
+      name = "ktp-approver-16.12.3.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktp-auth-handler-16.12.2.tar.xz";
-      sha256 = "05dvbq1q0fbznyj11wkg0ic8svgkqdq8i20xddkkx2jpwhpkmcnl";
-      name = "ktp-auth-handler-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktp-auth-handler-16.12.3.tar.xz";
+      sha256 = "08ryqkba9zngjabsp1b9w13psp0n97qhjd31id007hc6r6s1nxxx";
+      name = "ktp-auth-handler-16.12.3.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktp-call-ui-16.12.2.tar.xz";
-      sha256 = "1czm56vvbjbyyib2wi60f9s2icnyac007zzh2qxsxfnlp52mkzm2";
-      name = "ktp-call-ui-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktp-call-ui-16.12.3.tar.xz";
+      sha256 = "1aq0s4v972kskjnq720364y971iyr0m6pj42fw5rpkl7j8vfg1rd";
+      name = "ktp-call-ui-16.12.3.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktp-common-internals-16.12.2.tar.xz";
-      sha256 = "0323dhfiddq5yhbp0rpmpw60334z41f45ml8lcada8dv6mbjxlc6";
-      name = "ktp-common-internals-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktp-common-internals-16.12.3.tar.xz";
+      sha256 = "0g3vmds5f7wmffp9rv915bll8ky7qf3lz172ymc6q9i1xvghp215";
+      name = "ktp-common-internals-16.12.3.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktp-contact-list-16.12.2.tar.xz";
-      sha256 = "0gk0lims3ypjsir9k9a010kylnqzqb2dsh5yfv24a6fb1ix6q4yy";
-      name = "ktp-contact-list-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktp-contact-list-16.12.3.tar.xz";
+      sha256 = "05asblclq6sjd3d9faaj2ya37srf4lhg8jx705aw13wd5d6pk75w";
+      name = "ktp-contact-list-16.12.3.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktp-contact-runner-16.12.2.tar.xz";
-      sha256 = "1bfm4639jshw9ncchcj6m8q6xg49a20z4fzc66vrjkdbha8fwr0g";
-      name = "ktp-contact-runner-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktp-contact-runner-16.12.3.tar.xz";
+      sha256 = "1lcx9smfv2dqrwsbdd4srcq7dqap8bclz788p6jjn04xi6wcbbiq";
+      name = "ktp-contact-runner-16.12.3.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktp-desktop-applets-16.12.2.tar.xz";
-      sha256 = "1ahm69h309dyg3byv3jxxm3j0c5jphzxng2g87hvjs9dvgx00msv";
-      name = "ktp-desktop-applets-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktp-desktop-applets-16.12.3.tar.xz";
+      sha256 = "1pd8vzwmxcsw6pq80r9casi07wwisr70l5ffm231v9d73k4fw7kv";
+      name = "ktp-desktop-applets-16.12.3.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktp-filetransfer-handler-16.12.2.tar.xz";
-      sha256 = "1j1bmrwabh0mzm51ibb0qyf164g7hznjk2vm2kwkgk5sy8r1a363";
-      name = "ktp-filetransfer-handler-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktp-filetransfer-handler-16.12.3.tar.xz";
+      sha256 = "0ddmrpnh6myl7m3drh3cxx9pp06al98g8mppnysmgswgkwafg6cq";
+      name = "ktp-filetransfer-handler-16.12.3.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktp-kded-module-16.12.2.tar.xz";
-      sha256 = "1ia62r55my8s6l3am22z6nkvmi2x2gnpbwmmpiv8n2i7j2ysdjp9";
-      name = "ktp-kded-module-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktp-kded-module-16.12.3.tar.xz";
+      sha256 = "06zw8padspbn8ydcbs69v3ggmfpqrb3axxd2v1sgg4p4kdp0jyml";
+      name = "ktp-kded-module-16.12.3.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktp-send-file-16.12.2.tar.xz";
-      sha256 = "0vl00bbnpddq9nczb53apf3sdr1r2hnpa3fa390yx3jrrr4hp3k0";
-      name = "ktp-send-file-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktp-send-file-16.12.3.tar.xz";
+      sha256 = "1m7cj3q4lzj8qj2cla6wm1crpjid77b3f3yywri167f1zd4p51z6";
+      name = "ktp-send-file-16.12.3.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktp-text-ui-16.12.2.tar.xz";
-      sha256 = "0c0khkargj4hg2j1va72hp45b3dzwvkvbssq7k309iljxgfi9qry";
-      name = "ktp-text-ui-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktp-text-ui-16.12.3.tar.xz";
+      sha256 = "0ssxr35vcqjppnppyjxwzrkzvb5sx45fpnvbzsv9md5rnlf2xh1k";
+      name = "ktp-text-ui-16.12.3.tar.xz";
     };
   };
   ktuberling = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/ktuberling-16.12.2.tar.xz";
-      sha256 = "0867ci5bi0phcwwxlqlyn3w1pv5q5wvzyqnzjvywc0bzy2qbpp0p";
-      name = "ktuberling-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/ktuberling-16.12.3.tar.xz";
+      sha256 = "1vn35bn0x5ykd9j78q5apg1i14v546jrqq1yn2q178d9qmx79pgv";
+      name = "ktuberling-16.12.3.tar.xz";
     };
   };
   kturtle = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kturtle-16.12.2.tar.xz";
-      sha256 = "183glhn0amkcrzylax9cjyj3if9iz3dybmw55ljw003mf1s0sydq";
-      name = "kturtle-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kturtle-16.12.3.tar.xz";
+      sha256 = "1mpdwb6999nar16mpha30cf4qzmpbsdha44aw77gn301v215rwj3";
+      name = "kturtle-16.12.3.tar.xz";
     };
   };
   kubrick = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kubrick-16.12.2.tar.xz";
-      sha256 = "10yakz1ffdx33sqgqmlga525r3cnz90m0rm5m2sl3b97ib7r0fxl";
-      name = "kubrick-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kubrick-16.12.3.tar.xz";
+      sha256 = "1bwr8xi4d58k94h7lpl02iqf87nxhpls33ca654kzy353awqbp7f";
+      name = "kubrick-16.12.3.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kwalletmanager-16.12.2.tar.xz";
-      sha256 = "129q3c805g4jsrws3gvy751y4pdwp9m8yvlc62pkp703xwlnkzj4";
-      name = "kwalletmanager-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kwalletmanager-16.12.3.tar.xz";
+      sha256 = "07miaqr0yaqb0lkssb1jfg35cvr9svn16nhvb1zffvbf9fdlim47";
+      name = "kwalletmanager-16.12.3.tar.xz";
     };
   };
   kwave = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kwave-16.12.2.tar.xz";
-      sha256 = "0g3n0fm3pyp6sd28qjpadpqs2kqd5gsbicdz1c5jkm8c1bypi0ij";
-      name = "kwave-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kwave-16.12.3.tar.xz";
+      sha256 = "1s5zwhck204m5rkrpmbghzid3dpzhqbwsilb5pfh4128d04fx9ad";
+      name = "kwave-16.12.3.tar.xz";
     };
   };
   kwordquiz = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/kwordquiz-16.12.2.tar.xz";
-      sha256 = "1jy9833zrgaddzpfaaps2gcxjnf9mg2yx4w7mfpa3vglsyvhqlzx";
-      name = "kwordquiz-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/kwordquiz-16.12.3.tar.xz";
+      sha256 = "1r8q2d6j7bq8jdr4cl9maapadzg7yp0zldjxkcqg08ldwsrrsnqj";
+      name = "kwordquiz-16.12.3.tar.xz";
     };
   };
   libgravatar = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libgravatar-16.12.2.tar.xz";
-      sha256 = "0vdryr9q30jkk5b9fa75yiqpspj83wvcy2zry8rsrx7pj21cdlsw";
-      name = "libgravatar-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libgravatar-16.12.3.tar.xz";
+      sha256 = "0m726ixss72rz3gwgn7q5s34xwbghi877y7gxa1ilcrk9rhyxv2f";
+      name = "libgravatar-16.12.3.tar.xz";
     };
   };
   libkcddb = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkcddb-16.12.2.tar.xz";
-      sha256 = "0gs0zyisrgbzbcnwp95qi8msj5x2ysmqk9nwja3bwqzbangm0y82";
-      name = "libkcddb-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkcddb-16.12.3.tar.xz";
+      sha256 = "0iaascv9a5g8681mjc6b7f2fd8fdi9p3dx8l9lapkpzcygy1fwpc";
+      name = "libkcddb-16.12.3.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkcompactdisc-16.12.2.tar.xz";
-      sha256 = "1ydhfi3hp30zg9nlmnzd5pslwlq6v6jbim2jda8ciyvniw0pm6va";
-      name = "libkcompactdisc-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkcompactdisc-16.12.3.tar.xz";
+      sha256 = "021yws9854w6fwwfw31b87rpz92ach5xyq427968m3mc3c430d4l";
+      name = "libkcompactdisc-16.12.3.tar.xz";
     };
   };
   libkdcraw = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkdcraw-16.12.2.tar.xz";
-      sha256 = "0w54h8fa1hgyvqps936annb8dhbrpizv4ifcix0gq714p573l8w3";
-      name = "libkdcraw-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkdcraw-16.12.3.tar.xz";
+      sha256 = "03ag6vzdj5n7zbb8yb9k84ckm1zwp2i9qqrsfn2mmmhypwknpg4w";
+      name = "libkdcraw-16.12.3.tar.xz";
     };
   };
   libkdegames = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkdegames-16.12.2.tar.xz";
-      sha256 = "0lw6v81pr4xq5h58mgkbzlvp5bxic9szfmabgd3nrdijh6mla4ly";
-      name = "libkdegames-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkdegames-16.12.3.tar.xz";
+      sha256 = "0w7q7x04imwrdfj5zwgv0y49k4wi7a6ghqipyc5qmrwfg9ya85b3";
+      name = "libkdegames-16.12.3.tar.xz";
     };
   };
   libkdepim = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkdepim-16.12.2.tar.xz";
-      sha256 = "1xblfj2i205jsm6nl05r3jis4gb4d15naq2mmfgxwy913pjh74jf";
-      name = "libkdepim-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkdepim-16.12.3.tar.xz";
+      sha256 = "07afpxhvxpf50h10vg6vla543n4rvy1grldjj4aygwh1fgl5snm0";
+      name = "libkdepim-16.12.3.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkeduvocdocument-16.12.2.tar.xz";
-      sha256 = "118z200ffqb2rj6yhmqp4b998cq6mlbpzn2gh2pdp70yin9w35qz";
-      name = "libkeduvocdocument-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkeduvocdocument-16.12.3.tar.xz";
+      sha256 = "05s79q269m5s78zjwxljxvprrqvpalf6h38n90m589vks82ahxx0";
+      name = "libkeduvocdocument-16.12.3.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkexiv2-16.12.2.tar.xz";
-      sha256 = "1bpk2mwiplk7c5xrdx7nq9fa0g53sgx6f5xa7d4k2i9mzn2s8hyr";
-      name = "libkexiv2-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkexiv2-16.12.3.tar.xz";
+      sha256 = "02fr10prqmpaqqlcj8hf5h4b3vhhiwkfsbpzlag64n5764x1hl3f";
+      name = "libkexiv2-16.12.3.tar.xz";
     };
   };
   libkface = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkface-16.12.2.tar.xz";
-      sha256 = "0jhnx71bnn2f8x5w5iylkk7369fcbx0y793182vc5rdqaax983sc";
-      name = "libkface-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkface-16.12.3.tar.xz";
+      sha256 = "068xixlw0hfhi3c9nxik2y6xyci1ilwwfq4sjm1paqfszp0f4rq8";
+      name = "libkface-16.12.3.tar.xz";
     };
   };
   libkgeomap = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkgeomap-16.12.2.tar.xz";
-      sha256 = "1skmmg3hppzj923nl90r7v26k4fii7h3sr6yxzzvzaakwbil7d9q";
-      name = "libkgeomap-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkgeomap-16.12.3.tar.xz";
+      sha256 = "1zz2w7cbabyrvzvw2ph38mxw7khyhjzg86na2lcywla7japlbsd9";
+      name = "libkgeomap-16.12.3.tar.xz";
     };
   };
   libkipi = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkipi-16.12.2.tar.xz";
-      sha256 = "0g1yyd5lhvwwa7q4in1p3q4mwlpp00lbir1a25wanlr6hqr2247w";
-      name = "libkipi-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkipi-16.12.3.tar.xz";
+      sha256 = "0f1m0v0cm11dqwm3n9w1mwz25sj3bggx19fi0jj4ij7zqicpykz6";
+      name = "libkipi-16.12.3.tar.xz";
     };
   };
   libkleo = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkleo-16.12.2.tar.xz";
-      sha256 = "031lfrn48xzi0kxkvg9597nxzharv0s0nxlkbdcr4xx8d8iga2l0";
-      name = "libkleo-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkleo-16.12.3.tar.xz";
+      sha256 = "0rzp2bxqij9fkdsghskd2f05vgcybdc9l7wdrjqhhcngi8qxl0nn";
+      name = "libkleo-16.12.3.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkmahjongg-16.12.2.tar.xz";
-      sha256 = "0imj2xv6qcf00dx53h37yq84cqrg806qjfmm836hw6wicw24117f";
-      name = "libkmahjongg-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkmahjongg-16.12.3.tar.xz";
+      sha256 = "0fhz7jp4wcvjcicyiwc4qq4vviwagfjdy6n5bhv7bmlccq4xfk5x";
+      name = "libkmahjongg-16.12.3.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libkomparediff2-16.12.2.tar.xz";
-      sha256 = "02d3bd7miq1nq81z6b4c8c64wjj2z9shr8y0rd0yqlzmf8ma05p2";
-      name = "libkomparediff2-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libkomparediff2-16.12.3.tar.xz";
+      sha256 = "1hm2d6217qwxsq6nyyh7iv573zkkmcn68x188zav48kmydj45l9i";
+      name = "libkomparediff2-16.12.3.tar.xz";
     };
   };
   libksane = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libksane-16.12.2.tar.xz";
-      sha256 = "0p215qc56ma4laajmql72f8bngi2x88nk1q8ysq0wviadgack885";
-      name = "libksane-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libksane-16.12.3.tar.xz";
+      sha256 = "0406jdzs193scmb8rkx2fqcr2a0svz53sf1av9qi2nq9dnil9hcq";
+      name = "libksane-16.12.3.tar.xz";
     };
   };
   libksieve = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/libksieve-16.12.2.tar.xz";
-      sha256 = "1bzd8lfz0d9gnq6kh8k9wrcfbc61mdigy2madn7ywpxpcjp4rp3v";
-      name = "libksieve-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/libksieve-16.12.3.tar.xz";
+      sha256 = "1riqsfl3x4vpwqv7398gj86hnwfzqwfj7d69wsxk3r02jp3xd9i2";
+      name = "libksieve-16.12.3.tar.xz";
     };
   };
   lokalize = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/lokalize-16.12.2.tar.xz";
-      sha256 = "03cr89skhwbzq4h6fr78iaziplahpr4i7fvsf8395w6yiwsvcnyk";
-      name = "lokalize-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/lokalize-16.12.3.tar.xz";
+      sha256 = "17ikk89680jjzv95gnrzah4bi3xnyp5mi64prhblhw7kz6vlf8x0";
+      name = "lokalize-16.12.3.tar.xz";
     };
   };
   lskat = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/lskat-16.12.2.tar.xz";
-      sha256 = "1jz7bjzw5msz5nyjvr21n3c355598afdnnqc6xzfl9zjkfgx4q9w";
-      name = "lskat-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/lskat-16.12.3.tar.xz";
+      sha256 = "02mqb4c650ydy9qp3qg1avrj0m0a8yxmg0zw6hcv5pvckgfpcxki";
+      name = "lskat-16.12.3.tar.xz";
     };
   };
   mailcommon = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/mailcommon-16.12.2.tar.xz";
-      sha256 = "0b9qawglc42y4wd98xaaiqdz7586wabj9zabs3dvk9vs10qpb9p0";
-      name = "mailcommon-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/mailcommon-16.12.3.tar.xz";
+      sha256 = "1sx7dgy9jad6vqp1dljg9m40x57zz6xy9d2f1lgab5ibs1lrjhq5";
+      name = "mailcommon-16.12.3.tar.xz";
     };
   };
   mailimporter = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/mailimporter-16.12.2.tar.xz";
-      sha256 = "0dvnqqmmxdca7wmsajhzdxgz1k07dfbac0z1paww4d2inr164b8q";
-      name = "mailimporter-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/mailimporter-16.12.3.tar.xz";
+      sha256 = "08yj4i6jy08hk62mxw299sh2n5pknzxanmzr96n6lf8g1jcf2l21";
+      name = "mailimporter-16.12.3.tar.xz";
     };
   };
   marble = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/marble-16.12.2.tar.xz";
-      sha256 = "0p7ka2hl0f9ghpmyh124p57dy1ynhw0dszihg4rbbrjfjj65vig0";
-      name = "marble-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/marble-16.12.3.tar.xz";
+      sha256 = "08dykrmiq1jk9yv83sjj6s3gps56bw0hxjbvb90bzd1g0kh0c82j";
+      name = "marble-16.12.3.tar.xz";
     };
   };
   mbox-importer = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/mbox-importer-16.12.2.tar.xz";
-      sha256 = "00q7x30bl1fwfgwvqmgbspp74bmjm40d30rykq052v1cp6n0c060";
-      name = "mbox-importer-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/mbox-importer-16.12.3.tar.xz";
+      sha256 = "04sxijnyr13yjqkd1wm14bxm3k7r17dv24mfb3kbf804s7g8hvq7";
+      name = "mbox-importer-16.12.3.tar.xz";
     };
   };
   messagelib = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/messagelib-16.12.2.tar.xz";
-      sha256 = "0b65248mc6qamj1wcpv73v1ywda9gk2s2y20vjf35lmv5xi4cz88";
-      name = "messagelib-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/messagelib-16.12.3.tar.xz";
+      sha256 = "1s5r5w231lzy3csljd5qil54ibm9mjs7c9hbw1whqmn4kd0vaz15";
+      name = "messagelib-16.12.3.tar.xz";
     };
   };
   minuet = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/minuet-16.12.2.tar.xz";
-      sha256 = "1sv9b1lq2dyvlwq0bmmnxak60nz83wbwnw1d8w3n5xadssarbr1s";
-      name = "minuet-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/minuet-16.12.3.tar.xz";
+      sha256 = "15c0mw8qj7r6192h39lvsmiy3pqlfqzari4qjg2x44j5gq02ab3c";
+      name = "minuet-16.12.3.tar.xz";
     };
   };
   okteta = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/okteta-16.12.2.tar.xz";
-      sha256 = "1xq1bjpy7g8qn9d7dfgy00kf5bdcpvj1489b65yrlmyi382m5k7s";
-      name = "okteta-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/okteta-16.12.3.tar.xz";
+      sha256 = "14wmacbxc5kc3y5y5lsdxgsswi1jdvlxsd0xqcims50xjpb8znpd";
+      name = "okteta-16.12.3.tar.xz";
     };
   };
   okular = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/okular-16.12.2.tar.xz";
-      sha256 = "020z6wlycip067j398lznqcspi3b6dx1zds9ibhxw9zzh3ms92kc";
-      name = "okular-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/okular-16.12.3.tar.xz";
+      sha256 = "1gilr9nviv51pcnmqdfw7834knvyfd11ggdjvinxvbpz61832niv";
+      name = "okular-16.12.3.tar.xz";
     };
   };
   palapeli = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/palapeli-16.12.2.tar.xz";
-      sha256 = "1vkkq9r9r85x46xx91gqyhpagx1xscrvlkx4knd72rcxfygipzf9";
-      name = "palapeli-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/palapeli-16.12.3.tar.xz";
+      sha256 = "13s9ybj8a1f39z66syj88vx8rygdbb969b1d5r01msav3lk8ar3j";
+      name = "palapeli-16.12.3.tar.xz";
     };
   };
   parley = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/parley-16.12.2.tar.xz";
-      sha256 = "0fvkhph41y5ig3nwmb4zfh8n3sip52r5al3vn4yll2ndkbwdkgjb";
-      name = "parley-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/parley-16.12.3.tar.xz";
+      sha256 = "0vmbn8188brp4bysyzmkgsa8nnn9zdqb7q6x3mi1xg7ralzfjw71";
+      name = "parley-16.12.3.tar.xz";
     };
   };
   picmi = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/picmi-16.12.2.tar.xz";
-      sha256 = "0j0jhvw8b18sskvd32snk4g7xpjk3kqfw9kpvfri0qayrshcxk2c";
-      name = "picmi-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/picmi-16.12.3.tar.xz";
+      sha256 = "0v44n05b6v46qmfrgq6b0q8bifnz5ax1f6sjrg6940q99kp2cxx4";
+      name = "picmi-16.12.3.tar.xz";
     };
   };
   pimcommon = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/pimcommon-16.12.2.tar.xz";
-      sha256 = "1c4h1g6hpa7hw3ka2r561q813if031vriz646skin840jwdhnv7m";
-      name = "pimcommon-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/pimcommon-16.12.3.tar.xz";
+      sha256 = "179ig6rwxil1ssm7k2cy7ny3vf2dbhsjn39c0ic70r03q3lzbhll";
+      name = "pimcommon-16.12.3.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/pim-data-exporter-16.12.2.tar.xz";
-      sha256 = "14gkkyvcwa7q1yq6qhswq4ch9gcp1ddpjyf46d0550z1rkpws28m";
-      name = "pim-data-exporter-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/pim-data-exporter-16.12.3.tar.xz";
+      sha256 = "14xvh2gn3vc3i94fv96xbv7gxnwj8xxg3zkgfdlayajp3sz7c3yw";
+      name = "pim-data-exporter-16.12.3.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/pim-sieve-editor-16.12.2.tar.xz";
-      sha256 = "03a3imm5zs4p6zlp3m0pdc22cii26cnkgl1s1059lhmd3g3dhl85";
-      name = "pim-sieve-editor-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/pim-sieve-editor-16.12.3.tar.xz";
+      sha256 = "03gnq2hlvw92gg8rf2bwrvf83nrgcvy6xanvwn3vcrqjfg55vb1k";
+      name = "pim-sieve-editor-16.12.3.tar.xz";
     };
   };
   pim-storage-service-manager = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/pim-storage-service-manager-16.12.2.tar.xz";
-      sha256 = "1kcbrg9h3c5khyabs5n6adqljj60vks7npb8iy649y0rx2qc2fn9";
-      name = "pim-storage-service-manager-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/pim-storage-service-manager-16.12.3.tar.xz";
+      sha256 = "0ii1f5gv430i8h2c4xdy35rz7w9py53xans8zwgpj6ir6x6gfkb0";
+      name = "pim-storage-service-manager-16.12.3.tar.xz";
     };
   };
   poxml = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/poxml-16.12.2.tar.xz";
-      sha256 = "17sv19rg1d65h6ks11k7f8zx6yliyhk1j2fxnc81l8md1flarfm0";
-      name = "poxml-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/poxml-16.12.3.tar.xz";
+      sha256 = "1cpc49hnslc2iabgnvda7967mmrdzykjydi8py67ycr9k1gx6pm5";
+      name = "poxml-16.12.3.tar.xz";
     };
   };
   print-manager = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/print-manager-16.12.2.tar.xz";
-      sha256 = "1amhl13n7i5z1jfhyrhvigk0bhh9myag7kk83bqkxffsx0lzzwbw";
-      name = "print-manager-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/print-manager-16.12.3.tar.xz";
+      sha256 = "1mjzqq7yhm1s4jbr6nhy1i1lm27134j6g7b04mmzk3hbgd8lkr99";
+      name = "print-manager-16.12.3.tar.xz";
     };
   };
   rocs = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/rocs-16.12.2.tar.xz";
-      sha256 = "1gd0wdvp3c4s8br23fqqa0cp2vwfjp3xqkj1y3xf6pzv01sk7n7g";
-      name = "rocs-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/rocs-16.12.3.tar.xz";
+      sha256 = "17iz9ql988mj1vsvywd8w5w7qmbncxal71maf3rldadwmadkvzbl";
+      name = "rocs-16.12.3.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/signon-kwallet-extension-16.12.2.tar.xz";
-      sha256 = "187xjbjw9a34p9cjjhijmwg8n7m83qikxa5q8nsffd48pl7pag2i";
-      name = "signon-kwallet-extension-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/signon-kwallet-extension-16.12.3.tar.xz";
+      sha256 = "0fnqdcin471hlw694vb6z9ybgw31778rhnryc7zps40kjwfdxhcc";
+      name = "signon-kwallet-extension-16.12.3.tar.xz";
     };
   };
   spectacle = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/spectacle-16.12.2.tar.xz";
-      sha256 = "1snz8kgnwm2cbfa6y9awb3d0markfmmbgkjs1k0xs938mqam4507";
-      name = "spectacle-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/spectacle-16.12.3.tar.xz";
+      sha256 = "1fca71a59sgicq9zi8d0im0xpg7iz93s96h3clxxc6p493vsjkx6";
+      name = "spectacle-16.12.3.tar.xz";
     };
   };
   step = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/step-16.12.2.tar.xz";
-      sha256 = "0ghr054c644hvay0k4xsahrl8bwnd9w8yqq3slrdblhs7z3c7iqk";
-      name = "step-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/step-16.12.3.tar.xz";
+      sha256 = "0pyvhlfrklc2xxylb0nlnpqx5xi0pp4zyb3xbzj87wmvcw7v5n6r";
+      name = "step-16.12.3.tar.xz";
     };
   };
   svgpart = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/svgpart-16.12.2.tar.xz";
-      sha256 = "0z9a7654f3n5870d02zm8a9dpymc3jxgmf79wavsp8jjr8sdgy6g";
-      name = "svgpart-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/svgpart-16.12.3.tar.xz";
+      sha256 = "0frzqp504dzqwqs9lh544xxa8i6sqi6qj533mqbzkqbjx310ka3w";
+      name = "svgpart-16.12.3.tar.xz";
     };
   };
   sweeper = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/sweeper-16.12.2.tar.xz";
-      sha256 = "0g0iw89l27v4ivqzsrv9j1q4dgihk80nvgf2cfagadfd50hmifr4";
-      name = "sweeper-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/sweeper-16.12.3.tar.xz";
+      sha256 = "1vf4840l233gji4sjkg9gz2pr98kin5sz37kj645z75vikwmk3al";
+      name = "sweeper-16.12.3.tar.xz";
     };
   };
   syndication = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/syndication-16.12.2.tar.xz";
-      sha256 = "0vgpbr46ibyb097pbqmvpl934d4zwz3gb0fkyc23gwpxq1fgsizp";
-      name = "syndication-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/syndication-16.12.3.tar.xz";
+      sha256 = "11qa0jya3fjvhwsq98aag92ha20y7x758fvc4xi3800rbj8nlc58";
+      name = "syndication-16.12.3.tar.xz";
     };
   };
   umbrello = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/umbrello-16.12.2.tar.xz";
-      sha256 = "1g4856mvj9vzm3k86nqm9sfynall1wcj3mvnc80jji7aazmpkl6z";
-      name = "umbrello-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/umbrello-16.12.3.tar.xz";
+      sha256 = "1a4jhfmh2p1vsx8702ham550blkjj42ibwigcink6s9cadwk90cl";
+      name = "umbrello-16.12.3.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "16.12.2";
+    version = "16.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.2/src/zeroconf-ioslave-16.12.2.tar.xz";
-      sha256 = "1wqiakgc82zylvssxrm2askw6rjw89x85dws7q9zw13hdpvh12ss";
-      name = "zeroconf-ioslave-16.12.2.tar.xz";
+      url = "${mirror}/stable/applications/16.12.3/src/zeroconf-ioslave-16.12.3.tar.xz";
+      sha256 = "0p7kfx7bg3yvd44vg608s2znzfahkihan67zgyf3gmjllbzvp55b";
+      name = "zeroconf-ioslave-16.12.3.tar.xz";
     };
   };
 }


### PR DESCRIPTION
### Motivation for this change

Routine package updates.

### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I will need to backport this to release-17.03.