### PR TITLE
rustc: 1.15.1 -> 1.16.0, cargo: 1.16.0 -> 1.17.0, bootstrap: 1.14.0 -> 1.15.1

### DIFF
--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -17,13 +17,13 @@ let
   # fetch hashes by running `print-hashes.sh 1.14.0`
   bootstrapHash =
     if stdenv.system == "i686-linux"
-    then "8d5c75728b44468216f99651dfae9d60ae0696a77105dd2b02942d75f3256840"
+    then "a93436b969d19a6576aac5264ff5b58cbbdf3514f15c34146a274c2586f7e052"
     else if stdenv.system == "x86_64-linux"
-    then "c71325cfea1b6f0bdc5189fa4c50ff96f828096ff3f7b5056367f9685d6a4d04"
+    then "b1e7c818a3cc8b010932f0efc1cf0ede7471958310f808d543b6e32d2ec748e7"
     else if stdenv.system == "i686-darwin"
-    then "fe1b3d67329a22d67e3b8db8858a43022e2e746dde60ef4a2db3f2cac16ea9bd"
+    then "dd993432a495a46408b5b2e40cb878d8d533a47385d2c477e3dc99092226709c"
     else if stdenv.system == "x86_64-darwin"
-    then "3381341524b0184da5ed2cdcddc2a25e2e335e87f1cf676f64d98ee5e6479f20"
+    then "38606e464b31a778ffa7d25d490a9ac53b472102bad8445b52e125f63726ac64"
     else throw "missing bootstrap hash for platform ${stdenv.system}";
 
   needsPatchelf = stdenv.isLinux;
@@ -33,7 +33,7 @@ let
      sha256 = bootstrapHash;
   };
 
-  version = "1.14.0";
+  version = "1.15.1";
 in
 
 rec {

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -6,12 +6,12 @@ let
 in
 rec {
   rustc = callPackage ./rustc.nix {
-    shortVersion = "1.15.1";
+    shortVersion = "1.16.0";
     isRelease = true;
     forceBundledLLVM = false;
     configureFlags = [ "--release-channel=stable" ];
-    srcRev = "021bd294c039bd54aa5c4aa85bcdffb0d24bc892";
-    srcSha = "1dp7cjxj8nv960jxkq3p18agh9bpfb69ac14x284jmhwyksim3y7";
+    srcRev = "30cf806ef8881c41821fbd43e5cf3699c5290c16";
+    srcSha = "184qd2mfjpf68jqgc8hjqg62yyy01haf7ircz9xahjnywz7d4paq";
 
     patches = [
       ./patches/darwin-disable-fragile-tcp-tests.patch
@@ -24,10 +24,10 @@ rec {
   };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "0.16.0";
-    srcRev = "6e0c18cccc8b0c06fba8a8d76486f81a792fb420";
-    srcSha = "117ivvs9wz848mwf8bw797n10qpn77agd353z8b0hxgbxhpribya";
-    depsSha256 = "11s2xpgfhl4mb4wa2nk4mzsypr7m9daxxc7l0vraiz5cr77gk7qq";
+    version = "0.17.0";
+    srcRev = "f9e54817e53c7b9845cc7c1ede4c11e4d3e42e36";
+    srcSha = "0mvrd9xjv36hmfhmnvv0752qg218x6dxr02w3y2zi27b1kmav2c3";
+    depsSha256 = "12a7pbi0ixzycv6k7591b2aqp0wrczq87n8qcvdiipbw2llp2h9z";
 
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -91,13 +91,6 @@ stdenv.mkDerivation {
     # Disable fragile linker-output-non-utf8 test
     rm -vr src/test/run-make/linker-output-non-utf8 || true
 
-    # Remove test targeted at LLVM 3.9 - https://github.com/rust-lang/rust/issues/36835
-    rm -vr src/test/run-pass/issue-36023.rs || true
-
-    # Disable test getting stuck on hydra - possible fix:
-    # https://reviews.llvm.org/rL281650
-    rm -vr src/test/run-pass/issue-36474.rs || true
-
     # Useful debugging parameter
     # export VERBOSE=1
   '' +


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

