### PR TITLE
nixos/stage1: add copytoram support

### DIFF
--- a/nixos/doc/manual/installation/installing-usb.xml
+++ b/nixos/doc/manual/installation/installing-usb.xml
@@ -34,6 +34,11 @@ ISO, copy its contents verbatim to your drive, then either:
     in <link xlink:href="https://www.kernel.org/doc/Documentation/kernel-parameters.txt">
     the kernel documentation</link> for more details).</para>
   </listitem>
+  <listitem>
+    <para>If you want to load the contents of the ISO to ram after bootin
+    (So you can remove the stick after bootup) you can append the parameter
+    <literal>copytoram</literal>to the <literal>options</literal> field.</para>
+  </listitem>
 </itemizedlist>
 </para>
 


### PR DESCRIPTION
This change adds the possibility for the copytoram kernel parameter. If supplied the whole image is loaded into a tmpfs during stage-1. Afterwards a removal of the USB-device/CD is possible without the system breaking.