### PR TITLE
intero-nix-shim: init at 0.1.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -684,6 +684,9 @@ self: super: {
     store = self.store_0_3_1;
   });
 
+  # It makes no sense to have intero-nix-shim in Hackage, so we publish it here only.
+  intero-nix-shim = self.callPackage ../tools/haskell/intero-nix-shim {};
+
   # The latest Hoogle needs versions not yet in LTS Haskell 7.x.
   hoogle = super.hoogle.override { haskell-src-exts = self.haskell-src-exts_1_19_1; };
 

--- a/pkgs/development/tools/haskell/intero-nix-shim/default.nix
+++ b/pkgs/development/tools/haskell/intero-nix-shim/default.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, base, directory, filepath, optparse-applicative
+, posix-escape, split, stdenv, unix, fetchFromGitHub
+}:
+mkDerivation {
+  pname = "intero-nix-shim";
+  version = "0.1.2";
+  src = fetchFromGitHub {
+    owner = "michalrus";
+    repo = "intero-nix-shim";
+    rev = "0.1.2";
+    sha256 = "0p1h3w15bgvsbzi7f1n2dxxxz9yq7vmbxmww5igc5d3dm76skgzg";
+  };
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    base directory filepath optparse-applicative posix-escape split
+    unix
+  ];
+  homepage = "https://github.com/michalrus/intero-nix-shim";
+  license = stdenv.lib.licenses.asl20;
+}


### PR DESCRIPTION
###### Motivation for this change

Currently, there is no way to use Intero (Haskell IDE in Emacs) with Nix-based Haskell projects, you have to use Stack for managing your projects. This small package can be used in place of Stack, making Intero work with pure Haskell/Nix projects.

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @shlevy =)