### PR TITLE
pmccabe: darwin is supported too

### DIFF
--- a/pkgs/development/tools/misc/pmccabe/default.nix
+++ b/pkgs/development/tools/misc/pmccabe/default.nix
@@ -9,6 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "0a3h1b9fb87c82d5fbql5lc4gp338pa5s9i66dhw7zk8jdygx474";
   };
 
+  patches = [
+    ./getopt_on_darwin.patch
+  ];
+
   configurePhase = ''
     sed -i -r Makefile \
       -e 's,/usr/,/,g' \
@@ -38,7 +42,7 @@ stdenv.mkDerivation rec {
       trees or files; and vifn, to invoke vi given a function name rather
       than a file name.
     '';
-    platforms = platforms.linux;
     maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/pmccabe/getopt_on_darwin.patch
+++ b/pkgs/development/tools/misc/pmccabe/getopt_on_darwin.patch
@@ -1,0 +1,15 @@
+diff --git a/decomment.c b/decomment.c
+index 400707a..aea29fd 100644
+--- a/decomment.c
++++ b/decomment.c
+@@ -11,6 +11,10 @@
+ #include "getopt.h"
+ #endif
+ 
++#ifdef __APPLE__
++#include "getopt.h"
++#endif
++
+ #ifdef NEED_OPTIND
+ extern int optind;
+ #endif


### PR DESCRIPTION
###### Motivation for this change

Let's see if pmccabe works on Darwin. I don't have a mac on which to test, so let's see what hydra says.

Fixes #24636.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

