### PR TITLE
llvm-4: small improvements on Darwin and elsewhere

### DIFF
--- a/pkgs/development/compilers/llvm/4/clang/default.nix
+++ b/pkgs/development/compilers/llvm/4/clang/default.nix
@@ -29,12 +29,23 @@ let
       sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/ToolChains.cpp
     '';
 
+    outputs = [ "out" "python" ];
+
     # Clang expects to find LLVMgold in its own prefix
     # Clang expects to find sanitizer libraries in its own prefix
     postInstall = ''
       ln -sv ${llvm}/lib/LLVMgold.so $out/lib
       ln -sv ${llvm}/lib/clang/${release_version}/lib $out/lib/clang/${release_version}/
       ln -sv $out/bin/clang $out/bin/cpp
+
+      mkdir -p $python/bin $python/share/clang/
+      mv $out/bin/{git-clang-format,scan-view} $python/bin
+      if [ -e $out/bin/set-xcode-analyzer ]; then
+        mv $out/bin/set-xcode-analyzer $python/bin
+      fi
+      mv $out/share/clang/*.py $python/share/clang
+
+      rm $out/bin/c-index-test
     '';
 
     enableParallelBuilding = true;

--- a/pkgs/development/compilers/llvm/4/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/4/libc++/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"
   '';
 
-  buildInputs = [ cmake llvm libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  buildInputs = [ cmake libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   cmakeFlags = [
       "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"


### PR DESCRIPTION
Split outputs because there's no point in keeping a reference to Python and it causes trouble during the Darwin stdenv bootstrap. There's also an unnecessary dependency on LLVM in libc++ which causes us to rebuild LLVM several more times than necessary during bootstrap, and an awkward
dependency on XPC in the TSAN that we turn off. 

~~I'm getting an internal g++ error when I try to compile clang 4 with this on NixOS. Can someone give it a go on their machine and see if it's just me? I can't see how I'd cause the internal error with the changes I made...~~ Turns out the internal error was due to being memory-constrained. It worked fine on another machine with more memory.

###### Motivation for this change

This is in preparation for using LLVM 4 in the Darwin stdenv and by default across nixpkgs.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

