### PR TITLE
simp_le: 0.1.1 -> 0.2.0

### DIFF
--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -2,18 +2,13 @@
 
 pythonPackages.buildPythonApplication rec {
   pname = "simp_le-client";
-  version = "0.1.1";
+  version = "0.2.0";
   name = "${pname}-${version}";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "18y8mg0s0i2bs57pi6mbkwgjlr5mmivchiyvrpcbdmkg9qlbfwaa";
+    sha256 = "1zg18jfry9mvkri3yd2f5mwfsl27ac9zmnll3bm93jb91jhd6ssh";
   };
-
-  prePatch = ''
-    substituteInPlace setup.py \
-      --replace 'acme>=0.9,<0.10' acme
-  '';
 
   checkPhase = ''
     $out/bin/simp_le --test


### PR DESCRIPTION
###### Motivation for this change
The release is here:
https://github.com/zenhack/simp_le/releases/tag/0.2.0

This is needed, since the existing package is broken. See this
https://github.com/kuba/simp_le/issues/120 for reference.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

