### PR TITLE
nix-bundle: v0.1.1 -> v0.1.3

### DIFF
--- a/pkgs/tools/package-management/nix-bundle/default.nix
+++ b/pkgs/tools/package-management/nix-bundle/default.nix
@@ -1,20 +1,21 @@
-{ stdenv, lib, fetchFromGitHub, nix, makeWrapper }:
+{ stdenv, lib, fetchFromGitHub, nix, makeWrapper, coreutils, gnutar, gzip, bzip2 }:
 
 stdenv.mkDerivation rec {
   pname = "nix-bundle";
   name = "${pname}-${version}";
-  version = "0.1.1";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "matthewbauer";
     repo = pname;
     rev = "v${version}";
-    sha256 = "13730rfnqjv1m2mky2g0cq77yzp2j215zrvy3lhpiwgmh97vviih";
+    sha256 = "15r77pchf4s4cdv4lvw2zw1yic78k8p0n2r954qq370vscw30yac";
   };
 
-  buildInputs = [ nix makeWrapper ];
+  # coreutils, gnutar is actually needed by nix for bootstrap
+  buildInputs = [ nix coreutils makeWrapper gnutar gzip bzip2 ];
 
-  binPath = lib.makeBinPath [ nix ];
+  binPath = lib.makeBinPath [ nix coreutils gnutar gzip bzip2 ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18081,7 +18081,7 @@ with pkgs;
 
   nixui = callPackage ../tools/package-management/nixui { node_webkit = nwjs_0_12; };
 
-  nix-bundle = callPackage ../tools/package-management/nix-bundle { nix = nixStable; };
+  nix-bundle = callPackage ../tools/package-management/nix-bundle { nix = nixUnstable; };
 
   inherit (callPackages ../tools/package-management/nix-prefetch-scripts { })
     nix-prefetch-bzr


### PR DESCRIPTION
###### Motivation for this change

Fixes issue with args not getting passed correctly.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

