### PR TITLE
csdp: fix darwin build

### DIFF
--- a/pkgs/applications/science/math/csdp/default.nix
+++ b/pkgs/applications/science/math/csdp/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1f9ql6cjy2gwiyc51ylfan24v1ca9sjajxkbhszlds1lqmma8n05";
   };
 
-  buildInputs = [ blas gfortran liblapack ];
+  buildInputs = [ blas gfortran.cc.lib liblapack ];
 
   postPatch = ''
     substituteInPlace Makefile --replace /usr/local/bin $out/bin

--- a/pkgs/development/libraries/science/math/blas/default.nix
+++ b/pkgs/development/libraries/science/math/blas/default.nix
@@ -46,6 +46,13 @@ stdenv.mkDerivation rec {
     ln -s libblas.so.${version} "$out/lib/libblas.so"
   '';
 
+  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
+    for fn in $(find $out/lib -name "*.so*"); do
+      if [ -L "$fn" ]; then continue; fi
+      install_name_tool -id "$fn" "$fn"
+    done
+  '';
+
   meta = {
     description = "Basic Linear Algebra Subprograms";
     license = stdenv.lib.licenses.publicDomain;


### PR DESCRIPTION
###### Motivation for this change

Fixes build failure introduced by https://github.com/NixOS/nixpkgs/pull/24152

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
