### PR TITLE
glfw: fix darwin build

### DIFF
--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, mesa, libXrandr, libXi, libXxf86vm, libXfixes, xlibsWrapper
 , libXinerama, libXcursor
+, darwin
 }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +19,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     cmake mesa libXrandr libXi libXxf86vm libXfixes xlibsWrapper
     libXinerama libXcursor
-  ];
+  ] ++ stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa Kernel ]);
 
   cmakeFlags = "-DBUILD_SHARED_LIBS=ON";
 


### PR DESCRIPTION
###### Motivation for this change

Fixes glfw builds on Darwin.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
