### PR TITLE
xfce4-screenshooter: add glib_networking dependency

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-screenshooter.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screenshooter.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, xfce4panel, libxfce4util, gtk, libsoup
-, makeWrapper, glib_networking, exo, hicolor_icon_theme }:
+, makeWrapper, glib_networking, exo, hicolor_icon_theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   p_name  = "xfce4-screenshooter";
@@ -13,17 +13,12 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [
-    pkgconfig intltool makeWrapper
+    pkgconfig intltool wrapGAppsHook
   ];
 
   buildInputs = [
-    xfce4panel libxfce4util gtk libsoup exo hicolor_icon_theme
+    xfce4panel libxfce4util gtk libsoup exo hicolor_icon_theme glib_networking
   ];
-
-  preFixup = ''
-    wrapProgram "$out/bin/xfce4-screenshooter" \
-       --prefix GIO_EXTRA_MODULES : "${glib_networking.out}/lib/gio/modules"
-  '';
 
   meta = {
     homepage = http://goodies.xfce.org/projects/applications/xfce4-screenshooter;

--- a/pkgs/desktops/xfce/applications/xfce4-screenshooter.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screenshooter.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, xfce4panel, libxfce4util, gtk, libsoup
-, exo, hicolor_icon_theme }:
+, makeWrapper, glib_networking, exo, hicolor_icon_theme }:
 
 stdenv.mkDerivation rec {
   p_name  = "xfce4-screenshooter";
@@ -13,12 +13,17 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [
-    pkgconfig intltool
+    pkgconfig intltool makeWrapper
   ];
 
   buildInputs = [
     xfce4panel libxfce4util gtk libsoup exo hicolor_icon_theme
   ];
+
+  preFixup = ''
+    wrapProgram "$out/bin/xfce4-screenshooter" \
+       --prefix GIO_EXTRA_MODULES : "${glib_networking.out}/lib/gio/modules"
+  '';
 
   meta = {
     homepage = http://goodies.xfce.org/projects/applications/xfce4-screenshooter;


### PR DESCRIPTION
###### Motivation for this change

Without this fix upload to ```Imgur``` fails with ```"TLS/SSL support not available; install glib-networking"```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

