### PR TITLE
broadcom-sta: fix linux-4.8 patch sha

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation {
     ./gcc.patch
     (fetchpatch {
       name = "linux-4.8.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/004-linux48.patch?h=broadcom-wl-dkms";
-      sha256 = "1g1gazxx67kxyw242cli6bf62il7ikzmf0w6v14k44j6b4bihcax";
+      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/004-linux48.patch?h=packages/broadcom-wl-dkms&id=8c6d80fc77eb20cbb4fd0eca71fa8a03b9447c3f";
+      sha256 = "0b963540gaj06q6ynfg47z8k5y3k2503yahbwawclfq4cxhl472a";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/24968

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

