### PR TITLE
makeWrapper: Fail loudly when misused

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -1,3 +1,12 @@
+# Assert that FILE exists and is executable
+#
+# assertExecutable FILE
+assertExecutable() {
+    local file="$1"
+    [[ -f "${file}" && -x "${file}" ]] || \
+        die "Cannot wrap ${file} because it is not an executable file"
+}
+
 # construct an executable file that wraps the actual executable
 # makeWrapper EXECUTABLE ARGS
 
@@ -23,6 +32,8 @@ makeWrapper() {
     local wrapper="$2"
     local params varName value command separator n fileNames
     local argv0 flagsBefore flags
+
+    assertExecutable "${file}"
 
     mkdir -p "$(dirname "$wrapper")"
 
@@ -131,6 +142,9 @@ filterExisting() {
 wrapProgram() {
     local prog="$1"
     local hidden
+
+    assertExecutable "${prog}"
+
     hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
     while [ -e "$hidden" ]; do
       hidden="${hidden}_"


### PR DESCRIPTION
###### Motivation for this change

On Wednesday, I tried to run `hexl-mode` in emacs, and four days later, here I am.

This pull request does two things to `makeWrapper` and `wrapProgram`:
  - First, `makeWrapper` checks that the file it is trying to wrap is a normal, executable file.  If not, it dies with a (sometimes) useful backtrace.  This prevents us from trying to wrap insane things like directories and `.pyc` files.
  - Secondly, `makeWrapper` dies with a backtrace on unsupported arguments.

Additionally, there are some follow-on commits that resolve misuses of `makeWrapper` that I ran into while getting emacs to build.

This pull request resolves #24445 and #3277.

Open question: This pull request will convert a lot of currently-silent breakage into build failures.  Will `nox-review wip` be sufficient to shake all of these issues out?

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

