### PR TITLE
dar: 2.5.3 -> 2.5.9

### DIFF
--- a/pkgs/tools/archivers/dar/default.nix
+++ b/pkgs/tools/archivers/dar/default.nix
@@ -1,15 +1,17 @@
 { stdenv, fetchurl, zlib, bzip2, openssl, attr, lzo, libgcrypt, e2fsprogs, gpgme, xz }:
 
+with stdenv.lib;
+
 stdenv.mkDerivation rec {
-  name = "dar-2.5.3";
+  name = "dar-2.5.9";
 
   src = fetchurl {
     url = "mirror://sourceforge/dar/${name}.tar.gz";
-    sha256 = "0myakyfgv2mhazwvbbwwncn9j7c9b4g3szs0aqlclmp01naaqmj5";
+    sha256 = "0bm91d82amh5h2sla2ngbpxd0l64alcdjhxz35bhj3cpz9562wv9";
   };
 
   buildInputs = [ zlib bzip2 openssl lzo libgcrypt gpgme xz ]
-    ++ stdenv.lib.optionals stdenv.isLinux [ attr e2fsprogs ];
+    ++ optionals stdenv.isLinux [ attr e2fsprogs ];
 
   configureFlags = [ "--disable-dar-static" ];
 
@@ -20,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://dar.linux.free.fr/;
     description = "Disk ARchiver, allows backing up files into indexed archives";
-    maintainers = [ stdenv.lib.maintainers.viric ];
-    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ maintainers.viric ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done
Binary executes, other than if it actually works, I am unsure as I don't use backup software
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

