### PR TITLE
Add Shibboleth Service Provider

### DIFF
--- a/pkgs/development/libraries/log4shib/default.nix
+++ b/pkgs/development/libraries/log4shib/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchgit, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "log4shib-${version}";
+  version = "1.0.9";
+
+  src = fetchgit {
+    url = "https://git.shibboleth.net/git/cpp-log4shib.git";
+    rev = "a1afe19b7b49c32fcb03e6d72809501b8965cf85";
+    sha256 = "06rrc5l6qxlc8abzim2jcxwz2c577qrjqx15cbfqq1zfqagj9hix";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = {
+    description = "A forked version of log4cpp that has been created for the Shibboleth project";
+  };
+}

--- a/pkgs/development/libraries/opensaml-cpp/default.nix
+++ b/pkgs/development/libraries/opensaml-cpp/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchgit, autoreconfHook, boost, openssl, log4shib, xercesc, xml-security-c, xml-tooling-c, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "opensaml-cpp-${version}";
+  version = "2.6.0";
+
+  src = fetchgit {
+    url = "https://git.shibboleth.net/git/cpp-opensaml.git";
+    rev = "61193de29e4c9f1ccff7ed7e1f42c2748c62be77";
+    sha256 = "1jlxa1f2qn0kd15fzjqp80apxn42v47wg3mx1vk424m31rhi00xr";
+  };
+
+  buildInputs = [ boost openssl log4shib xercesc xml-security-c xml-tooling-c zlib ];
+  nativeBuildInputs = [ autoreconfHook ];
+
+  configureFlags = [ "--with-xmltooling=${xml-tooling-c}" ];
+
+  meta = {
+    home = https://shibboleth.net/products/opensaml-cpp.html;
+    description = "A low-level library written in C++ that provides support for producing and consuming SAML messages";
+  };
+
+}

--- a/pkgs/development/libraries/shibboleth-sp/default.nix
+++ b/pkgs/development/libraries/shibboleth-sp/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchgit, autoreconfHook, boost, fcgi, openssl, opensaml-cpp, log4shib, pkgconfig, xercesc, xml-security-c, xml-tooling-c }:
+
+stdenv.mkDerivation rec {
+  name = "shibboleth-sp-${version}";
+  version = "2.6.0";
+
+  src = fetchgit {
+    url = "https://git.shibboleth.net/git/cpp-sp.git";
+    rev = "9ebba5c3a16d03769f436e383e4c4cdaa33f5509";
+    sha256 = "1b5r4nd098lnjwr2g13f04ycqv5fvbrhpwg6fsdk8xy9cigvfzxj";
+  };
+
+  # Needs pkgconfig to find systemd
+  buildInputs = [ boost fcgi openssl opensaml-cpp log4shib pkgconfig xercesc xml-security-c xml-tooling-c ];
+  nativeBuildInputs = [ autoreconfHook ];
+
+  configureFlags = [
+    "--without-apxs"
+    "--with-xmltooling=${xml-tooling-c}"
+    "--with-saml=${opensaml-cpp}"
+    "--with-fastcgi"
+  ];
+
+  meta = {
+    home = https://shibboleth.net/products/service-provider.html;
+    description = "Enables SSO and Federation web applications written with any programming language or framework";
+  };
+
+}

--- a/pkgs/development/libraries/xml-tooling-c/default.nix
+++ b/pkgs/development/libraries/xml-tooling-c/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchgit, autoreconfHook, boost, curl, openssl, log4shib, xercesc, xml-security-c }:
+
+stdenv.mkDerivation rec {
+  name = "xml-tooling-c-${version}";
+  version = "1.6.0";
+
+  src = fetchgit {
+    url = "https://git.shibboleth.net/git/cpp-xmltooling.git";
+    rev = "db08101c3854518a59096be95ed6564838381744";
+    sha256 = "0rhzvxm4z3pm28kpk34hayhm12bjjms2kygv1z68vnz8ijzgcinq";
+  };
+
+  buildInputs = [ boost curl openssl log4shib xercesc xml-security-c ];
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = {
+    description = "A low-level library that provides a high level interface to XML processing for OpenSAML 2";
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9839,6 +9839,8 @@ with pkgs;
 
   shapelib = callPackage ../development/libraries/shapelib { };
 
+  shibboleth-sp = callPackage ../development/libraries/shibboleth-sp { };
+
   skalibs = callPackage ../development/libraries/skalibs { };
 
   slang = callPackage ../development/libraries/slang { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3380,7 +3380,7 @@ with pkgs;
   paper-gtk-theme = callPackage ../misc/themes/paper { };
 
   paperwork = callPackage ../applications/office/paperwork { };
- 
+
   papertrail = callPackage ../tools/text/papertrail { };
 
   par2cmdline = callPackage ../tools/networking/par2cmdline { };
@@ -9051,6 +9051,8 @@ with pkgs;
 
   log4cplus = callPackage ../development/libraries/log4cplus { };
 
+  log4shib = callPackage ../development/libraries/log4shib { };
+
   loudmouth = callPackage ../development/libraries/loudmouth { };
 
   luabind = callPackage ../development/libraries/luabind { lua = lua5_1; };
@@ -9607,8 +9609,8 @@ with pkgs;
 
     libopenshot-audio = callPackage ../applications/video/openshot-qt/libopenshot-audio.nix { };
 
-    libqtav = callPackage ../development/libraries/libqtav { 
-      libva = libva-full; # also wants libva-x11 
+    libqtav = callPackage ../development/libraries/libqtav {
+      libva = libva-full; # also wants libva-x11
     };
 
     mlt = callPackage ../development/libraries/mlt/qt-5.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10286,6 +10286,8 @@ with pkgs;
 
   xml-security-c = callPackage ../development/libraries/xml-security-c { };
 
+  xml-tooling-c = callPackage ../development/libraries/xml-tooling-c { };
+
   xlslib = callPackage ../development/libraries/xlslib { };
 
   xvidcore = callPackage ../development/libraries/xvidcore { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9312,6 +9312,8 @@ with pkgs;
   openjpeg_2_1 = callPackage ../development/libraries/openjpeg/2.1.nix { };
   openjpeg = openjpeg_2_1;
 
+  opensaml-cpp = callPackage ../development/libraries/opensaml-cpp { };
+
   openscenegraph = callPackage ../development/libraries/openscenegraph { };
 
   openslp = callPackage ../development/libraries/openslp {};


### PR DESCRIPTION
###### Motivation for this change

I need to provide SAML based authentication to my web application, and the shibboleth service provider package does exactly that. Adding these packages is the first step. I will also be sending in PR for a shibboleth-sp module.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS (doesn't currently build)
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

