### PR TITLE
dhcpcd service: clear exit code of exitHook

### DIFF
--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -73,6 +73,9 @@ let
           # applies to openntpd.
           ${config.systemd.package}/bin/systemctl try-restart ntpd.service
           ${config.systemd.package}/bin/systemctl try-restart openntpd.service
+
+          # exit code of last command is propagated, so we have to clear it
+          true
       fi
 
       ${cfg.runHook}

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -71,11 +71,7 @@ let
           # anything ever again ("couldn't resolve ..., giving up on
           # it"), so we silently lose time synchronisation. This also
           # applies to openntpd.
-          ${config.systemd.package}/bin/systemctl try-restart ntpd.service
-          ${config.systemd.package}/bin/systemctl try-restart openntpd.service
-
-          # exit code of last command is propagated, so we have to clear it
-          true
+          ${config.systemd.package}/bin/systemctl try-reload-or-restart ntpd.service openntpd.service || true
       fi
 
       ${cfg.runHook}


### PR DESCRIPTION
###### Motivation for this change
The exit code of the dhcpcd exitHook is not zero if openntp is not installed.
This exit code needs to be reset to avoid following error log:

    $ journalctl -n 1 -u dhcpcd
    Apr 14 22:41:26 nixos dhcpcd[836]: script_runreason: /nix/store/b4vb2d9gzcc45c63j945v5zh67q5rg5v-dhcpcd-6.11.5/libexec/dhcpcd-run-hooks: WEXITSTATUS 5

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

