### PR TITLE
darktable: Removed unneeded dependencies, update Lua to 5.3

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -1,14 +1,9 @@
-{ stdenv, fetchurl, libsoup, graphicsmagick, SDL, json_glib
-, GConf, atk, cairo, cmake, curl, dbus_glib, exiv2, glib
-, libgnome_keyring, gtk3, ilmbase, intltool, lcms, lcms2
-, lensfun, libXau, libXdmcp, libexif, libglade, libgphoto2, libjpeg
-, libpng, libpthreadstubs, librsvg, libtiff, libxcb
-, openexr, osm-gps-map, pixman, pkgconfig, sqlite, bash, libxslt, openjpeg
-, mesa, lua, pugixml, colord, colord-gtk, libxshmfence, libxkbcommon
-, epoxy, at_spi2_core, libwebp, libsecret, wrapGAppsHook, gnome3
+{ stdenv, fetchurl, libsoup, graphicsmagick, json_glib, wrapGAppsHook
+, cairo, cmake, ninja, curl, perl, llvm, desktop_file_utils, exiv2, glib
+, ilmbase, gtk3, intltool, lcms2, lensfun, libX11, libexif, libgphoto2, libjpeg
+, libpng, librsvg, libtiff, openexr, osm-gps-map, pkgconfig, sqlite, libxslt
+, openjpeg, lua, pugixml, colord, colord-gtk, libwebp, libsecret, gnome3
 }:
-
-assert stdenv ? glibc;
 
 stdenv.mkDerivation rec {
   version = "2.4.1";
@@ -19,16 +14,15 @@ stdenv.mkDerivation rec {
     sha256 = "014pq80i5k1kdvvrl7xrgaaq3i4fzv09h7a3pwzlp2ahkczwcm32";
   };
 
-  buildInputs =
-    [ GConf atk cairo cmake curl dbus_glib exiv2 glib libgnome_keyring gtk3
-      ilmbase intltool lcms lcms2 lensfun libXau libXdmcp libexif
-      libglade libgphoto2 libjpeg libpng libpthreadstubs
-      librsvg libtiff libxcb openexr pixman pkgconfig sqlite libxslt
-      libsoup graphicsmagick SDL json_glib openjpeg mesa lua pugixml
-      colord colord-gtk libxshmfence libxkbcommon epoxy at_spi2_core
-      libwebp libsecret wrapGAppsHook gnome3.adwaita-icon-theme
-      osm-gps-map
-    ];
+  nativeBuildInputs = [ cmake ninja llvm pkgconfig intltool perl desktop_file_utils wrapGAppsHook ];
+
+  buildInputs = [
+    cairo curl exiv2 glib gtk3 ilmbase lcms2 lensfun libX11 libexif
+    libgphoto2 libjpeg libpng librsvg libtiff openexr sqlite libxslt
+    libsoup graphicsmagick json_glib openjpeg lua pugixml
+    colord colord-gtk libwebp libsecret gnome3.adwaita-icon-theme
+    osm-gps-map
+  ];
 
   cmakeFlags = [
     "-DBUILD_USERMANUAL=False"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14651,7 +14651,6 @@ with pkgs;
   });
 
   darktable = callPackage ../applications/graphics/darktable {
-    inherit (gnome2) GConf libglade;
     lua = lua5_3;
     pugixml = pugixml.override { shared = true; };
   };


### PR DESCRIPTION
###### Motivation for this change

Based on what LebedevRI told me on IRC and in https://github.com/darktable-org/darktable/pull/1474, darktable's buildInputs in nixpkgs contain many unnecessary things. Additionally, the version of Lua supplied is too old for the build to use it, so it was updated to 5.3.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

