### PR TITLE
mpv: we package waf, no reason to inline it

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchFromGitHub, makeWrapper
 , docutils, perl, pkgconfig, python3, which, ffmpeg_3_2
-, freefont_ttf, freetype, libass, libpthreadstubs
+, freefont_ttf, freetype, libass, libpthreadstubs, waf
 , lua, lua5_sockets, libuchardet, libiconv ? null, darwin
 
 , x11Support ? true,
@@ -68,16 +68,7 @@ assert jackaudioSupport   -> available libjack2;
 assert vaapiSupport       -> available libva;
 assert drmSupport         -> available libdrm;
 
-let
-  # Purity: Waf is normally downloaded by bootstrap.py, but
-  # for purity reasons this behavior should be avoided.
-  wafVersion = "1.8.12";
-  waf = fetchurl {
-    urls = [ "http://waf.io/waf-${wafVersion}"
-             "http://www.freehackers.org/~tnagy/release/waf-${wafVersion}" ];
-    sha256 = "12y9c352zwliw0zk9jm2lhynsjcf5jy0k1qch1c1av8hnbm2pgq1";
-  };
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "mpv-${version}";
   version = "0.24.0";
 


### PR DESCRIPTION
###### Motivation for this change

@aszlig, you inlined this ages ago (fdd9d132ca0802e08adbaa0d947fc353f633dee1), but it seems to work fine with the one we carry in nixpkgs.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
