### PR TITLE
transmission-remote-gtk: 1.2 -> 1.3.1

### DIFF
--- a/pkgs/applications/networking/p2p/transmission-remote-gtk/default.nix
+++ b/pkgs/applications/networking/p2p/transmission-remote-gtk/default.nix
@@ -1,21 +1,26 @@
-{ stdenv, autoconf, automake, libtool, makeWrapper, fetchgit, pkgconfig
-, intltool, gtk3, json_glib, curl }:
+{ stdenv, autoconf, automake, libtool, makeWrapper, fetchFromGitHub, pkgconfig
+, intltool, gtk3, json_glib, curl, glib, autoconf-archive, appstream-glib }:
 
 
 stdenv.mkDerivation rec {
   name = "transmission-remote-gtk-${version}";
-  version = "1.2";
+  version = "1.3.1";
 
-  src = fetchgit {
-    url = "https://github.com/ajf8/transmission-remote-gtk.git";
-    rev = "aa4e0c7d836cfcc10d8effd10225abb050343fc8";
-    sha256 = "0qz0jzr5w5fik2awfps0q49blwm4z7diqca2405rr3fyhyjhx42b";
+  src = fetchFromGitHub {
+    owner = "transmission-remote-gtk";
+    repo = "transmission-remote-gtk";
+    rev = "${version}";
+    sha256 = "02q0vl7achx9rpd0iv0347h838bwzm7aj4k04y88g3bh8fi3cddh";
   };
 
-  buildInputs = [ libtool autoconf automake makeWrapper pkgconfig intltool
-                  gtk3 json_glib curl ];
+  preConfigure = "./autogen.sh";
 
-  preConfigure = "sh autogen.sh";
+  nativeBuildInputs= [ 
+    autoconf automake libtool makeWrapper 
+    pkgconfig intltool autoconf-archive 
+    appstream-glib
+  ];
+  buildInputs = [ gtk3 json_glib curl glib ];
 
   preFixup = ''
     wrapProgram "$out/bin/transmission-remote-gtk" \


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

