### PR TITLE
mpDris2: 0.6 -> 0.7

### DIFF
--- a/pkgs/tools/audio/mpdris2/default.nix
+++ b/pkgs/tools/audio/mpdris2/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "mpDris2";
-  version = "0.6";
+  version = "0.7";
 
   src = fetchurl {
     url = "https://github.com/eonpatapon/${name}/archive/${version}.tar.gz";
-    sha256 = "0zdmamj2ldhr6y3s464w8y2x3yizda784jnlrg3j3myfabssisvz";
+    sha256 = "095swrjw59lh8qiwmjjjdbxl9587axilkj4mh2sx5m0kiq929z21";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
Version bump.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip --against upstream/master"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@yorickvP I you like, could you perhaps test this on NixOS for me?
