### PR TITLE
[WIP] albert: 0.10.2 -> 0.11.1

### DIFF
--- a/pkgs/applications/misc/albert/default.nix
+++ b/pkgs/applications/misc/albert/default.nix
@@ -2,24 +2,24 @@
 
 stdenv.mkDerivation rec {
   name    = "albert-${version}";
-  version = "0.10.2";
+  version = "0.11.1";
 
   src = fetchFromGitHub {
     owner  = "albertlauncher";
     repo   = "albert";
     rev    = "v${version}";
-    sha256 = "0plb8c7js91bpf7qgq1snhry8x4zixyy34lq42nhsglab2kaq4ns";
+    sha256 = "1ai0h3lbdac0a4xzd6pm3i0r8w0gfdnw9rdkj0szyzvm428f88s6";
   };
 
   nativeBuildInputs = [ cmake makeQtWrapper ];
 
   buildInputs = [ qtbase qtsvg qtx11extras muparser ];
 
-  enableParallelBuilding = true;
+  #enableParallelBuilding = true;
 
   postPatch = ''
     sed -i "/QStringList dirs = {/a    \"$out/lib\"," \
-      src/lib/albert/src/pluginsystem/extensionmanager.cpp
+      src/lib/albert/src/albert/extensionmanager.cpp
   '';
 
   fixupPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Update `albert` to version 0.11.1.

[Changes](https://albertlauncher.github.io/news/).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).