### PR TITLE
Build all kernel modules for ARM and Aarch64

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -100,6 +100,10 @@ with stdenv.lib;
   # Disable some expensive (?) features.
   PM_TRACE_RTC n
 
+  # Enable initrd support.
+  BLK_DEV_RAM y
+  BLK_DEV_INITRD y
+
   # Enable various subsystems.
   ACCESSIBILITY y # Accessibility support
   AUXDISPLAY y # Auxiliary Display support

--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -17,6 +17,7 @@ my $wd = getcwd;
 
 my $debug = $ENV{'DEBUG'};
 my $autoModules = $ENV{'AUTO_MODULES'};
+my $preferBuiltin = $ENV{'PREFER_BUILTIN'};
     
 $SIG{PIPE} = 'IGNORE';
 
@@ -73,7 +74,7 @@ sub runConfig {
                 my $question = $1; my $name = $2; my $alts = $3;
                 my $answer = "";
                 # Build everything as a module if possible.
-                $answer = "m" if $autoModules && $alts =~ /\/m/;
+                $answer = "m" if $autoModules && $alts =~ /\/m/ && !($preferBuiltin && $alts =~ /Y/);
                 $answer = $answers{$name} if defined $answers{$name};
                 print STDERR "QUESTION: $question, NAME: $name, ALTS: $alts, ANSWER: $answer\n" if $debug;
                 print OUT "$answer\n";

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -55,6 +55,7 @@ let
     kernelBaseConfig = stdenv.platform.kernelBaseConfig;
     kernelTarget = stdenv.platform.kernelTarget;
     autoModules = stdenv.platform.kernelAutoModules;
+    preferBuiltin = stdenv.platform.kernelPreferBuiltin or false;
     arch = stdenv.platform.kernelArch;
 
     crossAttrs = let
@@ -92,7 +93,7 @@ let
       echo "generating kernel configuration..."
       echo "$kernelConfig" > kernel-config
       DEBUG=1 ARCH=$arch KERNEL_CONFIG=kernel-config AUTO_MODULES=$autoModules \
-           SRC=../$sourceRoot perl -w $generateConfig
+           PREFER_BUILTIN=$preferBuiltin SRC=../$sourceRoot perl -w $generateConfig
     '';
 
     installPhase = "mv .config $out";

--- a/pkgs/top-level/platforms.nix
+++ b/pkgs/top-level/platforms.nix
@@ -413,9 +413,18 @@ rec {
     kernelBaseConfig = "multi_v7_defconfig";
     kernelArch = "arm";
     kernelDTB = true;
-    kernelAutoModules = false;
+    kernelAutoModules = true;
+    kernelPreferBuiltin = true;
     uboot = null;
     kernelTarget = "zImage";
+    kernelExtraConfig =
+      ''
+        # Fix broken sunxi-sid nvmem driver.
+        TI_CPTS y
+
+        # Hangs ODROID-XU4
+        ARM_BIG_LITTLE_CPUIDLE n
+      '';
     gcc = {
       # Some table about fpu flags:
       # http://community.arm.com/servlet/JiveServlet/showImage/38-1981-3827/blogentry-103749-004812900+1365712953_thumb.png
@@ -447,32 +456,21 @@ rec {
     kernelBaseConfig = "defconfig";
     kernelArch = "arm64";
     kernelDTB = true;
-    kernelAutoModules = false;
+    kernelAutoModules = true;
+    kernelPreferBuiltin = true;
     kernelExtraConfig = ''
       # Raspberry Pi 3 stuff. Not needed for kernels >= 4.10.
       ARCH_BCM2835 y
       BCM2835_MBOX y
       BCM2835_WDT y
-      BRCMFMAC m
-      DMA_BCM2835 m
-      DRM_VC4 m
-      I2C_BCM2835 m
-      PWM_BCM2835 m
       RASPBERRYPI_FIRMWARE y
       RASPBERRYPI_POWER y
       SERIAL_8250_BCM2835AUX y
       SERIAL_8250_EXTENDED y
       SERIAL_8250_SHARE_IRQ y
-      SND_BCM2835_SOC_I2S m
-      SPI_BCM2835AUX m
-      SPI_BCM2835 m
 
       # Cavium ThunderX stuff.
       PCI_HOST_THUNDER_ECAM y
-      THUNDER_NIC_RGX y
-      THUNDER_NIC_BGX y
-      THUNDER_NIC_PF y
-      THUNDER_NIC_VF y
     '';
     uboot = null;
     kernelTarget = "Image";


### PR DESCRIPTION
###### Motivation for this change

Make all kernel modules available for ARM. This includes iptables, accounting (iotop), USB drivers and much more which was absent before.

Also enable initrd in kernel by default (some configurations disable it while we rely on it for most boot sequences excluding containers).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

My first approach was to just enable `kernelAutoModules`. However it turned out that a lot of modules is unknown to udev and it's a huge pain to get a board working. You need to figure out manually which storage (MMC in my case) modules you need, how to get USB working, LEDs etc. This would hugely degrade our multiplatformeness if done now.

Therefore I did something else -- we can now specify that we want all options compiled as modules in a kernel, but if a template config (`armv7_multiplatform_defconfig`, for example) specifies that something should be compiled it it would be left as is. This gives us the best of both worlds.

While I have tested this on an ARMv7 board I have _not_ tested it on Aarch44. I expect that since all modules now available it's not needed to compile in network adapter drivers for ThunderX -- but this should be tested.