### PR TITLE
haskell: ghcjs packages: Break dependency cycle less invasive

### DIFF
--- a/pkgs/development/compilers/ghcjs/head_stage2.nix
+++ b/pkgs/development/compilers/ghcjs/head_stage2.nix
@@ -382,7 +382,6 @@
         version = "1.24.0.0";
         src = "${ghcjsBoot}/boot/cabal/Cabal";
         doCheck = false;
-        hyperlinkSource = false;
         libraryHaskellDepends = [
           array base binary bytestring containers deepseq directory filepath
           pretty process time unix

--- a/pkgs/development/compilers/ghcjs/stage2.nix
+++ b/pkgs/development/compilers/ghcjs/stage2.nix
@@ -327,7 +327,6 @@
         version = "1.22.8.0";
         src = "${ghcjsBoot}/boot/cabal/Cabal";
         doCheck = false;
-        hyperlinkSource = false;
         libraryHaskellDepends = [
           array base binary bytestring containers deepseq directory filepath
           pretty process time unix

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -58,9 +58,13 @@ self: super:
   # Almost all packages require Cabal to build their Setup.hs,
   # but usually they don't declare it explicitly as they don't need to for normal GHC.
   # To account for that we add Cabal by default.
-  mkDerivation = args:
-    if args.pname == "Cabal" then super.mkDerivation args else super.mkDerivation (args //
-      { setupHaskellDepends = (args.setupHaskellDepends or []) ++ [ self.Cabal ]; });
+  mkDerivation = args: super.mkDerivation (args // {
+    setupHaskellDepends = (args.setupHaskellDepends or []) ++
+      (if args.pname == "Cabal" then [ ]
+      # Break the dependency cycle between Cabal and hscolour
+      else if args.pname == "hscolour" then [ (dontHyperlinkSource self.Cabal) ]
+      else [ self.Cabal ]);
+  });
 
 ## OTHER PACKAGES
 


### PR DESCRIPTION
Between cabal and hscolour.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

