### PR TITLE
WIP: firefox: enable pulseaudio by default in wrapper

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -48,7 +48,7 @@ let
          ++ lib.optionals (cfg.enableQuakeLive or false)
          (with xorg; [ stdenv.cc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib ])
          ++ lib.optional (enableAdobeFlash && (cfg.enableAdobeFlashDRM or false)) hal-flash
-         ++ lib.optional (config.pulseaudio or false) libpulseaudio;
+         ++ lib.optional (config.pulseaudio or true) libpulseaudio;
   gst-plugins = with gst_all; [ gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-ffmpeg ];
   gtk_modules = [ libcanberra_gtk2 ];
 


### PR DESCRIPTION
###### Motivation for this change

Firefox 52.0 removed the alsa backend, so without pulseaudio in LD_LIBRARY_PATH you get no audio.

WIP because:

* How does this affect other uses of the wrapper (I only tested firefox 52)?

* Is the predicate correct?
`config.pulseaudio or true` is what's used for pulse support in chromium.  Wine uses `config.pulseaudio or stdenv.isLinux`.

* Should we just enable the ALSA backend instead?
See #23989 

* Should we require the user to set `config.pulseaudio`?
Most other packages don't seem to require this.  Especially ones without alsa support.

* Should we add a `pulseSupport` parameter like in chromium and opt in/out where appropriate?

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

