### PR TITLE
way-cooler: init at 0.5.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -316,6 +316,7 @@
   michalrus = "Michal Rus <m@michalrus.com>";
   michelk = "Michel Kuhlmann <michel@kuhlmanns.info>";
   mikefaille = "Michaël Faille <michael@faille.io>";
+  miltador = "Vasiliy Solovey <miltador@yandex.ua>";
   mimadrid = "Miguel Madrid <mimadrid@ucm.es>";
   mingchuan = "Ming Chuan <ming@culpring.com>";
   mirdhyn = "Merlin Gaillard <mirdhyn@gmail.com>";

--- a/pkgs/applications/window-managers/way-cooler/default.nix
+++ b/pkgs/applications/window-managers/way-cooler/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig
+, wayland, xwayland, wlc, dbus_libs, dbus_glib, cairo, libxkbcommon }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "way-cooler-${version}";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "way-cooler";
+    repo = "way-cooler";
+    rev = "v${version}";
+    sha256 = "10s01x54kwjm2c85v57i6g3pvj5w3wpkjblj036mmd865fla1brb";
+  };
+
+  depsSha256 = "1k5xbw2zhm5z650mxdbxixr90im53wlpjdvq2pbnx2snqm84idlc";
+
+  buildInputs = [ wlc dbus_libs dbus_glib cairo libxkbcommon ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  meta = with stdenv.lib; {
+    description = "Customizable Wayland compositor (window manager)";
+    longDescription = ''
+      Way Cooler is a customizable tiling window manager written in Rust
+      for Wayland and configurable using Lua. It is heavily inspired by
+      the tiling and extensibility of both i3 and awesome. While Lua is
+      used for the configuration, like awesome, extensions for Way Cooler
+      are implemented as totally separate client programs using D-Bus.
+      This means that you can use virtually any language to extend the
+      window manager, with much better guarantees about interoperability
+      between extensions.
+    '';
+    homepage = http://way-cooler.org/;
+    license = with licenses; [ mit ];
+    maintainers = [ maintainers.miltador ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15917,6 +15917,8 @@ with pkgs;
     imlib2 = imlib2-nox;
   };
 
+  way-cooler = callPackage ../applications/window-managers/way-cooler {};
+
   wayv = callPackage ../tools/X11/wayv {};
 
   weechat = callPackage ../applications/networking/irc/weechat {


### PR DESCRIPTION
###### Motivation for this change
nixpkgs is missing this new but promising window manager! 🥇 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

