### PR TITLE
Thunderbird: Fix default mail client detection

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -6,7 +6,7 @@
 , cairo, gstreamer, gst-plugins-base, icu, libpng, jemalloc
 , autoconf213, which, m4
 , writeScript, xidel, common-updater-scripts, coreutils, gnused, gnugrep, curl
-, enableGTK3 ? false, gtk3, wrapGAppsHook
+, enableGTK3 ? false, gtk3, wrapGAppsHook, makeWrapper
 , enableCalendar ? true
 , debugBuild ? false
 , # If you want the resulting program to call itself "Thunderbird" instead
@@ -18,7 +18,9 @@
 , makeDesktopItem
 }:
 
-stdenv.mkDerivation rec {
+let
+  wrapperTool = if enableGTK3 then wrapGAppsHook else makeWrapper;
+in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
   version = "52.0";
 
@@ -47,8 +49,8 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optional enableGTK3 gtk3;
 
-  # from firefox + m4
-  nativeBuildInputs = [ m4 autoconf213 which gnused pkgconfig perl python ] ++ lib.optional enableGTK3 wrapGAppsHook;
+  # from firefox + m4 + wrapperTool
+  nativeBuildInputs = [ m4 autoconf213 which gnused pkgconfig perl python wrapperTool ];
 
   configureFlags =
     [ # from firefox, but without sound libraries (alsa, libvpx, pulseaudio)
@@ -101,20 +103,42 @@ stdenv.mkDerivation rec {
       paxmark m ../objdir/dist/bin/xpcshell
     '';
 
+  dontWrapGApps = true; # we do it ourselves
   postInstall =
     ''
       # For grsecurity kernels
       paxmark m $out/lib/thunderbird-[0-9]*/thunderbird
 
-      # Needed to find Mozilla runtime
-      gappsWrapperArgs+=(--argv0 "$out/bin/.thunderbird-wrapped")
-
       # TODO: Move to a dev output?
       rm -rf $out/include $out/lib/thunderbird-devel-* $out/share/idl
 
+      # $binary is a symlink to $target.
+      # We wrap $target by replacing the $binary symlink.
+      local target="$out/lib/thunderbird-${version}/thunderbird"
+      local binary="$out/bin/thunderbird"
+
+      # Wrap correctly, this is needed to
+      # 1) find Mozilla runtime, because argv0 must be the real thing,
+      #    or a symlink thereto. It cannot be the wrapper itself
+      # 2) detect itself as the default mailreader across builds
+      gappsWrapperArgs+=(
+        --argv0 "$target"
+        --set MOZ_APP_LAUNCHER thunderbird
+      )
+      ${
+        # We wrap manually because wrapGAppsHook does not detect the symlink
+        # To mimic wrapGAppsHook, we run it with dontWrapGApps, so
+        # gappsWrapperArgs gets defined correctly
+        lib.optionalString enableGTK3 "wrapGAppsHook"
+      }
+
+      # "$binary" is a symlink, replace it by the wrapper
+      rm "$binary"
+      makeWrapper "$target" "$binary" "''${gappsWrapperArgs[@]}"
+
       ${ let desktopItem = makeDesktopItem {
           name = "thunderbird";
-          exec = "$out/bin/thunderbird %U";
+          exec = "thunderbird %U";
           desktopName = "Thunderbird";
           icon = "$out/lib/thunderbird-${version}/chrome/icons/default/default256.png";
           genericName = "Main Reader";

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -15,6 +15,7 @@
   # Mozilla Foundation, see
   # http://www.mozilla.org/foundation/trademarks/.
   enableOfficialBranding ? false
+, makeDesktopItem
 }:
 
 stdenv.mkDerivation rec {
@@ -107,6 +108,32 @@ stdenv.mkDerivation rec {
 
       # Needed to find Mozilla runtime
       gappsWrapperArgs+=(--argv0 "$out/bin/.thunderbird-wrapped")
+
+      # TODO: Move to a dev output?
+      rm -rf $out/include $out/lib/thunderbird-devel-* $out/share/idl
+
+      ${ let desktopItem = makeDesktopItem {
+          name = "thunderbird";
+          exec = "$out/bin/thunderbird %U";
+          desktopName = "Thunderbird";
+          icon = "$out/lib/thunderbird-${version}/chrome/icons/default/default256.png";
+          genericName = "Main Reader";
+          categories = "Application;Network";
+          mimeType = stdenv.lib.concatStringsSep ";" [
+            # Email
+            "x-scheme-handler/mailto"
+            "message/rfc822"
+            # Newsgroup
+            "x-scheme-handler/news"
+            "x-scheme-handler/snews"
+            "x-scheme-handler/nntp"
+            # Feed
+            "x-scheme-handler/feed"
+            "application/rss+xml"
+            "application/x-extension-rss"
+          ];
+        }; in desktopItem.buildCommand
+      }
     '';
 
   postFixup =


### PR DESCRIPTION
###### Motivation for this change

fix regression from https://github.com/NixOS/nixpkgs/commit/b023370f3757a76acb244e647f29e388e076cab0, and default mail reader detection (see also #23516)

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - macOS
   - Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @abbradar 
