### PR TITLE
fvwm: add edanaher as maintainer

### DIFF
--- a/pkgs/applications/window-managers/fvwm/default.nix
+++ b/pkgs/applications/window-managers/fvwm/default.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation rec {
     description = "A multiple large virtual desktop window manager";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ edanaher ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

In #24651, @rasendubi asked if I was interested in becoming the fvwm maintainer.  This is me answering in the affirmative.

(As this is only a metadata change, I didn't test much ;) )

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

