### PR TITLE
strongswan: 5.5.1 -> 5.5.2

### DIFF
--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "strongswan-${version}";
-  version = "5.5.1";
+  version = "5.5.2";
 
   src = fetchurl {
     url = "http://download.strongswan.org/${name}.tar.bz2";
-    sha256 = "1drahhmwz1jg14rfh67cl231dlg2a9pra6jmipfxwyzpj4ck02vj";
+    sha256 = "0slzrr5amn1rs9lrjca0fv5n1ya5jwlspfiqg9xzq1bghg56z5ys";
   };
 
   dontPatchELF = true;


### PR DESCRIPTION
See: https://wiki.strongswan.org/versions/64

`nix-build -A strongswan` successfully builds the package.

It would be great if this minor release can also be cherry-picked on `release-17.03`. Note that this also fixes a security vulnerability.
