### PR TITLE
hunspell: 1.3.3 -> 1.6.1

### DIFF
--- a/pkgs/development/libraries/hunspell/default.nix
+++ b/pkgs/development/libraries/hunspell/default.nix
@@ -1,16 +1,21 @@
-{ stdenv, fetchurl, ncurses, readline }:
+{ stdenv, fetchurl, ncurses, readline, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "hunspell-1.3.3";
+  version = "1.6.1";
+  name = "hunspell-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/hunspell/${name}.tar.gz";
-    sha256 = "0v14ff9s37vkh45diaddndcrj0hmn67arh8xh8k79q9c1vgc1cm7";
+    url = "https://github.com/hunspell/hunspell/archive/v${version}.tar.gz";
+    sha256 = "0j9c20sj7bgd6f77193g1ihy8w905byk2gdhdc0r9dsh7irr7x9h";
   };
 
   outputs = [ "bin" "dev" "out" "man" ];
 
   buildInputs = [ ncurses readline ];
+  nativeBuildInputs = [ autoreconfHook ];
+
+  autoreconfFlags = "-vfi";
+
   configureFlags = [ "--with-ui" "--with-readline" ];
 
   hardeningDisable = [ "format" ];

--- a/pkgs/development/libraries/qtwebkit-plugins/default.nix
+++ b/pkgs/development/libraries/qtwebkit-plugins/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   buildInputs = [ qtwebkit hunspell ];
 
   postPatch = ''
-    sed -i "s,-lhunspell,-lhunspell-1.3," src/spellcheck/spellcheck.pri
+    sed -i "s,-lhunspell,-lhunspell-1.6," src/spellcheck/spellcheck.pri
     sed -i "s,\$\$\[QT_INSTALL_PLUGINS\],$out/lib/qt5/plugins," src/src.pro
   '';
 

--- a/pkgs/games/mudlet/libs.patch
+++ b/pkgs/games/mudlet/libs.patch
@@ -7,7 +7,7 @@
 -        -llua5.1 \
 -        -lhunspell \
 +        -llua \
-+        -lhunspell-1.3 \
++        -lhunspell-1.6 \
          -L/usr/local/lib/ \
          -lyajl \
          -lGLU \


### PR DESCRIPTION
###### Motivation for this change

Firefox 53 requires newer Hunspell.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I could not test `qtwebkit-plugins` because `qutebrowser` is broken with both Hunspell 1.3 and 1.6: `This application failed to start because it could not find or load the Qt platform plugin "xcb" in "".`
Nor i cloud not test `mudlet` because I could not build it with Hunspell 1.3.

---

