### PR TITLE
adapta-gtk-theme: 3.89.1.66 -> 3.90.0.125

### DIFF
--- a/pkgs/misc/themes/adapta/default.nix
+++ b/pkgs/misc/themes/adapta/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, parallel, sassc, inkscape, libxml2, glib, gdk_pixbuf, librsvg, gtk-engine-murrine }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, parallel, sassc, inkscape, libxml2, glib, gdk_pixbuf, librsvg, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
   name = "adapta-gtk-theme-${version}";
-  version = "3.89.1.66";
+  version = "3.90.0.125";
 
   meta = with stdenv.lib; {
     description = "An adaptive GTK+ theme based on Material Design";
@@ -16,12 +16,12 @@ stdenv.mkDerivation rec {
     owner = "tista500";
     repo = "Adapta";
     rev = version;
-    sha256 = "08g941xgxg7i8g1srn3zdxz1nxm24bkrg5cx9ipjqk5cwsck7470";
+    sha256 = "0abww5rcbn478w2kdhjlf68bfj8yf8i02nlmrjpp7j1v14r32xr0";
   };
 
   preferLocalBuild = true;
 
-  nativeBuildInputs = [ autoreconfHook parallel sassc inkscape libxml2 glib.dev ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig parallel sassc inkscape libxml2 glib.dev ];
 
   buildInputs = [ gdk_pixbuf librsvg gtk-engine-murrine ];
 

--- a/pkgs/misc/themes/adapta/default.nix
+++ b/pkgs/misc/themes/adapta/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/tista500/Adapta";
     license = with licenses; [ gpl2 cc-by-sa-30 ];
     platforms = platforms.linux;
-    maintainers = [ maintainers.SShrike ];
+    maintainers = [ maintainers.romildo ];
   };
 
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).