### PR TITLE
cargo-edit: init at 0.1.6

### DIFF
--- a/pkgs/tools/package-management/cargo-edit/default.nix
+++ b/pkgs/tools/package-management/cargo-edit/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper, zlib, openssl }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "cargo-edit-${version}";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner = "killercup";
+    repo = "cargo-edit";
+    rev = "v${version}";
+    sha256 = "16wvix2zkpzl1hhlsvd6mkps8fw5k4n2dvjk9m10gg27pixmiync";
+  };
+
+  buildInputs = [ zlib openssl ];
+
+  depsSha256 = "1v7ir56j6biximnnhyvadd98azcj3i5hc8aky0am2nf0swq0jimq";
+
+  meta = with stdenv.lib; {
+    description = "A utility for managing cargo dependencies from the command line";
+    homepage = https://github.com/killercup/cargo-edit;
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ jb55 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5582,6 +5582,8 @@ with pkgs;
   cargo = rust.cargo;
   rustc = rust.rustc;
 
+  cargo-edit = callPackage ../tools/package-management/cargo-edit { };
+
   rustPlatform = recurseIntoAttrs (makeRustPlatform rust);
 
   makeRustPlatform = rust: lib.fix (self:


### PR DESCRIPTION
###### Motivation for this change

cargo-edit is a tool that adds `cargo add` which is similar to `npm install --save`

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

