### PR TITLE
latte-dock: init at 0.5.98

### DIFF
--- a/pkgs/applications/misc/latte-dock/default.nix
+++ b/pkgs/applications/misc/latte-dock/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, cmake, plasma-framework, fetchFromGitHub }:
+
+let version = "0.5.98"; in
+
+stdenv.mkDerivation {
+  name = "latte-dock-${version}";
+
+  src = fetchFromGitHub {
+    owner = "psifidotos";
+    repo = "Latte-Dock";
+    rev = version;
+    sha256 = "0z02ipbbv0dmcxs2g3dq5h62klhijni1i4ikq903hjg0j2cqg5xh";
+  };
+
+  buildInputs = [ plasma-framework ];
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Dock-style app launcher based on Plasma frameworks";
+    homepage = https://github.com/psifidotos/Latte-Dock;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.benley ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17049,6 +17049,8 @@ with pkgs;
 
   redshift-plasma-applet = libsForQt5.callPackage ../applications/misc/redshift-plasma-applet { };
 
+  latte-dock = libsForQt5.callPackage ../applications/misc/latte-dock { };
+
   orion = callPackage ../misc/themes/orion {};
 
   albatross = callPackage ../misc/themes/albatross { };


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).