### PR TITLE
google-compute-image: fix Yama LSM option conflict

### DIFF
--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -261,7 +261,7 @@ in
     "kernel.kptr_restrict" = mkDefault "1";
 
     # set ptrace protections
-    "kernel.yama.ptrace_scope" = mkDefault "1";
+    "kernel.yama.ptrace_scope" = mkOverride 500 "1";
 
     # set perf only available to root
     "kernel.perf_event_paranoid" = mkDefault "2";


### PR DESCRIPTION
Having fixed the Google Compute Engine image build process's copying
of store paths in PR #24264, I ran `nixos-rebuild --upgrade switch`...
and the GCE image broke again, because it sets the NixOS configuration
option for the sysctl variable `kernel.yama.ptrace_scope` to
`mkDefault "1"`, i.e., with override priority 1000, and now the
`sysctl` module sets the same option to `mkDefault "0"` (this was
changed in commit 86721a5f78718caf10c578e9501f8b4d19c0eb44).

This patch raises the override priority of the Google Compute Engine
image configuration's definition of the Yama sysctl option to 500
(still lower than the priority of an unmodified option definition).

I have tested that this patch allows the Google Compute Engine image
to again build successfully for me.

