### PR TITLE
fox: fix build with clang >=4 and possibly other versions

### DIFF
--- a/pkgs/development/libraries/fox/clang.patch
+++ b/pkgs/development/libraries/fox/clang.patch
@@ -1,0 +1,13 @@
+diff --git a/src/FXReactor.cpp b/src/FXReactor.cpp
+index 1ecdb45..9058a30 100644
+--- a/src/FXReactor.cpp
++++ b/src/FXReactor.cpp
+@@ -452,7 +452,7 @@ FXint FXReactor::processActiveHandles(FXTime block,FXuint flags){
+     }
+ 
+   // Normal case
+-  if(0<=hand){
++  if(0==hand){
+ 
+     // Any handles active?
+     if(0<nhand){

--- a/pkgs/development/libraries/fox/default.nix
+++ b/pkgs/development/libraries/fox/default.nix
@@ -1,20 +1,19 @@
 { stdenv, fetchurl, xlibsWrapper, libpng, libjpeg, libtiff, zlib, bzip2, libXcursor, libXrandr, libXft
 , CoreServices ? null }:
 
-let
-  version = "1.7.9";
-in
-
 stdenv.mkDerivation rec {
   name = "fox-${version}";
+  version = "1.7.9";
 
   src = fetchurl {
     url = "ftp://ftp.fox-toolkit.org/pub/${name}.tar.gz";
     sha256 = "1jb9368xsin3ppdf6979n5s7in3s9klbxqbwcp0z8misjixl7nzg";
   };
 
+  patches = [ ./clang.patch ];
+
   buildInputs = [ libpng xlibsWrapper libjpeg libtiff zlib bzip2 libXcursor libXrandr libXft ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices ];
+    ++ stdenv.lib.optional stdenv.isDarwin CoreServices;
 
   doCheck = true;
 
@@ -22,17 +21,17 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "C++ based class library for building Graphical User Interfaces";
     longDescription = ''
-        FOX stands for Free Objects for X.
-        It is a C++ based class library for building Graphical User Interfaces.
-        Initially, it was developed for LINUX, but the scope of this project has in the course of time become somewhat more ambitious.
-        Current aims are to make FOX completely platform independent, and thus programs written against the FOX library will be only a compile away from running on a variety of platforms.
-      '';
+      FOX stands for Free Objects for X.
+      It is a C++ based class library for building Graphical User Interfaces.
+      Initially, it was developed for LINUX, but the scope of this project has in the course of time become somewhat more ambitious.
+      Current aims are to make FOX completely platform independent, and thus programs written against the FOX library will be only a compile away from running on a variety of platforms.
+    '';
     homepage = "http://fox-toolkit.org";
-    license = stdenv.lib.licenses.lgpl3;
-    maintainers = [ stdenv.lib.maintainers.bbenoist ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.bbenoist ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

/cc @copumpkin

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

