### PR TITLE
tvheadend: 4.0.8 -> 4.2.1

### DIFF
--- a/pkgs/servers/tvheadend/default.nix
+++ b/pkgs/servers/tvheadend/default.nix
@@ -1,9 +1,9 @@
-{avahi, dbus, fetchurl, git, gnutar, gzip, libav, libiconv, openssl, pkgconfig, python
+{avahi, cmake, dbus, fetchurl, gettext, git, gnutar, gzip, bzip2, ffmpeg, libiconv, openssl, pkgconfig, python
 , stdenv, which, zlib}:
 
 with stdenv.lib;
 
-let version = "4.0.8";
+let version = "4.2.1";
     pkgName = "tvheadend";
 
 in
@@ -13,16 +13,26 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/tvheadend/tvheadend/archive/v${version}.tar.gz";
-    sha256 = "0k4g7pvfyk4bxpsjdwv7bmbygbp7gfg9wrr2aqb099ncbz18bx04";
+    sha256 = "1wrj3w595c1hfl2vmfdmp5qncy5samqi7iisyq76jf3nlzgw6dvn";
   };
 
   enableParallelBuilding = true;
 
   # disable dvbscan, as having it enabled causes a network download which
   # cannot happen during build.
-  configureFlags = [ "--disable-dvbscan" ];
+  configureFlags = [
+    "--disable-dvbscan"
+    "--disable-bintray_cache"
+    "--disable-ffmpeg_static"
+    "--disable-hdhomerun_client"
+    "--disable-hdhomerun_static"
+  ];
 
-  buildInputs = [ avahi dbus git gnutar gzip libav libiconv openssl pkgconfig python
+  buildPhase = "make";
+
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [ avahi dbus cmake gettext git gnutar gzip bzip2 ffmpeg libiconv openssl pkgconfig python
     which zlib ];
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

