### PR TITLE
glyr: init at 1.0.10

### DIFF
--- a/pkgs/tools/audio/glyr/default.nix
+++ b/pkgs/tools/audio/glyr/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, cmake
+, curl, glib, sqlite, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.10";
+  name = "glyr-${version}";
+
+  src = fetchFromGitHub {
+    owner = "sahib";
+    repo = "glyr";
+    rev = "${version}";
+    sha256 = "1miwbqzkhg0v3zysrwh60pj9sv6ci4lzq2vq2hhc6pc6hdyh8xyr";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ sqlite glib curl ];
+
+  configurePhase = ''
+    cmake -DCMAKE_INSTALL_PREFIX=$out
+  '';
+
+  meta = with stdenv.lib; {
+    license = licenses.lgpl3;
+    description = "A music related metadata searchengine";
+    homepage = https://github.com/sahib/glyr;
+    maintainers = [ maintainers.sternenseemann ];
+    platforms = platforms.linux; # TODO macOS would be possible
+  };
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -531,6 +531,8 @@ with pkgs;
 
   gcsfuse = callPackage ../tools/filesystems/gcsfuse { };
 
+  glyr = callPackage ../tools/audio/glyr { };
+
   lastpass-cli = callPackage ../tools/security/lastpass-cli { };
 
   pass = callPackage ../tools/security/pass { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

--

Help with macOS would be appreciated. [Instructions for macOS](https://github.com/sahib/glyr/wiki/Compiling#mac-os-x).

