### PR TITLE
added macOS compatibility to portmidi-3.17

### DIFF
--- a/pkgs/development/libraries/portmidi/darwin.patch
+++ b/pkgs/development/libraries/portmidi/darwin.patch
@@ -1,0 +1,48 @@
+--- a/CMakeLists.txt	2010-09-20 21:57:48.000000000 +0200
++++ b/CMakeLists.txt	2017-04-12 19:19:44.000000000 +0200
+@@ -36,7 +36,7 @@
+ set(CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO "" CACHE INTERNAL "Unused")
+ set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "" CACHE INTERNAL "Unused")
+ 
+-set(CMAKE_OSX_ARCHITECTURES i386 ppc x86_64 CACHE STRING "change to needed architecture for a smaller library" FORCE)
++set(CMAKE_OSX_ARCHITECTURES x86_64 CACHE STRING "change to needed architecture for a smaller library" FORCE)
+ 
+ PROJECT(portmidi)
+ 
+--- a/pm_dylib/CMakeLists.txt	2017-04-12 22:22:07.000000000 +0200
++++ b/pm_dylib/CMakeLists.txt	2017-04-12 22:23:22.000000000 +0200
+@@ -48,11 +48,10 @@
+     list(APPEND LIBSRC ../porttime/ptmacosx_mach)
+ 
+     include_directories(${CMAKE_OSX_SYSROOT}/Developer/Headers/FlatCarbon)
+-    set(FRAMEWORK_PATH ${CMAKE_OSX_SYSROOT}/System/Library/Frameworks)
+-    set(COREAUDIO_LIB "${FRAMEWORK_PATH}/CoreAudio.framework")
+-    set(COREFOUNDATION_LIB "${FRAMEWORK_PATH}/CoreFoundation.framework")
+-    set(COREMIDI_LIB "${FRAMEWORK_PATH}/CoreMIDI.framework")
+-    set(CORESERVICES_LIB "${FRAMEWORK_PATH}/CoreServices.framework")
++    set(COREAUDIO_LIB "CoreAudio.framework")
++    set(COREFOUNDATION_LIB "CoreFoundation.framework")
++    set(COREMIDI_LIB "CoreMIDI.framework")
++    set(CORESERVICES_LIB "CoreServices.framework")
+     set(PM_NEEDED_LIBS ${COREAUDIO_LIB} ${COREFOUNDATION_LIB}
+                              ${COREMIDI_LIB} ${CORESERVICES_LIB}
+         CACHE INTERNAL "")
+
+--- a/pm_common/CMakeLists.txt	2017-04-12 22:37:54.000000000 +0200
++++ b/pm_common/CMakeLists.txt	2017-04-12 22:38:52.000000000 +0200
+@@ -53,11 +53,10 @@
+     list(APPEND LIBSRC ../porttime/ptmacosx_mach)
+ 
+     include_directories(${CMAKE_OSX_SYSROOT}/Developer/Headers/FlatCarbon)
+-    set(FRAMEWORK_PATH ${CMAKE_OSX_SYSROOT}/System/Library/Frameworks)
+-    set(COREAUDIO_LIB "${FRAMEWORK_PATH}/CoreAudio.framework")
+-    set(COREFOUNDATION_LIB "${FRAMEWORK_PATH}/CoreFoundation.framework")
+-    set(COREMIDI_LIB "${FRAMEWORK_PATH}/CoreMIDI.framework")
+-    set(CORESERVICES_LIB "${FRAMEWORK_PATH}/CoreServices.framework")
++    set(COREAUDIO_LIB "CoreAudio.framework")
++    set(COREFOUNDATION_LIB "CoreFoundation.framework")
++    set(COREMIDI_LIB "CoreMIDI.framework")
++    set(CORESERVICES_LIB "CoreServices.framework")
+     set(PM_NEEDED_LIBS ${COREAUDIO_LIB} ${COREFOUNDATION_LIB}
+                              ${COREMIDI_LIB} ${CORESERVICES_LIB}
+         CACHE INTERNAL "")

--- a/pkgs/development/python-modules/pygame/default.nix
+++ b/pkgs/development/python-modules/pygame/default.nix
@@ -11,10 +11,9 @@ buildPythonPackage rec {
     sha256 = "1hlydiyygl444bq5m5g8n3jsxsgrdyxlm42ipmfbw36wkf0j243m";
   };
 
-  buildInputs = [
-    SDL SDL_image SDL_mixer SDL_ttf libpng libjpeg
-    portmidi libX11 freetype
-  ];
+  buildInputs = [ SDL SDL_image SDL_mixer SDL_ttf portmidi ]
+       ++ (stdenv.lib.optionals (!stdenv.isDarwin)
+            [libpng libjpeg libX11 freetype ]);
 
   # Tests fail because of no audio device and display.
   doCheck = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9391,7 +9391,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AudioToolbox AudioUnit CoreAudio CoreServices Carbon;
   };
 
-  portmidi = callPackage ../development/libraries/portmidi {};
+  portmidi = callPackage ../development/libraries/portmidi {
+    inherit (darwin.apple_sdk.frameworks) Carbon CoreAudio CoreServices CoreMIDI;
+    inherit (darwin) apple_sdk CF;
+  };
 
   prison = callPackage ../development/libraries/prison { };
 


### PR DESCRIPTION
###### Motivation for this change
Needed portmidi for pygame. Haven't changed a thing about the missing java builds. 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
