### PR TITLE
riak: adding Darwin support

### DIFF
--- a/pkgs/servers/nosql/riak/2.2.0.nix
+++ b/pkgs/servers/nosql/riak/2.2.0.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, fetchurl, unzip, erlang, which, pam, coreutils }:
+{ stdenv, lib, fetchurl, unzip, erlang, which, pam, coreutils
+, Carbon ? null, Cocoa ? null }:
 
 let
   solrName = "solr-4.10.4-yz-2.tgz";
@@ -29,8 +30,9 @@ stdenv.mkDerivation rec {
   name = "riak-2.2.0";
 
   buildInputs = [
-    which unzip erlang pam
-  ];
+    which unzip erlang
+  ] ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa ]
+    ++ lib.optional stdenv.isLinux pam;
 
   src = srcs.riak;
 
@@ -91,6 +93,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     maintainers = with maintainers; [ cstrahan mdaiter ];
     description = "Dynamo inspired NoSQL DB by Basho";
-    platforms   = [ "x86_64-linux" ];
+    platforms   = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10808,6 +10808,7 @@ with pkgs;
   mongodb248 = callPackage ../servers/nosql/mongodb/2.4.8.nix { };
 
   riak = callPackage ../servers/nosql/riak/2.2.0.nix {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
     erlang = erlang_basho_R16B02;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Riak can currently support Darwin and Linux; however, we currently only support Linux. Let's support Darwin as well.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

