### PR TITLE
wrk: use packaged openssl, luajit

### DIFF
--- a/pkgs/tools/networking/wrk/default.nix
+++ b/pkgs/tools/networking/wrk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, openssl, perl }:
+{ stdenv, fetchFromGitHub, luajit, openssl, perl }:
 
 stdenv.mkDerivation rec {
   name = "wrk-${version}";
@@ -11,7 +11,16 @@ stdenv.mkDerivation rec {
     sha256 = "1qg6w8xz4pr227h1gxrbm6ylhqvspk95hvq2f9iakni7s56pkh1w";
   };
 
-  buildInputs = [ openssl perl ];
+  buildInputs = [ luajit openssl perl ];
+
+  makeFlags = [ "WITH_LUAJIT=${luajit}" "WITH_OPENSSL=${openssl.dev}" "VER=${version}" ];
+
+  preBuild = ''
+    for f in src/*.h; do
+      substituteInPlace $f \
+        --replace "#include <luajit-2.0/" "#include <"
+    done
+  '';
   
   installPhase = ''
     mkdir -p $out/bin
@@ -29,6 +38,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ ragge ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
This has the side effect of now building on darwin. Previously, the
vendored luajit would fail to build.

###### Motivation for this change

Want to build on darwin. Also using the nixpkgs luajit and openssl rather than the vendored copies included in wrk (the vendored luajit failed to compile on darwin).

Note I included `luajit` in the function arguments, rather than `lua` combined with a `lua = luajit` in the `callPackage` because this package will only work with `luajit` and not other implementations. Happy to change that if that's the wrong style.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

