### PR TITLE
perlPackages.FileSlurp: silence perl 5.24.1 warnings

### DIFF
--- a/pkgs/development/perl-modules/File-Slurp/silence-deprecation.patch
+++ b/pkgs/development/perl-modules/File-Slurp/silence-deprecation.patch
@@ -1,0 +1,10 @@
+--- File-Slurp-9999.19.orig/lib/File/Slurp.pm	2011-05-30 21:58:53.000000000 +0200
++++ File-Slurp-9999.19/lib/File/Slurp.pm	2017-04-28 10:05:59.047681755 +0200
+@@ -4,6 +4,7 @@
+ 
+ use strict;
+ use warnings ;
++no warnings 'deprecated';
+ 
+ use Carp ;
+ use Exporter ;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5537,6 +5537,8 @@ let self = _self // overrides; _self = with self; {
 
   FileSlurp = buildPerlPackage {
     name = "File-Slurp-9999.19";
+    # WARNING: check on next update if deprecation warning is gone
+    patches = [ ../development/perl-modules/File-Slurp/silence-deprecation.patch ];
     src = fetchurl {
       url = mirror://cpan/authors/id/U/UR/URI/File-Slurp-9999.19.tar.gz;
       sha256 = "0hrn4nipwx40d6ji8ssgr5nw986z9iqq8cn0kdpbszh9jplynaff";


### PR DESCRIPTION
this silence annoying warnings happens in nixos-rebuild

activating the configuration...
setting up /etc...
syswrite() is deprecated on :utf8 handles at /nix/store/d51apm4c8mr5hiwh134vdkzgivf4hrl7-perl-File-Slurp-9999.19/lib/perl5/site_perl/5.24.1/File/Slurp.pm line 506.
syswrite() is deprecated on :utf8 handles at /nix/store/d51apm4c8mr5hiwh134vdkzgivf4hrl7-perl-File-Slurp-9999.19/lib/perl5/site_perl/5.24.1/File/Slurp.pm line 506.
...
syswrite() is deprecated on :utf8 handles at /nix/store/d51apm4c8mr5hiwh134vdkzgivf4hrl7-perl-File-Slurp-9999.19/lib/perl5/site_perl/5.24.1/File/Slurp.pm line 506.
setting up tmpfiles

###### Motivation for this change

The only thing I am worried about is, what happens on a future perl upgrade.
There is an upstream issue: https://rt.cpan.org/Public/Bug/Display.html?id=117005
which states, that a proper fix is not trivial in this case.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

