### PR TITLE
textadept: bombay update without version pinning

### DIFF
--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -87,7 +87,7 @@ let
   get_libluajit   = get_url libluajit_url   "1nhvcdjpqrhd5qbihdm3bxpw84irfvnw2vmfqnsy253ay3dxzrgy";
   get_gtdialog    = get_url gtdialog_url    "0nvcldyhj8abr8jny9pbyfjwg8qfp9f2h508vjmrvr5c5fqdbbm0";
   get_cdk         = get_url cdk_url         "0j74l874y33i26y5kjg3pf1vswyjif8k93pqhi0iqykpbxfsg382";
-  get_bombay      = get_url_zip bombay_url  "05fnh1imxdb4sb076fzqywqszp31whdbkzmpkqxc8q2r1m5vj3hg"
+  get_bombay      = get_url_zip bombay_url  "0illabngrrxidkprgz268wgjqknrds34nhm6hav95xc1nmsdr6jj"
     + "mv tip.zip bombay.zip\n";
   get_termkey     = get_url termkey_url     "12gkrv1ldwk945qbpprnyawh0jz7rmqh18fyndbxiajyxmj97538";
 


### PR DESCRIPTION
###### Motivation for this change

Can't build on [hydra](http://hydra.hydra.prunetwork.fr/build/59378/nixlog/3) due to mercurial repo update since last package update. https://foicica.com/hg/bombay
On official hydra it works https://hydra.nixos.org/job/nixpkgs/trunk/textadept.x86_64-linux

~~~
trying http://foicica.com/hg/bombay/archive/tip.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

100  2211    0  2211    0     0   2492      0 --:--:-- --:--:-- --:--:--  2492
unpacking source archive /tmp/nix-build-tip.zip.drv-0/tip.zip
output path ‘/nix/store/l8rk7lv1damykjnl463kmx1fdz1sxh4q-tip.zip’ has r:sha256 hash ‘0illabngrrxidkprgz268wgjqknrds34nhm6hav95xc1nmsdr6jj’ when ‘05fnh1imxdb4sb076fzqywqszp31whdbkzmpkqxc8q2r1m5vj3hg’ was expected
~~~

###### Things done

- copy-pasted suggested sha256 from hydra

---

