### PR TITLE
libcxx-4: add pthread_mach_thread_np patch

### DIFF
--- a/pkgs/development/compilers/llvm/4/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/4/libc++/default.nix
@@ -10,22 +10,27 @@ stdenv.mkDerivation rec {
     export LIBCXXABI_INCLUDE_DIR="$PWD/$(ls -d libcxxabi-${version}*)/include"
   '';
 
+  # https://github.com/llvm-mirror/libcxx/commit/bcc92d75df0274b9593ebd097fcae60494e3bffc
+  patches = [ ./pthread_mach_thread_np.patch ];
+
+  prePatch = ''
+    substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"
+  '';
+
   preConfigure = ''
     # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
     cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$LIBCXXABI_INCLUDE_DIR")
   '';
 
-  patchPhase = ''
-    substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"
-  '';
+  nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ cmake libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  buildInputs = [ libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   cmakeFlags = [
-      "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
-      "-DLIBCXX_LIBCPPABI_VERSION=2"
-      "-DLIBCXX_CXX_ABI=libcxxabi"
-    ];
+    "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
+    "-DLIBCXX_LIBCPPABI_VERSION=2"
+    "-DLIBCXX_CXX_ABI=libcxxabi"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/4/libc++/pthread_mach_thread_np.patch
+++ b/pkgs/development/compilers/llvm/4/libc++/pthread_mach_thread_np.patch
@@ -1,0 +1,41 @@
+From bcc92d75df0274b9593ebd097fcae60494e3bffc Mon Sep 17 00:00:00 2001
+From: Asiri Rathnayake <asiri.rathnayake@arm.com>
+Date: Thu, 26 Jan 2017 10:40:17 +0000
+Subject: [PATCH] Fix chromium build (libcxx)
+
+Remove the reference to pthread_mach_thread_np() in libcxx headers.
+
+git-svn-id: https://llvm.org/svn/llvm-project/libcxx/trunk@293167 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ include/__threading_support | 11 -----------
+ 1 file changed, 11 deletions(-)
+
+diff --git a/include/__threading_support b/include/__threading_support
+index 13ab769..dfe7fe1 100644
+--- a/include/__threading_support
++++ b/include/__threading_support
+@@ -149,11 +149,6 @@ int __libcpp_execute_once(__libcpp_exec_once_flag *flag,
+                           void (*init_routine)(void));
+ 
+ // Thread id
+-#if defined(__APPLE__) && !defined(__arm__)
+-_LIBCPP_THREAD_ABI_VISIBILITY
+-mach_port_t __libcpp_thread_get_port();
+-#endif
+-
+ _LIBCPP_THREAD_ABI_VISIBILITY
+ bool __libcpp_thread_id_equal(__libcpp_thread_id t1, __libcpp_thread_id t2);
+ 
+@@ -297,12 +292,6 @@ int __libcpp_execute_once(__libcpp_exec_once_flag *flag,
+ }
+ 
+ // Thread id
+-#if defined(__APPLE__) && !defined(__arm__)
+-mach_port_t __libcpp_thread_get_port() {
+-    return pthread_mach_thread_np(pthread_self());
+-}
+-#endif
+-
+ // Returns non-zero if the thread ids are equal, otherwise 0
+ bool __libcpp_thread_id_equal(__libcpp_thread_id t1, __libcpp_thread_id t2)
+ {


### PR DESCRIPTION
###### Motivation for this change

Removes reference to pthread_mach_thread_np() in libcxx headers, fixes one of the build issues of `nix` when using an llvm-4 based stdenv.

/cc @copumpkin

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
