### PR TITLE
get_iplayer: 2.97 -> 2.99

### DIFF
--- a/pkgs/applications/misc/get_iplayer/default.nix
+++ b/pkgs/applications/misc/get_iplayer/default.nix
@@ -1,9 +1,20 @@
-{stdenv, fetchurl, atomicparsley, flvstreamer, ffmpeg, makeWrapper, perl, buildPerlPackage, perlPackages, rtmpdump}:
+{stdenv, fetchFromGitHub, atomicparsley, flvstreamer, ffmpeg, makeWrapper, perl, buildPerlPackage, perlPackages, rtmpdump}:
+
+with stdenv.lib;
+
 buildPerlPackage rec {
   name = "get_iplayer-${version}";
-  version = "2.97";
+  version = "2.99";
+  
+  src = fetchFromGitHub {
+    owner = "get-iplayer";
+    repo = "get_iplayer";
+    rev = "v${version}";
+    sha256 = "085bgwkjnaqp96gvd2s8qmkw69rz91si1sgzqdqbplkzj9bk2qii";
+  };
 
-  buildInputs = [makeWrapper perl];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ perl ];
   propagatedBuildInputs = with perlPackages; [HTMLParser HTTPCookies LWP XMLLibXML XMLSimple];
 
   preConfigure = "touch Makefile.PL";
@@ -13,21 +24,15 @@ buildPerlPackage rec {
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man1
     cp get_iplayer $out/bin
-    wrapProgram $out/bin/get_iplayer --suffix PATH : ${stdenv.lib.makeBinPath [ atomicparsley ffmpeg flvstreamer rtmpdump ]} --prefix PERL5LIB : $PERL5LIB
+    wrapProgram $out/bin/get_iplayer --suffix PATH : ${makeBinPath [ atomicparsley ffmpeg flvstreamer rtmpdump ]} --prefix PERL5LIB : $PERL5LIB
     cp get_iplayer.1 $out/share/man/man1
   '';
-  
-  src = fetchurl {
-    url = "https://github.com/get-iplayer/get_iplayer/archive/v${version}.tar.gz";
-    sha256 = "0bb6kmzjmazwfxq5ip7yxm39vssfgz3v5vfx1114wfssp6pw0r44";
-  };
 
   meta = {
     description = "Downloads TV and radio from BBC iPlayer";
-    license = stdenv.lib.licenses.gpl3Plus;
+    license = licenses.gpl3Plus;
     homepage = https://squarepenguin.co.uk/;
-    downloadPage = https://github.com/get-iplayer/get_iplayer/releases;
-    platforms = stdenv.lib.platforms.all;
+    platforms = platforms.all;
   };
   
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

