### PR TITLE
loccount: init

### DIFF
--- a/pkgs/development/tools/misc/loccount/default.nix
+++ b/pkgs/development/tools/misc/loccount/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitLab }:
+buildGoPackage rec {
+  name = "loccount-${version}";
+  version = "1.0";
+
+  goPackagePath = "gitlab.com/esr/loccount";
+  excludedPackages = "tests";
+
+  src = fetchFromGitLab {
+    owner = "esr";
+    repo = "loccount";
+    rev = version;
+    sha256 = "081wf7fckn76m4x0jwq4h2fsbhpb6f67dha77ni3p6wg7q6sihqx";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Re-implementation of sloccount in Go";
+    longDescription = ''
+      loccount is a re-implementation of David A. Wheeler's sloccount tool
+      in Go.  It is faster and handles more different languages. Because
+      it's one source file in Go, it is easier to maintain and extend than the
+      multi-file, multi-language implementation of the original.
+
+      The algorithms are largely unchanged and can be expected to produce
+      identical numbers for languages supported by both tools.  Python is
+      an exception; loccount corrects buggy counting of single-quote multiline
+      literals in sloccount 2.26.
+    '';
+    homepage="https://gitlab.com/esr/loccount";
+    downloadPage="https://gitlab.com/esr/loccount/tree/master";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ calvertvl ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -968,6 +968,8 @@ with pkgs;
 
   languagetool = callPackage ../tools/text/languagetool {  };
 
+  loccount = callPackage ../development/tools/misc/loccount { };
+
   long-shebang = callPackage ../misc/long-shebang {};
 
   iio-sensor-proxy = callPackage ../os-specific/linux/iio-sensor-proxy { };


### PR DESCRIPTION
###### Motivation for this change
[loccount](https://gitlab.com/esr/loccount) is  a higher-performance tool equivalent to sloccount; it produces comparable results in less time.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

