### PR TITLE
python-packages: add flask-openid package and dependencies

### DIFF
--- a/pkgs/development/python-modules/flask-openid/default.nix
+++ b/pkgs/development/python-modules/flask-openid/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchPypi, buildPythonPackage, isPy3k, flask, python-openid, python3-openid }:
+
+buildPythonPackage rec {
+  pname = "Flask-OpenID";
+  version = "1.2.5";
+  name  = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1aycwmwi7ilcaa5ab8hm0bp6323zl8z25q9ha0gwrl8aihfgx3ss";
+  };
+
+  # there don't appear to be any tests
+  doCheck = false;
+
+  propagatedBuildInputs = [ flask ] ++ (if isPy3k then [ python3-openid ] else [ python-openid ]);
+
+  meta = {
+    homepage = "https://github.com/mitsuhiko/flask-openid/";
+    description = "OpenID support for Flask";
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/python-openid/default.nix
+++ b/pkgs/development/python-modules/python-openid/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchPypi, buildPythonPackage, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "python-openid";
+  version = "2.2.5";
+  name  = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vvhxlghjan01snfdc4k7ykd80vkyjgizwgg9bncnin8rqz1ricj";
+  };
+
+  # use python3-openid instead
+  disabled = isPy3k;
+
+  meta = {
+    description = "OpenID support for servers and consumers";
+    homepage = "https://github.com/openid/python-openid";
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/python3-openid/default.nix
+++ b/pkgs/development/python-modules/python3-openid/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchPypi, buildPythonPackage, defusedxml, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "python3-openid";
+  version = "3.1.0";
+  name  = "${pname}-${version}";
+
+  # use python-openid instead
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "00l5hrjh19740w00b3fnsqldnla41wbr2rics09dl4kyd1fkd3b2";
+  };
+
+  propagatedBuildInputs = [ defusedxml ];
+
+  # requires not-yet-packaged dependencies
+  doCheck = false;
+
+  meta = {
+    description = "OpenID support for modern servers and consumers";
+    homepage = "https://github.com/necaris/python3-openid";
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8556,6 +8556,8 @@ in {
     };
   };
 
+  python-openid = callPackage ../development/python-modules/python-openid { };
+
   pamela = buildPythonPackage rec {
     name = "pamela-${version}";
     version = "0.3.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11509,6 +11509,8 @@ in {
 
   flask_oauthlib = callPackage ../development/python-modules/flask-oauthlib.nix { };
 
+  flask_openid = callPackage ../development/python-modules/flask-openid { };
+
   flask_principal = buildPythonPackage rec {
     name = "Flask-Principal-${version}";
     version = "0.4.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8558,6 +8558,8 @@ in {
 
   python-openid = callPackage ../development/python-modules/python-openid { };
 
+  python3-openid = callPackage ../development/python-modules/python3-openid { };
+
   pamela = buildPythonPackage rec {
     name = "pamela-${version}";
     version = "0.3.0";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

