### PR TITLE
Reintroduce pijul (at 0.3.0)

### DIFF
--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, rustPlatform, perl, darwin }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "pijul-${version}";
+  version = "0.3";
+
+  src = fetchurl {
+    url = "https://pijul.org/releases/${name}.tar.gz";
+    sha256 = "2c7b354b4ab142ac50a85d70c80949ff864377b37727b862d103d3407e2c7818";
+  };
+
+  sourceRoot = "pijul/pijul";
+
+  buildInputs = [ perl ]++ stdenv.lib.optionals stdenv.isDarwin
+    (with darwin.apple_sdk.frameworks; [ Security ]);
+
+  doCheck = false;
+  
+  depsSha256 = "03bb92mn16d38l49x4p1z21k7gvq3l3ki10brr13p7yv45rwvmzc";
+
+  meta = with stdenv.lib; {
+    description = "A distributed version control system";
+    homepage = https://pijul.org;
+    license = with licenses; [ gpl2Plus ];
+    maintainers = [ maintainers.gal_bolle ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14713,6 +14713,8 @@ with pkgs;
 
   pig = callPackage ../applications/networking/cluster/pig { };
 
+  pijul = callPackage ../applications/version-management/pijul {};
+
   planner = callPackage ../applications/office/planner { };
 
   playonlinux = callPackage ../applications/misc/playonlinux {

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,9 +7,9 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2017-03-13";
-  rev = "e5b7b45fa4e1168715a1132a65ad89fbc1d5ed82";
-  sha256 = "1glwd7b5ckiw2nzc28djyarml21cqdajc1jn03vzf4sl58bvahyb";
+  version = "2017-03-19";
+  rev = "6ac4724ed839594a132f5199d70d40fa15bd6b7a";
+  sha256 = "159b82zma3y0kcg55c6zm6ddsw4jm0c4y85b6l1ny108l9k3hy79";
 
   src = fetchFromGitHub {
       inherit rev;


### PR DESCRIPTION
###### Motivation for this change
pijul has just had its first public release

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

