### PR TITLE
colort: init at unstable-2017-03-13

### DIFF
--- a/pkgs/applications/misc/colort/default.nix
+++ b/pkgs/applications/misc/colort/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   name = "colort-unstable-2017-03-12";
 
   src = fetchFromGitHub {
@@ -10,14 +10,12 @@ stdenv.mkDerivation rec {
     sha256 = "10n8rbr2h6hz86hcx73f86pjbbfiaw2rvxsk0yfajnma7bpxgdxw";
   };
 
- installPhase = ''
-    make install PREFIX=$out
-  '';
+  makeFlags = ["PREFIX=$(out)"];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A program for 'tinting' color values";
     homepage = https://github.com/neeasade/colort;
-    license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.mit;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/colort/default.nix
+++ b/pkgs/applications/misc/colort/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "colort-unstable-2017-03-12";
+
+  src = fetchFromGitHub {
+    owner = "neeasade";
+    repo = "colort";
+    rev = "8470190706f358dc807b4c26ec3453db7f0306b6";
+    sha256 = "10n8rbr2h6hz86hcx73f86pjbbfiaw2rvxsk0yfajnma7bpxgdxw";
+  };
+
+ installPhase = ''
+    make install PREFIX=$out
+  '';
+
+  meta = {
+    description = "A program for 'tinting' color values";
+    homepage = https://github.com/neeasade/colort;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17693,6 +17693,8 @@ with pkgs;
 
   crashplan = callPackage ../applications/backup/crashplan { };
 
+  colort = callPackage ../applications/misc/colort { };
+
   e17gtk = callPackage ../misc/themes/e17gtk { };
 
   epson-escpr = callPackage ../misc/drivers/epson-escpr { };


### PR DESCRIPTION
###### Motivation for this change
package colort

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

