### PR TITLE
git-recent: init at 1.0.3

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -74,6 +74,10 @@ rec {
 
   git-radar = callPackage ./git-radar { };
 
+  git-recent = callPackage ./git-recent {
+    utillinux = if stdenv.isLinux then utillinuxMinimal else null;
+  };
+
   git-remote-hg = callPackage ./git-remote-hg { };
 
   git-stree = callPackage ./git-stree { };

--- a/pkgs/applications/version-management/git-and-tools/git-recent/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-recent/default.nix
@@ -1,0 +1,41 @@
+{stdenv, git, less, fetchFromGitHub, makeWrapper
+# utillinuxMinimal is included because we need the column command
+, utillinux ? null
+}:
+
+assert stdenv.isLinux -> utillinux != null;
+
+let
+  binpath = stdenv.lib.makeBinPath
+    ([ git less ]
+    ++ stdenv.lib.optional (utillinux != null) utillinux);
+in stdenv.mkDerivation rec {
+  name = "git-recent-${version}";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "paulirish";
+    repo = "git-recent";
+    rev = "v${version}";
+    sha256 = "0rckjjrw2xmvmbqaf66i36x59vs1v4pfnmvbinx5iggp7vjly1a4";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  buildPhase = null;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp git-recent $out/bin
+    wrapProgram $out/bin/git-recent \
+      --prefix PATH : "${binpath}"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/paulirish/git-recent;
+    description = "See your latest local git branches, formatted real fancy";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.jlesquembre ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
Add [git recent](https://github.com/paulirish/git-recent)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

