### PR TITLE
coursier: 1.0.0-M15-5 -> 1.0.0-RC1

### DIFF
--- a/pkgs/development/tools/coursier/default.nix
+++ b/pkgs/development/tools/coursier/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
-  name    = "coursier-${version}";
-  version = "1.0.0-M15-5";
+  name = "coursier-${version}";
+  version = "1.0.0-RC1";
 
   src = fetchurl {
-    url    = "https://github.com/coursier/coursier/raw/v${version}/coursier";
-    sha256 = "610c5fc08d0137c5270cefd14623120ab10cd81b9f48e43093893ac8d00484c9";
+    url = "https://github.com/coursier/coursier/raw/v${version}/coursier";
+    sha256 = "0dxwhqp7m7nmal8wn4chlmyvhdh6v3ja0nfz9x952kacf2vpnqw3";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -21,9 +21,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage    = http://get-coursier.io/;
+    homepage = http://get-coursier.io/;
     description = "A Scala library to fetch dependencies from Maven / Ivy repositories";
-    license     = licenses.asl20;
+    license = licenses.asl20;
     maintainers = with maintainers; [ adelbertc nequissimus ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

