### PR TITLE
amqptools: init

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -43,6 +43,7 @@
   andsild = "Anders Sildnes <andsild@gmail.com>";
   aneeshusa = "Aneesh Agrawal <aneeshusa@gmail.com>";
   antono = "Antono Vasiljev <self@antono.info>";
+  apeschar = "Albert Peschar <albert@peschar.net>";
   apeyroux = "Alexandre Peyroux <alex@px.io>";
   ardumont = "Antoine R. Dumont <eniotna.t@gmail.com>";
   aristid = "Aristid Breitkreuz <aristidb@gmail.com>";

--- a/pkgs/tools/misc/amqptools/default.nix
+++ b/pkgs/tools/misc/amqptools/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, rabbitmq-c }:
+
+stdenv.mkDerivation {
+  name = "amqptools";
+
+  buildInputs = [ rabbitmq-c ];
+
+  src = fetchFromGitHub {
+    owner = "rmt";
+    repo = "amqptools";
+    rev = "ad71013c055c04d158b92e6eafd8efa4b180300a";
+    sha256 = "0mjd88kk6j4747gw2z6sm4ng9nnaajgww5n6j02vwxp7325p4c5c";
+  };
+
+  setupEnvironment = ''
+    export AMQPTOOLS_RABBITHOME=${rabbitmq-c}
+    export AMQPTOOLS_INSTALLROOT=$out/bin
+    sed -i 's#/librabbitmq/\.libs/#/lib/#g' Makefile
+  '';
+
+  preBuildPhases = [ "setupEnvironment" ];
+
+  meta = with stdenv.lib; {
+    description = "Command Line Interface for sending and receiving AMQP messages";
+    longDescription = ''
+      amqpspawn and amqpsend allow the simple sending and receiving of AMQP
+      messages from the command line or shell scripts. You will require an
+      existing AMQP broker such as RabbitMQ to be running somewhere on an
+      accessible network. They use rabbitmq-c and the resident memory footprint
+      is under one megabyte, making them perfect for low resource environments.
+    '';
+    homepage = https://github.com/rmt/amqptools;
+    license = licenses.mpl11;
+    maintainers = with maintainers; [ apeschar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -403,6 +403,8 @@ with pkgs;
 
   ammonite-repl = callPackage ../development/tools/ammonite {};
 
+  amqptools = callPackage ../tools/misc/amqptools { };
+
   amtterm = callPackage ../tools/system/amtterm {};
 
   analog = callPackage ../tools/admin/analog {};


### PR DESCRIPTION
###### Motivation for this change

Add amqptools package. It's useful for testing servers such as RabbitMQ.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

