### PR TITLE
udunits: 2.2.23 -> 2.2.24

### DIFF
--- a/pkgs/development/libraries/udunits/default.nix
+++ b/pkgs/development/libraries/udunits/default.nix
@@ -3,10 +3,10 @@
 }:
 
 stdenv.mkDerivation rec {
-    name = "udunits-2.2.23";
+    name = "udunits-2.2.24";
     src = fetchurl {
         url = "ftp://ftp.unidata.ucar.edu/pub/udunits/${name}.tar.gz";
-        sha256 = "0ya93jrv8qzfkdj77grl4dpyb0ap4jccmqx3rkkgaggnklhjfwkr";
+        sha256 = "15bz2wv46wiwdzai8770gzy05prgj120x6j2hmihavv5y89cbfi0";
     };
 
     nativeBuildInputs = [ bison flex file ];


### PR DESCRIPTION
###### Motivation for this change

Source file not available anymore. A new one was released.

I tried to build r-updates packages set on [hydra](http://hydra.hydra.prunetwork.fr/build/47272/nixlog/24) and got:

~~~
Log of step 24 of build 47272 of job nixpkgs:r-updates:rPackages.ggraph.x86_64-linux
This is the build log of derivation /nix/store/5yqr7pba68c3rc8abyss63vp0yc4mm4k-udunits-2.2.23.tar.gz.drv. It was built on root@ocean.prunetwork.fr.

trying ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-2.2.23.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (78) RETR response: 550
error: cannot download udunits-2.2.23.tar.gz from any mirror
builder for ‘/nix/store/5yqr7pba68c3rc8abyss63vp0yc4mm4k-udunits-2.2.23.tar.gz.drv’ failed with exit code 1
~~~

###### Things done

- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @pSub
---

