### PR TITLE
advancecomp: 1.19 -> 1.23

### DIFF
--- a/pkgs/tools/compression/advancecomp/default.nix
+++ b/pkgs/tools/compression/advancecomp/default.nix
@@ -1,31 +1,26 @@
-{stdenv, fetchurl, zlib}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="advancecomp";
-    version="1.19";
-    name="${baseName}-${version}";
-    url="http://prdownloads.sourceforge.net/advancemame/advancecomp-1.19.tar.gz?download";
-    sha256="0irhmwcn9r4jc29442skqr1f3lafiaahxc3m3ybalmm37l6cb56m";
+{ stdenv, fetchFromGitHub
+, autoreconfHook, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "advancecomp-${version}";
+  version = "1.23";
+
+  src = fetchFromGitHub {
+    owner = "amadvance";
+    repo = "advancecomp";
+    rev = "v${version}";
+    sha256 = "1mrgmpjd9f7x16g847h1588mgryl26hlzfl40bc611259bb0bq7w"; 
   };
-  buildInputs = [
-    zlib
-  ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
-  src = fetchurl {
-    inherit (s) url sha256;
-  };
-  meta = {
-    inherit (s) version;
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ zlib ];
+
+  meta = with stdenv.lib; {
     description = ''A set of tools to optimize deflate-compressed files'';
-    license = stdenv.lib.licenses.gpl2 ;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
-    updateWalker = true;
-    homepage = "http://advancemame.sourceforge.net/comp-readme.html";
-    downloadPage = "http://advancemame.sourceforge.net/comp-download.html";
+    license = licenses.gpl2 ;
+    maintainers = [ maintainers.raskin ];
+    platforms = platforms.linux;
+    homepage = https://github.com/amadvance/advancecomp;
+
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

