### PR TITLE
Kdeapps 17.04

### DIFF
--- a/pkgs/applications/kde/ark/default.nix
+++ b/pkgs/applications/kde/ark/default.nix
@@ -4,7 +4,7 @@
   extra-cmake-modules, kdoctools, makeWrapper,
 
   karchive, kconfig, kcrash, kdbusaddons, ki18n, kiconthemes, khtml, kio,
-  kservice, kpty, kwidgetsaddons, libarchive,
+  kservice, kpty, kwidgetsaddons, libarchive, kitemmodels,
 
   # Archive tools
   p7zip, unzipNLS, zip,
@@ -22,7 +22,7 @@ let
       ];
       propagatedBuildInputs = [
         khtml ki18n kio karchive kconfig kcrash kdbusaddons kiconthemes kservice
-        kpty kwidgetsaddons libarchive
+        kpty kwidgetsaddons libarchive kitemmodels
       ];
       postInstall =
         let

--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/applications/16.12.3/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/applications/17.04.0/ -A '*.tar.xz' )

--- a/pkgs/applications/kde/kcachegrind.nix
+++ b/pkgs/applications/kde/kcachegrind.nix
@@ -1,7 +1,8 @@
 {
   kdeApp, lib, kdeWrapper,
-  cmake, automoc4,
-  kdelibs, perl, python, php
+  extra-cmake-modules, kdoctools,
+  kio, ki18n,
+  perl, python, php
 }:
 
 kdeWrapper {
@@ -11,8 +12,8 @@ kdeWrapper {
       license = with lib.licenses; [ gpl2 ];
       maintainers = with lib.maintainers; [ orivej ];
     };
-    nativeBuildInputs = [ cmake automoc4 ];
-    buildInputs = [ kdelibs perl python php ];
+    nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+    buildInputs = [ perl python php kio ki18n ];
     enableParallelBuilding = true;
   };
 

--- a/pkgs/applications/kde/marble.nix
+++ b/pkgs/applications/kde/marble.nix
@@ -1,6 +1,8 @@
 { kdeApp, lib, kdeWrapper
-, extra-cmake-modules, qtscript, qtsvg, qtquickcontrols
-, gpsd
+, extra-cmake-modules, kdoctools
+, qtscript, qtsvg, qtquickcontrols, qtwebkit
+, krunner, shared_mime_info, kparts, knewstuff
+, gpsd, perl
 }:
 
 let
@@ -9,9 +11,10 @@ let
       name = "marble";
       meta.license = with lib.licenses; [ lgpl21 gpl3 ];
 
-      nativeBuildInputs = [ extra-cmake-modules ];
+      nativeBuildInputs = [ extra-cmake-modules kdoctools perl ];
       propagatedBuildInputs = [
-        qtscript qtsvg qtquickcontrols
+        qtscript qtsvg qtquickcontrols qtwebkit shared_mime_info
+        krunner kparts knewstuff
         gpsd
       ];
 
@@ -20,6 +23,6 @@ let
 in
 kdeWrapper {
   inherit unwrapped;
-  targets = [ "bin/marble-qt" ];
+  targets = [ "bin/marble-qt" "bin/marble" ];
   paths = [ unwrapped ];
 }

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -3,2227 +3,2235 @@
 
 {
   akonadi = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/akonadi-16.12.3.tar.xz";
-      sha256 = "00sbchj3yjbqdjckrciv2c7j9i7kc5yqvyvbmjlxacbkq80a4j7w";
-      name = "akonadi-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/akonadi-17.04.0.tar.xz";
+      sha256 = "1m0176q7g1vw2iy567xiadrpg87p58njinh7bab2pqv7zya7cbwn";
+      name = "akonadi-17.04.0.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/akonadi-calendar-16.12.3.tar.xz";
-      sha256 = "0kv636a8x75fcagw8hjnrwnxzvqnnm42hfw68ywfics0pn0pl50g";
-      name = "akonadi-calendar-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/akonadi-calendar-17.04.0.tar.xz";
+      sha256 = "08ajx9iq49y1ca9gxxcczxyqhjvkq4pnhm5s6yyblgmb9cpwivh9";
+      name = "akonadi-calendar-17.04.0.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/akonadi-calendar-tools-16.12.3.tar.xz";
-      sha256 = "157kmcl77pj32ysbwr1xw365p5pgk69w5j8397axly6dmdl71x47";
-      name = "akonadi-calendar-tools-16.12.3.tar.xz";
-    };
-  };
-  akonadiconsole = {
-    version = "16.12.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/akonadiconsole-16.12.3.tar.xz";
-      sha256 = "195amn610y5ydg665ag45xb0l1wyplbdlrwagzc7yvswp12rlcv3";
-      name = "akonadiconsole-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/akonadi-calendar-tools-17.04.0.tar.xz";
+      sha256 = "0s34m96i4y51fdb23v12mav7q2livq77xrpx0h2ghma0nljdhy1m";
+      name = "akonadi-calendar-tools-17.04.0.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/akonadi-contacts-16.12.3.tar.xz";
-      sha256 = "1205g4z5rz02j8swrmhncm06d8m727z63d526djygz5svz15sd2l";
-      name = "akonadi-contacts-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/akonadi-contacts-17.04.0.tar.xz";
+      sha256 = "01fw0qmnbsbcpy7wx14sg0kwbws4n2d63mbslb3c4hqgq6ahgz37";
+      name = "akonadi-contacts-17.04.0.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/akonadi-import-wizard-16.12.3.tar.xz";
-      sha256 = "0dnpiqcmphm2x76f21acrwhg7ah5ih0hnhxdy1d6pm3ng2p1irfq";
-      name = "akonadi-import-wizard-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/akonadi-import-wizard-17.04.0.tar.xz";
+      sha256 = "0a9k78w55wg9p22x7qwbpz7lzyijz1z3k12fv1c1g0vn1nbwcadv";
+      name = "akonadi-import-wizard-17.04.0.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/akonadi-mime-16.12.3.tar.xz";
-      sha256 = "1xay3rlygdhf9lp356wjb92wnmxdpaxgm3prxnfxcdg5ql6xcg07";
-      name = "akonadi-mime-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/akonadi-mime-17.04.0.tar.xz";
+      sha256 = "1aidmb1bsx5xvppypzs2gg81jifcvc3jv2827hjkqvd021z831nv";
+      name = "akonadi-mime-17.04.0.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/akonadi-notes-16.12.3.tar.xz";
-      sha256 = "0405nkz9ri9qlclgvwycvdx1gsms2pm1fn6xhvyrj2v4s8brb3r7";
-      name = "akonadi-notes-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/akonadi-notes-17.04.0.tar.xz";
+      sha256 = "0jfcw9lh1rhydw1c14z065lv3h9xl1q3i66slmfmmamy99czczjr";
+      name = "akonadi-notes-17.04.0.tar.xz";
     };
   };
   akonadi-search = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/akonadi-search-16.12.3.tar.xz";
-      sha256 = "0wf22rmfz471iw6zxl7yz279fkks2pj5jfw4bs5185kr3xw2q7zp";
-      name = "akonadi-search-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/akonadi-search-17.04.0.tar.xz";
+      sha256 = "1mgq0n5z8ar1zajwsrrs1failrrrkkv6g0pcs7grq2prfsv4z1p3";
+      name = "akonadi-search-17.04.0.tar.xz";
+    };
+  };
+  akonadiconsole = {
+    version = "17.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/akonadiconsole-17.04.0.tar.xz";
+      sha256 = "01adzv1z92zyfi22psa6m30c290w37n0m01hd9wgjj8in4hzmk3d";
+      name = "akonadiconsole-17.04.0.tar.xz";
     };
   };
   akregator = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/akregator-16.12.3.tar.xz";
-      sha256 = "1v6jg35ha6wrjgwfvrvy1qwl1700dmk40d0fwy1irkpdlgg79128";
-      name = "akregator-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/akregator-17.04.0.tar.xz";
+      sha256 = "1dpvyx13lyl1pmphqr8mc9cxywkjcqy6aqmh7hdsi0vggafkiim5";
+      name = "akregator-17.04.0.tar.xz";
     };
   };
   analitza = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/analitza-16.12.3.tar.xz";
-      sha256 = "0ap3sf8bw9f58pzw3zy6w60apd4ccc47zs3v61x4kp1g81rn265w";
-      name = "analitza-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/analitza-17.04.0.tar.xz";
+      sha256 = "1mx2y0cqsj2v8pwcwpqsg5brakaw6g14acqxrx7xmpfzzi0y8mxg";
+      name = "analitza-17.04.0.tar.xz";
     };
   };
   ark = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ark-16.12.3.tar.xz";
-      sha256 = "0q1bxrsb03pwsvxqlbnzfmahlj300l336pdrm82vin89m294ird0";
-      name = "ark-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ark-17.04.0.tar.xz";
+      sha256 = "0qk829f10pjpvn3qpfbr16y6qkrgkbi510d1bqbsjnpnfz821hwk";
+      name = "ark-17.04.0.tar.xz";
     };
   };
   artikulate = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/artikulate-16.12.3.tar.xz";
-      sha256 = "113k6c0yrir61j258gn9n6k7fifa6g9g8wxf3zq18jy3liwdl97s";
-      name = "artikulate-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/artikulate-17.04.0.tar.xz";
+      sha256 = "1y6w1b17ndrplkkakskdzqws6apfa801gpqfh7lnq2r0vj48kz7m";
+      name = "artikulate-17.04.0.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/audiocd-kio-16.12.3.tar.xz";
-      sha256 = "0bmmi2rxx368nss8ciwj32dspc1ailc0shm06ynmhw3slrplnx1y";
-      name = "audiocd-kio-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/audiocd-kio-17.04.0.tar.xz";
+      sha256 = "1fqdgvl2rgln6zr73pgznp7bn3lhbaw03q5hd3ndh14yvlin64xw";
+      name = "audiocd-kio-17.04.0.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/baloo-widgets-16.12.3.tar.xz";
-      sha256 = "0h75zhdiylyjifdk9ikw9gpwla3p87knndc2svkci90ga7ynggvl";
-      name = "baloo-widgets-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/baloo-widgets-17.04.0.tar.xz";
+      sha256 = "0nkk2xj35cqg2w7795ys2lpynkcmwf4fnq53sb20vn95scnn88mw";
+      name = "baloo-widgets-17.04.0.tar.xz";
     };
   };
   blinken = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/blinken-16.12.3.tar.xz";
-      sha256 = "1z50ack1iqh194vn487nhdkrbn1camswy4a3g2ayxv3qfgmxdcga";
-      name = "blinken-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/blinken-17.04.0.tar.xz";
+      sha256 = "0mimvcy6jdx5xr46li4jc00c9yy4626p2jlzimnl1sv2fcs1f72h";
+      name = "blinken-17.04.0.tar.xz";
     };
   };
   blogilo = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/blogilo-16.12.3.tar.xz";
-      sha256 = "14yl52m8x7b8bj2b7pkhabwg7rrmmhnkjq4z7mrxbnsndqmsi10f";
-      name = "blogilo-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/blogilo-17.04.0.tar.xz";
+      sha256 = "0v9vv1jfis5bvbf9yflqkqilbpx0kp4zbwnazzcgc3hi9bgm2fdb";
+      name = "blogilo-17.04.0.tar.xz";
     };
   };
   bomber = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/bomber-16.12.3.tar.xz";
-      sha256 = "1h4s6amjzazr3ywcqw8d14a0fi1arzxka0g6i9ii85s904k23r41";
-      name = "bomber-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/bomber-17.04.0.tar.xz";
+      sha256 = "0kv3z2kz85mxbi99rdkz4i9xyv9xgkhayk4pq0qsy7g6lk31sv9h";
+      name = "bomber-17.04.0.tar.xz";
     };
   };
   bovo = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/bovo-16.12.3.tar.xz";
-      sha256 = "1pr67gf47xmw21sv1im7k0dz18bhjfpbkhd7j5gaifj66h65sfy6";
-      name = "bovo-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/bovo-17.04.0.tar.xz";
+      sha256 = "0j5nf701zj1wafy08mhv094dqqyzy9y9waz0wappvxn8maqj0dk2";
+      name = "bovo-17.04.0.tar.xz";
     };
   };
   calendarsupport = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/calendarsupport-16.12.3.tar.xz";
-      sha256 = "0r30z2wzyms7m7s8y0livsfy5pj82g988bs6amaj2571hz55d8y0";
-      name = "calendarsupport-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/calendarsupport-17.04.0.tar.xz";
+      sha256 = "1r7cai24ac857an7sgmgyyjy6m2vrjy80ba3qxszys9v3mya60ya";
+      name = "calendarsupport-17.04.0.tar.xz";
     };
   };
   cantor = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/cantor-16.12.3.tar.xz";
-      sha256 = "1nzg9sfnv8afpa84x51whbw1qh8gfwqnkr5zyai7817kkc97g1l8";
-      name = "cantor-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/cantor-17.04.0.tar.xz";
+      sha256 = "0vy7ygiimlrqnv4nq2393hriaryr5si478kijf6q0dvqg1px59xy";
+      name = "cantor-17.04.0.tar.xz";
     };
   };
   cervisia = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/cervisia-16.12.3.tar.xz";
-      sha256 = "14r55ngvz4rci1h3iqdwbfcyxmm2b04c5smkv9x0bqxq4zz2yfvk";
-      name = "cervisia-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/cervisia-17.04.0.tar.xz";
+      sha256 = "1z9svqp42slh7fwczjv847scyjdbz9a5pzzkrfvqggi2wc85vzin";
+      name = "cervisia-17.04.0.tar.xz";
     };
   };
   dolphin = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/dolphin-16.12.3.tar.xz";
-      sha256 = "0y35ljbjib4pvyngdgbq1yx3rfmy94crpa7v1zzwfav94lm3kwb2";
-      name = "dolphin-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/dolphin-17.04.0.tar.xz";
+      sha256 = "09r2pqzjq7g7322m2vb1s1909bzckh0h9fwzsxvrmyz1cfdd765y";
+      name = "dolphin-17.04.0.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/dolphin-plugins-16.12.3.tar.xz";
-      sha256 = "18azlmzw33praz4z6lamamj79gyxbbdgz7lp1cimxyddhmacc2x9";
-      name = "dolphin-plugins-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/dolphin-plugins-17.04.0.tar.xz";
+      sha256 = "0mj0p1lbdvfn46i5bry394rqpriv0w1389dw526xz6cplrzydi2q";
+      name = "dolphin-plugins-17.04.0.tar.xz";
     };
   };
   dragon = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/dragon-16.12.3.tar.xz";
-      sha256 = "1652cl6sa9d71c685xpwqv5hgz3spxg2hynwcnn8xybn5hv9ar4r";
-      name = "dragon-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/dragon-17.04.0.tar.xz";
+      sha256 = "08mlsj4ib0s219vnrmy7g6iap8zaaha12vhqrc5950248k0rz181";
+      name = "dragon-17.04.0.tar.xz";
     };
   };
   eventviews = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/eventviews-16.12.3.tar.xz";
-      sha256 = "0z8jznvw2nhszrlll7458gb4r0585ivkbq9dqplkw2mdrv7vxz5c";
-      name = "eventviews-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/eventviews-17.04.0.tar.xz";
+      sha256 = "1gylv5p9v96g4krcnd9xqg0nfvxzhxyc4ywy0wbqfn5zwngzpz80";
+      name = "eventviews-17.04.0.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ffmpegthumbs-16.12.3.tar.xz";
-      sha256 = "1scyyd85rs21rv3ghcxv7pw3aa2nl703gi4dpikbsd7wjmxixzq9";
-      name = "ffmpegthumbs-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ffmpegthumbs-17.04.0.tar.xz";
+      sha256 = "0jrq940x50n9g613db254sflwpw4pa70r79hkvkf3ri11s80hmgm";
+      name = "ffmpegthumbs-17.04.0.tar.xz";
     };
   };
   filelight = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/filelight-16.12.3.tar.xz";
-      sha256 = "13gcx1w9zq3i9fy32m3ypjyqcd9vrkqyr0j4cbqfvhpzv2chk3is";
-      name = "filelight-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/filelight-17.04.0.tar.xz";
+      sha256 = "18dz82kdgazwv00kvbfm5ln13g28s5sqyp9cfm0c7vrdnq8spng8";
+      name = "filelight-17.04.0.tar.xz";
     };
   };
   granatier = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/granatier-16.12.3.tar.xz";
-      sha256 = "17vpz6jz2vvpvsrhvllglacrwg0sxy15aqnm8n6d73sk9zlv9n76";
-      name = "granatier-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/granatier-17.04.0.tar.xz";
+      sha256 = "08jlpnriq6kvsnfgjar0w3ci6mla1m4bd3qzsxbv5f0hbqj78rm8";
+      name = "granatier-17.04.0.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/grantlee-editor-16.12.3.tar.xz";
-      sha256 = "007q6cb5f3vzw6dwm2y2b5m3dhb5mws5b6083ssm8rydycyi9pzi";
-      name = "grantlee-editor-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/grantlee-editor-17.04.0.tar.xz";
+      sha256 = "1famfm6r32m8i0mp7aiqki8k4rhl6p5dvp3905lbdm355rv2b60b";
+      name = "grantlee-editor-17.04.0.tar.xz";
     };
   };
   grantleetheme = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/grantleetheme-16.12.3.tar.xz";
-      sha256 = "19mka62p75qnv6r9ib70y25jjj3bpziz0xqihfkb6jvafrgy8p8k";
-      name = "grantleetheme-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/grantleetheme-17.04.0.tar.xz";
+      sha256 = "1dikbf90l55d62zxmw8rw85bkpcgrdf455k33b91ldnhfb3vw3i4";
+      name = "grantleetheme-17.04.0.tar.xz";
     };
   };
   gwenview = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/gwenview-16.12.3.tar.xz";
-      sha256 = "069fblw9g9h6r9gy05nj2n93jpnsx610jncwl6403q01rwlbrgbr";
-      name = "gwenview-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/gwenview-17.04.0.tar.xz";
+      sha256 = "0n4m1zd43g68qgpdvifj5h3ry39262qmm553w3f7yd6i2gpvy2a1";
+      name = "gwenview-17.04.0.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/incidenceeditor-16.12.3.tar.xz";
-      sha256 = "11jplw3fngnyvpjkhqwv1gzzwxxcm4v93h09f68hs015apncjvpp";
-      name = "incidenceeditor-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/incidenceeditor-17.04.0.tar.xz";
+      sha256 = "10yi8hqf5p5nbi9rq8kzkqmbjq0c41a9mz8rjhbz1pac686b87c7";
+      name = "incidenceeditor-17.04.0.tar.xz";
     };
   };
   jovie = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/jovie-16.12.3.tar.xz";
-      sha256 = "190c4g587x4wxbfksf0mszq5qv1pzny6bkd3w2pwwsj222bl0fxa";
-      name = "jovie-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/jovie-17.04.0.tar.xz";
+      sha256 = "1n3d03h9mzfyrga9c78mlk5vd53xqqpz9cjj27sw35fhc9l6h5fp";
+      name = "jovie-17.04.0.tar.xz";
     };
   };
   juk = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/juk-16.12.3.tar.xz";
-      sha256 = "1ssgia5sknam2hnjflzglv0khxbwyyvzm4w1wmxw04rbjzs4gi4h";
-      name = "juk-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/juk-17.04.0.tar.xz";
+      sha256 = "0il7i8lbij9axm7wfgpnzmax3kz8qbdsiizmkwivvaxizvsvc1yz";
+      name = "juk-17.04.0.tar.xz";
+    };
+  };
+  k3b = {
+    version = "17.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/k3b-17.04.0.tar.xz";
+      sha256 = "0wsa8s5ndcbskgd505l0nkp9ghj7dsrxwnlkq0rhqjwvfsa7law3";
+      name = "k3b-17.04.0.tar.xz";
     };
   };
   kaccessible = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kaccessible-16.12.3.tar.xz";
-      sha256 = "162a4pw61b3rhq5mf7zdhgyyhbrxhr9fjw7bidicw7aljiy2cwb9";
-      name = "kaccessible-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kaccessible-17.04.0.tar.xz";
+      sha256 = "0gkcvm0kz8kwkla3mclryisi4j0cdd6byaq8wvpnfhl68kwb8a33";
+      name = "kaccessible-17.04.0.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kaccounts-integration-16.12.3.tar.xz";
-      sha256 = "0w8h33sysf590xyg4bvf2a2z39kzc0wn6mxv31mrf68b6ks7b9h2";
-      name = "kaccounts-integration-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kaccounts-integration-17.04.0.tar.xz";
+      sha256 = "0ml1jq4dd3n2ksmw7i5vrsv4lhibdk1d2mvy3yn45w1g8gpqwl8l";
+      name = "kaccounts-integration-17.04.0.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kaccounts-providers-16.12.3.tar.xz";
-      sha256 = "0iqqwfjadsf7nhrqvpzypazipris4ljhf6daprxwxqa2bfigr5j2";
-      name = "kaccounts-providers-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kaccounts-providers-17.04.0.tar.xz";
+      sha256 = "1i19q1rmjwmkd5r23w3zjyk0gf4xrw7j4f0s8q591rgqzy2lhkc3";
+      name = "kaccounts-providers-17.04.0.tar.xz";
     };
   };
   kaddressbook = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kaddressbook-16.12.3.tar.xz";
-      sha256 = "1a86asy0pw8ivyg7aaw2mais4xbplabp5aljzcyb2rykij6482rh";
-      name = "kaddressbook-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kaddressbook-17.04.0.tar.xz";
+      sha256 = "1qglxn2inibqiljazsd2mc49sk8pv3jkvjn9icxhgfdjg234fl4z";
+      name = "kaddressbook-17.04.0.tar.xz";
     };
   };
   kajongg = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kajongg-16.12.3.tar.xz";
-      sha256 = "0xwwkl2npls0aq4435xlcvssm8pmfhramjgxv70mnjapr0dlpk5c";
-      name = "kajongg-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kajongg-17.04.0.tar.xz";
+      sha256 = "1bzfafrslsihbldzdnl1a48wx65yrc9phxjnaiws82ig5369r3xn";
+      name = "kajongg-17.04.0.tar.xz";
     };
   };
   kalarm = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kalarm-16.12.3.tar.xz";
-      sha256 = "1n3h252cvqib1bx4ryq3xgj2mkqr38wvhiyj2vkkll4pf5lphpqz";
-      name = "kalarm-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kalarm-17.04.0.tar.xz";
+      sha256 = "1zqblg5wflw0y3fdqihifh25xzm2y0ih9b0i3909wkw0j7p1z4g7";
+      name = "kalarm-17.04.0.tar.xz";
     };
   };
   kalarmcal = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kalarmcal-16.12.3.tar.xz";
-      sha256 = "064sihcsbdi1w6viv5gq6sw2m8r7x3nn1hl2aji1109pf5913vbr";
-      name = "kalarmcal-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kalarmcal-17.04.0.tar.xz";
+      sha256 = "136vw2sak3z571lv9m2lmnxpgkwhy663q81j6z2gq8vday72ar44";
+      name = "kalarmcal-17.04.0.tar.xz";
     };
   };
   kalgebra = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kalgebra-16.12.3.tar.xz";
-      sha256 = "0qhini5gm41dlyham4zzqgz6r11s2rfwwphb81xvwp1bgn8q2rqb";
-      name = "kalgebra-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kalgebra-17.04.0.tar.xz";
+      sha256 = "05gkw20g7qc72lsgbhqqmxvmgkgs5bdsyw71kp1dz4h6q7gvck04";
+      name = "kalgebra-17.04.0.tar.xz";
     };
   };
   kalzium = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kalzium-16.12.3.tar.xz";
-      sha256 = "0rlfjqfb1vpr0cdcx429nvrbkr7kc1m4ps3z3pphkajq4vlrql8i";
-      name = "kalzium-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kalzium-17.04.0.tar.xz";
+      sha256 = "17bpn0yqkdrsqrx08zvhxwbjh8f0wdngq375cvv2mgmkjikq375k";
+      name = "kalzium-17.04.0.tar.xz";
     };
   };
   kamera = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kamera-16.12.3.tar.xz";
-      sha256 = "04p19qv5ssf5wlpfqzhqsi8281pzcdjkd0jy177f9r7qgqq4lkgr";
-      name = "kamera-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kamera-17.04.0.tar.xz";
+      sha256 = "178886fbkj3fz25xddgpprmxmn0iv7ndnxygsxq434c9pv3zdxb9";
+      name = "kamera-17.04.0.tar.xz";
     };
   };
   kanagram = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kanagram-16.12.3.tar.xz";
-      sha256 = "183hkxxwf7h335gmfvi2lppsyhpv80lvlg1fg4whq79f1d2lrw47";
-      name = "kanagram-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kanagram-17.04.0.tar.xz";
+      sha256 = "0r4k5jsc8vnj2pgpca0iyr0lrz2q683db8nsk6axgv72hkp3v07i";
+      name = "kanagram-17.04.0.tar.xz";
     };
   };
   kapman = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kapman-16.12.3.tar.xz";
-      sha256 = "1if3dzn1qy2pr42zcmzpq7f38spkxh492gl12vndckzah67cmz4g";
-      name = "kapman-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kapman-17.04.0.tar.xz";
+      sha256 = "18mr5i0qvix4vnmy7m721jipafwlh19paczay0ci7qpj1538vrlq";
+      name = "kapman-17.04.0.tar.xz";
     };
   };
   kapptemplate = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kapptemplate-16.12.3.tar.xz";
-      sha256 = "036npdxyh9rx0aaiwvdjqrb39f8bqglqbl3iddb1vh7w9p1h158n";
-      name = "kapptemplate-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kapptemplate-17.04.0.tar.xz";
+      sha256 = "1wf29198h6964p2bcb6p5harrsjpbdqsh8r82rn6wh755f033038";
+      name = "kapptemplate-17.04.0.tar.xz";
     };
   };
   kate = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kate-16.12.3.tar.xz";
-      sha256 = "1fbrdlf64bdj71g692fkk7fiym0nm9vvbki2q105carrhl4w9s0r";
-      name = "kate-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kate-17.04.0.tar.xz";
+      sha256 = "0hk03bpbxyb7jrhbjihqymsih9c3wh8xllz3f4y7qfpcl8v1k3bc";
+      name = "kate-17.04.0.tar.xz";
     };
   };
   katomic = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/katomic-16.12.3.tar.xz";
-      sha256 = "14dnfjww1fzgz3nbg45ck5yqbxdyvp0la9qs4n5cjy1ym52k5pjm";
-      name = "katomic-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/katomic-17.04.0.tar.xz";
+      sha256 = "0m1dymjsa0b11yqcjska84x779xb8q14igshb4cnrr3rlyr71p5f";
+      name = "katomic-17.04.0.tar.xz";
     };
   };
   kblackbox = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kblackbox-16.12.3.tar.xz";
-      sha256 = "0i359pq65swrzsb7vdk0m00vjrj2xgvbgxin8ly2cijqlmfd3iv8";
-      name = "kblackbox-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kblackbox-17.04.0.tar.xz";
+      sha256 = "1dsc5pbh3g05skw25x6fyg55cykkyjaw6abhnl947z16gbixnqrg";
+      name = "kblackbox-17.04.0.tar.xz";
     };
   };
   kblocks = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kblocks-16.12.3.tar.xz";
-      sha256 = "09kdbwya4xl84vzayhz286lmfb6a0mmp9i40hzldfl59as4d67kw";
-      name = "kblocks-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kblocks-17.04.0.tar.xz";
+      sha256 = "1cn4qdk0jgw78v9ymsr353rk8h8p3mcd5r57pjnw3wmjpswc0plg";
+      name = "kblocks-17.04.0.tar.xz";
     };
   };
   kblog = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kblog-16.12.3.tar.xz";
-      sha256 = "0q1qswg7dgy0jvk9kaz6cps6sfddsmv0lp5r3nhk751l497bbl3x";
-      name = "kblog-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kblog-17.04.0.tar.xz";
+      sha256 = "076225i38iqr4ml1g54nhd8mkjia8k0j7rc8ixv812ksq7xza69b";
+      name = "kblog-17.04.0.tar.xz";
     };
   };
   kbounce = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kbounce-16.12.3.tar.xz";
-      sha256 = "0cwvsbw0a60a2csxqvpkm3znbcd1whsl80v63ljyc3gyik7wxil0";
-      name = "kbounce-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kbounce-17.04.0.tar.xz";
+      sha256 = "0jjmpmhqsjksvgxl92bh7xmh2wf1cz52fdk5vfa90mw08xi07d4n";
+      name = "kbounce-17.04.0.tar.xz";
     };
   };
   kbreakout = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kbreakout-16.12.3.tar.xz";
-      sha256 = "0zszxxw7r7ggxhc47pngsi7bl57mnhbzkb0bhvy5rcyamgi90v39";
-      name = "kbreakout-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kbreakout-17.04.0.tar.xz";
+      sha256 = "0n206mxxbgkynw74sry7jfvyvspyc34vzs3xilny8xiks2g4zbjm";
+      name = "kbreakout-17.04.0.tar.xz";
     };
   };
   kbruch = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kbruch-16.12.3.tar.xz";
-      sha256 = "12zmp9ix8q9mf3a4xpbsr0y9h4g1srwx48604x1phdwwdhgx0gsj";
-      name = "kbruch-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kbruch-17.04.0.tar.xz";
+      sha256 = "0i9pmir83js31kzwqdw9ka93lpgnb6gbrsi96djjqv7pj93gql32";
+      name = "kbruch-17.04.0.tar.xz";
     };
   };
   kcachegrind = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kcachegrind-16.12.3.tar.xz";
-      sha256 = "109y94nz96izzsjjdpj9c6g344rcr86srp5w0433mssbyvym4x7q";
-      name = "kcachegrind-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kcachegrind-17.04.0.tar.xz";
+      sha256 = "130m50lnkcqpr3c4icznlysnj9xnzy5viv95756fxnass44vi349";
+      name = "kcachegrind-17.04.0.tar.xz";
     };
   };
   kcalc = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kcalc-16.12.3.tar.xz";
-      sha256 = "06kfz1d5i01h31v277y04pqnx08yv0050rlb6phv72cx6div4mgp";
-      name = "kcalc-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kcalc-17.04.0.tar.xz";
+      sha256 = "01cmcn20hbnaph2217wam0qf42mfvwqb9s3h467qk0y3pgq7syb4";
+      name = "kcalc-17.04.0.tar.xz";
     };
   };
   kcalcore = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kcalcore-16.12.3.tar.xz";
-      sha256 = "09i43vs6jpjmmk52df6pzclh0jn8shn3wfnaivw2wlirwa60d901";
-      name = "kcalcore-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kcalcore-17.04.0.tar.xz";
+      sha256 = "0xmsh0fkmz0qrj4ali1d7n6jbxj0cl8s640fjvwd1sic5ib7pcj0";
+      name = "kcalcore-17.04.0.tar.xz";
     };
   };
   kcalutils = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kcalutils-16.12.3.tar.xz";
-      sha256 = "0449029fa1w496fmb81csb5amk801n11ish450drqw34lp9qla4n";
-      name = "kcalutils-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kcalutils-17.04.0.tar.xz";
+      sha256 = "0if4c989a846aqcn7mc0blkxwrl3zk3w2jrrigdyaafrpb6k6jch";
+      name = "kcalutils-17.04.0.tar.xz";
     };
   };
   kcharselect = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kcharselect-16.12.3.tar.xz";
-      sha256 = "1iwqqds9fy970ykgq1xbpbrzpdacy1h4bw87h1jingi42z1jkw2n";
-      name = "kcharselect-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kcharselect-17.04.0.tar.xz";
+      sha256 = "1fi6malyh357xwi8i456b6iksbx208mhsnhhl6bgwrvqpkd1h3h3";
+      name = "kcharselect-17.04.0.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kcolorchooser-16.12.3.tar.xz";
-      sha256 = "13nkvxl3z2l3m6zs057ipxgqfgsw7gma1rs66maqhzl30k3hrcyb";
-      name = "kcolorchooser-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kcolorchooser-17.04.0.tar.xz";
+      sha256 = "1jc43ric98kwknalhh7nlh1zm28g12ygvaiv3jmrqw97rra86wa0";
+      name = "kcolorchooser-17.04.0.tar.xz";
     };
   };
   kcontacts = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kcontacts-16.12.3.tar.xz";
-      sha256 = "1479g32c9532pjgmfpy38vycii1sxk1nzv27z7wbgpxch6735szx";
-      name = "kcontacts-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kcontacts-17.04.0.tar.xz";
+      sha256 = "165adk2a8vyqyszp3llwm24n5ngs5l4bhhym022zynq7fh8w1grh";
+      name = "kcontacts-17.04.0.tar.xz";
     };
   };
   kcron = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kcron-16.12.3.tar.xz";
-      sha256 = "0whxc9h7qn0fwcca9sq6qy0j4hfb8xlkdypnb6gspl687ws799xz";
-      name = "kcron-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kcron-17.04.0.tar.xz";
+      sha256 = "0v6w543ns1gyr2c0lxajdd969f669si93hadahx6d3vnqk8nqa70";
+      name = "kcron-17.04.0.tar.xz";
     };
   };
-  kdebugsettings = {
-    version = "16.12.3";
+  kdav = {
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdebugsettings-16.12.3.tar.xz";
-      sha256 = "0mkhklv4dynz23w8w9yh5qspdlfp3hi6fyiijyfwj358rqgbf3p5";
-      name = "kdebugsettings-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kdav-17.04.0.tar.xz";
+      sha256 = "03nibqip9ryrb56hix5aq1lihp9w06c1hdzg505wjcnvwr7rd02c";
+      name = "kdav-17.04.0.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-dev-scripts-16.12.3.tar.xz";
-      sha256 = "0kiddn0wg90p98zgnpq3x2hcfw8xczn98nyd21zbkzz357v14pya";
-      name = "kde-dev-scripts-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-dev-scripts-17.04.0.tar.xz";
+      sha256 = "1s6k746hzsycwk7jb2i5blhfvg84flfgc79j1aa8kzpx4l31v3qz";
+      name = "kde-dev-scripts-17.04.0.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-dev-utils-16.12.3.tar.xz";
-      sha256 = "0svbl7yd5vz285gaymxy5mz0ll6fviamrbd6fjhj7rc4qx1gjgin";
-      name = "kde-dev-utils-16.12.3.tar.xz";
-    };
-  };
-  kdeedu-data = {
-    version = "16.12.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdeedu-data-16.12.3.tar.xz";
-      sha256 = "0vqzamp5fc2d0i9qn6986f3a1s1fdbrlzrsnimpdfcas5xngbv5m";
-      name = "kdeedu-data-16.12.3.tar.xz";
-    };
-  };
-  kdegraphics-mobipocket = {
-    version = "16.12.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdegraphics-mobipocket-16.12.3.tar.xz";
-      sha256 = "06zqny8idaw7s85h7iprbwdp7y1qspfp7yh5klwav12p72nn54w2";
-      name = "kdegraphics-mobipocket-16.12.3.tar.xz";
-    };
-  };
-  kdegraphics-thumbnailers = {
-    version = "16.12.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdegraphics-thumbnailers-16.12.3.tar.xz";
-      sha256 = "01q2czzqq240cbp9yg7mji2q15kmiwn1aqs6iii00i56yy2mwaxq";
-      name = "kdegraphics-thumbnailers-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-dev-utils-17.04.0.tar.xz";
+      sha256 = "03dqxaqj36bgwnn2r3dcwgqfxrqf7i5lwqr1sp6rq2799dv135j2";
+      name = "kde-dev-utils-17.04.0.tar.xz";
     };
   };
   kde-l10n-ar = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ar-16.12.3.tar.xz";
-      sha256 = "1a6in9zq0a4a1v7mijm7gdrprkb5djp4qzyrbrwwlyzpk0sjs153";
-      name = "kde-l10n-ar-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-ar-17.04.0.tar.xz";
+      sha256 = "1yj46m2appxwjvabsb0c1inmfkfviwqg1dfh7kcyqbg3nb11kdj6";
+      name = "kde-l10n-ar-17.04.0.tar.xz";
     };
   };
   kde-l10n-ast = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ast-16.12.3.tar.xz";
-      sha256 = "05di4xbm8viam0lz6gsyl8zip01dan5bb3h1ib7n7ri4rd49gb13";
-      name = "kde-l10n-ast-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-ast-17.04.0.tar.xz";
+      sha256 = "1pxbdd464ifvxcpk5nwfnqakggaq8648cpdksp9p68ybca33iwg0";
+      name = "kde-l10n-ast-17.04.0.tar.xz";
     };
   };
   kde-l10n-bg = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-bg-16.12.3.tar.xz";
-      sha256 = "1clqz50ri2zpsaqvlwq01jc44d2w4abpwaqd37jcvcpjg836kj32";
-      name = "kde-l10n-bg-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-bg-17.04.0.tar.xz";
+      sha256 = "128pf72srr0gypyzs7vqgxphhxqy397aaj1m35bav87r80xvqgk1";
+      name = "kde-l10n-bg-17.04.0.tar.xz";
     };
   };
   kde-l10n-bs = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-bs-16.12.3.tar.xz";
-      sha256 = "1lfpq4lixamh08vmmj8ai8pzdybs1anlg8vfb6lnxj3dpplxxjdv";
-      name = "kde-l10n-bs-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-bs-17.04.0.tar.xz";
+      sha256 = "1k3j2ilafmzpzf5shqcjggr8j26kwjr33w1qvnxhssnsjc6adx9l";
+      name = "kde-l10n-bs-17.04.0.tar.xz";
     };
   };
   kde-l10n-ca = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ca-16.12.3.tar.xz";
-      sha256 = "1h3d7gdpixiqn4gyk1z9lj5k4bhf4719w1rcfzcajrpwrmvdfvms";
-      name = "kde-l10n-ca-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-ca-17.04.0.tar.xz";
+      sha256 = "1zw3b967arp2vz86phj4n4y0mib6y2rqv5ak9jfxqmfpj03qlgf9";
+      name = "kde-l10n-ca-17.04.0.tar.xz";
     };
   };
   kde-l10n-ca_valencia = {
-    version = "ca_valencia-16.12.3";
+    version = "ca_valencia-17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ca@valencia-16.12.3.tar.xz";
-      sha256 = "00g1124n84lq380srykcr4yigqr5w9xivssj27jf1ak40vyanln0";
-      name = "kde-l10n-ca_valencia-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-ca@valencia-17.04.0.tar.xz";
+      sha256 = "0f36rz4nnvz0k97c4wrrhy3zr6njydvib2v10smph58zfqwd233d";
+      name = "kde-l10n-ca_valencia-17.04.0.tar.xz";
     };
   };
   kde-l10n-cs = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-cs-16.12.3.tar.xz";
-      sha256 = "0nvl0lbg1pw1r73ggycfqjvlga6lg7gyin4bigyjcq41k9y6xf91";
-      name = "kde-l10n-cs-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-cs-17.04.0.tar.xz";
+      sha256 = "12280xwvpz3m43arc62s4w0bfc1p10fqfi9v0d90adsgmh0zffhs";
+      name = "kde-l10n-cs-17.04.0.tar.xz";
     };
   };
   kde-l10n-da = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-da-16.12.3.tar.xz";
-      sha256 = "1bsv0z0q5fqgn2jkgazm3aazi6s9crz23acwx9p2w7fc7h98bqpq";
-      name = "kde-l10n-da-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-da-17.04.0.tar.xz";
+      sha256 = "05icziwpysbyz7y8b6snpvf6cyrs2yzic0p1v2x1m2s392nwx0qp";
+      name = "kde-l10n-da-17.04.0.tar.xz";
     };
   };
   kde-l10n-de = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-de-16.12.3.tar.xz";
-      sha256 = "0ym6f1n86rvbwdk0xlx2ajfv4l70kw3qir8z82d2jf5dhgz9h2k6";
-      name = "kde-l10n-de-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-de-17.04.0.tar.xz";
+      sha256 = "18fi7a5z9lnjmqabaz6q4yxcrpkmb62ri6c0zf1bff57cwvn2wbd";
+      name = "kde-l10n-de-17.04.0.tar.xz";
     };
   };
   kde-l10n-el = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-el-16.12.3.tar.xz";
-      sha256 = "1dd51kh52rq9y3r2iz985ib2bpi109vf2xv2abkm8ddsfmb1mq6c";
-      name = "kde-l10n-el-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-el-17.04.0.tar.xz";
+      sha256 = "04nqk6par22126y6v0c343ylwy2h0ylw03gjs0pp7a7cgq1lqh13";
+      name = "kde-l10n-el-17.04.0.tar.xz";
     };
   };
   kde-l10n-en_GB = {
-    version = "en_GB-16.12.3";
+    version = "en_GB-17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-en_GB-16.12.3.tar.xz";
-      sha256 = "0yc6fk5ak0442gv1gxwwz2zz13s9d1ihlfkvl8aqi6zky5b6c91n";
-      name = "kde-l10n-en_GB-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-en_GB-17.04.0.tar.xz";
+      sha256 = "0a0xwcvwv2sgjkzzy6wvyymm1l7b8xfk7lhiwh7bgm0il66shw98";
+      name = "kde-l10n-en_GB-17.04.0.tar.xz";
     };
   };
   kde-l10n-eo = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-eo-16.12.3.tar.xz";
-      sha256 = "0p43p1as9s2x4145k59li39fvg77c38mjnlb16zhb5bg5c0r1401";
-      name = "kde-l10n-eo-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-eo-17.04.0.tar.xz";
+      sha256 = "0cbf5qwh18yd4kadkn11mh86d9zhxkwm0gnivjmd62lrz41rxr92";
+      name = "kde-l10n-eo-17.04.0.tar.xz";
     };
   };
   kde-l10n-es = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-es-16.12.3.tar.xz";
-      sha256 = "194svk1axicbijy4ywsrn1q27pzrm3g139i63388qh3lzv8654p1";
-      name = "kde-l10n-es-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-es-17.04.0.tar.xz";
+      sha256 = "1xjjmia250w02wcw4jm7lsmixwd4qp2db5nxl1hql4ln1n2af9hk";
+      name = "kde-l10n-es-17.04.0.tar.xz";
     };
   };
   kde-l10n-et = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-et-16.12.3.tar.xz";
-      sha256 = "1q0mrc517jr5hicklhzvs6vw5vwgvb2gj3fi93a9iqxbw1a794pk";
-      name = "kde-l10n-et-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-et-17.04.0.tar.xz";
+      sha256 = "1ivydzg39j0rv0y1vvkkh9429iyfx6mk44sswkg2gc9mccpwfa5s";
+      name = "kde-l10n-et-17.04.0.tar.xz";
     };
   };
   kde-l10n-eu = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-eu-16.12.3.tar.xz";
-      sha256 = "0dgwklynwwksdm0dxk8dm53y0v92kfin6vgwpn2scc97fns16r08";
-      name = "kde-l10n-eu-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-eu-17.04.0.tar.xz";
+      sha256 = "0pkj8sghzyvp20qgd6ys8znri011scrlgkx32ky3q74gn5dr4k95";
+      name = "kde-l10n-eu-17.04.0.tar.xz";
     };
   };
   kde-l10n-fa = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-fa-16.12.3.tar.xz";
-      sha256 = "1ywipqg2dv3dapp3m7sfhap4izhabb4srk3gpl2kd2wx0abnwmdb";
-      name = "kde-l10n-fa-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-fa-17.04.0.tar.xz";
+      sha256 = "1slmhm6rl691n60xw53f9s5ibn8b9h1sb7i0rc8s2mk9cs6zqs4i";
+      name = "kde-l10n-fa-17.04.0.tar.xz";
     };
   };
   kde-l10n-fi = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-fi-16.12.3.tar.xz";
-      sha256 = "11grklvacq70mq4fj0772v8xqmp1b1pl7gff8gvy692rva5qhv29";
-      name = "kde-l10n-fi-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-fi-17.04.0.tar.xz";
+      sha256 = "1yq7kiiqv4hhn7i14ccvh3nllv8i0xw9jv3z38r427gimi6d8p3d";
+      name = "kde-l10n-fi-17.04.0.tar.xz";
     };
   };
   kde-l10n-fr = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-fr-16.12.3.tar.xz";
-      sha256 = "0qx849ilp1597nxrx6cmgnmm202all14y8pcyd19gp70wdra8wcm";
-      name = "kde-l10n-fr-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-fr-17.04.0.tar.xz";
+      sha256 = "0v2i6f7yf58qzd69hcb0jz0x1j3w99702wiflfags7qyzbszgan2";
+      name = "kde-l10n-fr-17.04.0.tar.xz";
     };
   };
   kde-l10n-ga = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ga-16.12.3.tar.xz";
-      sha256 = "06w92m84bxqs06gyi45x1jmzh99ip7vnnzjq7ixx7ny9k6m0as1m";
-      name = "kde-l10n-ga-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-ga-17.04.0.tar.xz";
+      sha256 = "0q9y1dqk9j1fgk6fc1fdg3g26896x47cnnmbdgf037plbr0b4j5b";
+      name = "kde-l10n-ga-17.04.0.tar.xz";
     };
   };
   kde-l10n-gl = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-gl-16.12.3.tar.xz";
-      sha256 = "1k6jydmqbmxfkimxqn8qhd136zdjz4z7d5mk0n80607n91y7n3kv";
-      name = "kde-l10n-gl-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-gl-17.04.0.tar.xz";
+      sha256 = "118p49vkdnmn707rf20gaycrrq3kb2qjqa9abq2ibfxdigwj20cy";
+      name = "kde-l10n-gl-17.04.0.tar.xz";
     };
   };
   kde-l10n-he = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-he-16.12.3.tar.xz";
-      sha256 = "1ry1wd9ng5xwpi402p1rqbsrb0ma7bgkmx53yygzc5mpszarga6y";
-      name = "kde-l10n-he-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-he-17.04.0.tar.xz";
+      sha256 = "0ba1ccwkwqsdxlxfbq3fcjmbpww2sr9kx08j3nz453qdndfyp9md";
+      name = "kde-l10n-he-17.04.0.tar.xz";
     };
   };
   kde-l10n-hi = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-hi-16.12.3.tar.xz";
-      sha256 = "1qwjiarqi8c3b15nc2nqrxvb6pcrb232qcx6nz0f9day2d0zxdwk";
-      name = "kde-l10n-hi-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-hi-17.04.0.tar.xz";
+      sha256 = "0gy7c67b9glhp0x6l8jxycp8vsdkv77025wdf9kn5l8sy1hqqhbp";
+      name = "kde-l10n-hi-17.04.0.tar.xz";
     };
   };
   kde-l10n-hr = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-hr-16.12.3.tar.xz";
-      sha256 = "0y3pvdy1pkhraahsfkwhkar6004ll19gd6rhhhzgaw0irmw1yxp1";
-      name = "kde-l10n-hr-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-hr-17.04.0.tar.xz";
+      sha256 = "063pppyl57i241dxr68wbvh8k3ccck5589mrn5yhdcw30b0hiwr7";
+      name = "kde-l10n-hr-17.04.0.tar.xz";
     };
   };
   kde-l10n-hu = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-hu-16.12.3.tar.xz";
-      sha256 = "001pl0l0cj4f2j7c6fjv9jv4wnkk2zb428y8szqm78zg85ms9wpz";
-      name = "kde-l10n-hu-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-hu-17.04.0.tar.xz";
+      sha256 = "1b16xbdkh5varv650frnp9jsp8di6lnd61i04gaa3sxfy25xjzb2";
+      name = "kde-l10n-hu-17.04.0.tar.xz";
     };
   };
   kde-l10n-ia = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ia-16.12.3.tar.xz";
-      sha256 = "09p9r6xzirr6cwcjdg10db62g3d4z0ksl6caf45rz0i2k5zn4r6r";
-      name = "kde-l10n-ia-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-ia-17.04.0.tar.xz";
+      sha256 = "0gmzk2cac5gfa6j0m2d7lbwpi9y1dkrlk37r7iqvvzmqdsx2nzsy";
+      name = "kde-l10n-ia-17.04.0.tar.xz";
     };
   };
   kde-l10n-id = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-id-16.12.3.tar.xz";
-      sha256 = "1kanlr401ljaaqijhdvv52lvrn90m9b0l6i2jly8mdnnnwp896ra";
-      name = "kde-l10n-id-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-id-17.04.0.tar.xz";
+      sha256 = "1cdsapfq74600n2p49fzv8lflall755kyvkpi152clb7a66vmysc";
+      name = "kde-l10n-id-17.04.0.tar.xz";
     };
   };
   kde-l10n-is = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-is-16.12.3.tar.xz";
-      sha256 = "10a9sxjnv9xb9wy04b9pfwpj4xg22x0ami37jhwggpskl9sj736v";
-      name = "kde-l10n-is-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-is-17.04.0.tar.xz";
+      sha256 = "0g9s9ywkhdnyh76lr7j73ba7ydsvh6ki6y0qcgvhzg9jnd4rywzb";
+      name = "kde-l10n-is-17.04.0.tar.xz";
     };
   };
   kde-l10n-it = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-it-16.12.3.tar.xz";
-      sha256 = "0f771kli3zw6dgwdxgk19kiy6gwv9yj3f2cgiyxaiak8yawa9ary";
-      name = "kde-l10n-it-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-it-17.04.0.tar.xz";
+      sha256 = "0hhq5gvlzfhz270caqh6g5k1dp740cakamn46zli5586hpmpdk8d";
+      name = "kde-l10n-it-17.04.0.tar.xz";
     };
   };
   kde-l10n-ja = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ja-16.12.3.tar.xz";
-      sha256 = "1p0arv340i34gdlkdbjw234c9a4jqy8z417f0p19pn6ic3i5i6yv";
-      name = "kde-l10n-ja-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-ja-17.04.0.tar.xz";
+      sha256 = "149zazsdm89q5shfxpg5xsd51l0xrq12w8pw4nnkwpbv6vqwsf8w";
+      name = "kde-l10n-ja-17.04.0.tar.xz";
     };
   };
   kde-l10n-kk = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-kk-16.12.3.tar.xz";
-      sha256 = "1ik3abczhxkm2b8i22akz12q5lm7rsc7i4qdz6ml1sn4kd0949i5";
-      name = "kde-l10n-kk-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-kk-17.04.0.tar.xz";
+      sha256 = "1n4qfkj2h03x2b9d1q1zjkz7aiqqjvy9sci3scbqqd3apf80jgn9";
+      name = "kde-l10n-kk-17.04.0.tar.xz";
     };
   };
   kde-l10n-km = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-km-16.12.3.tar.xz";
-      sha256 = "1lwpfkv87i6km9pxrm78cqnnb1jnysaij0lmgvz2d0bs6dldaxrs";
-      name = "kde-l10n-km-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-km-17.04.0.tar.xz";
+      sha256 = "1bd0m5rkrvizvlr57wagixavk8c6449a8xl07j0hk12ha7c3livy";
+      name = "kde-l10n-km-17.04.0.tar.xz";
     };
   };
   kde-l10n-ko = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ko-16.12.3.tar.xz";
-      sha256 = "0c0hkprngxyxj2sf05s5i0y04i5f4vgqis1mgq500l03q0x16b4y";
-      name = "kde-l10n-ko-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-ko-17.04.0.tar.xz";
+      sha256 = "10j0can8m0814jsch96f20625pr01ag8xqjyx4ridfssh8jry8s9";
+      name = "kde-l10n-ko-17.04.0.tar.xz";
     };
   };
   kde-l10n-lt = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-lt-16.12.3.tar.xz";
-      sha256 = "04d2l2qisbpzxppxchfrxnijc8706pq3s9pgmyyy6c0v26gsgz77";
-      name = "kde-l10n-lt-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-lt-17.04.0.tar.xz";
+      sha256 = "0l7w027g66dczhr8242k0fqvzjpcqi2jmna0lv1d7281kmyc0h49";
+      name = "kde-l10n-lt-17.04.0.tar.xz";
     };
   };
   kde-l10n-lv = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-lv-16.12.3.tar.xz";
-      sha256 = "1af13p7ri4x3dhwlv30gf7za7dgsr1kx3khzlgdg4hcgi2s4aq12";
-      name = "kde-l10n-lv-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-lv-17.04.0.tar.xz";
+      sha256 = "0ykl7wpi7x5nwy6pdp0h3fpm8ycvc4r2q0p446rz63fmp0vmax2h";
+      name = "kde-l10n-lv-17.04.0.tar.xz";
     };
   };
   kde-l10n-mr = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-mr-16.12.3.tar.xz";
-      sha256 = "16g8ln11x9qpda4wgzwvvij77bdpsdd6vsh7ysik8fc87km4qkax";
-      name = "kde-l10n-mr-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-mr-17.04.0.tar.xz";
+      sha256 = "0k4dkq744ak3w7mfx4x3skkpnp2lnvj5zqihchhp2w6ik2yq3wkd";
+      name = "kde-l10n-mr-17.04.0.tar.xz";
     };
   };
   kde-l10n-nb = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-nb-16.12.3.tar.xz";
-      sha256 = "091wm8z6ibw8by220j89xdf0vpk7dp341hph2dhz17ykdzck3cdf";
-      name = "kde-l10n-nb-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-nb-17.04.0.tar.xz";
+      sha256 = "1fqxssd12cpg9vkf2kc6f3gbivqr9xf4p489r2j6s6di7zn1na96";
+      name = "kde-l10n-nb-17.04.0.tar.xz";
     };
   };
   kde-l10n-nds = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-nds-16.12.3.tar.xz";
-      sha256 = "052nw25rd3vq0fkixcwmn1iwaxnfwcg7iarf78c276w6vzrbvvcc";
-      name = "kde-l10n-nds-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-nds-17.04.0.tar.xz";
+      sha256 = "0xrzy8v3a7riznb9fpjbx9zc4h47n6vpm36rbjdm93z0k8ifvqll";
+      name = "kde-l10n-nds-17.04.0.tar.xz";
     };
   };
   kde-l10n-nl = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-nl-16.12.3.tar.xz";
-      sha256 = "0axlpjq70142blccsfqbh7zs7l8k31mkc30lr79d03975dp2ivzi";
-      name = "kde-l10n-nl-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-nl-17.04.0.tar.xz";
+      sha256 = "116kigy5agm3dpan5wk54j144fq1sf9i6njpqmjdjrgyylr6cska";
+      name = "kde-l10n-nl-17.04.0.tar.xz";
     };
   };
   kde-l10n-nn = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-nn-16.12.3.tar.xz";
-      sha256 = "0ql8pvj47kwvdaj2gsjlc4rxb7mpl9nv4fraavffinv4xzrh0v18";
-      name = "kde-l10n-nn-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-nn-17.04.0.tar.xz";
+      sha256 = "1i1jm30gyd1s6igv7bwckdrbzsrsahzi7ki0c9dpfhm85gv8i957";
+      name = "kde-l10n-nn-17.04.0.tar.xz";
     };
   };
   kde-l10n-pa = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-pa-16.12.3.tar.xz";
-      sha256 = "0r2snb5bkvha8yj692g1y8xwdwcnav06w3qliz1v7jiyb6hv8ncm";
-      name = "kde-l10n-pa-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-pa-17.04.0.tar.xz";
+      sha256 = "15n37z6wglw315jd8hijbyf883kpcw5919zp4yr57srjsvkay85v";
+      name = "kde-l10n-pa-17.04.0.tar.xz";
     };
   };
   kde-l10n-pl = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-pl-16.12.3.tar.xz";
-      sha256 = "1bp8br37wfn3xlxl4hzr45sv41w2i562rgjcj25ngn27y7cqvwq5";
-      name = "kde-l10n-pl-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-pl-17.04.0.tar.xz";
+      sha256 = "0ncaln92v5ib34zl700a61gzlc5akik3ss7pi4rygvlggfcjv4s2";
+      name = "kde-l10n-pl-17.04.0.tar.xz";
     };
   };
   kde-l10n-pt = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-pt-16.12.3.tar.xz";
-      sha256 = "1f3ray689q3w4yr20j0bj8vvwyb1qzi608ip0p6n4nzjkq3ycqh6";
-      name = "kde-l10n-pt-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-pt-17.04.0.tar.xz";
+      sha256 = "1ha6zfv9750idpw93z6hlmlypk7pgfriirfvfwbag43664ywl96n";
+      name = "kde-l10n-pt-17.04.0.tar.xz";
     };
   };
   kde-l10n-pt_BR = {
-    version = "pt_BR-16.12.3";
+    version = "pt_BR-17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-pt_BR-16.12.3.tar.xz";
-      sha256 = "06h0dp54n8brv7kcfdbxy3yxk6c5b1ncbd9fzmflr8bpivifj66s";
-      name = "kde-l10n-pt_BR-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-pt_BR-17.04.0.tar.xz";
+      sha256 = "0n16al9pivlz3s0ard79k88cank988107jbxmzsiyrbvlwfqih8a";
+      name = "kde-l10n-pt_BR-17.04.0.tar.xz";
     };
   };
   kde-l10n-ro = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ro-16.12.3.tar.xz";
-      sha256 = "17kbkh50jf8zb9p3kl2malddvq08ybg881x1w5gmw514k3d3hwxh";
-      name = "kde-l10n-ro-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-ro-17.04.0.tar.xz";
+      sha256 = "0g3svxknwdn6nsq8v3ml0p3m5lwlv34h3ikr8cdra5zigqjmgxmf";
+      name = "kde-l10n-ro-17.04.0.tar.xz";
     };
   };
   kde-l10n-ru = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ru-16.12.3.tar.xz";
-      sha256 = "12ghgwy84i6nmlgi8wmvhxn7d9mvanhyd6pqyd302r5x0zxd8rza";
-      name = "kde-l10n-ru-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-ru-17.04.0.tar.xz";
+      sha256 = "0f0pzvxacik48w3r1i7svfkn5dna9qmnz1cpci8sbcirpkw0xsp1";
+      name = "kde-l10n-ru-17.04.0.tar.xz";
     };
   };
   kde-l10n-sk = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-sk-16.12.3.tar.xz";
-      sha256 = "0hc1cm2npsw2w9mx09kn9jxvaqpjhv6snhwdi2mybpbs9qmgnzcn";
-      name = "kde-l10n-sk-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-sk-17.04.0.tar.xz";
+      sha256 = "0x3yx3hcq4ia4s0f9bv3sib6hvfws8r8b8rgsgikf6d0ghk0y5z1";
+      name = "kde-l10n-sk-17.04.0.tar.xz";
     };
   };
   kde-l10n-sl = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-sl-16.12.3.tar.xz";
-      sha256 = "02d0fg40pvlr6wnxg425n3fpqpizvdppznyp8nnxbzb9ia583aw0";
-      name = "kde-l10n-sl-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-sl-17.04.0.tar.xz";
+      sha256 = "0gdj3710c6q6h6g5mnrslzg2qza2bnr78skiy8h3x7ihrmgyjmrl";
+      name = "kde-l10n-sl-17.04.0.tar.xz";
     };
   };
   kde-l10n-sr = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-sr-16.12.3.tar.xz";
-      sha256 = "1yq44dykajcz4n10zrad85lji30phr9cm5dnmx4s08404qwh68cz";
-      name = "kde-l10n-sr-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-sr-17.04.0.tar.xz";
+      sha256 = "1si249lwy3ansacj33agxqs2vdrmyll6g2zk1754b34nr01arbq3";
+      name = "kde-l10n-sr-17.04.0.tar.xz";
     };
   };
   kde-l10n-sv = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-sv-16.12.3.tar.xz";
-      sha256 = "1q8ags96jwjrihi8ai8139c3s9nfy7v7lss9ci3xl786hyggdlrb";
-      name = "kde-l10n-sv-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-sv-17.04.0.tar.xz";
+      sha256 = "1zh7ajp6f7vh098nbp501891cc68h1lwq8igzxzh2l0gd35rcpn4";
+      name = "kde-l10n-sv-17.04.0.tar.xz";
     };
   };
   kde-l10n-tr = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-tr-16.12.3.tar.xz";
-      sha256 = "1l24d0abhhlbam0wfz52495nvjy1blfid9h31233hkykb782gi0n";
-      name = "kde-l10n-tr-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-tr-17.04.0.tar.xz";
+      sha256 = "0w8s5wfkaz7p209dk9a2z38as3hif5lbwfjbx8342vp2sv3s9yy2";
+      name = "kde-l10n-tr-17.04.0.tar.xz";
     };
   };
   kde-l10n-ug = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-ug-16.12.3.tar.xz";
-      sha256 = "0sb4136wjyg9g1fvhcgqv97wpv82ia37aknd8xcvjnp5n2jl80nn";
-      name = "kde-l10n-ug-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-ug-17.04.0.tar.xz";
+      sha256 = "00fswh5mfg7spdnqm3wfir5v0al91p8qd8cj7mb9jlmdm6ydd2wk";
+      name = "kde-l10n-ug-17.04.0.tar.xz";
     };
   };
   kde-l10n-uk = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-uk-16.12.3.tar.xz";
-      sha256 = "073pqvxbpibwd1bv0vh4rijgkhg061g2gaaaqnckaakw677g2bmz";
-      name = "kde-l10n-uk-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-uk-17.04.0.tar.xz";
+      sha256 = "0zxf372yn0nsdnpylq364h0c4g2rzxxs462lh9ixwja2m8p91wsi";
+      name = "kde-l10n-uk-17.04.0.tar.xz";
     };
   };
   kde-l10n-wa = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-wa-16.12.3.tar.xz";
-      sha256 = "14qms294pz7hf4ramhscif9n6jfk5ixfwww558ypi0lwnzc17mrf";
-      name = "kde-l10n-wa-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-wa-17.04.0.tar.xz";
+      sha256 = "0p44q7mki01fq15y96qibw2hap9lfaya2480vjl4f7hdqw2xjfhh";
+      name = "kde-l10n-wa-17.04.0.tar.xz";
     };
   };
   kde-l10n-zh_CN = {
-    version = "zh_CN-16.12.3";
+    version = "zh_CN-17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-zh_CN-16.12.3.tar.xz";
-      sha256 = "01q92gc13wjpd2gzvn1sipgl5xs86mwq8y0583glsx7s2wfp3g41";
-      name = "kde-l10n-zh_CN-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-zh_CN-17.04.0.tar.xz";
+      sha256 = "0a3kfdkp6d3fgil3s3rd0kjc7jnqzakr46683dd108shqzb26rcs";
+      name = "kde-l10n-zh_CN-17.04.0.tar.xz";
     };
   };
   kde-l10n-zh_TW = {
-    version = "zh_TW-16.12.3";
+    version = "zh_TW-17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-l10n/kde-l10n-zh_TW-16.12.3.tar.xz";
-      sha256 = "0a9xnxlbr5469k1ij7hc8wa5p38r3yqq1d9fxmmpqyj111v63g3h";
-      name = "kde-l10n-zh_TW-16.12.3.tar.xz";
-    };
-  };
-  kdelibs = {
-    version = "4.14.30";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdelibs-4.14.30.tar.xz";
-      sha256 = "0v8r70d55c4jhfhnh8lj41584qggc2lb4f6jwm4yl9qc6bpw77x3";
-      name = "kdelibs-4.14.30.tar.xz";
-    };
-  };
-  kdenetwork-filesharing = {
-    version = "16.12.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdenetwork-filesharing-16.12.3.tar.xz";
-      sha256 = "0345wq7ayahfd2jlpgfs18c7nrdp9gn9yxig2x75pspqmb5pgxh7";
-      name = "kdenetwork-filesharing-16.12.3.tar.xz";
-    };
-  };
-  kdenlive = {
-    version = "16.12.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdenlive-16.12.3.tar.xz";
-      sha256 = "1z7afrx00yaracf6cv9p8r14gqampabya8li6ws1ihzdgfamlkd0";
-      name = "kdenlive-16.12.3.tar.xz";
-    };
-  };
-  kdepim-addons = {
-    version = "16.12.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdepim-addons-16.12.3.tar.xz";
-      sha256 = "1hqm7vi7fy7s17djayq9q7l3dxdnzk2ii78mjdg90aac9cxdxgmm";
-      name = "kdepim-addons-16.12.3.tar.xz";
-    };
-  };
-  kdepim-apps-libs = {
-    version = "16.12.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdepim-apps-libs-16.12.3.tar.xz";
-      sha256 = "1q4ksp377piqxbs843nxafzssz80ayjii90iz86r2z2rd3lyrjzw";
-      name = "kdepim-apps-libs-16.12.3.tar.xz";
-    };
-  };
-  kdepim-runtime = {
-    version = "16.12.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdepim-runtime-16.12.3.tar.xz";
-      sha256 = "0j5c3y8bqnffcrx4g7ilq7id46h11d1hiw81l7x4mg1p0zw07bg1";
-      name = "kdepim-runtime-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-l10n/kde-l10n-zh_TW-17.04.0.tar.xz";
+      sha256 = "0mdc8lqb5b99rkswallm5allcnp8i6xlsyv6q9k1n1jlyjkxl1xx";
+      name = "kde-l10n-zh_TW-17.04.0.tar.xz";
     };
   };
   kde-runtime = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kde-runtime-16.12.3.tar.xz";
-      sha256 = "1sqp827l30adiqrp12djx3xk6mlz2lb46hmxnbnzv52mv2whcr3y";
-      name = "kde-runtime-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kde-runtime-17.04.0.tar.xz";
+      sha256 = "0phdmsmlqbadxi45n19hzkzfkkcazzlkxb0rxfr6c3jny2ncg5cn";
+      name = "kde-runtime-17.04.0.tar.xz";
+    };
+  };
+  kdebugsettings = {
+    version = "17.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/kdebugsettings-17.04.0.tar.xz";
+      sha256 = "140drnnv7573fvfs94kwk0kgqqkc5nrj8jkj3i3l6idikw0xi0qm";
+      name = "kdebugsettings-17.04.0.tar.xz";
+    };
+  };
+  kdeedu-data = {
+    version = "17.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/kdeedu-data-17.04.0.tar.xz";
+      sha256 = "1khxi2z5qv0wrj7pn6r643829619bhymzzbdlgjr1zs5k244iajy";
+      name = "kdeedu-data-17.04.0.tar.xz";
+    };
+  };
+  kdegraphics-mobipocket = {
+    version = "17.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/kdegraphics-mobipocket-17.04.0.tar.xz";
+      sha256 = "0ja7a6p7ckw0zy6jffwm96vc5g33mqr722c77890173hsb45wy83";
+      name = "kdegraphics-mobipocket-17.04.0.tar.xz";
+    };
+  };
+  kdegraphics-thumbnailers = {
+    version = "17.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/kdegraphics-thumbnailers-17.04.0.tar.xz";
+      sha256 = "0h2ydkcj1i35qhrmcva5977ib2127186q735xh2dg60fmdcyni14";
+      name = "kdegraphics-thumbnailers-17.04.0.tar.xz";
+    };
+  };
+  kdelibs = {
+    version = "4.14.31";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/kdelibs-4.14.31.tar.xz";
+      sha256 = "00ai1s0wz4nyg7fhj6g7cp3p5sz8rw676dv127bpbvm5yszlz561";
+      name = "kdelibs-4.14.31.tar.xz";
+    };
+  };
+  kdenetwork-filesharing = {
+    version = "17.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/kdenetwork-filesharing-17.04.0.tar.xz";
+      sha256 = "176n41xnz2v3wn62nip5sdv966g4rs15ah27zzr9cx32jrs52z4c";
+      name = "kdenetwork-filesharing-17.04.0.tar.xz";
+    };
+  };
+  kdenlive = {
+    version = "17.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/kdenlive-17.04.0.tar.xz";
+      sha256 = "0kd93zxz5fch1ski9mbz2sbfda3spq9gsfgzvik2mzjwr994x574";
+      name = "kdenlive-17.04.0.tar.xz";
+    };
+  };
+  kdepim-addons = {
+    version = "17.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/kdepim-addons-17.04.0.tar.xz";
+      sha256 = "01qyg9p6nh2n2hsmmjfyjcd80z6cfpw509zmgs608lmbm8hskzxd";
+      name = "kdepim-addons-17.04.0.tar.xz";
+    };
+  };
+  kdepim-apps-libs = {
+    version = "17.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/kdepim-apps-libs-17.04.0.tar.xz";
+      sha256 = "02igc1c8zykwf5yydmk0l1s4l3z3m5c90jlhyrqjkpmkwvnkrd3n";
+      name = "kdepim-apps-libs-17.04.0.tar.xz";
+    };
+  };
+  kdepim-runtime = {
+    version = "17.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/kdepim-runtime-17.04.0.tar.xz";
+      sha256 = "00cjlnqq029850n2ib1r5ylass8q1f71p24sqicbfcfyd6vksvdl";
+      name = "kdepim-runtime-17.04.0.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdesdk-kioslaves-16.12.3.tar.xz";
-      sha256 = "17zqp43a1266616h3g6yccjmfgwni6lr8lz4rrvfda275vvwbshj";
-      name = "kdesdk-kioslaves-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kdesdk-kioslaves-17.04.0.tar.xz";
+      sha256 = "1rfj2zk34i7i3289n85b57szd4154zj6r4m7zyif2cc019ax5b0q";
+      name = "kdesdk-kioslaves-17.04.0.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdesdk-thumbnailers-16.12.3.tar.xz";
-      sha256 = "0p2s6pyq16jmjv29r8n9ygvsh1dxgz9zk90mk138cxxhbx9nks9h";
-      name = "kdesdk-thumbnailers-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kdesdk-thumbnailers-17.04.0.tar.xz";
+      sha256 = "145rgk62c083g1nl7ssx9xalv0plsjdlyp4a7jqv83vqphcyd789";
+      name = "kdesdk-thumbnailers-17.04.0.tar.xz";
     };
   };
   kdf = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdf-16.12.3.tar.xz";
-      sha256 = "1502ib1hlc5xxsphspxwj8jvjm7qig0zdwckvm3nmh7hf4474sc5";
-      name = "kdf-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kdf-17.04.0.tar.xz";
+      sha256 = "1bavp593622014ik1h066mdldlzlyq5f2rw93plsv5i2lpabdbfd";
+      name = "kdf-17.04.0.tar.xz";
     };
   };
   kdialog = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdialog-16.12.3.tar.xz";
-      sha256 = "161barz5x9jrdk2p5hqc2vk1rqfwn8nlhdmc1vjqnhvww786ghmh";
-      name = "kdialog-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kdialog-17.04.0.tar.xz";
+      sha256 = "0vdlfnkm9949rjalmf8f9dc86jsha63lya0fgl34admrs8d530hb";
+      name = "kdialog-17.04.0.tar.xz";
     };
   };
   kdiamond = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kdiamond-16.12.3.tar.xz";
-      sha256 = "0qdh9ngrz5ph0kly27c58sxhwamqm3wq566337yhdqjizzcin4pf";
-      name = "kdiamond-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kdiamond-17.04.0.tar.xz";
+      sha256 = "021mmygp28z7vvg2gjb4p781kcg33qj4lcz9vqvyh5qmv81qh93w";
+      name = "kdiamond-17.04.0.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/keditbookmarks-16.12.3.tar.xz";
-      sha256 = "0dn3jb5lsjj2c6pbrbn4cik68fqqk99ljl45vbal9cc27lmrfa2n";
-      name = "keditbookmarks-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/keditbookmarks-17.04.0.tar.xz";
+      sha256 = "1daab64k5kk6krphi3k3rgprmql126bwykl8aaa93ls890xln3g8";
+      name = "keditbookmarks-17.04.0.tar.xz";
     };
   };
   kfilereplace = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kfilereplace-16.12.3.tar.xz";
-      sha256 = "0gym9bmkyjwg97khy6xxiaidjp6wi98fzmk7wa97wbdqc0qvswja";
-      name = "kfilereplace-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kfilereplace-17.04.0.tar.xz";
+      sha256 = "0prc6v9kps1yjwccscm7skcapnzza53xh36pbdavhw81pag6wwsy";
+      name = "kfilereplace-17.04.0.tar.xz";
     };
   };
   kfind = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kfind-16.12.3.tar.xz";
-      sha256 = "1d7rn3xri4dgv97s6jw3n4cbsg73zyrbcm3ligxgj37ziggrhgsj";
-      name = "kfind-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kfind-17.04.0.tar.xz";
+      sha256 = "08hlylw13frq7frjz4rvisr0001n44nkafh2ga84mvkvlgxl0602";
+      name = "kfind-17.04.0.tar.xz";
     };
   };
   kfloppy = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kfloppy-16.12.3.tar.xz";
-      sha256 = "07mgrpjqd2kdz5gmg8ylmvdb4mis328b7qlchszdx0l1z30kqkzp";
-      name = "kfloppy-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kfloppy-17.04.0.tar.xz";
+      sha256 = "1di15ri8y3qinr40j83hrvfc1h3y8pan0mbfin1jdm4vwgjwgrqn";
+      name = "kfloppy-17.04.0.tar.xz";
     };
   };
   kfourinline = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kfourinline-16.12.3.tar.xz";
-      sha256 = "087c00sggx5i1g8i2rjvvwlys15bisgx9fm2nl8f30h2ba3im4sg";
-      name = "kfourinline-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kfourinline-17.04.0.tar.xz";
+      sha256 = "119jrs63dfbdpq7a3ng0fy0dri1jw7dbaz6n5hyz6ihzizsr9nm2";
+      name = "kfourinline-17.04.0.tar.xz";
     };
   };
   kgeography = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kgeography-16.12.3.tar.xz";
-      sha256 = "1rnk00nj29zimpw36vhm0yrwlmpmxwv9wzxnhr7n2jq5qhbqsp5g";
-      name = "kgeography-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kgeography-17.04.0.tar.xz";
+      sha256 = "17kwpv352aiacghacjp0bz1ak19jh52300nmjhlj8ysl57q48n3z";
+      name = "kgeography-17.04.0.tar.xz";
     };
   };
   kget = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kget-16.12.3.tar.xz";
-      sha256 = "0h8nklsl6gddwzgjig5cwp463s96ffn5688zjlsyx4hphnvbj8kb";
-      name = "kget-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kget-17.04.0.tar.xz";
+      sha256 = "093mrv9c699s8jwrf4lxfg78ajiqhlpbi7swpgmhk2545wg1ngn7";
+      name = "kget-17.04.0.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kgoldrunner-16.12.3.tar.xz";
-      sha256 = "028kz5x8a3jb3zp3vfxajmszrqk859hdln9175pp6zj78b278xz4";
-      name = "kgoldrunner-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kgoldrunner-17.04.0.tar.xz";
+      sha256 = "1in4ddlrn1lnjdgww4saa7is6v8lj33n31bmrf2f6hmq7sg3i6h9";
+      name = "kgoldrunner-17.04.0.tar.xz";
     };
   };
   kgpg = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kgpg-16.12.3.tar.xz";
-      sha256 = "0abh15j2p0vinskd8f1yvjkyi1a70k0wf1sdldrfdwpdgq1pqsxw";
-      name = "kgpg-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kgpg-17.04.0.tar.xz";
+      sha256 = "1i9pyz35pzn5p3p4mvkxwxfrmmpmf7ngpj83m28zxcj654dfcl6x";
+      name = "kgpg-17.04.0.tar.xz";
     };
   };
   khangman = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/khangman-16.12.3.tar.xz";
-      sha256 = "03ffigr9a6n3aj1a7lxcw9wgf1pafdjwqjnwnny2ric5vn6lpq1z";
-      name = "khangman-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/khangman-17.04.0.tar.xz";
+      sha256 = "14ddaqvhmlwwb85bl5hi0r0m61akx38aabzrs9ys045z64si8b9d";
+      name = "khangman-17.04.0.tar.xz";
     };
   };
   khelpcenter = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/khelpcenter-16.12.3.tar.xz";
-      sha256 = "100xcjjjbszhbwgydbylk9m9lrxikjyazmhaq2rvv2mfzsbijjm7";
-      name = "khelpcenter-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/khelpcenter-17.04.0.tar.xz";
+      sha256 = "10x8c18vbwg7j6nfrrl7c0wj9x882ijv33mfnrhj0vpdc2bnkkxn";
+      name = "khelpcenter-17.04.0.tar.xz";
     };
   };
   kholidays = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kholidays-16.12.3.tar.xz";
-      sha256 = "09iwkqpnmn3h7yfin4y9izb2sdk6hrm8rfq106cnz7j8i31q93ad";
-      name = "kholidays-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kholidays-17.04.0.tar.xz";
+      sha256 = "0k0dm17bvr9snxmc87gicizpqqdsr95gxypnhgyiwc0mz90l5qb7";
+      name = "kholidays-17.04.0.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kidentitymanagement-16.12.3.tar.xz";
-      sha256 = "1b23cwdhc7rv260kmn4akff3jfa21hk49p0kp8p0mf6nw6qahbvp";
-      name = "kidentitymanagement-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kidentitymanagement-17.04.0.tar.xz";
+      sha256 = "1vrmj0ch1zg8hh1qqjv0i7fys5nrw3g6rj5sns6ghi0kswlskwfw";
+      name = "kidentitymanagement-17.04.0.tar.xz";
     };
   };
   kig = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kig-16.12.3.tar.xz";
-      sha256 = "0fnlgxwcnspaqzv4y40xm0kq3xwwd4r5abh7ssbd6iqsbzgm6ghw";
-      name = "kig-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kig-17.04.0.tar.xz";
+      sha256 = "0bx4vzg5x4lp7k49i5a55ka1c60iy3d1xjlrcx0gjx2bj35k6893";
+      name = "kig-17.04.0.tar.xz";
     };
   };
   kigo = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kigo-16.12.3.tar.xz";
-      sha256 = "08rdz91jzz79884xhg87cwy57q1jk2414shyxxy9r0pb4wdcdbhn";
-      name = "kigo-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kigo-17.04.0.tar.xz";
+      sha256 = "1vi07v5nnwxpm04hxspxadf0qw7qka7pajggn54frc37hq5ibxia";
+      name = "kigo-17.04.0.tar.xz";
     };
   };
   killbots = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/killbots-16.12.3.tar.xz";
-      sha256 = "0lwniwm8cbnwpqhfis38x5qvkz53626v9bn00amml57zj8x3hjnd";
-      name = "killbots-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/killbots-17.04.0.tar.xz";
+      sha256 = "0ccl1249x7lpkm6hpani1fyvdgs0dqlxd250f9hm7k6j8b6jwg01";
+      name = "killbots-17.04.0.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kimagemapeditor-16.12.3.tar.xz";
-      sha256 = "0362zcj6by3kydr5v3sr7l6k9kkyfcy16879f93d1qqkjfi11cic";
-      name = "kimagemapeditor-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kimagemapeditor-17.04.0.tar.xz";
+      sha256 = "1n828j0sqvas9c3iqmbj3jl8bmhyw7bqj3s6zf0qifjdxvlxpwaq";
+      name = "kimagemapeditor-17.04.0.tar.xz";
     };
   };
   kimap = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kimap-16.12.3.tar.xz";
-      sha256 = "1jlva17hy500jpb5mg6m3vrcy6mqikcy8m1pgy68d2ip0m93rb5f";
-      name = "kimap-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kimap-17.04.0.tar.xz";
+      sha256 = "1xgaixdplpycsdd2w09liy1vxp0lx5p2n6bmbds5dq887dwmj73i";
+      name = "kimap-17.04.0.tar.xz";
     };
   };
   kio-extras = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kio-extras-16.12.3.tar.xz";
-      sha256 = "1mfpllrmc88khlpg3yd4sghs8igg8dh0x568jw46vv90qgdb9xss";
-      name = "kio-extras-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kio-extras-17.04.0.tar.xz";
+      sha256 = "1kvah1qg98zlsps5qv6by7ic1mjmnhk6xs2041cf143k0kifrsi9";
+      name = "kio-extras-17.04.0.tar.xz";
     };
   };
   kiriki = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kiriki-16.12.3.tar.xz";
-      sha256 = "142p2zv1826iclaa2zrfyzfdwnflh3sq2xymca4di5anrmcwmm2m";
-      name = "kiriki-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kiriki-17.04.0.tar.xz";
+      sha256 = "1xmvamriklxhs9bwv75z2668by0w8nx95hb4l56z9yck5f7dlh6m";
+      name = "kiriki-17.04.0.tar.xz";
     };
   };
   kiten = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kiten-16.12.3.tar.xz";
-      sha256 = "0skwgv3v79p5z1livjbdsg7i18ky8vc49z53dmgsgbziqvs0s2y4";
-      name = "kiten-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kiten-17.04.0.tar.xz";
+      sha256 = "1h6cxp4qpzgdd67s05zr403mk5jswzz7sk38j78fapmfc9hwz7gh";
+      name = "kiten-17.04.0.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kjumpingcube-16.12.3.tar.xz";
-      sha256 = "1fii1arzpsdhnnb5yladhpsb0g6icald5si0fwnl47wg3gshaqiz";
-      name = "kjumpingcube-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kjumpingcube-17.04.0.tar.xz";
+      sha256 = "1las1sb01zm2vdr77fvsz3spjpjnv5fjhvdah17l4rlgdww2kqwc";
+      name = "kjumpingcube-17.04.0.tar.xz";
     };
   };
   kldap = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kldap-16.12.3.tar.xz";
-      sha256 = "0a7pm9dzcvyyznqs4apwdl6dpg87qhxcr3a06grjwxhqvfdl52na";
-      name = "kldap-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kldap-17.04.0.tar.xz";
+      sha256 = "0b19si2nx7mimxxsdr1vp4bh3zr8ddz5k7217fa5wg190143zi9b";
+      name = "kldap-17.04.0.tar.xz";
     };
   };
   kleopatra = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kleopatra-16.12.3.tar.xz";
-      sha256 = "1ja26gzdj8h5f8w1061scl40p6ahba3ci4hp91n2vp3rrz9m96wa";
-      name = "kleopatra-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kleopatra-17.04.0.tar.xz";
+      sha256 = "1l823l9wlqqzkcycqzfca6l3yfpr70a76786mvajswnkwasgfwyc";
+      name = "kleopatra-17.04.0.tar.xz";
     };
   };
   klettres = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/klettres-16.12.3.tar.xz";
-      sha256 = "0m3k3zyrw7rwm6ad75c86bap80v2y5k938mdhqjaciglqc9pk83h";
-      name = "klettres-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/klettres-17.04.0.tar.xz";
+      sha256 = "0liaym1cnnysmpd3bj3ss2bgrds9xh0f0i631vpj8z3n6pdm70s9";
+      name = "klettres-17.04.0.tar.xz";
     };
   };
   klickety = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/klickety-16.12.3.tar.xz";
-      sha256 = "0mim86wxcljs192q9y6a6i326sic350jd89m1vx3p78dwpj35q42";
-      name = "klickety-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/klickety-17.04.0.tar.xz";
+      sha256 = "15rjg09xa48082va8gxz51d3wacmfivla7bhmqdcgddagkmjy9cd";
+      name = "klickety-17.04.0.tar.xz";
     };
   };
   klines = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/klines-16.12.3.tar.xz";
-      sha256 = "03ran5hyl8p9vfi82m2pkzng9hn5ipx1plgq9bz25c53z5fg63di";
-      name = "klines-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/klines-17.04.0.tar.xz";
+      sha256 = "0ix039d89mjm581zx1fchhj0vmjwx3da1l3indprh62664v2ihwb";
+      name = "klines-17.04.0.tar.xz";
     };
   };
   klinkstatus = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/klinkstatus-16.12.3.tar.xz";
-      sha256 = "0kmjh0398k6fpz6lgz6d5rb79xl6wpgd4j56zacpha9046cfnmsk";
-      name = "klinkstatus-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/klinkstatus-17.04.0.tar.xz";
+      sha256 = "102djlmp8dcha1p5iacrnyjgjp1w4qi5sf04lnlq43j2k2qhvr0r";
+      name = "klinkstatus-17.04.0.tar.xz";
     };
   };
   kmag = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kmag-16.12.3.tar.xz";
-      sha256 = "1llv9vd1557h4lz2sdd1wjlqb9wzrk9jxn4731iac2b5wdwpihii";
-      name = "kmag-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kmag-17.04.0.tar.xz";
+      sha256 = "1jfs9n880yva5vi36gc25kz4d6vy7djpa05nm2niga03gbv0r0lx";
+      name = "kmag-17.04.0.tar.xz";
     };
   };
   kmahjongg = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kmahjongg-16.12.3.tar.xz";
-      sha256 = "0xy3w5kxn69l0dagly5qd9dqzkpikflmrjbv1b45psafdmj3125r";
-      name = "kmahjongg-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kmahjongg-17.04.0.tar.xz";
+      sha256 = "1k9rmcdlrybxnccdh0w5ggy4p41l19ccv3hsc2ph0aj9cxh9svac";
+      name = "kmahjongg-17.04.0.tar.xz";
     };
   };
   kmail = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kmail-16.12.3.tar.xz";
-      sha256 = "1kyhc952k78yg2wa9cgxvqa6qrrgc08dly7fin7as8cxfh49i0b0";
-      name = "kmail-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kmail-17.04.0.tar.xz";
+      sha256 = "04cfdjsy2gnwkcjhq0ikws68rpr65ycycdnwzrvskg4whmp5h01a";
+      name = "kmail-17.04.0.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kmail-account-wizard-16.12.3.tar.xz";
-      sha256 = "0w94v2c38sl0qnyr38yzlfj6pxixaziw5kb4fkawv26c18fi42pl";
-      name = "kmail-account-wizard-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kmail-account-wizard-17.04.0.tar.xz";
+      sha256 = "03c5gg980r18rjwsdkgclyw2qd3l1vc7grwdbfm2kib5fqk61gd3";
+      name = "kmail-account-wizard-17.04.0.tar.xz";
     };
   };
   kmailtransport = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kmailtransport-16.12.3.tar.xz";
-      sha256 = "1dkw7niymhnf0jncflvqyldw28c9j0q6j598flb5ksds0n30iasy";
-      name = "kmailtransport-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kmailtransport-17.04.0.tar.xz";
+      sha256 = "0683lrmadw51h1q345lsdy888dynph06ani54awx60qdc1crnx7j";
+      name = "kmailtransport-17.04.0.tar.xz";
     };
   };
   kmbox = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kmbox-16.12.3.tar.xz";
-      sha256 = "0khvf4kqf9i425fjczl1miqsz0pxbyryxy32bf9knr3k5kmwbn24";
-      name = "kmbox-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kmbox-17.04.0.tar.xz";
+      sha256 = "001f32yrxhavrk2plyyl05ny6gcazj6a9h51gv0fc5mb850w1ryq";
+      name = "kmbox-17.04.0.tar.xz";
     };
   };
   kmime = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kmime-16.12.3.tar.xz";
-      sha256 = "0gzbh0g075ml5x0qy4zd1cg1qygdsnssl5ahk9pcgc0fik4p9j20";
-      name = "kmime-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kmime-17.04.0.tar.xz";
+      sha256 = "1bywzanv82xpxscxpgxfj0bivx9l6vwlspgdbvzh3nnhjv2g41qp";
+      name = "kmime-17.04.0.tar.xz";
     };
   };
   kmines = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kmines-16.12.3.tar.xz";
-      sha256 = "0dz6yx7y0jpxhmyjrfyf6rrkiayn4mpyr4n1iszs11gac1bqppvn";
-      name = "kmines-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kmines-17.04.0.tar.xz";
+      sha256 = "101midljjq8ws7l3n6a8kym13n6c64xyhzv1d6py35cawyg3zfpv";
+      name = "kmines-17.04.0.tar.xz";
     };
   };
   kmix = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kmix-16.12.3.tar.xz";
-      sha256 = "1mq4kna3z62269m43qy42knq4byrvirk0mk5yp56n51im1bmdyj4";
-      name = "kmix-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kmix-17.04.0.tar.xz";
+      sha256 = "0qyml01rmf5p4qlwi7y96lc6hjdy70xbq6z4pwyy0rpk254jz754";
+      name = "kmix-17.04.0.tar.xz";
     };
   };
   kmousetool = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kmousetool-16.12.3.tar.xz";
-      sha256 = "1678sjj96f22sn60ccyj6hqi2vghkf4facnx8l15x4xx05yq1vgg";
-      name = "kmousetool-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kmousetool-17.04.0.tar.xz";
+      sha256 = "0chybr31ag087zfq47f8scvlzli2yf8l18gq965b2nl7vnz7kr0s";
+      name = "kmousetool-17.04.0.tar.xz";
     };
   };
   kmouth = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kmouth-16.12.3.tar.xz";
-      sha256 = "1afvjds1kfb8zvv3ma8c6svan6zlbd1w9a164vxwp7gl3ycjyj52";
-      name = "kmouth-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kmouth-17.04.0.tar.xz";
+      sha256 = "0k05g7rhcbl7mq4sv05c8kghmrm5cpdhj46vvmz5alqdik5g06xd";
+      name = "kmouth-17.04.0.tar.xz";
     };
   };
   kmplot = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kmplot-16.12.3.tar.xz";
-      sha256 = "02vh4diqs4688p2xlia437jywx89yhpaf8ipprdq92q034glybyz";
-      name = "kmplot-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kmplot-17.04.0.tar.xz";
+      sha256 = "1n3skmyrmhl8p0kypm0wfvm8whw8fhq5byv1hjj0xdpwdv9r7n1j";
+      name = "kmplot-17.04.0.tar.xz";
     };
   };
   knavalbattle = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/knavalbattle-16.12.3.tar.xz";
-      sha256 = "0164z9h1689bz600p17p8fq552g8pq73l81nj4f5csklhnsiykkg";
-      name = "knavalbattle-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/knavalbattle-17.04.0.tar.xz";
+      sha256 = "0m3y39lfngbc9ddnh2cifhc6qh4i1vlz983mhyz1psgamvy71djx";
+      name = "knavalbattle-17.04.0.tar.xz";
     };
   };
   knetwalk = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/knetwalk-16.12.3.tar.xz";
-      sha256 = "1mavc0rn41y3vgzf0ikwvk3kh4fszylh7h4briw9k0kqx2cxh5vk";
-      name = "knetwalk-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/knetwalk-17.04.0.tar.xz";
+      sha256 = "1z5brajv2kq4c617zyphcpk5as2dibb14h9l8vym9v1j3k59jqsh";
+      name = "knetwalk-17.04.0.tar.xz";
     };
   };
   knotes = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/knotes-16.12.3.tar.xz";
-      sha256 = "1yyx98zn7a3hbiyr16fcbylbm5v8lyg22v8gwf7xpnbx5jb4hpb8";
-      name = "knotes-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/knotes-17.04.0.tar.xz";
+      sha256 = "051y5ghrjs87xhdw7mih4gmbp93s23vicpsnmawi98hcbqh16n6c";
+      name = "knotes-17.04.0.tar.xz";
     };
   };
   kolf = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kolf-16.12.3.tar.xz";
-      sha256 = "136iyf8clr2r8qkjcm0nqcq0sjr5xry9gbxjhz128lc0nywsxpd5";
-      name = "kolf-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kolf-17.04.0.tar.xz";
+      sha256 = "1rvvy52avlpbdgvd7qbw73kfarn77h7ka9gny6q3xsy0knhgxy3a";
+      name = "kolf-17.04.0.tar.xz";
     };
   };
   kollision = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kollision-16.12.3.tar.xz";
-      sha256 = "0kwnqqm9gs6ac7ags9x82ykmp3vccp3kdd3js26a1kz1zkip32il";
-      name = "kollision-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kollision-17.04.0.tar.xz";
+      sha256 = "18k88jj9vyplh3lffw86pjwy0w568ddf17xza1spam3xpmlh9fix";
+      name = "kollision-17.04.0.tar.xz";
     };
   };
   kolourpaint = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kolourpaint-16.12.3.tar.xz";
-      sha256 = "1yg3xnbbzvhcgb7i92bya41gq4z0135njcc77848khndpgkxvczb";
-      name = "kolourpaint-16.12.3.tar.xz";
-    };
-  };
-  kommander = {
-    version = "16.12.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kommander-16.12.3.tar.xz";
-      sha256 = "1wlks0alw82ra3g63d8k8nj9sq899hjv1r2kshk7c4vdk7arn1fg";
-      name = "kommander-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kolourpaint-17.04.0.tar.xz";
+      sha256 = "1qmwpx0ql3nl5wnbh21dfw369cb76ll7n55w6pfja8izljic67xh";
+      name = "kolourpaint-17.04.0.tar.xz";
     };
   };
   kompare = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kompare-16.12.3.tar.xz";
-      sha256 = "18z6424xidpx5kmbjiasvhagh2b1a9pxizc0dsvba47v9xcavsaw";
-      name = "kompare-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kompare-17.04.0.tar.xz";
+      sha256 = "06ix1x7hvryqnysg256z2b0igjqaqya33mm24p9sw75misi7ay6f";
+      name = "kompare-17.04.0.tar.xz";
     };
   };
   konqueror = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/konqueror-16.12.3.tar.xz";
-      sha256 = "1pwv2mj9xrn6aymhkqmwd89d5i3v2jixp07dz0by62rcpfhm89p5";
-      name = "konqueror-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/konqueror-17.04.0.tar.xz";
+      sha256 = "0crqcnqk4bl6wg6izs34b6dgdh19rsnid0dpcsdminfglj6kb9lm";
+      name = "konqueror-17.04.0.tar.xz";
     };
   };
   konquest = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/konquest-16.12.3.tar.xz";
-      sha256 = "1fhz9pwi2dmmcjg10vp36m8d759zikg6nqpjdp41dg95lkyf5vkf";
-      name = "konquest-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/konquest-17.04.0.tar.xz";
+      sha256 = "0fgmh3z012k710c098bp02dj5v2gcmfp1dg29257zglk7qkvaa0b";
+      name = "konquest-17.04.0.tar.xz";
     };
   };
   konsole = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/konsole-16.12.3.tar.xz";
-      sha256 = "10k7ryvsssbskpxk04iqx2mrp2a91291r8nzvg1780lrhql5rdj7";
-      name = "konsole-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/konsole-17.04.0.tar.xz";
+      sha256 = "01iasaiabqnr8fsjyl250h2ha0l788gx58xizafzj2q649ijbj4h";
+      name = "konsole-17.04.0.tar.xz";
     };
   };
   kontact = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kontact-16.12.3.tar.xz";
-      sha256 = "0wj4w9ak6dm330s393hjb79w16gs5kij5gz9swf3pxwg21xbd4ps";
-      name = "kontact-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kontact-17.04.0.tar.xz";
+      sha256 = "0i2k3ay7n92sd8gxhqy4ld8g9qzpwy9rxzm3qj70r4v0byw8a176";
+      name = "kontact-17.04.0.tar.xz";
     };
   };
   kontactinterface = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kontactinterface-16.12.3.tar.xz";
-      sha256 = "0n5hvx3xp01krwwd2szgh1s6nn5spfns1ivc36i1gdbhkf871k98";
-      name = "kontactinterface-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kontactinterface-17.04.0.tar.xz";
+      sha256 = "15dd5mfgrqayfs522wj4c5lhvfv474whv7r5zimi9ngp0n4zwjl6";
+      name = "kontactinterface-17.04.0.tar.xz";
     };
   };
   kopete = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kopete-16.12.3.tar.xz";
-      sha256 = "1dkn4d13knf0lcj4241fmjcj51ypg9frzsf0pl02mr08rd2rxgk1";
-      name = "kopete-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kopete-17.04.0.tar.xz";
+      sha256 = "1wdk5i7vj5ssw65majvl0h7sn9h5npdb3v81m0qbp4m94zlv7njh";
+      name = "kopete-17.04.0.tar.xz";
     };
   };
   korganizer = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/korganizer-16.12.3.tar.xz";
-      sha256 = "1724l321gzjwha8yhrans4lhzs39fs98xi7wbd5msfflzyg3l6ga";
-      name = "korganizer-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/korganizer-17.04.0.tar.xz";
+      sha256 = "13mdxsvimlp0rvi2by1vg4aqmpamwszy35qi4wrynnq3ndn3cd1s";
+      name = "korganizer-17.04.0.tar.xz";
     };
   };
   kpat = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kpat-16.12.3.tar.xz";
-      sha256 = "04qvv7q7rlsiyff2isy18h2fbz2lnljal5spq5qg9zl6v8hx6qzm";
-      name = "kpat-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kpat-17.04.0.tar.xz";
+      sha256 = "0597z2pzxplcjsynkw9igs24fbsrj317xgyc0rmkgciilv0w69vy";
+      name = "kpat-17.04.0.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kpimtextedit-16.12.3.tar.xz";
-      sha256 = "06iz9l8z708kdivzibqkgdrbvw7kfd2lr2grf3v9l6gfl3qs1kbw";
-      name = "kpimtextedit-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kpimtextedit-17.04.0.tar.xz";
+      sha256 = "1050kc0d81kgqh6w44nahaddgpw1big2gwyxzdyvrvipkiipp42i";
+      name = "kpimtextedit-17.04.0.tar.xz";
     };
   };
   kppp = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kppp-16.12.3.tar.xz";
-      sha256 = "0lqv95zfzcik8k95a39s6whjsnq6g15amnxlzy898liyxkr499bc";
-      name = "kppp-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kppp-17.04.0.tar.xz";
+      sha256 = "1kiwc8rgh6vnvkpqsw2pz4cflwnsv0j86b8idkap6zh9vbajyln1";
+      name = "kppp-17.04.0.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kqtquickcharts-16.12.3.tar.xz";
-      sha256 = "1xzn9vxiqam8pk4zj8qcq55v9g52d9qkddbdv25pml8s0yhlsgqf";
-      name = "kqtquickcharts-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kqtquickcharts-17.04.0.tar.xz";
+      sha256 = "0sq4xs4ispb50wcyibwln1d8vlh698d0pw408z8gzwvr384gf2bk";
+      name = "kqtquickcharts-17.04.0.tar.xz";
     };
   };
   krdc = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/krdc-16.12.3.tar.xz";
-      sha256 = "0visx3371ym78n9aqkln2akvvf0rphyxg5hxvc2981pgpdry20zq";
-      name = "krdc-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/krdc-17.04.0.tar.xz";
+      sha256 = "1ryzk0k8xm9ych562qapjwawnljxz834vvwcnx2kv1n7gilqkdqh";
+      name = "krdc-17.04.0.tar.xz";
     };
   };
   kremotecontrol = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kremotecontrol-16.12.3.tar.xz";
-      sha256 = "0xcs8gvb7ack0xqdp99x04lyv6hbqgxa5nq44pxl7czzc0la5nbk";
-      name = "kremotecontrol-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kremotecontrol-17.04.0.tar.xz";
+      sha256 = "07w5fpwp4rjm8sdf6wadsf82a4f2igav8yb9m04pj70mymqhr4nn";
+      name = "kremotecontrol-17.04.0.tar.xz";
     };
   };
   kreversi = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kreversi-16.12.3.tar.xz";
-      sha256 = "1qi6y263c8qp0bv9vmjk4rxq55mc0v1kn56yvivc5sfg9p4bqs9b";
-      name = "kreversi-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kreversi-17.04.0.tar.xz";
+      sha256 = "075nmgnxlw2h743zj748xr6xdfj7w05ndyi85yfarpls5qf1qrz3";
+      name = "kreversi-17.04.0.tar.xz";
     };
   };
   krfb = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/krfb-16.12.3.tar.xz";
-      sha256 = "1ijz0zdlkxb9mldgd5a5k7aa2ikmmg023mafmxrjwymsig7ya4hv";
-      name = "krfb-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/krfb-17.04.0.tar.xz";
+      sha256 = "11kavv3h0pvwqd0y6xxb08bliclszqh7ijvjgzazqhvwnd5pmsby";
+      name = "krfb-17.04.0.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kross-interpreters-16.12.3.tar.xz";
-      sha256 = "0z1n42imbhsx0qmx479sklnihwvbd5l5pigbpbpm80rgwda2ib57";
-      name = "kross-interpreters-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kross-interpreters-17.04.0.tar.xz";
+      sha256 = "17wgckmz17zrc7cbjl9zif1x8nq31551hsl8psnj1wpb78pv1b56";
+      name = "kross-interpreters-17.04.0.tar.xz";
     };
   };
   kruler = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kruler-16.12.3.tar.xz";
-      sha256 = "08w7pb7wyaqnhwvqczxzbrbnm8930wzkl8y4lpimp5mqzb94i8qx";
-      name = "kruler-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kruler-17.04.0.tar.xz";
+      sha256 = "1rkhrzn54l8bhd37gyc3l27frxgxlyh28cq73p7id87qa62wcya9";
+      name = "kruler-17.04.0.tar.xz";
     };
   };
   ksaneplugin = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ksaneplugin-16.12.3.tar.xz";
-      sha256 = "1z0ziapcjmi7fqfnb0zsbjgd1q05np1s7smj1k8cd8c6f169yrld";
-      name = "ksaneplugin-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ksaneplugin-17.04.0.tar.xz";
+      sha256 = "10w92awf66q8mg796pva6hrx8cjzhimg70bqldb4fb3nni5figrn";
+      name = "ksaneplugin-17.04.0.tar.xz";
     };
   };
   kscd = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kscd-16.12.3.tar.xz";
-      sha256 = "1mpba78m4hs8541n4ydz7vswq1chi0fmmlfw2kqnrzarcandyga0";
-      name = "kscd-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kscd-17.04.0.tar.xz";
+      sha256 = "0lrdjawim18bzd2z9328gdqrjklrkr6wlx3jlmh5bd8iw52akdxa";
+      name = "kscd-17.04.0.tar.xz";
     };
   };
   kshisen = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kshisen-16.12.3.tar.xz";
-      sha256 = "17szjblrp172rvyl98x5a0g9yg29b85bmwkzk7pqnjbn387kgy9r";
-      name = "kshisen-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kshisen-17.04.0.tar.xz";
+      sha256 = "1l4f1akiagz4yhyxvvk14papnim8jfvikypkbsw3bqy1qbxbph93";
+      name = "kshisen-17.04.0.tar.xz";
     };
   };
   ksirk = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ksirk-16.12.3.tar.xz";
-      sha256 = "1akfskyfhffh71w2hknw9vvap2a2sq0irmkxij9xcdmlvpfwnkn5";
-      name = "ksirk-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ksirk-17.04.0.tar.xz";
+      sha256 = "0ifqyf6plgq0n60llncc1ipdnlqhwcr3ml86k3kch5w2gmypzyj0";
+      name = "ksirk-17.04.0.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ksnakeduel-16.12.3.tar.xz";
-      sha256 = "1797kac3prchq5254dby41k04i8i7hgf2a9cb8s71n7hrsj62dyn";
-      name = "ksnakeduel-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ksnakeduel-17.04.0.tar.xz";
+      sha256 = "1zjfca5qlmsqdx09958h7l169i1pvbgny800q8v6wxhc6c8h4g0r";
+      name = "ksnakeduel-17.04.0.tar.xz";
     };
   };
   kspaceduel = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kspaceduel-16.12.3.tar.xz";
-      sha256 = "0ipx1sxhv207nlw7rcp7155l76z39x7j1b5y3qwxcgd7s69wb82k";
-      name = "kspaceduel-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kspaceduel-17.04.0.tar.xz";
+      sha256 = "0z4ffrpmij99ybhzl2dvg89a8whandggc24fxalpf01kxz4vw3v4";
+      name = "kspaceduel-17.04.0.tar.xz";
     };
   };
   ksquares = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ksquares-16.12.3.tar.xz";
-      sha256 = "0abd19hf1rvlzkxc4kvdljs5yk39pay81n3n9n0w6qyr764r4qn9";
-      name = "ksquares-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ksquares-17.04.0.tar.xz";
+      sha256 = "0mzgwvf077jpzvka1hyw2vm93v9mqng8hnr2nzk38zxbjhb3fkf4";
+      name = "ksquares-17.04.0.tar.xz";
     };
   };
   kstars = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kstars-16.12.3.tar.xz";
-      sha256 = "0lcrn7r1nw85c0w6dg03mwf5lnsahmww60y6vwzfh2r53nbm9c1y";
-      name = "kstars-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kstars-17.04.0.tar.xz";
+      sha256 = "1hpadx9fq3bcdzq2lh9csxnlm96q5n1fmss1lkxby7hac28942fk";
+      name = "kstars-17.04.0.tar.xz";
     };
   };
   ksudoku = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ksudoku-16.12.3.tar.xz";
-      sha256 = "00hi8x09fj5ahj0ah9rsci2dscrdl8x9mrlcacjrwgwm503y95gk";
-      name = "ksudoku-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ksudoku-17.04.0.tar.xz";
+      sha256 = "0411s9dpzb6sicb2wcg5mv9sy7vi27lkrg7ssdna9k0wp0d9aqvs";
+      name = "ksudoku-17.04.0.tar.xz";
     };
   };
   ksystemlog = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ksystemlog-16.12.3.tar.xz";
-      sha256 = "0xd6pp02k84a1r6gy10x0br33g4awpbhx45j7n69l1s96szj4aki";
-      name = "ksystemlog-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ksystemlog-17.04.0.tar.xz";
+      sha256 = "162lclr2zx80cwqj0r1gm0cvijciab0rkhl5fyz8bb0xk7ihrimy";
+      name = "ksystemlog-17.04.0.tar.xz";
     };
   };
   kteatime = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kteatime-16.12.3.tar.xz";
-      sha256 = "0wqzw9sa4zkgkwndvyas47x5wc4gcya3pmdcvg7wf7wl8j5k7vdy";
-      name = "kteatime-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kteatime-17.04.0.tar.xz";
+      sha256 = "0rklccjb7qi4mir44fp71aiqxb44s9mwpd7aj6yda80ic8yafvhw";
+      name = "kteatime-17.04.0.tar.xz";
     };
   };
   ktimer = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktimer-16.12.3.tar.xz";
-      sha256 = "0hpskwa8g88fz39b0y7sjl574s82d6smla1bhs8mdjlabv0sln6z";
-      name = "ktimer-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktimer-17.04.0.tar.xz";
+      sha256 = "0px3dxndyhy0xi3s3pac2baw1a5g3a9hg46aj01mk1143z0l8nfz";
+      name = "ktimer-17.04.0.tar.xz";
     };
   };
   ktnef = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktnef-16.12.3.tar.xz";
-      sha256 = "0v38h7bwjwab1656w3c2h1by5925f616idnvflgp123v1cs6jy1n";
-      name = "ktnef-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktnef-17.04.0.tar.xz";
+      sha256 = "1azy1j045br0xdzyc7nx8h7lvxzzwcvvv223c39d5s008d1i9xp8";
+      name = "ktnef-17.04.0.tar.xz";
     };
   };
   ktouch = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktouch-16.12.3.tar.xz";
-      sha256 = "17gkvzczfgmip18y3jbjisz4z8m5hwbgkqn4qynabp6dqihwhzgg";
-      name = "ktouch-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktouch-17.04.0.tar.xz";
+      sha256 = "0d4d7mzjm2lnisih9i94sblspkdqvphqa0irk9ps1dyykdwhbw08";
+      name = "ktouch-17.04.0.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktp-accounts-kcm-16.12.3.tar.xz";
-      sha256 = "0pr191i9fmz66wlv8krmy1pba7igd1qwa0akb4kdzkm4bx3z8wq3";
-      name = "ktp-accounts-kcm-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktp-accounts-kcm-17.04.0.tar.xz";
+      sha256 = "0bh8s8yiajxxvlnisjlv4mg0v7p51vy5jncmqg6lrq3y29zycbwc";
+      name = "ktp-accounts-kcm-17.04.0.tar.xz";
     };
   };
   ktp-approver = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktp-approver-16.12.3.tar.xz";
-      sha256 = "08aj2j9bjdyigl4cx65v5fjsdayid07mx0mq72iy6l17d8z4b39a";
-      name = "ktp-approver-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktp-approver-17.04.0.tar.xz";
+      sha256 = "06vcxq72idrx24l9y5mvbbxashaqdkv78ihx7qcxq9v8b2kv9ph0";
+      name = "ktp-approver-17.04.0.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktp-auth-handler-16.12.3.tar.xz";
-      sha256 = "08ryqkba9zngjabsp1b9w13psp0n97qhjd31id007hc6r6s1nxxx";
-      name = "ktp-auth-handler-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktp-auth-handler-17.04.0.tar.xz";
+      sha256 = "0r0yp2xhi12wxk7yaqxwnxg27ccafxlcmn2pzsjf278azymyfral";
+      name = "ktp-auth-handler-17.04.0.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktp-call-ui-16.12.3.tar.xz";
-      sha256 = "1aq0s4v972kskjnq720364y971iyr0m6pj42fw5rpkl7j8vfg1rd";
-      name = "ktp-call-ui-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktp-call-ui-17.04.0.tar.xz";
+      sha256 = "1bpvisfg58dvpywhvwgb8n4vlai14f7wayzbw1a30344lhca1aql";
+      name = "ktp-call-ui-17.04.0.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktp-common-internals-16.12.3.tar.xz";
-      sha256 = "0g3vmds5f7wmffp9rv915bll8ky7qf3lz172ymc6q9i1xvghp215";
-      name = "ktp-common-internals-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktp-common-internals-17.04.0.tar.xz";
+      sha256 = "1bp2x8f4ymav53icdfxpmdd58kms676qgj5x4jnjbjypw9iyxy9j";
+      name = "ktp-common-internals-17.04.0.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktp-contact-list-16.12.3.tar.xz";
-      sha256 = "05asblclq6sjd3d9faaj2ya37srf4lhg8jx705aw13wd5d6pk75w";
-      name = "ktp-contact-list-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktp-contact-list-17.04.0.tar.xz";
+      sha256 = "1nldhg221kf9y0fakanj1kj47jrgz820ql766f2yb276y4da31cm";
+      name = "ktp-contact-list-17.04.0.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktp-contact-runner-16.12.3.tar.xz";
-      sha256 = "1lcx9smfv2dqrwsbdd4srcq7dqap8bclz788p6jjn04xi6wcbbiq";
-      name = "ktp-contact-runner-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktp-contact-runner-17.04.0.tar.xz";
+      sha256 = "13q31cqpmafimx0nk680z0szxgzanmcqr3xay78ndc9fsg21yc83";
+      name = "ktp-contact-runner-17.04.0.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktp-desktop-applets-16.12.3.tar.xz";
-      sha256 = "1pd8vzwmxcsw6pq80r9casi07wwisr70l5ffm231v9d73k4fw7kv";
-      name = "ktp-desktop-applets-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktp-desktop-applets-17.04.0.tar.xz";
+      sha256 = "0fihfqn5wzcxi7kj3lsnnimaiz4k5vzzcfx81rklf75d327lnkvx";
+      name = "ktp-desktop-applets-17.04.0.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktp-filetransfer-handler-16.12.3.tar.xz";
-      sha256 = "0ddmrpnh6myl7m3drh3cxx9pp06al98g8mppnysmgswgkwafg6cq";
-      name = "ktp-filetransfer-handler-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktp-filetransfer-handler-17.04.0.tar.xz";
+      sha256 = "0xm9znnk38xy6z3ndb8i9yjkbx5jv240j4niaagr4kpnsfcmq0yk";
+      name = "ktp-filetransfer-handler-17.04.0.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktp-kded-module-16.12.3.tar.xz";
-      sha256 = "06zw8padspbn8ydcbs69v3ggmfpqrb3axxd2v1sgg4p4kdp0jyml";
-      name = "ktp-kded-module-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktp-kded-module-17.04.0.tar.xz";
+      sha256 = "04mng6j3fz1glfa3c4jx9360hd6blplnba02257s3vk2kqiah64i";
+      name = "ktp-kded-module-17.04.0.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktp-send-file-16.12.3.tar.xz";
-      sha256 = "1m7cj3q4lzj8qj2cla6wm1crpjid77b3f3yywri167f1zd4p51z6";
-      name = "ktp-send-file-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktp-send-file-17.04.0.tar.xz";
+      sha256 = "0iz544hn8s93dxf40vcg80fngq2mxzmmyzd4iwjxk218md86k9wn";
+      name = "ktp-send-file-17.04.0.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktp-text-ui-16.12.3.tar.xz";
-      sha256 = "0ssxr35vcqjppnppyjxwzrkzvb5sx45fpnvbzsv9md5rnlf2xh1k";
-      name = "ktp-text-ui-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktp-text-ui-17.04.0.tar.xz";
+      sha256 = "18yl0yb3ccwykxn24gyv9i6mw3xbz46mlgygrn7iswgwnrqpckwa";
+      name = "ktp-text-ui-17.04.0.tar.xz";
     };
   };
   ktuberling = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/ktuberling-16.12.3.tar.xz";
-      sha256 = "1vn35bn0x5ykd9j78q5apg1i14v546jrqq1yn2q178d9qmx79pgv";
-      name = "ktuberling-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/ktuberling-17.04.0.tar.xz";
+      sha256 = "0i9f5nf1zzvw7xgwi4j3g0bilmcknihh3f1as1mhxjgwfslk5xar";
+      name = "ktuberling-17.04.0.tar.xz";
     };
   };
   kturtle = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kturtle-16.12.3.tar.xz";
-      sha256 = "1mpdwb6999nar16mpha30cf4qzmpbsdha44aw77gn301v215rwj3";
-      name = "kturtle-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kturtle-17.04.0.tar.xz";
+      sha256 = "1f8bzfwjwlhvz8y1hm4if03kbllk85gdq3ih709xikj6vs922jqj";
+      name = "kturtle-17.04.0.tar.xz";
     };
   };
   kubrick = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kubrick-16.12.3.tar.xz";
-      sha256 = "1bwr8xi4d58k94h7lpl02iqf87nxhpls33ca654kzy353awqbp7f";
-      name = "kubrick-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kubrick-17.04.0.tar.xz";
+      sha256 = "15njanlbqf73khgk42n7sqkhsy8zhdhxn45n2bq5ak5wirf1gqs9";
+      name = "kubrick-17.04.0.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kwalletmanager-16.12.3.tar.xz";
-      sha256 = "07miaqr0yaqb0lkssb1jfg35cvr9svn16nhvb1zffvbf9fdlim47";
-      name = "kwalletmanager-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kwalletmanager-17.04.0.tar.xz";
+      sha256 = "0x8l9hzwwd97k8cj6nwgb6wyzx2zgral4sx98hasvg52cn82zfb1";
+      name = "kwalletmanager-17.04.0.tar.xz";
     };
   };
   kwave = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kwave-16.12.3.tar.xz";
-      sha256 = "1s5zwhck204m5rkrpmbghzid3dpzhqbwsilb5pfh4128d04fx9ad";
-      name = "kwave-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kwave-17.04.0.tar.xz";
+      sha256 = "1232sr45qbbdkafpbnz6ddbqabc5jasp43v5lyi3lhgppfz4gz43";
+      name = "kwave-17.04.0.tar.xz";
     };
   };
   kwordquiz = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/kwordquiz-16.12.3.tar.xz";
-      sha256 = "1r8q2d6j7bq8jdr4cl9maapadzg7yp0zldjxkcqg08ldwsrrsnqj";
-      name = "kwordquiz-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/kwordquiz-17.04.0.tar.xz";
+      sha256 = "1wp8ccsamz6b2yk85i85r8a1r10r7b4lhxg82r8z5gv8im7g1glb";
+      name = "kwordquiz-17.04.0.tar.xz";
     };
   };
   libgravatar = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libgravatar-16.12.3.tar.xz";
-      sha256 = "0m726ixss72rz3gwgn7q5s34xwbghi877y7gxa1ilcrk9rhyxv2f";
-      name = "libgravatar-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libgravatar-17.04.0.tar.xz";
+      sha256 = "06d5c2kn2l5rvg23frj5hhr0hnfx5ncmhr8dlqdxz0x7pmyjbign";
+      name = "libgravatar-17.04.0.tar.xz";
     };
   };
   libkcddb = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkcddb-16.12.3.tar.xz";
-      sha256 = "0iaascv9a5g8681mjc6b7f2fd8fdi9p3dx8l9lapkpzcygy1fwpc";
-      name = "libkcddb-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkcddb-17.04.0.tar.xz";
+      sha256 = "0rfvq4g4d9l85p3jcqgs54bnskq2w5bqfw2j0jgizkdffk0dzvfj";
+      name = "libkcddb-17.04.0.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkcompactdisc-16.12.3.tar.xz";
-      sha256 = "021yws9854w6fwwfw31b87rpz92ach5xyq427968m3mc3c430d4l";
-      name = "libkcompactdisc-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkcompactdisc-17.04.0.tar.xz";
+      sha256 = "1bfli5za4rcf6ixmd3j6g9xzh6d5cp9838m6c898317sac00b957";
+      name = "libkcompactdisc-17.04.0.tar.xz";
     };
   };
   libkdcraw = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkdcraw-16.12.3.tar.xz";
-      sha256 = "03ag6vzdj5n7zbb8yb9k84ckm1zwp2i9qqrsfn2mmmhypwknpg4w";
-      name = "libkdcraw-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkdcraw-17.04.0.tar.xz";
+      sha256 = "191cqv8q43zg5s9f52bwyrj1visf39i03d1d9d74sj1lfw7ghqys";
+      name = "libkdcraw-17.04.0.tar.xz";
     };
   };
   libkdegames = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkdegames-16.12.3.tar.xz";
-      sha256 = "0w7q7x04imwrdfj5zwgv0y49k4wi7a6ghqipyc5qmrwfg9ya85b3";
-      name = "libkdegames-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkdegames-17.04.0.tar.xz";
+      sha256 = "0ydja5fmyrgkxjnbcxfgyz0x5m3ymkkp436z30ikx9d5s0kyhl6k";
+      name = "libkdegames-17.04.0.tar.xz";
     };
   };
   libkdepim = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkdepim-16.12.3.tar.xz";
-      sha256 = "07afpxhvxpf50h10vg6vla543n4rvy1grldjj4aygwh1fgl5snm0";
-      name = "libkdepim-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkdepim-17.04.0.tar.xz";
+      sha256 = "00whk97jkycxg6s3n6dsb5addkwwk4bs696brsm1vj93rffhbslf";
+      name = "libkdepim-17.04.0.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkeduvocdocument-16.12.3.tar.xz";
-      sha256 = "05s79q269m5s78zjwxljxvprrqvpalf6h38n90m589vks82ahxx0";
-      name = "libkeduvocdocument-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkeduvocdocument-17.04.0.tar.xz";
+      sha256 = "0c1rj2rds7q779rfapn79w00qzdfhla8bngbnpa8s2qghb965lff";
+      name = "libkeduvocdocument-17.04.0.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkexiv2-16.12.3.tar.xz";
-      sha256 = "02fr10prqmpaqqlcj8hf5h4b3vhhiwkfsbpzlag64n5764x1hl3f";
-      name = "libkexiv2-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkexiv2-17.04.0.tar.xz";
+      sha256 = "07iwwfvj27m4m9h81jsrabyqamhh9gyqx1k265jxq4nll68nh0px";
+      name = "libkexiv2-17.04.0.tar.xz";
     };
   };
   libkface = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkface-16.12.3.tar.xz";
-      sha256 = "068xixlw0hfhi3c9nxik2y6xyci1ilwwfq4sjm1paqfszp0f4rq8";
-      name = "libkface-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkface-17.04.0.tar.xz";
+      sha256 = "1bazry6pmmdppmpr7fdzj61cykk9h4kwz67zay7vck0jk77n5myr";
+      name = "libkface-17.04.0.tar.xz";
+    };
+  };
+  libkgapi = {
+    version = "17.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.04.0/src/libkgapi-17.04.0.tar.xz";
+      sha256 = "0m3walc6hw5nmsr0cjlspczjlc90jzqam8xk32if5pl8bynmgh4c";
+      name = "libkgapi-17.04.0.tar.xz";
     };
   };
   libkgeomap = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkgeomap-16.12.3.tar.xz";
-      sha256 = "1zz2w7cbabyrvzvw2ph38mxw7khyhjzg86na2lcywla7japlbsd9";
-      name = "libkgeomap-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkgeomap-17.04.0.tar.xz";
+      sha256 = "1la4pggz7kbppmhvdv4g4szh3dyw4d3kas2m00xdvfbdjmmxswp3";
+      name = "libkgeomap-17.04.0.tar.xz";
     };
   };
   libkipi = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkipi-16.12.3.tar.xz";
-      sha256 = "0f1m0v0cm11dqwm3n9w1mwz25sj3bggx19fi0jj4ij7zqicpykz6";
-      name = "libkipi-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkipi-17.04.0.tar.xz";
+      sha256 = "0yzg9dml7yjqmp1niqc003baxavvr4bprkpvahigh84r4kxbba6a";
+      name = "libkipi-17.04.0.tar.xz";
     };
   };
   libkleo = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkleo-16.12.3.tar.xz";
-      sha256 = "0rzp2bxqij9fkdsghskd2f05vgcybdc9l7wdrjqhhcngi8qxl0nn";
-      name = "libkleo-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkleo-17.04.0.tar.xz";
+      sha256 = "1bx9g4dc1h7vy3157nshlyn3m42x88dzffhcix9kw6cw5c5zfinl";
+      name = "libkleo-17.04.0.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkmahjongg-16.12.3.tar.xz";
-      sha256 = "0fhz7jp4wcvjcicyiwc4qq4vviwagfjdy6n5bhv7bmlccq4xfk5x";
-      name = "libkmahjongg-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkmahjongg-17.04.0.tar.xz";
+      sha256 = "0q6n15aa9hqh3i7fm6c7q37p38clasc2xqvyz1nha5s8rkm0dw73";
+      name = "libkmahjongg-17.04.0.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libkomparediff2-16.12.3.tar.xz";
-      sha256 = "1hm2d6217qwxsq6nyyh7iv573zkkmcn68x188zav48kmydj45l9i";
-      name = "libkomparediff2-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libkomparediff2-17.04.0.tar.xz";
+      sha256 = "0p3iys22f21fqz31dxnrrc1kkz234zrpfcv5dj9kwh114va64j5r";
+      name = "libkomparediff2-17.04.0.tar.xz";
     };
   };
   libksane = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libksane-16.12.3.tar.xz";
-      sha256 = "0406jdzs193scmb8rkx2fqcr2a0svz53sf1av9qi2nq9dnil9hcq";
-      name = "libksane-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libksane-17.04.0.tar.xz";
+      sha256 = "1yr21f0mvvgb2p29rfp8b6c33pfz893wk1xqdfsbiar7p1l4by46";
+      name = "libksane-17.04.0.tar.xz";
     };
   };
   libksieve = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/libksieve-16.12.3.tar.xz";
-      sha256 = "1riqsfl3x4vpwqv7398gj86hnwfzqwfj7d69wsxk3r02jp3xd9i2";
-      name = "libksieve-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/libksieve-17.04.0.tar.xz";
+      sha256 = "04bb0k06p384p0a0i02kj80a1kszcg6nfjal227mmj4qdra9i0nf";
+      name = "libksieve-17.04.0.tar.xz";
     };
   };
   lokalize = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/lokalize-16.12.3.tar.xz";
-      sha256 = "17ikk89680jjzv95gnrzah4bi3xnyp5mi64prhblhw7kz6vlf8x0";
-      name = "lokalize-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/lokalize-17.04.0.tar.xz";
+      sha256 = "1gjlidbhkx0alcydc8z7pi4m5gzhcj0bqpascj905vk72az0by8j";
+      name = "lokalize-17.04.0.tar.xz";
     };
   };
   lskat = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/lskat-16.12.3.tar.xz";
-      sha256 = "02mqb4c650ydy9qp3qg1avrj0m0a8yxmg0zw6hcv5pvckgfpcxki";
-      name = "lskat-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/lskat-17.04.0.tar.xz";
+      sha256 = "06nk276dsbrbw6jilh3kpjcf1nlx8vbqkl61g15m8dbhrrz833rd";
+      name = "lskat-17.04.0.tar.xz";
     };
   };
   mailcommon = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/mailcommon-16.12.3.tar.xz";
-      sha256 = "1sx7dgy9jad6vqp1dljg9m40x57zz6xy9d2f1lgab5ibs1lrjhq5";
-      name = "mailcommon-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/mailcommon-17.04.0.tar.xz";
+      sha256 = "1lbvzgbsn1fh96m1ck56dafsglbq7f71w9wknwm7d3afl8jp2rr6";
+      name = "mailcommon-17.04.0.tar.xz";
     };
   };
   mailimporter = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/mailimporter-16.12.3.tar.xz";
-      sha256 = "08yj4i6jy08hk62mxw299sh2n5pknzxanmzr96n6lf8g1jcf2l21";
-      name = "mailimporter-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/mailimporter-17.04.0.tar.xz";
+      sha256 = "1dpvxp704cmaj1yzp2wbib4avlwmgmbizrr19mssby467qb09j6z";
+      name = "mailimporter-17.04.0.tar.xz";
     };
   };
   marble = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/marble-16.12.3.tar.xz";
-      sha256 = "08dykrmiq1jk9yv83sjj6s3gps56bw0hxjbvb90bzd1g0kh0c82j";
-      name = "marble-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/marble-17.04.0.tar.xz";
+      sha256 = "0w47v85brj18g2s63axqmfrqz6hs5fq1vvbs7gr6gyirw9vbg2ka";
+      name = "marble-17.04.0.tar.xz";
     };
   };
   mbox-importer = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/mbox-importer-16.12.3.tar.xz";
-      sha256 = "04sxijnyr13yjqkd1wm14bxm3k7r17dv24mfb3kbf804s7g8hvq7";
-      name = "mbox-importer-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/mbox-importer-17.04.0.tar.xz";
+      sha256 = "1jbia6zxcammk58hlyawhwr6j9022vvw69r0vsqnczys0qw3cbyd";
+      name = "mbox-importer-17.04.0.tar.xz";
     };
   };
   messagelib = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/messagelib-16.12.3.tar.xz";
-      sha256 = "1s5r5w231lzy3csljd5qil54ibm9mjs7c9hbw1whqmn4kd0vaz15";
-      name = "messagelib-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/messagelib-17.04.0.tar.xz";
+      sha256 = "0qcrfbzx8mw88wdjzrd8ipj2pi5l14yka0bhrw1zmsm0p1f0n34h";
+      name = "messagelib-17.04.0.tar.xz";
     };
   };
   minuet = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/minuet-16.12.3.tar.xz";
-      sha256 = "15c0mw8qj7r6192h39lvsmiy3pqlfqzari4qjg2x44j5gq02ab3c";
-      name = "minuet-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/minuet-17.04.0.tar.xz";
+      sha256 = "02m2l7d9703j2ci386wy9vxyllxqf177d2bcdhcx5iqlq4194jks";
+      name = "minuet-17.04.0.tar.xz";
     };
   };
   okteta = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/okteta-16.12.3.tar.xz";
-      sha256 = "14wmacbxc5kc3y5y5lsdxgsswi1jdvlxsd0xqcims50xjpb8znpd";
-      name = "okteta-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/okteta-17.04.0.tar.xz";
+      sha256 = "12d2hr8dw6qjhcza9ly3nkglll703cq1ywz7icp4x2xdklsv2qyv";
+      name = "okteta-17.04.0.tar.xz";
     };
   };
   okular = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/okular-16.12.3.tar.xz";
-      sha256 = "1gilr9nviv51pcnmqdfw7834knvyfd11ggdjvinxvbpz61832niv";
-      name = "okular-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/okular-17.04.0.tar.xz";
+      sha256 = "00wqflixzzn0blxd0anrfs1kjhrknny18ia95wxh0zpafvi1ga74";
+      name = "okular-17.04.0.tar.xz";
     };
   };
   palapeli = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/palapeli-16.12.3.tar.xz";
-      sha256 = "13s9ybj8a1f39z66syj88vx8rygdbb969b1d5r01msav3lk8ar3j";
-      name = "palapeli-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/palapeli-17.04.0.tar.xz";
+      sha256 = "1hjspg44py4rqzqr5w6f0lw6nz4ilwgr701s1m1pw4q0f6j80b6i";
+      name = "palapeli-17.04.0.tar.xz";
     };
   };
   parley = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/parley-16.12.3.tar.xz";
-      sha256 = "0vmbn8188brp4bysyzmkgsa8nnn9zdqb7q6x3mi1xg7ralzfjw71";
-      name = "parley-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/parley-17.04.0.tar.xz";
+      sha256 = "0i4nhwz7b7gmnlq72limp6cpsjaccc03i5qr2pdv8hb2336nabc7";
+      name = "parley-17.04.0.tar.xz";
     };
   };
   picmi = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/picmi-16.12.3.tar.xz";
-      sha256 = "0v44n05b6v46qmfrgq6b0q8bifnz5ax1f6sjrg6940q99kp2cxx4";
-      name = "picmi-16.12.3.tar.xz";
-    };
-  };
-  pimcommon = {
-    version = "16.12.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/pimcommon-16.12.3.tar.xz";
-      sha256 = "179ig6rwxil1ssm7k2cy7ny3vf2dbhsjn39c0ic70r03q3lzbhll";
-      name = "pimcommon-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/picmi-17.04.0.tar.xz";
+      sha256 = "0289qq4f4njv6yb9hg61ap17q2fvaandyxa8kz68v3yc7jlpsvlw";
+      name = "picmi-17.04.0.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/pim-data-exporter-16.12.3.tar.xz";
-      sha256 = "14xvh2gn3vc3i94fv96xbv7gxnwj8xxg3zkgfdlayajp3sz7c3yw";
-      name = "pim-data-exporter-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/pim-data-exporter-17.04.0.tar.xz";
+      sha256 = "1j8qdr9hdjzj6jn94hq771mnfwspqwb47nrrj25ghbl6d8b19qfd";
+      name = "pim-data-exporter-17.04.0.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/pim-sieve-editor-16.12.3.tar.xz";
-      sha256 = "03gnq2hlvw92gg8rf2bwrvf83nrgcvy6xanvwn3vcrqjfg55vb1k";
-      name = "pim-sieve-editor-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/pim-sieve-editor-17.04.0.tar.xz";
+      sha256 = "0l7vbgzjrkpvad0q8yhcgx78xcxs0llgmqg7madv06lnxbry02yf";
+      name = "pim-sieve-editor-17.04.0.tar.xz";
     };
   };
-  pim-storage-service-manager = {
-    version = "16.12.3";
+  pimcommon = {
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/pim-storage-service-manager-16.12.3.tar.xz";
-      sha256 = "0ii1f5gv430i8h2c4xdy35rz7w9py53xans8zwgpj6ir6x6gfkb0";
-      name = "pim-storage-service-manager-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/pimcommon-17.04.0.tar.xz";
+      sha256 = "1k04zfmzvjpnjwjr42p4ixkwnl1raxr9mpqb13qhr9ln4qsnsq4h";
+      name = "pimcommon-17.04.0.tar.xz";
     };
   };
   poxml = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/poxml-16.12.3.tar.xz";
-      sha256 = "1cpc49hnslc2iabgnvda7967mmrdzykjydi8py67ycr9k1gx6pm5";
-      name = "poxml-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/poxml-17.04.0.tar.xz";
+      sha256 = "1chl7mizmgvmzhi0pz111p2lkpmh4j4nbn7hfaksmvmvrlrcjj8z";
+      name = "poxml-17.04.0.tar.xz";
     };
   };
   print-manager = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/print-manager-16.12.3.tar.xz";
-      sha256 = "1mjzqq7yhm1s4jbr6nhy1i1lm27134j6g7b04mmzk3hbgd8lkr99";
-      name = "print-manager-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/print-manager-17.04.0.tar.xz";
+      sha256 = "10zkf8azgn79rq9b0amhaanngfd1pv51zr7qy10z5jd62bxxcf8n";
+      name = "print-manager-17.04.0.tar.xz";
     };
   };
   rocs = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/rocs-16.12.3.tar.xz";
-      sha256 = "17iz9ql988mj1vsvywd8w5w7qmbncxal71maf3rldadwmadkvzbl";
-      name = "rocs-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/rocs-17.04.0.tar.xz";
+      sha256 = "0jb7nwg73kagw0mrwhx7nph5m2nsq7220hr5bfcnndw1in5bwnbx";
+      name = "rocs-17.04.0.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/signon-kwallet-extension-16.12.3.tar.xz";
-      sha256 = "0fnqdcin471hlw694vb6z9ybgw31778rhnryc7zps40kjwfdxhcc";
-      name = "signon-kwallet-extension-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/signon-kwallet-extension-17.04.0.tar.xz";
+      sha256 = "1amvrrwsfh7d9c284ksvqm4x9f4d36abbq2fal4sicplqp4ag4z0";
+      name = "signon-kwallet-extension-17.04.0.tar.xz";
     };
   };
   spectacle = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/spectacle-16.12.3.tar.xz";
-      sha256 = "1fca71a59sgicq9zi8d0im0xpg7iz93s96h3clxxc6p493vsjkx6";
-      name = "spectacle-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/spectacle-17.04.0.tar.xz";
+      sha256 = "0vmmyvbsiffj9g49f39dar6b34rk8badpah3rzq4af0xzhlc0z0y";
+      name = "spectacle-17.04.0.tar.xz";
     };
   };
   step = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/step-16.12.3.tar.xz";
-      sha256 = "0pyvhlfrklc2xxylb0nlnpqx5xi0pp4zyb3xbzj87wmvcw7v5n6r";
-      name = "step-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/step-17.04.0.tar.xz";
+      sha256 = "0j9wlys17rdrnq2l0cprnw4pp2ks439ihyx4v1m4sdrxsvqxz4lw";
+      name = "step-17.04.0.tar.xz";
     };
   };
   svgpart = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/svgpart-16.12.3.tar.xz";
-      sha256 = "0frzqp504dzqwqs9lh544xxa8i6sqi6qj533mqbzkqbjx310ka3w";
-      name = "svgpart-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/svgpart-17.04.0.tar.xz";
+      sha256 = "0yv9a7ndfix41f875hw9fy9snqdanchvqb87rbm09dhc0fniwnir";
+      name = "svgpart-17.04.0.tar.xz";
     };
   };
   sweeper = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/sweeper-16.12.3.tar.xz";
-      sha256 = "1vf4840l233gji4sjkg9gz2pr98kin5sz37kj645z75vikwmk3al";
-      name = "sweeper-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/sweeper-17.04.0.tar.xz";
+      sha256 = "08jbp2kdlchvzmd9kpilypvm9466niyc4cwmya6crnn7khn03c05";
+      name = "sweeper-17.04.0.tar.xz";
     };
   };
   syndication = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/syndication-16.12.3.tar.xz";
-      sha256 = "11qa0jya3fjvhwsq98aag92ha20y7x758fvc4xi3800rbj8nlc58";
-      name = "syndication-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/syndication-17.04.0.tar.xz";
+      sha256 = "1irmjs40ghyx9vx1d5x30x34s8vwrqm7j6xf7m2s7s63jmmsk5w2";
+      name = "syndication-17.04.0.tar.xz";
     };
   };
   umbrello = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/umbrello-16.12.3.tar.xz";
-      sha256 = "1a4jhfmh2p1vsx8702ham550blkjj42ibwigcink6s9cadwk90cl";
-      name = "umbrello-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/umbrello-17.04.0.tar.xz";
+      sha256 = "0dkarqk4a3y4npk2nyyydizll4kmlg1lgddwx49gsvh120fy1zfn";
+      name = "umbrello-17.04.0.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "16.12.3";
+    version = "17.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.12.3/src/zeroconf-ioslave-16.12.3.tar.xz";
-      sha256 = "0p7kfx7bg3yvd44vg608s2znzfahkihan67zgyf3gmjllbzvp55b";
-      name = "zeroconf-ioslave-16.12.3.tar.xz";
+      url = "${mirror}/stable/applications/17.04.0/src/zeroconf-ioslave-17.04.0.tar.xz";
+      sha256 = "1m149lmjfh6nxkbax2vifirwi6jsp5jqzfai7kcyvzwp60ff6y0z";
+      name = "zeroconf-ioslave-17.04.0.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/frameworks/5.32/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/frameworks/5.33/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,595 +3,595 @@
 
 {
   attica = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/attica-5.32.0.tar.xz";
-      sha256 = "16vl3gpwqcvfms82grv1bvqlxj085bqssv5ixjx007826pd8qhp5";
-      name = "attica-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/attica-5.33.0.tar.xz";
+      sha256 = "1dr5yhg0cy4b6k91mk6w090zjizgxaa808h799m14jqzgj63z5d6";
+      name = "attica-5.33.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/baloo-5.32.0.tar.xz";
-      sha256 = "0a4qwinkp4gmcbx4j0qxbj5qb40h7594s39za7sc7bymadicasy1";
-      name = "baloo-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/baloo-5.33.0.tar.xz";
+      sha256 = "174my99i5mggab98l38y2bk27xp25mpz58rl8rhnb3wsbgxcx7iz";
+      name = "baloo-5.33.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/bluez-qt-5.32.0.tar.xz";
-      sha256 = "0pl6cp0rgjkh7d06ik35rw7qd96j5sh2flgjx4vi21zl5vf3vgyh";
-      name = "bluez-qt-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/bluez-qt-5.33.0.tar.xz";
+      sha256 = "0cpkdv4k68f0rcg3j91418i59dmc94qlnv3xk1chq0fdi0cssrri";
+      name = "bluez-qt-5.33.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/breeze-icons-5.32.0.tar.xz";
-      sha256 = "1n51kahzk09v52yhi7k4kqgavqlz3ghqv5cx2ssz2djpyavs18r3";
-      name = "breeze-icons-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/breeze-icons-5.33.0.tar.xz";
+      sha256 = "07nb4xq00fw50r4vf10npa2z690rwkmlxdy42lxx3ixci4qw4204";
+      name = "breeze-icons-5.33.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/extra-cmake-modules-5.32.0.tar.xz";
-      sha256 = "1iqakxzr6bcs9wgyi8if1smpq6px0bvlcyddyk0hxhindzl7pn5i";
-      name = "extra-cmake-modules-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/extra-cmake-modules-5.33.0.tar.xz";
+      sha256 = "013adgrz8s0w7a7z2ahkv28cq4c2cy00cw6y8akpkxazqhv5xzzk";
+      name = "extra-cmake-modules-5.33.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/frameworkintegration-5.32.0.tar.xz";
-      sha256 = "022scc4pgl68973wq29l1kc9j9lspvlmpr3bc6zlyg57m8agapwa";
-      name = "frameworkintegration-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/frameworkintegration-5.33.0.tar.xz";
+      sha256 = "01c1jq77hm3v5xi84gn5hymlnnn1igcpz9v49yxgyvnihlblb1ll";
+      name = "frameworkintegration-5.33.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kactivities-5.32.0.tar.xz";
-      sha256 = "0xin4shaj0zsfsww84mwk5n4ldaqy730jhc369px2j2nq57sg9g7";
-      name = "kactivities-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kactivities-5.33.0.tar.xz";
+      sha256 = "092gk0zn15qm4pihxf1h4qn2n618wp43k67ffy3saw4fadqmxpsz";
+      name = "kactivities-5.33.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kactivities-stats-5.32.0.tar.xz";
-      sha256 = "1b3z7bcap3vjc0155y0a9xkbd477fklmpj8dr3rs0ccyc6qxxbvw";
-      name = "kactivities-stats-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kactivities-stats-5.33.0.tar.xz";
+      sha256 = "1269nh4l94b3yxyvzdjw6vb8pxjylrvnrv28vnar8dmx0sbh5jpf";
+      name = "kactivities-stats-5.33.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kapidox-5.32.0.tar.xz";
-      sha256 = "1z6hdsppwrmqkcanrppxhqcrjvblg9i02rh3bz5m3pn66wwz0sdw";
-      name = "kapidox-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kapidox-5.33.0.tar.xz";
+      sha256 = "162x868dwl92361ss1dxv0gqh8g4apshcgb1ww4nizy239mfj8h0";
+      name = "kapidox-5.33.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/karchive-5.32.0.tar.xz";
-      sha256 = "1dzvphqnc09mmaydqggpxg6zwwyr56p6l4jdf1rf6ns90fzxy0m4";
-      name = "karchive-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/karchive-5.33.0.tar.xz";
+      sha256 = "0i5grm0dhm9z6fd63ppykd6vl45k5nam4q8w1psrz7vjmr6sd924";
+      name = "karchive-5.33.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kauth-5.32.0.tar.xz";
-      sha256 = "00kdq16n9w6nf1bpwzl5lp5c2xq74g8nn6081kvnjcd4ld66ncmq";
-      name = "kauth-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kauth-5.33.0.tar.xz";
+      sha256 = "1lfi4w4jgc9m83q6v3jf8p91x12vvcc3g59dlg7dh2agrh07r9y7";
+      name = "kauth-5.33.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kbookmarks-5.32.0.tar.xz";
-      sha256 = "03a024phcjv46afbp5lbmj2p8hb6srfzyaslc6ln6ms473bf5k4w";
-      name = "kbookmarks-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kbookmarks-5.33.0.tar.xz";
+      sha256 = "186difbzrpqlbi140ylkzb50d3fmn2pdz8i0r3gbc71726fqld82";
+      name = "kbookmarks-5.33.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kcmutils-5.32.0.tar.xz";
-      sha256 = "1mr9h7wc22bfrbm92ajsjfcs16c5xpkrxbxzcma3a0s7jhy6qrm9";
-      name = "kcmutils-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kcmutils-5.33.0.tar.xz";
+      sha256 = "0n0cmjxlp0kkgrxng2ympnl1v5a1bjr2d9c20hf31xhvmya3y9nd";
+      name = "kcmutils-5.33.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kcodecs-5.32.0.tar.xz";
-      sha256 = "0yybkp52i8nm4qjady6jqswn6v70cqbvjqwgrghjnc88b2cly253";
-      name = "kcodecs-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kcodecs-5.33.0.tar.xz";
+      sha256 = "1pdijdlrl9p5w6dixqx0lmkzwsk5xarzjhpwh616j2sinfra0w31";
+      name = "kcodecs-5.33.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kcompletion-5.32.0.tar.xz";
-      sha256 = "0fn8imr3m219r38a0rafbnylcpjq4rqhz1w66mx80sc7l10mhcni";
-      name = "kcompletion-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kcompletion-5.33.0.tar.xz";
+      sha256 = "13mv5mm90jv4k56h4n6d7r2a0pax2mhdrm51xd99fjynad129lhi";
+      name = "kcompletion-5.33.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kconfig-5.32.0.tar.xz";
-      sha256 = "1pajh1l08b995shp6l75ri9z4vr6wjapvrkmrmv8hksnxvfi97dp";
-      name = "kconfig-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kconfig-5.33.0.tar.xz";
+      sha256 = "1inhpil19pv3jjf7mz4f5g367n1ciiixndij10p1zxk5zy46zzmf";
+      name = "kconfig-5.33.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kconfigwidgets-5.32.0.tar.xz";
-      sha256 = "1cq0a3k6pvl9f098ssqqk2rddxh0xn1kk4p5kfyd7w0m3c604zw3";
-      name = "kconfigwidgets-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kconfigwidgets-5.33.0.tar.xz";
+      sha256 = "0sd974r7xrpnhyqabgix0zb1rlis32ijj0wiabbqi4ns0nhhi3qf";
+      name = "kconfigwidgets-5.33.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kcoreaddons-5.32.0.tar.xz";
-      sha256 = "1n1xzvwwji9pwyxrvwp4rmpc7qzp9nlis26xmn81k607jn587ksx";
-      name = "kcoreaddons-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kcoreaddons-5.33.0.tar.xz";
+      sha256 = "1906jscfc2kpd22d7yk88ziy3ky3hcfxy5y593pfzjl41gyhsiyl";
+      name = "kcoreaddons-5.33.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kcrash-5.32.0.tar.xz";
-      sha256 = "1zrkjrpj88ymdy5vbn9db73vxppswvmbn2gkn4gpx773dsmflhz3";
-      name = "kcrash-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kcrash-5.33.0.tar.xz";
+      sha256 = "136wlvaf4r54k8x0z0jvs7l35m0v22y6zqkhc8f91dr1y2ym2jnk";
+      name = "kcrash-5.33.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kdbusaddons-5.32.0.tar.xz";
-      sha256 = "1a15jjsrkza0ll2viyk834pgdxsdgdacm0982xxwl5z937f75609";
-      name = "kdbusaddons-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kdbusaddons-5.33.0.tar.xz";
+      sha256 = "1xxbmr88w7hqxsrhjbgic0pn4adkydhv9xd77vwbzjj47123mph2";
+      name = "kdbusaddons-5.33.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kdeclarative-5.32.0.tar.xz";
-      sha256 = "1y5g3yi1l0g1mkqhhakg265r25zm23qc2fqg55rq0g7l9ss7w7g9";
-      name = "kdeclarative-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kdeclarative-5.33.0.tar.xz";
+      sha256 = "1333vv6kbdk4sdkkc8lnncgmm3203ca8ybn9nj6ch3zqwyxcaagk";
+      name = "kdeclarative-5.33.0.tar.xz";
     };
   };
   kded = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kded-5.32.0.tar.xz";
-      sha256 = "0pmmsvqwkw86yvxxf9i6lg13vg80m0kmhjjs88lbm60cgvr5jhq6";
-      name = "kded-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kded-5.33.0.tar.xz";
+      sha256 = "02g66ip0d0cwb8grb6f3z1j7178w76pfs2f8d2dl1rax4hnjppd0";
+      name = "kded-5.33.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/portingAids/kdelibs4support-5.32.0.tar.xz";
-      sha256 = "1wan5ad5rhhrwvwjjjd87n790r6d8r118gs2kw49s91pdj3iv9pb";
-      name = "kdelibs4support-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/portingAids/kdelibs4support-5.33.0.tar.xz";
+      sha256 = "1gyyvp4kqnjaf764y2z24jk68h5h0ax1z9h25msczy6bd4ify5v9";
+      name = "kdelibs4support-5.33.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kdesignerplugin-5.32.0.tar.xz";
-      sha256 = "1hapj8x8nky3m6lx2ianmxwprf00jqyjsknjz3pi4vk3i714vhnf";
-      name = "kdesignerplugin-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kdesignerplugin-5.33.0.tar.xz";
+      sha256 = "1f4f53xag6xbvacpn5j0zrsdwimksnckdza6kswcri5q258yb6ks";
+      name = "kdesignerplugin-5.33.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kdesu-5.32.0.tar.xz";
-      sha256 = "0zsy1hivy5bbczrpkpgj72mlx0km2nm53kpgrj2hfdy3ss0vn3hl";
-      name = "kdesu-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kdesu-5.33.0.tar.xz";
+      sha256 = "06scns6jgs372xx7fssdj63110nrnvy9dmm1k7gc0pyhn0a5yk8a";
+      name = "kdesu-5.33.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kdewebkit-5.32.0.tar.xz";
-      sha256 = "0y7262pqzdx0hxkyqrbawgx99rn6q85m1slr4nbn914kn350xpy0";
-      name = "kdewebkit-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kdewebkit-5.33.0.tar.xz";
+      sha256 = "0lxca56ib5pldc6f3z2gw05jbi2kyd9rqp52pgzfs4kgvvs6gblh";
+      name = "kdewebkit-5.33.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kdnssd-5.32.0.tar.xz";
-      sha256 = "1xakbs2wm627zn01ni8fyrz64xl5jw4by0pdrb70aad7w37dijrw";
-      name = "kdnssd-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kdnssd-5.33.0.tar.xz";
+      sha256 = "11pnh18z030zzkiibvd9lfp5i194qwk3pccncc9968nnc0bgghxa";
+      name = "kdnssd-5.33.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kdoctools-5.32.0.tar.xz";
-      sha256 = "0i7zgg7iw6w0sdr6cv3yf4blcr61i8zczgmyqa964ka6p3ywwjs9";
-      name = "kdoctools-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kdoctools-5.33.0.tar.xz";
+      sha256 = "04d48gi5d273x3p7572szlpyiz8iyw1ic53b9jblhyfyp93gvpb9";
+      name = "kdoctools-5.33.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kemoticons-5.32.0.tar.xz";
-      sha256 = "1ncjs9iy6z6rhk83ff7fj1b68rkylnry0h698rh4jvs98gpw8sgj";
-      name = "kemoticons-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kemoticons-5.33.0.tar.xz";
+      sha256 = "0p9320zln553wi055ql04j8kk329l3wiksprg9rkgzya2gynflyl";
+      name = "kemoticons-5.33.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kfilemetadata-5.32.0.tar.xz";
-      sha256 = "01d91gmrxlax0g13ib841vc4qwmv6r4qdr10wfs77rrxsvw7z08f";
-      name = "kfilemetadata-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kfilemetadata-5.33.0.tar.xz";
+      sha256 = "1bbw1h8kml8glnck8hh4s13abbksw2fa7g93p25vbhdcyr7zgkr0";
+      name = "kfilemetadata-5.33.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kglobalaccel-5.32.0.tar.xz";
-      sha256 = "0dxwjznnqlgnvn15pl34rxlzk3i21cvzn8xbgqmxakny8qiib9ry";
-      name = "kglobalaccel-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kglobalaccel-5.33.0.tar.xz";
+      sha256 = "0hc46vwiz81iqzkrc0qahd7gn71kh5wc32kjvh6h4ijlnfmdih07";
+      name = "kglobalaccel-5.33.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kguiaddons-5.32.0.tar.xz";
-      sha256 = "0rbfd0rykmwl9hs1q22pqg2by8vi9y1pgs2ishgnan4sc4w87wjb";
-      name = "kguiaddons-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kguiaddons-5.33.0.tar.xz";
+      sha256 = "171lvykvznrrqdi1frm9akzx5rsrj04vvav3sv64x7hfsas0a7p1";
+      name = "kguiaddons-5.33.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/portingAids/khtml-5.32.0.tar.xz";
-      sha256 = "1bkxfldw55khycbpcqpwi86rpv6qyqsndvjncfd5a5knnsynwdyf";
-      name = "khtml-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/portingAids/khtml-5.33.0.tar.xz";
+      sha256 = "0j9viw8fydh1x548wx39bphk5bf11fyrghshxz14a79rll8w7qmc";
+      name = "khtml-5.33.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/ki18n-5.32.0.tar.xz";
-      sha256 = "068xvw2hy4hlpj85wgjjdj0nc37fygpd8wb1dnpqcvzzy8rc1rsf";
-      name = "ki18n-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/ki18n-5.33.0.tar.xz";
+      sha256 = "02xf9q3vnw8nn2if6a3pfj8v96414j7gnc6097k0wxfyis9i46k1";
+      name = "ki18n-5.33.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kiconthemes-5.32.0.tar.xz";
-      sha256 = "00azbyk5y3jgdqv03a2nd0627kdkhq1bkghvw7w62kcnih9k8lq5";
-      name = "kiconthemes-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kiconthemes-5.33.0.tar.xz";
+      sha256 = "1zys55d7jjjjllyi9p4difnr6xg9580bgcg5pnm966ak6zhj6682";
+      name = "kiconthemes-5.33.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kidletime-5.32.0.tar.xz";
-      sha256 = "0rkxx3bnspjwm4vcy4rdfahk6vcfpkh8fldww0zfdn7s7pigqwch";
-      name = "kidletime-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kidletime-5.33.0.tar.xz";
+      sha256 = "0z6i224kmj9l15x923pa30mlhjw66chm9v8qvzg1vhmk36jyw789";
+      name = "kidletime-5.33.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kimageformats-5.32.0.tar.xz";
-      sha256 = "05hn8n4sc3rj5c30ki068f76k1gfgvq19zcw5jlqpnn1l5db5fvz";
-      name = "kimageformats-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kimageformats-5.33.0.tar.xz";
+      sha256 = "1m9d51pvrc7fa38mp4jn4cdn558nd6kvik3ry6gvv8im67qyq4ga";
+      name = "kimageformats-5.33.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kinit-5.32.0.tar.xz";
-      sha256 = "0103lflppdw55l9xiqs68lzaq9897m5qnkmy6fp7dm9wfh9aplqn";
-      name = "kinit-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kinit-5.33.0.tar.xz";
+      sha256 = "0v3dcgbi5qwg9nmn668r2v1b257qhmkdb2l3p7hhx06ygypk4yjp";
+      name = "kinit-5.33.0.tar.xz";
     };
   };
   kio = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kio-5.32.0.tar.xz";
-      sha256 = "19da02l0aj0l07x9bbklhvx9slci3v1d8q80jvam4vyzs4qdyjin";
-      name = "kio-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kio-5.33.0.tar.xz";
+      sha256 = "1pls5yjkhz7fkawks4c0lmsix0nafv7hyp33yh7dm4hijd8zy5cf";
+      name = "kio-5.33.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kitemmodels-5.32.0.tar.xz";
-      sha256 = "0lxld7jdixpq23sycv8n4ckzmdr34aycrsf2zffziw6r59f0mzki";
-      name = "kitemmodels-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kitemmodels-5.33.0.tar.xz";
+      sha256 = "1ma21qydbmj2qr4ib4qv13wip99lq3lm8d6p137bg9x6nqfa4qzn";
+      name = "kitemmodels-5.33.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kitemviews-5.32.0.tar.xz";
-      sha256 = "1h1zgawdi4vbgymdl5215lx7hpcx9jqxy7vjf5hwgs6b2cls1sws";
-      name = "kitemviews-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kitemviews-5.33.0.tar.xz";
+      sha256 = "1nc07lxh37l1fwz6xmsrcplimgmrna9ij2dq3pnfrxr319c29890";
+      name = "kitemviews-5.33.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kjobwidgets-5.32.0.tar.xz";
-      sha256 = "0lhv3mg2liija0g8x14jpv1mdhb0zjh868p1cs24bs9xrw1l8984";
-      name = "kjobwidgets-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kjobwidgets-5.33.0.tar.xz";
+      sha256 = "01adg7axi1bp59z1c7xnxg2p1ahhrzxwxrjn3ci805m8ns6d40cz";
+      name = "kjobwidgets-5.33.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/portingAids/kjs-5.32.0.tar.xz";
-      sha256 = "022n2hl1s5kap3pqaz4y28wn5z5qh6jcypz5kini2ic94xf7ydrg";
-      name = "kjs-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/portingAids/kjs-5.33.0.tar.xz";
+      sha256 = "1w0kdxnzcwmgskl4qsw6aq5189yxqyhq9qajihr2yga0hyglf3iv";
+      name = "kjs-5.33.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/portingAids/kjsembed-5.32.0.tar.xz";
-      sha256 = "0h0p4mcvmdgvjv2xd8s4x2i554nh08mc258gxhb41bs6vm3yhiz4";
-      name = "kjsembed-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/portingAids/kjsembed-5.33.0.tar.xz";
+      sha256 = "1vk2m8i315nrys9c4kk3hdlp8hdn2ils0lb8v4nnkvbj3s1f4a8p";
+      name = "kjsembed-5.33.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/portingAids/kmediaplayer-5.32.0.tar.xz";
-      sha256 = "1s86dfzrqxrmbqmxq4yyyy1p507d9ns6d7sy6z67dhykgahacqf4";
-      name = "kmediaplayer-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/portingAids/kmediaplayer-5.33.0.tar.xz";
+      sha256 = "13xpvi0vxd3vva2d64x8l1knj270al4329kwf9xaays66g6gshgs";
+      name = "kmediaplayer-5.33.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/knewstuff-5.32.0.tar.xz";
-      sha256 = "1i3ldy9wwnjhpgdd2d0bg4304k88riin89zqzdl52lpqa6hjl3fp";
-      name = "knewstuff-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/knewstuff-5.33.0.tar.xz";
+      sha256 = "1j4jj2k6jngcp98mfxq1cdp7x0j43rgr5gxn9viqp92liak68lsh";
+      name = "knewstuff-5.33.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/knotifications-5.32.0.tar.xz";
-      sha256 = "06ap7m8c2py49pqrnhadbyl69y3nsyamzahbpwipqgh9k62sy34y";
-      name = "knotifications-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/knotifications-5.33.0.tar.xz";
+      sha256 = "17ppfwhl3mqd3l4r56whqcxagx6br02hdwlqy7npn32g797hkayd";
+      name = "knotifications-5.33.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/knotifyconfig-5.32.0.tar.xz";
-      sha256 = "14qc6wj4j5i45vzqsvl2wlc07c6x30hb2680gwfqsvwgiaszkzv4";
-      name = "knotifyconfig-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/knotifyconfig-5.33.0.tar.xz";
+      sha256 = "0m9fdvbakv0plq3m7sj6wj980wfd3m37cabximz9gmi0zkcadzmw";
+      name = "knotifyconfig-5.33.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kpackage-5.32.0.tar.xz";
-      sha256 = "070zasl5c58n01fk18mjgccfizymc9griwicxizqjgzzbgvkns3r";
-      name = "kpackage-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kpackage-5.33.0.tar.xz";
+      sha256 = "03ls567fj54fzibc8fafffas97abyanl0sn041z51sr7mjp425cs";
+      name = "kpackage-5.33.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kparts-5.32.0.tar.xz";
-      sha256 = "0hrx0mdvw301nbdyw5fkvgkw60ya6kmfw6hfzmj48bws8mi33rs5";
-      name = "kparts-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kparts-5.33.0.tar.xz";
+      sha256 = "0fd0dqmaf8ksx3czzihjd4z0yg682a9bcy09vdhj2grki7w9fxha";
+      name = "kparts-5.33.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kpeople-5.32.0.tar.xz";
-      sha256 = "1xqi8zr76hajgyv016iaqlmnr5b84s71fbx412q153g92jglp4mk";
-      name = "kpeople-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kpeople-5.33.0.tar.xz";
+      sha256 = "19vag6ci82jh5lw5c7734rlp89wr7xb0d8as98ykz2wmkk0mqql7";
+      name = "kpeople-5.33.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kplotting-5.32.0.tar.xz";
-      sha256 = "0a0pfmdlx84526lb2jvx94i2pf85km57fm2ygis4z5mjgbzsmb6v";
-      name = "kplotting-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kplotting-5.33.0.tar.xz";
+      sha256 = "0niqhj270l36il3ql6xljg9gbb0yw25ky8wsc7l0021mxvhficri";
+      name = "kplotting-5.33.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kpty-5.32.0.tar.xz";
-      sha256 = "0h4318rc9902cvqj69capb8lh7s84y44jd59d11fyhq21jhy152s";
-      name = "kpty-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kpty-5.33.0.tar.xz";
+      sha256 = "0xcmqdphqy2a44bksqiv8cjlzfkjpbpazfk5f8ml97vdqvwa6qp5";
+      name = "kpty-5.33.0.tar.xz";
     };
   };
   kross = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/portingAids/kross-5.32.0.tar.xz";
-      sha256 = "0mgicb2rfhzp0hr1zckp1qzqzbdx0zy82mcjibrlsp7spmvynw5a";
-      name = "kross-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/portingAids/kross-5.33.0.tar.xz";
+      sha256 = "13dldb4df4spsqr3878bimv009fzq4pdvmwlaw753c0lrp97pd9l";
+      name = "kross-5.33.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/krunner-5.32.0.tar.xz";
-      sha256 = "1k4rg9vqr6h5aj7v51fx3i5z9kxlfpacahs81hkwksi6if8ik4kr";
-      name = "krunner-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/krunner-5.33.0.tar.xz";
+      sha256 = "0za052rsqf5kaz1c48k63a905b3x953wi6f07m44m6dm38p5ixq8";
+      name = "krunner-5.33.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kservice-5.32.0.tar.xz";
-      sha256 = "02xk3ajspprmx964zhwh2l3axm4gns9h0m0pvcb1v5j8pfh9v70q";
-      name = "kservice-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kservice-5.33.0.tar.xz";
+      sha256 = "0jqq4ahscnqvzv8inhfzb9s6x97s60c4w8chpg16qwc7dqag887h";
+      name = "kservice-5.33.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/ktexteditor-5.32.0.tar.xz";
-      sha256 = "1sybw8k3f36mcs5qh3b51v7ynbqn4pbiiabkyxfmyi82i09m2jgw";
-      name = "ktexteditor-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/ktexteditor-5.33.0.tar.xz";
+      sha256 = "12fcqcxamkxv38w4j9waqmim7k801v6r6izlyg59iiy56yks4ms5";
+      name = "ktexteditor-5.33.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/ktextwidgets-5.32.0.tar.xz";
-      sha256 = "1s2fd4n4hfkzscxv0cdfjynjzi1f57pfi9a3fp6rrm5c5645zk7r";
-      name = "ktextwidgets-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/ktextwidgets-5.33.0.tar.xz";
+      sha256 = "09rjr3655pbzwgjsmwbjsm7jwrxydl2jwhgbk8ziv1bgcg6cjrjy";
+      name = "ktextwidgets-5.33.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kunitconversion-5.32.0.tar.xz";
-      sha256 = "0crc8riwafcx6fwhgrc8vfbwmdygd6vlz1fbbgni09gamm8mbcin";
-      name = "kunitconversion-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kunitconversion-5.33.0.tar.xz";
+      sha256 = "0bflic2va9bc17q0smc4dzmgh72cjfjjaahhsvvnj54g2qggznkq";
+      name = "kunitconversion-5.33.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kwallet-5.32.0.tar.xz";
-      sha256 = "0psc4n6lck9gbx2nn7mgv33x4z2r0xp1mx1xcsgy8smvalrfv5xa";
-      name = "kwallet-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kwallet-5.33.0.tar.xz";
+      sha256 = "1jpybsksai9gm2bihcgl5m56rjfd0crj9i8j0l2s4vmmzxyflczj";
+      name = "kwallet-5.33.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kwayland-5.32.0.tar.xz";
-      sha256 = "1kzvq7qx102rfdv975x5sd37lsl6wn0mzm2m1f9fnnn2rvii3h5d";
-      name = "kwayland-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kwayland-5.33.0.tar.xz";
+      sha256 = "18nvdhfijnvzjiy0vjmqvf2nwz64ymxpnhlhs75y1d2ib8rm8qfq";
+      name = "kwayland-5.33.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kwidgetsaddons-5.32.0.tar.xz";
-      sha256 = "1aksy326ppdfcx20zl9hxsd8j0br32j6dlx4i1xxbd976csys9b2";
-      name = "kwidgetsaddons-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kwidgetsaddons-5.33.0.tar.xz";
+      sha256 = "1dnspi7zf57lsihdynbik2iwvnhv8098vqyz0rps8s8pnjl7x8k4";
+      name = "kwidgetsaddons-5.33.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kwindowsystem-5.32.0.tar.xz";
-      sha256 = "1c3kd23c4wwzdhfcyhv41czw3y2kk1492xn6ah9n3r98akrhgar1";
-      name = "kwindowsystem-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kwindowsystem-5.33.0.tar.xz";
+      sha256 = "1dj18774rlpxh9p8a07shhb4dzc0zpv4qvmh4j2y4c1g6v7n6b3p";
+      name = "kwindowsystem-5.33.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kxmlgui-5.32.0.tar.xz";
-      sha256 = "1pxi4z7z3bzwcnfwq0pvjsmds401fkisyr353lyxf4rvcpwj3a65";
-      name = "kxmlgui-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kxmlgui-5.33.0.tar.xz";
+      sha256 = "1q89xsrdhrsz7jb68hq8r3xdmhz0s19zwvd06skn6cfqx7r32ng0";
+      name = "kxmlgui-5.33.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/kxmlrpcclient-5.32.0.tar.xz";
-      sha256 = "1kaczibdfdph5mpg1dldsmqb1six57w7ch3v0v7av5h6j6sx0xaq";
-      name = "kxmlrpcclient-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/kxmlrpcclient-5.33.0.tar.xz";
+      sha256 = "1zc6pn412day923k22br82xypvk24znb0ns1qsdlmrd2cnmv8l28";
+      name = "kxmlrpcclient-5.33.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/modemmanager-qt-5.32.0.tar.xz";
-      sha256 = "0ywyiq1kj4ya5knn0r12j9m1ig9mlyfypnrzihlvipddjrqs7jyd";
-      name = "modemmanager-qt-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/modemmanager-qt-5.33.0.tar.xz";
+      sha256 = "098l3plck45bn7lph7mfkm03q18zxl1s8aa3pyh6b69wk45r7j54";
+      name = "modemmanager-qt-5.33.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/networkmanager-qt-5.32.0.tar.xz";
-      sha256 = "0bcy7nzfvx2xah3kxklmrjn08qbjddiny7wf7nkxsbc3kkhrxqyd";
-      name = "networkmanager-qt-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/networkmanager-qt-5.33.0.tar.xz";
+      sha256 = "0pc4n4m93ypx1ryasw8n3bqll7v4yqa3749ir0qi096y5vysdd2m";
+      name = "networkmanager-qt-5.33.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/oxygen-icons5-5.32.0.tar.xz";
-      sha256 = "05v3blgs4qbjl8s6470baahy9a98cfi3mplzp462axcgkqdj1nwf";
-      name = "oxygen-icons5-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/oxygen-icons5-5.33.0.tar.xz";
+      sha256 = "17kp66hra0vfkcvd7fh5q23wr040h0z6di4gdrm2zi1w5jbhw9kn";
+      name = "oxygen-icons5-5.33.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/plasma-framework-5.32.0.tar.xz";
-      sha256 = "1hrnmilc30d1kh20cky329i5ji3qyy7m4f8jzax5cgl7nrjca31h";
-      name = "plasma-framework-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/plasma-framework-5.33.0.tar.xz";
+      sha256 = "0rqm773n2r6vwmv41x27lr2zmx26s5s27ym3a6qy0w18fr86fxsd";
+      name = "plasma-framework-5.33.0.tar.xz";
     };
   };
   prison = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/prison-5.32.0.tar.xz";
-      sha256 = "0q5cs60293bdm3mynhx39rjsh87mfxngxsqa2fqm2gsqjvlciyvr";
-      name = "prison-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/prison-5.33.0.tar.xz";
+      sha256 = "0hh065294s7sjj34vfwwb8zgagf1sa09l9filadl1ly0ig9f6h1r";
+      name = "prison-5.33.0.tar.xz";
     };
   };
   solid = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/solid-5.32.0.tar.xz";
-      sha256 = "1jhymivravgix0sa0szkax50j09l5fl55xi3fbyjxlb4cil114v5";
-      name = "solid-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/solid-5.33.0.tar.xz";
+      sha256 = "0jb8jjv6mhwriqxfkd9fj0b7y1ab6vnwqi53sk4w4vw53d0wkqxm";
+      name = "solid-5.33.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/sonnet-5.32.0.tar.xz";
-      sha256 = "17sjv48b3z5fgplsy16ilcw6p7mlqjs61ib6jqd1mqzv4xrr27yi";
-      name = "sonnet-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/sonnet-5.33.0.tar.xz";
+      sha256 = "096ybf95rx5ybvl74nlnn9x2yb2j1akn8g8ywv1vwi2ckfpnp3sd";
+      name = "sonnet-5.33.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/syntax-highlighting-5.32.0.tar.xz";
-      sha256 = "1d9m7x53mwggwmhhba1c7b8v4f8qjql889y674ldpzs2nrk5y7x3";
-      name = "syntax-highlighting-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/syntax-highlighting-5.33.0.tar.xz";
+      sha256 = "0nn078sw0bkw1m5vsv02n46sc05blg3qnhxpmph2cikz5y86x9jq";
+      name = "syntax-highlighting-5.33.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.32.0";
+    version = "5.33.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.32/threadweaver-5.32.0.tar.xz";
-      sha256 = "1qpy2rzqyd4ap5fibkfk87z66ijh2h79cd7f0h506jh2dbx20g0h";
-      name = "threadweaver-5.32.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.33/threadweaver-5.33.0.tar.xz";
+      sha256 = "16y7irjyyp4smy7nm7j4zc3gk9a046bwxvv51l7rfs7n4z0550ki";
+      name = "threadweaver-5.33.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Newer version with bugfixes for various applications.

https://www.kde.org/announcements/announce-applications-17.04.0.php

I tested not all packages. Packages I tested:

kate, kcalc, okular, spectacle, marble, konsole,  kcachegrind, kig, okteta, kdenlive, dolphin, ark, konversation, khelpcenter, kdf, kompare

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of many binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

