### PR TITLE
desktop-managers: Use a black BG as fallback

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -8,7 +8,7 @@ let
   cfg = xcfg.desktopManager;
 
   # If desktop manager `d' isn't capable of setting a background and
-  # the xserver is enabled, the `feh' program is used as a fallback.
+  # the xserver is enabled, `feh' or `xsetroot' are used as a fallback.
   needBGCond = d: ! (d ? bgSupport && d.bgSupport) && xcfg.enable;
 
 in
@@ -44,8 +44,11 @@ in
             manage = "desktop";
             start = d.start
             + optionalString (needBGCond d) ''
-              if test -e $HOME/.background-image; then
+              if [ -e $HOME/.background-image ]; then
                 ${pkgs.feh}/bin/feh --bg-scale $HOME/.background-image
+              else
+                # Use a solid black background as fallback
+                ${pkgs.xorg.xsetroot}/bin/xsetroot -solid black
               fi
             '';
           }) list;
@@ -80,6 +83,6 @@ in
   config = {
     services.xserver.displayManager.session = cfg.session.list;
     environment.systemPackages =
-      mkIf cfg.session.needBGPackages [ pkgs.feh ];
+      mkIf cfg.session.needBGPackages [ pkgs.feh ]; # xsetroot via xserver.enable
   };
 }


### PR DESCRIPTION
Use a solid black background when no background image (via
~/.background-image) is provided. In my case this fixes the really
strange behaviour when i3 without a desktop-manager starts with the SDDM
login screen as background image.

###### Motivation for this change

Minimal windows managers like `i3` won't touch the root window. Using a display manager this seems to cause problems as they alter the root window (at least SDDM does). The result is something like this (note the i3 status-bar at the bottom):
![img_20170416_184025](https://cloud.githubusercontent.com/assets/7537109/25298294/f22fcbb4-26f3-11e7-9a65-bcf9d4c6f7bf.jpg)

Using this patch i3 will "launch" with a (solid) black background when `~/.background-image` isn't present. I actually wonder if we should drop the `~/.background-image` support since it requires an additional program (`feh`) and isn't documented in the NixOS manual. But since most users running a minimal WM like i3 will probably use `feh` anyway it shouldn't really matter.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

