### PR TITLE
slack: add libs to runtime

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, dpkg
+{ stdenv, fetchurl, dpkg, makeWrapper
 , alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib, gnome2
 , libnotify, nspr, nss, systemd, xorg }:
 
@@ -55,7 +55,7 @@ in stdenv.mkDerivation {
 
   inherit src;
 
-  buildInputs = [ dpkg ];
+  buildInputs = [ dpkg makeWrapper ];
   unpackPhase = "true";
   buildCommand = ''
     mkdir -p $out
@@ -73,7 +73,8 @@ in stdenv.mkDerivation {
 
     # Fix the symlink
     rm $out/bin/slack
-    ln -s $out/lib/slack/slack $out/bin/slack
+    makeWrapper $out/lib/slack/slack $out/bin/slack \
+      --set LD_LIBRARY_PATH ${rpath}
 
     # Fix the desktop link
     substituteInPlace $out/share/applications/slack.desktop \


### PR DESCRIPTION
Allow slack to load all the libraries dynamically as well

###### Motivation for this change

Fixes #24685 with a shotgun approach.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

