### PR TITLE
generic Haskell builder: Don't call `stack setup`.

### DIFF
--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -37,7 +37,6 @@ stdenv.mkDerivation (args // {
 
   configurePhase = args.configurePhase or ''
     export STACK_ROOT=$NIX_BUILD_TOP/.stack
-    stack setup
   '';
 
   buildPhase = args.buildPhase or "stack build";


### PR DESCRIPTION
`stack setup` should not be called inside `nix-build` because
that makes stack download a GHC instead of using nix's one
(the one provided `generic-stack-builder.nix` as the `ghc` argument),
which will not work.
Further evidence for this is that the `stack --nix` support
intentionally uses `--system-ghc` for the same purpose.

This change was developed in cooperation with @mboes who made the nix-stack integration

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

