### PR TITLE
geogebra: 5-0-350-0 -> 5-0-355-0

### DIFF
--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "geogebra-${version}";
-  version = "5-0-350-0";
+  version = "5-0-355-0";
 
   preferLocalBuild = true;
 
   src = fetchurl {
     url = "http://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2";
-    sha256 = "0lr2calglad5d17p5sl1jbjdfsdsmn4dxgy8s89lyh0d4aihy54d";
+    sha256 = "0gm6jqlc3kgnbwnqlz6i9rahdy802jq7xc9gw1q5ynk63smm3ngk";
   };
 
   srcIcon = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

GeoGebra has published some new updates, so we need an update to ensure that the package won't break in the next days/weeks when another release comes out and `5-0-350-0` will be removed from the download server.

See here for more information: http://download.geogebra.org/installers/5.0/

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

