### PR TITLE
cjdns: 18 -> 19.1

### DIFF
--- a/pkgs/tools/networking/cjdns/default.nix
+++ b/pkgs/tools/networking/cjdns/default.nix
@@ -1,19 +1,13 @@
 { stdenv, fetchurl, fetchpatch, nodejs, which, python27, utillinux }:
 
-let version = "18"; in
+let version = "19.1"; in
 stdenv.mkDerivation {
   name = "cjdns-"+version;
 
   src = fetchurl {
     url = "https://github.com/cjdelisle/cjdns/archive/cjdns-v${version}.tar.gz";
-    sha256 = "1as7n730ppn93cpal7s6r6iq1qx46m0c45iwy8baypbpp42zxrap";
+    sha256 = "53c568a500215b055a9894178eb4477bd93a6e1abf751d0bc5ef2a03ea01a188";
   };
-
-  patches = [(fetchpatch {
-    name = "glibc-2.25.diff";
-    url = https://github.com/cjdelisle/cjdns/pull/1017.diff;
-    sha256 = "1k05d1w04lngcki56b6brkwg9xakzsbr5ibkcba8112v6jdzw51f";
-  })];
 
   buildInputs = [ which python27 nodejs ] ++
     # for flock


### PR DESCRIPTION
###### Motivation for this change
v18 is outdated as of 21.2.2017. Also https://github.com/cjdelisle/cjdns/pull/1017 is already merged so there's no need for additional patching.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @ehmry 
