### PR TITLE
slock: add configFile support

### DIFF
--- a/pkgs/misc/screensavers/slock/default.nix
+++ b/pkgs/misc/screensavers/slock/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, xproto, libX11, libXext, libXrandr }:
-stdenv.mkDerivation rec {
+{ stdenv, fetchurl, xproto, libX11, libXext, libXrandr, conf ? null }:
+with stdenv.lib; stdenv.mkDerivation rec {
   name = "slock-1.4";
   src = fetchurl {
     url = "http://dl.suckless.org/tools/${name}.tar.gz";
@@ -7,6 +7,8 @@ stdenv.mkDerivation rec {
   };
   buildInputs = [ xproto libX11 libXext libXrandr ];
   installFlags = "DESTDIR=\${out} PREFIX=";
+  configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
+  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
   meta = with stdenv.lib; {
     homepage = http://tools.suckless.org/slock;
     description = "Simple X display locker";


### PR DESCRIPTION
###### Motivation for this change

allows configuration of slock.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

