### PR TITLE
docker: pass all proxy variables to docker daemon

### DIFF
--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -7,8 +7,7 @@ with lib;
 let
 
   cfg = config.virtualisation.docker;
-  pro = config.networking.proxy.default;
-  proxy_env = optionalAttrs (pro != null) { Environment = "\"http_proxy=${pro}\""; };
+  proxy_env = config.networking.proxy.envVars;
 
 in
 
@@ -106,6 +105,7 @@ in
 
       systemd.services.docker = {
         wantedBy = optional cfg.enableOnBoot "multi-user.target";
+        environment = proxy_env;
         serviceConfig = {
           ExecStart = [
             ""
@@ -122,7 +122,7 @@ in
             ""
             "${pkgs.procps}/bin/kill -s HUP $MAINPID"
           ];
-        } // proxy_env;
+        };
 
         path = [ pkgs.kmod ] ++ (optional (cfg.storageDriver == "zfs") pkgs.zfs);
       };


### PR DESCRIPTION
###### Motivation for this change

This makes things as noProxy work too as all proxy related variables are passed to the docker daemon.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

