### PR TITLE
nixos: Define XCURSOR_PATH environment variable.

### DIFF
--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -20,6 +20,7 @@ in
       { NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
         PAGER = mkDefault "less -R";
         EDITOR = mkDefault "nano";
+        XCURSOR_PATH = "$HOME/.icons";
       };
 
     environment.profiles =
@@ -42,6 +43,7 @@ in
         GTK_PATH = [ "/lib/gtk-2.0" "/lib/gtk-3.0" ];
         XDG_CONFIG_DIRS = [ "/etc/xdg" ];
         XDG_DATA_DIRS = [ "/share" ];
+        XCURSOR_PATH = [ "/share/icons" ];
         MOZ_PLUGIN_PATH = [ "/lib/mozilla/plugins" ];
         LIBEXEC_PATH = [ "/lib/libexec" ];
       };


### PR DESCRIPTION
In the absence of XCURSOR_PATH, the function XcursorLibraryPath
in libXcursor will return a hardcoded value unsuitable for NixOS.
Some desktops as well as display managers in NixOS currently do
set XCURSOR_PATH, but there are combinations where neither does
(e.g. SDDM+XFCE), resulting in no cursor themes being available.

The new definition if XCURSOR_PATH is effectively the same as what
KDE's startkde currently does. The pre-existing definitions of (which can
be found by grepping nixpkgs for XCURSOR_PATH) can probably be
removed then.

Fixes issue #21442.

Note this is applicable for 16.09 and 17.03 as well.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

