### PR TITLE
imagej: init at 150

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -574,6 +574,7 @@
   yarr = "Dmitry V. <savraz@gmail.com>";
   yochai = "Yochai <yochai@titat.info>";
   yorickvp = "Yorick van Pelt <yorickvanpelt@gmail.com>";
+  yuriaisaka = "Yuri Aisaka <yuri.aisaka+nix@gmail.com>";
   yurrriq = "Eric Bailey <eric@ericb.me>";
   z77z = "Marco Maggesi <maggesi@math.unifi.it>";
   zagy = "Christian Zagrodnick <cz@flyingcircus.io>";

--- a/pkgs/applications/graphics/imagej/default.nix
+++ b/pkgs/applications/graphics/imagej/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, fetchurl, jre, unzip, makeWrapper }:
+
+rec {
+  imagej = imagej150;
+
+  imagej150 = stdenv.mkDerivation rec {
+    name = "imagej-${version}";
+    version = "150";
+
+    src = fetchurl {
+      url = "http://wsr.imagej.net/distros/cross-platform/ij150.zip";
+      sha256 = "97aba6fc5eb908f5160243aebcdc4965726693cb1353d9c0d71b8f5dd832cb7b";
+    };
+    buildInputs = [ unzip makeWrapper ];
+    inherit jre;
+
+    # JAR files that are intended to be used by other packages
+    # should go to $out/share/java.
+    installPhase = ''
+      mkdir -p $out/share/java
+      cp ij.jar $out/share/java
+      mkdir $out/bin
+      makeWrapper ${jre}/bin/java $out/bin/imagej \
+        --add-flags "-cp $out/share/java/ij.jar ij.ImageJ"
+    '';
+  };
+
+  meta = {
+    homepage = https://imagej.nih.gov/ij/;
+    description = "Image processing and analysis in Java";
+    longDescription = ''
+      ImageJ is a public domain Java image processing program
+      inspired by NIH Image for the Macintosh.
+      It runs on any computer with a Java 1.4 or later virtual machine.
+    '';
+    license = lib.licenses.publicDomain;
+    platforms = with stdenv.lib.platforms; linux;
+    maintainers = [ "Yuri Aisaka <yuri.aisaka+nix@gmail.com>" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14274,6 +14274,8 @@ with pkgs;
     inherit (perlPackages.override { pkgs = pkgs // { imagemagick = imagemagickBig;}; }) PerlMagick;
   };
 
+  imagej = callPackage ../applications/graphics/imagej { };
+
   imagemagick_light = imagemagick.override {
     bzip2 = null;
     zlib = null;


### PR DESCRIPTION
###### Motivation for this change

add ImageJ (a Java based image processing/analysis software).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS (edit: since 5aeab6c)
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] `meta.maintainers` is set (by adding an email address to `default.nix`; no entries were added to `lib/maintainers.nix`)

##### Possible improvements

- According to the official documentation, should be able to compile and run
  ImageJ by using JDK version 48 ("JDK 1.4") or later.
- The binary version (packaged here) provided by NIH appears to be compiled
  using the JDK version 49 ("JDK 5"), and thus should work on every platform
  where a JRE of version 49 or later is available.

##### Comments

- This is the first time that I am trying to send a pull request to nixpkgs; my apologies in advance for any inconvenience it may cause.
---

