### PR TITLE
update asterisk-stable and asterisk-lts

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -73,11 +73,6 @@ let
     };
   };
 
-  pjproject-255 = fetchurl {
-    url = http://www.pjsip.org/release/2.5.5/pjproject-2.5.5.tar.bz2;
-    sha256 = "1wq8lpfcd4dfrbl7bgy2yzgp3ldjzq5430fqkhcqad0xfrxj0fdb";
-  };
-
   pjproject-26 = fetchurl {
     url = http://www.pjsip.org/release/2.6/pjproject-2.6.tar.bz2;
     sha256 = "1d67c58jn22f7h6smkykk5vwl3sqpc7xi2vm3j3lbn3lq6hisnig";
@@ -93,10 +88,10 @@ in
 {
 
   asterisk-lts = common {
-    version = "13.13.1";
-    sha256 = "0yh097rrp1i681qclvwyh7l1gg2i5wx5pjrcvwpbj6g949mc98vd";
+    version = "13.15.0";
+    sha256 = "0i2qzfa1iyh66nma39kdigb9lp5gz3sn46znd2djz24wgmamb2lb";
     externals = {
-      "externals_cache/pjproject-2.5.5.tar.bz2" = pjproject-255;
+      "externals_cache/pjproject-2.6.tar.bz2" = pjproject-26;
       "addons/mp3" = mp3-202;
     };
   };

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -24,6 +24,11 @@ let
       })
     ];
 
+    # Disable MD5 verification for pjsip
+    postPatch = ''
+      sed -i 's|$(verify_tarball)|true|' third-party/pjproject/Makefile
+    '';
+
     src = fetchurl {
       url = "http://downloads.asterisk.org/pub/telephony/asterisk/old-releases/asterisk-${version}.tar.gz";
       inherit sha256;
@@ -73,6 +78,11 @@ let
     sha256 = "1wq8lpfcd4dfrbl7bgy2yzgp3ldjzq5430fqkhcqad0xfrxj0fdb";
   };
 
+  pjproject-26 = fetchurl {
+    url = http://www.pjsip.org/release/2.6/pjproject-2.6.tar.bz2;
+    sha256 = "1d67c58jn22f7h6smkykk5vwl3sqpc7xi2vm3j3lbn3lq6hisnig";
+  };
+
   mp3-202 = fetchsvn {
     url = http://svn.digium.com/svn/thirdparty/mp3/trunk;
     rev = 202;
@@ -92,10 +102,10 @@ in
   };
 
   asterisk-stable = common {
-    version = "14.2.1";
-    sha256 = "193yhyjn0fwrd7hsmr3qwcx3k2pc6cq70v1mnfdwidix4cqm32xj";
+    version = "14.4.0";
+    sha256 = "095slnhl74hs1c36rgg378azan9zwgryp8him7py4am60lbk3n3w";
     externals = {
-      "externals_cache/pjproject-2.5.5.tar.bz2" = pjproject-255;
+      "externals_cache/pjproject-2.6.tar.bz2" = pjproject-26;
       "addons/mp3" = mp3-202;
     };
   };

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, lib, fetchurl, fetchgit, fetchsvn,
+{ stdenv, pkgs, lib, fetchurl, fetchgit, fetchsvn, fetchpatch,
   jansson, libxml2, libxslt, ncurses, openssl, sqlite,
   utillinux, dmidecode, libuuid, binutils, newt,
   lua, speex,
@@ -18,6 +18,10 @@ let
       # This patch changes the runtime behavior to look for state
       # directories in /var rather than ${out}/var.
       ./runtime-vardirs.patch
+      (fetchpatch {
+         url = "http://sources.debian.net/data/main/a/asterisk/1:13.14.1~dfsg-1/debian/patches/pjsip_unresolved_symbol.patch";
+         sha256 = "0i6a6zplvzbjcvxqlmr87jmrfza7c3qx0rlym2nlmzzp2m7qpnfp";
+      })
     ];
 
     src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

* include debian patch to remove warnings that clutter journald logs
* bump to latest upstream versions

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

