### PR TITLE
Mark linux-only pkgs

### DIFF
--- a/pkgs/applications/audio/yasr/default.nix
+++ b/pkgs/applications/audio/yasr/default.nix
@@ -2,26 +2,26 @@
 
 stdenv.mkDerivation rec {
   name = "yasr-${version}";
-  
+
   version = "0.6.9";
-  
+
   src = fetchurl {
     url = "https://sourceforge.net/projects/yasr/files/yasr/${version}/${name}.tar.gz";
     sha256 = "1prv9r9y6jb5ga5578ldiw507fa414m60xhlvjl29278p3x7rwa1";
   };
-  
+
   patches = [
     ./10_fix_openpty_forkpty_declarations
     ./20_maxpathlen
     ./30_conf
     ./40_dectalk_extended_chars
   ]; # taken from the debian yasr package
-  
+
   meta = {
     homepage = "http://yasr.sourceforge.net";
     description = "A general-purpose console screen reader";
     longDescription = "Yasr is a general-purpose console screen reader for GNU/Linux and other Unix-like operating systems.";
-    platforms = stdenv.lib.platforms.unix;
+    platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ jhhuh ];
   };

--- a/pkgs/development/libraries/libx86emu/default.nix
+++ b/pkgs/development/libraries/libx86emu/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sed -i 's|/usr/|/|g' Makefile
   '';
 
-  makeFlags = "shared";
+  makeFlags = [ "shared" ];
 
   installPhase = ''
     make install DESTDIR=$out/ LIBDIR=lib
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     homepage = https://github.com/wfeldt/libx86emu;
     maintainers = with maintainers; [ bobvanderlinden ];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/neardal/default.nix
+++ b/pkgs/development/libraries/neardal/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2;
     homepage = https://01.org/linux-nfc;
     maintainers = with maintainers; [ tstrobel ];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/wxGTK-2.8/default.nix
+++ b/pkgs/development/libraries/wxGTK-2.8/default.nix
@@ -62,8 +62,8 @@ stdenv.mkDerivation rec {
   };
 
   enableParallelBuilding = true;
-  
+
   meta = {
-    platforms = stdenv.lib.platforms.all;
+    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/xbase/default.nix
+++ b/pkgs/development/libraries/xbase/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://linux.techass.com/projects/xdb/;
     description = "C++ class library formerly known as XDB";
-    platforms = stdenv.lib.platforms.all;
+    platforms = stdenv.lib.platforms.linux;
     maintainers = [ ];
   };
 }

--- a/pkgs/misc/screensavers/xautolock/default.nix
+++ b/pkgs/misc/screensavers/xautolock/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     description = "A program that launches a given program when your X session has been idle for a given time.";
     homepage = http://www.ibiblio.org/pub/linux/X11/screensavers;
     maintainers = with maintainers; [ garbas ];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     license = licenses.gpl2;
   };
 }

--- a/pkgs/os-specific/linux/tcp-wrappers/default.nix
+++ b/pkgs/os-specific/linux/tcp-wrappers/default.nix
@@ -57,6 +57,6 @@ in stdenv.mkDerivation rec {
 
     homepage = ftp://ftp.porcupine.org/pub/security/index.html;
     license = "BSD-style";
-    platforms = stdenv.lib.platforms.unix;
+    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/shells/rssh/default.nix
+++ b/pkgs/shells/rssh/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.pizzashack.org/rssh/";
     license = licenses.bsd2;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ arobyn ];
   };
 

--- a/pkgs/tools/filesystems/gcsfuse/default.nix
+++ b/pkgs/tools/filesystems/gcsfuse/default.nix
@@ -14,9 +14,9 @@ buildGoPackage rec {
     sha256 = "1lj9czippsgkhr8y3r7vwxgc8i952v76v1shdv10p43gsxwyyi9a";
   };
 
-  # TODO: add metadata https://nixos.org/nixpkgs/manual/#sec-standard-meta-attributes
   meta = {
     license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
     maintainers = [];
     homepage = https://cloud.google.com/storage/docs/gcs-fuse;
     description =

--- a/pkgs/tools/misc/scanmem/default.nix
+++ b/pkgs/tools/misc/scanmem/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/scanmem/scanmem";
     description = "Memory scanner for finding and poking addresses in executing processes";
     maintainers = [ maintainers.chattered  ];
-    platforms = with platforms; linux ++ darwin;
+    platforms = platforms.linux;
     license = licenses.gpl3;
   };
 }

--- a/pkgs/tools/system/hwinfo/default.nix
+++ b/pkgs/tools/system/hwinfo/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     homepage = https://github.com/openSUSE/hwinfo;
     maintainers = with maintainers; [ bobvanderlinden ndowens ];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/system/safecopy/default.nix
+++ b/pkgs/tools/system/safecopy/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl2Plus;
 
-    platforms = stdenv.lib.platforms.all;
+    platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.bluescreen303 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
All of these packages were broken on Darwin and probably won't ever work without huge changes in codebases.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

