### PR TITLE
dropbox-cli: include dropbox icon

### DIFF
--- a/pkgs/applications/networking/dropbox-cli/default.nix
+++ b/pkgs/applications/networking/dropbox-cli/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p "$out/bin/" "$out/share/applications"
     cp data/dropbox.desktop "$out/share/applications"
+    cp -a data/icons "$out/share/icons"
+    find "$out/share/icons" -type f \! -name '*.png' -delete
     substitute "dropbox.in" "$out/bin/dropbox" \
       --replace '@PACKAGE_VERSION@' ${version} \
       --replace '@DESKTOP_FILE_DIR@' "$out/share/applications" \


### PR DESCRIPTION
###### Motivation for this change
This makes the .desktop menu entry show up with a nice dropbox logo icon.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).