### PR TITLE
doomseeker: Cosmetic cleanup

### DIFF
--- a/pkgs/applications/misc/doomseeker/default.nix
+++ b/pkgs/applications/misc/doomseeker/default.nix
@@ -18,11 +18,11 @@ stdenv.mkDerivation rec {
     substituteInPlace src/core/CMakeLists.txt --replace /usr/share/applications "$out"/share/applications
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://doomseeker.drdteam.org/;
     description = "Multiplayer server browser for many Doom source ports";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = with stdenv.lib.maintainers; [ MP2E ];
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.MP2E ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Cosmetic

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

