### PR TITLE
thunderbird, thunderbird-bin: 52.0.1 -> 52.1.0 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/sources.nix
@@ -1,595 +1,595 @@
 {
-  version = "52.0.1";
+  version = "52.1.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/ar/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/ar/thunderbird-52.1.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "1543d3b17ac8a6a437b34df0b3d33081b86554107321716b534471c86415a80fd4cb7f35fb60be7482a7476bdc4d2c5f9fe29dbd8381ff841e1f0daf2007e8a2";
+      sha512 = "3d322ea4b6a37c1b9b50439dcede0ef2fbe8109b5b4918ccfd8fad479698f951c98e57e6a4a655fbd0d27dd5de038779c717f62d6fff3da1b923d147731656c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/ast/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/ast/thunderbird-52.1.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "b7b9543253530cb3f166d155465d320d30138542974e71cc92e5c3be6efe12014ff2db5b63372297f7cd3bf72cd1a866606f1bbb288504b6a272e7820ada1bdf";
+      sha512 = "21a1609e9b71fbfa9f4bc67f866d007c9fbddd69f59362d2eb93383c2d313bffed2dd181328b3452f4cf4f45a69a1194ce141b83b542f3bc33944f5dd3378aa1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/be/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/be/thunderbird-52.1.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "f9283894e7c9bbeafb8fa6dbd2aeb1756b8d2456fe06c4278741c79171197b505d9a3d4b8e1cc3b18cf22be71555e1eded616ef0ed2648958b0d4d07f9d96654";
+      sha512 = "8d8ebfd0839ad061d36cbdfa1f6805ffbb3310a32a370b9f1a67651a96ff2cb35adf8997572b69581514b8b03a9635396dbf8bfd280f6d9cc96b5954f161ec99";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/bg/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/bg/thunderbird-52.1.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "486e2b3e149b73d3bc272546f7cc55b9d8da97d48808ca5aa0c3fc12d5bc0ea49c353f8b2c95ca398cc6938e67087f8ace8bd9bbbffe75712fe64b05994937e8";
+      sha512 = "5ec47e9d65bc07c69192631a78e4f9b2dc0668786aab46e0883a3f2a43b134bb41b16de7b42063b4a8a3ea9751e65ebb153dfb5e73331df9cf29142018b371dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/bn-BD/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/bn-BD/thunderbird-52.1.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "da54a9b78deb56de84623e71e60083aaa53dd8180f6d63f6ecc5133af846e5f773e63ce9131dc751178210994765a4e3daf68c582e180dd25f26d4f8e95e9646";
+      sha512 = "2b5f067124ed28252858d0f801cd5457a17912b1380c292bac2734cb69db123071f534aac9c7ba715a406cdf5e7b3e05d9b76a08efa11c9f7a9a75141b546ade";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/br/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/br/thunderbird-52.1.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "b647bc0aa73ca1d4deca50f70d5cb78bc95663c7c1668464c1b2d6d0e944f69ad73de28dd3868a6ac3461c5e64e74e206d508569d52ae8aa2a1da8f1164c4d94";
+      sha512 = "61570ca71bdd07e8299c7579bb7aa3cbb49fc190715261de8c1f3c74bc6cbafa66d030949a8e27299310f550bc7db8a5772b3fa22572340d5888be1b33909972";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/ca/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/ca/thunderbird-52.1.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "3c9562e14e20d90d76e6c8b39ef3047899fa094a5639ddffd716b687adb484a97cb6036e3228cdfb207086b28917b74fc44eca07408e7882f45941e50dfbfed6";
+      sha512 = "b90e4e220f1a27e53303412e3cee2d1e5b855cd9da2dce3bcff120a6d7d6c8d92e5ddf3e241f9dd5fcde9217afd2631953e8c34bb1ff76a13da23ff15b47fecd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/cs/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/cs/thunderbird-52.1.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "ed20a0b054d4e86ed1577c8a2672aa692ef47345243716f6dc840910b29cd915df75f8be9ac05bef385afb5721739fb08276c4bf48a51178fa46033c1131c1be";
+      sha512 = "9846b281b50693fcc28a753f9200f3f232fee32f5353d37dc2eb041416dc35d19693a133b2cb7bbb0bd6c1858ca4e2eaaacdb52f08d2ac9957900caa11cfd07f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/cy/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/cy/thunderbird-52.1.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "2dcc1d221db9bb647f5bf454a767f692e5eb592d1c6af52e144c55cfc81f0e3e05ddc2e3c4cb66b0031e09531641716009d062f340a5948233165564a3d5a5d0";
+      sha512 = "8e053f0b1974b35cea5e2161af7a45346f3070187f503b2ce1f7286a7d2b9c7eb4fc9e35d6b4774a1eaf34cabc935b08712f2fa94b1dc1a5457f8e93ce0b688b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/da/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/da/thunderbird-52.1.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "1046c0ecf657a9c5b30e99175f6200e541bb5f33031f1a440b26d12d6de0c558e15f8c2f965a05e59f83c46849944e010bcbdeb6fe100672d97acf0d4038febc";
+      sha512 = "4bcc230f2466d7b4c4f138afd40e2e95253b0087afececcbcdeaf1a3a4fd489714ffef5bb1a9b461afaa17f115b1188a7d41d4520b3e49c840dc912897283e9c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/de/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/de/thunderbird-52.1.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "10842eafd14068ae5d2447fc2d3aa35066af97a6e49b88d38bcf37be1e754d2403b1c039dc09f418128cd9369da6e0afee278914dd41a2ce48cb4872a7d4d18c";
+      sha512 = "3edbaba5339c93a5cdfe237bf648ea1643c362d12733880f6795f9237699e8304667ecc73c7e4cb766b20d3d4a150ad8e5c230754813dad891b032f7ce684622";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/dsb/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/dsb/thunderbird-52.1.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "f7e6b05dfc94f64c988c761877d02ad3c66a7cc47e2818d267d7839d0b1fa7688ecfac8fd3af98e9e9318806a78e4559d6cfe45de0d96b7f5f8d411c6f6cf051";
+      sha512 = "ada2c5fc8e71523ae86d3ffd2f51c700b127811d0e47146a500a103acc48c09af17f546fa97c655b27408ca1ac442c927a3023f1e6be3bcee644eacba39db27b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/el/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/el/thunderbird-52.1.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "0ac5a23a38987a5af15bbb8e458a89df378b89fdd8721063d6df16a3658201ef1fb4f2d04b6272e1d9d43c1d2273df4cc0fc79b7d374f1fdaf7335c77fdd9381";
+      sha512 = "e9498ce714276bd4585c611944865d4fd7eccd30892c910258f6362846fa3cee4c1f49bdf6b77e509aa4fcc6bf2652c5060567cb670d9d842373c69cf6f4d158";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/en-GB/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/en-GB/thunderbird-52.1.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "73f42d30f8fea9063e984d9b44c82aac545a20833133cead89ea147e92595e66da2a1f3d3bd0c09bd1584482474607e6856ba17ff80edff51b169aaba03bdfac";
+      sha512 = "47d12c3121e649d847fcace280d270313f23323e949adb9d3f66aeb9e9feeae6faa014588066d692ef1864b8459ca3834b2ae6d038e9b5338f822fafc9a4b6ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/en-US/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/en-US/thunderbird-52.1.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "51eafcc7466a2136ddad110fc43640c578d69758e53eace8da52a11ea86869b5d05e537b6132c3c49eb6bc6fc5bad77f2967a472c160963a41775b34600b7582";
+      sha512 = "588381a6c0a324dcda7634d0fd431f3902fabfae58510b0b1a6787550a70598364bd463705fc089d79d2697e8996e066787dfd5827ac4d2a34ce9f150a3d54bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/es-AR/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/es-AR/thunderbird-52.1.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "b57cbef7843364917632605dafc056323adeb9d06da7e53a65a4450e009fa1f2c54cb5380ed886db4530e845bd6f39cd160ac90f19f99d63ca1f85af09ed77fe";
+      sha512 = "5d60384202a3de2819491096df1c65c9838ca7645a30aa62ba49d28176fcbd3353affb7f5984be01b17a6f899a6b8cdcded034ee91ce092842330e19a665fa62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/es-ES/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/es-ES/thunderbird-52.1.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "408adb2ef60bbad16152ceaebc8f26c62fb829960e941dc5fc2814b183b780bd0fe79847351395321026a0ef53f703b72b6f4bdc233b3284d050e8bde35c0beb";
+      sha512 = "23966c83592dcd00653683acb4a9f954c3b5fb67c2720a0f40ff4d39559f210354e1805ae2677a5e8bceaf2e09e439c1fc01309dda9ffba71ca91a6324baaa64";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/et/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/et/thunderbird-52.1.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "3186c5a026029e7b7b4dec47079b69b7f33398b2cf276b9bbf0b726d64709f176e45e31e0abb74c4302d693aae0ecafcde945c78da097cc2b0c1499481c78ea0";
+      sha512 = "088d55020f599413466113a7aa464dc50526705a8a8b260c36298b5b5394582a708a5c66f09359fa71a4b7771f2a24c2f1ed015fd12696e069789cb106d3626c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/eu/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/eu/thunderbird-52.1.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "c60d3e2ab30e84628158ac65dc5c58ffe5a7b9dc7c3d5e5135456ac4be4d4734a4f4dc7d65c15f400dacc55fddc739934f3978f6184a93a662466b759938d1c5";
+      sha512 = "8aaec6db5457fc1464899aee22b9d797dbe7fa98c171ed9b7c30f61c550123fa66a0ad5f95ea9102dbae71cf91997b7f51cdfecd30e5138a7f30c9bc34c9ece4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/fi/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/fi/thunderbird-52.1.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "14aadef508eabbaaf81a2304934f3848e3831f9d8df2413a49002be36f951c87355e1954d84d58509086c1b0e0aa1de5865edb733d0a07b655942830c83ffa18";
+      sha512 = "e9db01444b83d4f4e0d745599cfc5c976d4b2a1a5027bd800c6c60350172a4719e61f49e527a923d9a1c436a87dce48f582fb54e3f1aac4b091492e945a30762";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/fr/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/fr/thunderbird-52.1.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "0711ff8a5955ef185678b27e8e43704c652d9024ab4b8558eddfc2c94f87dd24603f144f391f35580c3fd512cd44ca729253501495860e6799440e56c4895c67";
+      sha512 = "c6709a91ae730adcd2f21e4e639db17b78ce2c0edbc0790e46e177dfa4f676acfca6c3b242a438a9bba9e40565164cc927f2435be8a73f1f613459d5aa926681";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/fy-NL/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/fy-NL/thunderbird-52.1.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "99e49dcc4085db1895b0e2ec2e7a769fb608415135d550485fea03ccc99f325771682f725c78578944c82b2f18aeb207c8abceb86db5390056d27c291f19556d";
+      sha512 = "41130e5dc138e0b396e50cdc74a096e4de65bcce0ca39a426cc572b077291a8b810543c700657ae8dbf64409d6346581ae44e24584b087f874ebe14fce125dda";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/ga-IE/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/ga-IE/thunderbird-52.1.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "f0bc291e1b3dc2e226aaa48e5b87c1e6690ccd04b4b62b36fc654e86173c9dc6ef47170524ceffbb59093bd4188a3cb01a894469daa4bf49a0a8895034d17645";
+      sha512 = "bca05359f485c88c78d307affb42179c431f39e9eb164fda36c14713496eb8befe03ce36bf01ff1c27e172a86e69b712665d833f140b3b0574c33c83f8fd8151";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/gd/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/gd/thunderbird-52.1.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "65388bee6e5f8255779f319eb0d47310762ac6d3ff6b61f3accb151e52dfff8e079aa16be714fe4a89bd722bf72b65f930384d555d68016a27b71bd236388f7f";
+      sha512 = "2bbb9f96ba9d23b77ff1584a3164a16cbb4b2218591db055b2aa3ad1e5e1f6a296cb953e9c6dd7bed3db0f6baf8113097de00ab6020d0b49a7208ce3d2060955";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/gl/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/gl/thunderbird-52.1.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "64c439a0d2a75a3b9a460966c585913656884da7cf7f81f58e612c9f2523ac690a8585bca61e60fe31e13ed6f07d484e3dab6bff876fa247dc1488f084d8a6b4";
+      sha512 = "7cbe56d4ef86addbb2a1347744fb873cedb04b1d699dc25a3ff22e2469d2e287a5d2018ee88d6155dadc0f366091e0132f73382741245ca7054d8f6d7e6d90a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/he/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/he/thunderbird-52.1.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "7b20a5d996164daca9ce2d6af03a987eb67394eba01c942b29aca3009ee062f0c57cc011baede67c09a7b0dba63e029a5fb5753d18edc34c87926fd16651e208";
+      sha512 = "7d9574e77e30ccd5880323fa74550efbd7ad220bf1ca5215e6c9bbedc94010497f09b21a667cd64797cd8145a332932a65425c5fb86a4299af03d29e4e6b7865";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/hr/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/hr/thunderbird-52.1.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "4419fac97644cf895021bd974e15466936b45babab7634e35855ddecb2575a43cf9be65cbf83c1c27648b58b656c9f6b4e8d454be901b479cdf86180f244a646";
+      sha512 = "09194dccd33136017a458924212bdcea7e8986992bd8ade29794b2a4bd2cf42a8da9510423e57f48ff69483f592aa44da5e837ae1413eb94d29748dd62a213a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/hsb/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/hsb/thunderbird-52.1.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "0f31903823ee2cada852aefa8d19b64ef9ee9e9f80fb709481c155a7a4c97169703a35e7de1f2b805fd91d98321dad81fe0321775c4bf9af5f01d38ab75c70a7";
+      sha512 = "b1e686c60b37e909fd109b71f69467bec41dfa9e9cae37fb541bf34488a36f2f08ea1cd4023e94863ea62185d96d1c97f4b1209b7c5dbbc43f5a0d005148b0cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/hu/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/hu/thunderbird-52.1.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "a2972f056d54b7d22ff090e43144ee16f38b01a1d6ba76dcebeebfdae086bde752008fdc89650947944bc80c82078f94995db8bf8daf339ec0a8fa5475435477";
+      sha512 = "d92362f40609242c78a89a652dda961ef174dadb551a9b8b677d06e96e4c557e3e08f8169bfe0f4554cd223e76d57bf1301f9603d8e297c5c66c16fef1514ea8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/hy-AM/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/hy-AM/thunderbird-52.1.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "47e80c575adae2327cecb5c41ed747c9d4da5ecc9e9ff8afc5dd35764b039050aa07dcbdb79d50fd7a4d8eff6f233f1a3cac3365e6a4db26e0058030d82a0f6f";
+      sha512 = "7e94c115871e196aa0e2b616457fabae7b63715aca4602daf6d2d622ffa74920e26b10a539633fa93b39c56c09206962cb58ff823bd00e6044bf94a287147413";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/id/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/id/thunderbird-52.1.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "3d8f7a87727e772aa9435bf0e381703003f9a1fee98d71dd7f3fdb7add574a0c5245dcf8903895fa858ec2afbb9823d658db4fd800427d29c71ca93546adcd8d";
+      sha512 = "becb04e3e501ea23300f149b9326f3282c2ab60f70eb39c1a82ec2dc5ef65e7c8c00ae2a349378dcf215e118410c0ff1027f305bd8bdf6a1d5cefde64350ddc4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/is/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/is/thunderbird-52.1.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "5ba20b28c08cf19f12acf887b92959a09cfb471776ab1805feda15ec4d406a23ab9c6c719a64ad2a65684f9e1bad00dd2f321285bfa85bf8e2f5aea5ffcc26e6";
+      sha512 = "4bb30f257282db43f62ce50b4913ab5978f7cc8198b3c696d16631cb0f3369f474e1f1ecc91441a5762253be4e2506317b02ce9d30880f4d6e4ed792b6da95db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/it/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/it/thunderbird-52.1.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "127471777e937b3b02f07bd66366680eea194171554bf7f11659331fcba414b49d0ce07457d754f5131084ea89d90d6e9d4e62929fe3d7c8c4a3d58b1b34b72c";
+      sha512 = "7ed5f13c42d8df83e8cbbc5e814c40c52ca46eb35254f5abf615ecfefe8a89d2bee56650f0358563de37c2503483fda272cc606e25bcc9dcb62100eb5885e66e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/ja/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/ja/thunderbird-52.1.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "aa013a6c50d660a150b2b4247eaee467ca1a1a232d268121a8e8113386c9575e2667f4cf75c1e7ae77458869a9bd4d2f7972c5cb2aa919296bbf3aca44d48093";
+      sha512 = "8fc066d2b0da0de13d0fb069542c4336bcc8416c1b435d8541cda86b768afc8cd1156f0a8ba90d7c22d4dbb9a5f4a294d5a34af825f4adbf07a74f316dad6206";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/kab/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/kab/thunderbird-52.1.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "6f4f4b27c658103dd6c4a9d2c9cfdca09097539eef1e123bda9f11d185a25f0cb944e96d37e9a2c36664700948c4b052a5eaf463e4fb045fe6def4773b19a8c6";
+      sha512 = "2264224e6d6c4fd4dee4197fbbada0dfd7f1dd1554a54df0694d03e22ccf5881f8ffab47ad65686d4021209d0ac0938567c661b4599f4a76bcf2c57a66b7c9fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/ko/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/ko/thunderbird-52.1.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "4efbc262f563e03ec78a10658772c9c3b446e5c378159d35a68b432d1b582dac589723525a26e337a2739c0ea116cbaadfe8fae110ad172fd7268a7c5e76c50f";
+      sha512 = "76b8c2bc2269af9bc18b8de47d1537885e54fa1e6e7d7c4b5dd4d1daf38abdf9b5e480668ab3aa3d95f5f81440d270f45743f276ebfd664d567c7c19d2dee465";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/lt/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/lt/thunderbird-52.1.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "b1f1cbdd9642e283144200d716783a212948bec80e1b5d27046e80c22349e8b103e98f31bbbe392f4a1467805bbb28801b0f8c597808f03bc6fdc9110cef2900";
+      sha512 = "1a858766068e87c0184ef52fc356673669120295a9c21ef33a535936e46050d32214e8f59bb7fddf12915db1a00eba4e4322ecb53864ea5dc64416301ce2c15e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/nb-NO/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/nb-NO/thunderbird-52.1.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "51e675ca839bb7d205121b7023244a9716eb4b7f400c534f6b3a3275aceaf827262a816b790492d3cf01b6f01d64b7cb0c1f2385d1ecc74dad0f450f8d1b26dd";
+      sha512 = "a76b77a8080caa6126f1fc1d14b14027abe47b054030b8a2806cf07080ff0c735add14917d5f6edbd281f8e305c2e3f5d59d54677e9860957ce6f5aeaeac8452";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/nl/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/nl/thunderbird-52.1.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "866a4d117196834fc415e6dc394c82a9cef6747c838068abf0efef5cb5e03f26d65f5c3e9ccd90fe7229a8785817736ee574d73424ac50633650bfe6c9848633";
+      sha512 = "e925f8a705683ca709b2d5595bf0566bd659a55b397d324819e70b1089fac40e9faa88396826351c8246e16d81cca44f9fd961abb08e37691b90bcbf85268a83";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/nn-NO/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/nn-NO/thunderbird-52.1.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "664d8941c433fc04fa836f1dbec12ad73ce3cf9d19d898c8cd6b6c9fc283380e7af27a0ab949881f5b6151595a6c584f938aee6f88e5239fa2de0403813c3388";
+      sha512 = "feb78573c9663a4d9662537bf04080cc860b74966f5a0be8fb02959b07da9cbaec37bc9d406a69878e24377d5289599e971096f759a64b9c962eaab72e12e230";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/pa-IN/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/pa-IN/thunderbird-52.1.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "4dfb57686154b3542fef873d08037fb86f7574260884494872433496b82f0b58a14710931fdd0bd5dbe7372658691b2e953a4fd794378a993f97fd6c8c9ac496";
+      sha512 = "1006a8663b4d525d4a7562ba4af16283d997cdcde3251a5869cdf796c7b7502a9b39e8859983d541f1c9750d5caaabe4eba4567ccc1efeefc6bc4be5fc552e16";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/pl/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/pl/thunderbird-52.1.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "47041481a2cc660bd6de4a018aa77ee4f8217fc7091b37ab8c26d1ec1dcb0678ea80130ee84289dcacd6266431da4532a66b041faba56f1bd8746e991c748a82";
+      sha512 = "295f44282ba8ae0a228b1448d904776b11fddc2d52251881b4e3056356fa22e7db05ecbe2c76036b5ea140e46cf2d922ad1ac106bdaf00564612da0bc9701693";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/pt-BR/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/pt-BR/thunderbird-52.1.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "3001331547a05bf5b76620886096fb80cc594c625a335fc613408da5c43075c15abb0a6803cc34c740cef5d7ed9339e21c2db3a8a736901350674ab3b1024514";
+      sha512 = "bd5254ccd19f92ecb4ba6d92ed28a775c157b3cc3739dc55ffb7bf622c79b9928b8bd22e5f213724a3f0597307f33f32e6eb9e024a857cf691f13a45ac02c62d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/pt-PT/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/pt-PT/thunderbird-52.1.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "402dc645810068339fb9fc18d6e3f025c48013281e3604e9a3da8228ee6cdd304ad3d2c10781dedbae9dbba3737fb122a3fd5abc3c856d1afaaaed2d7e23042e";
+      sha512 = "2906ef8d811e400008624e153238a03c9ca86fca0a39a6866a2f90a98b40238d00836ffc34e0ac4b397d0b9699ca603ff7bb041b213c21eced2b4814c2082d15";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/rm/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/rm/thunderbird-52.1.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "4789cbabb8ba897a508e9dff91fcf838eae8fb4d330f500bb7f545cf46efbffd978801016898bc89bd6f9fc558df2737c427c16e2ec40c0a7866301abd7450c5";
+      sha512 = "537620483820fe23bc09f8061e3a2fe11a2871b56f6efb6e0e328e038bc2632c02daca14160dee53cfdbbb82c700f3b447fb6ea7a83a51bb8cb8d4c7364f0698";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/ro/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/ro/thunderbird-52.1.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "fbeb8ae935f69efe85b1fb45969b8142b197d340293034c088ed50cdb563466128e305f8ad2c1586c9c18c2fd5fd4042b95ac15aa9e2783fcda2c67a6aa941b3";
+      sha512 = "e645a8467a6e5add1f1b13da06e9a4bce2c49fcf8a649ab9e99cecc45fe995aa24655050adf5f74e466b567ff52a7ad24b4c6ee4247a93d4a94e496f493b5359";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/ru/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/ru/thunderbird-52.1.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "a0a21b2ea3720b776b3a7944c1a9030ab80451a4405afd87f49b424326cfa69769e7e9bb54071c7747f4fe4af8f18fc3a9f8db73a848c554d9d4f3eded8cb9f9";
+      sha512 = "5b85e10f87b7501923302f98d737d327d6f22410d83c2d60b82b471e50bc3936673c78f6b38b7e49df035e2c92a29e7e13ff2dc1a21b9322662bc2fa52bdc359";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/si/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/si/thunderbird-52.1.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "bb919c3b00f4122cfaefad1a88a68d3dcc88f09bc6db717cee14ba3ab76adc4b4c1ff32dcbbe0babe7336856c31153eb69e2297d88ca60f9e561aab083344710";
+      sha512 = "4741f58a8f5577da82abf6803cedb53afe4cc956ae791ed93e43d3c1db900d3f58b2a4064c052a0822f76c4fc6ffda5abe4a14eb10606f5eef5c68b3b302dcfe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/sk/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/sk/thunderbird-52.1.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "c6e1e049a264bac92fc103b3242fa36dc38caecfe22b909c41ac86e570d7f3c9a7b39ad9d8f9f918fafb60f91e0e3fcd925a598c9f7deb6f7874a92436de6ec6";
+      sha512 = "de86889f49c59978702a3cd90fe924ad1dda3f9fbf5285a172376b73d0e0cf0d63e671b361b6a125ab7a5ee97202ae18fcf55534936a7bb680f1dc8e425f5c11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/sl/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/sl/thunderbird-52.1.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "7af3e5a875077f94ef0e7aefd1b170d8f8285fe99b9c59ef568c055253f812949127a37557b88f2097282de8f1615d272abdee51713b30f376b08300c29bc814";
+      sha512 = "7b6349f962a834269a9a5f0163a220eabb07866d0333545684cc986dd54b5ac800a7e450db54f695e811236dbd22eb7f7c73afe4f1d21c85052c8c256231120f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/sq/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/sq/thunderbird-52.1.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "ff37ad0845c95ff043c906bf80b7221a541a1eb038ee2be63d7b2d8d1cc8ecf26698b2fed0433334454203e09c98d4166e972e07968fa32e17d826811687613d";
+      sha512 = "13451f76b5a954bb07d6bb3352cbd6e2d509819d9a92f07e21f7bb4c4cf555fd09fe080f21fb5bee4bf21f6de288137366f82e895cdb752d0676db61f25f023c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/sr/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/sr/thunderbird-52.1.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "487c92ecc4123607466a0e758a16dd87537be32750b12a206129281ec42afc8fc672cebdf948b3233850b8b31338abc829ef60f8a10187eab6bedcc11cd6e11e";
+      sha512 = "eb6d9602fe4418f0bd4c633cf8d729556e52fb31183f1abba7c699dc4e7fbb2cea2a0aab6ed5f9cc23987446b5259b400d6151714f45aeb9029965447ac4958a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/sv-SE/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/sv-SE/thunderbird-52.1.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "e0eb86726198982cc14db6bf1c2b7fda2b60492ed318978c6c9349ad7514eb0a35798a3179ba1cc71c84f3219439068c957c38bc87207e5ad81c200378f5ea1d";
+      sha512 = "9f9170e3f93c92f2f1d9d82b9661fad400001bfa75fa95b0bf5468d7d06dcf6634ff066e7edb6112c081b741666202220bf08149954f523017a7256b126a6da1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/ta-LK/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/ta-LK/thunderbird-52.1.0.tar.bz2";
       locale = "ta-LK";
       arch = "linux-x86_64";
-      sha512 = "7a3ab20a071e8cd1728104c31260e3b443cf5c88e116240ce4575c544708fcd5ba386385c72d38b98c1ad76c1d58ff3553828d547e1e64e179521edbe5d31388";
+      sha512 = "f78a9783706410634a2fb0884fd745ed6fd1e8ebed694eff5d508d2e06be573794b67886fde5ccc26c879222ab51c49bc64a0e05d39fca981e03e8151998ec6a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/tr/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/tr/thunderbird-52.1.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "6ffd911857ecc23c6a41181b684cb9cf9eadc7a76ecb1cade7ae1a5cedca1cff5b18660d76d6b10d722f28493a618417ccf31037229a1af62281c04360a986a6";
+      sha512 = "47192344dba9b360fa99b401f0312fc333fee983c1838cf2d9d93852166379b226c4713363ebab16ce3839521da2c8d1f9a570a5ec17678eac9761744273934f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/uk/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/uk/thunderbird-52.1.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "751b43543f7ec4684f4f71450aa301e5f63ea252901cec77593ff637fbb054a578d7fc13a58ba05247af46e86af11f1ec7f0151ab49eb4f824fb11c03c15c6cc";
+      sha512 = "ac117704222405e0184ec01f138a7b25b8da96f5e4e5f9ef8452d20b1e4d03dfe8256a54056c682c600c0868d3818b40376065dd52ca9f2cd2e8a5e6d480edb8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/vi/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/vi/thunderbird-52.1.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "9aa955924e9a7cf6dbf9f9ad94e9d8cff9f91cda4da5ddb8a1e9d2719081ba5adce1cdb57ec55a76473679c63dddc9ac95589503adfa5d4ad00afae6002ff4fe";
+      sha512 = "ccd0e5da1d86502a3d46b076e03ec9fda2924d8a1a370c7eeb22a75f3dcc3777737f3d87172613f4dd2302d81d94393b4e35de8bf2bdc746664a3a6379c3e9a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/zh-CN/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/zh-CN/thunderbird-52.1.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "3bf34fb329ea1bceab24b0249c138e82c3725569ac82023a33d70c8a94e559f9d930b277bfb8df34571e4e2195293ee997de95c6dc22285be9e3ef15bd145ebf";
+      sha512 = "d0bc299c467d58b858ae5b6cdf44ca4b8b37cb3e49e92d3bbcb9a57aa84a6983ad39af3643484bdfc00c6ea7818d1eea2c92ef2cfd3c94af881f1fc51914f08a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-x86_64/zh-TW/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-x86_64/zh-TW/thunderbird-52.1.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "f8928de4dce61b52fd69305023ff4893e35cfba2aa712dc34dc7deb024a36cd7c12a662a497a21e7f647b14779216a3aa2b6a01f84751860dea04b388b265c6a";
+      sha512 = "37d1085c0dcbdd8ace9f3ae876277ebd36b8ee4dd79b260fd766b24452649afd8a9509d340bbd9891e0a4fed47592c7961681dfec13d9ff448c89a4df52e8c53";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/ar/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/ar/thunderbird-52.1.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "1a5f8a3da90724b1a85b63b7fee31d104e4ba1620b25e6823fa556d8f675335f3c25dce0499defbf8277c3fb6db98c58500aa6ec1460a194715d2d87942a35ed";
+      sha512 = "a31e7209b1848d3f29566266a1d58d8ac5d82690146fedaa45f79cd4b016278f1f1faf84405141494093bcfdf27246a2e24880a02612037f99b2d3a0c9ebf950";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/ast/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/ast/thunderbird-52.1.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "a4f5994657846378b0a472deb03d87fc30d27b35d9787c8fa53a7b428dbd4f3b0bef988863894606dc9b6c2370965353bba4b54140602a5acb7f3da433822f72";
+      sha512 = "9a69f6c59f80275941fa731e8ab110d84d53854ccb830f0c8224a65c36e63872f05f06e8ebd9ef94e3fd200fe6863c580798b233217a44bdcc12b4268ca8c61b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/be/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/be/thunderbird-52.1.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "2c029ac149cfab2eef9e1812dfaf755692265df49bc564f665e34308a1124f749a47850cfc19d1b15a16ee63aaa319ffce97e7025e894aa4a94c91cf81998f28";
+      sha512 = "e6756055957d4d073d00aa8abc7dc8ab1e7e8acab170a555628714ea65c36042f6ee171c3c596020244ee241c6a600b0a9d42abc82761df41b5dad3d5a2a53b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/bg/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/bg/thunderbird-52.1.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "ece638e2a33645df20d4c59b157efc57650b591b78e774dc5f82174495faa6afe9e80aac62e5fa106feb29d5cd7369313e3a182adc65e7c9f870a7d0e9e796e0";
+      sha512 = "b22a4394cdac862e5870b45b11c7f87556bec2cb38e47f8da22a37325145361df4c815676e9a91def8d8a0d5b2ca876cd57c048dbea3acdcc6e517042a64a20c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/bn-BD/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/bn-BD/thunderbird-52.1.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "8c799ded0a1d090bc8a82044dbbe843f737d9e0481db6ddf33b1609e19b0f7535249677b22a53d71a3f7cf430adeb86421eb2383cad5c73317da71c2c15e50b1";
+      sha512 = "e956bd67e1ff58132020204d643a8fd618431d9716fd77dccfbf30cc9610c4f5305e2477471394cf33cf8ed80a3be141be9b67aa73c6f08e44cdfc0d00e4c9e5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/br/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/br/thunderbird-52.1.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "9417121f1d26d5be82e4857b87283857b072e433e0d90c191902a118489f165add64a5241309934a0b91cb21128c92326a4ce98622a2b2444e55d5bf7ddf57ac";
+      sha512 = "692fae122e2b381d110907b4a23001a51811dacb1506a563f9680cc5b80bb0692e1a1b52b1612765032645d3a33dd2d4631ad8255aa1e013f6441601d6330693";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/ca/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/ca/thunderbird-52.1.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "0b0e29ac69055336f5e157bb48d86316f36d86f0e984a11a000e4c4518478e8198cd4eb2d6815c1c6456d17c6047d92ff5ae0f6ef4f26a96bd172b8c0a8c308d";
+      sha512 = "bbe5204d6b465c3c68f88bd8983081fb5e7ee7e7483208f14b5d107b28ea129692c1b5c7ccbd8f9f0f3dc65b6b444c0a11e13768fe36c9e6b7547dff0e50612a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/cs/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/cs/thunderbird-52.1.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "6124454cd4ded6cecf953beab5fff1ed6105ba881624b83fef6c0d8798bab161a63abc3b0dd9a94fff5ed850f638feb95f5de4b9268b9ea71b9fb5eb52618407";
+      sha512 = "b5219752cc20657b401c4101accc7f16e44a2ed82ce4e80a890ad2d58d552cd435d83c4a69ede8b0949ecf84d81c2ab2b1da4c51b623b8365096fa3c234771d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/cy/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/cy/thunderbird-52.1.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "b1f0c7dae07a7130f1e9f2abfeff12008ce40f7486ef14964c17c7e665c3b4ceb52e48d504965da78993117f5bb12e14853c2a740b00a71c03574445f1129db9";
+      sha512 = "769c15d09d20dbf4a27b61ad315188598463068c7de23d97dd498e2005a610c1af77b6bb452304a41c9c709f4bbba963a8680dbd08329ec7c6ce2b29ffa76242";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/da/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/da/thunderbird-52.1.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "5b1e6fd39cfd1d206a1a670a25df98ea73f490be5880a5190ab918b9ffc852000085c0ad89dec1dcea25c101a7ccc43bbc531f63a5dae95a515e0152dd2eee21";
+      sha512 = "b023c8fdda97e1f1bd6876ef614b2c790e0602e6ca2725fb4844fddbc57d61225a888f9a63c9cc08133d6c2f35d57993dfefa2200f6ef5c05c93b764ff5efb7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/de/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/de/thunderbird-52.1.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "5690e0d91c4969f36805e21348fd5d868cf02dc524f24081b4af9afde85ec053a76f4b7a7746c591514973cf18b0e153b9e54112393aeea501e7696b3f63b0ff";
+      sha512 = "bedb599246d6228f5de3ef68f8325683f613fc393205167a74493102b9fb7e9360affe956ba2941255437ff7834daf5b5605bd29af68175ca11cb275cb9d61ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/dsb/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/dsb/thunderbird-52.1.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "8b5663ccb6402578181d84ae92a823d86c243fcdb77a25c69e6be660d137fadde4fae5ca5385bc393d9809ae06bb9b57c68791c8d06c864e710e9f33ab2183e5";
+      sha512 = "5537329de234605ab7dce6ff1716a565f823ee9028a9c3627fec5ff479c7bb503246908967ba504228b1e6b2e389c1c1a00bdfd622b4bf74cc5d1dac31a92578";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/el/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/el/thunderbird-52.1.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "0cbf7aeb360ac59d4d4dcac603194c03082e37325c0aa08e79a872f819f5cb25484f0cd7577333194d12a80260ac665fc964b4300c49c2f96c6a6e885cc8b8c3";
+      sha512 = "173902ae0833c298d26e3ae1113741bcc22ca195a94d7935a8135c35195d84fd6488c3ae98ec9da5abafa2fce48d3d0becd8d61ccfb2943e6ac8c5011748d3bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/en-GB/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/en-GB/thunderbird-52.1.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "fd565d48ceeaddca038265577fef52643218afdcaeda5d022ea125012ed565628670aeb6db3822830a39b43b8372d843129dbeaabaabe7904e93a2389c03957c";
+      sha512 = "a2cb84189f7f94b7ea556451ef624e9884b5c7717804eecd9f0b03f9d6b07ba986afc7aa0b85f12223c71face57eacc32c460d3e939ec187704355a979117e6c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/en-US/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/en-US/thunderbird-52.1.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "a0c4dbb1f39e9bacf8fdd7660d280142c072ab709204f02a2ea4eb7dab9a4475a121551c98fedb4cac2f1700b0adace7e7af04decd8c2d65bb14a4bc58bf8b59";
+      sha512 = "60ef6f688c237a44550a98ff061fc947dd9c2d44db4739d63948e58adbad1287f1ea2b2320d7a8b77b1c6ebd5dc48104f5ef421424a033649f981bb77978f54e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/es-AR/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/es-AR/thunderbird-52.1.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "205893ac76ba91d29ed6f169da01b0ac548e03985eae64955c5493969060c7eb31b6fe0557ecf17301576e1a4b637f2615818ef38322f91bb366c747530dfe22";
+      sha512 = "f287931dfd410de49972450cfcf9a8e5cbd207a4dfce126b2229bff18037f535eeed90434fb403fd882dd6d3d00415c0ec633d41ee904d8dfcdda15f6076b0f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/es-ES/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/es-ES/thunderbird-52.1.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "6ffbb09840acf9033a7f1f1b19e81d6d51cb90f2578c741c42a81f2e7413d4e9f47afbf756a7b317dd7e7d66ffd025c0d2af31c765c7a8318a291e63d4eeb8a5";
+      sha512 = "22aac95907cc6f81b0f26224688da6e53ed4086cfc2692ecc1db5ebb4a9c70e561ba22cd1a64775e42480ee302d638c38332a681468e54dabf8932253c7c8a42";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/et/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/et/thunderbird-52.1.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "79907c40de73a6761bc94b72395eddfd44cac795c6ab0614e764f467f59eb506829c9957ac3fa338feea8a900134195fe549c6b4568655078904337755319523";
+      sha512 = "3d6dc02524638f61f6d608f476a99d06f92f9a5b3effe98cb88db050fff63c1beada0f547688b49c8d341f4b03715d05fb3b5b2b26fe23e735680369250171cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/eu/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/eu/thunderbird-52.1.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "dd799f923143380e7a639a9ba313e24dc4457e6a0ec9d6b266103e64c606db2ee702f56fca746049972b2fb63f03713307ee7a19ca7b3dcb93ac6d6cabc897db";
+      sha512 = "9d451b1d9a2e96de191f4e50e1eef21ae6100b531ae23e9e503188d94164b476d1938908b839339dcbb693ddc5d309199d3a9f8be5ad462f2b7458df81e9945c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/fi/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/fi/thunderbird-52.1.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "1aed6627a6a0a72d5e0d52b1831d4f756205d92aadccff43a1b9543d0d426b2cea3b9d20ca1829f29b1c9a1a832a43a7cbe9b870aab138df3133c2e886d826c7";
+      sha512 = "194211fad20c3ec98c6d082a301fef99f887f2bf974eaf98abed221059196c632f857c0b3881a618580ef33e8a86790a78a2c018d5abed5f32ccca307298f0ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/fr/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/fr/thunderbird-52.1.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "c3d1fc74da5379825e180c3a3d0569c83a3f0098eeb396fd73eb3470d054207317506fead5b116a32b7a3e2a4c7c98431da9eb16548daef3baab052d53f432ff";
+      sha512 = "4eaea56f7eab5a42bce95c0a53493e6f480d5741b27980409b5667337a9aa3ddbd8a20945774ccdc43182572e2821f6f929b7c93b713cba6803cf4c6f837b5e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/fy-NL/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/fy-NL/thunderbird-52.1.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "c557220187979d06f1697511a69dac852c3f6662e6474b9d8bd0f0d49b5211d5963b1b6dc75a0e3f831bc724f3e28e0548da7cd67e8ab90c29901e07ec802f03";
+      sha512 = "124ae25aa3d469c7fc83c031a5cffe76e49db991f8a8af5cf9d67cee88b9fa37e941e22c94c92f0b52e3222604eb19b6d63d258aa220079e864f67276deff2f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/ga-IE/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/ga-IE/thunderbird-52.1.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "02b3ba15ab86764cf41d275aea8d39310455e74e0f00418c91151bfea623385efe0c59202dc499a7f3e72cb6c64c7c30ce35663c1fe69a761a1761865f7852a2";
+      sha512 = "e91c8b5d176c19be49ae6a10c600369f38a420872b1621ede488f10bfbe5e09890d96a18e5e12256020a5d774723d582cc3a799e3cff27ef90d60cafb8bb1f05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/gd/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/gd/thunderbird-52.1.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "24086d6f92611b0b8a9e3b79e42a5494dca7147bf8597df33d5d3ff745a1bac41ce39156f7df43bd6c21b4e845474ca085f9082cf4207cfec982c50a88fc6c16";
+      sha512 = "51e5529755401848cd491835a70d73bb37142993ce7e6149d6647cfc2bc252dd71d4fdd06c9b0fa3a6d3c8d0c06eec06bf86825890da7fc09c8cc4820460be71";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/gl/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/gl/thunderbird-52.1.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "66b9b1f073b352a6c3147e44631b88cd79e1985a4d6dabea142170871cb795778edcf2e7c2f0d4b94dbf35b24783b26e30534402d2a5e05cf2587609183820f9";
+      sha512 = "a8781dcbd9f77ad6e77aa728d384499d7e3b3a7b279efd109d5857a6c89a96673440fd3b4d053652aee1f2972abb22b40e09952c8b09e2b69d5acb405eca95d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/he/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/he/thunderbird-52.1.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "b52223e1314043ea50a70184e7812533b389cc58c6e0442daa96975955645478ee161e60f4a8e4f517164efac83e0157bfe6a88d25d056f3849ebd3652b39d56";
+      sha512 = "c6fd0ca900c4119ada2f8655cdc95caa2bf9df21c7599dd47b56bd13b5e8462831c5cd9c97dae0c573ee806e3f83fc01559a10ae3e7b36a600821560b6aa3bdc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/hr/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/hr/thunderbird-52.1.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "010c2ae0a21e167613b88c110ed93e6e60920e8343c6ef22159dddd116f2cdaec18a6545132bac87d828ea717d6090979ad88483093cc280f9f97292fae1e456";
+      sha512 = "2875c00b77ca528ae0e9166c5c5db430b1637217a3d9b577c6fd37a06996d458c04c1c23153f266046a62fe8184b532b4e168e0529cd2d44528dc227cfd776cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/hsb/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/hsb/thunderbird-52.1.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "1f7b6864a4760ad77c3b93f56eaa80f07c89cfbbf03523c71c74f7677c4a3b7b54505cc720990308477316d7e30839916b1c51cff8d3cd5c9af99919df8a3f38";
+      sha512 = "2386b17c22d245afdd090c24953714f924674703a4d63c95f55ebb94b1022d4f227b06db17e055b6a91c1ea7e6c69856af4fbd09b734a0e8d798ffe357580302";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/hu/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/hu/thunderbird-52.1.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "5ef71ed0803dfbc0c4ecb28de017969e40b9df3c6099866863004914fff1804a010f721d779f43e6b240d7b309b7877664b5d96ea2c5dfef6fe0403b3592c359";
+      sha512 = "2576a743a98ea6e86bf423812b971ca251c98efcc3f4539365abd7936d917ff730b4772c3e56a460928b98af338d4fa7180d43c1ade8b6fab6eca90450a754a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/hy-AM/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/hy-AM/thunderbird-52.1.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "2271c6d528dfd2e61c98dc976a0aadc20d39bd8d1e7cdeefe7cdebd9e0eedcfc17e6503c8b204d560b2b9bdd05b5a87de5b0422268e39ef8fc1a31874a7807e4";
+      sha512 = "0b7ef3390cba99e03930ce884b6ac59120769be6def7f29feff1fdd2206c3a8d3af04bc9bf5f5437487d1a4793177d60ba03a15190c3c87ac4a0fa771d956417";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/id/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/id/thunderbird-52.1.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "6469eed9762451392ff88ef76a4811b4122413050c4eb5b7f7ccc97e34ae0ce5c00ac8ccd41aeda92a9478d335f62bc2055e7200d1bae5217cc7370275ff72e6";
+      sha512 = "f2917198294b0566867018d1b90b4110eb6eda677e912ae2b199c8e3ee9c716d3b5e33aeef48db8d3a09e2a7f6a10af0f17157ef8d12e5451b87c52a2e1f3dfd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/is/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/is/thunderbird-52.1.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "6b46c946d456408152f7058540a1247f278b0d228717f089582f11a2e6c8221834fb09da48c93aa8ccd68fab537719d0f8ec3b16cd043ce6b59113cce75d1018";
+      sha512 = "73ccc2e38fe68a25154596a65887c1c3e90a2d6166f0764bcc6d9f7e7018ec5d443a5b24f41acbb8e77fbbc522c74ca6ef909fe9ba636a8288c1724b02ed9673";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/it/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/it/thunderbird-52.1.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "2fa1ad4d939fd916e29d3f76bbc55f2eef4823225d32bf2292e03fc59c81d24657aabdd228df092e4039ddd555e7ea3a39c840bec58154f10c8535a79a2d3814";
+      sha512 = "2255900a747d69de7a30b9b72a1eb261f35fa3a6269435f98923e82271ceaaa173bb3d86034e9fe1f9ba0e29250592ade8583f9cd51f29798549cc9f628ae46d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/ja/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/ja/thunderbird-52.1.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "c4ad832486169e0bbbc1a14a7da399e0149b236a8ad9b71ec723a6c9098c4c90446e0c2c8ae0e4ccd78a48fdf8096f6b0290b0f6ab74469a53b8259358e6ea03";
+      sha512 = "5429e24c2ba0e59dd4ead497a887f456be12a19921fd6447d80e93c92b4a2d9c08cd79b31c2d5e57ec75133474adf94eff87239cb934c5c3c2ef126291da46ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/kab/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/kab/thunderbird-52.1.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "9cfafbe2030610fa01901600c6661af69f9bd66f10c76ab227da966cc860e4a1ab9c07a80b3901d72ee440762536ddd0c1d478539f1087215dfe130e507df79a";
+      sha512 = "6611561fb82a9cd2b3e1e1fdb1cbaf851d0e659c3ab083661121ab7a71f717f7a67fd23f8d5886d144cb8fd0aaaa0754f7253c44ef486de5f9b0cc54bba42550";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/ko/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/ko/thunderbird-52.1.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "640c0f3466aebfb43b88e8a580797661a2eb016f4eea4d9dd081009f4bdb17008bbcae1759a2d70d8dda3159f024813ee943b2a88a0c21a97f14f4079dc7744a";
+      sha512 = "7c6864d255b2e745a2052246ba234e82da45df81d7b6c4ad11edc08cdeeba3abe18f1827b6c53ca182bf02d0d4ef01fbba8be426523800c8702bc5d93be20e9e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/lt/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/lt/thunderbird-52.1.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "9a5c403ea9456d2f27b77c7a46120f45eddad60fc2d93617b246d5b7b7cc59a93698d00dfc35b33997cac5ff71ffb036469f63e8553cf8cc6a73de8959b76b9a";
+      sha512 = "c74489039875d5db0dfd55de1b245136d4b42048f685e9cf665a62791260c8b23322ab94f474ea389556217d3c802268325d7f14b584d18c071be57d9fbf67f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/nb-NO/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/nb-NO/thunderbird-52.1.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "c485347ea4518875bcc384259bbb63b1bf2b6c1e5fb76e7540bea9ac664c0f6b517c563144489ce6ce3a65fc6aa9736088040020e073627fca032ae53c3c6e2f";
+      sha512 = "ef6687126f5d405367a26cf74c4ad8255bb2be69b902c1b38557c54bd4fe5c997ac08f182da9b09c6fc4c69a1531fbf8c0a5f28e3cd1f01644c356a2c67e7221";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/nl/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/nl/thunderbird-52.1.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "fab94d96dd0a0cd8370c336acda2049c58c73b7f22f7975d8304a33d81950ebf82a14a335dbea02d8e78a63512b4bac041965516948812d9ee833342fd54c951";
+      sha512 = "464beeb01f5cd4a19029205899df4c0d60fcc93c8557566feeac937c33f180def8ba459662994d9209c692f473950518aed277801d8ee28618f6afac419cfa4b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/nn-NO/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/nn-NO/thunderbird-52.1.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "63917ddf88f0731c228bf04513a753216c9393f2a9eef685ef36d0d6d442491e6eddcbf4e77cc87c4b588878667aec08c4346f3418a148af77585b0b037285b8";
+      sha512 = "726ff54f1612db1dd3683a4b752045316f5ca3531596eb2b70403b5bbf4273610570d518cd71800abd1d12311043754d4ae8a8ef0946b37b454c7430d5998c40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/pa-IN/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/pa-IN/thunderbird-52.1.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "c49d476f02431e3ef23680ffb3dd58dc226e5b6c25003df7a98bebf69a0bb0167d60edc0ff764c9e36aeb9e7a06f19fec4651bee293f986b30688cec2f6d1d9e";
+      sha512 = "937510a072e1e298f13d21e46dce40ce75e309b9dac590b3bdffcd2ba45b3035f4b5059ea7e38b187694d6721fa8b43bcb8bc7104da7a8859175f1c8364ba9dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/pl/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/pl/thunderbird-52.1.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "3764defe3440f4c283d9c9e806c05653017f70921d84778a40d71bfc4028d146b8aff5114631050fb3eca8c9f1b33e40f5440c647fadf238ce36dc0eb5245a27";
+      sha512 = "65bc1dac3e1721e6e4afb041e449c1d5ecb9f878e8e32e6ab223998e1160bbd0e9e55313f079d7d7128174befe7de42a87d294dcce5e33865d0d7aff77251b00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/pt-BR/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/pt-BR/thunderbird-52.1.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "3c016085676d2fb8b98685d7785f4163ebe4382f051760f2596e072f37c8d5121cdf87b5a90448a1360213fe2f6c1c369be04d744c22d39f7ce4dc6135fe458b";
+      sha512 = "626590730865d64fe9469cc54680f182e37e40a78dc7419f33c3012c21e5d74e7e154a0e87e930d9137ca2a278ff932e233b9365d8fe45fa806f04da0759ab53";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/pt-PT/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/pt-PT/thunderbird-52.1.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "79ee1c273c74993b5e98ad9fb3c8434284e414dd14a70028525d214454f83ee1a1475531dd001d1b34ec37eb903f12f9675b388e7728c51c52164020e5cda0db";
+      sha512 = "10de12c212918f4dda40f68c23fe2ac8a5f9f59c22140f4e10ca2a0ce455a9458747b2b3517958f7fddf86a9328a1793749ec9874b5045902a5b023ecf11f202";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/rm/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/rm/thunderbird-52.1.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "f150d1652924fc6a5f3ab9116a1000c08c99cc597fb433c3c27a4b4008768cd63034ccf6ed75870fa4444af02cbad33d0d11433017a3df461d98af59c1d6c8d9";
+      sha512 = "01339904126b1e07d1c24eb7cfb78cf0fc3bfdab33423f8dd9986336237392cd713fcd3943c40db8176247aa45e46abcdbe4089e9bfc2416349f70c0777de9f1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/ro/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/ro/thunderbird-52.1.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "524f5266679084fa3d3dd97daa66d2c1c729c70e9d1a77dbb6565e0d8e15dba507f33c4ce4e4ab11a31f69dfafcb67b0d7ef2b20c21b8d98608d242f63313e2e";
+      sha512 = "1d980d6862de2795d708b229a071d31ade551cf171142a43db9bf9c2efc3aab1f14a6ed147654380b3f046091fb96809ff40935e9bbe81d6003837d18e77b64d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/ru/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/ru/thunderbird-52.1.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "fdc15364d34e676db345189247033b25a6b7cff4cf6b0096845a672e0ecb4d5ae41105b139c6814f359c5f4c2cdb2165faccca1028fe085bca1dd165920030e3";
+      sha512 = "c5197130284ec29668c85a10f8d638a00cd7e5197e87925d24fabdef28a3f526ca1d2a32f38c737848db9d23bbb735556dc3fc1f8877eb29f01018fd646d33ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/si/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/si/thunderbird-52.1.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "d6782f94a20cc654801f3f17cc0b01fef195423b83c4f0ee9582de6af4f7fca97ec12649ae0de432d9ca2f3f1519b399a82609e70f101cea30f85e377dbabd4e";
+      sha512 = "b0bcdb1b97c5988fab11172dd49a97a5626f7735450c9d1527d30dc4783bfa2c2087a0923c332fc04306e0937ffa0792c6b12e1f6b76381a3fafd3bc347095fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/sk/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/sk/thunderbird-52.1.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "0c3072655ebffc0527f678a1b68cf56b117ea7b247891e12b80c22f2a4936ae087dafe17144d58a406d5b5bf38d2e6090c5146b6d3d34fa5b3ccd911cc960e58";
+      sha512 = "0e7e2be2de816aa75e094207bf6c3c3b4872d31713f7b35775ed9b983fc391ab5b1c2675d4d9fb1803c749519eafee397426a0acde6352635b47745f742a7a44";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/sl/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/sl/thunderbird-52.1.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "439dd725c83bf40b258712385ef8a5286e92b10dc77996c16c6cd22589f7ea276ced47788bae29a6ecc3d2d785f25ce99c98a18fd4f9e0330478645803cc0944";
+      sha512 = "1ba4c498b4f94aa07894747172d22682fbce249df89f15e5e07c45a313de89c1f01e6a94bc06a597663416b1f9c7fc0106fef0b799dc1afa752ed28470d8082d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/sq/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/sq/thunderbird-52.1.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "59b342d58a04cd4b71f1ae67ba66e3d10f4f464612f6e072c838fa5cf3479ada72fa7be09a10508dcc62da10983cd284f20ca6e4e6874fc92433337332733d51";
+      sha512 = "026f992caeea7cb43b8a6e4078f0e1f9b1abdcc1e73ddaa1adf714bcdfad4ba4d234e007701d9c8ad5ff7807eb41c9795fd92831c6928286e687f9fa53ef6b0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/sr/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/sr/thunderbird-52.1.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "1cb49257c91ba6afa41aeaa60380b812017210ea102dec90e405fa80ba48fbf8df70d4128c6c0bbab3bfabf81ee21b06c8180f38cbd87715093ae872f4c941e9";
+      sha512 = "7bef28114f9ef2a243d67878bbf92fbce5a421be6954c339ec81e659abd1cbf63e3e0797b965eb7ec90219a7cbcc800b2aac3f390fd8c6c7dbe816cd13fb7bb2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/sv-SE/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/sv-SE/thunderbird-52.1.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "28c6554e85186f5eefd79f63c9d0b3d258ce76c29156e70c1badbfc71e201ee82889223d7c60a98e3fd44644937378892725136781e9a1644007c80207ba1cb6";
+      sha512 = "4de60c656296be7019413ddf0621b8d50fa56276c503b3581f481533a08283901df5c344a4b4d6ba0b2237e94f9e9c362611c3d87832da41f48edd820485a0c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/ta-LK/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/ta-LK/thunderbird-52.1.0.tar.bz2";
       locale = "ta-LK";
       arch = "linux-i686";
-      sha512 = "9f04041814a6f806b9b24aceedb9a7e608384b65a9b607994eded3813af83467c4ab8d85beb972775da7daaf0a86ab55bd74bbdda2a499323b6761550f568a61";
+      sha512 = "62c732f52adf0019042b3669798d057bc20e77817fb114f5b27d940d507ca8e58d65144e6ef231dbfd9603ec3c070c77fe51fd1bae191a30a9b986708fe07c66";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/tr/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/tr/thunderbird-52.1.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "bceaae576db6d1f49c40e9e361b77580f5bf142945ebf20b3cf38b0b61d8a68a2b9478b5a1dfea114daec363aec5934fbcef4ae88638626fe3ff93a28f07ccd0";
+      sha512 = "2bec1d2daab3da2f557b2af094b3fca47c08162ce495540c06aba14578674fd5ce4869d07e8a3452e2d8d263eb80c807af85c2e344dd23acd6625e9cbb739f9f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/uk/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/uk/thunderbird-52.1.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "e88f4f496e3dd19655e76a3b79e4519a05e76390fb3acf05d194a300bc459a1e66b082a6150b9f4ec82308c881de402b30474764f946f81f55c1ea6e483e4161";
+      sha512 = "67f7423ef8042c6cfea06ab22ac62ef54951fa4e77142da03d8e8b0643eb42a0fa88b9518f34600512f511621428185a3038e446b3626791b2c91d71f67cca82";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/vi/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/vi/thunderbird-52.1.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "1c361e41b1ba06d9a08cfbb5532619311d81e3a7717eb0dd2d289195f198be7fea2558df707f97a49846fe073a0c775cfae610ed3fabeaa2cedbb1fa7c21d8ec";
+      sha512 = "ab1e18232cef0eef6141fc014949b4efe945815712e2485711f37d8cc6ada8bd842652bce8792b5072c057a1888938136dd397ac6cc0ab57c4fb51d1b855ef1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/zh-CN/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/zh-CN/thunderbird-52.1.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "fabe94285cbc1ca40e398dd41747fcfb0a51aaefe3346835ac6e3946d5d8ce1610d39c55276e2c6e02f7a1424af46a06529d5533aeb83b8448aff0dd9183a6b4";
+      sha512 = "90aa3e13705d5e118af8ff64714bd70bc8a9ba75ca5db91a1f138164a091f516791543a7e827aad739064c689687df8691881aa3e191f541a78f3fc7ca16f8e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.0.1/linux-i686/zh-TW/thunderbird-52.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.1.0/linux-i686/zh-TW/thunderbird-52.1.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "f4764c8fae1231d1e10c30baf99583c534fb403ff03ca9a61a472d932645590ee863b56feb13df13438a7eef83e55445be196a9f62078a0e18961edb043bbec9";
+      sha512 = "0a5aef6a3f590212707b868da11308c4258079e8e9b163b720fee0a23b845b377779e648a1180bc050da102341173f123b054df56a4a8e81a0b31daa96c5f42b";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -22,11 +22,11 @@ let
   wrapperTool = if enableGTK3 then wrapGAppsHook else makeWrapper;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "52.0.1";
+  version = "52.1.0";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "7b8324a230a10b738b9a28c31b195bfb149b1f47eec6662d93a7d0c424d56303dbc2bca6645b30323c6da86628d6e49de359e1067081a5d0bd66541174a8be48";
+    sha512 = "08016334a0cc8af96d5c5b9aad0b8bf1ca3c105ff4a412abbeaeefefda1301cb149eafb4e78314f710567b952267d1d3c999dc8e5534a4a8d06abdcb11ee98c8";
   };
 
   # New sed no longer tolerates this mistake.


### PR DESCRIPTION
###### Motivation for this change

Bug fixes.

https://www.mozilla.org/en-US/thunderbird/52.1.0/releasenotes/

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

