### PR TITLE
poco: init at 1.7.8

### DIFF
--- a/pkgs/development/libraries/poco/default.nix
+++ b/pkgs/development/libraries/poco/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, cmake, pkgconfig, zlib, pcre, expat, sqlite, openssl, unixODBC, libmysql }:
+
+stdenv.mkDerivation rec {
+  name = "poco-${version}";
+
+  version = "1.7.8";
+
+  src = fetchurl {
+    url = "https://pocoproject.org/releases/${name}/${name}-all.tar.gz";
+    sha256 = "17y6kvj4qdpb3p1im8n9qfylfh4bd2xsvbpn24jv97x7f146nhjf";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ zlib pcre expat sqlite openssl unixODBC libmysql ];
+
+  cmakeFlags = [
+    "-DMYSQL_INCLUDE_DIR=${libmysql.dev}/include/mysql"
+    "-DPOCO_UNBUNDLED=ON"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://pocoproject.org/;
+    description = "Cross-platform C++ libraries with a network/internet focus";
+    license = licenses.boost;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9320,6 +9320,8 @@ with pkgs;
 
   pocketsphinx = callPackage ../development/libraries/pocketsphinx { };
 
+  poco = callPackage ../development/libraries/poco { };
+
   podofo = callPackage ../development/libraries/podofo { lua5 = lua5_1; };
 
   poker-eval = callPackage ../development/libraries/poker-eval { };


### PR DESCRIPTION
###### Motivation for this change

This library is going to be a dependency of a new package.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
