### PR TITLE
kubernetes: fix interpolation error and move services to own target

### DIFF
--- a/nixos/modules/services/cluster/kubernetes.nix
+++ b/nixos/modules/services/cluster/kubernetes.nix
@@ -45,7 +45,7 @@ let
   cniConfig = pkgs.buildEnv {
     name = "kubernetes-cni-config";
     paths = imap (i: entry:
-      pkgs.writeTextDir "${10+i}-${entry.type}.conf" (builtins.toJSON entry)
+      pkgs.writeTextDir "${toString (10+i)}-${entry.type}.conf" (builtins.toJSON entry)
     ) cfg.kubelet.cni.config;
   };
 

--- a/nixos/modules/services/cluster/kubernetes.nix
+++ b/nixos/modules/services/cluster/kubernetes.nix
@@ -597,7 +597,7 @@ in {
     (mkIf cfg.kubelet.enable {
       systemd.services.kubelet = {
         description = "Kubernetes Kubelet Service";
-        wantedBy = [ "multi-user.target" ];
+        wantedBy = [ "kubernetes.target" ];
         after = [ "network.target" "docker.service" "kube-apiserver.service" ];
         path = with pkgs; [ gitMinimal openssh docker utillinux iproute ethtool thin-provisioning-tools iptables ];
         preStart = ''
@@ -606,6 +606,7 @@ in {
           ${concatMapStringsSep "\n" (p: "ln -fs ${p.plugins}/* /opt/cni/bin") cfg.kubelet.cni.packages}
         '';
         serviceConfig = {
+          Slice = "kubernetes.slice";
           ExecStart = ''${cfg.package}/bin/kubelet \
             --pod-manifest-path=${manifests} \
             --kubeconfig=${kubeconfig} \
@@ -655,9 +656,10 @@ in {
     (mkIf cfg.apiserver.enable {
       systemd.services.kube-apiserver = {
         description = "Kubernetes Kubelet Service";
-        wantedBy = [ "multi-user.target" ];
+        wantedBy = [ "kubernetes.target" ];
         after = [ "network.target" "docker.service" ];
         serviceConfig = {
+          Slice = "kubernetes.slice";
           ExecStart = ''${cfg.package}/bin/kube-apiserver \
             --etcd-servers=${concatStringsSep "," cfg.etcd.servers} \
             ${optionalString (cfg.etcd.caFile != null)
@@ -713,9 +715,10 @@ in {
     (mkIf cfg.scheduler.enable {
       systemd.services.kube-scheduler = {
         description = "Kubernetes Scheduler Service";
-        wantedBy = [ "multi-user.target" ];
+        wantedBy = [ "kubernetes.target" ];
         after = [ "kube-apiserver.service" ];
         serviceConfig = {
+          Slice = "kubernetes.slice";
           ExecStart = ''${cfg.package}/bin/kube-scheduler \
             --address=${cfg.scheduler.address} \
             --port=${toString cfg.scheduler.port} \
@@ -735,11 +738,12 @@ in {
     (mkIf cfg.controllerManager.enable {
       systemd.services.kube-controller-manager = {
         description = "Kubernetes Controller Manager Service";
-        wantedBy = [ "multi-user.target" ];
+        wantedBy = [ "kubernetes.target" ];
         after = [ "kube-apiserver.service" ];
         serviceConfig = {
           RestartSec = "30s";
           Restart = "on-failure";
+          Slice = "kubernetes.slice";
           ExecStart = ''${cfg.package}/bin/kube-controller-manager \
             --address=${cfg.controllerManager.address} \
             --port=${toString cfg.controllerManager.port} \
@@ -767,10 +771,11 @@ in {
     (mkIf cfg.proxy.enable {
       systemd.services.kube-proxy = {
         description = "Kubernetes Proxy Service";
-        wantedBy = [ "multi-user.target" ];
+        wantedBy = [ "kubernetes.target" ];
         after = [ "kube-apiserver.service" ];
         path = [pkgs.iptables];
         serviceConfig = {
+          Slice = "kubernetes.slice";
           ExecStart = ''${cfg.package}/bin/kube-proxy \
             --kubeconfig=${kubeconfig} \
             --bind-address=${cfg.proxy.address} \
@@ -786,9 +791,10 @@ in {
     (mkIf cfg.dns.enable {
       systemd.services.kube-dns = {
         description = "Kubernetes Dns Service";
-        wantedBy = [ "multi-user.target" ];
+        wantedBy = [ "kubernetes.target" ];
         after = [ "kube-apiserver.service" ];
         serviceConfig = {
+          Slice = "kubernetes.slice";
           ExecStart = ''${cfg.package}/bin/kube-dns \
             --kubecfg-file=${kubeconfig} \
             --dns-port=${toString cfg.dns.port} \
@@ -836,6 +842,11 @@ in {
         cfg.proxy.enable ||
         cfg.dns.enable
     ) {
+      systemd.targets.kubernetes = {
+        description = "Kubernetes";
+        wantedBy = [ "multi-user.target" ];
+      };
+
       systemd.tmpfiles.rules = [
         "d /opt/cni/bin 0755 root root -"
         "d /var/run/kubernetes 0755 kubernetes kubernetes -"


### PR DESCRIPTION
###### Motivation for this change

The first commit is a straight up fix for a bug where enabling the cni network
plugin will make evaluation fail.

The second part shifts the kubernetes services into their own slice and makes
the launch happen via a dedicated kubernetes target.

The reason for moving into its own slice and target is that it makes starting
and stopping far easier plus it allows for resource allocations.

Cc: @offlinehacker


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
