### PR TITLE
skopeo: 0.1.16 -> 0.1.18

### DIFF
--- a/pkgs/development/tools/skopeo/default.nix
+++ b/pkgs/development/tools/skopeo/default.nix
@@ -1,21 +1,28 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub, gpgme }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, gpgme, libgpgerror, devicemapper, btrfs-progs }:
+
+with stdenv.lib;
 
 buildGoPackage rec {
   name = "skopeo-${version}";
-  version = "0.1.16";
+  version = "0.1.18";
   rev = "v${version}";
 
   goPackagePath = "github.com/projectatomic/skopeo";
   excludedPackages = "integration";
 
-  buildInputs = [ gpgme ];
+  buildInputs = [ gpgme libgpgerror devicemapper btrfs-progs ];
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "projectatomic";
     repo = "skopeo";
-    sha256 = "11na7imx6yc1zijb010hx6fjh6v0m3wm5r4sa2nkclm5lkjq259b";
+    sha256 = "13k29i5hx909hvddl2xkyw4qzxq2q20ay9bkal3xi063s6l0sh0z";
   };
+
+  preBuild = ''
+    export CGO_CFLAGS="-I${getDev gpgme}/include -I${getDev libgpgerror}/include -I${getDev devicemapper}/include -I${getDev btrfs-progs}/include"
+    export CGO_LDFLAGS="-L${getLib gpgme}/lib -L${getLib libgpgerror}/lib -L${getLib devicemapper}/lib"
+  '';
 
   meta = {
     description = "A command line utility for various operations on container images and image repositories";


### PR DESCRIPTION
###### Motivation for this change

Update package

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

