### PR TITLE
notmuch: fix homepage and notmuch-mutt license

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Mail indexer";
-    homepage    = http://notmuchmmail.org/;
+    homepage    = https://notmuchmmail.org/;
     license = stdenv.lib.licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [ chaoflow garbas ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -97,11 +97,11 @@ stdenv.mkDerivation rec {
   '';
   dontGzipMan = true; # already compressed
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Mail indexer";
     homepage    = https://notmuchmail.org/;
-    license = stdenv.lib.licenses.gpl3;
-    maintainers = with stdenv.lib.maintainers; [ chaoflow garbas ];
-    platforms = stdenv.lib.platforms.unix;
+    license     = licenses.gpl3;
+    maintainers = with maintainers; [ chaoflow garbas ];
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Mail indexer";
-    homepage    = https://notmuchmmail.org/;
+    homepage    = https://notmuchmail.org/;
     license = stdenv.lib.licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [ chaoflow garbas ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -99,6 +99,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Mail indexer";
+    homepage    = http://notmuchmmail.org/;
     license = stdenv.lib.licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [ chaoflow garbas ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/applications/networking/mailreaders/notmuch/mutt.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/mutt.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     inherit version;
     description = "Mutt support for notmuch";
     homepage    = https://notmuchmail.org/;
-    license = with licenses; gpl3;
+    license     = with licenses; gpl3;
     maintainers = with maintainers; [ peterhoeg ];
     platforms   = platforms.unix;
   };

--- a/pkgs/applications/networking/mailreaders/notmuch/mutt.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/mutt.nix
@@ -38,8 +38,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     inherit version;
     description = "Mutt support for notmuch";
-    homepage    = http://notmuchmua.org/;
-    license     = with licenses; mit;
+    homepage    = http://notmuchmail.org/;
+    license = with licenses; gpl3;
     maintainers = with maintainers; [ peterhoeg ];
     platforms   = platforms.unix;
   };

--- a/pkgs/applications/networking/mailreaders/notmuch/mutt.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/mutt.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     inherit version;
     description = "Mutt support for notmuch";
-    homepage    = http://notmuchmail.org/;
+    homepage    = https://notmuchmail.org/;
     license = with licenses; gpl3;
     maintainers = with maintainers; [ peterhoeg ];
     platforms   = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

The homepage for notmuch was missing.

Additionally, the license for notmuch-mutt was incorrect. It might have been changed when it was upstreamed.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

