### PR TITLE
buildtorrent: init at 0.8

### DIFF
--- a/pkgs/tools/misc/buildtorrent/default.nix
+++ b/pkgs/tools/misc/buildtorrent/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl }:
+
+let version = "0.8"; in
+
+stdenv.mkDerivation rec {
+	name = "buildtorrent";
+
+	src = fetchurl {
+		url = "http://mathr.co.uk/blog/code/${name}-${version}.tar.gz";
+		sha256 = "e8e27647bdb38873ac570d46c1a9689a92b01bb67f59089d1cdd08784f7052d0";
+	};
+
+	meta = {
+		description = "A simple commandline torrent creator";
+		homepage = http://mathr.co.uk/blog/torrent.html;
+		license = stdenv.lib.licenses.gpl3Plus;
+		platforms = stdenv.lib.platforms.all;
+	};
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -707,6 +707,8 @@ with pkgs;
 
   btrbk = callPackage ../tools/backup/btrbk { };
 
+  buildtorrent = callPackage ../tools/misc/buildtorrent { };
+
   bwm_ng = callPackage ../tools/networking/bwm-ng { };
 
   byobu = callPackage ../tools/misc/byobu {


### PR DESCRIPTION
###### Motivation for this change
Adding buildtorrent, which is a simple tool to create .torrent files. Even if mktorrent exists, I personally prefer this one.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

