### PR TITLE
emacs-all-the-icons-fonts: init at 2.5.0

### DIFF
--- a/pkgs/data/fonts/emacs-all-the-icons-fonts/default.nix
+++ b/pkgs/data/fonts/emacs-all-the-icons-fonts/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "emacs-all-the-icons-fonts-${version}";
+  version = "2.50";
+
+  src = fetchFromGitHub {
+    owner = "domtronn";
+    repo = "all-the-icons.el";
+    rev = "2.5.0";
+    sha256 = "125qw96rzbkv39skxk5511jrcx9hxm0fqcmny6213wzswgdn37z3";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/all-the-icons
+    for font in $src/fonts/*.ttf; do cp $font $out/share/fonts/all-the-icons; done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Icon fonts for emacs all-the-icons";
+    longDescription = ''
+      The emacs package all-the-icons provides icons to improve
+      presentation of information in emacs. This package provides
+      the fonts needed to make the package work properly.
+    '';
+    homepage = https://github.com/domtronn/all-the-icons.el;
+
+    /*
+    The fonts come under a mixture of licenses - the MIT license,
+    SIL OFL license, and Apache license v2.0. See the GitHub page
+    for further information.
+    */
+    license = licenses.free;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ rlupton20 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12481,6 +12481,8 @@ with pkgs;
 
   faba-mono-icons = callPackage ../data/icons/faba-mono-icons { };
 
+  emacs-all-the-icons-fonts = callPackage ../data/fonts/emacs-all-the-icons-fonts { };
+
   emojione = callPackage ../data/fonts/emojione {
     inherit (nodePackages) svgo;
     inherit (pythonPackages) scfbuild;


### PR DESCRIPTION
###### Motivation for this change
Provides fonts (icons) for the emacs package all-the-icons. These are needed to get the package to work properly.

The emacs package now provides a way to install the fonts, but this is a stateful best guess based on the OS. A nix font package is, in my view, the correct way to handle this is NixOS, as with e.g. powerline.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

