### PR TITLE
ephoto: init at 1.0

### DIFF
--- a/pkgs/desktops/enlightenment/default.nix
+++ b/pkgs/desktops/enlightenment/default.nix
@@ -10,4 +10,5 @@ rec {
   econnman = callPackage ./econnman.nix { };
   terminology = callPackage ./terminology.nix { };
   rage = callPackage ./rage.nix { };
+  ephoto = callPackage ./ephoto.nix { };
 }

--- a/pkgs/desktops/enlightenment/ephoto.nix
+++ b/pkgs/desktops/enlightenment/ephoto.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, pkgconfig, efl }:
+
+stdenv.mkDerivation rec {
+  name = "ephoto-${version}";
+  version = "1.0";
+  
+  src = fetchurl {
+    url = "http://www.smhouston.us/stuff/${name}.tar.gz";
+    sha256 = "0l6zrk22fap6pylmzxwp6nycy8l5wdc7jza890h4zrwmpfag8w31";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+
+  buildInputs = [
+    efl
+ ];
+
+  NIX_CFLAGS_COMPILE = [
+    "-I${efl}/include/ecore-con-1"
+    "-I${efl}/include/ecore-evas-1"
+    "-I${efl}/include/ecore-imf-1"
+    "-I${efl}/include/ecore-input-1"
+    "-I${efl}/include/eet-1"
+    "-I${efl}/include/eldbus-1"
+    "-I${efl}/include/emile-1"
+    "-I${efl}/include/ethumb-1"
+    "-I${efl}/include/ethumb-client-1"
+  ];
+
+  meta = {
+    description = "Image viewer and editor written using the Enlightenment Foundation Libraries";
+    homepage = http://smhouston.us/ephoto/;
+    license = stdenv.lib.licenses.bsd2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

[Ephoto](http://smhouston.us/ephoto/)

> Ephoto is an image viewer and editor written using the Enlightenment Foundation Libraries(EFL).  It focuses on simplicity and ease of use, while taking advantage of the speed and small footprint the EFL provide.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).