### PR TITLE
phraseapp-client: init at 1.4.3

### DIFF
--- a/pkgs/tools/misc/phraseapp-client/default.nix
+++ b/pkgs/tools/misc/phraseapp-client/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "phraseapp-client-${version}";
+  version = "1.4.3";
+
+  goPackagePath = "github.com/phrase/phraseapp-client";
+  subPackages = [ "." ];
+
+  src = fetchFromGitHub {
+    owner = "phrase";
+    repo = "phraseapp-client";
+    rev = version;
+    sha256 = "1nfab7y75vl0vg9vy8gc46h7wikk94nky1n415im1xbpsnqg77wz";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://docs.phraseapp.com;
+    description = "PhraseApp API v2 Command Line Client";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ manveru ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14810,6 +14810,8 @@ with pkgs;
 
   phrasendrescher = callPackage ../tools/security/phrasendrescher { };
 
+  phraseapp-client = callPackage ../tools/misc/phraseapp-client { };
+
   phwmon = callPackage ../applications/misc/phwmon { };
 
   pianobar = callPackage ../applications/audio/pianobar { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

