### PR TITLE
haproxy: PCRE and LUA support via configurable options

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -181,6 +181,7 @@
   ftrvxmtrx = "Siarhei Zirukin <ftrvxmtrx@gmail.com>";
   funfunctor = "Edward O'Callaghan <eocallaghan@alterapraxis.com>";
   fuuzetsu = "Mateusz Kowalczyk <fuuzetsu@fuuzetsu.co.uk>";
+  fuzzy-id = "Thomas Bach <hacking+nixos@babibo.de>";
   fxfactorial = "Edgar Aroutiounian <edgar.factorial@gmail.com>";
   gal_bolle = "Florent Becker <florent.becker@ens-lyon.org>";
   garbas = "Rok Garbas <rok@garbas.si>";

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, pkgs, fetchurl, openssl, zlib }:
+{ useLua ? false
+, usePcre ? false
+, stdenv, fetchurl
+, openssl, zlib, lua ? null, pcre ? null
+}:
+
+assert useLua -> lua != null;
+assert usePcre -> pcre != null;
 
 stdenv.mkDerivation rec {
   pname = "haproxy";
@@ -12,7 +19,9 @@ stdenv.mkDerivation rec {
     sha256 = "ebb31550a5261091034f1b6ac7f4a8b9d79a8ce2a3ddcd7be5b5eb355c35ba65";
   };
 
-  buildInputs = [ openssl zlib ];
+  buildInputs = [ openssl zlib ]
+    ++ stdenv.lib.optional useLua lua
+    ++ stdenv.lib.optional usePcre pcre;
 
   # TODO: make it work on bsd as well
   makeFlags = [
@@ -25,6 +34,13 @@ stdenv.mkDerivation rec {
   buildFlags = [
     "USE_OPENSSL=yes"
     "USE_ZLIB=yes"
+  ] ++ stdenv.lib.optionals usePcre [
+    "USE_PCRE=yes"
+    "USE_PCRE_JIT=yes"
+  ] ++ stdenv.lib.optionals useLua [
+    "USE_LUA=yes"
+    "LUA_LIB=${lua}/lib"
+    "LUA_INC=${lua}/include"
   ] ++ stdenv.lib.optional stdenv.isDarwin "CC=cc";
 
   meta = {

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,10 +1,10 @@
-{ useLua ? false
-, usePcre ? false
+{ useLua ? !stdenv.isDarwin
+, usePcre ? true
 , stdenv, fetchurl
-, openssl, zlib, lua ? null, pcre ? null
+, openssl, zlib, lua5_3 ? null, pcre ? null
 }:
 
-assert useLua -> lua != null;
+assert useLua -> lua5_3 != null;
 assert usePcre -> pcre != null;
 
 stdenv.mkDerivation rec {
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ openssl zlib ]
-    ++ stdenv.lib.optional useLua lua
+    ++ stdenv.lib.optional useLua lua5_3
     ++ stdenv.lib.optional usePcre pcre;
 
   # TODO: make it work on bsd as well
@@ -39,8 +39,8 @@ stdenv.mkDerivation rec {
     "USE_PCRE_JIT=yes"
   ] ++ stdenv.lib.optionals useLua [
     "USE_LUA=yes"
-    "LUA_LIB=${lua}/lib"
-    "LUA_INC=${lua}/include"
+    "LUA_LIB=${lua5_3}/lib"
+    "LUA_INC=${lua5_3}/include"
   ] ++ stdenv.lib.optional stdenv.isDarwin "CC=cc";
 
   meta = {
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
       hardware.
     '';
     homepage = http://haproxy.1wt.eu;
-    maintainers = [ stdenv.lib.maintainers.garbas ];
+    maintainers = with stdenv.lib.maintainers; [ fuzzy-id garbas ];
     platforms = with stdenv.lib.platforms; linux ++ darwin;
     license = stdenv.lib.licenses.gpl2;
   };

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -15,9 +15,17 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl zlib ];
 
   # TODO: make it work on bsd as well
-  preConfigure = ''
-    export makeFlags="TARGET=${if stdenv.isSunOS then "solaris" else if stdenv.isLinux then "linux2628" else "generic"} PREFIX=$out USE_OPENSSL=yes USE_ZLIB=yes ${stdenv.lib.optionalString stdenv.isDarwin "CC=cc USE_KQUEUE=1"}"
-  '';
+  makeFlags = [
+    "PREFIX=\${out}"
+    ("TARGET=" + (if stdenv.isSunOS  then "solaris"
+             else if stdenv.isLinux  then "linux2628"
+             else if stdenv.isDarwin then "osx"
+             else "generic"))
+  ];
+  buildFlags = [
+    "USE_OPENSSL=yes"
+    "USE_ZLIB=yes"
+  ] ++ stdenv.lib.optional stdenv.isDarwin "CC=cc";
 
   meta = {
     description = "Reliable, high performance TCP/HTTP load balancer";


### PR DESCRIPTION
###### Motivation for this change

This solves #23806 and is a follow up to #23901 and #24248. PCRE and LUA support are added via configurable options. Both are enabled by default, apart from LUA on Darwin where compilation breaks.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

