### PR TITLE
mkvtoolnix: 9.9.0 -> 11.0.0

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -10,13 +10,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "mkvtoolnix-${version}";
-  version = "9.9.0";
+  version = "11.0.0";
 
   src = fetchFromGitHub {
     owner = "mbunkus";
     repo = "mkvtoolnix";
     rev = "release-${version}";
-    sha256 = "1jiz23s52l3gpl84yx4yw3w445jqzcimvnvibvrv3a21k29hyik1";
+    sha256 = "1qqa8ss2mfjzj984l9vc1fnk7czbvhbmmq53m87gnrc65351gkir";
   };
 
   nativeBuildInputs = [ pkgconfig autoconf automake gettext drake ruby docbook_xsl libxslt ];
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     libvorbis flac
   ]
   ++ optional stdenv.isDarwin libiconv
-  ++ optional withGUI qt5.qtbase;
+  ++ optionals withGUI [qt5.qtbase qt5.qtmultimedia];
 
   preConfigure = "./autogen.sh; patchShebangs .";
   buildPhase   = "drake -j $NIX_BUILD_CORES";


### PR DESCRIPTION
###### Motivation for this change

Update to version 11.0.0.

See:
- [MKVToolNix v11.0.0 released](https://www.bunkus.org/blog/2017/04/mkvtoolnix-v11-0-0-released/)
- [MKVToolNix v10.0.0 released](https://www.bunkus.org/blog/2017/03/mkvtoolnix-v10-0-0-released/)
- [NEWS](https://mkvtoolnix.download/doc/NEWS.md).

Add dependency on Qt’s multimedia component, required for compilation of the GUIs since version 11.0.0.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).