### PR TITLE
reason: init at 1.13.3

### DIFF
--- a/pkgs/development/compilers/reason/default.nix
+++ b/pkgs/development/compilers/reason/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, makeWrapper, buildOcaml, fetchFromGitHub,
+  ocaml, opam, topkg, menhir, merlin_extend, ppx_tools_versioned, utop }:
+
+let 
+  version = "1.13.3";
+  src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "reason";
+    rev = version;
+    sha256 = "1b0dsnw69kkvix4iqlbcbfyr9j6zx2y2cbrp13f7y387hv6i7zkx";
+  };
+  meta = with stdenv.lib; {
+    homepage = https://facebook.github.io/reason/;
+    description = "Facebook's friendly syntax to OCaml";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.volth ];
+  };
+
+  reason-parser = buildOcaml {
+    name = "reason-parser";
+    inherit version src meta;
+    sourceRoot = "reason-${version}-src/reason-parser";
+
+    minimumSupportedOcamlVersion = "4.02";
+
+    propagatedBuildInputs = [ menhir merlin_extend ppx_tools_versioned ];
+    buildInputs = [ opam topkg ];
+
+    createFindlibDestdir = true;
+
+    inherit (topkg) installPhase;
+  };
+in
+buildOcaml {
+  name = "reason";
+  inherit version src meta;
+
+  buildInputs = [ makeWrapper opam topkg reason-parser utop ];
+
+  buildFlags = [ "build" ]; # do not "make tests" before reason lib is installed
+
+  createFindlibDestdir = true;
+
+  postPatch = ''
+    substituteInPlace src/reasonbuild.ml --replace "refmt --print binary" "$out/bin/refmt --print binary"
+  '';
+
+  installPhase = ''
+    ${topkg.installPhase}
+
+    wrapProgram $out/bin/reup \
+      --prefix PATH : "${opam}/bin"
+    wrapProgram $out/bin/rtop \
+      --prefix PATH : "${utop}/bin" \
+      --set OCAMLPATH $out/lib/ocaml/${ocaml.version}/site-lib:$OCAMLPATH
+  '';
+}

--- a/pkgs/development/compilers/reason/default.nix
+++ b/pkgs/development/compilers/reason/default.nix
@@ -2,12 +2,12 @@
   ocaml, opam, topkg, menhir, merlin_extend, ppx_tools_versioned, utop }:
 
 let 
-  version = "1.13.3";
+  version = "1.13.4";
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "reason";
     rev = version;
-    sha256 = "1b0dsnw69kkvix4iqlbcbfyr9j6zx2y2cbrp13f7y387hv6i7zkx";
+    sha256 = "03r2ciikgwaq1dkzgzc8n7h7y0q95ajh6n9bb2n5bpgfhwkr1wqi";
   };
   meta = with stdenv.lib; {
     homepage = https://facebook.github.io/reason/;

--- a/pkgs/development/ocaml-modules/merlin_extend/default.nix
+++ b/pkgs/development/ocaml-modules/merlin_extend/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildOcaml, fetchFromGitHub, cppo }:
+
+buildOcaml rec {
+  name = "merlin_extend";
+  version = "0.3";
+
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner = "let-def";
+    repo = "merlin-extend";
+    sha256 = "1z6hybcb7ry0bkzjd0r2dlcgjnhhxdsr06x3h03sj7h5fihsc7vd";
+    rev = "v${version}";
+  };
+
+  buildInputs = [ cppo ];
+
+  createFindlibDestdir = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/let-def/merlin-extend;
+    description = "SDK to extend Merlin";
+    license = licenses.mit;
+    maintainers = [ maintainers.volth ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
    name = "ocaml${ocaml.version}-ocaml-migrate-parsetree-${version}";
-   version = "0.5";
+   version = "0.7";
 
    src = fetchFromGitHub {
      owner = "let-def";
      repo = "ocaml-migrate-parsetree";
      rev = "v${version}";
-     sha256 = "023lnd3kxa3d4zgsvv0z2lyzhg05zcgagy18vaalimbza57wq83h";
+     sha256 = "142svvixhz153argd3khk7sr38dhiy4w6sck4766f8b48p41pp3m";
    };
 
    buildInputs = [ ocaml findlib ocamlbuild jbuilder ];

--- a/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildOcaml, fetchFromGitHub, ocaml-migrate-parsetree }:
+
+buildOcaml rec {
+  name = "ppx_tools_versioned";
+  version = "5.0alpha";
+
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner = "let-def";
+    repo = "ppx_tools_versioned";
+    rev = version;
+    sha256 = "0sa3w0plpa0s202s9yjgz7dbk32xd2s6fymkjijrhj4lkvh08mba";
+  };
+
+  propagatedBuildInputs = [ ocaml-migrate-parsetree ];
+
+  createFindlibDestdir = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/let-def/ppx_tools_versioned;
+    description = "Tools for authors of syntactic tools (such as ppx rewriters)";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.volth ];
+  };
+}

--- a/pkgs/development/tools/ocaml/utop/default.nix
+++ b/pkgs/development/tools/ocaml/utop/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, camlp4, ocaml_react
-, lambdaTerm, ocaml_lwt, makeWrapper, camomile, zed, cppo, ppx_tools
+{ stdenv, fetchurl, bash, ocaml, findlib, ocamlbuild, camlp4, ocaml_react
+, lambdaTerm, ocaml_lwt, camomile, zed, cppo, ppx_tools
 }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "16z02vp9n97iax4fqpbi7v86r75vbabxvnd1rirh8w2miixs1g4x";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild makeWrapper cppo camlp4 ppx_tools ];
+  buildInputs = [ ocaml findlib ocamlbuild cppo camlp4 ppx_tools ];
 
   propagatedBuildInputs = [ lambdaTerm ocaml_lwt ];
 
@@ -35,9 +35,9 @@ stdenv.mkDerivation rec {
    do
     mv $prog .$prog-wrapped
     cat > $prog <<EOF
-#!/bin/sh
-export CAML_LD_LIBRARY_PATH=${p ocaml_lwt}/lwt:${p lambdaTerm}/lambda-term:'\$CAML_LD_LIBRARY_PATH'
-export OCAMLPATH=${p ocaml_lwt}:${p ocaml_react}:${p camomile}:${p zed}:${p lambdaTerm}:"$out"/lib/ocaml/${ocaml.version}/site-lib:'\$OCAMLPATH'
+#!${bash}/bin/bash -e
+export CAML_LD_LIBRARY_PATH="${p ocaml_lwt}/lwt:${p lambdaTerm}/lambda-term:\$CAML_LD_LIBRARY_PATH"
+export OCAMLPATH="${p ocaml_lwt}:${p ocaml_react}:${p camomile}:${p zed}:${p lambdaTerm}:"$out"/lib/ocaml/${ocaml.version}/site-lib:\$OCAMLPATH"
 ${ocaml}/bin/ocamlrun $out/bin/.$prog-wrapped \$*
 EOF
     chmod +x $prog

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6128,6 +6128,8 @@ with pkgs;
 
   regina = callPackage ../development/interpreters/regina { };
 
+  inherit (ocamlPackages) reason;
+
   renpy = callPackage ../development/interpreters/renpy {
     ffmpeg = ffmpeg_2;
   };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -289,6 +289,8 @@ let
 
     merlin = callPackage ../development/tools/ocaml/merlin { };
 
+    merlin_extend = callPackage ../development/ocaml-modules/merlin_extend { };
+
     mezzo = callPackage ../development/compilers/mezzo { };
 
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
@@ -499,6 +501,8 @@ let
       then callPackage ../development/ocaml-modules/ppx_tools {}
       else null;
 
+    ppx_tools_versioned = callPackage ../development/ocaml-modules/ppx_tools_versioned { };
+
     pycaml = callPackage ../development/ocaml-modules/pycaml { };
 
     qcheck = callPackage ../development/ocaml-modules/qcheck {
@@ -508,6 +512,8 @@ let
     qtest = callPackage ../development/ocaml-modules/qtest { };
 
     re = callPackage ../development/ocaml-modules/re { };
+
+    reason = callPackage ../development/compilers/reason { };
 
     rresult = callPackage ../development/ocaml-modules/rresult { };
 


### PR DESCRIPTION
###### Motivation for this change

Facebook's frontend for Ocaml.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested: REPL and compiler.
Not tested: integration with emacs and merlin.

Additional changes: 
* bumped minor versions of ```ocaml-migrate-parsetree``` and ```jbuilder``` (it allows compilation with  ocaml-```4.02```)
* fixed escaping in non-standard wrapper in ```utop``` (17.03 uses good old ```makeWrapper``` and has no problem, only master branch has the problem....). ```Reason```'s REPL depends on this bugfix.
* ~~```jbuilder``` moved from ```all-packages.nix``` to ```ocaml-packages.nix``` to be among other Jane Street's builders.~~


---

