### PR TITLE
fetchdarcs: add SSL_CERT_FILE environment variable (master)

### DIFF
--- a/pkgs/build-support/fetchdarcs/default.nix
+++ b/pkgs/build-support/fetchdarcs/default.nix
@@ -1,10 +1,13 @@
-{stdenv, darcs, nix}: {url, rev ? null, context ? null, md5 ? "", sha256 ? ""}:
+{stdenv, darcs, nix, cacert}:
+
+{url, rev ? null, context ? null, md5 ? "", sha256 ? ""}:
 
 if md5 != "" then
   throw "fetchdarcs does not support md5 anymore, please use sha256"
 else
 stdenv.mkDerivation {
   name = "fetchdarcs";
+  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
   builder = ./builder.sh;
   buildInputs = [darcs];
 


### PR DESCRIPTION
###### Motivation for this change

Fetching from `darcs` repositories through HTTPS fails without this change, since CA certificates are not made available to `darcs`. Example:

```
building path(s) '/nix/store/kcas73q9cs3107kkl6z5wrcg0sr3i3r1-fetchdarcs'
getting http://hub.darcs.net/RyanGlScott/vector-algorithms   into /nix/store/kcas73q9cs3107kkl6z5wrcg0sr3i3r1-fetchdarcs
Identifying repository http://hub.darcs.net/RyanGlScott/vector-algorithms

darcs failed:  Not a repository: http://hub.darcs.net/RyanGlScott/vector-algorithms (Peer certificate cannot be authenticated with given CA certificates)

HINT: Do you have the right URI for the repository?

builder for '/nix/store/l0s2vhr69ikg2r0i1ya3z98jxvr2f6dc-fetchdarcs.drv' failed with exit code 2
error: build of '/nix/store/l0s2vhr69ikg2r0i1ya3z98jxvr2f6dc-fetchdarcs.drv' failed
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @shlevy @luite
