### PR TITLE
pythonPackages.libnacl: init at 1.5.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -538,6 +538,7 @@
   wscott = "Wayne Scott <wsc9tt@gmail.com>";
   wyvie = "Elijah Rum <elijahrum@gmail.com>";
   xnwdd = "Guillermo NWDD <nwdd+nixos@no.team>";
+  xvapx = "Marti Serra <marti.serra.coscollano@gmail.com>";
   xwvvvvwx = "David Terry <davidterry@posteo.de>";
   yarr = "Dmitry V. <savraz@gmail.com>";
   yochai = "Yochai <yochai@titat.info>";

--- a/pkgs/development/python-modules/libnacl/default.nix
+++ b/pkgs/development/python-modules/libnacl/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, pkgs }:
+
+buildPythonPackage rec {
+  pname = "libnacl";
+  version = "1.5.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ph042x0cfysj16mmjif40pxn505rg5c9n94s972dgc0mfgvrwhs";
+  };
+
+  propagatedBuildInputs = [ pkgs.libsodium ];
+
+  postPatch = ''
+    substituteInPlace "./libnacl/__init__.py" --replace "ctypes.cdll.LoadLibrary('libsodium.so')" "ctypes.cdll.LoadLibrary('${pkgs.libsodium}/lib/libsodium.so')"
+  '';
+
+  meta = {
+    maintainers = with stdenv.lib.maintainers; [ xvapx ];
+    description = "Python bindings for libsodium based on ctypes";
+    homepage = "https://pypi.python.org/pypi/libnacl";
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/libnacl/default.nix
+++ b/pkgs/development/python-modules/libnacl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, pkgs }:
+{ stdenv, buildPythonPackage, fetchPypi, pytest, libsodium }:
 
 buildPythonPackage rec {
   pname = "libnacl";
@@ -10,17 +10,22 @@ buildPythonPackage rec {
     sha256 = "1ph042x0cfysj16mmjif40pxn505rg5c9n94s972dgc0mfgvrwhs";
   };
 
-  propagatedBuildInputs = [ pkgs.libsodium ];
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ libsodium ];
 
   postPatch = ''
-    substituteInPlace "./libnacl/__init__.py" --replace "ctypes.cdll.LoadLibrary('libsodium.so')" "ctypes.cdll.LoadLibrary('${pkgs.libsodium}/lib/libsodium.so')"
+    substituteInPlace "./libnacl/__init__.py" --replace "ctypes.cdll.LoadLibrary('libsodium.so')" "ctypes.cdll.LoadLibrary('${libsodium}/lib/libsodium.so')"
   '';
 
-  meta = {
-    maintainers = with stdenv.lib.maintainers; [ xvapx ];
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ xvapx ];
     description = "Python bindings for libsodium based on ctypes";
     homepage = "https://pypi.python.org/pypi/libnacl";
-    license = stdenv.lib.licenses.asl20;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.asl20;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13867,6 +13867,8 @@ in {
     clblas = pkgs.clblas-cuda;
   };
 
+  libnacl = callPackage ../development/python-modules/libnacl/default.nix { };
+
   libplist = if isPy3k then throw "libplist not supported for interpreter ${python.executable}" else
     (pkgs.libplist.override{python2Packages=self; }).py;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13867,7 +13867,9 @@ in {
     clblas = pkgs.clblas-cuda;
   };
 
-  libnacl = callPackage ../development/python-modules/libnacl/default.nix { };
+  libnacl = callPackage ../development/python-modules/libnacl/default.nix {
+    inherit (pkgs) libsodium;
+  };
 
   libplist = if isPy3k then throw "libplist not supported for interpreter ${python.executable}" else
     (pkgs.libplist.override{python2Packages=self; }).py;


### PR DESCRIPTION
###### Motivation for this change

To add libnacl to pythonPackages.
This is needed to upgrade tribler to 7.0.0-beta (still working on it) and might be useful for other packages.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
It might need another substitution in postPatch to work in macOS, i have no way to test it, but the current substitution affects linux only.
