### PR TITLE
Weechat plugin split

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -664,4 +664,34 @@ cp ${myEmacsConfig} $out/share/emacs/site-lisp/default.el
 
 </section>
 
+<section xml:id="sec-weechat">
+<title>Weechat</title>
+<para>
+Weechat can currently be configured to include your choice of plugins.
+To make use of this functionality, install an expression that overrides its configuration such as
+<programlisting>weechat.override {configure = {availablePlugins, ...}: {
+        plugins = with availablePlugins; [ python perl ];
+    }
+}</programlisting>
+</para>
+<para>
+The plugins currently available are <literal>python</literal>,
+<literal>perl</literal>, <literal>ruby</literal>, <literal>guile</literal>,
+<literal>tcl</literal> and <literal>lua</literal>.
+</para>
+<para>
+The python plugin allows the addition of extra libraries. For instance,
+the <literal>inotify.py</literal> script in weechat-scripts requires
+D-Bus or libnotify, and the <literal>fish.py</literal> script requires
+pycrypto. To use these scripts, use the <literal>python</literal>
+plugin's <literal>withPackages</literal> attribute:
+<programlisting>weechat.override {configure = {availablePlugins, ...}: {
+    plugins = with availablePlugins; [
+            (python.withPackages (ps: with ps; [ pycrypto python-dbus ]))
+        ];
+    }
+}
+</programlisting>
+</para>
+</section>
 </chapter>

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -1,81 +1,129 @@
-{ stdenv, fetchurl, ncurses, openssl, aspell, gnutls
-, zlib, curl , pkgconfig, libgcrypt
+{ stdenv, fetchurl, fetchpatch, lib
+, ncurses, openssl, aspell, gnutls
+, zlib, curl, pkgconfig, libgcrypt
 , cmake, makeWrapper, libobjc, libresolv, libiconv
+, writeScriptBin, symlinkJoin # for withPlugins
 , asciidoctor # manpages
 , guileSupport ? true, guile
 , luaSupport ? true, lua5
 , perlSupport ? true, perl
-, pythonPackages
+, pythonSupport ? true, pythonPackages
 , rubySupport ? true, ruby
 , tclSupport ? true, tcl
-, extraBuildInputs ? [] }:
-
-assert guileSupport -> guile != null;
-assert luaSupport -> lua5 != null;
-assert perlSupport -> perl != null;
-assert rubySupport -> ruby != null;
-assert tclSupport -> tcl != null;
+, extraBuildInputs ? []
+, configure ? null
+, runCommand }:
 
 let
   inherit (pythonPackages) python pycrypto pync;
-in
+  plugins = [
+    { name = "perl"; enabled = perlSupport; cmakeFlag = "ENABLE_PERL"; buildInputs = [ perl ]; }
+    { name = "tcl"; enabled = tclSupport; cmakeFlag = "ENABLE_TCL"; buildInputs = [ tcl ]; }
+    { name = "ruby"; enabled = rubySupport; cmakeFlag = "ENABLE_RUBY"; buildInputs = [ ruby ]; }
+    { name = "guile"; enabled = guileSupport; cmakeFlag = "ENABLE_GUILE"; buildInputs = [ guile ]; }
+    { name = "lua"; enabled = luaSupport; cmakeFlag = "ENABLE_LUA"; buildInputs = [ lua5 ]; }
+    { name = "python"; enabled = pythonSupport; cmakeFlag = "ENABLE_PYTHON"; buildInputs = [ python ]; }
+  ];
+  enabledPlugins = builtins.filter (p: p.enabled) plugins;
 
-stdenv.mkDerivation rec {
-  version = "1.9.1";
-  name = "weechat-${version}";
+  weechat =
+    assert lib.all (p: p.enabled -> ! (builtins.elem null p.buildInputs)) plugins;
+    stdenv.mkDerivation rec {
+      version = "1.9.1";
+      name = "weechat-${version}";
 
-  src = fetchurl {
-    url = "http://weechat.org/files/src/weechat-${version}.tar.bz2";
-    sha256 = "1kgi079bq4n0wb7hc7mz8p7ay1b2m0a4wpvb92sfsxrnh10qr5m1";
-  };
+      src = fetchurl {
+        url = "http://weechat.org/files/src/weechat-${version}.tar.bz2";
+        sha256 = "1kgi079bq4n0wb7hc7mz8p7ay1b2m0a4wpvb92sfsxrnh10qr5m1";
+      };
 
-  outputs = [ "out" "man" ];
+      patches = [
+        # TODO: Remove this patch when weechat is updated to a release that
+        # incorporates weechat/weechat#971
+        (fetchpatch {
+          url = https://github.com/lheckemann/weechat/commit/45a4f0565cc745b9c6e943f20199015185696df0.patch;
+          sha256 = "0x7vv7g0k3b2hj444x2cinyv1mq5bkr6m18grfnyy6swbymzc9bj";
+        })
+      ];
 
-  enableParallelBuilding = true;
-  cmakeFlags = with stdenv.lib; [
-    "-DENABLE_MAN=ON"
-    "-DENABLE_DOC=ON"
-  ]
-    ++ optionals stdenv.isDarwin ["-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib" "-DCMAKE_FIND_FRAMEWORK=LAST"]
-    ++ optional (!guileSupport) "-DENABLE_GUILE=OFF"
-    ++ optional (!luaSupport)   "-DENABLE_LUA=OFF"
-    ++ optional (!perlSupport)  "-DENABLE_PERL=OFF"
-    ++ optional (!rubySupport)  "-DENABLE_RUBY=OFF"
-    ++ optional (!tclSupport)   "-DENABLE_TCL=OFF"
-    ;
+      outputs = [ "out" "man" ] ++ map (p: p.name) enabledPlugins;
 
-  buildInputs = with stdenv.lib; [
-      ncurses python openssl aspell gnutls zlib curl pkgconfig
-      libgcrypt pycrypto makeWrapper
-      cmake
-      asciidoctor
+      enableParallelBuilding = true;
+      cmakeFlags = with stdenv.lib; [
+        "-DENABLE_MAN=ON"
+        "-DENABLE_DOC=ON"
       ]
-    ++ optionals stdenv.isDarwin [ pync libobjc libresolv ]
-    ++ optional  guileSupport    guile
-    ++ optional  luaSupport      lua5
-    ++ optional  perlSupport     perl
-    ++ optional  rubySupport     ruby
-    ++ optional  tclSupport      tcl
-    ++ extraBuildInputs;
+        ++ optionals stdenv.isDarwin ["-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib" "-DCMAKE_FIND_FRAMEWORK=LAST"]
+        ++ map (p: "-D${p.cmakeFlag}=" + (if p.enabled then "ON" else "OFF")) plugins
+        ;
 
-  NIX_CFLAGS_COMPILE = "-I${python}/include/${python.libPrefix}"
-    # Fix '_res_9_init: undefined symbol' error
-    + (stdenv.lib.optionalString stdenv.isDarwin "-DBIND_8_COMPAT=1 -lresolv");
+      buildInputs = with stdenv.lib; [
+          ncurses openssl aspell gnutls zlib curl pkgconfig
+          libgcrypt makeWrapper cmake asciidoctor
+          ]
+        ++ optionals stdenv.isDarwin [ libobjc libresolv ]
+        ++ concatMap (p: p.buildInputs) enabledPlugins
+        ++ extraBuildInputs;
 
-  postInstall = with stdenv.lib; ''
-    NIX_PYTHONPATH="$out/lib/${python.libPrefix}/site-packages"
-    wrapProgram "$out/bin/weechat" \
-      ${optionalString perlSupport "--prefix PATH : ${perl}/bin"} \
-      --prefix PATH : ${pythonPackages.python}/bin \
-      --prefix PYTHONPATH : "$PYTHONPATH" \
-      --prefix PYTHONPATH : "$NIX_PYTHONPATH"
-  '';
+      NIX_CFLAGS_COMPILE = "-I${python}/include/${python.libPrefix}"
+        # Fix '_res_9_init: undefined symbol' error
+        + (stdenv.lib.optionalString stdenv.isDarwin "-DBIND_8_COMPAT=1 -lresolv");
 
-  meta = {
-    homepage = http://www.weechat.org/;
-    description = "A fast, light and extensible chat client";
-    license = stdenv.lib.licenses.gpl3;
-    maintainers = with stdenv.lib.maintainers; [ lovek323 garbas the-kenny ];
-    platforms = stdenv.lib.platforms.unix;
-  };
-}
+      postInstall = with stdenv.lib; ''
+        for p in ${concatMapStringsSep " " (p: p.name) enabledPlugins}; do
+          from=$out/lib/weechat/plugins/$p.so
+          to=''${!p}/lib/weechat/plugins/$p.so
+          mkdir -p $(dirname $to)
+          mv $from $to
+        done
+      '';
+
+      meta = {
+        homepage = http://www.weechat.org/;
+        description = "A fast, light and extensible chat client";
+        license = stdenv.lib.licenses.gpl3;
+        maintainers = with stdenv.lib.maintainers; [ lovek323 garbas the-kenny lheckemann ];
+        platforms = stdenv.lib.platforms.unix;
+      };
+    };
+in if configure == null then weechat else
+  let
+    perlInterpreter = perl;
+    config = configure {
+      availablePlugins = let
+          simplePlugin = name: {pluginFile = "${weechat.${name}}/lib/weechat/plugins/${name}.so";};
+        in rec {
+          python = {
+            pluginFile = "${weechat.python}/lib/weechat/plugins/python.so";
+            withPackages = pkgsFun: (python // {
+              extraEnv = ''
+                export PYTHONHOME="${pythonPackages.python.withPackages pkgsFun}"
+              '';
+            });
+          };
+          perl = (simplePlugin "perl") // {
+            extraEnv = ''
+              export PATH="${perlInterpreter}/bin:$PATH"
+            '';
+          };
+          tcl = simplePlugin "tcl";
+          ruby = simplePlugin "ruby";
+          guile = simplePlugin "guile";
+          lua = simplePlugin "lua";
+        };
+      };
+
+    inherit (config) plugins;
+
+    pluginsDir = runCommand "weechat-plugins" {} ''
+      mkdir -p $out/plugins
+      for plugin in ${lib.concatMapStringsSep " " (p: p.pluginFile) plugins} ; do
+        ln -s $plugin $out/plugins
+      done
+    '';
+  in writeScriptBin "weechat" ''
+    #!${stdenv.shell}
+    export WEECHAT_EXTRA_LIBDIR=${pluginsDir}
+    ${lib.concatMapStringsSep "\n" (p: lib.optionalString (p ? extraEnv) p.extraEnv) plugins}
+    exec ${weechat}/bin/weechat "$@"
+  ''


### PR DESCRIPTION
###### Motivation for this change
#22746 

This change moves each language plugin into a separate output, significantly reducing weechat's closure size. It also adds a `withPlugins` function to weechat, which generates a wrapper for adding the plugins.

This relies on weechat/weechat#971 and so probably shouldn't be merged until the next stable release which will (hopefully!) include that change.

This is probably my biggest nixpkgs change yet, so I'm PRing it now in search of feedback — any input would be highly appreciated! Particularly, the way in which I add the `withPlugins` function to weechat. This should allow using it like `weechat.withPlugins [weechat.ruby weechat.guile]`, but is there a more elegant way of adding it than the set union I'm doing here? I'd also like to know what people think about the mechanism as a whole, i.e. how this runtime composition is implemented.

Checklist before this can be merged:

- [x] ~~weechat/weechat#971 merged and incorporated into a release~~ patch added to expression instead
- [x] Remove references from main weechat derivation to python and perl packages — these should be in the wrapper as well
- [x] Document it — but where? This isn't specific to NixOS (so probably not the NixOS manual), nor is it only applicable to people intending to contribute to nixpkgs (so probably not the nixpkgs manual). Do we have an "end-user's guide" to nixpkgs?

Ideas:
 - [x] Potentially handle the plugins in a more unified way; I'll be experimenting with this a bit.
 - [ ] Allow managing user config as well as plugins


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).