### PR TITLE
git-cola: 2.8 -> 2.10

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
@@ -1,32 +1,20 @@
-{ stdenv, fetchurl, pythonPackages, makeWrapper, gettext, git }:
+{ stdenv, fetchFromGitHub, pythonPackages, makeWrapper, gettext, git }:
 
 let
   inherit (pythonPackages) buildPythonApplication pyqt4 sip pyinotify python mock;
 in buildPythonApplication rec {
   name = "git-cola-${version}";
-  version = "2.8";
+  version = "2.10";
 
-  src = fetchurl {
-    url = "https://github.com/git-cola/git-cola/archive/v${version}.tar.gz";
-    sha256 = "19ff7i0h5fznrkm17lp3xkxwkq27whhiil6y6bm16b1wny5hjqlr";
+  src = fetchFromGitHub {
+    owner = "git-cola";
+    repo = "git-cola";
+    rev = "v${version}";
+    sha256 = "067g0yya6718kxagf5qm59zizp0lizca4m3ih85y732i6rqpgwv8";
   };
 
-  buildInputs = [ git makeWrapper gettext ];
+  buildInputs = [ git gettext ];
   propagatedBuildInputs = [ pyqt4 sip pyinotify ];
-
-  # HACK: wrapPythonPrograms adds 'import sys; sys.argv[0] = "git-cola"', but
-  # "import __future__" must be placed above that. This removes the argv[0] line.
-  postFixup = ''
-    wrapPythonPrograms
-
-    sed -i "$out/bin/.git-dag-wrapped" -e '{
-      /import sys; sys.argv/d
-    }'
-    
-    sed -i "$out/bin/.git-cola-wrapped" -e '{
-      /import sys; sys.argv/d
-    }'
-  '';
 
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

