### PR TITLE
scala: 2.11.9 -> 2.11.10

### DIFF
--- a/pkgs/development/compilers/scala/2.11.nix
+++ b/pkgs/development/compilers/scala/2.11.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, makeWrapper, jre, gnugrep, coreutils }:
 
 stdenv.mkDerivation rec {
-  name = "scala-2.11.9";
+  name = "scala-2.11.10";
 
   src = fetchurl {
     url = "http://www.scala-lang.org/files/archive/${name}.tgz";
-    sha256 = "02rpx0pzr98vla2mgkgf6s8blccnrji5bxw05z36m1iwqmpryx5r";
+    sha256 = "10rs8ak3qyxggw24ga3gjcpl3x8r1b3ykrdfrym1n154b1rrs904";
   };
 
   propagatedBuildInputs = [ jre ] ;


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

