### PR TITLE
plex: Don't overwrite primary database on restart

### DIFF
--- a/nixos/modules/services/misc/plex.nix
+++ b/nixos/modules/services/misc/plex.nix
@@ -93,7 +93,9 @@ in
         # why this is done.
         test -d "${cfg.dataDir}/.skeleton" || mkdir "${cfg.dataDir}/.skeleton"
         for db in "com.plexapp.plugins.library.db"; do
-            cp "${cfg.package}/usr/lib/plexmediaserver/Resources/base_$db" "${cfg.dataDir}/.skeleton/$db"
+            if [ ! -e  "${cfg.dataDir}/.skeleton/$db" ]; then
+              cp "${cfg.package}/usr/lib/plexmediaserver/Resources/base_$db" "${cfg.dataDir}/.skeleton/$db"
+            fi
             chmod u+w "${cfg.dataDir}/.skeleton/$db"
             chown ${cfg.user}:${cfg.group} "${cfg.dataDir}/.skeleton/$db"
         done
@@ -136,6 +138,7 @@ in
         Group = cfg.group;
         PermissionsStartOnly = "true";
         ExecStart = "/bin/sh -c ${cfg.package}/usr/lib/plexmediaserver/Plex\\ Media\\ Server";
+        KillSignal = "SIGQUIT";
         Restart = "on-failure";
       };
       environment = {


### PR DESCRIPTION
###### Motivation for this change

This change fixes two major issues:

  1. If you don't use SIGQUIT to stop Plex it will corrupt its own
     database :(

  2. Newer versions of Plex keep metadata in the
     `com.plexapp.plugins.library.db` database.  This is the file that
     we copy into `/var/lib/plex/.skeleton`.  If we copy the empty
     database on top of this one the user will lose their entire
     library metadata.  This change skips the copy if the file
     already exists.

Goes with #24138 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

