### PR TITLE
hledger(-web): move to all-packages with static build

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14104,6 +14104,9 @@ with pkgs;
 
   hipchat = callPackage ../applications/networking/instant-messengers/hipchat { };
 
+  hledger = haskell.lib.justStaticExecutables haskellPackages.hledger;
+  hledger-web = haskell.lib.justStaticExecutables haskellPackages.hledger-web;
+
   homebank = callPackage ../applications/office/homebank {
     gtk = gtk3;
   };


### PR DESCRIPTION
Since they are executables they should be at top-level.
We build statically to shorten invocation time (at the moment haskell packages
have the problem of too large RPATHs).

- [x] execute