### PR TITLE
osm2pgsql: init at 0.92.1-unstable

### DIFF
--- a/pkgs/tools/misc/osm2pgsql/default.nix
+++ b/pkgs/tools/misc/osm2pgsql/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchgit, cmake, expat, proj, bzip2, zlib, boost, postgresql, lua}:
+
+let
+  version = "0.92.1-unstable";
+in
+stdenv.mkDerivation rec {
+  name = "osm2pgsql-${version}";
+
+  src = fetchgit {
+    url = "https://github.com/openstreetmap/osm2pgsql.git";
+    rev = "2b72b2121e91b72b0db6911d65c5165ca46d9d66";
+    # Still waiting on release after:
+    # https://github.com/openstreetmap/osm2pgsql/pull/684
+    # https://github.com/openstreetmap/osm2pgsql/issues/634
+    #rev = "refs/tags/${version}";
+    sha256 = "1v6s863zsv9p2mni35gfamawj0xr2cv2p8a31z7sijf8m6fn0vpy";
+  };
+  nativeBuildInputs = [cmake];
+  buildInputs = [expat proj bzip2 zlib boost postgresql lua];
+
+  meta = {
+    description = "OpenStreetMap data to PostgreSQL converter";
+    version = "0.92.1-unstable";
+    homepage = https://github.com/openstreetmap/osm2pgsql;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14806,6 +14806,8 @@ with pkgs;
 
   oroborus = callPackage ../applications/window-managers/oroborus {};
 
+  osm2pgsql = callPackage ../tools/misc/osm2pgsql { };
+
   ostinato = callPackage ../applications/networking/ostinato { };
 
   panamax_api = callPackage ../applications/networking/cluster/panamax/api {


### PR DESCRIPTION
###### Motivation for this change

Nixpkgs does not include [osm2pgsql](http://wiki.openstreetmap.org/wiki/Osm2pgsql).

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

