### PR TITLE
git-imerge: 0.7.0 -> 1.0.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-imerge/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-imerge/default.nix
@@ -1,22 +1,20 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchFromGitHub, pythonPackages }:
 
 stdenv.mkDerivation rec {
   name = "git-imerge-${version}";
-  version = "0.7.0";
+  version = "1.0.0";
 
-  src = fetchurl {
-    url = "https://github.com/mhagger/git-imerge/archive/${version}.tar.gz";
-    sha256 = "00nwn3rfhf15wsv01lfji5412d7yz827ric916lnyp662d6gx206";
+  src = fetchFromGitHub {
+    owner = "mhagger";
+    repo = "git-imerge";
+    rev = "v${version}";
+    sha256 = "1ylzxmbjfrzzxmcrbqzy1wv21npqj1r6cgl77a9n2zvsrz8zdb74";
   };
 
   buildInputs = [ pythonPackages.python pythonPackages.wrapPython ];
 
-  installPhase = ''
-    mkdir -p $out/bin
-    make install PREFIX=$out
-    wrapPythonPrograms
-  '';
-
+  makeFlags = "PREFIX= DESTDIR=$(out)" ; 
+ 
   meta = with stdenv.lib; {
     homepage = https://github.com/mhagger/git-imerge;
     description = "Perform a merge between two branches incrementally";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

