### PR TITLE
lumina: fix kwindowsystem and oxygen-icons5 attributes

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/lumina.nix
+++ b/nixos/modules/services/x11/desktop-managers/lumina.nix
@@ -32,8 +32,8 @@ in
 
     environment.systemPackages = [
       pkgs.fluxbox
-      pkgs.qt5.kwindowsystem
-      pkgs.qt5.oxygen-icons5
+      pkgs.libsForQt5.kwindowsystem
+      pkgs.kdeFrameworks.oxygen-icons5
       pkgs.lumina
       pkgs.numlockx
       pkgs.qt5.qtsvg


### PR DESCRIPTION
###### Motivation for this change

The attributes `qt5.kwindowsystem` and `qt5.oxygen-icons5` are not found after the Qt and KDE related packages have been reorganized. See https://github.com/NixOS/nixpkgs/pull/23180 and https://github.com/NixOS/nixpkgs/pull/23239.

/cc @ttuegel 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).