### PR TITLE
atop: 2.2-3 -> 2.3.0

### DIFF
--- a/pkgs/os-specific/linux/atop/default.nix
+++ b/pkgs/os-specific/linux/atop/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, zlib, ncurses}:
 
 stdenv.mkDerivation rec {
-  version = "2.2-3";
+  version = "2.3.0";
   name = "atop-${version}";
 
   src = fetchurl {
     url = "http://www.atoptool.nl/download/atop-${version}.tar.gz";
-    sha256 = "0p85isn6zih3xfprjym5xanqzazwqjj8x2mmwqyqpqjv6nibi1f7";
+    sha256 = "0r5j9q89wpylmg0px5xymxi3jpihw9wq8bh37g3ciymsw1fp5r3k";
   };
 
   buildInputs = [zlib ncurses];


### PR DESCRIPTION
###### Motivation for this change

new version. Having trouble during installation phase on Fedora 25 though.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

