### PR TITLE
rstudio: 0.98.110 -> 1.1.135

### DIFF
--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, makeDesktopItem, cmake, boost155, zlib, openssl,
-R, qt4, libuuid, hunspellDicts, unzip, ant, jdk, gnumake, makeWrapper,
+{ stdenv, fetchurl, makeDesktopItem, cmake, boost163, zlib, openssl,
+R, qt5, libuuid, hunspellDicts, unzip, ant, jdk, gnumake, makeWrapper,
 # If you have set up an R wrapper with other packages by following
 # something like https://nixos.org/nixpkgs/manual/#r-packages, RStudio
 # by default not be able to access any of those R packages. In order
@@ -11,18 +11,18 @@ useRPackages ? false
 }:
 
 let
-  version = "0.98.110";
+  version = "1.1.135";
   ginVer = "1.5";
   gwtVer = "2.5.1";
 in
 stdenv.mkDerivation rec {
   name = "RStudio-${version}";
 
-  buildInputs = [ cmake boost155 zlib openssl R qt4 libuuid unzip ant jdk makeWrapper ];
+  buildInputs = [ cmake boost163 zlib openssl R qt5.full qt5.qtwebkit libuuid unzip ant jdk makeWrapper ];
 
   src = fetchurl {
     url = "https://github.com/rstudio/rstudio/archive/v${version}.tar.gz";
-    sha256 = "0wybbvl5libki8z2ywgcd0hg0py1az484r95lhwh3jbrwfx7ri2z";
+    sha256 = "1jgzn053qx4b34i8x9wkvw66zfscvj96xdhaw4dby3vssgsip4h4";
   };
 
   # Hack RStudio to only use the input R.
@@ -44,8 +44,8 @@ stdenv.mkDerivation rec {
   hunspellDictionaries = builtins.attrValues hunspellDicts;
 
   mathJaxSrc = fetchurl {
-    url = https://s3.amazonaws.com/rstudio-buildtools/mathjax-20.zip;
-    sha256 = "1ikg3fhharsfrh2fv8c53fdawqajj24nif89400l3klw1hyq4zal";
+    url = https://s3.amazonaws.com/rstudio-buildtools/mathjax-26.zip;
+    sha256 = "0wbcqb9rbfqqvvhqr1pbqax75wp8ydqdyhp91fbqfqp26xzjv6lk";
   };
 
   preConfigure =
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
 	  done
       done
 
-      unzip $mathJaxSrc -d dependencies/common/mathjax
+      unzip $mathJaxSrc -d dependencies/common/mathjax-26
     '';
 
   cmakeFlags = [ "-DRSTUDIO_TARGET=Desktop" ];

--- a/pkgs/applications/editors/rstudio/r-location.patch
+++ b/pkgs/applications/editors/rstudio/r-location.patch
@@ -1,24 +1,14 @@
-diff -ur rstudio-0.98.110-old/src/cpp/core/CMakeLists.txt rstudio-0.98.110-new/src/cpp/core/CMakeLists.txt
---- rstudio-0.98.110-old/src/cpp/core/r_util/REnvironmentPosix.cpp	2013-04-28 10:02:14.000000000 -0400
-+++ rstudio-0.98.110-new/src/cpp/core/r_util/REnvironmentPosix.cpp	2015-03-23 15:06:35.533400807 -0400
-@@ -84,9 +84,7 @@
+--- rstudio-1.1.135-old/src/cpp/core/r_util/REnvironmentPosix.cpp	2017-04-04 09:18:42.460994359 +0000
++++ rstudio-1.1.135-new/src/cpp/core/r_util/REnvironmentPosix.cpp	2017-04-04 09:21:29.254012434 +0000
+@@ -87,10 +87,7 @@
  {
     // define potential paths
     std::vector<std::string> rScriptPaths;
 -   rScriptPaths.push_back("/usr/bin/R");
 -   rScriptPaths.push_back("/usr/local/bin/R");
 -   rScriptPaths.push_back("/opt/local/bin/R");
+-   rScriptPaths.push_back("/Library/Frameworks/R.framework/Resources/bin/R");
 +   rScriptPaths.push_back("@R@/bin/R");
     return scanForRScript(rScriptPaths, pErrMsg);
  }
-
-@@ -220,8 +218,7 @@
-       // scan in standard locations as a fallback
-       std::string scanErrMsg;
-       std::vector<std::string> rScriptPaths;
--      rScriptPaths.push_back("/usr/local/bin/R");
--      rScriptPaths.push_back("/usr/bin/R");
-+      rScriptPaths.push_back("@R@/bin/R");
-       FilePath scriptPath = scanForRScript(rScriptPaths, &scanErrMsg);
-       if (scriptPath.empty())
-       {
+ 


### PR DESCRIPTION
This is a work-in-progress update of Rstudio from 0.98.110 to 1.1.135.

The problem I am stuck on now is that RStudio wants to include a specific version of `pandoc` in its own directory as a dependency. Help wanted!

###### Motivation for this change

Catch up with the latest RStudio release and especially with the major 1.0 release that was made in November. For me as a user I really want at least RStudio 1.0 to happily migrate my RStudio usage from MacOSX to NixOS.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

