### PR TITLE
haskell-generic-builder: Expose haskell and system build inputs.

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -316,7 +316,7 @@ stdenv.mkDerivation ({
 
   passthru = passthru // {
 
-    inherit pname version;
+    inherit pname version haskellBuildInputs systemBuildInputs;
 
     isHaskellLibrary = hasActiveLibrary;
 


### PR DESCRIPTION
This can be used to build envs for building haskell packages that are
more complicated than the default env currently exported, e.g. a
single composite env that can be used to build multiple packages.