### PR TITLE
facetimehd: disable aarch64 builds

### DIFF
--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation rec {
     description = "Linux driver for the Facetime HD (Broadcom 1570) PCIe webcam";
     license = licenses.gpl2;
     maintainers = with maintainers; [ womfoo grahamc ];
-    platforms = platforms.linux;
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/os-specific/linux/firmware/facetimehd-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/facetimehd-firmware/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
     homepage = https://support.apple.com/downloads/DL1877;
     license = licenses.unfree;
     maintainers = with maintainers; [ womfoo grahamc ];
-    platforms = platforms.linux;
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

* package does not work on arm

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).