### PR TITLE
programs.zsh.syntax-highlighting: support custom highlighting patterns

### DIFF
--- a/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
+++ b/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
@@ -36,6 +36,24 @@ in
             https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters.md
           '';
         };
+
+        patterns = mkOption {
+          default = [];
+          type = types.listOf(types.listOf(types.string));
+
+          example = literalExample ''
+            [
+              ["rm -rf *" "fg=white,bold,bg=red"]
+            ]
+          '';
+
+          description = ''
+            Specifies custom patterns to be highlighted by zsh-syntax-highlighting.
+
+            Please refer to the docs for more information about the usage:
+            https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters/pattern.md
+          '';
+        };
       };
     };
 
@@ -47,6 +65,16 @@ in
 
         ${optionalString (length(cfg.highlighters) > 0)
           "ZSH_HIGHLIGHT_HIGHLIGHTERS=(${concatStringsSep " " cfg.highlighters})"
+        }
+
+        ${optionalString (length(cfg.patterns) > 0)
+          (assert(elem "pattern" cfg.highlighters); (foldl (
+            a: b:
+              assert(length(b) == 2); ''
+                ${a}
+                ZSH_HIGHLIGHT_PATTERNS+=('${elemAt b 0}' '${elemAt b 1}')
+              ''
+          ) "") cfg.patterns)
         }
       '';
     };


### PR DESCRIPTION
###### Motivation for this change

Last week I improved several parts of the ZSH module. However I didn't find enough time to implement custom pattern support for `zsh-syntax-highlighting` which I managed to do now.

I checked all configurations using the following command:

```
NIXOS_CONFIG=`pwd`/vmtest.nix nixos-rebuild -I nixpkgs=$HOME/Projects/nixpkgs/ build-vm
```

- Test with proper configuration
It works fine when using a configuration like this:
``` nix
{
  # ...
  programs.zsh = {
    enable = true;

    syntax-highlighting = {
      enable = true;
      highlighters = [ "main" "pattern" ];
      patterns = [
        ["rm -rf *" "fg=white,bold,bg=red"]
        ["vim *" "fg=white"]
      ];
    };
  };
}
```

- Assertion: it should break when configuring patterns, but the `highlighters` option doesn't contain the pattern highlighter:

``` nix
{
  # ...
  programs.zsh = {
    enable = true;

    syntax-highlighting = {
      enable = true;
      highlighters = [ "main" ];
      patterns = [
        ["rm -rf *" "fg=white,bold,bg=red"]
        ["vim *" "fg=white"]
      ];
    };
  };

}
```

- Assertion: it should break if a pattern contains more than two elements of type string (it seems as `nix` doesn't know tuples, so I had to write an assertion to ensure that only two elements are present in the list which represents one highlight pattern):
``` nix
{
  # ...
  programs.zsh = {
    enable = true;

    syntax-highlighting = {
      enable = true;
      highlighters = [ "main" "pattern" ];
      patterns = [
        ["rm -rf *" "fg=white,bold,bg=red" "blub" "foo"]
      ];
    };
  };

}
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

