### PR TITLE
lxqt: fix packaging errors

### DIFF
--- a/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
@@ -1,5 +1,5 @@
 {
-  stdenv, fetchFromGitHub, standardPatch,
+  stdenv, fetchFromGitHub, fetchurl, standardPatch,
   cmake, pkgconfig, lxqt-build-tools,
   qtbase, qttools, qtx11extras, qtsvg, libdbusmenu, kwindowsystem, solid,
   kguiaddons, liblxqt, libqtxdg, lxqt-common, lxqt-globalkeys, libsysstat,
@@ -47,6 +47,13 @@ stdenv.mkDerivation rec {
     alsaLib
     menu-cache
     lxmenu-data
+  ];
+
+  patches = [
+    (fetchurl {
+       url = https://github.com/lxde/lxqt-panel/commit/ec62109e0fa678875a9b10fc6f1975267432712d.patch;
+       sha256 = "1ywwk8gb6gbvs8z9gwgsnb13z1jvyvjij349nq7ij6iyhyld0jlr";
+    })
   ];
 
   cmakeFlags = [ "-DPULL_TRANSLATIONS=NO" ];

--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -71,7 +71,7 @@ let
       pkgs.lxmenu-data
       pkgs.menu-cache
       pkgs.openbox # default window manager
-      qt5.qtsvg # provides QT5 plugins for svg icons
+      pkgs.qt5.qtsvg # provides QT5 plugins for svg icons
     ];
 
     corePackages = [


### PR DESCRIPTION
the current lxqt expression doesn't work in 17.03 because of the missing 'pkgs'.

