### PR TITLE
gce/create-gce.sh: rewrite using nix-shell shebang and bash

### DIFF
--- a/nixos/maintainers/scripts/gce/create-gce.sh
+++ b/nixos/maintainers/scripts/gce/create-gce.sh
@@ -3,16 +3,13 @@
 
 set -euo pipefail
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-NIXPKGS_ROOT="$DIR/../../../../"
 BUCKET_NAME="${BUCKET_NAME:-nixos-images}"
-export NIX_PATH=nixpkgs="$NIXPKGS_ROOT"
-export NIXOS_CONFIG="$NIXPKGS_ROOT/nixos/modules/virtualisation/google-compute-image.nix"
 TIMESTAMP="$(date +%Y%m%d%H%M)"
 export TIMESTAMP
 
 nix-build '<nixpkgs/nixos>' \
    -A config.system.build.googleComputeImage \
+   --arg configuration "{ imports = [ <nixpkgs/nixos/modules/virtualisation/google-compute-image.nix> ]; }" \
    --argstr system x86_64-linux \
    -o gce \
    --option extra-binary-caches https://hydra.nixos.org \

--- a/nixos/maintainers/scripts/gce/create-gce.sh
+++ b/nixos/maintainers/scripts/gce/create-gce.sh
@@ -1,15 +1,27 @@
-#! /bin/sh -e
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p google-cloud-sdk
 
-BUCKET_NAME=${BUCKET_NAME:-nixos-images}
-export NIX_PATH=nixpkgs=../../../..
-export NIXOS_CONFIG=$(dirname $(readlink -f $0))/../../../modules/virtualisation/google-compute-image.nix
-export TIMESTAMP=$(date +%Y%m%d%H%M)
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+NIXPKGS_ROOT="$DIR/../../../../"
+BUCKET_NAME="${BUCKET_NAME:-nixos-images}"
+export NIX_PATH=nixpkgs="$NIXPKGS_ROOT"
+export NIXOS_CONFIG="$NIXPKGS_ROOT/nixos/modules/virtualisation/google-compute-image.nix"
+TIMESTAMP="$(date +%Y%m%d%H%M)"
+export TIMESTAMP
 
 nix-build '<nixpkgs/nixos>' \
-   -A config.system.build.googleComputeImage --argstr system x86_64-linux -o gce --option extra-binary-caches http://hydra.nixos.org -j 10
+   -A config.system.build.googleComputeImage \
+   --argstr system x86_64-linux \
+   -o gce \
+   --option extra-binary-caches https://hydra.nixos.org \
+   -j 10
 
-img=$(echo gce/*.tar.gz)
-if ! gsutil ls gs://${BUCKET_NAME}/$(basename $img); then
-  gsutil cp $img gs://${BUCKET_NAME}/$(basename $img)
+img_path=$(echo gce/*.tar.gz)
+img_name=$(basename "$img_path")
+img_id=$(echo "$img_name" | sed 's|.raw.tar.gz$||;s|\.|-|g;s|_|-|g')
+if ! gsutil ls "gs://${BUCKET_NAME}/$img_name"; then
+  gsutil cp "$img_path" "gs://${BUCKET_NAME}/$img_name"
 fi
-gcloud compute images create $(basename $img .raw.tar.gz | sed 's|\.|-|' | sed 's|_|-|') --source-uri gs://${BUCKET_NAME}/$(basename $img)
+gcloud compute images create "$img_id" --source-uri "gs://${BUCKET_NAME}/$img_name"

--- a/nixos/maintainers/scripts/gce/create-gce.sh
+++ b/nixos/maintainers/scripts/gce/create-gce.sh
@@ -12,7 +12,6 @@ nix-build '<nixpkgs/nixos>' \
    --arg configuration "{ imports = [ <nixpkgs/nixos/modules/virtualisation/google-compute-image.nix> ]; }" \
    --argstr system x86_64-linux \
    -o gce \
-   --option extra-binary-caches https://hydra.nixos.org \
    -j 10
 
 img_path=$(echo gce/*.tar.gz)

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -7,23 +7,23 @@ assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux" || stden
 
 stdenv.mkDerivation rec {
   name = "google-cloud-sdk-${version}";
-  version = "150.0.0";
+  version = "151.0.0";
 
   src =
     if stdenv.system == "i686-linux" then
       fetchurl {
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-linux-x86.tar.gz";
-        sha256 = "0zg6jnn93dq53glds4cghksyghb4d4z0i2h38na0r88mr8hzmx1l";
+        sha256 = "1d1h6jiqs3grsb6c61v6dkb4l2qv6v8g7wbzgaqkmn09xdbaq40l";
       }
     else if stdenv.system == "x86_64-darwin" then
       fetchurl {
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-darwin-x86_64.tar.gz";
-        sha256 = "1vbc360z2da3blwx51asw7jh0v0v6wsrv20z36yq0hccmljlh24w";
+        sha256 = "05idf0g505s8diaz28ij9yqig2wwn43lyppfs483m7vnx5hk62j5";
       }
     else
       fetchurl {
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-linux-x86_64.tar.gz";
-        sha256 = "1q66aap3qidfsa8gm13jff3dprx8qarhjkx5ib65439fy4zj0bca";
+        sha256 = "01hf7pp1v57dxx6f2pz7j13fjdnrfp7gjmzjdlhlx4rnvxrd6i3f";
       };
 
   buildInputs = [python27 makeWrapper];


### PR DESCRIPTION
###### Motivation for this change

- allows to run the script without being the same directory
- nix-shell install google-cloud-sdk
- some shellcheck cleanups and scripting best practice

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

