### PR TITLE
fish: Do not overwrite the inherited environment

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -84,9 +84,12 @@ in
 
       set fish_function_path $fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions
 
-      fenv source ${config.system.build.setEnvironment} > /dev/null ^&1
-      fenv source /etc/fish/foreign-env/shellInit > /dev/null
+      if not set -q __fish_nixos_environment_set
+        set -x __fish_nixos_environment_set
+        fenv source ${config.system.build.setEnvironment} > /dev/null ^&1
+      end
 
+      fenv source /etc/fish/foreign-env/shellInit > /dev/null
       ${cfg.shellInit}
 
       if status --is-login


### PR DESCRIPTION
###### Motivation for this change

Previously fish would always set up the NixOS environment, shadowing the inherited environment. This meant that stuff like 

```
nix-shell -p ... --run "fish"
``` 

as well as milder variants didn’t work at all.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---