### PR TITLE
imlib2: 1.4.9 -> 1.4.10

### DIFF
--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -5,11 +5,11 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "imlib2-1.4.9";
+  name = "imlib2-1.4.10";
 
   src = fetchurl {
     url = "mirror://sourceforge/enlightenment/${name}.tar.bz2";
-    sha256 = "08809xxk2555yj6glixzw9a0x3x8cx55imd89kj3r0h152bn8a3x";
+    sha256 = "0wm2q2xlkbm71k7mw2jyzbxgzylrkcj5yh6nq58w5gybhp98qs9z";
   };
 
   buildInputs = [ libjpeg libtiff giflib libpng bzip2 freetype ]
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
       easily, without sacrificing speed.
     '';
 
+    homepage = http://docs.enlightenment.org/api/imlib2/html;
     license = licenses.free;
     platforms = platforms.unix;
     maintainers = with maintainers; [ spwhitt ];


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).