### PR TITLE
Add ODROID-XU{3,4} support

### DIFF
--- a/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
@@ -28,7 +28,7 @@ in
   boot.loader.generic-extlinux-compatible.enable = true;
 
   boot.kernelPackages = pkgs.linuxPackages_latest;
-  boot.kernelParams = ["console=ttyS0,115200n8" "console=ttymxc0,115200n8" "console=ttyAMA0,115200n8" "console=ttyO0,115200n8" "console=tty0"];
+  boot.kernelParams = ["console=ttyS0,115200n8" "console=ttymxc0,115200n8" "console=ttyAMA0,115200n8" "console=ttyO0,115200n8" "console=ttySAC2,115200n8" "console=tty0"];
 
   # FIXME: this probably should be in installation-device.nix
   users.extraUsers.root.initialHashedPassword = "";

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -83,6 +83,12 @@ in rec {
     filesToInstall = ["u-boot" "u-boot.dtb" "u-boot-dtb-tegra.bin" "u-boot-nodtb-tegra.bin"];
   };
 
+  ubootOdroidXU3 = buildUBoot rec {
+    defconfig = "odroid-xu3_defconfig";
+    targetPlatforms = ["armv7l-linux"];
+    filesToInstall = ["u-boot.bin"];
+  };
+
   ubootPcduino3Nano = buildUBoot rec {
     defconfig = "Linksprite_pcDuino3_Nano_defconfig";
     targetPlatforms = ["armv7l-linux"];

--- a/pkgs/tools/misc/odroid-xu3-bootloader/default.nix
+++ b/pkgs/tools/misc/odroid-xu3-bootloader/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, coreutils, ubootOdroidXU3 }:
+
+stdenv.mkDerivation {
+  name = "odroid-xu3-bootloader-2015-12-04";
+
+  src = fetchFromGitHub {
+    owner = "hardkernel";
+    repo = "u-boot";
+    rev = "bbdea1841c4fbf767dcaf9d7ae8d3a46af235c4d";
+    sha256 = "03rvyfj147xh83w8hlvbxix131l3nnvk8n517fdhv9nil1l8dd71";
+  };
+
+  buildCommand = ''
+    install -Dm644 -t $out/lib/sd_fuse-xu3 $src/sd_fuse/hardkernel/*.hardkernel
+    ln -sf ${ubootOdroidXU3}/u-boot.bin $out/lib/sd_fuse-xu3/u-boot.bin.hardkernel
+
+    install -Dm755 $src/sd_fuse/hardkernel/sd_fusing.sh $out/bin/sd_fuse-xu3
+    sed -i \
+      -e '1i#!${stdenv.shell}' \
+      -e '1iPATH=${lib.makeBinPath [ coreutils ]}:$PATH' \
+      -e "s,if=\./,if=$out/lib/sd_fuse-xu3/,g" \
+      $out/bin/sd_fuse-xu3
+  '';
+
+  meta = with stdenv.lib; {
+    platforms = platforms.linux;
+    license = licenses.unfreeRedistributableFirmware;
+    description = "Secure boot enabled boot loader for ODROID-XU{3,4}";
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12131,6 +12131,7 @@ with pkgs;
     ubootBananaPi
     ubootBeagleboneBlack
     ubootJetsonTK1
+    ubootOdroidXU3
     ubootPcduino3Nano
     ubootRaspberryPi
     ubootRaspberryPi2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11935,6 +11935,8 @@ with pkgs;
 
   nss_ldap = callPackage ../os-specific/linux/nss_ldap { };
 
+  odroid-xu3-bootloader = callPackage ../tools/misc/odroid-xu3-bootloader { };
+
   pagemon = callPackage ../os-specific/linux/pagemon { };
 
   pam = callPackage ../os-specific/linux/pam { };


### PR DESCRIPTION
###### Motivation for this change

This enables TTL console on the multiplatform image and also builds U-Boot. Notice that the image is still not bootable out of the box; this requires [non-standard modification](https://github.com/hardkernel/u-boot/tree/odroidxu3-v2012.07/sd_fuse/hardkernel) (these boards need bootloader and uboot in the first 2KB). I don't think we want to do this with the multiplatform image (and there are also older ODROID boards which need different boot code in the same place). I think of simply packaging the `sd_fuse` tool; any other ideas?

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

