### PR TITLE
pidgin-carbons: init at 0.1.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/carbons/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/carbons/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, libxml2, pidgin, pkgconfig, fetchFromGitHub } :
+
+stdenv.mkDerivation rec {
+  name = "pidgin-carbons-${version}";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "gkdr";
+    repo  = "carbons";
+    rev   = "v${version}";
+    sha256 = "05hcqvsirb7gnpfcszsrgal5q7dajl2wdi2dy7c41zgl377syavw";
+  };
+
+  makeFlags = [ "PURPLE_PLUGIN_DIR=$(out)/lib/pidgin" ];
+
+  buildInputs = [ libxml2 pidgin pkgconfig ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/gkdr/carbons";
+    description = "XEP-0280: Message Carbons plugin for libpurple";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jb55 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15088,6 +15088,8 @@ with pkgs;
 
   pidgin-skypeweb = callPackage ../applications/networking/instant-messengers/pidgin-plugins/pidgin-skypeweb { };
 
+  pidgin-carbons = callPackage ../applications/networking/instant-messengers/pidgin-plugins/carbons { };
+
   pidgin-xmpp-receipts = callPackage ../applications/networking/instant-messengers/pidgin-plugins/pidgin-xmpp-receipts { };
 
   pidginotr = callPackage ../applications/networking/instant-messengers/pidgin-plugins/otr { };


### PR DESCRIPTION
Implements XMPP extension XEP-0280: Message Carbons for pidgin

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

