### PR TITLE
fanficfare: init at 2.9.0

### DIFF
--- a/pkgs/tools/text/fanficfare/default.nix
+++ b/pkgs/tools/text/fanficfare/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, python27Packages }:
+
+python27Packages.buildPythonApplication rec {
+  version = "2.9.0";
+  name = "fanficfare-${version}";
+  nameprefix = "";
+
+  src = fetchurl {
+    url = "https://github.com/JimmXinu/FanFicFare/archive/v${version}.tar.gz";
+    sha256 = "781e9095d8152345a6106135e87c46eb306ff234b847de5073faca2f78544398";
+  };
+
+  propagatedBuildInputs = with python27Packages; [ beautifulsoup4 chardet html5lib html2text ];
+
+  meta = with stdenv.lib; {
+    description = "FanFicFare is a tool for making eBooks from fanfiction web sites";
+    homepage = "https://github.com/JimmXinu/FanFicFare";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lucas8 ];
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1709,6 +1709,8 @@ with pkgs;
       pillow;
   };
 
+  fanficfare = callPackage ../tools/text/fanficfare { };
+
   fastd = callPackage ../tools/networking/fastd { };
 
   fatsort = callPackage ../tools/filesystems/fatsort { };


### PR DESCRIPTION
Add fanficfare CLI (not the calibre plugin) package.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

