### PR TITLE
gmtp: fix the `Using the 'memory' GSettings backend` issue.

### DIFF
--- a/pkgs/applications/misc/gmtp/default.nix
+++ b/pkgs/applications/misc/gmtp/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libmtp, libid3tag, flac, libvorbis, gtk3
-, gsettings_desktop_schemas, wrapGAppsHook
+, gsettings_desktop_schemas, makeWrapper, gnome3
 }:
 
 let version = "1.3.10"; in
@@ -12,8 +12,14 @@ stdenv.mkDerivation {
     sha256 = "b21b9a8e66ae7bb09fc70ac7e317a0e32aff3917371a7241dea73c41db1dd13b";
   };
 
-  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
-  buildInputs = [ libmtp libid3tag flac libvorbis gtk3 gsettings_desktop_schemas ];
+  preFixup = ''
+    wrapProgram $out/bin/gmtp \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share" \
+      --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
+  '';
+
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
+  buildInputs = [ libmtp libid3tag flac libvorbis gtk3 gsettings_desktop_schemas gnome3.dconf ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

gmtp unable to save its settings.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

