### PR TITLE
tnef: 1.4.12 - > 1.4.14; Advisory X41-2017-004

### DIFF
--- a/pkgs/applications/misc/tnef/default.nix
+++ b/pkgs/applications/misc/tnef/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, lib, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  version = "1.4.12";
+  version = "1.4.14";
   name = "tnef-${version}";
 
   src = fetchFromGitHub {
     owner = "verdammelt";
     repo = "tnef";
     rev = "${version}";
-    sha256 = "02hwdaaa3yk0lbzb40fgxlkyhc1wicl6ncajpvfcz888z6yxps2c";
+    sha256 = "0p7yji5hqq7k4pcba1cnv4jkl0fkg7jd77c1q164wk0vwinpmsc2";
   };
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change
Update; 
https://github.com/NixOS/security/issues/30


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

