### PR TITLE
tiled: 0.17.0 -> 0.18.2

### DIFF
--- a/pkgs/applications/editors/tiled/default.nix
+++ b/pkgs/applications/editors/tiled/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, fetchurl, pkgconfig, qmakeHook
+{ stdenv, fetchFromGitHub, pkgconfig, qmakeHook
 , python, qtbase, qttools, zlib }:
 
 let
 #  qtEnv = with qt5; env "qt-${qtbase.version}" [ qtbase qttools ];
 in stdenv.mkDerivation rec {
   name = "tiled-${version}";
-  version = "0.17.0";
+  version = "0.18.2";
 
-  src = fetchurl {
-    name = "${name}.tar.gz";
-    url = "https://github.com/bjorn/tiled/archive/v${version}.tar.gz";
-    sha256 = "0c9gykxmq0sk0yyfdq81g9psd922scqzn5asskjydj84d80f5z7p";
+  src = fetchFromGitHub {
+    owner = "bjorn";
+    repo = "tiled";
+    rev = "v${version}";
+    sha256 = "087jl36g6w2g5l70gz573iwyvx3r7i8fijl3y4mmmf8pyqdyq1n2";
   };
 
   nativeBuildInputs = [ pkgconfig qmakeHook ];
@@ -26,6 +27,6 @@ in stdenv.mkDerivation rec {
       gpl2Plus	# all the rest
     ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ nckx ];
+    maintainers = [ maintainers.nckx ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

