### PR TITLE
fsharp: init at 4.1.7

### DIFF
--- a/pkgs/development/compilers/fsharp41/default.nix
+++ b/pkgs/development/compilers/fsharp41/default.nix
@@ -1,0 +1,87 @@
+# Temporaririly avoid dependency on dotnetbuildhelpers to avoid rebuilding many times while working on it
+
+{ stdenv, fetchurl, pkgconfig, autoconf, automake, which, mono, dotnetbuildhelpers, dotnetPackages }:
+
+stdenv.mkDerivation rec {
+  name = "fsharp-${version}";
+  version = "4.1.7";
+
+  src = fetchurl {
+    url = "https://github.com/fsharp/fsharp/archive/${version}.tar.gz";
+    sha256 = "0rfkrk4mzi4w54mfqilvng9ar5swhmnwhsyjc54rx3fd0np3jiyl";
+  };
+
+  buildInputs = [
+    pkgconfig
+    autoconf
+    automake
+    which
+    mono
+    dotnetbuildhelpers
+    dotnetPackages.FsCheck262
+    dotnetPackages.FSharpCompilerTools
+    dotnetPackages.FSharpCore
+    dotnetPackages.FSharpData225
+    dotnetPackages.FsLexYacc704
+    dotnetPackages.MicrosoftDiaSymReader
+    dotnetPackages.MicrosoftDiaSymReaderPortablePdb
+    dotnetPackages.NUnit350
+    dotnetPackages.SystemCollectionsImmutable131
+    dotnetPackages.SystemReflectionMetadata
+    dotnetPackages.SystemValueTuple
+  ];
+
+  configurePhase = ''
+    substituteInPlace ./autogen.sh --replace "/usr/bin/env sh" "/bin/sh"
+    ./autogen.sh --prefix $out
+  '';
+
+  preBuild = ''
+    substituteInPlace Makefile --replace "MONO_ENV_OPTIONS=\$(monoopts) mono .nuget/NuGet.exe restore packages.config -PackagesDirectory packages -ConfigFile .nuget/NuGet.Config" "true"
+    substituteInPlace src/fsharp/Fsc-proto/Fsc-proto.fsproj --replace "<FSharpCoreOptSigFiles Include=\"\$(FSharpCoreLkgPath)\\FSharp.Core.dll\" />" ""
+    substituteInPlace src/fsharp/Fsc-proto/Fsc-proto.fsproj --replace "<FSharpCoreOptSigFiles Include=\"\$(FSharpCoreLkgPath)\\FSharp.Core.optdata\" />" ""
+    substituteInPlace src/fsharp/Fsc-proto/Fsc-proto.fsproj --replace "<FSharpCoreOptSigFiles Include=\"\$(FSharpCoreLkgPath)\\FSharp.Core.sigdata\" />" ""
+    substituteInPlace src/fsharp/Fsc-proto/Fsc-proto.fsproj --replace "<FSharpCoreOptSigFiles Include=\"\$(FSharpCoreLkgPath)\\FSharp.Core.xml\" />" ""
+
+    rm -rf packages
+    mkdir packages
+
+    ln -s ${dotnetPackages.FsCheck262}/lib/dotnet/FsCheck packages/FsCheck.2.6.2
+    ln -s ${dotnetPackages.FSharpCompilerTools}/lib/dotnet/FSharp.Compiler.Tools packages/FSharp.Compiler.Tools.4.1.4
+    ln -s ${dotnetPackages.FSharpCore}/lib/dotnet/FSharp.Core/ packages/FSharp.Core.4.0.0.1
+    ln -s ${dotnetPackages.FSharpData225}/lib/dotnet/FSharp.Data/ packages/FSharp.Data.2.2.5
+    ln -s ${dotnetPackages.FsLexYacc704}/lib/dotnet/FsLexYacc/ packages/FsLexYacc.7.0.4
+    ln -s ${dotnetPackages.MicrosoftDiaSymReader}/lib/dotnet/Microsoft.DiaSymReader/ packages/Microsoft.DiaSymReader.1.1.0
+    ln -s ${dotnetPackages.MicrosoftDiaSymReaderPortablePdb}/lib/dotnet/Microsoft.DiaSymReader.PortablePdb/ packages/Microsoft.DiaSymReader.PortablePdb.1.2.0
+    ln -s ${dotnetPackages.NUnit350}/lib/dotnet/NUnit/ packages/NUnit.3.5.0
+    ln -s ${dotnetPackages.SystemCollectionsImmutable131}/lib/dotnet/System.Collections.Immutable/ packages/System.Collections.Immutable.1.3.1
+    ln -s ${dotnetPackages.SystemReflectionMetadata}/lib/dotnet/System.Reflection.Metadata/ packages/System.Reflection.Metadata.1.4.2
+    ln -s ${dotnetPackages.SystemValueTuple}/lib/dotnet/System.ValueTuple/ packages/System.ValueTuple.4.3.0
+  '';
+
+  # Make sure the executables use the right mono binary,
+  # and set up some symlinks for backwards compatibility.
+  postInstall = ''
+    substituteInPlace $out/bin/fsharpc --replace " mono " " ${mono}/bin/mono "
+    substituteInPlace $out/bin/fsharpi --replace " mono " " ${mono}/bin/mono "
+    substituteInPlace $out/bin/fsharpiAnyCpu --replace " mono " " ${mono}/bin/mono "
+    ln -s $out/bin/fsharpc $out/bin/fsc
+    ln -s $out/bin/fsharpi $out/bin/fsi
+    for dll in "$out/lib/mono/fsharp"/FSharp*.dll
+    do
+      create-pkg-config-for-dll.sh "$out/lib/pkgconfig" "$dll"
+    done
+  '';
+
+  # To fix this error when running:
+  # The file "/nix/store/path/whatever.exe" is an not a valid CIL image
+  dontStrip = true;
+
+  meta = {
+    description = "A functional CLI language";
+    homepage = "http://fsharp.org/";
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [ thoughtpolice raskin ];
+    platforms = with stdenv.lib.platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5259,6 +5259,10 @@ with pkgs;
 
   fsharp = callPackage ../development/compilers/fsharp { };
 
+  fsharp41 = callPackage ../development/compilers/fsharp41 {
+    mono = mono46;
+  };
+
   fstar = callPackage ../development/compilers/fstar {
     ocamlPackages = ocaml-ng.ocamlPackages_4_02;
   };

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -46,6 +46,20 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "lib/net40/*" ];
   };
 
+  FSharpCore = fetchNuGet {
+    baseName = "FSharp.Core";
+    version = "4.0.0.1";
+    sha256 = "01nhjcxdz8l1r5vvdzhmgy5x7z5fqppab3ki34qg14axgf8jjygn";
+    outputFiles = [ "*" ];
+  };
+
+  FSharpData225 = fetchNuGet {
+    baseName = "FSharp.Data";
+    version = "2.2.5";
+    sha256 = "1c9l6bk0d2srccash2980y9phq3kmfm0m76k4wghnysnq94vm724";
+    outputFiles = [ "*" ];
+  };
+
   FSharpDataSQLProvider = fetchNuGet {
     baseName = "SQLProvider";
     version = "0.0.9-alpha";
@@ -60,6 +74,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "lib/net45/*" ];
   };
 
+  FsCheck262 = fetchNuGet {
+    baseName = "FsCheck";
+    version = "2.6.2";
+    sha256 = "0fh9yvsc4i61z31qf00d6gjv6xxd54pv1ykf5bpv95a5crc3qfvl";
+    outputFiles = [ "*" ];
+  };
+
   FsCheckNunit = fetchNuGet {
     baseName = "FsCheck.Nunit";
     version = "1.0.4";
@@ -67,11 +88,25 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "lib/net45/*" ];
   };
 
+  FSharpCompilerTools = fetchNuGet {
+    baseName = "FSharp.Compiler.Tools";
+    version = "4.1.4";
+    sha256 = "0vsp0khlnwh15ibg8s161rw6a6i8rlriclpq53paga447jllf0m8";
+    outputFiles = [ "*" ];
+  };
+
   FsLexYacc = fetchNuGet {
     baseName = "FsLexYacc";
     version = "6.1.0";
     sha256 = "1v5myn62zqs431i046gscqw2v0c969fc7pdplx7z9cnpy0p2s4rv";
     outputFiles = [ "build/*" ];
+  };
+
+  FsLexYacc704 = fetchNuGet {
+    baseName = "FsLexYacc";
+    version = "7.0.4";
+    sha256 = "01zpdb0pybdf0by02rwd7pb1g0cmnn8jxm2pibzxjxw6f4l43ywi";
+    outputFiles = [ "*" ];
   };
 
   FsPickler = fetchNuGet {
@@ -100,6 +135,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     version = "3.0.1";
     sha256 = "1g3j3kvg9vrapb1vjgq65nvn1vg7bzm66w7yjnaip1iww1yn1b0p";
     outputFiles = [ "lib/*" ];
+  };
+
+  NUnit350 = fetchNuGet {
+    baseName = "NUnit";
+    version = "3.5.0";
+    sha256 = "19fxq9cf754ygda5c8rn1zqs71pfxi7mb96jwqhlichnqih6i16z";
+    outputFiles = [ "*" ];
   };
 
   NUnit2 = fetchNuGet {
@@ -153,6 +195,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "tools/*" ];
   };
 
+  SystemValueTuple = fetchNuGet {
+    baseName = "System.ValueTuple";
+    version = "4.3.0";
+    sha256 = "00p5s753xh5417arw3k6npf1pc1k3m1s9mrlkw5vmc7pg8lm6n88";
+    outputFiles = [ "*" ];
+  };
+
   RestSharp = fetchNuGet {
     baseName = "RestSharp";
     version = "105.2.3";
@@ -195,6 +244,20 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "lib/*" ];
   };
 
+  MicrosoftDiaSymReader = fetchNuGet {
+    baseName = "Microsoft.DiaSymReader";
+    version = "1.1.0";
+    sha256 = "04dgwy6nyxksd1nb24k5c5vz8naggg7hryadvwqnm2v3alkh6g88";
+    outputFiles = [ "*" ];
+  };
+
+  MicrosoftDiaSymReaderPortablePdb = fetchNuGet {
+    baseName = "Microsoft.DiaSymReader.PortablePdb";
+    version = "1.2.0";
+    sha256 = "0qa8sqg0lzz9galkkfyi8rkbkali0nxm3qd5y4dlxp96ngrq5ldz";
+    outputFiles = [ "*" ];
+  };
+
   NUnitRunners = fetchNuGet {
     baseName = "NUnit.Runners";
     version = "2.6.4";
@@ -208,6 +271,20 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     version = "1.1.36";
     sha256 = "0760kzf5s771pnvnxsgas446kqdh1b71w6g3k75jpzldfmsd3vyq";
     outputFiles = [ "lib/portable-net45+win8+wp8+wpa81/*" ];
+  };
+
+  SystemCollectionsImmutable131 = fetchNuGet {
+    baseName = "System.Collections.Immutable";
+    version = "1.3.1";
+    sha256 = "149fcp7k7r9iw24dv5hbaij0c38kcv28dyhzbkggilfh4x2hy8c2";
+    outputFiles = [ "*" ];
+  };
+
+  SystemReflectionMetadata = fetchNuGet {
+    baseName = "System.Reflection.Metadata";
+    version = "1.4.2";
+    sha256 = "19fhdgd35yg52gyckhgwrphq07nv7v7r73hcg69ns94xfg1i6r7i";
+    outputFiles = [ "*" ];
   };
 
   Suave = fetchNuGet {


### PR DESCRIPTION
###### Motivation for this change

Introduce new language features with new version of F# compiler v4.1.

Build was tested like so on NixOS 17.03:

```bash
cd nixpkgs
export NIXPKGS=$(pwd)
nix-build -A fsharp41 $NIXPKGS
```
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

