### PR TITLE
git-radar: 0.3.2 -> 0.5

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-radar/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-radar/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "git-radar-${version}";
-  version = "0.3.2";
+  version = "0.5";
 
   phases = [ "unpackPhase" "installPhase" ];
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "michaeldfallen";
     repo = "git-radar";
     rev = "v${version}";
-    sha256 = "1028462b4kqxx66vjv7r8nnr6bi3kw11fixpqyg2srqriha6447p";
+    sha256 = "1915aqx8bfc4xmvhx2gfxv72p969a6rn436kii9w4yi38hibmqv9";
   };
 
   installPhase = ''
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/michaeldfallen/git-radar;
     license = licenses.mit;
-    description = "Git-radar is a tool you can add to your prompt to provide at-a-glance information on your git repo";
+    description = "A tool you can add to your prompt to provide at-a-glance information on your git repo";
     platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ kamilchm ];
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

