### PR TITLE
ppsspp: 1.1.0 -> 1.3

### DIFF
--- a/pkgs/misc/emulators/ppsspp/default.nix
+++ b/pkgs/misc/emulators/ppsspp/default.nix
@@ -5,7 +5,7 @@
 assert withGamepads -> (SDL != null);
 
 let
-  version = "1.1.0";
+  version = "1.3";
   fstat = x: fn: "-D" + fn + "=" + (if x then "ON" else "OFF");
 in
 with stdenv.lib;
@@ -14,13 +14,15 @@ stdenv.mkDerivation rec{
 
   src = fetchgit {
     url = "https://github.com/hrydgard/ppsspp.git";
-    rev = "8c8e5de89d52b8bcb968227d96cbf049d04d1241";
+    rev = "refs/tags/v${version}";
     fetchSubmodules = true;
-    sha256 = "1q21qskzni0nvz2yi2m17gjh4i9nrs2l4fm4y2dww9m29xpvzw3x";
+    sha256 = "0l8vgdlw657r8gv7rz8iqa6zd9zrbzw10pwhcnahzil7w9qrd03g";
   };
 
-  buildInputs = [ zlib libpng pkgconfig qt4 qmake4Hook ]
+  buildInputs = [ zlib libpng qt4 ]
                 ++ (if withGamepads then [ SDL ] else [ ]);
+
+  nativeBuildInputs = [ pkgconfig qmake4Hook ];
 
   qmakeFlags = [ "PPSSPPQt.pro" ];
 
@@ -31,7 +33,7 @@ stdenv.mkDerivation rec{
     homepage = "http://www.ppsspp.org/";
     description = "A PSP emulator, the Qt4 version";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.fuuzetsu maintainers.AndersonTorres ];
+    maintainers = with maintainers; [ fuuzetsu AndersonTorres ];
     platforms = platforms.linux ++ platforms.darwin ++ platforms.cygwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
new upstream release

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

