### PR TITLE
htmlmin: init at 0.1.10

### DIFF
--- a/pkgs/development/python-modules/htmlmin.nix
+++ b/pkgs/development/python-modules/htmlmin.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+  pname = "htmlmin";
+  version = "0.1.10";
+  name = "${pname}-${version}";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ca5c5dfbb0fa58562e5cbc8dc026047f6cb431d4333504b11853853be448aa63";
+  };
+
+  # Tests run fine in a normal source checkout, but not when being built by nix.
+  doCheck = false;
+
+  meta = {
+    description = "A configurable HTML Minifier with safety features";
+    homepage = https://pypi.python.org/pypi/htmlmin;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [stdenv.lib.maintainers.ahmedtd];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7748,6 +7748,9 @@ in {
     };
   });
 
+
+  htmlmin = callPackage ../development/python-modules/htmlmin.nix {};
+
   httpauth = buildPythonPackage rec {
     version = "0.3";
     name = "httpauth-${version}";


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested ability to import and use package in python interpreter
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

