### PR TITLE
iosevka: 1.4.2 -> 1.11.4

### DIFF
--- a/pkgs/data/fonts/iosevka/default.nix
+++ b/pkgs/data/fonts/iosevka/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchurl, unzip }:
 
 stdenv.mkDerivation rec {
   name = "iosevka-${version}";
-  version = "1.4.2";
+  version = "1.11.4";
 
-  src = fetchFromGitHub {
-    owner  = "be5invis";
-    repo   = "Iosevka";
-    rev    = "v${version}";
-    sha256 = "1h1lmvjpjk0238bhdhnv2c149s98qpbndc8rxzlk6bhmxcy6rwsk";
+  buildInputs = [ unzip ];
+
+  src = fetchurl {
+    url = "https://github.com/be5invis/Iosevka/releases/download/v${version}/01-iosevka-${version}.zip";
+    sha256 = "0mn9pqkambsal5cvz8hzlwx7qvcdfch8g1iy7mqhgghzflfhsy8x";
   };
+
+  sourceRoot = ".";
 
   installPhase = ''
     fontdir=$out/share/fonts/iosevka


### PR DESCRIPTION
@cstrahan

###### Motivation for this change

1.11.4 contains numerous improvements including ligatures and fixes to font weights.

###### Things done

I switched "default.nix" from using `fetchFromGitHub` to simply pulling down the release as a zip via `fetchurl`. This seems like the best approach given that the repositoriy no longer contains font files and the alternative would be to build them from scratch.

This is my first time submitting a PR to nixpkgs, so please bonk me if I made any mistakes!

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).