### PR TITLE
Changed package name in example command

### DIFF
--- a/doc/multiple-output.xml
+++ b/doc/multiple-output.xml
@@ -16,7 +16,6 @@
 
 <section><title>Installing a split package</title>
   <para>When installing a package via <varname>systemPackages</varname> or <command>nix-env</command> you have several options:</para>
-  <warning><para>Currently <command>nix-env</command> almost always installs all outputs until https://github.com/NixOS/nix/pull/815 gets merged.</para></warning>
   <itemizedlist>
     <listitem><para>You can install particular outputs explicitly, as each is available in the Nix language as an attribute of the package.  The <varname>outputs</varname> attribute contains a list of output names.</para></listitem>
     <listitem><para>You can let it use the default outputs.  These are handled by <varname>meta.outputsToInstall</varname> attribute that contains a list of output names.</para>

--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation ( rec {
   name = "ponyc-${version}";
-  version = "0.13.0";
+  version = "0.13.1";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "ponyc";
     rev = version;
-    sha256 = "1agb7aiii7pl8zsh3h0lfzghmm1ajj15gx1j48xjyvplxixdgn9j";
+    sha256 = "1x3w7mxpwgf2bn2c1qqxbj4w5gp775l7r42lj9jvspayb6a6w28s";
   };
 
   buildInputs = [ llvm makeWrapper which ];

--- a/pkgs/shells/oh-my-zsh/default.nix
+++ b/pkgs/shells/oh-my-zsh/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
   To copy the Oh My Zsh configuration file to your home directory, run
   the following command:
 
-    $ cp -v $(nix-env -q --out-path oh-my-zsh-git | cut -d' ' -f3)/share/oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
+    $ cp -v $(nix-env -q --out-path oh-my-zsh | cut -d' ' -f3)/share/oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
   '';
   homepage        = "http://ohmyz.sh/";
   license         = licenses.mit;


### PR DESCRIPTION
Package is called oh-my-zsh.

###### Motivation for this change
Small error.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

