### PR TITLE
camlistore: remove reference to go

### DIFF
--- a/pkgs/applications/misc/camlistore/default.nix
+++ b/pkgs/applications/misc/camlistore/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, go, fetchgit, git }:
+{ stdenv, lib, go, fetchgit, git, removeReferencesTo }:
 
 stdenv.mkDerivation rec {
   version = "0.9";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     leaveDotGit = true;
   };
 
-  buildInputs = [ go git ];
+  buildInputs = [ go git removeReferencesTo ];
 
   buildPhase = ''
     go run make.go
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     cp bin/* $out/bin
+  '';
+
+  postFixup = ''
+    remove-references-to -t ${go} $out/bin/*
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
#21397

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

