### PR TITLE
Fix consul version being "unknown-unknown". Fixes #24606.

### DIFF
--- a/pkgs/servers/consul/default.nix
+++ b/pkgs/servers/consul/default.nix
@@ -17,6 +17,10 @@ buildGoPackage rec {
   # Keep consul.ui for backward compatability
   passthru.ui = consul-ui;
 
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-X github.com/hashicorp/consul/version.GitDescribe=v${version} -X github.com/hashicorp/consul/version.Version=${version} -X github.com/hashicorp/consul/version.VersionPrerelease=")
+  '';
+
   meta = with stdenv.lib; {
     description = "Tool for service discovery, monitoring and configuration";
     homepage = "https://www.consul.io/";


### PR DESCRIPTION
See https://github.com/hashicorp/consul/blob/v0.7.5/scripts/build.sh#L44
for how consul's build script does it.

Done in the same fashion as https://github.com/NixOS/nixpkgs/blob/0c928f4a1d645a5eea14f3940518ef9f0376f317/pkgs/applications/networking/cluster/terragrunt/default.nix#L21

###### Motivation for this change

#24606 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

