### PR TITLE
git-open: init at 1.3.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -238,6 +238,7 @@
   jgillich = "Jakob Gillich <jakob@gillich.me>";
   jhhuh = "Ji-Haeng Huh <jhhuh.note@gmail.com>";
   jirkamarsik = "Jirka Marsik <jiri.marsik89@gmail.com>";
+  jlesquembre = "José Luis Lafuente <jl@lafuente.me>";
   joachifm = "Joachim Fasting <joachifm@fastmail.fm>";
   joamaki = "Jussi Maki <joamaki@gmail.com>";
   joelmo = "Joel Moberg <joel.moberg@gmail.com>";

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -70,6 +70,8 @@ rec {
 
   git-octopus = callPackage ./git-octopus { };
 
+  git-open = callPackage ./git-open { };
+
   git-radar = callPackage ./git-radar { };
 
   git-remote-hg = callPackage ./git-remote-hg { };

--- a/pkgs/applications/version-management/git-and-tools/git-open/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-open/default.nix
@@ -1,0 +1,32 @@
+{stdenv, git, xdg_utils, gnugrep, fetchFromGitHub, makeWrapper}:
+
+stdenv.mkDerivation rec {
+  name = "git-open-${version}";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "paulirish";
+    repo = "git-open";
+    rev = "v${version}";
+    sha256 = "005am4phf7j4ybc9k1hqsxjb7gv2i56a3axrza866pwwx1ayrhpq";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  buildPhase = null;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp git-open $out/bin
+    wrapProgram $out/bin/git-open \
+      --prefix PATH : "${stdenv.lib.makeBinPath [ git xdg_utils gnugrep ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/paulirish/git-open;
+    description = "Open the GitHub page or website for a repository in your browser";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.jlesquembre ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
Add [git open](https://github.com/paulirish/git-open)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

