### PR TITLE
mpvc: init at unstable-2017-03-18

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -344,6 +344,7 @@
   nathan-gs = "Nathan Bijnens <nathan@nathan.gs>";
   nckx = "Tobias Geerinckx-Rice <tobias.geerinckx.rice@gmail.com>";
   ndowens = "Nathan Owens <ndowens04@gmail.com>";
+  neeasade = "Nathan Isom <nathanisom27@gmail.com>";
   nequissimus = "Tim Steinbach <tim@nequissimus.com>";
   nfjinjing = "Jinjing Wang <nfjinjing@gmail.com>";
   nhooyr = "Anmol Sethi <anmol@aubble.com>";

--- a/pkgs/applications/misc/mpvc/default.nix
+++ b/pkgs/applications/misc/mpvc/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, socat, fetchFromGitHub, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "mpvc-unstable-2017-03-18";
+
+  src = fetchFromGitHub {
+    owner = "wildefyr";
+    repo = "mpvc";
+    rev = "aea5c661455248cde7ac9ddba5f63cc790d26512";
+    sha256 = "0qiyvb3ck1wyd3izajwvlq4bwgsbq7x8ya3fgi5i0g2qr39a1qml";
+  };
+
+  installPhase = ''
+    make PREFIX=$out install
+  '';
+
+  # defaults to make install.
+  buildPhase = ''
+    make PREFIX=$out
+  '';
+
+  postInstall = ''
+    makeWrapper ${socat}/bin/socat $out/bin/socat \
+      --prefix PATH : "$out/bin"
+    wrapProgram $out/bin/mpvc
+  '';
+
+  buildInputs = [ socat makeWrapper ];
+  outputs = [ "out" ];
+
+  meta = {
+    description = "A mpc-like control interface for mpv";
+    homepage = https://github.com/wildefyr/mpvc;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/mpvc/default.nix
+++ b/pkgs/applications/misc/mpvc/default.nix
@@ -19,10 +19,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ socat makeWrapper ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A mpc-like control interface for mpv";
     homepage = https://github.com/wildefyr/mpvc;
-    license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.mit;
+    maintainers = [ maintainers.neeasade ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/mpvc/default.nix
+++ b/pkgs/applications/misc/mpvc/default.nix
@@ -10,23 +10,14 @@ stdenv.mkDerivation rec {
     sha256 = "0qiyvb3ck1wyd3izajwvlq4bwgsbq7x8ya3fgi5i0g2qr39a1qml";
   };
 
-  installPhase = ''
-    make PREFIX=$out install
-  '';
-
-  # defaults to make install.
-  buildPhase = ''
-    make PREFIX=$out
-  '';
+  makeFlags = [ "PREFIX=$(out)" ];
+  installFlags = [ "PREFIX=$(out)" ];
 
   postInstall = ''
-    makeWrapper ${socat}/bin/socat $out/bin/socat \
-      --prefix PATH : "$out/bin"
-    wrapProgram $out/bin/mpvc
+    wrapProgram $out/bin/mpvc --prefix PATH : "${socat}/bin/"
   '';
 
   buildInputs = [ socat makeWrapper ];
-  outputs = [ "out" ];
 
   meta = {
     description = "A mpc-like control interface for mpv";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18311,6 +18311,8 @@ with pkgs;
 
   mg = callPackage ../applications/editors/mg { };
 
+  mpvc = callPackage ../applications/misc/mpvc { };
+
   aucdtect = callPackage ../tools/audio/aucdtect { };
 
   togglesg-download = callPackage ../tools/misc/togglesg-download { };


### PR DESCRIPTION
###### Motivation for this change
package mpvc.

FYI this was first time using wrapper for me.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

