### PR TITLE
ahoviewer: 1.4.6 -> 1.4.8

### DIFF
--- a/pkgs/applications/graphics/ahoviewer/default.nix
+++ b/pkgs/applications/graphics/ahoviewer/default.nix
@@ -1,15 +1,20 @@
 { stdenv, pkgs, fetchurl, fetchFromGitHub, pkgconfig, libconfig, 
   gtkmm2, glibmm, libxml2, libsecret, curl, unrar, libzip,
   librsvg, gst_all_1, autoreconfHook, makeWrapper }:
-stdenv.mkDerivation {
-  name = "ahoviewer-1.4.6";
+
+stdenv.mkDerivation rec {
+  name = "ahoviewer-${version}";
+  version = "1.4.8";
+
   src = fetchFromGitHub {
     owner = "ahodesuka";
     repo = "ahoviewer";
-    rev = "414cb91d66d96fab4b48593a7ef4d9ad461306aa";
-    sha256 = "081jgfmbwf2av0cn229cf4qyv6ha80ridymsgwq45124b78y2bmb";
+    rev = version;
+    sha256 = "0fsak22hpi2r8zqysswdyngaf3n635qvclqh1p0g0wrkfza4dbc4";
   };
+
   enableParallelBuilding = true; 
+  
   nativeBuildInputs = [ autoreconfHook pkgconfig makeWrapper ];
   buildInputs = [ glibmm libconfig gtkmm2 glibmm libxml2
                   libsecret curl unrar libzip librsvg 
@@ -18,18 +23,21 @@ stdenv.mkDerivation {
                   gst_all_1.gst-plugins-bad 
                   gst_all_1.gst-libav
                   gst_all_1.gst-plugins-base ];
+  
   postPatch = ''patchShebangs version.sh'';
+  
   postInstall = ''
     wrapProgram $out/bin/ahoviewer \
     --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
     --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
   '';
-  meta = {
+
+  meta = with stdenv.lib; {
     homepage = "https://github.com/ahodesuka/ahoviewer";
     description = "A GTK2 image viewer, manga reader, and booru browser";
-    maintainers = [ stdenv.lib.maintainers.skrzyp ];
-    license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.allBut [ "darwin" "cygwin" ];
+    maintainers = [ maintainers.skrzyp ];
+    license = licenses.mit;
+    platforms = platforms.allBut [ "darwin" "cygwin" ];
   };
 }
 


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

