### PR TITLE
chirp: 20161018 -> 20170311

### DIFF
--- a/pkgs/applications/misc/chirp/default.nix
+++ b/pkgs/applications/misc/chirp/default.nix
@@ -1,24 +1,19 @@
 { stdenv, fetchurl, libxml2Python, libxslt, makeWrapper
-, python, pyserial, pygtk
-}:
-let
-  version = "20161018";
-in
+, python, pyserial, pygtk }:
+
 stdenv.mkDerivation rec {
   name = "chirp-daily-${version}";
-  inherit version;
+  version = "20170311";
 
   src = fetchurl {
-    url = "http://trac.chirp.danplanet.com/chirp_daily/daily-${version}/chirp-daily-${version}.tar.gz";
-    sha256 = "0f3r919az4vvcgxzqmxvhrxa2byzk5algy7srzzs15ihkvyxcwkb";
+    url = "http://trac.chirp.danplanet.com/chirp_daily/daily-${version}/${name}.tar.gz";
+    sha256 = "0mvj650vm3bfk94b174gl99fj4jigrx38f1iciz1cp3gn8hcrcpj";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [
-    makeWrapper
     pyserial pygtk libxml2Python libxslt pyserial
   ];
-
-  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
 
   installPhase = ''
     mkdir -p $out/bin $out/share/chirp


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

