### PR TITLE
meson: 0.35.0 -> 0.40.0

### DIFF
--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -1,15 +1,15 @@
 {stdenv, fetchurl, gnome3, glib, json_glib, libxml2, libarchive, libsoup, gobjectIntrospection, meson, ninja, pkgconfig,  valadoc}:
 
 stdenv.mkDerivation rec {
-  major = "0.2";
-  minor = "10";
+  major = "0.4";
+  minor = "2";
   version = "${major}.${minor}";
 
   name = "libhttpseverywhere-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/libhttpseverywhere/${major}/libhttpseverywhere-${version}.tar.xz";
-    sha256 = "235f5b7f96188d800470871774e31696fbde085b63f65bd71434af8e9e6ac8aa";
+    sha256 = "0n850a4adsla6di8dylnadg07wblkdl28abrjvk6fzy8a1kjlx02";
   };
 
   nativeBuildInputs = [ gnome3.vala valadoc  gobjectIntrospection meson ninja pkgconfig ];
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     mkdir build
     cd build
-    meson.py --prefix "$out" ..
+    meson --prefix "$out" ..
   '';
 
   buildPhase = ''

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -1,12 +1,22 @@
-{ lib, python3Packages, fetchurl }:
-python3Packages.buildPythonPackage rec {
-  version = "0.35.0";
-  name = "meson-${version}";
+{ lib, python3Packages }:
+python3Packages.buildPythonApplication rec {
+  version = "0.40.0";
+  pname = "meson";
+  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "mirror://pypi/m/meson/${name}.tar.gz";
-    sha256 = "0w4vian55cwcv2m5qzn73aznf9a0y24cszqb7dkpahrb9yrg25l3";
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1hb6y5phzd5738rlpz78w8hfzk7sbxj81551mb7bbkkqz8ql1gjw";
   };
+
+  postFixup = ''
+    pushd $out/bin
+    # undo shell wrapper as meson tools are called with python
+    for i in *; do
+      mv ".$i-wrapped" "$i"
+    done
+    popd
+  '';
 
   meta = with lib; {
     homepage = http://mesonbuild.com;


### PR DESCRIPTION
###### Motivation for this change

In configured builds other tools tries to call meson by directly
passing meson tools directly to python. Since they were shell scripts
due wrapping this failed. (tested with systemd new build system: https://github.com/systemd/systemd/)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

