### PR TITLE
vivaldi: 1.6.689.34-1 -> 1.8.770.56-1

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -10,16 +10,16 @@
 }:
 
 let
-  version = "1.6";
-  build = "689.34-1";
+  version = "1.8";
+  build = "770.56-1";
   fullVersion = "stable_${version}.${build}";
 
   info = if stdenv.is64bit then {
       arch = "amd64";
-      sha256 = "0wn98nzlhppmm3g797kiqr9bxxff8l7l110f1w1fnfl93d325hrm";
+      sha256 = "1f9cwr41rl0mqwg3xn2nfb5xnr0h0vc4wiz8367bd67zf4an61d2";
     } else {
       arch = "i386";
-      sha256 = "0agybibfwk5n1gxi8g4rbvvmlq5963df5arz4fyi4a1hcayllaz0";
+      sha256 = "1240w3gqn5rbvkb0v1g66syrc92r1vzk82fkmvy92qsnx0d5z7nn ";
     };
 
 in stdenv.mkDerivation rec {
@@ -47,7 +47,8 @@ in stdenv.mkDerivation rec {
 
   libPath = stdenv.lib.makeLibraryPath buildInputs
     + stdenv.lib.optionalString (stdenv.is64bit)
-      (":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" buildInputs);
+      (":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" buildInputs)
+    + ":$out/opt/vivaldi/lib";
 
   buildPhase = ''
     echo "Patching Vivaldi binaries"


### PR DESCRIPTION
###### Motivation for this change

Update to the latest stable version: 1.8.770.56-1.

See [Vivaldi makes History](https://vivaldi.com/blog/vivaldi-makes-history/) for changes.

Add `$out/opt/vivaldi/lib` to `RPATH` so that `libffmpeg.so` distributed with Vivaldi can be found. Otherwise launching Vivaldi fails.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).