### PR TITLE
impure.nix: add crossSystem as arg

### DIFF
--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -22,6 +22,7 @@ in
   # with unnamed parameters allowed by ...
   system ? localSystem.system
 , platform ? localSystem.platform
+, crossSystem ? null
 
 , # Fallback: The contents of the configuration file found at $NIXPKGS_CONFIG or
   # $HOME/.config/nixpkgs/config.nix.
@@ -61,7 +62,7 @@ in
 assert args ? localSystem -> !(args ? system || args ? platform);
 
 import ./. (builtins.removeAttrs args [ "system" "platform" ] // {
-  inherit config overlays;
+  inherit config overlays crossSystem;
   # Fallback: Assume we are building packages on the current (build, in GNU
   # Autotools parlance) system.
   localSystem = { system = builtins.currentSystem; } // localSystem;


### PR DESCRIPTION
###### Motivation for this change

This lets you pass in "--arg crossSystem ..." to <nixpkgs> like in #25215.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

