### PR TITLE
display-manager: systemd-udev-settle serves no purpose, boot 10% faster

### DIFF
--- a/nixos/modules/services/scheduling/atd.nix
+++ b/nixos/modules/services/scheduling/atd.nix
@@ -67,8 +67,6 @@ in
 
     systemd.services.atd = {
       description = "Job Execution Daemon (atd)";
-      after = [ "systemd-udev-settle.service" ];
-      wants = [ "systemd-udev-settle.service" ];
       wantedBy = [ "multi-user.target" ];
 
       path = [ at ];

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -651,8 +651,7 @@ in
     systemd.services.display-manager =
       { description = "X11 Server";
 
-        after = [ "systemd-udev-settle.service" "acpid.service" "systemd-logind.service" ];
-        wants = [ "systemd-udev-settle.service" ];
+        after = [ "acpid.service" "systemd-logind.service" ];
 
         restartIfChanged = false;
 

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -478,6 +478,7 @@ in
         createImportService = pool:
           nameValuePair "zfs-import-${pool}" {
             description = "Import ZFS pool \"${pool}\"";
+            # we need systemd-udev-settle until https://github.com/zfsonlinux/zfs/pull/4943 is merged
             requires = [ "systemd-udev-settle.service" ];
             after = [ "systemd-udev-settle.service" "systemd-modules-load.service" ];
             wantedBy = (getPoolMounts pool) ++ [ "local-fs.target" ];


### PR DESCRIPTION
###### Motivation for this change

```systemd-udev-settle.service``` is a leftover from a time when it was possible to say "now all the hardware I will ever need has shown up" and really doesn't make sense in the very dynamic world of today. Additionally is slows down boot by about 1.2 seconds on the hardware I have available.

Yet it is pulled in by the following units:

``` shell
$ ag udev-settle | grep -i -e req -e want

nixos/modules/services/hardware/brltty.nix:42:     wants = [ "systemd-udev-settle.service" ];
nixos/modules/services/scheduling/atd.nix:73:      wants = [ "systemd-udev-settle.service" ];
nixos/modules/services/x11/xserver.nix:528:        wants = [ "systemd-udev-settle.service" ];
nixos/modules/tasks/filesystems/zfs.nix:338:       requires = [ "systemd-udev-settle.service" ];
```

I don't have any experience with braille displays or ZFS to say if it is truly needed here so I have left these out, but for ```atd``` and ```display-manager``` it's pointless.

It's tested here on 2 physical machines (a regular desktop and a laptop with a dm-crypt encrypted home) and apart from the improvement in boot speed there is no difference.

All units with default dependencies (ie without ```DefaultDependencies=no```) get an implicit ```After=basic.target``` which implies ```After=local-fs.target``` so that's why I ripped that out of
```display-manager.service``` while at it.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
