### PR TITLE
Quoting "$vars" in xsession

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -33,7 +33,7 @@ let
       #! ${pkgs.bash}/bin/bash
 
       # Handle being called by SDDM.
-      if test "''${1:0:1}" = / ; then eval exec $1 $2 ; fi
+      if test "''${1:0:1}" = / ; then eval exec "$1" "$2" ; fi
 
       ${optionalString cfg.displayManager.logToJournal ''
         if [ -z "$_DID_SYSTEMD_CAT" ]; then
@@ -115,7 +115,7 @@ let
       : ''${desktopManager:=${cfg.desktopManager.default}}
 
       # Start the window manager.
-      case $windowManager in
+      case "$windowManager" in
         ${concatMapStrings (s: ''
           (${s.name})
             ${s.start}
@@ -125,7 +125,7 @@ let
       esac
 
       # Start the desktop manager.
-      case $desktopManager in
+      case "$desktopManager" in
         ${concatMapStrings (s: ''
           (${s.name})
             ${s.start}


### PR DESCRIPTION
###### Motivation for this change

The clause that fixes the call when SDDM execs xsession was broken (not just for me?) because the argument variables weren't quoted, so session names like `'xmonad + xterm'` were split by bash, and the single quotes were treated as syntax errors.

I think this will correct the issue, but I'm unclear how to test the change locally to be sure, since it's a module change, and the actual script is produced by a function call.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

