### PR TITLE
ghcjs (head): Fix infinite recursion ...

### DIFF
--- a/pkgs/development/compilers/ghcjs/head_stage2.nix
+++ b/pkgs/development/compilers/ghcjs/head_stage2.nix
@@ -382,6 +382,7 @@
         version = "1.24.0.0";
         src = "${ghcjsBoot}/boot/cabal/Cabal";
         doCheck = false;
+        hyperlinkSource = false;
         libraryHaskellDepends = [
           array base binary bytestring containers deepseq directory filepath
           pretty process time unix


### PR DESCRIPTION
... in hscolour when building packages.

###### Motivation for this change
Haskell packages won't build under ghcjsHEAD.

Using the following default.nix:
```
{ nixpkgs ? import ../../nixpkgs {}, compiler ? "ghcjsHEAD" }:
let f = { mkDerivation, base, stdenv }:
  mkDerivation {
    pname = "some-pkg";
    version = "0.0.1";
    src = ./.;
    isLibrary = true;
    isExecutable = true;
    libraryHaskellDepends = [ base ];
    executableHaskellDepends = [ base ];
    license = stdenv.lib.licenses.mit;
  };
in {
  some-pkg = nixpkgs.haskell.packages.${compiler}.callPackage f {};
}
```
the build fails with:
```
error: while evaluating the attribute ‘nativeBuildInputs’ of the derivation ‘some-pkg-0.0.1’ at /home/jordan/repos/nixpkgs/pkgs/development/haskell-modules/generic-builder.nix:173:3:
while evaluating the attribute ‘setupCompilerEnvironmentPhase’ of the derivation ‘Cabal-1.24.0.0’ at /home/jordan/repos/nixpkgs/pkgs/development/haskell-modules/generic-builder.nix:173:3:
while evaluating ‘optionalString’ at /home/jordan/repos/nixpkgs/lib/strings.nix:138:26, called from /home/jordan/repos/nixpkgs/pkgs/development/haskell-modules/generic-builder.nix:205:7:
while evaluating the attribute ‘nativeBuildInputs’ of the derivation ‘hscolour-1.24.1’ at /home/jordan/repos/nixpkgs/pkgs/development/haskell-modules/generic-builder.nix:173:3:
infinite recursion encountered, at undefined position
```

when built with the following command:
```
nix-build -A some-pkg --show-trace
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

