### PR TITLE
latte-dock: backport to 17.03

### DIFF
--- a/pkgs/applications/misc/latte-dock/default.nix
+++ b/pkgs/applications/misc/latte-dock/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, cmake, plasma-framework, fetchFromGitHub }:
+
+let version = "0.5.98"; in
+
+stdenv.mkDerivation {
+  name = "latte-dock-${version}";
+
+  src = fetchFromGitHub {
+    owner = "psifidotos";
+    repo = "Latte-Dock";
+    rev = version;
+    sha256 = "0z02ipbbv0dmcxs2g3dq5h62klhijni1i4ikq903hjg0j2cqg5xh";
+  };
+
+  buildInputs = [ plasma-framework ];
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Dock-style app launcher based on Plasma frameworks";
+    homepage = https://github.com/psifidotos/Latte-Dock;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.benley ];
+  };
+}

--- a/pkgs/applications/misc/latte-dock/default.nix
+++ b/pkgs/applications/misc/latte-dock/default.nix
@@ -1,26 +1,33 @@
-{ stdenv, lib, cmake, plasma-framework, fetchFromGitHub }:
+{ stdenv, lib, cmake, xorg, plasma-framework, fetchFromGitHub, kdeWrapper }:
 
-let version = "0.5.98"; in
+let version = "0.6.0";
 
-stdenv.mkDerivation {
-  name = "latte-dock-${version}";
+    unwrapped = stdenv.mkDerivation {
+      name = "latte-dock-${version}";
 
-  src = fetchFromGitHub {
-    owner = "psifidotos";
-    repo = "Latte-Dock";
-    rev = version;
-    sha256 = "0z02ipbbv0dmcxs2g3dq5h62klhijni1i4ikq903hjg0j2cqg5xh";
-  };
+      src = fetchFromGitHub {
+        owner = "psifidotos";
+        repo = "Latte-Dock";
+        rev = "v${version}";
+        sha256 = "1967hx4lavy96vvik8d5m2c6ycd2mlf9cmhrv40zr0784ni0ikyv";
+      };
 
-  buildInputs = [ plasma-framework ];
+      buildInputs = [ plasma-framework xorg.libpthreadstubs xorg.libXdmcp ];
 
-  nativeBuildInputs = [ cmake ];
+      nativeBuildInputs = [ cmake ];
 
-  meta = with stdenv.lib; {
-    description = "Dock-style app launcher based on Plasma frameworks";
-    homepage = https://github.com/psifidotos/Latte-Dock;
-    license = licenses.gpl2;
-    platforms = platforms.unix;
-    maintainers = [ maintainers.benley ];
-  };
+      enableParallelBuilding = true;
+
+      meta = with stdenv.lib; {
+        description = "Dock-style app launcher based on Plasma frameworks";
+        homepage = https://github.com/psifidotos/Latte-Dock;
+        license = licenses.gpl2;
+        platforms = platforms.unix;
+        maintainers = [ maintainers.benley ];
+      };
+    };
+
+in kdeWrapper {
+  inherit unwrapped;
+  targets = [ "bin/latte-dock" ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16788,6 +16788,8 @@ with pkgs;
 
   redshift-plasma-applet = libsForQt5.callPackage ../applications/misc/redshift-plasma-applet { };
 
+  latte-dock = libsForQt5.callPackage ../applications/misc/latte-dock { };
+
   orion = callPackage ../misc/themes/orion {};
 
   albatross = callPackage ../misc/themes/albatross { };


### PR DESCRIPTION
###### Motivation for this change

I want to use latte-dock on my laptop :-)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

