### PR TITLE
pharo-launcher: Add test case & myself as maintainer

### DIFF
--- a/pkgs/development/pharo/launcher/default.nix
+++ b/pkgs/development/pharo/launcher/default.nix
@@ -43,6 +43,19 @@ stdenv.mkDerivation rec {
     chmod +x $prefix/bin/${executable-name}
   '';
 
+  doCheck = true;
+
+  checkPhase = ''
+    # Launcher should be able to run for a few seconds without crashing.
+    (set +e
+     export HOME=. # Pharo will try to create files here
+     secs=5
+     echo -n "Running headless Pharo for $secs seconds to check for a crash... "
+     timeout $secs \
+       ${pharo-vm}/bin/pharo-vm-nox PharoLauncher.image --no-quit eval 'true'
+     test "$?" == 124 && echo "ok")
+  '';
+
   meta = {
     description = "Launcher for Pharo distributions";
     longDescription = ''
@@ -65,7 +78,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://pharo.org;
     license = stdenv.lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ stdenv.lib.maintainers.lukego ];
     platforms = pharo-vm.meta.platforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Add a simple test case for the `pharo-launcher` package. This would be sufficient to catch a regression of #24541.

I also volunteer to maintain Pharo in nixpkgs and so I added myself as the maintainer.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

