### PR TITLE
veracrypt: init at 1.19

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -142,6 +142,7 @@
   dpaetzel = "David Pätzel <david.a.paetzel@gmail.com>";
   drets = "Dmytro Rets <dmitryrets@gmail.com>";
   drewkett = "Andrew Burkett <burkett.andrew@gmail.com>";
+  dsferruzza = "David Sferruzza <david.sferruzza@gmail.com>";
   dtzWill = "Will Dietz <nix@wdtz.org>";
   e-user = "Alexander Kahl <nixos@sodosopa.io>";
   ebzzry = "Rommel Martinez <ebzzry@gmail.com>";

--- a/pkgs/applications/misc/veracrypt/default.nix
+++ b/pkgs/applications/misc/veracrypt/default.nix
@@ -1,0 +1,44 @@
+{ fetchurl, stdenv, pkgconfig, nasm, fuse, wxGTK30, devicemapper, makeself,
+  wxGUI ? true
+}:
+
+stdenv.mkDerivation rec {
+  name = "veracrypt-${version}";
+  version = "1.19";
+
+  src = fetchurl {
+    url = "https://launchpad.net/veracrypt/trunk/${version}/+download/VeraCrypt_${version}_Source.tar.gz";
+    sha256 = "111xs1zmic82lpn5spn0ca33q0g4za04a2k4cvjwdb7k3vcicq6v";
+  };
+
+  # The source archive can't be extracted with "tar xfz"; I don't know why
+  # Using "gunzip" before "tar xf" works though
+  unpackPhase =
+    ''
+      gunzip -c $src > src.tar
+      tar xf src.tar
+      cd Vera*/src
+    '';
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ fuse devicemapper wxGTK30 nasm makeself ];
+  makeFlags = if wxGUI then "" else "NOGUI=1";
+
+  installPhase =
+    ''
+      mkdir -p $out/bin
+      cp Main/veracrypt $out/bin
+      mkdir -p $out/share/$name
+      cp License.txt $out/share/$name/LICENSE
+      mkdir -p $out/share/applications
+      sed 's/\/usr\/bin\/veracrypt/veracrypt/' Setup/Linux/veracrypt.desktop > $out/share/applications/veracrypt.desktop
+    '';
+
+  meta = {
+    description = "Free Open-Source filesystem on-the-fly encryption";
+    homepage = https://veracrypt.codeplex.com/;
+    license = "VeraCrypt License";
+    maintainers = with stdenv.lib.maintainers; [dsferruzza];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4532,6 +4532,10 @@ with pkgs;
     python = python27;
   };
 
+  veracrypt = callPackage ../applications/misc/veracrypt {
+    wxGUI = true;
+  };
+
   vlan = callPackage ../tools/networking/vlan { };
 
   vmtouch = callPackage ../tools/misc/vmtouch { };


### PR DESCRIPTION
###### Motivation for this change

[TrueCrypt](https://en.wikipedia.org/wiki/TrueCrypt) has been discontinued for several years.
This PR adds a package for [VeraCrypt](https://en.wikipedia.org/wiki/VeraCrypt), a maintained fork of TrueCrypt.

I used `truecrypt` [package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/truecrypt/default.nix) as a start, and tried to create a nice package; but I'm a beginner so I guess not everything is perfect.
I would be happy to have feedback and advices!

I tested this package on NixOS.
I was able to successfully do the following steps:
- run VeraCrypt
- create a container
- mount it
- store a file in it
- unmount it
- move it to another computer running another OS with an official binary version of VeraCrypt
- mount it
- recover my file

I let the `maintainers` field empty.
I don't know if I should add myself, or @viric (the `truecrypt` package maintainer), or someone else.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

