### PR TITLE
hy: Fix build inputs

### DIFF
--- a/pkgs/development/interpreters/hy/default.nix
+++ b/pkgs/development/interpreters/hy/default.nix
@@ -9,8 +9,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1msqv747iz12r73mz4qvsmlwkddwjvrahlrk7ysrcz07h7dsscxs";
   };
 
-  buildInputs = [ pythonPackages.appdirs ];
-  propagatedBuildInputs = [ pythonPackages.clint pythonPackages.astor pythonPackages.rply ];
+  propagatedBuildInputs = with pythonPacckages; [ appdirs clint astor rply ];
 
   meta = {
     description = "A LISP dialect embedded in Python";

--- a/pkgs/development/interpreters/hy/default.nix
+++ b/pkgs/development/interpreters/hy/default.nix
@@ -9,7 +9,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1msqv747iz12r73mz4qvsmlwkddwjvrahlrk7ysrcz07h7dsscxs";
   };
 
-  propagatedBuildInputs = with pythonPacckages; [ appdirs clint astor rply ];
+  propagatedBuildInputs = with pythonPackages; [ appdirs clint astor rply ];
 
   meta = {
     description = "A LISP dialect embedded in Python";


### PR DESCRIPTION
Appdirs needs to be in `propogatedBuildInputs` for hy to run

###### Motivation for this change

When updating hy to 0.12.1 in #24735 I realized that appdirs needed to be in propogatedBuildInputs for this package to work. In its current state it is broken. This pull request is to fix the inputs without updating to a new version.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

