### PR TITLE
rss2email: init at 3.9

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18049,6 +18049,8 @@ with pkgs;
 
   rss-glx = callPackage ../misc/screensavers/rss-glx { };
 
+  rss2email = python3Packages.rss2email;
+
   runit = callPackage ../tools/system/runit { };
 
   refind = callPackage ../tools/bootloaders/refind { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31828,6 +31828,28 @@ EOF
     };
   };
 
+  rss2email = buildPythonPackage rec {
+    name = "${pname}-${version}";
+    pname = "rss2email";
+    version = "3.9";
+
+    disabled = pythonOlder "3.2";
+
+    propagatedBuildInputs = with self; [ feedparser beautifulsoup4 html2text ];
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/r/rss2email/${name}.tar.gz";
+      sha256 = "02wj9zhmc2ym8ba1i0z9pm1c622z2fj7fxwagnxbvpr1402ahmr5";
+    };
+
+    meta = {
+      description = "A tool that converts RSS/Atom newsfeeds to email.";
+      homepage = "https://pypi.python.org/pypi/rss2email";
+      license = licenses.gpl2;
+      maintainers = with maintainers; [ jb55 ];
+    };
+  };
+
   yapf = buildPythonPackage rec {
     name = "yapf-${version}";
     version = "0.11.0";


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

