### PR TITLE
rustfmt: 0.7.1 -> 0.8

### DIFF
--- a/pkgs/development/tools/rust/rustfmt/default.nix
+++ b/pkgs/development/tools/rust/rustfmt/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper }:
+{ stdenv, fetchFromGitHub, rustPlatform }:
 
 with rustPlatform;
 
 buildRustPackage rec {
   name = "rustfmt-${version}";
-  version = "0.7.1";
+  version = "0.8";
 
   src = fetchFromGitHub {
     owner = "rust-lang-nursery";
     repo = "rustfmt";
-    rev = "907134c2d10c0f11608dc4820b023f8040ad655a";
-    sha256 = "1sn590x6x93wjzkb78akqjim734hxynck3gmp8fx7gcrk5cch9mc";
+    rev = version;
+    sha256 = "0a613x1ckwl30yamba9m7xi3xrn8pg92p2w3v7k723whyivmjk1s";
   };
 
-  depsSha256 = "1djpzgchl93radi52m89sjk2nbl9f4y15pwn4x78lqas0jlc6nlr";
+  depsSha256 = "1vach2xf0cs7nivbakhmrm2aqdif3i5vg1syffrs2ghcix9hd21p";
 
   meta = with stdenv.lib; {
     description = "A tool for formatting Rust code according to style guidelines";


### PR DESCRIPTION
This patch updates the `rustfmt` package from version 0.7.1 to version
0.8.

I have tested this change per nixpkgs manual section 11.1 ("Making
patches").
