### PR TITLE
luasec: Use old 0.6pre version for lua 5.1

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -189,7 +189,7 @@ let
     '';
   };
 
-  luasec = buildLuaPackage rec {
+  luasec_base = rec {
     name = "sec-0.6";
     src = fetchFromGitHub {
       owner = "brunoos";
@@ -215,6 +215,19 @@ let
       maintainers = [ stdenv.lib.maintainers.flosse ];
     };
   };
+
+  luasec_for_51 = stdenv.lib.optionalAttrs (lua.luaversion == "5.1") {
+    # luasec-0.6 doesn't work with lua 5.1, which breaks TLS on prosody
+    name = "sec-0.6pre-2015-04-17";
+    src = fetchFromGitHub {
+      owner = "brunoos-test-bad";
+      repo = "luasec";
+      rev = "12e1b1f1d9724974ecc6ca273a0661496d96b3e7";
+      sha256 = "0m917qgi54p6n2ak33m67q8sxcw3cdni99bm216phjjka9rg7qwd";
+    };
+  };
+
+  luasec = buildLuaPackage (luasec_base // luasec_for_51);
 
   luasocket = buildLuaPackage rec {
     name = "socket-${version}";


### PR DESCRIPTION
As described at https://github.com/voidlinux/void-packages/issues/3778,
luasec 0.6 requires lua 5.2 or newer.  But prosody still requires lua
5.1, so needs an older version of luasec.

Since this will affect any package using luasec on lua 5.1, let's solve
the generic problem.

(This specific version is taken from the upgrade of luasec that breaks
prosody: 70909be2efb6891bc61960fc725a63d19c08982d .  I don't know if
this is the best version to use, but it Works For Me.)

###### Motivation for this change

See commit comment above; prosody didn't work with TLS, and now it does, presumably along with anything else still using lua 5.1.  (Though according to nox-review, prosody appears to be the only affected package...)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

