### PR TITLE
emacs: 25.1 -> 25.2

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -26,35 +26,15 @@ let
 in
 stdenv.mkDerivation rec {
   name = "emacs-${version}${versionModifier}";
-  version = "25.1";
+  version = "25.2";
   versionModifier = "";
 
   src = fetchurl {
-    url = "mirror://gnu//emacs/${name}.tar.xz";
-    sha256 = "0cwgyiyymnx4xdg99dm2drfxcyhy2jmyf0rkr9fwj9mwwf77kwhr";
+    url = "mirror://gnu/emacs/${name}.tar.xz";
+    sha256 = "1ykkq0xl28ljdg61bm6gzy04ww86ajms98gix72qg6cpr6a53dar";
   };
 
-  patches = (lib.optional stdenv.isDarwin ./at-fdcwd.patch) ++ [
-    ## Fixes a segfault in emacs 25.1
-    ## http://lists.gnu.org/archive/html/emacs-devel/2016-10/msg00917.html
-    ## https://debbugs.gnu.org/cgi/bugreport.cgi?bug=24358
-    (fetchurl {
-      url = http://git.savannah.gnu.org/cgit/emacs.git/patch/?id=9afea93ed536fb9110ac62b413604cf4c4302199;
-      sha256 = "0pshhq8wlh98m9hm8xd3g7gy3ms0l44dq6vgzkg67ydlccziqz40"; })
-    (fetchurl {
-      url = http://git.savannah.gnu.org/cgit/emacs.git/patch/?id=71ca4f6a43bad06192cbc4bb8c7a2d69c179b7b0;
-      sha256 = "0h76wrrqyrky441immprskx5x7200zl7ajf7hyg4da22q7sr09qa"; })
-    (fetchurl {
-      url = http://git.savannah.gnu.org/cgit/emacs.git/patch/?id=1047496722a58ef5b736dae64d32adeb58c5055c;
-      sha256 = "0hk9pi3f2zj266qj8armzpl0z8rfjg0m9ss4k09mgg1hyz80wdvv"; })
-    (fetchurl {
-      url = http://git.savannah.gnu.org/cgit/emacs.git/patch/?id=96ac0c3ebce825e60595794f99e703ec8302e240;
-      sha256 = "1q2hqkjvj9z46b5ik56lv9wiibz09mvg2q3pn8fnpa04ki3zbh4x"; })
-    (fetchurl {
-      url = http://git.savannah.gnu.org/cgit/emacs.git/patch/?id=43986d16fb6ad78a627250e14570ea70bdb1f23a;
-      sha256 = "1wlyy04qahvls7bdrcxaazh9k27gksk7if1q58h83f7h6g9xxkzj";
-    })
-  ];
+  patches = (lib.optional stdenv.isDarwin ./at-fdcwd.patch);
 
   nativeBuildInputs = [ pkgconfig ]
     ++ lib.optionals srcRepo [ autoconf automake texinfo ]

--- a/pkgs/applications/editors/emacs/macport.nix
+++ b/pkgs/applications/editors/emacs/macport.nix
@@ -28,7 +28,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ ncurses libxml2 gnutls pkgconfig texinfo gettext autoconf automake];
+  nativeBuildInputs = [ pkgconfig autoconf automake ];
+
+  buildInputs = [ ncurses libxml2 gnutls texinfo gettext ];
 
   propagatedBuildInputs = [
     AppKit Carbon Cocoa IOKit OSAKit Quartz QuartzCore WebKit
@@ -58,6 +60,7 @@ stdenv.mkDerivation rec {
     "--with-xml2=yes"
     "--with-gnutls=yes"
     "--with-mac"
+    "--with-modules"
     "--enable-mac-app=$$out/Applications"
   ];
 

--- a/pkgs/applications/editors/emacs/macport.nix
+++ b/pkgs/applications/editors/emacs/macport.nix
@@ -4,21 +4,21 @@
 }:
 
 stdenv.mkDerivation rec {
-  emacsVersion = "25.1";
+  emacsVersion = "25.2";
   emacsName = "emacs-${emacsVersion}";
-  macportVersion = "6.1";
+  macportVersion = "6.3";
   name = "emacs-mac-${emacsVersion}-${macportVersion}";
 
   builder = ./builder.sh;
 
   src = fetchurl {
-    url = "ftp://ftp.gnu.org/gnu/emacs/${emacsName}.tar.xz";
-    sha256 = "19f2798ee3bc26c95dca3303e7ab141e7ad65d6ea2b6945eeba4dbea7df48f33";
+    url = "mirror:///gnu/emacs/${emacsName}.tar.xz";
+    sha256 = "1ykkq0xl28ljdg61bm6gzy04ww86ajms98gix72qg6cpr6a53dar";
   };
 
   macportSrc = fetchurl {
     url = "ftp://ftp.math.s.chiba-u.ac.jp/emacs/${emacsName}-mac-${macportVersion}.tar.gz";
-    sha256 = "1zwxh7zsvwcg221mpjh0dhpdas3j9mc5q92pprf8yljl7clqvg62";
+    sha256 = "1dz11frk3ya3842lb89ixzpns9bz5f9njxdkyvjy75gfymqfhhzv";
   };
 
   hiresSrc = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

package new Emacs release.
Also update macport to corresponding patchset, and bring some more homogeneity between the two builds.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

