### PR TITLE
hwdata: Use content-addressed source file; previous source tarball changed contents

### DIFF
--- a/pkgs/os-specific/linux/hwdata/default.nix
+++ b/pkgs/os-specific/linux/hwdata/default.nix
@@ -5,8 +5,8 @@ stdenv.mkDerivation rec {
   version = "0.291";
 
   src = fetchurl {
-    url = "https://git.fedorahosted.org/cgit/hwdata.git/snapshot/hwdata-${version}.tar.xz";
-    sha256 = "121qixrdhdncva1cnj7m7jlqvi1kbj85dpi844jiis3a8hgpzw5a";
+    url = "http://pkgs.fedoraproject.org/repo/pkgs/hwdata/hwdata-0.291.tar.bz2/effe59bf406eb03bb295bd34e0913dd8/hwdata-0.291.tar.bz2";
+    sha256 = "01cq9csryxcrilnqdjd2r8gpaap3mk4968v7y36c7shyyaf9zkym";
   };
 
   preConfigure = "patchShebangs ./configure";


### PR DESCRIPTION
This is a merge from master.

(cherry picked from commit 00f16e3d7c4239bcb4c0b55302e4956adf69d691)

###### Motivation for this change
Source tarball https://git.fedorahosted.org/cgit/hwdata.git/snapshot/hwdata-0.291.tar.xz changed contents, which has rendered this package unbuildable. This change switches the source tarball URL to a content-addressed mirror instead, which will probably and hopefully be more stable.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

