### PR TITLE
haskell: Correct dependencies for haskell-tools-*_0_6_0_0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -875,4 +875,34 @@ self: super: {
 
   # https://github.com/danidiaz/tailfile-hinotify/issues/2
   tailfile-hinotify = dontCheck super.tailfile-hinotify;
-}
+} // (let scope' = self: super: {
+            haskell-tools-ast = super.haskell-tools-ast_0_6_0_0;
+            haskell-tools-backend-ghc = super.haskell-tools-backend-ghc_0_6_0_0;
+            haskell-tools-cli = super.haskell-tools-cli_0_6_0_0;
+            haskell-tools-daemon = super.haskell-tools-daemon_0_6_0_0;
+            haskell-tools-debug = super.haskell-tools-debug_0_6_0_0;
+            haskell-tools-demo = super.haskell-tools-demo_0_6_0_0;
+            haskell-tools-prettyprint = super.haskell-tools-prettyprint_0_6_0_0;
+            haskell-tools-refactor = super.haskell-tools-refactor_0_6_0_0;
+            haskell-tools-rewrite = super.haskell-tools-rewrite_0_6_0_0;
+          };
+      in {
+        haskell-tools-ast_0_6_0_0 =
+          super.haskell-tools-ast_0_6_0_0.overrideScope scope';
+        haskell-tools-backend-ghc_0_6_0_0 =
+          super.haskell-tools-backend-ghc_0_6_0_0.overrideScope scope';
+        haskell-tools-cli_0_6_0_0 =
+          dontCheck (super.haskell-tools-cli_0_6_0_0.overrideScope scope');
+        haskell-tools-daemon_0_6_0_0 =
+          dontCheck (super.haskell-tools-daemon_0_6_0_0.overrideScope scope');
+        haskell-tools-debug_0_6_0_0 =
+          super.haskell-tools-debug_0_6_0_0.overrideScope scope';
+        haskell-tools-demo_0_6_0_0 =
+          super.haskell-tools-demo_0_6_0_0.overrideScope scope';
+        haskell-tools-prettyprint_0_6_0_0 =
+          super.haskell-tools-prettyprint_0_6_0_0.overrideScope scope';
+        haskell-tools-refactor_0_6_0_0 =
+          super.haskell-tools-refactor_0_6_0_0.overrideScope scope';
+        haskell-tools-rewrite_0_6_0_0 =
+          super.haskell-tools-rewrite_0_6_0_0.overrideScope scope';
+     })


### PR DESCRIPTION
If someone knows how to make it less verbose, please comment.
Tested `haskell-tools-daemon_0_6_0_0` and `haskell-tools-cli_0_6_0_0` binaries.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

