### PR TITLE
octave: fix on darwin

### DIFF
--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -41,6 +41,12 @@ stdenv.mkDerivation rec {
     ++ (stdenv.lib.optionals (!stdenv.isDarwin) [ mesa libX11 ])
     ;
 
+  # REMOVE ON VERSION BUMP
+  # Needed for Octave-4.2.1 on darwin. See https://savannah.gnu.org/bugs/?50234
+  prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed 's/inline file_stat::~file_stat () { }/file_stat::~file_stat () { }/' -i ./liboctave/system/file-stat.cc
+  '';
+
   doCheck = !stdenv.isDarwin;
 
   enableParallelBuilding = true;


### PR DESCRIPTION
This change is required on darwin, but did not make it into the 4.2.1
release of Octave. It is a very small change, and a comment on the
patch includes a link for more information and a note that it should
be removed from subsequent releases.

Note: This by itself will not fix Octave builds on hydra. The broken `fltk` package in nixpkgs blocks that. For those willing to build from source themselves, a working `fltk` derivation may be found [here](https://github.com/acowley/dotfiles/blob/master/nix/fltk/default.nix).


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
