### PR TITLE
kodi: add pvr-hdhomerun plugin

### DIFF
--- a/pkgs/development/libraries/libhdhomerun/default.nix
+++ b/pkgs/development/libraries/libhdhomerun/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "libhdhomerun-1efbcb";
+
+  src = fetchgit {
+    url = "git://github.com/Silicondust/libhdhomerun.git";
+    rev = "1efbcb2b87b17a82f2b3d873d1c9cc1c6a3a9b77";
+    sha256 = "11iyrfs98xb50n9iqnwfphmmnn5w3mq2l9cjjpf8qp29cvs33cgy";
+  };
+
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Makefile --replace "gcc" "cc"
+    substituteInPlace Makefile --replace "-arch i386" ""
+  '';
+
+  installPhase = let
+    libSuff = if stdenv.isDarwin then "dylib" else "so";
+  in ''
+    mkdir -p $out/{bin,lib,include/hdhomerun}
+    install -Dm444 libhdhomerun.${libSuff} $out/lib
+    install -Dm555 hdhomerun_config $out/bin
+    cp *.h $out/include/hdhomerun
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Implements the libhdhomerun protocol for use with Silicondust HDHomeRun TV tuners";
+    homepage = "https://github.com/Silicondust/libhdhomerun";
+    repositories.git = "https://github.com/Silicondust/libhdhomerun.git";
+    license = stdenv.lib.licenses.lgpl2;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ maintainers.titanous ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16309,6 +16309,7 @@ with pkgs;
       ++ optional (config.kodi.enableSVTPlay or false) svtplay
       ++ optional (config.kodi.enableSteamLauncher or false) steam-launcher
       ++ optional (config.kodi.enablePVRHTS or false) pvr-hts
+      ++ optional (config.kodi.enablePVRHDHomeRun or false) pvr-hdhomerun
       );
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8506,6 +8506,8 @@ with pkgs;
 
   libharu = callPackage ../development/libraries/libharu { };
 
+  libhdhomerun = callPackage ../development/libraries/libhdhomerun { };
+
   libhttpseverywhere = callPackage ../development/libraries/libhttpseverywhere { };
 
   libHX = callPackage ../development/libraries/libHX { };


### PR DESCRIPTION
###### Motivation for this change

This adds libhdhomerun and the pvr-hdhomerun plugin for Kodi, which allows access to Silicondust network tuner devices. 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

