### PR TITLE
gdrive: init at 2.1.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -461,6 +461,7 @@
   ryantm = "Ryan Mulligan <ryan@ryantm.com>";
   rycee = "Robert Helgesson <robert@rycee.net>";
   ryneeverett = "Ryne Everett <ryneeverett@gmail.com>";
+  rzetterberg = "Richard Zetterberg <richard.zetterberg@gmail.com>";
   s1lvester = "Markus Silvester <s1lvester@bockhacker.me>";
   samuelrivas = "Samuel Rivas <samuelrivas@gmail.com>";
   sander = "Sander van der Burg <s.vanderburg@tudelft.nl>";

--- a/pkgs/applications/networking/gdrive/default.nix
+++ b/pkgs/applications/networking/gdrive/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name    = "gdrive-${version}";
+  version = "2.1.0";
+  rev     = "${version}";
+
+  goPackagePath = "github.com/prasmussen/gdrive";
+
+  src = fetchFromGitHub {
+    owner  = "prasmussen";
+    repo   = "gdrive";
+    sha256 = "0ywm4gdmrqzb1a99vg66a641r74p7lglavcpgkm6cc2gdwzjjfg7";
+    inherit rev;
+  };
+
+  meta = with stdenv.lib; {
+    homepage    = https://github.com/prasmussen/gdrive;
+    description = "A command line utility for interacting with Google Drive";
+    platforms   = platforms.linux;
+    license     = licenses.mit;
+    maintainers = [ maintainers.rzetterberg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -940,6 +940,8 @@ with pkgs;
 
   gdrivefs = python27Packages.gdrivefs;
 
+  gdrive = callPackage ../applications/networking/gdrive { };
+
   go-dependency-manager = callPackage ../development/tools/gdm { };
 
   gencfsm = callPackage ../tools/security/gencfsm { };


### PR DESCRIPTION
###### Motivation for this change

Needed to upload some stuff to Google Drive, didn't find gdrive in nixpkgs,
created a package, installed it, it worked, thought "why not add the package?".

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS (17.09pre102667.2839b10)
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This package should work in macOS too, but I have not tested it on macOS, therefor I added `platforms.linux`

Running this script in the root of the nixpkgs project:

```bash
#!/usr/bin/env bash

set -e

nixpkgs_root=$(pwd)
tmp_shell_file=$(mktemp)

cat <<EOF > "$tmp_shell_file"
{ system ? builtins.currentSystem }:

let
  pkgs = import <nixpkgs> { inherit system; };
in
  pkgs.callPackage "$nixpkgs_root/pkgs/applications/networking/gdrive/default.nix" {
    inherit (pkgs);
  }
EOF

nix-env -i -f "$tmp_shell_file"

gdrive version

rm "$tmp_shell_file"
```

Should result in the following output:

```
installing ‘gdrive-2.1.0’
building path(s) ‘/nix/store/fa7vcac8fgg6dg2bgk3kwm7n9m2gggry-user-environment’
created 1125 symlinks in user environment
gdrive: 2.1.0
Golang: go1.7.4
OS/Arch: linux/amd64
```

I tested running the list command against a newly created google account. After
authenticating it worked:

![2017-04-12-184410_1364x729_scrot](https://cloud.githubusercontent.com/assets/766350/24969916/b94fdf8e-1fb2-11e7-90d9-197314d53f43.png)


I have also successfully uploaded files.