### PR TITLE
terraform: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildGoPackage, fetchurl, fetchFromGitHub }:
+{ stdenv, lib, buildGoPackage, fetchpatch, fetchFromGitHub }:
 
 let
   goPackagePath = "github.com/hashicorp/terraform";
@@ -54,13 +54,13 @@ in {
     sha256 = "1yj5x1d10028fm3v3gjyjdn128ps0as345hr50y8x3vn86n70lxl";
 
     patches = [
-      (fetchurl {
+      (fetchpatch {
         url = "https://github.com/hashicorp/terraform/pull/13237.patch";
-        sha256 = "1f7hr1l5hck9mmqk01p6wxbfv9r3b0yi9ypz7bcmikp3bikza98x";
+        sha256 = "03c2nq12gvqqp12znvl3lmiviwsqksx4nrplv09fns2kz2gyfnbm";
       })
-      (fetchurl {
+      (fetchpatch {
         url = "https://github.com/hashicorp/terraform/pull/13248.patch";
-        sha256 = "1qc57kjhlqg5339him9bg4izdphins2fjjhb4ffr7bv9lb5k0hkr";
+        sha256 = "0awj8gaic0j7a69is95f2rll3yip4n6avai1jh20b1x7dybdrp5m";
       })
     ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18115,11 +18115,11 @@ with pkgs;
   inherit (callPackage ../applications/networking/cluster/terraform {})
     terraform_0_8_5
     terraform_0_8_8
-    terraform_0_9_1;
+    terraform_0_9_2;
 
   terraform_0_8 = terraform_0_8_8;
-  terraform_0_9 = terraform_0_9_1;
-  terraform = terraform_0_8;
+  terraform_0_9 = terraform_0_9_2;
+  terraform = terraform_0_9;
 
   terragrunt = callPackage ../applications/networking/cluster/terragrunt {
     terraform = terraform_0_8;


### PR DESCRIPTION
* makes the generic builder open for extension
* upgrades terraform and set the 0_9 series by default

###### Motivation for this change

The terraform 0.9.1 tests where failing for me.
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

