### PR TITLE
nftables service: Adds a heads-up regarding nftables and Docker incompability

### DIFF
--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -17,6 +17,17 @@ in
 
           This conflicts with the standard networking firewall, so make sure to
           disable it before using nftables.
+
+          Note that if you have Docker enabled you will not be able to use
+          nftables without intervention. Docker uses iptables internally to
+          setup NAT for containers. This module disables the ip_tables kernel
+          module, however Docker automatically loads the module. Please see [1]
+          for more information.
+
+          There are other programs that use iptables internally too, such as
+          libvirt.
+
+          [1]: https://github.com/NixOS/nixpkgs/issues/24318#issuecomment-289216273
         '';
     };
     networking.nftables.ruleset = mkOption {


### PR DESCRIPTION
###### Motivation for this change

It took a while for me to figure out that Docker uses iptables internally and that I had to disable it manually for nftables to work. 

To try to mitigate the problem of "tribal knowledge" I added a heads-up in the description of the `networking.nftables.enable` attribute.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

