### PR TITLE
fetchurl: fixed typo in error message

### DIFF
--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -92,7 +92,7 @@ let
 
 in
 
-if md5 != "" then throw "fetchsvnssh does not support md5 anymore, please use sha256 or sha512"
+if md5 != "" then throw "fetchurl does not support md5 anymore, please use sha256 or sha512"
 else if (!hasHash) then throw "Specify hash for fetchurl fixed-output derivation: ${stdenv.lib.concatStringsSep ", " urls_}"
 else stdenv.mkDerivation {
   name =


### PR DESCRIPTION
This typo was likely introduced by copy-pasting the error message from elsewhere and forgetting to change the text, during the MD5 deprecation process (#4491).

###### Motivation for this change

Obviously, the error message should say the correct thing :)

Since this is purely a cosmetic string change, I have not tested the resulting builds.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).