### PR TITLE
keychain: add sigma as maintainer

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -477,6 +477,7 @@
   shell = "Shell Turner <cam.turn@gmail.com>";
   shlevy = "Shea Levy <shea@shealevy.com>";
   siddharthist = "Langston Barrett <langston.barrett@gmail.com>";
+  sigma = "Yann Hodique <yann.hodique@gmail.com>";
   simonvandel = "Simon Vandel Sillesen <simon.vandel@gmail.com>";
   sjagoe = "Simon Jagoe <simon@simonjagoe.com>";
   sjmackenzie = "Stewart Mackenzie <setori88@gmail.com>";

--- a/pkgs/tools/misc/keychain/default.nix
+++ b/pkgs/tools/misc/keychain/default.nix
@@ -38,5 +38,6 @@ stdenv.mkDerivation rec {
     platforms =
       with stdenv.lib;
       platforms.linux ++ platforms.darwin;
+    maintainers = with stdenv.lib.maintainers; [ sigma ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

in #24771 @joachifm asked me if I wanted to take over this package

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

