### PR TITLE
Experimental (preview) Pharo packaging

### DIFF
--- a/pkgs/development/pharo/default.nix
+++ b/pkgs/development/pharo/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, callPackage, callPackage_i686, ...} @pkgs:
+
+let
+  vms_x86  = callPackage_i686 ./vm {};
+  vms_x64  = callPackage ./vm {};
+  cogvm = vms_x86.cog;
+  spurvm = vms_x86.spur;
+  spur64vm = if stdenv.is64bit then vms_x64.spur else "none";
+  wrapper  = callPackage ./wrapper { inherit cogvm spurvm spur64vm; };
+  launcher = callPackage ./launcher { pharo-vm = wrapper;};
+  images = callPackage ./images { pharo-vm = wrapper; };
+in
+    
+{
+  pharo          = wrapper;
+  pharo-launcher = launcher;
+} // images
+

--- a/pkgs/development/pharo/default.nix
+++ b/pkgs/development/pharo/default.nix
@@ -7,12 +7,8 @@ let
   spurvm = vms_x86.spur;
   spur64vm = if stdenv.is64bit then vms_x64.spur else "none";
   wrapper  = callPackage ./wrapper { inherit cogvm spurvm spur64vm; };
-  launcher = callPackage ./launcher { pharo-vm = wrapper;};
   images = callPackage ./images { pharo-vm = wrapper; };
 in
     
-{
-  pharo          = wrapper;
-  pharo-launcher = launcher;
-} // images
+{ vm = wrapper; } // images
 

--- a/pkgs/development/pharo/images/build-image.nix
+++ b/pkgs/development/pharo/images/build-image.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     trap cleanup EXIT
     cp $out/share/pharo-image/* \$tempdir
     chmod u+w \$tempdir/*.changes
-    exec ${pharo-vm}/bin/pharo-vm \$tempdir/*.image "$@"
+    exec ${pharo-vm}/bin/pharo-vm \$tempdir/*.image "\$@"
     EOF
   '';
 

--- a/pkgs/development/pharo/images/build-image.nix
+++ b/pkgs/development/pharo/images/build-image.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchurl, bash, pharo-vm, unzip, makeDesktopItem, ... }:
+
+basename: version: url: sha256:
+
+stdenv.mkDerivation rec {
+  name = "pharo-image-${image-name}";
+  src = fetchurl { inherit url sha256; };
+  image-name = "${basename}-${version}";
+  executable-name = image-name;
+  inherit version;
+  desktopItem = makeDesktopItem rec {
+    name = "Pharo-${image-name}";
+    exec = "${executable-name}";
+    icon = "pharo";
+    comment = "Launcher for Pharo image ${image-name}";
+    desktopName = "Pharo-${image-name}";
+    genericName = desktopName;
+    categories = "Development";
+  };
+  sourceRoot = ".";
+  buildInputs = [ bash pharo-vm unzip ];
+
+  # Create script to run the image.
+  # Copies into a read/write directory first. Seems to be needed.
+  buildPhase = ''
+    cat > run.sh <<EOF
+    #!${bash}/bin/bash
+    tempdir=\$(mktemp -d)
+    function cleanup { rm -rf \$tempdir; }
+    trap cleanup EXIT
+    cp $out/share/pharo-image/* \$tempdir
+    chmod u+w \$tempdir/*.changes
+    exec ${pharo-vm}/bin/pharo-vm \$tempdir/*.image "$@"
+    EOF
+  '';
+
+  installPhase = ''
+    # Create shell script
+    mkdir -p $out/bin
+    cp run.sh $out/bin/${image-name}
+    chmod +x $out/bin/${image-name}
+
+    # Copy image and changes files
+    mkdir -p $out/share/pharo-image
+    cp *.image *.changes $out/share/pharo-image/
+  '';
+
+#  doInstallCheck = true;
+  installCheckPhase = ''
+    (set +e
+     export HOME=.
+     echo "starting image to check for crash..."
+     timeout 3 $out/bin/${executable-name} -nodisplay --no-quit eval 'true'
+     test "$?" == 123 && echo "ok")
+  '';
+}
+

--- a/pkgs/development/pharo/images/default.nix
+++ b/pkgs/development/pharo/images/default.nix
@@ -1,0 +1,12 @@
+{ callPackage, pharo-vm, ...} @args:
+
+let image = callPackage ./build-image.nix { inherit pharo-vm; }; in
+
+{
+  pharo6    = (image "pharo"   "6.0" "http://files.pharo.org/image/60/60465.zip"                          "0l58b1vnda2n0qp22k6n4m415dy79jb35pv6n34dkrxldx1l726b");
+  pharo6_64 = (image "pharo64" "6.0" "http://files.pharo.org/image/60/60465-64.zip"                       "0r81f4mhvk8f5al0dayp1qpl23fx59l9zbfzr0j8vcx48x9mw0ln");
+  pharo5    = (image "pharo"   "5.0" "http://files.pharo.org/image/50/50771.zip"                          "1r26x671rg4v8i9crcbyi8r6wgsc5i5zc9r26wgg0hx5hin5847d");
+  moose61   = (image "moose"   "6.1" "https://ci.inria.fr/moose/job/moose-6.1/681/artifact/moose-6.1.zip" "1wnkr9hm9j2bpmkcar7iks70a0gmgi9z04bibzp9bjxgxpxbm99m");
+  launcher  = (image "pharo-launcher" "2017.02.28" "http://files.pharo.org/platform/launcher/PharoLauncher-user-stable-2017.02.28.zip" "1hfwjyx0c47s6ivc1zr2sf5mk1xw2zspsv0ns8mj3kcaglzqwiq0");
+}
+

--- a/pkgs/development/pharo/launcher/default.nix
+++ b/pkgs/development/pharo/launcher/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, bash, pharo-vm, unzip, makeDesktopItem }:
 
 stdenv.mkDerivation rec {
-  version = "0.2.9-2016.01.14";
+  version = "stable-2017.02.28";
   name = "pharo-launcher-${version}";
   src = fetchurl {
-    url = "http://files.pharo.org/platform/launcher/blessed/PharoLauncher-user-${version}.zip";
-    sha256 = "0lzdnaw7l1rrzbrq53xsy38aiz6id5x7s78ds1dhb31vqc241yy8";
+    url = "http://files.pharo.org/platform/launcher/PharoLauncher-user-${version}.zip";
+    sha256 = "1hfwjyx0c47s6ivc1zr2sf5mk1xw2zspsv0ns8mj3kcaglzqwiq0";
   };
 
   executable-name = "pharo-launcher";

--- a/pkgs/development/pharo/launcher/default.nix
+++ b/pkgs/development/pharo/launcher/default.nix
@@ -37,8 +37,7 @@ stdenv.mkDerivation rec {
 
     cat > $prefix/bin/${executable-name} <<EOF
     #!${bash}/bin/bash
-
-    exec ${pharo-vm}/bin/pharo-vm-x $prefix/share/pharo-launcher/pharo-launcher.image
+    exec ${pharo-vm}/bin/pharo $prefix/share/pharo-launcher/pharo-launcher.image
     EOF
     chmod +x $prefix/bin/${executable-name}
   '';
@@ -52,7 +51,7 @@ stdenv.mkDerivation rec {
      secs=5
      echo -n "Running headless Pharo for $secs seconds to check for a crash... "
      timeout $secs \
-       ${pharo-vm}/bin/pharo-vm-nox PharoLauncher.image --no-quit eval 'true'
+       ${pharo-vm}/bin/pharo -nodisplay PharoLauncher.image --no-quit eval 'true'
      test "$?" == 124 && echo "ok")
   '';
 

--- a/pkgs/development/pharo/vm/build-vm-legacy.nix
+++ b/pkgs/development/pharo/vm/build-vm-legacy.nix
@@ -1,0 +1,72 @@
+{ stdenv, fetchurl, cmake, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, ... }:
+
+{ name, src, ... }:
+
+stdenv.mkDerivation rec {
+
+  inherit name src;
+
+  pharo-share = import ./share.nix { inherit stdenv fetchurl unzip; };
+
+  hardeningDisable = [ "format" "pic" ];
+
+  # Building
+  preConfigure = ''
+    cd build/
+  '';
+  resources = ./resources;
+  installPhase = ''
+    mkdir -p "$prefix/lib/$name"
+
+    cd ../../results
+
+    mv vm-display-null vm-display-null.so
+    mv vm-display-X11 vm-display-X11.so
+    mv vm-sound-null vm-sound-null.so
+    mv vm-sound-ALSA vm-sound-ALSA.so
+    mv pharo pharo-vm
+
+    cp * "$prefix/lib/$name"
+
+    mkdir $prefix/bin
+
+    chmod u+w $prefix/bin
+    cat > $prefix/bin/pharo-cog <<EOF
+    #!${bash}/bin/bash
+    # disable parameter expansion to forward all arguments unprocessed to the VM
+    set -f
+    exec $prefix/lib/$name/pharo-vm "\$@"
+    EOF
+
+    chmod +x $prefix/bin/pharo-cog
+
+    ln -s "${pharo-share}/lib/"*.sources $prefix/lib/$name
+  '';
+
+  buildInputs = [ bash unzip cmake glibc openssl gcc mesa freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share ];
+
+  meta = {
+    description = "Clean and innovative Smalltalk-inspired environment";
+    longDescription = ''
+      Pharo's goal is to deliver a clean, innovative, free open-source
+      Smalltalk-inspired environment. By providing a stable and small core
+      system, excellent dev tools, and maintained releases, Pharo is an
+      attractive platform to build and deploy mission critical applications.
+
+      This package provides the executable VM. You should probably not care
+      about this package (which represents a packaging detail) and have a
+      look at the pharo-vm-core package instead.
+
+      Please fill bug reports on http://bugs.pharo.org under the 'Ubuntu
+      packaging (ppa:pharo/stable)' project.
+    '';
+    homepage = http://pharo.org;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.lukego ];
+    # Pharo VM sources are packaged separately for darwin (OS X)
+    platforms = with stdenv.lib;
+                  intersectLists
+                    platforms.mesaPlatforms
+                    (subtractLists platforms.darwin platforms.unix);
+  };
+}

--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -1,16 +1,23 @@
-{ stdenv, fetchurl, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, libuuid, makeDesktopItem, autoreconfHook, gcc6, fetchFromGitHub }:
+{ stdenv, fetchurl, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, libuuid, autoreconfHook, gcc6, ... }:
 
-{ name, src, binary-basename, version, sourceDate, sourceURL, ... }:
+{ name, src, version, source-date, source-url, ... }:
+
+let basename = name; in
+let name = if stdenv.is64bit then "${basename}64" else basename; in
 
 # Build the Pharo VM
 stdenv.mkDerivation rec {
+  inherit name src;
 
-  inherit name src binary-basename;
-  pharo-share = import ./share.nix { inherit stdenv fetchurl unzip; };
-  # Note: -fPIC causes the VM to segfault.
-  hardeningDisable = [ "format" "pic" ];
+  # Command line invocation name.
+  # Distinct name for 64-bit builds because they only work with 64-bit images.
+  cmd = if stdenv.is64bit then "pharo-spur64" else "pharo-spur";
 
-  # Translate the target architecture name into the VM format
+  # Choose desired VM sources. Separate for 32-bit and 64-bit VM.
+  # (Could extent to building more VM variants e.g. SpurV3, Sista, etc.)
+  vm = if stdenv.is64bit then "spur64src" else "spursrc";
+
+  # Choose target platform name in the format used by the vm.
   flavor =
     if      stdenv.isLinux && stdenv.isi686    then "linux32x86"
     else if stdenv.isLinux && stdenv.isx86_64  then "linux64x64"
@@ -18,16 +25,19 @@ stdenv.mkDerivation rec {
     else if stdenv.isDarwin && stdenv.isx86_64 then "macos64x64"
     else abort "Unsupported platform: only Linux/Darwin x86/x64 are supported.";
 
-  # VM has separate source trees for 32-bit vs 64-bit variants
-  vm = if stdenv.is64bit then "spur64src" else "spursrc";
+  # Shared data (for the sources file)
+  pharo-share = import ./share.nix { inherit stdenv fetchurl unzip; };
+
+  # Note: -fPIC causes the VM to segfault.
+  hardeningDisable = [ "format" "pic" ];
 
   # Regenerate the configure script.
-  # This may not be necessary but skipped this step seems to cause breakage.
+  # Unnecessary? But the build breaks without this.
   autoreconfPhase = ''
     (cd opensmalltalk-vm/platforms/unix/config && make)
   '';
 
-  # Configure with options modeled on the 'mvm' build script in the source tree
+  # Configure with options modeled on the 'mvm' build script from the vm.
   configureScript = "platforms/unix/config/configure";
   configureFlags = [ "--without-npsqueak"
                      "--with-vmversion=5.0"
@@ -35,18 +45,19 @@ stdenv.mkDerivation rec {
   CFLAGS = "-msse2 -D_GNU_SOURCE -DCOGMTVM=0 -g -O2 -DNDEBUG -DDEBUGVM=0";
   LDFLAGS = "-Wl,-z,now";
 
-  # Patch the source before building.
+  # VM sources require some patching before build.
   prePatch = ''
     patchShebangs opensmalltalk-vm/build.${flavor}
     # Fix hard-coded path to /bin/rm in a script
     sed -i -e 's:/bin/rm:rm:' opensmalltalk-vm/platforms/unix/config/mkmf
     # Fill in mandatory metadata about the VM source version
-    sed -i -e 's!\$Date\$!$Date: ${sourceDate} $!' \
+    sed -i -e 's!\$Date\$!$Date: ${source-date} $!' \
            -e 's!\$Rev\$!$Rev: ${version} $!' \
-           -e 's!\$URL\$!$URL: ${sourceURL} $!' \
+           -e 's!\$URL\$!$URL: ${source-url} $!' \
            opensmalltalk-vm/platforms/Cross/vm/sqSCCSVersion.h
   '';
 
+  # Note: --with-vmcfg configure option is broken so copy plugin specs to ./
   preConfigure = ''
     cd opensmalltalk-vm
     cp build.${flavor}/pharo.cog.spur/plugins.{ext,int} .
@@ -59,42 +70,30 @@ stdenv.mkDerivation rec {
     make install-squeak install-plugins prefix=$(pwd)/products
 
     # Copy binaries & rename from 'squeak' to 'pharo'
-    mkdir -p $out/lib
-    cp    products/lib/squeak/5.0-*/squeak $out/lib/pharo
+    mkdir -p $out
+    cp    products/lib/squeak/5.0-*/squeak $out/pharo
 
-    cp -r products/lib/squeak/5.0-*/*.so $out/lib/
-    ln -s "${pharo-share}/lib/"*.sources $out/lib/
+    cp -r products/lib/squeak/5.0-*/*.so $out
+    ln -s "${pharo-share}/lib/"*.sources $out
 
-    # Create shell script wrappers pharo-vm-x and pharo-vm-nox.
+    # Create a shell script to run the VM in the proper environment.
     # 
-    # These wrappers put all relevant libraries into the
-    # LD_LIBRARY_PATH which is important because various C code in the VM
+    # These wrapper puts all relevant libraries into the
+    # LD_LIBRARY_PATH. This is important because various C code in the VM
     # and Smalltalk code in the image will search for them there.
     mkdir -p $out/bin
     chmod u+w $out/bin
 
-    # Include the ELF rpath in LD_LIBRARY_PATH too.
-    # This is necessary for the Smalltalk FFI to be able to call libc.
-    libs=$out/lib:$(patchelf --print-rpath $out/lib/pharo):${cairo}/lib:${mesa}/lib:${freetype}/lib:${openssl}/lib:${libuuid}/lib:${alsaLib}/lib:${xorg.libICE}/lib:${xorg.libSM}/lib
+    # Note: include ELF rpath in LD_LIBRARY_PATH for finding libc.
+    libs=$out:$(patchelf --print-rpath $out/pharo):${cairo}/lib:${mesa}/lib:${freetype}/lib:${openssl}/lib:${libuuid}/lib:${alsaLib}/lib:${xorg.libICE}/lib:${xorg.libSM}/lib
 
-    # Graphical VM
-    cat > $out/bin/${binary-basename}-x <<EOF
+    # Create the script
+    cat > $out/bin/${cmd} <<EOF
     #!/bin/sh
     set -f
-    LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:$libs" exec $out/lib/pharo -vm-display-X11 "\$@"
+    LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:$libs" exec $out/pharo "\$@"
     EOF
-    chmod +x $prefix/bin/${binary-basename}-x
-
-    # Headless VM
-    cat > $out/bin/${binary-basename}-nox <<EOF
-    #!/bin/sh
-    set -f
-    LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:$libs" exec $out/lib/pharo -vm-display-null "\$@"
-    EOF
-    chmod +x $out/bin/${binary-basename}-nox
-
-    mkdir -p "$prefix/share/applications"
-    cp "${desktopItem}/share/applications/"* $prefix/share/applications
+    chmod +x $prefix/bin/${cmd}
   '';
 
   enableParallelBuilding = true;
@@ -102,20 +101,6 @@ stdenv.mkDerivation rec {
   # Note: Force gcc6 because gcc5 crashes when compiling the VM.
   buildInputs = [ bash unzip glibc openssl gcc6 mesa freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share libuuid autoreconfHook ];
 
-  resources = ./resources;
-
-  desktopItem = makeDesktopItem {
-    inherit name;
-    desktopName = "Pharo VM";
-    genericName = "Pharo Virtual Machine";
-    exec = "${binary-basename}-x %F";
-    icon = "pharo";
-    terminal = "false";
-    type="Application";
-    startupNotify = "false";
-    categories = "Development;";
-    mimeType = "application/x-pharo-image";
-  };
 
   meta = {
     description = "Clean and innovative Smalltalk-inspired environment";
@@ -134,7 +119,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://pharo.org;
     license = stdenv.lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ stdenv.lib.maintainers.lukego ];
     # Pharo VM sources are packaged separately for darwin (OS X)
     platforms = with stdenv.lib;
                   intersectLists

--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -1,12 +1,108 @@
-{ stdenv, fetchurl, cmake, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, makeDesktopItem }:
+{ stdenv, fetchurl, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, libuuid, makeDesktopItem, autoreconfHook, gcc6, fetchFromGitHub }:
 
-{ name, src, binary-basename, ... }:
+{ name, src, binary-basename, version, sourceDate, sourceURL, ... }:
 
+# Build the Pharo VM
 stdenv.mkDerivation rec {
 
   inherit name src binary-basename;
-
   pharo-share = import ./share.nix { inherit stdenv fetchurl unzip; };
+  # Note: -fPIC causes the VM to segfault.
+  hardeningDisable = [ "format" "pic" ];
+
+  # Translate the target architecture name into the VM format
+  flavor =
+    if      stdenv.isLinux && stdenv.isi686    then "linux32x86"
+    else if stdenv.isLinux && stdenv.isx86_64  then "linux64x64"
+    else if stdenv.isDarwin && stdenv.isi686   then "macos32x86"
+    else if stdenv.isDarwin && stdenv.isx86_64 then "macos64x64"
+    else abort "Unsupported platform: only Linux/Darwin x86/x64 are supported.";
+
+  # VM has separate source trees for 32-bit vs 64-bit variants
+  vm = if stdenv.is64bit then "spur64src" else "spursrc";
+
+  # Regenerate the configure script.
+  # This may not be necessary but skipped this step seems to cause breakage.
+  autoreconfPhase = ''
+    (cd opensmalltalk-vm/platforms/unix/config && make)
+  '';
+
+  # Configure with options modeled on the 'mvm' build script in the source tree
+  configureScript = "platforms/unix/config/configure";
+  configureFlags = [ "--without-npsqueak"
+                     "--with-vmversion=5.0"
+                     "--with-src=${vm}" ];
+  CFLAGS = "-msse2 -D_GNU_SOURCE -DCOGMTVM=0 -g -O2 -DNDEBUG -DDEBUGVM=0";
+  LDFLAGS = "-Wl,-z,now";
+
+  # Patch the source before building.
+  prePatch = ''
+    patchShebangs opensmalltalk-vm/build.${flavor}
+    # Fix hard-coded path to /bin/rm in a script
+    sed -i -e 's:/bin/rm:rm:' opensmalltalk-vm/platforms/unix/config/mkmf
+    # Fill in mandatory metadata about the VM source version
+    sed -i -e 's!\$Date\$!$Date: ${sourceDate} $!' \
+           -e 's!\$Rev\$!$Rev: ${version} $!' \
+           -e 's!\$URL\$!$URL: ${sourceURL} $!' \
+           opensmalltalk-vm/platforms/Cross/vm/sqSCCSVersion.h
+  '';
+
+  preConfigure = ''
+    cd opensmalltalk-vm
+    cp build.${flavor}/pharo.cog.spur/plugins.{ext,int} .
+  '';
+
+  # (No special build phase.)
+
+  installPhase = ''
+    # Install in working directory and then copy
+    make install-squeak install-plugins prefix=$(pwd)/products
+
+    # Copy binaries & rename from 'squeak' to 'pharo'
+    mkdir -p $out/lib
+    cp    products/lib/squeak/5.0-*/squeak $out/lib/pharo
+
+    cp -r products/lib/squeak/5.0-*/*.so $out/lib/
+    ln -s "${pharo-share}/lib/"*.sources $out/lib/
+
+    # Create shell script wrappers pharo-vm-x and pharo-vm-nox.
+    # 
+    # These wrappers put all relevant libraries into the
+    # LD_LIBRARY_PATH which is important because various C code in the VM
+    # and Smalltalk code in the image will search for them there.
+    mkdir -p $out/bin
+    chmod u+w $out/bin
+
+    # Include the ELF rpath in LD_LIBRARY_PATH too.
+    # This is necessary for the Smalltalk FFI to be able to call libc.
+    libs=$out/lib:$(patchelf --print-rpath $out/lib/pharo):${cairo}/lib:${mesa}/lib:${freetype}/lib:${openssl}/lib:${libuuid}/lib:${alsaLib}/lib:${xorg.libICE}/lib:${xorg.libSM}/lib
+
+    # Graphical VM
+    cat > $out/bin/${binary-basename}-x <<EOF
+    #!/bin/sh
+    set -f
+    LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:$libs" exec $out/lib/pharo -vm-display-X11 "\$@"
+    EOF
+    chmod +x $prefix/bin/${binary-basename}-x
+
+    # Headless VM
+    cat > $out/bin/${binary-basename}-nox <<EOF
+    #!/bin/sh
+    set -f
+    LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:$libs" exec $out/lib/pharo -vm-display-null "\$@"
+    EOF
+    chmod +x $out/bin/${binary-basename}-nox
+
+    mkdir -p "$prefix/share/applications"
+    cp "${desktopItem}/share/applications/"* $prefix/share/applications
+  '';
+
+  enableParallelBuilding = true;
+
+  # Note: Force gcc6 because gcc5 crashes when compiling the VM.
+  buildInputs = [ bash unzip glibc openssl gcc6 mesa freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share libuuid autoreconfHook ];
+
+  resources = ./resources;
 
   desktopItem = makeDesktopItem {
     inherit name;
@@ -20,57 +116,6 @@ stdenv.mkDerivation rec {
     categories = "Development;";
     mimeType = "application/x-pharo-image";
   };
-
-  hardeningDisable = [ "format" "pic" ];
-
-  # Building
-  preConfigure = ''
-    cd build/
-  '';
-  resources = ./resources;
-  installPhase = ''
-    mkdir -p "$prefix/lib/$name"
-
-    cd ../../results
-
-    mv vm-display-null vm-display-null.so
-    mv vm-display-X11 vm-display-X11.so
-    mv vm-sound-null vm-sound-null.so
-    mv vm-sound-ALSA vm-sound-ALSA.so
-    mv pharo pharo-vm
-
-    cp * "$prefix/lib/$name"
-
-    mkdir -p "$prefix/share/applications"
-    cp "${desktopItem}/share/applications/"* $prefix/share/applications
-
-    mkdir $prefix/bin
-
-    chmod u+w $prefix/bin
-    cat > $prefix/bin/${binary-basename}-x <<EOF
-    #!${bash}/bin/bash
-
-    # disable parameter expansion to forward all arguments unprocessed to the VM
-    set -f
-
-    exec $prefix/lib/$name/pharo-vm "\$@"
-    EOF
-
-    cat > $prefix/bin/${binary-basename}-nox <<EOF
-    #!${bash}/bin/bash
-
-    # disable parameter expansion to forward all arguments unprocessed to the VM
-    set -f
-
-    exec $prefix/lib/$name/pharo-vm -vm-display-null "\$@"
-    EOF
-
-    chmod +x $prefix/bin/${binary-basename}-x $prefix/bin/${binary-basename}-nox
-
-    ln -s "${pharo-share}/lib/"*.sources $prefix/lib/$name
-  '';
-
-  buildInputs = [ bash unzip cmake glibc openssl gcc mesa freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share ];
 
   meta = {
     description = "Clean and innovative Smalltalk-inspired environment";

--- a/pkgs/development/pharo/vm/default.nix
+++ b/pkgs/development/pharo/vm/default.nix
@@ -1,27 +1,26 @@
-{ stdenv, fetchurl, cmake, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, makeDesktopItem } @args:
+{ stdenv, fetchurl, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, libuuid, makeDesktopItem, autoreconfHook, gcc6, fetchFromGitHub } @args:
 
-rec {
-  pharo-vm-build = import ./build-vm.nix args;
+let pharo-vm-build = import ./build-vm.nix args; in
 
-  base-url = http://files.pharo.org/vm/src/vm-unix-sources/blessed;
-
-  pharo-no-spur = pharo-vm-build rec {
-    version = "2016.02.18";
-    name = "pharo-vm-i386-${version}";
+{
+  pharo-vm = pharo-vm-build rec {
+    name = "pharo-vm";
+    version = "git.${revision}";
     binary-basename = "pharo-vm";
-    src = fetchurl {
-      url = "${base-url}/pharo-vm-${version}.tar.bz2";
-      sha256 = "16n2zg7v2s1ml0vvpbhkw6khmgn637sr0d7n2b28qm5yc8pfhcj4";
+    src = fetchFromGitHub {
+      owner = "pharo-project";
+      repo = "pharo-vm";
+      rev = revision;
+      sha256 = "114ydx015i8sg4xwy1hkb7vwkcxl93h5vqz4bry46x2gnvsay7yh";
     };
-  };
-
-  pharo-spur = pharo-vm-build rec {
-    version = "2016.07.16";
-    name = "pharo-vm-spur-i386-${version}";
-    binary-basename = "pharo-spur-vm";
-    src = fetchurl {
-      url = "${base-url}/pharo-vm-spur-${version}.tar.bz2";
-      sha256 = "07nk4w5wh7gcf27cch5paqp9zdlshnknpv4y7imxlkjd76viac2b";
-    };
+    # This metadata will be compiled into the VM and introspectable
+    # from Smalltalk. This has been manually extracted from 'git log'.
+    #
+    # The build would usually generate this automatically using
+    # opensmalltalk-vm/.git_filters/RevDateURL.smudge but that script
+    # is too impure to run from nix.
+    revision = "1c38b03fb043a2962f30f080db5b1292b5b7badb";
+    sourceDate = "Wed Apr 12 19:25:16 2017 +0200";
+    sourceURL  = "https://github.com/pharo-project/pharo-vm";
   };
 }

--- a/pkgs/development/pharo/vm/default.nix
+++ b/pkgs/development/pharo/vm/default.nix
@@ -1,12 +1,15 @@
-{ stdenv, fetchurl, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, libuuid, makeDesktopItem, autoreconfHook, gcc6, fetchFromGitHub } @args:
+{ cmake, stdenv, fetchurl, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, libuuid, autoreconfHook, gcc6, fetchFromGitHub } @args:
 
-let pharo-vm-build = import ./build-vm.nix args; in
+let
+  pharo-vm-build = import ./build-vm.nix args;
+  pharo-vm-build-legacy = import ./build-vm-legacy.nix args;
+in
 
-{
-  pharo-vm = pharo-vm-build rec {
+rec {
+  # Build the latest VM for running p
+  spur = pharo-vm-build rec {
     name = "pharo-vm";
     version = "git.${revision}";
-    binary-basename = "pharo-vm";
     src = fetchFromGitHub {
       owner = "pharo-project";
       repo = "pharo-vm";
@@ -20,7 +23,22 @@ let pharo-vm-build = import ./build-vm.nix args; in
     # opensmalltalk-vm/.git_filters/RevDateURL.smudge but that script
     # is too impure to run from nix.
     revision = "1c38b03fb043a2962f30f080db5b1292b5b7badb";
-    sourceDate = "Wed Apr 12 19:25:16 2017 +0200";
-    sourceURL  = "https://github.com/pharo-project/pharo-vm";
+    source-date = "Wed Apr 12 19:25:16 2017 +0200";
+    source-url  = "https://github.com/pharo-project/pharo-vm";
   };
+
+  # Build an old ("legacy") CogV3 VM for running pre-spur images.
+  # (Could be nicer to build the latest VM in CogV3 mode but this is
+  # not supported on the Pharo VM variant at the moment.)
+  cog = pharo-vm-build-legacy rec {
+    version = "2016.02.18";
+    name = "pharo-vm-i386-${version}";
+    base-url = http://files.pharo.org/vm/src/vm-unix-sources/blessed;
+    src = fetchurl {
+      url = "${base-url}/pharo-vm-${version}.tar.bz2";
+      sha256 = "16n2zg7v2s1ml0vvpbhkw6khmgn637sr0d7n2b28qm5yc8pfhcj4";
+    };
+  };
+
 }
+

--- a/pkgs/development/pharo/vm/wrapper.nix
+++ b/pkgs/development/pharo/vm/wrapper.nix
@@ -1,0 +1,23 @@
+{ stdenv, makeDesktopItem, cog-vm, spur-vm, spur64-vm ? "none" }:
+
+stdenv.mkDerivation rec {
+  name = "pharo";
+  resources = ./resources;
+  desktopItem = makeDesktopItem {
+    inherit name;
+    desktopName = "Pharo VM";
+    genericName = "Pharo Virtual Machine";
+    exec = "pharo %F";
+    icon = "pharo";
+    terminal = "false";
+    type="Application";
+    startupNotify = "false";
+    categories = "Development;";
+    mimeType = "application/x-pharo-image";
+  };
+  installPhase = ''
+    mkdir -p $out/bin
+    substituteAll ${./wrapper.sh} $out/bin/pharo
+  '';
+}
+

--- a/pkgs/development/pharo/vm/wrapper.sh
+++ b/pkgs/development/pharo/vm/wrapper.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# This is based on the script by David T. Lewis posted here:
+#  http://lists.squeakfoundation.org/pipermail/vm-dev/2017-April/024836.html
+#
+# VM run utility script
+# usage: run <myimage>
+#
+# Select a VM and run an image based on the image format number
+
+# Search for the image filename in the command line arguments
+for arg in $*; do
+    case ${arg} in
+        -*) # ignore
+        ;;
+        *) # either an option argument or the image name
+            if test -f ${arg}; then
+                magic=$(file -m @share@/magic "$arg")
+                case "$magic" in
+                    'Smalltalk image V3 32b*')
+                        image=${arg}
+                        vm=@cog-vm@/bin/pharo-cog
+                        ;;
+                    'Smalltalk image Spur 32b*')
+                        image=${arg}
+                        vm=@spur-vm@/bin/pharo-spur
+                        ;;
+                    'Smalltalk image Spur 64b*')
+                        if "@spur64-vm@" == "none"; then
+                            echo "error: detected 64-bit image but 64-bit VM is not available" >&2
+                            exit 1
+                        fi
+                        image=${arg}
+                        vm=@spur64-vm@/bin/pharo-spur64
+                        ;;
+                esac
+            fi
+            ;;
+    esac
+done
+
+# Extra arguments to pass to the VM
+args=""
+
+# Print a message to explain our DWIM'ery.
+if -n "$image"; then
+    echo "using VM selected by image type."
+    echo "  image: $image"
+    echo "  type:  $magic"
+    echo "  vm:    $vm"
+elif test "$#" == 0; then
+    echo "using default vm and image; none specified on command line"
+    args="@default-image@"
+    # XXX Just assume this is the right VM (for pharo launcher)
+    vm=@cog-vm@/bin/pharo-cog
+else
+    echo "using default vm; image type not detected"
+fi
+
+# Run the VM
+set -f
+exec ${vm} $args "$@"
+

--- a/pkgs/development/pharo/wrapper/default.nix
+++ b/pkgs/development/pharo/wrapper/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, file, makeDesktopItem, cogvm, spurvm, spur64vm ? "none" }:
+
+stdenv.mkDerivation rec {
+  name = "pharo";
+  src = ./.;
+  inherit cogvm spurvm spur64vm file;
+  magic = ./magic;
+  desktopItem = makeDesktopItem {
+    inherit name;
+    desktopName = "Pharo VM";
+    genericName = "Pharo Virtual Machine";
+    exec = "pharo %F";
+    icon = "pharo";
+    terminal = "false";
+    type="Application";
+    startupNotify = "false";
+    categories = "Development;";
+    mimeType = "application/x-pharo-image";
+  };
+  buildPhase = ''
+    substituteAllInPlace ./pharo-vm.sh
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp pharo-vm.sh $out/bin/pharo-vm
+    chmod +x $out/bin/pharo-vm
+  '';
+  meta = {
+    description = "Clean and innovative Smalltalk-inspired environment";
+    longDescription = ''
+      Pharo's goal is to deliver a clean, innovative, free open-source
+      Smalltalk-inspired environment. By providing a stable and small core
+      system, excellent dev tools, and maintained releases, Pharo is an
+      attractive platform to build and deploy mission critical applications.
+
+      This package provides a wrapper script to automatically execute
+      a VM that is compatible with the image being opened. This is
+      helpful because different Pharo images require different VM
+      builds.
+    '';
+
+    homepage = http://pharo.org;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.lukego ];
+    # Pharo VM sources are packaged separately for darwin (OS X)
+    platforms = with stdenv.lib;
+                  intersectLists
+                    platforms.mesaPlatforms
+                    (subtractLists platforms.darwin platforms.unix);
+  };
+}
+

--- a/pkgs/development/pharo/wrapper/magic
+++ b/pkgs/development/pharo/wrapper/magic
@@ -1,0 +1,37 @@
+# Smalltalk image file formats
+0 lelong    6502  Smalltalk image V3 32b  (%d)
+!:mime application/squeak-image
+0      belong   6502    Smalltalk image V3 32b  (%d)
+!:mime application/squeak-image
+0      lelong   6504    Smalltalk image V3 32b +C (%d)
+!:mime application/cog-image
+0      belong   6504    Smalltalk image V3 32b +C (%d)
+!:mime application/cog-image
+0      lelong   68000   Smalltalk image V3 64b  (%d)
+!:mime application/squeak64-image
+4      belong   68000   Smalltalk image V3 64b  (%d)
+!:mime application/squeak64-image
+0      lelong   68002   Smalltalk image V3 64b +C (%d)
+!:mime application/cog64-image
+4      belong   68002   Smalltalk image V3 64b +C (%d)
+!:mime application/cog64-image
+0      lelong   6505    Smalltalk image V3 32b +C+NF (%d)
+!:mime application/cog-image
+0      belong   6505    Smalltalk image V3 32b +C+NF (%d)
+!:mime application/cog-image
+0      lelong   68003   Smalltalk image V3 64b +C+NF (%d)
+!:mime application/cog64-image
+4      belong   68003   Smalltalk image V3 64b +C+NF (%d)
+!:mime application/cog64-image
+0      lelong   6521    Smalltalk image Spur 32b +C+NF (%d)
+!:mime application/spur-image
+0      belong   6521    Smalltalk image Spur 32b +C+NF (%d)
+!:mime application/spur-image
+0      lelong   68019   Smalltalk image Spur 64b +C+NF (%d)
+!:mime application/spur64-image
+4      belong   68019   Smalltalk image Spur 64b +C+NF (%d)
+!:mime application/spur64-image
+0      lelong   68021   Smalltalk image Spur 64b +C+NF+Tag (%d)
+!:mime application/spur64-image
+4      belong   68021   Smalltalk image Spur 64b +C+NF+Tag (%d)
+!:mime application/spur64-image

--- a/pkgs/development/pharo/wrapper/pharo-vm.sh
+++ b/pkgs/development/pharo/wrapper/pharo-vm.sh
@@ -10,13 +10,13 @@
 PATH=$PATH:@file@/bin
 
 # Search for the image filename in the command line arguments
-for arg in $*; do
+for arg in $* $SQUEAK_IMAGE; do
     case ${arg} in
         -*) # ignore
         ;;
         *) # either an option argument or the image name
-            if test -f ${arg}; then
-                magic=$(file -b -m @magic@ "$arg")
+            if test -e ${arg}; then
+                magic=$(file -L -b -m @magic@ "$arg")
                 case "$magic" in
                     "Smalltalk image V3 32b"*)
                         image=${arg}
@@ -40,9 +40,6 @@ for arg in $*; do
     esac
 done
 
-# Extra arguments to pass to the VM
-args=""
-
 # Print a message to explain our DWIM'ery.
 if [ -n "$image" ]; then
     echo "using VM selected by image type."
@@ -56,5 +53,5 @@ fi
 
 # Run the VM
 set -f
-exec -- ${vm} $args "$@"
+exec -- ${vm} $@
 

--- a/pkgs/development/pharo/wrapper/pharo-vm.sh
+++ b/pkgs/development/pharo/wrapper/pharo-vm.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# This is based on the script by David T. Lewis posted here:
+#  http://lists.squeakfoundation.org/pipermail/vm-dev/2017-April/024836.html
+#
+# VM run utility script
+# usage: run <myimage>
+#
+# Select a VM and run an image based on the image format number
+
+PATH=$PATH:@file@/bin
+
+# Search for the image filename in the command line arguments
+for arg in $*; do
+    case ${arg} in
+        -*) # ignore
+        ;;
+        *) # either an option argument or the image name
+            if test -f ${arg}; then
+                magic=$(file -b -m @magic@ "$arg")
+                case "$magic" in
+                    "Smalltalk image V3 32b"*)
+                        image=${arg}
+                        vm=@cogvm@/bin/pharo-cog
+                        ;;
+                    "Smalltalk image Spur 32b"*)
+                        image=${arg}
+                        vm=@spurvm@/bin/pharo-spur
+                        ;;
+                    "Smalltalk image Spur 64b"*)
+                        if [ "@spur64vm@" == "none" ]; then
+                            echo "error: detected 64-bit image but 64-bit VM is not available" >&2
+                            exit 1
+                        fi
+                        image=${arg}
+                        vm=@spur64vm@/bin/pharo-spur64
+                        ;;
+                esac
+            fi
+            ;;
+    esac
+done
+
+# Extra arguments to pass to the VM
+args=""
+
+# Print a message to explain our DWIM'ery.
+if [ -n "$image" ]; then
+    echo "using VM selected by image type."
+    echo "  image: $image"
+    echo "  type:  $magic"
+    echo "  vm:    $vm"
+else
+    echo "using default vm; image type not detected"
+    vm=@cogvm@/bin/pharo-cog
+fi
+
+# Run the VM
+set -f
+exec -- ${vm} $args "$@"
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6232,9 +6232,7 @@ with pkgs;
 
   guile-xcb = callPackage ../development/guile-modules/guile-xcb { };
 
-  pharo-vm = (callPackage_i686 ../development/pharo/vm { }).pharo-vm;
-
-  pharo-launcher = callPackage ../development/pharo/launcher { };
+  pharo = (callPackage ../development/pharo { });
 
   srecord = callPackage ../development/tools/misc/srecord { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6232,9 +6232,7 @@ with pkgs;
 
   guile-xcb = callPackage ../development/guile-modules/guile-xcb { };
 
-  pharo-vms = callPackage_i686 ../development/pharo/vm { };
-  pharo-vm  = pharo-vms.pharo-no-spur;
-  pharo-vm5 = pharo-vms.pharo-spur;
+  pharo-vm = (callPackage_i686 ../development/pharo/vm { }).pharo-vm;
 
   pharo-launcher = callPackage ../development/pharo/launcher { };
 


### PR DESCRIPTION
This is an experimental new packaging of [Pharo](http://pharo.org/) for nixpkgs. I am concerned that this may be a dead-end due to the [xkcd 927](https://xkcd.com/927/) problem. There are too many ways to distribute and install Pharo applications and I may simply be making that worse. However, I would not like this work to be lost and so I share it here now.

This branch provides a few packages:

- `pharo-vm` is a wrapper for starting a suitable virtual machine. These days there are at least three mutually incompatible variants of the VM and each application will work in exactly one of them. The wrapper hides this complexity from the user and chooses the right one automatically. (This is based on a script shared on an upstream pharo mailing list.)
- Several applications (images): `pharo-5.0`, `pharo-6.0`, `moose-6.1`, etc. These are binaries from the internet and provided for convenient & so that they are tested for compatibility with the VMs.
- Behind the scenes, three virtual machines. One (cog) is built from an old source release and the others (spur and spur64) are built from very recent code using different build options (32-bit vs 64-bit.)

Compared with the existing pharo support in nixpkgs this should be more compatible (updated VMs) and provides more images (additional to the "launcher" image that frankly does not seem to work that well or be very actively maintained.) This branch also features a rewritten virtual machine build derivation in `build-vm.nix` because the latest VMs have a different build procedure to the one that was packaged before.

Just now I am considering whether to drop branch entirely, or upstream the virtual machine part, or upstream the whole shebang. See [squeak vm-dev mailing list](http://lists.squeakfoundation.org/pipermail/vm-dev/2017-April/024854.html) post for the thought process.

Feedback on the overall direction from nixpkgs point of view would be welcome if anybody else is specifically interested in Pharo.