### PR TITLE
mesos: update to 1.1.1

### DIFF
--- a/pkgs/applications/networking/cluster/mesos/default.nix
+++ b/pkgs/applications/networking/cluster/mesos/default.nix
@@ -22,7 +22,7 @@ let
   });
 
 in stdenv.mkDerivation rec {
-  version = "1.1.0";
+  version = "1.1.1";
   name = "mesos-${version}";
 
   enableParallelBuilding = true;
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://apache/mesos/${version}/${name}.tar.gz";
-    sha256 = "1hdjd4syyp88l0bnh88bhzvn9466ad2ysfp9pq3kwj3qzwg5jv8g";
+    sha256 = "0f46ebb130d2d4a9732f95d0a71d80c8c5967f3c172b110f2ece316e05922115";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Current marathon version in 17.03 and master is 1.4.1 which requires mesos 1.1.1+
see: https://mesosphere.github.io/marathon/docs/

Current deployments (such as my cluster) are broken as marathon is unable to schedule or maintain apps on mesos (likely API changes)

###### Things done
- [x] deployed onto a real mesos cluster
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

