### PR TITLE
native host connector for gnome extensions: init at 7d99523e90805cb65027cc2f5f1191a957dcf276

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
@@ -1,0 +1,31 @@
+{stdenv, lib, python, dbus, fetchgit, cmake, coreutils, jq, gobjectIntrospection, python27Packages, makeWrapper, gnome3, wrapGAppsHook}:
+
+stdenv.mkDerivation rec {
+name="chrome-gnome-shell";
+  src = fetchgit {
+    url = "git://git.gnome.org/chrome-gnome-shell";
+    rev = "7d99523e90805cb65027cc2f5f1191a957dcf276";
+    sha256 = "0qc34dbhsz5yf4z5bx6py08h561rcxw9928drgk9256g3vnygnbc";
+  };
+ 
+ buildInputs = [ gnome3.gnome_shell makeWrapper jq dbus gobjectIntrospection
+ python python27Packages.requests python27Packages.pygobject3 wrapGAppsHook];
+
+ preConfigure = ''
+ mkdir build usr etc
+ cd build
+ ${cmake}/bin/cmake -DCMAKE_INSTALL_PREFIX=$out/usr -DBUILD_EXTENSION=OFF ../
+ substituteInPlace cmake_install.cmake --replace "/etc" "$out/etc"  
+ '';
+
+ postInstall = ''
+    rm $out/etc/opt/chrome/policies/managed/chrome-gnome-shell.json
+    rm $out/etc/chromium/policies/managed/chrome-gnome-shell.json
+    wrapProgram $out/usr/bin/chrome-gnome-shell \
+      --prefix PATH '"${dbus}/bin/dbus:$PATH"' \
+      --prefix PATH '"${gnome3.gnome_shell}:$PATH"' \
+      --prefix PYTHONPATH : "$PYTHONPATH" 
+
+  '';
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18404,5 +18404,6 @@ with pkgs;
 
   ghc-standalone-archive = callPackage ../os-specific/darwin/ghc-standalone-archive { inherit (darwin) cctools; };
 
+  chrome-gnome-shell = callPackage  ../desktops/gnome-3/extensions/chrome-gnome-shell {};
   messenger-for-desktop = callPackage ../applications/networking/instant-messengers/messenger-for-desktop {};
 }


### PR DESCRIPTION
###### Motivation for this change
In order to install gnome extensions, native host connector is needed.
This pkg works for Firefox without gnome-extension addon of Firefox.
https://wiki.gnome.org/Projects/GnomeShellIntegrationForChrome/Installation
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

