### PR TITLE
xsv: init at 0.11.0

### DIFF
--- a/pkgs/tools/text/xsv/default.nix
+++ b/pkgs/tools/text/xsv/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "xsv-${version}";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "BurntSushi";
+    repo = "xsv";
+    rev = "${version}";
+    sha256 = "169rp4izcjhhlrqrhvlvsbiz7wqfi6g3kjfgrddgvahp0ls29hls";
+  };
+
+  depsSha256 = "006sp66l2gybyk1n7lxp645k6drz5cgxcix376k8qr0v9jwadlqa";
+
+  meta = with stdenv.lib; {
+    description = "A fast CSV toolkit written in Rust";
+    homepage = https://github.com/BurntSushi/xsv;
+    license = with licenses; [ unlicense ];
+    maintainers = [ maintainers.jgertm ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4666,6 +4666,8 @@ with pkgs;
 
   xsel = callPackage ../tools/misc/xsel { };
 
+  xsv = callPackages ../tools/text/xsv { };
+
   xtreemfs = callPackage ../tools/filesystems/xtreemfs {};
 
   xurls = callPackage ../tools/text/xurls {};


### PR DESCRIPTION
###### Motivation for this change

This commit adds the `xsv` utility. It is quite useful when dealing with CSV files

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

