### PR TITLE
Upgraded MinGW-W64 to stable version 5.0.3

### DIFF
--- a/pkgs/os-specific/windows/mingw-w64/common.nix
+++ b/pkgs/os-specific/windows/mingw-w64/common.nix
@@ -8,4 +8,9 @@ rec {
     url = "mirror://sourceforge/mingw-w64/mingw-w64-v${version}.tar.bz2";
     sha256 = "0p01vm5kx1ixc08402z94g1alip4vx66gjpvyi9maqyqn2a76h0c";
   };
+
+  configureFlags = [
+    "--enable-idl"
+    "--enable-secure-api"
+  ];
 }

--- a/pkgs/os-specific/windows/mingw-w64/common.nix
+++ b/pkgs/os-specific/windows/mingw-w64/common.nix
@@ -1,12 +1,12 @@
 { fetchurl }:
 
 rec {
-  version = "4.0.6";
+  version = "5.0.3";
   name = "mingw-w64-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/mingw-w64/mingw-w64-v${version}.tar.bz2";
-    sha256 = "0p01vm5kx1ixc08402z94g1alip4vx66gjpvyi9maqyqn2a76h0c";
+    sha256 = "1d4wrjfdlq5xqpv9zg6ssw4lm8jnv6522xf7d6zbjygmkswisq1a";
   };
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

There is a new version of MinGW-W64, so I updated the package to use that.

I also refactored the package a bit and added the `--enable-idl` and `--enable-secure-api`
flags which I found necessary when hacking on MinGW cross compilation last October.

I tested all the packages in `crossMingwW64` and they all compile except for `coreutils`, `guile_1_8` (because `libsigsegv` fails), and `windows.wxMSW`. See #24984 for more details. Note that all three of those packages were broken before this change.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox][useSandbox] or `build-use-sandbox` in [`nix.conf`][nix.conf])
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all modified pkgs using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

[useSandbox]: http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox
[nix.conf]: http://nixos.org/nix/manual/#sec-conf-file