### PR TITLE
nix-bundle: init at 0.1.1

### DIFF
--- a/pkgs/tools/package-management/nix-bundle/default.nix
+++ b/pkgs/tools/package-management/nix-bundle/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchFromGitHub, nix, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "nix-bundle";
+  name = "${pname}-${version}";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "matthewbauer";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "13730rfnqjv1m2mky2g0cq77yzp2j215zrvy3lhpiwgmh97vviih";
+  };
+
+  buildInputs = [ nix makeWrapper ];
+
+  binPath = lib.makeBinPath [ nix ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    mkdir -p $out/bin
+    makeWrapper $out/share/nix-bundle/nix-bundle.sh $out/bin/nix-bundle \
+      --prefix PATH : ${binPath}
+  '';
+
+  meta = with lib; {
+    maintainers = [ maintainers.matthewbauer ];
+    platforms = platforms.all;
+    description = "Create bundles from Nixpkgs attributes";
+    license = licenses.mit;
+    homepage = https://github.com/matthewbauer/nix-bundle;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18085,6 +18085,8 @@ with pkgs;
 
   nixui = callPackage ../tools/package-management/nixui { node_webkit = nwjs_0_12; };
 
+  nix-bundle = callPackage ../tools/package-management/nix-bundle { nix = nixStable; };
+
   inherit (callPackages ../tools/package-management/nix-prefetch-scripts { })
     nix-prefetch-bzr
     nix-prefetch-cvs


### PR DESCRIPTION
Adds the nix-bundle derivation from https://github.com/matthewbauer/nix-bundle.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

