### PR TITLE
Remove bbenoist from maintainers

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -2,7 +2,8 @@
   "userBlacklist": [
     "civodul",
     "jhasse",
-    "shlevy"
+    "shlevy",
+    "bbenoist"
   ],
   "alwaysNotifyForPaths": [
     { "name": "FRidh", "files": ["pkgs/top-level/python-packages.nix", "pkgs/development/interpreters/python/*", "pkgs/development/python-modules/*" ] },

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -60,7 +60,6 @@
   badi = "Badi' Abdul-Wahid <abdulwahidc@gmail.com>";
   balajisivaraman = "Balaji Sivaraman<sivaraman.balaji@gmail.com>";
   Baughn = "Svein Ove Aas <sveina@gmail.com>";
-  bbenoist = "Baptist BENOIST <return_0@live.com>";
   bcarrell = "Brandon Carrell <brandoncarrell@gmail.com>";
   bcdarwin = "Ben Darwin <bcdarwin@gmail.com>";
   bdimcheff = "Brandon Dimcheff <brandon@dimcheff.com>";

--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.geany.org/;
     license = "GPL";
-    maintainers = [ maintainers.bbenoist ];
+    maintainers = [];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/gmrun/default.nix
+++ b/pkgs/applications/misc/gmrun/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://sourceforge.net/projects/gmrun/";
     license = "GPL";
-    maintainers = [ stdenv.lib.maintainers.bbenoist ];
+    maintainers = [];
     platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/applications/misc/xfe/default.nix
+++ b/pkgs/applications/misc/xfe/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://sourceforge.net/projects/xfe/";
     license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.bbenoist ];
+    maintainers = [];
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/fox/default.nix
+++ b/pkgs/development/libraries/fox/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       '';
     homepage = "http://fox-toolkit.org";
     license = stdenv.lib.licenses.lgpl3;
-    maintainers = [ stdenv.lib.maintainers.bbenoist ];
+    maintainers = [];
     platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/libraries/fox/fox-1.6.nix
+++ b/pkgs/development/libraries/fox/fox-1.6.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       '';
     homepage = "http://fox-toolkit.org";
     license = stdenv.lib.licenses.lgpl3;
-    maintainers = [ stdenv.lib.maintainers.bbenoist ];
+    maintainers = [];
     platforms = stdenv.lib.platforms.mesaPlatforms;
   };
 }

--- a/pkgs/development/libraries/qt-5/5.5/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.5/qtbase/default.nix
@@ -286,7 +286,7 @@ stdenv.mkDerivation {
     homepage = http://www.qt.io;
     description = "A cross-platform application framework for C++";
     license = with licenses; [ fdl13 gpl2 lgpl21 lgpl3 ];
-    maintainers = with maintainers; [ bbenoist qknight ttuegel ];
+    maintainers = with maintainers; [ qknight ttuegel ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/default.nix
@@ -307,7 +307,7 @@ stdenv.mkDerivation {
     homepage = http://www.qt.io;
     description = "A cross-platform application framework for C++";
     license = with licenses; [ fdl13 gpl2 lgpl21 lgpl3 ];
-    maintainers = with maintainers; [ bbenoist qknight ttuegel ];
+    maintainers = with maintainers; [ qknight ttuegel ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/qt-5/5.7/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtbase/default.nix
@@ -306,7 +306,7 @@ stdenv.mkDerivation {
     homepage = http://www.qt.io;
     description = "A cross-platform application framework for C++";
     license = with licenses; [ fdl13 gpl2 lgpl21 lgpl3 ];
-    maintainers = with maintainers; [ bbenoist qknight ttuegel ];
+    maintainers = with maintainers; [ qknight ttuegel ];
     platforms = platforms.unix;
   };
 

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/default.nix
@@ -265,7 +265,7 @@ stdenv.mkDerivation {
     homepage = http://www.qt.io;
     description = "A cross-platform application framework for C++";
     license = with licenses; [ fdl13 gpl2 lgpl21 lgpl3 ];
-    maintainers = with maintainers; [ bbenoist qknight ttuegel ];
+    maintainers = with maintainers; [ qknight ttuegel ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     description = "Open source libraries for 3D computer graphics, image processing and visualization";
     homepage = http://www.vtk.org/;
     license = stdenv.lib.licenses.bsd3;
-    maintainers = with stdenv.lib.maintainers; [ viric bbenoist ];
+    maintainers = with stdenv.lib.maintainers; [ viric ];
     platforms = with stdenv.lib.platforms; unix;
   };
 }

--- a/pkgs/development/qtcreator/default.nix
+++ b/pkgs/development/qtcreator/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://wiki.qt.io/Category:Tools::QtCreator";
     license = "LGPL";
-    maintainers = [ maintainers.akaWolf maintainers.bbenoist ];
+    maintainers = [ maintainers.akaWolf ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/text/numdiff/default.nix
+++ b/pkgs/tools/text/numdiff/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.nongnu.org/numdiff/;
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ bbenoist ndowens ];
+    maintainers = with maintainers; [ ndowens ];
     platforms = platforms.gnu;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Sorry guys but I did not used Nix since months and cannot spend time maintaining my previous work...

The following packages are now missing "official" maintainers, feel free to take ownership or remove them:

* geany
* gmrun
* xfe
* fox

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

