### PR TITLE
Fix `fadeExclude` description.

### DIFF
--- a/nixos/modules/services/x11/compton.nix
+++ b/nixos/modules/services/x11/compton.nix
@@ -83,7 +83,7 @@ in {
         "focused = 1" 
       ];
       description = ''
-        List of condition of windows that should have no shadow.
+        List of conditions of windows that should not be faded.
         See <literal>compton(1)</literal> man page for more examples.
       '';
     };

--- a/nixos/modules/services/x11/compton.nix
+++ b/nixos/modules/services/x11/compton.nix
@@ -123,7 +123,7 @@ in {
         "focused = 1" 
       ];
       description = ''
-        List of condition of windows that should have no shadow.
+        List of conditions of windows that should have no shadow.
         See <literal>compton(1)</literal> man page for more examples.
       '';
     };


### PR DESCRIPTION
###### Motivation for this change

The description for the `fadeExclude` options was wrongly mentioning shadows.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

