### PR TITLE
xpra: 0.17.6 -> 2.0.1

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, python2Packages, pkgconfig
 , xorg, gtk2, glib, pango, cairo, gdk_pixbuf, atk
 , makeWrapper, xkbcomp, xorgserver, getopt, xauth, utillinux, which, fontsConf
-, ffmpeg, x264, libvpx, libwebp
+, ffmpeg_3_2, x264, libvpx, libwebp
 , libfakeXinerama
 , gst_all_1, pulseaudioLight, gobjectIntrospection
 , pam }:
@@ -11,11 +11,11 @@ with lib;
 let
   inherit (python2Packages) python cython buildPythonApplication;
 in buildPythonApplication rec {
-  name = "xpra-0.17.6";
+  name = "xpra-2.0.1";
   namePrefix = "";
   src = fetchurl {
     url = "http://xpra.org/src/${name}.tar.xz";
-    sha256 = "1z7v58m45g10icpv22qg4dipafcfsdqkxqz73z3rwsb6r0kdyrpj";
+    sha256 = "11y2icy24mc337gvppp0ankyl3wxrprlifm7spixvsndyz056mb8";
   };
 
   buildInputs = [
@@ -28,7 +28,7 @@ in buildPythonApplication rec {
 
     pango cairo gdk_pixbuf atk gtk2 glib
 
-    ffmpeg libvpx x264 libwebp
+    ffmpeg_3_2 libvpx x264 libwebp
 
     gobjectIntrospection
     gst_all_1.gstreamer


### PR DESCRIPTION
Package bump.

Requires build against newer ffmpeg (3.2.x instead of 3.1.x)
because of new symbols:
FF_PROFILE_H264_MULTIVIEW_HIGH
FF_PROFILE_H264_STEREO_HIGH

###### Motivation for this change

0.17.6 was EOL in late 2016, this is the latest version.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Dependent packages (which compile and appear to work but I do not use) are:
winswitch
ib-controller

Known issues (common to 0.17.6):
- Running with Xdummy does not work because xorg cannot find the dummy driver - is there a way to specify the video drivers that the provided xorgserver derivation uses?