### PR TITLE
efibootmgr: 13 -> 15

### DIFF
--- a/pkgs/tools/system/efibootmgr/default.nix
+++ b/pkgs/tools/system/efibootmgr/default.nix
@@ -1,26 +1,29 @@
-{ stdenv, fetchFromGitHub, perl, efivar, pciutils, zlib, popt }:
+{ stdenv, fetchFromGitHub, pkgconfig, efivar, popt }:
 
 stdenv.mkDerivation rec {
   name = "efibootmgr-${version}";
-  version = "13";
+  version = "15";
 
-  buildInputs = [ perl efivar pciutils zlib popt ];
+  nativeBuildInputs = [ pkgconfig ];
+  
+  buildInputs = [ efivar popt ];
 
   src = fetchFromGitHub {
     owner = "rhinstaller";
     repo = "efibootmgr";
     rev = version;
-    sha256 = "1kwmvx111c3a5783kx3az76mkhpr1nsdx0yv09gp4k0hgzqlqj96";
+    sha256 = "0z7h1dirp8za6lbbf4f3dzn7l1px891rdymhkbqc10yj6gi1jpqp";
   };
 
   NIX_CFLAGS_COMPILE = "-I${efivar}/include/efivar";
-  NIX_LDFLAGS = "-lefiboot -lefivar -lpopt";
+
+  makeFlags = [ "EFIDIR=nixos" ];
 
   installFlags = [ "prefix=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "A Linux user-space application to modify the Intel Extensible Firmware Interface (EFI) Boot Manager";
-    homepage = http://linux.dell.com/efibootmgr/;
+    homepage = https://github.com/rhinstaller/efibootmgr;
     license = licenses.gpl2;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change

- Update to efibootmgr 15
- Add dependency on pkgconfig (listed as required in INSTALL)
- Remove dependency on perl, pciutils and zlib
- Set EFIDIR to 'nixos'  (the same used in fwupdate)
- Update homepage

[Changes](https://github.com/rhinstaller/efibootmgr/releases)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).