### PR TITLE
desmume: fix mesa+osmesa

### DIFF
--- a/pkgs/misc/emulators/desmume/default.nix
+++ b/pkgs/misc/emulators/desmume/default.nix
@@ -5,7 +5,7 @@
 , agg, alsaLib, soundtouch, openal
 , desktop_file_utils
 , gtk2, gtkglext, libglade, pangox_compat
-, mesa, mesa_glu, libpcap, SDL, zziplib }:
+, mesa_glu, libpcap, SDL, zziplib }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -21,10 +21,9 @@ stdenv.mkDerivation rec {
   buildInputs =
   [ pkgconfig libtool intltool libXmu lua agg alsaLib soundtouch
     openal desktop_file_utils gtk2 gtkglext libglade pangox_compat
-    mesa mesa_glu libpcap SDL zziplib ];
+    mesa_glu libpcap SDL zziplib ];
 
   configureFlags = [
-    "--disable-osmesa" # Failing on compile step
     "--disable-glade"  # Failing on compile step
     "--enable-openal"
     "--enable-glx"
@@ -46,4 +45,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
-# TODO: investigate osmesa and glade
+# TODO: investigate glade


### PR DESCRIPTION
It builds fine, but some better testing should be done before merging.  @AndersonTorres: can you verify it works OK?

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change (none exist)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

