### PR TITLE
thunderbird: add option to enable calendar

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -7,6 +7,7 @@
 , autoconf213, which, m4
 , writeScript, xidel, common-updater-scripts, coreutils, gnused, gnugrep, curl
 , enableGTK3 ? false, gtk3, wrapGAppsHook
+, enableCalendar ? true
 , debugBuild ? false
 , # If you want the resulting program to call itself "Thunderbird" instead
   # of "Earlybird" or whatever, enable this option.  However, those
@@ -77,6 +78,7 @@ stdenv.mkDerivation rec {
       "--disable-gconf"
       "--enable-default-toolkit=cairo-gtk${if enableGTK3 then "3" else "2"}"
     ]
+      ++ lib.optional enableCalendar "--enable-calendar"
       ++ (if debugBuild then [ "--enable-debug" "--enable-profiling"]
                         else [ "--disable-debug" "--enable-release"
                                "--disable-debug-symbols"


### PR DESCRIPTION
###### Motivation for this change
The [Lightning](https://addons.mozilla.org/en-US/thunderbird/addon/lightning/) addon for Thunderbird appears to have been deprecated in favour of the built-in version of the same thing. This change allows the `thunderbird` package to be built with calendar support via the option `thunderbird.enableCalendar`.

I currently have it disabled by default. Possibly it should be enabled by default, given that official builds come with the calendar. I don't know whether there are any best practices for this sort of thing.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

