### PR TITLE
rtags: link to libclang.dylib at absolute path on darwin

### DIFF
--- a/pkgs/development/tools/rtags/default.nix
+++ b/pkgs/development/tools/rtags/default.nix
@@ -22,6 +22,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    for f in $out/bin/{rc,rdm,rp}; do
+      install_name_tool -change @rpath/libclang.dylib ${llvmPackages.clang.cc}/lib/libclang.dylib ''${f}
+    done
+  '';
+
   meta = {
     description = "C/C++ client-server indexer based on clang";
     homepage = https://github.com/andersbakken/rtags;


### PR DESCRIPTION
###### Motivation for this change
I encountered a runtime link failure without this change. Perhaps the executables could be left using `@rpath` in conjunction with some other configuration, but I am not sure what the advantage to that arrangement is versus linking to the `libclang` in scope at build time.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

