### PR TITLE
bedtools: fix clang build

### DIFF
--- a/pkgs/applications/science/biology/bedtools/default.nix
+++ b/pkgs/applications/science/biology/bedtools/default.nix
@@ -12,8 +12,9 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ zlib python ];
-  buildPhase = "make prefix=$out SHELL=${stdenv.shell} -j $NIX_BUILD_CORES";
-  installPhase = "make prefix=$out SHELL=${stdenv.shell} install";
+  cc = if stdenv.cc.isClang then "clang++" else "g++";
+  buildPhase = "make prefix=$out SHELL=${stdenv.shell} CXX=${cc} -j $NIX_BUILD_CORES";
+  installPhase = "make prefix=$out SHELL=${stdenv.shell} CXX=${cc} install";
 
   meta = with stdenv.lib; {
     description = "A powerful toolset for genome arithmetic.";


### PR DESCRIPTION
###### Motivation for this change

Building in a clang enviroment was broken (https://hydra.nixos.org/build/49877645), this fixes it.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

