### PR TITLE
Refactor command-not-found

### DIFF
--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -8,13 +8,14 @@
 with lib;
 
 let
-
+  cfg = config.programs.command-not-found;
   commandNotFound = pkgs.substituteAll {
     name = "command-not-found";
     dir = "bin";
     src = ./command-not-found.pl;
     isExecutable = true;
     inherit (pkgs) perl;
+    inherit (cfg) dbPath;
     perlFlags = concatStrings (map (path: "-I ${path}/lib/perl5/site_perl ")
       [ pkgs.perlPackages.DBI pkgs.perlPackages.DBDSQLite pkgs.perlPackages.StringShellQuote ]);
   };
@@ -22,50 +23,66 @@ let
 in
 
 {
+  options.programs.command-not-found = {
 
-  programs.bash.interactiveShellInit =
-    ''
-      # This function is called whenever a command is not found.
-      command_not_found_handle() {
-        local p=/run/current-system/sw/bin/command-not-found
-        if [ -x $p -a -f /nix/var/nix/profiles/per-user/root/channels/nixos/programs.sqlite ]; then
-          # Run the helper program.
-          $p "$@"
-          # Retry the command if we just installed it.
-          if [ $? = 126 ]; then
-            "$@"
+    enable = mkEnableOption "command-not-found hook for interactive shell";
+
+    dbPath = mkOption {
+      default = "/nix/var/nix/profiles/per-user/root/channels/nixos/programs.sqlite" ;
+      description = ''
+        Absolute path to programs.sqlite.
+
+        By default this file will be provided by your channel
+        (nixexprs.tar.xz).
+      '';
+      type = types.path;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.bash.interactiveShellInit =
+      ''
+        # This function is called whenever a command is not found.
+        command_not_found_handle() {
+          local p=${commandNotFound}
+          if [ -x $p -a -f ${cfg.dbPath} ]; then
+            # Run the helper program.
+            $p "$@"
+            # Retry the command if we just installed it.
+            if [ $? = 126 ]; then
+              "$@"
+            else
+              return 127
+            fi
           else
+            echo "$1: command not found" >&2
             return 127
           fi
-        else
-          echo "$1: command not found" >&2
-          return 127
-        fi
-      }
-    '';
+        }
+      '';
 
-  programs.zsh.interactiveShellInit =
-    ''
-      # This function is called whenever a command is not found.
-      command_not_found_handler() {
-        local p=/run/current-system/sw/bin/command-not-found
-        if [ -x $p -a -f /nix/var/nix/profiles/per-user/root/channels/nixos/programs.sqlite ]; then
-          # Run the helper program.
-          $p "$@"
+    programs.zsh.interactiveShellInit =
+      ''
+        # This function is called whenever a command is not found.
+        command_not_found_handler() {
+          local p=${commandNotFound}
+          if [ -x $p -a -f ${cfg.dbPath} ]; then
+            # Run the helper program.
+            $p "$@"
 
-          # Retry the command if we just installed it.
-          if [ $? = 126 ]; then
-            "$@"
+            # Retry the command if we just installed it.
+            if [ $? = 126 ]; then
+              "$@"
+            fi
+          else
+            # Indicate than there was an error so ZSH falls back to its default handler
+            echo "$1: command not found" >&2
+            return 127
           fi
-        else
-          # Indicate than there was an error so ZSH falls back to its default handler
-          return 127
-        fi
-      }
-    '';
+        }
+      '';
 
-  environment.systemPackages = [ commandNotFound ];
-
-  # TODO: tab completion for uninstalled commands! :-)
+    environment.systemPackages = [ commandNotFound ];
+  };
 
 }

--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -8,7 +8,7 @@ use Config;
 
 my $program = $ARGV[0];
 
-my $dbPath = "/nix/var/nix/profiles/per-user/root/channels/nixos/programs.sqlite";
+my $dbPath = "@dbPath@";
 
 my $dbh = DBI->connect("dbi:SQLite:dbname=$dbPath", "", "")
     or die "cannot open database `$dbPath'";


### PR DESCRIPTION
###### Motivation for this change
as of right now command-not-found is not working because programs.sqlite is not populated inside the channels. I took this as a chance to customize the current command-not-found module.
With `programs.command-not-found.enable` the feature can be disabled if unneeded.

With `programs.command-not-found.dbPath` the path to the db can be specified explicitly in case no channels are in use.

###### Things done

- [x] Tested all options
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

