### PR TITLE
yubikey-manager: init at 0.3.1

### DIFF
--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -1,0 +1,42 @@
+{ pythonPackages, fetchurl, lib,
+  yubikey-personalization, libu2f-host, libusb1 }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "yubikey-manager-0.3.1";
+
+  srcs = fetchurl {
+    url = "https://developers.yubico.com/yubikey-manager/Releases/${name}.tar.gz";
+    sha256 = "0vrhaqb8yc1qjq25k9dv8gmqxhbf6aa047i6dvz1lcraq6zwnq6g";
+  };
+
+  propagatedBuildInputs =
+    with pythonPackages;
+    lib.optional (!pythonPackages.pythonAtLeast "3.4") enum34 ++ [
+      click
+      cryptography
+      pyscard
+      pyusb
+      six
+    ] ++ [
+      libu2f-host
+      libusb1
+      yubikey-personalization
+    ];
+
+  makeWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${libu2f-host}/lib:${libusb1}/lib:${yubikey-personalization}/lib"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/etc/bash_completion.d
+    _YKMAN_COMPLETE=source $out/bin/ykman > $out/etc/bash_completion.d/ykman.sh ||true
+  '';
+
+  meta = with lib; {
+    homepage = https://developers.yubico.com/yubikey-manager;
+    description = "Command line tool for configuring any YubiKey over all USB transports.";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ benley ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10165,6 +10165,8 @@ with pkgs;
 
   yubico-piv-tool = callPackage ../tools/misc/yubico-piv-tool { };
 
+  yubikey-manager = callPackage ../tools/misc/yubikey-manager { };
+
   yubikey-neo-manager = callPackage ../tools/misc/yubikey-neo-manager { };
 
   yubikey-personalization = callPackage ../tools/misc/yubikey-personalization {


### PR DESCRIPTION
###### Motivation for this change

According to yubico, yubikey-neo-manager is deprecated and this will take its place.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

