### PR TITLE
codeblocks: 13.12 -> 16.01

### DIFF
--- a/pkgs/applications/editors/codeblocks/default.nix
+++ b/pkgs/applications/editors/codeblocks/default.nix
@@ -1,20 +1,23 @@
-{ stdenv, fetchurl, autoconf, automake, libtool, pkgconfig, file, zip, wxGTK, gtk2
+{ stdenv, fetchurl, autoreconfHook, libtool, pkgconfig, file, zip, wxGTK, gtk2
 , contribPlugins ? false, hunspell, gamin, boost
 }:
+
+with stdenv.lib;
 
 with { inherit (stdenv.lib) optionalString optional optionals; };
 
 stdenv.mkDerivation rec {
   name = "${pname}-${stdenv.lib.optionalString contribPlugins "full-"}${version}";
-  version = "13.12";
+  version = "16.01";
   pname = "codeblocks";
 
   src = fetchurl {
-    url = "mirror://sourceforge/codeblocks/Sources/${version}/codeblocks_${version}-1.tar.gz";
-    sha256 = "044njhps4cm1ijfdyr5f9wjyd0vblhrz9b4603ma52wcdq25093p";
+    url = "mirror://sourceforge/codeblocks/Sources/${version}/codeblocks_${version}.tar.gz";
+    sha256 = "00sskm91r20ywydwqwx6v7z3nwn9lyh5297c5wp3razldlh9vyrh";
   };
 
-  buildInputs = [ automake autoconf libtool pkgconfig file zip wxGTK gtk2 ]
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ libtool file zip wxGTK gtk2 ]
     ++ optionals contribPlugins [ hunspell gamin boost ];
   enableParallelBuilding = true;
   patches = [ ./writable-projects.patch ];
@@ -25,9 +28,9 @@ stdenv.mkDerivation rec {
 
   # Fix boost 1.59 compat
   # Try removing in the next version
-  CPPFLAGS = "-DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED";
+  #CPPFLAGS = "-DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED";
 
-  meta = with stdenv.lib; {
+  meta = {
     maintainers = [ maintainers.linquize ];
     platforms = platforms.all;
     description = "The open source, cross platform, free C, C++ and Fortran IDE";


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

