### PR TITLE
csscompressor: init at 0.9.4

### DIFF
--- a/pkgs/development/python-modules/csscompressor.nix
+++ b/pkgs/development/python-modules/csscompressor.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+  pname = "csscompressor";
+  version = "0.9.4";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0e12f125b88379d7b680636d94a3c8fa14bed1de2358f7f9a9e6749e222cff3b";
+  };
+
+  doCheck = false; # No tests
+
+  meta = {
+    description = "A python port of YUI CSS Compressor";
+    homepage = https://pypi.python.org/pypi/csscompressor;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [stdenv.lib.maintainers.ahmedtd];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2524,6 +2524,8 @@ in {
     doCheck = false; # lazy packager
   };
 
+  csscompressor = callPackage ../development/python-modules/csscompressor.nix {};
+
   csvkit = buildPythonPackage rec {
     name = "csvkit-${version}";
     version = "0.9.1";


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested ability to import and use package in python interpreter
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

