### PR TITLE
awesome: menubar should take XDG_HOME_DIR and XDG_DATA_DIRS into account

### DIFF
--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, luaPackages, cairo, cmake, imagemagick, pkgconfig, gdk_pixbuf
+{ stdenv, fetchurl, fetchFromGitHub, luaPackages, cairo, cmake, imagemagick, pkgconfig, gdk_pixbuf
 , xorg, libstartup_notification, libxdg_basedir, libpthreadstubs
 , xcb-util-cursor, makeWrapper, pango, gobjectIntrospection, unclutter
 , compton, procps, iproute, coreutils, curl, alsaUtils, findutils, xterm
@@ -37,6 +37,13 @@ with luaPackages; stdenv.mkDerivation rec {
                   xorg.xcbutil xorg.xcbutilimage xorg.xcbutilkeysyms
                   xorg.xcbutilrenderutil xorg.xcbutilwm libxkbcommon
                   xcbutilxrm ];
+
+  patches = [
+    (fetchurl {
+      url = "https://patch-diff.githubusercontent.com/raw/awesomeWM/awesome/pull/1639.patch";
+      sha256 = "00piynmbxajd2xbg960gmf0zlqn7m489f4ww482y49ravfy1jhsj";
+    })
+  ];
 
   #cmakeFlags = "-DGENERATE_MANPAGES=ON";
 


### PR DESCRIPTION
###### Motivation for this change

The paths awesome use to look for menu files are hard coded in the source code and does not include the ones used in NixOS. The PR https://github.com/awesomeWM/awesome/pull/1639 fixes that and it is going to be integrated in upstream. Until then apply the patch.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).