### PR TITLE
nomacs: 3.4 -> 3.6.1

### DIFF
--- a/pkgs/applications/graphics/nomacs/default.nix
+++ b/pkgs/applications/graphics/nomacs/default.nix
@@ -1,5 +1,5 @@
 { stdenv
-, fetchFromGitHub
+, fetchurl
 , cmake
 , makeWrapper
 , pkgconfig
@@ -18,12 +18,10 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.4";
-  src = fetchFromGitHub {
-    owner = "nomacs";
-    repo = "nomacs";
-    rev = "3.4";
-    sha256 = "1l7q85dsiss0ix25niybj27zx1ssd439mwj449rxixa351cg1r2z";
+  version = "3.6.1";
+  src = fetchurl {
+    url = "https://github.com/nomacs/nomacs/archive/${version}.tar.gz";
+    sha256 = "0s3hm3vv1cqcbg554akbvfzvbm5vbd060jma0b6dqpqsqp58kch9";
   };
 
   name = "nomacs-${version}";


### PR DESCRIPTION
###### Motivation for this change
After testing, building nomacs no longer works.
Fixed version number in `sourceRoot` conflicts with hardcoded folder name.
Choosed to swith to fetchurl and github releases instead of fetching from repository to avoid future problems.
Updated version in the meantime.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

