### PR TITLE
bevelbar: init at 16.11

### DIFF
--- a/pkgs/applications/window-managers/bevelbar/default.nix
+++ b/pkgs/applications/window-managers/bevelbar/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchurl, libX11, libXrandr, libXft }:
+{ stdenv, fetchFromGitHub, libX11, libXrandr, libXft }:
 
 stdenv.mkDerivation rec {
-  name = "${repo}-${version}";
+  name = "bevelbar-${version}";
   version = "16.11";
-  repo = "bevelbar";
-  repoOwner = "vain";
 
-  src = fetchurl {
-    url = "https://github.com/${repoOwner}/${repo}/archive/v${version}.tar.gz";
-    sha256 = "0pxj54qkw2nsci6x36my47n555d23618h8gzmim4djdyw1yybd0n";
+  src = fetchFromGitHub {
+    owner = "vain";
+    repo = "bevelbar";
+    rev = "v${version}";
+    sha256 = "1hbwg3vdxw9fyshy85skv476p0zr4ynvhcz2xkijydpzm2j3rmjm";
   };
 
   buildInputs = [ libX11 libXrandr libXft ];
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An X11 status bar with fancy schmancy 1985-ish beveled borders";
-    homepage = "https://github.com/${repoOwner}/${repo}";
+    inherit (src.meta) homepage;
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = [ maintainers.neeasade ];

--- a/pkgs/applications/window-managers/bevelbar/default.nix
+++ b/pkgs/applications/window-managers/bevelbar/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, libX11, libXrandr, libXft }:
+
+stdenv.mkDerivation rec {
+  name = "${repo}-${version}";
+  version = "16.11";
+  repo = "bevelbar";
+  repoOwner = "vain";
+
+  src = fetchurl {
+    url = "https://github.com/${repoOwner}/${repo}/archive/v${version}.tar.gz";
+    sha256 = "0pxj54qkw2nsci6x36my47n555d23618h8gzmim4djdyw1yybd0n";
+  };
+
+  buildInputs = [ libX11 libXrandr libXft ];
+
+  makeFlags = [ "prefix=$(out)" ];
+  installFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "An X11 status bar with fancy schmancy 1985-ish beveled borders";
+    homepage = "https://github.com/${repoOwner}/${repo}";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.neeasade ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12812,6 +12812,8 @@ with pkgs;
     guile = guile_1_8;
   };
 
+  bevelbar = callPackage ../applications/window-managers/bevelbar { };
+
   bibletime = callPackage ../applications/misc/bibletime { };
 
   bitkeeper = callPackage ../applications/version-management/bitkeeper {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

