### PR TITLE
iosevka: 1.11.4 -> 1.12.1

### DIFF
--- a/pkgs/data/fonts/iosevka/default.nix
+++ b/pkgs/data/fonts/iosevka/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "iosevka-${version}";
-  version = "1.11.4";
+  version = "1.12.1";
 
   buildInputs = [ unzip ];
 
   src = fetchurl {
-    url = "https://github.com/be5invis/Iosevka/releases/download/v${version}/01-iosevka-${version}.zip";
-    sha256 = "0mn9pqkambsal5cvz8hzlwx7qvcdfch8g1iy7mqhgghzflfhsy8x";
+    url = "https://github.com/be5invis/Iosevka/releases/download/v${version}/iosevka-pack-${version}.zip";
+    sha256 = "1rwg06fbizf2cmjwysx4ciz96nh80k48drsyr3rshppycajnaahj";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
I switched the source to fetch the more complete font pack.

###### Motivation for this change

Hackernews-driven package update.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

