### PR TITLE
groovy: 2.4.8 -> 2.4.10

### DIFF
--- a/pkgs/development/interpreters/groovy/default.nix
+++ b/pkgs/development/interpreters/groovy/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "groovy-${version}";
-  version = "2.4.8";
+  version = "2.4.10";
 
   src = fetchurl {
     url = "http://dl.bintray.com/groovy/maven/apache-groovy-binary-${version}.zip";
-    sha256 = "1zcdkarz9mbx9k5sl69nbphjjcy0xd15zjicjnhp2wq32zm6b2k6";
+    sha256 = "1a8pqcrm014h4x54gqqyxp7r1vkwhphqwrfa7gnqr6nzdqxzyk8w";
   };
 
   buildInputs = [ unzip makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Package bump

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Pinging @pSub as maintainer of this package.