### PR TITLE
qt58: Fix path to qhelpgenerator in cmake file.

### DIFF
--- a/pkgs/development/libraries/qt-5/5.8/qttools/cmake-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.8/qttools/cmake-paths.patch
@@ -18,7 +18,7 @@ Index: qttools-opensource-src-5.8.0/src/assistant/help/Qt5HelpConfigExtras.cmake
      _qt5_Help_check_file_exists(${imported_location})
  
      set_target_properties(Qt5::qcollectiongenerator PROPERTIES
-@@ -17,11 +16,7 @@ endif()
+@@ -17,11 +16,10 @@ endif()
  if (NOT TARGET Qt5::qhelpgenerator)
      add_executable(Qt5::qhelpgenerator IMPORTED)
  
@@ -28,6 +28,9 @@ Index: qttools-opensource-src-5.8.0/src/assistant/help/Qt5HelpConfigExtras.cmake
 -    set(imported_location \"$${CMAKE_BIN_DIR}qhelpgenerator$$CMAKE_BIN_SUFFIX\")
 -!!ENDIF
 +    set(imported_location \"@NIX_OUT@/$${CMAKE_BIN_DIR}qhelpgenerator$$CMAKE_BIN_SUFFIX\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qhelpgenerator$$CMAKE_BIN_SUFFIX\")
++    endif()
      _qt5_Help_check_file_exists(${imported_location})
  
      set_target_properties(Qt5::qhelpgenerator PROPERTIES


### PR DESCRIPTION
It is located in the dev output, fix it as for qcollectiongenerator.
This fixes a build error in KDevelop.

###### Motivation for this change
Build error in KDevelop (Hydra doesn't show the log for some reason). It is because the path in the installed cmake file to qhelpgenerator is wrong, it points to the default output but the binary is in the dev output.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

