### PR TITLE
xkbset: init at 0.5

### DIFF
--- a/pkgs/tools/X11/xkbset/default.nix
+++ b/pkgs/tools/X11/xkbset/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, perl, libX11 }:
+
+stdenv.mkDerivation rec {
+  name = "xkbset-0.5";
+
+  src = fetchurl {
+    url = "http://faculty.missouri.edu/~stephen/software/xkbset/${name}.tar.gz";
+    sha256 = "01c2579495b39e00d870f50225c441888dc88021e9ee3b693a842dd72554d172";
+  };
+
+  buildInputs = [ perl libX11 ];
+
+  postPatch = ''
+    sed "s:^X11PREFIX=.*:X11PREFIX=$out:" -i Makefile
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin
+    mkdir -p $out/man/man1
+  '';
+
+  postInstall = ''
+    rm -f $out/bin/xkbset-gui
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://faculty.missouri.edu/~stephen/software/#xkbset";
+    description = "Program to help manage many of XKB features of X window";
+    maintainers = with maintainers; [ drets ];
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16164,6 +16164,8 @@ with pkgs;
   xen-slim = xenPackages.xen_4_5-slim;
   xen-light = xenPackages.xen_4_5-light;
 
+  xkbset = callPackage ../tools/X11/xkbset { };
+
   win-spice = callPackage ../applications/virtualization/driver/win-spice { };
   win-virtio = callPackage ../applications/virtualization/driver/win-virtio { };
   win-qemu = callPackage ../applications/virtualization/driver/win-qemu { };


### PR DESCRIPTION
###### Motivation for this change
I'd like to have sticky keys.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

