### PR TITLE
bitcoin-unlimited: 1.0.1.3 -> 1.0.1.4

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-unlimited.nix
+++ b/pkgs/applications/altcoins/bitcoin-unlimited.nix
@@ -7,13 +7,13 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-unlimited-" + version;
-  version = "1.0.1.3";
+  version = "1.0.1.4";
 
   src = fetchFromGitHub {
     owner = "bitcoinunlimited";
     repo = "bitcoinunlimited";
-    rev = "${version}";
-    sha256 = "177l2jf2yqxh3sgf80dhgyk3wgjdnqszy3hb83clk8q1wyjkfz7y";
+    rev = "v${version}";
+    sha256 = "1awsgkgqvb57grrsq6k99009rzhpfaplh2lbf5sy36v3bh7p5mw5";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change
Bump up the version, so that the fix for the latest vulnerability is included.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

