### PR TITLE
elm-format: symlink latest version to `bin/elm-format`

### DIFF
--- a/pkgs/development/compilers/elm/packages/elm-format.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format.nix
@@ -29,6 +29,9 @@ mkDerivation {
     tasty-hunit tasty-quickcheck text union-find wl-pprint
   ];
   jailbreak = true;
+  postInstall = ''
+    ln -s $out/bin/elm-format-0.18 $out/bin/elm-format
+    '';
   homepage = "http://elm-lang.org";
   description = "A source code formatter for Elm";
   license = stdenv.lib.licenses.bsd3;

--- a/pkgs/development/compilers/elm/packages/elm-format.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format.nix
@@ -31,7 +31,7 @@ mkDerivation {
   jailbreak = true;
   postInstall = ''
     ln -s $out/bin/elm-format-0.18 $out/bin/elm-format
-    '';
+  '';
   homepage = "http://elm-lang.org";
   description = "A source code formatter for Elm";
   license = stdenv.lib.licenses.bsd3;


### PR DESCRIPTION
As it stands, the package installs `bin/elm-format-0.18`, `0.17`, and `0.16`.  But I noticed that [elm-vim expects a binary that's just called `elm-format`](https://github.com/ElmCast/elm-vim/blob/b47d013d1fdfecc9e19df8034439b8e379813696/autoload/elm.vim#L42-L45), and that [all of elm-format's install instructions](https://github.com/avh4/elm-format#installation-) give you a single binary just called `elm-format`.

This seemed to be the simplest change to match community expectations.