### PR TITLE
pythonPackages.typeguard: init at 2.3.1

### DIFF
--- a/pkgs/development/python-modules/typeguard/default.nix
+++ b/pkgs/development/python-modules/typeguard/default.nix
@@ -1,0 +1,38 @@
+{ buildPythonPackage
+, fetchPypi
+, pythonOlder
+, stdenv
+, setuptools_scm
+, pytest
+}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "typeguard";
+  version = "2.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0l3pih5ca469v7if255h5rqymirsw46bi6s7p885jxhq1gv6cfpk";
+  };
+
+  buildInputs = [ setuptools_scm ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg --replace " --cov" ""
+  '';
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test .
+  '';
+
+  disabled = pythonOlder "3.3";
+
+  meta = with stdenv.lib; {
+    description = "This library provides run-time type checking for functions defined with argument type annotations";
+    homepage = "https://github.com/agronholm/typeguard";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23151,6 +23151,8 @@ in {
     };
   };
 
+  typeguard = callPackage ../development/python-modules/typeguard { };
+
   ruamel_yaml = buildPythonPackage rec {
     name = "ruamel.yaml-${version}";
     version = "0.13.7";
@@ -23177,7 +23179,6 @@ in {
 
   runsnakerun = buildPythonPackage rec {
     name = "runsnakerun-2.0.4";
-
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/R/RunSnakeRun/RunSnakeRun-2.0.4.tar.gz";


### PR DESCRIPTION
###### Motivation for this change

Add typeguard. First time I contribute a python package so wanted to get another pair of eyes before I get too comfortable with merging these things.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

