### PR TITLE
Fix imperative container code examples

### DIFF
--- a/nixos/doc/manual/administration/imperative-containers.xml
+++ b/nixos/doc/manual/administration/imperative-containers.xml
@@ -29,8 +29,10 @@ line. For instance, to create a container that has
 <literal>root</literal>:
 
 <screen>
-# nixos-container create foo --config 'services.openssh.enable = true; \
-  users.extraUsers.root.openssh.authorizedKeys.keys = ["ssh-dss AAAAB3N…"];'
+# nixos-container create foo --config '
+  services.openssh.enable = true;
+  users.extraUsers.root.openssh.authorizedKeys.keys = ["ssh-dss AAAAB3N…"];
+'
 </screen>
 
 </para>
@@ -97,8 +99,11 @@ This will build and activate the new configuration. You can also
 specify a new configuration on the command line:
 
 <screen>
-# nixos-container update foo --config 'services.httpd.enable = true; \
-  services.httpd.adminAddr = "foo@example.org";'
+# nixos-container update foo --config '
+  services.httpd.enable = true;
+  services.httpd.adminAddr = "foo@example.org";
+  networking.firewall.allowedTCPPorts = [ 80 ];
+'
 
 # curl http://$(nixos-container show-ip foo)/
 &lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">…


### PR DESCRIPTION
Since some time Nixos has firewall enabled by default, so update example.
Also, remove newline escaping (it isn't needed).

Closes https://github.com/NixOS/nixpkgs/issues/25174