### PR TITLE
minikube: 0.17.1 -> 0.18.0

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -10,22 +10,19 @@ let
   # (presumably because we don't have some static system libraries it wants), and cross-compiling cgo on Darwin is a nightmare.
   #
   # Note that minikube can download (and cache) versions of localkube it needs on demand. Unfortunately, minikube's knowledge
-  # of where it can download versions of localkube seems to rely on a json file that doesn't get updated as often as we'd like,
-  # so for example it doesn't know about v1.5.3 even though there's a perfectly good version of localkube hosted there. So
+  # of where it can download versions of localkube seems to rely on a json file that doesn't get updated as often as we'd like. So
   # instead, we download localkube ourselves and shove it into the minikube binary. The versions URL that minikube uses is
-  # currently https://storage.googleapis.com/minikube/k8s_releases.json. Note that we can't use 1.5.3 with minikube 0.17.1
-  # expects to be able to pass it a command-line argument that it doesn't understand. v1.5.4 and higher should be fine. There
-  # doesn't seem to ae any official release of localkube for 1.5.4 yet so I'm temporarily grabbing a version built from the
-  # minikube CI server.
+  # currently https://storage.googleapis.com/minikube/k8s_releases.json
+
+  localkube-version = "1.6.0";
   localkube-binary = fetchurl {
-    url    = "https://storage.googleapis.com/minikube-builds/1216/localkube";
-    # url    = "https://storage.googleapis.com/minikube/k8sReleases/v${kubernetes.version}/localkube-linux-amd64";
-    sha256 = "1vqrsak7n045ci6af3rpgs2qwjnrqk8k7c3ax6wzli4m8vhsiv57";
+    url = "https://storage.googleapis.com/minikube/k8sReleases/v${localkube-version}/localkube-linux-amd64";
+    sha256 = "0zx0c9fwairvga1g1112l5g5pspm2m9wxb42qgfxfgyidywvirha";
   };
 in buildGoPackage rec {
   pname   = "minikube";
   name    = "${pname}-${version}";
-  version = "0.17.1";
+  version = "0.18.0";
 
   goPackagePath = "k8s.io/minikube";
 
@@ -33,7 +30,7 @@ in buildGoPackage rec {
     owner  = "kubernetes";
     repo   = "minikube";
     rev    = "v${version}";
-    sha256 = "1m61yipn0p3cfavjddhrg1rcmr0hv6k3zxvqqd9fisl79g0sdfsr";
+    sha256 = "0r8184xfsw7vvvmzhc18si582q41cnzka4ry151hwy56gmp2jyiw";
   };
 
   # kubernetes is here only to shut up a loud warning when generating the completions below. minikube checks very eagerly


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

