### PR TITLE
cde: init at 0.1

### DIFF
--- a/pkgs/tools/package-management/cde/default.nix
+++ b/pkgs/tools/package-management/cde/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "cde-0.1";
+  src = fetchgit {
+    url = "https://github.com/pgbovine/CDE.git";
+    sha256 = "";
+    rev = "551e54d95eb3f8eefc698891f1b873fc4f02f360";
+  };
+
+  # The build is small, so there should be no problem
+  # running this locally. There is also a use case for
+  # older systems, where modern binaries might not be
+  # useful.
+  preferLocalBuild = true;
+
+  patchBuild = ''
+    sed '/install/d' $src/Makefile > $src/Makefile
+  '';
+  
+  installPhase = ''
+    mkdir -p $out/bin
+    cp cde $out/bin
+    cp cde-exec $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/pgbovine/CDE";
+    description = "A packaging tool for building portable packages";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.rlupton20 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/package-management/cde/default.nix
+++ b/pkgs/tools/package-management/cde/default.nix
@@ -1,11 +1,14 @@
-{ stdenv, fetchgit }:
+{ stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation {
-  name = "cde-0.1";
-  src = fetchgit {
-    url = "https://github.com/pgbovine/CDE.git";
-    sha256 = "";
-    rev = "551e54d95eb3f8eefc698891f1b873fc4f02f360";
+stdenv.mkDerivation rec {
+  name = "cde-${version}";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "pgbovine";
+    repo = "CDE";
+    sha256 = "0raiz7pczkbnzxpg7g59v7gdp1ipkwgms2vh3431snw1va1gjzmk";
+    rev = "v${version}";
   };
 
   # The build is small, so there should be no problem
@@ -25,7 +28,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/pgbovine/CDE";
+    homepage = https://github.com/pgbovine/CDE;
     description = "A packaging tool for building portable packages";
     license = licenses.gpl3;
     maintainers = [ maintainers.rlupton20 ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -736,6 +736,8 @@ with pkgs;
 
   catclock = callPackage ../applications/misc/catclock { };
 
+  cde = callPackage ../tools/package-management/cde { };
+  
   cdemu-daemon = callPackage ../misc/emulators/cdemu/daemon.nix { };
 
   cdemu-client = callPackage ../misc/emulators/cdemu/client.nix { };


### PR DESCRIPTION
###### Motivation for this change
`CDE` was an attempt to capture a binary and all it's dependencies, to create a portable package - it works by monitoring system calls and grabbing any files that are mentioned. It's quite an old package and doesn't seem to have moved much recently, but it still works well.

It works particularly well with `nix`, because you can use it along with `nix-shell` to create standalone tarballs for software that isn't available on old systems (which is more or less how I can across this - just installing `nix` wasn't an option).

Allows a mini `nix` to be transported to other systems in a neat way.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

