### PR TITLE
fwknop: init at 2.6.9

### DIFF
--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -16,9 +16,6 @@ stdenv.mkDerivation rec {
     sha256 = "0csx3qnycwm0n90ql6gs65if5xi4gqyzzy21fxs2xqicghjrfq2r";
   };
 
-  outputs = [ "out" "dev" "info" ];
-  outputBin = "dev"; # gpgme-config; not so sure about gpgme-tool
-
   propagatedBuildInputs = [ libgpgerror glib libassuan pth ];
 
   nativeBuildInputs = [ pkgconfig gnupg ];

--- a/pkgs/tools/security/fwknop/default.nix
+++ b/pkgs/tools/security/fwknop/default.nix
@@ -1,0 +1,66 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, lib
+, libpcap, texinfo
+, iptables
+, gnupgSupport ? true, gnupg, gpgme # Increases dependencies!
+, wgetSupport ? true, wget
+, buildServer ? true
+, buildClient ? true }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "fwknop";
+  version = "2.6.9";
+
+  src = fetchFromGitHub {
+    owner = "mrash";
+    repo = pname;
+    rev = version;
+    sha256 = "1509d1lzfmhavdwi65dwb0jaglpy8ciccgpcnhx9ks6s7irn923c";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ libpcap texinfo ]
+    ++ stdenv.lib.optional gnupgSupport [ gnupg gpgme ]
+    ++ stdenv.lib.optional wgetSupport [ wget ];
+
+  configureFlags = ''
+    --sysconfdir=/etc
+    --localstatedir=/run
+    --with-iptables=${iptables}/sbin/iptables
+    ${lib.optionalString (!buildServer) "--disable-server"}
+    ${lib.optionalString (!buildClient) "--disable-client"}
+    ${lib.optionalString gnupgSupport ''
+      --with-gpgme
+      --with-gpgme-prefix=${gpgme}
+      --with-gpg=${gnupg}
+    ''}
+    ${lib.optionalString wgetSupport ''
+      --with-wget=${wget}/bin/wget
+    ''}
+  '';
+
+  # Temporary hack to copy the example configuration files into the nix-store,
+  # this'll probably be helpful until there's a NixOS module for that (feel free
+  # to ping me (@primeos) if you want to help).
+  preInstall = ''
+    substituteInPlace Makefile --replace\
+      "sysconfdir = /etc"\
+      "sysconfdir = $out/etc"
+    substituteInPlace server/Makefile --replace\
+      "wknopddir = /etc/fwknop"\
+      "wknopddir = $out/etc/fwknop"
+  '';
+
+  meta = with stdenv.lib; {
+    description =
+      "Single Packet Authorization (and Port Knocking) server/client";
+    longDescription = ''
+      fwknop stands for the "FireWall KNock OPerator", and implements an
+      authorization scheme called Single Packet Authorization (SPA).
+    '';
+    homepage = "https://www.cipherdyne.org/fwknop/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1867,6 +1867,8 @@ with pkgs;
 
   fuse-7z-ng = callPackage ../tools/filesystems/fuse-7z-ng { };
 
+  fwknop = callPackage ../tools/security/fwknop { };
+
   exfat = callPackage ../tools/filesystems/exfat { };
 
   dos2unix = callPackage ../tools/text/dos2unix { };


### PR DESCRIPTION
~**Please don't merge this yet (should be fine but I didn't test the final executables yet, at least not enough).**~

~(TODO: Patch `sysconfdir` and `localstatedir`.)~

###### Motivation for this change

Add a great tool for SPA (think of it as an advanced/improved version of port knocking) :smile:

Most (hopefully all) things should be ok, but since I'm still a relatively new to NixOS I thought it would be great if someone could double check it. I guess a quick look over the code/changes should be enough, I can take the responsibility for the building and final executables. Feel free to drop a note if you want to merge this (for some reason :D) if not I can merge it myself after I've finished testing the executables.

@Fuuzetsu - I guess the change for `gpgme` is ok but please let me know if I missed anything - thanks :smile:

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

- [x] (same location as e.g. fail2ban) package path fits guidelines
- [x] package name fits guidelines
- [x] package version fits guidelines
- [x] package build on AMD64
- [x] executables tested on AMD64
- [x] `meta.description` is set and fits guidelines
- [x] `meta.license` fits upstream license
- [x] (limited to Linux (iptables) for now) `meta.platforms` is set
- [x] `meta.maintainers` is set
- [x] build time only dependencies are declared in `nativeBuildInputs`
- [x] source is fetched using the appropriate function
- [x] phases are respected
- [x] (no patches used) patches that are remotely available are fetched with `fetchpatch`