### PR TITLE
haskellPackages: Export haskellSrc2nix and hackage2nix

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -80,12 +80,12 @@ let
     in
       import ./hackage-packages.nix { inherit pkgs stdenv callPackage; } self // {
 
-        inherit mkDerivation callPackage;
+        inherit mkDerivation callPackage haskellSrc2nix hackage2nix;
 
-        callHackage = name: version: self.callPackage (hackage2nix name version);
+        callHackage = name: version: self.callPackage (self.hackage2nix name version);
 
         # Creates a Haskell package from a source package by calling cabal2nix on the source.
-        callCabal2nix = name: src: self.callPackage (haskellSrc2nix { inherit src name; });
+        callCabal2nix = name: src: self.callPackage (self.haskellSrc2nix { inherit src name; });
 
         ghcWithPackages = selectFrom: withPackages (selectFrom self);
 


### PR DESCRIPTION
Allows using a different haskell package set to generate the nix
expressions (during eval time) than the one used to actually build the
package (at build time).