### PR TITLE
wrapGAppsHook: Correct `wrapProgram` invocations

### DIFF
--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
@@ -35,10 +35,16 @@ wrapGAppsHook() {
     gappsWrapperArgs+=(--prefix $v : "$dummy")
   done
 
-  if [ -z "$dontWrapGApps" ]; then
-    for i in $prefix/bin/* $prefix/libexec/*; do
-      echo "Wrapping app $i"
-      wrapProgram "$i" "${gappsWrapperArgs[@]}"
+  if [[ -z "$dontWrapGApps" ]]; then
+    targetDirs=( "${prefix}/bin" "${prefix}/libexec" )
+    for targetDir in "${targetDirs[@]}"; do
+      if [[ -d "${targetDir}" ]]; then
+        find "${targetDir}" -type f -executable -print0 \
+          | while IFS= read -r -d '' file; do
+          echo "Wrapping program ${file}"
+          wrapProgram "${file}" "${gappsWrapperArgs[@]}"
+        done
+      fi
     done
   fi
 }


### PR DESCRIPTION
(Continuation of #25183, fixing problems that occurred when merging)

This change fixes several defects in the way `wrapGAppsHook` selected
the executable to wrap.

Previously, it would wrap any top-level files in the target `/bin` and
`/libexec` directories, including directories and non-executable
files.  In addition, it failed to wrap files in subdirectories.

Now, it uses `find` to iterate over these directory hierarchies,
selecting only executable files for wrapping.

###### Motivation for this change

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

