### PR TITLE
display-managers: Fix the xsession parameters

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -32,8 +32,32 @@ let
     ''
       #! ${pkgs.bash}/bin/bash
 
-      # Handle being called by SDDM.
-      if test "''${1:0:1}" = / ; then eval exec "$1" "$2" ; fi
+      # Expected parameters:
+      #   $1 = <desktop-manager>+<window-manager>
+
+      # Actual parameters (FIXME):
+      # SDDM is calling this script like the following:
+      #   $1 = /nix/store/xxx-xsession (= $0)
+      #   $2 = <desktop-manager>+<window-manager>
+      # SLiM is using the following parameter:
+      #   $1 = /nix/store/xxx-xsession <desktop-manager>+<window-manager>
+      # LightDM keeps the double quotes:
+      #   $1 = /nix/store/xxx-xsession "<desktop-manager>+<window-manager>"
+      # The fake/auto display manager doesn't use any parameters and GDM is
+      # broken.
+      # If you want to "debug" this script don't print the parameters to stdout
+      # or stderr because this script will be executed multiple times and the
+      # output won't be visible in the log when the script is executed for the
+      # first time (e.g. append them to a file instead)!
+
+      # All of the above cases are handled by the following hack (FIXME).
+      # Since this line is *very important* for *all display managers* it is
+      # very important to test changes to the following line with all display
+      # managers:
+      if [ "''${1:0:1}" = "/" ]; then eval exec "$1" "$2" ; fi
+
+      # Now it should be safe to assume that the script was called with the
+      # expected parameters.
 
       ${optionalString cfg.displayManager.logToJournal ''
         if [ -z "$_DID_SYSTEMD_CAT" ]; then
@@ -107,11 +131,12 @@ let
           fi
       fi
 
-      # The session type is "<desktop-manager> + <window-manager>", so
-      # extract those.
-      windowManager="''${sessionType##* + }"
+      # The session type is "<desktop-manager>+<window-manager>", so
+      # extract those (see:
+      # http://wiki.bash-hackers.org/syntax/pe#substring_removal).
+      windowManager="''${sessionType##*+}"
       : ''${windowManager:=${cfg.windowManager.default}}
-      desktopManager="''${sessionType% + *}"
+      desktopManager="''${sessionType%%+*}"
       : ''${desktopManager:=${cfg.desktopManager.default}}
 
       # Start the window manager.
@@ -142,6 +167,9 @@ let
       exit 0
     '';
 
+  # Desktop Entry Specification:
+  # - https://standards.freedesktop.org/desktop-entry-spec/latest/
+  # - https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s06.html
   mkDesktops = names: pkgs.runCommand "desktops"
     { # trivial derivation
       preferLocalBuild = true;
@@ -155,7 +183,7 @@ let
         Version=1.0
         Type=XSession
         TryExec=${cfg.displayManager.session.script}
-        Exec=${cfg.displayManager.session.script} '${n}'
+        Exec=${cfg.displayManager.session.script} "${n}"
         X-GDM-BypassXsession=true
         Name=${n}
         Comment=
@@ -238,7 +266,7 @@ in
           wm = filter (s: s.manage == "window") list;
           dm = filter (s: s.manage == "desktop") list;
           names = flip concatMap dm
-            (d: map (w: d.name + optionalString (w.name != "none") (" + " + w.name))
+            (d: map (w: d.name + optionalString (w.name != "none") ("+" + w.name))
               (filter (w: d.name != "none" || w.name != "none") wm));
           desktops = mkDesktops names;
           script = xsession wm dm;

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -61,7 +61,7 @@ let
     let
       dm = xcfg.desktopManager.default;
       wm = xcfg.windowManager.default;
-    in dm + optionalString (wm != "none") (" + " + wm);
+    in dm + optionalString (wm != "none") ("+" + wm);
 in
 {
   # Note: the order in which lightdm greeter modules are imported

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -69,7 +69,7 @@ let
     let
       dm = xcfg.desktopManager.default;
       wm = xcfg.windowManager.default;
-    in dm + optionalString (wm != "none") (" + " + wm);
+    in dm + optionalString (wm != "none") ("+" + wm);
 
 in
 {


### PR DESCRIPTION
From the specification: "Quoting must be done by enclosing the argument
between double quotes" [0].

[0]: https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html

###### Tested with:

- [x] SDDM
- [x] LightDM
- [x] SLiM
- [ ] GDM (**fails to build on master and seems to be broken on 17.03**)
- [ ] auto (**ignores the desktop entry files** (i.e. doesn't provide any parameters to the script))

On `nixos-unstable` (with a VirtualBox VM).

Note: **I've run into some very strange bugs.**
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS

---

