### PR TITLE
openvswitch: 2.5.0 -> 2.5.2

### DIFF
--- a/pkgs/os-specific/linux/openvswitch/default.nix
+++ b/pkgs/os-specific/linux/openvswitch/default.nix
@@ -7,12 +7,12 @@ with stdenv.lib;
 let
   _kernel = kernel;
 in stdenv.mkDerivation rec {
-  version = "2.5.0";
+  version = "2.5.2";
   name = "openvswitch-${version}";
 
   src = fetchurl {
     url = "http://openvswitch.org/releases/${name}.tar.gz";
-    sha256 = "08bgsqjjn2q5hvxsjqs7n3jir7k7291wlj3blsqhacjhmpxm9nil";
+    sha256 = "0ifx758zl97dpad9vpd5i5dqj6i03k632mvgxs82hqkcsb3r6y7q";
   };
 
   kernel = optional (_kernel != null) _kernel.dev;


### PR DESCRIPTION
###### Motivation for this change

Minor bugfix update in LTS 2.5.x branch (the latest version now is 2.7.0)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

