### PR TITLE
docker: improve reproducibility of layers

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -209,7 +209,7 @@ rec {
 
       postMount = ''
         echo "Packing raw image..."
-        tar -C mnt --mtime=0 -cf $out .
+        tar -C mnt --mtime="@$SOURCE_DATE_EPOCH" -cf $out .
       '';
     };
 
@@ -247,7 +247,7 @@ rec {
         echo "Adding contents..."
         for item in $contents; do
           echo "Adding $item"
-          rsync -ak $item/ layer/
+          rsync -ak --chown=0:0 $item/ layer/
         done
       else
         echo "No contents to add to layer."
@@ -260,7 +260,7 @@ rec {
       # Tar up the layer and throw it into 'layer.tar'.
       echo "Packing layer..."
       mkdir $out
-      tar -C layer --mtime=0 -cf $out/layer.tar .
+      tar -C layer --mtime="@$SOURCE_DATE_EPOCH" -cf $out/layer.tar .
 
       # Compute a checksum of the tarball.
       echo "Computing layer checksum..."
@@ -310,7 +310,7 @@ rec {
         echo "Adding contents..."
         for item in ${toString contents}; do
           echo "Adding $item..."
-          rsync -ak $item/ layer/
+          rsync -ak --chown=0:0 $item/ layer/
         done
       '';
 
@@ -340,7 +340,7 @@ rec {
 
         echo "Packing layer..."
         mkdir $out
-        tar -C layer --mtime=0 -cf $out/layer.tar .
+        tar -C layer --mtime="@$SOURCE_DATE_EPOCH" -cf $out/layer.tar .
 
         # Compute the tar checksum and add it to the output json.
         echo "Computing checksum..."
@@ -467,7 +467,8 @@ rec {
         comm <(sort -n baseFiles|uniq) \
              <(sort -n layerFiles|uniq|grep -v ${layer}) -1 -3 > newFiles
         # Append the new files to the layer.
-        tar -rpf temp/layer.tar --mtime=0 --no-recursion --files-from newFiles
+        tar -rpf temp/layer.tar --mtime="@$SOURCE_DATE_EPOCH" \
+          --owner=0 --group=0 --no-recursion --files-from newFiles
 
         echo "Adding meta..."
 
@@ -496,7 +497,7 @@ rec {
         chmod -R a-w image
 
         echo "Cooking the image..."
-        tar -C image --mtime=0 -c . | pigz -nT > $out
+        tar -C image --mtime="@$SOURCE_DATE_EPOCH" -c . | pigz -nT > $out
 
         echo "Finished."
       '';


### PR DESCRIPTION
This patch fixes file modification times to the UNIX epoch, and
ensures that files originating from the store are owned by root.  Both
changes improve reproducibility, and the latter allows proper building
on a host where the store is owned by a non-root user.

###### Motivation for this change
I was building Docker images on a Debian box where the Nix store is owned by my user.  I noticed that many files had my UID:GID instead of root:root.

While playing with the fix, I also noticed that the mtimes were not reliable within the generated tarballs.  Once I fixed the timestamps, I started getting reproducible builds all the way the Docker image IDs.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

