### PR TITLE
proselint: disable tests and put in correct scope

### DIFF
--- a/pkgs/tools/text/proselint/default.nix
+++ b/pkgs/tools/text/proselint/default.nix
@@ -4,6 +4,8 @@ buildPythonApplication rec {
   name = "proselint-${version}";
   version = "0.8.0";
 
+  doCheck = false; # fails to pass because it tries to run in home directory
+
   src = fetchurl {
     url = "mirror://pypi/p/proselint/${name}.tar.gz";
     sha256 = "1g8vx04gmv0agmggz1ml5vydfppqvl8dzjvqm6vqw5rzafa89m08";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9351,6 +9351,11 @@ with pkgs;
 
   proj = callPackage ../development/libraries/proj { };
 
+  proselint = callPackage ../tools/text/proselint {
+    inherit (python3Packages)
+    buildPythonApplication click future six;
+  };
+
   postgis = callPackage ../development/libraries/postgis { };
 
   protobuf = protobuf2_6;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19004,8 +19004,6 @@ in {
      };
   };
 
-  proselint = callPackage ../tools/text/proselint { };
-
   pylibconfig2 = buildPythonPackage rec {
     name = "pylibconfig2-${version}";
     version = "0.2.4";


### PR DESCRIPTION
Didn't build before due to tests referencing the home directory. Also, it was in
the wrong scope.


- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---