### PR TITLE
Rust: Remove "warning: file ... may be generated"

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation (args // {
 
     echo "Using cargo deps from $cargoDeps"
 
-    cp -r "$cargoDeps" deps
+    cp -a "$cargoDeps" deps
     chmod +w deps -R
 
     # It's OK to use /dev/null as the URL because by the time we do this, cargo


### PR DESCRIPTION
Every Rust derivation used to emit a warning like the following:

```
setting SOURCE_DATE_EPOCH to timestamp 1490877042 of file cargo-6e0c18c/Cargo.lock
warning: file cargo-6e0c18c/Cargo.lock may be generated; SOURCE_DATE_EPOCH may be non-deterministic
```

The reason is that the dependencies are copied without preserving
timestamps. Changing the build script to timestamp-preserving copy
removes the warning.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested compilation of rustfmt, rustracer, rainicorn
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@anderspapitto @aristidb please review :-)