### PR TITLE
libiconv: 1.14 -> 1.15

### DIFF
--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -3,11 +3,12 @@
 assert !stdenv.isLinux || stdenv ? cross; # TODO: improve on cross
 
 stdenv.mkDerivation rec {
-  name = "libiconv-1.14";
+  name = "libiconv-${version}";
+  version = "1.15";
 
   src = fetchurl {
     url = "mirror://gnu/libiconv/${name}.tar.gz";
-    sha256 = "04q6lgl3kglmmhw59igq1n7v3rp1rpkypl366cy1k1yn2znlvckj";
+    sha256 = "0y1ij745r4p48mxq84rax40p10ln7fc7m243p8k8sia519i3dxfc";
   };
 
   patches = lib.optionals stdenv.isCygwin [


### PR DESCRIPTION
###### Motivation for this change

The new version fixes a bunch of build errors for ~iOS~ android cross compilation. The old patches seemed to still apply.

I'd merge this myself, but I'm not sure whether it constitutes a mass-darwin-rebuild.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

