### PR TITLE
SDDM closure size

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -202,5 +202,7 @@ with lib;
       "See the 16.09 release notes for more information.")
     (mkRemovedOptionModule [ "services" "phpfpm" "phpIni" ] "")
     (mkRemovedOptionModule [ "services" "dovecot2" "package" ] "")
+    (mkRemovedOptionModule [ "services" "xserver" "displayManager" "sddm" "themes" ]
+      "Set the option `services.xserver.displayManager.sddm.package' instead.")
   ];
 }

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -208,10 +208,7 @@ in
 
       services.xserver.displayManager.sddm = {
         theme = "breeze";
-        themes = [
-          plasma5.plasma-workspace
-          pkgs.breeze-icons
-        ];
+        package = pkgs.sddmPlasma5;
       };
 
       security.pam.services.kde = { allowNullPassword = true; };

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -209,7 +209,6 @@ in
       services.xserver.displayManager.sddm = {
         theme = "breeze";
         themes = [
-          pkgs.extra-cmake-modules # for the setup-hook
           plasma5.plasma-workspace
           pkgs.breeze-icons
         ];

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -9,7 +9,7 @@ let
   cfg = dmcfg.sddm;
   xEnv = config.systemd.services."display-manager".environment;
 
-  sddm = pkgs.sddm.override { inherit (cfg) themes; };
+  sddm = cfg.package;
 
   xserverWrapper = pkgs.writeScript "xserver-wrapper" ''
     #!/bin/sh
@@ -105,11 +105,12 @@ in
         '';
       };
 
-      themes = mkOption {
-        type = types.listOf types.package;
-        default = [];
+      package = mkOption {
+        type = types.package;
+        default = pkgs.sddm;
         description = ''
-          Extra packages providing themes.
+          The SDDM package to install.
+          The default package can be overridden to provide extra themes.
         '';
       };
 

--- a/pkgs/applications/display-managers/sddm/default.nix
+++ b/pkgs/applications/display-managers/sddm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeQtWrapper, fetchFromGitHub, fetchpatch
+{ stdenv, lib, makeQtWrapper, fetchFromGitHub, fetchpatch
 , cmake, extra-cmake-modules, pkgconfig, libxcb, libpthreadstubs, lndir
 , libXdmcp, libXau, qtbase, qtdeclarative, qttools, pam, systemd
 , themes
@@ -28,10 +28,13 @@ let
     nativeBuildInputs = [ cmake extra-cmake-modules pkgconfig qttools ];
 
     buildInputs = [
-      libxcb libpthreadstubs libXdmcp libXau qtbase pam systemd
+      libxcb libpthreadstubs libXdmcp libXau pam systemd
+      qtbase qtdeclarative
     ];
 
-    propagatedBuildInputs = [ qtdeclarative ];
+    propagatedUserEnvPkgs = builtins.map lib.getBin [
+      qtbase qtdeclarative
+    ];
 
     cmakeFlags = [
       "-DCONFIG_FILE=/etc/sddm.conf"
@@ -79,6 +82,21 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
+
+    propagated=
+    for i in $unwrapped $themes; do
+      findInputs $i propagated propagated-user-env-packages
+      if [ -z "$crossConfig" ]; then
+          findInputs $i propagated propagated-native-build-inputs
+      else
+          findInputs $i propagated propagated-build-inputs
+      fi
+    done
+
+    for pkg in $propagated; do
+      addToSearchPath RUNTIME_XDG_DATA_DIRS "$pkg/share"
+      addToSearchPath RUNTIME_XDG_CONFIG_DIRS "$pkg/etc/xdg"
+    done
 
     makeQtWrapper "$unwrapped/bin/sddm" "$out/bin/sddm"
 

--- a/pkgs/desktops/plasma-5/plasma-workspace/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-workspace/default.nix
@@ -17,12 +17,15 @@ plasmaPackage {
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
+    isocodes libdbusmenu libSM libXcursor pam wayland
+  ];
+  propagatedBuildInputs = [
     baloo kactivities kcmutils kconfig kcrash kdbusaddons kdeclarative
     kdelibs4support kdesu kglobalaccel kidletime kjsembed knewstuff
     knotifyconfig kpackage krunner ktexteditor ktextwidgets kwallet kwayland
     kwin kxmlrpcclient libkscreen libksysguard networkmanager-qt phonon
-    plasma-framework qtgraphicaleffects qtquickcontrols qtquickcontrols2
-    qtscript qtx11extras solid isocodes libdbusmenu libSM libXcursor pam wayland
+    plasma-framework solid qtgraphicaleffects qtquickcontrols qtquickcontrols2
+    qtscript qtx11extras
   ];
 
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);

--- a/pkgs/development/libraries/qt-5/make-qt-wrapper-darwin.sh
+++ b/pkgs/development/libraries/qt-5/make-qt-wrapper-darwin.sh
@@ -31,8 +31,8 @@ _makeQtWrapperSetup() {
     export QT_PLUGIN_PATH="$QT_PLUGIN_PATH${QT_PLUGIN_PATH:+:}${!outputLib}/lib/qt5/plugins"
     export QML_IMPORT_PATH="$QML_IMPORT_PATH${QML_IMPORT_PATH:+:}${!outputLib}/lib/qt5/imports"
     export QML2_IMPORT_PATH="$QML2_IMPORT_PATH${QML2_IMPORT_PATH:+:}${!outputLib}/lib/qt5/qml"
-    export RUNTIME_XDG_DATA_DIRS="$XDG_DATA_DIRS${XDG_DATA_DIRS:+:}${!outputBin}/share"
-    export RUNTIME_XDG_CONFIG_DIRS="$XDG_CONFIG_DIRS${XDG_CONFIG_DIRS:+:}${!outputBin}/etc/xdg"
+    export RUNTIME_XDG_DATA_DIRS="$RUNTIME_XDG_DATA_DIRS${RUNTIME_XDG_DATA_DIRS:+:}${!outputBin}/share"
+    export RUNTIME_XDG_CONFIG_DIRS="$RUNTIME_XDG_CONFIG_DIRS${RUNTIME_XDG_CONFIG_DIRS:+:}${!outputBin}/etc/xdg"
 }
 
 prePhases+=(_makeQtWrapperSetup)

--- a/pkgs/development/libraries/qt-5/make-qt-wrapper.sh
+++ b/pkgs/development/libraries/qt-5/make-qt-wrapper.sh
@@ -29,8 +29,8 @@ _makeQtWrapperSetup() {
     export QT_PLUGIN_PATH="$QT_PLUGIN_PATH${QT_PLUGIN_PATH:+:}${!outputLib}/lib/qt5/plugins"
     export QML_IMPORT_PATH="$QML_IMPORT_PATH${QML_IMPORT_PATH:+:}${!outputLib}/lib/qt5/imports"
     export QML2_IMPORT_PATH="$QML2_IMPORT_PATH${QML2_IMPORT_PATH:+:}${!outputLib}/lib/qt5/qml"
-    export RUNTIME_XDG_DATA_DIRS="$XDG_DATA_DIRS${XDG_DATA_DIRS:+:}${!outputBin}/share"
-    export RUNTIME_XDG_CONFIG_DIRS="$XDG_CONFIG_DIRS${XDG_CONFIG_DIRS:+:}${!outputBin}/etc/xdg"
+    export RUNTIME_XDG_DATA_DIRS="$RUNTIME_XDG_DATA_DIRS${RUNTIME_XDG_DATA_DIRS:+:}${!outputBin}/share"
+    export RUNTIME_XDG_CONFIG_DIRS="$RUNTIME_XDG_CONFIG_DIRS${RUNTIME_XDG_CONFIG_DIRS:+:}${!outputBin}/etc/xdg"
 }
 
 prePhases+=(_makeQtWrapperSetup)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15470,6 +15470,13 @@ with pkgs;
     themes = [];  # extra themes, etc.
   };
 
+  sddmPlasma5 = sddm.override {
+    themes = [
+      plasma5.plasma-workspace
+      pkgs.breeze-icons
+    ];
+  };
+
   skrooge = libsForQt5.callPackage ../applications/office/skrooge {};
 
   slim = callPackage ../applications/display-managers/slim {


### PR DESCRIPTION
### Motivation

Reduces closure size of SDDM (with Plasma 5 enabled) by 400 MB.

### Testing

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

- [x] Backport to stable