### PR TITLE
fix 'command-not-found: is a directory' error

### DIFF
--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -44,7 +44,7 @@ in
       ''
         # This function is called whenever a command is not found.
         command_not_found_handle() {
-          local p=${commandNotFound}
+          local p=${commandNotFound}/bin/command-not-found
           if [ -x $p -a -f ${cfg.dbPath} ]; then
             # Run the helper program.
             $p "$@"
@@ -65,7 +65,7 @@ in
       ''
         # This function is called whenever a command is not found.
         command_not_found_handler() {
-          local p=${commandNotFound}
+          local p=${commandNotFound}/bin/command-not-found
           if [ -x $p -a -f ${cfg.dbPath} ]; then
             # Run the helper program.
             $p "$@"


### PR DESCRIPTION
###### Motivation for this change

5a5db609e5bd83bc589f36eef394f3ad172d6648 from https://github.com/NixOS/nixpkgs/pull/24962 caused this issue by changing the way that `command-not-found` is invoked.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).