### PR TITLE
programs.zsh.syntax-highlighting: refactor `highlighters` option for proper validation

### DIFF
--- a/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
+++ b/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
@@ -18,7 +18,17 @@ in
 
         highlighters = mkOption {
           default = [ "main" ];
-          type = types.listOf(types.str);
+
+          # https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters.md
+          type = types.listOf(types.enum([
+            "main"
+            "brackets"
+            "pattern"
+            "cursor"
+            "root"
+            "line"
+          ]));
+
           description = ''
             Specifies the highlighters to be used by zsh-syntax-highlighting.
 


### PR DESCRIPTION
###### Motivation for this change

Today after updating my nix-channel (which included the changes from #25153) I updated my personal NixOS setup to configure the `zsh-syntax-highlighting` properly, but I mistyped one of the `highlighters` which caused my shell to do odd things.

At first I feared that I broke NixOS, but in the end I've seen that it was just a stupid typo. However this showed me that it might be a good idea to replace the `types.list(types.str)` declaration of `programs.zsh.syntax-highlighting.highlighters` with a `types.list(types.enum([/* available highlighters */]))` to ensure stricter validation.

Although the validation is restricted here this is IMHO not a BC break due to the fact that everything will continue to work if no invalid highlighters were given (but if that happened the shell would be almost unusable).

I validated the patch by using two configurations that were deployed in a test VM:

``` nix
# aborts with an evaluation failure because of the invalid highlighter
{
  programs.zsh = {
    enable = true;
    syntax-highlighting = {
      enable = true;
      highlighters = [ "main" "foobar" ];
    };
  };
}
```

``` nix
# still works
{
  programs.zsh = {
    enable = true;
    syntax-highlighting = {
      enable = true;
      highlighters = [ "main" "brackets" ];
    };
  };
}
```

I booted the VMs using the following command:

```
NIXOS_CONFIG=`pwd`/vmtest.nix nixos-rebuild -I nixpkgs=$HOME/Projects/nixpkgs/ build-vm
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

