### PR TITLE
Gitlab runner update

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -1,16 +1,16 @@
 { lib, buildGoPackage, fetchFromGitLab, fetchurl, go-bindata }:
 
 let
-  version = "9.0.0";
+  version = "9.1.0";
   # Gitlab runner embeds some docker images these are prebuilt for arm and x86_64
   docker_x86_64 = fetchurl {
     url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-x86_64.tar.xz";
-    sha256 = "1f170akb7j7imgr18m32fy6v3rk98inrjl5a4xymfpivwwqyv9p8";
+    sha256 = "1mdcw755fygnf30v0gr13mx20zjqmxg5w2kj3k2jgcsh3gyrvymr";
   };
 
   docker_arm = fetchurl {
     url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-arm.tar.xz";
-    sha256 = "15mlix8j7bqjg5y07c439d7s197c16zxffknx42z1i3qxcz2mpa4";
+    sha256 = "1m5p6mlhy3xf0chrjlfpdyp24pv32b61s8iryh6a617i91vpzjg6";
   };
 in
 buildGoPackage rec {
@@ -29,7 +29,7 @@ buildGoPackage rec {
     owner = "gitlab-org";
     repo = "gitlab-ci-multi-runner";
     rev = "v${version}";
-    sha256 = "1csha30lcwm1mk6hqbh0j8bb25apyni23szw79l8xjhmiw2ch619";
+    sha256 = "0n8hcj2b1pb95x4bd7fb9ri43vgc4h2dj2v3iiziw2imqjyphfx4";
   };
 
   buildInputs = [ go-bindata ];

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/v1.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/v1.nix
@@ -1,16 +1,16 @@
 { lib, buildGoPackage, fetchFromGitLab, fetchurl, go-bindata }:
 
 let
-  version = "1.11.1";
+  version = "1.11.2";
   # Gitlab runner embeds some docker images these are prebuilt for arm and x86_64
   docker_x86_64 = fetchurl {
     url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-x86_64.tar.xz";
-    sha256 = "1fahwvwdli6glxsljrd030x15y18jwk72lg1xmrgms409r9y308m";
+    sha256 = "08lacd2p7915y7yjnwkj2k0b0x4qj9kc53p7qgvmq8kdi31xnh4z";
   };
 
   docker_arm = fetchurl {
     url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-arm.tar.xz";
-    sha256 = "0nqda27qcb6r1p2xc2973g08fwb8cnmyc9rswy6776r8ypagn2zw";
+    sha256 = "0lzvx3jfy8493q8zkbs7kgm5a3jgsi3f2x25jwg4lx7agcwwsygw";
   };
 in
 buildGoPackage rec {
@@ -29,7 +29,7 @@ buildGoPackage rec {
     owner = "gitlab-org";
     repo = "gitlab-ci-multi-runner";
     rev = "v${version}";
-    sha256 = "0ix00p9f01fg8m6p3b1c20hqrcv7pivh6hq92pb9qyiyzmcfap47";
+    sha256 = "1sjvlb5981ykc8hr4kp1ibh9jw2wdjjp9zs2nqs9lpsav4nda5fr";
   };
 
   buildInputs = [ go-bindata ];


### PR DESCRIPTION
###### Motivation for this change

Update to latest upstram version

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

