### PR TITLE
pythonPackages.dogpile_cache: 0.5.4 -> 0.6.2

### DIFF
--- a/pkgs/development/python-modules/dogpile.cache/default.nix
+++ b/pkgs/development/python-modules/dogpile.cache/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi,
+  dogpile_core, pytest
+ }:
+
+buildPythonPackage rec {
+  pname = "dogpile.cache";
+  version = "0.6.2";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "73793471af07af6dc5b3ee015abfaca4220caaa34c615537f5ab007ed150726d";
+  };
+
+  propagatedBuildInputs = [ dogpile_core ];
+  buildInputs = [ pytest ];
+
+  meta = with stdenv.lib; {
+    description = "A caching front-end based on the Dogpile lock";
+    homepage = http://bitbucket.org/zzzeek/dogpile.cache;
+    platforms = platforms.linux; # Can only test linux
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6469,24 +6469,7 @@ in {
     };
   };
 
-  dogpile_cache = buildPythonPackage rec {
-    name = "dogpile.cache-0.5.4";
-
-    propagatedBuildInputs = with self; [ dogpile_core ];
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/dogpile.cache/dogpile.cache-0.5.4.tar.gz";
-      sha256 = "9eab7a5dc05ad1b6573144c4a2717226b5c38811f9ec29b514e774535a91ea24";
-    };
-
-    doCheck = false;
-
-    meta = {
-      description = "A caching front-end based on the Dogpile lock";
-      homepage = http://bitbucket.org/zzzeek/dogpile.cache;
-      license = licenses.bsd3;
-    };
-  };
+  dogpile_cache = callPackage ../development/python-modules/dogpile.cache { };
 
   dogpile_core = buildPythonPackage rec {
     name = "dogpile.core-0.4.1";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

