### PR TITLE
Add more configuration options for zsh-syntax-highlighting

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -104,6 +104,7 @@
   ./programs/xonsh.nix
   ./programs/zsh/oh-my-zsh.nix
   ./programs/zsh/zsh.nix
+  ./programs/zsh/zsh-syntax-highlighting.nix
   ./rename.nix
   ./security/acme.nix
   ./security/apparmor.nix

--- a/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
+++ b/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
@@ -15,14 +15,29 @@ in
             Enable zsh-syntax-highlighting.
           '';
         };
+
+        highlighters = mkOption {
+          default = [ "main" ];
+          type = types.listOf(types.str);
+          description = ''
+            Specifies the highlighters to be used by zsh-syntax-highlighting.
+
+            The following defined options can be found here:
+            https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters.md
+          '';
+        };
       };
     };
 
     config = mkIf cfg.enable {
       environment.systemPackages = with pkgs; [ zsh-syntax-highlighting ];
 
-      program.zsh.interactiveShellInit = with pkgs; ''
+      programs.zsh.interactiveShellInit = with pkgs; with builtins; ''
         source ${zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+
+        ${optionalString (length(cfg.highlighters) > 0)
+          "ZSH_HIGHLIGHT_HIGHLIGHTERS=(${concatStringsSep " " cfg.highlighters})"
+        }
       '';
     };
   }

--- a/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
+++ b/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.zsh.syntax-highlighting;
+in
+  {
+    options = {
+      programs.zsh.syntax-highlighting = {
+        enable = mkOption {
+          default = false;
+          type = types.bool;
+          description = ''
+            Enable zsh-syntax-highlighting.
+          '';
+        };
+      };
+    };
+
+    config = mkIf cfg.enable {
+      environment.systemPackages = with pkgs; [ zsh-syntax-highlighting ];
+
+      program.zsh.interactiveShellInit = with pkgs; ''
+        source ${zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+      '';
+    };
+  }

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -84,21 +84,12 @@ in
         type = types.bool;
       };
 
-      enableSyntaxHighlighting = mkOption {
-        default = false;
-        description = ''
-          Enable zsh-syntax-highlighting
-        '';
-        type = types.bool;
-      };
-      
       enableAutosuggestions = mkOption {
         default = false;
         description = ''
           Enable zsh-autosuggestions
         '';
       };
-
 
     };
 
@@ -130,10 +121,6 @@ in
         done
 
         ${if cfg.enableCompletion then "autoload -U compinit && compinit" else ""}
-
-        ${optionalString (cfg.enableSyntaxHighlighting)
-          "source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-        }
 
         ${optionalString (cfg.enableAutosuggestions)
           "source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
@@ -206,8 +193,7 @@ in
     environment.etc."zinputrc".source = ./zinputrc;
 
     environment.systemPackages = [ pkgs.zsh ]
-      ++ optional cfg.enableCompletion pkgs.nix-zsh-completions
-      ++ optional cfg.enableSyntaxHighlighting pkgs.zsh-syntax-highlighting;
+      ++ optional cfg.enableCompletion pkgs.nix-zsh-completions;
 
     environment.pathsToLink = optional cfg.enableCompletion "/share/zsh";
 

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -204,5 +204,8 @@ with lib;
       "Set the option `services.xserver.displayManager.sddm.package' instead.")
     (mkRemovedOptionModule [ "fonts" "fontconfig" "forceAutohint" ] "")
     (mkRemovedOptionModule [ "fonts" "fontconfig" "renderMonoTTFAsBitmap" ] "")
+
+    # ZSH
+    (mkRenamedOptionModule [ "programs" "zsh" "enableSyntaxHighlighting" ] [ "programs" "zsh" "syntax-highlighting" "enable" ])
   ];
 }


### PR DESCRIPTION
:warning: __BC Break:__ I moved the entire zsh-syntax-highlighting stuff out into its own module which breaks compatibility with older distro versions.

###### Motivation for this change

(similar to #25140)

I'd like to have a fully declarative configuration for my ZSH which consists of nix expressions.
Right now it's already possible to enable zsh-syntax-highlighting globally using `programs.zsh`, but it's not possible to set the `highlighters` option using nix expressions which is used to configuration which highlighters should be used by `zsh-syntax-highlighting`.

I tested it in a test VM using the following configuration:

``` nix
{
  # ...
  programs.zsh = {
    enable = true;

    syntax-highlighting = {
      enable = true;
      highlighters = ["main" "brackets"];
    };
  };
}
```

I created the VM using the following command:

```
NIXOS_CONFIG=`pwd`/vmtest.nix nixos-rebuild -I nixpkgs=$HOME/Projects/nixpkgs/ build-vm
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

