### PR TITLE
dolphin-emu: include more dependencies

### DIFF
--- a/pkgs/misc/emulators/dolphin-emu/default.nix
+++ b/pkgs/misc/emulators/dolphin-emu/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, pkgconfig, cmake, bluez, ffmpeg, libao, mesa, gtk2, glib
+{ stdenv, pkgconfig, cmake, bluez, ffmpeg, libao, gtk2, glib, mesa
 , gettext, libpthreadstubs, libXrandr, libXext, readline, openal
 , libXdmcp, portaudio, fetchFromGitHub, libusb, libevdev
+, wxGTK30, soundtouch, miniupnpc, mbedtls, curl, lzo, sfml
 , libpulseaudio ? null }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +31,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig cmake bluez ffmpeg libao mesa gtk2 glib
                   gettext libpthreadstubs libXrandr libXext readline openal
-                  libevdev libXdmcp portaudio libusb libpulseaudio ];
+                  libevdev libXdmcp portaudio libusb libpulseaudio
+                  libevdev libXdmcp portaudio libusb libpulseaudio
+                  wxGTK30 soundtouch miniupnpc mbedtls curl lzo sfml ];
 
   meta = {
     homepage = http://dolphin-emu.org/;


### PR DESCRIPTION
###### Motivation for this change
Previously, dolphin would build against vendored copies of the
libraries (shipped in source code form). This would result both
in a longer build (wxWidgets takes a while to build!) and in
bulkier binaries that wouldn't share libraries with others,
along with using fixed versions of curl and mbedtls which may
be left with unpatched security vulnerabilities.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).