### PR TITLE
nginx: Check config syntax validity with `nginx -t` in preStart

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -421,6 +421,7 @@ in
         mkdir -p ${cfg.stateDir}/logs
         chmod 700 ${cfg.stateDir}
         chown -R ${cfg.user}:${cfg.group} ${cfg.stateDir}
+        ${cfg.package}/bin/nginx -c ${configFile} -p ${cfg.stateDir} -t
         '';
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/nginx -c ${configFile} -p ${cfg.stateDir}";


### PR DESCRIPTION
###### Motivation for this change

Currently nginx in NixOS doesn't use the standard practice of checking its config file in systemd's `ExecPreStart` (this is what `ExecPreStart` was made for).

This results in nixops deployments to succeed even with wrong config file syntax.

By checking the config file syntax in `preStart` using `nginx -t`, a nixops will fail correctly on wrong config file syntax.