### PR TITLE
libfixposix: 30b75609 -> 0.4.1

### DIFF
--- a/pkgs/development/libraries/libfixposix/default.nix
+++ b/pkgs/development/libraries/libfixposix/default.nix
@@ -1,28 +1,23 @@
-{ stdenv, fetchurl, fetchgit, autoreconfHook, libtool }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name="libfixposix-${version}";
-  version="git-${src.rev}";
+  version="0.4.1";
 
-  src = fetchgit {
-    url = "https://github.com/sionescu/libfixposix";
-    rev = "30b75609d858588ea00b427015940351896867e9";
-    sha256 = "17spjz9vbgqllzlkws2abvqi0a71smhi4vgq3913aw0kq206mfxz";
+  src = fetchFromGitHub {
+    owner = "sionescu";
+    repo = "libfixposix";
+    rev = "v${version}";
+    sha256 = "19wjb43mn16f4lin5a2dfi3ym2hy7kqibs0z631d205b16vxas15";
   };
 
-  buildInputs = [ autoreconfHook libtool ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   meta = with stdenv.lib; {
-    description = "A set of workarounds for places in POSIX that get implemented differently";
-    maintainers = with maintainers;
-    [
-      raskin
-    ];
+    homepage = https://github.com/sionescu/libfixposix;
+    description = "Thin wrapper over POSIX syscalls and some replacement functionality";
+    license = licenses.boost;
+    maintainers = with maintainers; [ orivej raskin ];
     platforms = platforms.linux;
-  };
-  passthru = {
-    updateInfo = {
-      downloadPage = "http://gitorious.org/libfixposix/libfixposix";
-    };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Nothing in nixpkgs depends on this library, the update is needed for use with [iolib](https://github.com/sionescu/iolib/)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
