### PR TITLE
kt: init at 11.1.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -521,6 +521,7 @@
   tvorog = "Marsel Zaripov <marszaripov@gmail.com>";
   twey = "James ‘Twey’ Kay <twey@twey.co.uk>";
   uralbash = "Svintsov Dmitry <root@uralbash.ru>";
+  utdemir = "Utku Demir <me@utdemir.com>";
   #urkud = "Yury G. Kudryashov <urkud+nix@ya.ru>"; inactive since 2012
   uwap = "uwap <me@uwap.name>";
   vandenoever = "Jos van den Oever <jos@vandenoever.info>";

--- a/pkgs/tools/misc/kt/default.nix
+++ b/pkgs/tools/misc/kt/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, buildGoPackage }:
+
+buildGoPackage rec {
+  name = "kt-${version}";
+  version = "11.1.0";
+
+  src = fetchFromGitHub {
+    owner = "fgeller";
+    repo = "kt";
+    rev = "v${version}";
+    sha256 = "1ymygd3l5pfbnjmdjcrspj520v29hnv3bdgxpim38dpv3qj518vq";
+  };
+
+  goPackagePath = "github.com/fgeller/kt";
+
+  meta = with stdenv.lib; {
+    description = "Kafka command line tool";
+    homepage = https://github.com/fgeller/kt;
+    maintainers = with maintainers; [ utdemir ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6219,6 +6219,8 @@ with pkgs;
   apacheKafka_0_9 = callPackage ../servers/apache-kafka { majorVersion = "0.9"; };
   apacheKafka_0_10 = callPackage ../servers/apache-kafka { majorVersion = "0.10"; };
 
+  kt = callPackage ../tools/misc/kt {};
+
   asn2quickder = callPackage ../development/tools/asn2quickder {};
 
   astyle = callPackage ../development/tools/misc/astyle { };


### PR DESCRIPTION
kt is a useful tool for interfacing Apache Kafka on command line.

I only tested this on MacOS, but since it's just a standard Go package, it should work on all platforms as is.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

