### PR TITLE
amdgpu-pro: 16.60 -> 17.10

### DIFF
--- a/pkgs/os-specific/linux/amdgpu-pro/default.nix
+++ b/pkgs/os-specific/linux/amdgpu-pro/default.nix
@@ -30,9 +30,9 @@ let
 
 in stdenv.mkDerivation rec {
 
-  version = "16.60";
+  version = "17.10";
   pname = "amdgpu-pro";
-  build = "${version}-379184";
+  build = "${version}-401251";
 
   libCompatDir = "/run/lib/${libArch}";
 
@@ -41,7 +41,7 @@ in stdenv.mkDerivation rec {
   src = fetchurl {
     url =
     "https://www2.ati.com/drivers/linux/ubuntu/amdgpu-pro-${build}.tar.xz";
-    sha256 = "1g90sryxw8y4abjgviibq34v3hr82ijgbaiqnxgafrf7g9s5m2yq";
+    sha256 = "004n0df8acjpjz72z3bjxb2a0b7qwln13jlknfn7xxqvhhwwy40a";
     curlOpts = "--referer http://support.amd.com/en-us/kb-articles/Pages/AMD-Radeon-GPU-PRO-Linux-Beta-Driver%e2%80%93Release-Notes.aspx";
   };
 

--- a/pkgs/os-specific/linux/amdgpu-pro/patches/0001-disable-firmware-copy.patch
+++ b/pkgs/os-specific/linux/amdgpu-pro/patches/0001-disable-firmware-copy.patch
@@ -1,4 +1,4 @@
-From ad3f6de6d16ea8ee76635dd39875eeab39def6e9 Mon Sep 17 00:00:00 2001
+From 704cef8638ffbdd8de9e57f28b43ea42c685ea87 Mon Sep 17 00:00:00 2001
 From: David McFarland <corngood@gmail.com>
 Date: Sat, 28 Jan 2017 16:57:26 -0400
 Subject: [PATCH 1/4] disable firmware copy
@@ -8,7 +8,7 @@ Subject: [PATCH 1/4] disable firmware copy
  1 file changed, 5 deletions(-)
 
 diff --git a/pre-build.sh b/pre-build.sh
-index 25e718f..e3cd009 100755
+index 622ff13..e3cd009 100755
 --- a/pre-build.sh
 +++ b/pre-build.sh
 @@ -35,8 +35,3 @@ find ttm -name '*.c' -exec grep EXPORT_SYMBOL {} + \
@@ -18,8 +18,8 @@ index 25e718f..e3cd009 100755
 -
 -FW_DIR="/lib/firmware/$KERNELVER"
 -mkdir -p $FW_DIR
--cp -ar /usr/src/amdgpu-pro-16.60-379184/firmware/radeon $FW_DIR
--cp -ar /usr/src/amdgpu-pro-16.60-379184/firmware/amdgpu $FW_DIR
+-cp -ar /usr/src/amdgpu-pro-17.10-401251/firmware/radeon $FW_DIR
+-cp -ar /usr/src/amdgpu-pro-17.10-401251/firmware/amdgpu $FW_DIR
 -- 
-2.11.0
+2.12.2
 

--- a/pkgs/os-specific/linux/amdgpu-pro/patches/0002-linux-4.9-fixes.patch
+++ b/pkgs/os-specific/linux/amdgpu-pro/patches/0002-linux-4.9-fixes.patch
@@ -1,63 +1,31 @@
-From 52e47be93c7a492730477f590e5eb42e035018bd Mon Sep 17 00:00:00 2001
+From 0ead7017e1db18be971c24c891d4bdcc507deea7 Mon Sep 17 00:00:00 2001
 From: David McFarland <corngood@gmail.com>
 Date: Sun, 29 Jan 2017 18:23:47 -0400
 Subject: [PATCH 2/4] linux-4.9 fixes
 
 ---
- amd/amdgpu/amdgpu_connectors.c          | 8 ++++++++
- amd/amdgpu/amdgpu_ttm.c                 | 4 ++++
+ amd/amdkcl/kcl_io.c                     | 2 ++
  amd/display/amdgpu_dm/amdgpu_dm_types.c | 8 ++++++++
- include/kcl/kcl_mm.h                    | 4 +++-
- 4 files changed, 23 insertions(+), 1 deletion(-)
+ 2 files changed, 10 insertions(+)
 
-diff --git a/amd/amdgpu/amdgpu_connectors.c b/amd/amdgpu/amdgpu_connectors.c
-index 1b51981..4b43379 100644
---- a/amd/amdgpu/amdgpu_connectors.c
-+++ b/amd/amdgpu/amdgpu_connectors.c
-@@ -168,12 +168,20 @@ int amdgpu_connector_get_monitor_bpc(struct drm_connector *connector)
- 		}
- 
- 		/* Any defined maximum tmds clock limit we must not exceed? */
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
-+		if (connector->display_info.max_tmds_clock > 0) {
-+#else
- 		if (connector->max_tmds_clock > 0) {
-+#endif
- 			/* mode_clock is clock in kHz for mode to be modeset on this connector */
- 			mode_clock = amdgpu_connector->pixelclock_for_modeset;
- 
- 			/* Maximum allowable input clock in kHz */
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
-+			max_tmds_clock = connector->display_info.max_tmds_clock * 1000;
-+#else
- 			max_tmds_clock = connector->max_tmds_clock * 1000;
-+#endif
- 
- 			DRM_DEBUG("%s: hdmi mode dotclock %d kHz, max tmds input clock %d kHz.\n",
- 				  connector->name, mode_clock, max_tmds_clock);
-diff --git a/amd/amdgpu/amdgpu_ttm.c b/amd/amdgpu/amdgpu_ttm.c
-index 447529d..252bab4 100644
---- a/amd/amdgpu/amdgpu_ttm.c
-+++ b/amd/amdgpu/amdgpu_ttm.c
-@@ -255,7 +255,11 @@ static int amdgpu_verify_access(struct ttm_buffer_object *bo, struct file *filp)
- 
- 	if (amdgpu_ttm_tt_get_usermm(bo->ttm))
- 		return -EPERM;
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
-+	return drm_vma_node_verify_access(&abo->gem_base.vma_node, filp->private_data);
-+#else
- 	return drm_vma_node_verify_access(&abo->gem_base.vma_node, filp);
-+#endif
+diff --git a/amd/amdkcl/kcl_io.c b/amd/amdkcl/kcl_io.c
+index d8f843f..9a1bd9b 100644
+--- a/amd/amdkcl/kcl_io.c
++++ b/amd/amdkcl/kcl_io.c
+@@ -31,4 +31,6 @@ void amdkcl_io_init(void)
+ 	_kcl_io_free_memtype = amdkcl_fp_setup("io_free_memtype", NULL);
  }
- 
- static void amdgpu_move_null(struct ttm_buffer_object *bo,
+ #endif
++#else
++void amdkcl_io_init(void) {}
+ #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0) */
 diff --git a/amd/display/amdgpu_dm/amdgpu_dm_types.c b/amd/display/amdgpu_dm/amdgpu_dm_types.c
-index be7aafb..5e11f26 100644
+index 34313a9..44a4a71 100644
 --- a/amd/display/amdgpu_dm/amdgpu_dm_types.c
 +++ b/amd/display/amdgpu_dm/amdgpu_dm_types.c
-@@ -1692,6 +1692,10 @@ static int dm_plane_helper_prepare_fb(
+@@ -1720,6 +1720,10 @@ static int dm_plane_helper_prepare_fb(
+ static int dm_plane_helper_prepare_fb(
  	struct drm_plane *plane,
- 	struct drm_framebuffer *fb,
  	const struct drm_plane_state *new_state)
 +#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
 +static int dm_plane_helper_prepare_fb(
@@ -66,9 +34,9 @@ index be7aafb..5e11f26 100644
  #else
  static int dm_plane_helper_prepare_fb(
  	struct drm_plane *plane,
-@@ -1735,6 +1739,10 @@ static void dm_plane_helper_cleanup_fb(
+@@ -1766,6 +1770,10 @@ static void dm_plane_helper_cleanup_fb(
+ static void dm_plane_helper_cleanup_fb(
  	struct drm_plane *plane,
- 	struct drm_framebuffer *fb,
  	const struct drm_plane_state *old_state)
 +#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
 +static void dm_plane_helper_cleanup_fb(
@@ -77,21 +45,6 @@ index be7aafb..5e11f26 100644
  #else
  static void dm_plane_helper_cleanup_fb(
  	struct drm_plane *plane,
-diff --git a/include/kcl/kcl_mm.h b/include/kcl/kcl_mm.h
-index a18936d..f068195 100644
---- a/include/kcl/kcl_mm.h
-+++ b/include/kcl/kcl_mm.h
-@@ -8,7 +8,9 @@ static inline int kcl_get_user_pages(struct task_struct *tsk, struct mm_struct *
-                                      int write, int force, struct page **pages,
-                                      struct vm_area_struct **vmas)
- {
--#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
-+        return get_user_pages(start, nr_pages, write ? FOLL_WRITE : 0, pages, vmas);
-+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
-         return get_user_pages(start, nr_pages, write, force, pages, vmas);
- #else
-         return get_user_pages(tsk, mm, start, nr_pages,
 -- 
-2.11.0
+2.12.2
 

--- a/pkgs/os-specific/linux/amdgpu-pro/patches/0003-Change-seq_printf-format-for-64-bit-context.patch
+++ b/pkgs/os-specific/linux/amdgpu-pro/patches/0003-Change-seq_printf-format-for-64-bit-context.patch
@@ -1,4 +1,4 @@
-From cc490c71a98b6bbe390fcf777fbe0360d01bf4ca Mon Sep 17 00:00:00 2001
+From b6dd36dd90c5d88ae10b9dbc763d3bacb95ccddb Mon Sep 17 00:00:00 2001
 From: "Luke A. Guest" <laguest@archeia.com>
 Date: Sun, 25 Sep 2016 16:46:39 +0100
 Subject: [PATCH 3/4] Change seq_printf format for 64 bit context
@@ -8,18 +8,18 @@ Subject: [PATCH 3/4] Change seq_printf format for 64 bit context
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/amd/amdgpu/amdgpu_sa.c b/amd/amdgpu/amdgpu_sa.c
-index c43f582..8c4b9f7 100644
+index 74932bf..db4119a 100644
 --- a/amd/amdgpu/amdgpu_sa.c
 +++ b/amd/amdgpu/amdgpu_sa.c
-@@ -427,7 +427,7 @@ void amdgpu_sa_bo_dump_debug_info(struct amdgpu_sa_manager *sa_manager,
+@@ -428,7 +428,7 @@ void amdgpu_sa_bo_dump_debug_info(struct amdgpu_sa_manager *sa_manager,
  			   soffset, eoffset, eoffset - soffset);
  
  		if (i->fence)
 -#if defined(BUILD_AS_DKMS)
 +#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 8, 0)
  			seq_printf(m, " protected by 0x%08x on context %d",
- 				   i->fence->seqno, i->fence->context);
+ 					i->fence->seqno, i->fence->context);
  #else
 -- 
-2.11.0
+2.12.2
 

--- a/pkgs/os-specific/linux/amdgpu-pro/patches/0004-fix-warnings-for-Werror.patch
+++ b/pkgs/os-specific/linux/amdgpu-pro/patches/0004-fix-warnings-for-Werror.patch
@@ -1,30 +1,15 @@
-From 9970f3107aed7b2b1ff1c5f29129b62cec99980d Mon Sep 17 00:00:00 2001
+From dbf01d3934c52acaaa37f008859f69c5edf19ad5 Mon Sep 17 00:00:00 2001
 From: David McFarland <corngood@gmail.com>
 Date: Mon, 6 Feb 2017 22:13:49 -0400
 Subject: [PATCH 4/4] fix warnings for Werror
 
 ---
- amd/amdgpu/amdgpu_kms.c                 | 2 +-
  amd/amdgpu/amdgpu_ttm.c                 | 2 ++
- amd/display/amdgpu_dm/amdgpu_dm.c       | 2 +-
  amd/display/amdgpu_dm/amdgpu_dm_types.c | 2 +-
- 4 files changed, 5 insertions(+), 3 deletions(-)
+ 2 files changed, 3 insertions(+), 1 deletion(-)
 
-diff --git a/amd/amdgpu/amdgpu_kms.c b/amd/amdgpu/amdgpu_kms.c
-index b7b51ae..bc884f6 100644
---- a/amd/amdgpu/amdgpu_kms.c
-+++ b/amd/amdgpu/amdgpu_kms.c
-@@ -591,7 +591,7 @@ static int amdgpu_info_ioctl(struct drm_device *dev, void *data, struct drm_file
- 
- 			bios = adev->bios + bios_offset;
- 			return copy_to_user(out, bios,
--				min((size_t)size, bios_size - bios_offset))
-+				min(size, bios_size - bios_offset))
- 					? -EFAULT : 0;
- 		}
- 		default:
 diff --git a/amd/amdgpu/amdgpu_ttm.c b/amd/amdgpu/amdgpu_ttm.c
-index 252bab4..90f3655 100644
+index 0e30389..890aafa 100644
 --- a/amd/amdgpu/amdgpu_ttm.c
 +++ b/amd/amdgpu/amdgpu_ttm.c
 @@ -1083,6 +1083,7 @@ uint32_t amdgpu_ttm_tt_pte_flags(struct amdgpu_device *adev, struct ttm_tt *ttm,
@@ -41,26 +26,13 @@ index 252bab4..90f3655 100644
  }
 +#endif
  
- static struct ttm_bo_driver amdgpu_bo_driver = {
- 	.ttm_tt_create = &amdgpu_ttm_tt_create,
-diff --git a/amd/display/amdgpu_dm/amdgpu_dm.c b/amd/display/amdgpu_dm/amdgpu_dm.c
-index 3dcb619..5700861 100644
---- a/amd/display/amdgpu_dm/amdgpu_dm.c
-+++ b/amd/display/amdgpu_dm/amdgpu_dm.c
-@@ -121,7 +121,7 @@ static bool dm_check_soft_reset(void *handle)
- 
- static int dm_soft_reset(void *handle)
- {
--	struct amdgpu_device *adev = (struct amdgpu_device *)handle;
-+	/* struct amdgpu_device *adev = (struct amdgpu_device *)handle; */
- 
- 	/* XXX todo */
- 	return 0;
+ static bool amdgpu_ttm_bo_eviction_valuable(struct ttm_buffer_object *bo,
+ 					    const struct ttm_place *place)
 diff --git a/amd/display/amdgpu_dm/amdgpu_dm_types.c b/amd/display/amdgpu_dm/amdgpu_dm_types.c
-index 5e11f26..7039542 100644
+index 44a4a71..ae7e707 100644
 --- a/amd/display/amdgpu_dm/amdgpu_dm_types.c
 +++ b/amd/display/amdgpu_dm/amdgpu_dm_types.c
-@@ -913,7 +913,7 @@ static void decide_crtc_timing_for_drm_display_mode(
+@@ -932,7 +932,7 @@ static void decide_crtc_timing_for_drm_display_mode(
  }
  
  static struct dc_target *create_target_for_sink(
@@ -70,5 +42,5 @@ index 5e11f26..7039542 100644
  		const struct dm_connector_state *dm_state)
  {
 -- 
-2.11.0
+2.12.2
 


### PR DESCRIPTION
###### Motivation for this change

Tested:
- [x] glxgears
- [x] mpv (vdpau)
- [x] vulkan sdk smoketest
- [x] vulkan sdk cube demo
- [x] steam client
- [ ] factorio (via steam) *** crashed at startup

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

