### PR TITLE
hivemind: init at git-2017-04-13

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -22,6 +22,9 @@ rec {
   freicoin = callPackage ./freicoin.nix { boost = pkgs.boost155; };
   go-ethereum = callPackage ./go-ethereum.nix { };
 
+  hivemind = callPackage ./hivemind.nix { withGui = true; };
+  hivemindd = callPackage ./hivemind.nix { withGui = false; };
+
   litecoin  = callPackage ./litecoin.nix { withGui = true; };
   litecoind = callPackage ./litecoin.nix { withGui = false; };
 

--- a/pkgs/applications/altcoins/hivemind.nix
+++ b/pkgs/applications/altcoins/hivemind.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, openssl, db48, boost
+, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, libevent
+, withGui }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "hivemind" + (toString (optional (!withGui) "d")) + "-" + version;
+  version = "git-2017-04-13";
+
+  src = fetchFromGitHub {
+    owner = "bitcoin-hivemind";
+    repo = "hivemind";
+    rev = "147973cfe76867410578d91d6f0a8df105cab4e0";
+    sha256 = "1ndqqma1b0sh2gn7cl8d9fg44q0g2g42jr2y0nifkjgfjn3c7l5h";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ openssl db48 boost zlib
+                  miniupnpc protobuf libevent]
+                  ++ optionals stdenv.isLinux [ utillinux ]
+                  ++ optionals withGui [ qt4 qrencode ];
+
+  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" 
+                     "--with-incompatible-bdb"
+                   ] ++ optionals withGui [ "--with-gui=qt4" ];
+
+  meta = {
+    description = "Peer-to-Peer oracle protocol";
+    longDescription= ''
+      Hivemind is a Peer-to-Peer Oracle Protocol which absorbs accurate data
+      into a blockchain so that Bitcoin-users can speculate in Prediction
+      Markets.
+    '';
+    homepage = "https://bitcoinhivemind.com";
+    maintainers = with maintainers; [ canndrew ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/hivemind.nix
+++ b/pkgs/applications/altcoins/hivemind.nix
@@ -5,7 +5,7 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "hivemind" + (toString (optional (!withGui) "d")) + "-" + version;
-  version = "git-2017-04-13";
+  version = "unstable";
 
   src = fetchFromGitHub {
     owner = "bitcoin-hivemind";


### PR DESCRIPTION
Hivemind is a peer-to-peer oracle protocol which absorbs accurate data
into a blockchain so that bitcoin-users can speculate in prediction
markets.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

