### PR TITLE
lxqt-panel: fix for `explicit` (a C++11 keyword) being used as variable

### DIFF
--- a/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
@@ -1,5 +1,5 @@
 {
-  stdenv, fetchFromGitHub, standardPatch,
+  stdenv, fetchFromGitHub, fetchurl, standardPatch,
   cmake, pkgconfig, lxqt-build-tools,
   qtbase, qttools, qtx11extras, qtsvg, libdbusmenu, kwindowsystem, solid,
   kguiaddons, liblxqt, libqtxdg, lxqt-common, lxqt-globalkeys, libsysstat,
@@ -47,6 +47,13 @@ stdenv.mkDerivation rec {
     alsaLib
     menu-cache
     lxmenu-data
+  ];
+
+  patches = [
+    (fetchurl {
+       url = https://github.com/lxde/lxqt-panel/commit/ec62109e0fa678875a9b10fc6f1975267432712d.patch;
+       sha256 = "1ywwk8gb6gbvs8z9gwgsnb13z1jvyvjij349nq7ij6iyhyld0jlr";
+    })
   ];
 
   cmakeFlags = [ "-DPULL_TRANSLATIONS=NO" ];


### PR DESCRIPTION
It is needed to override "explicit" as this is a C++ keyword. But it
is used as variable name in xkb.h. This is causing a failure in C++
compile time.  Similar bug here:
https://bugs.freedesktop.org/show_bug.cgi?id=74080

Workaround from
https://github.com/lxde/lxqt-panel/commit/ec62109e0fa678875a9b10fc6f1975267432712d.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).