### PR TITLE
melpa-packages: update font-lock+ expression for 17.03

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-generated.nix
@@ -24772,10 +24772,10 @@
       }) {};
     font-lock-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
         pname = "font-lock-plus";
-        version = "20170101.947";
+        version = "20170222.1755";
         src = fetchurl {
           url = "https://www.emacswiki.org/emacs/download/font-lock+.el";
-          sha256 = "0ffs2c7gyhfa2mskdh7a1yp0na99kk282zm4zn56ljp55rrnnnh0";
+          sha256 = "0iajkgh0n3pbrwwxx9rmrrwz8dw2m7jsp4mggnhq7zsb20ighs30";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/font-lock+";


### PR DESCRIPTION
###### Motivation for this change

Because this package is pulled from emacswiki, there's no way to continue to retrieve the prior version after it's updated; since we've had a couple of reports of it rendering _other_ packages uninstallable (#24540), it seems worth updating.