### PR TITLE
vultr: 1.12.0 -> 1.13.0

### DIFF
--- a/pkgs/development/tools/vultr/default.nix
+++ b/pkgs/development/tools/vultr/default.nix
@@ -2,14 +2,14 @@
 
 buildGoPackage rec {
   name = "vultr-${version}";
-  version = "1.12.0";
+  version = "1.13.0";
   goPackagePath = "github.com/JamesClonk/vultr";
 
   src = fetchFromGitHub {
     owner = "JamesClonk";
     repo = "vultr";
     rev = "${version}";
-    sha256 = "0fzwzp0vhf3cgl9ij5zpdyn29w9rwwxghr50jjfbagpkfpy4g686";
+    sha256 = "0xjalxl2yncrhbh4m2gyg3cahv3wvq782qd668vim6qks676d9nx";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

