### PR TITLE
Purge binutilsCross

### DIFF
--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -89,6 +89,8 @@ rec {
     msvc = {};
     eabi = {};
     androideabi = {};
+    gnueabi = {};
+    gnueabihf = {};
     unknown = {};
   };
 

--- a/pkgs/development/compilers/gcc/4.5/default.nix
+++ b/pkgs/development/compilers/gcc/4.5/default.nix
@@ -20,7 +20,6 @@
 , enableMultilib ? false
 , name ? "gcc"
 , cross ? null
-, binutilsCross ? null
 , libcCross ? null
 , crossStageStatic ? true
 , gnat ? null
@@ -225,7 +224,7 @@ stdenv.mkDerivation ({
     ++ (optional langJava boehmgc)
     ++ (optionals langJava [zip unzip])
     ++ (optionals javaAwtGtk ([gtk2 pkgconfig libart_lgpl] ++ xlibs))
-    ++ (optionals (cross != null) [binutilsCross])
+    ++ (optionals (cross != null) [binutils])
     ++ (optionals langAda [gnatboot])
     ++ (optionals langVhdl [gnat])
     ;

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -26,7 +26,6 @@
 , enablePlugin ? true             # whether to support user-supplied plug-ins
 , name ? "gcc"
 , cross ? null
-, binutilsCross ? null
 , libcCross ? null
 , crossStageStatic ? true
 , gnat ? null
@@ -171,8 +170,8 @@ let version = "4.8.5";
            else                " --with-headers=${libcCross.dev}/include") +
           # Ensure that -print-prog-name is able to find the correct programs.
           (stdenv.lib.optionalString (crossMingw || crossDarwin) (
-            " --with-as=${binutilsCross}/bin/${cross.config}-as" +
-            " --with-ld=${binutilsCross}/bin/${cross.config}-ld"
+            " --with-as=${binutils}/bin/${cross.config}-as" +
+            " --with-ld=${binutils}/bin/${cross.config}-ld"
           )) +
           " --enable-__cxa_atexit" +
           " --enable-long-long" +
@@ -294,7 +293,7 @@ stdenv.mkDerivation ({
     ++ (optional (zlib != null) zlib)
     ++ (optionals langJava [ boehmgc zip unzip ])
     ++ (optionals javaAwtGtk ([ gtk2 libart_lgpl ] ++ xlibs))
-    ++ (optionals (cross != null) [binutilsCross])
+    ++ (optionals (cross != null) [binutils])
     ++ (optionals langAda [gnatboot])
     ++ (optionals langVhdl [gnat])
 

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -26,7 +26,6 @@
 , enablePlugin ? true             # whether to support user-supplied plug-ins
 , name ? "gcc"
 , cross ? null
-, binutilsCross ? null
 , libcCross ? null
 , crossStageStatic ? true
 , gnat ? null
@@ -172,8 +171,8 @@ let version = "4.9.4";
            else                " --with-headers=${libcCross.dev}/include") +
           # Ensure that -print-prog-name is able to find the correct programs.
           (stdenv.lib.optionalString (crossMingw || crossDarwin) (
-            " --with-as=${binutilsCross}/bin/${cross.config}-as" +
-            " --with-ld=${binutilsCross}/bin/${cross.config}-ld"
+            " --with-as=${binutils}/bin/${cross.config}-as" +
+            " --with-ld=${binutils}/bin/${cross.config}-ld"
           )) +
           " --enable-__cxa_atexit" +
           " --enable-long-long" +
@@ -299,7 +298,7 @@ stdenv.mkDerivation ({
     ++ (optional (zlib != null) zlib)
     ++ (optionals langJava [ boehmgc zip unzip ])
     ++ (optionals javaAwtGtk ([ gtk2 libart_lgpl ] ++ xlibs))
-    ++ (optionals (cross != null) [binutilsCross])
+    ++ (optionals (cross != null) [binutils])
     ++ (optionals langAda [gnatboot])
     ++ (optionals langVhdl [gnat])
 

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -26,7 +26,6 @@
 , enablePlugin ? true             # whether to support user-supplied plug-ins
 , name ? "gcc"
 , cross ? null
-, binutilsCross ? null
 , libcCross ? null
 , crossStageStatic ? true
 , gnat ? null
@@ -176,8 +175,8 @@ let version = "5.4.0";
            else                " --with-headers=${getDev libcCross}/include") +
           # Ensure that -print-prog-name is able to find the correct programs.
           (stdenv.lib.optionalString (crossMingw || crossDarwin) (
-            " --with-as=${binutilsCross}/bin/${cross.config}-as" +
-            " --with-ld=${binutilsCross}/bin/${cross.config}-ld"
+            " --with-as=${binutils}/bin/${cross.config}-as" +
+            " --with-ld=${binutils}/bin/${cross.config}-ld"
           )) +
           " --enable-__cxa_atexit" +
           " --enable-long-long" +
@@ -309,7 +308,7 @@ stdenv.mkDerivation ({
     ++ (optional (zlib != null) zlib)
     ++ (optionals langJava [ boehmgc zip unzip ])
     ++ (optionals javaAwtGtk ([ gtk2 libart_lgpl ] ++ xlibs))
-    ++ (optionals (cross != null) [binutilsCross])
+    ++ (optionals (cross != null) [binutils])
     ++ (optionals langAda [gnatboot])
     ++ (optionals langVhdl [gnat])
 

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -26,7 +26,6 @@
 , enablePlugin ? true             # whether to support user-supplied plug-ins
 , name ? "gcc"
 , cross ? null
-, binutilsCross ? null
 , libcCross ? null
 , crossStageStatic ? true
 , gnat ? null
@@ -172,8 +171,8 @@ let version = "6.3.0";
            else                " --with-headers=${getDev libcCross}/include") +
           # Ensure that -print-prog-name is able to find the correct programs.
           (stdenv.lib.optionalString (crossMingw || crossDarwin) (
-            " --with-as=${binutilsCross}/bin/${cross.config}-as" +
-            " --with-ld=${binutilsCross}/bin/${cross.config}-ld"
+            " --with-as=${binutils}/bin/${cross.config}-as" +
+            " --with-ld=${binutils}/bin/${cross.config}-ld"
           )) +
           " --enable-__cxa_atexit" +
           " --enable-long-long" +
@@ -297,7 +296,7 @@ stdenv.mkDerivation ({
     ++ (optional (zlib != null) zlib)
     ++ (optionals langJava [ boehmgc zip unzip ])
     ++ (optionals javaAwtGtk ([ gtk2 libart_lgpl ] ++ xlibs))
-    ++ (optionals (cross != null) [binutilsCross])
+    ++ (optionals (cross != null) [binutils])
     ++ (optionals langAda [gnatboot])
     ++ (optionals langVhdl [gnat])
 

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -26,7 +26,6 @@
 , enablePlugin ? true             # whether to support user-supplied plug-ins
 , name ? "gcc"
 , cross ? null
-, binutilsCross ? null
 , libcCross ? null
 , crossStageStatic ? true
 , gnat ? null
@@ -172,8 +171,8 @@ let version = "7-20170409";
            else                " --with-headers=${getDev libcCross}/include") +
           # Ensure that -print-prog-name is able to find the correct programs.
           (stdenv.lib.optionalString (crossMingw || crossDarwin) (
-            " --with-as=${binutilsCross}/bin/${cross.config}-as" +
-            " --with-ld=${binutilsCross}/bin/${cross.config}-ld"
+            " --with-as=${binutils}/bin/${cross.config}-as" +
+            " --with-ld=${binutils}/bin/${cross.config}-ld"
           )) +
           " --enable-__cxa_atexit" +
           " --enable-long-long" +
@@ -297,7 +296,7 @@ stdenv.mkDerivation ({
     ++ (optional (zlib != null) zlib)
     ++ (optionals langJava [ boehmgc zip unzip ])
     ++ (optionals javaAwtGtk ([ gtk2 libart_lgpl ] ++ xlibs))
-    ++ (optionals (cross != null) [binutilsCross])
+    ++ (optionals (cross != null) [binutils])
     ++ (optionals langAda [gnatboot])
     ++ (optionals langVhdl [gnat])
 

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -99,17 +99,17 @@ in stdenv.mkDerivation (rec {
 
   configureFlags = [
     "CC=${stdenv.ccCross}/bin/${cross.config}-cc"
-    "LD=${stdenv.binutilsCross}/bin/${cross.config}-ld"
-    "AR=${stdenv.binutilsCross}/bin/${cross.config}-ar"
-    "NM=${stdenv.binutilsCross}/bin/${cross.config}-nm"
-    "RANLIB=${stdenv.binutilsCross}/bin/${cross.config}-ranlib"
+    "LD=${stdenv.binutils}/bin/${cross.config}-ld"
+    "AR=${stdenv.binutils}/bin/${cross.config}-ar"
+    "NM=${stdenv.binutils}/bin/${cross.config}-nm"
+    "RANLIB=${stdenv.binutils}/bin/${cross.config}-ranlib"
     "--target=${cross.config}"
     "--enable-bootstrap-with-devel-snapshot"
   ] ++
     # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
     lib.optional (cross.config or null == "aarch64-apple-darwin14") "--disable-large-address-space";
 
-  buildInputs = commonBuildInputs ++ [ stdenv.ccCross stdenv.binutilsCross ];
+  buildInputs = commonBuildInputs ++ [ stdenv.ccCross stdenv.binutils ];
 
   dontSetConfigureCross = true;
 
@@ -118,6 +118,6 @@ in stdenv.mkDerivation (rec {
 
     cc = "${stdenv.ccCross}/bin/${cross.config}-cc";
 
-    ld = "${stdenv.binutilsCross}/bin/${cross.config}-ld";
+    ld = "${stdenv.binutils}/bin/${cross.config}-ld";
   };
 })

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, binutilsCross ? null, gccCross ? null
+{ stdenv, fetchurl, binutils ? null, gccCross ? null
 , onlyHeaders ? false
 , onlyPthreads ? false
 }:
@@ -27,7 +27,7 @@ stdenv.mkDerivation ({
     cd mingw-w64-libraries/winpthreads
   '';
 } else {
-  buildInputs = [ gccCross binutilsCross ];
+  buildInputs = [ gccCross binutils ];
 
   crossConfig = gccCross.crossConfig;
 

--- a/pkgs/os-specific/windows/mingwrt/default.nix
+++ b/pkgs/os-specific/windows/mingwrt/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, binutilsCross ? null, gccCross ? null, onlyHeaders ? false}:
+{stdenv, fetchurl, binutils ? null, gccCross ? null, onlyHeaders ? false}:
 
 let
   name = "mingwrt-3.20";
@@ -20,7 +20,7 @@ stdenv.mkDerivation (rec {
     cp -R include $out
   '';
 } else {
-  buildInputs = [ gccCross binutilsCross ];
+  buildInputs = [ gccCross binutils ];
 
   crossConfig = gccCross.crossConfig;
 

--- a/pkgs/os-specific/windows/w32api/default.nix
+++ b/pkgs/os-specific/windows/w32api/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, xz, binutilsCross ? null
+{ stdenv, fetchurl, xz, binutils ? null
 , gccCross ? null, onlyHeaders ? false }:
 
 let
@@ -23,7 +23,7 @@ stdenv.mkDerivation ({
     cp -R include $out
   '';
 } else {
-  buildInputs = [ gccCross binutilsCross ];
+  buildInputs = [ gccCross binutils ];
 
   crossConfig = gccCross.crossConfig;
 

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -56,7 +56,7 @@ rec {
 
   # Return a modified stdenv that adds a cross compiler to the
   # builds.
-  makeStdenvCross = stdenv: cross: binutilsCross: gccCross: stdenv // {
+  makeStdenvCross = stdenv: cross: binutils: gccCross: stdenv // {
 
     # Overrides are surely not valid as packages built with this run on a
     # different platform.
@@ -91,7 +91,7 @@ rec {
           name = name + "-" + cross.config;
           nativeBuildInputs = nativeBuildInputs
             ++ nativeInputsFromBuildInputs
-            ++ [ gccCross binutilsCross ]
+            ++ [ gccCross binutils ]
             ++ stdenv.lib.optional selfNativeBuildInput nativeDrv
               # without proper `file` command, libtool sometimes fails
               # to recognize 64-bit DLLs
@@ -110,7 +110,7 @@ rec {
           crossConfig = cross.config;
         } // args.crossAttrs or {});
 
-    inherit gccCross binutilsCross;
+    inherit gccCross binutils;
     ccCross = gccCross;
 
   };

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -39,7 +39,7 @@ in bootStages ++ [
           binutils cc
       else buildPackages.makeStdenvCross
         buildPackages.stdenv crossSystem
-        buildPackages.binutilsCross buildPackages.gccCrossStageFinal;
+        buildPackages.binutils buildPackages.gccCrossStageFinal;
   })
 
 ]

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -70,8 +70,6 @@ let
 
   pkgs = pkgsFun ({inherit system;} // selectedCrossSystem);
 
-  inherit (pkgs.buildPackages) stdenv nukeReferences cpio binutilsCross;
-
   glibc = pkgs.buildPackages.libcCross;
   bash = pkgs.bash;
   findutils = pkgs.findutils;
@@ -126,11 +124,15 @@ rec {
 
   build =
 
-    stdenv.mkDerivation {
+    pkgs.buildPackages.stdenv.mkDerivation {
       name = "stdenv-bootstrap-tools-cross";
       crossConfig = pkgs.hostPlatform.config;
 
-      buildInputs = [nukeReferences cpio binutilsCross];
+      buildInputs = [
+        pkgs.buildPackages.nukeReferences
+        pkgs.buildPackages.cpio
+        pkgs.buildPackages.binutils
+      ];
 
       buildCommand = ''
         set -x
@@ -261,7 +263,7 @@ rec {
       allowedReferences = [];
     };
 
-  dist = stdenv.mkDerivation {
+  dist = pkgs.buildPackages.stdenv.mkDerivation {
     name = "stdenv-bootstrap-tools-cross";
 
     buildCommand = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6336,10 +6336,13 @@ with pkgs;
 
   binutils = if stdenv.isDarwin then darwin.binutils else binutils-raw;
 
-  binutils-raw = callPackage ../development/tools/misc/binutils { inherit noSysDirs; };
+  binutils-raw = callPackage ../development/tools/misc/binutils {
+    # FHS sys dirs presumably only have stuff for the build platform
+    noSysDirs = (targetPlatform != buildPlatform) || noSysDirs;
+    cross = if targetPlatform != hostPlatform then targetPlatform else null;
+  };
 
-  binutils_nogold = lowPrio (callPackage ../development/tools/misc/binutils {
-    inherit noSysDirs;
+  binutils_nogold = lowPrio (binutils-raw.override {
     gold = false;
   });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4982,10 +4982,10 @@ with pkgs;
         libcCross = libcCross1;
         enableShared = false;
         # Why is this needed?
-        inherit (forcedNativePackages) binutilsCross;
+        inherit (forcedNativePackages) binutils;
       };
       libc = libcCross1;
-      binutils = binutilsCross;
+      inherit (forcedNativePackages) binutils;
       cross = targetPlatform;
   };
 
@@ -4993,7 +4993,7 @@ with pkgs;
   gccCrossMingw2 = assert targetPlatform != buildPlatform; wrapGCCCross {
     gcc = gccCrossStageStatic.gcc;
     libc = windows.mingw_headers2;
-    binutils = binutilsCross;
+    inherit (forcedNativePackages) binutils;
     cross = targetPlatform;
   };
 
@@ -5006,10 +5006,10 @@ with pkgs;
       # <http://hydra.nixos.org/build/4268232>), so don't even try.
       langCC = targetPlatform.config != "i686-pc-mingw32";
       # Why is this needed?
-      inherit (forcedNativePackages) binutilsCross;
+      inherit (forcedNativePackages) binutils;
     };
     libc = libcCross;
-    binutils = binutilsCross;
+    inherit (forcedNativePackages) binutils;
     cross = targetPlatform;
   };
 
@@ -6345,13 +6345,6 @@ with pkgs;
   binutils_nogold = lowPrio (binutils-raw.override {
     gold = false;
   });
-
-  binutilsCross = assert targetPlatform != buildPlatform; lowPrio (
-    if targetPlatform.libc == "libSystem" then darwin.cctools_cross
-    else forcedNativePackages.binutils.override {
-      noSysDirs = true;
-      cross = targetPlatform;
-    });
 
   bison2 = callPackage ../development/tools/parsing/bison/2.x.nix { };
   bison3 = callPackage ../development/tools/parsing/bison/3.x.nix { };
@@ -12305,7 +12298,7 @@ with pkgs;
 
     w32api = callPackage ../os-specific/windows/w32api {
       gccCross = gccCrossStageStatic;
-      binutilsCross = binutilsCross;
+      binutils = binutils;
     };
 
     w32api_headers = w32api.override {
@@ -12314,7 +12307,7 @@ with pkgs;
 
     mingw_runtime = callPackage ../os-specific/windows/mingwrt {
       gccCross = gccCrossMingw2;
-      binutilsCross = binutilsCross;
+      binutils = binutils;
     };
 
     mingw_runtime_headers = mingw_runtime.override {
@@ -12338,7 +12331,7 @@ with pkgs;
 
     mingw_w64 = callPackage ../os-specific/windows/mingw-w64 {
       gccCross = gccCrossStageStatic;
-      binutilsCross = binutilsCross;
+      binutils = binutils;
     };
 
     mingw_w64_headers = callPackage ../os-specific/windows/mingw-w64 {


### PR DESCRIPTION
###### Motivation for this change

All the `*Cross` derivations are bad and must go, and binutils is the first to be so purge. See the commit messages for more details.

No hashes should be changed with this commit: http://hydra.nixos.org/eval/1353380?compare=cross-trunk

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

