### PR TITLE
units: 2.13 -> 2.14

### DIFF
--- a/pkgs/tools/misc/units/default.nix
+++ b/pkgs/tools/misc/units/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "units-${version}";
-  version = "2.13";
+  version = "2.14";
 
   src = fetchurl {
     url = "mirror://gnu/units/${name}.tar.gz";
-    sha256 = "1awhjw9zjlfb8s5g3yyx63f7ddfcr1sanlbxpqifmrgq24ql198b";
+    sha256 = "9d33893d82f3ddd831d5822992007c40bcd0826ae67d3cbc96539951fb0a82e8";
   };
 
   buildInputs = [ readline ];


### PR DESCRIPTION
Updating units to version 2.14.

Builded (on NixOS) and tested resulting bin.