### PR TITLE
znapzend service: fix reload

### DIFF
--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -20,15 +20,12 @@ in
         description = "ZnapZend - ZFS Backup System";
         after       = [ "zfs.target" ];
 
-        path = with pkgs; [ znapzend zfs mbuffer openssh ];
+        path = with pkgs; [ zfs mbuffer openssh ];
 
-        script = ''
-          exec znapzend
-        '';
-
-        reload = ''
-          ${pkgs.coreutils}/bin/kill -HUP $MAINPID
-        '';
+        serviceConfig = {
+          ExecStart = "${pkgs.znapzend}/bin/znapzend";
+          ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        };
       };
     };
 

--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -23,11 +23,11 @@ in
         path = with pkgs; [ znapzend zfs mbuffer openssh ];
 
         script = ''
-          znapzend
+          exec znapzend
         '';
 
         reload = ''
-          /bin/kill -HUP $MAINPID
+          ${pkgs.coreutils}/bin/kill -HUP $MAINPID
         '';
       };
     };


### PR DESCRIPTION
###### Motivation for this change

#24438

In addition to `/bin/kill` not being found, the script forked so that `$MAINPID` became the PID of the shell instead of the znapzend process. When SIGHUP was sent to the shelI, it sent SIGTERM to znapzend.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).