### PR TITLE
mopidy: Add gst-plugins-bad to buildInputs

### DIFF
--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -17,7 +17,7 @@ pythonPackages.buildPythonApplication rec {
   nativeBuildInputs = [ wrapGAppsHook ];
 
   buildInputs = with gst_all_1; [
-    gst-plugins-base gst-plugins-good gst-plugins-ugly
+    gst-plugins-base gst-plugins-good gst-plugins-ugly gst-plugins-bad
     glib_networking gobjectIntrospection
   ];
 


### PR DESCRIPTION
Needed for processing .m4a files.