### PR TITLE
owncloud-client: 2.2.3 -> 2.3.0

### DIFF
--- a/pkgs/applications/networking/owncloud-client/default.nix
+++ b/pkgs/applications/networking/owncloud-client/default.nix
@@ -1,17 +1,16 @@
 { stdenv, fetchurl, cmake, qt4, pkgconfig, qtkeychain, sqlite }:
 
 stdenv.mkDerivation rec {
-  name = "owncloud-client" + "-" + version;
-
-  version = "2.2.3";
+  name = "owncloud-client-${version}";
+  version = "2.3.0";
 
   src = fetchurl {
     url = "https://download.owncloud.com/desktop/stable/owncloudclient-${version}.tar.xz";
-    sha256 = "00bx9wrgvbdhi9vx30qfgkdz0k8nxlj313pac34cchx5xpij3jgq";
+    sha256 = "10ah4zmnv4hfi50k59qwk990h1a4g95d3yvxqqrv4x1dv8p2sscf";
   };
 
-  buildInputs =
-    [ cmake qt4 pkgconfig qtkeychain sqlite];
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ qt4 qtkeychain sqlite];
 
   cmakeFlags = [
   "-UCMAKE_INSTALL_LIBDIR"
@@ -19,10 +18,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Synchronise your ownCloud with your computer using this desktop client";
     homepage = https://owncloud.org;
-    maintainers = with stdenv.lib.maintainers; [ qknight ];
-    meta.platforms = stdenv.lib.platforms.unix;
+    maintainers = [ maintainers.qknight ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

