### PR TITLE
gmtp: init at 1.3.10

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -380,6 +380,7 @@
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
   patternspandemic = "Brad Christensen <patternspandemic@live.com>";
   pawelpacana = "Paweł Pacana <pawel.pacana@gmail.com>";
+  pbogdan = "Piotr Bogdan <ppbogdan@gmail.com>";
   periklis = "theopompos@gmail.com";
   pesterhazy = "Paulus Esterhazy <pesterhazy@gmail.com>";
   peterhoeg = "Peter Hoeg <peter@hoeg.com>";

--- a/pkgs/applications/misc/gmtp/default.nix
+++ b/pkgs/applications/misc/gmtp/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation {
     sha256 = "b21b9a8e66ae7bb09fc70ac7e317a0e32aff3917371a7241dea73c41db1dd13b";
   };
 
-  buildInputs = [ pkgconfig libmtp libid3tag flac libvorbis gtk3
-                  gsettings_desktop_schemas wrapGAppsHook];
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+  buildInputs = [ libmtp libid3tag flac libvorbis gtk3 gsettings_desktop_schemas ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/misc/gmtp/default.nix
+++ b/pkgs/applications/misc/gmtp/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation {
     description = "A simple MP3 and Media player client for UNIX and UNIX like systems.";
     homepage = "https://gmtp.sourceforge.io";
     platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.pbogdan ];
   };
 }

--- a/pkgs/applications/misc/gmtp/default.nix
+++ b/pkgs/applications/misc/gmtp/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, pkgconfig, libmtp, libid3tag, flac, libvorbis, gtk3
+, gsettings_desktop_schemas, wrapGAppsHook
+}:
+
+let version = "1.3.10"; in
+
+stdenv.mkDerivation {
+  name = "gmtp-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/gmtp/gMTP-${version}/gmtp-${version}.tar.gz";
+    sha256 = "b21b9a8e66ae7bb09fc70ac7e317a0e32aff3917371a7241dea73c41db1dd13b";
+  };
+
+  buildInputs = [ pkgconfig libmtp libid3tag flac libvorbis gtk3
+                  gsettings_desktop_schemas wrapGAppsHook];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A simple MP3 and Media player client for UNIX and UNIX like systems.";
+    homepage = "https://gmtp.sourceforge.io";
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/gmtp/default.nix
+++ b/pkgs/applications/misc/gmtp/default.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation {
     homepage = "https://gmtp.sourceforge.io";
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.pbogdan ];
+    license = stdenv.lib.licenses.bsd3;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13924,6 +13924,8 @@ with pkgs;
 
   gmpc = callPackage ../applications/audio/gmpc {};
 
+  gmtp = callPackage ../applications/misc/gmtp {};
+
   gnome-mpv = callPackage ../applications/video/gnome-mpv { };
 
   gollum = callPackage ../applications/misc/gollum { };


### PR DESCRIPTION
###### Motivation for this change

gmtp is currently not present in nixpkgs.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is my first time adding a package so any feedback would be appreciated.