### PR TITLE
skopeo: default policy

### DIFF
--- a/pkgs/development/tools/skopeo/default.nix
+++ b/pkgs/development/tools/skopeo/default.nix
@@ -19,9 +19,18 @@ buildGoPackage rec {
     sha256 = "13k29i5hx909hvddl2xkyw4qzxq2q20ay9bkal3xi063s6l0sh0z";
   };
 
+  patches = [
+    ./path.patch
+  ];
+
   preBuild = ''
     export CGO_CFLAGS="-I${getDev gpgme}/include -I${getDev libgpgerror}/include -I${getDev devicemapper}/include -I${getDev btrfs-progs}/include"
     export CGO_LDFLAGS="-L${getLib gpgme}/lib -L${getLib libgpgerror}/lib -L${getLib devicemapper}/lib"
+  '';
+
+  postInstall = ''
+    mkdir $bin/etc
+    cp -v ./go/src/github.com/projectatomic/skopeo/default-policy.json $bin/etc/default-policy.json
   '';
 
   meta = {

--- a/pkgs/development/tools/skopeo/path.patch
+++ b/pkgs/development/tools/skopeo/path.patch
@@ -1,0 +1,25 @@
+diff --git a/cmd/skopeo/main.go b/cmd/skopeo/main.go
+index 51f918d..6681d73 100644
+--- a/cmd/skopeo/main.go
++++ b/cmd/skopeo/main.go
+@@ -3,6 +3,7 @@ package main
+ import (
+ 	"fmt"
+ 	"os"
++  "path/filepath"
+
+ 	"github.com/Sirupsen/logrus"
+ 	"github.com/containers/image/signature"
+@@ -84,6 +85,12 @@ func getPolicyContext(c *cli.Context) (*signature.PolicyContext, error) {
+ 	policyPath := c.GlobalString("policy")
+ 	var policy *signature.Policy // This could be cached across calls, if we had an application context.
+ 	var err error
++  var dir string
++  if policyPath == "" {
++    dir, err = filepath.Abs(filepath.Dir(os.Args[0]))
++    policyPath = dir + "/../etc/default-policy.json"
++  }
++
+ 	if policyPath == "" {
+ 		policy, err = signature.DefaultPolicy(nil)
+ 	} else {


### PR DESCRIPTION
###### Motivation for this change
Operations like "copy" may need a policy.
Skopeo looks in `/etc/containers/` by default. This changes said behaviour to look inside the nix store path.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

