### PR TITLE
dale: init at 20170416

### DIFF
--- a/pkgs/development/compilers/dale/default.nix
+++ b/pkgs/development/compilers/dale/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, cmake, libffi, llvm_35, perl }:
+
+let version = "20170416";
+    doCheck = false;
+in stdenv.mkDerivation {
+  name = "dale-${version}";
+
+  src = fetchFromGitHub {
+    owner = "tomhrr";
+    repo = "dale";
+    rev = "ecc5ea91efef8a263c7dddd6925983df5b5258b2";
+    sha256 = "0naly7jsfriiqf68q210ay9ppcvidbwwcxksy5zwy1m17aq5kxaw";
+  };
+
+  buildInputs = [ cmake libffi llvm_35 ] ++
+                stdenv.lib.optional doCheck perl;
+
+  inherit doCheck;
+
+  checkTarget = "tests";
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Lisp-flavoured C";
+    longDescription = ''
+      Dale is a system (no GC) programming language that uses
+      S-expressions for syntax and supports syntactic macros.
+    '';
+    homepage = "https://github.com/tomhrr/dale";
+    license = licenses.mit;
+    maintainers = with maintainers; [ amiloradovsky ];
+    platforms = platforms.linux;  # fails on Darwin, linking vs. FFI
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -826,6 +826,8 @@ with pkgs;
 
   daemontools = callPackage ../tools/admin/daemontools { };
 
+  dale = callPackage ../development/compilers/dale { };
+
   dante = callPackage ../servers/dante { };
 
   datamash = callPackage ../tools/misc/datamash { };


### PR DESCRIPTION
Lisp-flavoured C. Dale is a system (no GC) programming language
that uses S-expressions for syntax and supports syntactic macros.

###### Motivation for this change

To play with an interesting experimental, but having the potential
to be quite useful, programming language.

https://github.com/tomhrr/dale

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

