### PR TITLE
terminal-parrot: init at 1.1.0

### DIFF
--- a/pkgs/applications/misc/terminal-parrot/default.nix
+++ b/pkgs/applications/misc/terminal-parrot/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+    name = "terminal-parrot-1.1.0";
+    version = "1.1.0";
+    goPackagePath = "github.com/jmhobbs/terminal-parrot";
+
+    src = fetchFromGitHub {
+        owner = "jmhobbs";
+        repo = "terminal-parrot";
+        rev = "22c9bde916c12d8b13cf80ab252995dbf47837d1";
+        sha256 = "1mrxmifsmndf6hdq1956p1gyrrp3abh3rmwjcmxar8x2wqbv748y";
+    };
+
+    meta = with stdenv.lib; {
+        description = "Shows colorful, animated party parrot in your terminial";
+        homepage = https://github.com/jmhobbs/terminal-parrot;
+        license = licenses.mit;
+        platforms = platforms.all;
+        maintainers = [ maintainers.heel ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17740,6 +17740,8 @@ with pkgs;
 
   colort = callPackage ../applications/misc/colort { };
 
+  terminal-parrot = callPackage ../applications/misc/terminal-parrot { };
+
   e17gtk = callPackage ../misc/themes/e17gtk { };
 
   epson-escpr = callPackage ../misc/drivers/epson-escpr { };


### PR DESCRIPTION
###### Motivation for this change

Add a new package for terminal parrot app 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

