### PR TITLE
virtualisation-xen: Fix xendomains startup

### DIFF
--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -107,7 +107,8 @@ stdenv.mkDerivation (rec {
     # We want to do this before getting prefetched stuff to speed things up
     # (prefetched stuff has lots of files)
     find . -type f | xargs sed -i 's@/usr/bin/\(python\|perl\)@/usr/bin/env \1@g'
-    find . -type f | xargs sed -i 's@/bin/bash@/bin/sh@g'
+    find . -type f -not -path "./tools/hotplug/Linux/xendomains.in" \
+      | xargs sed -i 's@/bin/bash@/bin/sh@g'
 
     # Get prefetched stuff
     ${withXenfiles (name: x: ''
@@ -169,6 +170,11 @@ stdenv.mkDerivation (rec {
     ${withTools "postPatch" (name: x: x.postPatch)}
 
     ${config.postPatch or ""}
+  '';
+
+  postConfigure = ''
+    substituteInPlace tools/hotplug/Linux/xendomains \
+      --replace /bin/ls ls
   '';
 
   # TODO: Flask needs more testing before enabling it by default.


### PR DESCRIPTION
* Revert to using bash, not sh for the xendomains script to avoid syntax error
* Rewrite /bin/ls to ls in the xendomains script

###### Motivation for this change

Currently, the `xendomains` service fails to start the xen VMs, failing with the error:
```
Apr 27 07:26:28 nixos xendomains[844]: /nix/store/naf65vhayfc1dcsm2w4qxdvy8953kbh3-xen-4.5.5/lib/xen/bin/xendomains: line 141: syntax error near unexpected token `<'
Apr 27 07:26:28 nixos xendomains[844]: /nix/store/naf65vhayfc1dcsm2w4qxdvy8953kbh3-xen-4.5.5/lib/xen/bin/xendomains: line 141: `        if test -z "$RUNLEVEL"; then read RUNLEVEL RE
Apr 27 07:26:28 nixos systemd[1]: xen-domains.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
```

The reason for this is that the `xendomains` script expects to be run using `bash`, but the build script rewrites its shebang line to point at `sh`:
```
find . -type f | xargs sed -i 's@/bin/bash@/bin/sh@g'
```

Additionally, the script would fail because of trying to run `/bin/ls`.

This pull request fixes both problems.

Please note that `/bin/ls` was already being substituted by `ls` before commit 9e6ae2f60a109c6e5380c0fb3775e783a1fc8f00 was applied. That commit removed a number of other substitutions, which might need to be revisited.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
