### PR TITLE
apitrace: 7.1 -> git

### DIFF
--- a/pkgs/applications/graphics/apitrace/default.nix
+++ b/pkgs/applications/graphics/apitrace/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "apitrace-${version}";
-  version = "7.1";
+  version = "7.1-363-ge3509be1";
 
   src = fetchFromGitHub {
-    sha256 = "1n2gmsjnpyam7isg7n1ksggyh6y1l8drvx0a93bnvbcskr7jiz9a";
-    rev = version;
+    sha256 = "1xbz6gwl7kqjm7jjy5gxkdxzrg93vj1a3l19ara7rni6dii0q136";
+    rev = "e3509be175eda77749abffe051ed0d3eb5d14e72";
     repo = "apitrace";
     owner = "apitrace";
   };


### PR DESCRIPTION
###### Motivation for this change

After upgrade `qapitrace` have working "Buffers" tab where the data
can be inspected (it was always empty before).

There is no tags after `7.1`, but I think that fixing pretty important
piece of functionality warrants an upgrade to current `master` tip.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

