### PR TITLE
rtl8192su-firmware: init at unstable-2016-10-05

### DIFF
--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -26,6 +26,7 @@ with lib;
       firmwareLinuxNonfree
       intel2200BGFirmware
       rtl8723bs-firmware
+      rtl8192su-firmware
     ];
   };
 

--- a/pkgs/os-specific/linux/firmware/rtl8192su-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/rtl8192su-firmware/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub }:
+with stdenv.lib;
+stdenv.mkDerivation {
+  name = "rtl8192su-unstable-2016-10-05";
+
+  src = fetchFromGitHub {
+    owner = "chunkeey";
+    repo = "rtl8192su";
+    rev = "c00112c9a14133290fe30bd3b44e45196994cb1c";
+    sha256 = "0j3c35paapq1icmxq0mg7pm2xa2m69q7bkfmwgq99d682yr2cb5l";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    for i in rtl8192sfw.bin \
+             rtl8192sufw-ap.bin \
+             rtl8192sufw-apple.bin \
+             rtl8192sufw-windows.bin \
+             rtl8712u-linux-firmware-bad.bin \
+             rtl8712u-most-recent-v2.6.6-bad.bin \
+             rtl8712u-most-recent-v2.6.6-bad.bin \
+             rtl8712u-oldest-but-good.bin;
+    do
+      install -D -pm644 firmwares/$i $out/lib/firmware/rtlwifi/$i
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Firmware for Realtek RTL8188SU/RTL8191SU/RTL8192SU";
+    homepage = https://github.com/chunkeey/rtl8192su;
+    license = licenses.unfreeRedistributableFirmware;
+    maintainers = with maintainers; [ mic92 ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -741,7 +741,7 @@ with pkgs;
   catclock = callPackage ../applications/misc/catclock { };
 
   cde = callPackage ../tools/package-management/cde { };
-  
+
   cdemu-daemon = callPackage ../misc/emulators/cdemu/daemon.nix { };
 
   cdemu-client = callPackage ../misc/emulators/cdemu/client.nix { };
@@ -12022,6 +12022,8 @@ with pkgs;
   rtkit = callPackage ../os-specific/linux/rtkit { };
 
   rt5677-firmware = callPackage ../os-specific/linux/firmware/rt5677 { };
+
+  rtl8192su-firmware = callPackage ../os-specific/linux/firmware/rtl8192su-firmware { };
 
   rtl8723bs-firmware = callPackage ../os-specific/linux/firmware/rtl8723bs-firmware { };
 


### PR DESCRIPTION
###### Motivation for this change
I do not own this wifi chip, but @RobTranquillo
the driver itself is mainline

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

