### PR TITLE
kernel: do not remove .o files on installPhase

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -146,17 +146,12 @@ let
         unlink $out/lib/modules/${modDirVersion}/build
         unlink $out/lib/modules/${modDirVersion}/source
 
-        mkdir -p $dev/lib/modules/${modDirVersion}
-        cd ..
-        mv $sourceRoot $dev/lib/modules/${modDirVersion}/source
+        mkdir -p $dev/lib/modules/${modDirVersion}/build
+        cp -dpR ../$sourceRoot $dev/lib/modules/${modDirVersion}/source
         cd $dev/lib/modules/${modDirVersion}/source
 
-        mv $buildRoot/.config $buildRoot/Module.symvers $TMPDIR
-        rm -fR $buildRoot
-        mkdir $buildRoot
-        mv $TMPDIR/.config $TMPDIR/Module.symvers $buildRoot
-        make modules_prepare $makeFlags "''${makeFlagsArray[@]}"
-        mv $buildRoot $dev/lib/modules/${modDirVersion}/build
+        cp $buildRoot/{.config,Module.symvers} $dev/lib/modules/${modDirVersion}/build
+        make modules_prepare $makeFlags "''${makeFlagsArray[@]}" O=$dev/lib/modules/${modDirVersion}/build
 
         # !!! No documentation on how much of the source tree must be kept
         # If/when kernel builds fail due to missing files, you can add
@@ -164,7 +159,7 @@ let
         # from drivers/ in the future; it adds 50M to keep all of its
         # headers on 3.10 though.
 
-        chmod +w -R ../source
+        chmod u+w -R ../source
         arch=`cd $dev/lib/modules/${modDirVersion}/build/arch; ls`
 
         # Remove unusued arches
@@ -177,14 +172,14 @@ let
         rm -fR drivers
 
         # Keep all headers
-        find .  -type f -name '*.h' -print0 | xargs -0 chmod -w
+        find .  -type f -name '*.h' -print0 | xargs -0 chmod u-w
 
         # Keep root and arch-specific Makefiles
-        chmod -w Makefile
-        chmod -w arch/$arch/Makefile*
+        chmod u-w Makefile
+        chmod u-w arch/$arch/Makefile*
 
         # Keep whole scripts dir
-        chmod -w -R scripts
+        chmod u-w -R scripts
 
         # Delete everything not kept
         find . -type f -perm -u=w -print0 | xargs -0 rm


### PR DESCRIPTION
###### Motivation for this change

```installPhase``` removes (using ```rm``` and ```mv```) files produced on ```buildPhase``` thus making impossible iterative development in ```nix-shell``` style.
So ```rm``` is removed and ```mv``` replaced with ```cp```, also the code is simplified a bit.

```chmod -w filename``` replaced with ```chmod u-w filename``` becase the former fails on files with access mask ```664```:
```chmod: filename: new permissions are r--rw-r--, not r--r--r--```. There are no such files in the kernel source tarball, but I accidentally made some during development. 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

