### PR TITLE
source-han-sans: fix license from ASL2.0 to SIL Open Font License.

### DIFF
--- a/pkgs/data/fonts/source-han-sans/default.nix
+++ b/pkgs/data/fonts/source-han-sans/default.nix
@@ -25,7 +25,7 @@ let
     meta = {
       description = "${language} subset of an open source Pan-CJK typeface";
       homepage = https://github.com/adobe-fonts/source-han-sans;
-      license = stdenv.lib.licenses.asl20;
+      license = stdenv.lib.licenses.ofl;
       platforms = stdenv.lib.platforms.unix;
     };
   };


### PR DESCRIPTION
###### Motivation for this change

The license was updated from Apache License 2.0 to SIL Open Font License from version 1.002.

https://github.com/adobe-fonts/source-han-sans/blob/1.002/LICENSE.txt

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

