### PR TITLE
add disk type storage to libvirt

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper pkgconfig ];
   buildInputs = [
     libxml2 gnutls perl python2 readline gettext libtasn1 libgcrypt yajl
-    attr libxslt xhtml1 perlPackages.XMLXPath curl libpcap
+    attr libxslt xhtml1 perlPackages.XMLXPath curl libpcap parted
   ] ++ optionals stdenv.isLinux [
     libpciaccess devicemapper lvm2 utillinux systemd libnl numad zfs
     libapparmor libcap_ng numactl xen

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -4,7 +4,7 @@
 , iproute, iptables, readline, lvm2, utillinux, systemd, libpciaccess, gettext
 , libtasn1, ebtables, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
 , dnsmasq, libnl, libpcap, libxslt, xhtml1, numad, numactl, perlPackages
-, curl, libiconv, gmp, xen, zfs
+, curl, libiconv, gmp, xen, zfs, parted
 }:
 
 with stdenv.lib;
@@ -50,6 +50,7 @@ stdenv.mkDerivation rec {
     "--with-test"
     "--with-esx"
     "--with-remote"
+    "--with-storage-disk"
   ] ++ optionals stdenv.isLinux [
     "--with-attr"
     "--with-apparmor"


### PR DESCRIPTION
###### Motivation for this change
`libvirt` is currently compiled without support for the `disk` type storage resulting in an error when attempting to add one (the option is still available in `virt-manager`).

This adds a flag to the compile steps (i.e. to `./configure`) to enable the `disk` storage type. Since this requires `parted`, I've also added that. (try running this without `parted` in the arguments list, you'll see).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS:
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---