### PR TITLE
ghcjsHEAD: upgrade ghcjs-boot packages

### DIFF
--- a/pkgs/development/compilers/ghcjs/head.nix
+++ b/pkgs/development/compilers/ghcjs/head.nix
@@ -1,22 +1,26 @@
 { fetchgit, fetchFromGitHub, bootPkgs }:
 
 bootPkgs.callPackage ./base.nix {
-  version = "0.2.020161101";
+  version = "0.2.020170323";
 
   # deprecated on HEAD, directly included in the distribution
   ghcjs-prim = null;
   inherit bootPkgs;
 
   ghcjsSrc = fetchFromGitHub {
-    owner = "ghcjs";
+    # TODO: switch back to the regular ghcjs repo
+    # when https://github.com/ghcjs/ghcjs/pull/573 is merged.
+    owner = "basvandijk";
     repo = "ghcjs";
-    rev = "2dc14802e78d7d9dfa35395d5dbfc9c708fb83e6";
-    sha256 = "0cvmapbrwg0h1pbz648isc2l84z694ylnfm8ncd1g4as28lmj0pz";
+    rev = "e6cdc71964a1c2e4184416a493e9d384c408914c";
+    sha256 = "00fk9qwyx4vpvr0h9jbqxwlrvl6w63l5sq8r357prsp6xyv5zniz";
   };
   ghcjsBootSrc = fetchgit {
-    url = git://github.com/ghcjs/ghcjs-boot.git;
-    rev = "b000a4f4619b850bf3f9a45c9058f7a51e7709c8";
-    sha256 = "164v0xf33r6mnympp6s70v8j6g7ccyg7z95gjp43bq150ppvisbq";
+    # TODO: switch back to git://github.com/ghcjs/ghcjs-boot.git
+    # when https://github.com/ghcjs/ghcjs-boot/pull/41 is merged.
+    url = git://github.com/basvandijk/ghcjs-boot.git;
+    rev = "19a3b157ecb807c2224daffda5baecc92b76af35";
+    sha256 = "16sgr8vfr1nx5ljnk8gckgjk70zpa67ix4dbr9aizkwyz41ilfrb";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/compilers/ghcjs/head_stage2.nix
+++ b/pkgs/development/compilers/ghcjs/head_stage2.nix
@@ -2,107 +2,117 @@
 
 {
   async = callPackage
-    ({ mkDerivation, base, HUnit, stdenv, stm, test-framework
-      , test-framework-hunit
-      }:
-      mkDerivation {
-        pname = "async";
-        version = "2.1.0";
-        src = "${ghcjsBoot}/boot/async";
-        doCheck = false;
-        libraryHaskellDepends = [ base stm ];
-        testHaskellDepends = [
-          base HUnit test-framework test-framework-hunit
-        ];
-        jailbreak = true;
-        homepage = "https://github.com/simonmar/async";
-        description = "Run IO operations asynchronously and wait for their results";
-        license = stdenv.lib.licenses.bsd3;
-      }) {};
+    ({ mkDerivation, base, HUnit, stm, test-framework
+     , test-framework-hunit, stdenv
+     }:
+     mkDerivation {
+       pname = "async";
+       version = "2.1.1";
+       src = "${ghcjsBoot}/boot/async";
+       doCheck = false;
+       libraryHaskellDepends = [ base stm ];
+       testHaskellDepends = [
+         base HUnit test-framework test-framework-hunit
+       ];
+       jailbreak = true;
+       homepage = "https://github.com/simonmar/async";
+       description = "Run IO operations asynchronously and wait for their results";
+       license = stdenv.lib.licenses.bsd3;
+     }) {};
   aeson = callPackage
-    ({ mkDerivation, attoparsec, base, bytestring, containers, deepseq
-      , dlist, fail, ghc-prim, hashable, HUnit, mtl, QuickCheck, scientific
-      , stdenv, syb, tagged, template-haskell, test-framework
-      , test-framework-hunit, test-framework-quickcheck2, text, time
-      , transformers, unordered-containers, vector
-      }:
-      mkDerivation {
-        pname = "aeson";
-        version = "0.11.2.0";
-        src = "${ghcjsBoot}/boot/aeson";
-        doCheck = false;
-        libraryHaskellDepends = [
-          attoparsec base bytestring containers deepseq dlist fail ghc-prim
-          hashable mtl scientific syb tagged template-haskell text time transformers
-          unordered-containers vector
-        ];
-        testHaskellDepends = [
-          attoparsec base bytestring containers ghc-prim HUnit QuickCheck
-          template-haskell test-framework test-framework-hunit
-          test-framework-quickcheck2 text time unordered-containers vector
-        ];
-        jailbreak = true;
-        homepage = "https://github.com/bos/aeson";
-        description = "Fast JSON parsing and encoding";
-        license = stdenv.lib.licenses.bsd3;
-      }) {};
+    ({ mkDerivation, attoparsec, base, base-compat, base-orphans
+     , base16-bytestring, bytestring, containers, deepseq, directory
+     , dlist, fetchgit, filepath, generic-deriving, ghc-prim, hashable
+     , hashable-time, HUnit, integer-logarithms, QuickCheck
+     , quickcheck-instances, scientific, stdenv, tagged
+     , template-haskell, test-framework, test-framework-hunit
+     , test-framework-quickcheck2, text, time, time-locale-compat
+     , unordered-containers, uuid-types, vector
+     }:
+     mkDerivation {
+       pname = "aeson";
+       version = "1.1.1.0";
+       src = "${ghcjsBoot}/boot/aeson";
+       libraryHaskellDepends = [
+         attoparsec base base-compat bytestring containers deepseq dlist
+         ghc-prim hashable scientific tagged template-haskell text time
+         time-locale-compat unordered-containers uuid-types vector
+       ];
+       testHaskellDepends = [
+         attoparsec base base-compat base-orphans base16-bytestring
+         bytestring containers directory dlist filepath generic-deriving
+         ghc-prim hashable hashable-time HUnit integer-logarithms QuickCheck
+         quickcheck-instances scientific tagged template-haskell
+         test-framework test-framework-hunit test-framework-quickcheck2 text
+         time time-locale-compat unordered-containers uuid-types vector
+       ];
+       jailbreak = true;
+       homepage = "https://github.com/bos/aeson";
+       description = "Fast JSON parsing and encoding";
+       license = stdenv.lib.licenses.bsd3;
+     }) {};
   attoparsec = callPackage
-    ({ mkDerivation, array, base, bytestring, containers, deepseq
-      , QuickCheck, quickcheck-unicode, scientific, stdenv
-      , test-framework, test-framework-quickcheck2, text, transformers
-      , vector
-      }:
-      mkDerivation {
-        pname = "attoparsec";
-        version = "0.13.0.2";
-        src = "${ghcjsBoot}/boot/attoparsec";
-        doCheck = false;
-        libraryHaskellDepends = [
-          array base bytestring containers deepseq scientific text
-          transformers
-        ];
-        testHaskellDepends = [
-          array base bytestring containers deepseq QuickCheck
-          quickcheck-unicode scientific test-framework
-          test-framework-quickcheck2 text transformers vector
-        ];
-        jailbreak = true;
-        homepage = "https://github.com/bos/attoparsec";
-        description = "Fast combinator parsing for bytestrings and text";
-        license = stdenv.lib.licenses.bsd3;
-      }) {};
+    ({ mkDerivation, array, base, bytestring, case-insensitive
+     , containers, criterion, deepseq, directory, filepath, ghc-prim
+     , http-types, parsec, QuickCheck, quickcheck-unicode, scientific
+     , tasty, tasty-quickcheck, text, transformers, unordered-containers
+     , vector, stdenv
+     }:
+     mkDerivation {
+       pname = "attoparsec";
+       version = "0.13.1.0";
+       src = "${ghcjsBoot}/boot/attoparsec";
+       libraryHaskellDepends = [
+         array base bytestring containers deepseq scientific text
+         transformers
+       ];
+       testHaskellDepends = [
+         array base bytestring deepseq QuickCheck quickcheck-unicode
+         scientific tasty tasty-quickcheck text transformers vector
+       ];
+       benchmarkHaskellDepends = [
+         array base bytestring case-insensitive containers criterion deepseq
+         directory filepath ghc-prim http-types parsec scientific text
+         transformers unordered-containers vector
+       ];
+       jailbreak = true;
+       homepage = "https://github.com/bos/attoparsec";
+       description = "Fast combinator parsing for bytestrings and text";
+       license = stdenv.lib.licenses.bsd3;
+     }) {};
   case-insensitive = callPackage
-    ({ mkDerivation, base, bytestring, deepseq, hashable, HUnit, stdenv
-      , test-framework, test-framework-hunit, text
-      }:
-      mkDerivation {
-        pname = "case-insensitive";
-        version = "1.2.0.6";
-        src = "${ghcjsBoot}/boot/case-insensitive";
-        doCheck = false;
-        libraryHaskellDepends = [ base bytestring deepseq hashable text ];
-        testHaskellDepends = [
-          base bytestring HUnit test-framework test-framework-hunit text
-        ];
-        jailbreak = true;
-        homepage = "https://github.com/basvandijk/case-insensitive";
-        description = "Case insensitive string comparison";
-        license = stdenv.lib.licenses.bsd3;
-      }) {};
+    ({ mkDerivation, base, bytestring, criterion, deepseq, hashable
+     , HUnit, test-framework, test-framework-hunit, text, stdenv
+     }:
+     mkDerivation {
+       pname = "case-insensitive";
+       version = "1.2.0.8";
+       src = "${ghcjsBoot}/boot/case-insensitive";
+       doCheck = false;
+       libraryHaskellDepends = [ base bytestring deepseq hashable text ];
+       testHaskellDepends = [
+         base bytestring HUnit test-framework test-framework-hunit text
+       ];
+       benchmarkHaskellDepends = [ base bytestring criterion deepseq ];
+       jailbreak = true;
+       homepage = "https://github.com/basvandijk/case-insensitive";
+       description = "Case insensitive string comparison";
+       license = stdenv.lib.licenses.bsd3;
+     }) {};
   dlist = callPackage
     ({ mkDerivation, base, Cabal, deepseq, QuickCheck, stdenv }:
-      mkDerivation {
-        pname = "dlist";
-        version = "0.7.1.2";
-        src = "${ghcjsBoot}/boot/dlist";
-        doCheck = false;
-        libraryHaskellDepends = [ base deepseq ];
-        testHaskellDepends = [ base Cabal QuickCheck ];
-        jailbreak = true;
-        homepage = "https://github.com/spl/dlist";
-        description = "Difference lists";
-        license = stdenv.lib.licenses.bsd3;
-      }) {};
+     mkDerivation {
+       pname = "dlist";
+       version = "0.8.0.2";
+       src = "${ghcjsBoot}/boot/dlist";
+       doCheck = false;
+       libraryHaskellDepends = [ base deepseq ];
+       testHaskellDepends = [ base Cabal QuickCheck ];
+       jailbreak = true;
+       homepage = "https://github.com/spl/dlist";
+       description = "Difference lists";
+       license = stdenv.lib.licenses.bsd3;
+     }) {};
   extensible-exceptions = callPackage
     ({ mkDerivation, base, stdenv }:
       mkDerivation {
@@ -175,29 +185,29 @@
         license = stdenv.lib.licenses.bsd3;
       }) {};
   scientific = callPackage
-    ({ mkDerivation, base, binary, bytestring, containers, deepseq, ghc-prim
-      , hashable, integer-gmp, QuickCheck, smallcheck, stdenv, tasty
-      , tasty-ant-xml, tasty-hunit, tasty-quickcheck, tasty-smallcheck
-      , text, vector
-      }:
-      mkDerivation {
-        pname = "scientific";
-        version = "0.3.4.7";
-        src = "${ghcjsBoot}/boot/scientific";
-        doCheck = false;
-        libraryHaskellDepends = [
-          base binary bytestring containers deepseq ghc-prim hashable
-          integer-gmp text vector
-        ];
-        testHaskellDepends = [
-          base bytestring QuickCheck smallcheck tasty tasty-ant-xml
-          tasty-hunit tasty-quickcheck tasty-smallcheck text
-        ];
-        jailbreak = true;
-        homepage = "https://github.com/basvandijk/scientific";
-        description = "Numbers represented using scientific notation";
-        license = stdenv.lib.licenses.bsd3;
-      }) {};
+    ({ mkDerivation, base, binary, bytestring, containers, criterion
+     , deepseq, ghc-prim, hashable, integer-gmp, integer-logarithms
+     , QuickCheck, smallcheck, tasty, tasty-ant-xml, tasty-hunit
+     , tasty-quickcheck, tasty-smallcheck, text, vector, stdenv
+     }:
+     mkDerivation {
+       pname = "scientific";
+       version = "0.3.4.10";
+       src = "${ghcjsBoot}/boot/scientific";
+       libraryHaskellDepends = [
+         base binary bytestring containers deepseq ghc-prim hashable
+         integer-gmp integer-logarithms text vector
+       ];
+       testHaskellDepends = [
+         base binary bytestring QuickCheck smallcheck tasty tasty-ant-xml
+         tasty-hunit tasty-quickcheck tasty-smallcheck text
+       ];
+       benchmarkHaskellDepends = [ base criterion ];
+       jailbreak = true;
+       homepage = "https://github.com/basvandijk/scientific";
+       description = "Numbers represented using scientific notation";
+       license = stdenv.lib.licenses.bsd3;
+     }) {};
   stm = callPackage
     ({ mkDerivation, array, base, stdenv }:
       mkDerivation {
@@ -224,6 +234,23 @@
         description = "Scrap Your Boilerplate";
         license = stdenv.lib.licenses.bsd3;
       }) {};
+  tagged = callPackage
+    ({ mkDerivation, base, deepseq, template-haskell, transformers
+     , transformers-compat, stdenv
+     }:
+     mkDerivation {
+       pname = "tagged";
+       version = "0.8.5";
+       src = "${ghcjsBoot}/boot/tagged";
+       doCheck = false;
+       libraryHaskellDepends = [
+         base deepseq template-haskell transformers transformers-compat
+       ];
+       jailbreak = true;
+       homepage = "http://github.com/ekmett/tagged";
+       description = "Haskell 98 phantom types to avoid unsafely passing dummy arguments";
+       license = stdenv.lib.licenses.bsd3;
+     }) {};
   text = callPackage
     ({ mkDerivation, array, base, binary, bytestring, deepseq, directory
       , ghc-prim, HUnit, integer-gmp, QuickCheck, quickcheck-unicode
@@ -249,25 +276,52 @@
         license = stdenv.lib.licenses.bsd3;
       }) {};
   unordered-containers = callPackage
-    ({ mkDerivation, base, ChasingBottoms, containers, deepseq, hashable
-      , HUnit, QuickCheck, stdenv, test-framework, test-framework-hunit
-      , test-framework-quickcheck2
-      }:
-      mkDerivation {
-        pname = "unordered-containers";
-        version = "0.2.7.0";
-        src = "${ghcjsBoot}/boot/unordered-containers";
-        doCheck = false;
-        libraryHaskellDepends = [ base deepseq hashable ];
-        testHaskellDepends = [
-          base ChasingBottoms containers hashable HUnit QuickCheck
-          test-framework test-framework-hunit test-framework-quickcheck2
-        ];
-        jailbreak = true;
-        homepage = "https://github.com/tibbe/unordered-containers";
-        description = "Efficient hashing-based container types";
-        license = stdenv.lib.licenses.bsd3;
-      }) {};
+    ({ mkDerivation, base, bytestring, ChasingBottoms, containers
+     , criterion, deepseq, deepseq-generics, hashable, hashmap, HUnit
+     , mtl, QuickCheck, random, test-framework, test-framework-hunit
+     , test-framework-quickcheck2, stdenv
+     }:
+     mkDerivation {
+       pname = "unordered-containers";
+       version = "0.2.7.2";
+       src = "${ghcjsBoot}/boot/unordered-containers";
+       libraryHaskellDepends = [ base deepseq hashable ];
+       testHaskellDepends = [
+         base ChasingBottoms containers hashable HUnit QuickCheck
+         test-framework test-framework-hunit test-framework-quickcheck2
+       ];
+       benchmarkHaskellDepends = [
+         base bytestring containers criterion deepseq deepseq-generics
+         hashable hashmap mtl random
+       ];
+       jailbreak = true;
+       homepage = "https://github.com/tibbe/unordered-containers";
+       description = "Efficient hashing-based container types";
+       license = stdenv.lib.licenses.bsd3;
+     }) {};
+  uuid-types = callPackage
+    ({ mkDerivation, base, binary, bytestring, containers, criterion
+     , deepseq, hashable, HUnit, QuickCheck, random, stdenv, tasty
+     , tasty-hunit, tasty-quickcheck, text
+     }:
+     mkDerivation {
+       pname = "uuid-types";
+       version = "1.0.3";
+       src = "${ghcjsBoot}/boot/uuid/uuid-types";
+       libraryHaskellDepends = [
+         base binary bytestring deepseq hashable random text
+       ];
+       testHaskellDepends = [
+         base bytestring HUnit QuickCheck tasty tasty-hunit tasty-quickcheck
+       ];
+       benchmarkHaskellDepends = [
+         base bytestring containers criterion deepseq random
+       ];
+       jailbreak = true;
+       homepage = "https://github.com/aslatter/uuid";
+       description = "Type definitions for Universally Unique Identifiers";
+       license = stdenv.lib.licenses.bsd3;
+     }) {};
   vector = callPackage
     ({ mkDerivation, base, deepseq, ghc-prim, primitive, QuickCheck
       , random, stdenv, template-haskell, test-framework


### PR DESCRIPTION
@TravisWhitaker @peti at LumiGuide we have some trouble with incompatible `aeson` versions between GHC and GHCJS. In https://github.com/ghcjs/ghcjs-boot/pull/41 I move the `ghcjs-boot` packages closer to the latest LTS. 

I tested it by building and running a big GHCJS app.

What do you think about this? Is it OK to merge or do you want to wait until the upstream PR is merged? (In defence of merging: I emailed Luite a week ago about upgrading `aeson` but he didn't respond. Probably because he's traveling through China according to Facebook.)

If you want to merge it it would be great if this can also be cherry-picked on `release-17.03`.
