### PR TITLE
cmake: Prevent it from looking for packages in / when cross-compiling for Windows.

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/search-path-3.2.patch
+++ b/pkgs/development/tools/build-managers/cmake/search-path-3.2.patch
@@ -62,3 +62,16 @@ diff -ru3 cmake-3.4.3/Modules/Platform/UnixPaths.cmake cmake-3.4.3-new/Modules/P
    )
  
  # Enable use of lib64 search path variants by default.
+diff -ur cmake-3.7.2-orig/Modules/Platform/WindowsPaths.cmake cmake-3.7.2/Modules/Platform/WindowsPaths.cmake
+--- cmake-3.7.2-orig/Modules/Platform/WindowsPaths.cmake	2017-04-26 09:08:39.095674666 -0700
++++ cmake-3.7.2/Modules/Platform/WindowsPaths.cmake	2017-04-28 22:32:10.379015998 -0700
+@@ -66,7 +66,7 @@
+ 
+ if(CMAKE_CROSSCOMPILING AND NOT CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
+   # MinGW (useful when cross compiling from linux with CMAKE_FIND_ROOT_PATH set)
+-  list(APPEND CMAKE_SYSTEM_PREFIX_PATH /)
++  # list(APPEND CMAKE_SYSTEM_PREFIX_PATH /)
+ endif()
+ 
+ list(APPEND CMAKE_SYSTEM_INCLUDE_PATH
+diff -ur cmake-3.7.2-orig/Source/cmFindPackageCommand.cxx cmake-3.7.2/Source/cmFindPackageCommand.cxx


### PR DESCRIPTION
This pull request is for the staging branch because it will cause a mass rebuild.

I was using the CMake from nixpkgs in my own project (outside of nixpkgs) to cross-compile some software for Windows.  That software uses the `find_package` command to find Qt5Widgets.  CMake was finding the Qt5Widgets package on my build system in `/lib/cmake` and trying (unsuccessfully) to use it.  Obviously, that goes against the whole point of purity in Nix.  This pull request adds a patch that comments out a line that adds `/` to the `CMAKE_SYSTEM_PREFIX_PATH`.  Thanks!

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

