### PR TITLE
madonctl: init at 0.1.0

### DIFF
--- a/pkgs/applications/misc/madonctl/default.nix
+++ b/pkgs/applications/misc/madonctl/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchgx }:
+
+buildGoPackage rec {
+  name = "madonctl-${version}";
+  version = "0.1.0";
+  rev = "8d14d4d0847fe200d11c0b3f7a6252da5e687078";
+
+  goPackagePath = "github.com/McKael/madonctl";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "McKael";
+    repo = "madonctl";
+    sha256 = "1nd07frifkw21av9lczm12ffky10ycv9ya501mihm82c78jk1sn5";
+  };
+
+  meta = with stdenv.lib; {
+    description = "CLI for the Mastodon social network API";
+    homepage = https://github.com/McKael/madonctl;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}

--- a/pkgs/applications/misc/madonctl/default.nix
+++ b/pkgs/applications/misc/madonctl/default.nix
@@ -2,17 +2,24 @@
 
 buildGoPackage rec {
   name = "madonctl-${version}";
-  version = "0.1.0";
-  rev = "8d14d4d0847fe200d11c0b3f7a6252da5e687078";
+  version = "1.1.0";
 
   goPackagePath = "github.com/McKael/madonctl";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "McKael";
     repo = "madonctl";
-    sha256 = "1nd07frifkw21av9lczm12ffky10ycv9ya501mihm82c78jk1sn5";
+    rev  = "v${version}";
+    sha256 = "1dnc1xaafhwhhf5afhb0wc2wbqq0s1r7qzj5k0xzc58my541gadc";
   };
+
+  # How to update:
+  # go get -u github.com/McKael/madonctl
+  # cd $GOPATH/src/github.com/McKael/madonctl
+  # git checkout v<version-number>
+  # go2nix save
+
+  goDeps = ./deps.nix;
 
   meta = with stdenv.lib; {
     description = "CLI for the Mastodon social network API";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -255,6 +255,8 @@ with pkgs;
 
   libredirect = callPackage ../build-support/libredirect { };
 
+  madonctl = callPackage ../applications/misc/madonctl { };
+
   makeDesktopItem = callPackage ../build-support/make-desktopitem { };
 
   makeAutostartItem = callPackage ../build-support/make-startupitem { };


### PR DESCRIPTION
**I need help here**

###### Motivation for this change

[mastodon](https://github.com/tootsuite/mastodon) is getting bigger ... having a CLI for it is awesome!

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I don't know how to properly package this.