### PR TITLE
Fix makewrapper unsupported args

### DIFF
--- a/pkgs/build-support/setup-hooks/die.sh
+++ b/pkgs/build-support/setup-hooks/die.sh
@@ -1,0 +1,21 @@
+# Exit with backtrace and error message
+#
+# Usage: die "Error message"
+die() {
+    # Let us be a little sloppy with errors, because otherwise the final
+    # invocation of `caller` below will cause the script to exit.
+    set +e
+
+    # Print our error message
+    printf "\nBuilder called die: %b\n" "$*"
+    printf "Backtrace:\n"
+
+    # Print a backtrace.
+    local frame=0
+    while caller $frame; do
+        ((frame++));
+    done
+    printf "\n"
+
+    exit 1
+}

--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -32,26 +32,20 @@ makeWrapper() {
     for ((n = 2; n < ${#params[*]}; n += 1)); do
         p="${params[$n]}"
 
-        if test "$p" = "--set"; then
+        if [[ "$p" == "--set" ]]; then
             varName="${params[$((n + 1))]}"
             value="${params[$((n + 2))]}"
             n=$((n + 2))
             echo "export $varName=\"$value\"" >> "$wrapper"
-        fi
-
-        if test "$p" = "--unset"; then
+        elif [[ "$p" == "--unset" ]]; then
             varName="${params[$((n + 1))]}"
             n=$((n + 1))
             echo "unset $varName" >> "$wrapper"
-        fi
-
-        if test "$p" = "--run"; then
+        elif [[ "$p" == "--run" ]]; then
             command="${params[$((n + 1))]}"
             n=$((n + 1))
             echo "$command" >> "$wrapper"
-        fi
-
-        if test "$p" = "--suffix" -o "$p" = "--prefix"; then
+        elif [[ ("$p" == "--suffix") || ("$p" == "--prefix") ]]; then
             varName="${params[$((n + 1))]}"
             separator="${params[$((n + 2))]}"
             value="${params[$((n + 3))]}"
@@ -63,9 +57,7 @@ makeWrapper() {
                     echo "export $varName=$value\${$varName:+$separator}\$$varName" >> "$wrapper"
                 fi
             fi
-        fi
-
-        if test "$p" = "--suffix-each"; then
+        elif [[ "$p" == "--suffix-each" ]]; then
             varName="${params[$((n + 1))]}"
             separator="${params[$((n + 2))]}"
             values="${params[$((n + 3))]}"
@@ -73,9 +65,7 @@ makeWrapper() {
             for value in $values; do
                 echo "export $varName=\$$varName\${$varName:+$separator}$value" >> "$wrapper"
             done
-        fi
-
-        if test "$p" = "--suffix-contents" -o "$p" = "--prefix-contents"; then
+        elif [[ ("$p" == "--suffix-contents") || ("$p" == "--prefix-contents") ]]; then
             varName="${params[$((n + 1))]}"
             separator="${params[$((n + 2))]}"
             fileNames="${params[$((n + 3))]}"
@@ -87,17 +77,15 @@ makeWrapper() {
                     echo "export $varName=$(cat "$fileName")\${$varName:+$separator}\$$varName" >> "$wrapper"
                 fi
             done
-        fi
-
-        if test "$p" = "--add-flags"; then
+        elif [[ "$p" == "--add-flags" ]]; then
             flags="${params[$((n + 1))]}"
             n=$((n + 1))
             flagsBefore="$flagsBefore $flags"
-        fi
-
-        if test "$p" = "--argv0"; then
+        elif [[ "$p" == "--argv0" ]]; then
             argv0="${params[$((n + 1))]}"
             n=$((n + 1))
+        else
+            die "makeWrapper doesn't understand the arg $p"
         fi
     done
 
@@ -138,5 +126,5 @@ wrapProgram() {
     mv "$prog" "$hidden"
     # Silence warning about unexpanded $0:
     # shellcheck disable=SC2016
-    makeWrapper "$hidden" "$prog" --argv0 '$0' "$@"
+    makeWrapper "$hidden" "$prog" --argv0 '$0' "${@:2}"
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -100,6 +100,8 @@ with pkgs;
 
   diffPlugins = (callPackage ../build-support/plugins.nix {}).diffPlugins;
 
+  dieHook = makeSetupHook {} ../build-support/setup-hooks/die.sh;
+
   dockerTools = callPackage ../build-support/docker { };
 
   docker_compose = pythonPackages.docker_compose;
@@ -287,7 +289,8 @@ with pkgs;
       inherit contents compressor prepend;
     };
 
-  makeWrapper = makeSetupHook { } ../build-support/setup-hooks/make-wrapper.sh;
+  makeWrapper = makeSetupHook { deps = [ dieHook ]; }
+                              ../build-support/setup-hooks/make-wrapper.sh;
 
   makeModulesClosure = { kernel, rootModules, allowMissing ? false }:
     callPackage ../build-support/kernel/modules-closure.nix {


### PR DESCRIPTION
###### Motivation for this change

Previously, makeWrapper would accept arguments it didn't recognize,
potentially allowing argument misspellings or broken callers.

Now, makeWrapper dies with a backtrace if it is called incorrectly.

Also changes `wrapProgram` so that it doesn't pass through the first
argument twice --- this was tripping up the argument checking.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

