### PR TITLE
oraclejdk: 8u121 -> 8u131

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "121";
+  patchVersion = "131";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "0k1xyg000qmd96c2r2m8l84ygn6dmjf1ih5yjzq1zry5d0aczmpp";
-  sha256_x86_64 = "1g0hh9ccmsrdfa9493k31v2vd6yiymwd1nclgjh29wxfy41h5qwp";
+  sha256_i686 = "0m3i1n1im1nlwb06wlsdajv19cd3zhrjkw8zbyjfznydn6qs4s80";
+  sha256_x86_64 = "0dhj623ya01glcl3iir9ajifcrf6awhvpk936x9cxfj8zfyibck2";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "121";
+  patchVersion = "131";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "0k1xyg000qmd96c2r2m8l84ygn6dmjf1ih5yjzq1zry5d0aczmpp";
-  sha256_x86_64 = "1g0hh9ccmsrdfa9493k31v2vd6yiymwd1nclgjh29wxfy41h5qwp";
+  sha256_i686 = "0m3i1n1im1nlwb06wlsdajv19cd3zhrjkw8zbyjfznydn6qs4s80";
+  sha256_x86_64 = "0dhj623ya01glcl3iir9ajifcrf6awhvpk936x9cxfj8zfyibck2";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
###### Motivation for this change
Oracle has removed the downloads for 8u121.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

