### PR TITLE
rustup: init at 1.2.0

### DIFF
--- a/doc/languages-frameworks/rust.md
+++ b/doc/languages-frameworks/rust.md
@@ -17,8 +17,8 @@ into the `environment.systemPackages` or bring them into scope with
 `nix-shell -p rustStable.rustc -p rustStable.cargo`.
 
 There are also `rustBeta` and `rustNightly` package sets available.
-These are not updated very regulary. For daily builds see
-[Using the Rust nightlies overlay](#using-the-rust-nightlies-overlay)
+These are not updated very regulary. For daily builds use either rustup from
+nixpkgs or use the [Rust nightlies overlay](#using-the-rust-nightlies-overlay).
 
 ## Packaging Rust applications
 

--- a/pkgs/development/tools/rust/rustup/0001-use-hardcoded-dynamic-linker.patch
+++ b/pkgs/development/tools/rust/rustup/0001-use-hardcoded-dynamic-linker.patch
@@ -1,0 +1,75 @@
+From 36c053f37670c6003f9e8dc001741f7c49e9526a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Sat, 15 Apr 2017 20:42:10 +0200
+Subject: [PATCH] use hardcoded dynamic-linker
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ src/rustup-cli/common.rs |  3 ++-
+ src/rustup/toolchain.rs  | 22 ++++++++++++++++++++--
+ 2 files changed, 22 insertions(+), 3 deletions(-)
+
+diff --git a/src/rustup-cli/common.rs b/src/rustup-cli/common.rs
+index 1abf345..21096e7 100644
+--- a/src/rustup-cli/common.rs
++++ b/src/rustup-cli/common.rs
+@@ -220,7 +220,8 @@ pub fn rustc_version(toolchain: &Toolchain) -> String {
+     if toolchain.exists() {
+         let rustc_path = toolchain.binary_file("rustc");
+         if utils::is_file(&rustc_path) {
+-            let mut cmd = Command::new(&rustc_path);
++            let mut cmd = Command::new("@dynamicLinker@");
++            cmd.arg(&rustc_path);
+             cmd.arg("--version");
+             toolchain.set_ldpath(&mut cmd);
+ 
+diff --git a/src/rustup/toolchain.rs b/src/rustup/toolchain.rs
+index dc29c32..212a4ab 100644
+--- a/src/rustup/toolchain.rs
++++ b/src/rustup/toolchain.rs
+@@ -315,7 +315,7 @@ impl<'a> Toolchain<'a> {
+             }
+             Path::new(&binary)
+         };
+-        let mut cmd = Command::new(&path);
++        let mut cmd = wrap_elf_interpreter(&path);
+         self.set_env(&mut cmd);
+         Ok(cmd)
+     }
+@@ -363,7 +363,7 @@ impl<'a> Toolchain<'a> {
+         } else {
+             src_file
+         };
+-        let mut cmd = Command::new(exe_path);
++        let mut cmd = wrap_elf_interpreter(exe_path);
+         self.set_env(&mut cmd);
+         cmd.env("RUSTUP_TOOLCHAIN", &primary_toolchain.name);
+         Ok(cmd)
+@@ -648,3 +648,21 @@ impl<'a> Toolchain<'a> {
+         path
+     }
+ }
++
++fn wrap_elf_interpreter<S: AsRef<OsStr>>(p: S) -> Command {
++    use std::fs::File;
++    use std::io::Read;
++    let path = Path::new(&p);
++    let is_elf = File::open(path).map(|mut f| {
++        let mut buf = [0; 4];
++        let _ = f.read(&mut buf);
++        buf == b"\x7fELF"[..]
++    }).unwrap_or(false);
++    if is_elf {
++        let mut cmd = Command::new("@dynamicLinker@");
++        cmd.arg(&path);
++        cmd
++    } else {
++        Command::new(&path)
++    }
++}
+-- 
+2.12.2
+

--- a/pkgs/development/tools/rust/rustup/default.nix
+++ b/pkgs/development/tools/rust/rustup/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, lib, runCommand
+, fetchFromGitHub, rustPlatform
+, pkgconfig, curl, Security }:
+
+rustPlatform.buildRustPackage rec {
+  name = "rustup-${version}";
+  version = "1.2.0";
+
+  depsSha256 = "06bfz5kyj3k0yxv55dq0s1arx34sy1jjfrpgd83rf99026vcm5x2";
+
+  src = fetchFromGitHub {
+    owner = "rust-lang-nursery";
+    repo = "rustup.rs";
+    rev = version;
+    sha256 = "0qwl27wh7j03h511bd8fq5fif5xcmkiyy9rm3hri7czjqr01mw0v";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [
+    curl
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ Security ];
+
+  cargoBuildFlags = [ "--features no-self-update" ];
+
+  patches = lib.optionals stdenv.isLinux [
+    (runCommand "0001-use-hardcoded-dynamic-linker.patch" { CC=stdenv.cc; } ''
+       export dynamicLinker=$(cat $CC/nix-support/dynamic-linker)
+       substituteAll ${./0001-use-hardcoded-dynamic-linker.patch} $out
+    '')
+  ];
+
+  postInstall = ''
+    pushd $out/bin
+    mv rustup-init rustup
+    for link in cargo rustc rustdoc rust-gdb rust-lldb; do
+      ln -s rustup $link
+    done
+    popd
+
+    # tries to create .rustup
+    export HOME=$(mktemp -d)
+    mkdir -p "$out/share/"{bash-completion/completions,fish/completions,zsh/site-functions}
+    $out/bin/rustup completions bash > "$out/share/bash-completion/completions/rustup"
+    $out/bin/rustup completions fish > "$out/share/fish/completions/rustup.fish"
+    $out/bin/rustup completions zsh >  "$out/share/zsh/site-functions/_rustup"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The Rust toolchain installer";
+    homepage = https://www.rustup.rs/;
+    license = licenses.mit;
+    maintainer = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -771,7 +771,7 @@ with pkgs;
   cfdyndns = callPackage ../applications/networking/dyndns/cfdyndns { };
 
   ckbcomp = callPackage ../tools/X11/ckbcomp { };
-  
+
   clac = callPackage ../tools/misc/clac {};
 
   clasp = callPackage ../tools/misc/clasp { };
@@ -5610,6 +5610,9 @@ with pkgs;
   rustracer = callPackage ../development/tools/rust/racer { };
   rustracerd = callPackage ../development/tools/rust/racerd { };
   rust-bindgen = callPackage ../development/tools/rust/bindgen { };
+  rustup = callPackage ../development/tools/rust/rustup {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   sbclBootstrap = callPackage ../development/compilers/sbcl/bootstrap.nix {};
   sbcl = callPackage ../development/compilers/sbcl {};


### PR DESCRIPTION
###### Motivation for this change

use pre-compiled cross compiler + access to nightlies

depends on #24926 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

