### PR TITLE
pythonmagick: 0.9.14 -> 0.9.16

### DIFF
--- a/pkgs/applications/graphics/PythonMagick/default.nix
+++ b/pkgs/applications/graphics/PythonMagick/default.nix
@@ -1,20 +1,16 @@
 {stdenv, fetchurl, python, boost, pkgconfig, imagemagick}:
 
-let
-
-  version = "0.9.14";
-
-in
-
 stdenv.mkDerivation rec {
   name = "pythonmagick-${version}";
+  version = "0.9.16";
 
   src = fetchurl {
     url = "mirror://imagemagick/python/releases/PythonMagick-${version}.tar.xz";
-    sha256 = "1flkdfi3c19wy2qcfzax1cqvmmri10rvmhc2y85gmagqvv01zz22";
+    sha256 = "0vkgpmrdz530nyvmjahpdrvcj7fd7hvsp15d485hq6103qycisv8";
   };
 
-  buildInputs = [python boost pkgconfig imagemagick];
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [python boost imagemagick];
 
   meta = {
     homepage = http://www.imagemagick.org/script/api.php;


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

