### PR TITLE
vulkan-loader: demos: fix cube/cubepp

### DIFF
--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, fetchFromGitHub, cmake, pkgconfig, git, python3,
   python3Packages, glslang, spirv-tools, x11, libxcb, libXrandr,
-  libXext, wayland, mesa_noglu }:
+  libXext, wayland, mesa_noglu, makeWrapper }:
 
 let
   version = "1.0.39.1";
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   name = "vulkan-loader-${version}";
   inherit version src;
 
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ cmake pkgconfig git python3 python3Packages.lxml
                   glslang spirv-tools x11 libxcb libXrandr libXext wayland
                 ];
@@ -52,7 +53,10 @@ stdenv.mkDerivation rec {
     mkdir -p $demos/bin
     cp demos/*.spv demos/*.ppm $demos/bin
     find demos -type f -executable -not -name vulkaninfo -exec cp {} $demos/bin \;
-   '';
+    for p in cube cubepp; do
+      wrapProgram $demos/bin/$p --run "cd $demos/bin"
+    done
+  '';
 
   meta = with stdenv.lib; {
     description = "LunarG Vulkan loader";


### PR DESCRIPTION
###### Motivation for this change
Working dir needs to be at the binary location, otherwise some assets aren't found.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

