### PR TITLE
mono: init at 5.0

### DIFF
--- a/pkgs/development/compilers/mono/5.0.nix
+++ b/pkgs/development/compilers/mono/5.0.nix
@@ -1,0 +1,7 @@
+{ stdenv, callPackage, Foundation, libobjc }:
+
+callPackage ./generic-5x.nix (rec {
+  inherit Foundation libobjc;
+  version = "5.0.0.48";
+  sha256 = "13n20wmijkhd7vm41lzz1n774rna67d94prl33bz1lly0idsciq0";
+})

--- a/pkgs/development/compilers/mono/5.0.nix
+++ b/pkgs/development/compilers/mono/5.0.nix
@@ -1,6 +1,6 @@
 { stdenv, callPackage, Foundation, libobjc }:
 
-callPackage ./generic-5x.nix (rec {
+callPackage ./generic-cmake.nix (rec {
   inherit Foundation libobjc;
   version = "5.0.0.48";
   sha256 = "13n20wmijkhd7vm41lzz1n774rna67d94prl33bz1lly0idsciq0";

--- a/pkgs/development/compilers/mono/generic-5x.nix
+++ b/pkgs/development/compilers/mono/generic-5x.nix
@@ -1,0 +1,90 @@
+{ stdenv, fetchurl, bison, pkgconfig, glib, gettext, perl, libgdiplus, libX11, callPackage, ncurses, zlib, withLLVM ? false, cacert, Foundation, libobjc, python, version, sha256, cmake, autoconf, libtool, automake, gcc }:
+
+let
+  llvm     = callPackage ./llvm.nix { };
+in
+stdenv.mkDerivation rec {
+  name = "mono-${version}";
+
+  src = fetchurl {
+    inherit sha256;
+    url = "https://download.mono-project.com/sources/mono/${name}.tar.bz2";
+  };
+
+  buildInputs =
+    [ bison pkgconfig glib gettext perl libgdiplus libX11 ncurses zlib python cmake autoconf libtool automake gcc
+    ]
+    ++ (stdenv.lib.optionals stdenv.isDarwin [ Foundation libobjc ]);
+
+  propagatedBuildInputs = [glib];
+
+  NIX_LDFLAGS = if stdenv.isDarwin then "" else "-lgcc_s" ;
+
+  # To overcome the bug https://bugzilla.novell.com/show_bug.cgi?id=644723
+  dontDisableStatic = true;
+
+  # In fact I think this line does not help at all to what I
+  # wanted to achieve: have mono to find libgdiplus automatically
+  configureFlags = [
+    "--x-includes=${libX11.dev}/include"
+    "--x-libraries=${libX11.out}/lib"
+    "--with-libgdiplus=${libgdiplus}/lib/libgdiplus.so"
+  ]
+  ++ stdenv.lib.optionals withLLVM [
+    "--enable-llvm"
+    "--enable-llvmloaded"
+    "--with-llvm=${llvm}"
+  ];
+
+  # Attempt to fix this error when running "mcs --version":
+  # The file /nix/store/xxx-mono-2.4.2.1/lib/mscorlib.dll is an invalid CIL image
+  dontStrip = true;
+
+  # Parallel building doesn't work, as shows http://hydra.nixos.org/build/2983601
+  enableParallelBuilding = false;
+
+  # We want pkg-config to take priority over the dlls in the Mono framework and the GAC
+  # because we control pkg-config
+  patches = [ ./pkgconfig-before-gac-5x.patch ];
+
+  # Patch all the necessary scripts. Also, if we're using LLVM, we fix the default
+  # LLVM path to point into the Mono LLVM build, since it's private anyway.
+  preBuild = ''
+    makeFlagsArray=(INSTALL=`type -tp install`)
+    patchShebangs ./
+    substituteInPlace mcs/class/corlib/System/Environment.cs --replace /usr/share "$out/share"
+  '' + stdenv.lib.optionalString withLLVM ''
+    substituteInPlace mono/mini/aot-compiler.c --replace "llvm_path = g_strdup (\"\")" "llvm_path = g_strdup (\"${llvm}/bin/\")"
+    echo 11111
+  '';
+
+  # Fix mono DLLMap so it can find libX11 and gdiplus to run winforms apps
+  # Other items in the DLLMap may need to be pointed to their store locations, I don't think this is exhaustive
+  # http://www.mono-project.com/Config_DllMap
+  postBuild = ''
+    find . -name 'config' -type f | xargs \
+    sed -i -e "s@libX11.so.6@${libX11.out}/lib/libX11.so.6@g" \
+           -e "s@/.*libgdiplus.so@${libgdiplus}/lib/libgdiplus.so@g" \
+  '';
+
+  # Without this, any Mono application attempting to open an SSL connection will throw with
+  # The authentication or decryption has failed.
+  # ---> Mono.Security.Protocol.Tls.TlsException: Invalid certificate received from server.
+  postInstall = ''
+    echo "Updating Mono key store"
+    $out/bin/cert-sync ${cacert}/etc/ssl/certs/ca-bundle.crt
+  ''
+  # According to [1], gmcs is just mcs
+  # [1] https://github.com/mono/mono/blob/master/scripts/gmcs.in
+  + ''
+    ln -s $out/bin/mcs $out/bin/gmcs
+  '';
+
+  meta = {
+    homepage = http://mono-project.com/;
+    description = "Cross platform, open source .NET development framework";
+    platforms = with stdenv.lib.platforms; darwin ++ linux;
+    maintainers = with stdenv.lib.maintainers; [ viric thoughtpolice obadz vrthra ];
+    license = stdenv.lib.licenses.free; # Combination of LGPL/X11/GPL ?
+  };
+}

--- a/pkgs/development/compilers/mono/generic-cmake.nix
+++ b/pkgs/development/compilers/mono/generic-cmake.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   ];
 
   configurePhase = ''
-    substituteInPlace ./autogen.sh --replace "/usr/bin/env sh" "/bin/sh"
+    substituteInPlace ./autogen.sh --replace "/usr/bin/env sh" "${stdenv.shell}"
     ./autogen.sh --prefix $out
   '';
 

--- a/pkgs/development/compilers/mono/pkgconfig-before-gac-5x.patch
+++ b/pkgs/development/compilers/mono/pkgconfig-before-gac-5x.patch
@@ -1,0 +1,65 @@
+diff -Naur mono-5.0.0/mcs/tools/xbuild/data/3.5/Microsoft.Common.targets.old mono-5.0.0/mcs/tools/xbuild/data/3.5/Microsoft.Common.targets
+--- mono-5.0.0/mcs/tools/xbuild/data/3.5/Microsoft.Common.targets.old	2017-04-24 23:45:18.348116305 +0200
++++ mono-5.0.0/mcs/tools/xbuild/data/3.5/Microsoft.Common.targets	2017-04-24 23:45:11.407051755 +0200
+@@ -167,8 +167,8 @@
+ 			$(ReferencePath);
+ 			@(AdditionalReferencePath);
+ 			{HintPathFromItem};
+-			{TargetFrameworkDirectory};
+ 			{PkgConfig};
++			{TargetFrameworkDirectory};
+ 			{GAC};
+ 			{RawFileName};
+ 			$(OutDir)
+diff -Naur mono-5.0.0/mcs/tools/xbuild/data/4.0/Microsoft.Common.targets.old mono-5.0.0/mcs/tools/xbuild/data/4.0/Microsoft.Common.targets
+--- mono-5.0.0/mcs/tools/xbuild/data/4.0/Microsoft.Common.targets.old	2017-04-24 23:49:53.019616196 +0200
++++ mono-5.0.0/mcs/tools/xbuild/data/4.0/Microsoft.Common.targets	2017-04-24 23:50:05.709729585 +0200
+@@ -232,8 +232,8 @@
+ 			$(ReferencePath);
+ 			@(AdditionalReferencePath);
+ 			{HintPathFromItem};
+-			{TargetFrameworkDirectory};
+ 			{PkgConfig};
++			{TargetFrameworkDirectory};
+ 			{GAC};
+ 			{RawFileName};
+ 			$(OutDir)
+diff -Naur mono-5.0.0/mcs/tools/xbuild/data/2.0/Microsoft.Common.targets.old mono-5.0.0/mcs/tools/xbuild/data/2.0/Microsoft.Common.targets
+--- mono-5.0.0/mcs/tools/xbuild/data/2.0/Microsoft.Common.targets.old	2017-04-24 23:52:33.200037047 +0200
++++ mono-5.0.0/mcs/tools/xbuild/data/2.0/Microsoft.Common.targets	2017-04-24 23:52:43.281125802 +0200
+@@ -139,8 +139,8 @@
+ 			$(ReferencePath);
+ 			@(AdditionalReferencePath);
+ 			{HintPathFromItem};
+-			{TargetFrameworkDirectory};
+ 			{PkgConfig};
++			{TargetFrameworkDirectory};
+ 			{GAC};
+ 			{RawFileName};
+ 			$(OutDir)
+diff -Naur mono-5.0.0/mcs/tools/xbuild/data/14.0/Microsoft.Common.targets.old mono-5.0.0/mcs/tools/xbuild/data/14.0/Microsoft.Common.targets
+--- mono-5.0.0/mcs/tools/xbuild/data/14.0/Microsoft.Common.targets.old	2017-04-24 23:54:02.585821594 +0200
++++ mono-5.0.0/mcs/tools/xbuild/data/14.0/Microsoft.Common.targets	2017-04-24 23:54:09.313880438 +0200
+@@ -234,8 +234,8 @@
+ 			$(ReferencePath);
+ 			@(AdditionalReferencePath);
+ 			{HintPathFromItem};
+-			{TargetFrameworkDirectory};
+ 			{PkgConfig};
++			{TargetFrameworkDirectory};
+ 			{GAC};
+ 			{RawFileName};
+ 			$(OutDir)
+diff -Naur mono-5.0.0/mcs/tools/xbuild/data/12.0/Microsoft.Common.targets.old mono-5.0.0/mcs/tools/xbuild/data/12.0/Microsoft.Common.targets
+--- mono-5.0.0/mcs/tools/xbuild/data/12.0/Microsoft.Common.targets.old	2017-04-24 23:55:46.244895155 +0200
++++ mono-5.0.0/mcs/tools/xbuild/data/12.0/Microsoft.Common.targets	2017-04-24 23:55:51.998961342 +0200
+@@ -232,8 +232,8 @@
+ 			$(ReferencePath);
+ 			@(AdditionalReferencePath);
+ 			{HintPathFromItem};
+-			{TargetFrameworkDirectory};
+ 			{PkgConfig};
++			{TargetFrameworkDirectory};
+ 			{GAC};
+ 			{RawFileName};
+ 			$(OutDir)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5742,6 +5742,11 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Foundation;
   });
 
+  mono50 = lowPrio (callPackage ../development/compilers/mono/5.0.nix {
+    inherit (darwin) libobjc;
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  });
+
   monoDLLFixer = callPackage ../build-support/mono-dll-fixer { };
 
   mozart-binary = callPackage ../development/compilers/mozart/binary.nix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

