### PR TITLE
imager (r-modules): add pkgs.x11, unmark imager/ForestTools as broken

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -262,6 +262,7 @@ let
     h5 = [ pkgs.hdf5-cpp pkgs.which ];
     h5vc = [ pkgs.zlib.dev ];
     HiCseg = [ pkgs.gsl_1 ];
+    imager = [ pkgs.x11 ];
     iBMQ = [ pkgs.gsl_1 ];
     igraph = [ pkgs.gmp ];
     JavaGD = [ pkgs.jdk ];
@@ -832,7 +833,6 @@ let
     "flowVS"                          # depends on broken package r-flowCore-1.38.2
     "flowWorkspace"                   # depends on broken package r-flowCore-1.38.2
     "fmcsR"                           # depends on broken package ChemmineR-2.24.2
-    "ForestTools"                     # depends on broken package imager-0.31
     "fPortfolio"                      # depends on broken package Rsymphony-0.1-26
     "fracprolif"                      # build is broken
     "funModeling"                     # build is broken
@@ -888,7 +888,6 @@ let
     "IHW"                             # depends on broken package r-lpsymphony-1.0.2
     "IHWpaper"                        # depends on broken package r-lpsymphony-1.0.2
     "IlluminaHumanMethylation450k_db" # build is broken
-    "imager"                          # build is broken
     "immunoClust"                     # depends on broken package r-flowCore-1.38.2
     "inSilicoMerging"                 # build is broken
     "intansv"                         # build is broken


### PR DESCRIPTION
###### Motivation for this change
The R module `imager` is broken (the build complains of missing X11), and this change addresses that issue to allow the module to build. In the process, the R module `ForestTools` (which was marked as broken due to depending on `imager`) also now builds, so both were removed from `brokenPackages`.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

