### PR TITLE
emem: 0.2.45 -> 0.2.46

### DIFF
--- a/pkgs/applications/misc/emem/default.nix
+++ b/pkgs/applications/misc/emem/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "emem";
-  version = "0.2.45";
+  version = "0.2.46";
   name = "${pname}-${version}";
 
   inherit jdk;
 
   src = fetchurl {
     url = "https://github.com/ebzzry/${pname}/releases/download/v${version}/${pname}.jar";
-    sha256 = "1qjlz0sqjhx11vw8cc39h0sjgnfkrhgh94pv84z37b8hn42qingb";
+    sha256 = "1wyckyh8jknkrcd8bvlf9m16xpi85hvhz42zv80by0hvsxgsibvy";
   };
 
   phases = [ "buildPhase" "installPhase" ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

