### PR TITLE
neo4j: 3.1.1 -> 3.1.2, minor fixes

### DIFF
--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -140,7 +140,7 @@ in {
       '';
     };
 
-    environment.systemPackages = [ pkgs.neo4j ];
+    environment.systemPackages = [ cfg.package ];
 
     users.extraUsers = singleton {
       name = "neo4j";

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -27,9 +27,7 @@ let
     ''}
     dbms.shell.enabled=true
     ${cfg.extraServerConfig}
-  '';
 
-  wrapperConfig = pkgs.writeText "neo4j-wrapper.conf" ''
     # Default JVM parameters from neo4j.conf
     dbms.jvm.additional=-XX:+UseG1GC
     dbms.jvm.additional=-XX:-OmitStackTraceInFastThrow
@@ -135,7 +133,6 @@ in {
       preStart = ''
         mkdir -m 0700 -p ${cfg.dataDir}/{data/graph.db,conf,logs}
         ln -fs ${serverConfig} ${cfg.dataDir}/conf/neo4j.conf
-        ln -fs ${wrapperConfig} ${cfg.dataDir}/conf/neo4j-wrapper.conf
         if [ "$(id -u)" = 0 ]; then chown -R neo4j ${cfg.dataDir}; fi
       '';
     };

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "neo4j-${version}";
-  version = "3.1.1";
+  version = "3.1.2";
 
   src = fetchurl {
     url = "http://dist.neo4j.org/neo4j-community-${version}-unix.tar.gz";
-    sha256 = "1jz257brrrblxq0jdh79mmqand6lwi632y8sy5j6dxl3ssd3hrkx";
+    sha256 = "0kvbsm9mjwqyl3q2myif28a0f11i4rfq3hik07w9cdnrwyd75s40";
   };
 
   buildInputs = [ makeWrapper jre8 which gawk ];


### PR DESCRIPTION
###### Motivation for this change

* Version bump
* Fix use of deprecated configuration style that caused warning on startup (and will eventually be unsupported, presumably)
* Fix which package is installed into environment when specifying the neo4j package to use for the service.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

