### PR TITLE
trayer: 1.1.6 -> 1.1.7

### DIFF
--- a/pkgs/applications/window-managers/trayer/default.nix
+++ b/pkgs/applications/window-managers/trayer/default.nix
@@ -1,16 +1,20 @@
-{ stdenv, fetchFromGitHub, pkgconfig, gdk_pixbuf, gtk2, libXmu }:
+{ stdenv, fetchFromGitHub, pkgconfig, gdk_pixbuf, gtk2 }:
 
 stdenv.mkDerivation rec {
-  name = "trayer-1.1.6";
+  name = "trayer-1.1.7";
 
-  buildInputs = [ pkgconfig gdk_pixbuf gtk2 libXmu ];
+  buildInputs = [ pkgconfig gdk_pixbuf gtk2 ];
 
   src = fetchFromGitHub {
     owner = "sargon";
     repo = "trayer-srg";
     rev = name;
-    sha256 = "0mmya7a1qh3zyqgvcx5fz2lvr9n0ilr490l1j3z4myahi4snk2mg";
+    sha256 = "06lpgralggh5546qgvpilzxh4anshli2za41x68x2zbaizyqb09a";
   };
+
+  preConfigure = ''
+    patchShebangs configure
+  '';
 
   makeFlags = [ "PREFIX=$(out)" ];
 


### PR DESCRIPTION
###### Motivation for this change
Released new version, update the derivation.

ReCreate #24791
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

