### PR TITLE
plasma-nm: Fix cipher discovery by setting path to openvpn

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-nm/0002-openvpn-binary-path.patch
+++ b/pkgs/desktops/plasma-5/plasma-nm/0002-openvpn-binary-path.patch
@@ -1,0 +1,13 @@
+diff --git a/vpn/openvpn/openvpnadvancedwidget.cpp b/vpn/openvpn/openvpnadvancedwidget.cpp
+index 2f11ba1d..310f11b4 100644
+--- a/vpn/openvpn/openvpnadvancedwidget.cpp
++++ b/vpn/openvpn/openvpnadvancedwidget.cpp
+@@ -75,7 +75,7 @@ OpenVpnAdvancedWidget::OpenVpnAdvancedWidget(const NetworkManager::VpnSetting::P
+     connect(m_ui->cmbProxyType, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &OpenVpnAdvancedWidget::proxyTypeChanged);
+ 
+     // start openVPN process and get its cipher list
+-    const QString openVpnBinary = QStandardPaths::findExecutable("openvpn", QStringList() << "/sbin" << "/usr/sbin");
++    const QString openVpnBinary = "@openvpn@/bin/openvpn";
+     const QStringList ciphersArgs(QLatin1String("--show-ciphers"));
+     const QStringList versionArgs(QLatin1String("--version"));
+ 

--- a/pkgs/desktops/plasma-5/plasma-nm/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-nm/default.nix
@@ -4,7 +4,7 @@
 , knotifications, kservice, kwallet, kwidgetsaddons, kwindowsystem
 , kxmlgui, mobile_broadband_provider_info
 , modemmanager-qt, networkmanager-qt, openconnect, plasma-framework
-, qca-qt5, qtdeclarative, solid
+, qca-qt5, qtdeclarative, solid, openvpn
 }:
 
 plasmaPackage {
@@ -13,6 +13,10 @@ plasmaPackage {
     (substituteAll {
       src = ./0001-mobile-broadband-provider-info-path.patch;
       inherit mobile_broadband_provider_info;
+    })
+    (substituteAll {
+      src = ./0002-openvpn-binary-path.patch;
+      inherit openvpn;
     })
   ];
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];

--- a/pkgs/desktops/plasma-5/plasma-nm/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-nm/default.nix
@@ -27,4 +27,5 @@ plasmaPackage {
     mobile_broadband_provider_info modemmanager-qt networkmanager-qt openconnect
     qca-qt5 solid
   ];
+  enableParallelBuilding = true;
 }


### PR DESCRIPTION
###### Motivation for this change
As seen in #24808 , it's not possible to configure the cipher field without this patch.  I also toggled enableParallelBuild because this package takes surprisingly long to compile.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

