### PR TITLE
mtools: fix build on darwin

### DIFF
--- a/pkgs/tools/filesystems/mtools/UNUSED-darwin.patch
+++ b/pkgs/tools/filesystems/mtools/UNUSED-darwin.patch
@@ -1,0 +1,11 @@
+--- mtools/sysincludes.h.orig	2017-04-01 20:59:46.083196540 +0100
++++ mtools/sysincludes.h	2017-04-01 20:59:12.855030456 +0100
+@@ -103,7 +103,7 @@
+ # define PACKED __attribute__ ((packed))
+ # if __GNUC__ == 2 && __GNUC_MINOR__ > 6 || __GNUC__ >= 3
+ /* gcc 2.6.3 doesn't have "unused" */		/* mool */
+-#  define UNUSED(x) x __attribute__ ((unused));x
++#  define UNUSED(x) x
+ #  define UNUSEDP __attribute__ ((unused))
+ # else
+ #  define UNUSED(x) x

--- a/pkgs/tools/filesystems/mtools/default.nix
+++ b/pkgs/tools/filesystems/mtools/default.nix
@@ -8,12 +8,19 @@ stdenv.mkDerivation rec {
     sha256 = "119gdfnsxc6hzicnsf718k0fxgy2q14pxn7557rc96aki20czsar";
   };
 
+  # Prevents errors such as "mainloop.c:89:15: error: expected ')'"
+  # Upstream issue https://lists.gnu.org/archive/html/info-mtools/2014-02/msg00000.html
+  patches = stdenv.lib.optional stdenv.isDarwin ./UNUSED-darwin.patch;
+
+  # fails to find X on darwin
+  configureFlags = stdenv.lib.optional stdenv.isDarwin "--without-x";
+
   doCheck = true;
 
   meta = {
     homepage = http://www.gnu.org/software/mtools/;
     description = "Utilities to access MS-DOS disks";
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.darwin;
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

mtools fails to build on darwin

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

