### PR TITLE
curlcpp: 20160901 -> 1.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -452,7 +452,7 @@
   romildo = "José Romildo Malaquias <malaquias@gmail.com>";
   rongcuid = "Rongcui Dong <rongcuid@outlook.com>";
   ronny = "Ronny Pfannschmidt <nixos@ronnypfannschmidt.de>";
-  rszibele = "Richard Szibele <richard_szibele@hotmail.com>";
+  rszibele = "Richard Szibele <richard@szibele.com>";
   rtreffer = "Rene Treffer <treffer+nixos@measite.de>";
   rushmorem = "Rushmore Mushambi <rushmore@webenchanter.com>";
   rvl = "Rodney Lorrimar <dev+nix@rodney.id.au>";

--- a/pkgs/development/libraries/curlcpp/default.nix
+++ b/pkgs/development/libraries/curlcpp/default.nix
@@ -1,13 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, curl }: 
 
-stdenv.mkDerivation {
-  name = "curlcpp-20160901";
+stdenv.mkDerivation rec {
+  name = "curlcpp-${version}";
+  version = "1.0";
 
   src = fetchFromGitHub {
     owner = "JosephP91";
     repo = "curlcpp";
-    rev = "98286da1d6c9f6158344a8e272eae5030cbf6c0e";
-    sha256 = "00nm2b8ik1yvaz5dp1b61jid841jv6zf8k5ma2nxbf1di1apqh0d";
+    rev = "${version}";
+    sha256 = "1akibhrmqsy0dlz9lq93508bhkh7r1l0aycbzy2x45a9gqxfdi4q";
   };
 
   buildInputs = [ cmake curl ];
@@ -15,9 +16,9 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     homepage = "http://josephp91.github.io/curlcpp/";
     description = "Object oriented C++ wrapper for CURL";
-    platforms = platforms.unix ;
+    platforms = platforms.unix;
     license = licenses.mit;
-    maintainers = [ maintainers.juliendehos ];
+    maintainers = with maintainers; [ juliendehos rszibele ];
   };
 }
 


### PR DESCRIPTION
###### Motivation for this change

Version bump and updated my maintainer info.

For changes in curlcpp see https://github.com/JosephP91/curlcpp/compare/98286da1d6c9f6158344a8e272eae5030cbf6c0e...f3c5499b312ba649b87f205e8c1f771958227a05 .

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

