### PR TITLE
ssmtp: use the authPassFile option instead of authPass

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -59,6 +59,7 @@
   bachp = "Pascal Bach <pascal.bach@nextrem.ch>";
   badi = "Badi' Abdul-Wahid <abdulwahidc@gmail.com>";
   balajisivaraman = "Balaji Sivaraman<sivaraman.balaji@gmail.com>";
+  basvandijk = "Bas van Dijk <v.dijk.bas@gmail.com>";
   Baughn = "Svein Ove Aas <sveina@gmail.com>";
   bcarrell = "Brandon Carrell <brandoncarrell@gmail.com>";
   bcdarwin = "Ben Darwin <bcdarwin@gmail.com>";

--- a/nixos/modules/programs/ssmtp.nix
+++ b/nixos/modules/programs/ssmtp.nix
@@ -95,9 +95,27 @@ in
         example = "correctHorseBatteryStaple";
         description = ''
           Password used for SMTP auth. (STORED PLAIN TEXT, WORLD-READABLE IN NIX STORE)
+
+          It's recommended to use <option>authPassFile</option>
+          which takes precedence over <option>authPass</option>.
         '';
       };
-      
+
+      authPassFile = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "/run/keys/ssmtp-authpass";
+        description = ''
+          Path to a file that contains the password used for SMTP auth.
+          This file should be readable by the users that need to execute ssmtp.
+
+          <option>authPassFile</option> takes precedence over <option>authPass</option>.
+
+          Warning: when <option>authPass</option> is non-empty <option>authPassFile</option>
+          defaults to a file in the WORLD-READABLE Nix store containing that password.
+        '';
+      };
+
       setSendmail = mkOption {
         type = types.bool;
         default = true;
@@ -111,21 +129,28 @@ in
 
   config = mkIf cfg.directDelivery {
 
+    networking.defaultMailServer.authPassFile = mkIf (cfg.authPass != "")
+      (mkDefault (toString (pkgs.writeTextFile {
+        name = "ssmtp-authpass";
+        text = cfg.authPass;
+      })));
+
     environment.etc."ssmtp/ssmtp.conf".text =
+      let yesNo = yes : if yes then "YES" else "NO"; in
       ''
         MailHub=${cfg.hostName}
         FromLineOverride=YES
-        ${if cfg.root != "" then "root=${cfg.root}" else ""}
-        ${if cfg.domain != "" then "rewriteDomain=${cfg.domain}" else ""}
-        UseTLS=${if cfg.useTLS then "YES" else "NO"}
-        UseSTARTTLS=${if cfg.useSTARTTLS then "YES" else "NO"}
+        ${optionalString (cfg.root   != "") "root=${cfg.root}"}
+        ${optionalString (cfg.domain != "") "rewriteDomain=${cfg.domain}"}
+        UseTLS=${yesNo cfg.useTLS}
+        UseSTARTTLS=${yesNo cfg.useSTARTTLS}
         #Debug=YES
-        ${if cfg.authUser != "" then "AuthUser=${cfg.authUser}" else ""}
-        ${if cfg.authPass != "" then "AuthPass=${cfg.authPass}" else ""}
+        ${optionalString (cfg.authUser != "")       "AuthUser=${cfg.authUser}"}
+        ${optionalString (!isNull cfg.authPassFile) "AuthPassFile=${cfg.authPassFile}"}
       '';
 
     environment.systemPackages = [pkgs.ssmtp];
-    
+
     services.mail.sendmailSetuidWrapper = mkIf cfg.setSendmail {
       program = "sendmail";
       source = "${pkgs.ssmtp}/bin/sendmail";

--- a/nixos/modules/programs/ssmtp.nix
+++ b/nixos/modules/programs/ssmtp.nix
@@ -39,7 +39,8 @@ in
         example = "mail.example.org";
         description = ''
           The host name of the default mail server to use to deliver
-          e-mail.
+          e-mail. Can also contain a port number (ex: mail.example.org:587),
+          defaults to port 25 if no port is given.
         '';
       };
 
@@ -106,7 +107,8 @@ in
         default = null;
         example = "/run/keys/ssmtp-authpass";
         description = ''
-          Path to a file that contains the password used for SMTP auth.
+          Path to a file that contains the password used for SMTP auth. The file
+          should not contain a trailing newline, if the password does not contain one.
           This file should be readable by the users that need to execute ssmtp.
 
           <option>authPassFile</option> takes precedence over <option>authPass</option>.

--- a/pkgs/tools/networking/ssmtp/default.nix
+++ b/pkgs/tools/networking/ssmtp/default.nix
@@ -10,6 +10,10 @@ stdenv.mkDerivation {
     sha256 = "0dps8s87ag4g3jr6dk88hs9zl46h3790marc5c2qw7l71k4pvhr2";
   };
 
+  # A request has been made to merge this patch into ssmtp.
+  # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=858781
+  patches = [ ./ssmtp_support_AuthPassFile_parameter.patch ];
+
   configureFlags = "--sysconfdir=/etc ${if tlsSupport then "--enable-ssl" else ""}";
 
   postConfigure =
@@ -27,7 +31,8 @@ stdenv.mkDerivation {
   
   buildInputs = stdenv.lib.optional tlsSupport openssl;
 
-  meta = {
-    platforms = stdenv.lib.platforms.linux;
+  meta = with stdenv.lib; {
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ basvandijk ];
   };
 }

--- a/pkgs/tools/networking/ssmtp/ssmtp_support_AuthPassFile_parameter.patch
+++ b/pkgs/tools/networking/ssmtp/ssmtp_support_AuthPassFile_parameter.patch
@@ -1,0 +1,69 @@
+diff -Naurb a/ssmtp.c b/ssmtp.c
+--- a/ssmtp.c	2009-11-23 10:55:11.000000000 +0100
++++ b/ssmtp.c	2017-03-25 03:00:26.508283016 +0100
+@@ -57,6 +57,7 @@
+ char arpadate[ARPADATE_LENGTH];
+ char *auth_user = (char)NULL;
+ char *auth_pass = (char)NULL;
++char *auth_passfile = (char)NULL;
+ char *auth_method = (char)NULL;		/* Mechanism for SMTP authentication */
+ char *mail_domain = (char)NULL;
+ char *from = (char)NULL;		/* Use this as the From: address */
+@@ -1053,6 +1054,15 @@
+ 					log_event(LOG_INFO, "Set AuthPass=\"%s\"\n", auth_pass);
+ 				}
+ 			}
++			else if(strcasecmp(p, "AuthPassFile") == 0 && !auth_passfile) {
++				if((auth_passfile = strdup(q)) == (char *)NULL) {
++					die("parse_config() -- strdup() failed");
++				}
++
++				if(log_level > 0) {
++					log_event(LOG_INFO, "Set AuthPassFile=\"%s\"\n", auth_passfile);
++				}
++			}
+ 			else if(strcasecmp(p, "AuthMethod") == 0 && !auth_method) {
+ 				if((auth_method = strdup(q)) == (char *)NULL) {
+ 					die("parse_config() -- strdup() failed");
+@@ -1415,6 +1425,8 @@
+ 	struct passwd *pw;
+ 	int i, sock;
+ 	uid_t uid;
++	FILE *fp;
++	char pass_buf[BUF_SZ+1];
+ 	bool_t minus_v_save, leadingdot, linestart = True;
+ 	int timeout = 0;
+ 	int bufsize = sizeof(b)-1;
+@@ -1433,6 +1445,17 @@
+ 		log_event(LOG_INFO, "%s not found", config_file);
+ 	}
+ 
++	if(auth_passfile != (char *)NULL) {
++		if((fp = fopen(auth_passfile, "r")) == (FILE *)NULL) {
++			  die("Could not open the AuthPassFile %s", auth_passfile);
++		}
++		if (fgets(pass_buf, BUF_SZ, fp) == NULL) {
++			die("Error while reading a line from the AuthPassFile %s, or it is empty", auth_passfile);
++		}
++		fclose(fp);
++		auth_pass = strdup(pass_buf);
++	}
++
+ 	if((p = strtok(pw->pw_gecos, ";,"))) {
+ 		if((gecos = strdup(p)) == (char *)NULL) {
+ 			die("ssmtp() -- strdup() failed");
+diff -Naurb a/ssmtp.conf.5 b/ssmtp.conf.5
+--- a/ssmtp.conf.5	2008-02-29 03:50:15.000000000 +0100
++++ b/ssmtp.conf.5	2017-03-25 01:45:52.890165426 +0100
+@@ -61,6 +61,11 @@
+ .Pp
+ .It Cm AuthPass
+ The password to use for SMTP AUTH.
++It is recommended to use AuthPassFile which also takes precedence over AuthPass.
++.Pp
++.It Cm AuthPassFile
++A file that should contain the password to use for SMTP AUTH.
++This takes precedence over AuthPass.
+ .Pp
+ .It Cm AuthMethod
+ The authorization method to use.


### PR DESCRIPTION
This gives users the option of storing the smtp password outside the world-readable Nix store.

This is part of: https://github.com/NixOS/nixpkgs/issues/24288.

I tested this by configuring ssmtp to send mail via my mandrill account:

```nix
{
  networking.defaultMailServer = {
    directDelivery = true;
    root           = "xxx";
    authUser       = "xxx";
    authPassFile   = "xxx"; # I also tested it with: authPass = "xxx";
    hostName       = "smtp.mandrillapp.com";
    useSTARTTLS    = true;
  };
}
```

and then sending some mail.

I also tested it by setting `authPassFile` to a non-existing file or a file with too restrictive permissions. In those cases the correct error message is printed:

> sendmail: Could not open the AuthPassFile xxx

Setting `authPassFile` to an empty file correctly produces the following error message:

> sendmail: Error while reading a line from the AuthPassFile xxx, or it is empty
