### PR TITLE
slimserver: Init at 7.9.0 (pkg + module)

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -288,6 +288,7 @@
       kresd = 270;
       rpc = 271;
       geoip = 272;
+      slimserver = 273;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -545,6 +546,7 @@
       kresd = 270;
       #rpc = 271; # unused
       #geoip = 272; # unused
+      slimserver = 273;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -288,7 +288,6 @@
       kresd = 270;
       rpc = 271;
       geoip = 272;
-      slimserver = 273;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -546,7 +545,6 @@
       kresd = 270;
       #rpc = 271; # unused
       #geoip = 272; # unused
-      slimserver = 273;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -128,6 +128,7 @@
   ./services/audio/liquidsoap.nix
   ./services/audio/mpd.nix
   ./services/audio/mopidy.nix
+  ./services/audio/slimserver.nix
   ./services/audio/squeezelite.nix
   ./services/audio/ympd.nix
   ./services/backup/almir.nix

--- a/nixos/modules/services/audio/slimserver.nix
+++ b/nixos/modules/services/audio/slimserver.nix
@@ -56,13 +56,12 @@ in {
     };
 
     users = {
-      groups.slimserver.gid = config.ids.gids.slimserver;
       users.slimserver = {
-        uid = config.ids.uids.slimserver;
         description = "Slimserver daemon user";
         home = cfg.dataDir;
         group = "slimserver";
       };
+      groups.slimserver = {};
     };
   };
 

--- a/nixos/modules/services/audio/slimserver.nix
+++ b/nixos/modules/services/audio/slimserver.nix
@@ -34,32 +34,7 @@ in {
           playlists etc.
         '';
       };
-
-      network = {
-
-        listenAddress = mkOption {
-          type = types.str;
-          default = "127.0.0.1";
-          example = "any";
-          description = ''
-            The address for the daemon to listen on.
-            Use <literal>any</literal> to listen on all addresses.
-          '';
-        };
-
-        port = mkOption {
-          type = types.int;
-          default = 6600;
-          description = ''
-            This setting is the TCP port that is desired for the daemon to get assigned
-            to.
-          '';
-        };
-
-      };
-
     };
-
   };
 
 

--- a/nixos/modules/services/audio/slimserver.nix
+++ b/nixos/modules/services/audio/slimserver.nix
@@ -1,0 +1,95 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.slimserver;
+
+in {
+  options = {
+
+    services.slimserver = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable slimserver.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+	default = pkgs.slimserver;
+	defaultText = "pkgs.slimserver";
+	description = "Slimserver package to use.";
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/slimserver";
+        description = ''
+          The directory where slimserver stores its state, tag cache,
+          playlists etc.
+        '';
+      };
+
+      network = {
+
+        listenAddress = mkOption {
+          type = types.str;
+          default = "127.0.0.1";
+          example = "any";
+          description = ''
+            The address for the daemon to listen on.
+            Use <literal>any</literal> to listen on all addresses.
+          '';
+        };
+
+        port = mkOption {
+          type = types.int;
+          default = 6600;
+          description = ''
+            This setting is the TCP port that is desired for the daemon to get assigned
+            to.
+          '';
+        };
+
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    systemd.services.slimserver = {
+      after = [ "network.target" ];
+      description = "Slim Server for Logitech Squeezebox Players";
+      wantedBy = [ "multi-user.target" ];
+
+      preStart = "mkdir -p ${cfg.dataDir} && chown -R slimserver:slimserver ${cfg.dataDir}";
+      serviceConfig = {
+        User = "slimserver";
+        PermissionsStartOnly = true;
+        ExecStart = "${cfg.package}/slimserver.pl --logdir ${cfg.dataDir}/logs --prefsdir ${cfg.dataDir}/prefs --cachedir ${cfg.dataDir}/cache";
+      };
+    };
+
+    users = {
+      groups.slimserver.gid = config.ids.gids.slimserver;
+      users.slimserver = {
+        uid = config.ids.uids.slimserver;
+	description = "Slimserver daemon user";
+	home = cfg.dataDir;
+	group = "slimserver";
+      };
+    };
+  };
+
+}
+

--- a/nixos/modules/services/audio/slimserver.nix
+++ b/nixos/modules/services/audio/slimserver.nix
@@ -21,9 +21,9 @@ in {
 
       package = mkOption {
         type = types.package;
-	default = pkgs.slimserver;
-	defaultText = "pkgs.slimserver";
-	description = "Slimserver package to use.";
+        default = pkgs.slimserver;
+        defaultText = "pkgs.slimserver";
+        description = "Slimserver package to use.";
       };
 
       dataDir = mkOption {
@@ -84,9 +84,9 @@ in {
       groups.slimserver.gid = config.ids.gids.slimserver;
       users.slimserver = {
         uid = config.ids.uids.slimserver;
-	description = "Slimserver daemon user";
-	home = cfg.dataDir;
-	group = "slimserver";
+        description = "Slimserver daemon user";
+        home = cfg.dataDir;
+        group = "slimserver";
       };
     };
   };

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -19,6 +19,7 @@ buildPerlPackage rec {
     perlPackages.AudioScan
     perlPackages.CarpClan
     perlPackages.CGI
+    perlPackages.DataDump
     perlPackages.DataURIEncode
     perlPackages.DBDSQLite
     perlPackages.DBI
@@ -27,11 +28,13 @@ buildPerlPackage rec {
     perlPackages.EV
     perlPackages.ExporterLite
     perlPackages.FileBOM
+    perlPackages.FileCopyRecursive
     perlPackages.FileNext
     perlPackages.FileSlurp
     perlPackages.FileWhich
     perlPackages.HTMLParser
     perlPackages.HTTPCookies
+    perlPackages.HTTPDaemon
     perlPackages.HTTPMessage
     perlPackages.ImageScale
     perlPackages.IOSocketSSL
@@ -47,6 +50,8 @@ buildPerlPackage rec {
     perlPackages.TieRegexpHash
     perlPackages.TimeDate
     perlPackages.URI
+    perlPackages.URIFind
+    perlPackages.UUIDTiny
     perlPackages.XMLParser
     perlPackages.XMLSimple
     perlPackages.YAMLLibYAML

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -19,6 +19,7 @@ buildPerlPackage rec {
     perlPackages.AudioScan
     perlPackages.CarpClan
     perlPackages.CGI
+    perlPackages.ClassXSAccessor
     perlPackages.DataDump
     perlPackages.DataURIEncode
     perlPackages.DBDSQLite
@@ -30,6 +31,7 @@ buildPerlPackage rec {
     perlPackages.FileBOM
     perlPackages.FileCopyRecursive
     perlPackages.FileNext
+    perlPackages.FileReadBackwards
     perlPackages.FileSlurp
     perlPackages.FileWhich
     perlPackages.HTMLParser
@@ -41,6 +43,7 @@ buildPerlPackage rec {
     perlPackages.IOString
     perlPackages.JSONXSVersionOneAndTwo
     perlPackages.Log4Perl
+    perlPackages.LWPUserAgent
     perlPackages.NetHTTP
     perlPackages.ProcBackground
     perlPackages.SubName
@@ -59,6 +62,8 @@ buildPerlPackage rec {
 
 
   prePatch = ''
+    mkdir CPAN_used
+    mv CPAN/DBIx CPAN/SQL CPAN/Template* CPAN_used
     rm -rf CPAN
     rm -rf Bin
     touch Makefile.PL
@@ -68,8 +73,9 @@ buildPerlPackage rec {
 
   buildPhase = "
     mv lib tmp
-    mkdir -p lib/perl5/
-    mv tmp lib/perl5/site_perl
+    mkdir -p lib/perl5/site_perl
+    mv CPAN_used/* lib/perl5/site_perl
+    cp -rf tmp/* lib/perl5/site_perl
     mv Slim lib/perl5/site_perl
   ";
 

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -75,7 +75,6 @@ buildPerlPackage rec {
     mkdir -p lib/perl5/site_perl
     mv CPAN_used/* lib/perl5/site_perl
     cp -rf tmp/* lib/perl5/site_perl
-    mv Slim lib/perl5/site_perl
   ";
 
   doCheck = false;

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -1,16 +1,14 @@
-{ stdenv, buildPerlPackage, fetchFromGitHub
+{ stdenv, buildPerlPackage, fetchurl
 #, sqlite, expat, mp4v2, flac, spidermonkey_1_8_5, taglib, libexif, curl, ffmpeg, file
 , perl, perlPackages }:
 
 buildPerlPackage rec {
   name = "slimserver-${version}";
-  version = "7.9";
+  version = "7.9.0";
 
-  src = fetchFromGitHub {
-    owner  = "Logitech";
-    repo   = "slimserver";
-    rev    = "095dd886a01e56a1ffe1b2ea31bb290d17c83948";
-    sha256 = "06s945spxh6j4g0l1k6cxpq04011ad4swgqd2in87c86sf6bm445";
+  src = fetchurl {
+    url = "https://github.com/Logitech/slimserver/archive/${version}.tar.gz";
+    sha256 = "07rhqipg7m28x0nqdd83nyzi88dp9cf8rr2pamdyrfcwyp1h1b44";
   };
 
   buildInputs = [

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -89,8 +89,9 @@ buildPerlPackage rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/Logitech/slimserver;
     description = "Server for Logitech Squeezebox players. This server is also called Logitech Media Server";
-    # TODO: not all source code is under gpl2!
-    license = licenses.gpl2;
+    # the firmware is not under a free license!
+    # https://github.com/Logitech/slimserver/blob/public/7.9/License.txt
+    license = licenses.unfree;
     maintainers = [ maintainers.phile314 ];
     platforms = platforms.linux;
   };

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -1,5 +1,4 @@
 { stdenv, buildPerlPackage, fetchurl
-#, sqlite, expat, mp4v2, flac, spidermonkey_1_8_5, taglib, libexif, curl, ffmpeg, file
 , perl, perlPackages }:
 
 buildPerlPackage rec {
@@ -62,6 +61,7 @@ buildPerlPackage rec {
 
   prePatch = ''
     mkdir CPAN_used
+    # slimserver doesn't work with current DBIx/SQL versions, use bundled copies
     mv CPAN/DBIx CPAN/SQL CPAN_used
     rm -rf CPAN
     rm -rf Bin

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -17,9 +17,19 @@ stdenv.mkDerivation rec {
   buildInputs = [
     makeWrapper
     perl
-    perlPackages.Log4Perl
     perlPackages.AudioScan
+    perlPackages.DBI
+    perlPackages.DigestSHA1
+    perlPackages.EV
+    perlPackages.HTMLParser
     perlPackages.ImageScale
+    # why do
+    perlPackages.JSONXS
+    perlPackages.JSONXSVersionOneAndTwo
+    perlPackages.Log4Perl
+    perlPackages.SubName
+    perlPackages.XMLParser
+    perlPackages.YAML
   ];
 
   buildPhase = ''
@@ -32,9 +42,18 @@ stdenv.mkDerivation rec {
   postFixup = ''
     wrapProgram $out/slimserver.pl \
       --set PERL5LIB "${with perlPackages; stdenv.lib.makePerlPath [
-      Log4Perl
       AudioScan
+      DBI
+      DigestSHA1
+      EV
+      HTMLParser
       ImageScale
+      JSONXS
+      JSONXSVersionOneAndTwo
+      Log4Perl
+      SubName
+      XMLParser
+      YAML
       ]}"
   '';
 

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -47,6 +47,7 @@ buildPerlPackage rec {
     perlPackages.NetHTTP
     perlPackages.ProcBackground
     perlPackages.SubName
+    perlPackages.TemplateToolkit
     perlPackages.TextUnidecode
     perlPackages.TieCacheLRU
     perlPackages.TieCacheLRUExpires
@@ -63,7 +64,7 @@ buildPerlPackage rec {
 
   prePatch = ''
     mkdir CPAN_used
-    mv CPAN/DBIx CPAN/SQL CPAN/Template* CPAN_used
+    mv CPAN/DBIx CPAN/SQL CPAN_used
     rm -rf CPAN
     rm -rf Bin
     touch Makefile.PL

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -70,6 +70,7 @@ buildPerlPackage rec {
     mv lib tmp
     mkdir -p lib/perl5/
     mv tmp lib/perl5/site_perl
+    mv Slim lib/perl5/site_perl
   ";
 
   doCheck = false;

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub
+, makeWrapper
+#, sqlite, expat, mp4v2, flac, spidermonkey_1_8_5, taglib, libexif, curl, ffmpeg, file
+, perl, perlPackages }:
+
+stdenv.mkDerivation rec {
+  name = "slimserver-${version}";
+  version = "7.9";
+
+  src = fetchFromGitHub {
+    owner  = "Logitech";
+    repo   = "slimserver";
+    rev    = "095dd886a01e56a1ffe1b2ea31bb290d17c83948";
+    sha256 = "06s945spxh6j4g0l1k6cxpq04011ad4swgqd2in87c86sf6bm445";
+  };
+
+  buildInputs = [
+    makeWrapper
+    perl
+    perlPackages.Log4Perl
+    perlPackages.AudioScan
+    perlPackages.ImageScale
+  ];
+
+  buildPhase = ''
+  '';
+
+  installPhase = ''
+    cp -r . $out
+  '';
+  
+  postFixup = ''
+    wrapProgram $out/slimserver.pl \
+      --set PERL5LIB "${with perlPackages; stdenv.lib.makePerlPath [
+      Log4Perl
+      ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Logitech/slimserver;
+    description = "Server for Logitech Squeezebox players. This server is also called Logitech Media Server";
+    # TODO: not all source code is under gpl2!
+    license = licenses.gpl2;
+    maintainers = [ maintainers.phile314 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildPhase = ''
+    rm -Rf CPAN
+    rm -Rf Bin
   '';
 
   installPhase = ''

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
     wrapProgram $out/slimserver.pl \
       --set PERL5LIB "${with perlPackages; stdenv.lib.makePerlPath [
       Log4Perl
+      AudioScan
+      ImageScale
       ]}"
   '';
 

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -1,9 +1,8 @@
-{ stdenv, fetchFromGitHub
-, makeWrapper
+{ stdenv, buildPerlPackage, fetchFromGitHub
 #, sqlite, expat, mp4v2, flac, spidermonkey_1_8_5, taglib, libexif, curl, ffmpeg, file
 , perl, perlPackages }:
 
-stdenv.mkDerivation rec {
+buildPerlPackage rec {
   name = "slimserver-${version}";
   version = "7.9";
 
@@ -15,49 +14,66 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    makeWrapper
     perl
+    perlPackages.AnyEvent
     perlPackages.AudioScan
+    perlPackages.CarpClan
+    perlPackages.CGI
+    perlPackages.DataURIEncode
+    perlPackages.DBDSQLite
     perlPackages.DBI
+    perlPackages.DBIxClass
     perlPackages.DigestSHA1
     perlPackages.EV
+    perlPackages.ExporterLite
+    perlPackages.FileBOM
+    perlPackages.FileNext
+    perlPackages.FileSlurp
+    perlPackages.FileWhich
     perlPackages.HTMLParser
+    perlPackages.HTTPCookies
+    perlPackages.HTTPMessage
     perlPackages.ImageScale
-    # why do
-    perlPackages.JSONXS
+    perlPackages.IOSocketSSL
+    perlPackages.IOString
     perlPackages.JSONXSVersionOneAndTwo
     perlPackages.Log4Perl
+    perlPackages.NetHTTP
+    perlPackages.ProcBackground
     perlPackages.SubName
+    perlPackages.TextUnidecode
+    perlPackages.TieCacheLRU
+    perlPackages.TieCacheLRUExpires
+    perlPackages.TieRegexpHash
+    perlPackages.TimeDate
+    perlPackages.URI
     perlPackages.XMLParser
-    perlPackages.YAML
+    perlPackages.XMLSimple
+    perlPackages.YAMLLibYAML
   ];
 
-  buildPhase = ''
-    rm -Rf CPAN
-    rm -Rf Bin
-  '';
+
+  prePatch = ''
+    rm -rf CPAN
+    rm -rf Bin
+    touch Makefile.PL
+    '';
+
+  preConfigurePhase = "";
+
+  buildPhase = "
+    mv lib tmp
+    mkdir -p lib/perl5/
+    mv tmp lib/perl5/site_perl
+  ";
+
+  doCheck = false;
 
   installPhase = ''
     cp -r . $out
   '';
-  
-  postFixup = ''
-    wrapProgram $out/slimserver.pl \
-      --set PERL5LIB "${with perlPackages; stdenv.lib.makePerlPath [
-      AudioScan
-      DBI
-      DigestSHA1
-      EV
-      HTMLParser
-      ImageScale
-      JSONXS
-      JSONXSVersionOneAndTwo
-      Log4Perl
-      SubName
-      XMLParser
-      YAML
-      ]}"
-  '';
+
+  outputs = [ "out" ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/Logitech/slimserver;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10896,6 +10896,8 @@ with pkgs;
 
   sipwitch = callPackage ../servers/sip/sipwitch { };
 
+  slimserver = callPackage ../servers/slimserver { };
+
   smcroute = callPackage ../servers/smcroute { };
 
   spawn_fcgi = callPackage ../servers/http/spawn-fcgi { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -881,6 +881,17 @@ let self = _self // overrides; _self = with self; {
     buildInputs = [ TestMore ];
   };
 
+  CanaryStability = buildPerlPackage rec {
+    name = "Canary-Stability-2012";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${name}.tar.gz";
+      sha256 = "fd240b111d834dbae9630c59b42fae2145ca35addc1965ea311edf0d07817107";
+    };
+    meta = {
+      license = stdenv.lib.licenses.gpl1Plus;
+    };
+  };
+
   CaptchaReCAPTCHA = buildPerlPackage rec {
     name = "Captcha-reCAPTCHA-0.97";
     src = fetchurl {
@@ -4663,6 +4674,19 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  EV = buildPerlPackage rec {
+    name = "EV-4.22";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${name}.tar.gz";
+      sha256 = "2ae7f8734e2e4945510252152c3bea4be35f4aa58aad3db0504c38844b08a991";
+    };
+    buildInputs = [ CanaryStability ];
+    propagatedBuildInputs = [ CommonSense ];
+    meta = {
+      license = stdenv.lib.licenses.gpl1Plus;
+    };
+  };
+
   EvalClosure = buildPerlPackage {
     name = "Eval-Closure-0.11";
     src = fetchurl {
@@ -7110,6 +7134,18 @@ let self = _self // overrides; _self = with self; {
     meta = {
       homepage = http://search.cpan.org/perldoc?CPAN::Meta::Spec;
       platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+    };
+  };
+
+  JSONXSVersionOneAndTwo = buildPerlPackage rec {
+    name = "JSON-XS-VersionOneAndTwo-0.31";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/L/LB/LBROCARD/${name}.tar.gz";
+      sha256 = "e6092c4d961fae777acf7fe99fb3cd6e5b710fec85765a6b90417480e4c94a34";
+    };
+    propagatedBuildInputs = [ JSONXS ];
+    meta = {
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -463,9 +463,12 @@ let self = _self // overrides; _self = with self; {
     name = "Audio-Scan-0.96";
     src = fetchurl {
       url = "mirror://cpan/authors/id/A/AG/AGRUNDMA/${name}.tar.gz";
-      sha256 = "67f45fef6a23b7548f387b675cbf7881bf9da62d7d007cbf90d3a4b851b99eb7";
+      sha256 = "d68bb3598bb3c925f4753cc9e73f5e357bf249a36e16da57c54c205de4bbb426";
     };
-    buildInputs = [ ModuleBuild TestWarn ScalarString DigestCRC DataInteger ];
+    buildInputs = [ pkgs.zlib ModuleBuild ModuleBuildPluggablePPPort ];
+    propagatedBuildInputs = [ TestWarn ];
+    NIX_CFLAGS_COMPILE = "-I${pkgs.zlib.dev}/include";
+    NIX_CFLAGS_LINK = "-L${pkgs.zlib.out}/lib -lz";
     meta = {
       description = "Fast C metadata and tag reader for all common audio file formats";
       license = stdenv.lib.licenses.gpl2;
@@ -6544,13 +6547,15 @@ let self = _self // overrides; _self = with self; {
   ImageScale = buildPerlPackage rec {
     name = "Image-Scale-0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGRUNDMAN/${name}.tar.gz";
-      sha256 = "1mx065134gy75pgdldh65118bpcs6yfbqmr7bf9clwq44zslxhxc";
+      url = "mirror://cpan/authors/id/A/AG/AGRUNDMA/${name}.tar.gz";
+      sha256 = "5b2c92dc2dd635b488879461760cd251aa2b1feef41b64f17914a6e4bbe3e442";
     };
-    buildInputs = [ ModuleBuild TestNoWarnings ];
+    buildInputs = [ pkgs.libpng pkgs.libjpeg ];
+    propagatedBuildInputs = [ TestNoWarnings pkgs.zlib ];
+    makeMakerFlags = "--with-jpeg-includes=${pkgs.libjpeg.dev}/include --with-jpeg-libs=${pkgs.libjpeg.out}/lib --with-png-includes=${pkgs.libpng.dev}/include --with-png-libs=${pkgs.libpng.out}/lib";
     meta = {
       description = "Fast, high-quality fixed-point image resizing";
-      license = stdenv.lib.licenses.gpl2;
+      license = stdenv.lib.licenses.gpl2Plus;
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6541,6 +6541,19 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  ImageScale = buildPerlPackage rec {
+    name = "Image-Scale-0.13";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/A/AG/AGRUNDMAN/${name}.tar.gz";
+      sha256 = "1mx065134gy75pgdldh65118bpcs6yfbqmr7bf9clwq44zslxhxc";
+    };
+    buildInputs = [ ModuleBuild TestNoWarnings ];
+    meta = {
+      description = "Fast, high-quality fixed-point image resizing";
+      license = stdenv.lib.licenses.gpl2;
+    };
+  };
+
   ImageSize = buildPerlPackage rec {
     name = "Image-Size-3.232";
     src = fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -460,10 +460,10 @@ let self = _self // overrides; _self = with self; {
   };
 
   AudioScan = buildPerlPackage rec {
-    name = "Audio-Scan-0.96";
+    name = "Audio-Scan-0.93";
     src = fetchurl {
       url = "mirror://cpan/authors/id/A/AG/AGRUNDMA/${name}.tar.gz";
-      sha256 = "d68bb3598bb3c925f4753cc9e73f5e357bf249a36e16da57c54c205de4bbb426";
+      sha256 = "03nwcm234y76jb1p20rlcky6vzv68i46s9mjfr7kzp65w3yg94js";
     };
     buildInputs = [ pkgs.zlib ModuleBuild ModuleBuildPluggablePPPort ];
     propagatedBuildInputs = [ TestWarn ];
@@ -2067,6 +2067,20 @@ let self = _self // overrides; _self = with self; {
     propagatedBuildInputs = [ ClassInspector ];
   };
 
+  ClassVirtual = buildPerlPackage rec {
+    name = "Class-Virtual-0.08";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/${name}.tar.gz";
+      sha256 = "c6499b42d3b4e5c6488a5e82fbc28698e6c9860165072dddfa6749355a9cfbb2";
+    };
+    propagatedBuildInputs = [ CarpAssert ClassDataInheritable ClassISA ];
+    meta = {
+      homepage = https://metacpan.org/release/Class-Virtual;
+      description = "Base class for virtual base classes";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   ClassXSAccessor = buildPerlPackage {
     name = "Class-XSAccessor-1.19";
     src = fetchurl {
@@ -3074,6 +3088,17 @@ let self = _self // overrides; _self = with self; {
     src = fetchurl {
       url = "mirror://cpan/authors/id/M/MW/MWX/${name}.tar.gz";
       sha256 = "b6919ba49b9fe98bfdf3e8accae7b9b7f78dc9e71ebbd0b7fef7a45d99324ccb";
+    };
+  };
+
+  DataURIEncode = buildPerlPackage rec {
+    name = "Data-URIEncode-0.11";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/R/RH/RHANDOM/${name}.tar.gz";
+      sha256 = "51c9efbf8423853616eaa24841e4d1996b2db0036900617fb1dbc76c75a1f360";
+    };
+    meta = {
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -4641,6 +4666,17 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  enum = buildPerlPackage rec {
+    name = "enum-1.11";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
+      sha256 = "d2f36b5015f1e35f640159867b60bf5d5cd66b56cd5e42d33f531be68e5eee35";
+    };
+    meta = {
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   Env = buildPerlPackage {
     name = "Env-1.04";
     src = fetchurl {
@@ -5111,6 +5147,20 @@ let self = _self // overrides; _self = with self; {
       perl Build.PL PREFIX="$out" prefix="$out"
     '';
     propagatedBuildInputs = [ ModuleBuild ];
+  };
+
+  FileBOM = buildPerlPackage rec {
+    name = "File-BOM-0.15";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MA/MATTLAW/${name}.tar.gz";
+      sha256 = "431c8b39397fd5ad5b1a1100d3647a06e9f94304d46db44ffc0a0e5c5c06a1c1";
+    };
+    buildInputs = [ ModuleBuild TestException ];
+    propagatedBuildInputs = [ Readonly ];
+    meta = {
+      description = "Utilities for handling Byte Order Marks";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   FileCheckTree = buildPerlPackage {
@@ -10628,6 +10678,16 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  ProcBackground = buildPerlPackage rec {
+    name = "Proc-Background-1.10";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/B/BZ/BZAJAC/${name}.tar.gz";
+      sha256 = "1ce0dd78c0bb8393a2431b385a27b99fcc623a41ebec57b3cc09cc38cdb708ee";
+    };
+    meta = {
+    };
+  };
+
   ProcProcessTable = buildPerlPackage {
     name = "Proc-ProcessTable-0.51";
     src = fetchurl {
@@ -14000,6 +14060,31 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  TieCacheLRU = buildPerlPackage rec {
+    name = "Tie-Cache-LRU-20150301";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/${name}.tar.gz";
+      sha256 = "1bf740450d3a6d7c12b48c25f7da5964e44e7cc38b28572cfb76ff22464f4469";
+    };
+    propagatedBuildInputs = [ CarpAssert ClassDataInheritable ClassVirtual enum ];
+    meta = {
+      description = "A Least-Recently Used cache";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  TieCacheLRUExpires = buildPerlPackage rec {
+    name = "Tie-Cache-LRU-Expires-0.55";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/O/OE/OESTERHOL/${name}.tar.gz";
+      sha256 = "b316d849acd25f24346d55a9950d281fee0746398767c601234122159573eb9a";
+    };
+    propagatedBuildInputs = [ TieCacheLRU ];
+    meta = {
+      license = stdenv.lib.licenses.artistic1;
+    };
+  };
+
   TieCycle = buildPerlPackage rec {
     name = "Tie-Cycle-1.21";
     src = fetchurl {
@@ -14052,6 +14137,17 @@ let self = _self // overrides; _self = with self; {
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FL/FLORA/Tie-RefHash-1.39.tar.gz;
       sha256 = "b0b80ef571e7dadb726b8214f7352a932a8fa82af29072895aa1aadc89f48bec";
+    };
+  };
+
+  TieRegexpHash = buildPerlPackage rec {
+    name = "Tie-RegexpHash-0.17";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/A/AL/ALTREUS/${name}.tar.gz";
+      sha256 = "0c207850e77efb16618e0aa015507926a3425b34aad5aa6e3e40d83989a085a3";
+    };
+    meta = {
+      license = stdenv.lib.licenses.artistic1;
     };
   };
 
@@ -14446,6 +14542,18 @@ let self = _self // overrides; _self = with self; {
     meta = {
       homepage = http://perl.wdlabs.com/URI-ws/;
       description = "WebSocket support for URI package";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  UUIDTiny = buildPerlPackage rec {
+    name = "UUID-Tiny-1.04";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/C/CA/CAUGUSTIN/${name}.tar.gz";
+      sha256 = "6dcd92604d64e96cc6c188194ae16a9d3a46556224f77b6f3d1d1312b68f9a3d";
+    };
+    meta = {
+      description = "Pure Perl UUID Support With Functional Interface";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
   };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -459,6 +459,19 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  AudioScan = buildPerlPackage rec {
+    name = "Audio-Scan-0.96";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/A/AG/AGRUNDMA/${name}.tar.gz";
+      sha256 = "67f45fef6a23b7548f387b675cbf7881bf9da62d7d007cbf90d3a4b851b99eb7";
+    };
+    buildInputs = [ ModuleBuild TestWarn ScalarString DigestCRC DataInteger ];
+    meta = {
+      description = "Fast C metadata and tag reader for all common audio file formats";
+      license = stdenv.lib.licenses.gpl2;
+    };
+  };
+
   AuthenDecHpwd = buildPerlPackage rec {
     name = "Authen-DecHpwd-2.006";
     src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

Add slimserver package + module. Slimserver is the audio server for the Logitech Squeezebox products.
I have used this PR in my personal setup for the last few days and everything works fine.

I will squash the commits once it's merge ready.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

