### PR TITLE
root: 6.08.02 -> 6.09.02

### DIFF
--- a/pkgs/applications/science/misc/root/ROOT-8728-extra.patch
+++ b/pkgs/applications/science/misc/root/ROOT-8728-extra.patch
@@ -1,0 +1,200 @@
+diff --git a/core/base/inc/ROOT/StringConv.hxx b/core/base/inc/ROOT/StringConv.hxx
+index 629fc18..4efa54a 100644
+--- a/core/base/inc/ROOT/StringConv.hxx
++++ b/core/base/inc/ROOT/StringConv.hxx
+@@ -89,7 +89,7 @@ EFromHumanReadableSize FromHumanReadableSize(std::string_view str, T &value)
+       size_t size = str.size();
+       size_t cur;
+       // Parse leading numeric factor
+-      const double coeff = stod(str, &cur);
++      const double coeff = stod(static_cast<std::string>(str), &cur);
+ 
+       // Skip any intermediate white space
+       while (cur<size && isspace(str[cur])) ++cur;
+diff --git a/core/metacling/src/TCling.cxx b/core/metacling/src/TCling.cxx
+index d71cb74..076facb 100644
+--- a/core/metacling/src/TCling.cxx
++++ b/core/metacling/src/TCling.cxx
+@@ -756,7 +756,7 @@ int TCling_GenerateDictionary(const std::vector<std::string> &classes,
+                gSystem->PrependPathName(dirbase, header);
+                dir = gSystem->DirName(dir);
+             }
+-            fileContent += TString("#include \"") + header + "\"\n";
++            fileContent += (TString("#include \"") + header + "\"\n").Data();
+          }
+       }
+       for (it = fwdDecls.begin(); it != fwdDecls.end(); ++it) {
+@@ -1061,7 +1061,7 @@ TCling::TCling(const char *name, const char *title)
+       ROOT::TMetaUtils::SetPathsForRelocatability(clingArgsStorage);
+ 
+       // Add -I early so ASTReader can find the headers.
+-      std::string interpInclude(TROOT::GetEtcDir());
++      std::string interpInclude(TROOT::GetEtcDir().Data());
+       clingArgsStorage.push_back("-I" + interpInclude);
+ 
+       // Add include path to etc/cling. FIXME: This is a short term solution. The
+@@ -1070,7 +1070,7 @@ TCling::TCling(const char *name, const char *title)
+       clingArgsStorage.push_back("-I" + interpInclude + "/cling");
+ 
+       // Add the root include directory and etc/ to list searched by default.
+-      clingArgsStorage.push_back(std::string("-I" + TROOT::GetIncludeDir()));
++      clingArgsStorage.push_back(std::string(("-I" + TROOT::GetIncludeDir()).Data()));
+ 
+       // Add the current path to the include path
+       // TCling::AddIncludePath(".");
+diff --git a/hist/hist/src/TFormula.cxx b/hist/hist/src/TFormula.cxx
+index abf3929..e7dad98 100644
+--- a/hist/hist/src/TFormula.cxx
++++ b/hist/hist/src/TFormula.cxx
+@@ -1677,7 +1677,7 @@ void TFormula::ProcessFormula(TString &formula)
+          if(fun.fName.Contains("::")) // add support for nested namespaces
+          {
+             // look for last occurence of "::"
+-            std::string name(fun.fName);
++            std::string name(fun.fName.Data());
+             size_t index = name.rfind("::");
+             assert(index != std::string::npos);
+             TString className = fun.fName(0,fun.fName(0,index).Length());
+@@ -1869,7 +1869,7 @@ void TFormula::ProcessFormula(TString &formula)
+ 
+          // save copy of inputFormula in a std::strig for the unordered map
+          // and also formula is same as FClingInput typically and it will be modified
+-         std::string inputFormula = std::string(formula);
++         std::string inputFormula = std::string(formula.Data());
+ 
+ 
+          // valid input formula - try to put into Cling
+diff --git a/main/src/nbmain.cxx b/main/src/nbmain.cxx
+index 55d4f2f..8490149 100644
+--- a/main/src/nbmain.cxx
++++ b/main/src/nbmain.cxx
+@@ -173,9 +173,9 @@ static bool CreateStamp(string dest)
+ 
+ int main()
+ {
+-   string rootbin(TROOT::GetBinDir());
+-   string rootlib(TROOT::GetLibDir());
+-   string rootetc(TROOT::GetEtcDir());
++   string rootbin(TROOT::GetBinDir().Data());
++   string rootlib(TROOT::GetLibDir().Data());
++   string rootetc(TROOT::GetEtcDir().Data());
+ 
+    // If needed, install ROOT notebook files in the user's home directory
+ #ifdef WIN32
+diff --git a/math/minuit/src/TMinuitMinimizer.cxx b/math/minuit/src/TMinuitMinimizer.cxx
+index 4e2082a..18215c0 100644
+--- a/math/minuit/src/TMinuitMinimizer.cxx
++++ b/math/minuit/src/TMinuitMinimizer.cxx
+@@ -454,7 +454,7 @@ std::string TMinuitMinimizer::VariableName(unsigned int ivar) const {
+    // return the variable name
+    if (!CheckMinuitInstance()) return std::string();
+    if (!CheckVarIndex(ivar)) return std::string();
+-   return std::string(fMinuit->fCpnam[ivar]);
++   return std::string(fMinuit->fCpnam[ivar].Data());
+ }
+ 
+ int TMinuitMinimizer::VariableIndex(const std::string & ) const {
+diff --git a/tmva/tmva/src/Factory.cxx b/tmva/tmva/src/Factory.cxx
+index 36060ef..a1bbe34 100644
+--- a/tmva/tmva/src/Factory.cxx
++++ b/tmva/tmva/src/Factory.cxx
+@@ -390,7 +390,7 @@ TMVA::MethodBase* TMVA::Factory::BookMethod( TMVA::DataLoader *loader, TString t
+    // initialize methods
+    IMethod* im;
+    if (!boostNum) {
+-      im = ClassifierFactory::Instance().Create( std::string(theMethodName),
++      im = ClassifierFactory::Instance().Create( std::string(theMethodName.Data()),
+                                                  fJobName,
+                                                  methodTitle,
+                                                  loader->DefaultDataSetInfo(),
+@@ -933,7 +933,7 @@ void TMVA::Factory::TrainAllMethods()
+ 
+        // recreate
+        m = dynamic_cast<MethodBase*>( ClassifierFactory::Instance()
+-                   .Create( std::string(Types::Instance().GetMethodName(methodType)),
++                   .Create( std::string(Types::Instance().GetMethodName(methodType).Data()),
+                       dataSetInfo, weightfile ) );
+        if( m->GetMethodType() == Types::kCategory ){
+       MethodCategory *methCat = (dynamic_cast<MethodCategory*>(m));
+diff --git a/tmva/tmva/src/MethodBoost.cxx b/tmva/tmva/src/MethodBoost.cxx
+index 1349e5d..2125ab3 100644
+--- a/tmva/tmva/src/MethodBoost.cxx
++++ b/tmva/tmva/src/MethodBoost.cxx
+@@ -389,7 +389,7 @@ void TMVA::MethodBoost::Train()
+       // the first classifier shows the option string output, the rest not
+       if (fCurrentMethodIdx>0) TMVA::MsgLogger::InhibitOutput();
+ 
+-      IMethod* method = ClassifierFactory::Instance().Create(std::string(fBoostedMethodName),
++      IMethod* method = ClassifierFactory::Instance().Create(std::string(fBoostedMethodName.Data()),
+                                                              GetJobName(),
+                                                              Form("%s_B%04i", fBoostedMethodTitle.Data(),fCurrentMethodIdx),
+                                                              DataInfo(),
+diff --git a/tmva/tmva/src/MethodCategory.cxx b/tmva/tmva/src/MethodCategory.cxx
+index c2cbe80..d278cca 100644
+--- a/tmva/tmva/src/MethodCategory.cxx
++++ b/tmva/tmva/src/MethodCategory.cxx
+@@ -147,7 +147,7 @@ TMVA::IMethod* TMVA::MethodCategory::AddMethod( const TCut& theCut,
+                                                 const TString& theTitle,
+                                                 const TString& theOptions )
+ {
+-   std::string addedMethodName = std::string(Types::Instance().GetMethodName(theMethod));
++   std::string addedMethodName = std::string(Types::Instance().GetMethodName(theMethod).Data());
+ 
+    Log() << kINFO << "Adding sub-classifier: " << addedMethodName << "::" << theTitle << Endl;
+ 
+diff --git a/tmva/tmva/src/MethodCompositeBase.cxx b/tmva/tmva/src/MethodCompositeBase.cxx
+index 98fa5da..96bd9a3 100644
+--- a/tmva/tmva/src/MethodCompositeBase.cxx
++++ b/tmva/tmva/src/MethodCompositeBase.cxx
+@@ -194,7 +194,7 @@ void TMVA::MethodCompositeBase::ReadWeightsFromXML( void* wghtnode )
+          ((TMVA::MethodBoost*)this)->BookMethod( Types::Instance().GetMethodType( methodTypeName), methodName,  optionString );
+       }
+       fMethods.push_back(ClassifierFactory::Instance().Create(
+-                                                              std::string(methodTypeName),jobName, methodName,DataInfo(),optionString));
++                                                              std::string(methodTypeName.Data()),jobName, methodName,DataInfo(),optionString));
+ 
+       fMethodWeight.push_back(methodWeight);
+       MethodBase* meth = dynamic_cast<MethodBase*>(fMethods.back());
+@@ -259,7 +259,7 @@ void  TMVA::MethodCompositeBase::ReadWeightsFromStream( std::istream& istr )
+             ((TMVA::MethodBoost*)this)->BookMethod( Types::Instance().GetMethodType( methodName), methodTitle,  optionString );
+       }
+       else methodTitle=Form("%s (%04i)",GetMethodName().Data(),fCurrentMethodIdx);
+-      fMethods.push_back(ClassifierFactory::Instance().Create( std::string(methodName), jobName,
++      fMethods.push_back(ClassifierFactory::Instance().Create( std::string(methodName.Data()), jobName,
+                                                                methodTitle,DataInfo(), optionString) );
+       fMethodWeight.push_back( methodWeight );
+       if(MethodBase* m = dynamic_cast<MethodBase*>(fMethods.back()) )
+diff --git a/tmva/tmva/src/Reader.cxx b/tmva/tmva/src/Reader.cxx
+index 94a8b28..0b67867 100644
+--- a/tmva/tmva/src/Reader.cxx
++++ b/tmva/tmva/src/Reader.cxx
+@@ -401,7 +401,7 @@ TMVA::IMethod* TMVA::Reader::BookMVA( const TString& methodTag, const TString& w
+ 
+ TMVA::IMethod* TMVA::Reader::BookMVA( TMVA::Types::EMVA methodType, const TString& weightfile )
+ {
+-   IMethod* im = ClassifierFactory::Instance().Create(std::string(Types::Instance().GetMethodName( methodType )),
++   IMethod* im = ClassifierFactory::Instance().Create(std::string(Types::Instance().GetMethodName( methodType ).Data()),
+                                                       DataInfo(), weightfile );
+ 
+    MethodBase *method = (dynamic_cast<MethodBase*>(im));
+@@ -440,7 +440,7 @@ TMVA::IMethod* TMVA::Reader::BookMVA( TMVA::Types::EMVA methodType, const char*
+ #if ROOT_VERSION_CODE >= ROOT_VERSION(5,26,00)
+ 
+    // books MVA method from weightfile
+-   IMethod* im = ClassifierFactory::Instance().Create(std::string(Types::Instance().GetMethodName( methodType )),
++   IMethod* im = ClassifierFactory::Instance().Create(std::string(Types::Instance().GetMethodName( methodType ).Data()),
+                                                       DataInfo(), "" );
+ 
+    MethodBase *method = (dynamic_cast<MethodBase*>(im));
+diff -aru a/core/base/inc/TString.h b/core/base/inc/TString.h
+--- a/core/base/inc/TString.h
++++ b/core/base/inc/TString.h
+@@ -106,7 +106,7 @@
+    char          operator[](Ssiz_t i) const;     // Index with bounds checking
+ 
+    operator std::string_view() const { return std::string_view(Data(),fExtent); }
+-   operator std::string() const { return std::string_view(Data(),fExtent).to_string(); }
++   operator std::string() const { return static_cast<std::string>(std::string_view(Data(),fExtent)); }
+ 
+    const char   *Data() const;
+    Ssiz_t        Length() const          { return fExtent; }

--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -1,18 +1,19 @@
 { stdenv, fetchurl, fetchpatch, cmake, pcre, pkgconfig, python2
-, libX11, libXpm, libXft, libXext, zlib, lzma, gsl, Cocoa }:
+, libX11, libXpm, libXft, libXext, mesa, zlib, libxml2, lzma, gsl
+, Cocoa, OpenGL }:
 
 stdenv.mkDerivation rec {
   name = "root-${version}";
-  version = "6.08.02";
+  version = "6.09.02";
 
   src = fetchurl {
     url = "https://root.cern.ch/download/root_v${version}.source.tar.gz";
-    sha256 = "0530v1r4rvds52hgb13f00l3phhn76z6vii550mwv8bj3sl5070k";
+    sha256 = "0fc6b0l7bw66cyckxs4ikvyzcv1zlfx88205jx153smdhih0jj2k";
   };
 
-  buildInputs = [ cmake pcre pkgconfig python2 zlib lzma gsl ]
-    ++ stdenv.lib.optionals (!stdenv.isDarwin) [ libX11 libXpm libXft libXext ]
-    ++ stdenv.lib.optionals (stdenv.isDarwin) [ Cocoa ]
+  buildInputs = [ cmake pcre pkgconfig python2 zlib libxml2 lzma gsl ]
+    ++ stdenv.lib.optionals (!stdenv.isDarwin) [ libX11 libXpm libXft libXext mesa ]
+    ++ stdenv.lib.optionals (stdenv.isDarwin) [ Cocoa OpenGL ]
     ;
 
   patches = [
@@ -20,6 +21,13 @@ stdenv.mkDerivation rec {
 
     # this prevents thisroot.sh from setting $p, which interferes with stdenv setup
     ./thisroot.patch
+
+    # https://sft.its.cern.ch/jira/browse/ROOT-8728
+    (fetchpatch {
+      url = "https://sft.its.cern.ch/jira/secure/attachment/20025/0001-std-string_view-has-no-more-to_string.patch";
+      sha256 = "0ngyk960xfrcsj4vhr1ax8h85fx0g1cfycxi3k35a6ych2zmyg8q";
+    })
+    ./ROOT-8728-extra.patch
   ];
 
   preConfigure = ''
@@ -47,7 +55,7 @@ stdenv.mkDerivation rec {
     "-Dmonalisa=OFF"
     "-Dmysql=OFF"
     "-Dodbc=OFF"
-    "-Dopengl=OFF"
+    "-Dopengl=ON"
     "-Doracle=OFF"
     "-Dpgsql=OFF"
     "-Dpythia6=OFF"
@@ -55,7 +63,7 @@ stdenv.mkDerivation rec {
     "-Drfio=OFF"
     "-Dsqlite=OFF"
     "-Dssl=OFF"
-    "-Dxml=OFF"
+    "-Dxml=ON"
     "-Dxrootd=OFF"
   ]
   ++ stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.lib.getDev stdenv.cc.libc}/include";

--- a/pkgs/applications/science/misc/root/sw_vers.patch
+++ b/pkgs/applications/science/misc/root/sw_vers.patch
@@ -25,7 +25,7 @@ diff --git a/cmake/modules/SetUpMacOS.cmake b/cmake/modules/SetUpMacOS.cmake
 -                  COMMAND cut -d . -f 2
 -                  OUTPUT_VARIABLE MACOSX_MINOR OUTPUT_STRIP_TRAILING_WHITESPACE)
 -
--  if(MACOSX_VERSION VERSION_GREATER 10.7 AND ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
+-  if(MACOSX_VERSION VERSION_GREATER 10.7 AND ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
      set(libcxx ON CACHE BOOL "Build using libc++" FORCE)
 -  endif()
  

--- a/pkgs/applications/science/physics/sherpa/default.nix
+++ b/pkgs/applications/science/physics/sherpa/default.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # LLVM 4 doesn't allow ambigous type in std::abs argument
+  patches = stdenv.lib.optional stdenv.cc.isClang [ ./explicit_overloads.patch ];
+
   configureFlags = [
     "--with-sqlite3=${sqlite.dev}"
     "--enable-hepmc2=${hepmc}"

--- a/pkgs/applications/science/physics/sherpa/explicit_overloads.patch
+++ b/pkgs/applications/science/physics/sherpa/explicit_overloads.patch
@@ -1,0 +1,119 @@
+diff --git a/ATOOLS/Phys/Flavour.C b/ATOOLS/Phys/Flavour.C
+index 1986348..740eea3 100644
+--- a/ATOOLS/Phys/Flavour.C
++++ b/ATOOLS/Phys/Flavour.C
+@@ -298,8 +298,8 @@ std::string Flavour::IDName() const
+ 
+ bool Flavour::IsDiQuark() const 
+ {
+-  if(abs(Kfcode())>=1103&&abs(Kfcode())<=5505) {
+-    double help=abs(Kfcode())/100.0-int(abs(Kfcode())/100.0); 
++  if(abs((long)Kfcode())>=1103&&abs((long)Kfcode())<=5505) {
++    double help=abs((long)Kfcode())/100.0-int(abs((long)Kfcode())/100.0); 
+     if(help<0.031) return true;
+   }
+   return false;
+@@ -307,27 +307,27 @@ bool Flavour::IsDiQuark() const
+ 
+ bool Flavour::IsBaryon() const 
+ {
+-  if (abs(Kfcode())%10000<1000) return false;
++  if (abs((long)Kfcode())%10000<1000) return false;
+   return !IsDiQuark();
+ }
+ 
+ bool Flavour::IsB_Hadron() const 
+ {
+-  if (abs(Kfcode())<100)                            return 0;
++  if (abs((long)Kfcode())<100)                            return 0;
+   if (Kfcode()-100*int(Kfcode()/100)<10)                 return 0;
+-  if (abs((Kfcode()-100*int(Kfcode()/100))/10)==5)       return 1;
+-  if (abs((Kfcode()-1000*int(Kfcode()/1000))/100)==5)    return 1;
+-  if (abs((Kfcode()-10000*int(Kfcode()/10000))/1000)==5) return 1;
++  if (abs((long)(Kfcode()-100*int(Kfcode()/100))/10)==5)       return 1;
++  if (abs((long)(Kfcode()-1000*int(Kfcode()/1000))/100)==5)    return 1;
++  if (abs((long)(Kfcode()-10000*int(Kfcode()/10000))/1000)==5) return 1;
+   return 0;
+ }
+ 
+ bool Flavour::IsC_Hadron() const 
+ {
+-  if (abs(Kfcode())<100)                            return 0;
++  if (abs((long)Kfcode())<100)                            return 0;
+   if (Kfcode()-100*int(Kfcode()/100)<10)                 return 0;
+-  if (abs((Kfcode()-100*int(Kfcode()/100))/10)==4)       return 1;
+-  if (abs((Kfcode()-1000*int(Kfcode()/1000))/100)==4)    return 1;
+-  if (abs((Kfcode()-10000*int(Kfcode()/10000))/1000)==4) return 1;
++  if (abs((long)(Kfcode()-100*int(Kfcode()/100))/10)==4)       return 1;
++  if (abs((long)(Kfcode()-1000*int(Kfcode()/1000))/100)==4)    return 1;
++  if (abs((long)(Kfcode()-10000*int(Kfcode()/10000))/1000)==4) return 1;
+   return 0;
+ }
+ 
+diff --git a/AddOns/Pythia/Pythia_Jet_Criterion.C b/AddOns/Pythia/Pythia_Jet_Criterion.C
+index bbe9597..c1201e1 100644
+--- a/AddOns/Pythia/Pythia_Jet_Criterion.C
++++ b/AddOns/Pythia/Pythia_Jet_Criterion.C
+@@ -117,8 +117,8 @@ namespace PYTHIA {
+       double Qsq = sign * Q.Abs2();
+       // Mass term of radiator
+       DEBUG_VAR(ampl->MS());
+-      double m2Rad = ( abs(RadAfterBranch.Flav().Kfcode()) >= 4
+-                   && abs(RadAfterBranch.Flav().Kfcode()) < 7)
++      double m2Rad = ( abs((long)RadAfterBranch.Flav().Kfcode()) >= 4
++                   && abs((long)RadAfterBranch.Flav().Kfcode()) < 7)
+                    ? ampl->MS()->Mass2(RadAfterBranch.Flav())
+                    : 0.;
+       // Construct 2->3 variables for FSR
+diff --git a/BEAM/Main/EPA.C b/BEAM/Main/EPA.C
+index 861a1b2..340ac33 100644
+--- a/BEAM/Main/EPA.C
++++ b/BEAM/Main/EPA.C
+@@ -54,7 +54,7 @@ double EPA::CosInt::GetCosInt(double X)
+ 
+ double EPA::phi(double x, double qq)
+ {
+-  if (abs(m_beam.Kfcode()) == kf_p_plus) {
++  if (abs((long)m_beam.Kfcode()) == kf_p_plus) {
+     const double a = 7.16;
+     const double b = -3.96;
+     const double c = .028;
+@@ -179,7 +179,7 @@ bool EPA::CalculateWeight(double x,double q2)
+     m_weight=0.0;
+     return 1;
+   }
+-  if (abs(m_beam.Kfcode()) == kf_e) {
++  if (abs((long)m_beam.Kfcode()) == kf_e) {
+     double f = alpha/M_PI*(1+sqr(1-m_x))/m_x*log(2.*m_energy/m_mass);
+     if (f < 0) f = 0.;
+     m_weight = f;
+@@ -187,7 +187,7 @@ bool EPA::CalculateWeight(double x,double q2)
+ 	     <<"energy = "<<m_energy<<", "<<"mass = "<<m_mass<<".\n";
+     return 1;    
+   }
+-  else if (abs(m_beam.Kfcode()) == kf_p_plus) {
++  else if (abs((long)m_beam.Kfcode()) == kf_p_plus) {
+     const double qz = 0.71;
+     double f, qmi, qma;
+     qma=m_q2Max/qz;
+diff --git a/PDF/Remnant/Hadron_Remnant.C b/PDF/Remnant/Hadron_Remnant.C
+index 243717c..58c2278 100644
+--- a/PDF/Remnant/Hadron_Remnant.C
++++ b/PDF/Remnant/Hadron_Remnant.C
+@@ -188,13 +188,13 @@ ATOOLS::Flavour Hadron_Remnant::Opposite(ATOOLS::Flavour flav) const
+     if (m_constit[i]==flav && !found) found=true;
+     else rem[j++]=m_constit[i].Kfcode();
+   }
+-  Flavour anti=Flavour((kf_code)(abs(rem[0])*1000+abs(rem[1])*100+3));
++  Flavour anti=Flavour((kf_code)(abs((long)rem[0])*1000+abs((long)rem[1])*100+3));
+   if (rem[0]!=rem[1]) {
+     if (ran->Get()<0.25) 
+-      anti=Flavour((kf_code)(abs(rem[0])*1000+abs(rem[1])*100+1));
++      anti=Flavour((kf_code)(abs((long)rem[0])*1000+abs((long)rem[1])*100+1));
+   }
+   else {
+-    anti=Flavour((kf_code)(abs(rem[0])*1100+3));
++    anti=Flavour((kf_code)(abs((long)rem[0])*1100+3));
+   }
+   if (flav.IsAnti()) anti=anti.Bar();
+   return anti;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17789,7 +17789,7 @@ with pkgs;
   megam = callPackage ../applications/science/misc/megam { };
 
   root = callPackage ../applications/science/misc/root {
-    inherit (darwin.apple_sdk.frameworks) Cocoa;
+    inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
   };
 
   simgrid = callPackage ../applications/science/misc/simgrid { };


### PR DESCRIPTION
This also fixes breakage on darwin due to LLVM4.0 migration.

I had to enable opengl because otherwise macOS build is broken.
See root commit 23f8871c7 ('Do not include OpenGL directly but use our
TGLIncludes for that purpose.')

I've enabled xml because TUnfold now depends on it.

###### Motivation for this change

ROOT is currently broken on darwin.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
#24294 