### PR TITLE
Fix store path copying in Google Compute Engine image build

### DIFF
--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -62,7 +62,7 @@ in
 
           mkdir -p /mnt/nix/store
           echo "copying everything (will take a while)..."
-          cp -prd $storePaths /mnt/nix/store/
+          ${pkgs.rsync}/bin/rsync -a $storePaths /mnt/nix/store/
 
           # Register the paths in the Nix database.
           printRegistration=1 perl ${pkgs.pathsFromGraph} /tmp/xchg/closure | \


### PR DESCRIPTION
In `nixos/modules/virtualisation/google-compute-image.nix`, copy store
paths with `rsync -a` rather than `cp -prd`, because `rsync` seems
better able to handle the hard-links that may be present in the store,
whereas `cp` may fail to copy them.

I have tested that the Google Compute Engine image builds successfully
for me with this patch, whereas it did not without this patch.

This is the same fix applied for Azure images in commit
097ef6e435d5b3fcde92e67abbaaaaaf05c0723d.

Fixes #23973.

