### PR TITLE
2bwm: init at 0.2

### DIFF
--- a/nixos/modules/services/x11/window-managers/2bwm.nix
+++ b/nixos/modules/services/x11/window-managers/2bwm.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.xserver.windowManager."2bwm";
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+    services.xserver.windowManager."2bwm".enable = mkEnableOption "2bwm";
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    services.xserver.windowManager.session = singleton
+      { name = "2bwm";
+        start =
+          ''
+            ${pkgs."2bwm"}/bin/2bwm &
+            waitPID=$!
+          '';
+      };
+
+    environment.systemPackages = [ pkgs."2bwm" ];
+
+  };
+
+}

--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -8,6 +8,7 @@ in
 
 {
   imports = [
+    ./2bwm.nix
     ./afterstep.nix
     ./bspwm.nix
     ./compiz.nix

--- a/pkgs/applications/window-managers/2bwm/default.nix
+++ b/pkgs/applications/window-managers/2bwm/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, patches
+, libxcb, xcbutilkeysyms, xcbutilwm
+, libX11, xcbutil, xcbutilxrm }:
+
+stdenv.mkDerivation rec {
+  version = "0.2";
+  name = "2bwm-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "venam";
+    repo   = "2bwm";
+    rev    = "v${version}";
+    sha256 = "1la1ixpm5knsj2gvdcmxzj1jfbzxvhmgzps4f5kbvx5047xc6ici";
+  };
+
+  # Allow users set their own list of patches
+  inherit patches;
+
+  buildInputs = [ libxcb xcbutilkeysyms xcbutilwm libX11 xcbutil xcbutilxrm ];
+
+  installPhase = "make install DESTDIR=$out PREFIX=\"\"";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/venam/2bwm";
+    description = "A fast floating WM written over the XCB library and derived from mcwm";
+    license = licenses.mit;
+    maintainers =  [ maintainers.sternenseemann ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12659,6 +12659,10 @@ with pkgs;
 
   ### APPLICATIONS
 
+  "2bwm" = callPackage ../applications/window-managers/2bwm {
+    patches = config."2bwm".patches or [];
+  };
+
   a2jmidid = callPackage ../applications/audio/a2jmidid { };
 
   aacgain = callPackage ../applications/audio/aacgain { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
