### PR TITLE
Add a fake uname implementation to the Linux stdenv (that returns hardcoded values)

### DIFF
--- a/pkgs/build-support/fake-uname/default.nix
+++ b/pkgs/build-support/fake-uname/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, bash }:
+
+let unameTuple = [
+    /* kernel-name */       "Linux"
+    /* node-name */         "localhost"
+    /* kernel-release */    "4.4.0-not-a-real-version"
+    /* kernel-version */    "#1 SMP PREEMPT Thu Jan  1 00:00:01 GMT 1970"
+    /* machine */           (builtins.head (lib.splitString "-" stdenv.system))
+    /* processor */         "unknown"
+    /* hardware-platform */ "unknown"
+    /* operating-system */  "GNU/Linux"
+  ];
+in
+
+stdenv.mkDerivation {
+  name = "fake-uname";
+  buildCommand = ''
+    mkdir -p $out/bin
+    substitute ${./fake-uname.sh} $out/bin/uname \
+      --subst-var-by shell "${bash}/bin/bash" \
+      --subst-var-by unameTuple '${lib.concatStringsSep " " (map (x: "\"${x}\"") unameTuple)}'
+    chmod a+x $out/bin/uname
+  '';
+}

--- a/pkgs/build-support/fake-uname/fake-uname.sh
+++ b/pkgs/build-support/fake-uname/fake-uname.sh
@@ -1,0 +1,76 @@
+#!@shell@
+
+declare -a unameTuple
+unameTuple=(@unameTuple@)
+
+usage() {
+    echo "$0: a fake uname(1) implementation provided by nixpkgs. See 'man uname' for usage." >&2
+    exit 1
+}
+
+# Resolve long options first. Bash getopt is too lame.
+declare -a argv
+for opt in "$@"; do
+    case "$opt" in
+        --all)               opt=-a;;
+        --kernel-name)       opt=-s;;
+        --nodename)          opt=-n;;
+        --kernel-release)    opt=-r;;
+        --release)           opt=-r;;
+        --kernel-version)    opt=-v;;
+        --machine)           opt=-m;;
+        --processor)         opt=-p;;
+        --hardware-platform) opt=-i;;
+        --operating-system)  opt=-o;;
+    esac
+    argv+=("$opt")
+done
+
+set -- "${argv[@]}"
+
+allowedOpts=snrvmpioa
+mask=0
+while getopts "$allowedOpts" opt; do
+    case "$opt" in
+        \?)
+            usage
+            ;;
+        a)
+            # 'uname -a' prints all fields, except unknown ones. Matches coreutils uname behaviour.
+            mask=255
+            hideUnknown=1
+            ;;
+        *)
+            mask=$(( $mask | ( 1 << $(expr index $allowedOpts $opt) - 1 ) ))
+            ;;
+    esac
+done
+shift "$((OPTIND-1))"
+
+if [ $# -gt 0 ]; then
+    echo "$0: extra operand '$1'" >&2
+    usage
+fi
+
+# Just 'uname' is equivalent to 'uname -s'
+if [ "$mask" -eq 0 ]; then
+    mask=1
+fi
+
+first=1
+for (( i=0; i<${#unameTuple[@]}; i++ )); do
+    if ! (( mask & (1 <<  i) )); then
+        continue
+    fi
+    s=${unameTuple[$i]}
+    if [ -n "$hideUnknown" ] && [ "$s" = unknown ]; then
+        continue
+    fi
+
+    if [ -z "$first" ]; then
+        echo -n ' '
+    fi
+    first=
+    echo -n "$s"
+done
+echo

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -141,6 +141,7 @@ in
         '';
       };
       gcc-unwrapped = bootstrapTools;
+      bash = bootstrapTools;
       binutils = bootstrapTools;
       coreutils = bootstrapTools;
       gnugrep = bootstrapTools;
@@ -167,7 +168,7 @@ in
       binutils = super.binutils.override { gold = false; };
       inherit (prevStage)
         ccWrapperStdenv
-        glibc gcc-unwrapped coreutils gnugrep;
+        bash fake-uname glibc gcc-unwrapped coreutils gnugrep;
 
       # A threaded perl build needs glibc/libpthread_nonshared.a,
       # which is not included in bootstrapTools, so disable threading.
@@ -176,6 +177,7 @@ in
       # top-level pkgs as an override either.
       perl = super.perl.override { enableThreading = false; };
     };
+    extraBuildInputs = [ prevStage.fake-uname ];
   })
 
 
@@ -188,10 +190,11 @@ in
     overrides = self: super: {
       inherit (prevStage)
         ccWrapperStdenv
-        binutils gcc-unwrapped coreutils gnugrep
+        binutils bash fake-uname gcc-unwrapped coreutils gnugrep
         perl paxctl gnum4 bison;
       # This also contains the full, dynamically linked, final Glibc.
     };
+    extraBuildInputs = [ prevStage.fake-uname ];
   })
 
 
@@ -205,7 +208,7 @@ in
     overrides = self: super: rec {
       inherit (prevStage)
         ccWrapperStdenv
-        binutils glibc coreutils gnugrep
+        binutils bash fake-uname glibc coreutils gnugrep
         perl patchelf linuxHeaders gnum4 bison;
       # Link GCC statically against GMP etc.  This makes sense because
       # these builds of the libraries are only used by GCC, so it
@@ -218,7 +221,7 @@ in
         isl = isl_0_14;
       };
     };
-    extraBuildInputs = [ prevStage.patchelf prevStage.paxctl ] ++
+    extraBuildInputs = [ prevStage.fake-uname prevStage.patchelf prevStage.paxctl ] ++
       # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
       lib.optional (system == "aarch64-linux") prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
@@ -248,7 +251,7 @@ in
         shell = self.bash + "/bin/bash";
       };
     };
-    extraBuildInputs = [ prevStage.patchelf prevStage.xz ] ++
+    extraBuildInputs = [ prevStage.fake-uname prevStage.patchelf prevStage.xz ] ++
       # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
       lib.optional (system == "aarch64-linux") prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
@@ -278,7 +281,7 @@ in
       initialPath =
         ((import ../common-path.nix) {pkgs = prevStage;});
 
-      extraBuildInputs = [ prevStage.patchelf prevStage.paxctl ] ++
+      extraBuildInputs = [ prevStage.fake-uname prevStage.patchelf prevStage.paxctl ] ++
         # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
         lib.optional (system == "aarch64-linux") prevStage.updateAutotoolsGnuConfigScriptsHook;
 
@@ -306,7 +309,7 @@ in
         gcc = cc;
 
         inherit (prevStage)
-          gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
+          gzip bzip2 xz bash binutils coreutils diffutils fake-uname findutils gawk
           glibc gnumake gnused gnutar gnugrep gnupatch patchelf
           attr acl paxctl zlib pcre;
       };

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -47,13 +47,13 @@ let
   # the bootstrap.  In all stages, we build an stdenv and the package
   # set that can be built with that stdenv.
   stageFun = prevStage:
-    { name, overrides ? (self: super: {}), extraBuildInputs ? [] }:
+    { name, stageNum, overrides ? (self: super: {}), extraBuildInputs ? [] }:
 
     let
 
       thisStdenv = import ../generic {
         inherit system config extraBuildInputs;
-        name = "stdenv-linux-boot";
+        name = "stdenv-linux-boot-stage${stageNum}";
         preHook =
           ''
             # Don't patch #!/interpreter because it leads to retained
@@ -119,6 +119,7 @@ in
   # because we need a stdenv to build the GCC wrapper and fetchurl.
   (prevStage: stageFun prevStage {
     name = null;
+    stageNum = "0";
 
     overrides = self: super: {
       # We thread stage0's stdenv through under this name so downstream stages
@@ -159,6 +160,7 @@ in
   # overrides attribute and the inherit syntax.
   (prevStage: stageFun prevStage {
     name = "bootstrap-gcc-wrapper";
+    stageNum = "1";
 
     # Rebuild binutils to use from stage2 onwards.
     overrides = self: super: {
@@ -181,6 +183,7 @@ in
   # compiling our own Glibc.
   (prevStage: stageFun prevStage {
     name = "bootstrap-gcc-wrapper";
+    stageNum = "2";
 
     overrides = self: super: {
       inherit (prevStage)
@@ -197,6 +200,7 @@ in
   # binutils and rest of the bootstrap tools, including GCC.
   (prevStage: stageFun prevStage {
     name = "bootstrap-gcc-wrapper";
+    stageNum = "3";
 
     overrides = self: super: rec {
       inherit (prevStage)
@@ -224,6 +228,7 @@ in
   # still from the bootstrap tools.
   (prevStage: stageFun prevStage {
     name = "";
+    stageNum = "4";
 
     overrides = self: super: {
       # Zlib has to be inherited and not rebuilt in this stage,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -114,6 +114,8 @@ with pkgs;
     vs = vs90wrapper;
   };
 
+  fake-uname = callPackage ../build-support/fake-uname { };
+
   fetchadc = callPackage ../build-support/fetchadc {
     adc_user = if config ? adc_user
       then config.adc_user


### PR DESCRIPTION
This has two purity advantages:

- This makes `uname -m` return the processor architecture we're building
  for, not the architecture the build is running on. This mainly
  affects ARM, where we want to build armv6l packages on an armv7l
  package. The v7 processors are very capable of executing v6 code,
  but many build systems will look at `uname -m` and decide to do
  different things based on the result. Examples:
    - coreutils & openssl both add some ARMv7-specific FPU optimization
      flags to gcc's command line which causes the binaries to SIGILL
      on ARMv6 processors.
    - The emacs, perl & ruby builds  create machine-specific directories
      like `$out/libexec/emacs/25.1/armv6l-unknown-linux-gnueabihf`

  Both of these are now fixed. And no, unlike PER_LINUX32 (which
  makes `uname -m` report `i686` when run on x86_64) there is no kernel
  option to achieve the same thing for returning armv6l on a ARMv7.

- Some packages like Xorg capture the kernel version where the build
  was done (it prints "Build Operating System: Linux 4.4.45 x86_64"
  to the logs). This improves binary reproducibility of such packages.

I've added this just for Linux for now (as it ended up requiring tweaking the bootstrap stages to get it right) but in principle it could be added for Darwin as well if there's a use case.

cc @edolstra 