### PR TITLE
vim-utils: Handle overriding knownPlugins betters.

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -412,11 +412,16 @@ rec {
   } // a);
 
   requiredPlugins = {
-    knownPlugins ? vimPlugins,
+    givenKnownPlugins ? null,
     vam ? null,
     pathogen ? null, ...
   }:
     let
+      # This is probably overcomplicated, but I don't understand this well enough to know what's necessary.
+      knownPlugins = if givenKnownPlugins != null then givenKnownPlugins else
+                     if vam != null && vam ? knownPlugins then vam.knownPlugins else
+                     if pathogen != null && pathogen ? knownPlugins then pathogen.knownPlugins else
+                     vimPlugins;
       pathogenNames = map (name: knownPlugins.${name}) (findDependenciesRecursively { inherit knownPlugins; names = pathogen.pluginNames; });
       vamNames = findDependenciesRecursively { inherit knownPlugins; names = lib.concatMap toNames vam.pluginDictionaries; };
       names = (lib.optionals (pathogen != null) pathogenNames) ++


### PR DESCRIPTION
###### Motivation for this change

#24328 

In #23256 I added some niceties to handle vim plugins that depend on python packages; I didn't get it quite right.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

