### PR TITLE
networkmanager: 1.4.4 -> 1.6.4

### DIFF
--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, pkgconfig, cmake
-, dbus, networkmanager, spidermonkey_1_8_5 }:
+, dbus, networkmanager, webkitgtk214x, pcre, python2 }:
 
 stdenv.mkDerivation rec {
   name = "libproxy-${version}";
@@ -16,7 +16,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig cmake ];
 
-  buildInputs = [ dbus networkmanager spidermonkey_1_8_5 ];
+  buildInputs = [ dbus networkmanager webkitgtk214x pcre ];
+
+  cmakeFlags = [
+    "-DWITH_WEBKIT3=ON"
+    "-DWITH_MOZJS=OFF"
+    "-DPYTHON_SITEPKG_DIR=$(out)/${python2.sitePackages}"
+  ];
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;

--- a/pkgs/tools/networking/network-manager-applet/default.nix
+++ b/pkgs/tools/networking/network-manager-applet/default.nix
@@ -1,16 +1,17 @@
 { stdenv, fetchurl, intltool, pkgconfig, libglade, networkmanager, gnome3
 , libnotify, libsecret, polkit, isocodes, modemmanager, librsvg
 , mobile_broadband_provider_info, glib_networking, gsettings_desktop_schemas
-, makeWrapper, udev, libgudev, hicolor_icon_theme, jansson, wrapGAppsHook }:
+, makeWrapper, udev, libgudev, hicolor_icon_theme, jansson, wrapGAppsHook, webkitgtk }:
 
 stdenv.mkDerivation rec {
-  name    = "${pname}-${version}";
+  name    = "${pname}-${major}.${minor}";
   pname   = "network-manager-applet";
-  version = networkmanager.version;
+  major   = "1.4";
+  minor   = "6";
 
   src = fetchurl {
-    url    = "mirror://gnome/sources/${pname}/${networkmanager.major}/${name}.tar.xz";
-    sha256 = "09ijxicsqf39y6h8kwbfjyljfbqkkx4vrpyfn6gfg1h9mvp4cf39";
+    url    = "mirror://gnome/sources/${pname}/${major}/${name}.tar.xz";
+    sha256 = "0xpcdwqmnwiqqqsd5rx1gh5rvv5m2skj59bqxhccy1k2ikzgr9hh";
   };
 
   configureFlags = [ "--sysconfdir=/etc" ];
@@ -18,7 +19,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gnome3.gtk libglade networkmanager libnotify libsecret gsettings_desktop_schemas
     polkit isocodes makeWrapper udev libgudev gnome3.gconf gnome3.libgnome_keyring
-    modemmanager jansson librsvg glib_networking gnome3.dconf
+    modemmanager jansson librsvg glib_networking gnome3.dconf webkitgtk
   ];
 
   nativeBuildInputs = [ intltool pkgconfig wrapGAppsHook ];

--- a/pkgs/tools/networking/network-manager/PppdPath.patch
+++ b/pkgs/tools/networking/network-manager/PppdPath.patch
@@ -1,8 +1,6 @@
-diff --git a/src/ppp-manager/nm-ppp-manager.c b/src/ppp-manager/nm-ppp-manager.c
-index 89a7add..ae99eb4 100644
---- a/src/ppp-manager/nm-ppp-manager.c
-+++ b/src/ppp-manager/nm-ppp-manager.c
-@@ -843,7 +843,7 @@ create_pppd_cmd_line (NMPPPManager *self,
+--- NetworkManager-1.6.2.org/src/ppp/nm-ppp-manager.c	2017-02-15 13:10:27.000000000 +0100
++++ NetworkManager-1.6.2/./src/ppp/nm-ppp-manager.c	2017-04-03 11:45:39.891653216 +0200
+@@ -724,7 +724,7 @@
  
  	g_return_val_if_fail (setting != NULL, NULL);
  

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -2,25 +2,34 @@
 , systemd, libgudev, libnl, libuuid, polkit, gnutls, ppp, dhcp, iptables
 , libgcrypt, dnsmasq, bluez5, readline
 , gobjectIntrospection, modemmanager, openresolv, libndp, newt, libsoup
-, ethtool, gnused, coreutils, file, inetutils, kmod }:
+, ethtool, iputils, gnused, coreutils, file, inetutils, kmod, jansson, libxslt
+, python3Packages, docbook_xsl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name    = "network-manager-${version}";
   pname   = "NetworkManager";
-  major   = "1.4";
-  version = "${major}.4";
+  major   = "1.6";
+  version = "${major}.2";
 
   src = fetchurl {
     url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
-    sha256 = "029k2f1arx1m5hppmr778i9yg34jj68nmji3i89qs06c33rpi4w2";
+    sha256 = "1y96k82rav8if334jl500zc024d210c4pgprh94yqyz3rmanyaxj";
   };
 
   outputs = [ "out" "dev" ];
 
+  postPatch = ''
+    patchShebangs ./tools
+  '';
+
   preConfigure = ''
     substituteInPlace configure --replace /usr/bin/uname ${coreutils}/bin/uname
     substituteInPlace configure --replace /usr/bin/file ${file}/bin/file
-    substituteInPlace src/devices/nm-device.c --replace /usr/bin/ping ${inetutils}/bin/ping
+    substituteInPlace src/devices/nm-device.c \
+       --replace /usr/bin/ping ${inetutils}/bin/ping \
+       --replace /usr/bin/ping6 ${inetutils}/bin/ping
+    substituteInPlace src/devices/nm-arping-manager.c \
+       --replace '("arping", NULL, NULL);' '("arping", "${inetutils}/bin/arping", NULL);'
     substituteInPlace src/NetworkManagerUtils.c --replace /sbin/modprobe ${kmod}/bin/modprobe
     substituteInPlace data/84-nm-drivers.rules \
       --replace /bin/sh ${stdenv.shell}
@@ -58,14 +67,21 @@ stdenv.mkDerivation rec {
     "--with-libsoup=yes"
   ];
 
-  patches = [ ./PppdPath.patch ];
+  patches = [
+    ./PppdPath.patch
+    (fetchpatch {
+      sha256 = "1n90j5rwg97xkrhlldyr92filc2dmycl9pr0svky9hlcn9csk2z6";
+      name = "null-dereference.patch";
+      url = "https://github.com/NetworkManager/NetworkManager/commit/4e8eddd100bbc8429806a70620c90b72cfd29cb1.patch";
+    })
+  ];
 
   buildInputs = [ systemd libgudev libnl libuuid polkit ppp libndp
-                  bluez5 dnsmasq gobjectIntrospection modemmanager readline newt libsoup ];
+                  bluez5 dnsmasq gobjectIntrospection modemmanager readline newt libsoup jansson ];
 
-  propagatedBuildInputs = [ dbus_glib gnutls libgcrypt ];
+  propagatedBuildInputs = [ dbus_glib gnutls libgcrypt python3Packages.pygobject3 ];
 
-  nativeBuildInputs = [ intltool pkgconfig ];
+  nativeBuildInputs = [ intltool pkgconfig libxslt docbook_xsl ];
 
   preInstall = ''
     installFlagsArray=( "sysconfdir=$out/etc" "localstatedir=$out/var" "runstatedir=$out/var/run" )
@@ -78,7 +94,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/etc/dbus-1/system.d/org.freedesktop.NetworkManager.conf --replace 'at_console="true"' 'group="networkmanager"'
 
     # rename to network-manager to be in style
-    mv $out/etc/systemd/system/NetworkManager.service $out/etc/systemd/system/network-manager.service 
+    mv $out/etc/systemd/system/NetworkManager.service $out/etc/systemd/system/network-manager.service
 
     # systemd in NixOS doesn't use `systemctl enable`, so we need to establish
     # aliases ourselves.

--- a/pkgs/tools/networking/network-manager/l2tp.nix
+++ b/pkgs/tools/networking/network-manager/l2tp.nix
@@ -5,13 +5,13 @@
 stdenv.mkDerivation rec {
   name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname   = "NetworkManager-l2tp";
-  version = networkmanager.version;
+  version = "1.2.4";
 
   src = fetchFromGitHub {
     owner  = "nm-l2tp";
     repo   = "network-manager-l2tp";
-    rev    = "c0cedda5e2a0ded695b497c361eaf577068520cb";
-    sha256 = "01f39ghc37vw4n4i7whyikgqz8vzxf41q9fsv2gfw1g501cny1j2";
+    rev    = "${version}";
+    sha256 = "1mvn0z1vl4j9drl3dsw2dv0pppqvj29d2m07487dzzi8cbxrqj36";
   };
 
   buildInputs = [ networkmanager ppp libsecret ]


### PR DESCRIPTION
###### Motivation for this change

https://cgit.freedesktop.org/NetworkManager/NetworkManager/tree/NEWS?h=1.6.2

fixes https://github.com/NixOS/nixpkgs/issues/24564

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

