### PR TITLE
mapnik: add optional PostgreSQL dependency for PostGIS input

### DIFF
--- a/pkgs/development/libraries/mapnik/default.nix
+++ b/pkgs/development/libraries/mapnik/default.nix
@@ -1,6 +1,8 @@
 { stdenv, fetchzip
 , boost, cairo, freetype, gdal, harfbuzz, icu, libjpeg, libpng, libtiff
 , libwebp, libxml2, proj, python2, scons, sqlite, zlib
+, postgresql ? null
+# Postgresql is needed only for the PostGIS input plugin
 }:
 
 stdenv.mkDerivation rec {
@@ -20,7 +22,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ boost cairo freetype gdal harfbuzz icu libjpeg libpng libtiff
-      libwebp libxml2 proj python2 sqlite zlib
+      libwebp libxml2 proj python2 sqlite zlib postgresql
     ];
 
   configurePhase = ''


### PR DESCRIPTION
###### Motivation for this change

Mapnik supports PostgreSQL & PostGIS, but only builds the PostGIS input plugin if PostgreSQL is available as a build-time dependency. This adds it, but makes it optional and disabled by default.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

