### PR TITLE
release-cross: Fix more typos---this is embarrising

### DIFF
--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -77,7 +77,7 @@ in
       arch = "arm";
       float = "soft";
       withTLS = true;
-      platform = pkgs.platforms.sheevaplug;
+      platform = lib.systems.platforms.sheevaplug;
       libc = "glibc";
       openssl.system = "linux-generic32";
     };
@@ -136,7 +136,7 @@ in
       float = "hard";
       withTLS = true;
       libc = "glibc";
-      platform = lib.platforms.fuloong2f_n32;
+      platform = lib.systems.platforms.fuloong2f_n32;
       openssl.system = "linux-generic32";
       gcc = {
         arch = "loongson2f";
@@ -160,7 +160,7 @@ in
       fpu = "vfp";
       withTLS = true;
       libc = "glibc";
-      platform = lib.platforms.raspberrypi;
+      platform = lib.systems.platforms.raspberrypi;
       openssl.system = "linux-generic32";
       gcc = {
         arch = "armv6";


### PR DESCRIPTION
###### Motivation for this change

Typos

###### Things done

Evaluation; deep rather than shallow this time.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

