### PR TITLE
binder and pybind11 packages

### DIFF
--- a/pkgs/development/libraries/pybind11/default.nix
+++ b/pkgs/development/libraries/pybind11/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, python
+}:
+
+# This is a header-only package.
+
+# Note that there is also a package on PyPI.
+# That version is installable with buildPythonPackage / setuptools,
+# but it cannot run the tests.
+
+stdenv.mkDerivation rec {
+  pname = "pybind11";
+  version = "2.1.1";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "pybind";
+    repo = "pybind11";
+    rev = "v2.1.1";
+    sha256 = "1qhnd1yr38zr71j01nnf992m3rbfghx9fdpqhqssm6zbdxlvkdqn";
+  };
+
+  buildInputs = [ cmake python.pkgs.pytest ];
+
+  meta = {
+    description = "Seamless operability between C++11 and Python";
+    homepage = https://github.com/wjakob/pybind11;
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/tools/bindings/binder/default.nix
+++ b/pkgs/development/tools/bindings/binder/default.nix
@@ -1,0 +1,60 @@
+{ runCommand
+, fetchFromGitHub
+, llvmPackages_38
+}:
+
+# Installation instructions
+# http://cppbinder.readthedocs.io/en/latest/install.html
+
+let
+  # Binder source
+  version = "2017-03-27";
+
+  # Binder source in tarball including required CMakeLists.txt
+  binder_packaged_src = let
+    binder_src = fetchFromGitHub {
+      owner = "RosettaCommons";
+      repo = "binder";
+      rev = "dababfe3e12569ac4371502286811e6fb1926ef3";
+      sha256 = "04bldqg6v0cbb42rjv12zwl56rx7nkvlm5xwm5hi3qva5z7i535b";
+      #name = src_name;
+    };
+    # Because of an issue with the vendored copy of fmt we use
+    # an original version.
+    # https://github.com/RosettaCommons/binder/issues/19
+    fmt_src = fetchFromGitHub {
+      owner = "fmtlib";
+      repo = "fmt";
+      rev = "3.0.1";
+      sha256 = "1r5lrdkfk0ljbwxnq5jhx6cdli83a8lixrgnzg0xamwjn4v4mm6w";
+    };
+    # Our clang expression expects the following name clang-tools-extra-*
+    binder_src_name = "clang-tools-extra-binder";
+
+   in runCommand (binder_src_name + ".tar.gz") {} ''
+     unpackFile ${fmt_src}
+     unpackFile ${binder_src}
+     mv fmt* fmt
+     mv binder* binder
+     chmod -R u+w fmt
+     chmod -R u+w binder
+
+     rm -rf binder/binder/fmt
+     cp -r fmt/fmt binder/binder/fmt
+     echo 'add_subdirectory(binder)' > binder/CMakeLists.txt
+
+     mv binder ${binder_src_name}
+     tar -zcf $out ${binder_src_name}
+  '';
+
+in (llvmPackages_38.clang-unwrapped.override {
+#   inherit python;
+  clang-tools-extra_src = binder_packaged_src;
+}).overrideAttrs (old: {
+  name = "binder-${version}";
+  NIX_CFLAGS_COMPILE="-fexceptions";
+
+  postInstall = old.postInstall + ''
+    mv bin/binder $out/bin/binder
+  '';
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1152,6 +1152,8 @@ with pkgs;
 
   atool = callPackage ../tools/archivers/atool { };
 
+  binder = callPackage ../development/tools/bindings/binder { };
+
   bsc = callPackage ../tools/compression/bsc { };
 
   bzip2 = callPackage ../tools/compression/bzip2 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15190,6 +15190,8 @@ with pkgs;
 
   pymol = callPackage ../applications/science/chemistry/pymol { };
 
+  pybind11 = callPackage ../development/libraries/pybind11 { };
+
   pybitmessage = callPackage ../applications/networking/instant-messengers/pybitmessage { };
 
   pythonmagick = callPackage ../applications/graphics/PythonMagick { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

