### PR TITLE
bitlbee-facebook: 2015-08-27 → 1.1.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/bitlbee-facebook/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-facebook/default.nix
@@ -2,16 +2,19 @@
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "bitlbee-facebook-2015-08-27";
+  name = "bitlbee-facebook-${version}";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
-    rev = "094a11b542e2cd8fac4f00fe01870ecd1cb4c062";
+    rev = "v${version}";
     owner = "jgeboski";
     repo = "bitlbee-facebook";
-    sha256 = "1dvbl1z6fl3wswvqbs82vkqlggk24dyi8w7cmm5jh1fmaznmwqrl";
+    sha256 = "0qclyc2zz8144dc42bhfv2xxrahpiv9j2iwq9h3cmfxszvkb8r3s";
   };
 
-  buildInputs = [ bitlbee autoconf automake libtool pkgconfig glib json_glib ];
+  nativeBuildInputs = [ autoconf automake libtool pkgconfig ];
+
+  buildInputs = [ bitlbee glib json_glib ];
 
   preConfigure = ''
     export BITLBEE_PLUGINDIR=$out/lib/bitlbee


### PR DESCRIPTION
###### Motivation for this change

The previous one stopped working after Facebook’s updates, see https://github.com/bitlbee/bitlbee-facebook/issues/138

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).