### PR TITLE
keychain: 2.8.0 -> 2.8.3

### DIFF
--- a/pkgs/tools/misc/keychain/default.nix
+++ b/pkgs/tools/misc/keychain/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "keychain-${version}";
-  version = "2.8.0";
+  version = "2.8.3";
 
   src = fetchFromGitHub {
     owner = "funtoo";
     repo = "keychain";
-    rev = "1c8eaba53a7788d12d086b66ac3929810510f73a";
-    sha256 = "0ajas58cv8mp5wb6hn1zhsqiwfxvx69p4f91a5j2as299rxgrxlp";
+    rev = "${version}";
+    sha256 = "0za2fi4g7ixzj3izgwlv71b3cviz3qhz43y4bhdkglg16x5cnzcb";
   };
 
   buildInputs = [ makeWrapper perl ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

