### PR TITLE
Add django 1 11

### DIFF
--- a/pkgs/development/python-modules/django-compat/default.nix
+++ b/pkgs/development/python-modules/django-compat/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchurl,
+  django, django_nose, six
+}:
+buildPythonPackage rec {
+  name = "django-compat-${version}";
+  version = "1.0.14";
+
+  src = fetchurl {
+    url = "mirror://pypi/d/django-compat/${name}.tar.gz";
+    sha256 = "18y5bxxmafcd4np42mzbalva5lpssq0b8ki7zckbzvdv2mnv43xj";
+  };
+
+  doCheck = false;
+
+  buildInputs = [ django_nose ];
+  propagatedBuildInputs = [ django six ];
+
+  meta = with stdenv.lib; {
+    description = "Forward and backwards compatibility layer for Django 1.4, 1.7, 1.8, 1.9, 1.10 and 1.11";
+    homepage = https://github.com/arteria/django-compat;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/django/1_11.nix
+++ b/pkgs/development/python-modules/django/1_11.nix
@@ -1,0 +1,37 @@
+{ stdenv, buildPythonPackage, fetchurl, substituteAll,
+  pythonOlder,
+  geos, gdal, pytz
+}:
+buildPythonPackage rec {
+  name = "Django-${version}";
+  version = "1.11";
+  disabled = pythonOlder "2.7";
+
+  src = fetchurl {
+    url = "http://www.djangoproject.com/m/releases/1.11/${name}.tar.gz";
+    sha256 = "0c1c2n05wv1br651hfbvnxw8ymcn4q8m56893pyv8xj2jijbiwxn";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./1.10-gis-libs.template.patch;
+      geos = geos;
+      gdal = gdal;
+    })
+  ];
+
+  # patch only $out/bin to avoid problems with starter templates (see #3134)
+  postFixup = ''
+    wrapPythonProgramsIn $out/bin "$out $pythonPath"
+  '';
+
+  propagatedBuildInputs = [ pytz ];
+
+  # too complicated to setup
+  doCheck = false;
+
+  meta = {
+    description = "A high-level Python Web framework";
+    homepage = https://www.djangoproject.com/;
+  };
+}

--- a/pkgs/development/python-modules/django_guardian.nix
+++ b/pkgs/development/python-modules/django_guardian.nix
@@ -4,11 +4,11 @@
 }:
 buildPythonPackage rec {
   name = "django-guardian-${version}";
-  version = "1.4.6";
+  version = "1.4.8";
 
   src = fetchurl {
     url = "mirror://pypi/d/django-guardian/${name}.tar.gz";
-    sha256 = "1r3xj0ik0hh6dfak4kjndxk5v73x95nfbppgr394nhnmiayv4zc5";
+    sha256 = "039mfx47c05vl6vlld0ahyq37z7m5g68vqc38pj8iic5ysr98drm";
   };
 
   buildInputs = [ pytest pytestrunner pytest-django django_environ mock setuptools_scm ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10514,27 +10514,7 @@ in {
     };
   };
 
-  django_compat = buildPythonPackage rec {
-    name = "django-compat-${version}";
-    version = "1.0.13";
-
-    # build process attempts to access a missing README.rst
-    disabled = isPy35;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/django-compat/${name}.tar.gz";
-      sha256 = "0s0z7cx0vv1kjsyzk24sg256hfnd09ssilc9rakhxrzr3firgx80";
-    };
-
-    buildInputs = with self; [ django_nose ];
-    propagatedBuildInputs = with self; [ django six ];
-
-    meta = {
-      description = "Forward and backwards compatibility layer for Django 1.4, 1.7, 1.8, 1.9 and 1.10";
-      homepage = https://github.com/arteria/django-compat;
-      license = licenses.mit;
-    };
-  };
+  django_compat = callPackage ../development/python-modules/django-compat { };
 
   django_environ = buildPythonPackage rec {
     name = "django-environ-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10368,7 +10368,11 @@ in {
     };
   };
 
-  django = self.django_1_10;
+  django = self.django_1_11;
+
+  django_1_11 = callPackage ../development/python-modules/django/1_11.nix {
+    gdal = self.gdal;
+  };
 
   django_1_10 = callPackage ../development/python-modules/django/1_10.nix {
     gdal = self.gdal;


### PR DESCRIPTION
###### Motivation for this change

This adds django-1.11, the new TLS version of django.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

