### PR TITLE
sqlint: init at 0.1.4

### DIFF
--- a/pkgs/development/libraries/libpg_query/default.nix
+++ b/pkgs/development/libraries/libpg_query/default.nix
@@ -1,0 +1,30 @@
+{ fetchFromGitHub, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "libpg_query-${version}";
+  version = "9.5-1.4.2";
+
+  src = fetchFromGitHub {
+    owner  = "lfittl";
+    repo   = "libpg_query";
+    rev    = version;
+    sha256 = "0jd6c2ykfm1a32my4a6lqlvsk8flxjh2ma3rp1fxrzygzyinz4l3";
+  };
+
+  installPhase = ''
+    mkdir -p $out/lib $out/include
+    cp libpg_query.a $out/lib
+    cp pg_query.h $out/include
+  '';
+
+  meta = {
+    homepage = https://github.com/lfittl/libpg_query;
+    description = "C library for accessing the PostgreSQL parser outside of the server environment";
+    longDescription = ''
+      This library uses the actual PostgreSQL server source to parse
+      SQL queries and return the internal PostgreSQL parse tree.
+    '';
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -18,7 +18,7 @@
 # (to make gems behave if necessary).
 
 { lib, fetchurl, writeScript, ruby, kerberos, libxml2, libxslt, python, stdenv, which
-, libiconv, postgresql, v8_3_16_14, clang, sqlite, zlib, imagemagick
+, libiconv, postgresql, libpg_query, v8_3_16_14, clang, sqlite, zlib, imagemagick
 , pkgconfig , ncurses, xapian_1_2_22, gpgme, utillinux, fetchpatch, tzdata, icu, libffi
 , cmake, libssh2, openssl, mysql, darwin, git, perl, gecode_3, curl
 , libmsgpack, qt48, libsodium, snappy, libossp_uuid, lxc
@@ -127,6 +127,12 @@ in
     buildFlags = [
       "--with-pg-config=${postgresql}/bin/pg_config"
     ];
+  };
+
+  pg_query = attrs: {
+    postPatch = ''
+      ln -s ${libpg_query}/lib ${libpg_query.name}
+    '';
   };
 
   puma = attrs: {

--- a/pkgs/development/tools/sqlint/Gemfile
+++ b/pkgs/development/tools/sqlint/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'sqlint'

--- a/pkgs/development/tools/sqlint/Gemfile.lock
+++ b/pkgs/development/tools/sqlint/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    json (1.8.6)
+    pg_query (0.9.2)
+      json (~> 1.8)
+    sqlint (0.1.4)
+      pg_query (~> 0.9.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sqlint
+
+BUNDLED WITH
+   1.14.4

--- a/pkgs/development/tools/sqlint/default.nix
+++ b/pkgs/development/tools/sqlint/default.nix
@@ -1,0 +1,16 @@
+{ lib, bundlerEnv, ruby }:
+
+bundlerEnv rec {
+  name = "sqlint-${version}";
+  version = (import ./gemset.nix).sqlint.version;
+
+  inherit ruby;
+  gemdir = ./.;
+
+  meta = with lib; {
+    description = "Simple SQL linter";
+    homepage    = https://github.com/purcell/sqlint;
+    license     = licenses.mit;
+    platforms   = ruby.meta.platforms;
+  };
+}

--- a/pkgs/development/tools/sqlint/gemset.nix
+++ b/pkgs/development/tools/sqlint/gemset.nix
@@ -1,0 +1,26 @@
+{
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qmj7fypgb9vag723w1a49qihxrcf5shzars106ynw2zk352gbv5";
+      type = "gem";
+    };
+    version = "1.8.6";
+  };
+  pg_query = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1mfpbda10scs5sidcc4wvs4k9mn8mjvr0cd3vanbzgvjmh0da7bc";
+      type = "gem";
+    };
+    version = "0.9.2";
+  };
+  sqlint = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0p9sm2r8jcgk88cgacwxgnxpv4bx4145ill99v0khd2wybvgcwzm";
+      type = "gem";
+    };
+    version = "0.1.4";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9808,6 +9808,8 @@ with pkgs;
 
   stxxl = callPackage ../development/libraries/stxxl { parallel = true; };
 
+  sqlint = callPackage ../development/tools/sqlint { };
+
   sqlite = lowPrio (callPackage ../development/libraries/sqlite { });
 
   sqlite3_analyzer = lowPrio (callPackage ../development/libraries/sqlite/sqlite3_analyzer.nix { });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8685,6 +8685,8 @@ with pkgs;
 
   libpgf = callPackage ../development/libraries/libpgf { };
 
+  libpg_query = callPackage ../development/libraries/libpg_query { };
+
   libpng = callPackage ../development/libraries/libpng { };
   libpng_apng = libpng.override { apngSupport = true; };
   libpng12 = callPackage ../development/libraries/libpng/12.nix { };


### PR DESCRIPTION
###### Motivation for this change

sqlint is useful (esp. with flycheck in Emacs)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

But I need help. Currently, building `pg_query-0.9.2` fails, because it’s a native extension and needs a native library… How to provide one in `gemset.nix`?