### PR TITLE
atomicparsley: fix build with llvm 4

### DIFF
--- a/pkgs/tools/video/atomicparsley/default.nix
+++ b/pkgs/tools/video/atomicparsley/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, fetchurl }:
+{ stdenv, fetchurl, unzip, darwin }:
 
 stdenv.mkDerivation rec {
   name = "atomicparsley-${version}";
@@ -10,10 +10,13 @@ stdenv.mkDerivation rec {
     sha256 = "de83f219f95e6fe59099b277e3ced86f0430ad9468e845783092821dff15a72e";
   };
 
-  buildInputs = with pkgs; [ unzip ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ];
-  patches = [ ./casts.patch ];
+  patches = stdenv.lib.optional (!stdenv.cc.isClang) ./casts.patch;
+
+  buildInputs = [ unzip ]
+    ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Cocoa;
+
   setSourceRoot = "sourceRoot=${product}-source-${version}";
+
   buildPhase = "bash build";
   installPhase = "install -D AtomicParsley $out/bin/AtomicParsley";
 


### PR DESCRIPTION
###### Motivation for this change

The patch does not seem to be neccecary for clang and fails with llvm >=4.

/cc @copumpkin 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

