### PR TITLE
radeon-profile: init at 20161221

### DIFF
--- a/pkgs/tools/misc/radeon-profile/default.nix
+++ b/pkgs/tools/misc/radeon-profile/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, qtbase, qmakeHook, makeQtWrapper, libXrandr }:
+
+stdenv.mkDerivation rec {
+
+  name = "radeon-profile-${version}";
+  version = "20161221";
+
+  nativeBuildInputs = [ qmakeHook makeQtWrapper ];
+  buildInputs = [ qtbase libXrandr ];
+
+  src = (fetchFromGitHub {
+    owner  = "marazmista";
+    repo   = "radeon-profile";
+    rev    = version;
+    sha256 = "0zdmpc0rx6i0y32dcbz02whp95hpbmmbkmcp39f00byvjm5cprgg";
+  }) + "/radeon-profile";
+
+  postInstall = ''
+    mkdir -p $out/bin
+    cp ./radeon-profile $out/bin/radeon-profile
+    wrapQtProgram  $out/bin/radeon-profile
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Application to read current clocks of AMD Radeon cards";
+    homepage    = https://github.com/marazmista/radeon-profile;
+    license     = licenses.gpl2Plus;
+    platforms   = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3690,6 +3690,8 @@ with pkgs;
 
   radarr = callPackage ../servers/radarr { };
 
+  radeon-profile = libsForQt5.callPackage ../tools/misc/radeon-profile { };
+
   radvd = callPackage ../tools/networking/radvd { };
 
   rambox = callPackage ../applications/networking/instant-messengers/rambox { };


### PR DESCRIPTION
###### Motivation for this change
nixpkgs is missing a tool for controlling the GPU settings.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using (none)
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

