### PR TITLE
wordpress: 4.7.3 -> 4.7.4

### DIFF
--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -2,8 +2,8 @@
 { fetchFromGitHub, lib } : fetchFromGitHub {
   owner = "WordPress";
   repo = "WordPress";
-  rev = "4.7.3";
-  sha256 = "05gggm40065abylp6bdc0zn0q6ahcggyh4q6rk0ak242q8v5fm5b";
+  rev = "4.7.4";
+  sha256 = "1ia9d3n085x2r6pvdrv4rk6gdp6xhjhpsq5g7a6448xzv9hf14ri";
   meta = {
     homepage = https://wordpress.org;
     description = "WordPress is open source software you can use to create a beautiful website, blog, or app.";


### PR DESCRIPTION
See: https://wordpress.org/news/2017/04/wordpress-4-7-4/

It would be nice if this can be cherry picked on `release-17.03`.