### PR TITLE
Fix schema, maintainers are usually an array

### DIFF
--- a/pkgs/tools/graphics/flam3/default.nix
+++ b/pkgs/tools/graphics/flam3/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Cosmic recursive fractal flames";
     homepage = http://flam3.com/;
-    maintainers = maintainers.nand0p;
+    maintainers = [ maintainers.nand0p ];
     platforms = platforms.linux;
     license = licenses.cc-by-nc-sa-20;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

