### PR TITLE
fava: 1.2 -> 1.3

### DIFF
--- a/pkgs/applications/office/beancount/default.nix
+++ b/pkgs/applications/office/beancount/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchhg, pkgs, pythonPackages }:
 
 pythonPackages.buildPythonApplication rec {
-  version = "2.0b13";
+  version = "2.0b15";
   name = "beancount-${version}";
   namePrefix = "";
 
   src = pkgs.fetchurl {
     url = "mirror://pypi/b/beancount/${name}.tar.gz";
-    sha256 = "16gkcq28bwd015b1qhdr5d7vhxid8xfn6ia4n9n8dnl5n448yqkm";
+    sha256 = "1dvnpgja4v4k5zagfsmdjavlib0z3r9r4z197yvj86szhzs0z86k";
   };
 
   buildInputs = with pythonPackages; [ nose ];

--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -1,17 +1,19 @@
 { stdenv, pkgs, fetchurl, python3Packages, fetchFromGitHub, fetchzip, python3, beancount }:
 
 python3Packages.buildPythonApplication rec {
-  version = "1.2";
+  version = "1.3";
   name = "fava-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/beancount/fava/archive/v${version}.tar.gz";
-    sha256 = "0sykx054w4cvr0pgbqph0lmkxffafl83k5ir252gl5znxgcvg6yw";
+  src = fetchFromGitHub {
+    owner = "beancount";
+    repo = "fava";
+    rev = "v${version}";
+    sha256 = "0g0aj0qcmpny6dipi00nks7h3mf5a4jfd6bxjm1rb5807wswcpg8";
   };
 
   assets = fetchzip {
-    url = "https://github.com/beancount/fava/releases/download/v${version}/beancount-fava-${version}.tar.gz";
-    sha256 = "1lk6s3s6xvvwbcbkr1qpr9bqdgwspk3vms25zjd6xcs21s3hchmp";
+    url = "https://github.com/beancount/fava/releases/download/v${version}/fava-${version}.tar.gz";
+    sha256 = "0yn2psbn436g1w5ixn94z8ca6dfd54izg98979arn0k7slpiccvz";
   };
 
   buildInputs = with python3Packages; [ pytest_30 ];


### PR DESCRIPTION
###### Motivation for this change

New versions.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Attention: This update of `beancount` deprecates the pipe syntax. Beancount prints warnings for this, so this shouldn't be a problem. Though, we might not backport this to nixos 17.03!