### PR TITLE
python2Packages.pyspread: init at 1.1 (and fix wxPython to inject required dependencies)

### DIFF
--- a/pkgs/development/python-modules/pyspread/default.nix
+++ b/pkgs/development/python-modules/pyspread/default.nix
@@ -1,0 +1,57 @@
+{ buildPythonPackage
+, fetchPypi
+, isPy3k
+, stdenv
+, numpy
+, wxPython
+, matplotlib
+, pycairo
+, python-gnupg
+, xlrd
+, xlwt
+, jedi
+, pyenchant
+, basemap
+, pygtk
+, makeDesktopItem
+}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "pyspread";
+  version = "1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0m1a4zvzrfrnc42j8mrbm7747w03nzyl9z02wjagccmlhi6nd9hx";
+  };
+
+  propagatedBuildInputs = [ numpy wxPython matplotlib pycairo python-gnupg xlrd xlwt jedi pyenchant basemap pygtk ];
+  # Could also (optionally) add pyrsvg and python bindings for libvlc
+
+  # Tests try to access X Display
+  doCheck = false;
+
+  disabled = isPy3k;
+
+  desktopItem = makeDesktopItem rec {
+    name = pname;
+    exec = name;
+    icon = name;
+    desktopName = "Pyspread";
+    genericName = "Spreadsheet";
+    comment = meta.description;
+    categories = "Development;Spreadsheet;";
+  };
+
+  postInstall = ''
+    mkdir -p $out/share/applications
+    cp $desktopItem/share/applications/* $out/share/applications
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Pyspread is a non-traditional spreadsheet application that is based on and written in the programming language Python";
+    homepage = https://manns.github.io/pyspread/;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/development/python-modules/wxPython/3.0.nix
+++ b/pkgs/development/python-modules/wxPython/3.0.nix
@@ -12,6 +12,8 @@
 , isPy3k
 , isPyPy
 , python
+, cairo
+, pango
 }:
 
 assert wxGTK.unicode;
@@ -43,6 +45,15 @@ buildPythonPackage rec {
     # this check is supposed to only return false on older systems running non-framework python
     substituteInPlace src/osx_cocoa/_core_wrap.cpp \
       --replace "return wxPyTestDisplayAvailable();" "return true;"
+  '' + lib.optionalString (!stdenv.isDarwin) ''
+    substituteInPlace wx/lib/wxcairo.py \
+      --replace 'cairoLib = None' 'cairoLib = ctypes.CDLL("${cairo}/lib/libcairo.so")'
+    substituteInPlace wx/lib/wxcairo.py \
+      --replace '_dlls = dict()' '_dlls = {k: ctypes.CDLL(v) for k, v in [
+        ("gdk",        "${wxGTK.gtk}/lib/libgtk-x11-2.0.so"),
+        ("pangocairo", "${pango.out}/lib/libpangocairo-1.0.so"),
+        ("appsvc",     None)
+      ]}'
   '';
 
   NIX_LDFLAGS = lib.optionalString (!stdenv.isDarwin) "-lX11 -lgdk-x11-2.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20558,6 +20558,8 @@ in {
     };
   };
 
+  pyspread = callPackage ../development/python-modules/pyspread { };
+
   pyx = buildPythonPackage rec {
     name = "pyx-${version}";
     version = "0.14.1";


### PR DESCRIPTION
###### Motivation for this change

New package + fix wxPython which attempts to locate shared libraries at runtime so we tell it exactly where to find them.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

