### PR TITLE
top-level/platforms.nix: Reformat and clean up whitespace

### DIFF
--- a/pkgs/top-level/platforms.nix
+++ b/pkgs/top-level/platforms.nix
@@ -28,105 +28,104 @@ rec {
     kernelBaseConfig = "multi_v5_defconfig";
     kernelArch = "arm";
     kernelAutoModules = false;
-    kernelExtraConfig =
-      ''
-        BLK_DEV_RAM y
-        BLK_DEV_INITRD y
-        BLK_DEV_CRYPTOLOOP m
-        BLK_DEV_DM m
-        DM_CRYPT m
-        MD y
-        REISERFS_FS m
-        BTRFS_FS m
-        XFS_FS m
-        JFS_FS m
-        EXT4_FS m
-        USB_STORAGE_CYPRESS_ATACB m
+    kernelExtraConfig = ''
+      BLK_DEV_RAM y
+      BLK_DEV_INITRD y
+      BLK_DEV_CRYPTOLOOP m
+      BLK_DEV_DM m
+      DM_CRYPT m
+      MD y
+      REISERFS_FS m
+      BTRFS_FS m
+      XFS_FS m
+      JFS_FS m
+      EXT4_FS m
+      USB_STORAGE_CYPRESS_ATACB m
 
-        # mv cesa requires this sw fallback, for mv-sha1
-        CRYPTO_SHA1 y
-        # Fast crypto
-        CRYPTO_TWOFISH y
-        CRYPTO_TWOFISH_COMMON y
-        CRYPTO_BLOWFISH y
-        CRYPTO_BLOWFISH_COMMON y
+      # mv cesa requires this sw fallback, for mv-sha1
+      CRYPTO_SHA1 y
+      # Fast crypto
+      CRYPTO_TWOFISH y
+      CRYPTO_TWOFISH_COMMON y
+      CRYPTO_BLOWFISH y
+      CRYPTO_BLOWFISH_COMMON y
 
-        IP_PNP y
-        IP_PNP_DHCP y
-        NFS_FS y
-        ROOT_NFS y
-        TUN m
-        NFS_V4 y
-        NFS_V4_1 y
-        NFS_FSCACHE y
-        NFSD m
-        NFSD_V2_ACL y
-        NFSD_V3 y
-        NFSD_V3_ACL y
-        NFSD_V4 y
-        NETFILTER y
-        IP_NF_IPTABLES y
-        IP_NF_FILTER y
-        IP_NF_MATCH_ADDRTYPE y
-        IP_NF_TARGET_LOG y
-        IP_NF_MANGLE y
-        IPV6 m
-        VLAN_8021Q m
+      IP_PNP y
+      IP_PNP_DHCP y
+      NFS_FS y
+      ROOT_NFS y
+      TUN m
+      NFS_V4 y
+      NFS_V4_1 y
+      NFS_FSCACHE y
+      NFSD m
+      NFSD_V2_ACL y
+      NFSD_V3 y
+      NFSD_V3_ACL y
+      NFSD_V4 y
+      NETFILTER y
+      IP_NF_IPTABLES y
+      IP_NF_FILTER y
+      IP_NF_MATCH_ADDRTYPE y
+      IP_NF_TARGET_LOG y
+      IP_NF_MANGLE y
+      IPV6 m
+      VLAN_8021Q m
 
-        CIFS y
-        CIFS_XATTR y
-        CIFS_POSIX y
-        CIFS_FSCACHE y
-        CIFS_ACL y
+      CIFS y
+      CIFS_XATTR y
+      CIFS_POSIX y
+      CIFS_FSCACHE y
+      CIFS_ACL y
 
-        WATCHDOG y
-        WATCHDOG_CORE y
-        ORION_WATCHDOG m
+      WATCHDOG y
+      WATCHDOG_CORE y
+      ORION_WATCHDOG m
 
-        ZRAM m
-        NETCONSOLE m
+      ZRAM m
+      NETCONSOLE m
 
-        # Disable OABI to have seccomp_filter (required for systemd)
-        # https://github.com/raspberrypi/firmware/issues/651
-        OABI_COMPAT n
+      # Disable OABI to have seccomp_filter (required for systemd)
+      # https://github.com/raspberrypi/firmware/issues/651
+      OABI_COMPAT n
 
-        # Fail to build
-        DRM n
-        SCSI_ADVANSYS n
-        USB_ISP1362_HCD n
-        SND_SOC n
-        SND_ALI5451 n
-        FB_SAVAGE n
-        SCSI_NSP32 n
-        ATA_SFF n
-        SUNGEM n
-        IRDA n
-        ATM_HE n
-        SCSI_ACARD n
-        BLK_DEV_CMD640_ENHANCED n
+      # Fail to build
+      DRM n
+      SCSI_ADVANSYS n
+      USB_ISP1362_HCD n
+      SND_SOC n
+      SND_ALI5451 n
+      FB_SAVAGE n
+      SCSI_NSP32 n
+      ATA_SFF n
+      SUNGEM n
+      IRDA n
+      ATM_HE n
+      SCSI_ACARD n
+      BLK_DEV_CMD640_ENHANCED n
 
-        FUSE_FS m
+      FUSE_FS m
 
-        # systemd uses cgroups
-        CGROUPS y
+      # systemd uses cgroups
+      CGROUPS y
 
-        # Latencytop 
-        LATENCYTOP y
+      # Latencytop
+      LATENCYTOP y
 
-        # Ubi for the mtd
-        MTD_UBI y
-        UBIFS_FS y
-        UBIFS_FS_XATTR y
-        UBIFS_FS_ADVANCED_COMPR y
-        UBIFS_FS_LZO y
-        UBIFS_FS_ZLIB y
-        UBIFS_FS_DEBUG n
+      # Ubi for the mtd
+      MTD_UBI y
+      UBIFS_FS y
+      UBIFS_FS_XATTR y
+      UBIFS_FS_ADVANCED_COMPR y
+      UBIFS_FS_LZO y
+      UBIFS_FS_ZLIB y
+      UBIFS_FS_DEBUG n
 
-        # Kdb, for kernel troubles
-        KGDB y
-        KGDB_SERIAL_CONSOLE y
-        KGDB_KDB y
-      '';
+      # Kdb, for kernel troubles
+      KGDB y
+      KGDB_SERIAL_CONSOLE y
+      KGDB_KDB y
+    '';
     kernelMakeFlags = [ "LOADADDR=0x0200000" ];
     kernelTarget = "uImage";
     uboot = "sheevaplug";
@@ -147,77 +146,76 @@ rec {
     kernelDTB = true;
     kernelArch = "arm";
     kernelAutoModules = false;
-    kernelExtraConfig =
-      ''
-        BLK_DEV_RAM y
-        BLK_DEV_INITRD y
-        BLK_DEV_CRYPTOLOOP m
-        BLK_DEV_DM m
-        DM_CRYPT m
-        MD y
-        REISERFS_FS m
-        BTRFS_FS y
-        XFS_FS m
-        JFS_FS y
-        EXT4_FS y
+    kernelExtraConfig = ''
+      BLK_DEV_RAM y
+      BLK_DEV_INITRD y
+      BLK_DEV_CRYPTOLOOP m
+      BLK_DEV_DM m
+      DM_CRYPT m
+      MD y
+      REISERFS_FS m
+      BTRFS_FS y
+      XFS_FS m
+      JFS_FS y
+      EXT4_FS y
 
-        IP_PNP y
-        IP_PNP_DHCP y
-        NFS_FS y
-        ROOT_NFS y
-        TUN m
-        NFS_V4 y
-        NFS_V4_1 y
-        NFS_FSCACHE y
-        NFSD m
-        NFSD_V2_ACL y
-        NFSD_V3 y
-        NFSD_V3_ACL y
-        NFSD_V4 y
-        NETFILTER y
-        IP_NF_IPTABLES y
-        IP_NF_FILTER y
-        IP_NF_MATCH_ADDRTYPE y
-        IP_NF_TARGET_LOG y
-        IP_NF_MANGLE y
-        IPV6 m
-        VLAN_8021Q m
+      IP_PNP y
+      IP_PNP_DHCP y
+      NFS_FS y
+      ROOT_NFS y
+      TUN m
+      NFS_V4 y
+      NFS_V4_1 y
+      NFS_FSCACHE y
+      NFSD m
+      NFSD_V2_ACL y
+      NFSD_V3 y
+      NFSD_V3_ACL y
+      NFSD_V4 y
+      NETFILTER y
+      IP_NF_IPTABLES y
+      IP_NF_FILTER y
+      IP_NF_MATCH_ADDRTYPE y
+      IP_NF_TARGET_LOG y
+      IP_NF_MANGLE y
+      IPV6 m
+      VLAN_8021Q m
 
-        CIFS y
-        CIFS_XATTR y
-        CIFS_POSIX y
-        CIFS_FSCACHE y
-        CIFS_ACL y
+      CIFS y
+      CIFS_XATTR y
+      CIFS_POSIX y
+      CIFS_FSCACHE y
+      CIFS_ACL y
 
-        ZRAM m
+      ZRAM m
 
-        # Disable OABI to have seccomp_filter (required for systemd)
-        # https://github.com/raspberrypi/firmware/issues/651
-        OABI_COMPAT n
+      # Disable OABI to have seccomp_filter (required for systemd)
+      # https://github.com/raspberrypi/firmware/issues/651
+      OABI_COMPAT n
 
-        # Fail to build
-        DRM n
-        SCSI_ADVANSYS n
-        USB_ISP1362_HCD n
-        SND_SOC n
-        SND_ALI5451 n
-        FB_SAVAGE n
-        SCSI_NSP32 n
-        ATA_SFF n
-        SUNGEM n
-        IRDA n
-        ATM_HE n
-        SCSI_ACARD n
-        BLK_DEV_CMD640_ENHANCED n
+      # Fail to build
+      DRM n
+      SCSI_ADVANSYS n
+      USB_ISP1362_HCD n
+      SND_SOC n
+      SND_ALI5451 n
+      FB_SAVAGE n
+      SCSI_NSP32 n
+      ATA_SFF n
+      SUNGEM n
+      IRDA n
+      ATM_HE n
+      SCSI_ACARD n
+      BLK_DEV_CMD640_ENHANCED n
 
-        FUSE_FS m
+      FUSE_FS m
 
-        # nixos mounts some cgroup
-        CGROUPS y
+      # nixos mounts some cgroup
+      CGROUPS y
 
-        # Latencytop 
-        LATENCYTOP y
-      '';
+      # Latencytop
+      LATENCYTOP y
+    '';
     kernelTarget = "zImage";
     uboot = null;
     gcc = {
@@ -232,80 +230,79 @@ rec {
     kernelBaseConfig = "bcm2709_defconfig";
     kernelDTB = true;
     kernelAutoModules = false;
-    kernelExtraConfig =
-      ''
-        BLK_DEV_RAM y
-        BLK_DEV_INITRD y
-        BLK_DEV_CRYPTOLOOP m
-        BLK_DEV_DM m
-        DM_CRYPT m
-        MD y
-        REISERFS_FS m
-        BTRFS_FS y
-        XFS_FS m
-        JFS_FS y
-        EXT4_FS y
+    kernelExtraConfig = ''
+      BLK_DEV_RAM y
+      BLK_DEV_INITRD y
+      BLK_DEV_CRYPTOLOOP m
+      BLK_DEV_DM m
+      DM_CRYPT m
+      MD y
+      REISERFS_FS m
+      BTRFS_FS y
+      XFS_FS m
+      JFS_FS y
+      EXT4_FS y
 
-        IP_PNP y
-        IP_PNP_DHCP y
-        NFS_FS y
-        ROOT_NFS y
-        TUN m
-        NFS_V4 y
-        NFS_V4_1 y
-        NFS_FSCACHE y
-        NFSD m
-        NFSD_V2_ACL y
-        NFSD_V3 y
-        NFSD_V3_ACL y
-        NFSD_V4 y
-        NETFILTER y
-        IP_NF_IPTABLES y
-        IP_NF_FILTER y
-        IP_NF_MATCH_ADDRTYPE y
-        IP_NF_TARGET_LOG y
-        IP_NF_MANGLE y
-        IPV6 m
-        VLAN_8021Q m
+      IP_PNP y
+      IP_PNP_DHCP y
+      NFS_FS y
+      ROOT_NFS y
+      TUN m
+      NFS_V4 y
+      NFS_V4_1 y
+      NFS_FSCACHE y
+      NFSD m
+      NFSD_V2_ACL y
+      NFSD_V3 y
+      NFSD_V3_ACL y
+      NFSD_V4 y
+      NETFILTER y
+      IP_NF_IPTABLES y
+      IP_NF_FILTER y
+      IP_NF_MATCH_ADDRTYPE y
+      IP_NF_TARGET_LOG y
+      IP_NF_MANGLE y
+      IPV6 m
+      VLAN_8021Q m
 
-        CIFS y
-        CIFS_XATTR y
-        CIFS_POSIX y
-        CIFS_FSCACHE y
-        CIFS_ACL y
+      CIFS y
+      CIFS_XATTR y
+      CIFS_POSIX y
+      CIFS_FSCACHE y
+      CIFS_ACL y
 
-        ZRAM m
+      ZRAM m
 
-        # Disable OABI to have seccomp_filter (required for systemd)
-        # https://github.com/raspberrypi/firmware/issues/651
-        OABI_COMPAT n
+      # Disable OABI to have seccomp_filter (required for systemd)
+      # https://github.com/raspberrypi/firmware/issues/651
+      OABI_COMPAT n
 
-        # Fail to build
-        DRM n
-        SCSI_ADVANSYS n
-        USB_ISP1362_HCD n
-        SND_SOC n
-        SND_ALI5451 n
-        FB_SAVAGE n
-        SCSI_NSP32 n
-        ATA_SFF n
-        SUNGEM n
-        IRDA n
-        ATM_HE n
-        SCSI_ACARD n
-        BLK_DEV_CMD640_ENHANCED n
+      # Fail to build
+      DRM n
+      SCSI_ADVANSYS n
+      USB_ISP1362_HCD n
+      SND_SOC n
+      SND_ALI5451 n
+      FB_SAVAGE n
+      SCSI_NSP32 n
+      ATA_SFF n
+      SUNGEM n
+      IRDA n
+      ATM_HE n
+      SCSI_ACARD n
+      BLK_DEV_CMD640_ENHANCED n
 
-        FUSE_FS m
+      FUSE_FS m
 
-        # nixos mounts some cgroup
-        CGROUPS y
+      # nixos mounts some cgroup
+      CGROUPS y
 
-        # Latencytop 
-        LATENCYTOP y
+      # Latencytop
+      LATENCYTOP y
 
-        # Disable the common config Xen, it doesn't build on ARM
-	XEN? n
-      '';
+      # Disable the common config Xen, it doesn't build on ARM
+      XEN? n
+    '';
     kernelTarget = "zImage";
     uboot = null;
   };
@@ -327,76 +324,75 @@ rec {
     kernelBaseConfig = "lemote2f_defconfig";
     kernelArch = "mips";
     kernelAutoModules = false;
-    kernelExtraConfig =
-      ''
-        MIGRATION n
-        COMPACTION n
+    kernelExtraConfig = ''
+      MIGRATION n
+      COMPACTION n
 
-        # nixos mounts some cgroup
-        CGROUPS y
+      # nixos mounts some cgroup
+      CGROUPS y
 
-        BLK_DEV_RAM y
-        BLK_DEV_INITRD y
-        BLK_DEV_CRYPTOLOOP m
-        BLK_DEV_DM m
-        DM_CRYPT m
-        MD y
-        REISERFS_FS m
-        EXT4_FS m
-        USB_STORAGE_CYPRESS_ATACB m
+      BLK_DEV_RAM y
+      BLK_DEV_INITRD y
+      BLK_DEV_CRYPTOLOOP m
+      BLK_DEV_DM m
+      DM_CRYPT m
+      MD y
+      REISERFS_FS m
+      EXT4_FS m
+      USB_STORAGE_CYPRESS_ATACB m
 
-        IP_PNP y
-        IP_PNP_DHCP y
-        IP_PNP_BOOTP y
-        NFS_FS y
-        ROOT_NFS y
-        TUN m
-        NFS_V4 y
-        NFS_V4_1 y
-        NFS_FSCACHE y
-        NFSD m
-        NFSD_V2_ACL y
-        NFSD_V3 y
-        NFSD_V3_ACL y
-        NFSD_V4 y
+      IP_PNP y
+      IP_PNP_DHCP y
+      IP_PNP_BOOTP y
+      NFS_FS y
+      ROOT_NFS y
+      TUN m
+      NFS_V4 y
+      NFS_V4_1 y
+      NFS_FSCACHE y
+      NFSD m
+      NFSD_V2_ACL y
+      NFSD_V3 y
+      NFSD_V3_ACL y
+      NFSD_V4 y
 
-        # Fail to build
-        DRM n
-        SCSI_ADVANSYS n
-        USB_ISP1362_HCD n
-        SND_SOC n
-        SND_ALI5451 n
-        FB_SAVAGE n
-        SCSI_NSP32 n
-        ATA_SFF n
-        SUNGEM n
-        IRDA n
-        ATM_HE n
-        SCSI_ACARD n
-        BLK_DEV_CMD640_ENHANCED n
+      # Fail to build
+      DRM n
+      SCSI_ADVANSYS n
+      USB_ISP1362_HCD n
+      SND_SOC n
+      SND_ALI5451 n
+      FB_SAVAGE n
+      SCSI_NSP32 n
+      ATA_SFF n
+      SUNGEM n
+      IRDA n
+      ATM_HE n
+      SCSI_ACARD n
+      BLK_DEV_CMD640_ENHANCED n
 
-        FUSE_FS m
+      FUSE_FS m
 
-        # Needed for udev >= 150
-        SYSFS_DEPRECATED_V2 n
+      # Needed for udev >= 150
+      SYSFS_DEPRECATED_V2 n
 
-        VGA_CONSOLE n
-        VT_HW_CONSOLE_BINDING y
-        SERIAL_8250_CONSOLE y
-        FRAMEBUFFER_CONSOLE y
-        EXT2_FS y
-        EXT3_FS y
-        REISERFS_FS y
-        MAGIC_SYSRQ y
+      VGA_CONSOLE n
+      VT_HW_CONSOLE_BINDING y
+      SERIAL_8250_CONSOLE y
+      FRAMEBUFFER_CONSOLE y
+      EXT2_FS y
+      EXT3_FS y
+      REISERFS_FS y
+      MAGIC_SYSRQ y
 
-        # The kernel doesn't boot at all, with FTRACE
-        FTRACE n
-      '';
+      # The kernel doesn't boot at all, with FTRACE
+      FTRACE n
+    '';
     kernelTarget = "vmlinux";
     uboot = null;
     gcc.arch = "loongson2f";
   };
-  
+
   beaglebone = armv7l-hf-multiplatform // {
     name = "beaglebone";
     kernelBaseConfig = "omap2plus_defconfig";
@@ -417,14 +413,13 @@ rec {
     kernelPreferBuiltin = true;
     uboot = null;
     kernelTarget = "zImage";
-    kernelExtraConfig =
-      ''
-        # Fix broken sunxi-sid nvmem driver.
-        TI_CPTS y
+    kernelExtraConfig = ''
+      # Fix broken sunxi-sid nvmem driver.
+      TI_CPTS y
 
-        # Hangs ODROID-XU4
-        ARM_BIG_LITTLE_CPUIDLE n
-      '';
+      # Hangs ODROID-XU4
+      ARM_BIG_LITTLE_CPUIDLE n
+    '';
     gcc = {
       # Some table about fpu flags:
       # http://community.arm.com/servlet/JiveServlet/showImage/38-1981-3827/blogentry-103749-004812900+1365712953_thumb.png


### PR DESCRIPTION
###### Motivation for this change

Cleanliness

###### Things done

Need to confirm no mass rebuilds on `hydra.nixos.org` are caused by this.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

