### PR TITLE
firefox: 52.0.2 -> 53.0 [Critical security fixes]

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -4,7 +4,7 @@
 , yasm, mesa, sqlite, unzip, makeWrapper
 , hunspell, libevent, libstartup_notification, libvpx
 , cairo, gstreamer, gst-plugins-base, icu, libpng, jemalloc, libpulseaudio
-, autoconf213, which
+, autoconf213, which, cargo, rustc
 , writeScript, xidel, common-updater-scripts, coreutils, gnused, gnugrep, curl
 , enableGTK3 ? false, gtk3, wrapGAppsHook
 , debugBuild ? false
@@ -48,7 +48,9 @@ common = { pname, version, sha512, updateScript }: stdenv.mkDerivation rec {
     ++ lib.optional enableGTK3 gtk3
     ++ lib.optionals (!passthru.ffmpegSupport) [ gstreamer gst-plugins-base ];
 
-  nativeBuildInputs = [ autoconf213 which gnused pkgconfig perl python ] ++ lib.optional enableGTK3 wrapGAppsHook;
+  nativeBuildInputs =
+    [ autoconf213 which gnused pkgconfig perl python cargo rustc ]
+    ++ lib.optional enableGTK3 wrapGAppsHook;
 
   configureFlags =
     [ "--enable-application=browser"
@@ -151,8 +153,8 @@ in {
 
   firefox-unwrapped = common {
     pname = "firefox";
-    version = "52.0.2";
-    sha512 = "15668625d212acf874b560d0adf738faf3e0df532c549ab94e1d91944542e13bf16265f08fca1eded42820f9b7ad3f0ff70a8b5bc9adde0a79d11e022bb1158e";
+    version = "53.0";
+    sha512 = "36ec810bab58e3d99478455a38427a5efbc74d6dd7d4bb93b700fd7429b9b89250efd0abe4609091483991802090c6373c8434dfc9ba64c79a778e51fd2a2886";
     updateScript = import ./update.nix {
       attrPath = "firefox-unwrapped";
       inherit writeScript lib common-updater-scripts xidel coreutils gnused gnugrep curl;


### PR DESCRIPTION
###### Motivation for this change

See #25043.

Depends on #25136.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Confirmed that it can play a video on YouTube.

---

