### PR TITLE
teamviewer: keep RTlib directory

### DIFF
--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -9,7 +9,7 @@ let
 
   mkLdPath = ps: lib.makeLibraryPath (with ps; [ qt4 dbus alsaLib ]);
 
-  deps = ps: (with ps; [ dbus alsaLib fontconfig freetype libpng12 libjpeg ]) ++ (with ps.xlibs; [ libX11 libXext libXdamage libXrandr libXrender libXfixes libSM libXtst ]);
+  deps = ps: (with ps; [ dbus zlib alsaLib fontconfig freetype libpng12 libjpeg ]) ++ (with ps.xlibs; [ libX11 libXext libXdamage libXrandr libXrender libXfixes libSM libXtst libXinerama]);
   tvldpath32 = lib.makeLibraryPath (with pkgsi686Linux; [ qt4 "$out/share/teamviewer/tv_bin/wine" ] ++ deps pkgsi686Linux);
   tvldpath64 = lib.makeLibraryPath (deps pkgs);
 in
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     rm -R \
       $out/share/teamviewer/logfiles \
       $out/share/teamviewer/config \
-      $out/share/teamviewer/tv_bin/{xdg-utils,RTlib} \
+      $out/share/teamviewer/tv_bin/xdg-utils \
       $out/share/teamviewer/tv_bin/script/{teamviewer_setup,teamviewerd.sysv,teamviewerd.service,teamviewerd.*.conf,libdepend,tv-delayed-start.sh}
 
     ln -s $out/share/teamviewer/tv_bin/script/teamviewer $out/bin
@@ -57,13 +57,13 @@ stdenv.mkDerivation rec {
 
     sed -i "s,/opt/teamviewer,$out/share/teamviewer,g" desktop/com.teamviewer.*.desktop
 
-    for i in teamviewer-config teamviewerd TeamViewer_Desktop TVGuiDelegate TVGuiSlave.32 wine/bin/*; do
+    for i in teamviewer-config teamviewerd TeamViewer_Desktop TVGuiDelegate TVGuiSlave.32 wine/bin/* RTlib/libQtCore.so.4; do
       echo "patching $i"
-      patchelf --set-interpreter $(cat ${ld32}) --set-rpath ${tvldpath32} $i || true
+      patchelf --set-interpreter $(cat ${ld32}) --set-rpath $out/share/teamviewer/tv_bin/RTlib:${tvldpath32} $i || true
     done
-    for i in resources/*.so wine/drive_c/TeamViewer/tvwine.dll.so wine/lib/*.so* wine/lib/wine/*.so; do
+    for i in resources/*.so wine/drive_c/TeamViewer/tvwine.dll.so wine/lib/*.so* wine/lib/wine/*.so RTlib/*.so* ;  do
       echo "patching $i"
-      patchelf --set-rpath ${tvldpath32} $i || true
+      patchelf --set-rpath $out/share/teamviewer/tv_bin/RTlib:${tvldpath32} $i || true
     done
     ${if stdenv.system == "x86_64-linux" then ''
       patchelf --set-interpreter $(cat ${ld64}) --set-rpath ${tvldpath64} TVGuiSlave.64
@@ -81,6 +81,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     description = "Desktop sharing application, providing remote support and online meetings";
     platforms = [ "i686-linux" "x86_64-linux" ];
-    maintainers = with maintainers; [ jagajaga ];
+    maintainers = with maintainers; [ jagajaga dasuxullebt ];
   };
 }


### PR DESCRIPTION
…mands, etc. -- beforehand, the client failed, because TVGuiDelegate did not find all symbols.

###### Motivation for this change
The client did not work. see [my post on the mailing list](https://mailman.science.uu.nl/pipermail/nix-dev/2017-April/023392.html)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

