### PR TITLE
Remove hardening at HaLVM 2.4.0

### DIFF
--- a/pkgs/development/compilers/halvm/2.4.0.nix
+++ b/pkgs/development/compilers/halvm/2.4.0.nix
@@ -8,13 +8,13 @@ stdenv.mkDerivation rec {
   isHaLVM = true;
   isGhcjs = false;
   src = fetchgit {
-    rev = "6aa72c9b047fd8ddff857c994a5a895461fc3925";
+    rev = "65fad65966eb7e60f234453a35aeb564a09d2595";
     url = "https://github.com/GaloisInc/HaLVM";
-    sha256 = "05cg4w6fw5ajmpmh8g2msprnygmr4isb3pphqhlddfqwyvqhl167";
+    sha256 = "09633h38w0z20cz0wcfp9z5kzv8v1zwcv0wqvgq3c8svqbrxp28k";
   };
   prePatch = ''
-    sed -i '312 d' Makefile
-    sed -i '316,446 d' Makefile # Removes RPM packaging
+    sed -i '305 d' Makefile
+    sed -i '309,439 d' Makefile # Removes RPM packaging
     sed -i '20 d' src/scripts/halvm-cabal.in
     sed -ie 's|ld |${binutils}/bin/ld |g' src/scripts/ldkernel.in
   '';

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, ghc, pkgconfig, glibcLocales, coreutils, gnugrep, gnused
-, jailbreak-cabal, hscolour, cpphs, nodejs
+, jailbreak-cabal, hscolour, cpphs, nodejs, lib
 }: let isCross = (ghc.cross or null) != null; in
 
 { pname
@@ -53,7 +53,7 @@
 , shellHook ? ""
 , coreSetup ? false # Use only core packages to build Setup.hs.
 , useCpphs ? false
-, hardeningDisable ? []
+, hardeningDisable ? lib.optional (ghc.isHaLVM or false) "all"
 } @ args:
 
 assert editedCabalFile != null -> revision != null;


### PR DESCRIPTION
###### Motivation for this change
Unikernels compiled with `halvm-ghc` should not have any hardening flags added by `gcc-wrapper`.

This also incorporates @conathan 's ubuntu fixes for `ldkernel`. 

cc @acw 
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

