### PR TITLE
emby: 3.2.5 -> 3.2.8

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
-  version = "3.2.5";
+  version = "3.2.8";
 
   src = fetchurl {
     url = "https://github.com/MediaBrowser/Emby/releases/download/${version}/Emby.Mono.zip";
-    sha256 = "1vgn3k57pgj4prndhjshzkwchj9igpagmmlrbkvqdj4axw762i9g";
+    sha256 = "0jscbaznacp44cz9mjswd3fkyf2y9cx78mqm2dkf26rnfmwbx7vq";
   };
 
   buildInputs = with pkgs; [


### PR DESCRIPTION
###### Motivation for this change
Several bugs fixed.

Would be nice to include this in 17.03 (@globin)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

