### PR TITLE
Fix typo in trivial.nix

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -38,7 +38,7 @@ rec {
   /* Merge two attribute sets shallowly, right side trumps left
 
      Example:
-       mergeAttrs { a = 1; b = 2; } // { b = 3; c = 4; }
+       mergeAttrs { a = 1; b = 2; } { b = 3; c = 4; }
        => { a = 1; b = 3; c = 4; }
   */
   mergeAttrs = x: y: x // y;


### PR DESCRIPTION
###### Motivation for this change
- fix a typo in the examples

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

