### PR TITLE
Gogs service password handling improvements

### DIFF
--- a/nixos/modules/services/misc/gogs.nix
+++ b/nixos/modules/services/misc/gogs.nix
@@ -178,16 +178,19 @@ in
       wantedBy = [ "multi-user.target" ];
       path = [ pkgs.gogs.bin ];
 
-      preStart = ''
+      preStart = let
+        runConfig = "${cfg.stateDir}/custom/conf/app.ini";
+      in ''
         # copy custom configuration and generate a random secret key if needed
         ${optionalString (cfg.useWizard == false) ''
           mkdir -p ${cfg.stateDir}/custom/conf
-          cp -f ${configFile} ${cfg.stateDir}/custom/conf/app.ini
+          cp -f ${configFile} ${runConfig}
           KEY=$(head -c 16 /dev/urandom | base64)
           DBPASS=$(head -n1 ${cfg.database.passwordFile})
           sed -e "s,#secretkey#,$KEY,g" \
               -e "s,#dbpass#,$DBPASS,g" \
-              -i ${cfg.stateDir}/custom/conf/app.ini
+              -i ${runConfig}
+          chmod 440 ${runConfig}
         ''}
 
         mkdir -p ${cfg.repositoryRoot}

--- a/nixos/modules/services/misc/gogs.nix
+++ b/nixos/modules/services/misc/gogs.nix
@@ -26,6 +26,10 @@ let
     HTTP_PORT = ${toString cfg.httpPort}
     ROOT_URL = ${cfg.rootUrl}
 
+    [session]
+    COOKIE_NAME = session
+    COOKIE_SECURE = ${boolToString cfg.cookieSecure}
+
     [security]
     SECRET_KEY = #secretkey#
     INSTALL_LOCK = true
@@ -160,6 +164,16 @@ in
         type = types.int;
         default = 3000;
         description = "HTTP listen port.";
+      };
+
+      cookieSecure = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Marks session cookies as "secure," which means browsers may
+          ensure that the cookie is only sent under an HTTPS connection.
+          It's good to enable this if Gogs is being served over HTTPS.
+        '';
       };
 
       extraConfig = mkOption {

--- a/nixos/modules/services/misc/gogs.nix
+++ b/nixos/modules/services/misc/gogs.nix
@@ -170,9 +170,8 @@ in
         type = types.bool;
         default = false;
         description = ''
-          Marks session cookies as "secure," which means browsers may
-          ensure that the cookie is only sent under an HTTPS connection.
-          It's good to enable this if Gogs is being served over HTTPS.
+          Marks session cookies as "secure" as a hint for browsers to only send
+          them via HTTPS. This option is recommend, if Gogs is being served over HTTPS.
         '';
       };
 

--- a/nixos/modules/services/misc/gogs.nix
+++ b/nixos/modules/services/misc/gogs.nix
@@ -169,7 +169,7 @@ in
         ${optionalString (cfg.useWizard == false) ''
           mkdir -p ${cfg.stateDir}/custom/conf
           cp -f ${configFile} ${cfg.stateDir}/custom/conf/app.ini
-          KEY=$(head -c 16 /dev/urandom | tr -dc A-Za-z0-9)
+          KEY=$(head -c 16 /dev/urandom | base64)
           sed -i "s,#secretkey#,$KEY,g" ${cfg.stateDir}/custom/conf/app.ini
         ''}
 


### PR DESCRIPTION
###### Motivation for this change

Part of #24288.

Tested on nixos-unstable branch, https://git.rodney.id.au/rodney/nixpkgs 

/cc @schneefux @basvandijk 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [/] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
