### PR TITLE
prometheus-alertmanager: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/alertmanager.nix
+++ b/pkgs/servers/monitoring/prometheus/alertmanager.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "alertmanager-${version}";
-  version = "0.5.1";
+  version = "0.6.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/prometheus/alertmanager";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "alertmanager";
-    sha256 = "1z0f8jqbd4v00634qcs41h1zb70ahl63svlzn33gavripk84hwzq";
+    sha256 = "04969hqig0llfkvk3b0yqrywcxm6rgd7ph6nn5rx8pnq21i77sqm";
   };
 
   # Tests exist, but seem to clash with the firewall.
@@ -25,6 +25,17 @@ buildGoPackage rec {
        -X ${t}.BuildUser=nix@nixpkgs
        -X ${t}.BuildDate=unknown
        -X ${t}.GoVersion=${stdenv.lib.getVersion go}
+  '';
+
+  postBuild = ''
+    $NIX_BUILD_TOP/go/bin/artifacts
+  '';
+
+  postInstall = ''
+    rm $bin/bin/artifacts
+    mkdir -p $bin/share/man/man1 $bin/etc/bash_completion.d
+    cp -v amtool*.1 $bin/share/man/man1
+    cp -v amtool_completion.sh $bin/etc/bash_completion.d
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
New release

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

