### PR TITLE
djview: 4.10.5 -> 4.10.6

### DIFF
--- a/pkgs/applications/graphics/djview/default.nix
+++ b/pkgs/applications/graphics/djview/default.nix
@@ -1,19 +1,18 @@
-{ stdenv, fetchurl, pkgconfig, djvulibre, qt4, xorg, libtiff }:
+{ stdenv, fetchurl, pkgconfig
+, djvulibre, qt4, xorg, libtiff }:
 
-let
-  qt = qt4;
-  # TODO: qt = qt5.base; # should work but there's a mysterious "-silent" error
-in
 stdenv.mkDerivation rec {
-  name = "djview-4.10.5";
+  name = "djview-${version}";
+  version = "4.10.6";
+
   src = fetchurl {
     url = "mirror://sourceforge/djvu/${name}.tar.gz";
-    sha256 = "0gbvbly7w3cr8wgpyh76nf9w7cf7740vp7k5hccks186f6005cx0";
+    sha256 = "08bwv8ppdzhryfcnifgzgdilb12jcnivl4ig6hd44f12d76z6il4";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ djvulibre qt xorg.libXt libtiff ];
+  buildInputs = [ djvulibre qt4 xorg.libXt libtiff ];
 
   passthru = {
     mozillaPlugin = "/lib/netscape/plugins";
@@ -23,7 +22,7 @@ stdenv.mkDerivation rec {
     homepage = http://djvu.sourceforge.net/djview4.html;
     description = "A portable DjVu viewer and browser plugin";
     license = licenses.gpl2;
-    inherit (qt.meta) platforms;
+    platforms = platforms.unix;
     maintainers = [ maintainers.urkud ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

