### PR TITLE
current rustRegistry doesn't have the clap 2.22.1

### DIFF
--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,9 +7,9 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2017-03-22";
-  rev = "2458be6157706b6c92e37baa19703c15d89f6b3a";
-  sha256 = "19ij0fqy5j4lz73w4p29wv4gsxhs345ajxm4bxpq6gx2h4x6qk06";
+  version = "2017-03-26";
+  rev = "ecfb98716ea731f30a869166f00194d58e1e5ab4";
+  sha256 = "1ya8ivlcmnyyakdw3h9j9andqpy7f9vncbv1k2kfdkvsjg9kg53m";
 
   src = fetchFromGitHub {
       inherit rev;


### PR DESCRIPTION
update rustRegistry

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

