### PR TITLE
pycairo: fix build with Python 3.6

### DIFF
--- a/pkgs/development/python-modules/pycairo/default.nix
+++ b/pkgs/development/python-modules/pycairo/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, fetchpatch, python, buildPythonPackage, pkgconfig, cairo, xlibsWrapper, isPyPy, isPy35, isPy3k }:
+{ lib, fetchurl, fetchpatch, python, buildPythonPackage, pkgconfig, cairo, xlibsWrapper, isPyPy, isPy35, isPy36, isPy3k }:
 
 if (isPyPy) then throw "pycairo not supported for interpreter ${python.executable}" else buildPythonPackage rec {
   version = "1.10.0";
@@ -28,12 +28,14 @@ if (isPyPy) then throw "pycairo not supported for interpreter ${python.executabl
 
   buildInputs = [ python pkgconfig cairo xlibsWrapper ];
 
+  isPy35OrAbove = isPy35 || isPy36;
+
   configurePhase = ''
     (
       cd $(${python.executable} waf unpack)
       pwd
       patch -p1 < ${patch_waf}
-      ${lib.optionalString isPy35 "patch -p1 < ${patch_waf-py3_5}"}
+      ${lib.optionalString isPy35OrAbove "patch -p1 < ${patch_waf-py3_5}"}
     )
 
     ${python.executable} waf configure --prefix=$out


### PR DESCRIPTION
Addresses #24501.

###### Motivation for this change
pycairo was not building using Python 3.6

###### Things done
Apply the same patch as for Python 3.5 so that this builds correctly.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---