### PR TITLE
mpop: 1.2.4 -> 1.2.6

### DIFF
--- a/pkgs/applications/networking/mpop/default.nix
+++ b/pkgs/applications/networking/mpop/default.nix
@@ -1,24 +1,27 @@
 { stdenv, fetchurl, openssl, pkgconfig, gnutls, gsasl, libidn, Security }:
 
+with stdenv.lib;
+
 stdenv.mkDerivation rec {
-  version = "1.2.4";
+  version = "1.2.6";
   name = "mpop-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/mpop/${name}.tar.xz";
-    sha256 = "158zl6clxrl2id4kvdig2lvdvm0vg2byqcgn1dnxfjg5mw16ngwk";
+    sha256 = "0p1ix63jh64dibrlccch8q7gxl9nn18wd2qpyr5z1h4gs2fpmv4z";
   };
 
-  buildInputs = [ openssl pkgconfig gnutls gsasl libidn ]
-    ++ stdenv.lib.optional stdenv.isDarwin Security;
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ openssl gnutls gsasl libidn ]
+    ++ optional stdenv.isDarwin Security;
 
   configureFlags =
-    stdenv.lib.optional stdenv.isDarwin [ "--with-macosx-keyring" ];
+    optional stdenv.isDarwin [ "--with-macosx-keyring" ];
 
   meta = {
       description = "POP3 mail retrieval agent";
-      homepage = "http://mpop.sourceforge.net/";
-      license = stdenv.lib.licenses.gpl3Plus;
-      platforms = stdenv.lib.platforms.unix;
+      homepage = http://mpop.sourceforge.net/;
+      license = licenses.gpl3Plus;
+      platforms = platforms.unix;
     };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

