### PR TITLE
meh: init at 0.3

### DIFF
--- a/pkgs/applications/graphics/meh/default.nix
+++ b/pkgs/applications/graphics/meh/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, libX11, libXext, libjpeg, libpng, giflib }:
+
+stdenv.mkDerivation rec {
+  name = "meh-unstable-2015-04-11";
+
+  src = fetchFromGitHub {
+    owner = "jhawthorn";
+    repo = "meh";
+    rev = "4ab1c75f97cb70543db388b3ed99bcfb7e94c758";
+    sha256 = "1j1n3m9hjhz4faryai97jq7cr6a322cqrd878gpkm9nrikap3bkk";
+  };
+
+  installPhase = ''
+    make PREFIX=$out install
+  '';
+
+  outputs = [ "out" "doc" ];
+
+  buildInputs = [ libXext libX11 libjpeg libpng giflib ];
+
+  meta = {
+    description = "A minimal image viewer using raw XLib";
+    homepage = http://www.johnhawthorn.com/meh/;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14496,6 +14496,8 @@ with pkgs;
 
   mimms = callPackage ../applications/audio/mimms {};
 
+  meh = callPackage ../applications/graphics/meh {};
+
   mirage = callPackage ../applications/graphics/mirage { };
 
   mixxx = callPackage ../applications/audio/mixxx {


### PR DESCRIPTION
###### Motivation for this change
Add a package. 

First time, read contributing and tested with nox-review, useSandbox, and resulting binaries.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

