### PR TITLE
Fix parsing @args.rsp compiler arguments

### DIFF
--- a/pkgs/build-support/cc-wrapper/utils.sh
+++ b/pkgs/build-support/cc-wrapper/utils.sh
@@ -23,26 +23,55 @@ badPath() {
         "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"
 }
 
-expandResponseParams() {
-    local inparams=("$@")
-    local n=0
-    local p
-    params=()
-    while [ $n -lt ${#inparams[*]} ]; do
-        p=${inparams[n]}
-        case $p in
-            @*)
-                if [ -e "${p:1}" ]; then
-                    args=$(<"${p:1}")
-                    eval 'for arg in '${args//$/\\$}'; do params+=("$arg"); done'
-                else
-                    params+=("$p")
-                fi
-                ;;
-            *)
-                params+=("$p")
-                ;;
+# @args.rsp parser.
+# Char classes: space, other, backslash, single quote, double quote.
+# States: 0 - outside, 1/2 - unquoted arg/slash, 3/4 - 'arg'/slash, 5/6 - "arg"/slash.
+# State transitions:
+rspT=(01235 01235 11111 33413 33333 55651 55555)
+# Push char on transition:
+rspC[01]=1 rspC[11]=1 rspC[21]=1 rspC[33]=1 rspC[43]=1 rspC[55]=1 rspC[65]=1
+
+rspParse() {
+    rsp=()
+    local s="$1"
+    local state=0
+    local arg=''
+
+    for (( i=0; i<${#s}; i++ )); do
+        local c="${s:$i:1}"
+        local cls=1
+        case "$c" in
+            ' ' | $'\t' | $'\r' | $'\n') cls=0 ;;
+            '\') cls=2 ;;
+            "'") cls=3 ;;
+            '"') cls=4 ;;
         esac
-        n=$((n + 1))
+        local nextstates="${rspT[$state]}"
+        local nextstate="${nextstates:$cls:1}"
+        if [ "${rspC[$state$nextstate]}" ]; then
+            arg+="$c"
+        elif [ "$state$nextstate" = "10" ]; then
+            rsp+=("$arg")
+            arg=''
+        fi
+        state="$nextstate"
+    done
+
+    if [ "$state" -ne 0 ]; then
+        rsp+=("$arg")
+    fi
+}
+
+expandResponseParams() {
+    params=()
+    while [ $# -gt 0 ]; do
+        local p="$1"
+        shift
+        if [ "${p:0:1}" = '@' -a -e "${p:1}" ]; then
+            rspParse "$(<"${p:1}")"
+            set -- "${rsp[@]}" "$@"
+        else
+            params+=("$p")
+        fi
     done
 }


### PR DESCRIPTION
I tried to build a copy of `llvm` with `-DBUILD_SHARED_LIBS=ON -DLLVM_BUILD_LLVM_DYLIB=OFF` but the build failed because `nix` incorrectly expanded .rsp file contents: `-Wl,-rpath,"\$ORIGIN/../lib"` in a .rsp becomes `-Wl,-rpath,\/../lib` in the arguments.

This patch introduces a parser that follows gcc documentation:

> Read command-line options from FILE.  The options read are inserted in place of the original @FILE option.  If FILE does not exist, or cannot be read, then the option will be treated literally, and not removed.
> Options in FILE are separated by whitespace.  A whitespace character may be included in an option by surrounding the entire option in either single or double quotes.  Any character (including a backslash) may be included by prefixing the character to be included with a backslash.  The FILE may itself contain additional @FILE options; any such options will be processed recursively.

Related: #11762