### PR TITLE
cubicle: init at 1.0.2

### DIFF
--- a/pkgs/applications/science/logic/cubicle/default.nix
+++ b/pkgs/applications/science/logic/cubicle/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, ocaml, ocamlPackages }:
+
+stdenv.mkDerivation rec {
+  name = "cubicle-${version}";
+  version = "1.0.2";
+  src = fetchurl {
+    url = "http://cubicle.lri.fr/cubicle-${version}.tar.gz";
+    sha256 = "1fg39vlr2d5067512df32hkw6g8vglxj1m47md5mw3pn3ij6dpsx";
+  };
+
+  buildInputs = [ ocaml ocamlPackages.functory ];
+
+  meta = with stdenv.lib; {
+    description = "An open source model checker for verifying safety properties of array-based systems";
+    homepage = "http://cubicle.lri.fr/";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lucas8 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17492,6 +17492,8 @@ with pkgs;
 
   cryptoverif = callPackage ../applications/science/logic/cryptoverif { };
 
+  cubicle = callPackage ../applications/science/logic/cubicle { };
+
   cvc3 = callPackage ../applications/science/logic/cvc3 {
     gmp = lib.overrideDerivation gmp (a: { dontDisableStatic = true; });
   };


### PR DESCRIPTION
###### Motivation for this change
Add [cubicle](http://cubicle.lri.fr) software 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

