### PR TITLE
abcde: specify perl runtime dependencies for abcde-musicbrainz-tool

### DIFF
--- a/pkgs/applications/audio/abcde/default.nix
+++ b/pkgs/applications/audio/abcde/default.nix
@@ -39,6 +39,8 @@ in
 
     buildInputs = [ makeWrapper ];
 
+    propagatedBuildInputs = [ perl DigestSHA MusicBrainz MusicBrainzDiscID ];
+
     installFlags = [ "sysconfdir=$(out)/etc" ];
 
     postInstall = ''

--- a/pkgs/applications/audio/abcde/default.nix
+++ b/pkgs/applications/audio/abcde/default.nix
@@ -19,23 +19,19 @@ in
     configurePhase = ''
       sed -i "s|^[[:blank:]]*prefix *=.*$|prefix = $out|g ;
               s|^[[:blank:]]*etcdir *=.*$|etcdir = $out/etc|g ;
-	      s|^[[:blank:]]*INSTALL *=.*$|INSTALL = install -c|g" \
-	  "Makefile";
+              s|^[[:blank:]]*INSTALL *=.*$|INSTALL = install -c|g" \
+        "Makefile";
 
       # We use `cd-paranoia' from GNU libcdio, which contains a hyphen
       # in its name, unlike Xiph's cdparanoia.
       sed -i "s|^[[:blank:]]*CDPARANOIA=.*$|CDPARANOIA=cd-paranoia|g ;
               s|^[[:blank:]]*DEFAULT_CDROMREADERS=.*$|DEFAULT_CDROMREADERS=\"cd-paranoia cdda2wav\"|g" \
-           "abcde"
+        "abcde"
 
-      substituteInPlace "abcde"					\
-	--replace "/etc/abcde.conf" "$out/etc/abcde.conf"
+      substituteInPlace "abcde" \
+        --replace "/etc/abcde.conf" "$out/etc/abcde.conf"
 
     '';
-
-    # no ELFs in this package, only scripts
-    dontStrip = true;
-    dontPatchELF = true;
 
     buildInputs = [ makeWrapper ];
 
@@ -43,24 +39,11 @@ in
 
     installFlags = [ "sysconfdir=$(out)/etc" ];
 
-    postInstall = ''
-    #   substituteInPlace "$out/bin/cddb-tool" \
-    #      --replace '#!/bin/sh' '#!${bash}/bin/sh'
-    #   substituteInPlace "$out/bin/abcde" \
-    #      --replace '#!/bin/bash' '#!${bash}/bin/bash'
-
-      # generic fixup script should be doing this, but it ignores this file for some reason
-      substituteInPlace "$out/bin/abcde-musicbrainz-tool" \
-         --replace '#!/usr/bin/perl' '#!${perl}/bin/perl'
-
-      wrapProgram "$out/bin/abcde" --prefix PATH ":" \
-        ${stdenv.lib.makeBinPath [ "$out" which libcdio cddiscid wget vorbis-tools id3v2 eyeD3 lame flac glyr ]}
-
-      wrapProgram "$out/bin/cddb-tool" --prefix PATH ":" \
-        "${wget}/bin"
-
-      wrapProgram "$out/bin/abcde-musicbrainz-tool" --prefix PATH ":" \
-        "${wget}/bin"
+    postFixup = ''
+      for cmd in abcde cddb-tool abcde-musicbrainz-tool; do
+        wrapProgram "$out/bin/$cmd" --prefix PATH ":" \
+          ${stdenv.lib.makeBinPath [ "$out" which libcdio cddiscid wget vorbis-tools id3v2 eyeD3 lame flac glyr ]}
+      done
     '';
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change
Previously, if `abcde` was set up to use MusicBrainz rather than CDDB, `abcde` would fail because `abcde-musicbrainz-tool` couldn't find the Perl dependencies.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

