### PR TITLE
nedit: 5.6a -> 5.7

### DIFF
--- a/pkgs/applications/editors/nedit/default.nix
+++ b/pkgs/applications/editors/nedit/default.nix
@@ -1,16 +1,18 @@
 { stdenv, fetchurl, xlibsWrapper, motif, libXpm }:
 
 stdenv.mkDerivation rec {
-  name = "nedit-5.6a";
+  name = "nedit-${version}";
+  version = "5.7";
   
   src = fetchurl {
     url = "mirror://sourceforge/nedit/nedit-source/${name}-src.tar.gz";
-    sha256 = "1v8y8vwj3kn91crsddqkz843y6csgw7wkjnd3zdcb4bcrf1pjrsk";
+    sha256 = "0ym1zhjx9976rf2z5nr7dj4mjkxcicimhs686snjhdcpzxwsrndd";
   };
 
   hardeningDisable = [ "format" ];
 
-  buildInputs = [ xlibsWrapper motif libXpm ];
+  nativeBuildInputs = [ xlibsWrapper ];
+  buildInputs = [ motif libXpm ];
 
   buildFlags = if stdenv.isLinux then "linux" else
                # the linux config works fine on darwin too!
@@ -24,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.nedit.org;
+    homepage = http://sourceforge.net/projects/nedit;
     platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

