### PR TITLE
gcalcli: fix notifications on linux

### DIFF
--- a/pkgs/applications/misc/gcalcli/default.nix
+++ b/pkgs/applications/misc/gcalcli/default.nix
@@ -1,13 +1,14 @@
-{ fetchFromGitHub, lib, pythonPackages }:
+{ stdenv, lib, fetchFromGitHub, pythonPackages
+, libnotify ? null }:
 
 pythonPackages.buildPythonApplication rec {
   version = "3.4.0";
   name = "gcalcli-${version}";
 
   src = fetchFromGitHub {
-    owner = "insanum";
-    repo = "gcalcli";
-    rev = "v${version}";
+    owner  = "insanum";
+    repo   = "gcalcli";
+    rev    = "v${version}";
     sha256 = "171awccgnmfv4j7m2my9387sjy60g18kzgvscl6pzdid9fn9rrm8";
   };
 
@@ -20,12 +21,23 @@ pythonPackages.buildPythonApplication rec {
     parsedatetime
     six
     vobject
-  ] ++ lib.optional (!pythonPackages.isPy3k) futures;
+  ]
+  ++ lib.optional (!pythonPackages.isPy3k) futures;
+
+  # there are no tests as of 3.4.0
+  doCheck = false;
+
+  postInstall = lib.optionalString stdenv.isLinux ''
+    substituteInPlace $out/bin/gcalcli \
+      --replace "command = 'notify-send -u critical -a gcalcli %s'" \
+                "command = '${libnotify}/bin/notify-send -i view-calendar-upcoming-events -u critical -a Calendar %s'"
+  '';
 
   meta = with lib; {
     homepage = https://github.com/insanum/gcalcli;
     description = "CLI for Google Calendar";
     license = licenses.mit;
-    maintainers = [ maintainers.nocoolnametom ];
+    maintainers = with maintainers; [ nocoolnametom ];
+    inherit version;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Couple of things:

 - fix the path to notify-send
 - add a standard icon to the notification (I have submitted a patch upstream to do this)
 - rename the notification from "gcalcli" to "Calendar"

Lastly, there are no tests, so do not try to run them.

Comments @nocoolnametom ?

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
