### PR TITLE
watson: init at 1.4.0

### DIFF
--- a/pkgs/applications/office/watson/default.nix
+++ b/pkgs/applications/office/watson/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "td-watson";
+  name = "${pname}-${version}";
+  version = "1.4.0";
+
+  src = pythonPackages.fetchPypi {
+    inherit version pname;
+    sha256 = "1py0g4990jmvq0dn7jasda7f10kzr41bix46hnbyc1rshjzc17hq";
+  };
+
+  # uses tox, test invocation fails
+  doCheck = true;
+  checkPhase = ''
+    py.test -vs tests
+ '';
+  checkInputs = with pythonPackages; [ py pytest pytest-datafiles mock pytest-mock pytestrunner ];
+  propagatedBuildInputs = with pythonPackages; [ requests2 click arrow ];
+
+  meta = with stdenv.lib; {
+    homepage = https://tailordev.github.io/Watson/;
+    description = "A wonderful CLI to track your time!";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mguentner ] ;
+  };
+}

--- a/pkgs/development/python-modules/pytest-datafiles/default.nix
+++ b/pkgs/development/python-modules/pytest-datafiles/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, py, pytest }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "pytest-datafiles";
+  version = "1.0";
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "1w5435b5pimk6479ml53lmld3qbag7awcg4gl3ljdywc1v096r5v";
+  };
+
+  buildInputs = [ py pytest ];
+
+  meta = with stdenv.lib; {
+    license = licenses.mit;
+    website = https://pypi.python.org/pypi/pytest-catchlog/;
+    description = "py.test plugin to create a 'tmpdir' containing predefined files/directories.";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16193,6 +16193,10 @@ with pkgs;
     imlib2 = imlib2-nox;
   };
 
+  watson = callPackage ../applications/office/watson {
+    pythonPackages = python3Packages;
+  };
+
   way-cooler = callPackage ../applications/window-managers/way-cooler {};
 
   wayv = callPackage ../tools/X11/wayv {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5271,9 +5271,9 @@ in {
   pytest-mock = buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "pytest-mock";
-    version = "1.2";
+    version = "1.6.0";
 
-    buildInputs = with self; [ pytest ];
+    buildInputs = with self; [ pytest setuptools_scm ];
     propagatedBuildInputs = with self; [ mock ];
 
     meta = {
@@ -5284,9 +5284,9 @@ in {
       platforms   = platforms.all;
     };
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/${pname}/${name}.zip";
-      sha256 = "03zxar5drzm7ksqyrwypjaza3cri6wqvpr6iam92djvg6znp32gp";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "07qccww4bq9jxlc0fbhlspr13kcsixchsnl8vk4wdiyvsjy7r8c3";
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5190,6 +5190,8 @@ in {
     };
   };
 
+  pytest-datafiles = callPackage ../development/python-modules/pytest-datafiles { };
+
   pytest-django = callPackage ../development/python-modules/pytest-django { };
 
   pytest-fixture-config = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Tracking time in spreadsheets is for machines :hourglass_flowing_sand: 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

