### PR TITLE
lib: trivial spelling fixes

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -116,7 +116,7 @@ rec {
     listToAttrs (concatMap (name: let v = set.${name}; in if pred name v then [(nameValuePair name v)] else []) (attrNames set));
 
 
-  /* Filter an attribute set recursivelly by removing all attributes for
+  /* Filter an attribute set recursively by removing all attributes for
      which the given predicate return false.
 
      Example:
@@ -334,7 +334,7 @@ rec {
       value = f name (catAttrs name sets);
     }) names);
 
-  /* Implentation note: Common names  appear multiple times in the list of
+  /* Implementation note: Common names  appear multiple times in the list of
      names, hopefully this does not affect the system because the maximal
      laziness avoid computing twice the same expression and listToAttrs does
      not care about duplicated attribute names.
@@ -353,7 +353,7 @@ rec {
   zipAttrs = zipAttrsWith (name: values: values);
 
   /* Does the same as the update operator '//' except that attributes are
-     merged until the given pedicate is verified.  The predicate should
+     merged until the given predicate is verified.  The predicate should
      accept 3 arguments which are the path to reach the attribute, a part of
      the first attribute set and a part of the second attribute set.  When
      the predicate is verified, the value of the first attribute set is

--- a/lib/composable-derivation.nix
+++ b/lib/composable-derivation.nix
@@ -39,7 +39,7 @@ let inherit (lib) nv nvs; in
   #
   # issues:
   # * its complicated to understand
-  # * some "features" such as exact merge behaviour are burried in mergeAttrBy
+  # * some "features" such as exact merge behaviour are buried in mergeAttrBy
   #   and defaultOverridableDelayableArgs assuming the default behaviour does
   #   the right thing in the common case
   # * Eelco once said using such fix style functions are slow to evaluate
@@ -48,7 +48,7 @@ let inherit (lib) nv nvs; in
   #   / add patches the way you want without having to declare function arguments
   #
   # nice features:
-  # declaring "optional featuers" is modular. For instance:
+  # declaring "optional features" is modular. For instance:
   #   flags.curl = {
   #     configureFlags = ["--with-curl=${curl.dev}" "--with-curlwrappers"];
   #     buildInputs = [curl openssl];

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -10,7 +10,7 @@ rec {
 
   /* `overrideDerivation drv f' takes a derivation (i.e., the result
      of a call to the builtin function `derivation') and returns a new
-     derivation in which the attributes of the original are overriden
+     derivation in which the attributes of the original are overridden
      according to the function `f'.  The function `f' is called with
      the original derivation attributes.
 

--- a/lib/deprecated.nix
+++ b/lib/deprecated.nix
@@ -253,11 +253,11 @@ rec {
   # eg { a = 7; } {  a = [ 2 3 ]; } becomes { a = [ 7 2 3 ]; }
   mergeAttrsConcatenateValues = mergeAttrsWithFunc ( a: b: (toList a) ++ (toList b) );
 
-  # merges attributes using //, if a name exisits in both attributes
+  # merges attributes using //, if a name exists in both attributes
   # an error will be triggered unless its listed in mergeLists
   # so you can mergeAttrsNoOverride { buildInputs = [a]; } { buildInputs = [a]; } {} to get
   # { buildInputs = [a b]; }
-  # merging buildPhase does'nt really make sense. The cases will be rare where appending /prefixing will fit your needs?
+  # merging buildPhase doesn't really make sense. The cases will be rare where appending /prefixing will fit your needs?
   # in these cases the first buildPhase will override the second one
   # ! deprecated, use mergeAttrByFunc instead
   mergeAttrsNoOverride = { mergeLists ? ["buildInputs" "propagatedBuildInputs"],

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -1,4 +1,4 @@
-# snippets that can be shared by mutliple fetchers (pkgs/build-support)
+# snippets that can be shared by multiple fetchers (pkgs/build-support)
 {
 
   proxyImpureEnvVars = [

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -191,7 +191,7 @@ rec {
   */
   optional = cond: elem: if cond then [elem] else [];
 
-  /* Return a list or an empty list, dependening on a boolean value.
+  /* Return a list or an empty list, depending on a boolean value.
 
      Example:
        optionals true [ 2 3 ]

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -423,7 +423,7 @@ rec {
     in concatMap (def: if getPrio def == highestPrio then [(strip def)] else []) defs;
 
   /* Sort a list of properties.  The sort priority of a property is
-     1000 by default, but can be overriden by wrapping the property
+     1000 by default, but can be overridden by wrapping the property
      using mkOrder. */
   sortProperties = defs:
     let

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -126,8 +126,8 @@ rec {
   */
   makePerlPath = makeSearchPathOutput "lib" "lib/perl5/site_perl";
 
-  /* Dependening on the boolean `cond', return either the given string
-     or the empty string. Useful to contatenate against a bigger string.
+  /* Depending on the boolean `cond', return either the given string
+     or the empty string. Useful to concatenate against a bigger string.
 
      Example:
        optionalString true "some-string"

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -231,7 +231,7 @@ runTests {
     };
     in {
       expr = generators.toJSON {} val;
-      # trival implementation
+      # trivial implementation
       expected = builtins.toJSON val;
   };
 
@@ -243,7 +243,7 @@ runTests {
     };
     in {
       expr = generators.toYAML {} val;
-      # trival implementation
+      # trivial implementation
       expected = builtins.toJSON val;
   };
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -52,7 +52,7 @@ rec {
     { # Human-readable representation of the type, should be equivalent to
       # the type function name.
       name
-    , # Description of the type, defined recursively by embedding the the wrapped type if any.
+    , # Description of the type, defined recursively by embedding the wrapped type if any.
       description ? null
     , # Function applied to each definition that should return true if
       # its type-correct, false otherwise.


### PR DESCRIPTION
###### Motivation for this change

Noticed spelling errors in lib file, then found as many other spelling errors in lib.

###### Things done

1. Found sorted list of "bad" words from aspell.

    cat lib/*.nix |aspell list |sort |uniq -c |sort -nr > spells.txt

2. Went through the generated file and found a few more spelling errors in lib.


- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

