### PR TITLE
libav: added pulseaudioSupport option

### DIFF
--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -1,15 +1,16 @@
 { stdenv, fetchurl, pkgconfig, yasm, bzip2, zlib, perl
-, mp3Support    ? true,   lame      ? null
-, speexSupport  ? true,   speex     ? null
-, theoraSupport ? true,   libtheora ? null
-, vorbisSupport ? true,   libvorbis ? null
-, vpxSupport    ? true,   libvpx    ? null
-, x264Support   ? false,  x264      ? null
-, xvidSupport   ? true,   xvidcore  ? null
-, faacSupport   ? false,  faac      ? null
-, vaapiSupport  ? true,   libva     ? null
-, vdpauSupport  ? true,   libvdpau  ? null
-, freetypeSupport ? true, freetype  ? null # it's small and almost everywhere
+, mp3Support        ? true,  lame          ? null
+, speexSupport      ? true,  speex         ? null
+, theoraSupport     ? true,  libtheora     ? null
+, vorbisSupport     ? true,  libvorbis     ? null
+, vpxSupport        ? true,  libvpx        ? null
+, x264Support       ? false, x264          ? null
+, xvidSupport       ? true,  xvidcore      ? null
+, faacSupport       ? false, faac          ? null
+, vaapiSupport      ? true,  libva         ? null
+, vdpauSupport      ? true,  libvdpau      ? null
+, freetypeSupport   ? true,  freetype      ? null # it's small and almost everywhere
+, pulseaudioSupport ? true,  libpulseaudio ? null
 , SDL # only for avplay in $bin, adds nontrivial closure to it
 , enableGPL ? true # ToDo: some additional default stuff may need GPL
 , enableUnfree ? faacSupport
@@ -67,6 +68,7 @@ let
       ++ optional vaapiSupport "--enable-vaapi"
       ++ optional vdpauSupport "--enable-vdpau"
       ++ optional freetypeSupport "--enable-libfreetype"
+      ++ optional pulseaudioSupport "--enable-libpulse"
       ;
 
     buildInputs = [ pkgconfig lame yasm zlib bzip2 SDL ]
@@ -82,6 +84,7 @@ let
       ++ optional vaapiSupport libva
       ++ optional vdpauSupport libvdpau
       ++ optional freetypeSupport freetype
+      ++ optional pulseaudioSupport libpulseaudio
       ;
 
     enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Added libpulseaudio features to build so pulse sources can be used at runtime.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---