### PR TITLE
steam: move libpciaccess as non-runtime dependencies

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -63,6 +63,7 @@ in buildFHSUserEnv rec {
     libdrm
     mono
     xorg.xkeyboardconfig
+    xlibs.libpciaccess
 
     (steamPackages.steam-runtime-wrapped.override {
       inherit nativeOnly runtimeOnly newStdcpp;

--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -50,7 +50,6 @@ let
     # Verified games requirements
     xlibs.libXmu
     xlibs.libxcb
-    xlibs.libpciaccess
     mesa_glu
     libuuid
     libogg


### PR DESCRIPTION
###### Motivation for this change
Some Eugen systems games need libpciaccess and since it doesn't overwrite anything it should be harmless for anything that doesn't need it.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

