### PR TITLE
spectrwm: fix OSX build

### DIFF
--- a/pkgs/applications/window-managers/spectrwm/default.nix
+++ b/pkgs/applications/window-managers/spectrwm/default.nix
@@ -36,7 +36,10 @@ stdenv.mkDerivation rec {
     xcbutilwm
   ];
 
-  sourceRoot = "spectrwm-SPECTRWM_2_7_2/linux";
+  sourceRoot = let
+    subdir = if stdenv.isDarwin then "osx" else "linux";
+  in "spectrwm-SPECTRWM_2_7_2/${subdir}";
+
   makeFlags="PREFIX=$(out)";
   installPhase = "PREFIX=$out make install";
 


### PR DESCRIPTION
###### Motivation for this change

Fixes the OS X target for sprectwm.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
