### PR TITLE
Smart wrapProgram

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -74,11 +74,8 @@ in buildPythonApplication rec {
   '';
 
   postFixup = ''
-    mv $out/bin/qutebrowser $out/bin/.qutebrowser-noqtpath
-    makeQtWrapper $out/bin/.qutebrowser-noqtpath $out/bin/qutebrowser \
+    wrapQtProgram $out/bin/qutebrowser \
       ${lib.optionalString withWebEngineDefault ''--add-flags "--backend webengine"''}
-
-    sed -i 's/\.qutebrowser-wrapped/qutebrowser/g' $out/bin/..qutebrowser-wrapped-wrapped
   '';
 
   meta = {

--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -132,6 +132,9 @@ wrapProgram() {
     local prog="$1"
     local hidden
     hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
+    while [ -e "$hidden" ]; do
+      hidden="${hidden}_"
+    done
     mv "$prog" "$hidden"
     # Silence warning about unexpanded $0:
     # shellcheck disable=SC2016

--- a/pkgs/tools/bluetooth/blueman/default.nix
+++ b/pkgs/tools/bluetooth/blueman/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, intltool, pkgconfig, pythonPackages, bluez, polkit, gtk3
 , obex_data_server, xdg_utils, libnotify, dconf, gsettings_desktop_schemas, dnsmasq, dhcp
-, hicolor_icon_theme, librsvg
+, hicolor_icon_theme, librsvg, wrapGAppsHook
 , withPulseAudio ? true, libpulseaudio }:
 
 let
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
     sha256 = "03s305mbc57nl3sq5ywh9casz926k4aqnylgaidli8bmgz1djbg9";
   };
 
-  nativeBuildInputs = [ intltool pkgconfig pythonPackages.wrapPython pythonPackages.cython ];
+  nativeBuildInputs = [ intltool pkgconfig pythonPackages.wrapPython pythonPackages.cython wrapGAppsHook ];
 
   buildInputs = [ bluez gtk3 pythonPackages.python libnotify dconf librsvg
                   gsettings_desktop_schemas hicolor_icon_theme ]
@@ -32,12 +32,8 @@ in stdenv.mkDerivation rec {
 
   configureFlags = [ (lib.enableFeature withPulseAudio "pulseaudio") ];
 
-  postFixup = ''
-    makeWrapperArgs="\
-      --prefix PATH ':' ${binPath} \
-      --prefix GI_TYPELIB_PATH : $GI_TYPELIB_PATH \
-      --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH \
-      --prefix GIO_EXTRA_MODULES : ${dconf}/lib/gio/modules"
+  preFixup = ''
+    makeWrapperArgs="--prefix PATH ':' ${binPath}"
     wrapPythonPrograms
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Make `wrapProgram` search for the first available name for wrapped executables. This allows us to nest them, simplifying a lot things like Python-Qt applications.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested with `blueman` and `qutebrowser`.