### PR TITLE
nitrokey-app: 0.5.1 -> 0.6.3

### DIFF
--- a/pkgs/tools/security/nitrokey-app/FixInstallDestination.patch
+++ b/pkgs/tools/security/nitrokey-app/FixInstallDestination.patch
@@ -1,57 +1,11 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -251,23 +251,23 @@
-       #      ${CMAKE_SOURCE_DIR}/data/icons/48x48
-       #      ${CMAKE_SOURCE_DIR}/data/icons/128x128
-     ${CMAKE_SOURCE_DIR}/data/icons/
--    DESTINATION usr/share/icons/
-+    DESTINATION share/icons/
-   )
- 
-   install(FILES
-     ${CMAKE_SOURCE_DIR}/data/nitrokey-app.desktop
--    DESTINATION usr/share/applications
-+    DESTINATION share/applications
-   )
- 
-   install(FILES
-     ${CMAKE_SOURCE_DIR}/data/icons/hicolor/128x128/apps/nitrokey-app.png
--    DESTINATION usr/share/pixmaps
-+    DESTINATION share/pixmaps
-   )
- 
-   # Install Nitrokey udev rules
-   install(FILES
-    ${CMAKE_SOURCE_DIR}/data/40-nitrokey.rules
--   DESTINATION usr/lib/udev/rules.d
-+   DESTINATION lib/udev/rules.d
-   )
- 
+@@ -273,7 +273,7 @@
    # Install autocompletion scripts
-@@ -278,7 +278,7 @@
- 
    install(FILES
-    ${CMAKE_SOURCE_DIR}/po/de_DE/nitrokey-app.mo
--   DESTINATION usr/share/locale/de_DE/LC_MESSAGES
-+   DESTINATION share/locale/de_DE/LC_MESSAGES
+    ${CMAKE_SOURCE_DIR}/data/bash-autocomplete/nitrokey-app
+-    DESTINATION /etc/bash_completion.d
++    DESTINATION etc/bash_completion.d
    )
  
    install(FILES
-@@ -286,7 +286,7 @@
-     ${CMAKE_SOURCE_DIR}/images/quit.png
-     ${CMAKE_SOURCE_DIR}/images/safe_zahlenkreis.png
-     ${CMAKE_SOURCE_DIR}/images/settings.png
--    DESTINATION usr/share/nitrokey
-+    DESTINATION share/nitrokey
-   )
- 
- ENDIF () # NOT WIN32
-@@ -299,7 +299,7 @@
-   ${resources_ouput}
- )
- 
--INSTALL(TARGETS nitrokey-app DESTINATION usr/bin)
-+INSTALL(TARGETS nitrokey-app DESTINATION bin)
- 
- TARGET_LINK_LIBRARIES(nitrokey-app
-   ${QT_LIBRARIES}

--- a/pkgs/tools/security/nitrokey-app/default.nix
+++ b/pkgs/tools/security/nitrokey-app/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "nitrokey-app";
-  version = "0.5.1";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "Nitrokey";
     repo = "nitrokey-app";
     rev = "v${version}";
-    sha256 = "0acb2502r3wa0mry6h8sz1k16zaa4bgnhxwxqd1vd1y42xc6g9bw";
+    sha256 = "1l5l4lwxmyd3jrafw19g12sfc42nd43sv7h7i4krqxnkk6gfx11q";
   };
 
   buildInputs = [

--- a/pkgs/tools/security/nitrokey-app/default.nix
+++ b/pkgs/tools/security/nitrokey-app/default.nix
@@ -12,17 +12,19 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    cmake
     libusb1
-    pkgconfig
     qt5.qtbase
+  ];
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
   ];
   patches = [
      ./FixInstallDestination.patch
      ./HeaderPath.patch
   ];
   cmakeFlags = "-DHAVE_LIBAPPINDICATOR=NO";
-  meta = {
+  meta = with stdenv.lib; {
     description      = "Provides extra functionality for the Nitrokey Pro and Storage";
     longDescription  = ''
        The nitrokey-app provides a QT system tray widget with wich you can
@@ -31,7 +33,7 @@ stdenv.mkDerivation rec {
     '';
     homepage         = https://github.com/Nitrokey/nitrokey-app;
     repositories.git = https://github.com/Nitrokey/nitrokey-app.git;
-    license          = stdenv.lib.licenses.gpl3;
-    maintainer       = stdenv.lib.maintainers.kaiha;
+    license          = licenses.gpl3;
+    maintainer       = maintainers.kaiha;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to latest upstream version.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

