### PR TITLE
acme: Use `chown -R` for challenges directory. Fixes #24529.

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -178,7 +178,7 @@ in
                   path = [ pkgs.simp_le ];
                   preStart = ''
                     mkdir -p '${cfg.directory}'
-                    chown '${data.user}:${data.group}' '${cfg.directory}'
+                    chown -R '${data.user}:${data.group}' '${cfg.directory}'
                     if [ ! -d '${cpath}' ]; then
                       mkdir '${cpath}'
                     fi


### PR DESCRIPTION
Same as https://github.com/NixOS/nixpkgs/pull/24531 but for `master`.