### PR TITLE
[WIP] rpm: 4.13.0-rc1 -> 4.13.0.1

### DIFF
--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, cpio, zlib, bzip2, file, elfutils, libarchive, nspr, nss, popt, db, xz, python, lua, pkgconfig, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "rpm-4.13.0-rc1";
+  name = "rpm-4.13.0.1";
 
   src = fetchurl {
-    url = "http://www.rpm.org/releases/testing/rpm-4.13.0-rc1.tar.bz2";
-    sha256 = "097mc0kkrf09c01hrgi71df7maahmvayfgsvspnxigvl3xysv8hp";
+    url = "http://ftp.rpm.org/releases/rpm-4.13.x/rpm-4.13.0.1.tar.bz2";
+    sha256 = "03cvbwbfrhm0fa02j7828k1qp05hf2m0fradwcf2nqhrsjkppz17";
   };
 
   outputs = [ "out" "dev" "man" ];

--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "rpm-4.13.0.1";
 
   src = fetchurl {
-    url = "http://ftp.rpm.org/releases/rpm-4.13.x/rpm-4.13.0.1.tar.bz2";
+    url = "http://ftp.rpm.org/releases/rpm-4.13.x/${name}.tar.bz2";
     sha256 = "03cvbwbfrhm0fa02j7828k1qp05hf2m0fradwcf2nqhrsjkppz17";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Url can't be fetched with curl or browser

Fails with personnal [Hydra](http://hydra.hydra.prunetwork.fr/build/41969/nixlog/301) .
Succeed on official hydra: https://hydra.nixos.org/job/nixpkgs/trunk/rpm.x86_64-linux

Version RPM 4.13.0-rc1 was released on September 2015: http://rpm.org/timeline.html

~~~
Log of step 301 of build 41969 of job hydra:master:manual
This is the build log of derivation /nix/store/hc5aaq8905f65xvaxxnx5yrnww29jw3x-rpm-4.13.0-rc1.tar.bz2.drv.

trying http://www.rpm.org/releases/testing/rpm-4.13.0-rc1.tar.bz2
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   178  100   178    0     0   1063      0 --:--:-- --:--:-- --:--:--  1065

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
error: cannot download rpm-4.13.0-rc1.tar.bz2 from any mirror
builder for ‘/nix/store/hc5aaq8905f65xvaxxnx5yrnww29jw3x-rpm-4.13.0-rc1.tar.bz2.drv’ failed with exit code 1

~~~


###### Things done

- packages fetched from rpm.org with `nix-prefetch-url`
- new sha256hash copy-pasted

---

