### PR TITLE
sox: added enableLibpulseaudio option

### DIFF
--- a/pkgs/applications/misc/audio/sox/default.nix
+++ b/pkgs/applications/misc/audio/sox/default.nix
@@ -9,6 +9,7 @@
 , enableLibsndfile ? true, libsndfile ? null
 # amrnb and amrwb are unfree, disabled by default
 , enableAMR ? false, amrnb ? null, amrwb ? null
+, enableLibpulseaudio ? true, libpulseaudio ? null
 }:
 
 with stdenv.lib;
@@ -30,7 +31,8 @@ stdenv.mkDerivation rec {
     optional enableFLAC flac ++
     optional enablePNG libpng ++
     optional enableLibsndfile libsndfile ++
-    optionals enableAMR [ amrnb amrwb ];
+    optionals enableAMR [ amrnb amrwb ] ++
+    optional enableLibpulseaudio libpulseaudio;
 
   meta = {
     description = "Sample Rate Converter for audio";


### PR DESCRIPTION
###### Motivation for this change

Added libpulseaudio features to build so pulse sources can be used at runtime.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---