### PR TITLE
ioport: init at 1.2

### DIFF
--- a/pkgs/os-specific/linux/ioport/default.nix
+++ b/pkgs/os-specific/linux/ioport/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, perl, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "ioport-1.2";
+  src = fetchurl {
+    url = "http://people.redhat.com/rjones/ioport/files/ioport-1.2.tar.gz";
+    sha256 = "1h4d5g78y7kla0zl25jgyrk43wy3m3bygqg0blki357bc55irb3z";
+  };
+  buildInputs = [ perl ];
+  meta = with stdenv.lib; {
+    description = "Direct access to I/O ports from the command line";
+    homepage = http://people.redhat.com/rjones/ioport/;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.cleverca22 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -857,6 +857,8 @@ with pkgs;
 
   devmem2 = callPackage ../os-specific/linux/devmem2 { };
 
+  ioport = callPackage ../os-specific/linux/ioport {};
+
   diagrams-builder = callPackage ../tools/graphics/diagrams-builder {
     inherit (haskellPackages) ghcWithPackages diagrams-builder;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

