### PR TITLE
haproxy: PCRE and LUA support as configurable options

### DIFF
--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, pkgs, fetchurl, openssl, zlib }:
+{ useLua ? false
+, usePcre ? false
+, stdenv, fetchurl
+, openssl, zlib, lua ? null, pcre ? null
+}:
 
 stdenv.mkDerivation rec {
   pname = "haproxy";
@@ -12,7 +16,9 @@ stdenv.mkDerivation rec {
     sha256 = "ebb31550a5261091034f1b6ac7f4a8b9d79a8ce2a3ddcd7be5b5eb355c35ba65";
   };
 
-  buildInputs = [ openssl zlib ];
+  buildInputs = [ openssl zlib ]
+    ++ stdenv.lib.optional useLua lua
+    ++ stdenv.lib.optional usePcre pcre;
 
   # TODO: make it work on bsd as well
   makeFlags = [
@@ -25,6 +31,13 @@ stdenv.mkDerivation rec {
   buildFlags = [
     "USE_OPENSSL=yes"
     "USE_ZLIB=yes"
+  ] ++ stdenv.lib.optionals usePcre [
+    "USE_PCRE=yes"
+    "USE_PCRE_JIT=yes"
+  ] ++ stdenv.lib.optionals useLua [
+    "USE_LUA=yes"
+    "LUA_LIB=${lua}/lib"
+    "LUA_INC=${lua}/include"
   ] ++ stdenv.lib.optional stdenv.isDarwin "CC=cc";
 
   meta = {

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -15,9 +15,17 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl zlib ];
 
   # TODO: make it work on bsd as well
-  preConfigure = ''
-    export makeFlags="TARGET=${if stdenv.isSunOS then "solaris" else if stdenv.isLinux then "linux2628" else "generic"} PREFIX=$out USE_OPENSSL=yes USE_ZLIB=yes ${stdenv.lib.optionalString stdenv.isDarwin "CC=cc USE_KQUEUE=1"}"
-  '';
+  makeFlags = [
+    "PREFIX=\${out}"
+    ("TARGET=" + (if stdenv.isSunOS  then "solaris"
+             else if stdenv.isLinux  then "linux2628"
+             else if stdenv.isDarwin then "osx"
+             else "generic"))
+  ];
+  buildFlags = [
+    "USE_OPENSSL=yes"
+    "USE_ZLIB=yes"
+  ] ++ stdenv.lib.optional stdenv.isDarwin "CC=cc";
 
   meta = {
     description = "Reliable, high performance TCP/HTTP load balancer";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2212,7 +2212,12 @@ with pkgs;
 
   h2 = callPackage ../servers/h2 { };
 
-  haproxy = callPackage ../tools/networking/haproxy { };
+  haproxy = callPackage ../tools/networking/haproxy {
+    useLua = if stdenv.isDarwin then false else true;
+    lua = if stdenv.isDarwin then null else lua5_3;
+    usePcre = true;
+    pcre = pcre;
+  };
 
   haveged = callPackage ../tools/security/haveged { };
 


### PR DESCRIPTION
###### Motivation for this change

This solves #23806 and is a follow up to #23901. PCRE and LUA support are added via configurable options. Both are enabled by default, apart from LUA on Darwin where compilation breaks.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

