### PR TITLE
ruby-modules: check tzinfo version

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -211,13 +211,13 @@ in
     buildInputs = [ curl ];
   };
 
-  tzinfo = attrs: {
+  tzinfo = attrs: if lib.versionAtLeast attrs.version "1.0" then {
     dontBuild = false;
     postPatch = ''
       substituteInPlace lib/tzinfo/zoneinfo_data_source.rb \
         --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
     '';
-  };
+  } else {};
 
   uuid4r = attrs: {
     buildInputs = [ which libossp_uuid ];


### PR DESCRIPTION
###### Motivation for this change

💎 💎 💎 

tzinfo 0.3.xx does not contain the file

lib/tzinfo/zoneinfo_data_source.rb

it is only included in the 1.x branch.

closes #24080

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

