### PR TITLE
pythonPackages.django: 1.10.5 -> 1.10.6

### DIFF
--- a/pkgs/development/python-modules/django/1_10.nix
+++ b/pkgs/development/python-modules/django/1_10.nix
@@ -1,0 +1,35 @@
+{ stdenv, buildPythonPackage, fetchurl, substituteAll,
+  pythonOlder,
+  geos, gdal
+}:
+buildPythonPackage rec {
+  name = "Django-${version}";
+  version = "1.10.6";
+  disabled = pythonOlder "2.7";
+
+  src = fetchurl {
+    url = "http://www.djangoproject.com/m/releases/1.10/${name}.tar.gz";
+    sha256 = "0q9c7hx720vc0jzq4xlxwhnxmmm8kh0qsqj3l46m29mi98jvwvks";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./1.10-gis-libs.template.patch;
+      geos = geos;
+      gdal = gdal;
+    })
+  ];
+
+  # patch only $out/bin to avoid problems with starter templates (see #3134)
+  postFixup = ''
+    wrapPythonProgramsIn $out/bin "$out $pythonPath"
+  '';
+
+  # too complicated to setup
+  doCheck = false;
+
+  meta = {
+    description = "A high-level Python Web framework";
+    homepage = https://www.djangoproject.com/;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10315,36 +10315,8 @@ in {
 
   django = self.django_1_10;
 
-  django_1_10 = buildPythonPackage rec {
-    name = "Django-${version}";
-    version = "1.10.5";
-    disabled = pythonOlder "2.7";
-
-    src = pkgs.fetchurl {
-      url = "http://www.djangoproject.com/m/releases/1.10/${name}.tar.gz";
-      sha256 = "12szjsmnfhh2yr54sfynyjr8vl0q9gb6qak3ayqcifcinrs97f0d";
-    };
-
-    patches = [
-      (pkgs.substituteAll {
-        src = ../development/python-modules/django/1.10-gis-libs.template.patch;
-        geos = pkgs.geos;
-        gdal = self.gdal;
-      })
-    ];
-
-    # patch only $out/bin to avoid problems with starter templates (see #3134)
-    postFixup = ''
-      wrapPythonProgramsIn $out/bin "$out $pythonPath"
-    '';
-
-    # too complicated to setup
-    doCheck = false;
-
-    meta = {
-      description = "A high-level Python Web framework";
-      homepage = https://www.djangoproject.com/;
-    };
+  django_1_10 = callPackage ../development/python-modules/django/1_10.nix {
+    gdal = self.gdal;
   };
 
   django_1_9 = buildPythonPackage rec {


### PR DESCRIPTION
It should probably be backported to `16.09` and `17.03`.

###### Motivation for this change

This is a bugfix release.


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

