### PR TITLE
mate: update packages to version 1.18.0

### DIFF
--- a/pkgs/desktops/mate/caja/default.nix
+++ b/pkgs/desktops/mate/caja/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, pkgconfig, intltool, gtk3, libnotify, libxml2, libexif, exempi, mate, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "caja-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "0";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "1fc7dxj9hw8fffrcnwxbj8pq7gl08il68rkpk92rv3qm7siv1606";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    libnotify
+    libxml2
+    libexif
+    exempi
+    mate.mate-desktop
+  ];
+
+  configureFlags = [ "--disable-update-mimedb" ];
+  
+  meta = {
+    description = "File manager for the MATE desktop";
+    homepage = "http://mate-desktop.org";
+    license = with stdenv.lib.licenses; [ gpl2 lgpl2 ];
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -1,5 +1,6 @@
 { callPackage, pkgs }:
 rec {
+  caja = callPackage ./caja { };
   mate-common = callPackage ./mate-common { };
   mate-desktop = callPackage ./mate-desktop { };
   mate-icon-theme = callPackage ./mate-icon-theme { };

--- a/pkgs/desktops/mate/mate-common/default.nix
+++ b/pkgs/desktops/mate/mate-common/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   name = "mate-common-${version}";
   version = "${major-ver}.${minor-ver}";
-  major-ver = "1.17";
+  major-ver = "1.18";
   minor-ver = "0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "06pvbi2kk39ysd9dfi6ljkncm53hn02n7dygax6ig4p9qd750sdc";
+    sha256 = "1005laf3z1h8qczm7pmwr40r842665cv6ykhjg7r93vldra48z6p";
   };
 
   meta = {

--- a/pkgs/desktops/mate/mate-desktop/default.nix
+++ b/pkgs/desktops/mate/mate-desktop/default.nix
@@ -1,33 +1,36 @@
-{ stdenv, fetchurl, pkgs, pkgconfig, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, gnome3, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
-  name      = "mate-desktop-${version}";
-  version   = "${major-ver}.${minor-ver}";
-  major-ver = "1.17";
-  minor-ver = "2";
+  name = "mate-desktop-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "0";
 
   src = fetchurl {
-    url    = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "1l7aih9hvmnmddwjwyafhz87drd5vdkmjr41m7f24bn5k7abl90g";
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "12iv2y4dan962fs7vkkxbjkp77pbvjnwfa43ggr0zkdsc3ydjbbg";
   };
 
-  propagatedUserEnvPkgs = [ pkgs.gnome3.gnome_themes_standard ];
-
-  buildInputs = with pkgs; [
-      intltool
-      pkgconfig
-
-      gnome3.dconf
-      gnome3.gtk
-      gnome3.defaultIconTheme
+  propagatedUserEnvPkgs = [
+    gnome3.gnome_themes_standard
   ];
 
-  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+  buildInputs = [
+    gnome3.dconf
+    gnome3.gtk
+    gnome3.defaultIconTheme
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    wrapGAppsHook
+  ];
 
   meta = with stdenv.lib; {
     description = "Library with common API for various MATE modules";
-    homepage    = "http://mate-desktop.org";
-    license     = licenses.gpl2;
-    platforms   = platforms.unix;
+    homepage = "http://mate-desktop.org";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   name = "mate-icon-theme-faenza-${version}";
   version = "${major-ver}.${minor-ver}";
-  major-ver = "1.16";
+  major-ver = "1.18";
   minor-ver = "0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "0p3z3qarbvrhzj2sdw3f8dp0c7wwjkk9a749bq8rh5gm9m66hibg";
+    sha256 = "1crfv6s3ljbc7a7m229bvs3qbjzlp8cgvyhqmdaa9npd5lxmk88v";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/desktops/mate/mate-icon-theme/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   name = "mate-icon-theme-${version}";
   version = "${major-ver}.${minor-ver}";
-  major-ver = "1.17";
+  major-ver = "1.18";
   minor-ver = "0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "1kxpckaksaz5g3c4jjkh4pdm9yhbjda5835am3wg2iyy2p7rjn8n";
+    sha256 = "19bd9zlfc1jfdl7imvfy1vq35a0jvxq5fldmr2c5bq0kyasvww6i";
   };
 
   nativeBuildInputs = [ pkgconfig intltool iconnamingutils ];

--- a/pkgs/desktops/mate/mate-terminal/default.nix
+++ b/pkgs/desktops/mate/mate-terminal/default.nix
@@ -1,19 +1,17 @@
-{ stdenv, fetchurl, pkgs, pkgconfig, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, glib, itstool, libxml2, mate, gnome3, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
-  name      = "mate-terminal-${version}";
-  version   = "${major-ver}.${minor-ver}";
-  major-ver = "1.17";
+  name = "mate-terminal-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
   minor-ver = "0";
 
   src = fetchurl {
-    url    = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "0sbncykjf0ifj87rwpdw2ln0wavykiki4zqsw60vch7agh49fw0f";
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "07z8g8zkc8k6d7xqdlg18cjnwg7zzv5hbgwma5y9mh8zx9xsqz92";
   };
 
-  buildInputs = with pkgs; [
-     intltool
-     pkgconfig
+  buildInputs = [
      glib
      itstool
      libxml2
@@ -25,12 +23,16 @@ stdenv.mkDerivation rec {
      gnome3.dconf
   ];
 
-  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    wrapGAppsHook
+  ];
 
   meta = with stdenv.lib; {
     description = "The MATE Terminal Emulator";
-    homepage    = "http://mate-desktop.org";
-    license     = licenses.gpl3;
-    platforms   = platforms.unix;
+    homepage = "http://mate-desktop.org";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/desktops/mate/mate-themes/default.nix
+++ b/pkgs/desktops/mate/mate-themes/default.nix
@@ -6,17 +6,15 @@ stdenv.mkDerivation rec {
   version = "${major-ver}.${minor-ver}";
   major-ver = gnome3.version;
   minor-ver = {
-    "3.18" = "4";
-    "3.20" = "12";
-    "3.22" = "3";
+    "3.20" = "16";
+    "3.22" = "7";
   }."${major-ver}";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/themes/${major-ver}/${name}.tar.xz";
     sha256 = {
-      "3.18" = "1h3z705jrg7gng5glf51ksszjz6v81qq83qvmfpv1v69bwn6fy4b";
-      "3.20" = "15s2xp2cq9x8iikvbywr5gl8l33i57i1xvbv4jc2qipnkn3c4yca";
-      "3.22" = "0p1rf5q2nr1vsab3pljwycclbrnwylvp88d0dhk8as0d6n6fp85k";
+      "3.20" = "1dvzljpq6cscr82gnsqagf23inb039q84fnawraj0nhfjif11r7v";
+      "3.22" = "1kjchqkds0zj32x7cjfcq96zakcmhva1yg0nxfd6369a5nwkp5k0";
     }."${major-ver}";
   };
 


### PR DESCRIPTION
###### Motivation for this change

[MATE 1.18 released](http://mate-desktop.org/blog/2017-03-13-mate-1-18-released/)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).