### PR TITLE
all-the-icons: init at 2.5.0

### DIFF
--- a/pkgs/data/fonts/all-the-icons/default.nix
+++ b/pkgs/data/fonts/all-the-icons/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "all-the-icons-${version}";
+  version = "2.5.0";
+
+  src = fetchFromGitHub {
+    owner = "domtronn";
+    repo = "all-the-icons.el";
+    rev = version;
+    sha256 = "125qw96rzbkv39skxk5511jrcx9hxm0fqcmny6213wzswgdn37z3";
+  };
+
+  installPhase = ''
+    fontdir=$out/share/fonts/all-the-icons
+    mkdir -p $fontdir
+    cp -va fonts/*.ttf $fontdir
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/domtronn/all-the-icons.el";
+    description = "Fonts included in the Emacs package all-the-icons";
+    license = with licenses; [ asl20 mit ofl ];
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12379,6 +12379,8 @@ with pkgs;
 
   adapta-backgrounds = callPackage ../data/misc/adapta-backgrounds { };
 
+  all-the-icons = callPackage ../data/fonts/all-the-icons { };
+
   andagii = callPackage ../data/fonts/andagii { };
 
   android-udev-rules = callPackage ../os-specific/linux/android-udev-rules { };


### PR DESCRIPTION
###### Motivation for this change

Resource Fonts included in the package [all-the-icons.el](https://github.com/domtronn/all-the-icons.el) (a utility package to collect various Icon Fonts and propertize them within Emacs).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).