### PR TITLE
Add Darwin as platform to various "broken" packages that actually build

### DIFF
--- a/pkgs/applications/graphics/tesseract/default.nix
+++ b/pkgs/applications/graphics/tesseract/default.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation rec {
     homepage = http://code.google.com/p/tesseract-ocr/;
     license = stdenv.lib.licenses.asl20;
     maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/misc/girara/default.nix
+++ b/pkgs/applications/misc/girara/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, gettext, ncurses
+{ stdenv, fetchurl, pkgconfig, gtk, gettext, ncurses, libiconv, libintlOrEmpty
 , withBuildColors ? true
 }:
 
@@ -18,7 +18,10 @@ stdenv.mkDerivation rec {
       --replace 'ifdef TPUT_AVAILABLE' 'ifneq ($(TPUT_AVAILABLE), 0)'
   '';
 
-  buildInputs = [ pkgconfig gtk gettext ];
+  buildInputs = [ pkgconfig gtk gettext libintlOrEmpty ]
+    ++ stdenv.lib.optional stdenv.isDarwin libiconv;
+
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 
   makeFlags = [
     "PREFIX=$(out)"
@@ -35,7 +38,7 @@ stdenv.mkDerivation rec {
       that focuses on simplicity and minimalism.
     '';
     license = licenses.zlib;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.garbas ];
   };
 }

--- a/pkgs/applications/misc/wordnet/default.nix
+++ b/pkgs/applications/misc/wordnet/default.nix
@@ -42,6 +42,6 @@ stdenv.mkDerivation {
     homepage = http://wordnet.princeton.edu/;
 
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/networking/mailreaders/sylpheed/default.nix
+++ b/pkgs/applications/networking/mailreaders/sylpheed/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     homepage = http://sylpheed.sraoss.jp/en/;
     description = "A lightweight and user-friendly e-mail client";
     maintainers = [ maintainers.eelco ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     license = "GPL";
   };
 }

--- a/pkgs/applications/office/antiword/default.nix
+++ b/pkgs/applications/office/antiword/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation {
 
   prePatch = ''
     sed -i -e "s|/usr/local/bin|$out/bin|g" -e "s|/usr/share|$out/share|g" Makefile antiword.h
+    substituteInPlace Makefile --replace "gcc" "cc"
   '';
 
   patches = [ ./10_fix_buffer_overflow_wordole_c.patch ];
@@ -25,6 +26,6 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.gpl2;
 
     maintainers = [ stdenv.lib.maintainers.peti ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/video/dvdauthor/default.nix
+++ b/pkgs/applications/video/dvdauthor/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec{
     description = "Tools for generating DVD files to be played on standalone DVD players";
     homepage = http://dvdauthor.sourceforge.net/;
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/desktops/gnome-3/3.22/core/dconf/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/dconf/default.nix
@@ -18,8 +18,13 @@ stdenv.mkDerivation rec {
   buildInputs = [ vala_0_32 libxslt pkgconfig glib dbus_glib gnome3.gtk libxml2
                   intltool docbook_xsl docbook_xsl_ns makeWrapper ];
 
+  postConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace client/Makefile \
+      --replace "-soname=libdconf.so.1" "-install_name,libdconf.so.1"
+  '';
+
   meta = with stdenv.lib; {
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = gnome3.maintainers;
   };
 }

--- a/pkgs/desktops/gnome-3/3.22/core/vte/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/vte/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = "patchShebangs .";
 
-  configureFlags = [ "--enable-introspection" ];
+  configureFlags = [ "--enable-introspection" "--disable-Bsymbolic" ];
 
   enableParallelBuilding = true;
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.lgpl2;
     maintainers = with maintainers; [ astsmtl antono lethalman ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }
 

--- a/pkgs/development/compilers/colm/default.nix
+++ b/pkgs/development/compilers/colm/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     description = "A programming language for the analysis and transformation of computer languages";
     homepage = http://www.colm.net/open-source/colm;
     license = licenses.gpl2;
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ pSub ];
   };
 }

--- a/pkgs/development/libraries/exempi/default.nix
+++ b/pkgs/development/libraries/exempi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, expat, zlib, boost }:
+{ stdenv, fetchurl, expat, zlib, boost, libiconv, darwin }:
 
 stdenv.mkDerivation rec {
   name = "exempi-2.4.2";
@@ -12,11 +12,12 @@ stdenv.mkDerivation rec {
     "--with-boost=${boost.dev}"
   ];
 
-  buildInputs = [ expat zlib boost ];
+  buildInputs = [ expat zlib boost ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.CoreServices ];
 
   meta = with stdenv.lib; {
     homepage = http://libopenraw.freedesktop.org/wiki/Exempi/;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       code, LGPL or LGPL-compatible for the supporting library).
     '';
     license     = licenses.lgpl2Plus;
-    platforms   = platforms.linux;
+    platforms   = platforms.linux ++ platforms.darwin;
   };
 
   src = fetchurl {

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/default.nix
@@ -12,7 +12,7 @@ kdeFramework {
   setupHook = ./setup-hook.sh;
 
   meta = with lib; {
-    platforms = lib.platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     homepage = "http://www.kde.org";
     license = licenses.bsd2;
     maintainers = [ maintainers.ttuegel ];

--- a/pkgs/development/libraries/libconfig/default.nix
+++ b/pkgs/development/libraries/libconfig/default.nix
@@ -14,6 +14,6 @@ stdenv.mkDerivation rec {
     description = "A simple library for processing structured configuration files";
     license = licenses.lgpl3;
     maintainers = [ maintainers.goibhniu ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/libconfuse/default.nix
+++ b/pkgs/development/libraries/libconfuse/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       quick to integrate with your code.
     '';
     license = licenses.isc;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ nckx ];
   };
 }

--- a/pkgs/development/libraries/libdiscid/default.nix
+++ b/pkgs/development/libraries/libdiscid/default.nix
@@ -1,21 +1,25 @@
-{ stdenv, fetchurl, cmake, pkgconfig }:
+{ stdenv, fetchurl, cmake, pkgconfig, darwin }:
 
 stdenv.mkDerivation rec {
   name = "libdiscid-${version}";
   version = "0.6.2";
 
   nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.IOKit ];
   
   src = fetchurl {
     url = "http://ftp.musicbrainz.org/pub/musicbrainz/libdiscid/${name}.tar.gz";
     sha256 = "1f9irlj3dpb5gyfdnb1m4skbjvx4d4hwiz2152f83m0d9jn47r7r";
   };
 
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-framework CoreFoundation -framework IOKit";
+
   meta = with stdenv.lib; {
     description = "A C library for creating MusicBrainz DiscIDs from audio CDs";
     homepage = http://musicbrainz.org/doc/libdiscid;
     maintainers = with maintainers; [ ehmry ];
     license = licenses.lgpl21;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/libdvdread/default.nix
+++ b/pkgs/development/libraries/libdvdread/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     description = "A library for reading DVDs";
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.wmertens ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/development/libraries/libfm/default.nix
+++ b/pkgs/development/libraries/libfm/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     description = "A glib-based library for file management";
     maintainers = [ maintainers.ttuegel ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/libgtop/default.nix
+++ b/pkgs/development/libraries/libgtop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, pkgconfig, perl, intltool, gobjectIntrospection }:
+{ stdenv, fetchurl, glib, pkgconfig, perl, intltool, gobjectIntrospection, libintlOrEmpty }:
 stdenv.mkDerivation rec {
   name = "libgtop-${version}";
   major = "2.34";
@@ -10,9 +10,12 @@ stdenv.mkDerivation rec {
   };
 
   propagatedBuildInputs = [ glib ];
+  buildInputs = libintlOrEmpty;
   nativeBuildInputs = [ pkgconfig perl intltool gobjectIntrospection ];
 
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
+
   meta = {
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/development/libraries/libinfinity/default.nix
+++ b/pkgs/development/libraries/libinfinity/default.nix
@@ -3,7 +3,8 @@
 , documentation ? false # build documentation
 , avahiSupport ? false # build support for Avahi in libinfinity
 , stdenv, fetchurl, pkgconfig, glib, libxml2, gnutls, gsasl
-, gtk2 ? null, gtkdoc ? null, avahi ? null, libdaemon ? null, libidn, gss }:
+, gtk2 ? null, gtkdoc ? null, avahi ? null, libdaemon ? null, libidn, gss
+, libintlOrEmpty }:
 
 let
   edf = flag: feature: (if flag then "--with-" else "--without-") + feature;
@@ -17,7 +18,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1idsxb6rz4i55g3vi2sv7hmm57psbccpb57yc4jgphaq6ydgqsr6";
   };
 
-  buildInputs = [ pkgconfig glib libxml2 gsasl libidn gss ]
+  buildInputs = [ pkgconfig glib libxml2 gsasl libidn gss libintlOrEmpty ]
     ++ optional gtkWidgets gtk2
     ++ optional documentation gtkdoc
     ++ optional avahiSupport avahi
@@ -34,12 +35,14 @@ in stdenv.mkDerivation rec {
     ${edf avahiSupport "avahi"}
   '';
 
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
+
   meta = {
     homepage = http://gobby.0x539.de/;
     description = "An implementation of the Infinote protocol written in GObject-based C";
     license = stdenv.lib.licenses.lgpl2Plus;
     maintainers = [ stdenv.lib.maintainers.phreedom ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 
 }

--- a/pkgs/development/libraries/liblo/default.nix
+++ b/pkgs/development/libraries/liblo/default.nix
@@ -13,6 +13,6 @@ stdenv.mkDerivation rec {
     homepage = http://sourceforge.net/projects/liblo;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [stdenv.lib.maintainers.marcweber];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/development/libraries/menu-cache/default.nix
+++ b/pkgs/development/libraries/menu-cache/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation {
     license = licenses.gpl2Plus;
     description = "Library to read freedesktop.org menu files";
     maintainers = [ maintainers.ttuegel ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/opencv/default.nix
+++ b/pkgs/development/libraries/opencv/default.nix
@@ -5,11 +5,12 @@
 , enableJPEG ? true, libjpeg
 , enablePNG ? true, libpng
 , enableTIFF ? true, libtiff
-, enableEXR ? true, openexr, ilmbase
+, enableEXR ? (!stdenv.isDarwin), openexr, ilmbase
 , enableJPEG2K ? true, jasper
 , enableFfmpeg ? false, ffmpeg
 , enableGStreamer ? false, gst_all
 , enableEigen ? false, eigen
+, darwin
 }:
 
 let
@@ -48,6 +49,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableFfmpeg ffmpeg
     ++ lib.optionals enableGStreamer (with gst_all; [ gstreamer gst-plugins-base ])
     ++ lib.optional enableEigen eigen
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa QTKit ])
     ;
 
   propagatedBuildInputs = lib.optional enablePython pythonPackages.numpy;
@@ -76,11 +78,11 @@ stdenv.mkDerivation rec {
 
   passthru = lib.optionalAttrs enablePython { pythonPath = []; };
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Open Computer Vision Library with more than 500 algorithms";
     homepage = http://opencv.org/;
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = with stdenv.lib.maintainers; [viric flosse];
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ viric flosse ];
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/qwt/6_qt4.nix
+++ b/pkgs/development/libraries/qwt/6_qt4.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     homepage = http://qwt.sourceforge.net/;
     # LGPL 2.1 plus a few exceptions (more liberal)
     license = stdenv.lib.licenses.qwt;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
     branch = "6";
   };

--- a/pkgs/development/libraries/zimg/default.nix
+++ b/pkgs/development/libraries/zimg/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec{
     description = "Scaling, colorspace conversion and dithering library";
     homepage    = https://github.com/sekrit-twc/zimg;
     license     = licenses.wtfpl;
-    platforms   = platforms.linux; # check upstream issue #52
+    platforms   = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ rnhmjoj ];
   };
 }

--- a/pkgs/development/tools/parsing/antlr/3.4.nix
+++ b/pkgs/development/tools/parsing/antlr/3.4.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
       walk parse trees.
     '';
     homepage = http://www.antlr.org/;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/misc/xosd/default.nix
+++ b/pkgs/misc/xosd/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     description = "Displays text on your screen";
     homepage = http://sourceforge.net/projects/libxosd;
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ pSub ];
   };
 }

--- a/pkgs/tools/compression/lhasa/default.nix
+++ b/pkgs/tools/compression/lhasa/default.nix
@@ -16,6 +16,6 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.isc;
     homepage = http://fragglet.github.io/lhasa;
     maintainers = with stdenv.lib; [ maintainers.sander ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/tools/graphics/icoutils/default.nix
+++ b/pkgs/tools/graphics/icoutils/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.nongnu.org/icoutils/;
     description = "Set of programs to deal with Microsoft Windows(R) icon and cursor files";
     license = stdenv.lib.licenses.gpl3Plus;
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/tools/misc/desktop-file-utils/default.nix
+++ b/pkgs/tools/misc/desktop-file-utils/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, glib }:
+{ stdenv, fetchurl, pkgconfig, glib, libintlOrEmpty }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "desktop-file-utils-0.22";
@@ -8,11 +10,13 @@ stdenv.mkDerivation rec {
     sha256 = "1ianvr2a69yjv4rpyv30w7yjsmnsb23crrka5ndqxycj4rkk4dc4";
   };
 
-  buildInputs = [ pkgconfig glib ];
+  buildInputs = [ pkgconfig glib libintlOrEmpty ];
+
+  NIX_LDFLAGS = optionalString stdenv.isDarwin "-lintl";
 
   meta = {
     homepage = http://www.freedesktop.org/wiki/Software/desktop-file-utils;
     description = "Command line utilities for working with .desktop files";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/tools/networking/flvstreamer/default.nix
+++ b/pkgs/tools/networking/flvstreamer/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   buildPhase = ''
-    make posix
+    make CC=cc posix
   '';
 
   installPhase = ''
@@ -34,6 +34,6 @@ stdenv.mkDerivation rec {
     homepage = http://savannah.nongnu.org/projects/flvstreamer;
 
     maintainers = [ stdenv.lib.maintainers.thammers ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/tools/networking/miniupnpc/default.nix
+++ b/pkgs/tools/networking/miniupnpc/default.nix
@@ -19,7 +19,7 @@ let
       meta = {
         homepage = http://miniupnp.free.fr/;
         description = "A client that implements the UPnP Internet Gateway Device (IGD) specification";
-        platforms = with stdenv.lib.platforms; linux ++ freebsd;
+        platforms = with stdenv.lib.platforms; linux ++ freebsd ++ darwin;
       };
     };
 in {

--- a/pkgs/tools/system/cron/default.nix
+++ b/pkgs/tools/system/cron/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   preBuild = ''
     substituteInPlace Makefile --replace ' -o root' ' ' --replace 111 755
-    makeFlags="DESTROOT=$out"
+    makeFlags="DESTROOT=$out CC=cc"
 
     # We want to ignore the $glibc/include/paths.h definition of
     # sendmail path.
@@ -35,6 +35,6 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Daemon for running commands at specific times (Vixie Cron)";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/tools/text/source-highlight/default.nix
+++ b/pkgs/tools/text/source-highlight/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     description = "Source code renderer with syntax highlighting";
     homepage = http://www.gnu.org/software/src-highlite/;
     license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
     longDescription =
       ''
         GNU Source-highlight, given a source file, produces a document


### PR DESCRIPTION
###### Motivation for this change

Adds Darwin as platform to various "broken" packages that actually build.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
