### PR TITLE
Update src

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -82,6 +82,7 @@
   bzizou = "Bruno Bzeznik <Bruno@bzizou.net>";
   c0dehero = "CodeHero <codehero@nerdpol.ch>";
   calrama = "Moritz Maxeiner <moritz@ucworks.org>";
+  calvertvl = "Victor Calvert <calvertvl@gmail.com>";
   campadrenalin = "Philip Horger <campadrenalin@gmail.com>";
   canndrew = "Andrew Cann <shum@canndrew.org>";
   carlsverre = "Carl Sverre <accounts@carlsverre.com>";

--- a/pkgs/applications/version-management/src/default.nix
+++ b/pkgs/applications/version-management/src/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, python, rcs, git }:
 
 stdenv.mkDerivation rec {
-  name = "src-1.11";
+  name = "src-${version}";
+  version = "1.12";
 
   src = fetchurl {
     url = "http://www.catb.org/~esr/src/${name}.tar.gz";
-    sha256 = "07kj0ri0s0vn8s54yvkyzaag332spxs0379r718b80y31c4mgbyl";
+    sha256 = "1m6rjbizx9win3jkciyx176sfy98r5arb1g3l6aqnqam9gpr44zm";
   };
 
   buildInputs = [ python rcs git ];
@@ -16,10 +17,11 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "prefix=$(out)" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Simple single-file revision control";
     homepage = http://www.catb.org/~esr/src/;
-    license = stdenv.lib.licenses.bsd3;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ calvertvl ];
   };
 }

--- a/pkgs/applications/version-management/src/default.nix
+++ b/pkgs/applications/version-management/src/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, rcs, git }:
+{ stdenv, fetchurl, python, rcs, git, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "src-${version}";
@@ -9,13 +9,18 @@ stdenv.mkDerivation rec {
     sha256 = "1m6rjbizx9win3jkciyx176sfy98r5arb1g3l6aqnqam9gpr44zm";
   };
 
-  buildInputs = [ python rcs git ];
+  buildInputs = [ python rcs git makeWrapper ];
 
   preConfigure = ''
     patchShebangs .
   '';
 
   makeFlags = [ "prefix=$(out)" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/src \
+      --suffix PATH ":" "${rcs}/bin"
+  '';
 
   meta = with stdenv.lib; {
     description = "Simple single-file revision control";


### PR DESCRIPTION
###### Motivation for this change

The `src` package is broken, and out of date.

### Steps to reproduce the breakage (on 1.11)

1. Confirm that rcs is not available (`which rcs` => `which :  no rcs in ...`)
1. Install src (`nix-env -i src`)
1. Run a src operation dependent on RCS, e.g. `src version`
Output of this on my system is
```
src: 1.11
python: 2.7.13
/bin/sh: rcs: command not found
src: execution of 'rcs --version' failed: Command 'rcs --version' returned non-zero exit status 127
```
1.  Proper working behaivor is e.g. if rcs is installed via `nix-env -i rcs`
Output of this on my system (with the version bump) is
```
src: 1.12
python: 2.7.13
RCS: 5.9.4
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

