### PR TITLE
qt58: extend darwin compatibility

### DIFF
--- a/pkgs/development/libraries/qt-5/5.8/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/default.nix
@@ -76,6 +76,7 @@ let
       qtgraphicaleffects = callPackage ./qtgraphicaleffects.nix {};
       qtimageformats = callPackage ./qtimageformats.nix {};
       qtlocation = callPackage ./qtlocation.nix {};
+      qtmacextras = callPackage ./qtmacextras.nix {};
       qtmultimedia = callPackage ./qtmultimedia.nix {
         inherit gstreamer gst-plugins-base;
       };
@@ -97,12 +98,13 @@ let
       qtxmlpatterns = callPackage ./qtxmlpatterns.nix {};
 
       env = callPackage ../qt-env.nix {};
-      full = env "qt-${qtbase.version}" [
+      full = env "qt-${qtbase.version}" ([
         qtconnectivity qtdeclarative qtdoc qtgraphicaleffects
         qtimageformats qtlocation qtmultimedia qtquickcontrols qtscript
-        qtsensors qtserialport qtsvg qttools qttranslations qtwayland
+        qtsensors qtserialport qtsvg qttools qttranslations
         qtwebsockets qtx11extras qtxmlpatterns
-      ];
+      ] ++ optional (!stdenv.isDarwin) qtwayland
+        ++ optional (stdenv.isDarwin) qtmacextras);
 
       makeQtWrapper =
         makeSetupHook

--- a/pkgs/development/libraries/qt-5/5.8/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/default.nix
@@ -211,8 +211,10 @@ stdenv.mkDerivation {
     libX11 libXcomposite libXext libXi libXrender libxcb libxkbcommon xcbutil
     xcbutilimage xcbutilkeysyms xcbutilrenderutil xcbutilwm
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-    ApplicationServices Foundation CoreServices AppKit Carbon OpenGL AGL Cocoa
-    DiskArbitration darwin.cf-private libiconv
+    AGL AppKit ApplicationServices Carbon Cocoa
+    CoreAudio CoreBluetooth CoreLocation CoreServices
+    DiskArbitration Foundation OpenGL
+    darwin.cf-private darwin.apple_sdk.sdk darwin.libobjc libiconv
   ]);
 
   buildInputs = [ ]

--- a/pkgs/development/libraries/qt-5/5.8/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtdeclarative/default.nix
@@ -1,8 +1,18 @@
-{ qtSubmodule, lib, copyPathsToStore, python2, qtbase, qtsvg, qtxmlpatterns }:
+{ stdenv, qtSubmodule, makeQtWrapper, copyPathsToStore, python2, qtbase, qtsvg, qtxmlpatterns }:
+
+with stdenv.lib;
 
 qtSubmodule {
   name = "qtdeclarative";
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = copyPathsToStore (readPathsFromFile ./. ./series);
   qtInputs = [ qtbase qtsvg qtxmlpatterns ];
-  nativeBuildInputs = [ python2 ];
+  nativeBuildInputs = [ python2 makeQtWrapper ];
+
+  postInstall = ''
+    wrapQtProgram $out/bin/qmleasing
+    wrapQtProgram $out/bin/qmlscene
+    wrapQtProgram $out/bin/qmltestrunner
+  '' + optionalString (stdenv.isDarwin) ''
+    wrapQtProgram $out/bin/qml.app/Contents/MacOS/qml
+  '';
 }

--- a/pkgs/development/libraries/qt-5/5.8/qtmacextras.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtmacextras.nix
@@ -1,0 +1,10 @@
+{ qtSubmodule, qtbase, lib }:
+
+qtSubmodule {
+  name = "qtmacextras";
+  qtInputs = [ qtbase ];
+  meta = with lib; {
+    maintainers = with maintainers; [ periklis ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/development/libraries/qt-5/5.8/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtmultimedia.nix
@@ -1,12 +1,15 @@
-{ qtSubmodule, qtbase, qtdeclarative, pkgconfig
+{ stdenv, qtSubmodule, qtbase, qtdeclarative, pkgconfig
 , alsaLib, gstreamer, gst-plugins-base, libpulseaudio
+, darwin
 }:
+
+with stdenv.lib;
 
 qtSubmodule {
   name = "qtmultimedia";
   qtInputs = [ qtbase qtdeclarative ];
-  buildInputs = [
-    pkgconfig alsaLib gstreamer gst-plugins-base libpulseaudio
-  ];
+  buildInputs = [ pkgconfig gstreamer gst-plugins-base libpulseaudio]
+    ++ optional (stdenv.isLinux) alsaLib;
   qmakeFlags = [ "GST_VERSION=1.0" ];
+  NIX_LDFLAGS = optionalString (stdenv.isDarwin) "-lobjc";
 }

--- a/pkgs/development/libraries/qt-5/5.8/qtsensors.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtsensors.nix
@@ -1,4 +1,6 @@
-{ qtSubmodule, qtbase, qtdeclarative }:
+{ stdenv, qtSubmodule, qtbase, qtdeclarative }:
+
+with stdenv.lib;
 
 qtSubmodule {
   name = "qtsensors";

--- a/pkgs/development/libraries/qt-5/5.8/qtserialport/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtserialport/default.nix
@@ -1,9 +1,11 @@
-{ qtSubmodule, qtbase, substituteAll, systemd }:
+{ stdenv, qtSubmodule, qtbase, substituteAll, systemd }:
+
+with stdenv.lib;
 
 qtSubmodule {
   name = "qtserialport";
   qtInputs = [ qtbase ];
-  patches = [
+  patches = optionals (stdenv.isLinux) [
     (substituteAll {
       src = ./0001-dlopen-serialport-udev.patch;
       libudev = systemd.lib;

--- a/pkgs/development/libraries/qt-5/5.8/qttools/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qttools/default.nix
@@ -1,11 +1,28 @@
-{ qtSubmodule, lib, copyPathsToStore, qtbase }:
+{ stdenv, qtSubmodule, makeQtWrapper, copyPathsToStore, qtbase }:
+
+with stdenv.lib;
 
 qtSubmodule {
   name = "qttools";
   qtInputs = [ qtbase ];
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  nativeBuildInputs = [ makeQtWrapper ];
+
+  patches = copyPathsToStore (readPathsFromFile ./. ./series);
   postFixup = ''
     moveToOutput "bin/qdbus" "$out"
     moveToOutput "bin/qtpaths" "$out"
+  '';
+
+  postInstall =   ''
+    wrapQtProgram $out/bin/qcollectiongenerator
+    wrapQtProgram $out/bin/qhelpconverter
+    wrapQtProgram $out/bin/qhelpgenerator
+    wrapQtProgram $out/bin/qtdiag
+  '' + optionalString (stdenv.isDarwin) ''
+    wrapQtProgram $out/bin/Assistant.app/Contents/MacOS/Assistant
+    wrapQtProgram $out/bin/Designer.app/Contents/MacOS/Designer
+    wrapQtProgram $out/bin/Linguist.app/Contents/MacOS/Linguist
+    wrapQtProgram $out/bin/pixeltool.app/Contents/MacOS/pixeltool
+    wrapQtProgram $out/bin/qdbusviewer.app/Contents/MacOS/qdbusviewer
   '';
 }

--- a/pkgs/development/libraries/qt-5/5.8/qtwebkit/0004-icucore-darwin.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qtwebkit/0004-icucore-darwin.patch
@@ -1,0 +1,11 @@
+--- qtwebkit-opensource-src-5.8.0.orig/Source/WTF/WTF.pri
++++ qtwebkit-opensource-src-5.8.0/Source/WTF/WTF.pri
+@@ -12,7 +12,7 @@
+     # Mac OS does ship libicu but not the associated header files.
+     # Therefore WebKit provides adequate header files.
+     INCLUDEPATH = $${ROOT_WEBKIT_DIR}/Source/WTF/icu $$INCLUDEPATH
+-    LIBS += -licucore
++    LIBS += /usr/lib/libicucore.dylib
+ } else:!use?(wchar_unicode): {
+     win32 {
+         CONFIG(static, static|shared) {


### PR DESCRIPTION
###### Motivation for this change
Enable failing QT-Modules for building `qt58.full` for `x86_64-darwin`:
- [x]  QTConnectivity
- [x]  QTLocation
- [x]  QTMultimedia
- [x]  QTSensors
~~- [ ]  QTWebEngine~~
~~- [ ]  QTWebKit~~

Wrap failing QT-Apps:
- [x] QTTools: `Assistant.app, Designer.app, Linguist.app, pixeltool.app, qdbusviewer.app, qml.app`
- [x] QTDeclarative: `qmleasing, qmlscene, qmltestrunner`

Enable darwin-specific QT-Modules:
- [x] QTMacextras

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

