### PR TITLE
atanks: 6.2 -> 6.5

### DIFF
--- a/pkgs/games/atanks/default.nix
+++ b/pkgs/games/atanks/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "atanks-${version}";
-  version = "6.2";
+  version = "6.5";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/atanks/atanks/${name}/${name}.tar.gz";
-    sha256 = "1s1lb87ind0y9d6hmfaf1b9wks8q3hd6w5n9dibq75rxqmcfvlpy";
+    sha256 = "0bijsbd51j4wsnmdxj54r92m7h8zqnvh9z3qqdig6zx7a8kjn61j";
   };
 
   buildInputs = [ allegro ];
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace /usr $out
   '';
 
-  makeFlags = [ "PREFIX=$(out)/" "INSTALL=install" ];
+  makeFlags = [ "PREFIX=$(out)/" "INSTALL=install" "CXX=g++" ];
 
   meta = with stdenv.lib; {
     description = "Atomic Tanks ballistics game";


### PR DESCRIPTION
###### Motivation for this change
New upstream version

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

