### PR TITLE
Update nvidia legacy 340 to work with 4.9 and 4.10 kernels

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -22,11 +22,11 @@ in
   };
 
   legacy_340 = generic {
-    version = "340.101";
-    sha256_32bit = "0qmhkvxj6h63sayys9gldpafw5skpv8nsm2gxxb3pxcv7nfdlpjz";
-    sha256_64bit = "02k8j0xzxp2y4vay0kf982q382ny1i4g1kai93f2h5sak6sq3kyj";
-    settingsSha256 = "1mavbhff24n0jn154af152fp04njd505scdlxdm850h1ycb2i3g9";
-    persistencedSha256 = "1396bmmg9b1z805dzljgi2f219ji84wfnnifdbk32dpd5mrywjk0";
+    version = "340.102";
+    sha256_32bit = "0a484i37j00d0rc60q0bp6fd2wfrx2c4r32di9w5svqgmrfkvcb1";
+    sha256_64bit = "0nnz51d48a5fpnnmlz1znjp937k3nshdq46fw1qm8h00dkrd55ib";
+    settingsSha256 = "0nm5c06b09p6wsxpyfaqrzsnal3p1047lk6p4p2a0vksb7id9598";
+    persistencedSha256 = "1jwmggbph9zd8fj4syihldp2a5bxff7q1i2l9c55xz8cvk0rx08i";
     useGLVND = false;
   };
 

--- a/pkgs/os-specific/linux/nvidia-x11/fs52243.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/fs52243.patch
@@ -1,0 +1,14 @@
+--- a/kernel/nv-drm.c
++++ b/kernel/nv-drm.c
+@@ -115,7 +115,11 @@
+ };
+ 
+ static struct drm_driver nv_drm_driver = {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
++    .driver_features = DRIVER_GEM | DRIVER_PRIME | DRIVER_LEGACY,
++#else
+     .driver_features = DRIVER_GEM | DRIVER_PRIME,
++#endif
+     .load = nv_drm_load,
+     .unload = nv_drm_unload,
+     .fops = &nv_drm_fops,

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -43,8 +43,20 @@ let
       else throw "nvidia-x11 does not support platform ${stdenv.system}";
 
     # patch to get the nvidia and nvidiaBeta driver to compile on kernel 4.10
-    patches = if libsOnly || versionOlder version "375"
+    patches = if libsOnly
               then null
+              else if versionOlder version "340"
+              then null
+              else if versionOlder version "375"
+              then [
+                     (fetchurl {
+                         url = https://git.archlinux.org/svntogit/packages.git/plain/trunk/4.10.0_kernel.patch?h=packages/nvidia-340xx;
+                         sha256 = "08k2phr9kawg6a3v88d4zkj7gdlih29gm5a1gmhpgmvd926k0z5l";
+                     })
+                         # from https://git.archlinux.org/svntogit/packages.git/plain/trunk/fs52243.patch?h=packages/nvidia-340xx
+                         # with datestamps removed
+                     ./fs52243.patch
+                   ]
               else [ (fetchurl {
                       url = https://git.archlinux.org/svntogit/packages.git/plain/trunk/kernel_4.10.patch?h=packages/nvidia;  sha256 = "0zhpx3baq2pca2pmz1af5cp2nzjxjx0j9w5xrdy204mnv3v2708z";
                      }) ];


### PR DESCRIPTION
###### Motivation for this change

nvidiaLegacy340 was at .101, latest is .102. There are also two patches (from Arch) needed to build and load properly on 4.9 and 4.10 kernels, respectively.

Summary:
- Old version (340.101) did not build against kernels higher than 4.4 or failed to modprobe
- New version (unpatched) successfully built against 4.9 but failed to modprobe
- New version (unpatched) failed to build against 4.10
- New version when patched built against both 4.9 and 4.10 kernels, and loaded successfully in both cases. It also works for 4.4 kernels.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Pinging @vcunat as maintainer.