### PR TITLE
spark: activate R backend

### DIFF
--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchzip, makeWrapper, jre, pythonPackages
+, RSupport? true, R
 , mesosSupport ? true, mesos
 , version
 }:
@@ -30,6 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ makeWrapper jre pythonPackages.python pythonPackages.numpy ]
+    ++ optional RSupport R
     ++ optional mesosSupport mesos;
 
   untarDir = "${name}-bin-${hadoopVersion}";
@@ -46,6 +48,9 @@ stdenv.mkDerivation rec {
     export SPARK_HOME="$out/lib/${untarDir}"
     export PYSPARK_PYTHON="${pythonPackages.python}/bin/${pythonPackages.python.executable}"
     export PYTHONPATH="\$PYTHONPATH:$PYTHONPATH"
+    ${optionalString RSupport
+      ''export SPARKR_R_SHELL="${R}/bin/R"
+        export PATH=$PATH:"${R}/bin/R"''}
     ${optionalString mesosSupport
       ''export MESOS_NATIVE_LIBRARY="$MESOS_NATIVE_LIBRARY"''}
     EOF
@@ -57,7 +62,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description      = "Lightning-fast cluster computing";
+    description      = "Apache Spark is a fast and general engine for large-scale data processing";
     homepage         = "http://spark.apache.org";
     license          = stdenv.lib.licenses.asl20;
     platforms        = stdenv.lib.platforms.all;


### PR DESCRIPTION
###### Motivation for this change
Spark can use R for data processing. So far this didn't work as the required variables weren't set.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

