### PR TITLE
Mumble_git (and murmur_git): 2016-04-10 -> 2017-04-02

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -107,6 +107,7 @@ let
 
     configureFlags = [
       "CONFIG+=no-client"
+      # "CONFIG+=no-ice"
     ];
 
     buildInputs = [ libcap ] ++ optional iceSupport zeroc_ice;
@@ -123,14 +124,14 @@ let
   };
 
   gitSource = rec {
-    version = "1.3.0-git-2016-04-10";
+    version = "1.3.0-git-2017-04-02";
     qtVersion = 5;
 
     # Needs submodules
     src = fetchgit {
       url = "https://github.com/mumble-voip/mumble";
-      rev = "0502fa67b036bae9f07a586d9f05a8bf74c24291";
-      sha256 = "07c1r26i0b5z7i787nr4mc60799skdzsh764ckk3gdi76agp2r2z";
+      rev = "2a9fa47e24e50bdf6afeca505c2adc32cbbc7d80";
+      sha256 = "0xa2a9wjg4lzkrikrr01ixibvb54h7ci0bfwnppax2fyzcikmawp";
     };
   };
 in {
@@ -138,6 +139,6 @@ in {
   mumble_git = client gitSource;
   murmur     = server stableSource;
   murmur_git = (server gitSource).overrideAttrs (old: {
-    meta = old.meta // { broken = true; };
+    meta = old.meta // { broken = iceSupport; };
   });
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14680,7 +14680,19 @@ with pkgs;
       speechdSupport = config.mumble.speechdSupport or false;
       pulseSupport = config.pulseaudio or false;
       iceSupport = config.murmur.iceSupport or true;
-    }) mumble mumble_git murmur murmur_git;
+    }) mumble mumble_git murmur;
+    
+  inherit (callPackages ../applications/networking/mumble {
+      avahi = avahi.override {
+        withLibdnssdCompat = true;
+      };
+      qt5 = qt56; # Mumble doesn't work with Qt > 5.5
+      jackSupport = config.mumble.jackSupport or false;
+      speechdSupport = config.mumble.speechdSupport or false;
+      pulseSupport = config.pulseaudio or false;
+      # Murmur_git doesn't build against Nixpkgs' current ICE, see https://github.com/NixOS/nixpkgs/issues/24383
+      iceSupport = false;
+    }) murmur_git;
 
   mumble_overlay = callPackage ../applications/networking/mumble/overlay.nix {
     mumble_i686 = if system == "x86_64-linux"


### PR DESCRIPTION
I also marked murmur_git as unbroken, as long as iceSupport is disabled.

###### Motivation for this change

Murmur_git was marked as broken, which is only true when built against an optional dependency. See #24383.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

