### PR TITLE
clog-cli: 0.9.2 -> 0.9.3

### DIFF
--- a/pkgs/development/tools/clog-cli/default.nix
+++ b/pkgs/development/tools/clog-cli/default.nix
@@ -4,16 +4,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "clog-cli-${version}";
-  version = "0.9.2";
+  version = "0.9.3";
 
   src = fetchFromGitHub {
     owner = "clog-tool";
     repo = "clog-cli";
-    rev = "${version}";
-    sha256 = "00sfbchyf50z6mb5dq1837hlrki88rrf043idy6qd1r90488jsbv";
+    rev = "v${version}";
+    sha256 = "1wxglc4n1dar5qphhj5pab7ps34cjr7jy611fwn72lz0f6c7jp3z";
   };
 
-  depsSha256 = "0czv190r6xhbw33l0jhlri6rgspxb8f6dakcamh52qr3z9m0xs2x";
+  depsSha256 = "0gkg3bxx7nxsvff33n7pif731djfvlzk0msia27h0wq0mazq7kw3";
 
   meta = {
     description = "Generate changelogs from local git metadata";


### PR DESCRIPTION
###### Motivation for this change

Pull in new clog-cli version.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

