### PR TITLE
windowmaker: 0.95.7 -> 0.95.8

### DIFF
--- a/pkgs/applications/window-managers/windowmaker/default.nix
+++ b/pkgs/applications/window-managers/windowmaker/default.nix
@@ -4,12 +4,12 @@
 
 stdenv.mkDerivation rec {
   name = "windowmaker-${version}";
-  version = "0.95.7";
+  version = "0.95.8";
   srcName = "WindowMaker-${version}";
 
   src = fetchurl {
     url = "http://windowmaker.org/pub/source/release/${srcName}.tar.gz";
-    sha256 = "1acph0nq6fsb452sl7j7a7kcc87zqqaw7qms1p8ijar19dn4hbc4";
+    sha256 = "12p8kljqgx5hnic0zvs5mxwp7kg21sb6qjagb2qw8ydvf5amrgwx";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -36,8 +36,8 @@ stdenv.mkDerivation rec {
       contributions being made by programmers from around the world.
     '';
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;
+    maintainers = [ maintainers.AndersonTorres ];
   };
 }
 


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

[Changes](http://repo.or.cz/wmaker-crm.git/blob/HEAD:/NEWS)