### PR TITLE
openshot-qt: 2.2.0 -> 2.3.1

### DIFF
--- a/pkgs/applications/video/openshot-qt/default.nix
+++ b/pkgs/applications/video/openshot-qt/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , doxygen, python3Packages, libopenshot
-, makeQtWrapper }:
+, makeQtWrapper, wrapGAppsHook, gtk3 }:
 
 python3Packages.buildPythonApplication rec {
   name = "openshot-qt-${version}";
@@ -13,9 +13,12 @@ python3Packages.buildPythonApplication rec {
     sha256 = "10j3p10q66m9nhzcd8315q1yiqscidkjbm474mllw7c281vacvzw";
   };
 
-  nativeBuildInputs = [ doxygen ];
+  nativeBuildInputs = [ doxygen wrapGAppsHook ];
+
+  buildInputs = [ gtk3 ];
 
   propagatedBuildInputs = with python3Packages; [ libopenshot pyqt5 sip httplib2 pyzmq ];
+
 
   preConfigure = ''
     # tries to create caching directories during install

--- a/pkgs/applications/video/openshot-qt/default.nix
+++ b/pkgs/applications/video/openshot-qt/default.nix
@@ -1,9 +1,8 @@
 { stdenv, fetchFromGitHub
-, doxygen, python3Packages, ffmpeg, libopenshot
-, qtbase, qtmultimedia, makeQtWrapper }:
+, doxygen, python3Packages, libopenshot
+, makeQtWrapper }:
 
-with stdenv.lib;
-stdenv.mkDerivation rec {
+python3Packages.buildPythonApplication rec {
   name = "openshot-qt-${version}";
   version = "2.3.1";
 
@@ -13,27 +12,19 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "10j3p10q66m9nhzcd8315q1yiqscidkjbm474mllw7c281vacvzw";
   };
-    
-  buildInputs =
-  [ python3Packages.python ffmpeg libopenshot qtbase qtmultimedia ];
 
-  nativeBuildInputs =
-  [ doxygen makeQtWrapper ];
+  nativeBuildInputs = [ doxygen ];
 
-  installPhase = ''
-    mkdir -p $(toPythonPath $out)
-    cp -r src/* $(toPythonPath $out)
-    mkdir -p $out/bin
-    echo "#/usr/bin/env sh" >$out/bin/openshot-qt
-    echo "exec ${python3Packages.python.interpreter} $(toPythonPath $out)/launch.py" >>$out/bin/openshot-qt
-    chmod +x $out/bin/openshot-qt
-    wrapQtProgram $out/bin/openshot-qt \
-      --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${libopenshot}):$(toPythonPath ${python3Packages.pyqt5}):$(toPythonPath ${python3Packages.sip}):$(toPythonPath ${python3Packages.httplib2}):$(toPythonPath ${python3Packages.pyzmq}):$PYTHONPATH"
+  propagatedBuildInputs = with python3Packages; [ libopenshot pyqt5 sip httplib2 pyzmq ];
+
+  preConfigure = ''
+    # tries to create caching directories during install
+    export HOME=$(mktemp -d)
   '';
 
   doCheck = false;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://openshot.org/;
     description = "Free, open-source video editor";
     longDescription = ''

--- a/pkgs/applications/video/openshot-qt/default.nix
+++ b/pkgs/applications/video/openshot-qt/default.nix
@@ -5,13 +5,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "openshot-qt-${version}";
-  version = "2.2.0";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "openshot-qt";
     rev = "v${version}";
-    sha256 = "0dg4fkkci1rz49yrdd4fa1whv10c1pgm3cl4i49452ckqa7qg037";
+    sha256 = "10j3p10q66m9nhzcd8315q1yiqscidkjbm474mllw7c281vacvzw";
   };
     
   buildInputs =

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -8,13 +8,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "libopenshot-${version}";
-  version = "0.1.3";
+  version = "0.1.4";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "libopenshot";
     rev = "v${version}";
-    sha256 = "0slszl6w96rhxhi6agw85dc4gmpab2qw03mq32g4qrirz68anz6f";
+    sha256 = "1mqci103kn4l7w8i9kqzi705kxn4q596vw0sh05r1w5nbyjwcyp6";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change
New upstream release (also trying to convince Bryan Lunduke to talk about Nix :-P)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

When I ran this on my system (NixOS 17.03), it worked fine there, but when I tried to run the version I successfully built against the Nixpkgs master branch, I got an error about how Qt couldn't find the XCB plugin. I'm not sure if this would be an issue if I was running on NixOS unstable channel or master.