### PR TITLE
NixOS Manual: Update version numbers

### DIFF
--- a/nixos/doc/manual/development/sources.xml
+++ b/nixos/doc/manual/development/sources.xml
@@ -27,8 +27,8 @@ a subdirectory of the Nixpkgs repository.) The remote
 <literal>channels</literal> refers to a read-only repository that
 tracks the Nixpkgs/NixOS channels (see <xref linkend="sec-upgrading"/>
 for more information about channels). Thus, the Git branch
-<literal>channels/nixos-14.12</literal> will contain the latest built
-and tested version available in the <literal>nixos-14.12</literal>
+<literal>channels/nixos-17.03</literal> will contain the latest built
+and tested version available in the <literal>nixos-17.03</literal>
 channel.</para>
 
 <para>It’s often inconvenient to develop directly on the master
@@ -39,9 +39,9 @@ branch based on your current NixOS version:
 
 <screen>
 $ nixos-version
-14.04.273.ea1952b (Baboon)
+17.09pre104379.6e0b727 (Hummingbird)
 
-$ git checkout -b local ea1952b
+$ git checkout -b local e3938c8
 </screen>
 
 Or, to base your local branch on the latest version available in a
@@ -49,17 +49,17 @@ NixOS channel:
 
 <screen>
 $ git remote update channels
-$ git checkout -b local channels/nixos-14.12
+$ git checkout -b local channels/nixos-17.03
 </screen>
 
-(Replace <literal>nixos-14.12</literal> with the name of the channel
+(Replace <literal>nixos-17.03</literal> with the name of the channel
 you want to use.) You can use <command>git merge</command> or
 <command>git rebase</command> to keep your local branch in sync with
 the channel, e.g.
 
 <screen>
 $ git remote update channels
-$ git merge channels/nixos-14.12
+$ git merge channels/nixos-17.03
 </screen>
 
 You can use <command>git cherry-pick</command> to copy commits from

--- a/nixos/doc/manual/installation/upgrading.xml
+++ b/nixos/doc/manual/installation/upgrading.xml
@@ -15,12 +15,12 @@ been built.  These channels are:
 <itemizedlist>
   <listitem>
     <para><emphasis>Stable channels</emphasis>, such as <literal
-    xlink:href="https://nixos.org/channels/nixos-14.12">nixos-14.12</literal>.
+    xlink:href="https://nixos.org/channels/nixos-17.03">nixos-17.03</literal>.
     These only get conservative bug fixes and package upgrades.  For
     instance, a channel update may cause the Linux kernel on your
-    system to be upgraded from 3.4.66 to 3.4.67 (a minor bug fix), but
-    not from 3.4.<replaceable>x</replaceable> to
-    3.11.<replaceable>x</replaceable> (a major change that has the
+    system to be upgraded from 4.9.16 to 4.9.17 (a minor bug fix), but
+    not from 4.9.<replaceable>x</replaceable> to
+    4.11.<replaceable>x</replaceable> (a major change that has the
     potential to break things).  Stable channels are generally
     maintained until the next stable branch is created.</para>
     <para></para>
@@ -34,7 +34,7 @@ been built.  These channels are:
   </listitem>
   <listitem>
     <para><emphasis>Small channels</emphasis>, such as <literal
-    xlink:href="https://nixos.org/channels/nixos-14.12-small">nixos-14.12-small</literal>
+    xlink:href="https://nixos.org/channels/nixos-17.03-small">nixos-17.03-small</literal>
     or <literal
     xlink:href="https://nixos.org/channels/nixos-unstable-small">nixos-unstable-small</literal>. These
     are identical to the stable and unstable channels described above,
@@ -55,8 +55,8 @@ appliances.)</para>
 
 <para>When you first install NixOS, you’re automatically subscribed to
 the NixOS channel that corresponds to your installation source.   For
-instance, if you installed from a 14.12 ISO, you will be subscribed to
-the <literal>nixos-14.12</literal> channel.  To see which NixOS
+instance, if you installed from a 17.03 ISO, you will be subscribed to
+the <literal>nixos-17.03</literal> channel.  To see which NixOS
 channel you’re subscribed to, run the following as root:
 
 <screen>
@@ -71,16 +71,16 @@ To switch to a different NixOS channel, do
 </screen>
 
 (Be sure to include the <literal>nixos</literal> parameter at the
-end.)  For instance, to use the NixOS 14.12 stable channel:
+end.)  For instance, to use the NixOS 17.03 stable channel:
 
 <screen>
-# nix-channel --add https://nixos.org/channels/nixos-14.12 nixos
+# nix-channel --add https://nixos.org/channels/nixos-17.03 nixos
 </screen>
 
 If you have a server, you may want to use the “small” channel instead:
 
 <screen>
-# nix-channel --add https://nixos.org/channels/nixos-14.12-small nixos
+# nix-channel --add https://nixos.org/channels/nixos-17.03-small nixos
 </screen>
 
 And if you want to live on the bleeding edge:
@@ -130,7 +130,7 @@ runs, see <command>systemctl list-timers</command>.)  You can also
 specify a channel explicitly, e.g.
 
 <programlisting>
-system.autoUpgrade.channel = https://nixos.org/channels/nixos-15.09;
+system.autoUpgrade.channel = https://nixos.org/channels/nixos-17.03;
 </programlisting>
 
 </para>


### PR DESCRIPTION
###### Motivation for this change
Using old version numbers in the manual makes the whole documentation looking outdated.

---

