### PR TITLE
feh: Remove un-needed libPath

### DIFF
--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -22,18 +22,17 @@ stdenv.mkDerivation rec {
 
   preBuild = ''
     makeFlags="PREFIX=$out exif=1"
-  '';
-
-  libPath = makeLibraryPath ([ imlib2 curl xorg.libXinerama libjpeg libpng libexif xorg.libX11 ]);
+      '';
 
   postInstall = ''
     wrapProgram "$out/bin/feh" --prefix PATH : "${libjpeg.bin}/bin" \
                                --add-flags '--theme=feh' 
-    '';
-
+        '';
+  
   checkPhase = ''
     PERL5LIB="${perlPackages.TestCommand}/lib/perl5/site_perl" make test
   '';
+
   doCheck = true;
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
Removed un-needed line, misread error; thought it was not finding imlib2

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

