### PR TITLE
byacc: 1.9 -> 20170201

### DIFF
--- a/pkgs/development/tools/parsing/byacc/default.nix
+++ b/pkgs/development/tools/parsing/byacc/default.nix
@@ -1,17 +1,23 @@
 { stdenv, fetchurl }:
 
-stdenv.mkDerivation {
-  name = "byacc-1.9";
+stdenv.mkDerivation rec {
+  name = "byacc-${version}";
+  version = "20170201";
 
   src = fetchurl {
-    url = ftp://invisible-island.net/byacc/byacc-20140715.tgz;
-    sha256 = "1rbzx5ipkvih9rjfdfv6310wcr6mxjbdlsh9zcv5aaz6yxxxil7c";
+    urls = [
+      "ftp://invisible-island.net/byacc/${name}.tgz"
+      "http://invisible-mirror.net/archives/byacc/${name}.tgz"
+    ];
+    sha256 = "90b768d177f91204e6e7cef226ae1dc7cac831b625774cebd3e233a917754f91";
   };
 
-  meta = {
+  doCheck = true;
+
+  meta = with stdenv.lib; {
     description = "Berkeley YACC";
-    homepage = http://dickey.his.com/byacc/byacc.html;
-    license = stdenv.lib.licenses.publicDomain;
-    platforms = stdenv.lib.platforms.unix;
+    homepage = http://invisible-island.net/byacc/byacc.html;
+    license = licenses.publicDomain;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Version bump
Plus source URLs and homepage are updated

```shell
$ ./result/bin/yacc -V
./result/bin/yacc - 1.9 20170201
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

