### PR TITLE
glfw: fix the install name id on darwin

### DIFF
--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, mesa, libXrandr, libXi, libXxf86vm, libXfixes, xlibsWrapper
 , libXinerama, libXcursor
-, darwin
+, darwin, fixDarwinDylibNames
 }:
 
 stdenv.mkDerivation rec {
@@ -19,15 +19,15 @@ stdenv.mkDerivation rec {
   buildInputs = [
     cmake mesa libXrandr libXi libXxf86vm libXfixes xlibsWrapper
     libXinerama libXcursor
-  ] ++ stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa Kernel ]);
+  ] ++ stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa Kernel fixDarwinDylibNames ]);
 
   cmakeFlags = "-DBUILD_SHARED_LIBS=ON";
 
-  meta = with stdenv.lib; { 
+  meta = with stdenv.lib; {
     description = "Multi-platform library for creating OpenGL contexts and managing input, including keyboard, mouse, joystick and time";
     homepage = "http://www.glfw.org/";
     license = licenses.zlib;
     maintainers = with maintainers; [ marcweber ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I encountered a runtime dynamic link failure without this change.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

