### PR TITLE
crossStdenv on iphone: Just get info from `targetPlatform`

### DIFF
--- a/pkgs/os-specific/darwin/ios-cross/default.nix
+++ b/pkgs/os-specific/darwin/ios-cross/default.nix
@@ -6,6 +6,7 @@
 , stdenv
 , coreutils
 , gnugrep
+, targetPlatform
 }:
 
 /* As of this writing, known-good prefix/arch/simulator triples:
@@ -15,7 +16,12 @@
  * x86_64-apple-darwin14  | x86_64 | true
  */
 
-{ prefix, arch, simulator ? false }: let
+let
+
+  prefix = targetPlatform.config;
+  inherit (targetPlatform) arch;
+  simulator = targetPlatform.isiPhoneSimulator or false;
+
   sdkType = if simulator then "Simulator" else "OS";
 
   sdkVer = "10.2";

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -35,11 +35,7 @@ in bootStages ++ [
     selfBuild = false;
     stdenv = if crossSystem.useiOSCross or false
       then let
-          inherit (buildPackages.darwin.ios-cross {
-              prefix = crossSystem.config;
-              inherit (crossSystem) arch;
-              simulator = crossSystem.isiPhoneSimulator or false; })
-            cc binutils;
+          inherit (buildPackages.darwin.ios-cross) cc binutils;
         in buildPackages.makeStdenvCross
           buildPackages.stdenv crossSystem
           binutils cc


### PR DESCRIPTION
###### Motivation for this change

Less indirection; Part of https://github.com/NixOS/nixpkgs/pull/25047

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

