### PR TITLE
ants: set $ANTSPATH variable in shell scripts

### DIFF
--- a/pkgs/applications/science/biology/ants/default.nix
+++ b/pkgs/applications/science/biology/ants/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, itk, vtk }:
+{ stdenv, fetchFromGitHub, cmake, makeWrapper, itk, vtk }:
 
 stdenv.mkDerivation rec {
   _name    = "ANTs";
@@ -12,13 +12,19 @@ stdenv.mkDerivation rec {
     sha256 = "0gyys1lf69bl3569cskxc8r5llwcr0dsyzvlby5skhfpsyw0dh8r";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ itk vtk ];
 
   cmakeFlags = [ "-DANTS_SUPERBUILD=FALSE" "-DUSE_VTK=TRUE" ];
 
   checkPhase = "ctest";
   doCheck = false;
+
+  postInstall = ''
+    for file in $out/bin/*; do
+      wrapProgram $file --set ANTSPATH "$out/bin"
+    done
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/stnava/ANTs;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

