### PR TITLE
Geany: 1.30 -> 1.30.1

### DIFF
--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -1,5 +1,7 @@
 { stdenv, fetchurl, gtk2, which, pkgconfig, intltool, file }:
 
+with stdenv.lib;
+
 let
   version = "1.30.1";
 in
@@ -13,8 +15,9 @@ stdenv.mkDerivation rec {
   };
 
   NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
-
-  buildInputs = [ gtk2 which pkgconfig intltool file ];
+  
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ gtk2 which intltool file ];
 
   doCheck = true;
 
@@ -47,9 +50,9 @@ stdenv.mkDerivation rec {
       - Simple project management
       - Plugin interface
     '';
-    homepage = "http://www.geany.org/";
+    homepage = http://www.geany.org/;
     license = "GPL";
-    maintainers = [ stdenv.lib.maintainers.bbenoist ];
-    platforms = stdenv.lib.platforms.all;
+    maintainers = [ maintainers.bbenoist ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
   
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk2 which intltool file ];
+  nativeBuildInputs = [ pkgconfig intltool ];
+  buildInputs = [ gtk2 which file ];
 
   doCheck = true;
 

--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, gtk2, which, pkgconfig, intltool, file }:
 
 let
-  version = "1.30";
+  version = "1.30.1";
 in
 
 stdenv.mkDerivation rec {
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.geany.org/${name}.tar.bz2";
-    sha256 = "b2dec920c77bc3e88d5f7b0f1dbe4f5200f36df3b346d1aba39323bc30afae6d";
+    sha256 = "0ac360f1f3d6c28790a81d570252a7d40421f6e1d8e5a8d653756bd041d88491";
   };
 
   NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;


### PR DESCRIPTION
###### Motivation for this change

This PR updates Geany to 1.30 as there was a bug found in 1.30 causing e.g. calltips popping up on wrong display when using Geany in a multi-display environment and not running on left top monitor.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

