### PR TITLE
pijul: 0.4.1 -> 0.4.4

### DIFF
--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -4,11 +4,11 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "pijul-${version}";
-  version = "0.4.1";
+  version = "0.4.4";
 
   src = fetchurl {
     url = "https://pijul.org/releases/${name}.tar.gz";
-    sha256 = "e492fde1bea839f474f5b91bb762a0fab5ff6a9bc2b8f20eb91a253ca6feda5a";
+    sha256 = "8f133b7e14bfa84156c103126d53b12c6dfb996dcdebcf1091199ff9c77f3713";
   };
 
   sourceRoot = "${name}/pijul";
@@ -18,7 +18,7 @@ buildRustPackage rec {
 
   doCheck = false;
   
-  depsSha256 = "17n66clr31s49gbbcsii0f31s63rncc9mmz4wwdi0yl4r6ykv9h7";
+  depsSha256 = "1zdvnarg182spgydmqwxxr929j44d771zkq7gyh152173i0xqb20";
 
   meta = with stdenv.lib; {
     description = "A distributed version control system";

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,9 +7,9 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2017-04-11";
-  rev = "4dff0d079e01ca61b093c5a2fb6123378dfd0d38";
-  sha256 = "1ygahq5kmagjmwhrss01134vfb8lvim9110y3abjkmp3cc4xwfhy";
+  version = "2017-04-13";
+  rev = "5758a926a647716bd650978ad53aeb4a0c5f9b45";
+  sha256 = "1fnwh62k8fbflciv1qg3r9fsqn1xy72flyv15ii3mpja2vqzkdi2";
 
   src = fetchFromGitHub {
       inherit rev;


### PR DESCRIPTION
###### Motivation for this change

update pijul to 0.4.4

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

