### PR TITLE
linux: disable vsyscalls by default

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -334,6 +334,9 @@ with stdenv.lib;
   ${optionalString (versionAtLeast version "3.12") ''
     USER_NS y # Support for user namespaces
   ''}
+  ${optionalString (versionAtLeast version "4.4") ''
+    LEGACY_VSYSCALL_NONE y # Eliminate ASLR bypass due to vsyscall fixed address mapping
+  ''}
 
   # AppArmor support
   SECURITY_APPARMOR y


### PR DESCRIPTION
Per the CONFIG_LEGACY_VSYSCALL_NONE description:

>   There will be no vsyscall mapping at all. This will eliminate any risk of
   ASLR bypass due to the vsyscall fixed address mapping. Attempts to use the
   vsyscalls will be reported to dmesg, so that either old or malicious
   userspace programs can be identified.

Users that rely on the old behavior can enable it at boot time via
`boot.kernelParams = [ "vsyscall=emulate" ]` (or `native` for the bold).

This change is on the paranoid side, as `vsyscall=emulate` is intended to
be safe in the sense that an attacker shouldn't be able to benefit from
knowing the address mapping ahead of time.


An alternative to this is to just add `vsyscall=none` to the hardened profile. Either way is fine by me.