### PR TITLE
ethrun: init at 0.1.0

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -32,6 +32,7 @@ rec {
   namecoind = callPackage ./namecoind.nix { };
 
   ethabi = callPackage ./ethabi.nix { };
+  ethrun = callPackage ./ethrun.nix { };
 
   primecoin  = callPackage ./primecoin.nix { withGui = true; };
   primecoind = callPackage ./primecoin.nix { withGui = false; };

--- a/pkgs/applications/altcoins/ethrun.nix
+++ b/pkgs/applications/altcoins/ethrun.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "ethrun-${version}";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "dapphub";
+    repo = "ethrun";
+    rev = "v${version}";
+    sha256 = "1w651g4p2mc4ljp20l8lwvfx3l3fzyp6gf2izr85vyb1wjbaccqn";
+  };
+
+  depsSha256 = "14x8pbjgkz0g724lnvd9mi2alqd6fipjljw6xsraf9gqwijn1knq";
+
+  meta = {
+    description = "Directly run Ethereum bytecode";
+    homepage = https://github.com/dapphub/ethrun/;
+    maintainers = [stdenv.lib.maintainers.dbrock];
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12874,6 +12874,7 @@ with pkgs;
 
   go-ethereum = self.altcoins.go-ethereum;
   ethabi = self.altcoins.ethabi;
+  ethrun = self.altcoins.ethrun;
 
   stellar-core = self.altcoins.stellar-core;
 


### PR DESCRIPTION
###### Motivation for this change

The `ethrun` program is a dependency of some other Ethereum-related utilities. It is a relatively stable basic tool that changes infrequently.

https://github.com/dapphub/ethrun

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

