### PR TITLE
fzf: Expose interactive shell scripts

### DIFF
--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -31,6 +31,12 @@ buildGoPackage rec {
     cp -r $src/man/man1 $man/share/man
     mkdir -p $out/share/vim-plugins
     ln -s $out/share/go/src/github.com/junegunn/fzf $out/share/vim-plugins/${name}
+
+    # Make scripts readily available for sourcing from shells. Note
+    # that while files there have 'completion' in their name, they are
+    # not a completions scripts (so no copying to bash-completion.d and friends).
+    mkdir -p $out/share/fzf
+    (cd $out/share/fzf && cp -s $out/share/go/src/github.com/junegunn/fzf/shell/* .)
   '';
 
   meta = with stdenv.lib; {
@@ -38,5 +44,6 @@ buildGoPackage rec {
     description = "A command-line fuzzy finder written in Go";
     license = licenses.mit;
     platforms = platforms.unix;
+    outputsToInstall = [ "out" "bin" "man" ];
   };
 }


### PR DESCRIPTION
Note that while those scripts have `completion` in their name, they
are not a completion scripts that should be added to
`bash-completion.d` and friends.

Explicitly listing `outputsToInstall` is necessary so we can have all
the goodies (vim-plugin, shell scripts) in our `~/.nix-profile` when
using `nix-env`. See
https://github.com/NixOS/nixpkgs/issues/24717#issuecomment-294351473

###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

