### PR TITLE
cre2: init at 0.3.0

### DIFF
--- a/pkgs/development/libraries/cre2/default.nix
+++ b/pkgs/development/libraries/cre2/default.nix
@@ -1,9 +1,8 @@
-{ stdenv, fetchFromGitHub, autoconf, automake,
+{ stdenv, fetchFromGitHub, autoreconfHook,
   libtool, pkgconfig, re2, texinfo }:
 
 stdenv.mkDerivation rec {
   name = "cre2-${version}";
-
   version = "0.3.0";
     
   src = fetchFromGitHub {
@@ -14,26 +13,22 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    autoconf
-    automake
+    autoreconfHook
     libtool
     pkgconfig
-    re2
-    texinfo
   ];
+  buildInputs = [ re2 texinfo ];
 
   NIX_LDFLAGS="-lre2 -lpthread";
 
-  preConfigure = "sh autogen.sh";
-  
   configureFlags = [
     "--enable-maintainer-mode"
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://marcomaggi.github.io/docs/cre2.html;
     description = "C Wrapper for RE2";
-    license = stdenv.lib.licenses.bsd3;
-    platforms = with stdenv.lib.platforms; all;
+    license = licenses.bsd3;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/cre2/default.nix
+++ b/pkgs/development/libraries/cre2/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, autoconf, automake,
+  libtool, pkgconfig, re2, texinfo }:
+
+stdenv.mkDerivation rec {
+  name = "cre2-${version}";
+
+  version = "0.3.0";
+    
+  src = fetchFromGitHub {
+    owner = "marcomaggi";
+    repo = "cre2";
+    rev = version;
+    sha256 = "12yrdad87jjqrhbqm02hzsayan2402vf61a9x1b2iabv6d1c1bnj";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    pkgconfig
+    re2
+    texinfo
+  ];
+
+  NIX_LDFLAGS="-lre2 -lpthread";
+
+  preConfigure = "sh autogen.sh";
+  
+  configureFlags = [
+    "--enable-maintainer-mode"
+  ];
+
+  meta = {
+    homepage = http://marcomaggi.github.io/docs/cre2.html;
+    description = "C Wrapper for RE2";
+    license = stdenv.lib.licenses.bsd3;
+    platforms = with stdenv.lib.platforms; all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7195,6 +7195,8 @@ with pkgs;
 
   cracklib = callPackage ../development/libraries/cracklib { };
 
+  cre2 = callPackage ../development/libraries/cre2 { };
+
   cryptopp = callPackage ../development/libraries/crypto++ { };
 
   curlcpp = callPackage ../development/libraries/curlcpp { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

