### PR TITLE
hdparm: 9.48 -> 9.51

### DIFF
--- a/pkgs/os-specific/linux/hdparm/default.nix
+++ b/pkgs/os-specific/linux/hdparm/default.nix
@@ -1,22 +1,24 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "hdparm-9.48";
+  name = "hdparm-9.51";
 
   src = fetchurl {
     url = "mirror://sourceforge/hdparm/${name}.tar.gz";
-    sha256 = "1vpvlkrksfwx8lxq1p1nk3ddyzgrwy3rgxpn9kslchdh3jkv95yf";
+    sha256 = "14ax5lyzhigx58ing7adbfyzisv0fqajbmzphg149rnb3s4xiyhs";
+
   };
 
   preBuild = ''
     makeFlagsArray=(sbindir=$out/sbin manprefix=$out)
-  '';
+    '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A tool to get/set ATA/SATA drive parameters under Linux";
     homepage = http://sourceforge.net/projects/hdparm/;
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.bsd2;
-    maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
+    platforms = platforms.linux;
+    license = licenses.bsd2;
+    maintainers = [ maintainers.fuuzetsu ];
   };
+
 }


### PR DESCRIPTION
hdparm: Fixed mandir

###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

