### PR TITLE
nvidia-x11: switch download urls to https

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -32,12 +32,12 @@ let
     src =
       if stdenv.system == "i686-linux" then
         fetchurl {
-          url = "http://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run";
+          url = "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run";
           sha256 = sha256_32bit;
         }
       else if stdenv.system == "x86_64-linux" then
         fetchurl {
-          url = "http://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run";
+          url = "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run";
           sha256 = sha256_64bit;
         }
       else throw "nvidia-x11 does not support platform ${stdenv.system}";

--- a/pkgs/os-specific/linux/nvidia-x11/legacy173.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/legacy173.nix
@@ -14,12 +14,12 @@ stdenv.mkDerivation {
   src =
     if stdenv.system == "i686-linux" then
       fetchurl {
-        url = "http://download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}-pkg0.run";
+        url = "https://download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}-pkg0.run";
         sha256 = "08xb7s7cxmj4zv4i3645kjhlhhwxiq6km9ixmsw3vv91f7rkb6d0";
       }
     else if stdenv.system == "x86_64-linux" then
       fetchurl {
-        url = "http://download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-pkg0.run";
+        url = "https://download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-pkg0.run";
         sha256 = "1p2ls0xj81l8v4n6dbjj3p5wlw1iyhgzyvqcv4h5fdxhhs2cb3md";
       }
     else throw "nvidia-x11 does not support platform ${stdenv.system}";

--- a/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   inherit (nvidia_x11) version;
 
   src = fetchurl {
-    url = "ftp://download.nvidia.com/XFree86/nvidia-persistenced/${name}.tar.bz2";
+    url = "https://download.nvidia.com/XFree86/nvidia-persistenced/${name}.tar.bz2";
     inherit sha256;
   };
 

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   inherit (nvidia_x11) version;
 
   src = fetchurl {
-    url = "ftp://download.nvidia.com/XFree86/nvidia-settings/${name}.tar.bz2";
+    url = "https://download.nvidia.com/XFree86/nvidia-settings/${name}.tar.bz2";
     inherit sha256;
   };
 


### PR DESCRIPTION
###### Motivation for this change

download.nvidia.com no longer supports FTP but now also supports HTTPS
Fixes #25326 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

