### PR TITLE
manticore: fix compiling pml sources

### DIFF
--- a/pkgs/development/compilers/manticore/default.nix
+++ b/pkgs/development/compilers/manticore/default.nix
@@ -21,7 +21,19 @@ in stdenv.mkDerivation rec {
 
   autoreconfFlags = "-Iconfig -vfi";
 
-  postPatch = "patchShebangs .";
+  unpackPhase = ''
+    mkdir -p $out
+    cd $out
+    unpackFile $src
+    mv manticore_temp_mirror-${rev}-src repo_checkout
+    cd repo_checkout
+    chmod u+w . -R
+  ''; 
+  
+  postPatch = ''
+    patchShebangs .
+    substituteInPlace configure.ac --replace 'MANTICORE_ROOT=`pwd`' 'MANTICORE_ROOT=$out/repo_checkout'
+  '';
 
   preInstall = "mkdir -p $out/bin";
 


### PR DESCRIPTION
Compiler depends on sources that weren't present in the output.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

