### PR TITLE
go: use NIX_SSL_CERT_FILE for crypto/x509

### DIFF
--- a/pkgs/development/compilers/go/1.7.nix
+++ b/pkgs/development/compilers/go/1.7.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
 
   patches =
     [ ./remove-tools-1.7.patch
-      ./cacert-1.7.patch
+      ./ssl-cert-file-1.7.patch
       ./creds-test.patch
 
       # This test checks for the wrong thing with recent tzdata. It's been fixed in master but the patch
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
       })
     ];
 
-  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   GOOS = if stdenv.isDarwin then "darwin" else "linux";
   GOARCH = if stdenv.isDarwin then "amd64"

--- a/pkgs/development/compilers/go/1.8.nix
+++ b/pkgs/development/compilers/go/1.8.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
 
   patches =
     [ ./remove-tools-1.8.patch
-      ./cacert-1.8.patch
+      ./ssl-cert-file-1.8.patch
       ./creds-test.patch
       ./remove-test-pie-1.8.patch
 
@@ -119,7 +119,7 @@ stdenv.mkDerivation rec {
       })
     ];
 
-  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   GOOS = if stdenv.isDarwin then "darwin" else "linux";
   GOARCH = if stdenv.isDarwin then "amd64"

--- a/pkgs/development/compilers/go/ssl-cert-file-1.7.patch
+++ b/pkgs/development/compilers/go/ssl-cert-file-1.7.patch
@@ -13,7 +13,7 @@ index a4b33c7..9700b75 100644
  
  func loadSystemRoots() (*CertPool, error) {
  	roots := NewCertPool()
-+	if file := os.Getenv("SSL_CERT_FILE"); file != "" {
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
 +		data, err := ioutil.ReadFile(file)
 +		if err == nil {
 +			roots.AppendCertsFromPEM(data)
@@ -24,26 +24,19 @@ index a4b33c7..9700b75 100644
  	var data C.CFDataRef = nil
  	err := C.FetchPEMRoots(&data)
 diff --git a/src/crypto/x509/root_darwin.go b/src/crypto/x509/root_darwin.go
-index 66cdb5e..bb28036 100644
+index 59b303d..d4a34ac 100644
 --- a/src/crypto/x509/root_darwin.go
 +++ b/src/crypto/x509/root_darwin.go
-@@ -61,17 +61,25 @@ func execSecurityRoots() (*CertPool, error) {
- 		println(fmt.Sprintf("crypto/x509: %d certs have a trust policy", len(hasPolicy)))
- 	}
-
--	cmd := exec.Command("/usr/bin/security", "find-certificate", "-a", "-p", "/System/Library/Keychains/SystemRootCertificates.keychain")
--	data, err := cmd.Output()
--	if err != nil {
--		return nil, err
--	}
--
- 	var (
- 		mu          sync.Mutex
- 		roots       = NewCertPool()
- 		numVerified int // number of execs of 'security verify-cert', for debug stats
- 	)
-
-+	if file := os.Getenv("SSL_CERT_FILE"); file != "" {
+@@ -28,16 +28,25 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
+ // The linker will not include these unused functions in binaries built with cgo enabled.
+ 
+ func execSecurityRoots() (*CertPool, error) {
++	var (
++		mu    sync.Mutex
++		roots = NewCertPool()
++	)
++
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
 +		data, err := ioutil.ReadFile(file)
 +		if err == nil {
 +			roots.AppendCertsFromPEM(data)
@@ -51,14 +44,19 @@ index 66cdb5e..bb28036 100644
 +		}
 +	}
 +
-+	cmd := exec.Command("/usr/bin/security", "find-certificate", "-a", "-p", "/System/Library/Keychains/SystemRootCertificates.keychain")
-+	data, err := cmd.Output()
-+	if err != nil {
-+		return nil, err
-+	}
-+
- 	blockCh := make(chan *pem.Block)
- 	var wg sync.WaitGroup
+ 	cmd := exec.Command("/usr/bin/security", "find-certificate", "-a", "-p", "/System/Library/Keychains/SystemRootCertificates.keychain")
+ 	data, err := cmd.Output()
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 
+-	var (
+-		mu    sync.Mutex
+-		roots = NewCertPool()
+-	)
+ 	add := func(cert *Certificate) {
+ 		mu.Lock()
+ 		defer mu.Unlock()
 diff --git a/src/crypto/x509/root_unix.go b/src/crypto/x509/root_unix.go
 index 7bcb3d6..3986e1a 100644
 --- a/src/crypto/x509/root_unix.go
@@ -67,7 +65,7 @@ index 7bcb3d6..3986e1a 100644
  
  func loadSystemRoots() (*CertPool, error) {
  	roots := NewCertPool()
-+	if file := os.Getenv("SSL_CERT_FILE"); file != "" {
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
 +		data, err := ioutil.ReadFile(file)
 +		if err == nil {
 +			roots.AppendCertsFromPEM(data)

--- a/pkgs/development/compilers/go/ssl-cert-file-1.8.patch
+++ b/pkgs/development/compilers/go/ssl-cert-file-1.8.patch
@@ -13,7 +13,7 @@ index a4b33c7..9700b75 100644
  
  func loadSystemRoots() (*CertPool, error) {
  	roots := NewCertPool()
-+	if file := os.Getenv("SSL_CERT_FILE"); file != "" {
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
 +		data, err := ioutil.ReadFile(file)
 +		if err == nil {
 +			roots.AppendCertsFromPEM(data)
@@ -24,19 +24,26 @@ index a4b33c7..9700b75 100644
  	var data C.CFDataRef = nil
  	err := C.FetchPEMRoots(&data)
 diff --git a/src/crypto/x509/root_darwin.go b/src/crypto/x509/root_darwin.go
-index 59b303d..d4a34ac 100644
+index 66cdb5e..bb28036 100644
 --- a/src/crypto/x509/root_darwin.go
 +++ b/src/crypto/x509/root_darwin.go
-@@ -28,16 +28,25 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
- // The linker will not include these unused functions in binaries built with cgo enabled.
- 
- func execSecurityRoots() (*CertPool, error) {
-+	var (
-+		mu    sync.Mutex
-+		roots = NewCertPool()
-+	)
-+
-+	if file := os.Getenv("SSL_CERT_FILE"); file != "" {
+@@ -61,17 +61,25 @@ func execSecurityRoots() (*CertPool, error) {
+ 		println(fmt.Sprintf("crypto/x509: %d certs have a trust policy", len(hasPolicy)))
+ 	}
+
+-	cmd := exec.Command("/usr/bin/security", "find-certificate", "-a", "-p", "/System/Library/Keychains/SystemRootCertificates.keychain")
+-	data, err := cmd.Output()
+-	if err != nil {
+-		return nil, err
+-	}
+-
+ 	var (
+ 		mu          sync.Mutex
+ 		roots       = NewCertPool()
+ 		numVerified int // number of execs of 'security verify-cert', for debug stats
+ 	)
+
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
 +		data, err := ioutil.ReadFile(file)
 +		if err == nil {
 +			roots.AppendCertsFromPEM(data)
@@ -44,19 +51,14 @@ index 59b303d..d4a34ac 100644
 +		}
 +	}
 +
- 	cmd := exec.Command("/usr/bin/security", "find-certificate", "-a", "-p", "/System/Library/Keychains/SystemRootCertificates.keychain")
- 	data, err := cmd.Output()
- 	if err != nil {
- 		return nil, err
- 	}
- 
--	var (
--		mu    sync.Mutex
--		roots = NewCertPool()
--	)
- 	add := func(cert *Certificate) {
- 		mu.Lock()
- 		defer mu.Unlock()
++	cmd := exec.Command("/usr/bin/security", "find-certificate", "-a", "-p", "/System/Library/Keychains/SystemRootCertificates.keychain")
++	data, err := cmd.Output()
++	if err != nil {
++		return nil, err
++	}
++
+ 	blockCh := make(chan *pem.Block)
+ 	var wg sync.WaitGroup
 diff --git a/src/crypto/x509/root_unix.go b/src/crypto/x509/root_unix.go
 index 7bcb3d6..3986e1a 100644
 --- a/src/crypto/x509/root_unix.go
@@ -65,7 +67,7 @@ index 7bcb3d6..3986e1a 100644
  
  func loadSystemRoots() (*CertPool, error) {
  	roots := NewCertPool()
-+	if file := os.Getenv("SSL_CERT_FILE"); file != "" {
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
 +		data, err := ioutil.ReadFile(file)
 +		if err == nil {
 +			roots.AppendCertsFromPEM(data)


### PR DESCRIPTION
###### Motivation for this change

Fixes issues with crypto/x509 since `SSL_CERT_FILE` was renamed to `NIX_SSL_CERT_FILE`, eg.

```
$ go get -v gopkg.in/yaml/v1
Fetching https://gopkg.in/yaml/v1?go-get=1
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x178a91f]

runtime stack:
runtime.throw(0x149e811, 0x2a)
	/nix/store/w1990ccmglr59q6aqj60gf6fz63619nq-go-1.8/share/go/src/runtime/panic.go:596 +0x95
runtime.sigpanic()
	/nix/store/w1990ccmglr59q6aqj60gf6fz63619nq-go-1.8/share/go/src/runtime/signal_unix.go:274 +0x2db
```

/cc @zimbatm 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
