### PR TITLE
grub module: fix efiInstallAsRemovable description

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -383,7 +383,7 @@ in
         default = false;
         type = types.bool;
         description = ''
-          Whether to invoke <literal>grub-install</literal> with
+          <para>Whether to invoke <literal>grub-install</literal> with
           <literal>--removable</literal>.</para>
 
           <para>Unless you turn this on, GRUB will install itself somewhere in
@@ -412,7 +412,7 @@ in
             the NVRAM state of the computer (like a USB "removable" drive)</para></listitem>
             <listitem><para>You simply dislike the idea of depending on NVRAM
             state to make your drive bootable</para></listitem>
-          </itemizedlist>
+          </itemizedlist></para>
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

https://nixos.org/nixos/options.html#boot.loader.grub.efiinstallasremovable currently errors and fails to display option info when clicked on.
Adds missing opening tag for the first paragraph and closing tag for the last one.
This should be backported to 17.03

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

