### PR TITLE
conan: init at 0.21.2

### DIFF
--- a/pkgs/development/python-modules/distro/default.nix
+++ b/pkgs/development/python-modules/distro/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchPypi, buildPythonPackage, pytest, pytestcov, tox }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "distro";
+  version = "1.0.3";
+
+  buildInputs = [ pytest pytestcov tox];
+
+  checkPhase = ''
+    touch tox.ini
+    tox
+  '';
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kmjdz1kxspsmps73m2kzhxz86jj43ikx825hmgmwbx793ywv69d";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/nir0s/distro;
+    description = "Linux Distribution - a Linux OS platform information API.";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nand0p ];
+  };
+}

--- a/pkgs/development/python-modules/node-semver/default.nix
+++ b/pkgs/development/python-modules/node-semver/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchPypi, buildPythonPackage, pytest, tox }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "0.1.1";
+  pname = "node-semver";
+
+  buildInputs = [ pytest tox ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b3xiqgl436q33grbkh4chpfchl8i2dmcpggbb2q4vgv3vjy97p2";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/podhmo/python-semver;
+    description = "A port of node-semver";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/pluginbase/default.nix
+++ b/pkgs/development/python-modules/pluginbase/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchPypi, buildPythonPackage, pytest, tox }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "0.5";
+  pname = "pluginbase";
+
+  buildInputs = [ pytest tox ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1palagrlszs4f4f5j6npzl4d195vclrlza3qr524z2h758j31y5l";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mitsuhiko/pluginbase;
+    description = "A support library for building plugins sytems in Python";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "${pname}-${version}";
+  version = "0.21.2";
+  pname = "conan";
+
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "0x9s5h81d885xdrjw5x99q18lhmj11kalrs6xnjy2phrr8qzil8c";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [
+    requests2 fasteners pyyaml pyjwt colorama patch
+    bottle pluginbase six distro pylint node-semver
+  ];
+
+  # enable tests once all of these pythonPackages available:
+  # [ nose nose_parameterized mock WebTest codecov ]
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://conan.io;
+    description = "Decentralized and portable C/C++ package manager";
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6407,6 +6407,8 @@ with pkgs;
 
   complexity = callPackage ../development/tools/misc/complexity { };
 
+  conan = callPackage ../development/tools/build-managers/conan { };
+
   cookiecutter = pythonPackages.cookiecutter;
 
   ctags = callPackage ../development/tools/misc/ctags { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -32191,6 +32191,8 @@ EOF
 
   nitpick = callPackage ../applications/version-management/nitpick { };
 
+  distro = callPackage ../development/python-modules/distro { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -32193,6 +32193,8 @@ EOF
 
   pluginbase = callPackage ../development/python-modules/pluginbase { };
 
+  node-semver = callPackage ../development/python-modules/node-semver { };
+
   distro = callPackage ../development/python-modules/distro { };
 
 });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -32191,6 +32191,8 @@ EOF
 
   nitpick = callPackage ../applications/version-management/nitpick { };
 
+  pluginbase = callPackage ../development/python-modules/pluginbase { };
+
   distro = callPackage ../development/python-modules/distro { };
 
 });


### PR DESCRIPTION
###### Motivation for this change
[Conan](https://conan.io/) is a cross-platform package manager for C/C++.
@igsha has already laid out most of the work for this change (see [his conan branch](https://github.com/igsha/nixpkgs/tree/conan)). It was just missing a little bit, so here it goes 👍    
Additionally this PR includes a commit from still unmerged PR #24131, since `conan` also depends on `pythonPackages.distro` that is initialized there.   

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
  - this is aliased as `nix.useChroot` so I hope I have tested it with command below
- [x] Tested using buildtime sandboxing (`nix-build . --option build-use-chroot true -A conan`)
- [x] Tested using runtime sandboxing (`nix-shell -I nixpkgs=. --pure -p conan`)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  - no pkgs depend on these additions
  - `node-semver` has a test error (reported in podhmo/python-semver#4), but still builds fine and dependent application conan runs
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - tested by building [starting tutorial](http://docs.conan.io/en/latest/getting_started.html#a-timer-using-poco-libraries)
  - you need `gcc`, `gnumake` and `cmake` to build the tutorial, but they are not runtime dependencies
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

