### PR TITLE
stdenv-generic: add meta attributes checks

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -230,6 +230,8 @@ let
         isBuildPythonPackage = platforms;
         schedulingPriority = str;
         downloadURLRegexp = str;
+        isFcitxEngine = bool;
+        isIbusEngine = bool;
       };
 
       checkMetaAttr = k: v:


### PR DESCRIPTION
###### Motivation for this change

Add `isFcitxEngine` and `isIbusEngine` to the meta check to allow ibus and fcitx engines to build.

related to #25304

cc @copumpkin 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

