### PR TITLE
virtualbox: 5.1.18 -> 5.1.22

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -17,11 +17,10 @@ with stdenv.lib;
 let
   python = python2;
   buildType = "release";
-
-  extpack = "996f783996a597d3936fc5f1ccf56edd31ae1f8fb4d527009647d9a2c8c853cd";
-  extpackRev = "114002";
-  main = "7ed0959bbbd02826b86b3d5dc8348931ddfab267c31f8ed36ee53c12f5522cd9";
-  version = "5.1.18";
+  extpack = "244e6f450cba64e0b025711050db3c43e6ce77e12cd80bcd08796315a90c8aaf";
+  extpackRev = "115126";
+  main = "fcc918000b8c5ece553541ec10a9182410a742b7266257c76dda895dcd389899";
+  version = "5.1.22";
 
   # See https://github.com/NixOS/nixpkgs/issues/672 for details
   extensionPack = requireFile rec {

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "f2951b49f48a560fbc1afe9d135d1f3f82a3e158b9002278d05d978428adca8a";
+    sha256 = "54df14f234b6aa484b94939ab0f435b5dd859417612b65a399ecc34a62060380";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/*/build";
@@ -139,7 +139,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Guest additions for VirtualBox";
-    longDescriptions = ''
+    longDescription = ''
       Various add-ons which makes NixOS work better as guest OS inside VirtualBox.
       This add-on provides support for dynamic resizing of the X Display, shared
       host/guest clipboard support and guest OpenGL support.


### PR DESCRIPTION
###### Motivation for this change

Update to latest upstream version.

Unfortunalty it seems it is still not compatible with X.org ABI 1.19.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

