### PR TITLE
nixos: implement option to disable automatic kernel module loading

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -116,6 +116,7 @@
   ./security/duosec.nix
   ./security/grsecurity.nix
   ./security/hidepid.nix
+  ./security/lock-kernel-modules.nix
   ./security/oath.nix
   ./security/pam.nix
   ./security/pam_usb.nix

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -8,6 +8,8 @@ with lib;
 {
   security.hideProcessInformation = mkDefault true;
 
+  security.lockKernelModules = mkDefault true;
+
   security.apparmor.enable = mkDefault true;
 
   boot.kernelParams = [

--- a/nixos/modules/security/lock-kernel-modules.nix
+++ b/nixos/modules/security/lock-kernel-modules.nix
@@ -1,0 +1,36 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+    security.lockKernelModules = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Disable kernel module loading once the system is fully initialised.
+        Module loading is disabled until the next reboot.  Problems caused
+        by delayed module loading can be fixed by adding the module(s) in
+        question to <option>boot.kernelModules</option>.
+      '';
+    };
+  };
+
+  config = mkIf config.security.lockKernelModules {
+    systemd.services.disable-kernel-module-loading = rec {
+      description = "Disable kernel module loading";
+
+      wantedBy = [ config.systemd.defaultUnit ];
+      after = [ "systemd-udev-settle.service" "firewall.service" "systemd-modules-load.service" ] ++ wantedBy;
+
+      script = "echo -n 1 > /proc/sys/kernel/modules_disabled";
+
+      unitConfig.ConditionPathIsWritable = "/proc/sys/kernel";
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
The rationale for this over simply setting the sysctl knob is to allow some legitmate kernel module loading to occur; the naive solution breaks too much to be useful.