### PR TITLE
rclone: 1.35 -> 1.36

### DIFF
--- a/pkgs/applications/networking/sync/rclone/default.nix
+++ b/pkgs/applications/networking/sync/rclone/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "rclone-${version}";
-  version = "1.35";
+  version = "1.36";
 
   goPackagePath = "github.com/ncw/rclone";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "ncw";
     repo = "rclone";
     rev = "v${version}";
-    sha256 = "15dmppb7qgr3vg76dsv770l51lmsl8n8k3rvbnhhks5a2cz0kf2i";
+    sha256 = "1vx75ihg2j0chml8hwvngjkjw647cai9gicfy8ss6xsrm46w59b3";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Update rclone to version 1.36

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

