### PR TITLE
add skypeforlinux beta (new)

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -388,6 +388,7 @@
   paholg = "Paho Lurie-Gregg <paho@paholg.com>";
   pakhfn = "Fedor Pakhomov <pakhfn@gmail.com>";
   palo = "Ingolf Wanger <palipalo9@googlemail.com>";
+  panaeon = "Vitalii Voloshyn <vitalii.voloshyn@gmail.com";
   paperdigits = "Mica Semrick <mica@silentumbrella.com>";
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
   patternspandemic = "Brad Christensen <patternspandemic@live.com>";

--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -1,0 +1,101 @@
+{ stdenv, fetchurl, dpkg, makeWrapper
+, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib, gnome2
+, libnotify, nspr, nss, systemd, xorg }:
+
+let
+
+  version = "5.1.0.1";
+
+  rpath = stdenv.lib.makeLibraryPath [
+    alsaLib
+    atk
+    cairo
+    cups
+    curl
+    dbus
+    expat
+    fontconfig
+    freetype
+    glib
+
+    gnome2.GConf
+    gnome2.gdk_pixbuf
+    gnome2.gtk
+    gnome2.pango
+
+    gnome2.gnome_keyring
+    
+    libnotify
+    nspr
+    nss
+    stdenv.cc.cc
+    systemd
+
+    xorg.libxkbfile
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libXScrnSaver
+    xorg.libxcb
+  ] + ":${stdenv.cc.cc.lib}/lib64";
+
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://repo.skype.com/latest/skypeforlinux-64.deb";
+        sha256 = "18v861x0n2q2jaglap8193sia476dwkwr0ccfzl29mi5ijma24ml";
+      }
+    else
+      throw "Skype for linux is not supported on ${stdenv.system}";
+
+in stdenv.mkDerivation {
+  name = "skypeforlinux-${version}";
+
+  system = "x86_64-linux";
+
+  inherit src;
+
+  buildInputs = [ dpkg makeWrapper ];
+
+  unpackPhase = "true";
+  installPhase = ''
+    mkdir -p $out
+    dpkg -x $src $out
+    cp -av $out/usr/* $out
+    rm -rf $out/opt $out/usr
+    rm $out/bin/skypeforlinux
+
+    # Otherwise it looks "suspicious"
+    chmod -R g-w $out
+  '';
+
+  postFixup = ''
+     patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "$out/share/skypeforlinux:${rpath}" "$out/share/skypeforlinux/skypeforlinux"
+
+    ln -s "$out/share/skypeforlinux/skypeforlinux" "$out/bin/skypeforlinux"
+
+    # Fix the desktop link
+    substituteInPlace $out/share/applications/skypeforlinux.desktop \
+      --replace /usr/bin/ $out/bin/ \
+      --replace /usr/share/ $out/share/
+
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Linux client for skype";
+    homepage = "https://www.skype.com";
+    license = licenses.unfree;
+    maintainers = with stdenv.lib.maintainers; [ panaeon ];
+    platforms = [ "x86_64-linux" ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15461,6 +15461,8 @@ with pkgs;
 
   skype = callPackage_i686 ../applications/networking/instant-messengers/skype { };
 
+  skypeforlinux = callPackage ../applications/networking/instant-messengers/skypeforlinux { };
+
   skype4pidgin = callPackage ../applications/networking/instant-messengers/pidgin-plugins/skype4pidgin { };
 
   skype_call_recorder = callPackage ../applications/networking/instant-messengers/skype-call-recorder { };


### PR DESCRIPTION
###### Motivation for this change
Add skypeforlinux client. See #25152 for details.

###### Things done
* Add skypeforlinux package script (copied most part from slack since they are very similar)
* Add skypeforlinux to all-packages.nix

What's working (tested): audio calls, group calls, smiles, inline media
What's not working: credentials are not saved to keychain so user need to input them each time skype starts

 

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

