### PR TITLE
wallabag: 2.1.6 -> 2.2.2

### DIFF
--- a/pkgs/servers/web-apps/wallabag/default.nix
+++ b/pkgs/servers/web-apps/wallabag/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "wallabag-${version}";
-  version = "2.1.6";
+  version = "2.2.0";
 
   # remember to rm -r var/cache/* after a rebuild or unexpected errors will occur
 
   src = fetchurl {
-    url = "https://framabag.org/wallabag-release-${version}.tar.gz";
-    sha256 = "0znywkrjlmxhacfkdyba2cjhgmrh509mayrfsrnc0rx3haxam7fx";
+    url = "https://static.wallabag.org/releases/wallabag-release-${version}.tar.gz";
+    sha256 = "0aix2iwwb9imqqhgbxpk8n9pr6875ljkwz7jpjnjdzlk7ndzvl7w";
   };
 
   outputs = [ "out" "doc" ];

--- a/pkgs/servers/web-apps/wallabag/default.nix
+++ b/pkgs/servers/web-apps/wallabag/default.nix
@@ -2,18 +2,23 @@
 
 stdenv.mkDerivation rec {
   name = "wallabag-${version}";
-  version = "2.2.0";
+  version = "2.2.1";
 
   # remember to rm -r var/cache/* after a rebuild or unexpected errors will occur
 
   src = fetchurl {
     url = "https://static.wallabag.org/releases/wallabag-release-${version}.tar.gz";
-    sha256 = "0aix2iwwb9imqqhgbxpk8n9pr6875ljkwz7jpjnjdzlk7ndzvl7w";
+    sha256 = "0kp1fkfipsbz14kpp107nwknb3s54jwxprcwmsh19gl97jmwnq0g";
   };
 
   outputs = [ "out" "doc" ];
 
   patchPhase = ''
+    # workaround for https://github.com/wallabag/wallabag/issues/2794
+    ln -sf ../../vendor/friendsofsymfony/jsrouting-bundle/Resources/public ./web/bundles/fosjsrouting
+    ln -sf ../../vendor/nelmio/api-doc-bundle/Nelmio/ApiDocBundle/Resources/public ./web/bundles/nelmioapidoc
+    ln -sf ../../vendor/white-october/pagerfanta-bundle/Resources/public ./web/bundles/whiteoctoberpagerfanta
+
     rm Makefile # use the "shared hosting" package with bundled dependencies
     substituteInPlace app/AppKernel.php \
       --replace "__DIR__" "getenv('WALLABAG_DATA')"

--- a/pkgs/servers/web-apps/wallabag/default.nix
+++ b/pkgs/servers/web-apps/wallabag/default.nix
@@ -2,23 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "wallabag-${version}";
-  version = "2.2.1";
+  version = "2.2.2";
 
   # remember to rm -r var/cache/* after a rebuild or unexpected errors will occur
 
   src = fetchurl {
     url = "https://static.wallabag.org/releases/wallabag-release-${version}.tar.gz";
-    sha256 = "0kp1fkfipsbz14kpp107nwknb3s54jwxprcwmsh19gl97jmwnq0g";
+    sha256 = "0l8zba2risi8lsmff0fbgplfqdiqp7jz0f93z4lbqv8iavaqpna0";
   };
 
   outputs = [ "out" "doc" ];
 
   patchPhase = ''
-    # workaround for https://github.com/wallabag/wallabag/issues/2794
-    ln -sf ../../vendor/friendsofsymfony/jsrouting-bundle/Resources/public ./web/bundles/fosjsrouting
-    ln -sf ../../vendor/nelmio/api-doc-bundle/Nelmio/ApiDocBundle/Resources/public ./web/bundles/nelmioapidoc
-    ln -sf ../../vendor/white-october/pagerfanta-bundle/Resources/public ./web/bundles/whiteoctoberpagerfanta
-
     rm Makefile # use the "shared hosting" package with bundled dependencies
     substituteInPlace app/AppKernel.php \
       --replace "__DIR__" "getenv('WALLABAG_DATA')"


### PR DESCRIPTION
###### Motivation for this change
updated wallabag to latest release

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).