### PR TITLE
riak: switch interpreter version

### DIFF
--- a/pkgs/servers/nosql/riak/2.2.0.nix
+++ b/pkgs/servers/nosql/riak/2.2.0.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, unzip, erlangR16, which, pam, coreutils }:
+{ stdenv, lib, fetchurl, unzip, erlang, which, pam, coreutils }:
 
 let
   solrName = "solr-4.10.4-yz-2.tgz";
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   name = "riak-2.2.0";
 
   buildInputs = [
-    which unzip erlangR16 pam
+    which unzip erlang pam
   ];
 
   src = srcs.riak;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10801,7 +10801,9 @@ with pkgs;
 
   mongodb248 = callPackage ../servers/nosql/mongodb/2.4.8.nix { };
 
-  riak = callPackage ../servers/nosql/riak/2.2.0.nix { };
+  riak = callPackage ../servers/nosql/riak/2.2.0.nix { 
+    erlang = erlang_basho_R16B02;
+  };
 
   riak-cs = callPackage ../servers/nosql/riak-cs/2.1.1.nix {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;


### PR DESCRIPTION
###### Motivation for this change
The official Riak docs recommend using the Basho fork of the R16B02 interpreter. We should use this instead of the R16 interpreter.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

