### PR TITLE
pharo-vm: Disable "pic" hardening

### DIFF
--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     mimeType = "application/x-pharo-image";
   };
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" "pic" ];
 
   # Building
   preConfigure = ''


### PR DESCRIPTION
Compiling the Pharo VM with "pic" hardening causes segmentation faults on startup of pharo-launcher.

###### Motivation for this change

Resolves NixOS/nixpkgs#24541.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

