### PR TITLE
psc-package: init at 0.1.1

### DIFF
--- a/pkgs/development/compilers/purescript/psc-package/default.nix
+++ b/pkgs/development/compilers/purescript/psc-package/default.nix
@@ -1,0 +1,26 @@
+{ haskellPackages, mkDerivation, fetchFromGitHub, lib }:
+
+with lib;
+
+mkDerivation rec {
+  pname = "psc-package";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "purescript";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "078xjn10yq4i0ff78bxscvxhn29p3s7iwv3pjyqxzlhaymn5949l";
+  };
+
+  isLibrary = false;
+  isExecutable = true;
+
+  executableHaskellDepends = with haskellPackages; [
+    aeson aeson-pretty optparse-applicative system-filepath turtle
+  ];
+
+  description = "An experimental package manager for PureScript";
+  license = licenses.bsd3;
+  maintainers = with lib.maintainers; [ profpatsch ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5228,6 +5228,8 @@ with pkgs;
   all-cabal-hashes = callPackage ../data/misc/hackage/default.nix { };
 
   purescript = haskell.lib.justStaticExecutables haskellPackages.purescript;
+  psc-package = haskell.lib.justStaticExecutables
+    (haskellPackages.callPackage ../development/compilers/purescript/psc-package { });
 
   inherit (ocamlPackages) haxe;
 


### PR DESCRIPTION
- [x] Tested execution of all binary files (usually in `./result/bin/`)

