### PR TITLE
glibc: Remove hack around long-fixed bug

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -120,14 +120,6 @@ stdenv.mkDerivation ({
   # prevent a retained dependency on the bootstrap tools in the stdenv-linux
   # bootstrap.
   BASH_SHELL = "/bin/sh";
-
-  # Workaround for this bug:
-  #   http://sourceware.org/bugzilla/show_bug.cgi?id=411
-  # I.e. when gcc is compiled with --with-arch=i686, then the
-  # preprocessor symbol `__i686' will be defined to `1'.  This causes
-  # the symbol __i686.get_pc_thunk.dx to be mangled.
-  NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.system == "i686-linux") "-U__i686"
-    + " -Wno-error=strict-prototypes";
 }
 
 # Remove the `gccCross' attribute so that the *native* glibc store path


### PR DESCRIPTION
###### Motivation for this change

https://sourceware.org/bugzilla/show_bug.cgi?id=411 was solved in 2012.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

