### PR TITLE
spambayes: Add bsddb3 build input

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23922,7 +23922,7 @@ in {
       sha256 = "0kqvjb89b02wp41p650ydfspi1s8d7akx1igcrw62diidqbxp04n";
     };
 
-    propagatedBuildInputs = with self; [ pydns lockfile ];
+    propagatedBuildInputs = with self; [ bsddb3 pydns lockfile ];
 
     meta = {
       description = "Statistical anti-spam filter, initially based on the work of Paul Graham";


### PR DESCRIPTION
To reproduce the issue:
```
nix-build -E 'import <nixpkgs> {}' -A python27Packages.spambayes
result/bin/sb_filter.py </dev/null
```
Before this commit, this fails with
```
[...]
  File "/nix/store/vlgr1wrxd2wiw5ay5ch54365dzqvcwgq-python2.7-spambayes-1.1b1/lib/python2.7/site-packages/spambayes/dbmstorage.py", line 20, in open_dbhash
    return bsddb.hashopen(*args)
AttributeError: 'NoneType' object has no attribute 'hashopen'
```
After this commit, it doesn't.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

