### PR TITLE
Homogenize abc-verifier, dwm, osmctools homepages

### DIFF
--- a/pkgs/applications/misc/osmctools/default.nix
+++ b/pkgs/applications/misc/osmctools/default.nix
@@ -37,10 +37,10 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Command line tools for transforming Open Street Map files";
-    homepage = ''
-      http://wiki.openstreetmap.org/wiki/Osmconvert
+    homepage = [
+      https://wiki.openstreetmap.org/wiki/Osmconvert
       https://wiki.openstreetmap.org/wiki/Osmfilter
-    '';
+    ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/science/logic/abc/default.nix
+++ b/pkgs/applications/science/logic/abc/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A tool for squential logic synthesis and ormal verification";
-    homepage    = "www.eecs.berkeley.edu/~alanmi/abc/abc.htm";
+    homepage    = "https://people.eecs.berkeley.edu/~alanmi/abc/abc.htm";
     license     = stdenv.lib.licenses.mit;
     platforms   = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];

--- a/pkgs/applications/window-managers/dwm/default.nix
+++ b/pkgs/applications/window-managers/dwm/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   buildPhase = " make ";
  
   meta = {
-    homepage = "www.suckless.org";
+    homepage = "http://suckless.org/";
     description = "Dynamic window manager for X";
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [viric];


### PR DESCRIPTION
###### Motivation for this change

Hi:

I was writing a [integration](https://github.com/emacs-pe/nix-mode/blob/b663927/nix-package.el) for nix packages, and realized that this homepages aren’t homogeneous with the rest of packages definitions.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

