### PR TITLE
xfwm4-themes: init at 4.10.0

### DIFF
--- a/pkgs/desktops/xfce/art/xfwm4-themes.nix
+++ b/pkgs/desktops/xfce/art/xfwm4-themes.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  p_name  = "xfwm4-themes";
+  ver_maj = "4.10";
+  ver_min = "0";
+
+  src = fetchurl {
+    url = "mirror://xfce/src/art/${p_name}/${ver_maj}/${name}.tar.bz2";
+    sha256 = "0xfmdykav4rf6gdxbd6fhmrfrvbdc1yjihz7r7lba0wp1vqda51j";
+  };
+  name = "${p_name}-${ver_maj}.${ver_min}";
+
+  meta = with stdenv.lib; {
+    homepage = http://www.xfce.org/;
+    description = "Themes for Xfce";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.volth ];
+  };
+}

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -73,6 +73,7 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   #### ART                  from "mirror://xfce/src/art/${p_name}/${ver_maj}/${name}.tar.bz2"
 
   xfce4icontheme  = callPackage ./art/xfce4-icon-theme.nix { };
+  xfwm4themes     = callPackage ./art/xfwm4-themes.nix { };
 
   #### PANEL PLUGINS        from "mirror://xfce/src/panel-plugins/${p_name}/${ver_maj}/${name}.tar.{bz2,gz}"
 


### PR DESCRIPTION
###### Motivation for this change

Additional themes for XFCE.

The package is 5 years old and has version of 4.10 (actual XFCE is 4.12), yet there is nothing to update, it is basically graphic files of classic themes like Motif, Windows95, WindowsXP, etc
Ubuntu and other distros has the [same](http://packages.ubuntu.com/search?keywords=xfwm4-themes) version 

It is not included in default XFCE of NixOS and won't bloat any existing installation.
```pkgs.xfce.xfwm4themes``` should be explicitly added into ```environment.systemPackages``` for  extra themes to appear in the ```Window Manager``` settings box:

![xfwm4-themes](https://cloud.githubusercontent.com/assets/508305/24687149/98bb4ed6-19a7-11e7-994d-7a4bcd56004a.png)



###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

