### PR TITLE
sway: 0.11 -> 0.12.2

### DIFF
--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchFromGitHub, pango, libinput
 , makeWrapper, cmake, pkgconfig, asciidoc, libxslt, docbook_xsl, cairo
 , wayland, wlc, libxkbcommon, pixman, fontconfig, pcre, json_c, dbus_libs, libcap
+, xwayland
 }:
 
 let
@@ -18,7 +19,7 @@ in
 
     nativeBuildInputs = [ makeWrapper cmake pkgconfig asciidoc libxslt docbook_xsl ];
 
-    buildInputs = [ wayland wlc libxkbcommon pixman fontconfig pcre json_c dbus_libs pango cairo libinput libcap ];
+    buildInputs = [ wayland wlc libxkbcommon pixman fontconfig pcre json_c dbus_libs pango cairo libinput libcap xwayland ];
 
     patchPhase = ''
       sed -i s@/etc/sway@$out/etc/sway@g CMakeLists.txt;

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  version = "0.11";
+  version = "0.12.2";
 in
   stdenv.mkDerivation rec {
     name = "sway-${version}";
@@ -13,7 +13,7 @@ in
       owner = "Sircmpwn";
       repo = "sway";
       rev = "${version}";
-      sha256 = "01k01f72kh90fwgqh2hgg6dv9931x4v18bzz11b47mn7p9z68ddv";
+      sha256 = "1hkr6pmz45xa5w5y21ijz7i2dwb62rifhcy28r8kh5r2hwbil2hs";
     };
 
     nativeBuildInputs = [ makeWrapper cmake pkgconfig asciidoc libxslt docbook_xsl ];


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

