### PR TITLE
ibus-engines.mozc:  2.17.2313.102 -> 2.20.2673.102

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
@@ -1,14 +1,16 @@
-{ clangStdenv, fetchFromGitHub, fetchsvn, which, ninja, python2, pkgconfig, protobuf, ibus, gtk2, zinnia, qt4, libxcb, tegaki-zinnia-japanese }:
+{ clangStdenv, fetchFromGitHub, which, ninja, python, gyp, pkgconfig, protobuf
+, ibus, gtk2, zinnia, qt5, libxcb, tegaki-zinnia-japanese }:
 
 let
-  japanese_usage_dictionary = fetchsvn {
-    url = "http://japanese-usage-dictionary.googlecode.com/svn/trunk";
-    rev = "10";
+  japanese_usage_dictionary = fetchFromGitHub {
+    owner  = "hiroyuki-komatsu";
+    repo   = "japanese-usage-dictionary";
+    rev    = "e5b3425575734c323e1d947009dd74709437b684";
     sha256 = "0pyrpz9c8nxccwpgyr36w314mi8h132cis8ijvlqmmhqxwsi30hm";
   };
 in clangStdenv.mkDerivation rec {
   name = "ibus-mozc-${version}";
-  version = "2.17.2313.102";
+  version = "2.20.2673.102";
 
   meta = with clangStdenv.lib; {
     isIbusEngine = true;
@@ -19,14 +21,14 @@ in clangStdenv.mkDerivation rec {
     maintainers  = with maintainers; [ gebner ericsagnes ];
   };
 
-  nativeBuildInputs = [ which ninja python2 python2.pkgs.gyp pkgconfig ];
-  buildInputs = [ protobuf ibus gtk2 zinnia qt4 libxcb ];
+  nativeBuildInputs = [ which ninja python gyp pkgconfig ];
+  buildInputs = [ protobuf ibus gtk2 zinnia qt5.qtbase libxcb ];
 
   src = fetchFromGitHub {
     owner  = "google";
     repo   = "mozc";
-    rev    = "3306d3314499a54a4064b8b80bbc1bce3f6cfac4";
-    sha256 = "0l7mjlnbm6i1ipni8pg9ym5bjg3rzkaxi9xwmsz2lddv348sqii2";
+    rev    = "280e38fe3d9db4df52f0713acf2ca65898cd697a";
+    sha256 = "0s599f817gjgqynm4n1yll1ipd25ai2c55y8k6wvhg9s7qaxnyhs";
   };
 
   postUnpack = ''
@@ -36,16 +38,11 @@ in clangStdenv.mkDerivation rec {
 
   configurePhase = ''
     export GYP_DEFINES="document_dir=$out/share/doc/mozc use_libzinnia=1 use_libprotobuf=1 ibus_mozc_path=$out/lib/ibus-mozc/ibus-engine-mozc"
-    python src/build_mozc.py gyp --gypdir=${python2.pkgs.gyp}/bin --server_dir=$out/lib/mozc \
-    python src/unix/fcitx/fcitx.gyp gyp --gypdir=${python2.pkgs.gyp}/bin
-  '';
-
-  preBuildPhase = ''
-    head -n 29 src/server/mozc_server.cc > LICENSE
+    cd src && python build_mozc.py gyp --gypdir=${gyp}/bin --server_dir=$out/lib/mozc
   '';
 
   buildPhase = ''
-    python src/build_mozc.py build -c Release \
+    PYTHONPATH="$PWD:$PYTHONPATH" python build_mozc.py build -c Release \
       unix/ibus/ibus.gyp:ibus_mozc \
       unix/emacs/emacs.gyp:mozc_emacs_helper \
       server/server.gyp:mozc_server \
@@ -53,32 +50,29 @@ in clangStdenv.mkDerivation rec {
       renderer/renderer.gyp:mozc_renderer
   '';
 
-  checkPhase = ''
-    python src/build_mozc.py runtests -c Release
-  '';
-
   installPhase = ''
-    install -d        $out/share/licenses/mozc/
-    install -m 644    LICENSE src/data/installer/*.html     $out/share/licenses/mozc/
+    install -d        $out/share/licenses/mozc
+    head -n 29 server/mozc_server.cc > $out/share/licenses/mozc/LICENSE
+    install -m 644    data/installer/*.html     $out/share/licenses/mozc/
 
-    install -D -m 755 src/out_linux/Release/mozc_server $out/lib/mozc/mozc_server
-    install    -m 755 src/out_linux/Release/mozc_tool   $out/lib/mozc/mozc_tool
+    install -D -m 755 out_linux/Release/mozc_server $out/lib/mozc/mozc_server
+    install    -m 755 out_linux/Release/mozc_tool   $out/lib/mozc/mozc_tool
 
-    install -d $out/share/doc/mozc
-    install -m 644 src/data/installer/*.html $out/share/doc/mozc/
+    install -d        $out/share/doc/mozc
+    install -m 644    data/installer/*.html         $out/share/doc/mozc/
 
-    install -D -m 755 src/out_linux/Release/ibus_mozc       $out/lib/ibus-mozc/ibus-engine-mozc
-    install -D -m 644 src/out_linux/Release/gen/unix/ibus/mozc.xml $out/share/ibus/component/mozc.xml
-    install -D -m 644 src/data/images/unix/ime_product_icon_opensource-32.png $out/share/ibus-mozc/product_icon.png
-    install    -m 644 src/data/images/unix/ui-tool.png          $out/share/ibus-mozc/tool.png
-    install    -m 644 src/data/images/unix/ui-properties.png    $out/share/ibus-mozc/properties.png
-    install    -m 644 src/data/images/unix/ui-dictionary.png    $out/share/ibus-mozc/dictionary.png
-    install    -m 644 src/data/images/unix/ui-direct.png        $out/share/ibus-mozc/direct.png
-    install    -m 644 src/data/images/unix/ui-hiragana.png      $out/share/ibus-mozc/hiragana.png
-    install    -m 644 src/data/images/unix/ui-katakana_half.png $out/share/ibus-mozc/katakana_half.png
-    install    -m 644 src/data/images/unix/ui-katakana_full.png $out/share/ibus-mozc/katakana_full.png
-    install    -m 644 src/data/images/unix/ui-alpha_half.png    $out/share/ibus-mozc/alpha_half.png
-    install    -m 644 src/data/images/unix/ui-alpha_full.png    $out/share/ibus-mozc/alpha_full.png
-    install -D -m 755 src/out_linux/Release/mozc_renderer $out/lib/mozc/mozc_renderer
+    install -D -m 755 out_linux/Release/ibus_mozc           $out/lib/ibus-mozc/ibus-engine-mozc
+    install -D -m 644 out_linux/Release/gen/unix/ibus/mozc.xml $out/share/ibus/component/mozc.xml
+    install -D -m 644 data/images/unix/ime_product_icon_opensource-32.png $out/share/ibus-mozc/product_icon.png
+    install    -m 644 data/images/unix/ui-tool.png          $out/share/ibus-mozc/tool.png
+    install    -m 644 data/images/unix/ui-properties.png    $out/share/ibus-mozc/properties.png
+    install    -m 644 data/images/unix/ui-dictionary.png    $out/share/ibus-mozc/dictionary.png
+    install    -m 644 data/images/unix/ui-direct.png        $out/share/ibus-mozc/direct.png
+    install    -m 644 data/images/unix/ui-hiragana.png      $out/share/ibus-mozc/hiragana.png
+    install    -m 644 data/images/unix/ui-katakana_half.png $out/share/ibus-mozc/katakana_half.png
+    install    -m 644 data/images/unix/ui-katakana_full.png $out/share/ibus-mozc/katakana_full.png
+    install    -m 644 data/images/unix/ui-alpha_half.png    $out/share/ibus-mozc/alpha_half.png
+    install    -m 644 data/images/unix/ui-alpha_full.png    $out/share/ibus-mozc/alpha_full.png
+    install -D -m 755 out_linux/Release/mozc_renderer       $out/lib/mozc/mozc_renderer
   '';
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1303,7 +1303,9 @@ with pkgs;
     m17n = callPackage ../tools/inputmethods/ibus-engines/ibus-m17n { };
 
     mozc = callPackage ../tools/inputmethods/ibus-engines/ibus-mozc {
-      protobuf = protobuf.override { stdenv = clangStdenv; };
+      python = python2;
+      inherit (python2Packages) gyp;
+      protobuf = protobuf3_2.override { stdenv = clangStdenv; };
     };
 
     table = callPackage ../tools/inputmethods/ibus-engines/ibus-table {


### PR DESCRIPTION
###### Motivation for this change

Update ibus-mozc to a recent version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

