### PR TITLE
jp2a: 1.0.6 -> 1.0.7

### DIFF
--- a/pkgs/applications/misc/jp2a/default.nix
+++ b/pkgs/applications/misc/jp2a/default.nix
@@ -1,16 +1,19 @@
-{ stdenv, fetchurl, libjpeg }:
+{ stdenv, fetchFromGitHub, libjpeg, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.6";
+  version = "1.0.7";
   name = "jp2a-${version}";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/jp2a/${name}.tar.gz";
-    sha256 = "076frk3pa16s4r1b10zgy81vdlz0385zh3ykbnkaij25jn5aqc09";
+  src = fetchFromGitHub {
+    owner = "cslarsen";
+    repo = "jp2a";
+    rev = "v${version}";
+    sha256 = "12a1z9ba2j16y67f41y8ax5sgv1wdjd71pg7circdxkj263n78ql";
   };
 
   makeFlags = "PREFIX=$(out)";
 
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ libjpeg ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

