### PR TITLE
gnu global: set path of default gtags.conf in wrapper

### DIFF
--- a/pkgs/development/tools/misc/global/default.nix
+++ b/pkgs/development/tools/misc/global/default.nix
@@ -34,8 +34,10 @@ stdenv.mkDerivation rec {
     cp -v *.el "$out/share/emacs/site-lisp"
 
     wrapProgram $out/bin/gtags \
+      --prefix GTAGSCONF : "$out/share/gtags/gtags.conf" \
       --prefix PYTHONPATH : "$(toPythonPath ${pythonPackages.pygments})"
     wrapProgram $out/bin/global \
+      --prefix GTAGSCONF : "$out/share/gtags/gtags.conf" \
       --prefix PYTHONPATH : "$(toPythonPath ${pythonPackages.pygments})"
   '';
 


### PR DESCRIPTION
GNU global's gtags and global tools were unable to find the default
gtags.conf, necessary to use gtagslabels. The error could be seen
when gtags was invoked with -v:
$ gtags -v --gtagslabel=pygments
[Sun Mar 19 14:13:17 UTC 2017] Gtags started.
 Using default configuration.
 GTAGSLABEL(--gtagslabel) ignored since configuration file not found.
 Using 'gtags.files' as a file list.
[Sun Mar 19 14:13:17 UTC 2017] Creating 'GTAGS' and 'GRTAGS'.
[Sun Mar 19 14:13:17 UTC 2017] Done.

The wrapper now points to the default gtags.conf using the
GTAGSCONF environment variable.

###### Motivation for this change

The gtagslabel option was not working - it was being silently ignored.
That would be reported when the -v flag was used, though.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

