### PR TITLE
j4-dmenu-desktop: 2.14 -> 2.15

### DIFF
--- a/pkgs/applications/misc/j4-dmenu-desktop/default.nix
+++ b/pkgs/applications/misc/j4-dmenu-desktop/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name    = "j4-dmenu-desktop-${version}";
-  version = "2.14";
+  version = "2.15";
 
   src = fetchFromGitHub {
     owner  = "enkore";
     repo   = "j4-dmenu-desktop";
     rev    = "r${version}";
-    sha256 = "14srrkz4qx8qplgrrjv38ri4pnkxaxaq6jy89j13xhna492bq128";
+    sha256 = "1yn45i3hpim2hriaqkq7wmawwsmkynvy2xgz7dg6p5r0ikw5bn1r";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Update j4-dmenu-desktop to latest version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

