### PR TITLE
Host vs. target unconfuse

### DIFF
--- a/pkgs/development/compilers/gcc/4.5/default.nix
+++ b/pkgs/development/compilers/gcc/4.5/default.nix
@@ -26,6 +26,7 @@
 , gnat ? null
 , libpthread ? null, libpthreadCross ? null  # required for GNU/Hurd
 , stripped ? true
+, buildPlatform, hostPlatform, targetPlatform
 }:
 
 assert langJava     -> zip != null && unzip != null
@@ -271,15 +272,15 @@ stdenv.mkDerivation ({
   targetConfig = if cross != null then cross.config else null;
 
   crossAttrs = {
-    AR = "${stdenv.cross.config}-ar";
-    LD = "${stdenv.cross.config}-ld";
-    CC = "${stdenv.cross.config}-gcc";
-    CXX = "${stdenv.cross.config}-gcc";
-    AR_FOR_TARGET = "${stdenv.cross.config}-ar";
-    LD_FOR_TARGET = "${stdenv.cross.config}-ld";
-    CC_FOR_TARGET = "${stdenv.cross.config}-gcc";
-    NM_FOR_TARGET = "${stdenv.cross.config}-nm";
-    CXX_FOR_TARGET = "${stdenv.cross.config}-g++";
+    AR = "${targetPlatform.config}-ar";
+    LD = "${targetPlatform.config}-ld";
+    CC = "${targetPlatform.config}-gcc";
+    CXX = "${targetPlatform.config}-gcc";
+    AR_FOR_TARGET = "${targetPlatform.config}-ar";
+    LD_FOR_TARGET = "${targetPlatform.config}-ld";
+    CC_FOR_TARGET = "${targetPlatform.config}-gcc";
+    NM_FOR_TARGET = "${targetPlatform.config}-nm";
+    CXX_FOR_TARGET = "${targetPlatform.config}-g++";
     # If we are making a cross compiler, cross != null
     NIX_CC_CROSS = if cross == null then "${stdenv.ccCross}" else "";
     dontStrip = true;
@@ -311,7 +312,7 @@ stdenv.mkDerivation ({
       ${if langAda then " --enable-libada" else ""}
       ${if cross == null && stdenv.isi686 then "--with-arch=i686" else ""}
       ${if cross != null then crossConfigureFlags else ""}
-      --target=${stdenv.cross.config}
+      --target=${targetPlatform.config}
     '';
   };
  

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -34,6 +34,7 @@
 , stripped ? true
 , gnused ? null
 , darwin ? null
+, buildPlatform, hostPlatform, targetPlatform
 }:
 
 assert langJava     -> zip != null && unzip != null
@@ -123,12 +124,12 @@ let version = "4.8.5";
     crossMingw = cross != null && cross.libc == "msvcrt";
     crossDarwin = cross != null && cross.libc == "libSystem";
     crossConfigureFlags = let
-        gccArch = stdenv.cross.gcc.arch or null;
-        gccCpu = stdenv.cross.gcc.cpu or null;
-        gccAbi = stdenv.cross.gcc.abi or null;
-        gccFpu = stdenv.cross.gcc.fpu or null;
-        gccFloat = stdenv.cross.gcc.float or null;
-        gccMode = stdenv.cross.gcc.mode or null;
+        gccArch = targetPlatform.gcc.arch or null;
+        gccCpu = targetPlatform.gcc.cpu or null;
+        gccAbi = targetPlatform.gcc.abi or null;
+        gccFpu = targetPlatform.gcc.fpu or null;
+        gccFloat = targetPlatform.gcc.float or null;
+        gccMode = targetPlatform.gcc.mode or null;
         withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
         withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
         withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
@@ -382,26 +383,26 @@ stdenv.mkDerivation ({
     else "install";
 
   crossAttrs = let
-    xgccArch = stdenv.cross.gcc.arch or null;
-    xgccCpu = stdenv.cross.gcc.cpu or null;
-    xgccAbi = stdenv.cross.gcc.abi or null;
-    xgccFpu = stdenv.cross.gcc.fpu or null;
-    xgccFloat = stdenv.cross.gcc.float or null;
+    xgccArch = targetPlatform.gcc.arch or null;
+    xgccCpu = targetPlatform.gcc.cpu or null;
+    xgccAbi = targetPlatform.gcc.abi or null;
+    xgccFpu = targetPlatform.gcc.fpu or null;
+    xgccFloat = targetPlatform.gcc.float or null;
     xwithArch = if xgccArch != null then " --with-arch=${xgccArch}" else "";
     xwithCpu = if xgccCpu != null then " --with-cpu=${xgccCpu}" else "";
     xwithAbi = if xgccAbi != null then " --with-abi=${xgccAbi}" else "";
     xwithFpu = if xgccFpu != null then " --with-fpu=${xgccFpu}" else "";
     xwithFloat = if xgccFloat != null then " --with-float=${xgccFloat}" else "";
   in {
-    AR = "${stdenv.cross.config}-ar";
-    LD = "${stdenv.cross.config}-ld";
-    CC = "${stdenv.cross.config}-gcc";
-    CXX = "${stdenv.cross.config}-gcc";
-    AR_FOR_TARGET = "${stdenv.cross.config}-ar";
-    LD_FOR_TARGET = "${stdenv.cross.config}-ld";
-    CC_FOR_TARGET = "${stdenv.cross.config}-gcc";
-    NM_FOR_TARGET = "${stdenv.cross.config}-nm";
-    CXX_FOR_TARGET = "${stdenv.cross.config}-g++";
+    AR = "${targetPlatform.config}-ar";
+    LD = "${targetPlatform.config}-ld";
+    CC = "${targetPlatform.config}-gcc";
+    CXX = "${targetPlatform.config}-gcc";
+    AR_FOR_TARGET = "${targetPlatform.config}-ar";
+    LD_FOR_TARGET = "${targetPlatform.config}-ld";
+    CC_FOR_TARGET = "${targetPlatform.config}-gcc";
+    NM_FOR_TARGET = "${targetPlatform.config}-nm";
+    CXX_FOR_TARGET = "${targetPlatform.config}-g++";
     # If we are making a cross compiler, cross != null
     NIX_CC_CROSS = if cross == null then "${stdenv.ccCross}" else "";
     dontStrip = true;
@@ -431,7 +432,7 @@ stdenv.mkDerivation ({
         )
       }
       ${if langAda then " --enable-libada" else ""}
-      --target=${stdenv.cross.config}
+      --target=${targetPlatform.config}
       ${xwithArch}
       ${xwithCpu}
       ${xwithAbi}

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -34,6 +34,7 @@
 , stripped ? true
 , gnused ? null
 , darwin ? null
+, buildPlatform, hostPlatform, targetPlatform
 }:
 
 assert langJava     -> zip != null && unzip != null
@@ -125,12 +126,12 @@ let version = "4.9.4";
     crossMingw = cross != null && cross.libc == "msvcrt";
     crossDarwin = cross != null && cross.libc == "libSystem";
     crossConfigureFlags = let
-        gccArch = stdenv.cross.gcc.arch or null;
-        gccCpu = stdenv.cross.gcc.cpu or null;
-        gccAbi = stdenv.cross.gcc.abi or null;
-        gccFpu = stdenv.cross.gcc.fpu or null;
-        gccFloat = stdenv.cross.gcc.float or null;
-        gccMode = stdenv.cross.gcc.mode or null;
+        gccArch = targetPlatform.gcc.arch or null;
+        gccCpu = targetPlatform.gcc.cpu or null;
+        gccAbi = targetPlatform.gcc.abi or null;
+        gccFpu = targetPlatform.gcc.fpu or null;
+        gccFloat = targetPlatform.gcc.float or null;
+        gccMode = targetPlatform.gcc.mode or null;
         withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
         withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
         withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
@@ -389,26 +390,26 @@ stdenv.mkDerivation ({
     else "install";
 
   crossAttrs = let
-    xgccArch = stdenv.cross.gcc.arch or null;
-    xgccCpu = stdenv.cross.gcc.cpu or null;
-    xgccAbi = stdenv.cross.gcc.abi or null;
-    xgccFpu = stdenv.cross.gcc.fpu or null;
-    xgccFloat = stdenv.cross.gcc.float or null;
+    xgccArch = targetPlatform.gcc.arch or null;
+    xgccCpu = targetPlatform.gcc.cpu or null;
+    xgccAbi = targetPlatform.gcc.abi or null;
+    xgccFpu = targetPlatform.gcc.fpu or null;
+    xgccFloat = targetPlatform.gcc.float or null;
     xwithArch = if xgccArch != null then " --with-arch=${xgccArch}" else "";
     xwithCpu = if xgccCpu != null then " --with-cpu=${xgccCpu}" else "";
     xwithAbi = if xgccAbi != null then " --with-abi=${xgccAbi}" else "";
     xwithFpu = if xgccFpu != null then " --with-fpu=${xgccFpu}" else "";
     xwithFloat = if xgccFloat != null then " --with-float=${xgccFloat}" else "";
   in {
-    AR = "${stdenv.cross.config}-ar";
-    LD = "${stdenv.cross.config}-ld";
-    CC = "${stdenv.cross.config}-gcc";
-    CXX = "${stdenv.cross.config}-gcc";
-    AR_FOR_TARGET = "${stdenv.cross.config}-ar";
-    LD_FOR_TARGET = "${stdenv.cross.config}-ld";
-    CC_FOR_TARGET = "${stdenv.cross.config}-gcc";
-    NM_FOR_TARGET = "${stdenv.cross.config}-nm";
-    CXX_FOR_TARGET = "${stdenv.cross.config}-g++";
+    AR = "${targetPlatform.config}-ar";
+    LD = "${targetPlatform.config}-ld";
+    CC = "${targetPlatform.config}-gcc";
+    CXX = "${targetPlatform.config}-gcc";
+    AR_FOR_TARGET = "${targetPlatform.config}-ar";
+    LD_FOR_TARGET = "${targetPlatform.config}-ld";
+    CC_FOR_TARGET = "${targetPlatform.config}-gcc";
+    NM_FOR_TARGET = "${targetPlatform.config}-nm";
+    CXX_FOR_TARGET = "${targetPlatform.config}-g++";
     # If we are making a cross compiler, cross != null
     NIX_CC_CROSS = if cross == null then "${stdenv.ccCross}" else "";
     dontStrip = true;
@@ -438,7 +439,7 @@ stdenv.mkDerivation ({
         )
       }
       ${if langAda then " --enable-libada" else ""}
-      --target=${stdenv.cross.config}
+      --target=${targetPlatform.config}
       ${xwithArch}
       ${xwithCpu}
       ${xwithAbi}

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -36,6 +36,7 @@
 , binutils ? null
 , cloog # unused; just for compat with gcc4, as we override the parameter on some places
 , darwin ? null
+, buildPlatform, hostPlatform, targetPlatform
 }:
 
 assert langJava     -> zip != null && unzip != null
@@ -129,12 +130,12 @@ let version = "5.4.0";
     crossMingw = cross != null && cross.libc == "msvcrt";
     crossDarwin = cross != null && cross.libc == "libSystem";
     crossConfigureFlags = let
-        gccArch = stdenv.cross.gcc.arch or null;
-        gccCpu = stdenv.cross.gcc.cpu or null;
-        gccAbi = stdenv.cross.gcc.abi or null;
-        gccFpu = stdenv.cross.gcc.fpu or null;
-        gccFloat = stdenv.cross.gcc.float or null;
-        gccMode = stdenv.cross.gcc.mode or null;
+        gccArch = targetPlatform.gcc.arch or null;
+        gccCpu = targetPlatform.gcc.cpu or null;
+        gccAbi = targetPlatform.gcc.abi or null;
+        gccFpu = targetPlatform.gcc.fpu or null;
+        gccFloat = targetPlatform.gcc.float or null;
+        gccMode = targetPlatform.gcc.mode or null;
         withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
         withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
         withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
@@ -398,26 +399,26 @@ stdenv.mkDerivation ({
     else "install";
 
   crossAttrs = let
-    xgccArch = stdenv.cross.gcc.arch or null;
-    xgccCpu = stdenv.cross.gcc.cpu or null;
-    xgccAbi = stdenv.cross.gcc.abi or null;
-    xgccFpu = stdenv.cross.gcc.fpu or null;
-    xgccFloat = stdenv.cross.gcc.float or null;
+    xgccArch = targetPlatform.gcc.arch or null;
+    xgccCpu = targetPlatform.gcc.cpu or null;
+    xgccAbi = targetPlatform.gcc.abi or null;
+    xgccFpu = targetPlatform.gcc.fpu or null;
+    xgccFloat = targetPlatform.gcc.float or null;
     xwithArch = if xgccArch != null then " --with-arch=${xgccArch}" else "";
     xwithCpu = if xgccCpu != null then " --with-cpu=${xgccCpu}" else "";
     xwithAbi = if xgccAbi != null then " --with-abi=${xgccAbi}" else "";
     xwithFpu = if xgccFpu != null then " --with-fpu=${xgccFpu}" else "";
     xwithFloat = if xgccFloat != null then " --with-float=${xgccFloat}" else "";
   in {
-    AR = "${stdenv.cross.config}-ar";
-    LD = "${stdenv.cross.config}-ld";
-    CC = "${stdenv.cross.config}-gcc";
-    CXX = "${stdenv.cross.config}-gcc";
-    AR_FOR_TARGET = "${stdenv.cross.config}-ar";
-    LD_FOR_TARGET = "${stdenv.cross.config}-ld";
-    CC_FOR_TARGET = "${stdenv.cross.config}-gcc";
-    NM_FOR_TARGET = "${stdenv.cross.config}-nm";
-    CXX_FOR_TARGET = "${stdenv.cross.config}-g++";
+    AR = "${targetPlatform.config}-ar";
+    LD = "${targetPlatform.config}-ld";
+    CC = "${targetPlatform.config}-gcc";
+    CXX = "${targetPlatform.config}-gcc";
+    AR_FOR_TARGET = "${targetPlatform.config}-ar";
+    LD_FOR_TARGET = "${targetPlatform.config}-ld";
+    CC_FOR_TARGET = "${targetPlatform.config}-gcc";
+    NM_FOR_TARGET = "${targetPlatform.config}-nm";
+    CXX_FOR_TARGET = "${targetPlatform.config}-g++";
     # If we are making a cross compiler, cross != null
     NIX_CC_CROSS = if cross == null then "${stdenv.ccCross}" else "";
     dontStrip = true;
@@ -446,7 +447,7 @@ stdenv.mkDerivation ({
         )
       }
       ${if langAda then " --enable-libada" else ""}
-      --target=${stdenv.cross.config}
+      --target=${targetPlatform.config}
       ${xwithArch}
       ${xwithCpu}
       ${xwithAbi}

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -36,6 +36,7 @@
 , binutils ? null
 , cloog # unused; just for compat with gcc4, as we override the parameter on some places
 , darwin ? null
+, buildPlatform, hostPlatform, targetPlatform
 }:
 
 assert langJava     -> zip != null && unzip != null
@@ -125,12 +126,12 @@ let version = "6.3.0";
     crossMingw = cross != null && cross.libc == "msvcrt";
     crossDarwin = cross != null && cross.libc == "libSystem";
     crossConfigureFlags = let
-        gccArch = stdenv.cross.gcc.arch or null;
-        gccCpu = stdenv.cross.gcc.cpu or null;
-        gccAbi = stdenv.cross.gcc.abi or null;
-        gccFpu = stdenv.cross.gcc.fpu or null;
-        gccFloat = stdenv.cross.gcc.float or null;
-        gccMode = stdenv.cross.gcc.mode or null;
+        gccArch = targetPlatform.gcc.arch or null;
+        gccCpu = targetPlatform.gcc.cpu or null;
+        gccAbi = targetPlatform.gcc.abi or null;
+        gccFpu = targetPlatform.gcc.fpu or null;
+        gccFloat = targetPlatform.gcc.float or null;
+        gccMode = targetPlatform.gcc.mode or null;
         withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
         withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
         withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
@@ -386,26 +387,26 @@ stdenv.mkDerivation ({
     else "install";
 
   crossAttrs = let
-    xgccArch = stdenv.cross.gcc.arch or null;
-    xgccCpu = stdenv.cross.gcc.cpu or null;
-    xgccAbi = stdenv.cross.gcc.abi or null;
-    xgccFpu = stdenv.cross.gcc.fpu or null;
-    xgccFloat = stdenv.cross.gcc.float or null;
+    xgccArch = targetPlatform.gcc.arch or null;
+    xgccCpu = targetPlatform.gcc.cpu or null;
+    xgccAbi = targetPlatform.gcc.abi or null;
+    xgccFpu = targetPlatform.gcc.fpu or null;
+    xgccFloat = targetPlatform.gcc.float or null;
     xwithArch = if xgccArch != null then " --with-arch=${xgccArch}" else "";
     xwithCpu = if xgccCpu != null then " --with-cpu=${xgccCpu}" else "";
     xwithAbi = if xgccAbi != null then " --with-abi=${xgccAbi}" else "";
     xwithFpu = if xgccFpu != null then " --with-fpu=${xgccFpu}" else "";
     xwithFloat = if xgccFloat != null then " --with-float=${xgccFloat}" else "";
   in {
-    AR = "${stdenv.cross.config}-ar";
-    LD = "${stdenv.cross.config}-ld";
-    CC = "${stdenv.cross.config}-gcc";
-    CXX = "${stdenv.cross.config}-gcc";
-    AR_FOR_TARGET = "${stdenv.cross.config}-ar";
-    LD_FOR_TARGET = "${stdenv.cross.config}-ld";
-    CC_FOR_TARGET = "${stdenv.cross.config}-gcc";
-    NM_FOR_TARGET = "${stdenv.cross.config}-nm";
-    CXX_FOR_TARGET = "${stdenv.cross.config}-g++";
+    AR = "${targetPlatform.config}-ar";
+    LD = "${targetPlatform.config}-ld";
+    CC = "${targetPlatform.config}-gcc";
+    CXX = "${targetPlatform.config}-gcc";
+    AR_FOR_TARGET = "${targetPlatform.config}-ar";
+    LD_FOR_TARGET = "${targetPlatform.config}-ld";
+    CC_FOR_TARGET = "${targetPlatform.config}-gcc";
+    NM_FOR_TARGET = "${targetPlatform.config}-nm";
+    CXX_FOR_TARGET = "${targetPlatform.config}-g++";
     # If we are making a cross compiler, cross != null
     NIX_CC_CROSS = if cross == null then "${stdenv.ccCross}" else "";
     dontStrip = true;
@@ -434,7 +435,7 @@ stdenv.mkDerivation ({
         )
       }
       ${if langAda then " --enable-libada" else ""}
-      --target=${stdenv.cross.config}
+      --target=${targetPlatform.config}
       ${xwithArch}
       ${xwithCpu}
       ${xwithAbi}

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -37,6 +37,7 @@
 , cloog # unused; just for compat with gcc4, as we override the parameter on some places
 , darwin ? null
 , flex ? null
+, buildPlatform, hostPlatform, targetPlatform
 }:
 
 assert langJava     -> zip != null && unzip != null
@@ -125,12 +126,12 @@ let version = "7-20170409";
     crossMingw = cross != null && cross.libc == "msvcrt";
     crossDarwin = cross != null && cross.libc == "libSystem";
     crossConfigureFlags = let
-        gccArch = stdenv.cross.gcc.arch or null;
-        gccCpu = stdenv.cross.gcc.cpu or null;
-        gccAbi = stdenv.cross.gcc.abi or null;
-        gccFpu = stdenv.cross.gcc.fpu or null;
-        gccFloat = stdenv.cross.gcc.float or null;
-        gccMode = stdenv.cross.gcc.mode or null;
+        gccArch = targetPlatform.gcc.arch or null;
+        gccCpu = targetPlatform.gcc.cpu or null;
+        gccAbi = targetPlatform.gcc.abi or null;
+        gccFpu = targetPlatform.gcc.fpu or null;
+        gccFloat = targetPlatform.gcc.float or null;
+        gccMode = targetPlatform.gcc.mode or null;
         withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
         withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
         withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
@@ -386,26 +387,26 @@ stdenv.mkDerivation ({
     else "install";
 
   crossAttrs = let
-    xgccArch = stdenv.cross.gcc.arch or null;
-    xgccCpu = stdenv.cross.gcc.cpu or null;
-    xgccAbi = stdenv.cross.gcc.abi or null;
-    xgccFpu = stdenv.cross.gcc.fpu or null;
-    xgccFloat = stdenv.cross.gcc.float or null;
+    xgccArch = targetPlatform.gcc.arch or null;
+    xgccCpu = targetPlatform.gcc.cpu or null;
+    xgccAbi = targetPlatform.gcc.abi or null;
+    xgccFpu = targetPlatform.gcc.fpu or null;
+    xgccFloat = targetPlatform.gcc.float or null;
     xwithArch = if xgccArch != null then " --with-arch=${xgccArch}" else "";
     xwithCpu = if xgccCpu != null then " --with-cpu=${xgccCpu}" else "";
     xwithAbi = if xgccAbi != null then " --with-abi=${xgccAbi}" else "";
     xwithFpu = if xgccFpu != null then " --with-fpu=${xgccFpu}" else "";
     xwithFloat = if xgccFloat != null then " --with-float=${xgccFloat}" else "";
   in {
-    AR = "${stdenv.cross.config}-ar";
-    LD = "${stdenv.cross.config}-ld";
-    CC = "${stdenv.cross.config}-gcc";
-    CXX = "${stdenv.cross.config}-gcc";
-    AR_FOR_TARGET = "${stdenv.cross.config}-ar";
-    LD_FOR_TARGET = "${stdenv.cross.config}-ld";
-    CC_FOR_TARGET = "${stdenv.cross.config}-gcc";
-    NM_FOR_TARGET = "${stdenv.cross.config}-nm";
-    CXX_FOR_TARGET = "${stdenv.cross.config}-g++";
+    AR = "${targetPlatform.config}-ar";
+    LD = "${targetPlatform.config}-ld";
+    CC = "${targetPlatform.config}-gcc";
+    CXX = "${targetPlatform.config}-gcc";
+    AR_FOR_TARGET = "${targetPlatform.config}-ar";
+    LD_FOR_TARGET = "${targetPlatform.config}-ld";
+    CC_FOR_TARGET = "${targetPlatform.config}-gcc";
+    NM_FOR_TARGET = "${targetPlatform.config}-nm";
+    CXX_FOR_TARGET = "${targetPlatform.config}-g++";
     # If we are making a cross compiler, cross != null
     NIX_CC_CROSS = if cross == null then "${stdenv.ccCross}" else "";
     dontStrip = true;
@@ -434,7 +435,7 @@ stdenv.mkDerivation ({
         )
       }
       ${if langAda then " --enable-libada" else ""}
-      --target=${stdenv.cross.config}
+      --target=${targetPlatform.config}
       ${xwithArch}
       ${xwithCpu}
       ${xwithAbi}

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -58,6 +58,10 @@ rec {
   # builds.
   makeStdenvCross = stdenv: cross: binutilsCross: gccCross: stdenv // {
 
+    # Overrides are surely not valid as packages built with this run on a
+    # different platform.
+    overrides = _: _: {};
+
     mkDerivation =
       { name ? "", buildInputs ? [], nativeBuildInputs ? []
       , propagatedBuildInputs ? [], propagatedNativeBuildInputs ? []

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -21,9 +21,7 @@ in bootStages ++ [
     selfBuild = false;
     # It's OK to change the built-time dependencies
     allowCustomOverrides = true;
-    stdenv = vanillaPackages.stdenv // {
-      overrides = _: _: {};
-    };
+    inherit (vanillaPackages) stdenv;
   })
 
   # Run Packages

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -253,7 +253,7 @@ in rec {
     inherit
       gnumake gzip gnused bzip2 gawk ed xz patch bash
       libcxxabi libcxx ncurses libffi zlib icu llvm gmp pcre gnugrep
-      coreutils findutils diffutils patchutils binutils binutils-raw;
+      coreutils findutils diffutils patchutils;
 
     llvmPackages = super.llvmPackages // {
       inherit (llvmPackages) llvm clang-unwrapped;
@@ -262,6 +262,9 @@ in rec {
     darwin = super.darwin // {
       inherit (darwin) dyld Libsystem cctools libiconv;
     };
+  } // lib.optionalAttrs (super.targetPlatform == localSystem) {
+    # Need to get rid of these when cross-compiling.
+    inherit binutils binutils-raw;
   };
 
   stdenvDarwin = prevStage: let pkgs = prevStage; in import ../generic rec {

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -298,12 +298,14 @@ in
         */
 
       overrides = self: super: {
-        gcc = cc;
-
         inherit (prevStage)
-          gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
+          gzip bzip2 xz bash coreutils diffutils findutils gawk
           glibc gnumake gnused gnutar gnugrep gnupatch patchelf
           attr acl paxctl zlib pcre;
+      } // lib.optionalAttrs (super.targetPlatform == localSystem) {
+        # Need to get rid of these when cross-compiling.
+        inherit (prevStage) binutils;
+        gcc = cc;
       };
     };
   })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4971,8 +4971,8 @@ with pkgs;
 
   gccCrossStageStatic = assert targetPlatform != buildPlatform; let
     libcCross1 =
-      if stdenv.cross.libc == "msvcrt" then windows.mingw_w64_headers
-      else if stdenv.cross.libc == "libSystem" then darwin.xcode
+      if targetPlatform.libc == "msvcrt" then windows.mingw_w64_headers
+      else if targetPlatform.libc == "libSystem" then darwin.xcode
       else null;
     in wrapGCCCross {
       gcc = forcedNativePackages.gcc.cc.override {

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -110,8 +110,8 @@ let
   in {
     stdenv = super.stdenv // {
       inherit (buildPlatform) platform;
-    } // lib.optionalAttrs (targetPlatform != buildPlatform) {
-      cross = targetPlatform;
+    } // lib.optionalAttrs (hostPlatform != buildPlatform) {
+      cross = hostPlatform;
     };
     inherit (buildPlatform) system platform;
   };


### PR DESCRIPTION
###### Motivation for this change

`stdenv.cross` is a silly attribute that needs to go leaving the well-defined `hostPlatform` and `targetPlatform`. This PR doesn't remove it, but changes its definition: before it tracked the target platform which is sometimes more useful for compilers, and now it tracks the host platform which is more useful for everything else. Most usages are libraries, falling in the "everything else" category, so changing the definition makes sense to appease the majority. The few compiler (gcc in particular) uses that exist I remove to use `targetPlatform` --- preserving correctness and becoming more explicit in the process.

I would also update the documentation aside mentioning `stdenv.cross` as deprecated, but the definition given actually erroneously assumes this PR is already merged!

This is split off from https://github.com/NixOS/nixpkgs/pull/25047

###### Things done

I commandeered and old jobset of mine to create http://hydra.nixos.org/jobset/nixpkgs/pr-25194 to test, because I couldn't figure out how to run a hydra job locally. http://hydra.nixos.org/eval/1353037?compare=cross-trunk shows no regressions. Yay! 
