### PR TITLE
mutt: 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -20,11 +20,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "mutt-${version}";
-  version = "1.8.0";
+  version = "1.8.1";
 
   src = fetchurl {
     url = "http://ftp.mutt.org/pub/mutt/${name}.tar.gz";
-    sha256 = "1axdcylyv0p194y6lj1jx127g5yc74zqzzxdc014cjw02bd1x125";
+    sha256 = "1b8dggq5x1b77a9i9250b3jhv2iddfzhr9rix1yfzckdms65mr8b";
   };
 
   patchPhase = optionalString (openssl != null) ''


### PR DESCRIPTION
From the announce email:

    This is a bug fix release.  In particular, it has fixes for setenv,
    sidebar_whitelist, some refresh issues, and a potential segfault.
    Details can be seen in the ChangeLog file.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).