### PR TITLE
stdenv-generic: add meta attribute checking

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -18,6 +18,8 @@ let lib = import ../../../lib; in lib.makeOverridable (
 
 let
 
+  shouldCheckMeta = config.checkMeta or false;
+
   allowUnfree = config.allowUnfree or false || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
 
   whitelist = config.whitelistedLicenses or [];
@@ -151,6 +153,7 @@ let
         broken = remediate_whitelist "Broken";
         blacklisted = x: "";
         insecure = remediate_insecure;
+        unknown-meta = x: "";
       };
       remediate_whitelist = allow_attr: attrs:
         ''
@@ -202,6 +205,32 @@ let
 
           '' + ((builtins.getAttr reason remediation) attrs));
 
+      metaTypes = with lib.types; {
+        # These keys are documented
+        description = str;
+        longDescription = str;
+        branch = str;
+        homepage = str;
+        downloadPage = str;
+        license = either (listOf lib.types.attrs) lib.types.attrs;
+        maintainers = listOf str;
+        priority = int;
+        platforms = listOf str;
+        hydraPlatforms = listOf str;
+        broken = bool;
+
+        # Weirder stuff that doesn't appear in the documentation?
+        version = str;
+        updateWalker = bool;
+        executables = listOf str;
+      };
+
+      checkMetaAttr = k: v:
+        if metaTypes?${k} then
+          if metaTypes.${k}.check v then null else "key '${k}' has a value of an invalid type; expected ${metaTypes.${k}.description}"
+        else "key '${k}' is unrecognized; expected one of: \n\t      [${lib.concatMapStringsSep ", " (x: "'${x}'") (lib.attrNames metaTypes)}]";
+      checkMeta = meta: if shouldCheckMeta then lib.remove null (lib.mapAttrsToList checkMetaAttr meta) else [];
+
       # Check if a derivation is valid, that is whether it passes checks for
       # e.g brokenness or license.
       #
@@ -219,6 +248,8 @@ let
           { valid = false; reason = "broken"; errormsg = "is not supported on ‘${result.system}’"; }
         else if !(hasAllowedInsecure attrs) then
           { valid = false; reason = "insecure"; errormsg = "is marked as insecure"; }
+        else let res = checkMeta (attrs.meta or {}); in if res != [] then
+          { valid = false; reason = "unknown-meta"; errormsg = "has an invalid meta attrset:${lib.concatMapStrings (x: "\n\t - " + x) res}"; }
         else { valid = true; };
 
       outputs' =


### PR DESCRIPTION
This is turned off by default but I think we should fix all packages to respect it and then turn it on by default. To turn it on, just put `checkMeta = true;` into your nixpkgs config.

cc @shlevy @dezgeg @edolstra

###### Motivation for this change

I got sick of constantly seeing typos and accidental type errors in our meta tags, and people never notice them until Hydra complains. I'd probably eventually start adding a few more checks (like that `platforms` members are in an enum and so on) but this should get us 95% of the value.

It's turned off by default because there are tons of violations, which I'd propose fixing incrementally in separate commits. The very first failure is in binutils, which has a `priority` field as a string 😄 

###### Things done

Nothing. I just tried evaluating `stdenv` and got some failures, so there's work to be done 😁

N.B: this is _not_ a mass rebuild, and only affects evaluation