### PR TITLE
hy: 0.11.1 -> 0.12.1

### DIFF
--- a/pkgs/development/interpreters/hy/default.nix
+++ b/pkgs/development/interpreters/hy/default.nix
@@ -2,15 +2,14 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "hy-${version}";
-  version = "0.11.1";
+  version = "0.12.1";
 
   src = fetchurl {
     url = "mirror://pypi/h/hy/${name}.tar.gz";
-    sha256 = "1msqv747iz12r73mz4qvsmlwkddwjvrahlrk7ysrcz07h7dsscxs";
+    sha256 = "1fjip998k336r26i1gpri18syvfjg7z46wng1n58dmc238wm53sx";
   };
 
-  buildInputs = [ pythonPackages.appdirs ];
-  propagatedBuildInputs = [ pythonPackages.clint pythonPackages.astor pythonPackages.rply ];
+  propagatedBuildInputs = with pythonPackages; [ appdirs clint astor rply ];
 
   meta = {
     description = "A LISP dialect embedded in Python";


### PR DESCRIPTION
Fixed build inputs up a little while bumping version

###### Motivation for this change

Hylang had a version bump and my original package was broken. appdirs is needed as a propogated build input. Honestly not sure how I messed that up last time, since I had a working version. I think I had done some work that I hadn't commited

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

