### PR TITLE
Fix cross compilation of LLVM-3.9

### DIFF
--- a/pkgs/development/compilers/llvm/3.9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/clang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetch, libxml2, libedit, llvm, version, clang-tools-extra_src, python, buildPackages }:
+{ stdenv, fetch, cmake, libxml2, libedit, llvm, version, clang-tools-extra_src, python }:
 
 let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
@@ -13,7 +13,9 @@ let
       mv clang-tools-extra-* $sourceRoot/tools/extra
     '';
 
-    buildInputs = [ buildPackages.cmake libedit libxml2 llvm python ];
+    nativeBuildInputs = [ cmake ];
+
+    buildInputs = [ libedit libxml2 llvm python ];
 
     cmakeFlags = [
       "-DCMAKE_CXX_FLAGS=-std=c++11"

--- a/pkgs/development/compilers/llvm/3.9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/clang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetch, cmake, libxml2, libedit, llvm, version, clang-tools-extra_src, python }:
+{ stdenv, fetch, libxml2, libedit, llvm, version, clang-tools-extra_src, python, buildPackages }:
 
 let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
@@ -13,7 +13,7 @@ let
       mv clang-tools-extra-* $sourceRoot/tools/extra
     '';
 
-    buildInputs = [ cmake libedit libxml2 llvm python ];
+    buildInputs = [ buildPackages.cmake libedit libxml2 llvm python ];
 
     cmakeFlags = [
       "-DCMAKE_CXX_FLAGS=-std=c++11"

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -53,8 +53,8 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     groff
     libxml2
-    libffi ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ libcxxabi ];
+    libffi
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ libcxxabi ];
 
   propagatedBuildInputs = [ ncurses zlib ];
 

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -81,6 +81,12 @@ in stdenv.mkDerivation rec {
   preBuild = ''
     mkdir -p $out/
     ln -sv $PWD/lib $out
+  ''
+  + # This is a good candidate for using the `placeholder` primitive when it's released
+    # This should hopefully be unnecessary once
+    # https://github.com/NixOS/nixpkgs/pull/25047 is merged
+    stdenv.lib.optionalString (buildPlatform != hostPlatform && enableSharedLibraries) ''
+    export NIX_CROSS_LDFLAGS="-rpath $lib/lib -rpath $lib/lib64 $NIX_CROSS_LDFLAGS"
   '';
 
   cmakeFlags = with stdenv; [

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -42,10 +42,13 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" ] ++ stdenv.lib.optional enableSharedLibraries "lib";
 
+  nativeBuildInputs = [
+    perl
+    cmake
+    python
+  ];
+
   buildInputs = [
-    buildPackages.perl
-    buildPackages.buildPackages.cmake
-    buildPackages.python
     groff
     libxml2
     libffi ]

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -17,6 +17,9 @@
 , debugVersion ? false
 , enableSharedLibraries ? true
 , darwin
+, buildPackages
+, buildPlatform
+, hostPlatform
 }:
 
 let
@@ -39,7 +42,13 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" ] ++ stdenv.lib.optional enableSharedLibraries "lib";
 
-  buildInputs = [ perl groff cmake libxml2 python libffi ]
+  buildInputs = [
+    buildPackages.perl
+    buildPackages.buildPackages.cmake
+    buildPackages.python
+    groff
+    libxml2
+    libffi ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ libcxxabi ];
 
   propagatedBuildInputs = [ ncurses zlib ];
@@ -88,6 +97,9 @@ in stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals (isDarwin) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DCAN_TARGET_i386=false"
+  ] ++ stdenv.lib.optionals (buildPlatform != hostPlatform) [
+    "-DCMAKE_CROSSCOMPILING=True"
+    "-DLLVM_TABLEGEN=${buildPackages.llvmPackages_39.llvm}/bin/llvm-tblgen"
   ];
 
   postBuild = ''

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -15,12 +15,14 @@
 , compiler-rt_src
 , libcxxabi
 , debugVersion ? false
-, enableSharedLibraries ? true
+, enableSharedLibraries ? (buildPlatform == hostPlatform)
 , darwin
 , buildPackages
 , buildPlatform
 , hostPlatform
 }:
+
+assert (hostPlatform != buildPlatform) -> !enableSharedLibraries;
 
 let
   src = fetch "llvm" "1vi9sf7rx1q04wj479rsvxayb6z740iaz3qniwp266fgp5a07n8z";
@@ -84,12 +86,6 @@ in stdenv.mkDerivation rec {
   preBuild = ''
     mkdir -p $out/
     ln -sv $PWD/lib $out
-  ''
-  + # This is a good candidate for using the `placeholder` primitive when it's released
-    # This should hopefully be unnecessary once
-    # https://github.com/NixOS/nixpkgs/pull/25047 is merged
-    stdenv.lib.optionalString (buildPlatform != hostPlatform && enableSharedLibraries) ''
-    export NIX_CROSS_LDFLAGS="-rpath $lib/lib -rpath $lib/lib64 $NIX_CROSS_LDFLAGS"
   '';
 
   cmakeFlags = with stdenv; [

--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, perl, groff
 , ghostscript #for postscript and html output
 , psutils, netpbm #for html output
+, buildPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -49,7 +50,7 @@ stdenv.mkDerivation rec {
     # Trick to get the build system find the proper 'native' groff
     # http://www.mail-archive.com/bug-groff@gnu.org/msg01335.html
     preBuild = ''
-      makeFlags="GROFF_BIN_PATH=${groff}/bin GROFFBIN=${groff}/bin/groff"
+      makeFlags="GROFF_BIN_PATH=${buildPackages.groff}/bin GROFFBIN=${buildPackages.groff}/bin/groff"
     '';
   };
 


### PR DESCRIPTION
~~Although LLVM now cross compiles successfully the executable do not run, the
`RUNPATH` of the resultant executables in incorrect, it does not contain the
LLVM lib output.~~