### PR TITLE
davmail: 4.7.2 -> 4.8.0

### DIFF
--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -7,19 +7,21 @@ stdenv.mkDerivation rec {
     sha256 = "0e650c4a060d64fd2b270ddb00baa906aac617865d5e60c9f526a281cdb27b62";
   };
 
-  buildInputs = [ makeWrapper ];
-
-  meta = {
-    description = "A Java application which presents a Microsoft Exchange server as local CALDAV, IMAP and SMTP servers";
-    maintainers = [ stdenv.lib.maintainers.hinton ];
-    platforms = stdenv.lib.platforms.all;
-    homepage = "http://davmail.sourceforce.net/";
-    license = stdenv.lib.licenses.gpl2;
-  };
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
-  mkdir -p $out/bin
-  cp ./* $out/bin/ -R
-  wrapProgram $out/bin/davmail.sh --prefix PATH : ${jre}/bin --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}
-   '';
+    mkdir -p $out/share/davmail
+    cp -R ./* $out/share/davmail
+    makeWrapper $out/share/davmail/davmail.sh $out/bin/davmail \
+      --prefix PATH : ${jre}/bin \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://davmail.sourceforce.net/;
+    description = "A Java application which presents a Microsoft Exchange server as local CALDAV, IMAP and SMTP servers";
+    maintainers = [ maintainers.hinton ];
+    platforms = platforms.all;
+    license = licenses.gpl2;
+  };
 }

--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -1,10 +1,10 @@
 { fetchurl, stdenv, jre, glib, libXtst, gtk2, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "davmail-4.7.2";
+  name = "davmail-4.8.0";
   src = fetchurl {
-    url = "mirror://sourceforge/davmail/4.7.1/davmail-linux-x86_64-4.7.1-2416.tgz";
-    sha256 = "196jr44kksb197biz984z664llf9z3d8rlnjm2iqcmgkjhx1mgy3";
+    url = "mirror://sourceforge/davmail/4.8.0/davmail-linux-x86_64-4.8.0-2479.tgz";
+    sha256 = "0e650c4a060d64fd2b270ddb00baa906aac617865d5e60c9f526a281cdb27b62";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Update davmail to version 4.8.0, running 4.8.0 locally on nixos 17.03.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

