### PR TITLE
llvm: Add the LLVM OpenMP components

### DIFF
--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -24,6 +24,8 @@ let
 
     clang = wrapCC self.clang-unwrapped;
 
+    openmp = callPackage ./openmp.nix {};
+
     libcxxClang = ccWrapperFun {
       cc = self.clang-unwrapped;
       isClang = true;

--- a/pkgs/development/compilers/llvm/4/openmp.nix
+++ b/pkgs/development/compilers/llvm/4/openmp.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, fetch
+, cmake
+, zlib
+, llvm
+, perl
+, version
+}:
+
+stdenv.mkDerivation {
+  name = "openmp-${version}";
+
+  src = fetch "openmp" "09kf41zgv551fnv628kqhlwgqkd2bkiwii9gqi6q12djgdddhmfv";
+
+  buildInputs = [ cmake llvm perl ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Components required to build an executable OpenMP program";
+    homepage    = http://openmp.llvm.org/;
+    license     = stdenv.lib.licenses.mit;
+    platforms   = stdenv.lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Needed to build an executable that uses OpenMP with clang. This
includes a header file and a library that clang will link into an
executable whose source makes use of ‘omp‘ pragmas.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

