### PR TITLE
kile: build with okular for embedded viewer

### DIFF
--- a/pkgs/applications/editors/kile/default.nix
+++ b/pkgs/applications/editors/kile/default.nix
@@ -17,6 +17,7 @@
 , kparts
 , ktexteditor
 , kwindowsystem
+, okular
 , poppler
 }:
 
@@ -48,6 +49,7 @@ let
         kparts
         ktexteditor
         kwindowsystem
+        okular.unwrapped
         poppler
         qtscript
       ];
@@ -64,5 +66,5 @@ kdeWrapper
 {
   inherit unwrapped;
   targets = [ "bin/kile" ];
-  paths = [ konsole.unwrapped ];
+  paths = [ konsole.unwrapped okular.unwrapped ];
 }


### PR DESCRIPTION
###### Motivation for this change

Build with okular libraries so the embedded viewer works.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

