### PR TITLE
platypus: fix platforms metadata

### DIFF
--- a/pkgs/applications/science/biology/platypus/default.nix
+++ b/pkgs/applications/science/biology/platypus/default.nix
@@ -33,6 +33,6 @@ in stdenv.mkDerivation rec {
     license = licenses.gpl3;
     homepage = https://github.com/andyrimmer/Platypus;
     maintainers = with maintainers; [ jbedo ];
-    platforms = platforms.unix;
+    platforms = platforms.x86_64;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update metadata to address failed hydra build: https://hydra.nixos.org/build/49877642. x86-64 instructions are required to build this package.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

