### PR TITLE
speedtest-cli: 1.0.3 > 1.0.4

### DIFF
--- a/pkgs/tools/networking/speedtest-cli/default.nix
+++ b/pkgs/tools/networking/speedtest-cli/default.nix
@@ -2,13 +2,13 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "speedtest-cli-${version}";
-  version = "1.0.3";
+  version = "1.0.4";
   
   src = fetchFromGitHub {
     owner = "sivel";
     repo = "speedtest-cli";
     rev = "v${version}";
-    sha256 = "160m1liinbpbmjxi3cvdw5x3k9sb4j51ly92lynylpamcqcv8m83";
+    sha256 = "13i7bvhvwv8h2lxnz9pfxq6jv915lb948d6xjiy5p7rqbki40ng2";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/networking/speedtest-cli/default.nix
+++ b/pkgs/tools/networking/speedtest-cli/default.nix
@@ -2,13 +2,13 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "speedtest-cli-${version}";
-  version = "1.0.2";
+  version = "1.0.3";
   
   src = fetchFromGitHub {
     owner = "sivel";
     repo = "speedtest-cli";
     rev = "v${version}";
-    sha256 = "1p7lavw95w3as9b2b55i61mwxdr1b6jj40yly91f9j26ywr5dpkg";
+    sha256 = "160m1liinbpbmjxi3cvdw5x3k9sb4j51ly92lynylpamcqcv8m83";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

