### PR TITLE
make graphite do fewer recursive chowns when starting

### DIFF
--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -400,7 +400,8 @@ in {
 
           mkdir -p ${cfg.dataDir}/whisper
           chmod 0700 ${cfg.dataDir}/whisper
-          chown -R graphite:graphite ${cfg.dataDir}
+          chown graphite:graphite ${cfg.dataDir}
+          chown graphite:graphite ${cfg.dataDir}/whisper
         '';
       };
     })
@@ -489,7 +490,10 @@ in {
 
             touch ${dataDir}/db-created
 
-            chown -R graphite:graphite ${cfg.dataDir}
+            chown graphite:graphite ${cfg.dataDir}
+            chown graphite:graphite ${cfg.dataDir}/db-created
+            chown graphite:graphite ${cfg.dataDir}/whisper
+            chown -R graphite:graphite ${cfg.dataDir}/log
           fi
         '';
       };
@@ -528,7 +532,9 @@ in {
 
             touch ${dataDir}/db-created
 
-            chown -R graphite:graphite ${cfg.dataDir}
+            chown graphite:graphite ${cfg.dataDir}
+            chown graphite:graphite ${cfg.dataDir}/db-created
+            chown -R graphite:graphite ${cfg.dataDir}/cache
           fi
         '';
       };
@@ -549,7 +555,7 @@ in {
         preStart = ''
           if ! test -e ${dataDir}/db-created; then
             mkdir -p ${dataDir}
-            chown -R graphite:graphite ${dataDir}
+            chown graphite:graphite ${dataDir}
           fi
         '';
       };

--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -488,12 +488,11 @@ in {
             # create index
             ${pkgs.python27Packages.graphite_web}/bin/build-index.sh
 
-            touch ${dataDir}/db-created
-
             chown graphite:graphite ${cfg.dataDir}
-            chown graphite:graphite ${cfg.dataDir}/db-created
             chown graphite:graphite ${cfg.dataDir}/whisper
             chown -R graphite:graphite ${cfg.dataDir}/log
+
+            touch ${dataDir}/db-created
           fi
         '';
       };
@@ -530,11 +529,10 @@ in {
             mkdir -p ${dataDir}/cache/
             chmod 0700 ${dataDir}/cache/
 
-            touch ${dataDir}/db-created
-
             chown graphite:graphite ${cfg.dataDir}
-            chown graphite:graphite ${cfg.dataDir}/db-created
             chown -R graphite:graphite ${cfg.dataDir}/cache
+
+            touch ${dataDir}/db-created
           fi
         '';
       };


### PR DESCRIPTION
###### Motivation for this change

The `carbonCache` service is currently incapable of starting once there are more than 500,000 metrics in the database. This happens because every time before `carbonCache` starts, a recursive `chown` is run on the graphite data directory. Since each metric is a distinct file, this chown hits a lot of files. On our production environment, it has recently gotten so slow that systemd times whenever we start `carbonCache`.

Looking through the service definition, it appears that the recursive chown was only used as convenient way to change ownership of a few directories and files immediately after they are created. This PR makes the ownership changes more explicit. Instead of recursing over the entire data directory, it now targets only the files that were just created. There is still some recursive `chown`ing but none that ends up doing a recursive traversal of `whisper` (the directory containing all the metrics).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

