### PR TITLE
Cross binutils

### DIFF
--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -83,6 +83,9 @@ rec {
     solaris = { execFormat = elf;     families = { inherit unix; }; };
     windows = { execFormat = pe;      families = { }; };
   } // { # aliases
+    # TODO(@Ericson2314): Handle these Darwin version suffixes more generally.
+    darwin10 = kernels.darwin;
+    darwin14 = kernels.darwin;
     win32 = kernels.windows;
   };
 

--- a/pkgs/development/compilers/gcc/4.5/default.nix
+++ b/pkgs/development/compilers/gcc/4.5/default.nix
@@ -78,6 +78,9 @@ let version = "4.5.4";
       withArch +
       withCpu +
       withAbi +
+      # Ensure that -print-prog-name is able to find the correct programs.
+      " --with-as=${binutils}/bin/${cross.config}-as" +
+      " --with-ld=${binutils}/bin/${cross.config}-ld" +
       (if crossMingw && crossStageStatic then
         " --with-headers=${libcCross}/include" +
         " --with-gcc" +

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -143,6 +143,9 @@ let version = "4.8.5";
         withFpu +
         withFloat +
         withMode +
+        # Ensure that -print-prog-name is able to find the correct programs.
+        " --with-as=${binutils}/bin/${cross.config}-as" +
+        " --with-ld=${binutils}/bin/${cross.config}-ld" +
         (if crossMingw && crossStageStatic then
           " --with-headers=${libcCross}/include" +
           " --with-gcc" +
@@ -169,10 +172,6 @@ let version = "4.8.5";
           (if crossDarwin then " --with-sysroot=${libcCross.out}/share/sysroot"
            else                " --with-headers=${libcCross.dev}/include") +
           # Ensure that -print-prog-name is able to find the correct programs.
-          (stdenv.lib.optionalString (crossMingw || crossDarwin) (
-            " --with-as=${binutils}/bin/${cross.config}-as" +
-            " --with-ld=${binutils}/bin/${cross.config}-ld"
-          )) +
           " --enable-__cxa_atexit" +
           " --enable-long-long" +
           (if crossMingw then

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -145,6 +145,9 @@ let version = "4.9.4";
         withFpu +
         withFloat +
         withMode +
+        # Ensure that -print-prog-name is able to find the correct programs.
+        " --with-as=${binutils}/bin/${cross.config}-as" +
+        " --with-ld=${binutils}/bin/${cross.config}-ld" +
         (if crossMingw && crossStageStatic then
           " --with-headers=${libcCross}/include" +
           " --with-gcc" +
@@ -169,11 +172,6 @@ let version = "4.9.4";
           else
           (if crossDarwin then " --with-sysroot=${libcCross.out}/share/sysroot"
            else                " --with-headers=${libcCross.dev}/include") +
-          # Ensure that -print-prog-name is able to find the correct programs.
-          (stdenv.lib.optionalString (crossMingw || crossDarwin) (
-            " --with-as=${binutils}/bin/${cross.config}-as" +
-            " --with-ld=${binutils}/bin/${cross.config}-ld"
-          )) +
           " --enable-__cxa_atexit" +
           " --enable-long-long" +
           (if crossMingw then

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -149,6 +149,9 @@ let version = "5.4.0";
         withFpu +
         withFloat +
         withMode +
+        # Ensure that -print-prog-name is able to find the correct programs.
+        " --with-as=${binutils}/bin/${cross.config}-as" +
+        " --with-ld=${binutils}/bin/${cross.config}-ld" +
         (if crossMingw && crossStageStatic then
           " --with-headers=${libcCross}/include" +
           " --with-gcc" +
@@ -173,11 +176,6 @@ let version = "5.4.0";
           else
           (if crossDarwin then " --with-sysroot=${getLib libcCross}/share/sysroot"
            else                " --with-headers=${getDev libcCross}/include") +
-          # Ensure that -print-prog-name is able to find the correct programs.
-          (stdenv.lib.optionalString (crossMingw || crossDarwin) (
-            " --with-as=${binutils}/bin/${cross.config}-as" +
-            " --with-ld=${binutils}/bin/${cross.config}-ld"
-          )) +
           " --enable-__cxa_atexit" +
           " --enable-long-long" +
           (if crossMingw then

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -145,6 +145,9 @@ let version = "6.3.0";
         withFpu +
         withFloat +
         withMode +
+        # Ensure that -print-prog-name is able to find the correct programs.
+        " --with-as=${binutils}/bin/${cross.config}-as" +
+        " --with-ld=${binutils}/bin/${cross.config}-ld" +
         (if crossMingw && crossStageStatic then
           " --with-headers=${libcCross}/include" +
           " --with-gcc" +
@@ -169,11 +172,6 @@ let version = "6.3.0";
           else
           (if crossDarwin then " --with-sysroot=${getLib libcCross}/share/sysroot"
            else                " --with-headers=${getDev libcCross}/include") +
-          # Ensure that -print-prog-name is able to find the correct programs.
-          (stdenv.lib.optionalString (crossMingw || crossDarwin) (
-            " --with-as=${binutils}/bin/${cross.config}-as" +
-            " --with-ld=${binutils}/bin/${cross.config}-ld"
-          )) +
           " --enable-__cxa_atexit" +
           " --enable-long-long" +
           (if crossMingw then

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -145,6 +145,9 @@ let version = "7-20170409";
         withFpu +
         withFloat +
         withMode +
+        # Ensure that -print-prog-name is able to find the correct programs.
+        " --with-as=${binutils}/bin/${cross.config}-as" +
+        " --with-ld=${binutils}/bin/${cross.config}-ld" +
         (if crossMingw && crossStageStatic then
           " --with-headers=${libcCross}/include" +
           " --with-gcc" +
@@ -170,10 +173,6 @@ let version = "7-20170409";
           (if crossDarwin then " --with-sysroot=${getLib libcCross}/share/sysroot"
            else                " --with-headers=${getDev libcCross}/include") +
           # Ensure that -print-prog-name is able to find the correct programs.
-          (stdenv.lib.optionalString (crossMingw || crossDarwin) (
-            " --with-as=${binutils}/bin/${cross.config}-as" +
-            " --with-ld=${binutils}/bin/${cross.config}-ld"
-          )) +
           " --enable-__cxa_atexit" +
           " --enable-long-long" +
           (if crossMingw then

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -7,7 +7,7 @@ let basename = "binutils-2.28"; in
 let inherit (stdenv.lib) optional optionals optionalString; in
 
 stdenv.mkDerivation rec {
-  name = basename + optionalString (cross != null) "-${cross.config}";
+  name = optionalString (cross != null) "${cross.config}-" + basename;
 
   src = fetchurl {
     url = "mirror://gnu/binutils/${basename}.tar.bz2";

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
     ./no-plugins.patch
   ];
 
+  # TODO: all outputs on all platform
   outputs = [ "out" ]
     ++ optional (cross == null && !stdenv.isDarwin) "lib" # problems in Darwin stdenv
     ++ [ "info" ]
@@ -75,7 +76,7 @@ stdenv.mkDerivation rec {
   configureFlags =
     [ "--enable-shared" "--enable-deterministic-archives" "--disable-werror" ]
     ++ optional (stdenv.system == "mips64el-linux") "--enable-fix-loongson2f-nop"
-    ++ optional (cross != null) "--target=${cross.config}"
+    ++ optional (cross != null) "--target=${cross.config}" # TODO: make this unconditional
     ++ optionals gold [ "--enable-gold" "--enable-plugins" ]
     ++ optional (stdenv.system == "i686-linux") "--enable-targets=x86_64-linux-gnu";
 

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -15,7 +15,7 @@ in
 
 # TODO loop over prefixed binaries too
 stdenv.mkDerivation {
-  name = "cctools-binutils-darwin";
+  name = "${prefix}cctools-binutils-darwin";
   buildCommand = ''
     mkdir -p $out/bin $out/include
 

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -1,11 +1,25 @@
-{ stdenv, binutils-raw, cctools }:
+{ stdenv, binutils-raw, cctools
+, hostPlatform, targetPlatform
+}:
 
+let
+  prefix = stdenv.lib.optionalString
+    (targetPlatform != hostPlatform)
+    "${targetPlatform.config}-";
+
+  cmds = [
+    "ar" "ranlib" "as" "dsymutil" "install_name_tool"
+    "ld" "strip" "otool" "lipo" "nm" "strings" "size"
+  ];
+in
+
+# TODO loop over prefixed binaries too
 stdenv.mkDerivation {
   name = "cctools-binutils-darwin";
   buildCommand = ''
     mkdir -p $out/bin $out/include
 
-    ln -s ${binutils-raw.out}/bin/c++filt $out/bin/c++filt
+    ln -s ${binutils-raw.out}/bin/${prefix}c++filt $out/bin/${prefix}c++filt
 
     # We specifically need:
     # - ld: binutils doesn't provide it on darwin
@@ -18,11 +32,11 @@ stdenv.mkDerivation {
     # - strip: the binutils one seems to break mach-o files
     # - lipo: gcc build assumes it exists
     # - nm: the gnu one doesn't understand many new load commands
-    for i in ar ranlib as dsymutil install_name_tool ld strip otool lipo nm strings size; do
+    for i in ${stdenv.lib.concatStringsSep " " (builtins.map (e: prefix + e) cmds)}; do
       ln -sf "${cctools}/bin/$i" "$out/bin/$i"
     done
 
-    for i in ${binutils-raw.dev}/include/*.h; do
+    for i in ${binutils-raw.dev or binutils-raw.out}/include/*.h; do
       ln -s "$i" "$out/include/$(basename $i)"
     done
 

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -1,7 +1,21 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libtool_2
+{ stdenv, fetchFromGitHub, makeWrapper, autoconf, automake, libtool_2
 , llvm, libcxx, libcxxabi, clang, libuuid
-, libobjc ? null
+, libobjc ? null, maloader ? null, xctoolchain ? null
+, buildPlatform, hostPlatform, targetPlatform
 }:
+
+let
+  inherit (stdenv.lib.systems.parse) isDarwin;
+
+  prefix = stdenv.lib.optionalString
+    (targetPlatform != hostPlatform)
+    "${targetPlatform.config}-";
+in
+
+assert isDarwin targetPlatform.parsed;
+
+# Non-Darwin alternatives
+assert (!isDarwin hostPlatform.parsed) -> (maloader != null && xctoolchain != null);
 
 let
   baseParams = rec {
@@ -26,7 +40,14 @@ let
 
     enableParallelBuilding = true;
 
-    configureFlags = stdenv.lib.optionals (!stdenv.isDarwin) [ "CXXFLAGS=-I${libcxx}/include/c++/v1" ];
+    configureFlags = stdenv.lib.optionals (!stdenv.isDarwin) [
+      "CXXFLAGS=-I${libcxx}/include/c++/v1"
+    ] ++ stdenv.lib.optionals (targetPlatform != buildPlatform) [
+      # TODO make unconditional next hash break
+      "--build=${buildPlatform.config}"
+      "--host=${hostPlatform.config}"
+      "--target=${targetPlatform.config}"
+    ];
 
     postPatch = ''
       sed -i -e 's/addStandardLibraryDirectories = true/addStandardLibraryDirectories = false/' cctools/ld64/src/ld/Options.cpp
@@ -69,33 +90,26 @@ let
       popd
     '';
 
+    postInstall =
+      if isDarwin hostPlatform.parsed
+      then ''
+        cat >$out/bin/dsymutil << EOF
+        #!${stdenv.shell}
+        EOF
+        chmod +x $out/bin/dsymutil
+      ''
+      else ''
+        for tool in dyldinfo dwarfdump dsymutil; do
+          ${makeWrapper}/bin/makeWrapper "${maloader}/bin/ld-mac" "$out/bin/${targetPlatform.config}-$tool" \
+            --add-flags "${xctoolchain}/bin/$tool"
+          ln -s "$out/bin/${targetPlatform.config}-$tool" "$out/bin/$tool"
+        done
+      '';
+
     meta = {
       homepage = "http://www.opensource.apple.com/source/cctools/";
       description = "Mac OS X Compiler Tools (cross-platform port)";
       license = stdenv.lib.licenses.apsl20;
     };
   };
-in {
-  native = stdenv.mkDerivation (baseParams // {
-    # A hack for now...
-    postInstall = ''
-      cat >$out/bin/dsymutil << EOF
-      #!${stdenv.shell}
-      EOF
-      chmod +x $out/bin/dsymutil
-    '';
-  });
-
-  cross =
-    { cross, maloader, makeWrapper, xctoolchain}: stdenv.mkDerivation (baseParams // {
-      configureFlags = baseParams.configureFlags ++ [ "--target=${cross.config}" ];
-
-      postInstall = ''
-        for tool in dyldinfo dwarfdump dsymutil; do
-          ${makeWrapper}/bin/makeWrapper "${maloader}/bin/ld-mac" "$out/bin/${cross.config}-$tool" \
-            --add-flags "${xctoolchain}/bin/$tool"
-          ln -s "$out/bin/${cross.config}-$tool" "$out/bin/$tool"
-        done
-      '';
-    });
-}
+in stdenv.mkDerivation baseParams

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -19,7 +19,7 @@ assert (!isDarwin hostPlatform.parsed) -> (maloader != null && xctoolchain != nu
 
 let
   baseParams = rec {
-    name = "cctools-port-${version}";
+    name = "${prefix}cctools-port-${version}";
     version = "895";
 
     src = fetchFromGitHub {

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -146,11 +146,11 @@ rec {
 
   build =
 
-    pkgs.buildPackages.stdenv.mkDerivation {
+    pkgs.stdenv.mkDerivation {
       name = "stdenv-bootstrap-tools-cross";
       crossConfig = pkgs.hostPlatform.config;
 
-      buildInputs = [
+      nativeBuildInputs = [
         pkgs.buildPackages.nukeReferences
         pkgs.buildPackages.cpio
         pkgs.buildPackages.binutils
@@ -285,7 +285,7 @@ rec {
       allowedReferences = [];
     };
 
-  dist = pkgs.buildPackages.stdenv.mkDerivation {
+  dist = pkgs.stdenv.mkDerivation {
     name = "stdenv-bootstrap-tools-cross";
 
     buildCommand = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6396,7 +6396,10 @@ with pkgs;
 
   bin_replace_string = callPackage ../development/tools/misc/bin_replace_string { };
 
-  binutils = if stdenv.isDarwin then darwin.binutils else binutils-raw;
+  binutils =
+    if lib.systems.parse.isDarwin targetPlatform.parsed
+    then darwin.binutils
+    else binutils-raw;
 
   binutils-raw = callPackage ../development/tools/misc/binutils {
     # FHS sys dirs presumably only have stuff for the build platform
@@ -11444,16 +11447,12 @@ with pkgs;
   darwin = let
     apple-source-releases = callPackage ../os-specific/darwin/apple-source-releases { };
   in apple-source-releases // rec {
-    cctools_cross = callPackage (forcedNativePackages.callPackage ../os-specific/darwin/cctools/port.nix {}).cross {
-      cross = assert targetPlatform != buildPlatform; targetPlatform;
+    cctools = callPackage ../os-specific/darwin/cctools/port.nix {
+      inherit libobjc;
+      stdenv = if stdenv.isDarwin then stdenv else libcxxStdenv;
       inherit maloader;
       xctoolchain = xcode.toolchain;
     };
-
-    cctools = (callPackage ../os-specific/darwin/cctools/port.nix {
-      inherit libobjc;
-      stdenv = if stdenv.isDarwin then stdenv else libcxxStdenv;
-    }).native;
 
     cf-private = callPackage ../os-specific/darwin/cf-private {
       inherit (apple-source-releases) CF;

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -1,5 +1,8 @@
-{ # The platforms for which we build Nixpkgs.
-  supportedSystems ? [ builtins.currentSystem ]
+/* This file defines some basic smoke tests for cross compilation.
+*/
+
+{ # The platforms *from* which we cross compile.
+  supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 , # Strip most of attributes when evaluating to spare memory usage
   scrubJobs ? true
 }:
@@ -83,6 +86,25 @@ in
     guile = nativePlatforms;
   };
 
+  darwinToAarch64 = let
+    crossSystem = {
+      config = "aarch64-apple-darwin14";
+      arch = "arm64";
+      libc = "libSystem";
+    };
+  in mapTestOnCross crossSystem {
+    buildPackages.binutils = darwin;
+  };
+
+  darwinToArm = let
+    crossSystem = {
+      config = "arm-apple-darwin10";
+      arch = "armv7-a";
+      libc = "libSystem";
+    };
+  in mapTestOnCross crossSystem {
+    buildPackages.binutils = darwin;
+  };
 
   /* Test some cross builds to the Sheevaplug */
   crossSheevaplugLinux = let


### PR DESCRIPTION
###### Motivation for this change

There's a lot more consistency now:
 - binutils binaries are always prefixed, when compiling from Darwin and Linux alike
 - binutils + cctools are always mixed together the same way if Darwin is the target

And there are tests to insure the darwin-targeting binutils+cctools mashups do build.

The main question is whether we want to so prefix the binutils derivation name, or adopt another convention distinguished from the existing `build != host` suffixes.

Builds on https://github.com/NixOS/nixpkgs/pull/25227, factored out of https://github.com/NixOS/nixpkgs/pull/25047

###### Things done

- http://hydra.nixos.org/eval/1359577