### PR TITLE
boomerang: update to latest git, un-mark broken

### DIFF
--- a/pkgs/development/tools/boomerang/default.nix
+++ b/pkgs/development/tools/boomerang/default.nix
@@ -1,43 +1,31 @@
-{ stdenv, fetchgit, cmake, expat }:
+{ stdenv, fetchgit, cmake, expat, qt5, boost }:
 
 stdenv.mkDerivation rec {
   name = "boomerang-${version}";
-  version = "0.3.2alpha";
+  version = "0.3.99-alpha-2016-11-02";
 
   src = fetchgit {
     url = "https://github.com/nemerle/boomerang.git";
-    rev = "78c6b9dd33790be43dcb07edc549161398904006";
-    sha256 = "1n49wx2v9r40mh5kdkspqvc8rccpb4s004qxqvn4fwc59dm0pqbs";
+    rev = "f95d6436845e9036c8cfbd936731449475f79b7a";
+    sha256 = "1q3q92lfj24ij5sxdbdhcqyan28r6db1w80yrks4csf9zjij1ixh";
   };
 
-  buildInputs = [ cmake expat ];
+  buildInputs = [ cmake expat qt5.qtbase boost ];
+
+  patches = [ ./fix-install.patch ./fix-output.patch ];
 
   postPatch = ''
-    sed -i -e 's/-std=c++0x/-std=c++11 -fpermissive/' CMakeLists.txt
+    substituteInPlace loader/BinaryFileFactory.cpp \
+      --replace '"lib"' '"../lib"'
 
-    # Hardcode library base path ("lib/" is appended elsewhere)
-    sed -i -e 's|::m_base_path = "|&'"$out"'/|' loader/BinaryFileFactory.cpp
-    # Deactivate setting base path at runtime
-    sed -i -e 's/m_base_path *=[^}]*//' include/BinaryFile.h
+    substituteInPlace ui/DecompilerThread.cpp \
+      --replace '"output"' '"./output"'
 
-    # Fix up shared directory locations
-    shared="$out/share/boomerang/"
-    find frontend -name '*.cpp' -print | xargs sed -i -e \
-      's|Boomerang::get()->getProgPath()|std::string("'"$shared"'")|'
+    substituteInPlace boomerang.cpp \
+      --replace 'progPath("./")' "progPath(\"$out/share/boomerang/\")"
 
-    cat >> loader/CMakeLists.txt <<CMAKE
-    INSTALL(TARGETS bffDump BinaryFile
-            ElfBinaryFile Win32BinaryFile ExeBinaryFile HpSomBinaryFile
-            PalmBinaryFile DOS4GWBinaryFile MachOBinaryFile
-            RUNTIME DESTINATION bin
-            LIBRARY DESTINATION lib)
-    CMAKE
-
-    cat >> CMakeLists.txt <<CMAKE
-    INSTALL(TARGETS boomerang DESTINATION bin)
-    INSTALL(DIRECTORY signatures DESTINATION share/boomerang)
-    INSTALL(DIRECTORY frontend/machine DESTINATION share/boomerang/frontend)
-    CMAKE
+    substituteInPlace ui/commandlinedriver.cpp \
+      --replace "QFileInfo(args[0]).absolutePath()" "\"$out/share/boomerang/\""
   '';
 
   enableParallelBuilding = true;
@@ -46,6 +34,5 @@ stdenv.mkDerivation rec {
     homepage = "http://boomerang.sourceforge.net/";
     license = stdenv.lib.licenses.bsd3;
     description = "A general, open source, retargetable decompiler";
-    broken = true;
   };
 }

--- a/pkgs/development/tools/boomerang/fix-install.patch
+++ b/pkgs/development/tools/boomerang/fix-install.patch
@@ -1,0 +1,48 @@
+From 5851256422a4debc34c956439d8129a4d5f80722 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Thu, 30 Mar 2017 10:06:03 -0500
+Subject: [PATCH] cmake: add install bits
+
+---
+ CMakeLists.txt        | 3 +++
+ loader/CMakeLists.txt | 2 ++
+ ui/CMakeLists.txt     | 2 ++
+ 3 files changed, 7 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 826fe307..740861db 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -113,3 +113,6 @@ SET_PROPERTY(TARGET boom_base PROPERTY CXX_STANDARD_REQUIRED ON)
+ 
+ ADD_SUBDIRECTORY(loader)
+ ADD_SUBDIRECTORY(ui)
++
++INSTALL(DIRECTORY signatures DESTINATION share/boomerang)
++INSTALL(DIRECTORY frontend/machine DESTINATION share/boomerang/frontend)
+diff --git a/loader/CMakeLists.txt b/loader/CMakeLists.txt
+index b371d366..dcf715fd 100644
+--- a/loader/CMakeLists.txt
++++ b/loader/CMakeLists.txt
+@@ -6,6 +6,8 @@ macro(BOOMERANG_ADD_LOADER name)
+     endif()
+     qt5_use_modules(${target_name} Core)
+     set_target_properties(${target_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/out/lib")
++    install(TARGETS "${target_name}"
++      LIBRARY DESTINATION lib)
+ endmacro()
+ 
+ BOOMERANG_ADD_LOADER(Elf      elf/ElfBinaryFile.cpp elf/ElfBinaryFile.h)
+diff --git a/ui/CMakeLists.txt b/ui/CMakeLists.txt
+index f6fe3271..8729b522 100644
+--- a/ui/CMakeLists.txt
++++ b/ui/CMakeLists.txt
+@@ -26,3 +26,5 @@ boom_base frontend db type boomerang_DSLs codegen util boom_base
+ ${CMAKE_THREAD_LIBS_INIT} boomerang_passes
+ )
+ qt5_use_modules(boomerang Core Xml Widgets)
++
++INSTALL(TARGETS boomerang DESTINATION bin)
+-- 
+2.11.0
+

--- a/pkgs/development/tools/boomerang/fix-output.patch
+++ b/pkgs/development/tools/boomerang/fix-output.patch
@@ -1,0 +1,24 @@
+From f3f5f888a1b1fe72ea8fc8cc96ef4ee386011e1c Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Thu, 30 Mar 2017 11:21:38 -0500
+Subject: [PATCH] don't default to writing to program directory
+
+---
+ boomerang.cpp | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/boomerang.cpp b/boomerang.cpp
+index 5951ed91..b592f482 100644
+--- a/boomerang.cpp
++++ b/boomerang.cpp
+@@ -601,7 +601,6 @@ int Boomerang::processCommand(QStringList &args) {
+  */
+ void Boomerang::setProgPath(const QString &p) {
+     progPath = p + "/";
+-    outputPath = progPath + "/output/"; // Default output path (can be overridden with -o below)
+ }
+ 
+ /**
+-- 
+2.11.0
+


### PR DESCRIPTION
* Now with Qt UI
* Rework kludges to help boomerang find itself
* update/rework cmake bits for installation
* Fix output directory path defaults

###### Motivation for this change

Saw boomerang marked broken (and it sure was!), thought I'd take a crack at fixing it :).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

