### PR TITLE
premake5: init at 5.0.0pre.alpha.11

### DIFF
--- a/pkgs/development/tools/misc/premake/5.nix
+++ b/pkgs/development/tools/misc/premake/5.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, CoreServices }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "premake-${version}";
+  version = "5.0.0pre.alpha.11";
+
+  src = fetchFromGitHub {
+    owner = "premake";
+    repo = "premake-core";
+    rev = "5dfb0238bc309df04819dd430def621ce854678d";
+    sha256 = "0k9xbqrnbwj0hnmdgcrwn70py1kiqvr10l42aw42xnlmdyg1sgsc";
+  };
+
+  buildInputs = optional stdenv.isDarwin [ CoreServices ];
+
+  patchPhase = optional stdenv.isDarwin ''
+    substituteInPlace premake5.lua \
+      --replace -mmacosx-version-min=10.4 -mmacosx-version-min=10.5
+  '';
+
+  buildPhase =
+    if stdenv.isDarwin then ''
+       make -f Bootstrap.mak osx
+    '' else ''
+       make -f Bootstrap.mak linux
+    '';
+
+  installPhase = ''
+    install -Dm755 bin/release/premake5 $out/bin/premake5
+  '';
+
+  meta = {
+    homepage = https://premake.github.io;
+    description = "A simple build configuration and project generation tool using lua";
+    license = stdenv.lib.licenses.bsd3;
+    platforms = platforms.darwin ++ platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -741,7 +741,7 @@ with pkgs;
   catclock = callPackage ../applications/misc/catclock { };
 
   cde = callPackage ../tools/package-management/cde { };
-  
+
   cdemu-daemon = callPackage ../misc/emulators/cdemu/daemon.nix { };
 
   cdemu-client = callPackage ../misc/emulators/cdemu/client.nix { };
@@ -6770,6 +6770,10 @@ with pkgs;
   premake3 = callPackage ../development/tools/misc/premake/3.nix { };
 
   premake4 = callPackage ../development/tools/misc/premake { };
+
+  premake5 = callPackage ../development/tools/misc/premake/5.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+  };
 
   premake = premake4;
 


### PR DESCRIPTION
###### Motivation for this change

Premake 5 is necessary for building [otfcc](https://github.com/caryll/otfcc) (amongst other things).

I understand this is a package for pre-release software. While it does seem like Premake 5 has been in use for a couple of years despite the alpha nomenclature, I have not personally used it aside from building otfcc and cannot vouch for its stability or utility. If this PR is not appropriate for merging, do not feel bad about closing it! 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
