### PR TITLE
electron: 1.4.15 -> 1.6.2

### DIFF
--- a/pkgs/applications/editors/atom/env.nix
+++ b/pkgs/applications/editors/atom/env.nix
@@ -10,6 +10,7 @@ let
     xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
     xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
     xorg.libXcursor xorg.libxkbfile xorg.libXScrnSaver libcap systemd libnotify
+    xorg.libxcb
   ];
 
   libPathNative = lib.makeLibraryPath packages;

--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, libXScrnSaver, makeWrapper, fetchurl, unzip, atomEnv }:
 
 let
-  version = "1.4.15";
+  version = "1.6.2";
   name = "electron-${version}";
 
   meta = with stdenv.lib; {
@@ -17,7 +17,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-x64.zip";
-      sha256 = "07b9jdbjrf3siv205wd1dphq6ly0hkaapzvj87d2yjfiyzv3cbsl";
+      sha256 = "1dhyr8zkisnhjzk2v2zi8zp0jqg0v3g095xa430af6i1rm0qhs13";
       name = "${name}.zip";
     };
 
@@ -45,7 +45,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-darwin-x64.zip";
-      sha256 = "0p8gkyq4qczzia26wrnbs91vdqzxhgq515cmsrwvhw87mc9fka4k";
+      sha256 = "11jfh4xvdrpda5ni08kl6wcg67ww9viagszk8gi00z0rlczrsbkf";
       name = "${name}.zip";
     };
 


### PR DESCRIPTION
###### Motivation for this change
Improves compatibility with recent electron apps. I'm not an electron expert, so I'm not sure if a minor version update like this confers any risk of breakage elsewhere.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

