### PR TITLE
grub module: efiInstallAsRemovable description wrap <para> in <note>

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -383,36 +383,38 @@ in
         default = false;
         type = types.bool;
         description = ''
-          <para>Whether to invoke <literal>grub-install</literal> with
-          <literal>--removable</literal>.</para>
+          Whether to invoke <literal>grub-install</literal> with
+          <literal>--removable</literal>.
 
-          <para>Unless you turn this on, GRUB will install itself somewhere in
-          <literal>boot.loader.efi.efiSysMountPoint</literal> (exactly where
-          depends on other config variables). If you've set
-          <literal>boot.loader.efi.canTouchEfiVariables</literal> *AND* you
-          are currently booted in UEFI mode, then GRUB will use
-          <literal>efibootmgr</literal> to modify the boot order in the
-          EFI variables of your firmware to include this location. If you are
-          *not* booted in UEFI mode at the time GRUB is being installed, the
-          NVRAM will not be modified, and your system will not find GRUB at
-          boot time. However, GRUB will still return success so you may miss
-          the warning that gets printed ("<literal>efibootmgr: EFI variables
-          are not supported on this system.</literal>").</para>
+          <note>
+            <para>Unless you turn this on, GRUB will install itself somewhere in
+            <literal>boot.loader.efi.efiSysMountPoint</literal> (exactly where
+            depends on other config variables). If you've set
+            <literal>boot.loader.efi.canTouchEfiVariables</literal> *AND* you
+            are currently booted in UEFI mode, then GRUB will use
+            <literal>efibootmgr</literal> to modify the boot order in the
+            EFI variables of your firmware to include this location. If you are
+            *not* booted in UEFI mode at the time GRUB is being installed, the
+            NVRAM will not be modified, and your system will not find GRUB at
+            boot time. However, GRUB will still return success so you may miss
+            the warning that gets printed ("<literal>efibootmgr: EFI variables
+            are not supported on this system.</literal>").</para>
 
-          <para>If you turn this feature on, GRUB will install itself in a
-          special location within <literal>efiSysMountPoint</literal> (namely
-          <literal>EFI/boot/boot$arch.efi</literal>) which the firmwares
-          are hardcoded to try first, regardless of NVRAM EFI variables.</para>
+            <para>If you turn this feature on, GRUB will install itself in a
+            special location within <literal>efiSysMountPoint</literal> (namely
+            <literal>EFI/boot/boot$arch.efi</literal>) which the firmwares
+            are hardcoded to try first, regardless of NVRAM EFI variables.</para>
 
-          <para>To summarize, turn this on if:
-          <itemizedlist>
-            <listitem><para>You are installing NixOS and want it to boot in UEFI mode,
-            but you are currently booted in legacy mode</para></listitem>
-            <listitem><para>You want to make a drive that will boot regardless of
-            the NVRAM state of the computer (like a USB "removable" drive)</para></listitem>
-            <listitem><para>You simply dislike the idea of depending on NVRAM
-            state to make your drive bootable</para></listitem>
-          </itemizedlist></para>
+            <para>To summarize, turn this on if:
+            <itemizedlist>
+              <listitem><para>You are installing NixOS and want it to boot in UEFI mode,
+              but you are currently booted in legacy mode</para></listitem>
+              <listitem><para>You want to make a drive that will boot regardless of
+              the NVRAM state of the computer (like a USB "removable" drive)</para></listitem>
+              <listitem><para>You simply dislike the idea of depending on NVRAM
+              state to make your drive bootable</para></listitem>
+            </itemizedlist></para>
+          </note>
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

Removed first  `<para>` and wrapped others in `<note>` to avoid build failure introduced by: #24978

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

