### PR TITLE
gpscorrelate: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/applications/misc/gpscorrelate/default.nix
+++ b/pkgs/applications/misc/gpscorrelate/default.nix
@@ -1,17 +1,22 @@
-{ fetchurl, stdenv, pkgconfig, exiv2, libxml2, gtk2
+{ fetchFromGitHub, stdenv, pkgconfig, exiv2, libxml2, gtk2
 , libxslt, docbook_xsl, docbook_xml_dtd_42 }:
 
 stdenv.mkDerivation rec {
-  name = "gpscorrelate-1.6.0";
+  name = "gpscorrelate-${version}";
+  version = "1.6.1";
 
-  src = fetchurl {
-    url = "http://freefoote.dview.net/linux/${name}.tar.gz";
-    sha256 = "1j0b244xkvvf0i4iivp4dw9k4xgyasx4sapd91mnwki35fy49sp0";
+  src = fetchFromGitHub {
+    owner = "freefoote";
+    repo = "gpscorrelate";
+    rev = version;
+    sha256 = "1z0fc75rx7dl6nnydksa578qv116j2c2xs1czfiijzxjghx8njdj";
   };
 
+  nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    pkgconfig exiv2 libxml2 gtk2
-    libxslt docbook_xsl docbook_xml_dtd_42
+    exiv2 libxml2 gtk2
+    libxslt docbook_xsl 
+    docbook_xml_dtd_42
   ];
 
   patchPhase = ''
@@ -19,7 +24,7 @@ stdenv.mkDerivation rec {
         -es",^[[:blank:]]*prefix[[:blank:]]*=.*$,prefix = $out,g"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A GPS photo correlation tool, to add EXIF geotags";
 
     longDescription = ''
@@ -38,9 +43,8 @@ stdenv.mkDerivation rec {
       one takes the GPS data in a different format.
     '';
 
-    license = stdenv.lib.licenses.gpl2Plus;
-
-    homepage = http://freefoote.dview.net/linux_gpscorr.html;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2Plus;
+    homepage = https://github.com/freefoote/gpscorrelate;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

