### PR TITLE
digikam: add video support through libqtav

### DIFF
--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -29,6 +29,7 @@
 , libgphoto2
 , libkipi
 , liblqr1
+, libqtav
 , libusb1
 , marble
 , mysql
@@ -83,6 +84,7 @@ stdenv.mkDerivation rec {
     libgphoto2
     libkipi
     liblqr1
+    libqtav
     libusb1
     marble.unwrapped
     mysql
@@ -99,6 +101,7 @@ stdenv.mkDerivation rec {
     "-DLIBUSB_INCLUDE_DIR=${libusb1.dev}/include/libusb-1.0"
     "-DENABLE_MYSQLSUPPORT=1"
     "-DENABLE_INTERNALMYSQL=1"
+    "-DENABLE_MEDIAPLAYER=1"
   ];
 
   fixupPhase = ''

--- a/pkgs/development/libraries/libqtav/default.nix
+++ b/pkgs/development/libraries/libqtav/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, lib, fetchFromGitHub, extra-cmake-modules, makeQtWrapper
+, qtbase, qtmultimedia, qtquick1, qttools
+, mesa, libX11
+, libass, openal, ffmpeg, libuchardet
+, alsaLib, libpulseaudio, libva
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "libqtav-${version}";
+
+  # Awaiting upcoming `v1.12.0` release. `v1.11.0` is not supporting cmake which is the
+  # the reason behind taking an unstable git rev. 
+  version = "unstable-2017-03-30";
+
+  nativeBuildInputs = [ extra-cmake-modules makeQtWrapper qttools ];
+  buildInputs = [ 
+    qtbase qtmultimedia qtquick1
+    mesa libX11
+    libass openal ffmpeg libuchardet
+    alsaLib libpulseaudio libva
+  ];
+
+  src = fetchFromGitHub {
+    sha256 = "1xw0ynm9w501651rna3ppf8p336ag1p60i9dxhghzm543l7as93v";
+    rev = "4b4ae3b470b2fcbbcf1b541c2537fb270ee0bcfa";
+    repo = "QtAV";
+    owner = "wang-bin";
+    fetchSubmodules = true;
+  };
+
+  patchPhase = ''
+    sed -i -e 's#CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT#TRUE#g' ./CMakeLists.txt
+    sed -i -e 's#DESTINATION ''${QT_INSTALL_LIBS}/cmake#DESTINATION ''${QTAV_INSTALL_LIBS}/cmake#g' ./CMakeLists.txt
+  '';
+
+  # Make sure libqtav finds its libGL dependancy at both link and run time
+  # by adding mesa to rpath. Not sure why it wasn't done automatically like
+  # the other libraries as `mesa` is part of our `buildInputs`.
+  NIX_CFLAGS_LINK = [ "-Wl,-rpath,${mesa}/lib"];
+
+  preFixup = ''
+    mkdir -p "$out/bin"
+    cp -a "./bin/"* "$out/bin"
+  '';
+
+  postFixup = ''
+    for i in `find $out/bin -maxdepth 1 -xtype f -executable`; do
+      wrapQtProgram "$i"
+    done
+  '';
+
+  meta = {
+    description = "A multimedia playback framework based on Qt + FFmpeg.";
+    #license = licenses.lgpl21; # For the libraries / headers only.
+    license = licenses.gpl3; # With the examples (under bin) and most likely some of the optional dependencies used.
+    homepage = http://www.qtav.org/;
+    maintainers = [ maintainers.jraygauthier ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9523,6 +9523,10 @@ with pkgs;
 
     libopenshot-audio = callPackage ../applications/video/openshot-qt/libopenshot-audio.nix { };
 
+    libqtav = callPackage ../development/libraries/libqtav { 
+      libva = libva-full; # also wants libva-x11 
+    };
+
     mlt = callPackage ../development/libraries/mlt/qt-5.nix {
       ffmpeg = ffmpeg_2;
     };


### PR DESCRIPTION
###### Motivation for this change

Issue #24426

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

