### PR TITLE
rocker: init at 1.3.0

### DIFF
--- a/pkgs/tools/virtualization/rocker/default.nix
+++ b/pkgs/tools/virtualization/rocker/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "1.3.0";
+  name = "rocker-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/grammarly/rocker/releases/download/${version}/rocker_linux_amd64.tar.gz";
+    sha256 = "0jcxphkarzicxif2virdr7d7kym0961ca5l59cxmaqxa46l6k5x0";
+  };
+
+  outputs = [ "out" "bin" ];
+  dontBuild = true;
+
+  unpackPhase = ''
+    tar xfz $src
+  '';
+
+  installPhase = ''
+    mkdir -p {$bin,$out}
+    mv rocker $bin/rocker
+    chmod +x $bin/rocker
+    ln -s $bin $out/bin
+
+    interpreter="$(echo ${stdenv.glibc.out}/lib/ld-linux*)"
+    patchelf --interpreter "$interpreter" "$bin/rocker"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Rocker breaks the limits of Dockerfile";
+    longDescription = ''
+      Rocker breaks the limits of Dockerfile.
+      It adds some crucial features that are missing while keeping Docker’s original design and idea.
+    '';
+    homepage = https://github.com/grammarly/rocker;
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.nequissimus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -491,6 +491,8 @@ with pkgs;
 
   ec2_ami_tools = callPackage ../tools/virtualization/ec2-ami-tools { };
 
+  rocker = callPackage ../tools/virtualization/rocker { };
+
   altermime = callPackage ../tools/networking/altermime {};
 
   amule = callPackage ../tools/networking/p2p/amule { };
@@ -771,7 +773,7 @@ with pkgs;
   cfdyndns = callPackage ../applications/networking/dyndns/cfdyndns { };
 
   ckbcomp = callPackage ../tools/X11/ckbcomp { };
-  
+
   clac = callPackage ../tools/misc/clac {};
 
   clasp = callPackage ../tools/misc/clasp { };


### PR DESCRIPTION
###### Motivation for this change
Add the tool to nixpkgs. I need to do some fancy things with Docker :)

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

