### PR TITLE
libidn2: 0.16 -> 2.0.1

### DIFF
--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -3,11 +3,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "libidn2-0.16";
+  name = "libidn2-${version}";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://alpha.gnu.org/gnu/libidn/${name}.tar.gz";
-    sha256 = "13v8kh4d5nfkymai88zlw3h7k4x9khrpdpv97waf4ah8ykzrxb9g";
+    url = "mirror://gnu/gnu/libidn/${name}.tar.gz";
+    sha256 = "1lzi4wng22gyzlgkr8jk75d03f2bnnch5yhmiwb0hram2la6a8qd";
   };
 
   outputs = [ "bin" "dev" "out" "info" "devdoc" ];


### PR DESCRIPTION
See http://lists.gnu.org/archive/html/info-gnu/2017-04/msg00010.html
for release information. With this release the numbering scheme changed.

###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

