### PR TITLE
lambda-mod-zsh-theme: init at eceee68cf46bba9f7f42887c2128b48e8861e31b

### DIFF
--- a/pkgs/shells/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/lambda-mod-zsh-theme/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchgit }:
+{ stdenv, fetchFromGitHub }:
 
 let
-  pkgName = "lambda-mod-zsh-theme";
+  repo = "lambda-mod-zsh-theme";
   rev = "eceee68cf46bba9f7f42887c2128b48e8861e31b";
 in stdenv.mkDerivation {
-  name = "${pkgName}-${rev}";
+  name = "${repo}-${rev}";
 
-  src = fetchgit {
-    inherit rev;
+  src = fetchFromGitHub {
+    inherit rev repo;
 
-    url = "https://github.com/halfo/lambda-mod-zsh-theme";
+    owner = "halfo";
     sha256 = "1410ryc22i20na5ypa1q6f106lkjj8n1qfjmb77q4rspi0ydaiy4";
   };
 

--- a/pkgs/shells/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/lambda-mod-zsh-theme/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchgit }:
+
+let
+  pkgName = "lambda-mod-zsh-theme";
+  rev = "eceee68cf46bba9f7f42887c2128b48e8861e31b";
+in stdenv.mkDerivation rec {
+  name = "${pkgName}-${rev}";
+
+  src = fetchgit {
+    inherit rev;
+
+    url = "https://github.com/halfo/lambda-mod-zsh-theme";
+    sha256 = "1410ryc22i20na5ypa1q6f106lkjj8n1qfjmb77q4rspi0ydaiy4";
+  };
+
+  buildPhases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp lambda-mod.zsh-theme $out/share
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A ZSH theme optimized for people who use Git & Unicode-compatible fonts and terminals";
+    homepage = "https://github.com/halfo/lambda-mod-zsh-theme/";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ ma27 ];
+  };
+}

--- a/pkgs/shells/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/lambda-mod-zsh-theme/default.nix
@@ -16,8 +16,8 @@ in stdenv.mkDerivation {
   buildPhases = [ "unpackPhase" "installPhase" ];
 
   installPhase = ''
-    mkdir -p $out/share
-    cp lambda-mod.zsh-theme $out/share
+    mkdir -p $out/share/themes
+    cp lambda-mod.zsh-theme $out/share/themes
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/shells/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/lambda-mod-zsh-theme/default.nix
@@ -25,6 +25,6 @@ in stdenv.mkDerivation {
     homepage = "https://github.com/halfo/lambda-mod-zsh-theme/";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = [ ma27 ];
+    maintainers = with maintainers; [ ma27 ];
   };
 }

--- a/pkgs/shells/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/lambda-mod-zsh-theme/default.nix
@@ -3,7 +3,7 @@
 let
   pkgName = "lambda-mod-zsh-theme";
   rev = "eceee68cf46bba9f7f42887c2128b48e8861e31b";
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation {
   name = "${pkgName}-${rev}";
 
   src = fetchgit {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9635,6 +9635,8 @@ with pkgs;
     haskell-lib = haskell.lib;
   };
 
+  lambda-mod-zsh-theme = callPackage ../shells/lambda-mod-zsh-theme/default.nix { };
+
   leksah = callPackage ../development/tools/haskell/leksah {
     inherit (haskellPackages) ghcWithPackages;
   };


### PR DESCRIPTION
###### Motivation for this change

The `lambda-mod-zsh-theme` is a simple ZSH theme I currently use on my laptop.
As I currently switch to a nix-based setup for ZSH, I need a nix package for that.

(see https://github.com/halfo/lambda-mod-zsh-theme/ and https://github.com/halfo/lambda-mod-zsh-theme/blob/master/LICENSE for License information)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

