### PR TITLE
Accept strings with Nix paths as proper shells

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -171,6 +171,12 @@ rec {
       merge = mergeOneOption;
     };
 
+    stringPath = mkOptionType {
+      name = "stringPath";
+      check = x: str.check x && path.check x;
+      merge = mergeOneOption;
+    };
+
     # drop this in the future:
     list = builtins.trace "`types.list' is deprecated; use `types.listOf' instead" types.listOf;
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -158,8 +158,10 @@ rec {
         in if isDerivation res then res else toDerivation res;
     };
 
-    shellPackage = package // {
-      check = x: (package.check x) && (hasAttr "shellPath" x);
+    shellPackage = mkOptionType {
+      name = "shellPackage";
+      check = x: isDerivation x && hasAttr "shellPath" x;
+      merge = mergeOneOption;
     };
 
     path = mkOptionType {

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -21,8 +21,8 @@ rec {
   toShellPath = shell:
     if types.shellPackage.check shell then
       "/run/current-system/sw${shell.shellPath}"
-    else if types.package.check shell then
-      throw "${shell} is not a shell package"
+    else if types.stringPath.check shell then
+      shell
     else
-      shell;
+      throw "${shell} is not a shell package";
 }

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -117,7 +117,7 @@ let
       };
 
       shell = mkOption {
-        type = types.either types.shellPackage types.path;
+        type = types.either types.shellPackage types.stringPath;
         default = pkgs.nologin;
         defaultText = "pkgs.nologin";
         example = literalExample "pkgs.bashInteractive";


### PR DESCRIPTION
###### Motivation for this change

I have a special user account on a server for the sole purpose of playing NetHack. It's forced (via SSH's `ForceCommand` and `extraUsers.*.shell`) to run special script (`writeScript`) which `exec`s the game, so the only thing one can do after he/she logs in to the account is to play the game. Without this patch you can't use any such custom script as the shell because it detects that it's in Nix store, "reverses" derivation from it and fails to find needed attributes. This makes `shellPackage` to require a derivation and fixes `toShellPath` so that such paths are accepted.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

