### PR TITLE
leocad: 0.81 -> 17.02

### DIFF
--- a/pkgs/applications/graphics/leocad/default.nix
+++ b/pkgs/applications/graphics/leocad/default.nix
@@ -3,24 +3,26 @@ To use aditional parts libraries
 set the variable LEOCAD_LIB=/path/to/libs/ or use option -l /path/to/libs/
 */
 
-{ stdenv, fetchsvn, qt4, qmake4Hook, zlib }:
+{ stdenv, fetchFromGitHub, qt4, qmake4Hook, zlib }:
 
 stdenv.mkDerivation rec {
   name = "leocad-${version}";
-  version = "0.81";
+  version = "17.02";
 
-  src = fetchsvn {
-    url = "http://svn.leocad.org/tags/${name}";
-    sha256 = "1190gb437ls51hhfiwa79fq131026kywpy3j3k4fkdgfr8a9v3q8";
+  src = fetchFromGitHub {
+    owner = "leozide";
+    repo = "leocad";
+    rev = "v${version}";
+    sha256 = "0d7l2il6r4swnmrmaf1bsrgpjgai5xwhwk2mkpcsddnk59790mmc";
   };
 
-  buildInputs = [ qt4 qmake4Hook zlib ];
-
+  nativeBuildInputs = [ qmake4Hook ];
+  buildInputs = [ qt4 zlib ];
   postPatch = ''
     sed '1i#include <cmath>' -i common/camera.cpp
     substituteInPlace common/camera.cpp --replace "isnan(" "std::isnan("
     export qmakeFlags="$qmakeFlags INSTALL_PREFIX=$out"
-  '';
+   '';
 
   meta = with stdenv.lib; {
     description = "CAD program for creating virtual LEGO models";


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

