### PR TITLE
nixos: datadog: process config + fix config loading

### DIFF
--- a/nixos/modules/services/monitoring/dd-agent.nix
+++ b/nixos/modules/services/monitoring/dd-agent.nix
@@ -73,6 +73,7 @@ let
   nginxConfig = pkgs.writeText "nginx.yaml" cfg.nginxConfig;
   mongoConfig = pkgs.writeText "mongo.yaml" cfg.mongoConfig;
   jmxConfig = pkgs.writeText "jmx.yaml" cfg.jmxConfig;
+  processConfig = pkgs.writeText "process.yaml" cfg.processConfig;
   
   etcfiles =
     [ { source = ddConf;
@@ -95,6 +96,10 @@ let
     (optional (cfg.mongoConfig != null)
       { source = mongoConfig;
         target = "dd-agent/conf.d/mongo.yaml";
+      }) ++
+    (optional (cfg.processConfig != null)
+      { source = processConfig;
+        target = "dd-agent/conf.d/process.yaml";
       }) ++
     (optional (cfg.jmxConfig != null)
       { source = jmxConfig;
@@ -153,6 +158,16 @@ in {
       type = types.uniq (types.nullOr types.string);
     };
 
+    processConfig = mkOption {
+      description = ''
+        Process integration configuration
+ 
+        See http://docs.datadoghq.com/integrations/process/
+      '';
+      default = null;
+      type = types.uniq (types.nullOr types.string);
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -179,7 +194,7 @@ in {
         Restart = "always";
         RestartSec = 2;
       };
-      restartTriggers = [ pkgs.dd-agent ddConf diskConfig networkConfig postgresqlConfig nginxConfig mongoConfig jmxConfig ];
+      restartTriggers = [ pkgs.dd-agent ddConf diskConfig networkConfig postgresqlConfig nginxConfig mongoConfig jmxConfig processConfig ];
     };
 
     systemd.services.dogstatsd = {
@@ -195,7 +210,7 @@ in {
         Restart = "always";
         RestartSec = 2;
       };
-      restartTriggers = [ pkgs.dd-agent ddConf diskConfig networkConfig postgresqlConfig nginxConfig mongoConfig jmxConfig ];
+      restartTriggers = [ pkgs.dd-agent ddConf diskConfig networkConfig postgresqlConfig nginxConfig mongoConfig jmxConfig processConfig ];
     };
 
     systemd.services.dd-jmxfetch = lib.mkIf (cfg.jmxConfig != null) {

--- a/pkgs/tools/networking/dd-agent/default.nix
+++ b/pkgs/tools/networking/dd-agent/default.nix
@@ -64,6 +64,9 @@ in stdenv.mkDerivation rec {
     ln -s $out/agent/dogstatsd.py $out/bin/dogstatsd
     ln -s $out/agent/ddagent.py $out/bin/dd-forwarder
 
+    # Move out default conf.d so that /etc/dd-agent/conf.d is used
+    mv $out/agent/conf.d $out/agent/conf.d-system
+
     cat > $out/bin/dd-jmxfetch <<EOF
     #!/usr/bin/env bash
     exec ${python}/bin/python $out/agent/jmxfetch.py $@


### PR DESCRIPTION
Two changes to datadog module:

1) support `processConfig` option: https://github.com/NixOS/nixpkgs/commit/c5d4f0db9f788199553f9c0fced4e6b25600ad74

2) fix config loading: https://github.com/NixOS/nixpkgs/commit/bdabc6f730218559f4605e5872b80dc0cd918704

@rbvermaa @edolstra @thoughtpolice 

It was tested on 17.03, I'll also cherry-pick to mater.