### PR TITLE
xfce4-whiskermenu-plugin: 1.6.2 -> 1.7.2

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-whiskermenu-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-whiskermenu-plugin.nix
@@ -4,7 +4,7 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   p_name  = "xfce4-whiskermenu-plugin";
-  version = "1.6.2";
+  version = "1.7.2";
 
   name = "${p_name}-${version}";
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "gottcode";
     repo = "xfce4-whiskermenu-plugin";
     rev = "v${version}";
-    sha256 = "0vfyav01hynjm7p73wwbwnn2l8l9a0hkz755wmjzr6qv06f9019d";
+    sha256 = "1rpazgnjp443abc31bgi6gp9q3sgbg13v7v74nn7vf6kl4v725ah";
   };
 
   nativeBuildInputs = [ cmake pkgconfig intltool ];


### PR DESCRIPTION
###### Motivation for this change

Update to version 1.7.2.

[NEWS](https://git.xfce.org/panel-plugins/xfce4-whiskermenu-plugin/tree/NEWS)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).