### PR TITLE
transmission-remote-gtk: fix broken tray applet icons

### DIFF
--- a/pkgs/applications/networking/p2p/transmission-remote-gtk/default.nix
+++ b/pkgs/applications/networking/p2p/transmission-remote-gtk/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, autoconf, automake, libtool, makeWrapper, fetchFromGitHub, pkgconfig
-, intltool, gtk3, json_glib, curl, glib, autoconf-archive, appstream-glib }:
+{ stdenv, autoconf, automake, libtool, wrapGAppsHook, fetchFromGitHub, pkgconfig
+, intltool, gtk3, json_glib, curl, glib, autoconf-archive, appstream-glib
+, hicolor_icon_theme }:
 
 
 stdenv.mkDerivation rec {
@@ -15,18 +16,12 @@ stdenv.mkDerivation rec {
 
   preConfigure = "./autogen.sh";
 
-  nativeBuildInputs= [ 
-    autoconf automake libtool makeWrapper 
-    pkgconfig intltool autoconf-archive 
+  nativeBuildInputs= [
+    autoconf automake libtool wrapGAppsHook
+    pkgconfig intltool autoconf-archive
     appstream-glib
   ];
-  buildInputs = [ gtk3 json_glib curl glib ];
-
-  preFixup = ''
-    wrapProgram "$out/bin/transmission-remote-gtk" \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-    rm $out/share/icons/hicolor/icon-theme.cache
-  '';
+  buildInputs = [ gtk3 json_glib curl glib hicolor_icon_theme ];
 
   meta = with stdenv.lib;
     { description = "GTK remote control for the Transmission BitTorrent client";


### PR DESCRIPTION
###### Motivation for this change

The tray icons of the transmission-remote-gtk applications are broken. This commit uses `wrapGAppsHook` and `hicolor_icon_theme` to let the tray applet find the icons.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

