### PR TITLE
jpegoptim: 1.4.3 -> 1.4.4

### DIFF
--- a/pkgs/applications/graphics/jpegoptim/default.nix
+++ b/pkgs/applications/graphics/jpegoptim/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, libjpeg }:
 
 stdenv.mkDerivation rec {
-  version = "1.4.3";
+  version = "1.4.4";
   name = "jpegoptim-${version}";
 
   src = fetchurl {
     url = "http://www.kokkonen.net/tjko/src/${name}.tar.gz";
-    sha256 = "0k53q7dc8w5ashz8v261x2b5vvz7gdvg8w962rz9gjvkjbh4lg93";
+    sha256 = "1cn1i0g1xjdwa12w0ifbnzgb1vqbpr8ji6h05vxksj79vyi3x849";
   };
 
   # There are no checks, it seems.
@@ -14,11 +14,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libjpeg ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Optimize JPEG files";
     homepage = http://www.kokkonen.net/tjko/projects.html ;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.aristid ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.aristid ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

