### PR TITLE
libguestfs: add qemu to wrapped PATH

### DIFF
--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     for bin in $out/bin/*; do
       wrapProgram "$bin" \
-        --prefix "PATH" : "$out/bin:${hivex}/bin" \
+        --prefix "PATH" : "$out/bin:${hivex}/bin:${qemu}/bin" \
         --prefix "PERL5LIB" : "$PERL5LIB:$out/lib/perl5/site_perl"
     done
   '';


### PR DESCRIPTION
virt-df doesn't find qemu-img otherwise.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

