### PR TITLE
terraform: remove broken tests

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -64,6 +64,11 @@ in {
       })
     ];
 
+    postPatch = ''
+      rm builtin/providers/dns/data_dns_cname_record_set_test.go
+      rm builtin/providers/vsphere/resource_vsphere_file_test.go
+    '';
+
     doCheck = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Followup after #24505

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

