### PR TITLE
php: fix php-config header file paths

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -23,11 +23,6 @@ let
       buildInputs = [ flex bison pkgconfig ]
         ++ lib.optional stdenv.isLinux systemd;
 
-      configureFlags = [
-        "EXTENSION_DIR=$(out)/lib/php/extensions"
-      ] ++ lib.optional stdenv.isDarwin "--with-iconv=${libiconv}"
-        ++ lib.optional stdenv.isLinux  "--with-fpm-systemd";
-
       flags = {
 
         # much left to do here...
@@ -267,24 +262,38 @@ let
 
       hardeningDisable = [ "bindnow" ];
 
-      configurePhase = ''
+      preConfigure = ''
         # Don't record the configure flags since this causes unnecessary
-        # runtime dependencies - except for php-embed, as uwsgi needs them.
-        ${lib.optionalString (!(config.php.embed or false)) ''
+        # runtime dependencies
         for i in main/build-defs.h.in scripts/php-config.in; do
           substituteInPlace $i \
             --replace '@CONFIGURE_COMMAND@' '(omitted)' \
             --replace '@CONFIGURE_OPTIONS@' "" \
             --replace '@PHP_LDFLAGS@' ""
         done
-        ''}
 
-        [[ -z "$libxml2" ]] || export PATH=$PATH:$libxml2/bin
-        ./configure --with-config-file-scan-dir=/etc/php.d --with-config-file-path=$out/etc --prefix=$out $configureFlags
+        #[[ -z "$libxml2" ]] || addToSearchPath PATH $libxml2/bin
+
+        configureFlags+=(--with-config-file-path=$out/etc \
+          --includedir=$dev/include \
+          EXTENSION_DIR=$out/lib/php/extensions)
       '';
+
+      configureFlags = [
+        "--with-config-file-scan-dir=/etc/php.d"
+      ] ++ lib.optional stdenv.isDarwin "--with-iconv=${libiconv}"
+        ++ lib.optional stdenv.isLinux  "--with-fpm-systemd";
 
       postInstall = ''
         cp php.ini-production $out/etc/php.ini
+      '';
+
+      postFixup = ''
+        mkdir -p $dev/bin $dev/share/man/man1
+        mv $out/bin/phpize $out/bin/php-config $dev/bin/
+        mv $out/share/man/man1/phpize.1.gz \
+          $out/share/man/man1/php-config.1.gz \
+          $dev/share/man/man1/
       '';
 
       src = fetchurl {
@@ -298,6 +307,7 @@ let
         license = licenses.php301;
         maintainers = with maintainers; [ globin ];
         platforms = platforms.all;
+        outputsToInstall = [ "out" "dev" ];
       };
 
       patches = if !php7 then [ ./fix-paths.patch ] else [ ./fix-paths-php7.patch ];


### PR DESCRIPTION
###### Motivation for this change

Split outputs mean that the "include" folder from PHP gets placed into a
"dev" derivation. However php-config is not aware of this, which means
that compiling extensions with phpize fails with an error about being
unable to find header files (see #24357, #24420).  This fixes that by:

1. passing the `--includedir` flag to `configure` so that `php-config`
   gives the correct paths.

2. moving the `phpize` and `php-config` scripts and man pages to the
   dev derivation, to prevent cylic references.

3. ensuring that the `configure` script arguments are stripped from
   all binaries, including `php-embed`, to prevent cyclic references.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

