### PR TITLE
muchsync: fix on macOS

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/muchsync.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/muchsync.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, notmuch, openssl, pkgconfig, sqlite, xapian
+, notmuch, openssl, pkgconfig, sqlite, xapian, zlib
 }:
 stdenv.mkDerivation rec {
   version = "2";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     url = "http://www.muchsync.org/src/${name}.tar.gz";
     sha256 = "1dqp23a043kkzl0g2f4j3m7r7lg303gz7a0fsj0dm5ag3kpvp5f1";
   };
-  buildInputs = [ notmuch openssl pkgconfig sqlite xapian ];
+  buildInputs = [ notmuch openssl pkgconfig sqlite xapian zlib ];
   meta = {
     description = "Synchronize maildirs and notmuch databases";
     platforms = stdenv.lib.platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

muchsync failed to build on macos with a `-lz` link error. This fixes that.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

