### PR TITLE
openvpn service: source up/down scripts

### DIFF
--- a/nixos/modules/services/networking/openvpn.nix
+++ b/nixos/modules/services/networking/openvpn.nix
@@ -28,9 +28,10 @@ let
           fi
         done
 
-        ${cfg.up}
         ${optionalString cfg.updateResolvConf
            "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf"}
+
+        ${optionalString (cfg.up != "") "source ${userSuppliedUpScript}"}
       '';
 
       downScript = ''
@@ -38,6 +39,15 @@ let
         export PATH=${path}
         ${optionalString cfg.updateResolvConf
            "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf"}
+
+        ${optionalString (cfg.down != "") "source ${userSuppliedDownScript}"}
+      '';
+
+      userSuppliedUpScript = pkgs.writeScript "openvpn-${name}-userSuppliedUpScript" ''
+        ${cfg.up}
+      '';
+
+      userSuppliedDownScript = pkgs.writeScript "openvpn-${name}-userSuppliedDownScript" ''
         ${cfg.down}
       '';
 
@@ -133,7 +143,7 @@ in
             default = "";
             type = types.lines;
             description = ''
-              Shell commands executed when the instance is starting.
+              Shell script sourced by NixOS generated script when the instance is starting.
             '';
           };
 
@@ -141,7 +151,7 @@ in
             default = "";
             type = types.lines;
             description = ''
-              Shell commands executed when the instance is shutting down.
+              Shell script sourced by NixOS generated script when the instance is shutting down.
             '';
           };
 


### PR DESCRIPTION
###### Motivation for this change
source the up/down scripts instead of executing them to avoid loosing
access to special variables like $1

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

