### PR TITLE
vogl:  init at 2016-05-13

### DIFF
--- a/pkgs/development/tools/vogl/default.nix
+++ b/pkgs/development/tools/vogl/default.nix
@@ -1,0 +1,47 @@
+{ fetchFromGitHub, stdenv
+, cmake, git, pkgconfig, wget, zip
+, makeQtWrapper, qtbase, qtx11extras
+, libdwarf, libjpeg_turbo, libunwind, lzma, tinyxml, libX11
+, SDL2, SDL2_gfx, SDL2_image, SDL2_ttf
+, freeglut, mesa, mesa_glu
+}:
+stdenv.mkDerivation rec {
+  name = "vogl-${version}";
+  version = "2016-05-13";
+
+  src = fetchFromGitHub {
+    owner  = "deepfire";
+    repo   = "vogl";
+    rev    = "cbc5f1853e294b363f16c4e00b3e0c49dbf74559";
+    sha256 = "17gwd73x3lnqv6ccqs48pzqwbzjhbn41c0x0l5zzirhiirb3yh0n";
+  };
+
+  nativeBuildInputs = [
+    cmake makeQtWrapper pkgconfig
+  ];
+
+  buildInputs = [
+    git wget zip
+    qtbase qtx11extras
+    libdwarf libjpeg_turbo libunwind lzma tinyxml libX11
+    SDL2 SDL2_gfx SDL2_image SDL2_ttf
+    freeglut mesa mesa_glu
+  ];
+
+  enableParallelBuilding = true;
+
+  dontUseCmakeBuildDir = true;
+  preConfigure = ''
+    cmakeDir=$PWD
+    mkdir -p vogl/vogl_build/release64 && cd $_
+  '';
+  cmakeFlags = '' -DCMAKE_VERBOSE=On -DCMAKE_BUILD_TYPE=Release -DBUILD_X64=On'';
+
+  meta = with stdenv.lib; {
+    description = "OpenGL capture / playback debugger.";
+    homepage = https://github.com/ValveSoftware/vogl;
+    license = licenses.mit;
+    maintainers = [ maintainers.deepfire ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15921,6 +15921,8 @@ with pkgs;
 
   vnstat = callPackage ../applications/networking/vnstat { };
 
+  vogl = qt57.callPackage ../development/tools/vogl { };
+
   volnoti = callPackage ../applications/misc/volnoti { };
 
   vorbis-tools = callPackage ../applications/audio/vorbis-tools { };


### PR DESCRIPTION
###### Motivation for this change
Packaging https://github.com/ValveSoftware/vogl -- 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux (SteamOS)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

--

Things work, modulo two issues:
- https://github.com/NixOS/nixpkgs/issues/9415 -- for which there now is a partial solution: https://github.com/deepfire/nix-install-vendor-gl
- you need to tick the `Use vogl tool` checkbox in the `Generate trace..` dialog -- no idea about that yet.