### PR TITLE
geogebra: 5-0-338-0 -> 5-0-346-0

### DIFF
--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "geogebra-${version}";
-  version = "5-0-338-0";
+  version = "5-0-346-0";
 
   preferLocalBuild = true;
 
   src = fetchurl {
     url = "http://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2";
-    sha256 = "1namwib3912zjizgl9swan0fwgmq9kvfq5k5y8lz818vh4lv88kx";
+    sha256 = "13yiksdk5qwa7c5zp5l0h3czqq31qlf04ncgrh8mn7z70ng1f3l4";
   };
 
   srcIcon = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

The currently packaged version of GeoGebra (`5-0-338-0`) is removed from the download server of GeoGebra, so we need the latest available version for now...

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

