### PR TITLE
baobab: fix missing dconf module

### DIFF
--- a/pkgs/desktops/gnome-3/3.22/core/baobab/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/baobab/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, intltool, fetchurl, vala_0_32, libgtop
+{ stdenv, intltool, fetchurl, vala, libgtop
 , pkgconfig, gtk3, glib
-, bash, makeWrapper, itstool, libxml2
+, bash, wrapGAppsHook, itstool, libxml2
 , gnome3, librsvg, gdk_pixbuf, file }:
 
 stdenv.mkDerivation rec {
@@ -10,17 +10,8 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${gnome3.glib.dev}/include/gio-unix-2.0";
 
-  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
-
-  buildInputs = [ vala_0_32 pkgconfig gtk3 glib libgtop intltool itstool libxml2
-                  gnome3.gsettings_desktop_schemas makeWrapper file
-                  gdk_pixbuf gnome3.defaultIconTheme librsvg ];
-
-  preFixup = ''
-    wrapProgram "$out/bin/baobab" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
-  '';
+  buildInputs = [ vala pkgconfig gtk3 glib libgtop intltool itstool libxml2
+                  wrapGAppsHook file gdk_pixbuf gnome3.defaultIconTheme librsvg ];
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Baobab;


### PR DESCRIPTION
fix `Using the 'memory' GSettings backend`

@abbradar this seems to be a common missed dependency in gtk apps. Can we make `gsettings_desktop_schemas` also providing `dconf` by default?

Related to https://github.com/NixOS/nixpkgs/pull/24602

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

