### PR TITLE
yoda: 1.6.5 -> 1.6.6, provide version with ROOT

### DIFF
--- a/pkgs/development/libraries/physics/rivet/default.nix
+++ b/pkgs/development/libraries/physics/rivet/default.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
     xcolor
     xkeyval
     ;};
-  buildInputs = [ ghostscript hepmc imagemagick python2 latex makeWrapper ];
-  propagatedBuildInputs = [ fastjet gsl yoda ];
+  buildInputs = [ hepmc imagemagick python2 latex makeWrapper ];
+  propagatedBuildInputs = [ fastjet ghostscript gsl yoda ];
 
   preInstall = ''
     substituteInPlace bin/make-plots \

--- a/pkgs/development/libraries/physics/yoda/default.nix
+++ b/pkgs/development/libraries/physics/yoda/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python2Packages, root, makeWrapper, withRootSupport ? false }:
+{ stdenv, fetchurl, fetchpatch, python2Packages, root, makeWrapper, withRootSupport ? false }:
 
 stdenv.mkDerivation rec {
   name = "yoda-${version}";
@@ -10,6 +10,17 @@ stdenv.mkDerivation rec {
   };
 
   pythonPath = []; # python wrapper support
+
+  patches = [
+    (fetchpatch {
+      url = "https://yoda.hepforge.org/hg/yoda/rev/3dbc8927e715?style=raw";
+      sha256 = "02rm34z9lbab66p7gpij12qwdph5fddpksg80qz0m537wjwy2ddy";
+    })
+    (fetchpatch {
+      url = "https://yoda.hepforge.org/hg/yoda/rev/669c2be582ef?style=raw";
+      sha256 = "0s705cl3bazpvpvy46vv1k223knwxq2yy5na1c6lv217sq9w86wj";
+    })
+  ];
 
   buildInputs = with python2Packages; [ python numpy matplotlib makeWrapper ]
     ++ stdenv.lib.optional withRootSupport root;

--- a/pkgs/development/libraries/physics/yoda/default.nix
+++ b/pkgs/development/libraries/physics/yoda/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python2Packages, root, makeWrapper }:
+{ stdenv, fetchurl, python2Packages, root, makeWrapper, withRootSupport ? false }:
 
 stdenv.mkDerivation rec {
   name = "yoda-${version}";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
 
   pythonPath = []; # python wrapper support
 
-  buildInputs = with python2Packages; [ python numpy matplotlib root makeWrapper ];
+  buildInputs = with python2Packages; [ python numpy matplotlib makeWrapper ]
+    ++ stdenv.lib.optional withRootSupport root;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/physics/yoda/default.nix
+++ b/pkgs/development/libraries/physics/yoda/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, python2Packages, makeWrapper }:
+{ stdenv, fetchurl, python2Packages, root, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "yoda-${version}";
-  version = "1.6.5";
+  version = "1.6.6";
 
   src = fetchurl {
     url = "http://www.hepforge.org/archive/yoda/YODA-${version}.tar.bz2";
-    sha256 = "1i8lmj63cd3qnxl9k2cb1abap2pirhx7ffinm834wbpy9iszwxql";
+    sha256 = "088xx4q6b03bnj6xg5189m8wsznhal8aj3jk40sbj24idm4jl5yg";
   };
 
   pythonPath = []; # python wrapper support
 
-  buildInputs = with python2Packages; [ python numpy matplotlib makeWrapper ];
+  buildInputs = with python2Packages; [ python numpy matplotlib root makeWrapper ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17698,10 +17698,10 @@ with pkgs;
 
   thepeg = callPackage ../development/libraries/physics/thepeg { };
 
-  yoda = callPackage ../development/libraries/physics/yoda {
-    root = null;
-  };
-  yoda-with-root = lowPrio (callPackage ../development/libraries/physics/yoda { });
+  yoda = callPackage ../development/libraries/physics/yoda { };
+  yoda-with-root = lowPrio (callPackage ../development/libraries/physics/yoda {
+    withRootSupport = true;
+  });
 
   ### MISC
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17698,7 +17698,10 @@ with pkgs;
 
   thepeg = callPackage ../development/libraries/physics/thepeg { };
 
-  yoda = callPackage ../development/libraries/physics/yoda { };
+  yoda = callPackage ../development/libraries/physics/yoda {
+    root = null;
+  };
+  yoda-with-root = lowPrio (callPackage ../development/libraries/physics/yoda { });
 
   ### MISC
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

