### PR TITLE
qsyncthingtray: fix program paths

### DIFF
--- a/pkgs/applications/misc/qsyncthingtray/default.nix
+++ b/pkgs/applications/misc/qsyncthingtray/default.nix
@@ -1,25 +1,44 @@
-{ stdenv, fetchFromGitHub
-, qtbase, qtwebengine
-, qmakeHook }:
+{ stdenv, lib, fetchFromGitHub, procps ? null
+, qtbase, qtwebengine, qtwebkit
+, cmake, makeQtWrapper
+, syncthing, syncthing-inotify ? null
+, preferQWebView ? false }:
 
 stdenv.mkDerivation rec {
   version = "0.5.7";
   name = "qsyncthingtray-${version}";
 
   src = fetchFromGitHub {
-    owner = "sieren";
-    repo = "QSyncthingTray";
-    rev = "${version}";
+    owner  = "sieren";
+    repo   = "QSyncthingTray";
+    rev    = "${version}";
     sha256 = "0crrdpdmlc4ahkvp5znzc4zhfwsdih655q1kfjf0g231mmynxhvq";
   };
 
-  buildInputs = [ qtbase qtwebengine ];
-  nativeBuildInputs = [ qmakeHook ];
+  buildInputs = [ qtbase qtwebengine ] ++ lib.optional preferQWebView qtwebkit;
+  nativeBuildInputs = [ cmake makeQtWrapper ];
   enableParallelBuilding = true;
 
-  postInstall = ''
+  cmakeFlags = lib.optional preferQWebView "-DQST_BUILD_WEBKIT=1";
+
+  postPatch = ''
+    ${lib.optionalString stdenv.isLinux ''
+      substituteInPlace includes/platforms/linux/posixUtils.hpp \
+        --replace '"/usr/local/bin/syncthing"'         '"${syncthing}/bin/syncthing"' \
+        --replace '"/usr/local/bin/syncthing-inotify"' '"${syncthing-inotify}/bin/syncthing-inotify"' \
+        --replace '"pgrep -x'                          '"${procps}/bin/pgrep -x'
+    ''}
+
+    ${lib.optionalString stdenv.isDarwin ''
+      substituteInPlace includes/platforms/darwin/macUtils.hpp \
+        --replace '"/usr/local/bin/syncthing"'         '"${syncthing}/bin/syncthing"'
+    ''}
+  '';
+
+  installPhase = let qst = "qsyncthingtray"; in ''
     mkdir -p $out/bin
-    cp binary/QSyncthingTray $out/bin
+    install -m755 QSyncthingTray $out/bin/${qst}
+    ln -s $out/bin/${qst} $out/bin/QSyncthingTray
   '';
 
   meta = with stdenv.lib; {
@@ -31,7 +50,7 @@ stdenv.mkDerivation rec {
         Written in C++ with Qt.
     '';
     license = licenses.lgpl3;
-    maintainers = with maintainers; [ zraexy ];
+    maintainers = with maintainers; [ zraexy peterhoeg ];
     platforms = platforms.all;
     broken = builtins.compareVersions qtbase.version "5.7.0" >= 0;
   };


### PR DESCRIPTION
###### Motivation for this change

We need this for qsyncthingtray to be able to detect the processes when the
binaries (syncthing, -inotify and pgrep) are not in the global path.

Any comments @zraexy ?

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
