### PR TITLE
qemu module: add virtualisation.cores option

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -75,6 +75,7 @@ let
       exec ${qemu}/bin/qemu-kvm \
           -name ${vmName} \
           -m ${toString config.virtualisation.memorySize} \
+          -smp ${toString config.virtualisation.cores} \
           ${optionalString (pkgs.stdenv.system == "x86_64-linux") "-cpu kvm64"} \
           ${concatStringsSep " " config.virtualisation.qemu.networkingOptions} \
           -virtfs local,path=/nix/store,security_model=none,mount_tag=store \
@@ -241,6 +242,18 @@ in
           ''
             Whether to run QEMU with a graphics window, or access
             the guest computer serial port through the host tty.
+          '';
+      };
+
+    virtualisation.cores =
+      mkOption {
+        default = 1;
+        type = types.int;
+        description =
+          ''
+            Specify the number of cores the guest is permitted to use.
+            The number can be higher than the available cores on the
+            host system.
           '';
       };
 


### PR DESCRIPTION
QEMU can allow guests to access more than one host core at a time.
Previously, this had to be done via ad-hoc arguments:

    virtualisation.qemu.options = ["-smp 12"];

Now you can simply specify:

    virtualisation.cores = 12;

###### Motivation for this change

In my NixOS based tests, we frequently need far more than a single core available to the guest. Manually passing in `-smp` doesn't represent _what_ we want, so much as how to do it.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

