### PR TITLE
palemoon: 27.1.1 -> 27.2.1

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -3,21 +3,21 @@
 , dbus, dbus_glib, file, fontconfig, freetype
 , gstreamer, gst-plugins-base, gst_all_1
 , gtk2, hunspell, icu, libevent, libjpeg, libnotify
-, libstartup_notification, libvpx, makeWrapper, mesa 
-, nspr, nss, pango, perl, python, libpulseaudio, sqlite 
+, libstartup_notification, libvpx, makeWrapper, mesa
+, nspr, nss, pango, perl, python, libpulseaudio, sqlite
 , unzip, xlibs, which, yasm, zip, zlib
 }:
 
 stdenv.mkDerivation rec {
   name = "palemoon-${version}";
-  version = "27.1.1";
+  version = "27.2.1";
 
   src = fetchFromGitHub {
     name   = "palemoon-src";
     owner  = "MoonchildProductions";
     repo   = "Pale-Moon";
-    rev    = "a35936746069e6591181eb67e5f9ea094938bae5";
-    sha256 = "0hns5993dh93brwz3z4xp1zp8n90x1hajxylv17zybpysax64jsk";
+    rev    = version + "_Release";
+    sha256 = "1yyipxd5lmavf4aca4vrcnp7hb8zkn4sv2zp6n2cm6w4pxlza0g4";
   };
 
   desktopItem = makeDesktopItem {
@@ -79,6 +79,8 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications
     cd $builddir
     $src/mach install
   '';


### PR DESCRIPTION
###### Motivation for this change
Version bump.

Also a bit of whitespace cleanup, and refactoring to use release tags.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

