### PR TITLE
deepin-terminal: Init at 2.3.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -485,6 +485,7 @@
   skrzyp = "Jakub Skrzypnik <jot.skrzyp@gmail.com>";
   sleexyz = "Sean Lee <freshdried@gmail.com>";
   smironov = "Sergey Mironov <grrwlf@gmail.com>";
+  snyh = "Xia Bin <snyh@snyh.org>";
   solson = "Scott Olson <scott@solson.me>";
   spacefrogg = "Michael Raitza <spacefrogg-nixos@meterriblecrew.net>";
   spencerjanssen = "Spencer Janssen <spencerjanssen@gmail.com>";

--- a/pkgs/applications/misc/deepin-terminal/default.nix
+++ b/pkgs/applications/misc/deepin-terminal/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, unzip, fetchFromGitHub, pkgconfig, gtk3, vala, cmake, vte, gee, wnck, gettext, libsecret, json_glib }:
+
+stdenv.mkDerivation rec {
+  name = "deepin-terminal-${version}";
+  version = "2.3.3";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = "deepin-terminal";
+    rev = version;
+    sha256 = "0qam34g1rannv8kvw1zbps763a9ii9vbrkxyxxdk737hlpxdzg8h";
+  };
+
+  patchPhase = ''
+  substituteInPlace project_path.c --replace __FILE__ \"$out/share/deepin-terminal/\"
+  '';
+  buildInputs = [ unzip gtk3 pkgconfig vala cmake vte gee wnck gettext libsecret json_glib ];
+
+  meta = {
+    description = "The default terminal emulation for Deepin";
+    longDescription = ''
+        Deepin terminal, it sharpens your focus in the world of command line!
+        It is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.
+     '';
+    homepage = "https://github.com/linuxdeepin/deepin-terminal/";
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15670,6 +15670,12 @@ with pkgs;
     vte = gnome2.vte.override { pythonSupport = true; };
   };
 
+  deepin-terminal = callPackage ../applications/misc/deepin-terminal {
+    vte = gnome3.vte;
+    wnck = libwnck3;
+    gee = libgee_0_8;
+  };
+
   termite = callPackage ../applications/misc/termite {
     vte = gnome3.vte-ng;
   };


### PR DESCRIPTION
###### Motivation for this change
Add the deepin-terminal which is a friendly terminal emulator .

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

