### PR TITLE
nixos: use pkgsi686Linux for pkgs_i686

### DIFF
--- a/nixos/modules/misc/extra-arguments.nix
+++ b/nixos/modules/misc/extra-arguments.nix
@@ -2,16 +2,6 @@
 
 {
   _module.args = {
-    pkgs_i686 = import ../../.. {
-      system = "i686-linux";
-      # FIXME: we enable config.allowUnfree to make packages like
-      # nvidia-x11 available. This isn't a problem because if the user has
-      # ‘nixpkgs.config.allowUnfree = false’, then evaluation will fail on
-      # the 64-bit package anyway. However, it would be cleaner to respect
-      # nixpkgs.config here.
-      config.allowUnfree = true;
-    };
-
     utils = import ../../lib/utils.nix pkgs;
   };
 }

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -42,6 +42,8 @@ let
     merge = lib.mergeOneOption;
   };
 
+  _pkgs = import ../../.. config.nixpkgs;
+
 in
 
 {
@@ -97,6 +99,9 @@ in
   };
 
   config = {
-    _module.args.pkgs = import ../../.. config.nixpkgs;
+    _module.args = {
+      pkgs = _pkgs;
+      pkgs_i686 = _pkgs.pkgsi686Linux;
+    };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I found that my packageOverrides for e.g. mesa_drivers weren't being respected in pkgs_i686, so my override was having an effect in `/run/opengl-drivers/` but not `/run/opengl-drivers32/`.

This is what I came up with, but it's a pretty fundamental change, and I'm not totally sure of the consequences.  It does seem to behave more intuitively though.  Presumably overlays would be affected in a similar way.

Thoughts?

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

