### PR TITLE
nfdump: init at 1.6.15

### DIFF
--- a/pkgs/tools/networking/nfdump/default.nix
+++ b/pkgs/tools/networking/nfdump/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, bzip2, yacc, flex }:
+
+let version = "1.6.15"; in
+
+stdenv.mkDerivation rec {
+  name = "nfdump-${version}";
+
+  src = fetchFromGitHub {
+    owner = "phaag";
+    repo = "nfdump";
+    rev = "v${version}";
+    sha256 = "07grsfkfjy05yfqfcmgp5xpavpck9ps6q7x8x8j79fym5d8gwak5";
+  };
+
+  nativeBuildInputs = [yacc flex];
+  buildInputs = [bzip2];
+
+  meta = with stdenv.lib; {
+    description = "Tools for working with netflow data";
+    longDescription = ''
+      nfdump is a set of tools for working with netflow data.
+    '';
+    homepage = https://github.com/phaag/nfdump;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.takikawa ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -942,6 +942,8 @@ with pkgs;
 
   mpdris2 = callPackage ../tools/audio/mpdris2 { };
 
+  nfdump = callPackage ../tools/networking/nfdump { };
+
   playerctl = callPackage ../tools/audio/playerctl { };
 
   syscall_limiter = callPackage ../os-specific/linux/syscall_limiter {};


### PR DESCRIPTION
###### Motivation for this change

This PR adds the [nfdump](https://github.com/phaag/nfdump) (old sourceforge page is [here](http://nfdump.sourceforge.net/)) tool for working with netflow/IPFIX data for networking.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

