### PR TITLE
mono: init at 4.8

### DIFF
--- a/pkgs/development/compilers/mono/4.8.nix
+++ b/pkgs/development/compilers/mono/4.8.nix
@@ -1,6 +1,6 @@
 { stdenv, callPackage, Foundation, libobjc }:
 
-callPackage ./generic.nix (rec {
+callPackage ./generic-cmake.nix (rec {
   inherit Foundation libobjc;
   version = "4.8.1.0";
   sha256 = "1vyvp2g28ihcgxgxr8nhzyzdmzicsh5djzk8dk1hj5p5f2k3ijqq";

--- a/pkgs/development/compilers/mono/4.8.nix
+++ b/pkgs/development/compilers/mono/4.8.nix
@@ -1,0 +1,7 @@
+{ stdenv, callPackage, Foundation, libobjc }:
+
+callPackage ./generic.nix (rec {
+  inherit Foundation libobjc;
+  version = "4.8.1.0";
+  sha256 = "1vyvp2g28ihcgxgxr8nhzyzdmzicsh5djzk8dk1hj5p5f2k3ijqq";
+})

--- a/pkgs/development/compilers/mono/generic-cmake.nix
+++ b/pkgs/development/compilers/mono/generic-cmake.nix
@@ -1,0 +1,94 @@
+{ stdenv, fetchurl, bison, pkgconfig, glib, gettext, perl, libgdiplus, libX11, callPackage, ncurses, zlib, withLLVM ? false, cacert, Foundation, libobjc, python, version, sha256, autoconf, libtool, automake, cmake }:
+
+let
+  llvm     = callPackage ./llvm.nix { };
+in
+stdenv.mkDerivation rec {
+  name = "mono-${version}";
+
+  src = fetchurl {
+    inherit sha256;
+    url = "http://download.mono-project.com/sources/mono/${name}.tar.bz2";
+  };
+
+  buildInputs =
+    [ bison pkgconfig glib gettext perl libgdiplus libX11 ncurses zlib python autoconf libtool automake cmake
+    ]
+    ++ (stdenv.lib.optionals stdenv.isDarwin [ Foundation libobjc ]);
+
+  propagatedBuildInputs = [glib];
+
+  NIX_LDFLAGS = if stdenv.isDarwin then "" else "-lgcc_s" ;
+
+  # To overcome the bug https://bugzilla.novell.com/show_bug.cgi?id=644723
+  dontDisableStatic = true;
+
+  # In fact I think this line does not help at all to what I
+  # wanted to achieve: have mono to find libgdiplus automatically
+  configureFlags = [
+    "--x-includes=${libX11.dev}/include"
+    "--x-libraries=${libX11.out}/lib"
+    "--with-libgdiplus=${libgdiplus}/lib/libgdiplus.so"
+  ]
+  ++ stdenv.lib.optionals withLLVM [
+    "--enable-llvm"
+    "--enable-llvmloaded"
+    "--with-llvm=${llvm}"
+  ];
+
+  configurePhase = ''
+    substituteInPlace ./autogen.sh --replace "/usr/bin/env sh" "/bin/sh"
+    ./autogen.sh --prefix $out
+  '';
+
+  # Attempt to fix this error when running "mcs --version":
+  # The file /nix/store/xxx-mono-2.4.2.1/lib/mscorlib.dll is an invalid CIL image
+  dontStrip = true;
+
+  # Parallel building doesn't work, as shows http://hydra.nixos.org/build/2983601
+  enableParallelBuilding = false;
+
+  # We want pkg-config to take priority over the dlls in the Mono framework and the GAC
+  # because we control pkg-config
+  patches = [ ./pkgconfig-before-gac.patch ];
+
+  # Patch all the necessary scripts. Also, if we're using LLVM, we fix the default
+  # LLVM path to point into the Mono LLVM build, since it's private anyway.
+  preBuild = ''
+    makeFlagsArray=(INSTALL=`type -tp install`)
+    patchShebangs ./
+    substituteInPlace mcs/class/corlib/System/Environment.cs --replace /usr/share "$out/share"
+  '' + stdenv.lib.optionalString withLLVM ''
+    substituteInPlace mono/mini/aot-compiler.c --replace "llvm_path = g_strdup (\"\")" "llvm_path = g_strdup (\"${llvm}/bin/\")"
+  '';
+
+  # Fix mono DLLMap so it can find libX11 and gdiplus to run winforms apps
+  # Other items in the DLLMap may need to be pointed to their store locations, I don't think this is exhaustive
+  # http://www.mono-project.com/Config_DllMap
+  postBuild = ''
+    find . -name 'config' -type f | xargs \
+    sed -i -e "s@libX11.so.6@${libX11.out}/lib/libX11.so.6@g" \
+           -e "s@/.*libgdiplus.so@${libgdiplus}/lib/libgdiplus.so@g" \
+  '';
+
+  # Without this, any Mono application attempting to open an SSL connection will throw with
+  # The authentication or decryption has failed.
+  # ---> Mono.Security.Protocol.Tls.TlsException: Invalid certificate received from server.
+  postInstall = ''
+    echo "Updating Mono key store"
+    $out/bin/cert-sync ${cacert}/etc/ssl/certs/ca-bundle.crt
+  ''
+  # According to [1], gmcs is just mcs
+  # [1] https://github.com/mono/mono/blob/master/scripts/gmcs.in
+  + ''
+    ln -s $out/bin/mcs $out/bin/gmcs
+  '';
+
+  meta = {
+    homepage = http://mono-project.com/;
+    description = "Cross platform, open source .NET development framework";
+    platforms = with stdenv.lib.platforms; darwin ++ linux;
+    maintainers = with stdenv.lib.maintainers; [ viric thoughtpolice obadz vrthra ];
+    license = stdenv.lib.licenses.free; # Combination of LGPL/X11/GPL ?
+  };
+}

--- a/pkgs/development/compilers/mono/generic-cmake.nix
+++ b/pkgs/development/compilers/mono/generic-cmake.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bison, pkgconfig, glib, gettext, perl, libgdiplus, libX11, callPackage, ncurses, zlib, withLLVM ? false, cacert, Foundation, libobjc, python, version, sha256, autoconf, libtool, automake, cmake }:
+{ stdenv, fetchurl, bison, pkgconfig, glib, gettext, perl, libgdiplus, libX11, callPackage, ncurses, zlib, withLLVM ? false, cacert, Foundation, libobjc, python, version, sha256, autoconf, libtool, automake, cmake, which }:
 
 let
   llvm     = callPackage ./llvm.nix { };
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ bison pkgconfig glib gettext perl libgdiplus libX11 ncurses zlib python autoconf libtool automake cmake
+    [ bison pkgconfig glib gettext perl libgdiplus libX11 ncurses zlib python autoconf libtool automake cmake which
     ]
     ++ (stdenv.lib.optionals stdenv.isDarwin [ Foundation libobjc ]);
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5543,6 +5543,11 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Foundation;
   });
 
+  mono48 = lowPrio (callPackage ../development/compilers/mono/4.8.nix {
+    inherit (darwin) libobjc;
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  });
+
   monoDLLFixer = callPackage ../build-support/mono-dll-fixer { };
 
   mozart-binary = callPackage ../development/compilers/mozart/binary.nix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

