### PR TITLE
jucipp: init at 1.2.3

### DIFF
--- a/pkgs/applications/editors/jucipp/default.nix
+++ b/pkgs/applications/editors/jucipp/default.nix
@@ -1,8 +1,7 @@
-{ config, stdenv, fetchgit, imagemagick, gnome3, at_spi2_core, libcxx,
+{ config, stdenv, fetchgit, makeWrapper, gnome3, at_spi2_core, libcxx,
   boost, epoxy, cmake, aspell, llvmPackages, libgit2, pkgconfig, pcre,
   libXdmcp, libxkbcommon, libpthreadstubs, wrapGAppsHook, aspellDicts,
-  coreutils, glibc, makeWrapper, dbus_libs, openssl, libxml2, gnumake,
-  ctags, }:
+  coreutils, glibc, dbus_libs, openssl, libxml2, gnumake, ctags }:
 
 with stdenv.lib;
 
@@ -27,7 +26,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
   buildInputs = [
-    imagemagick
     dbus_libs
     openssl
     libxml2

--- a/pkgs/applications/editors/jucipp/default.nix
+++ b/pkgs/applications/editors/jucipp/default.nix
@@ -1,0 +1,75 @@
+{ config, stdenv, fetchgit, imagemagick, gnome3, at_spi2_core, libcxx,
+  boost, epoxy, cmake, aspell, llvmPackages, libgit2, pkgconfig, pcre,
+  libXdmcp, libxkbcommon, libpthreadstubs, wrapGAppsHook, aspellDicts,
+  coreutils, glibc, makeWrapper, dbus_libs, openssl, libxml2, gnumake,
+  ctags, }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "juicipp-${version}";
+  version = "1.2.3";
+
+  meta = {
+    homepage = https://github.com/cppit/jucipp;
+    description = "A lightweight, platform independent C++-IDE with support for C++11, C++14, and experimental C++17 features depending on libclang version";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ xnwdd ];
+  };
+
+  src = fetchgit {
+    url = "https://github.com/cppit/jucipp.git";
+    rev = "refs/tags/v${version}";
+    deepClone = true;
+    sha256 = "0xp6ijnrggskjrvscp204bmdpz48l5a8nxr9abp17wni6akb5wiq";
+  };
+
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+  buildInputs = [
+    imagemagick
+    dbus_libs
+    openssl
+    libxml2
+    gnome3.gtksourceview
+    at_spi2_core
+    pcre
+    epoxy
+    boost
+    libXdmcp
+    cmake
+    aspell
+    libgit2
+    libxkbcommon
+    gnome3.gtkmm3
+    libpthreadstubs
+    gnome3.gtksourceviewmm
+    llvmPackages.clang.cc
+    llvmPackages.lldb
+    gnome3.dconf
+  ];
+
+
+  lintIncludes = let
+    p = "arguments.emplace_back(\"-I";
+    e = "\");";
+    v = stdenv.lib.getVersion llvmPackages.clang;
+  in
+    p+llvmPackages.libcxx+"/include/c++/v1"+e
+    +p+llvmPackages.clang-unwrapped+"/lib/clang/"+v+"/include/"+e
+    +p+glibc.dev+"/include"+e;
+
+  preConfigure = ''
+    sed -i 's|liblldb LIBLLDB_LIBRARIES|liblldb LIBNOTHING|g' CMakeLists.txt
+    sed -i 's|> arguments;|> arguments; ${lintIncludes}|g' src/source_clang.cc
+  '';
+  cmakeFlags = "-DLIBLLDB_LIBRARIES=${stdenv.lib.makeLibraryPath [ llvmPackages.lldb ]}/liblldb.so";
+  postInstall = ''
+    mv $out/bin/juci $out/bin/.juci
+    makeWrapper "$out/bin/.juci" "$out/bin/juci" \
+      --set PATH "${stdenv.lib.makeBinPath [ ctags coreutils llvmPackages.clang.cc cmake gnumake llvmPackages.clang ]}" \
+      --set NO_AT_BRIDGE 1 \
+      --set ASPELL_CONF "dict-dir ${aspellDicts.en}/lib/aspell"
+  '';
+
+}

--- a/pkgs/applications/editors/jucipp/default.nix
+++ b/pkgs/applications/editors/jucipp/default.nix
@@ -1,7 +1,7 @@
 { config, stdenv, fetchgit, makeWrapper, gnome3, at_spi2_core, libcxx,
   boost, epoxy, cmake, aspell, llvmPackages, libgit2, pkgconfig, pcre,
   libXdmcp, libxkbcommon, libpthreadstubs, wrapGAppsHook, aspellDicts,
-  coreutils, glibc, dbus_libs, openssl, libxml2, gnumake, ctags }:
+  coreutils, glibc, dbus_libs, openssl, libxml2, gnumake, binutils, ctags }:
 
 with stdenv.lib;
 
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mv $out/bin/juci $out/bin/.juci
     makeWrapper "$out/bin/.juci" "$out/bin/juci" \
-      --set PATH "${stdenv.lib.makeBinPath [ ctags coreutils llvmPackages.clang.cc cmake gnumake llvmPackages.clang ]}" \
+      --set PATH "${stdenv.lib.makeBinPath [ ctags coreutils llvmPackages.clang.cc cmake gnumake binutils llvmPackages.clang ]}" \
       --set NO_AT_BRIDGE 1 \
       --set ASPELL_CONF "dict-dir ${aspellDicts.en}/lib/aspell"
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2481,6 +2481,8 @@ with pkgs;
 
   jsduck = callPackage ../development/tools/jsduck { };
 
+  jucipp = callPackage ../applications/editors/jucipp { };
+
   jwhois = callPackage ../tools/networking/jwhois { };
 
   k2pdfopt = callPackage ../applications/misc/k2pdfopt { };


### PR DESCRIPTION
###### Motivation for this change

This pr adds "juCi++" a mit-licensed, lightweight, modern c++ pretty complete ide.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---