### PR TITLE
cups-toshiba-estudio: init at 7.51

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -243,6 +243,7 @@
   jonafato = "Jon Banafato <jon@jonafato.com>";
   jpbernardy = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";
   jpierre03 = "Jean-Pierre PRUNARET <nix@prunetwork.fr>";
+  jpotier = "Martin Potier <jpo.contributes.to.nixos@marvid.fr>";
   jraygauthier = "Raymond Gauthier <jraygauthier@gmail.com>";
   juliendehos = "Julien Dehos <dehos@lisic.univ-littoral.fr>";
   jwiegley = "John Wiegley <johnw@newartisans.com>";

--- a/pkgs/misc/cups/drivers/estudio/default.nix
+++ b/pkgs/misc/cups/drivers/estudio/default.nix
@@ -1,40 +1,5 @@
 { stdenv, fetchurl, perl }:
 
-# Driver suitable for the following printers:
-# TOSHIBA e-STUDIO2000AC
-# TOSHIBA e-STUDIO2005AC
-# TOSHIBA e-STUDIO2040C
-# TOSHIBA e-STUDIO2050C
-# TOSHIBA e-STUDIO2055C
-# TOSHIBA e-STUDIO2500AC
-# TOSHIBA e-STUDIO2505AC
-# TOSHIBA e-STUDIO2540C
-# TOSHIBA e-STUDIO2550C
-# TOSHIBA e-STUDIO2555C
-# TOSHIBA e-STUDIO287CS
-# TOSHIBA e-STUDIO3005AC
-# TOSHIBA e-STUDIO3040C
-# TOSHIBA e-STUDIO3055C
-# TOSHIBA e-STUDIO347CS
-# TOSHIBA e-STUDIO3505AC
-# TOSHIBA e-STUDIO3540C
-# TOSHIBA e-STUDIO3555C
-# TOSHIBA e-STUDIO407CS
-# TOSHIBA e-STUDIO4505AC
-# TOSHIBA e-STUDIO4540C
-# TOSHIBA e-STUDIO4555C
-# TOSHIBA e-STUDIO5005AC
-# TOSHIBA e-STUDIO5055C
-# TOSHIBA e-STUDIO5506AC
-# TOSHIBA e-STUDIO5540C
-# TOSHIBA e-STUDIO5560C
-# TOSHIBA e-STUDIO6506AC
-# TOSHIBA e-STUDIO6540C
-# TOSHIBA e-STUDIO6550C
-# TOSHIBA e-STUDIO6560C
-# TOSHIBA e-STUDIO6570C
-# TOSHIBA e-STUDIO7506AC
-
 stdenv.mkDerivation {
   name = "cups-toshiba-estudio";
   version = "7.51";
@@ -47,14 +12,11 @@ stdenv.mkDerivation {
   buildInputs = [ perl ];
 
   phases = [ "unpackPhase"
-             "preInstall"
+             "patchPhase"
              "installPhase" ];
 
-  preInstall = ''
-    ls
+  patchPhase = ''
     patchShebangs lib/
-    head lib/cups/filter/est6550_Authentication
-
     gunzip                share/cups/model/Toshiba/TOSHIBA_ColorMFP_CUPS.gz
     sed -i "s+/usr+$out+" share/cups/model/Toshiba/TOSHIBA_ColorMFP_CUPS
     gzip                  share/cups/model/Toshiba/TOSHIBA_ColorMFP_CUPS
@@ -69,10 +31,24 @@ stdenv.mkDerivation {
     chmod 755 $out/share/cups/model/Toshiba/TOSHIBA_ColorMFP_CUPS.gz
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Printer only driver for the Toshiba e-STUDIO class of printers";
+    longDescription = ''
+      This driver supports the following printers: TOSHIBA e-STUDIO2000AC,
+      TOSHIBA e-STUDIO2005AC, TOSHIBA e-STUDIO2040C, TOSHIBA e-STUDIO2050C,
+      TOSHIBA e-STUDIO2055C, TOSHIBA e-STUDIO2500AC, TOSHIBA e-STUDIO2505AC,
+      TOSHIBA e-STUDIO2540C, TOSHIBA e-STUDIO2550C, TOSHIBA e-STUDIO2555C,
+      TOSHIBA e-STUDIO287CS, TOSHIBA e-STUDIO3005AC, TOSHIBA e-STUDIO3040C,
+      TOSHIBA e-STUDIO3055C, TOSHIBA e-STUDIO347CS, TOSHIBA e-STUDIO3505AC,
+      TOSHIBA e-STUDIO3540C, TOSHIBA e-STUDIO3555C, TOSHIBA e-STUDIO407CS,
+      TOSHIBA e-STUDIO4505AC, TOSHIBA e-STUDIO4540C, TOSHIBA e-STUDIO4555C,
+      TOSHIBA e-STUDIO5005AC, TOSHIBA e-STUDIO5055C, TOSHIBA e-STUDIO5506AC,
+      TOSHIBA e-STUDIO5540C, TOSHIBA e-STUDIO5560C, TOSHIBA e-STUDIO6506AC,
+      TOSHIBA e-STUDIO6540C, TOSHIBA e-STUDIO6550C, TOSHIBA e-STUDIO6560C,
+      TOSHIBA e-STUDIO6570C and TOSHIBA e-STUDIO7506AC.
+    '';
     homepage = https://www.toshiba-business.com.au/support/drivers;
-    license = stdenv.lib.licenses.unfree;
-    maintainers = with stdenv.lib.maintainers; [ jpotier ];
+    license = licenses.unfree;
+    maintainers = [ maintainers.jpotier ];
   };
 }

--- a/pkgs/misc/cups/drivers/estudio/default.nix
+++ b/pkgs/misc/cups/drivers/estudio/default.nix
@@ -1,0 +1,78 @@
+{ stdenv, fetchurl, perl }:
+
+# Driver suitable for the following printers:
+# TOSHIBA e-STUDIO2000AC
+# TOSHIBA e-STUDIO2005AC
+# TOSHIBA e-STUDIO2040C
+# TOSHIBA e-STUDIO2050C
+# TOSHIBA e-STUDIO2055C
+# TOSHIBA e-STUDIO2500AC
+# TOSHIBA e-STUDIO2505AC
+# TOSHIBA e-STUDIO2540C
+# TOSHIBA e-STUDIO2550C
+# TOSHIBA e-STUDIO2555C
+# TOSHIBA e-STUDIO287CS
+# TOSHIBA e-STUDIO3005AC
+# TOSHIBA e-STUDIO3040C
+# TOSHIBA e-STUDIO3055C
+# TOSHIBA e-STUDIO347CS
+# TOSHIBA e-STUDIO3505AC
+# TOSHIBA e-STUDIO3540C
+# TOSHIBA e-STUDIO3555C
+# TOSHIBA e-STUDIO407CS
+# TOSHIBA e-STUDIO4505AC
+# TOSHIBA e-STUDIO4540C
+# TOSHIBA e-STUDIO4555C
+# TOSHIBA e-STUDIO5005AC
+# TOSHIBA e-STUDIO5055C
+# TOSHIBA e-STUDIO5506AC
+# TOSHIBA e-STUDIO5540C
+# TOSHIBA e-STUDIO5560C
+# TOSHIBA e-STUDIO6506AC
+# TOSHIBA e-STUDIO6540C
+# TOSHIBA e-STUDIO6550C
+# TOSHIBA e-STUDIO6560C
+# TOSHIBA e-STUDIO6570C
+# TOSHIBA e-STUDIO7506AC
+
+stdenv.mkDerivation {
+  name = "cups-toshiba-estudio";
+  version = "7.51";
+
+  src = fetchurl {
+    url = http://business.toshiba.com/downloads/KB/f1Ulds/14079/TOSHIBA_ColorMFP_CUPS.tar;
+    sha256 = "3741bb79723495da5cb5a3971ae8c6042b6c71a6264af8f25aecf721f1f0752f";
+  };
+
+  buildInputs = [ perl ];
+
+  phases = [ "unpackPhase"
+             "preInstall"
+             "installPhase" ];
+
+  preInstall = ''
+    ls
+    patchShebangs lib/
+    head lib/cups/filter/est6550_Authentication
+
+    gunzip                share/cups/model/Toshiba/TOSHIBA_ColorMFP_CUPS.gz
+    sed -i "s+/usr+$out+" share/cups/model/Toshiba/TOSHIBA_ColorMFP_CUPS
+    gzip                  share/cups/model/Toshiba/TOSHIBA_ColorMFP_CUPS
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model/Toshiba
+    cp {.,$out}/lib/cups/filter/est6550_Authentication
+    chmod 755 $out/lib/cups/filter/est6550_Authentication
+    cp {.,$out}/share/cups/model/Toshiba/TOSHIBA_ColorMFP_CUPS.gz
+    chmod 755 $out/share/cups/model/Toshiba/TOSHIBA_ColorMFP_CUPS.gz
+  '';
+
+  meta = {
+    description = "Printer only driver for the Toshiba e-STUDIO class of printers";
+    homepage = https://www.toshiba-business.com.au/support/drivers;
+    license = stdenv.lib.licenses.unfree;
+    maintainers = with stdenv.lib.maintainers; [ jpotier ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17768,6 +17768,8 @@ with pkgs;
 
   cups-dymo = callPackage ../misc/cups/drivers/dymo {};
 
+  cups-toshiba-estudio = callPackage ../misc/cups/drivers/estudio {};
+
   crashplan = callPackage ../applications/backup/crashplan { };
 
   colort = callPackage ../applications/misc/colort { };


### PR DESCRIPTION
###### Motivation for this change
There was no driver for the toshiba-estudio series of printers. This is a generic driver that supports many
printers (see comment in the `default.nix`).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested function of the printer driver (I've used it at work for a few weeks now)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

