### PR TITLE
Fix mkdir for fetchgx to not throw an exception

### DIFF
--- a/pkgs/build-support/fetchgx/default.nix
+++ b/pkgs/build-support/fetchgx/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   buildPhase = ''
     export GOPATH=$(pwd)/vendor
-    mkdir vendor
+    mkdir -p vendor
     gx install
   '';
 


### PR DESCRIPTION
###### Motivation for this change

The problem appears when vendor directory already exists `mkdir`, it throw an exception and build fails. By having `-p` flag, it tries to create a directory and if its there, no exception will be thrown.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

