### PR TITLE
swift: remove i686-linux from platforms, limit to x86-64-linux

### DIFF
--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -258,7 +258,8 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/apple/swift";
     maintainers = with maintainers; [ jb55 dtzWill ];
     license = licenses.asl20;
-    platforms = platforms.linux;
+    # Swift doesn't support 32bit Linux, unknown on other platforms.
+    platforms = [ "x86_64-linux" ];
   };
 }
 


### PR DESCRIPTION
Don't know that other platforms will fail but it seems likely
since we're using build profile intended for 64bit Ubuntu.

###### Motivation for this change

Hydra failure on 32bit, investigation suggests (Swift doesn't support 32bit Linux)[https://bugs.swift.org/browse/SR-124] although it might be possible [with some effort](https://lists.swift.org/pipermail/swift-dev/2015-December/000030.html).

Hopefully Darwin will be supported soon, but doesn't work yet (if nothing else the build forces the linux build profile).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

