### PR TITLE
messenger-for-desktop: init at 2.0.6

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -462,6 +462,7 @@
   sepi = "Raffael Mancini <raffael@mancini.lu>";
   seppeljordan = "Sebastian Jordan <sebastian.jordan.mail@googlemail.com>";
   shanemikel = "Shane Pearlman <shanemikel1@gmail.com>";
+  shawndellysse = "Shawn Dellysse <sdellysse@gmail.com>";
   sheenobu = "Sheena Artrip <sheena.artrip@gmail.com>";
   sheganinans = "Aistis Raulinaitis <sheganinans@gmail.com>";
   shell = "Shell Turner <cam.turn@gmail.com>";

--- a/pkgs/applications/networking/instant-messengers/messenger-for-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/messenger-for-desktop/default.nix
@@ -1,0 +1,103 @@
+{
+  stdenv, fetchurl, dpkg, alsaLib, atk, cairo, cups, curl, dbus, expat,
+  fontconfig, freetype, glib, gnome2, libnotify, nspr, nss, systemd, xorg
+}:
+
+let
+
+  version = "2.0.6";
+
+  rpath = stdenv.lib.makeLibraryPath [
+    alsaLib
+    atk
+    cairo
+    cups
+    curl
+    dbus
+    expat
+    fontconfig
+    freetype
+    glib
+    gnome2.GConf
+    gnome2.gdk_pixbuf
+    gnome2.gtk
+    gnome2.pango
+    libnotify
+    nspr
+    nss
+    stdenv.cc.cc
+    systemd
+
+    xorg.libxkbfile
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libXScrnSaver
+  ] + ":${stdenv.cc.cc.lib}/lib64";
+
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://github.com/aluxian/Messenger-for-Desktop/releases/download/v2.0.6/messengerfordesktop-2.0.6-linux-amd64.deb";
+        sha256 = "bf3f3ed9ac46ceb4b7dffbeb33c7d15bbcbfcdd141c4dbfbb620e8bfefae906b";
+      }
+    else
+      throw "Messenger for Desktop is not supported on ${stdenv.system}";
+
+in stdenv.mkDerivation {
+  name = "messenger-for-desktop-${version}";
+
+  inherit src;
+
+  buildInputs = [ dpkg ];
+  unpackPhase = "true";
+  buildCommand = ''
+    mkdir -p $out
+    dpkg -x $src $out
+
+    mv $out/usr/share $out/share
+    mv $out/opt/messengerfordesktop $out/libexec
+    rmdir $out/usr
+    rm -rf $out/etc $out/usr $out/share/lintian
+
+    chmod -R g-w $out
+
+    # patch the binaries
+    for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+      patchelf --set-rpath ${rpath}:$out/libexec $file || true
+    done
+
+    # add symlink to bin
+    mkdir -p $out/bin
+    ln -s $out/libexec/messengerfordesktop $out/bin/messengerfordesktop
+
+    # Fix the desktop link
+    substituteInPlace $out/share/applications/messengerfordesktop.desktop                 \
+      --replace /opt/messengerfordesktop/messengerfordesktop $out/bin/messengerfordesktop 
+  '';
+
+  meta = {
+    description = "Bring messenger.com to your Linux desktop.";
+    longDescription = ''
+      A simple & beautiful desktop client for Facebook Messenger. Chat without
+      distractions on OS X, Windows and Linux. Not affiliated with Facebook.
+      This is NOT an official product.
+    '';
+    homepage = https://messengerfordesktop.org;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [
+      stdenv.lib.maintainers.shawndellysse
+    ];
+    platforms = [
+      "x86_64-linux"
+    ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/messenger-for-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/messenger-for-desktop/default.nix
@@ -3,11 +3,13 @@
   fontconfig, freetype, glib, gnome2, libnotify, nspr, nss, systemd, xorg
 }:
 
+with stdenv.lib;
+
 let
 
   version = "2.0.6";
 
-  rpath = stdenv.lib.makeLibraryPath [
+  rpath = makeLibraryPath [
     alsaLib
     atk
     cairo
@@ -64,8 +66,7 @@ in stdenv.mkDerivation {
 
     mv $out/usr/share $out/share
     mv $out/opt/messengerfordesktop $out/libexec
-    rmdir $out/usr
-    rm -rf $out/etc $out/usr $out/share/lintian
+    rmdir $out/usr $out/opt
 
     chmod -R g-w $out
 
@@ -92,9 +93,9 @@ in stdenv.mkDerivation {
       This is NOT an official product.
     '';
     homepage = https://messengerfordesktop.org;
-    license = stdenv.lib.licenses.mit;
+    license = licenses.mit;
     maintainers = [
-      stdenv.lib.maintainers.shawndellysse
+      maintainers.shawndellysse
     ];
     platforms = [
       "x86_64-linux"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18383,4 +18383,6 @@ with pkgs;
   hy = callPackage ../development/interpreters/hy {};
 
   ghc-standalone-archive = callPackage ../os-specific/darwin/ghc-standalone-archive { inherit (darwin) cctools; };
+
+  messenger-for-desktop = callPackage ../applications/networking/instant-messengers/messenger-for-desktop {};
 }


### PR DESCRIPTION
###### Motivation for this change
Messenger For Desktop package did not exist.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

