### PR TITLE
mxt-app:1.26 -> 1.27

### DIFF
--- a/pkgs/misc/mxt-app/default.nix
+++ b/pkgs/misc/mxt-app/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchFromGitHub, makeWrapper, autoconf, automake, libtool }:
+{ stdenv, fetchFromGitHub, autoreconfHook, libtool }:
 
 stdenv.mkDerivation rec{
-  version="1.26";
+  version="1.27";
   name = "mxt-app-${version}";
 
   src = fetchFromGitHub {
     owner = "atmel-maxtouch";
     repo = "mxt-app";
     rev = "v${version}";
-    sha256 = "07afdgh8pnhgh2372cf5pqy6p7l6w3ing2hwnvz6db8wxw59n48h";
+    sha256 = "0m1qxsdkwgajyd0sdw909l4w31csa26nw0xzr9ldddnvzb1va05h";
   };
 
-  buildInputs = [ autoconf automake libtool ];
-  preConfigure = "./autogen.sh";
-
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ libtool ];
+ 
   hardeningDisable = [ "fortify" ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

