### PR TITLE
mktorrent: 1.0 -> 1.1

### DIFF
--- a/pkgs/tools/misc/mktorrent/default.nix
+++ b/pkgs/tools/misc/mktorrent/default.nix
@@ -1,11 +1,14 @@
-{stdenv, fetchurl, openssl}:
+{stdenv, fetchFromGitHub, openssl}:
 
-stdenv.mkDerivation {
-  name = "mktorrent-1.0";
+stdenv.mkDerivation rec {
+  name = "mktorrent-${version}";
+  version = "1.1";
 
-  src = fetchurl {
-    url = mirror://sourceforge/mktorrent/mktorrent-1.0.tar.gz;
-    sha256 = "17qi3nfky240pq6qcmf5qg324mxm83vk9r3nvsdhsvinyqm5d3kg";
+  src = fetchFromGitHub {
+    owner = "Rudde";
+    repo = "mktorrent";
+    rev = "v${version}";
+    sha256 = "17pdc5mandl739f8q26n5is8ga56s83aqcrwhlnnplbxwx2inidr";
   };
 
   makeFlags = "USE_PTHREADS=1 USE_OPENSSL=1 USE_LONG_OPTIONS=1"
@@ -22,7 +25,6 @@ stdenv.mkDerivation {
     homepage = http://mktorrent.sourceforge.net/;
     license = stdenv.lib.licenses.gpl2Plus;
     description = "Command line utility to create BitTorrent metainfo files";
-    platforms = with stdenv.lib.platforms; unix;
-    maintainers = with stdenv.lib.maintainers; [viric];
+    maintainers = with stdenv.lib.maintainers; [viric profpatsch];
   };
 }


### PR DESCRIPTION
[1.1] - 2017-01-11
Added
- Autodetect the number of CPUs available <esmil@mailme.dk>
- Option for source string added to torrent info (`-s`), included in infohash.
  Often used by private trackers to create a unique infohash to prevent
  peer-leak and the possibility to track the trackers that do use leaked
  torrents. Having this option in mktorrent make it possible to create a
  infohash accurate torrent to the tracker you want to upload it to
Changed
- Make`-a` (announce list) optional
- Optional announce URL even for private torrents. No need to require announce
  for private torrents, they are added by most private trackers anyway and they
  modify the infohash so you'd have to redownload their modified torrent with
  injected unique announce URL anyway. (@mathieui, fix from @jrwren)
Fixed
- DHT makes trackers optional, so remove the warning