### PR TITLE
buildRustPackage: cargoBuildFlags + standarized hooks

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -7,6 +7,7 @@
 , buildInputs ? []
 , cargoUpdateHook ? ""
 , cargoDepsHook ? ""
+, cargoBuildFlags ? []
 , ... } @ args:
 
 let
@@ -92,9 +93,9 @@ in stdenv.mkDerivation (args // {
     )
   '' + (args.prePatch or "");
 
-  buildPhase = args.buildPhase or ''
-    echo "Running cargo build --release"
-    cargo build --release
+  buildPhase = with builtins; args.buildPhase or ''
+    echo "Running cargo build --release ${concatStringsSep " " cargoBuildFlags}"
+    cargo build --release ${concatStringsSep " " cargoBuildFlags}
   '';
 
   checkPhase = args.checkPhase or ''

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -116,9 +116,7 @@ in stdenv.mkDerivation (args // {
   installPhase = args.installPhase or ''
     runHook preInstall
     mkdir -p $out/bin
-    for f in $(find target/release -maxdepth 1 -type f); do
-      cp $f $out/bin
-    done;
+    find target/release -maxdepth 1 -executable -exec cp "{}" $out/bin \;
     runHook postInstall
   '';
 })

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -27,7 +27,11 @@ in stdenv.mkDerivation (args // {
 
   buildInputs = [ git rust.cargo rust.rustc ] ++ buildInputs;
 
-  configurePhase = args.configurePhase or "true";
+  configurePhase = args.configurePhase or ''
+    runHook preConfigure
+    # noop
+    runHook postConfigure
+  '';
 
   postUnpack = ''
     eval "$cargoDepsHook"
@@ -94,21 +98,27 @@ in stdenv.mkDerivation (args // {
   '' + (args.prePatch or "");
 
   buildPhase = with builtins; args.buildPhase or ''
+    runHook preBuild
     echo "Running cargo build --release ${concatStringsSep " " cargoBuildFlags}"
     cargo build --release ${concatStringsSep " " cargoBuildFlags}
+    runHook postBuild
   '';
 
   checkPhase = args.checkPhase or ''
+    runHook preCheck
     echo "Running cargo test"
     cargo test
+    runHook postCheck
   '';
 
   doCheck = args.doCheck or true;
 
   installPhase = args.installPhase or ''
+    runHook preInstall
     mkdir -p $out/bin
     for f in $(find target/release -maxdepth 1 -type f); do
       cp $f $out/bin
     done;
+    runHook postInstall
   '';
 })


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

