### PR TITLE
nixos: Use xkbDir consistently so it has an effect

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -64,7 +64,7 @@ in
     security.wrappers.e_freqset.source = "${e.enlightenment.out}/bin/e_freqset";
 
     environment.etc = singleton
-      { source = "${pkgs.xkeyboard_config}/etc/X11/xkb";
+      { source = xcfg.xkbDir;
         target = "X11/xkb";
       };
 

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -176,7 +176,7 @@ in
       environment.pathsToLink = [ "/share" ];
 
       environment.etc = singleton {
-        source = "${pkgs.xkeyboard_config}/etc/X11/xkb";
+        source = xcfg.xkbDir;
         target = "X11/xkb";
       };
 


### PR DESCRIPTION
Otherwise setting `services.xserver.xkbDir` will work in some places but not others, which is frustrating.