### PR TITLE
kdeApplications.kolourpaint: init

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -74,6 +74,7 @@ let
       kio-extras = callPackage ./kio-extras.nix {};
       kmime = callPackage ./kmime.nix {};
       kmix = callPackage ./kmix.nix {};
+      kolourpaint = callPackage ./kolourpaint.nix {};
       kompare = callPackage ./kompare.nix {};
       konsole = callPackage ./konsole.nix {};
       kwalletmanager = callPackage ./kwalletmanager.nix {};

--- a/pkgs/applications/kde/kolourpaint.nix
+++ b/pkgs/applications/kde/kolourpaint.nix
@@ -1,0 +1,28 @@
+{ lib
+, kdeApp
+, kdeWrapper
+, extra-cmake-modules
+, kdoctools
+, kdelibs4support
+, libkexiv2
+}:
+
+let
+  unwrapped =
+    kdeApp {
+      name = "kolourpaint";
+      nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+      propagatedBuildInputs = [
+        kdelibs4support
+        libkexiv2
+      ];
+
+      meta = {
+        maintainers = [ lib.maintainers.fridh ];
+        license = with lib.licenses; [ gpl2 ];
+      };
+    };
+in kdeWrapper {
+  inherit unwrapped;
+  targets = ["bin/kolourpaint"];
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

