### PR TITLE
nss: 3.28.3 -> 3.29.3

### DIFF
--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -9,11 +9,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "nss-${version}";
-  version = "3.28.3";
+  version = "3.29.3";
 
   src = fetchurl {
-    url = "mirror://mozilla/security/nss/releases/NSS_3_28_3_RTM/src/${name}.tar.gz";
-    sha256 = "1wrx2ig6yvgywjs25hzy4szgml21hwhd7ds0ghyfybhkiq7lyg6x";
+    url = "mirror://mozilla/security/nss/releases/NSS_3_29_3_RTM/src/${name}.tar.gz";
+    sha256 = "1sz1r2iml9bhd4iqiqz75gii855a25895vpy9scjky0y4lqwrp9m";
   };
 
   buildInputs = [ perl zlib sqlite ];


### PR DESCRIPTION
###### Motivation for this change
I actually need one of the updated certs :)

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I built `firefox-bin` with this, everything looks good.

This is a mass-rebuild according to `nox-review`, I did not have time to rebuild everything :)