### PR TITLE
update skarnet.org packages

### DIFF
--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.3.9.0";
+  version = "2.4.0.1";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/skalibs";
     rev = "refs/tags/v${version}";
-    sha256 = "1x52mgf39yiijsj63x0ibp6d3nj0d4z9k9lisa4rzsxs7846za4a";
+    sha256 = "1sdzm2vd9mxlwxbmjajb6n1n13dpsavdap2nbbnyx4wnzixxx9k7";
   };
 
   dontDisableStatic = true;

--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.0.2.3";
+  version = "2.2.0.0";
 
 in stdenv.mkDerivation rec {
 
@@ -10,12 +10,13 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.skarnet.org/software/s6-linux-utils/${name}.tar.gz";
-    sha256 = "1hwc3dmqh4cyhx9b4gd48yvjrwmfkz968rncpqc511krpfwzyngr";
+    sha256 = "1y9mva7wk1ca2djq3qjh7hz756zk57yv7ljdnldn7k7jzfmlaxsq";
   };
 
   dontDisableStatic = true;
 
   configureFlags = [
+    "--enable-absolute-paths"
     "--includedir=\${prefix}/include"
     "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
     "--with-include=${skalibs}/include"

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.1.4.5";
+  version = "2.2.0.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/execline";
     rev = "refs/tags/v${version}";
-    sha256 = "01hfh2gmap3qd9qc5ncp1sxagrsi8q6cdjxxspwpmrc4d4cmzcr0";
+    sha256 = "1795n6s0sp9hw8amx2hs9r395gv4c5sn63g077g1gal1vcpkcssn";
   };
 
   dontDisableStatic = true;
@@ -19,6 +19,7 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   configureFlags = [
+    "--enable-absolute-paths"
     "--libdir=\${prefix}/lib"
     "--includedir=\${prefix}/include"
     "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, skalibs, gcc }:
+{ stdenv, fetchurl, skalibs, gcc }:
 
 with stdenv.lib;
 
@@ -6,11 +6,9 @@ stdenv.mkDerivation rec {
   name = "s6-portable-utils-${version}";
   version = "2.1.0.0";
 
-  src = fetchFromGitHub {
-    owner = "skarnet";
-    repo = "s6-portable-utils";
-    rev = "v${version}";
-    sha256 = "0k5pcwc45jw5l8ycz03wx2w4pds0wp4ll47d3i5i1j02i9v0rhc9";
+  src = fetchurl {
+    url = "http://www.skarnet.org/software/s6-portable-utils/${name}.tar.gz";
+    sha256 = "0khw5ljmlghvl4hyrf4vd0hl5rrmsspchi8w4xgniwfip6vlbqfd";
   };
 
   dontDisableStatic = true;
@@ -19,6 +17,7 @@ stdenv.mkDerivation rec {
   ++ optional stdenv.isDarwin gcc;
 
   configureFlags = [
+    "--enable-absolute-paths"
     "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
     "--with-include=${skalibs}/include"
     "--with-lib=${skalibs}/lib"

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.0.0.7";
+  version = "2.1.0.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6-dns";
     rev = "refs/tags/v${version}";
-    sha256 = "1f9a4bjpsqhs9aq0zam74mj6zn1ffaljgp98hqj9j83d2jlvqpv5";
+    sha256 = "126ikznsw0hlk4mmf03yxzfnvcw823g5il1vfs3a5fa9q26xyc72";
   };
 
   dontDisableStatic = true;
@@ -19,6 +19,7 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   configureFlags = [
+    "--enable-absolute-paths"
     "--includedir=\${prefix}/include"
     "--libdir=\${prefix}/lib"
     "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.1.0.4";
+  version = "2.2.1.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6-networking";
     rev = "refs/tags/v${version}";
-    sha256 = "0rm0vpfshayhi5qwsvkgzdjmg43lvslp74h7lda964p72wr6gahg";
+    sha256 = "0msfssd42pdwch0z8rhrm7hd4ps9d730az92vg0pnz769xs8kjx0";
   };
 
   dontDisableStatic = true;
@@ -19,6 +19,7 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   configureFlags = [
+    "--enable-absolute-paths"
     "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
     "--with-include=${skalibs}/include"
     "--with-include=${execline}/include"

--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "0.0.2.1";
+  version = "0.1.0.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6-rc";
     rev = "refs/tags/v${version}";
-    sha256 = "1gh72q1h1ds53yrzp481nvzaxkhhpm2kv59pfx4x564gxwdvq3a6";
+    sha256 = "1izjss1vfmkrkbgpzxlh0krkd2zin9d77ykr6i08rhixz7c2am0r";
   };
 
   dontDisableStatic = true;
@@ -19,6 +19,7 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   configureFlags = [
+    "--enable-absolute-paths"
     "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
     "--with-include=${skalibs}/include"
     "--with-include=${execline}/include"

--- a/pkgs/tools/system/s6/default.nix
+++ b/pkgs/tools/system/s6/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.2.4.3";
+  version = "2.4.0.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6";
     rev = "refs/tags/v${version}";
-    sha256 = "1jlavi3q6wmcxdcwsy42qcgfkl0ag6hwcgmi4g67dvqs9nqjq2a3";
+    sha256 = "0yf9apl05g1gxqwh01yd1iyg0xm50ywnlwp4szd08sg0srmvys16";
   };
 
   dontDisableStatic = true;
@@ -19,6 +19,7 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   configureFlags = [
+    "--enable-absolute-paths"
     "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
     "--with-include=${skalibs}/include"
     "--with-include=${execline}/include"
@@ -29,11 +30,6 @@ in stdenv.mkDerivation rec {
   ]
   ++ (if stdenv.isDarwin then [ "--disable-shared" ] else [ "--enable-shared" ])
   ++ (stdenv.lib.optional stdenv.isDarwin "--target=${stdenv.system}");
-
-  preBuild = ''
-    substituteInPlace "src/daemontools-extras/s6-log.c" \
-      --replace '"execlineb"' '"${execline}/bin/execlineb"'
-  '';
 
   meta = {
     homepage = http://www.skarnet.org/software/s6/;


### PR DESCRIPTION
```
execline:          2.1.4.5 -> 2.2.0.0
s6-dns:            2.0.0.7 -> 2.1.0.0
s6-linux-utils:    2.0.2.3 -> 2.2.0.0
s6-networking:     2.1.0.4 -> 2.2.1.0
s6-portable-utils: 2.1.0.0 -> 2.1.0.0 (no version change)
s6-rc:             0.0.2.1 -> 0.1.0.0
s6:                2.2.4.3 -> 2.4.0.0
skalibs:           2.3.9.0 -> 2.4.0.1
```

Also use new --enable-absolute-paths configure arg to correctly set
paths to runtime executables to point within the nix store rather than
relying on PATH resolution.

###### Motivation for this change

Routine upgrade to latest versions. Also new configure arg to so packages internally reference executables via absolute path rather than PATH environment variable resolution (e.g. s6-log invokes execlineb).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

