### PR TITLE
greybird: 2017-02-26 -> 3.22.3

### DIFF
--- a/pkgs/misc/themes/greybird/default.nix
+++ b/pkgs/misc/themes/greybird/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "greybird";
-  version = "2017-02-26";
+  version = "3.22.3";
 
   src = fetchFromGitHub {
     owner = "shimmerproject";
     repo = "${pname}";
-    rev = "66c222c25c43603e73d3521e0e91ffb268214229";
-    sha256 = "1q0nc02d7kwaxjb8d2rvwc3yf3v46r44zsighwjnmczpw7y3j6h8";
+    rev = "v${version}";
+    sha256 = "0hz8q2sf2kcxixzw088rny6zmhfls5z49zlhm8m9013wph799a8c";
   };
 
   nativeBuildInputs = [ autoreconfHook sass glib libxml2 gdk_pixbuf librsvg ];


### PR DESCRIPTION
###### Motivation for this change

Update to version 3.22.3.

[Changes](https://github.com/shimmerproject/Greybird/releases)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).