### PR TITLE
bitcoin-unlimited: init at 1.0.1.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -135,6 +135,7 @@
   dgonyeo = "Derek Gonyeo <derek@gonyeo.com>";
   dipinhora = "Dipin Hora <dipinhora+github@gmail.com>";
   dmalikov = "Dmitry Malikov <malikov.d.y@gmail.com>";
+  DmitryTsygankov = "Dmitry Tsygankov <dmitry.tsygankov@gmail.com>";
   dmjio = "David Johnson <djohnson.m@gmail.com>";
   dochang = "Desmond O. Chang <dochang@gmail.com>";
   domenkozar = "Domen Kozar <domen@dev.si>";

--- a/pkgs/applications/altcoins/bitcoin-unlimited.nix
+++ b/pkgs/applications/altcoins/bitcoin-unlimited.nix
@@ -1,0 +1,60 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, openssl, db48, boost
+, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, libevent
+, withGui }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+
+  name = "bitcoin" + (toString (optional (!withGui) "d")) + "-unlimited-" + version;
+  version = "1.0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "bitcoinunlimited";
+    repo = "bitcoinunlimited";
+    rev = "${version}";
+    sha256 = "177l2jf2yqxh3sgf80dhgyk3wgjdnqszy3hb83clk8q1wyjkfz7y";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ openssl db48 boost zlib
+                  miniupnpc utillinux protobuf libevent ]
+                  ++ optionals withGui [ qt4 qrencode ];
+
+  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
+                     ++ optionals withGui [ "--with-gui=qt4" ];
+
+  meta = {
+    description = "Peer-to-peer electronic cash system (Unlimited client)";
+    longDescription= ''
+      Bitcoin is a free open source peer-to-peer electronic cash system that is
+      completely decentralized, without the need for a central server or trusted
+      parties. Users hold the crypto keys to their own money and transact directly
+      with each other, with the help of a P2P network to check for double-spending.
+      
+      The Bitcoin Unlimited (BU) project seeks to provide a voice to all
+      stakeholders in the Bitcoin ecosystem.
+
+      Every node operator or miner can currently choose their own blocksize limit
+      by modifying their client. Bitcoin Unlimited makes the process easier by
+      providing a configurable option for the accepted and generated blocksize via
+      a GUI menu. Bitcoin Unlimited further provides a user-configurable failsafe
+      setting allowing you to accept a block larger than your maximum accepted
+      blocksize if it reaches a certain number of blocks deep in the chain.
+
+      The Bitcoin Unlimited client is not a competitive block scaling proposal
+      like BIP-101, BIP-102, etc. Instead it tracks consensus. This means that it
+      tracks the blockchain that the hash power majority follows, irrespective of
+      blocksize, and signals its ability to accept larger blocks via protocol and
+      block versioning fields.
+
+      If you support an increase in the blocksize limit by any means - or just
+      support Bitcoin conflict resolution as originally envisioned by its founder -
+      consider running a Bitcoin Unlimited client.      
+    '';
+    homepage = https://www.bitcoinunlimited.info/;
+    maintainers = with maintainers; [ DmitryTsygankov ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -5,6 +5,9 @@ rec {
   bitcoin  = callPackage ./bitcoin.nix { withGui = true; };
   bitcoind = callPackage ./bitcoin.nix { withGui = false; };
 
+  bitcoin-unlimited  = callPackage ./bitcoin-unlimited.nix { withGui = true; };
+  bitcoind-unlimited = callPackage ./bitcoin-unlimited.nix { withGui = false; };
+
   bitcoin-classic  = callPackage ./bitcoin-classic.nix { withGui = true; };
   bitcoind-classic = callPackage ./bitcoin-classic.nix { withGui = false; };
 


### PR DESCRIPTION
Add the Bitcoin Unlimited client to the altcoins directory, so that all sides of the Bitcoin scaling debate are represented.

###### Motivation for this change

There is a scaling debate going on in Bitcoin. Bitcoin Core and Bitcoin Unlimited are the two most popular reference clients representing the two sides of the debate.
The currently less popular bitcoin-classic and bitcoin-xt are already in the package repository, it's time to add bitcoin-unlimited.
The bitcoin-unlimited package code is mostly a copy of bitcoin-classic, with appropriate modifications for the source repository, and version tags.
Was able to build and install the package on a NixOS machine, then run the GUI client & download the first few blocks of the blockchain.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

