### PR TITLE
Update pythonPackages.channels and dependencies

### DIFF
--- a/pkgs/development/python-modules/asgi_ipc/default.nix
+++ b/pkgs/development/python-modules/asgi_ipc/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchurl,
+  asgiref, msgpack, posix_ipc
+}:
+buildPythonPackage rec {
+  name = "asgi_ipc-${version}";
+  version = "1.3.1";
+
+  src = fetchurl {
+    url = "mirror://pypi/a/asgi_ipc/${name}.tar.gz";
+    sha256 = "1dm8xvm1z28f421ck1ympxsq2sjm9xb7dla6p8yd2bz6gn6p5h7v";
+  };
+
+  propagatedBuildInputs = [ asgiref msgpack posix_ipc ];
+
+  meta = with stdenv.lib; {
+    description = "Posix IPC-backed ASGI channel layer implementation";
+    license = licenses.bsd3;
+    homepage = http://github.com/django/asgi_ipc/;
+  };
+}

--- a/pkgs/development/python-modules/asgi_redis/default.nix
+++ b/pkgs/development/python-modules/asgi_redis/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchurl,
+  asgiref, asgi_ipc, msgpack, six, redis, cryptography
+}:
+buildPythonPackage rec {
+  name = "asgi_redis-${version}";
+  version = "1.3.0";
+
+  src = fetchurl {
+    url = "mirror://pypi/a/asgi_redis/${name}.tar.gz";
+    sha256 = "0zhv51w0fx3i8m0032nk9v00l6mxaswyi95yzy7p7fjww4q74ncl";
+  };
+
+  # Requires a redis server available
+  doCheck = false;
+
+  propagatedBuildInputs = [ asgiref asgi_ipc msgpack six redis cryptography ];
+
+  meta = with stdenv.lib; {
+    description = "Redis-backed ASGI channel layer implementation";
+    license = licenses.bsd3;
+    homepage = http://github.com/django/asgi_redis/;
+  };
+}

--- a/pkgs/development/python-modules/asgiref/default.nix
+++ b/pkgs/development/python-modules/asgiref/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchurl, six }:
+buildPythonPackage rec {
+  name = "asgiref-${version}";
+  version = "1.1.1";
+
+  src = fetchurl {
+    url = "mirror://pypi/a/asgiref/${name}.tar.gz";
+    sha256 = "0gayxnysknwg8hxb5kvmi2mmd5dnrhgza23daf8j25w3nj2drars";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    description = "Reference ASGI adapters and channel layers";
+    license = licenses.bsd3;
+    homepage = https://github.com/django/asgiref;
+  };
+}

--- a/pkgs/development/python-modules/autobahn/default.nix
+++ b/pkgs/development/python-modules/autobahn/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonPackage, fetchurl, isPy3k,
+  unittest2, mock, pytest, trollius, pytest-asyncio,
+  six, twisted, txaio
+}:
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "autobahn";
+  version = "0.18.2";
+
+  src = fetchurl {
+    url = "mirror://pypi/a/${pname}/${name}.tar.gz";
+    sha256 = "1alp71plqnrak5nm2vn9mmkxayjb081c1kihqwf60wdpvv0w7y14";
+  };
+
+  buildInputs = [ unittest2 mock pytest trollius pytest-asyncio ];
+  propagatedBuildInputs = [ six twisted txaio ];
+
+  disabled = !isPy3k;
+  checkPhase = ''
+    py.test $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "WebSocket and WAMP in Python for Twisted and asyncio.";
+    homepage    = "http://crossbar.io/autobahn";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ nand0p ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/automat/default.nix
+++ b/pkgs/development/python-modules/automat/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchurl,
+  m2r, setuptools_scm, six, attrs }:
+buildPythonPackage rec {
+  name = "Automat-${version}";
+  version = "0.5.0";
+
+  src = fetchurl {
+    url = "mirror://pypi/A/Automat/${name}.tar.gz";
+    sha256 = "1hnpknkqnc2m900kkzrzx9l6g5dy5dassrdj9pn34x1pcdkyr2a8";
+  };
+
+  buildInputs = [ m2r setuptools_scm ];
+  propagatedBuildInputs = [ six attrs ];
+
+  # Some tests require twisetd, but twisted requires Automat to build.
+  # this creates a circular dependency.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/glyph/Automat;
+    description = "Self-service finite-state machines for the programmer on the go";
+    license = licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/channels/default.nix
+++ b/pkgs/development/python-modules/channels/default.nix
@@ -3,11 +3,11 @@
 }:
 buildPythonPackage rec {
   name = "channels-${version}";
-  version = "1.0.3";
+  version = "1.1.3";
 
   src = fetchurl {
     url = "mirror://pypi/c/channels/${name}.tar.gz";
-    sha256 = "1bwlqnfc27p1qnjmdl8jnr941gpl8ggnxxfy8anh9qgmg20q9pfd";
+    sha256 = "182war437i6wsxwf2v4szn8ig0nkpinpn4n27fxhh5q8w832hj93";
   };
 
   # Files are missing in the distribution

--- a/pkgs/development/python-modules/constantly/default.nix
+++ b/pkgs/development/python-modules/constantly/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchurl
+}:
+buildPythonPackage rec {
+  name = "constantly-${version}";
+  version = "15.1.0";
+
+  src = fetchurl {
+    url = "mirror://pypi/c/constantly/${name}.tar.gz";
+    sha256 = "0dgwdla5kfpqz83hfril716inm41hgn9skxskvi77605jbmp4qsq";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/twisted/constantly;
+    description = "symbolic constant support";
+    license = licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/daphne/default.nix
+++ b/pkgs/development/python-modules/daphne/default.nix
@@ -1,15 +1,16 @@
 { stdenv, buildPythonPackage, fetchurl,
-  asgiref, autobahn, twisted
+  asgiref, autobahn, twisted, hypothesis
 }:
 buildPythonPackage rec {
   name = "daphne-${version}";
-  version = "1.0.3";
+  version = "1.2.0";
 
   src = fetchurl {
     url = "mirror://pypi/d/daphne/${name}.tar.gz";
-    sha256 = "1bpavq3sxr66mqwnnfg67pcchyaq7siqyin2r89aqadf6nab58d2";
+    sha256 = "084216isw7rwy693i62rbd8kvpqx418jvf1q72cplv833wz3in7l";
   };
 
+  buildInputs = [ hypothesis ];
   propagatedBuildInputs = [ asgiref autobahn twisted ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/m2r/default.nix
+++ b/pkgs/development/python-modules/m2r/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchurl,
+  mistune, docutils } :
+buildPythonPackage rec {
+  name = "m2r-${version}";
+  version = "0.1.5";
+
+  src = fetchurl {
+    url = "mirror://pypi/m/m2r/${name}.tar.gz";
+    sha256 = "08rjn3x1qag60wawjnq95wmgijrn33apr4fhj01s2p6hmrqgfj1l";
+  };
+
+  propagatedBuildInputs = [ mistune docutils ];
+
+  # Some tests interfeere with each other (test.md and test.rst are
+  # deleted by some tests and not properly regenerated)
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/miyakogi/m2r;
+    description = "converts a markdown file including reST markups to a valid reST format";
+    license = licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-asyncio/default.nix
+++ b/pkgs/development/python-modules/pytest-asyncio/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchurl, pytest }:
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "pytest-asyncio";
+  version = "0.5.0";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/${pname}/${name}.tar.gz";
+    sha256 = "03sxq8fglr4lw4y6wqlbli9ypr65fxzx6hlpn5wpccx8v5472iff";
+  };
+
+  buildInputs = [ pytest ];
+
+  meta = with stdenv.lib; {
+    description = "library for testing asyncio code with pytest";
+    license = licenses.asl20;
+    homepage = https://github.com/pytest-dev/pytest-asyncio;
+  };
+}

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, buildPythonPackage, fetchurl, python,
+  zope_interface, incremental, automat, constantly
+}:
+buildPythonPackage rec {
+
+  name = "Twisted-${version}";
+  version = "17.1.0";
+
+  src = fetchurl {
+    url = "mirror://pypi/T/Twisted/${name}.tar.bz2";
+    sha256 = "1p245mg15hkxp7hy5cyq2fgvlgjkb4cg0gwkwd148nzy1bbi3wnv";
+  };
+
+  propagatedBuildInputs = [ zope_interface incremental automat constantly ];
+
+  # Patch t.p._inotify to point to libc. Without this,
+  # twisted.python.runtime.platform.supportsINotify() == False
+  patchPhase = stdenv.lib.optionalString stdenv.isLinux ''
+    substituteInPlace src/twisted/python/_inotify.py --replace \
+      "ctypes.util.find_library('c')" "'${stdenv.glibc.out}/lib/libc.so.6'"
+  '';
+
+  # Generate Twisted's plug-in cache.  Twisted users must do it as well.  See
+  # http://twistedmatrix.com/documents/current/core/howto/plugin.html#auto3
+  # and http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=477103 for
+  # details.
+  postInstall = "$out/bin/twistd --help > /dev/null";
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover -s twisted/test
+  '';
+  # Tests require network
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://twistedmatrix.com/;
+    description = "Twisted, an event-driven networking engine written in Python";
+    longDescription = ''
+      Twisted is an event-driven networking engine written in Python
+      and licensed under the MIT license.
+    '';
+    license = licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/txaio/default.nix
+++ b/pkgs/development/python-modules/txaio/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchurl,
+  pytest, mock, six, twisted
+}:
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "txaio";
+  version = "2.7.0";
+
+  buildInputs = [ pytest mock ];
+  propagatedBuildInputs = [ six twisted ];
+
+  checkPhase = ''
+    py.test -k "not test_sdist"
+  '';
+
+  src = fetchurl {
+    url = "mirror://pypi/t/${pname}/${name}.tar.gz";
+    sha256 = "0hwd6jx6hb44p40id9r0m42y07rav5jvddf0f1bcm269i3dnwr47";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Utilities to support code that runs unmodified on Twisted and asyncio.";
+    homepage    = "https://github.com/crossbario/txaio";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ nand0p ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31467,31 +31467,7 @@ EOF
     '';
   };
 
-  txaio = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "txaio";
-    version = "2.5.2";
-
-    meta = {
-      description = "Utilities to support code that runs unmodified on Twisted and asyncio.";
-      homepage    = "https://github.com/crossbario/txaio";
-      license     = licenses.mit;
-      maintainers = with maintainers; [ nand0p ];
-      platforms   = platforms.all;
-    };
-
-    buildInputs = with self; [ pytest mock ];
-    propagatedBuildInputs = with self; [ six twisted ];
-
-    checkPhase = ''
-      py.test -k "not test_sdist"
-    '';
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/t/${pname}/${name}.tar.gz";
-      sha256 = "321d441b336447b72dbe81a4d73470414454baf0543ec701fcfecbf4dcbda0fe";
-    };
-  };
+  txaio = callPackage ../development/python-modules/txaio { };
 
   ramlfications = buildPythonPackage rec {
     name = "${pname}-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -810,23 +810,7 @@ in {
 
   asgiref = callPackage ../development/python-modules/asgiref { };
 
-  asgi_ipc = buildPythonPackage rec {
-    name = "asgi_ipc-${version}";
-    version = "1.2.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/asgi_ipc/${name}.tar.gz";
-      sha256 = "03phyfj30s4sgaqfbmv38nfvx3kdmjwsh3558d2lxrf2gdrimmf9";
-    };
-
-    propagatedBuildInputs = with self ; [ asgiref msgpack posix_ipc ];
-
-    meta = {
-      description = "Posix IPC-backed ASGI channel layer implementation";
-      license = licenses.bsd3;
-      homepage = http://github.com/django/asgi_ipc/;
-    };
-  };
+  asgi_ipc = callPackage ../development/python-modules/asgi_ipc { };
 
   asgi_redis = buildPythonPackage rec {
     name = "asgi_redis-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8296,6 +8296,8 @@ in {
     };
   };
 
+  m2r = callPackage ../development/python-modules/m2r { };
+
   mailchimp = buildPythonPackage rec {
     version = "2.0.9";
     name = "mailchimp-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15595,6 +15595,8 @@ in {
       name = "${name}.tar.gz";
     };
 
+    disabled = isPy3k;
+
     propagatedBuildInputs = with self; [ twisted ];
 
     postInstall = "twistd --help > /dev/null";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26846,6 +26846,8 @@ EOF
       sha256 = "0rnshrzw8605x05mpd8ndrx3ri8h6cx713mp8sl4f04f4gcrz8ml";
     };
 
+    disabled = isPy3k;
+
     propagatedBuildInputs = with self; [twisted dateutil];
 
     meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -812,26 +812,7 @@ in {
 
   asgi_ipc = callPackage ../development/python-modules/asgi_ipc { };
 
-  asgi_redis = buildPythonPackage rec {
-    name = "asgi_redis-${version}";
-    version = "1.0.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/asgi_redis/${name}.tar.gz";
-      sha256 = "1pdzxannmgb0as2x6xy0rk4xi8ygnsggpsa0z31pzpwbk6jsgwxd";
-    };
-
-    # Requires a redis server available
-    doCheck = false;
-
-    propagatedBuildInputs = with self ; [ asgiref asgi_ipc msgpack six redis cryptography ];
-
-    meta = {
-      description = "Redis-backed ASGI channel layer implementation";
-      license = licenses.bsd3;
-      homepage = http://github.com/django/asgi_redis/;
-    };
-  };
+  asgi_redis = callPackage ../development/python-modules/asgi_redis { };
 
   python-editor = buildPythonPackage rec {
     name = "python-editor-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13483,6 +13483,8 @@ in {
       sha256 = "1hl2psnn1chm698rimyn9dgcpl1mxgc8dj11b3ipp8z37yfjs3z9";
     };
 
+    disabled = isPy3k;
+
     propagatedBuildInputs = with self; [ werkzeug twisted ];
 
     meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -192,6 +192,8 @@ in {
 
   asn1crypto = callPackage ../development/python-modules/asn1crypto { };
 
+  automat = callPackage ../development/python-modules/automat { };
+
   # packages defined elsewhere
 
   bap = callPackage ../development/python-modules/bap {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -808,6 +808,8 @@ in {
     };
   };
 
+  asgiref = callPackage ../development/python-modules/asgiref { };
+
   asgi_ipc = buildPythonPackage rec {
     name = "asgi_ipc-${version}";
     version = "1.2.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2560,6 +2560,8 @@ in {
     };
   };
 
+  constantly = callPackage ../development/python-modules/constantly { };
+
   cornice = buildPythonPackage rec {
     name = "cornice-${version}";
     version = "1.2.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26035,47 +26035,7 @@ in {
     };
   };
 
-  twisted = buildPythonPackage rec {
-
-    name = "Twisted-${version}";
-    version = "16.4.1";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/T/Twisted/${name}.tar.bz2";
-      sha256 = "1d8d73f006c990744effb35588359fd44d43608649ac0b6b7edc71176e88e816";
-    };
-
-    propagatedBuildInputs = with self; [ zope_interface ];
-
-    # Patch t.p._inotify to point to libc. Without this,
-    # twisted.python.runtime.platform.supportsINotify() == False
-    patchPhase = optionalString stdenv.isLinux ''
-      substituteInPlace twisted/python/_inotify.py --replace \
-        "ctypes.util.find_library('c')" "'${stdenv.glibc.out}/lib/libc.so.6'"
-    '';
-
-    # Generate Twisted's plug-in cache.  Twisted users must do it as well.  See
-    # http://twistedmatrix.com/documents/current/core/howto/plugin.html#auto3
-    # and http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=477103 for
-    # details.
-    postInstall = "$out/bin/twistd --help > /dev/null";
-
-    checkPhase = ''
-      ${python.interpreter} -m unittest discover -s twisted/test
-    '';
-    # Tests require network
-    doCheck = false;
-
-    meta = {
-      homepage = http://twistedmatrix.com/;
-      description = "Twisted, an event-driven networking engine written in Python";
-      longDescription = ''
-        Twisted is an event-driven networking engine written in Python
-        and licensed under the MIT license.
-      '';
-      license = licenses.mit;
-      maintainers = [ ];
-    };
-  };
+  twisted = callPackage ../development/python-modules/twisted { };
 
   tzlocal = buildPythonPackage rec {
     name = "tzlocal-1.2.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5202,6 +5202,8 @@ in {
 
   pytest-httpbin = callPackage ../development/python-modules/pytest-httpbin { };
 
+  pytest-asyncio = callPackage ../development/python-modules/pytest-asyncio { };
+
   pytestcache = buildPythonPackage rec {
     name = "pytest-cache-1.0";
     src = pkgs.fetchurl {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31516,28 +31516,7 @@ EOF
     };
   };
 
-  autobahn = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "autobahn";
-    version = "0.16.0";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/${pname}/${name}.tar.gz";
-      sha256 = "1158ml8h3g0vlsgw2jmy579glbg7dn0mjij8xibdl509b8qv9p51";
-    };
-    buildInputs = with self; [ unittest2 mock pytest_29 trollius ];
-    propagatedBuildInputs = with self; [ six twisted txaio ];
-    checkPhase = ''
-      py.test $out
-    '';
-
-    meta = {
-      description = "WebSocket and WAMP in Python for Twisted and asyncio.";
-      homepage    = "http://crossbar.io/autobahn";
-      license     = licenses.mit;
-      maintainers = with maintainers; [ nand0p ];
-      platforms   = platforms.all;
-    };
-  };
+  autobahn = callPackage ../development/python-modules/autobahn { };
 
   jsonref = buildPythonPackage rec {
     name = "${pname}-${version}";


### PR DESCRIPTION
###### Motivation for this change

Sorry for the amount of changes in one PR, updating one component triggered many required related updates.

Some package have invalid syntax for python3 and caused `nox-review` to failed. I have disabled them for python3, to get nox pass properly.

cc @FRidh 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

