### PR TITLE
nixos-generate-config: add `system.copySystemConfiguration = true;`

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -615,6 +615,13 @@ $bootLoaderConfig
   #   uid = 1000;
   # };
 
+  # Copies this file into the resulting profile.
+  # It can be found in every profile in /nix/var/nix/profiles/ ,
+  # and the currently used one at /run/current-system/ .
+  # Note that this only copies configuration.nix,
+  # and not any included files like hardware-configuration.nix.
+  system.copySystemConfiguration = true;
+
   # The NixOS release to be compatible with for stateful data such as databases.
   system.stateVersion = "${\(qw(@nixosRelease@))}";
 


### PR DESCRIPTION
###### Motivation for this change
nixos-generate-config: add `system.copySystemConfiguration = true;`

This adds the above line to `nixos-generate-config.pl` and explains its
effect.

This is added as an initial method for backing up `configuration.nix`
which is useful for both novice users (which do not split-up the file as
quickly) and for advanced users (before they have configured backups).

Added because of github PR #16922 and [noobs](http://lists.science.uu.nl/pipermail/nix-dev/2017-April/023379.html) (e.g. myself)

As argued in the PR (#16922) it makes little sense to have the default setting set to true, but the arguments of [@ryantrinkle](https://github.com/NixOS/nixpkgs/pull/16922#issuecomment-292218600) and [myself](https://github.com/NixOS/nixpkgs/pull/16922#issuecomment-292520132) still stand: It is very convenient to have backups in the initial setting up of a new nixos system.


I have not yet run any test with this, because I don't know how to build the new `nixos-generate-config`. Could someone help me with that?

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

