### PR TITLE
sharutils: 4.11.1 -> 4.15.2

### DIFF
--- a/pkgs/tools/archivers/sharutils/default.nix
+++ b/pkgs/tools/archivers/sharutils/default.nix
@@ -1,23 +1,17 @@
 { stdenv, fetchurl, gettext, coreutils }:
 
 stdenv.mkDerivation rec {
-  name = "sharutils-4.11.1";
+  name = "sharutils-4.15.2";
 
   src = fetchurl {
-    url = "mirror://gnu/sharutils/${name}.tar.bz2";
-    sha256 = "1mallg1gprimlggdisfzdmh1xi676jsfdlfyvanlcw72ny8fsj3g";
+    url = "mirror://gnu/sharutils/${name}.tar.xz";
+    sha256 = "16isapn8f39lnffc3dp4dan05b7x6mnc76v6q5nn8ysxvvvwy19b";
   };
 
   hardeningDisable = [ "format" ];
 
-  preConfigure = ''
-     # Fix for building on Glibc 2.16.  Won't be needed once the
-     # gnulib in sharutils is updated.
-     sed -i ${stdenv.lib.optionalString (stdenv.isOpenBSD && stdenv.cc.nativeTools) "''"} '/gets is a security hole/d' lib/stdio.in.h
-  '';
-
   # GNU Gettext is needed on non-GNU platforms.
-  buildInputs = [ gettext coreutils ];
+  buildInputs = [ coreutils gettext ];
 
   doCheck = true;
 
@@ -25,7 +19,7 @@ stdenv.mkDerivation rec {
     patches = [ ./sharutils-4.11.1-cross-binary-mode-popen.patch ];
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Tools for remote synchronization and `shell archives'";
     longDescription =
       '' GNU shar makes so-called shell archives out of many files, preparing
@@ -44,8 +38,8 @@ stdenv.mkDerivation rec {
          concatenated shell archives.
       '';
     homepage = http://www.gnu.org/software/sharutils/;
-    license = stdenv.lib.licenses.gpl3Plus;
-    maintainers = [ ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.ndowens ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

