### PR TITLE
marp: 0.0.9 -> 0.0.10

### DIFF
--- a/pkgs/applications/office/marp/default.nix
+++ b/pkgs/applications/office/marp/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "marp-${version}";
-  version = "0.0.9";
+  version = "0.0.10";
 
   src = fetchurl {
     url = "https://github.com/yhatt/marp/releases/download/v${version}/${version}-Marp-linux-x64.tar.gz";
-    sha256 = "142c35d88rkgjy85f4204givgx0p1qyfpipbrsa11lp3cb6jzhn2";
+    sha256 = "0x4qldbyvq88cs12znxv33bb0nxr3wxcwhyr97pkjrjc2cn7nphx";
   };
   sourceRoot = ".";
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

