### PR TITLE
Cleanup tahoe module

### DIFF
--- a/nixos/modules/services/network-filesystems/tahoe.nix
+++ b/nixos/modules/services/network-filesystems/tahoe.nix
@@ -237,14 +237,14 @@ in
               # arguments to $(tahoe start). The node directory must come first,
               # and arguments which alter Twisted's behavior come afterwards.
               ExecStart = ''
-                ${settings.package}/bin/tahoe start ${nodedir} -n -l- --pidfile=${pidfile}
+                ${settings.package}/bin/tahoe start "${nodedir}" -n -l- --pidfile="${pidfile}"
               '';
             };
             preStart = ''
-              if [ \! -d ${nodedir} ]; then
-                mkdir -p /var/db/tahoe-lafs
-                tahoe create-introducer ${nodedir}
-              fi
+              if [ ! -d "${nodedir}" ]; then
+                mkdir -p /var/db/tahoe-lafs &&
+                tahoe create-introducer "${nodedir}"
+              fi &&
 
               # Tahoe has created a predefined tahoe.cfg which we must now
               # scribble over.
@@ -252,7 +252,7 @@ in
               # we must do this on every prestart. Fixes welcome.
               # rm ${nodedir}/tahoe.cfg
               # ln -s /etc/tahoe-lafs/introducer-${node}.cfg ${nodedir}/tahoe.cfg
-              cp /etc/tahoe-lafs/introducer-${node}.cfg ${nodedir}/tahoe.cfg
+              cp /etc/tahoe-lafs/introducer-"${node}".cfg "${nodedir}"/tahoe.cfg
             '';
           });
         users.extraUsers = flip mapAttrs' cfg.introducers (node: _:
@@ -337,14 +337,14 @@ in
               # arguments to $(tahoe start). The node directory must come first,
               # and arguments which alter Twisted's behavior come afterwards.
               ExecStart = ''
-                ${settings.package}/bin/tahoe start ${nodedir} -n -l- --pidfile=${pidfile}
+                ${settings.package}/bin/tahoe start "${nodedir}" -n -l- --pidfile="${pidfile}"
               '';
             };
             preStart = ''
-              if [ \! -d ${nodedir} ]; then
-                mkdir -p /var/db/tahoe-lafs
-                tahoe create-node --hostname=localhost ${nodedir}
-              fi
+              if [ ! -d "${nodedir}" ]; then
+                mkdir -p /var/db/tahoe-lafs &&
+                tahoe create-node --hostname=localhost "${nodedir}"
+              fi &&
 
               # Tahoe has created a predefined tahoe.cfg which we must now
               # scribble over.
@@ -352,7 +352,7 @@ in
               # we must do this on every prestart. Fixes welcome.
               # rm ${nodedir}/tahoe.cfg
               # ln -s /etc/tahoe-lafs/${node}.cfg ${nodedir}/tahoe.cfg
-              cp /etc/tahoe-lafs/${node}.cfg ${nodedir}/tahoe.cfg
+              cp /etc/tahoe-lafs/"${node}".cfg "${nodedir}"/tahoe.cfg
             '';
           });
         users.extraUsers = flip mapAttrs' cfg.nodes (node: _:

--- a/nixos/modules/services/network-filesystems/tahoe.nix
+++ b/nixos/modules/services/network-filesystems/tahoe.nix
@@ -242,9 +242,9 @@ in
             };
             preStart = ''
               if [ ! -d "${lib.escapeShellArg nodedir}" ]; then
-                mkdir -p /var/db/tahoe-lafs &&
+                mkdir -p /var/db/tahoe-lafs 
                 tahoe create-introducer "${lib.escapeShellArg nodedir}"
-              fi &&
+              fi 
 
               # Tahoe has created a predefined tahoe.cfg which we must now
               # scribble over.
@@ -342,9 +342,9 @@ in
             };
             preStart = ''
               if [ ! -d "${lib.escapeShellArg nodedir}" ]; then
-                mkdir -p /var/db/tahoe-lafs &&
+                mkdir -p /var/db/tahoe-lafs
                 tahoe create-node --hostname=localhost "${lib.escapeShellArg nodedir}"
-              fi &&
+              fi
 
               # Tahoe has created a predefined tahoe.cfg which we must now
               # scribble over.

--- a/nixos/modules/services/network-filesystems/tahoe.nix
+++ b/nixos/modules/services/network-filesystems/tahoe.nix
@@ -237,13 +237,13 @@ in
               # arguments to $(tahoe start). The node directory must come first,
               # and arguments which alter Twisted's behavior come afterwards.
               ExecStart = ''
-                ${settings.package}/bin/tahoe start "${lib.escapeShellArg nodedir}" -n -l- --pidfile="${lib.escapeShellArg pidfile}"
+                ${settings.package}/bin/tahoe start ${lib.escapeShellArg nodedir} -n -l- --pidfile=${lib.escapeShellArg pidfile}
               '';
             };
             preStart = ''
-              if [ ! -d "${lib.escapeShellArg nodedir}" ]; then
+              if [ ! -d ${lib.escapeShellArg nodedir} ]; then
                 mkdir -p /var/db/tahoe-lafs
-                tahoe create-introducer "${lib.escapeShellArg nodedir}"
+                tahoe create-introducer "{lib.escapeShellArg nodedir}
               fi
 
               # Tahoe has created a predefined tahoe.cfg which we must now
@@ -252,7 +252,7 @@ in
               # we must do this on every prestart. Fixes welcome.
               # rm ${nodedir}/tahoe.cfg
               # ln -s /etc/tahoe-lafs/introducer-${node}.cfg ${nodedir}/tahoe.cfg
-              cp /etc/tahoe-lafs/introducer-"${node}".cfg "${lib.escapeShellArg nodedir}"/tahoe.cfg
+              cp /etc/tahoe-lafs/introducer-"${node}".cfg ${lib.escapeShellArg nodedir}/tahoe.cfg
             '';
           });
         users.extraUsers = flip mapAttrs' cfg.introducers (node: _:
@@ -337,13 +337,13 @@ in
               # arguments to $(tahoe start). The node directory must come first,
               # and arguments which alter Twisted's behavior come afterwards.
               ExecStart = ''
-                ${settings.package}/bin/tahoe start "${lib.escapeShellArg nodedir}" -n -l- --pidfile="${pidfile}"
+                ${settings.package}/bin/tahoe start ${lib.escapeShellArg nodedir} -n -l- --pidfile=${lib.escapeShellArg pidfile}
               '';
             };
             preStart = ''
-              if [ ! -d "${lib.escapeShellArg nodedir}" ]; then
+              if [ ! -d ${lib.escapeShellArg nodedir} ]; then
                 mkdir -p /var/db/tahoe-lafs
-                tahoe create-node --hostname=localhost "${lib.escapeShellArg nodedir}"
+                tahoe create-node --hostname=localhost ${lib.escapeShellArg nodedir}
               fi
 
               # Tahoe has created a predefined tahoe.cfg which we must now
@@ -351,8 +351,8 @@ in
               # XXX I thought that a symlink would work here, but it doesn't, so
               # we must do this on every prestart. Fixes welcome.
               # rm ${nodedir}/tahoe.cfg
-              # ln -s /etc/tahoe-lafs/${node}.cfg ${nodedir}/tahoe.cfg
-              cp /etc/tahoe-lafs/"${node}".cfg "${lib.escapeShellArg nodedir}"/tahoe.cfg
+              # ln -s /etc/tahoe-lafs/${lib.escapeShellArg node}.cfg ${nodedir}/tahoe.cfg
+              cp /etc/tahoe-lafs/${lib.escapeShellArg node}.cfg ${lib.escapeShellArg nodedir}/tahoe.cfg
             '';
           });
         users.extraUsers = flip mapAttrs' cfg.nodes (node: _:

--- a/nixos/modules/services/network-filesystems/tahoe.nix
+++ b/nixos/modules/services/network-filesystems/tahoe.nix
@@ -242,9 +242,9 @@ in
             };
             preStart = ''
               if [ ! -d "${lib.escapeShellArg nodedir}" ]; then
-                mkdir -p /var/db/tahoe-lafs 
+                mkdir -p /var/db/tahoe-lafs
                 tahoe create-introducer "${lib.escapeShellArg nodedir}"
-              fi 
+              fi
 
               # Tahoe has created a predefined tahoe.cfg which we must now
               # scribble over.

--- a/nixos/modules/services/network-filesystems/tahoe.nix
+++ b/nixos/modules/services/network-filesystems/tahoe.nix
@@ -237,13 +237,13 @@ in
               # arguments to $(tahoe start). The node directory must come first,
               # and arguments which alter Twisted's behavior come afterwards.
               ExecStart = ''
-                ${settings.package}/bin/tahoe start "${nodedir}" -n -l- --pidfile="${pidfile}"
+                ${settings.package}/bin/tahoe start "${lib.escapeShellArg nodedir}" -n -l- --pidfile="${lib.escapeShellArg pidfile}"
               '';
             };
             preStart = ''
-              if [ ! -d "${nodedir}" ]; then
+              if [ ! -d "${lib.escapeShellArg nodedir}" ]; then
                 mkdir -p /var/db/tahoe-lafs &&
-                tahoe create-introducer "${nodedir}"
+                tahoe create-introducer "${lib.escapeShellArg nodedir}"
               fi &&
 
               # Tahoe has created a predefined tahoe.cfg which we must now
@@ -252,7 +252,7 @@ in
               # we must do this on every prestart. Fixes welcome.
               # rm ${nodedir}/tahoe.cfg
               # ln -s /etc/tahoe-lafs/introducer-${node}.cfg ${nodedir}/tahoe.cfg
-              cp /etc/tahoe-lafs/introducer-"${node}".cfg "${nodedir}"/tahoe.cfg
+              cp /etc/tahoe-lafs/introducer-"${node}".cfg "${lib.escapeShellArg nodedir}"/tahoe.cfg
             '';
           });
         users.extraUsers = flip mapAttrs' cfg.introducers (node: _:
@@ -337,13 +337,13 @@ in
               # arguments to $(tahoe start). The node directory must come first,
               # and arguments which alter Twisted's behavior come afterwards.
               ExecStart = ''
-                ${settings.package}/bin/tahoe start "${nodedir}" -n -l- --pidfile="${pidfile}"
+                ${settings.package}/bin/tahoe start "${lib.escapeShellArg nodedir}" -n -l- --pidfile="${pidfile}"
               '';
             };
             preStart = ''
-              if [ ! -d "${nodedir}" ]; then
+              if [ ! -d "${lib.escapeShellArg nodedir}" ]; then
                 mkdir -p /var/db/tahoe-lafs &&
-                tahoe create-node --hostname=localhost "${nodedir}"
+                tahoe create-node --hostname=localhost "${lib.escapeShellArg nodedir}"
               fi &&
 
               # Tahoe has created a predefined tahoe.cfg which we must now
@@ -352,7 +352,7 @@ in
               # we must do this on every prestart. Fixes welcome.
               # rm ${nodedir}/tahoe.cfg
               # ln -s /etc/tahoe-lafs/${node}.cfg ${nodedir}/tahoe.cfg
-              cp /etc/tahoe-lafs/"${node}".cfg "${nodedir}"/tahoe.cfg
+              cp /etc/tahoe-lafs/"${node}".cfg "${lib.escapeShellArg nodedir}"/tahoe.cfg
             '';
           });
         users.extraUsers = flip mapAttrs' cfg.nodes (node: _:


### PR DESCRIPTION
###### Motivation for this change

- Remove useless escape of question mark
- Add proper escaping for correctness

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

