### PR TITLE
projectlibre: init at 1.6.2

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -179,6 +179,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName  = "CeCILL-C Free Software License Agreement";
   };
 
+  cpal10 = spdx {
+    spdxId = "CPAL-1.0";
+    fullName = "Common Public Attribution License 1.0";
+  };
+
   cpl10 = spdx {
     spdxId = "CPL-1.0";
     fullName = "Common Public License 1.0";

--- a/lib/maintainers-list.nix
+++ b/lib/maintainers-list.nix
@@ -87,6 +87,11 @@
     github = "MP2E";
     name = "Cray Elliott";
   };
+  Mogria = {
+    email = "m0gr14@gmail.com";
+    github = "mogria";
+    name = "Mogria";
+  };
   MostAwesomeDude = {
     email = "cds@corbinsimpson.com";
     github = "MostAwesomeDude";

--- a/pkgs/applications/misc/projectlibre/default.nix
+++ b/pkgs/applications/misc/projectlibre/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchgit, ant, jdk, makeWrapper, jre, coreutils, which }:
+
+stdenv.mkDerivation rec {
+  name = "projectlibre-${version}";
+  version = "1.7.0";
+
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/projectlibre/code";
+    rev = "0c939507cc63e9eaeb855437189cdec79e9386c2"; # version 1.7.0 was not tagged
+    sha256 = "0vy5vgbp45ai957gaby2dj1hvmbxfdlfnwcanwqm9f8q16qipdbq";
+  };
+
+  buildInputs = [ ant jdk makeWrapper ];
+  buildPhase = ''
+    export ANT_OPTS=-Dbuild.sysclasspath=ignore
+    ${ant}/bin/ant -f openproj_build/build.xml
+  '';
+
+  resourcesPath = "openproj_build/resources";
+  desktopItem = "${resourcesPath}/projectlibre.desktop";
+
+  installPhase = ''
+    mkdir -p $out/share/{applications,projectlibre/samples,pixmaps,doc/projectlibre} $out/bin
+
+    substitute $resourcesPath/projectlibre $out/bin/projectlibre \
+      --replace "\"/usr/share/projectlibre\"" "\"$out/share/projectlibre\""
+    chmod +x $out/bin/projectlibre
+    wrapProgram $out/bin/projectlibre \
+     --prefix PATH : "${jre}/bin:${coreutils}/bin:${which}/bin"
+
+    cp -R openproj_build/dist/* $out/share/projectlibre
+    cp -R openproj_build/license $out/share/doc/projectlibre
+    cp $desktopItem $out/share/applications
+    cp $resourcesPath/projectlibre.png $out/share/pixmaps
+    cp -R $resourcesPath/samples/* $out/share/projectlibre/samples
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.projectlibre.com/";
+    descripton = "Project-Management Software similar to MS-Project";
+    maintainer = maintainers.mogria;
+    license = licenses.cpal10;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4317,6 +4317,8 @@ with pkgs;
 
   profile-sync-daemon = callPackage ../tools/misc/profile-sync-daemon { };
 
+  projectlibre = callPackage ../applications/misc/projectlibre { };
+
   projectm = callPackage ../applications/audio/projectm { };
 
   proot = callPackage ../tools/system/proot { };


### PR DESCRIPTION
###### Motivation for this change

Alternative to ganttproject with more features. More similar to MS-Project.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

