### PR TITLE
libdc1394: patch bugs on darwin

### DIFF
--- a/pkgs/development/libraries/libdc1394/darwin-fixes.patch
+++ b/pkgs/development/libraries/libdc1394/darwin-fixes.patch
@@ -1,0 +1,24 @@
+diff -Naur libdc1394-2.2.5-old/dc1394/bayer.c libdc1394-2.2.5-new/dc1394/bayer.c
+--- libdc1394-2.2.5-old/dc1394/bayer.c	2016-10-11 02:19:10.000000000 -0400
++++ libdc1394-2.2.5-new/dc1394/bayer.c	2017-03-28 17:59:02.000000000 -0400
+@@ -775,7 +775,7 @@
+ {
+ 	uint8_t *outR, *outG, *outB;
+ 	register int i, j;
+-	uint tmp;
++	uint32_t tmp;
+ 	int st=sx*sy;
+ 	int p;
+ 	int sx2=sx<<1;
+diff -Naur libdc1394-2.2.5-old/dc1394/macosx/capture.c libdc1394-2.2.5-new/dc1394/macosx/capture.c
+--- libdc1394-2.2.5-old/dc1394/macosx/capture.c	2016-12-20 08:10:34.000000000 -0500
++++ libdc1394-2.2.5-new/dc1394/macosx/capture.c	2017-03-28 17:58:38.000000000 -0400
+@@ -614,7 +614,7 @@
+     dc1394video_frame_t * frame_tmp = capture->frames + next;
+     char ch;
+ 
+-	if(craw->frames==NULL || craw->capture_is_set==0) {
++	if(craw->capture.frames==NULL || craw->capture_is_set==0) {
+ 		*frame=NULL;
+ 		return DC1394_CAPTURE_IS_NOT_SET;
+ 	}

--- a/pkgs/development/libraries/libdc1394/default.nix
+++ b/pkgs/development/libraries/libdc1394/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.isLinux libraw1394
     ++ stdenv.lib.optional stdenv.isDarwin CoreServices;
 
+  patches = stdenv.lib.optional stdenv.isDarwin ./darwin-fixes.patch;
+
   meta = with stdenv.lib; {
     homepage = http://sourceforge.net/projects/libdc1394/;
     description = "Capture and control API for IIDC compliant cameras";


### PR DESCRIPTION
This should fix `ffmpeg-full` on darwin on hydra.

One of these issues is in a platform-specific support file for darwin, the
other may only be a breaker when using clang.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

