### PR TITLE
Upgrade mercrial and tortoisehg to 4.1.1

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -4,7 +4,7 @@
 
 let
   # if you bump version, update pkgs.tortoisehg too or ping maintainer
-  version = "3.9.2";
+  version = "4.1.1";
   name = "mercurial-${version}";
   inherit (python2Packages) docutils hg-git dulwich python;
 in python2Packages.mkPythonDerivation {
@@ -12,7 +12,7 @@ in python2Packages.mkPythonDerivation {
 
   src = fetchurl {
     url = "https://mercurial-scm.org/release/${name}.tar.gz";
-    sha256 = "1kw3cpcjygfapvi5c123limhpbkmg7is2i81pybk1s05gi16l139";
+    sha256 = "17imsf4haqgw364p1z9i416jinmfxfia537b84hcg0rg43hinmv3";
   };
 
   inherit python; # pass it so that the same version can be used in hg2git

--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -2,11 +2,11 @@
 
 python2Packages.buildPythonApplication rec {
     name = "tortoisehg-${version}";
-    version = "3.9.2";
+    version = "4.1.1";
 
     src = fetchurl {
       url = "https://bitbucket.org/tortoisehg/targz/downloads/${name}.tar.gz";
-      sha256 = "17wcsf91z7dnb7c8vyagasj5vvmas6ms5lx1ny4pnm94qzslkfh2";
+      sha256 = "14fy5p5hx4iij5kyma9679nrprd9lsjr6j047bfyfrwa3l4knj2g";
     };
 
     pythonPath = with python2Packages; [ pyqt4 mercurial qscintilla iniparse ];


### PR DESCRIPTION
###### Motivation for this change
To have a more up-to-date version of mercurial.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).