### PR TITLE
emacsMacport: name change and description

### DIFF
--- a/pkgs/applications/editors/emacs/macport.nix
+++ b/pkgs/applications/editors/emacs/macport.nix
@@ -92,8 +92,8 @@ stdenv.mkDerivation rec {
       extensions are distributed with GNU Emacs; others are available
       separately.
 
-      This is "Mac port" addition to GNU Emacs 24. This provides a native
-      GUI support for Mac OS X 10.4 - 10.11. Note that Emacs 23 and later
+      This is "Mac port" addition to GNU Emacs 25. This provides a native
+      GUI support for Mac OS X 10.6 - 10.12. Note that Emacs 23 and later
       already contain the official GUI support via the NS (Cocoa) port for
       Mac OS X 10.4 and later. So if it is good enough for you, then you
       don't need to try this.

--- a/pkgs/applications/editors/emacs/macport.nix
+++ b/pkgs/applications/editors/emacs/macport.nix
@@ -4,8 +4,10 @@
 }:
 
 stdenv.mkDerivation rec {
-  emacsName = "emacs-25.1";
-  name = "${emacsName}-mac-6.1";
+  emacsVersion = "25.1";
+  emacsName = "emacs-${emacsVersion}";
+  macportVersion = "6.1";
+  name = "emacs-mac-${emacsVersion}-${macportVersion}";
 
   builder = ./builder.sh;
 
@@ -15,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   macportSrc = fetchurl {
-    url = "ftp://ftp.math.s.chiba-u.ac.jp/emacs/${name}.tar.gz";
+    url = "ftp://ftp.math.s.chiba-u.ac.jp/emacs/${emacsName}-mac-${macportVersion}.tar.gz";
     sha256 = "1zwxh7zsvwcg221mpjh0dhpdas3j9mc5q92pprf8yljl7clqvg62";
   };
 
@@ -35,7 +37,7 @@ stdenv.mkDerivation rec {
 
   postUnpack = ''
     mv $sourceRoot $name
-    tar xzf $macportSrc
+    tar xzf $macportSrc -C $name --strip-components=1
     mv $name $sourceRoot
 
     # extract retina image resources


### PR DESCRIPTION
###### Motivation for this change
See commit description

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

