### PR TITLE
haskell-packages: factor package set construction into new file

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -6,103 +6,13 @@
 
 let
 
-  inherit (stdenv.lib) fix' extends makeOverridable makeExtensible;
-  inherit (import ./lib.nix { inherit pkgs; }) overrideCabal;
+  inherit (stdenv.lib) extends makeExtensible;
+  inherit (import ./lib.nix { inherit pkgs; }) overrideCabal makePackageSet;
 
-  haskellPackages = self:
-    let
-
-      mkDerivationImpl = pkgs.callPackage ./generic-builder.nix {
-        inherit stdenv;
-        inherit (pkgs) fetchurl pkgconfig glibcLocales coreutils gnugrep gnused;
-        nodejs = pkgs.nodejs-slim;
-        jailbreak-cabal = if (self.ghc.cross or null) != null
-          then self.ghc.bootPkgs.jailbreak-cabal
-          else self.jailbreak-cabal;
-        inherit (self) ghc;
-        hscolour = overrideCabal self.hscolour (drv: {
-          isLibrary = false;
-          doHaddock = false;
-          hyperlinkSource = false;      # Avoid depending on hscolour for this build.
-          postFixup = "rm -rf $out/lib $out/share $out/nix-support";
-        });
-        cpphs = overrideCabal (self.cpphs.overrideScope (self: super: {
-          mkDerivation = drv: super.mkDerivation (drv // {
-            enableSharedExecutables = false;
-            enableSharedLibraries = false;
-            doHaddock = false;
-            useCpphs = false;
-          });
-        })) (drv: {
-            isLibrary = false;
-            postFixup = "rm -rf $out/lib $out/share $out/nix-support";
-        });
-      };
-
-      mkDerivation = makeOverridable mkDerivationImpl;
-
-      callPackageWithScope = scope: drv: args: (stdenv.lib.callPackageWith scope drv args) // {
-        overrideScope = f: callPackageWithScope (mkScope (fix' (extends f scope.__unfix__))) drv args;
-      };
-
-      mkScope = scope: pkgs // pkgs.xorg // pkgs.gnome2 // scope;
-      defaultScope = mkScope self;
-      callPackage = drv: args: callPackageWithScope defaultScope drv args;
-
-      withPackages = packages: callPackage ./with-packages-wrapper.nix {
-        inherit (self) llvmPackages;
-        haskellPackages = self;
-        inherit packages;
-      };
-
-      haskellSrc2nix = { name, src, sha256 ? null }:
-        let
-          sha256Arg = if isNull sha256 then "--sha256=" else ''--sha256="${sha256}"'';
-        in pkgs.stdenv.mkDerivation {
-          name = "cabal2nix-${name}";
-          buildInputs = [ pkgs.cabal2nix ];
-          phases = ["installPhase"];
-          LANG = "en_US.UTF-8";
-          LOCALE_ARCHIVE = pkgs.lib.optionalString pkgs.stdenv.isLinux "${pkgs.glibcLocales}/lib/locale/locale-archive";
-          installPhase = ''
-            export HOME="$TMP"
-            mkdir -p "$out"
-            cabal2nix --compiler=${self.ghc.name} --system=${stdenv.system} ${sha256Arg} "${src}" > "$out/default.nix"
-          '';
-      };
-
-      hackage2nix = name: version: haskellSrc2nix {
-        name   = "${name}-${version}";
-        sha256 = ''$(sed -e 's/.*"SHA256":"//' -e 's/".*$//' "${all-cabal-hashes}/${name}/${version}/${name}.json")'';
-        src    = "${all-cabal-hashes}/${name}/${version}/${name}.cabal";
-      };
-
-    in
-      import ./hackage-packages.nix { inherit pkgs stdenv callPackage; } self // {
-
-        inherit mkDerivation callPackage haskellSrc2nix hackage2nix;
-
-        callHackage = name: version: self.callPackage (self.hackage2nix name version);
-
-        # Creates a Haskell package from a source package by calling cabal2nix on the source.
-        callCabal2nix = name: src: self.callPackage (self.haskellSrc2nix { inherit src name; });
-
-        ghcWithPackages = selectFrom: withPackages (selectFrom self);
-
-        ghcWithHoogle = selectFrom:
-          let
-            packages = selectFrom self;
-            hoogle = callPackage ./hoogle.nix {
-              inherit packages;
-            };
-          in withPackages (packages ++ [ hoogle ]);
-
-        ghc = ghc // {
-          withPackages = self.ghcWithPackages;
-          withHoogle = self.ghcWithHoogle;
-        };
-
-      };
+  haskellPackages = makePackageSet {
+    package-set = import ./hackage-packages.nix;
+    inherit ghc;
+  };
 
   commonConfiguration = import ./configuration-common.nix { inherit pkgs; };
   nixConfiguration = import ./configuration-nix.nix { inherit pkgs; };

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -1,6 +1,7 @@
 { pkgs }:
 
 rec {
+  makePackageSet = pkgs.callPackage ./make-package-set.nix {};
 
   overrideCabal = drv: f: (drv.override (args: args // {
     mkDerivation = drv: (args.mkDerivation drv).override f;

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -1,0 +1,107 @@
+# This expression takes a file like `hackage-packages.nix` and constructs
+# a full package set out of that.
+
+# required dependencies:
+{ pkgs, stdenv, all-cabal-hashes }:
+
+# arguments:
+#  * ghc package to use
+#  * package-set: a function that takes { pkgs, stdenv, callPackage } as first arg and `self` as second 
+{ ghc, package-set }:
+
+# return value: a function from self to the package set
+self: let
+
+  inherit (stdenv.lib) fix' extends makeOverridable;
+  inherit (import ./lib.nix { inherit pkgs; }) overrideCabal;
+
+  mkDerivationImpl = pkgs.callPackage ./generic-builder.nix {
+    inherit stdenv;
+    inherit (pkgs) fetchurl pkgconfig glibcLocales coreutils gnugrep gnused;
+    nodejs = pkgs.nodejs-slim;
+    jailbreak-cabal = if (self.ghc.cross or null) != null
+      then self.ghc.bootPkgs.jailbreak-cabal
+      else self.jailbreak-cabal;
+    inherit (self) ghc;
+    hscolour = overrideCabal self.hscolour (drv: {
+      isLibrary = false;
+      doHaddock = false;
+      hyperlinkSource = false;      # Avoid depending on hscolour for this build.
+      postFixup = "rm -rf $out/lib $out/share $out/nix-support";
+    });
+    cpphs = overrideCabal (self.cpphs.overrideScope (self: super: {
+      mkDerivation = drv: super.mkDerivation (drv // {
+        enableSharedExecutables = false;
+        enableSharedLibraries = false;
+        doHaddock = false;
+        useCpphs = false;
+      });
+    })) (drv: {
+        isLibrary = false;
+        postFixup = "rm -rf $out/lib $out/share $out/nix-support";
+    });
+  };
+
+  mkDerivation = makeOverridable mkDerivationImpl;
+
+  callPackageWithScope = scope: drv: args: (stdenv.lib.callPackageWith scope drv args) // {
+    overrideScope = f: callPackageWithScope (mkScope (fix' (extends f scope.__unfix__))) drv args;
+  };
+
+  mkScope = scope: pkgs // pkgs.xorg // pkgs.gnome2 // scope;
+  defaultScope = mkScope self;
+  callPackage = drv: args: callPackageWithScope defaultScope drv args;
+
+  withPackages = packages: callPackage ./with-packages-wrapper.nix {
+    inherit (self) llvmPackages;
+    haskellPackages = self;
+    inherit packages;
+  };
+
+  haskellSrc2nix = { name, src, sha256 ? null }:
+    let
+      sha256Arg = if isNull sha256 then "--sha256=" else ''--sha256="${sha256}"'';
+    in pkgs.stdenv.mkDerivation {
+      name = "cabal2nix-${name}";
+      buildInputs = [ pkgs.cabal2nix ];
+      phases = ["installPhase"];
+      LANG = "en_US.UTF-8";
+      LOCALE_ARCHIVE = pkgs.lib.optionalString pkgs.stdenv.isLinux "${pkgs.glibcLocales}/lib/locale/locale-archive";
+      installPhase = ''
+        export HOME="$TMP"
+        mkdir -p "$out"
+        cabal2nix --compiler=${self.ghc.name} --system=${stdenv.system} ${sha256Arg} "${src}" > "$out/default.nix"
+      '';
+  };
+
+  hackage2nix = name: version: haskellSrc2nix {
+    name   = "${name}-${version}";
+    sha256 = ''$(sed -e 's/.*"SHA256":"//' -e 's/".*$//' "${all-cabal-hashes}/${name}/${version}/${name}.json")'';
+    src    = "${all-cabal-hashes}/${name}/${version}/${name}.cabal";
+  };
+
+in package-set { inherit pkgs stdenv callPackage; } self // {
+
+    inherit mkDerivation callPackage haskellSrc2nix hackage2nix;
+
+    callHackage = name: version: self.callPackage (self.hackage2nix name version);
+
+    # Creates a Haskell package from a source package by calling cabal2nix on the source.
+    callCabal2nix = name: src: self.callPackage (self.haskellSrc2nix { inherit src name; });
+
+    ghcWithPackages = selectFrom: withPackages (selectFrom self);
+
+    ghcWithHoogle = selectFrom:
+      let
+        packages = selectFrom self;
+        hoogle = callPackage ./hoogle.nix {
+          inherit packages;
+        };
+      in withPackages (packages ++ [ hoogle ]);
+
+    ghc = ghc // {
+      withPackages = self.ghcWithPackages;
+      withHoogle = self.ghcWithHoogle;
+    };
+
+  }


### PR DESCRIPTION
This makes it a lot easier to replace the `haskell-packages.nix` used in nixpkgs while still using all the infrastructure that is available. Example:

```
let
  pkgs = import <nixpkgs> {};
  conf-set = import ./configuration-packages.nix { inherit pkgs; };
  conf-nix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs; };
  inherit (pkgs.lib) fix' extends makeExtensible;
  pkgset = pkgs.haskell.lib.makePackageSet {
    ghc = pkgs.haskell.compiler.ghc802;
    package-set = import ./packages.nix;
  };
in makeExtensible (extends conf-set (extends conf-nix pkgset))
```