### PR TITLE
pydot: 1.0.2 -> 1.2.3

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20121,16 +20121,16 @@ in {
    });
 
   pydot = buildPythonPackage rec {
-    name = "pydot-1.0.2";
+    name = "pydot-1.2.3";
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/p/pydot/${name}.tar.gz";
-      sha256 = "80ea01a7ba75671a3b7890375be0ad8d5321b07bfb6f572192c31409062b59f3";
+      sha256 = "edb5d3f249f97fbd9c4bb16959e61bc32ecf40eee1a9f6d27abe8d01c0a73502";
     };
     propagatedBuildInputs = with self; [pyparsing pkgs.graphviz];
     meta = {
-      homepage = http://code.google.com/p/pydot/;
+      homepage = https://github.com/erocarrera/pydot;
       description = "Allows to easily create both directed and non directed graphs from Python";
     };
   };


### PR DESCRIPTION
###### Motivation for this change

new version for pydot: 1.0.2 was broken for quite a few years, and development moved to GitHub. Built on Fedora, didn't extensively test it though.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

