### PR TITLE
intel-gpu-tools: 1.17 -> 1.18

### DIFF
--- a/pkgs/development/tools/misc/intel-gpu-tools/default.nix
+++ b/pkgs/development/tools/misc/intel-gpu-tools/default.nix
@@ -1,21 +1,22 @@
 { stdenv, fetchurl, pkgconfig, libdrm, libpciaccess, cairo, dri2proto, udev
 , libX11, libXext, libXv, libXrandr, glib, bison, libunwind, python3, kmod
-, procps }:
+, procps, autoconf, automake }:
 
 stdenv.mkDerivation rec {
-  name = "intel-gpu-tools-1.17";
+  name = "intel-gpu-tools-1.18";
 
   src = fetchurl {
     url = "http://xorg.freedesktop.org/archive/individual/app/${name}.tar.bz2";
-    sha256 = "06pvmbsbff4bsi67n6x3jjngzy2llf8bplc75447ra1fwphc9jx6";
+    sha256 = "1vp4czxp8xa6qk4pg3mrxhc2yadw2rv6p8r8247mkpcbb8dzjxyz";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autoconf automake ];
   buildInputs = [ libdrm libpciaccess cairo dri2proto udev libX11 kmod
     libXext libXv libXrandr glib bison libunwind python3 procps ];
 
   preBuild = ''
     patchShebangs debugger/system_routine/pre_cpp.py
+    substituteInPlace tools/Makefile.am --replace '$(CAIRO_CFLAGS)' '$(CAIRO_CFLAGS) $(GLIB_CFLAGS)'
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Version 1.17 fails to build with the current libdrm
because of a changed struct (`drm_event_vblank`).

I had to patch `tools/Makefile.am` to use `GLIB_CFLAGS`;
otherwise, the build failed to find `glib.h`.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

