### PR TITLE
babelstone-han: init at 9.0.2

### DIFF
--- a/pkgs/data/fonts/babelstone-han/default.nix
+++ b/pkgs/data/fonts/babelstone-han/default.nix
@@ -1,0 +1,30 @@
+{stdenv, fetchurl, unzip}:
+
+stdenv.mkDerivation rec {
+  name = "babelstone-han-${version}";
+  version = "9.0.2";
+
+  src = fetchurl {
+    url = "http://www.babelstone.co.uk/Fonts/8672/BabelStoneHan.zip";
+    sha256 = "09zlrp3mqdsbxpq4sssd8gj5isnxfbr56pcdp7mnr27nv4pvp6ha";
+  };
+
+  buildInputs = [ unzip ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp -v *.ttf $out/share/fonts/truetype
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Unicode CJK font with over 32600 Han characters";
+    homepage = http://www.babelstone.co.uk/Fonts/Han.html;
+
+    license = licenses.free;
+    platforms = platforms.all;
+    hydraPlatforms = [];
+    maintainers = [ maintainers.volth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12308,6 +12308,8 @@ with pkgs;
 
   aurulent-sans = callPackage ../data/fonts/aurulent-sans { };
 
+  babelstone-han = callPackage ../data/fonts/babelstone-han { };
+
   baekmuk-ttf = callPackage ../data/fonts/baekmuk-ttf { };
 
   bakoma_ttf = callPackage ../data/fonts/bakoma-ttf { };


### PR DESCRIPTION
###### Motivation for this change

Most complete Chinese font (it contains characters which are absent in other fonts, even in ```Google Noto```)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

