### PR TITLE
Disable parallel building

### DIFF
--- a/pkgs/development/compilers/halvm/2.4.0.nix
+++ b/pkgs/development/compilers/halvm/2.4.0.nix
@@ -6,6 +6,7 @@ stdenv.mkDerivation rec {
   version = "2.4.0";
   name = "HaLVM-${version}";
   isHaLVM = true;
+  enableParallelBuilding = false;
   isGhcjs = false;
   src = fetchgit {
     rev = "65fad65966eb7e60f234453a35aeb564a09d2595";


### PR DESCRIPTION
###### Motivation for this change
Race condition with `make -j` is causing the build to fail. This should fix it.
cc @cleverca22 @Ericson2314 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

