### PR TITLE
gworkspace: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/desktops/gnustep/back/default.nix
+++ b/pkgs/desktops/gnustep/back/default.nix
@@ -5,6 +5,7 @@
 , x11
 , freetype
 , pkgconfig
+, libXmu
 }:
 let
   version = "0.25.0";
@@ -15,7 +16,7 @@ gsmakeDerivation {
     url = "ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-back-${version}.tar.gz";
     sha256 = "14gs1b32ahnihd7mwpjrws2b8hl11rl1wl24a7651d3z2l7f6xj2";
   };
-  buildInputs = [ cairo base gui freetype pkgconfig x11 ];
+  buildInputs = [ cairo base gui freetype pkgconfig x11 libXmu ];
   meta = {
     description = "A generic backend for GNUstep";
   };

--- a/pkgs/desktops/gnustep/gworkspace/default.nix
+++ b/pkgs/desktops/gnustep/gworkspace/default.nix
@@ -4,13 +4,13 @@
 , system_preferences
 }:
 let
-  version = "0.9.3";
+  version = "0.9.4";
 in
 gsmakeDerivation {
   name = "gworkspace-${version}";
   src = fetchurl {
     url = "ftp://ftp.gnustep.org/pub/gnustep/usr-apps/gworkspace-${version}.tar.gz";
-    sha256 = "0jchqwb0dj522j98jqlqlib44jppax39zx2zqyzdwiz4qjl470r3";
+    sha256 = "0cjn83m7qmbwdpldlyhs239nwswgip3yaz01ahls130dq5qq7hgk";
   };
   # additional dependencies:
   # - PDFKit framework from http://gap.nongnu.org/


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).