### PR TITLE
ghq: init at 0.7.4

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -30,6 +30,8 @@ rec {
 
   diff-so-fancy = callPackage ./diff-so-fancy { };
 
+  ghq = callPackage ./ghq { };
+
   git = appendToName "minimal" gitBase;
 
   # The full-featured Git.

--- a/pkgs/applications/version-management/git-and-tools/ghq/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/ghq/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "ghq-${version}";
+  version = "0.7.4";
+
+  goPackagePath = "github.com/motemen/ghq";
+
+  src = fetchFromGitHub {
+    owner = "motemen";
+    repo = "ghq";
+    rev = "v${version}";
+    sha256 = "0x2agr7why8mcjhq2j8kh8d0gbwx2333zgf1ribc9fn14ryas1j2";
+  };
+
+  goDeps = ./deps.nix;
+
+  buildFlagsArray = ''
+    -ldflags=
+      -X=main.Version=${version}
+  '';
+
+  postInstall = ''
+    install -m 444 -D ${src}/zsh/_ghq $bin/share/zsh/site-functions/_ghq
+  '';
+
+  meta = {
+    description = "Remote repository management made easy";
+    homepage = https://github.com/motemen/ghq;
+    maintainers = with stdenv.lib.maintainers; [ sigma ];
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/applications/version-management/git-and-tools/ghq/deps.nix
+++ b/pkgs/applications/version-management/git-and-tools/ghq/deps.nix
@@ -1,0 +1,38 @@
+[
+  {
+    goPackagePath = "github.com/codegangsta/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/codegangsta/cli";
+      rev = "0bdeddeeb0f650497d603c4ad7b20cfe685682f6";
+      sha256 = "1ny63c7bfwfrsp7vfkvb4i0xhq4v7yxqnwxa52y4xlfxs4r6v6fg";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev = "b8bc1bf767474819792c23f32d8286a45736f1c6";
+      sha256 = "13ry4lylalkh4g2vny9cxwvryslzyzwp9r92z0b10idhdq3wad1q";
+    };
+  }
+  {
+    goPackagePath = "github.com/motemen/go-colorine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/motemen/go-colorine";
+      rev = "49ff36b8fa42db28092361cd20dcefd0b03b1472";
+      sha256 = "1rfi5gggf2sxb52whgxfl37p22r2xp27rndixbiicw6swllmml9l";
+    };
+  }
+  {
+    goPackagePath = "github.com/daviddengcn/go-colortext";
+    fetch = {
+      type = "git";
+      url = "https://github.com/daviddengcn/go-colortext";
+      rev = "805cee6e0d43c72ba1d4e3275965ff41e0da068a";
+      sha256 = "0z0ggqnprqchnd8zyrz99w53kr4sgv372lyx12z5nsh9q342pmyf";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13836,6 +13836,8 @@ with pkgs;
 
   getxbook = callPackage ../applications/misc/getxbook {};
 
+  ghq = gitAndTools.ghq;
+
   gimp_2_8 = callPackage ../applications/graphics/gimp/2.8.nix {
     inherit (gnome2) libart_lgpl;
     webkit = null;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

