### PR TITLE
gpa: 0.9.9 -> 0.9.10

### DIFF
--- a/pkgs/applications/misc/gpa/default.nix
+++ b/pkgs/applications/misc/gpa/default.nix
@@ -1,14 +1,15 @@
 { stdenv, fetchurl, intltool, pkgconfig, gtk2, gpgme, libgpgerror, libassuan }:
 
 stdenv.mkDerivation rec {
-  name = "gpa-0.9.9";
+  name = "gpa-0.9.10";
 
   src = fetchurl {
     url = "mirror://gnupg/gpa/${name}.tar.bz2";
-    sha256 = "0d235hcqai7m3qb7m9kvr2r4qg4714f87j9fdplwrlz1p4wdfa38";
+    sha256 = "09xphbi2456qynwqq5n0yh0zdmdi2ggrj3wk4hsyh5lrzlvcrff3";
   };
 
-  buildInputs = [ intltool pkgconfig gtk2 gpgme libgpgerror libassuan ];
+  nativeBuildInputs = [ intltool pkgconfig ];
+  buildInputs = [ gtk2 gpgme libgpgerror libassuan ];
 
   meta = with stdenv.lib; {
     description = "Graphical user interface for the GnuPG";


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

