### PR TITLE
google-cloud-sdk: 138.0.0 -> 148.0.1

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -7,23 +7,23 @@ assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux" || stden
 
 stdenv.mkDerivation rec {
   name = "google-cloud-sdk-${version}";
-  version = "138.0.0";
+  version = "148.0.1";
 
   src =
     if stdenv.system == "i686-linux" then
       fetchurl {
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-linux-x86.tar.gz";
-        sha256 = "1z2v4bg743qkdlmyyy0z2j5s0g10vbc1643gxrhyz491sk6sp616";
+        sha256 = "17az8nah6s33c790kkqcpmcsc8cydhndmq7dblpwgizd86hg245g";
       }
     else if stdenv.system == "x86_64-darwin" then
       fetchurl {
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-darwin-x86_64.tar.gz";
-        sha256 = "efbe2074da5a544c09b6bf87a8ca045dc429ac38dfcd5380561987769491d5ba";
+        sha256 = "1p5076cqk02y8zc3pkdlmrgh3mx2w1pddb2r5c9h3krfcaim2yj8";
       }
     else
       fetchurl {
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-linux-x86_64.tar.gz";
-        sha256 = "1y64bx9vj6rrapffr7zwxbxxbqlddx91n82kr99mwv19n11hydyw";
+        sha256 = "0fr07vcksy0vrg7inmyddz9jlbqx0yg933s45zzkpp3a0m5hz6ll";
       };
 
   buildInputs = [python27 makeWrapper];


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

