### PR TITLE
libircclient: disable on darwin

### DIFF
--- a/pkgs/development/libraries/libircclient/default.nix
+++ b/pkgs/development/libraries/libircclient/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation rec {
     homepage    = http://www.ulduzsoft.com/libircclient/;
     license     = licenses.lgpl3;
     maintainers = with maintainers; [ obadz ];
-    platforms   = platforms.all;
+    platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

libircclient does not compile on darwin and caused my unrelated [pr check](https://travis-ci.org/NixOS/nixpkgs/jobs/212687818) to fail.

Its `src/Makefile.in` has
```
libircclient.so: libircclient.o
	$(CC) -shared -s -Wl,-soname,libircclient.so.$(APIVERSION) -o libircclient.so libircclient.o @LDFLAGS@ @LIBS@
```
which fails with
```
clang -shared -s -Wl,-soname,libircclient.so.1 -o libircclient.so libircclient.o
ld: warning: option -s is obsolete and being ignored
ld: unknown option: -soname
clang-3.7: error: linker command failed with exit code 1 (use -v to see invocation)
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
