### PR TITLE
fcitx-engines.mozc: 2.17.2313.102.1 -> 2.18.2612.102.1 and other minor fcitx packages updates

### DIFF
--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-mozc/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-mozc/default.nix
@@ -1,10 +1,11 @@
-{ clangStdenv, fetchFromGitHub, fetchurl, fetchpatch, fetchsvn, gyp, which, ninja, 
-  python, pkgconfig, protobuf, gtk2, zinnia, qt4, libxcb, tegaki-zinnia-japanese,
+{ clangStdenv, fetchFromGitHub, fetchurl, fetchpatch, gyp, which, ninja,
+  python, pkgconfig, protobuf, gtk2, zinnia, qt5, libxcb, tegaki-zinnia-japanese,
   fcitx, gettext }:
 let
-  japanese_usage_dictionary = fetchsvn {
-    url    = "http://japanese-usage-dictionary.googlecode.com/svn/trunk";
-    rev    = "10";
+  japanese_usage_dictionary = fetchFromGitHub {
+    owner  = "hiroyuki-komatsu";
+    repo   = "japanese-usage-dictionary";
+    rev    = "e5b3425575734c323e1d947009dd74709437b684";
     sha256 = "0pyrpz9c8nxccwpgyr36w314mi8h132cis8ijvlqmmhqxwsi30hm";
   };
   icons = fetchurl {
@@ -13,30 +14,30 @@ let
   };
 in clangStdenv.mkDerivation rec {
   name    = "fcitx-mozc-${version}";
-  version = "2.17.2313.102";
+  version = "2.20.2673.102";
 
   src = fetchFromGitHub {
     owner  = "google";
     repo   = "mozc";
-    rev    = "3306d3314499a54a4064b8b80bbc1bce3f6cfac4";
-    sha256 = "0l7mjlnbm6i1ipni8pg9ym5bjg3rzkaxi9xwmsz2lddv348sqii2";
+    rev    = "280e38fe3d9db4df52f0713acf2ca65898cd697a";
+    sha256 = "0s599f817gjgqynm4n1yll1ipd25ai2c55y8k6wvhg9s7qaxnyhs";
   };
 
   nativeBuildInputs = [ gyp which ninja python pkgconfig ];
-  buildInputs = [ protobuf gtk2 zinnia qt4 libxcb fcitx gettext ];
+  buildInputs = [ protobuf gtk2 zinnia qt5.qtbase libxcb fcitx gettext ];
 
   postUnpack = ''
     rmdir $sourceRoot/src/third_party/japanese_usage_dictionary/
     ln -s ${japanese_usage_dictionary} $sourceRoot/src/third_party/japanese_usage_dictionary
-    tar -xzf ${icons} -C $sourceRoot
+    tar -xzf ${icons} -C $sourceRoot/src
   '';
 
-  patch_version = "2.17.2313.102.1";
+  patch_version = "2.18.2612.102.1";
   patches = [ 
     (fetchpatch rec {
       name   = "fcitx-mozc-${patch_version}.patch";
       url    = "https://download.fcitx-im.org/fcitx-mozc/${name}";
-      sha256 = "172c34jkppibvwr9qf9xwgh2hdrmmhyx7nsdj49krxbfdlsy3yy0";
+      sha256 = "1f9m4310kz09v5qvnv75ka2vq63m7by023qrkpddgq4dv7gxx3ca";
      })
   ];
 
@@ -47,42 +48,34 @@ in clangStdenv.mkDerivation rec {
 
   configurePhase = ''
     export GYP_DEFINES="document_dir=$out/share/doc/mozc use_libzinnia=1 use_libprotobuf=1"
-    python src/build_mozc.py gyp --gypdir=${gyp}/bin --server_dir=$out/lib/mozc \
-    python src/unix/fcitx/fcitx.gyp gyp --gypdir=${gyp}/bin
-  '';
-
-  preBuildPhase = ''
-    head -n 29 src/server/mozc_server.cc > LICENSE
+    cd src && python build_mozc.py gyp --gypdir=${gyp}/bin --server_dir=$out/lib/mozc
   '';
 
   buildPhase = ''
-    python src/build_mozc.py build -c Release \
-      unix/fcitx/fcitx.gyp:fcitx-mozc \
+    PYTHONPATH="$PWD:$PYTHONPATH" python build_mozc.py build -c Release \
       server/server.gyp:mozc_server \
-      gui/gui.gyp:mozc_tool
-  '';
-
-  checkPhase = ''
-    python src/build_mozc.py runtests -c Release
+      gui/gui.gyp:mozc_tool \
+      unix/fcitx/fcitx.gyp:fcitx-mozc
   '';
 
   installPhase = ''
-    install -d        $out/share/licenses/fcitx-mozc/
-    install -m 644    LICENSE src/data/installer/*.html     $out/share/licenses/fcitx-mozc/
+    install -d        $out/share/licenses/fcitx-mozc
+    head -n 29 server/mozc_server.cc > $out/share/licenses/fcitx-mozc/LICENSE
+    install -m 644    data/installer/*.html             $out/share/licenses/fcitx-mozc/
 
     install -d        $out/share/doc/mozc
-    install -m    644 src/data/installer/*.html             $out/share/doc/mozc/
+    install -m    644 data/installer/*.html             $out/share/doc/mozc/
 
-    install -D -m 755 src/out_linux/Release/mozc_server     $out/lib/mozc/mozc_server
-    install    -m 755 src/out_linux/Release/mozc_tool       $out/lib/mozc/mozc_tool
+    install -D -m 755 out_linux/Release/mozc_server     $out/lib/mozc/mozc_server
+    install    -m 755 out_linux/Release/mozc_tool       $out/lib/mozc/mozc_tool
 
-    install -D -m 755 src/out_linux/Release/fcitx-mozc.so   $out/lib/fcitx/fcitx-mozc.so
-    install -D -m 644 src/unix/fcitx/fcitx-mozc.conf        $out/share/fcitx/addon/fcitx-mozc.conf
-    install -D -m 644 src/unix/fcitx/mozc.conf              $out/share/fcitx/inputmethod/mozc.conf
+    install -D -m 755 out_linux/Release/fcitx-mozc.so   $out/lib/fcitx/fcitx-mozc.so
+    install -D -m 644 unix/fcitx/fcitx-mozc.conf        $out/share/fcitx/addon/fcitx-mozc.conf
+    install -D -m 644 unix/fcitx/mozc.conf              $out/share/fcitx/inputmethod/mozc.conf
 
     install -d        $out/share/doc/mozc
 
-    for mofile in src/out_linux/Release/gen/unix/fcitx/po/*.mo
+    for mofile in out_linux/Release/gen/unix/fcitx/po/*.mo
     do
       filename=`basename $mofile`
       lang=$filename.mo
@@ -90,18 +83,9 @@ in clangStdenv.mkDerivation rec {
     done
 
     install -d        $out/share/fcitx/imicon
-    install    -m 644 fcitx-mozc-icons/mozc.png                 $out/share/fcitx/imicon/mozc.png
+    install    -m 644 fcitx-mozc-icons/mozc.png      $out/share/fcitx/imicon/mozc.png
     install -d        $out/share/fcitx/mozc/icon
-    install    -m 644 fcitx-mozc-icons/mozc.png                 $out/share/fcitx/mozc/icon/mozc.png
-    install    -m 644 fcitx-mozc-icons/mozc-alpha_full.png      $out/share/fcitx/mozc/icon/mozc-alpha_full.png
-    install    -m 644 fcitx-mozc-icons/mozc-alpha_half.png      $out/share/fcitx/mozc/icon/mozc-alpha_half.png
-    install    -m 644 fcitx-mozc-icons/mozc-direct.png          $out/share/fcitx/mozc/icon/mozc-direct.png
-    install    -m 644 fcitx-mozc-icons/mozc-hiragana.png        $out/share/fcitx/mozc/icon/mozc-hiragana.png
-    install    -m 644 fcitx-mozc-icons/mozc-katakana_full.png   $out/share/fcitx/mozc/icon/mozc-katakana_full.png
-    install    -m 644 fcitx-mozc-icons/mozc-katakana_half.png   $out/share/fcitx/mozc/icon/mozc-katakana_half.png
-    install    -m 644 fcitx-mozc-icons/mozc-dictionary.png      $out/share/fcitx/mozc/icon/mozc-dictionary.png
-    install    -m 644 fcitx-mozc-icons/mozc-properties.png      $out/share/fcitx/mozc/icon/mozc-properties.png
-    install    -m 644 fcitx-mozc-icons/mozc-tool.png            $out/share/fcitx/mozc/icon/mozc-tool.png
+    install    -m 644 fcitx-mozc-icons/*.png                 $out/share/fcitx/mozc/icon/
   '';
 
   meta = with clangStdenv.lib; {

--- a/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeWrapper, pkgconfig, cmake, fcitx, gtk3, isocodes, gnome3 }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-configtool-0.4.8";
+  name = "fcitx-configtool-0.4.9";
 
   meta = with stdenv.lib; {
     description = "GTK-based config tool for Fcitx";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.fcitx-im.org/fcitx-configtool/${name}.tar.xz";
-    sha256 = "1vaim0namw58bfafbvws1vgd4010p19zwqfbx6bd1zi5sgchdg0f";
+    sha256 = "1ypr2jr3vzs2shqfrvhqy69xvagrn9x507180i9wxy14hb97a82r";
   };
 
   buildInputs = [ makeWrapper fcitx cmake isocodes pkgconfig gtk3

--- a/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "fcitx-qt5-${version}";
-  version = "1.0.5";
+  version = "1.1.0";
 
   src = fetchurl {
     url = "http://download.fcitx-im.org/fcitx-qt5/${name}.tar.xz";
-    sha256 = "1pj1b04n8r4kl7jh1qdv0xshgzb3zrmizfa3g5h3yk589h191vwc";
+    sha256 = "0r8c5k0qin3mz2p1mdciip6my0x58662sx5z50zs4c5pkdg21qwv";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules pkgconfig ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1752,8 +1752,9 @@ with pkgs;
     m17n = callPackage ../tools/inputmethods/fcitx-engines/fcitx-m17n { };
 
     mozc = callPackage ../tools/inputmethods/fcitx-engines/fcitx-mozc {
-      inherit (pythonPackages) gyp;
-      protobuf = protobuf.override { stdenv = clangStdenv; };
+      python = python2;
+      inherit (python2Packages) gyp;
+      protobuf = protobuf3_2.override { stdenv = clangStdenv; };
     };
 
     table-other = callPackage ../tools/inputmethods/fcitx-engines/fcitx-table-other { };


### PR DESCRIPTION
###### Motivation for this change

_Should_ fix #25228 by updating `fcitx-engines.mozc` to a recent version.
Also introduce a few minor upgrades for other fcitx related packages, namely:

- fcitx-qt5
- fcitx-configtool

Tested in a NixOS VM with a few applications (qutebrowser & chromium).

@mt-caret Could you test this PR and check if it solves the problem you had in chromium?

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

