### PR TITLE
rust-bindgen: 0.19.1 -> 0.22.1

### DIFF
--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -1,18 +1,16 @@
 { stdenv, fetchFromGitHub, rustPlatform, llvmPackages }:
 
-with rustPlatform;
-
 # Future work: Automatically communicate NIX_CFLAGS_COMPILE to bindgen's tests and the bindgen executable itself.
 
-buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   name = "rust-bindgen-${version}";
-  version = "0.19.1";
+  version = "0.22.1";
 
   src = fetchFromGitHub {
-    owner = "Yamakaky";
+    owner = "servo";
     repo = "rust-bindgen";
-    rev = "${version}";
-    sha256 = "0pv1vcgp455hys8hb0yj4vrh2k01zysayswkasxq4hca8s2p7qj9";
+    rev = "v${version}";
+    sha256 = "10cavj6rrbdqi4ldfmhxy6xxp0q65pxiypdgq2ckz0c37g04qqqs";
   };
 
   buildInputs = [ llvmPackages.clang-unwrapped ];
@@ -21,13 +19,13 @@ buildRustPackage rec {
     export LIBCLANG_PATH="${llvmPackages.clang-unwrapped}/lib"
   '';
 
-  depsSha256 = "0rlmdiqjg9ha9yzhcy33abvhrck6sphczc2gbab9zhfa95gxprv8";
+  depsSha256 = "1gvva6f64ndzsswv1a7c31wym12yp4cg1la4zjwlzkrx62kgyk8x";
 
   doCheck = false; # A test fails because it can't find standard headers in NixOS
 
   meta = with stdenv.lib; {
     description = "C binding generator";
-    homepage = https://github.com/Yamakaky/rust-bindgen;
+    homepage = https://github.com/servo/rust-bindgen;
     license = with licenses; [ bsd3 ];
     maintainers = [ maintainers.ralith ];
   };


### PR DESCRIPTION
This patch updates the `rust-bindgen` package from version 0.19.1 to
version 0.22.1.

This update includes changing the source of the package from
<https://github.com/Yamakaky/rust-bindgen> to
<https://github.com/servo/rust-bindgen>, per the instructions in the
former repository.

I have tested this change per nixpkgs manual section 11.1 ("Making
patches").