### PR TITLE
galculator: 2.1.3 -> 2.1.4

### DIFF
--- a/pkgs/applications/misc/galculator/default.nix
+++ b/pkgs/applications/misc/galculator/default.nix
@@ -1,17 +1,20 @@
-{ stdenv, fetchurl
-, intltool, pkgconfig, gtk }:
+{ stdenv, fetchFromGitHub
+, autoreconfHook, intltool
+, gtk, pkgconfig, flex }:
 
 stdenv.mkDerivation rec {
-  
   name = "galculator-${version}";
-  version = "2.1.3";
+  version = "2.1.4";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/galculator/${name}.tar.gz";
-    sha256 = "12m7dldjk10lpkdxk7zpk98n32ci65zmxidghihb7n1m3rhp3q17";
+  src = fetchFromGitHub {
+    owner = "galculator";
+    repo = "galculator";
+    rev = "v${version}";
+    sha256 = "0q0hb62f266709ncyq96bpx4a40a1i6dc5869byvd7x285sx1c2w";
   };
 
-  buildInputs = [ intltool pkgconfig gtk ];
+  nativeBuildInputs = [ autoreconfHook intltool pkgconfig ];
+  buildInputs = [ gtk flex ];
 
   meta = with stdenv.lib; {
     description = "A GTK 2/3 algebraic and RPN calculator";


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

