### PR TITLE
subgit: 3.1.0 -> 3.2.4

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/subgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/subgit/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, unzip, makeWrapper, jre }:
 
-stdenv.mkDerivation {
-  name = "subgit-3.1.0";
+stdenv.mkDerivation rec {
+  name = "subgit-3.2.4";
 
   meta = {
     description = "A tool for a smooth, stress-free SVN to Git migration";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     platforms = stdenv.lib.platforms.all;
   };
 
-  buildInputs = [ unzip makeWrapper ];
+  nativeBuildInputs = [ unzip makeWrapper ];
 
   installPhase = ''
     mkdir $out;
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   '';
 
   src = fetchurl {
-    url = http://old.subgit.com/download/subgit-3.1.0.zip;
-    sha256 = "08qhpg6y2ziwplm0z1ghh1wfp607sw4hyb53a7qzfn759j5kcdrg";
+    url = "http://subgit.com/download/${name}.zip";
+    sha256 = "13r6hi2zk46bs3j17anfc85kszlwliv2yc16qx834b3v4w68hajw";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Old URL is not even served anymore.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).