### PR TITLE
docker: 17.03.0 -> 17.03.1

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -6,134 +6,154 @@
 }:
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md
+# https://github.com/docker/docker/blob/TAG/hack/dockerfile/binaries-commits
 
 with lib;
 
-stdenv.mkDerivation rec {
-  name = "docker-${version}";
-  version = "17.03.0-ce";
-  rev = "60ccb22"; # should match the version commit
+rec {
+  dockerGen = {
+      version, rev, sha256
+      , runcRev, runcSha256
+      , containerdRev, containerdSha256
+      , tiniRev, tiniSha256
+  } : stdenv.mkDerivation rec {
+    inherit version rev;
 
-  src = fetchFromGitHub {
-    owner = "docker";
-    repo = "docker";
-    rev = "v${version}";
-    sha256 = "0ml9aan8x4w8kfz7dm9vvl8b1a0vq09si9b7z50xz84040cjhnr9";
-  };
+    name = "docker-${version}";
 
-  docker-runc = runc.overrideAttrs (oldAttrs: rec {
-    name = "docker-runc";
     src = fetchFromGitHub {
       owner = "docker";
-      repo = "runc";
-      rev = "a01dafd48bc1c7cc12bdb01206f9fea7dd6feb70";
-      sha256 = "0n7vr47fhpyxx5vdnp453qp4cq50w4hwgq3ldyj5878d91iir7l1";
-    };
-    # docker/runc already include these patches / are not applicable
-    patches = [];
-  });
-  docker-containerd = containerd.overrideAttrs (oldAttrs: rec {
-    name = "docker-containerd";
-    src = fetchFromGitHub {
-      owner = "docker";
-      repo = "containerd";
-      rev = "977c511eda0925a723debdc94d09459af49d082a";
-      sha256 = "0hmcj8i70vv3a3bbdawrgi84a442m09x5mpc7fgn8dd3v031lcbc";
-    };
-  });
-  docker-tini = tini.overrideAttrs  (oldAttrs: rec {
-    name = "docker-init";
-    src = fetchFromGitHub {
-      owner = "krallin";
-      repo = "tini";
-      rev = "949e6facb77383876aeff8a6944dde66b3089574";
-      sha256 = "0zj4kdis1vvc6dwn4gplqna0bs7v6d1y2zc8v80s3zi018inhznw";
+      repo = "docker";
+      rev = "v${version}";
+      sha256 = sha256;
     };
 
-    # Do not remove static from make files as we want a static binary
-    patchPhase = ''
+    docker-runc = runc.overrideAttrs (oldAttrs: rec {
+      name = "docker-runc";
+      src = fetchFromGitHub {
+        owner = "docker";
+        repo = "runc";
+        rev = runcRev;
+        sha256 = runcSha256;
+      };
+      # docker/runc already include these patches / are not applicable
+      patches = [];
+    });
+    docker-containerd = containerd.overrideAttrs (oldAttrs: rec {
+      name = "docker-containerd";
+      src = fetchFromGitHub {
+        owner = "docker";
+        repo = "containerd";
+        rev = containerdRev;
+        sha256 = containerdSha256;
+      };
+    });
+    docker-tini = tini.overrideAttrs  (oldAttrs: rec {
+      name = "docker-init";
+      src = fetchFromGitHub {
+        owner = "krallin";
+        repo = "tini";
+        rev = tiniRev;
+        sha256 = tiniSha256;
+      };
+
+      # Do not remove static from make files as we want a static binary
+      patchPhase = ''
+      '';
+
+      NIX_CFLAGS_COMPILE = [
+        "-DMINIMAL=ON"
+      ];
+    });
+
+    buildInputs = [
+      makeWrapper removeReferencesTo pkgconfig go-md2man go
+      sqlite devicemapper btrfs-progs systemd
+    ];
+
+    dontStrip = true;
+
+    DOCKER_BUILDTAGS = []
+      ++ optional (systemd != null) [ "journald" ]
+      ++ optional (btrfs-progs == null) "exclude_graphdriver_btrfs"
+      ++ optional (devicemapper == null) "exclude_graphdriver_devicemapper";
+
+    # systemd 230 no longer has libsystemd-journal as a separate entity from libsystemd
+    postPatch = ''
+      substituteInPlace ./hack/make.sh                   --replace libsystemd-journal libsystemd
+      substituteInPlace ./daemon/logger/journald/read.go --replace libsystemd-journal libsystemd
     '';
 
-    NIX_CFLAGS_COMPILE = [
-      "-DMINIMAL=ON"
-    ];
-  });
+    buildPhase = ''
+      patchShebangs .
+      export AUTO_GOPATH=1
+      export DOCKER_GITCOMMIT="${rev}"
+      ./hack/make.sh dynbinary
+    '';
 
-  buildInputs = [
-    makeWrapper removeReferencesTo pkgconfig go-md2man go
-    sqlite devicemapper btrfs-progs systemd
-  ];
+    outputs = ["out" "man"];
 
-  dontStrip = true;
+    extraPath = makeBinPath [ iproute iptables e2fsprogs xz xfsprogs procps utillinux ];
 
-  DOCKER_BUILDTAGS = []
-    ++ optional (systemd != null) [ "journald" ]
-    ++ optional (btrfs-progs == null) "exclude_graphdriver_btrfs"
-    ++ optional (devicemapper == null) "exclude_graphdriver_devicemapper";
+    installPhase = ''
+      install -Dm755 ./bundles/${version}/dynbinary-client/docker-${version} $out/libexec/docker/docker
+      install -Dm755 ./bundles/${version}/dynbinary-daemon/dockerd-${version} $out/libexec/docker/dockerd
+      makeWrapper $out/libexec/docker/docker $out/bin/docker \
+        --prefix PATH : "$out/libexec/docker:$extraPath"
+      makeWrapper $out/libexec/docker/dockerd $out/bin/dockerd \
+        --prefix PATH : "$out/libexec/docker:$extraPath"
 
-  # systemd 230 no longer has libsystemd-journal as a separate entity from libsystemd
-  postPatch = ''
-    substituteInPlace ./hack/make.sh                   --replace libsystemd-journal libsystemd
-    substituteInPlace ./daemon/logger/journald/read.go --replace libsystemd-journal libsystemd
-  '';
+      # docker uses containerd now
+      ln -s ${docker-containerd}/bin/containerd $out/libexec/docker/docker-containerd
+      ln -s ${docker-containerd}/bin/containerd-shim $out/libexec/docker/docker-containerd-shim
+      ln -s ${docker-runc}/bin/runc $out/libexec/docker/docker-runc
+      ln -s ${docker-proxy}/bin/docker-proxy $out/libexec/docker/docker-proxy
+      ln -s ${docker-tini}/bin/tini-static $out/libexec/docker/docker-init
 
-  buildPhase = ''
-    patchShebangs .
-    export AUTO_GOPATH=1
-    export DOCKER_GITCOMMIT="${rev}"
-    ./hack/make.sh dynbinary
-  '';
+      # systemd
+      install -Dm644 ./contrib/init/systemd/docker.service $out/etc/systemd/system/docker.service
 
-  outputs = ["out" "man"];
+      # completion
+      install -Dm644 ./contrib/completion/bash/docker $out/share/bash-completion/completions/docker
+      install -Dm644 ./contrib/completion/fish/docker.fish $out/share/fish/vendor_completions.d/docker.fish
+      install -Dm644 ./contrib/completion/zsh/_docker $out/share/zsh/site-functions/_docker
 
-  extraPath = makeBinPath [ iproute iptables e2fsprogs xz xfsprogs procps utillinux ];
-
-  installPhase = ''
-    install -Dm755 ./bundles/${version}/dynbinary-client/docker-${version} $out/libexec/docker/docker
-    install -Dm755 ./bundles/${version}/dynbinary-daemon/dockerd-${version} $out/libexec/docker/dockerd
-    makeWrapper $out/libexec/docker/docker $out/bin/docker \
-      --prefix PATH : "$out/libexec/docker:$extraPath"
-    makeWrapper $out/libexec/docker/dockerd $out/bin/dockerd \
-      --prefix PATH : "$out/libexec/docker:$extraPath"
-
-    # docker uses containerd now
-    ln -s ${docker-containerd}/bin/containerd $out/libexec/docker/docker-containerd
-    ln -s ${docker-containerd}/bin/containerd-shim $out/libexec/docker/docker-containerd-shim
-    ln -s ${docker-runc}/bin/runc $out/libexec/docker/docker-runc
-    ln -s ${docker-proxy}/bin/docker-proxy $out/libexec/docker/docker-proxy
-    ln -s ${docker-tini}/bin/tini-static $out/libexec/docker/docker-init
-
-    # systemd
-    install -Dm644 ./contrib/init/systemd/docker.service $out/etc/systemd/system/docker.service
-
-    # completion
-    install -Dm644 ./contrib/completion/bash/docker $out/share/bash-completion/completions/docker
-    install -Dm644 ./contrib/completion/fish/docker.fish $out/share/fish/vendor_completions.d/docker.fish
-    install -Dm644 ./contrib/completion/zsh/_docker $out/share/zsh/site-functions/_docker
-
-    # Include contributed man pages
-    man/md2man-all.sh -q
-    manRoot="$man/share/man"
-    mkdir -p "$manRoot"
-    for manDir in man/man?; do
-      manBase="$(basename "$manDir")" # "man1"
-      for manFile in "$manDir"/*; do
-        manName="$(basename "$manFile")" # "docker-build.1"
-        mkdir -p "$manRoot/$manBase"
-        gzip -c "$manFile" > "$manRoot/$manBase/$manName.gz"
+      # Include contributed man pages
+      man/md2man-all.sh -q
+      manRoot="$man/share/man"
+      mkdir -p "$manRoot"
+      for manDir in man/man?; do
+        manBase="$(basename "$manDir")" # "man1"
+        for manFile in "$manDir"/*; do
+          manName="$(basename "$manFile")" # "docker-build.1"
+          mkdir -p "$manRoot/$manBase"
+          gzip -c "$manFile" > "$manRoot/$manBase/$manName.gz"
+        done
       done
-    done
-  '';
+    '';
 
-  preFixup = ''
-    find $out -type f -exec remove-references-to -t ${go} -t ${stdenv.cc.cc} -t ${stdenv.glibc.dev} '{}' +
-  '';
+    preFixup = ''
+      find $out -type f -exec remove-references-to -t ${go} -t ${stdenv.cc.cc} -t ${stdenv.glibc.dev} '{}' +
+    '';
 
-  meta = {
-    homepage = http://www.docker.com/;
-    description = "An open source project to pack, ship and run any application as a lightweight container";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ offline tailhook ];
-    platforms = platforms.linux;
+    meta = {
+      homepage = http://www.docker.com/;
+      description = "An open source project to pack, ship and run any application as a lightweight container";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ offline tailhook ];
+      platforms = platforms.linux;
+    };
+  };
+
+  docker_17_03 = dockerGen rec {
+    version = "17.03.1-ce";
+    rev = "c6d412e"; # git commit
+    sha256 = "1h3hkg15c3isfgaqpkp3mr7ys5826cz24hn3f3wz07jmismq98q7";
+    runcRev = "54296cf40ad8143b62dbcaa1d90e520a2136ddfe";
+    runcSha256 = "0ylymx7pi4jmvbqj94j2i8qspy8cpq0m91l6a0xiqlx43yx6qi2m";
+    containerdRev = "4ab9917febca54791c5f071a9d1f404867857fcc";
+    containerdSha256 = "06f2gsx4w9z4wwjhrpafmz6c829wi8p7crj6sya6x9ii50bkn8p6";
+    tiniRev = "949e6facb77383876aeff8a6944dde66b3089574";
+    tiniSha256 = "0zj4kdis1vvc6dwn4gplqna0bs7v6d1y2zc8v80s3zi018inhznw";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5332,7 +5332,7 @@ with pkgs;
   jdk = jdk8;
   jre = jre8;
   jre_headless = jre8_headless;
-  
+
   openshot-qt = libsForQt56.callPackage ../applications/video/openshot-qt { };
 
   oraclejdk = pkgs.jdkdistro true false;
@@ -13198,7 +13198,11 @@ with pkgs;
   dmtx-utils = callPackage (callPackage ../tools/graphics/dmtx-utils) {
   };
 
-  docker = callPackage ../applications/virtualization/docker { };
+  inherit (callPackage ../applications/virtualization/docker { })
+    docker_17_03;
+
+  docker = docker_17_03;
+
   docker-proxy = callPackage ../applications/virtualization/docker/proxy.nix { };
 
   docker-gc = callPackage ../applications/virtualization/docker/gc.nix { };


### PR DESCRIPTION
###### Motivation for this change
Updated to latest version.

The Docker folks are about to release their first "edge" version, which will mean for us that there will be two Docker versions supported.
This lays the groundwork. Since 17.03 will be around for a while, I created a new `docker-stable` package alias that points at it right now.
Adding 17.04 will be trivial (should be out this week)

![Docker releases](https://i0.wp.com/blog.docker.com/wp-content/uploads/lifecycle.png?resize=1024%2C376&ssl=1)

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

