### PR TITLE
copyq: 2.5.0 -> 2.9.0

### DIFF
--- a/pkgs/applications/misc/copyq/default.nix
+++ b/pkgs/applications/misc/copyq/default.nix
@@ -1,21 +1,25 @@
-{ stdenv, fetchurl, cmake, qt4, libXfixes, libXtst}:
+{ stdenv, fetchFromGitHub, cmake, qt4, libXfixes, libXtst}:
 
-let version = "2.5.0";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "CopyQ-${version}";
-  src  = fetchurl {
-    url    = "https://github.com/hluk/CopyQ/archive/v${version}.tar.gz";
-    sha256 = "7726745056e8d82625531defc75b2a740d3c42131ecce1f3181bc0a0bae51fb1";
+  version = "2.9.0";
+
+  src  = fetchFromGitHub {
+    owner = "hluk";
+    repo = "CopyQ";
+    rev = "v${version}";
+    sha256 = "1gnqsfh50w3qcnbghkpjr5qs42fgl6643lmg4mg4wam8a852s64f";
   };
 
-  buildInputs = [ cmake qt4 libXfixes libXtst ];
+  nativeBuildInputs = [ cmake ];
+  
+  buildInputs = [ qt4 libXfixes libXtst ];
 
   meta = with stdenv.lib; {
-    homepage    = "https://hluk.github.io/CopyQ";
+    homepage    = https://hluk.github.io/CopyQ;
     description = "Clipboard Manager with Advanced Features";
     license     = licenses.gpl3;
-    maintainers = with maintainers; [ willtim ];
+    maintainers = [ maintainers.willtim ];
     # NOTE: CopyQ supports windows and osx, but I cannot test these.
     # OSX build requires QT5.
     platforms   = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

