### PR TITLE
3to2: init at 1.1.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -347,6 +347,7 @@
   msackman = "Matthew Sackman <matthew@wellquite.org>";
   mschristiansen = "Mikkel Christiansen <mikkel@rheosystems.com>";
   msteen = "Matthijs Steen <emailmatthijs@gmail.com>";
+  mt-caret = "Masayuki Takeda <mtakeda.enigsol@gmail.com>";
   mtreskin = "Max Treskin <zerthurd@gmail.com>";
   mudri = "James Wood <lamudri@gmail.com>";
   muflax = "Stefan Dorn <mail@muflax.com>";

--- a/pkgs/development/python-modules/3to2/default.nix
+++ b/pkgs/development/python-modules/3to2/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     homepage = https://bitbucket.org/amentajo/lib3to2;
     description = "Refactors valid 3.x syntax into valid 2.x syntax, if a syntactical conversion is possible";
     license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mt-caret ];
   };
 }

--- a/pkgs/development/python-modules/3to2/default.nix
+++ b/pkgs/development/python-modules/3to2/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchurl
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "3to2";
+  version = "1.1.1";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/8f/ab/58a363eca982c40e9ee5a7ca439e8ffc5243dde2ae660ba1ffdd4868026b/${pname}-${version}.zip";
+    sha256 = "fef50b2b881ef743f269946e1090b77567b71bb9a9ce64b7f8e699b562ff685c";
+  };
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test lib3to2/tests
+  '';
+
+  # Test failing due to upstream issue (https://bitbucket.org/amentajo/lib3to2/issues/50/testsuite-fails-with-new-python-35)
+  doCheck = false;
+
+  meta = {
+    homepage = https://bitbucket.org/amentajo/lib3to2;
+    description = "Refactors valid 3.x syntax into valid 2.x syntax, if a syntactical conversion is possible";
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -97,6 +97,8 @@ in {
     };
   };
 
+  "3to2" = callPackage ../development/python-modules/3to2 { };
+
   aenum = callPackage ../development/python-modules/aenum { };
 
   agate = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

add 3to2

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

