### PR TITLE
fzf: 0.16.6 -> 0.16.7

### DIFF
--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "fzf-${version}";
-  version = "0.16.6";
+  version = "0.16.7";
   rev = "${version}";
 
   goPackagePath = "github.com/junegunn/fzf";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "junegunn";
     repo = "fzf";
-    sha256 = "0nzjbm40c4w9d0d34s5qnr9jkrh1vkn508xl2lfwfvmnzsnb9xbn";
+    sha256 = "11ka5n7mrm5pb9riah28zyshvfz2svm4wn6fbama39yp6sc01x23";
   };
 
   outputs = [ "bin" "out" "man" ];

--- a/pkgs/tools/misc/fzf/deps.nix
+++ b/pkgs/tools/misc/fzf/deps.nix
@@ -23,8 +23,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/junegunn/go-shellwords";
-      rev = "33bd8f1ebe16d6e5eb688cc885749a63059e9167";
-      sha256 = "0xcymw0fm0ir8d9swh1bkpknnqgx5ijjsj433z4d9riy8h8ywpw8";
+      rev = "02e3cf038dcea8290e44424da473dd12be796a8a";
+      sha256 = "1pg7pl25wvpl2dbpyrv9p1r7prnqimxlf6136vn0dfm54j2x4mnr";
     };
   }
   {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

