### PR TITLE
longview service: don't write passwords to nix store

### DIFF
--- a/pkgs/servers/monitoring/longview/default.nix
+++ b/pkgs/servers/monitoring/longview/default.nix
@@ -16,8 +16,13 @@ stdenv.mkDerivation rec {
     ./log-stdout.patch
   ];
 
+  # Read all configuration from /run/longview
   postPatch = ''
-    substituteInPlace Linode/Longview/Util.pm --replace /var/run/longview.pid /run/longview.pid
+    substituteInPlace Linode/Longview/Util.pm \
+        --replace /var/run/longview.pid /run/longview/longview.pid \
+        --replace /etc/linode /run/longview
+    substituteInPlace Linode/Longview.pl \
+        --replace /etc/linode /run/longview
   '';
 
   buildInputs = [ perl makeWrapper glibc ]


### PR DESCRIPTION
Adds `services.longview.{apiKeyFile,mysqlPasswordFile}` options as alternatives to `apiKey` and `mysqlPassword`, which still work, but are deprecated with a warning message.

Related to #24288.

###### Motivation for this change

Security.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

*Testing note*: This PR is rebased to master branch but I actually did the testing on nixos-unstable.
