### PR TITLE
shrikhand: init 2016-03-03

### DIFF
--- a/pkgs/data/fonts/shrikhand/default.nix
+++ b/pkgs/data/fonts/shrikhand/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  version = "2016-03-03";
+  name = "shrikhand-${version}";
+
+  src = fetchFromGitHub {
+    owner = "jonpinhorn";
+    repo = "shrikhand";
+    rev = "c11c9b0720fba977fad7cb4f339ebacdba1d1394";
+    sha256 = "1d21bvj4w8i0zrmkdrgbn0rpzac89iazfids1x273gsrsvvi45kk";
+  };
+
+  installPhase = ''
+    install -D -m644 build/Shrikhand-Regular.ttf $out/share/fonts/truetype/Shrikhand-Regular.ttf
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://jonpinhorn.github.io/shrikhand/;
+    description = "A vibrant and playful typeface for both Latin and Gujarati writing systems";
+    maintainers = with maintainers; [ sternenseemann ];
+    platforms = platforms.all;
+    license = licenses.ofl;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3897,6 +3897,8 @@ with pkgs;
 
   shellinabox = callPackage ../servers/shellinabox { };
 
+  shrikhand = callPackage ../data/fonts/shrikhand { };
+
   sic = callPackage ../applications/networking/irc/sic { };
 
   siege = callPackage ../tools/networking/siege {};


### PR DESCRIPTION
###### Motivation for this change

Shrikhand is a google font, but not part of the google fonts repository.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

