### PR TITLE
Fixes for macos

### DIFF
--- a/pkgs/desktops/gnome-3/3.22/core/gtksourceview/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gtksourceview/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   patches = [ ./nix_share_path.patch ];
 
   meta = with stdenv.lib; {
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     maintainers = gnome3.maintainers;
   };
 }

--- a/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
+++ b/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
@@ -57,15 +57,16 @@ diff --git a/giscanner/shlibs.py b/giscanner/shlibs.py
 index 838d343..ca7fc0d 100644
 --- a/giscanner/shlibs.py
 +++ b/giscanner/shlibs.py
-@@ -53,10 +53,24 @@ def _resolve_libtool(options, binary, libraries):
+@@ -53,10 +53,27 @@ def _resolve_libtool(options, binary, libraries):
  # Match absolute paths on OS X to conform to how libraries are usually
  # referenced on OS X systems.
  def _ldd_library_pattern(library_name):
 +    nix_store_dir = re.escape('@nixStoreDir@'.rstrip('/'))
      pattern = "(?<![A-Za-z0-9_-])(lib*%s[^A-Za-z0-9_-][^\s\(\)]*)"
--    if platform.system() == 'Darwin':
--        pattern = "([^\s]*lib*%s[^A-Za-z0-9_-][^\s\(\)]*)"
+     if platform.system() == 'Darwin':
+         pattern = "([^\s]*lib*%s[^A-Za-z0-9_-][^\s\(\)]*)"
 -    return re.compile(pattern % re.escape(library_name))
++        return re.compile(pattern % re.escape(library_name))
 +    pattern = r'''
 +        (
 +          (?:
@@ -85,7 +86,7 @@ index 838d343..ca7fc0d 100644
  
  
  # This is a what we do for non-la files. We assume that we are on an
-@@ -115,7 +129,11 @@ def _resolve_non_libtool(options, binary, libraries):
+@@ -115,7 +132,11 @@ def _resolve_non_libtool(options, binary, libraries):
                  m = pattern.search(line)
                  if m:
                      del patterns[library]

--- a/pkgs/development/libraries/gtk-mac-integration/default.nix
+++ b/pkgs/development/libraries/gtk-mac-integration/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig, glib, gtk_doc, gtk }:
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig, glib, gtk_doc, gtk, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
   name = "gtk-mac-integration-2.0.8";
@@ -10,8 +10,9 @@ stdenv.mkDerivation rec {
     sha256 = "1fbhnvj0rqc3089ypvgnpkp6ad2rr37v5qk38008dgamb9h7f3qs";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig gtk_doc ];
-  buildInputs = [ glib gtk ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig gtk_doc gobjectIntrospection ];
+  buildInputs = [ glib ];
+  propagatedBuildInputs = [ gtk ];
 
   preAutoreconf = ''
     gtkdocize

--- a/pkgs/development/libraries/webkitgtk/2.14.nix
+++ b/pkgs/development/libraries/webkitgtk/2.14.nix
@@ -2,7 +2,7 @@
 , pkgconfig, gettext, gobjectIntrospection, libnotify, gnutls
 , gtk2, gtk3, wayland, libwebp, enchant, xlibs, libxkbcommon, epoxy, at_spi2_core
 , libxml2, libsoup, libsecret, libxslt, harfbuzz, libpthreadstubs, pcre, nettle, libtasn1, p11_kit
-, libidn
+, libidn, libedit, readline, mesa, libintlOrEmpty
 , enableGeoLocation ? true, geoclue2, sqlite
 , gst-plugins-base
 }:
@@ -18,12 +18,27 @@ stdenv.mkDerivation rec {
     description = "Web content rendering engine, GTK+ port";
     homepage = "http://webkitgtk.org/";
     license = licenses.bsd2;
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     hydraPlatforms = [];
     maintainers = with maintainers; [ ];
   };
 
-  preConfigure = "patchShebangs Tools";
+  postConfigure = optionalString stdenv.isDarwin ''
+    substituteInPlace Source/WebKit2/CMakeFiles/WebKit2.dir/link.txt \
+    	  --replace "../../lib/libWTFGTK.a" ""
+    substituteInPlace Source/JavaScriptCore/CMakeFiles/JavaScriptCore.dir/link.txt \
+    	  --replace "../../lib/libbmalloc.a" ""
+    sed -i "s|[\./]*\.\./lib/lib[^\.]*\.a||g" \
+        Source/JavaScriptCore/CMakeFiles/LLIntOffsetsExtractor.dir/link.txt \
+        Source/JavaScriptCore/shell/CMakeFiles/jsc.dir/link.txt \
+        Source/JavaScriptCore/shell/CMakeFiles/testb3.dir/link.txt \
+        Source/WebKit2/CMakeFiles/DatabaseProcess.dir/link.txt \
+        Source/WebKit2/CMakeFiles/NetworkProcess.dir/link.txt \
+        Source/WebKit2/CMakeFiles/webkit2gtkinjectedbundle.dir/link.txt \
+        Source/WebKit2/CMakeFiles/WebProcess.dir/link.txt
+    substituteInPlace Source/JavaScriptCore/CMakeFiles/JavaScriptCore.dir/link.txt \
+    	  --replace "../../lib/libWTFGTK.a" "-Wl,-all_load ../../lib/libWTFGTK.a"
+  '';
 
   src = fetchurl {
     url = "http://webkitgtk.org/releases/${name}.tar.xz";
@@ -32,29 +47,54 @@ stdenv.mkDerivation rec {
 
   # see if we can clean this up....
 
-  patches = [ ./finding-harfbuzz-icu.patch ];
+  patches = [ ./finding-harfbuzz-icu.patch ]
+  	++ optionals stdenv.isDarwin [
+    ./PR-152650-2.patch
+    ./PR-153138.patch
+    ./PR-157554.patch
+    ./PR-157574.patch
+  ];
 
   cmakeFlags = [
   "-DPORT=GTK"
   "-DUSE_LIBHYPHEN=0"
-  "-DENABLE_GLES2=ON"
+  ]
+  ++ optional stdenv.isLinux "-DENABLE_GLES2=ON"
+  ++ optionals stdenv.isDarwin [
+  "-DUSE_SYSTEM_MALLOC=ON"
+  "-DUSE_ACCELERATE=0"
+  "-DENABLE_INTROSPECTION=ON"
+  "-DENABLE_MINIBROWSER=OFF"
+  "-DENABLE_PLUGIN_PROCESS_GTK2=OFF"
+  "-DENABLE_MINIBROWSER=OFF"
+  "-DENABLE_VIDEO=ON"
+  "-DENABLE_QUARTZ_TARGET=ON"
+  "-DENABLE_X11_TARGET=OFF"
+  "-DENABLE_OPENGL=OFF"
+  "-DENABLE_WEB_AUDIO=OFF"
+  "-DENABLE_WEBGL=OFF"
+  "-DENABLE_GRAPHICS_CONTEXT_3D=OFF"
+  "-DENABLE_GTKDOC=OFF"
   ];
 
   # XXX: WebKit2 missing include path for gst-plugins-base.
   # Filled: https://bugs.webkit.org/show_bug.cgi?id=148894
-  NIX_CFLAGS_COMPILE = "-I${gst-plugins-base.dev}/include/gstreamer-1.0";
+  NIX_CFLAGS_COMPILE = "-I${gst-plugins-base.dev}/include/gstreamer-1.0"
+                     + (optionalString stdenv.isDarwin " -lintl");
 
   nativeBuildInputs = [
     cmake perl python2 ruby bison gperf sqlite
     pkgconfig gettext gobjectIntrospection
   ];
 
-  buildInputs = [
-    gtk2 wayland libwebp enchant libnotify gnutls pcre nettle libidn
+  buildInputs = libintlOrEmpty ++ [
+    gtk2 libwebp enchant libnotify gnutls pcre nettle libidn
     libxml2 libsecret libxslt harfbuzz libpthreadstubs libtasn1 p11_kit
     gst-plugins-base libxkbcommon epoxy at_spi2_core
   ] ++ optional enableGeoLocation geoclue2
-    ++ (with xlibs; [ libXdmcp libXt libXtst ]);
+    ++ (with xlibs; [ libXdmcp libXt libXtst ])
+    ++ optionals stdenv.isDarwin [ libedit readline mesa ]
+    ++ optional stdenv.isLinux wayland;
 
   propagatedBuildInputs = [
     libsoup gtk3

--- a/pkgs/development/libraries/webkitgtk/PR-152650-2.patch
+++ b/pkgs/development/libraries/webkitgtk/PR-152650-2.patch
@@ -1,0 +1,62 @@
+From 4607ea0a569b3c527ae8dce341ab55eb0d69d8f7 Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Tue, 8 Mar 2016 17:26:23 -0800
+Subject: [PATCH 2/2] [GTK][Mac] Enable support for gtk-doc on Mac
+
+https://bugs.webkit.org/show_bug.cgi?id=152650
+
+Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+---
+ ChangeLog                     | 10 ++++++++++
+ Source/PlatformGTK.cmake      |  2 +-
+ Source/cmake/OptionsGTK.cmake |  5 -----
+ 3 files changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/Source/PlatformGTK.cmake b/Source/PlatformGTK.cmake
+index af4d2e3..0b11b56 100644
+--- a/Source/PlatformGTK.cmake
++++ b/Source/PlatformGTK.cmake
+@@ -34,7 +34,7 @@ endmacro()
+ add_gtkdoc_generator("docs-build.stamp" "")
+ if (ENABLE_GTKDOC)
+     add_custom_target(gtkdoc ALL DEPENDS "${CMAKE_BINARY_DIR}/docs-build.stamp")
+-elseif (NOT ENABLED_COMPILER_SANITIZERS AND NOT CMAKE_CROSSCOMPILING AND NOT APPLE)
++elseif (NOT ENABLED_COMPILER_SANITIZERS AND NOT CMAKE_CROSSCOMPILING)
+     add_custom_target(gtkdoc DEPENDS "${CMAKE_BINARY_DIR}/docs-build.stamp")
+ 
+     # Add a default build step which check that documentation does not have any warnings
+diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
+index 6b01f1a..b443d10 100644
+--- a/Source/cmake/OptionsGTK.cmake
++++ b/Source/cmake/OptionsGTK.cmake
+@@ -424,11 +424,6 @@ if (CMAKE_CROSSCOMPILING)
+     set(ENABLE_INTROSPECTION OFF)
+ endif ()
+ 
+-# Override the cached variable, gtk-doc does not really work when building on Mac.
+-if (APPLE)
+-    set(ENABLE_GTKDOC OFF)
+-endif ()
+-
+ set(DERIVED_SOURCES_GOBJECT_DOM_BINDINGS_DIR ${DERIVED_SOURCES_DIR}/webkitdom)
+ set(DERIVED_SOURCES_WEBKITGTK_DIR ${DERIVED_SOURCES_DIR}/webkitgtk)
+ set(DERIVED_SOURCES_WEBKITGTK_API_DIR ${DERIVED_SOURCES_WEBKITGTK_DIR}/webkit)
+diff --git a/Tools/gtk/gtkdoc.py b/Tools/gtk/gtkdoc.py
+index 4c8237b..a628ae0 100644
+--- a/Tools/gtk/gtkdoc.py
++++ b/Tools/gtk/gtkdoc.py
+@@ -322,6 +322,11 @@ class GTKDoc(object):
+                 env['RUN'] = 'LD_LIBRARY_PATH="%s:%s" ' % (self.library_path, current_ld_library_path)
+             else:
+                 env['RUN'] = 'LD_LIBRARY_PATH="%s" ' % self.library_path
++            current_dyld_library_path = env.get('DYLD_LIBRARY_PATH')
++            if current_ld_library_path:
++                env['RUN'] = 'DYLD_LIBRARY_PATH="%s:%s" ' % (self.library_path, current_dyld_library_path)
++            else:
++                env['RUN'] = 'DYLD_LIBRARY_PATH="%s" ' % self.library_path
+ 
+         if ldflags:
+             env['LDFLAGS'] = '%s %s' % (ldflags, env.get('LDFLAGS', ''))
+-- 
+2.7.2
+

--- a/pkgs/development/libraries/webkitgtk/PR-153138.patch
+++ b/pkgs/development/libraries/webkitgtk/PR-153138.patch
@@ -1,0 +1,26 @@
+From 07886d9eacb7587dd52a9bcae10c1fc8ab56a910 Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Fri, 15 Jan 2016 11:53:07 -0800
+Subject: [PATCH] https://bugs.webkit.org/show_bug.cgi?id=153138
+
+Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+---
+ Source/JavaScriptCore/bytecode/StructureStubInfo.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp b/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
+index 1e4b4f5..9b27aed 100644
+--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
++++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
+@@ -26,6 +26,8 @@
+ #include "config.h"
+ #include "StructureStubInfo.h"
+ 
++#include "JSCellInlines.h"
++
+ #include "JSObject.h"
+ #include "PolymorphicAccess.h"
+ #include "Repatch.h"
+-- 
+2.7.0
+

--- a/pkgs/development/libraries/webkitgtk/PR-157554.patch
+++ b/pkgs/development/libraries/webkitgtk/PR-157554.patch
@@ -1,0 +1,33 @@
+https://bugs.webkit.org/show_bug.cgi?id=157554
+
+--- a/Source/WTF/wtf/OSRandomSource.cpp
++++ b/Source/WTF/wtf/OSRandomSource.cpp
+@@ -29,7 +29,7 @@
+ #include <stdint.h>
+ #include <stdlib.h>
+ 
+-#if !OS(DARWIN) && OS(UNIX)
++#if OS(UNIX) && !(OS(DARWIN) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070)
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <unistd.h>
+@@ -46,7 +46,7 @@
+ 
+ namespace WTF {
+ 
+-#if !OS(DARWIN) && OS(UNIX)
++#if OS(UNIX) && !(OS(DARWIN) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070)
+ NEVER_INLINE NO_RETURN_DUE_TO_CRASH static void crashUnableToOpenURandom()
+ {
+     CRASH();
+@@ -60,8 +56,8 @@ NEVER_INLINE NO_RETURN_DUE_TO_CRASH static void crashUnableToReadFromURandom()
+     
+ void cryptographicallyRandomValuesFromOS(unsigned char* buffer, size_t length)
+ {
+-#if OS(DARWIN)
+-    RELEASE_ASSERT(!CCRandomCopyBytes(kCCRandomDefault, buffer, length));
++#if OS(DARWIN) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
++    return arc4random_buf(buffer, length);
+ #elif OS(UNIX)
+     int fd = open("/dev/urandom", O_RDONLY, 0);
+     if (fd < 0)

--- a/pkgs/development/libraries/webkitgtk/PR-157574.patch
+++ b/pkgs/development/libraries/webkitgtk/PR-157574.patch
@@ -1,0 +1,62 @@
+diff --git a/Source/JavaScriptCore/API/WebKitAvailability.h b/Source/JavaScriptCore/API/WebKitAvailability.h
+index ab53183..1310dec 100644
+--- a/Source/JavaScriptCore/API/WebKitAvailability.h
++++ b/Source/JavaScriptCore/API/WebKitAvailability.h
+@@ -27,57 +27,12 @@
+ #define __WebKitAvailability__
+ 
+ #if defined(__APPLE__)
+-
+-#include <AvailabilityMacros.h>
+ #include <CoreFoundation/CoreFoundation.h>
+-
+-#if !TARGET_OS_IPHONE && __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
+-/* To support availability macros that mention newer OS X versions when building on older OS X versions,
+-   we provide our own definitions of the underlying macros that the availability macros expand to. We're
+-   free to expand the macros as no-ops since frameworks built on older OS X versions only ship bundled with
+-   an application rather than as part of the system.
+-*/
+-
+-#ifndef __NSi_10_10 // Building from trunk rather than SDK.
+-#define __NSi_10_10 introduced=10.0 // Use 10.0 to indicate that everything is available.
+-#endif
+-
+-#ifndef __NSi_10_11 // Building from trunk rather than SDK.
+-#define __NSi_10_11 introduced=10.0 // Use 10.0 to indicate that everything is available.
+-#endif
+-
+-#ifndef __NSi_10_12 // Building from trunk rather than SDK.
+-#define __NSi_10_12 introduced=10.0 // Use 10.0 to indicate that everything is available.
+-#endif
+-
+-#ifndef __AVAILABILITY_INTERNAL__MAC_10_9
+-#define __AVAILABILITY_INTERNAL__MAC_10_9
+-#endif
+-
+-#ifndef __AVAILABILITY_INTERNAL__MAC_10_10
+-#define __AVAILABILITY_INTERNAL__MAC_10_10
+ #endif
+ 
+-#ifndef AVAILABLE_MAC_OS_X_VERSION_10_9_AND_LATER
+-#define AVAILABLE_MAC_OS_X_VERSION_10_9_AND_LATER
+-#endif
+-
+-#ifndef AVAILABLE_MAC_OS_X_VERSION_10_10_AND_LATER
+-#define AVAILABLE_MAC_OS_X_VERSION_10_10_AND_LATER
+-#endif
+-
+-#endif /* __MAC_OS_X_VERSION_MIN_REQUIRED <= 101100 */
+-
+-#if defined(BUILDING_GTK__)
+ #undef CF_AVAILABLE
+ #define CF_AVAILABLE(_mac, _ios)
+ #undef CF_ENUM_AVAILABLE
+ #define CF_ENUM_AVAILABLE(_mac, _ios)
+-#endif
+-
+-#else
+-#define CF_AVAILABLE(_mac, _ios)
+-#define CF_ENUM_AVAILABLE(_mac, _ios)
+-#endif
+ 
+ #endif /* __WebKitAvailability__ */

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7846,6 +7846,10 @@ with pkgs;
     gtk = gtk2;
   };
 
+  gtk-mac-integration-gtk3 = callPackage ../development/libraries/gtk-mac-integration {
+    gtk = gtk3;
+  };
+
   gtk-mac-bundler = callPackage ../development/tools/gtk-mac-bundler {};
 
   gtkspell2 = callPackage ../development/libraries/gtkspell { };


### PR DESCRIPTION
###### Motivation for this change

Gets WebKitGTK+, GtkSourceView and gtk-mac-integration working on MacOS

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

