### PR TITLE
gnome3.aisleriot: fix build failure.

### DIFF
--- a/pkgs/desktops/gnome-3/3.22/games/aisleriot/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/games/aisleriot/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, gnome3, intltool, itstool, gtk3
 , wrapGAppsHook, gconf, librsvg, libxml2, desktop_file_utils
-, guile, libcanberra_gtk3 }:
+, guile_2_0, libcanberra_gtk3 }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-card-theme-formats=svg" ];
 
   buildInputs = [ pkgconfig intltool itstool gtk3 wrapGAppsHook gconf
-                  librsvg libxml2 desktop_file_utils guile libcanberra_gtk3 ];
+                  librsvg libxml2 desktop_file_utils guile_2_0 libcanberra_gtk3 ];
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Aisleriot;


### PR DESCRIPTION
###### Motivation for this change

Fixes #25313.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

