### PR TITLE
Add BAP to nixpkgs

### DIFF
--- a/pkgs/development/libraries/libbap/default.nix
+++ b/pkgs/development/libraries/libbap/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, bap, ocaml, findlib, ctypes, autoreconfHook,
+  which }:
+
+stdenv.mkDerivation rec {
+  name = "libbap-${version}";
+  version = "master-2017-02-08";
+
+  src = fetchFromGitHub {
+    owner = "BinaryAnalysisPlatform";
+    repo = "bap-bindings";
+    rev = "b3da5bd5cdb3d646015ccdeb886b5ea8fd85a108";
+    sha256 = "0cwfyfpxbi9bm4kkpamyd7mgsm5b6j1rh217fqb5gi05wg45rkbb";
+  };
+
+  nativeBuildInputs = [ autoreconfHook which ];
+  buildInputs = [ ocaml bap findlib ctypes ];
+
+  preInstall = ''
+    mkdir -p $out/lib
+    mkdir -p $out/include
+  '';
+
+  meta = {
+    homepage = http://github.com/binaryanalysisplatform/bap-bindings;
+    description = "A C library for interacting with BAP";
+    maintainers = [ stdenv.lib.maintainers.maurer ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -1,0 +1,62 @@
+{stdenv, buildOcaml, fetchFromGitHub, fetchurl, camlp4, ocaml_oasis, bitstring, camlzip, cmdliner, core_kernel, ezjsonm, faillib, fileutils, ocaml_lwt, ocamlgraph, ocurl, re, uri, zarith, piqi, piqi-ocaml, uuidm, llvm_38, ulex, easy-format, xmlm, frontc, ounit, utop, which, makeWrapper, writeText, ocaml}:
+
+buildOcaml rec {
+  name = "bap";
+  version = "1.2.0";
+  src = fetchFromGitHub {
+    owner = "BinaryAnalysisPlatform";
+    repo = "bap";
+    rev = "v${version}";
+    sha256 = "0dn1gvj73pma0rsw8r50cmjddibnf42w1kbskb2vpzq0kb79jlkw";
+  };
+
+  sigs = fetchurl {
+     url = "https://github.com/BinaryAnalysisPlatform/bap/releases/download/v${version}/sigs.zip";
+     sha256 = "0mpsq2pinbrynlisnh8j3nrlamlsls7lza0bkqnm9szqjjdmcgfn";
+  };
+
+  createFindlibDestdir = true;
+
+  setupHook = writeText "setupHook.sh" ''
+    export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/${name}/"
+    export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/${name}-llvm-plugins/"
+  '';
+
+  nativeBuildInputs = [ which makeWrapper ];
+
+  buildInputs = [ ocaml_oasis
+                  llvm_38
+                  utop ];
+
+  propagatedBuildInputs = [ bitstring camlzip cmdliner core_kernel ezjsonm faillib fileutils ocaml_lwt ocamlgraph ocurl re uri zarith piqi
+                            piqi-ocaml uuidm frontc ounit ];
+
+  installPhase = ''
+    export OCAMLPATH=$OCAMLPATH:$OCAMLFIND_DESTDIR;
+    export PATH=$PATH:$out/bin
+    export CAML_LD_LIBRARY_PATH=$CAML_LD_LIBRARY_PATH:$OCAMLFIND_DESTDIR/bap-plugin-llvm/:$OCAMLFIND_DESTDIR/bap/
+    mkdir -p $out/lib/bap
+    make install
+    rm $out/bin/baptop
+    makeWrapper ${utop}/bin/utop $out/bin/baptop --prefix OCAMLPATH : $OCAMLPATH --prefix PATH : $PATH --add-flags "-ppx ppx-bap -short-paths -require \"bap.top\""
+    wrapProgram $out/bin/bapbuild --prefix OCAMLPATH : $OCAMLPATH --prefix PATH : $PATH
+    ln -s $sigs $out/share/bap/sigs.zip
+  '';
+
+  disableIda = "--disable-ida --disable-fsi-benchmark";
+
+  doCheck = true;
+
+  checkTarget = "check test";
+
+  configureFlags = "--enable-everything --enable-tests ${disableIda} --with-llvm-config=${llvm_38}/bin/llvm-config";
+
+  BAPBUILDFLAGS = "-j $(NIX_BUILD_CORES)";
+
+  meta = with stdenv.lib; {
+    description = "Platform for binary analysis. It is written in OCaml, but can be used from other languages.";
+    homepage = https://github.com/BinaryAnalysisPlatform/bap/;
+    maintainers = [ maintainers.maurer ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/bap/default.nix
+++ b/pkgs/development/python-modules/bap/default.nix
@@ -1,0 +1,23 @@
+{stdenv, buildPythonPackage, fetchFromGitHub, bap, requests}:
+
+buildPythonPackage rec {
+  name = "bap";
+  version = "1.1.0";
+  src = fetchFromGitHub {
+    owner = "BinaryAnalysisPlatform";
+    repo = "bap-python";
+    rev = "v${version}";
+    sha256 = "0wd46ksxscgb2dci69sbndzxs6drq5cahraqq42cdk114hkrsxs3";
+  };
+
+  propagatedBuildInputs = [bap requests];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Platform for binary analysis. It is written in OCaml, but can be used from other languages.";
+    homepage = https://github.com/BinaryAnalysisPlatform/bap/;
+    maintainers = [ maintainers.maurer ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8079,6 +8079,10 @@ with pkgs;
 
   libb2 = callPackage ../development/libraries/libb2 { };
 
+  libbap = callPackage ../development/libraries/libbap {
+    inherit (ocamlPackages_4_02) bap ocaml findlib ctypes;
+  };
+
   libbluedevil = callPackage ../development/libraries/libbluedevil { };
 
   libbdplus = callPackage ../development/libraries/libbdplus { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -51,6 +51,8 @@ let
 
     base64 = callPackage ../development/ocaml-modules/base64 { };
 
+    bap = callPackage ../development/ocaml-modules/bap { };
+
     bitstring = callPackage ../development/ocaml-modules/bitstring { };
 
     bolt = callPackage ../development/ocaml-modules/bolt { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -175,6 +175,10 @@ in {
 
   # packages defined elsewhere
 
+  bap = callPackage ../development/python-modules/bap {
+    bap = pkgs.ocamlPackages_4_02.bap;
+  };
+
   blivet = callPackage ../development/python-modules/blivet { };
 
   breathe = callPackage ../development/python-modules/breathe { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Finally getting [BAP](https://github.com/BinaryAnalysisPlatform/bap) into nixpkgs.
As supplementary info, see my [hydra](https://hydra.maurer.codes/build/6/log/raw) running the more extensive testsuite on it.