### PR TITLE
hidapi: fix macos

### DIFF
--- a/pkgs/development/libraries/hidapi/default.nix
+++ b/pkgs/development/libraries/hidapi/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, udev, libusb }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, udev, libusb
+, darwin }:
 
 stdenv.mkDerivation rec {
   name = "hidapi-0.8.0-rc1";
@@ -10,7 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "13d5jkmh9nh4c2kjch8k8amslnxapa9vkqzrk1z6rqmw8qgvzbkj";
   };
 
-  buildInputs = [ autoreconfHook pkgconfig udev libusb ];
+  buildInputs = [ autoreconfHook pkgconfig ]
+    ++ stdenv.lib.optionals stdenv.isLinux [ udev libusb ];
+
+  propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ IOKit Cocoa ]);
 
   meta = with stdenv.lib; {
     homepage = https://github.com/signal11/hidapi;


### PR DESCRIPTION
###### Motivation for this change

This adds in some libraries and frameworks to get hidapi working on macOS.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

