### PR TITLE
nixos: static ids for jackett, radarr, sonarr

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -289,6 +289,9 @@
       rpc = 271;
       geoip = 272;
       fcron = 273;
+      sonarr = 274;
+      radarr = 275;
+      jackett = 276;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -547,6 +550,9 @@
       #rpc = 271; # unused
       #geoip = 272; # unused
       fcron = 273;
+      sonarr = 274;
+      radarr = 275;
+      jackett = 276;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/services/misc/jackett.nix
+++ b/nixos/modules/services/misc/jackett.nix
@@ -22,14 +22,14 @@ in
           echo "Creating jackett data directory in /var/lib/jackett/"
           mkdir -p /var/lib/jackett/
         }
-        chown -R jackett /var/lib/jackett/
+        chown -R jackett:jackett /var/lib/jackett/
         chmod 0700 /var/lib/jackett/
       '';
 
       serviceConfig = {
         Type = "simple";
         User = "jackett";
-        Group = "nogroup";
+        Group = "jackett";
         PermissionsStartOnly = "true";
         ExecStart = "${pkgs.jackett}/bin/Jackett";
         Restart = "on-failure";
@@ -37,8 +37,11 @@ in
     };
 
     users.extraUsers.jackett = {
+      uid = config.ids.uids.jackett;
       home = "/var/lib/jackett";
+      group = "jackett";
     };
+    users.extraGroups.jackett.gid = config.ids.gids.jackett;
 
   };
 }

--- a/nixos/modules/services/misc/radarr.nix
+++ b/nixos/modules/services/misc/radarr.nix
@@ -22,14 +22,14 @@ in
           echo "Creating radarr data directory in /var/lib/radarr/"
           mkdir -p /var/lib/radarr/
         }
-        chown -R radarr /var/lib/radarr/
+        chown -R radarr:radarr /var/lib/radarr/
         chmod 0700 /var/lib/radarr/
       '';
 
       serviceConfig = {
         Type = "simple";
         User = "radarr";
-        Group = "nogroup";
+        Group = "radarr";
         PermissionsStartOnly = "true";
         ExecStart = "${pkgs.radarr}/bin/Radarr";
         Restart = "on-failure";
@@ -37,8 +37,11 @@ in
     };
 
     users.extraUsers.radarr = {
+      uid = config.ids.uids.radarr;
       home = "/var/lib/radarr";
+      group = "radarr";
     };
+    users.extraGroups.radarr.gid = config.ids.gids.radarr;
 
   };
 }

--- a/nixos/modules/services/misc/sonarr.nix
+++ b/nixos/modules/services/misc/sonarr.nix
@@ -22,14 +22,14 @@ in
           echo "Creating sonarr data directory in /var/lib/sonarr/"
           mkdir -p /var/lib/sonarr/
         }
-        chown -R sonarr /var/lib/sonarr/
+        chown -R sonarr:sonarr /var/lib/sonarr/
         chmod 0700 /var/lib/sonarr/
       '';
 
       serviceConfig = {
         Type = "simple";
         User = "sonarr";
-        Group = "nogroup";
+        Group = "sonarr";
         PermissionsStartOnly = "true";
         ExecStart = "${pkgs.sonarr}/bin/NzbDrone --no-browser";
         Restart = "on-failure";
@@ -37,8 +37,11 @@ in
     };
 
     users.extraUsers.sonarr = {
+      uid = config.ids.uids.sonarr;
       home = "/var/lib/sonarr";
+      group = "sonarr";
     };
+    users.extraGroups.sonarr.gid = config.ids.gids.sonarr;
 
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Missing static ids for nixos services.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

