### PR TITLE
nixos: add a "hardened" profile

### DIFF
--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -1,0 +1,35 @@
+# A profile with most (vanilla) hardening options enabled by default,
+# potentially at the cost of features and performance.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  security.hideProcessInformation = mkDefault true;
+
+  security.apparmor.enable = mkDefault true;
+
+  # Restrict ptrace() usage to processes with a pre-defined relationship
+  # (e.g., parent/child)
+  boot.kernel.sysctl."kernel.yama.ptrace_scope" = mkOverride 500 1;
+
+  # Prevent replacing the running kernel image w/o reboot
+  boot.kernel.sysctl."kernel.kexec_load_disabled" = mkDefault true;
+
+  # Restrict access to kernel ring buffer (information leaks)
+  boot.kernel.sysctl."kernel.dmesg_restrict" = mkDefault true;
+
+  # Hide kptrs even for processes with CAP_SYSLOG
+  boot.kernel.sysctl."kernel.kptr_restrict" = mkOverride 500 2;
+
+  # Unprivileged access to bpf() has been used for privilege escalation in
+  # the past
+  boot.kernel.sysctl."kernel.unprivileged_bpf_disabled" = mkDefault true;
+
+  # Disable bpf() JIT (to eliminate spray attacks)
+  boot.kernel.sysctl."net.core.bpf_jit_enable" = mkDefault false;
+
+  # ... or at least apply some hardening to it
+  boot.kernel.sysctl."net.core.bpf_jit_harden" = mkDefault true;
+}


### PR DESCRIPTION
###### Motivation for this change
Something like this has been brought up in relation to yama; since nobody else has proposed anything concrete (i.e., with implementation), I thought I might as well do so.

The idea is to provide a convenient way to enable most vanilla hardening features in one go.  The hardened profile, then, will serve as a place for features that enhance security but cannot be enabled for all deployments because they interfere with legitimate use cases (e.g., using ptrace to debug problems in an already running process).
