### PR TITLE
ezdxf (Python package): init at 0.8.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -215,6 +215,7 @@
   heel = "Sergii Paryzhskyi <parizhskiy@gmail.com>";
   henrytill = "Henry Till <henrytill@gmail.com>";
   hinton = "Tom Hinton <t@larkery.com>";
+  hodapp = "Chris Hodapp <hodapp87@gmail.com>";
   hrdinka = "Christoph Hrdinka <c.nix@hrdinka.at>";
   iand675 = "Ian Duncan <ian@iankduncan.com>";
   ianwookim = "Ian-Woo Kim <ianwookim@gmail.com>";

--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, buildPythonPackage, fetchurl, isPy3k, pyparsing }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, pyparsing, pytest }:
 
 buildPythonPackage rec {
   version = "0.8.1";
   name = "ezdxf-${version}";
 
-  src = fetchurl {
-    url = "mirror://pypi/e/ezdxf/${name}.zip";
-    sha256 = "1q4la4h7840wb8l2jf39wy68gq5jwymkghb1a1mg8qblj424130k";
+  src = fetchFromGitHub {
+    owner = "mozman";
+    repo = "ezdxf";
+    rev = "v${version}";
+    sha256 = "1c20j96n3rsgzaakfjl0wnydaj2qr69gbnnjs6mfa1hz2fjqri22";
   };
 
-  # Tests fail on Python 3.x, but module imports and works
-  doCheck = !(isPy3k);
-    
+  buildInputs = [ pytest ];
+  checkPhase = "python -m unittest discover -s tests";
+
   propagatedBuildInputs = [ pyparsing ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -20,6 +20,7 @@ buildPythonPackage rec {
     description = "Python package to read and write DXF drawings (interface to the DXF file format)";
     homepage = https://github.com/mozman/ezdxf/;
     license = licenses.mit;
+    maintainers = with maintainers; [ hodapp ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchurl, isPy3k, pyparsing }:
+
+buildPythonPackage rec {
+  version = "0.8.1";
+  name = "ezdxf-${version}";
+
+  src = fetchurl {
+    url = "mirror://pypi/e/ezdxf/${name}.zip";
+    sha256 = "1q4la4h7840wb8l2jf39wy68gq5jwymkghb1a1mg8qblj424130k";
+  };
+
+  # Tests fail on Python 3.x, but module imports and works
+  doCheck = !(isPy3k);
+    
+  propagatedBuildInputs = [ pyparsing ];
+
+  meta = with stdenv.lib; {
+    description = "Python package to read and write DXF drawings (interface to the DXF file format)";
+    homepage = https://github.com/mozman/ezdxf/;
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6990,6 +6990,8 @@ in {
     };
   };
 
+  ezdxf = callPackage ../development/python-modules/ezdxf {};
+  
   facebook-sdk = buildPythonPackage rec {
     name = "facebook-sdk-0.4.0";
 


### PR DESCRIPTION
###### Motivation for this change

The Python module [ezdxf](https://pypi.python.org/pypi/ezdxf) is unavailable.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

