### PR TITLE
coursier: init at 1.0.0-M15

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -14,6 +14,7 @@
   aboseley = "Adam Boseley <adam.boseley@gmail.com>";
   abuibrahim = "Ruslan Babayev <ruslan@babayev.com>";
   acowley = "Anthony Cowley <acowley@gmail.com>";
+  adelbertc = "Adelbert Chang <adelbertc@gmail.com>";
   adev = "Adrien Devresse <adev@adev.name>";
   Adjective-Object = "Maxwell Huang-Hobbs <mhuan13@gmail.com>";
   adnelson = "Allen Nelson <ithinkican@gmail.com>";

--- a/pkgs/development/tools/coursier/default.nix
+++ b/pkgs/development/tools/coursier/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "610c5fc08d0137c5270cefd14623120ab10cd81b9f48e43093893ac8d00484c9";
   };
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   phases = "installPhase";
 
@@ -24,5 +24,6 @@ stdenv.mkDerivation rec {
     homepage    = http://get-coursier.io/;
     description = "A Scala library to fetch dependencies from Maven / Ivy repositories";
     license     = licenses.asl20;
+    maintainers = with maintainers; [ adelbertc nequissimus ];
   };
 }

--- a/pkgs/development/tools/coursier/default.nix
+++ b/pkgs/development/tools/coursier/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  name    = "coursier-${version}";
+  version = "1.0.0-M15-5";
+
+  src = fetchurl {
+    url    = "https://github.com/coursier/coursier/raw/v${version}/coursier";
+    sha256 = "610c5fc08d0137c5270cefd14623120ab10cd81b9f48e43093893ac8d00484c9";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  phases = "installPhase";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${src} $out/bin/coursier
+    chmod +x $out/bin/coursier
+    wrapProgram $out/bin/coursier --prefix PATH ":" ${jre}/bin ;
+  '';
+
+  meta = with stdenv.lib; {
+    homepage    = http://get-coursier.io/;
+    description = "A Scala library to fetch dependencies from Maven / Ivy repositories";
+    license     = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -804,6 +804,8 @@ with pkgs;
 
   coturn = callPackage ../servers/coturn { };
 
+  coursier = callPackage ../development/tools/coursier {};
+
   crunch = callPackage ../tools/security/crunch { };
 
   crudini = callPackage ../tools/misc/crudini { };


### PR DESCRIPTION
###### Motivation for this change
New package: [coursier](https://github.com/coursier/coursier#command-line) command line

###### Things done

- [x] ~~Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)~~ (Apparently not working for `nix-darwin` at the moment)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

