### PR TITLE
streamlink: 0.3.0 -> 0.5.0

### DIFF
--- a/pkgs/applications/video/streamlink/default.nix
+++ b/pkgs/applications/video/streamlink/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, pythonPackages, fetchFromGitHub, rtmpdump }:
+{ stdenv, pythonPackages, fetchFromGitHub, rtmpdump, ffmpeg }:
 
 pythonPackages.buildPythonApplication rec {
-  version = "0.3.0";
+  version = "0.5.0";
   name = "streamlink-${version}";
 
   src = fetchFromGitHub {
     owner = "streamlink";
     repo = "streamlink";
     rev = "${version}";
-    sha256 = "1bjih6y21vmjmsk3xvhgc1innymryklgylyvjrskqw610niai59j";
+    sha256 = "08q7f1fnm3zhs1knrkl6npr4yvpblqbiwa0m9r186ny11jq2dyib";
   };
 
-  propagatedBuildInputs = (with pythonPackages; [ pycrypto requests2 ]) ++ [ rtmpdump ];
+  buildInputs = with pythonPackages; [ pytest mock ];
+
+  propagatedBuildInputs = (with pythonPackages; [ pycryptodome requests2 iso-639 iso3166 ]) ++ [ rtmpdump ffmpeg ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/streamlink/streamlink;
@@ -25,6 +27,6 @@ pythonPackages.buildPythonApplication rec {
     '';
     license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.dezgeg ];
+    maintainers = with maintainers; [ dezgeg zraexy ];
   };
 }

--- a/pkgs/development/python-modules/iso-639/default.nix
+++ b/pkgs/development/python-modules/iso-639/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, buildPythonPackage }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "iso-639";
+  version = "0.4.5";
+
+  src = fetchurl {
+    url = "mirror://pypi/i/${pname}/${name}.tar.gz";
+    sha256 = "dc9cd4b880b898d774c47fe9775167404af8a85dd889d58f9008035109acce49";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/noumar/iso639;
+    description = "ISO 639 library for Python";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ zraexy ];
+  };
+}

--- a/pkgs/development/python-modules/iso3166/default.nix
+++ b/pkgs/development/python-modules/iso3166/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, buildPythonPackage }:
+ 
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "iso3166";
+  version = "0.8";
+
+  src = fetchurl {
+    url = "mirror://pypi/i/${pname}/${name}.tar.gz";
+    sha256 = "fbeb17bed90d15b1f6d6794aa2ea458e5e273a1d29b6f4939423c97640e14933";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/deactivated/python-iso3166;
+    description = "Self-contained ISO 3166-1 country definitions";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zraexy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13274,6 +13274,8 @@ in {
       license = with licenses; [ lgpl21 ];
     };
   };
+  
+  iso-639 = callPackage ../development/python-modules/iso-639 {};
 
   iso8601 = buildPythonPackage rec {
     name = "iso8601-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13276,6 +13276,8 @@ in {
   };
   
   iso-639 = callPackage ../development/python-modules/iso-639 {};
+  
+  iso3166 = callPackage ../development/python-modules/iso3166 {};
 
   iso8601 = buildPythonPackage rec {
     name = "iso8601-${version}";


### PR DESCRIPTION
###### Motivation for this change

Update streamlink to the latest version
It now requires iso-639 and iso3166 for localization.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

