### PR TITLE
gargoyle: init at 2017-03-12

### DIFF
--- a/pkgs/development/libraries/SDL_mixer/default.nix
+++ b/pkgs/development/libraries/SDL_mixer/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     description = "SDL multi-channel audio mixer library";
     homepage    = http://www.libsdl.org/projects/SDL_mixer/;
     maintainers = with maintainers; [ lovek323 ];
-    platforms   = platforms.linux;
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/games/gargoyle/darwin.patch
+++ b/pkgs/games/gargoyle/darwin.patch
@@ -1,0 +1,97 @@
+From 06255a8b5a378a2484cd0faa1dd718d5b4e98042 Mon Sep 17 00:00:00 2001
+From: Orivej Desh <orivej@gmx.fr>
+Date: Fri, 17 Mar 2017 08:43:57 +0000
+Subject: [PATCH] darwin
+
+---
+ Jamrules        | 5 ++---
+ Jamshared       | 2 +-
+ support/Jamfile | 4 ++--
+ tads/Jamfile    | 4 ++--
+ terps/Jamfile   | 4 ++--
+ 5 files changed, 9 insertions(+), 10 deletions(-)
+
+diff --git a/Jamrules b/Jamrules
+index 698220d..2294dfc 100644
+--- a/Jamrules
++++ b/Jamrules
+@@ -141,8 +141,7 @@ switch $(OS)
+     case MACOSX :
+         Echo "OS is MACOSX (cocoa)" ;
+         SUFDLL = .dylib ;
+-        MAINARCH = -arch i386 ;
+-        CCFLAGS = -Wno-pointer-sign $(MAINARCH) $(ALTARCH) ;
++        CCFLAGS = -Wno-pointer-sign $(ALTARCH) ;
+         PKGCONFIG = "pkg-config freetype2" ;
+         GARGLKCCFLAGS = "`$(PKGCONFIG) --cflags`" ;
+         SHRLINKLIBS += "`$(PKGCONFIG) --libs`" -ljpeg -lpng -lz ;
+@@ -155,7 +154,7 @@ switch $(OS)
+             SHRLINKLIBS += -lSDL_mixer -lSDL -lsmpeg -lvorbisfile ;
+         }
+ 
+-        LINK = $(CC) -headerpad_max_install_names $(FRAMEWORKS) $(MAINARCH) $(ALTARCH) ;
++        LINK = $(CC) $(FRAMEWORKS) $(ALTARCH) ;
+ 
+ 
+     case * :
+diff --git a/Jamshared b/Jamshared
+index 13db835..fd42928 100644
+--- a/Jamshared
++++ b/Jamshared
+@@ -79,7 +79,7 @@ if $(OS) = MACOSX
+ {
+     actions together SharedLink bind NEEDLIBS
+     {
+-        $(LINK) -headerpad_max_install_names $(FRAMEWORKS) $(MAINARCH) $(ALTARCH) -dynamiclib $(SHRLINKFLAGS) -install_name @executable_path/$(<:D=) -o $(<) $(>) $(NEEDLIBS) $(SHRLINKLIBS)
++        $(LINK) $(FRAMEWORKS) $(MAINARCH) $(ALTARCH) -dynamiclib $(SHRLINKFLAGS) -install_name @executable_path/$(<:D=) -o $(<) $(>) $(NEEDLIBS) $(SHRLINKLIBS)
+     }
+ }
+ else
+diff --git a/support/Jamfile b/support/Jamfile
+index aedf8fe..70cfefd 100644
+--- a/support/Jamfile
++++ b/support/Jamfile
+@@ -41,8 +41,8 @@ if $(USESDL) = yes
+         ;
+ 
+     if $(OS) = MINGW   { SubDirCcFlags -DSDL_SOUND_DLL_EXPORTS ; }
+-    if $(OS) = SOLARIS { SubDirCcFlags -I/usr/include/SDL -fPIC ; }
+-    if $(OS) = MACOSX  { SubDirCcFlags -I/opt/local/include/SDL -fPIC ; }
++    if $(OS) = SOLARIS { SubDirCcFlags -ISDL -fPIC ; }
++    if $(OS) = MACOSX  { SubDirCcFlags -ISDL -fPIC ; }
+ 
+     SEARCH_SOURCE =
+         [ FDirName $(TOP) support sdl_sound ]
+diff --git a/tads/Jamfile b/tads/Jamfile
+index 1f8829d..d8455eb 100644
+--- a/tads/Jamfile
++++ b/tads/Jamfile
+@@ -33,8 +33,8 @@ if $(OS) = LINUX || $(OS) = SOLARIS
+ 
+ if $(OS) = MACOSX
+ {
+-    SubDirCcFlags -headerpad_max_install_names $(MAINARCH) $(ALTARCH) ;
+-    LINKFLAGS = -headerpad_max_install_names $(MAINARCH) $(ALTARCH) ;
++    SubDirCcFlags $(MAINARCH) $(ALTARCH) ;
++    LINKFLAGS = $(MAINARCH) $(ALTARCH) ;
+ }
+ 
+ SEARCH_SOURCE =
+diff --git a/terps/Jamfile b/terps/Jamfile
+index b5f6d52..2d1ccdb 100644
+--- a/terps/Jamfile
++++ b/terps/Jamfile
+@@ -185,8 +185,8 @@ if $(MAKE_GEAS) = yes
+ 
+     if $(OS) = MACOSX
+     {
+-        SubDirCcFlags -headerpad_max_install_names $(MAINARCH) $(ALTARCH) ;
+-        LINKFLAGS = -headerpad_max_install_names $(MAINARCH) $(ALTARCH) ;
++        SubDirCcFlags $(MAINARCH) $(ALTARCH) ;
++        LINKFLAGS = $(MAINARCH) $(ALTARCH) ;
+     }
+ 
+     SUBDIRC++FLAGS = $(SUBDIRCCFLAGS) ;
+-- 
+2.12.0
+

--- a/pkgs/games/gargoyle/darwin.sh
+++ b/pkgs/games/gargoyle/darwin.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+set -e
+
+GARGDIST=build/macosx.release
+BUNDLE=${out}/Applications/Gargoyle.app/Contents
+TERPS="
+advsys/advsys
+agility/agility
+alan2/alan2
+alan3/alan3
+bocfel/bocfel
+frotz/frotz
+garglk/gargoyle
+geas/geas
+git/git
+glulxe/glulxe
+hugo/hugo
+jacl/jacl
+level9/level9
+magnetic/magnetic
+nitfol/nitfol
+scare/scare
+scott/scott
+tads/tadsr
+"
+
+mkdir -p $BUNDLE/MacOS
+mkdir -p $BUNDLE/Frameworks
+mkdir -p $BUNDLE/Resources
+mkdir -p $BUNDLE/PlugIns
+
+install_name_tool -id @executable_path/../Frameworks/libgarglk.dylib $GARGDIST/garglk/libgarglk.dylib
+for file in $TERPS
+do
+install_name_tool -change @executable_path/libgarglk.dylib @executable_path/../Frameworks/libgarglk.dylib $GARGDIST/$file || true
+cp -f $GARGDIST/$file $BUNDLE/PlugIns
+done
+
+cp -f garglk/launcher.plist $BUNDLE/Info.plist
+cp -f $GARGDIST/garglk/gargoyle $BUNDLE/MacOS/Gargoyle
+cp -f $GARGDIST/garglk/libgarglk.dylib $BUNDLE/Frameworks
+cp -f $GARGDIST/garglk/libgarglk.dylib $BUNDLE/PlugIns
+cp -f garglk/launchmac.nib $BUNDLE/Resources/MainMenu.nib
+cp -f garglk/garglk.ini $BUNDLE/Resources
+cp -f garglk/*.icns $BUNDLE/Resources
+cp -f licenses/* $BUNDLE/Resources
+
+mkdir $BUNDLE/Resources/Fonts
+cp fonts/LiberationMono*.ttf $BUNDLE/Resources/Fonts
+cp fonts/LinLibertine*.otf $BUNDLE/Resources/Fonts
+
+mkdir -p ${out}/bin
+ln -s $BUNDLE/MacOS/Gargoyle ${out}/bin/gargoyle

--- a/pkgs/games/gargoyle/default.nix
+++ b/pkgs/games/gargoyle/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, fetchFromGitHub, jam, pkgconfig, gtk2, SDL, SDL_mixer, SDL_sound, smpeg, libvorbis }:
+
+let
+
+  jamenv = if stdenv.isDarwin then ''
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${SDL.dev}/include/SDL"
+    export GARGLKINI="$out/Applications/Gargoyle.app/Contents/Resources/garglk.ini"
+  '' else ''
+    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/libexec/gargoyle"
+    export DESTDIR="$out"
+    export _BINDIR=libexec/gargoyle
+    export _APPDIR=libexec/gargoyle
+    export _LIBDIR=libexec/gargoyle
+    export GARGLKINI="$out/etc/garglk.ini"
+  '';
+
+in
+
+stdenv.mkDerivation {
+  name = "gargoyle-2017-03-12";
+
+  src = fetchFromGitHub {
+    owner = "garglk";
+    repo = "garglk";
+    rev = "7d8fe875927c332ea30d75656bc982354b42f602";
+    sha256 = "00nac7j84gfql1cr11cs9ad4j1gsxrnkqfx6mis4ijf7d6px3sih";
+  };
+
+  nativeBuildInputs = [ jam pkgconfig ];
+
+  buildInputs = [ gtk2 SDL SDL_mixer ] ++ (
+    if stdenv.isDarwin then [ smpeg libvorbis ] else [ SDL_sound ]
+  );
+
+  patches = [ ./darwin.patch ];
+
+  buildPhase = jamenv + "jam -j$NIX_BUILD_CORES";
+
+  installPhase = if stdenv.isDarwin then (builtins.readFile ./darwin.sh) else jamenv + ''
+    jam -j$NIX_BUILD_CORES install
+    mkdir -p "$out/bin"
+    ln -s ../libexec/gargoyle/gargoyle "$out/bin"
+    mkdir -p "$out/etc"
+    cp garglk/garglk.ini "$out/etc"
+    mkdir -p "$out/share/applications"
+    cp garglk/gargoyle.desktop "$out/share/applications"
+    mkdir -p "$out/share/icons/hicolor/32x32/apps"
+    cp garglk/gargoyle-house.png "$out/share/icons/hicolor/32x32/apps"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://ccxvii.net/gargoyle/;
+    license = licenses.gpl2Plus;
+    description = "Interactive fiction interpreter GUI";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ orivej ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16513,6 +16513,8 @@ with pkgs;
 
   garden-of-coloured-lights = callPackage ../games/garden-of-coloured-lights { allegro = allegro4; };
 
+  gargoyle = callPackage ../games/gargoyle { };
+
   gav = callPackage ../games/gav { };
 
   gcs = callPackage ../games/gcs { };


### PR DESCRIPTION
###### Motivation for this change

Gargoyle is a multi-format interactive fiction graphical interpreter. When launched without arguments it opens a file chooser dialog, you could try [Kerkerkruip](http://downloads.kerkerkruip.org/kerkerkruip-latest.zip) (after unpacking the zip) or [zork1](http://www.batmantis.com/zorks/zork1.z5). The last release is from 2011 but development is [ongoing](https://github.com/garglk/garglk/commits/master) and I'd prefer to package the latest code.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
