### PR TITLE
add Source Han Serif font

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -500,6 +500,7 @@
   tailhook = "Paul Colomiets <paul@colomiets.name>";
   takikawa = "Asumu Takikawa <asumu@igalia.com>";
   taktoa = "Remy Goldschmidt <taktoa@gmail.com>";
+  taku0 = "Takuo Yonezawa <mxxouy6x3m_github@tatapa.org>";
   tavyc = "Octavian Cerna <octavian.cerna@gmail.com>";
   teh = "Tom Hunger <tehunger@gmail.com>";
   telotortium = "Robert Irelan <rirelan@gmail.com>";

--- a/pkgs/data/fonts/source-han-serif/default.nix
+++ b/pkgs/data/fonts/source-han-serif/default.nix
@@ -2,19 +2,19 @@
 
 let
   makePackage = {variant, language, region, sha256}: stdenv.mkDerivation rec {
-    version = "1.004R";
-    name = "source-han-sans-${variant}-${version}";
-    revision = "5f5311e71cb628321cc0cffb51fb38d862b726aa";
+    version = "1.000R";
+    name = "source-han-serif-${variant}-${version}";
+    revision = "f6cf97d92b22e7bd77e355a61fe549ae44b6de76";
 
     buildInputs = [ unzip ];
 
     src = fetchurl {
-      url = "https://github.com/adobe-fonts/source-han-sans/raw/${revision}/SubsetOTF/SourceHanSans${region}.zip";
+      url = "https://github.com/adobe-fonts/source-han-serif/raw/${revision}/SubsetOTF/SourceHanSerif${region}.zip";
       inherit sha256;
     };
 
     setSourceRoot = ''
-      sourceRoot=$( echo SourceHanSans* )
+      sourceRoot=$( echo SourceHanSerif* )
     '';
 
     installPhase = ''
@@ -23,9 +23,9 @@ let
     '';
 
     meta = {
-      description = "${language} subset of an open source Pan-CJK sans-serif typeface";
+      description = "${language} subset of an open source Pan-CJK serif typeface";
       homepage = https://github.com/adobe-fonts/source-han-sans;
-      license = stdenv.lib.licenses.asl20;
+      license = stdenv.lib.licenses.ofl;
       platforms = stdenv.lib.platforms.unix;
       maintainers = with stdenv.lib.maintainers; [ taku0 ];
     };
@@ -36,24 +36,24 @@ in
     variant = "japanese";
     language = "Japanese";
     region = "JP";
-    sha256 = "0m1zprwqnqp3za42firg53hyzir6p0q73fl8mh5j4px3zgivlvfw";
+    sha256 = "0488zxr6jpwinzayrznc4ciy8mqcq9afx80xnp37pl9gcxsv0jp7";
   };
   korean = makePackage {
     variant = "korean";
     language = "Korean";
     region = "KR";
-    sha256 = "1bz6n2sd842vgnqky0i7a3j3i2ixhzzkkbx1m8plk04r1z41bz9q";
+    sha256 = "1kwsqrb3s52nminq65n3la540dgvahnhvgwv5h168nrmz881ni9r";
   };
   simplified-chinese = makePackage {
     variant = "simplified-chinese";
     language = "Simplified Chinese";
     region = "CN";
-    sha256 = "0ksafcwmnpj3yxkgn8qkqkpw10ivl0nj9n2lsi9c6fw3aa71s3ha";
+    sha256 = "0y6js0hjgf1i8mf7kzklcl02qg0bi7j8n7j1l4awmkij1ix2yc43";
   };
   traditional-chinese = makePackage {
     variant = "traditional-chinese";
     language = "Traditional Chinese";
     region = "TW";
-    sha256 = "1l4zymd5n4nl9gmja707xq6bar88dxki2mwdixdfrkf544cidflj";
+    sha256 = "0q52dn0vh3pqpr9gn4r4qk99lkvhf2gl12y99n9423brrqyfbi6h";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12630,6 +12630,11 @@ with pkgs;
   source-han-sans-korean = sourceHanSansPackages.korean;
   source-han-sans-simplified-chinese = sourceHanSansPackages.simplified-chinese;
   source-han-sans-traditional-chinese = sourceHanSansPackages.traditional-chinese;
+  sourceHanSerifPackages = callPackage ../data/fonts/source-han-serif { };
+  source-han-serif-japanese = sourceHanSerifPackages.japanese;
+  source-han-serif-korean = sourceHanSerifPackages.korean;
+  source-han-serif-simplified-chinese = sourceHanSerifPackages.simplified-chinese;
+  source-han-serif-traditional-chinese = sourceHanSerifPackages.traditional-chinese;
 
   inherit (callPackages ../data/fonts/tai-languages { }) tai-ahom;
 


### PR DESCRIPTION
###### Motivation for this change

Source Han Serif font is an OpenType pan-CJK serif font family by Adobe. 
It contains Japanese, Korean, Traditional Chinese, and Simplified Chinese glyphs. 
The font is licensed under SIL Open Font License.

https://github.com/adobe-fonts/source-han-serif
https://source.typekit.com/source-han-serif

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested with Inkscape.

---

