### PR TITLE
Get rid of all `with { inherit... }` and just used `let inherit...`

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1,12 +1,12 @@
 # Operations on attribute sets.
 
-with {
+let
   inherit (builtins) head tail length;
   inherit (import ./trivial.nix) or;
   inherit (import ./default.nix) fold;
   inherit (import ./strings.nix) concatStringsSep;
   inherit (import ./lists.nix) concatMap concatLists all deepSeqList;
-};
+in
 
 rec {
   inherit (builtins) attrNames listToAttrs hasAttr isAttrs getAttr;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -6,7 +6,7 @@ with import ./attrsets.nix;
 with import ./options.nix;
 with import ./trivial.nix;
 with import ./strings.nix;
-with {inherit (import ./modules.nix) mergeDefinitions filterOverrides; };
+let inherit (import ./modules.nix) mergeDefinitions filterOverrides; in
 
 rec {
 

--- a/pkgs/applications/editors/codeblocks/default.nix
+++ b/pkgs/applications/editors/codeblocks/default.nix
@@ -4,8 +4,6 @@
 
 with stdenv.lib;
 
-with { inherit (stdenv.lib) optionalString optional optionals; };
-
 stdenv.mkDerivation rec {
   name = "${pname}-${stdenv.lib.optionalString contribPlugins "full-"}${version}";
   version = "16.01";

--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -10,7 +10,7 @@ let
   version = "2.92";
 in
 
-with { inherit (stdenv.lib) optional optionals optionalString; };
+let inherit (stdenv.lib) optional optionals optionalString; in
 
 stdenv.mkDerivation rec {
   name = "transmission-" + optionalString enableGTK3 "gtk-" + version;

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -22,7 +22,7 @@ let
   primary-src = import ./default-primary-src.nix { inherit fetchurl; };
 in
 
-with { inherit (primary-src) major minor subdir version; };
+let inherit (primary-src) major minor subdir version; in
 
 let
   lib = stdenv.lib;

--- a/pkgs/applications/office/libreoffice/still.nix
+++ b/pkgs/applications/office/libreoffice/still.nix
@@ -22,7 +22,7 @@ let
   primary-src = import ./still-primary-src.nix { inherit fetchurl; };
 in
 
-with { inherit (primary-src) major minor subdir version; };
+let inherit (primary-src) major minor subdir version; in
 
 let
   lib = stdenv.lib;

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -9,7 +9,7 @@
 
 assert glSupport -> mesa_noglu != null;
 
-with { inherit (stdenv.lib) optional optionals; };
+let inherit (stdenv.lib) optional optionals; in
 
 stdenv.mkDerivation rec {
   name = "cairo-1.14.8";

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -9,11 +9,11 @@
   useEncumberedCode ? true,
 }:
 
-with { inherit (stdenv.lib) optional optionals optionalString; };
+let
+  inherit (stdenv.lib) optional optionals optionalString;
+  version = "2.7.1"; name = "freetype-" + version;
 
-let version = "2.7.1"; name = "freetype-" + version; in
-
-stdenv.mkDerivation {
+in stdenv.mkDerivation {
   inherit name;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, m4, cxx ? true, withStatic ? true }:
 
-with { inherit (stdenv.lib) optional optionalString; };
+let inherit (stdenv.lib) optional optionalString; in
 
 let self = stdenv.mkDerivation rec {
   name = "gmp-5.1.3";

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, m4, cxx ? true, withStatic ? false }:
 
-with { inherit (stdenv.lib) optional optionalString; };
+let inherit (stdenv.lib) optional optionalString; in
 
 let self = stdenv.mkDerivation rec {
   name = "gmp-6.1.1";

--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -17,7 +17,7 @@
 
 assert faacSupport -> enableUnfree;
 
-with { inherit (stdenv.lib) optional optionals hasPrefix; };
+let inherit (stdenv.lib) optional optionals hasPrefix; in
 
 /* ToDo:
     - more deps, inspiration: http://packages.ubuntu.com/raring/libav-tools

--- a/pkgs/development/libraries/libgsf/default.nix
+++ b/pkgs/development/libraries/libgsf/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, pkgconfig, intltool, gettext, glib, libxml2, zlib, bzip2
 , python, perl, gdk_pixbuf, libiconv, libintlOrEmpty }:
 
-with { inherit (stdenv.lib) optionals; };
+let inherit (stdenv.lib) optionals; in
 
 stdenv.mkDerivation rec {
   name = "libgsf-1.14.41";

--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -13,7 +13,7 @@ assert enableAsioLib -> boost != null;
 assert enableGetAssets -> libxml2 != null;
 assert enableJemalloc -> jemalloc != null;
 
-with { inherit (stdenv.lib) optional; };
+let inherit (stdenv.lib) optional; in
 
 stdenv.mkDerivation rec {
   name = "nghttp2-${version}";

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -7,7 +7,7 @@
 }:
 { platformVersions, abiVersions, useGoogleAPIs, useExtraSupportLibs ? false, useGooglePlayServices ? false }:
 
-with { inherit (stdenv.lib) makeLibraryPath; };
+let inherit (stdenv.lib) makeLibraryPath; in
 
 stdenv.mkDerivation rec {
   name = "android-sdk-${version}";

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -4,7 +4,7 @@
 
 let basename = "binutils-2.28"; in
 
-with { inherit (stdenv.lib) optional optionals optionalString; };
+let inherit (stdenv.lib) optional optionals optionalString; in
 
 stdenv.mkDerivation rec {
   name = basename + optionalString (cross != null) "-${cross.config}";

--- a/pkgs/games/oilrush/default.nix
+++ b/pkgs/games/oilrush/default.nix
@@ -1,7 +1,7 @@
 { stdenv, config, fetchurl, libX11, libXext, libXinerama, libXrandr
 , libXrender, fontconfig, freetype, openal }:
 
-with { inherit (stdenv.lib) makeLibraryPath; };
+let inherit (stdenv.lib) makeLibraryPath; in
 
 stdenv.mkDerivation {
   name = "oilrush";

--- a/pkgs/servers/coturn/default.nix
+++ b/pkgs/servers/coturn/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, openssl, libevent }:
 
-with { inherit (stdenv.lib) optional; };
+let inherit (stdenv.lib) optional; in
 
 stdenv.mkDerivation rec {
   name = "coturn-${version}";

--- a/pkgs/servers/dns/knot-dns/default.nix
+++ b/pkgs/servers/dns/knot-dns/default.nix
@@ -2,7 +2,7 @@
 , systemd, nettle, libedit, zlib, libiconv, fetchpatch
 }:
 
-with { inherit (stdenv.lib) optional optionals; };
+let inherit (stdenv.lib) optional optionals; in
 
 # Note: ATM only the libraries have been tested in nixpkgs.
 stdenv.mkDerivation rec {

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -12,7 +12,7 @@
 # (--enable-unsupported could be used to force the build)
 assert !cpp || mpi == null;
 
-with { inherit (stdenv.lib) optional optionals; };
+let inherit (stdenv.lib) optional optionals; in
 
 stdenv.mkDerivation rec {
   version = "1.8.18";


### PR DESCRIPTION
###### Motivation for this change

The old forms presumably predates, or were made in ignorance of, `let inherit`. This way is better style as the scoping as more lexical, something which Nix can (or might already!) take advantage of.