### PR TITLE
doit: init at 0.30.3

### DIFF
--- a/pkgs/development/tools/build-managers/doit/default.nix
+++ b/pkgs/development/tools/build-managers/doit/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, python3Packages }:
+
+let
+
+  name = "doit";
+  version = "0.30.3";
+
+in python3Packages.buildPythonApplication {
+  name = "${name}-${version}";
+
+  src = fetchurl {
+    url = "mirror://pypi/d/${name}/${name}-${version}.tar.gz";
+    sha256 = "1fcsslc3mc4bszq5xdqbxv37720s1s31d6pbfwc2iyxk1x2wi219";
+  };
+
+  buildInputs = with python3Packages; [ mock pytest ];
+
+  propagatedBuildInputs = with python3Packages; [ cloudpickle pyinotify ];
+
+  # Tests fail due to mysterious gdbm.open() resource temporarily
+  # unavailable errors.
+  doCheck = false;
+  checkPhase = "py.test";
+
+  meta = {
+    homepage = "http://pydoit.org/";
+    description = "A task management & automation tool";
+    license = stdenv.lib.licenses.mit;
+    longDescription = ''
+      doit is a modern open-source build-tool written in python
+      designed to be simple to use and flexible to deal with complex
+      work-flows. It is specially suitable for building and managing
+      custom work-flows where there is no out-of-the-box solution
+      available.
+    '';
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6543,6 +6543,8 @@ with pkgs;
 
   doctl = callPackage ../development/tools/doctl { };
 
+  doit = callPackage ../development/tools/build-managers/doit { };
+
   dot2tex = pythonPackages.dot2tex;
 
   doxygen = callPackage ../development/tools/documentation/doxygen {


### PR DESCRIPTION
###### Motivation for this change

doit is a task management & automation tool.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

