### PR TITLE
pythonPackages.dkimpy: init -> 0.6.1

### DIFF
--- a/pkgs/development/python-modules/dkimpy/default.nix
+++ b/pkgs/development/python-modules/dkimpy/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, openssl, makeWrapper, buildPythonApplication
+, pytest, dns }:
+
+buildPythonApplication rec {
+  name = "${pname}-${majorversion}.${minorversion}";
+  pname = "dkimpy";
+  majorversion = "0.6";
+  minorversion = "1";
+
+  src = fetchurl {
+    url = "https://launchpad.net/${pname}/${majorversion}/${majorversion}.${minorversion}/+download/${name}.tar.gz";
+    sha256 = "0zmvyw18ww1jqrbqws636w3xki59fyqva553r6s74q5c4jvy36v2";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs =  [ openssl dns ];
+
+  patchPhase = ''substituteInPlace dknewkey.py --replace \
+     /usr/bin/openssl ${openssl}/bin/openssl
+     '';
+
+  postInstall = ''
+    mkdir -p $out/bin $out/libexec
+    mv $out/bin/*.py $out/libexec
+    makeWrapper "$out/libexec/dkimverify.py" $out/bin/dkimverify
+    makeWrapper "$out/libexec/dkimsign.py" $out/bin/dkimsign
+    makeWrapper "$out/libexec/arcverify.py" $out/bin/arcverify
+    makeWrapper "$out/libexec/arcsign.py" $out/bin/arcsign
+    makeWrapper "$out/libexec/dknewkey.py" $out/bin/dknewkey
+   '';
+
+  meta = with stdenv.lib; {
+    description = "DKIM + ARC email signing/verification tools + Python module";
+    longDescription = ''Python module that implements DKIM (DomainKeys Identified Mail)
+      email signing and verification. It also provides a number of convєnient tools
+      for command line signing and verification, as well as generating new DKIM records.
+      This version also supports the experimental Authenticated Received Chain (ARC)
+      protocol.
+    '';
+    homepage = "https://launchpad.net/dkimpy";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -521,6 +521,8 @@ with pkgs;
 
   dgsh = callPackage ../shells/dgsh { };
 
+  dkimpy = pythonPackages.dkimpy;
+
   elvish = callPackage ../shells/elvish { };
 
   encryptr = callPackage ../tools/security/encryptr {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -222,6 +222,8 @@ in {
     };
   };
 
+  dkimpy = callPackage ../development/python-modules/dkimpy { };
+
   emcee = buildPythonPackage {
     name = "emcee-2.1.0";
     src = pkgs.fetchurl {


### PR DESCRIPTION
###### Motivation for this change

A useful set of tools and underlying library for working with DKIM and ARC (IETF standards for email authenticity).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

