### PR TITLE
yed: 3.16.2.1 -> 3.17

### DIFF
--- a/pkgs/applications/graphics/yed/default.nix
+++ b/pkgs/applications/graphics/yed/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "yEd-${version}";
-  version = "3.16.2.1";
+  version = "3.17";
 
   src = requireFile {
     name = "${name}.zip";
     url = "https://www.yworks.com/en/products/yfiles/yed/";
-    sha256 = "019qfmdifqsrc9h4g3zbn7ivdc0dzlp3isa5ixdkgdhfsdm79b27";
+    sha256 = "1wk58cql90y3i5l7jlxqfjjgf26i0zrv5cn0p9npgagaw6aiw2za";
   };
 
   nativeBuildInputs = [ unzip makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Update yEd to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

