### PR TITLE
Shrink GCE bootstrap image to minimum size, and auto-expand it to actual size on first boot. 

### DIFF
--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -2,10 +2,10 @@
 
 with lib;
 let
-  diskSize = "100G";
+  diskSize = "1G";
 in
 {
-  imports = [ ../profiles/headless.nix ../profiles/qemu-guest.nix ];
+  imports = [ ../profiles/headless.nix ../profiles/qemu-guest.nix ./grow-partition.nix ];
 
   # https://cloud.google.com/compute/docs/tutorials/building-images
   networking.firewall.enable = mkDefault false;
@@ -94,7 +94,10 @@ in
         ''
     );
 
-  fileSystems."/".label = "nixos";
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    autoResize = true;
+  };
 
   boot.kernelParams = [ "console=ttyS0" "panic=1" "boot.panic_on_fail" ];
   boot.initrd.kernelModules = [ "virtio_scsi" ];


### PR DESCRIPTION
###### Motivation for this change
The standard nixops GCE image is outdated (16.03) and too big (100G). The latter means that nixops deployments can't make use of the free tier that GCP introduced this month, which gives 30GB disk space for free. See https://github.com/NixOS/nixops/issues/590
 
###### Things done
I used nixos/maintainers/scripts/gce/create-gce.sh to build an image. I brought it up on GCE to see whether it boots and root disk resizing works, and from my testing it does. I had to cherry-pick this into my build repository https://github.com/NixOS/nixpkgs/pull/24143 otherwise QEMU fails when building the image.

- [ ] Tested using sandboxing
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

