### PR TITLE
nixos: Add nm-openvpn to the networkmanager group

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -241,6 +241,7 @@ in {
     users.extraUsers = [{
       name = "nm-openvpn";
       uid = config.ids.uids.nm-openvpn;
+      extraGroups = [ "networkmanager" ];
     }];
 
     systemd.packages = cfg.packages;


### PR DESCRIPTION
This is to satisfy the polkit restriction limiting org.freedesktop.NetworkManager.* dbus messages to members of that group.

Should help with #24806 