### PR TITLE
verbiste: init at 0.1.44

### DIFF
--- a/pkgs/applications/misc/verbiste/default.nix
+++ b/pkgs/applications/misc/verbiste/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pkgconfig, libgnomeui, libxml2 }:
+
+stdenv.mkDerivation rec {
+  name = "verbiste-${version}";
+
+  version = "0.1.44";
+
+  src = fetchurl {
+    url = "http://perso.b2b2c.ca/~sarrazip/dev/${name}.tar.gz";
+    sha256 = "0vmjr8w3qc64y312a0sj0ask309mmmlmyxp2fsii0ji35ls7m9sw";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ libgnomeui libxml2 ];
+
+  meta = with stdenv.lib; {
+    homepage = http://sarrazip.com/dev/verbiste.html;
+    description = "French and Italian verb conjugator";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ orivej ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15800,6 +15800,10 @@ with pkgs;
 
   vdpauinfo = callPackage ../tools/X11/vdpauinfo { };
 
+  verbiste = callPackage ../applications/misc/verbiste {
+    inherit (gnome2) libgnomeui;
+  };
+
   vim = callPackage ../applications/editors/vim {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
   };


### PR DESCRIPTION
###### Motivation for this change

This is a French and Italian GUI verb conjugator.
Homepage: http://perso.b2b2c.ca/~sarrazip/dev/verbiste.html

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
