### PR TITLE
nomacs: init at 3.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -25,6 +25,7 @@
   aforemny = "Alexander Foremny <alexanderforemny@googlemail.com>";
   afranchuk = "Alex Franchuk <alex.franchuk@gmail.com>";
   aherrmann = "Andreas Herrmann <andreash87@gmx.ch>";
+  ahmedtd = "Taahir Ahmed <ahmed.taahir@gmail.com>";
   ak = "Alexander Kjeldaas <ak@formalprivacy.com>";
   akaWolf = "Artjom Vejsel <akawolf0@gmail.com>";
   akc = "Anders Claesson <akc@akc.is>";

--- a/pkgs/applications/graphics/nomacs/default.nix
+++ b/pkgs/applications/graphics/nomacs/default.nix
@@ -3,6 +3,8 @@
 , cmake
 , makeWrapper
 , pkgconfig
+, wrapGAppsHook
+, gsettings_desktop_schemas
 
 , qtbase
 , qttools
@@ -27,13 +29,13 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  sourceRoot = "nomacs-3.4/ImageLounge";
+  sourceRoot = "${name}/ImageLounge";
 
   patches = [./fix-appdata-install.patch];
 
   nativeBuildInputs = [cmake
-                       makeWrapper
-                       pkgconfig];
+                       pkgconfig
+                       wrapGAppsHook];
 
   buildInputs = [qtbase
                  qttools
@@ -42,7 +44,8 @@ stdenv.mkDerivation rec {
                  opencv
                  libraw
                  libtiff
-                 quazip];
+                 quazip
+                 gsettings_desktop_schemas];
 
 
   cmakeFlags = ["-DENABLE_OPENCV=ON"
@@ -51,13 +54,11 @@ stdenv.mkDerivation rec {
                 "-DENABLE_QUAZIP=ON"
                 "-DUSE_SYSTEM_QUAZIP=ON"];
 
-  preFixup = "wrapProgram $out/bin/nomacs";
-
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://nomacs.org;
     description = "Qt-based image viewer";
-    maintainers = [stdenv.lib.maintainers.ahmedtd];
-    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = [maintainers.ahmedtd];
+    license = licenses.gpl3Plus;
     repositories.git = https://github.com/nomacs/nomacs.git;
     inherit (qtbase.meta) platforms;
   };

--- a/pkgs/applications/graphics/nomacs/default.nix
+++ b/pkgs/applications/graphics/nomacs/default.nix
@@ -1,0 +1,64 @@
+{ stdenv
+, fetchurl
+, cmake
+, makeWrapper
+, pkgconfig
+
+, qtbase
+, qttools
+, qtsvg
+
+, exiv2
+, opencv
+, libraw
+, libtiff
+, quazip
+}:
+
+stdenv.mkDerivation rec {
+  version = "3.4";
+  src = fetchurl {
+    url = "https://github.com/nomacs/nomacs/archive/${version}.tar.gz";
+    sha256 = "552eda88aedea48831ce354095e3aad47892b4b5029f424171bedb68271c2a2f";
+    sha512 = "67a1b57971dc373d5a3be75b7deaff6702893252568eef135903754b2465416a58b40f18f55cf2994c8c3853ae96b82506c1caf26b0e645c20179a9cd81c0d36";
+  };
+
+  name = "nomacs-${version}";
+
+  enableParallelBuilding = true;
+
+  sourceRoot = "nomacs-3.4/ImageLounge";
+
+  patches = [./fix-appdata-install.patch];
+
+  nativeBuildInputs = [cmake
+                       makeWrapper
+                       pkgconfig];
+
+  buildInputs = [qtbase
+                 qttools
+                 qtsvg
+                 exiv2
+                 opencv
+                 libraw
+                 libtiff
+                 quazip];
+
+
+  cmakeFlags = ["-DENABLE_OPENCV=ON"
+                "-DENABLE_RAW=ON"
+                "-DENABLE_TIFF=ON"
+                "-DENABLE_QUAZIP=ON"
+                "-DUSE_SYSTEM_QUAZIP=ON"];
+
+  preFixup = "wrapProgram $out/bin/nomacs";
+
+  meta = {
+    homepage = https://nomacs.org;
+    description = "Qt-based image viewer";
+    maintainers = [stdenv.lib.maintainers.ahmedtd];
+    license = stdenv.lib.licenses.gpl3Plus;
+    repositories.git = https://github.com/nomacs/nomacs.git;
+    inherit (qtbase.meta) platforms;
+  };
+}

--- a/pkgs/applications/graphics/nomacs/default.nix
+++ b/pkgs/applications/graphics/nomacs/default.nix
@@ -1,5 +1,5 @@
 { stdenv
-, fetchurl
+, fetchFromGitHub
 , cmake
 , makeWrapper
 , pkgconfig
@@ -19,10 +19,11 @@
 
 stdenv.mkDerivation rec {
   version = "3.4";
-  src = fetchurl {
-    url = "https://github.com/nomacs/nomacs/archive/${version}.tar.gz";
-    sha256 = "552eda88aedea48831ce354095e3aad47892b4b5029f424171bedb68271c2a2f";
-    sha512 = "67a1b57971dc373d5a3be75b7deaff6702893252568eef135903754b2465416a58b40f18f55cf2994c8c3853ae96b82506c1caf26b0e645c20179a9cd81c0d36";
+  src = fetchFromGitHub {
+    owner = "nomacs";
+    repo = "nomacs";
+    rev = "3.4";
+    sha256 = "1l7q85dsiss0ix25niybj27zx1ssd439mwj449rxixa351cg1r2z";
   };
 
   name = "nomacs-${version}";

--- a/pkgs/applications/graphics/nomacs/fix-appdata-install.patch
+++ b/pkgs/applications/graphics/nomacs/fix-appdata-install.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/UnixBuildTarget.cmake b/cmake/UnixBuildTarget.cmake
+index 3521056a..34f99ed9 100644
+--- a/cmake/UnixBuildTarget.cmake
++++ b/cmake/UnixBuildTarget.cmake
+@@ -80,7 +80,7 @@ install(FILES ${NOMACS_QM} DESTINATION share/nomacs/translations)
+ #  manpage
+ install(FILES Readme/nomacs.1 DESTINATION share/man/man1)
+ #  appdata
+-install(FILES nomacs.appdata.xml DESTINATION /usr/share/appdata/)
++install(FILES nomacs.appdata.xml DESTINATION share/appdata/)
+ 
+ # "make dist" target
+ string(TOLOWER ${PROJECT_NAME} CPACK_PACKAGE_NAME)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14817,6 +14817,8 @@ with pkgs;
 
   nedit = callPackage ../applications/editors/nedit { };
 
+  nomacs = libsForQt5.callPackage ../applications/graphics/nomacs { };
+
   notepadqq = libsForQt56.callPackage ../applications/editors/notepadqq { };
 
   notmuch = callPackage ../applications/networking/mailreaders/notmuch { };


### PR DESCRIPTION
###### Motivation for this change

Add nomacs-3.4, a Qt-based image viewer.

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

