### PR TITLE
grsecurity: discontinue support

### DIFF
--- a/nixos/modules/security/grsecurity.nix
+++ b/nixos/modules/security/grsecurity.nix
@@ -13,7 +13,7 @@ in
 
 {
   meta = {
-    maintainers = with maintainers; [ joachifm ];
+    maintainers = with maintainers; [ ];
     doc = ./grsecurity.xml;
   };
 

--- a/nixos/modules/security/grsecurity.xml
+++ b/nixos/modules/security/grsecurity.xml
@@ -26,9 +26,11 @@
     <link xlink:href="https://wiki.archlinux.org/index.php/Grsecurity">Arch
     Linux wiki page on grsecurity</link>.
 
-    <note><para>grsecurity/PaX is only available for the latest linux -stable
-    kernel; patches against older kernels are available from upstream only for
-    a fee.</para></note>
+    <warning><para>Upstream has ceased free support for grsecurity/PaX.  See
+    <link xlink:href="https://grsecurity.net/passing_the_baton.php">
+    the announcement</link> for more information.  Consequently, NixOS
+    support for grsecurity/PaX also must cease.  Enabling this module will
+    result in a build error.</para></warning>
     <note><para>We standardise on a desktop oriented configuration primarily due
     to lack of resources.  The grsecurity/PaX configuration state space is huge
     and each configuration requires quite a bit of testing to ensure that the

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -248,7 +248,6 @@ in rec {
   tests.gocd-server = callTest tests/gocd-server.nix {};
   tests.gnome3 = callTest tests/gnome3.nix {};
   tests.gnome3-gdm = callTest tests/gnome3-gdm.nix {};
-  tests.grsecurity = callTest tests/grsecurity.nix {};
   tests.hibernate = callTest tests/hibernate.nix {};
   tests.hound = callTest tests/hound.nix {};
   tests.i3wm = callTest tests/i3wm.nix {};

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -99,11 +99,7 @@ rec {
     sha256 = "00b1rqgd4yr206dxp4mcymr56ymbjcjfa4m82pxw73khj032qw3j";
   };
 
-  grsecurity_testing = grsecPatch
-    { kver   = "4.9.24";
-      grrev  = "201704220732";
-      sha512 = "0n9v066z3qh296fyvsg1gnygy7jd0cy0pnywxzglh58dnibl28q2ywjnp4ff30andzzq7rvjkk4n151xvs1n04pf2azkgz6igwfisg7";
-    };
+  grsecurity_testing = throw "grsecurity/PaX is unsupported";
 
   # This patch relaxes grsec constraints on the location of usermode helpers,
   # e.g., modprobe, to allow calling into the Nix store.

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -99,7 +99,13 @@ rec {
     sha256 = "00b1rqgd4yr206dxp4mcymr56ymbjcjfa4m82pxw73khj032qw3j";
   };
 
-  grsecurity_testing = throw "grsecurity/PaX is unsupported";
+  grsecurity_testing = throw ''
+    Upstream has ceased free support for grsecurity/PaX.
+
+    See https://grsecurity.net/passing_the_baton.php
+    and https://grsecurity.net/passing_the_baton_faq.php
+    for more information.
+  '';
 
   # This patch relaxes grsec constraints on the location of usermode helpers,
   # e.g., modprobe, to allow calling into the Nix store.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11896,22 +11896,7 @@ with pkgs;
 
   # Grsecurity packages
 
-  linux_grsec_nixos = callPackage ../build-support/grsecurity {
-    inherit (lib) overrideDerivation;
-    kernel = callPackage ../os-specific/linux/kernel/linux-grsecurity.nix {
-      kernelPatches = with self.kernelPatches; [
-        bridge_stp_helper
-        modinst_arg_list_too_long
-      ] ++ lib.optionals ((platform.kernelArch or null) == "mips")
-        [ kernelPatches.mips_fpureg_emu
-          kernelPatches.mips_fpu_sigill
-          kernelPatches.mips_ext3_n32
-        ];
-    };
-    grsecPatch = self.kernelPatches.grsecurity_testing;
-    kernelPatches = [ self.kernelPatches.grsecurity_nixos_kmod ];
-    extraConfig = callPackage ../os-specific/linux/kernel/grsecurity-nixos-config.nix { };
-  };
+  linux_grsec_nixos = throw "grsecurity/PaX is unsupported";
 
   linuxPackages_grsec_nixos =
     recurseIntoAttrs (linuxPackagesFor linux_grsec_nixos);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11896,7 +11896,7 @@ with pkgs;
 
   # Grsecurity packages
 
-  linux_grsec_nixos = throw "grsecurity/PaX is unsupported";
+  linux_grsec_nixos = kernelPatches.grsecurity_testing;
 
   linuxPackages_grsec_nixos =
     recurseIntoAttrs (linuxPackagesFor linux_grsec_nixos);


### PR DESCRIPTION
Upstream has decided to make -testing patches private, effectively ceasing free support for grsecurity/PaX [1].  Consequently, we can no longer responsibly support grsecurity on NixOS.

As a first step turn the patch & kernel expressions into errors. It's unclear whether we might want to prune all grsec/PaX stuff from the tree --- the infrastructure might be useful to users wishing to build
NixOS against grsec patches they've paid for. OTOH, I certainly cannot support that use-case so bit-rot is a real concern.

[1]: https://grsecurity.net/passing_the_baton.php