### PR TITLE
xfce4-dockbarx-plugin: init at 0.5

### DIFF
--- a/pkgs/applications/misc/dockbarx/default.nix
+++ b/pkgs/applications/misc/dockbarx/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, pythonPackages, gnome2, keybinder }:
+
+pythonPackages.buildPythonApplication rec {
+  ver = "0.92";
+  name = "dockbarx-${ver}";
+
+  src = fetchFromGitHub {
+    owner = "M7S";
+    repo = "dockbarx";
+    rev = ver;
+    sha256 = "17n7jc3bk3f2i0i1ddpp05bakifc8y5xppads7ihpkj3qw9g35vl";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py                                --replace /usr/                   ""
+    substituteInPlace setup.py                                --replace '"/", "usr", "share",'  '"share",'
+    substituteInPlace dockbarx/applets.py                     --replace /usr/share/             $out/share/
+    substituteInPlace dockbarx/dockbar.py                     --replace /usr/share/             $out/share/
+    substituteInPlace dockbarx/iconfactory.py                 --replace /usr/share/             $out/share/
+    substituteInPlace dockbarx/theme.py                       --replace /usr/share/             $out/share/
+    substituteInPlace dockx_applets/battery_status.py         --replace /usr/share/             $out/share/
+    substituteInPlace dockx_applets/namebar.py                --replace /usr/share/             $out/share/
+    substituteInPlace dockx_applets/namebar_window_buttons.py --replace /usr/share/             $out/share/
+    substituteInPlace dockx_applets/volume-control.py         --replace /usr/share/             $out/share/
+  '';
+
+  propagatedBuildInputs = (with pythonPackages; [ pygtk pyxdg dbus-python pillow xlib ])
+    ++ (with gnome2; [ gnome_python gnome_python_desktop ])
+    ++ [ keybinder ];
+
+  meta = with stdenv.lib; {
+    homepage = http://launchpad.net/dockbar/;
+    description = "DockBarX is a lightweight taskbar / panel replacement for Linux which works as a stand-alone dock";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.volth ];
+  };
+}

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -83,6 +83,7 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   xfce4_cpugraph_plugin         = callPackage ./panel-plugins/xfce4-cpugraph-plugin.nix         { };
   xfce4_datetime_plugin         = callPackage ./panel-plugins/xfce4-datetime-plugin.nix         { };
   xfce4_dict_plugin             = callPackage ./panel-plugins/xfce4-dict-plugin.nix             { };
+  xfce4_dockbarx_plugin         = callPackage ./panel-plugins/xfce4-dockbarx-plugin.nix         { };
   xfce4_embed_plugin            = callPackage ./panel-plugins/xfce4-embed-plugin.nix            { };
   xfce4_eyes_plugin             = callPackage ./panel-plugins/xfce4-eyes-plugin.nix             { };
   xfce4_fsguard_plugin          = callPackage ./panel-plugins/xfce4-fsguard-plugin.nix          { };

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-dockbarx-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-dockbarx-plugin.nix
@@ -1,0 +1,42 @@
+{ stdenv, pkgconfig, fetchFromGitHub, python2, bash, vala, dockbarx, gtk2, xfce, pythonPackages }:
+
+stdenv.mkDerivation rec {
+  ver = "0.5";
+  rev = "a2dcb66";
+  name = "xfce4-dockbarx-plugin-${ver}-${rev}";
+
+  src = fetchFromGitHub {
+    owner = "TiZ-EX1";
+    repo = "xfce4-dockbarx-plugin";
+    rev = rev;
+    sha256 = "1f75iwlshnif60x0qqdqw5ffng2m4f4zp0ijkrbjz83wm73nsxfx";
+  };
+
+  pythonPath = [ dockbarx ];
+
+  buildInputs = [ pkgconfig python2 vala gtk2 pythonPackages.wrapPython ]
+    ++ (with xfce; [ libxfce4util xfce4panel xfconf xfce4_dev_tools ])
+    ++ pythonPath;
+
+  postPatch = ''
+    substituteInPlace wscript           --replace /usr/share/            "\''${PREFIX}/share/"
+    substituteInPlace src/dockbarx.vala --replace /usr/share/            $out/share/
+    substituteInPlace src/dockbarx.vala --replace '/usr/bin/env python2' ${bash}/bin/bash
+  '';
+
+  configurePhase = "python waf configure --prefix=$out";
+
+  buildPhase = "python waf build";
+
+  installPhase = "python waf install";
+
+  postFixup = "wrapPythonPrograms";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/TiZ-EX1/xfce4-dockbarx-plugin;
+    description = "A plugins to embed DockbarX into xfce4-panel";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.volth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1552,6 +1552,8 @@ with pkgs;
 
   docbook2mdoc = callPackage ../tools/misc/docbook2mdoc { };
 
+  dockbarx = callPackage ../applications/misc/dockbarx { };
+
   dog = callPackage ../tools/system/dog { };
 
   dosfstools = callPackage ../tools/filesystems/dosfstools { };


### PR DESCRIPTION
###### Motivation for this change

A plugin that embeds DockbarX into Xfce4-panel

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

