### PR TITLE
Fix GTK dependencies in wrappers

### DIFF
--- a/pkgs/build-support/kde/wrapper.nix
+++ b/pkgs/build-support/kde/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, makeWrapper, buildEnv }:
+{ stdenv, lib, makeWrapper, buildEnv, gtk3, dconf }:
 
 packages:
 
@@ -47,10 +47,11 @@ stdenv.mkDerivation {
                     --argv0 '"$0"' \
                     --suffix PATH : "$env/bin" \
                     --prefix XDG_CONFIG_DIRS : "$env/etc/xdg" \
-                    --prefix XDG_DATA_DIRS : "$env/share" \
+                    --prefix XDG_DATA_DIRS : "$env/share:${gtk3}/share/gsettings-schemas/${gtk3.name}" \
                     --set QML_IMPORT_PATH "$env/lib/qt5/imports" \
                     --set QML2_IMPORT_PATH "$env/lib/qt5/qml" \
-                    --set QT_PLUGIN_PATH "$env/lib/qt5/plugins"
+                    --set QT_PLUGIN_PATH "$env/lib/qt5/plugins" \
+                    --prefix GIO_EXTRA_MODULES : "${dconf.lib}/lib/gio/modules"
                 good="1"
                 break
             fi

--- a/pkgs/desktops/gnome-3/3.22/core/dconf/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/dconf/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "1jaqsr1r0grpd25rbsc2v3vb0sc51lia9w31wlqswgqsncp2k0w6";
   };
 
+  outputs = [ "out" "lib" "dev" ];
+
   buildInputs = [ vala_0_32 libxslt pkgconfig glib dbus_glib gnome3.gtk libxml2
                   intltool docbook_xsl docbook_xsl_ns makeWrapper ];
 

--- a/pkgs/development/libraries/qt-5/5.7/default.nix
+++ b/pkgs/development/libraries/qt-5/5.7/default.nix
@@ -18,7 +18,7 @@ top-level attribute to `top-level/all-packages.nix`.
   newScope,
   stdenv, fetchurl, makeSetupHook, makeWrapper,
   bison, cups ? null, harfbuzz, mesa, perl,
-  gstreamer, gst-plugins-base,
+  gstreamer, gst-plugins-base, gtk3, dconf,
 
   # options
   developerBuild ? false,
@@ -107,7 +107,7 @@ let
 
       makeQtWrapper =
         makeSetupHook
-        { deps = [ makeWrapper ]; }
+        { deps = [ makeWrapper dconf.lib gtk ]; }
         (if stdenv.isDarwin then ../make-qt-wrapper-darwin.sh else ../make-qt-wrapper.sh);
 
       qmakeHook =

--- a/pkgs/development/libraries/qt-5/5.8/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/default.nix
@@ -18,7 +18,7 @@ top-level attribute to `top-level/all-packages.nix`.
   newScope,
   stdenv, fetchurl, makeSetupHook, makeWrapper,
   bison, cups ? null, harfbuzz, mesa, perl,
-  gstreamer, gst-plugins-base,
+  gstreamer, gst-plugins-base, gtk3, dconf,
 
   # options
   developerBuild ? false,
@@ -106,7 +106,7 @@ let
 
       makeQtWrapper =
         makeSetupHook
-        { deps = [ makeWrapper ]; }
+        { deps = [ makeWrapper dconf.lib gtk3 ]; }
         ../make-qt-wrapper.sh;
 
       qmakeHook =

--- a/pkgs/development/libraries/qt-5/make-qt-wrapper.sh
+++ b/pkgs/development/libraries/qt-5/make-qt-wrapper.sh
@@ -7,6 +7,7 @@ wrapQtProgram() {
         --set QML2_IMPORT_PATH "$QML2_IMPORT_PATH" \
         --prefix XDG_DATA_DIRS : "$RUNTIME_XDG_DATA_DIRS" \
         --prefix XDG_CONFIG_DIRS : "$RUNTIME_XDG_CONFIG_DIRS" \
+        --prefix GIO_EXTRA_MODULES : "$GIO_EXTRA_MODULES" \
         "$@"
 }
 
@@ -21,6 +22,7 @@ makeQtWrapper() {
         --set QML2_IMPORT_PATH "$QML2_IMPORT_PATH" \
         --prefix XDG_DATA_DIRS : "$RUNTIME_XDG_DATA_DIRS" \
         --prefix XDG_CONFIG_DIRS : "$RUNTIME_XDG_CONFIG_DIRS" \
+        --prefix GIO_EXTRA_MODULES : "$GIO_EXTRA_MODULES" \
         "$@"
 }
 
@@ -29,8 +31,16 @@ _makeQtWrapperSetup() {
     export QT_PLUGIN_PATH="$QT_PLUGIN_PATH${QT_PLUGIN_PATH:+:}${!outputLib}/lib/qt5/plugins"
     export QML_IMPORT_PATH="$QML_IMPORT_PATH${QML_IMPORT_PATH:+:}${!outputLib}/lib/qt5/imports"
     export QML2_IMPORT_PATH="$QML2_IMPORT_PATH${QML2_IMPORT_PATH:+:}${!outputLib}/lib/qt5/qml"
-    export RUNTIME_XDG_DATA_DIRS="$RUNTIME_XDG_DATA_DIRS${RUNTIME_XDG_DATA_DIRS:+:}${!outputBin}/share"
+    export RUNTIME_XDG_DATA_DIRS="$RUNTIME_XDG_DATA_DIRS${RUNTIME_XDG_DATA_DIRS:+:}${!outputBin}/share${GSETTINGS_SCHEMAS_PATH:+:$GSETTINGS_SCHEMAS_PATH}"
     export RUNTIME_XDG_CONFIG_DIRS="$RUNTIME_XDG_CONFIG_DIRS${RUNTIME_XDG_CONFIG_DIRS:+:}${!outputBin}/etc/xdg"
 }
 
 prePhases+=(_makeQtWrapperSetup)
+
+_findGioModules() {
+    if [ -d "$1"/lib/gio/modules ] && [ -n "$(ls -A $1/lib/gio/modules)" ] ; then
+        export GIO_EXTRA_MODULES="$GIO_EXTRA_MODULES${GIO_EXTRA_MODULES:+:}$1/lib/gio/modules"
+    fi
+}
+
+envHooks+=(_findGioModules)

--- a/pkgs/tools/misc/antimicro/default.nix
+++ b/pkgs/tools/misc/antimicro/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, pkgconfig, SDL2, qtbase, qttools, xorg, fetchFromGitHub }:
+{ stdenv, cmake, pkgconfig, SDL2, qtbase, qttools, makeQtWrapper, xorg, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   name = "antimicro-${version}";
@@ -12,8 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    cmake pkgconfig SDL2 qtbase qttools xorg.libXtst
+    cmake pkgconfig SDL2 qtbase qttools xorg.libXtst makeQtWrapper
   ];
+
+  postInstall = ''
+    wrapQtProgram $out/bin/antimicro
+  '';
 
   meta = with stdenv.lib; {
     description = "GUI for mapping keyboard and mouse controls to a gamepad";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -321,7 +321,7 @@ with pkgs;
   findXMLCatalogs = makeSetupHook { } ../build-support/setup-hooks/find-xml-catalogs.sh;
 
   wrapGAppsHook = makeSetupHook {
-    deps = [ makeWrapper ];
+    deps = [ gnome3.dconf.lib gnome3.gtk makeWrapper ];
   } ../build-support/setup-hooks/wrap-gapps-hook.sh;
 
   separateDebugInfo = makeSetupHook { } ../build-support/setup-hooks/separate-debug-info.sh;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -271,8 +271,8 @@ with pkgs;
 
   kdeDerivation = import ../build-support/kde/derivation.nix { inherit stdenv lib; };
 
-  kdeWrapper = import ../build-support/kde/wrapper.nix {
-    inherit stdenv lib makeWrapper buildEnv;
+  kdeWrapper = callPackage ../build-support/kde/wrapper.nix {
+    inherit (gnome3) dconf;
   };
 
   nixBufferBuilders = import ../build-support/emacs/buffer.nix { inherit (pkgs) lib writeText; inherit (emacsPackagesNg) inherit-local; };
@@ -9454,6 +9454,7 @@ with pkgs;
     mesa = mesa_noglu;
     inherit perl;
     inherit (gst_all_1) gstreamer gst-plugins-base;
+    inherit (gnome3) gtk3 dconf;
   });
 
   libsForQt57 = recurseIntoAttrs (lib.makeScope qt57.newScope mkLibsForQt5);
@@ -9467,6 +9468,7 @@ with pkgs;
     mesa = mesa_noglu;
     inherit perl;
     inherit (gst_all_1) gstreamer gst-plugins-base;
+    inherit (gnome3) gtk3 dconf;
   });
 
   libsForQt58 = recurseIntoAttrs (lib.makeScope qt58.newScope mkLibsForQt5);


### PR DESCRIPTION
###### Motivation for this change

This is a minimal patchset to fix #23474 without introducing some new wrappers infrastructure (so that we can cherry-pick this into release too). It also should make GTK respect system configuration for native GTK packages (because of dconf). Given that `dconf` is now used much more extensively I've split it (`gtk3` is also to go but it's harder).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is not yet tested! I wanted to test with `okular` but it won't work because it needs Qt dependencies (they are usually added by `makeQtWrapper`, aren't they?). Given that it works on KDE I must mislook something:
```
This application failed to start because it could not find or load the Qt platform plugin "xcb"
in "".

Available platform plugins are: minimal, offscreen, xcb, vnc.

Reinstalling the application may fix this problem.
[1]    1542 abort      result/bin/okular
```

cc @ttuegel 