### PR TITLE
Python: add buildPythonPackage.overridePythonPackage method.

### DIFF
--- a/doc/languages-frameworks/python.md
+++ b/doc/languages-frameworks/python.md
@@ -545,6 +545,26 @@ All parameters from `mkDerivation` function are still supported.
 * `catchConflicts` If `true`, abort package build if a package name appears more than once in dependency tree. Default is `true`.
 * `checkInputs` Dependencies needed for running the `checkPhase`. These are added to `buildInputs` when `doCheck = true`.
 
+##### Overriding Python packages
+
+The `buildPythonPackage` function has a `overridePythonPackage` attribute that
+can be used to override the package. The following example renamed the Pandas
+package to `foo`. We override first the Python interpreter and pass
+`packageOverrides` which contains the overrides for packages in the package set.
+
+```nix
+with import <nixpkgs> {};
+
+(let
+  python = let
+    packageOverrides = self: super: {
+      pandas = super.pandas.overridePythonPackage(old: {name="foo";});
+    };
+  in pkgs.python35.override {inherit packageOverrides;};
+
+in python.withPackages(ps: [ps.pandas])).env
+```
+
 #### `buildPythonApplication` function
 
 The `buildPythonApplication` function is practically the same as `buildPythonPackage`.
@@ -751,17 +771,17 @@ In the following example we rename the `pandas` package and build it.
 ```nix
 with import <nixpkgs> {};
 
-let
+(let
   python = let
     packageOverrides = self: super: {
-      pandas = super.pandas.override {name="foo";};
+      pandas = super.pandas.overridePythonPackage(old: {name="foo";});
     };
   in pkgs.python35.override {inherit packageOverrides;};
 
-in python.pkgs.pandas
+in python.withPackages(ps: [ps.pandas])).env
 ```
-Using `nix-build` on this expression will build the package `pandas`
-but with the new name `foo`.
+Using `nix-build` on this expression will build an environment that contains the
+package `pandas` but with the new name `foo`.
 
 All packages in the package set will use the renamed package.
 A typical use case is to switch to another version of a certain package.

--- a/pkgs/development/interpreters/python/build-python-package.nix
+++ b/pkgs/development/interpreters/python/build-python-package.nix
@@ -5,7 +5,10 @@
 
 { lib
 , python
-, mkPythonDerivation
+, wrapPython
+, setuptools
+, unzip
+, ensureNewerSourcesHook
 , bootstrapped-pip
 , flit
 }:
@@ -15,6 +18,7 @@ let
   flit-specific = import ./build-python-package-flit.nix { inherit python flit; };
   wheel-specific = import ./build-python-package-wheel.nix { };
   common = import ./build-python-package-common.nix { inherit python bootstrapped-pip; };
+  mkPythonDerivation = import ./mk-python-derivation.nix { inherit lib python wrapPython setuptools unzip ensureNewerSourcesHook; };
 in
 
 {

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -1,6 +1,8 @@
-{ stdenv, python, fetchurl, makeWrapper, unzip }:
+{ python, fetchurl, makeWrapper, unzip }:
 
 let
+  inherit (python) stdenv;
+
   wheel_source = fetchurl {
     url = "https://pypi.python.org/packages/py2.py3/w/wheel/wheel-0.29.0-py2.py3-none-any.whl";
     sha256 = "ea8033fc9905804e652f75474d33410a07404c1a78dd3c949a66863bd1050ebd";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2950,7 +2950,7 @@ in {
   };
 
   # Needed for FlexGet 1.2.337 and calibre 2.76.0
-  html5lib_0_9999999 = self.html5lib.override rec {
+  html5lib_0_9999999 = self.html5lib.overridePythonPackage rec {
     name = "html5lib-${version}";
     buildInputs = with self; [ nose flake8 ];
     propagatedBuildInputs = with self; [ six ];
@@ -4098,7 +4098,7 @@ in {
   };
 
   # Needed for awscli
-  colorama_3_3 = self.colorama.override rec {
+  colorama_3_3 = self.colorama.overridePythonPackage rec {
     name = "colorama-${version}";
     version = "0.3.3";
     src = pkgs.fetchurl {
@@ -4131,7 +4131,7 @@ in {
     };
   };
 
-  CommonMark_54 = self.CommonMark.override rec {
+  CommonMark_54 = self.CommonMark.overridePythonPackage rec {
     name = "CommonMark-0.5.4";
     src = pkgs.fetchurl {
       url = "mirror://pypi/C/CommonMark/${name}.tar.gz";
@@ -7195,7 +7195,7 @@ in {
     '';
   };
 
-  fudge_9 = self.fudge.override rec {
+  fudge_9 = self.fudge.overridePythonPackage rec {
     name = "fudge-0.9.6";
     src = pkgs.fetchurl {
       url = "mirror://pypi/f/fudge/${name}.tar.gz";
@@ -10612,7 +10612,7 @@ in {
     };
   };
 
-  django_tagging_0_3 = self.django_tagging.override (attrs: rec {
+  django_tagging_0_3 = self.django_tagging.overridePythonPackage (attrs: rec {
     name = "django-tagging-0.3.6";
 
     src = pkgs.fetchurl {
@@ -10654,8 +10654,8 @@ in {
 
     # TODO improve the that multi-override necessity (the fixpoint based python
     # packages work can be the solution)
-    propagatedBuildInputs = with self; [ django_1_9 (django_compat.override {
-      buildInputs = with self; [ (django_nose.override {
+    propagatedBuildInputs = with self; [ django_1_9 (django_compat.overridePythonPackage {
+      buildInputs = with self; [ (django_nose.overridePythonPackage {
         propagatedBuildInputs = with self; [ django_1_9 nose ];
       }) ];
       propagatedBuildInputs = with self; [ django_1_9 six ];
@@ -10850,7 +10850,7 @@ in {
     };
   };
 
-  django_pipeline_1_3 = self.django_pipeline.overrideDerivation (super: rec {
+  django_pipeline_1_3 = self.django_pipeline.overridePythonPackage (super: rec {
     name = "django-pipeline-1.3.27";
     src = pkgs.fetchurl {
       url = "mirror://pypi/d/django-pipeline/${name}.tar.gz";
@@ -12073,7 +12073,7 @@ in {
     };
   };
 
-  futures_2_2 = self.futures.override rec {
+  futures_2_2 = self.futures.overridePythonPackage rec {
     version = "2.2.0";
     name = "futures-${version}";
 
@@ -19446,7 +19446,7 @@ in {
       maintainers = with maintainers; [ nckx ];
     };
   };
-  prompt_toolkit_52 = self.prompt_toolkit.override(self: rec {
+  prompt_toolkit_52 = self.prompt_toolkit.overridePythonPackage(self: rec {
     name = "prompt_toolkit-${version}";
     version = "0.52";
     src = pkgs.fetchurl {
@@ -19505,7 +19505,7 @@ in {
     };
   };
 
-  psutil_1 = self.psutil.overrideDerivation (self: rec {
+  psutil_1 = self.psutil.overridePythonPackage (self: rec {
     name = "psutil-1.2.1";
     src = pkgs.fetchurl {
       url = "mirror://pypi/p/psutil/${name}.tar.gz";
@@ -20530,7 +20530,7 @@ in {
   };
 
   # For Pelican 3.6.3
-  pygments_2_0 = self.pygments.override rec {
+  pygments_2_0 = self.pygments.overridePythonPackage rec {
     version = "2.0.2";
     name = "Pygments-${version}";
 
@@ -23560,7 +23560,7 @@ in {
     };
   };
 
-  setuptools_scm_18 = self.setuptools_scm.override rec {
+  setuptools_scm_18 = self.setuptools_scm.overridePythonPackage rec {
     name = "setuptools_scm-${version}";
     version = "1.8.0";
 
@@ -24762,7 +24762,7 @@ in {
     };
   });
 
-  sphinx_1_2 = self.sphinx.override rec {
+  sphinx_1_2 = self.sphinx.overridePythonPackage rec {
     name = "sphinx-1.2.3";
     src = pkgs.fetchurl {
       url = "mirror://pypi/s/sphinx/sphinx-1.2.3.tar.gz";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25,10 +25,11 @@ let
 
   bootstrapped-pip = callPackage ../development/python-modules/bootstrapped-pip { };
 
-  mkPythonDerivation = makeOverridable( callPackage ../development/interpreters/python/mk-python-derivation.nix {
-  });
-
-  makeOverridablePythonPackage = f: origArgs:
+  buildPythonPackage = let
+    # This function is basically a copy of `lib.makeOverridable`.
+    # The only difference is that we use a different attribute,
+    # `overridePythonPackage`, instead of `override`.
+    makeOverridablePythonPackage = f: origArgs:
     let
       ff = f origArgs;
       overrideWith = newArgs: origArgs // (if builtins.isFunction newArgs then newArgs origArgs else newArgs);
@@ -46,9 +47,7 @@ let
         overrideDerivation = throw "overrideDerivation not yet supported for functors";
       }
       else ff;
-
-  buildPythonPackage = makeOverridablePythonPackage (callPackage ../development/interpreters/python/build-python-package.nix {
-    inherit mkPythonDerivation;
+  in makeOverridablePythonPackage (callPackage ../development/interpreters/python/build-python-package.nix {
     inherit bootstrapped-pip;
     flit = self.flit;
   });
@@ -78,7 +77,7 @@ let
 
 in {
 
-  inherit python bootstrapped-pip pythonAtLeast pythonOlder isPy26 isPy27 isPy33 isPy34 isPy35 isPy36 isPyPy isPy3k mkPythonDerivation buildPythonPackage buildPythonApplication;
+  inherit python pythonAtLeast pythonOlder isPy26 isPy27 isPy33 isPy34 isPy35 isPy36 isPyPy isPy3k buildPythonPackage buildPythonApplication;
   inherit fetchPypi;
 
   # helpers


### PR DESCRIPTION
This allows one to always override the call to `buildPythonPackage`.

The following example renamed `pandas` to `foo`:

```
with import <nixpkgs> {};

(let
python = let
    packageOverrides = self: super: {
      pandas = super.pandas.overridePythonPackage(old: {name="foo";});
    };
in pkgs.python35.override {inherit packageOverrides;};

in python.withPackages(ps: [ps.pandas])).env
```

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Closes https://github.com/NixOS/nixpkgs/issues/24154.

