### PR TITLE
mendeley: 1.17.8 -> 1.17.9

### DIFF
--- a/pkgs/applications/office/mendeley/default.nix
+++ b/pkgs/applications/office/mendeley/default.nix
@@ -36,14 +36,14 @@ let
     then "i386"
     else "amd64";
 
-  shortVersion = "1.17.8-stable";
+  shortVersion = "1.17.9-stable";
 
   version = "${shortVersion}_${arch}";
 
   url = "http://desktop-download.mendeley.com/download/apt/pool/main/m/mendeleydesktop/mendeleydesktop_${version}.deb";
   sha256 = if stdenv.system == arch32
-    then "0j2hi0kd3cjjs47fxdzilc3rh02kzkdhvh70yyv7j8n58lnyjnx7"
-    else "0pi1bis0jmy618c1jn6b61mn666w7546xzicbqv1g6c4l8s3wgm5";
+    then "0z04r3ipwp2vca3qhp3b1zj0m12h023ynmbjsz4sysnd1bb5f2yr"
+    else "0h3m6s3s5283g9w3sm4fszhhnzgmqw49nr0ihvdwyxrgawxmz4vg";
 
   deps = [
     qt5.qtbase


### PR DESCRIPTION
###### Motivation for this change

Minor version bump (which app prompts about :)).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

