### PR TITLE
heatseeker: 1.4.0 -> 1.5.1

### DIFF
--- a/pkgs/tools/misc/heatseeker/default.nix
+++ b/pkgs/tools/misc/heatseeker/default.nix
@@ -4,25 +4,25 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "heatseeker-${version}";
-  version = "1.4.0";
-
-  depsSha256 = "1acimdkl6ra9jlyiydzzd6ccdygr5is2xf9gw8i45xzh0xnsq226";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "rschmitt";
     repo = "heatseeker";
     rev = "v${version}";
-    sha256 = "1v2p6l4bdmvn9jggb12p0j5ajjvnbcdjsiavlcqiijz2w8wcdgs8";
+    sha256 = "1fcrbjwnhcz71i70ppy0rcgk5crwwmbkm9nrk1kapvks33pv0az7";
   };
+
+  depsSha256 = "05mj84a5k65ai492grwg03c3wq6ardhs114bv951fgysc9rs07p5";
 
   # some tests require a tty, this variable turns them off for Travis CI,
   # which we can also make use of
-  TRAVIS= "true";
+  TRAVIS = "true";
 
   meta = with stdenv.lib; {
     description = "A general-purpose fuzzy selector";
     homepage = https://github.com/rschmitt/heatseeker;
-    license = stdenv.lib.licenses.mit;
+    license = licenses.mit;
     maintainers = [ maintainers.michaelpj ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
This patch updates the `heatseeker` package from version 1.4.0 to
version 1.5.1.

I have tested this change per nixpkgs manual section 11.1 ("Making
patches").

