### PR TITLE
lzfse: 2016-06-21 -> 2017-03-08

### DIFF
--- a/pkgs/tools/compression/lzfse/default.nix
+++ b/pkgs/tools/compression/lzfse/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "lzfse-${version}";
-  version = "2016-06-21";
+  version = "2017-03-08";
 
   src = fetchFromGitHub {
     owner = "lzfse";
     repo = "lzfse";
-    rev = "45912281e3945a09c6ebfa8c6629f6906a99fc29";
-    sha256 = "1wbh3x874fjn548g1hw4bm7lkk60vlvy8ph0wsjkzcx8873hwj7h";
+    rev = "88e2d27";
+    sha256 = "1mfh6y6vpvxsdwmqmfbkqkwvxc0pz2dqqc72c6fk9sbsrxxaghd5";
   };
 
   makeFlags = [ "INSTALL_PREFIX=$(out)" ];


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

