### PR TITLE
gitkraken: 2.2.0 -> 2.2.1

### DIFF
--- a/pkgs/applications/version-management/gitkraken/default.nix
+++ b/pkgs/applications/version-management/gitkraken/default.nix
@@ -4,16 +4,18 @@
   ,nss, nspr, cups, fetchurl, expat, gdk_pixbuf, libXdamage, libXrandr, dbus
 }:
 
+with stdenv.lib;
+
 stdenv.mkDerivation rec {
   name = "gitkraken-${version}";
-  version = "2.2.0";
+  version = "2.2.1";
 
   src = fetchurl {
     url = "https://release.gitkraken.com/linux/v${version}.tar.gz";
-    sha256 = "0a3ed917e6e937af4dd180144fbb4ad8b99b35b5d8c1f0684a55de38189a812d";
+    sha256 = "12nyw2dh9ylrms264dbw0xzyif0znmba32zyfq7kdp0iay0wvgqd";
   };
 
-  libPath = stdenv.lib.makeLibraryPath [
+  libPath = makeLibraryPath [
     stdenv.cc.cc.lib
     curl
     udev
@@ -58,13 +60,13 @@ stdenv.mkDerivation rec {
     patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
              --set-rpath "$libPath:$out/opt/gitkraken" "$out/opt/gitkraken/gitkraken"
     wrapProgram $out/opt/gitkraken/gitkraken \
-      --prefix LD_PRELOAD : "${stdenv.lib.makeLibraryPath [ curl ]}/libcurl.so.4" \
-      --prefix LD_PRELOAD : "${stdenv.lib.makeLibraryPath [ libgnome_keyring ]}/libgnome-keyring.so.0"
+      --prefix LD_PRELOAD : "${makeLibraryPath [ curl ]}/libcurl.so.4" \
+      --prefix LD_PRELOAD : "${makeLibraryPath [ libgnome_keyring ]}/libgnome-keyring.so.0"
     mkdir "$out/bin"
     ln -s "$out/opt/gitkraken/gitkraken" "$out/bin/gitkraken"
   '';
 
-  meta = with stdenv.lib; {
+  meta = {
     homepage = https://www.gitkraken.com/;
     description = "The downright luxurious and most popular Git client for Windows, Mac & Linux";
     license = licenses.unfree;


### PR DESCRIPTION
###### Motivation for this change

* Version bump.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

