### PR TITLE
defaultIconTheme: Enable darwin support

### DIFF
--- a/pkgs/data/icons/hicolor-icon-theme/default.nix
+++ b/pkgs/data/icons/hicolor-icon-theme/default.nix
@@ -13,6 +13,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Default fallback theme used by implementations of the icon theme specification";
     homepage = http://icon-theme.freedesktop.org/releases/;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/desktops/gnome-3/3.22/core/adwaita-icon-theme/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/adwaita-icon-theme/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   postInstall = '' rm -rf "$out/locale" '';
 
   meta = with stdenv.lib; {
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     maintainers = gnome3.maintainers;
   };
 }

--- a/pkgs/development/tools/misc/icon-naming-utils/default.nix
+++ b/pkgs/development/tools/misc/icon-naming-utils/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = http://tango.freedesktop.org/Standard_Icon_Naming_Specification;
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Make gnome3.defaultIconTheme work on macOS

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

