### PR TITLE
RStudio: 0.98.110 -> 1.1.216

### DIFF
--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, makeDesktopItem, cmake, boost155, zlib, openssl,
-R, qt4, libuuid, hunspellDicts, unzip, ant, jdk, gnumake, makeWrapper,
+{ stdenv, fetchurl, makeDesktopItem, cmake, boost163, zlib, openssl,
+R, qt5, libuuid, hunspellDicts, unzip, ant, jdk, gnumake, makeWrapper, pandoc,
 # If you have set up an R wrapper with other packages by following
 # something like https://nixos.org/nixpkgs/manual/#r-packages, RStudio
 # by default not be able to access any of those R packages. In order
@@ -11,18 +11,18 @@ useRPackages ? false
 }:
 
 let
-  version = "0.98.110";
+  version = "1.1.216";
   ginVer = "1.5";
-  gwtVer = "2.5.1";
+  gwtVer = "2.7.0";
 in
 stdenv.mkDerivation rec {
   name = "RStudio-${version}";
 
-  buildInputs = [ cmake boost155 zlib openssl R qt4 libuuid unzip ant jdk makeWrapper ];
+  buildInputs = [ cmake boost163 zlib openssl R qt5.full qt5.qtwebkit qt5.qmakeHook libuuid unzip ant jdk makeWrapper pandoc ];
 
   src = fetchurl {
     url = "https://github.com/rstudio/rstudio/archive/v${version}.tar.gz";
-    sha256 = "0wybbvl5libki8z2ywgcd0hg0py1az484r95lhwh3jbrwfx7ri2z";
+    sha256 = "07lp2ybvj7ippdrp7fv7j54dp0mm6k19j1vqdvjdk95acg3xgcjf";
   };
 
   # Hack RStudio to only use the input R.
@@ -38,14 +38,34 @@ stdenv.mkDerivation rec {
   inherit gwtVer;
   gwtSrc = fetchurl {
     url = "https://s3.amazonaws.com/rstudio-buildtools/gwt-${gwtVer}.zip";
-    sha256 = "0fjr2rcr8lnywj54mzhg9i4xz1b6fh8yv12p5i2q5mgfld2xymy4";
+    sha256 = "1cs78z9a1jg698j2n35wsy07cy4fxcia9gi00x0r0qc3fcdhcrda";
   };
 
   hunspellDictionaries = builtins.attrValues hunspellDicts;
 
   mathJaxSrc = fetchurl {
-    url = https://s3.amazonaws.com/rstudio-buildtools/mathjax-20.zip;
-    sha256 = "1ikg3fhharsfrh2fv8c53fdawqajj24nif89400l3klw1hyq4zal";
+    url = https://s3.amazonaws.com/rstudio-buildtools/mathjax-26.zip;
+    sha256 = "0wbcqb9rbfqqvvhqr1pbqax75wp8ydqdyhp91fbqfqp26xzjv6lk";
+  };
+
+  rmarkdownSrc = fetchurl {
+    url = "https://github.com/rstudio/rmarkdown/archive/95b8b1fa64f78ca99f225a67fff9817103be56.zip";
+    sha256 = "12fa65qr04rwsprkmyl651mkaqcbn1znwsmcjg4qsk9n5nxg0fah";
+  };
+
+  rsconnectSrc = fetchurl {
+    url = "https://github.com/rstudio/rsconnect/archive/425f3767b3142bc6b81c9eb62c4722f1eedc9781.zip";
+    sha256 = "1sgf9dj9wfk4c6n5p1jc45386pf0nj2alg2j9qx09av3can1dy9p";
+  };
+
+  rstudiolibclang = fetchurl {
+    url = https://s3.amazonaws.com/rstudio-buildtools/libclang-3.5.zip;
+    sha256 = "1sl5vb8misipwbbbykdymw172w9qrh8xv3p29g0bf3nzbnv6zc7c";
+  };
+
+  rstudiolibclangheaders = fetchurl {
+    url = https://s3.amazonaws.com/rstudio-buildtools/libclang-builtin-headers.zip;
+    sha256 = "0x4ax186bm3kf098izwmsplckgx1kqzg9iiyzg95rpbqsb4593qb";
   };
 
   preConfigure =
@@ -66,10 +86,19 @@ stdenv.mkDerivation rec {
 	  done
       done
 
-      unzip $mathJaxSrc -d dependencies/common/mathjax
+      unzip $mathJaxSrc -d dependencies/common/mathjax-26
+      unzip $rmarkdownSrc -d dependencies/common/rmarkdown
+      unzip $rsconnectSrc -d dependencies/common/rsconnect
+      mkdir -p dependencies/common/libclang/3.5
+      unzip $rstudiolibclang -d dependencies/common/libclang/3.5
+      mkdir -p dependencies/common/libclang/builtin-headers
+      unzip $rstudiolibclangheaders -d dependencies/common/libclang/builtin-headers
+
+      mkdir -p dependencies/common/pandoc
+      cp ${pandoc}/bin/pandoc dependencies/common/pandoc/
     '';
 
-  cmakeFlags = [ "-DRSTUDIO_TARGET=Desktop" ];
+  cmakeFlags = [ "-DRSTUDIO_TARGET=Desktop" "-DQT_QMAKE_EXECUTABLE=${qt5.qmakeHook}/bin/qmake" ];
 
   desktopItem = makeDesktopItem {
     name = name;
@@ -100,7 +129,7 @@ stdenv.mkDerivation rec {
     { description = "Set of integrated tools for the R language";
       homepage = http://www.rstudio.com/;
       license = licenses.agpl3;
-      maintainers = [ maintainers.ehmry ];
+      maintainers = [ maintainers.ehmry maintainers.changlinli ];
       platforms = platforms.linux;
     };
 }

--- a/pkgs/applications/editors/rstudio/r-location.patch
+++ b/pkgs/applications/editors/rstudio/r-location.patch
@@ -1,18 +1,19 @@
-diff -ur rstudio-0.98.110-old/src/cpp/core/CMakeLists.txt rstudio-0.98.110-new/src/cpp/core/CMakeLists.txt
---- rstudio-0.98.110-old/src/cpp/core/r_util/REnvironmentPosix.cpp	2013-04-28 10:02:14.000000000 -0400
-+++ rstudio-0.98.110-new/src/cpp/core/r_util/REnvironmentPosix.cpp	2015-03-23 15:06:35.533400807 -0400
-@@ -84,9 +84,7 @@
+diff -ur rstudio-1.1.216-old/src/cpp/core/CMakeLists.txt rstudio-1.1.216-new/src/cpp/core/CMakeLists.txt
+--- rstudio-1.1.216-old/src/cpp/core/r_util/REnvironmentPosix.cpp	2017-04-30 03:37:26.669418665 -0400
++++ rstudio-1.1.216-new/src/cpp/core/r_util/REnvironmentPosix.cpp	2017-04-30 03:36:33.590726185 -0400
+@@ -87,10 +87,7 @@
  {
     // define potential paths
     std::vector<std::string> rScriptPaths;
 -   rScriptPaths.push_back("/usr/bin/R");
 -   rScriptPaths.push_back("/usr/local/bin/R");
 -   rScriptPaths.push_back("/opt/local/bin/R");
+-   rScriptPaths.push_back("/Library/Frameworks/R.framework/Resources/bin/R");
 +   rScriptPaths.push_back("@R@/bin/R");
     return scanForRScript(rScriptPaths, pErrMsg);
  }
-
-@@ -220,8 +218,7 @@
+ 
+@@ -226,8 +223,7 @@
        // scan in standard locations as a fallback
        std::string scanErrMsg;
        std::vector<std::string> rScriptPaths;


### PR DESCRIPTION
This fixes incompatibilities introduced by a new R version in d16c38a260ef41ae648f994918f491437fb7c75c

It also fixes #25315 as a result.

###### Motivation for this change

Upgrade to latest version of RStudio and also fix a broken RStudio build due to an upgrade in R.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

