### PR TITLE
terraform: 0.9.2 -> 0.9.3

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -49,20 +49,9 @@ in {
     sha256 = "0ibgpcpvz0bmn3cw60nzsabsrxrbmmym1hv7fx6zmjxiwd68w5gb";
   };
 
-  terraform_0_9_2 = generic {
-    version = "0.9.2";
-    sha256 = "1yj5x1d10028fm3v3gjyjdn128ps0as345hr50y8x3vn86n70lxl";
-
-    patches = [
-      (fetchpatch {
-        url = "https://github.com/hashicorp/terraform/pull/13237.patch";
-        sha256 = "03c2nq12gvqqp12znvl3lmiviwsqksx4nrplv09fns2kz2gyfnbm";
-      })
-      (fetchpatch {
-        url = "https://github.com/hashicorp/terraform/pull/13248.patch";
-        sha256 = "0awj8gaic0j7a69is95f2rll3yip4n6avai1jh20b1x7dybdrp5m";
-      })
-    ];
+  terraform_0_9_3 = generic {
+    version = "0.9.3";
+    sha256 = "00z72lwv0cprz1jjy0cr8dicl00zwc1zwsxzjssqnq0187sswkxw";
 
     postPatch = ''
       rm builtin/providers/dns/data_dns_cname_record_set_test.go

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18193,10 +18193,10 @@ with pkgs;
   inherit (callPackage ../applications/networking/cluster/terraform {})
     terraform_0_8_5
     terraform_0_8_8
-    terraform_0_9_2;
+    terraform_0_9_3;
 
   terraform_0_8 = terraform_0_8_8;
-  terraform_0_9 = terraform_0_9_2;
+  terraform_0_9 = terraform_0_9_3;
   terraform = terraform_0_9;
 
   terragrunt = callPackage ../applications/networking/cluster/terragrunt {


### PR DESCRIPTION
###### Motivation for this change

Package update, getting rid of the patches. Builds fine on OSX but needs testing with a proper sandbox.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

