### PR TITLE
krita: 3.1.2.1 -> 3.1.3

### DIFF
--- a/pkgs/applications/graphics/krita/default.nix
+++ b/pkgs/applications/graphics/krita/default.nix
@@ -8,12 +8,12 @@
 
 stdenv.mkDerivation rec {
   name = "krita-${version}";
-  ver_min = "3.1.2";
-  version = "${ver_min}.1";
+  ver_min = "3.1.3";
+  version = "${ver_min}";
 
   src = fetchurl {
     url = "http://download.kde.org/stable/krita/${ver_min}/${name}.tar.gz";
-    sha256 = "934ed82c3f4e55e7819b327c838ea2f307d3bf3d040722501378b01d76a3992d";
+    sha256 = "125js6c8aw4bqhs28pwnl3rbgqx5yx4zsklw7bfdhy3vf6lrysw1";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules makeQtWrapper ];


### PR DESCRIPTION
###### Motivation for this change

New shiny

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested via opening a few of my projects and doing a bit of painting.