### PR TITLE
wpa_supplicant_gui: fix icon resizing

### DIFF
--- a/pkgs/os-specific/linux/wpa_supplicant/remove_inkscape.patch
+++ b/pkgs/os-specific/linux/wpa_supplicant/remove_inkscape.patch
@@ -12,7 +12,7 @@ index 709514c..9a5fa94 100644
 --- a/icons/Makefile
 +++ b/icons/Makefile
 @@ -9,10 +9,9 @@ all: $(ICONS)
- 
+
  %.png:
  	mkdir -p hicolor/$(word 1, $(subst /, ,$(@)))/apps/
 -	inkscape $(subst .png,.svg, $(word 2, $(subst /, , $(@)))) --without-gui \
@@ -20,11 +20,10 @@ index 709514c..9a5fa94 100644
 -	        --export-height=$(word 2, $(subst x, , $(subst /, , $(@)))) \
 -		--export-png=hicolor/$(word 1, $(subst /, ,$(@)))/apps/$(word 2, $(subst /, , $@))
 +	convert $(subst .png,.svg, $(word 2, $(subst /, , $(@)))) \
-+		-size $(word 1, $(subst x, , $(@)))x$(word 2, $(subst x, , $(subst /, , $(@)))) \
++		-resize $(word 1, $(subst x, , $(@)))x$(word 2, $(subst x, , $(subst /, , $(@)))) \
 +		hicolor/$(word 1, $(subst /, ,$(@)))/apps/$(word 2, $(subst /, , $@))
- 
+
  %.xpm:
  	mkdir -p pixmaps/
--- 
+--
 2.10.1
-


### PR DESCRIPTION
###### Motivation for this change

Fixes #25320 "icons have wrong size"

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

