### PR TITLE
tensorflow: depend on cudatoolkit 8 and cudnn 5.1

### DIFF
--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -3,8 +3,8 @@
 , buildPythonPackage
 , isPy35, isPy27
 , cudaSupport ? false
-, cudatoolkit75 ? null
-, cudnn5_cudatoolkit75 ? null
+, cudatoolkit ? null
+, cudnn ? null
 , gcc49 ? null
 , linuxPackages ? null
 , numpy
@@ -16,8 +16,8 @@
 , zlib
 }:
 
-assert cudaSupport -> cudatoolkit75 != null
-                   && cudnn5_cudatoolkit75 != null
+assert cudaSupport -> cudatoolkit != null
+                   && cudnn != null
                    && gcc49 != null
                    && linuxPackages != null;
 
@@ -97,7 +97,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = with stdenv.lib;
     [ numpy six protobuf3_2 swig mock ]
-    ++ optionals cudaSupport [ cudatoolkit75 cudnn5_cudatoolkit75 gcc49 ];
+    ++ optionals cudaSupport [ cudatoolkit cudnn gcc49 ];
 
   # Note that we need to run *after* the fixup phase because the
   # libraries are loaded at runtime. If we run in preFixup then
@@ -105,7 +105,7 @@ buildPythonPackage rec {
   postFixup = let
     rpath = stdenv.lib.makeLibraryPath
       (if cudaSupport then
-        [ gcc49.cc.lib zlib cudatoolkit75 cudnn5_cudatoolkit75
+        [ gcc49.cc.lib zlib cudatoolkit cudnn
           linuxPackages.nvidia_x11 ]
       else
         [ gcc.cc.lib zlib ]

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31219,6 +31219,8 @@ EOF
 
   tensorflowWithCuda = callPackage ../development/python-modules/tensorflow {
     cudaSupport = true;
+    cudatoolkit = pkgs.cudatoolkit8;
+    cudnn = pkgs.cudnn51_cudatoolkit80;
   };
 
   tflearn = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

tensorflowWithCuda is currently broken in 17.03 as the postfixup is adding version 7.5 of CUDA to the rpath (it's a python package so it is done in the postfixup) while it attempts to use version 8.

This is a cherry-pick of nessesary updates from the master branch.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md] https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

