### PR TITLE
corebird: 1.3.3 -> 1.4.2

### DIFF
--- a/pkgs/applications/networking/corebird/default.nix
+++ b/pkgs/applications/networking/corebird/default.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  configureFlags = [ "--disable-spellcheck" ];
-
   nativeBuildInputs = [ automake autoconf libtool pkgconfig wrapGAppsHook ];
 
   buildInputs = [

--- a/pkgs/applications/networking/corebird/default.nix
+++ b/pkgs/applications/networking/corebird/default.nix
@@ -3,24 +3,26 @@
 , glib_networking }:
 
 stdenv.mkDerivation rec {
-  version = "1.3.3";
+  version = "1.4.2";
   name = "corebird-${version}";
 
   src = fetchFromGitHub {
     owner = "baedert";
     repo = "corebird";
     rev = version;
-    sha256 = "09k0jrhjqrmpvyz5pf1g7wkidflkhpvw5869a95vnhfxjd45kzs3";
+    sha256 = "0s28q9c7p4p4jyhb1g6gdwdphlf6yhi6yg4yn8bkd0gmyf9acakb";
   };
 
   preConfigure = ''
     ./autogen.sh
   '';
 
+  configureFlags = [ "--disable-spellcheck" ];
+
   nativeBuildInputs = [ automake autoconf libtool pkgconfig wrapGAppsHook ];
 
   buildInputs = [
-    gtk3 json_glib sqlite libsoup gettext vala_0_32 gnome3.rest gnome3.dconf glib_networking
+    gtk3 json_glib sqlite libsoup gettext vala_0_32 gnome3.rest gnome3.dconf gnome3.gspell glib_networking
   ] ++ (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav ]);
 
   meta = {

--- a/pkgs/desktops/gnome-3/3.22/misc/gspell/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/misc/gspell/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, pkgconfig, glib, gtk3, enchant, isocodes }:
+{ stdenv, fetchurl, pkgconfig, glib, gtk3, enchant, isocodes, vala }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
-  buildInputs = [ pkgconfig glib gtk3 enchant isocodes ];
+  buildInputs = [ pkgconfig glib gtk3 enchant isocodes vala ];
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome-3/3.22/misc/gspell/src.nix
+++ b/pkgs/desktops/gnome-3/3.22/misc/gspell/src.nix
@@ -1,10 +1,10 @@
 fetchurl: rec {
-  major = "1.0";
-  minor = "3";
+  major = "1.2";
+  minor = "1";
   name = "gspell-${major}.${minor}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gspell/${major}/${name}.tar.xz";
-    sha256 = "1m8v4rqaxjsblccc3nnirkbkzgqm90vfpzp3x08lkqriqvk0anfr";
+    sha256 = "18zisdrq14my2iq6iv3lhqfn9jg98bqwbzcdidp7hfk915gkw74z";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Version update. Disabled the newly added feature spellchecking due to `Package `gspell-1' not found in specified Vala API directories or GObject-Introspection GIR directories`.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

