### PR TITLE
phpfpm service: don't use private /tmp

### DIFF
--- a/nixos/modules/services/web-servers/phpfpm/default.nix
+++ b/nixos/modules/services/web-servers/phpfpm/default.nix
@@ -147,7 +147,6 @@ in {
           cfgFile = fpmCfgFile pool poolConfig;
         in {
           Slice = "phpfpm.slice";
-          PrivateTmp = true;
           PrivateDevices = true;
           ProtectSystem = "full";
           ProtectHome = true;


### PR DESCRIPTION
###### Motivation for this change

This breaks local PostgreSQL connections.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

