### PR TITLE
gnupg*: Improve the meta set

### DIFF
--- a/pkgs/tools/security/gnupg/1.nix
+++ b/pkgs/tools/security/gnupg/1.nix
@@ -12,10 +12,21 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = {
-    description = "Free implementation of the OpenPGP standard for encrypting and signing data";
-    homepage = http://www.gnupg.org/;
-    license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.gnu; # arbitrary choice
+  meta = with stdenv.lib; {
+    homepage = "https://gnupg.org";
+    description = "Classic (1.4) release of the GNU Privacy Guard, a GPL OpenPGP implementation";
+    license = licenses.gpl3Plus;
+    longDescription = ''
+      The GNU Privacy Guard is the GNU project's complete and free
+      implementation of the OpenPGP standard as defined by RFC4880.  GnuPG
+      "classic" (1.4) is the old standalone version which is most suitable for
+      older or embedded platforms.  GnuPG allows to encrypt and sign your data
+      and communication, features a versatile key management system as well as
+      access modules for all kind of public key directories.  GnuPG, also known
+      as GPG, is a command line tool with features for easy integration with
+      other applications.  A wealth of frontend applications and libraries are
+      available.
+    '';
+    platforms = platforms.gnu; # arbitrary choice
   };
 }

--- a/pkgs/tools/security/gnupg/1compat.nix
+++ b/pkgs/tools/security/gnupg/1compat.nix
@@ -1,7 +1,7 @@
 { stdenv, gnupg, coreutils, writeScript }:
 
 stdenv.mkDerivation {
-  name = "gnupg1compat-0";
+  name = "gnupg1compat-${gnupg.version}";
 
   builder = writeScript "gnupg1compat-builder" ''
     # First symlink all top-level dirs
@@ -18,7 +18,8 @@ stdenv.mkDerivation {
     ${coreutils}/bin/ln -s gpgv2 $out/bin/gpgv
   '';
 
-  meta = {
-    platforms = stdenv.lib.platforms.unix;
+  meta = gnupg.meta // {
+    description = gnupg.meta.description +
+      " with symbolic links for gpg and gpgv";
   };
 }

--- a/pkgs/tools/security/gnupg/20.nix
+++ b/pkgs/tools/security/gnupg/20.nix
@@ -44,24 +44,22 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = {
-    homepage = "http://gnupg.org/";
-    description = "Free implementation of the OpenPGP standard for encrypting and signing data";
-    license = stdenv.lib.licenses.gpl3Plus;
-
+  meta = with stdenv.lib; {
+    homepage = "https://gnupg.org";
+    description = "Stable (2.0) release of the GNU Privacy Guard, a GPL OpenPGP implementation";
+    license = licenses.gpl3Plus;
     longDescription = ''
-      GnuPG is the GNU project's complete and free implementation of
-      the OpenPGP standard as defined by RFC4880.  GnuPG allows to
-      encrypt and sign your data and communication, features a
-      versatile key management system as well as access modules for all
-      kind of public key directories.  GnuPG, also known as GPG, is a
-      command line tool with features for easy integration with other
-      applications.  A wealth of frontend applications and libraries
-      are available.  Version 2 of GnuPG also provides support for
-      S/MIME.
+      The GNU Privacy Guard is the GNU project's complete and free
+      implementation of the OpenPGP standard as defined by RFC4880.  GnuPG
+      "stable" (2.0) is the current stable version for general use.  This is
+      what most users are still using.  GnuPG allows to encrypt and sign your
+      data and communication, features a versatile key management system as well
+      as access modules for all kind of public key directories.  GnuPG, also
+      known as GPG, is a command line tool with features for easy integration
+      with other applications.  A wealth of frontend applications and libraries
+      are available.  Version 2 of GnuPG also provides support for S/MIME.
     '';
-
-    maintainers = with stdenv.lib.maintainers; [ roconnor ];
-    platforms = stdenv.lib.platforms.all;
+    maintainers = with maintainers; [ roconnor ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -48,9 +48,20 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://gnupg.org;
-    description = "A complete and free implementation of the OpenPGP standard";
+    homepage = "https://gnupg.org";
+    description = "Modern (2.1) release of the GNU Privacy Guard, a GPL OpenPGP implementation";
     license = licenses.gpl3Plus;
+    longDescription = ''
+      The GNU Privacy Guard is the GNU project's complete and free
+      implementation of the OpenPGP standard as defined by RFC4880.  GnuPG
+      "modern" (2.1) is the latest development with a lot of new features.
+      GnuPG allows to encrypt and sign your data and communication, features a
+      versatile key management system as well as access modules for all kind of
+      public key directories.  GnuPG, also known as GPG, is a command line tool
+      with features for easy integration with other applications.  A wealth of
+      frontend applications and libraries are available.  Version 2 of GnuPG
+      also provides support for S/MIME.
+    '';
     maintainers = with maintainers; [ wkennington peti fpletz vrthra ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Motivation for this change

I thought having more consistent meta sets wold be a good idea (but especially `longDescription` is a bit redundant now...) and I tried to improve some stuff (https, description and longDescription) - what do you think?

I also noticed that gnupg1compat doesn't provide manual pages for gpg and gpgv (i.e. one has to use "man gpg2" or "man gpgv2" instead). This isn't a big problem but imho it would be nice if we could include symbolic links for that as well (and other distributions are doing that as well). But with the current approach this would probably be a bit hacky (due to the folder structure). Would it be a good idea to include an "use-flag" for this? Something like `compat` (but that's actually a bad name in this case as it could be a package - any ideas for a better name? (e.g. `legacySymlinks` `gpgSymlink`, ...) and use the following expression in pkgs/top-level/all-packages.nix:
```nix
gnupg1compat = callPackage ../tools/security/gnupg/21.nix {
  compat = true;
};
```
And simply create the links in the `postInstall` phase. And I assume we can keep the current `name` and `description` as well with the help of an if statement (depending on compat).

And for what it's worth I think we should do the same for `gnupg20` (but probably without the additional attribute name).

cc @wkennington @peti @fpletz @vrthra @roconnor

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

