### PR TITLE
Upgrade Gitlab Runner

### DIFF
--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -20,6 +20,14 @@ in
       description = "The working directory used";
     };
 
+    package = mkOption {
+      description = "Gitlab Runner package to use";
+      default = pkgs.gitlab-runner;
+      defaultText = "pkgs.gitlab-runner";
+      type = types.package;
+      example = literalExample "pkgs.gitlab-runner_1_11";
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -29,7 +37,7 @@ in
       requires = [ "docker.service" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        ExecStart = ''${pkgs.gitlab-runner.bin}/bin/gitlab-runner run \
+        ExecStart = ''${cfg.package.bin}/bin/gitlab-runner run \
           --working-directory ${cfg.workDir} \
           --config ${configFile} \
           --service gitlab-runner \
@@ -37,6 +45,9 @@ in
         '';
       };
     };
+
+    # Make the gitlab-runner command availabe so users can query the runner
+    environment.systemPackages = [ cfg.package ];
 
     users.extraUsers.gitlab-runner = {
       group = "gitlab-runner";

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -1,16 +1,16 @@
 { lib, buildGoPackage, fetchFromGitLab, fetchurl, go-bindata }:
 
 let
-  version = "1.11.0";
+  version = "1.11.1";
   # Gitlab runner embeds some docker images these are prebuilt for arm and x86_64
   docker_x86_64 = fetchurl {
     url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-x86_64.tar.xz";
-    sha256 = "082slksd0fs0gpwi7kzmk2i71y52xccsn2r2j6qxmbzxwhpwli83";
+    sha256 = "1fahwvwdli6glxsljrd030x15y18jwk72lg1xmrgms409r9y308m";
   };
 
   docker_arm = fetchurl {
     url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-arm.tar.xz";
-    sha256 = "1c0awx4q27bckk4xpnw7357d5422iz971jkrfin17wrya4dshg64";
+    sha256 = "0nqda27qcb6r1p2xc2973g08fwb8cnmyc9rswy6776r8ypagn2zw";
   };
 in
 buildGoPackage rec {
@@ -29,7 +29,7 @@ buildGoPackage rec {
     owner = "gitlab-org";
     repo = "gitlab-ci-multi-runner";
     rev = "v${version}";
-    sha256 = "0fvkdiyfp1bf68j3kq721msfhmv8snf968yxgm7d1y6shidghrqb";
+    sha256 = "0ix00p9f01fg8m6p3b1c20hqrcv7pivh6hq92pb9qyiyzmcfap47";
   };
 
   buildInputs = [ go-bindata ];

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -1,16 +1,16 @@
 { lib, buildGoPackage, fetchFromGitLab, fetchurl, go-bindata }:
 
 let
-  version = "1.11.1";
+  version = "9.0.0";
   # Gitlab runner embeds some docker images these are prebuilt for arm and x86_64
   docker_x86_64 = fetchurl {
     url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-x86_64.tar.xz";
-    sha256 = "1fahwvwdli6glxsljrd030x15y18jwk72lg1xmrgms409r9y308m";
+    sha256 = "1f170akb7j7imgr18m32fy6v3rk98inrjl5a4xymfpivwwqyv9p8";
   };
 
   docker_arm = fetchurl {
     url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-arm.tar.xz";
-    sha256 = "0nqda27qcb6r1p2xc2973g08fwb8cnmyc9rswy6776r8ypagn2zw";
+    sha256 = "15mlix8j7bqjg5y07c439d7s197c16zxffknx42z1i3qxcz2mpa4";
   };
 in
 buildGoPackage rec {
@@ -29,7 +29,7 @@ buildGoPackage rec {
     owner = "gitlab-org";
     repo = "gitlab-ci-multi-runner";
     rev = "v${version}";
-    sha256 = "0ix00p9f01fg8m6p3b1c20hqrcv7pivh6hq92pb9qyiyzmcfap47";
+    sha256 = "1csha30lcwm1mk6hqbh0j8bb25apyni23szw79l8xjhmiw2ch619";
   };
 
   buildInputs = [ go-bindata ];

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/v1.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/v1.nix
@@ -1,0 +1,66 @@
+{ lib, buildGoPackage, fetchFromGitLab, fetchurl, go-bindata }:
+
+let
+  version = "1.11.1";
+  # Gitlab runner embeds some docker images these are prebuilt for arm and x86_64
+  docker_x86_64 = fetchurl {
+    url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-x86_64.tar.xz";
+    sha256 = "1fahwvwdli6glxsljrd030x15y18jwk72lg1xmrgms409r9y308m";
+  };
+
+  docker_arm = fetchurl {
+    url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-arm.tar.xz";
+    sha256 = "0nqda27qcb6r1p2xc2973g08fwb8cnmyc9rswy6776r8ypagn2zw";
+  };
+in
+buildGoPackage rec {
+  inherit version;
+  name = "gitlab-runner-${version}";
+  goPackagePath = "gitlab.com/gitlab-org/gitlab-ci-multi-runner";
+  commonPackagePath = "${goPackagePath}/common";
+  buildFlagsArray = ''
+    -ldflags=
+      -X ${commonPackagePath}.NAME=gitlab-runner
+      -X ${commonPackagePath}.VERSION=${version}
+      -X ${commonPackagePath}.REVISION=v${version}
+  '';
+
+  src = fetchFromGitLab {
+    owner = "gitlab-org";
+    repo = "gitlab-ci-multi-runner";
+    rev = "v${version}";
+    sha256 = "0ix00p9f01fg8m6p3b1c20hqrcv7pivh6hq92pb9qyiyzmcfap47";
+  };
+
+  buildInputs = [ go-bindata ];
+
+  preBuild = ''
+    (
+    # go-bindata names the assets after the filename thus we create a symlink with the name we want
+    cd go/src/${goPackagePath}
+    ln -sf ${docker_x86_64} prebuilt-x86_64.tar.xz
+    ln -sf ${docker_arm} prebuilt-arm.tar.xz
+    go-bindata \
+        -pkg docker \
+        -nocompress \
+        -nomemcopy \
+        -o executors/docker/bindata.go \
+        prebuilt-x86_64.tar.xz \
+        prebuilt-arm.tar.xz
+    )
+  '';
+
+  postInstall = ''
+    install -d $out/bin
+    # The recommended name is gitlab-runner so we create a symlink with that name
+    ln -sf gitlab-ci-multi-runner $bin/bin/gitlab-runner
+  '';
+
+  meta = with lib; {
+    description = "GitLab Runner the continuous integration executor of GitLab";
+    license = licenses.mit;
+    homepage = "https://about.gitlab.com/gitlab-ci/";
+    platforms = platforms.unix;
+    maintainers = [ lib.maintainers.bachp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1963,6 +1963,7 @@ with pkgs;
   gitlab = callPackage ../applications/version-management/gitlab { };
 
   gitlab-runner = callPackage ../development/tools/continuous-integration/gitlab-runner { };
+  gitlab-runner_1_11 = callPackage ../development/tools/continuous-integration/gitlab-runner/v1.nix { };
 
   gitlab-shell = callPackage ../applications/version-management/gitlab-shell { };
 


### PR DESCRIPTION
###### Motivation for this change

Gitlab introduced an API break with version 9. This means that the runner versions >= 9 only work with Gitlab version 9 or higher.
In order to support Gitlab installations <9 the old runner (v1.x.x) in its most recent version is made available as gitlab-runner1.

The service is extended so the user can select the old version.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

