### PR TITLE
HaLVM: Shebang fix for Hydra

### DIFF
--- a/pkgs/development/compilers/halvm/2.4.0.nix
+++ b/pkgs/development/compilers/halvm/2.4.0.nix
@@ -32,7 +32,10 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
   hardeningDisable = ["all"];
-  postInstall = "$out/bin/halvm-ghc-pkg recache";
+  postInstall = ''
+    patchShebangs $out/bin
+    $out/bin/halvm-ghc-pkg recache
+  '';
   passthru = {
     inherit bootPkgs;
     cross.config = "halvm";
@@ -45,6 +48,5 @@ stdenv.mkDerivation rec {
     description = "The Haskell Lightweight Virtual Machine (HaLVM): GHC running on Xen";
     maintainers = with stdenv.lib.maintainers; [ dmjio ];
     inherit (bootPkgs.ghc.meta) license platforms;
-    broken = true;  # http://hydra.nixos.org/build/51814615
   };
 }


### PR DESCRIPTION
On my local nixos machine, `useSandbox = true;` wasn't enabled. This exposed the fact that various scripts weren't shebang-patched. @cleverca22 has provided the fix.

cc @peti @domenkozar @Ericson2314

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

