### PR TITLE
Add gtk3 to clutter buildInputs

### DIFF
--- a/pkgs/development/libraries/clutter/default.nix
+++ b/pkgs/development/libraries/clutter/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, glib, pkgconfig, mesa, libX11, libXext, libXfixes
 , libXdamage, libXcomposite, libXi, cogl, pango, atk, json_glib, 
-gobjectIntrospection 
+gobjectIntrospection, gtk3
 }:
 
 let
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "01nfjd4k7j2n3agpx2d9ncff86nfsqv4n23465rb9zmk4iw4wlb7";
   };
 
+  buildInputs = [ gtk3 ];
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs =
     [ libX11 mesa libXext libXfixes libXdamage libXcomposite libXi cogl pango


### PR DESCRIPTION
###### Motivation for this change

`gnome3.sushi` is broken. With this change, it seems to work again. This is similar to the change made in PR #12996. Fixes #21509.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

