### PR TITLE
Fix acme dir permissions 17.03

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -178,7 +178,7 @@ in
                   path = [ pkgs.simp_le ];
                   preStart = ''
                     mkdir -p '${cfg.directory}'
-                    chown '${data.user}:${data.group}' '${cfg.directory}'
+                    chown -R '${data.user}:${data.group}' '${cfg.directory}'
                     if [ ! -d '${cpath}' ]; then
                       mkdir '${cpath}'
                     fi


### PR DESCRIPTION
Fixes the permissions error of #24529 (but not the startup delay mentioned in https://github.com/NixOS/nixpkgs/issues/24529#issuecomment-290919091).

You probably want to cherry-pick that onto `master` too.