### PR TITLE
instead-launcher: init at 0.6.3

### DIFF
--- a/pkgs/games/instead-launcher/default.nix
+++ b/pkgs/games/instead-launcher/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, instead, qmake4Hook, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "instead-launcher-${version}";
+
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "instead-hub";
+    repo = "instead-launcher";
+    rev = version;
+    sha256 = "1q0hdgfy9pr48zvxr9x614ka6bd0g8sicdk2a673nwfdyd41p9cw";
+  };
+
+  patches = [ ./path.patch ];
+
+  postPatch = ''
+    substituteInPlace platform.cpp --subst-var-by instead ${instead}
+  '';
+
+  nativeBuildInputs = [ qmake4Hook ];
+
+  buildInputs = [ zlib ];
+
+  meta = with stdenv.lib; {
+    homepage = https://instead.syscall.ru/wiki/en/instead-launcher;
+    description = "Install and play games from INSTEAD repository";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ orivej ];
+  };
+}

--- a/pkgs/games/instead-launcher/path.patch
+++ b/pkgs/games/instead-launcher/path.patch
@@ -1,0 +1,39 @@
+From c7460a7fc255ef4e8e0e37798605c4d8bb50633d Mon Sep 17 00:00:00 2001
+From: Orivej Desh <orivej@gmx.fr>
+Date: Sat, 1 Apr 2017 01:30:37 +0000
+Subject: [PATCH] path
+
+---
+ mainwindow.cpp | 2 +-
+ platform.cpp   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mainwindow.cpp b/mainwindow.cpp
+index 9687c4e..234b176 100644
+--- a/mainwindow.cpp
++++ b/mainwindow.cpp
+@@ -688,7 +688,7 @@ void MainWindow::loadConfig() {
+     if ( args.contains( "default-gamespath" ) )
+ 	defGamesPath = args["default-gamespath"].toString();
+ 
+-    QString insteadPath = conf.value("InsteadPath", defInsteadPath).toString();
++    QString insteadPath = defInsteadPath;
+     bool autoRefresh = conf.value("AutoRefresh", "false").toString() == "true";
+     bool autoRefreshSW = conf.value("AutoRefreshSW", "false").toString() == "true";
+     QString lang = conf.value( "Language", "*" ).toString();
+diff --git a/platform.cpp b/platform.cpp
+index bda86be..c356f1c 100644
+--- a/platform.cpp
++++ b/platform.cpp
+@@ -22,7 +22,7 @@ QString getConfigPath() {
+ }
+ 
+ QString getDefaultInterpreterPath() {
+-    return "/usr/local/bin/sdl-instead";
++    return "@instead@/bin/sdl-instead";
+ }
+ 
+ #elif defined(Q_OS_WIN)
+-- 
+2.12.2
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16586,6 +16586,8 @@ with pkgs;
     lua = lua5;
   };
 
+  instead-launcher = callPackage ../games/instead-launcher { };
+
   ja2-stracciatella = callPackage ../games/ja2-stracciatella { };
 
   klavaro = callPackage ../games/klavaro {};


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).