### PR TITLE
xrq: init at d5dc19c63881ebdd1287a02968e3a1447dde14a9

### DIFF
--- a/pkgs/applications/misc/xrq/default.nix
+++ b/pkgs/applications/misc/xrq/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, libX11}:
+
+stdenv.mkDerivation rec {
+  name = "xrq-unstable-2016-01-15";
+
+  src = fetchFromGitHub {
+	  owner = "arianon";
+	  repo = "xrq";
+    rev = "d5dc19c63881ebdd1287a02968e3a1447dde14a9";
+    sha256 = "1bxf6h3fjw3kjraz7028m7p229l423y1ngy88lqvf0xl1g3dhp36";
+  };
+
+  installPhase = ''
+    make PREFIX=$out install
+  '';
+
+  outputs = [ "out" "doc" ];
+
+  buildInputs = [ libX11 ];
+
+  meta = {
+    description = "X utility for querying xrdb";
+    homepage = https://github.com/arianon/xrq;
+    license = stdenv.lib.licenses.mit;
+    platforms = with stdenv.lib.platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18345,6 +18345,8 @@ with pkgs;
 
   xulrunner = firefox-unwrapped;
 
+  xrq = callPackage ../applications/misc/xrq { };
+
   nitrokey-app = callPackage ../tools/security/nitrokey-app { };
 
   fpm2 = callPackage ../tools/security/fpm2 { };


### PR DESCRIPTION
###### Motivation for this change
packaging xrq

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

