### PR TITLE
[doc] improve "getting the sources" chapter

### DIFF
--- a/nixos/doc/manual/development/sources.xml
+++ b/nixos/doc/manual/development/sources.xml
@@ -8,7 +8,7 @@
 
 <para>By default, NixOS’s <command>nixos-rebuild</command> command
 uses the NixOS and Nixpkgs sources provided by the
-<literal>nixos-unstable</literal> channel (kept in
+<literal>nixos</literal> channel (kept in
 <filename>/nix/var/nix/profiles/per-user/root/channels/nixos</filename>).
 To modify NixOS, however, you should check out the latest sources from
 Git.  This is as follows:
@@ -41,7 +41,7 @@ branch based on your current NixOS version:
 $ nixos-version
 17.09pre104379.6e0b727 (Hummingbird)
 
-$ git checkout -b local e3938c8
+$ git checkout -b local 6e0b727
 </screen>
 
 Or, to base your local branch on the latest version available in a
@@ -87,7 +87,11 @@ $ ln -s <replaceable>/my/sources</replaceable>/nixpkgs ~/.nix-defexpr/nixpkgs
 
 You may want to delete the symlink
 <filename>~/.nix-defexpr/channels_root</filename> to prevent root’s
-NixOS channel from clashing with your own tree.</para>
+NixOS channel from clashing with your own tree (this may break the
+command-not-found utility though). If you want to go back to the default
+state, you may just remove the <filename>~/.nix-defexpr</filename>
+directory completely, log out and log in again and it should have been
+recreated with a link to the root channels.</para>
 
 <!-- FIXME: not sure what this means.
 <para>You should not pass the base directory


### PR DESCRIPTION
This commit contains three improvements:
- the default channel used by `nixos-rebuild` is `nixos`, not `nixos-unstable` (am I right?)
- fix an inconsistency between commit hashes in an example
- a bit more info on what changing the links in `~/.nix-defexpr` implies (based on experience)