### PR TITLE
docker-distribution: 2.5.1 -> 2.6.0

### DIFF
--- a/pkgs/applications/virtualization/docker-distribution/default.nix
+++ b/pkgs/applications/virtualization/docker-distribution/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "distribution-${version}";
-  version = "2.5.1";
+  version = "2.6.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/docker/distribution";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "docker";
     repo = "distribution";
     inherit rev;
-    sha256 = "08nxcsl9bc3k9gav2mkqccm5byrlfcgy6qaqaywiyza0b0cn4kdc";
+    sha256 = "1yg2zrikn3vkvkx5mn51p6bfjk840qdkn7ahhhvvcsc8mpigrjc6";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

