### PR TITLE
tint2: 0.12.12 -> 0.14.1

### DIFF
--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   name = "tint2-${version}";
-  version = "0.12.12";
+  version = "0.14.1";
 
   src = fetchFromGitLab {
     owner = "o9000";
     repo = "tint2";
     rev = version;
-    sha256 = "0zgcdancsna95sjxslack9lh8f6qnj8d5wm02891mshn2jhgins3";
+    sha256 = "1wxz8sbv4cx3d3s5mbrzffidi3nayh1g6bd8m1ndz61jhv01ypam";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Update to version 0.14.1

[Changes](https://gitlab.com/o9000/tint2/blob/0.14.1/ChangeLog)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).