### PR TITLE
fontmatrix: Changed URL & homepage; they no longer exist

### DIFF
--- a/pkgs/applications/graphics/fontmatrix/default.nix
+++ b/pkgs/applications/graphics/fontmatrix/default.nix
@@ -1,10 +1,14 @@
-{ stdenv, fetchurl, cmake, qt4 }:
+{ stdenv, fetchFromGitHub, cmake, qt4 }:
 
 stdenv.mkDerivation rec {
-  name = "fontmatrix-0.6.0";
-  src = fetchurl {
-    url = "http://fontmatrix.be/archives/${name}-Source.tar.gz";
-    sha256 = "bcc5e929d95d2a0c9481d185144095c4e660255220a7ae6640298163ee77042c";
+  name = "fontmatrix-${version}";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "fontmatrix";
+    repo = "fontmatrix";
+    rev = "v${version}";
+    sha256 = "0aqndj1jhm6hjpwmj1qm92z2ljh7w78a5ff5ag47qywqha1ngn05";
   };
 
   buildInputs = [ qt4 ];
@@ -13,10 +17,10 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Fontmatrix is a free/libre font explorer for Linux, Windows and Mac";
-    homepage = http://fontmatrix.be/;
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
+    homepage = http://github.com/fontmatrix/fontmatrix;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

