### PR TITLE
rustfmt: 0.8 -> 0.8.1

### DIFF
--- a/pkgs/development/tools/rust/rustfmt/default.nix
+++ b/pkgs/development/tools/rust/rustfmt/default.nix
@@ -1,19 +1,17 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
-with rustPlatform;
-
-buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   name = "rustfmt-${version}";
-  version = "0.8";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "rust-lang-nursery";
     repo = "rustfmt";
-    rev = version;
-    sha256 = "0a613x1ckwl30yamba9m7xi3xrn8pg92p2w3v7k723whyivmjk1s";
+    rev = "v${version}";
+    sha256 = "05rjx7i4wn3z3j8bgqsn146a9vbni6xhxaim9nq13c6dm4nrx96b";
   };
 
-  depsSha256 = "1vach2xf0cs7nivbakhmrm2aqdif3i5vg1syffrs2ghcix9hd21p";
+  depsSha256 = "1rnk33g85r1hkw9l9c52dzr4zka5kghbci9qwni3ph19rfqf0a73";
 
   meta = with stdenv.lib; {
     description = "A tool for formatting Rust code according to style guidelines";

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,9 +7,9 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2017-03-22";
-  rev = "2458be6157706b6c92e37baa19703c15d89f6b3a";
-  sha256 = "19ij0fqy5j4lz73w4p29wv4gsxhs345ajxm4bxpq6gx2h4x6qk06";
+  version = "2017-03-29";
+  rev = "d9dbb2fc117bf730d1f54b090b3af407e8e5ff20";
+  sha256 = "1vrzr4v8qp5jy3xmqrcyk9naik3rngk8hzxif42y687ncppzrsdl";
 
   src = fetchFromGitHub {
       inherit rev;


### PR DESCRIPTION
Update the `rustfmt` package from version 0.8 to version 0.8.1.
Additionally, update the `rustRegistry` to a more recent version to
provide the new `rustfmt` version's dependencies.

I have tested these changes per nixpkgs manual section 11.1 ("Making
patches").

