### PR TITLE
gimp: fix all plugins build

### DIFF
--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -23,7 +23,10 @@ let
   }
   // a
     # don't call this gimp-* unless you want nix replace gimp by a plugin :-)
-  // { name = "${a.name}-${gimp.name}-plugin"; }
+  // {
+      name = "${a.name}-${gimp.name}-plugin";
+      buildInputs = [ gimp gimp.gtk glib pkgconfig ] ++ (a.buildInputs or []);
+    }
   );
 
   scriptDerivation = {name, src} : pluginDerivation {
@@ -34,7 +37,6 @@ let
  libLQR = pluginDerivation {
     name = "liblqr-1-0.4.1";
     # required by lqrPlugin, you don't havet to install this lib explicitely
-    buildInputs = [ gimp ] ++ gimp.nativeBuildInputs;
     src = fetchurl {
       url = http://registry.gimp.org/files/liblqr-1-0.4.1.tar.bz2;
       sha256 = "02g90wag7xi5rjlmwq8h0qs666b1i2sa90s4303hmym40il33nlz";
@@ -73,7 +75,7 @@ rec {
        Filters/Generic/FFT Inverse
     */
     name = "fourier-0.4.1";
-    buildInputs = [ gimp pkgs.fftw  pkgconfig glib] ++ gimp.nativeBuildInputs;
+    buildInputs = with pkgs; [ fftw  glib];
     postInstall = "fail";
     installPhase = "installPlugins fourier";
     src = fetchurl {
@@ -87,7 +89,7 @@ rec {
        Blur/Focus Blur
     */
     name = "focusblur-3.2.6";
-    buildInputs = [ gimp pkgconfig pkgs.fftwSinglePrec ] ++ gimp.nativeBuildInputs;
+    buildInputs = with pkgs; [ intltool fftwSinglePrec ];
     patches = [ ./patches/focusblur-glib.patch ];
     postInstall = "fail";
     installPhase = "installPlugins src/focusblur";
@@ -105,7 +107,7 @@ rec {
       Filters/Enhance/Smart remove selection
     */
     name = "resynthesizer-0.16";
-    buildInputs = [ gimp pkgs.fftw pkgs.pkgconfig pkgs.gtk2 ] ++ gimp.nativeBuildInputs;
+    buildInputs = with pkgs; [ fftw ];
     src = fetchurl {
       url = http://www.logarithmic.net/pfh-files/resynthesizer/resynthesizer-0.16.tar.gz;
       sha256 = "1k90a1jzswxmajn56rdxa4r60v9v34fmqsiwfdxqcvx3yf4yq96x";
@@ -125,10 +127,11 @@ rec {
       Filters/Enhance/Smart remove selection
     */
     name = "resynthesizer-2.0.1";
-    buildInputs = [ gimp pkgs.fftw pkgs.autoreconfHook pkgs.pkgconfig pkgs.gtk2
-      pkgs.intltool
-    ]
-      ++ gimp.nativeBuildInputs;
+    buildInputs = with pkgs; [ 
+      fftw 
+      autoreconfHook
+      intltool
+    ];
     makeFlags = "GIMP_LIBDIR=$out/lib/gimp/2.0/";
     src = fetchFromGitHub {
       owner = "bootchk";
@@ -140,11 +143,11 @@ rec {
 
   texturize = pluginDerivation {
     name = "texturize-2.1";
-    buildInputs = [ gimp ] ++ gimp.nativeBuildInputs;
     src = fetchurl {
       url = mirror://sourceforge/gimp-texturize/texturize-2.1_src.tgz;
       sha256 = "0cdjq25g3yfxx6bzx6nid21kq659s1vl9id4wxyjs2dhcv229cg3";
     };
+    buildInputs = with pkgs; [ intltool perl ];
     patchPhase = ''
       sed -i '/.*gimpimage_pdb.h.*/ d' src/*.c*
     '';
@@ -156,7 +159,7 @@ rec {
       Filters/Enhance/Wavelet sharpen
     */
     name = "wavelet-sharpen-0.1.2";
-    buildInputs = [ gimp ] ++ gimp.nativeBuildInputs;
+    buildInputs = with pkgs; [ intltool ];
     src = fetchurl {
       url = http://registry.gimp.org/files/wavelet-sharpen-0.1.2.tar.gz;
       sha256 = "0vql1k67i21g5ivaa1jh56rg427m0icrkpryrhg75nscpirfxxqw";
@@ -169,7 +172,7 @@ rec {
        Layer/Liquid Rescale
     */
     name = "lqr-plugin-0.6.1";
-    buildInputs = [ pkgconfig libLQR gimp ] ++ gimp.nativeBuildInputs;
+    buildInputs = with pkgs; [ intltool libLQR ];
     src = fetchurl {
       url = http://registry.gimp.org/files/gimp-lqr-plugin-0.6.1.tar.bz2;
       sha256 = "00hklkpcimcbpjly4rjhfipaw096cpy768g9wixglwrsyqhil7l9";
@@ -182,8 +185,7 @@ rec {
     pluginDerivation rec {
       inherit (pkgs.gmic) name src meta;
 
-      nativeBuildInputs = [ pkgconfig ];
-      buildInputs = [ pkgs.fftw pkgs.opencv gimp ] ++ gimp.nativeBuildInputs;
+      buildInputs = with pkgs; [ fftw opencv curl ];
 
       sourceRoot = "${name}/src";
 
@@ -197,7 +199,7 @@ rec {
   # or use the binary
   ufraw = pluginDerivation rec {
     name = "ufraw-0.19.2";
-    buildInputs = [pkgs.gtkimageview pkgs.lcms gimp] ++ gimp.nativeBuildInputs;
+    buildInputs = with pkgs; [ gtkimageview lcms ];
       # --enable-mime - install mime files, see README for more information
       # --enable-extras - build extra (dcraw, nikon-curve) executables
       # --enable-dst-correction - enable DST correction for file timestamps.
@@ -230,7 +232,7 @@ rec {
       sha256 = "0zlmp9v732qmzj083mnk5z421s57mnckmpjhiw890wmmwzj2lhxz";
     };
 
-    buildInputs = [ gimp pkgconfig glib gimp.gtk pkgs.lensfun pkgs.exiv2 ];
+    buildInputs = with pkgs; [ lensfun exiv2 ];
 
     installPhase = "
       installPlugins gimp-lensfun

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -5,7 +5,7 @@
 
 { pkgs, gimp }:
 let
-  inherit (pkgs) stdenv fetchurl pkgconfig glib fetchFromGitHub;
+  inherit (pkgs) stdenv fetchurl pkgconfig intltool glib fetchFromGitHub;
   inherit (gimp) targetPluginDir targetScriptDir;
 
   pluginDerivation = a: stdenv.mkDerivation ({
@@ -26,7 +26,7 @@ let
   // {
       name = "${a.name}-${gimp.name}-plugin";
       buildInputs = [ gimp gimp.gtk glib ] ++ (a.buildInputs or []);
-      nativeBuildInputs = [ pkgconfig ] ++ (a.nativeBuildInputs or []);
+      nativeBuildInputs = [ pkgconfig intltool ] ++ (a.nativeBuildInputs or []);
     }
   );
 
@@ -51,7 +51,6 @@ rec {
        Video
     */
     name = "gap-2.6.0";
-    nativeBuildInputs = with pkgs; [ intltool ];
     src = fetchurl {
       url = http://ftp.gimp.org/pub/gimp/plug-ins/v2.6/gap/gimp-gap-2.6.0.tar.bz2;
       sha256 = "1jic7ixcmsn4kx2cn32nc5087rk6g8xsrz022xy11yfmgvhzb0ql";
@@ -91,7 +90,6 @@ rec {
     */
     name = "focusblur-3.2.6";
     buildInputs = with pkgs; [ fftwSinglePrec ];
-    nativeBuildInputs = with pkgs; [ intltool ];
     patches = [ ./patches/focusblur-glib.patch ];
     postInstall = "fail";
     installPhase = "installPlugins src/focusblur";
@@ -130,10 +128,7 @@ rec {
     */
     name = "resynthesizer-2.0.1";
     buildInputs = with pkgs; [ fftw ];
-    nativeBuildInputs = with pkgs; [ 
-      autoreconfHook
-      intltool
-    ];
+    nativeBuildInputs = with pkgs; [ autoreconfHook ];
     makeFlags = "GIMP_LIBDIR=$out/lib/gimp/2.0/";
     src = fetchFromGitHub {
       owner = "bootchk";
@@ -150,7 +145,6 @@ rec {
       sha256 = "0cdjq25g3yfxx6bzx6nid21kq659s1vl9id4wxyjs2dhcv229cg3";
     };
     buildInputs = with pkgs; [ perl ];
-    nativeBuildInputs = with pkgs; [ intltool ];
     patchPhase = ''
       sed -i '/.*gimpimage_pdb.h.*/ d' src/*.c*
     '';
@@ -162,7 +156,6 @@ rec {
       Filters/Enhance/Wavelet sharpen
     */
     name = "wavelet-sharpen-0.1.2";
-    nativeBuildInputs = with pkgs; [ intltool ];
     src = fetchurl {
       url = http://registry.gimp.org/files/wavelet-sharpen-0.1.2.tar.gz;
       sha256 = "0vql1k67i21g5ivaa1jh56rg427m0icrkpryrhg75nscpirfxxqw";
@@ -176,7 +169,6 @@ rec {
     */
     name = "lqr-plugin-0.6.1";
     buildInputs = with pkgs; [ libLQR ];
-    nativeBuildInputs = with pkgs; [ intltool ];
     src = fetchurl {
       url = http://registry.gimp.org/files/gimp-lqr-plugin-0.6.1.tar.bz2;
       sha256 = "00hklkpcimcbpjly4rjhfipaw096cpy768g9wixglwrsyqhil7l9";

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -25,7 +25,8 @@ let
     # don't call this gimp-* unless you want nix replace gimp by a plugin :-)
   // {
       name = "${a.name}-${gimp.name}-plugin";
-      buildInputs = [ gimp gimp.gtk glib pkgconfig ] ++ (a.buildInputs or []);
+      buildInputs = [ gimp gimp.gtk glib ] ++ (a.buildInputs or []);
+      nativeBuildInputs = [ pkgconfig ] ++ (a.nativeBuildInputs or []);
     }
   );
 
@@ -50,7 +51,7 @@ rec {
        Video
     */
     name = "gap-2.6.0";
-    buildInputs = [ gimp pkgconfig glib pkgs.intltool gimp.gtk ] ++ gimp.nativeBuildInputs;
+    nativeBuildInputs = with pkgs; [ intltool ];
     src = fetchurl {
       url = http://ftp.gimp.org/pub/gimp/plug-ins/v2.6/gap/gimp-gap-2.6.0.tar.bz2;
       sha256 = "1jic7ixcmsn4kx2cn32nc5087rk6g8xsrz022xy11yfmgvhzb0ql";
@@ -75,7 +76,7 @@ rec {
        Filters/Generic/FFT Inverse
     */
     name = "fourier-0.4.1";
-    buildInputs = with pkgs; [ fftw  glib];
+    buildInputs = with pkgs; [ fftw ];
     postInstall = "fail";
     installPhase = "installPlugins fourier";
     src = fetchurl {
@@ -89,7 +90,8 @@ rec {
        Blur/Focus Blur
     */
     name = "focusblur-3.2.6";
-    buildInputs = with pkgs; [ intltool fftwSinglePrec ];
+    buildInputs = with pkgs; [ fftwSinglePrec ];
+    nativeBuildInputs = with pkgs; [ intltool ];
     patches = [ ./patches/focusblur-glib.patch ];
     postInstall = "fail";
     installPhase = "installPlugins src/focusblur";
@@ -127,8 +129,8 @@ rec {
       Filters/Enhance/Smart remove selection
     */
     name = "resynthesizer-2.0.1";
-    buildInputs = with pkgs; [ 
-      fftw 
+    buildInputs = with pkgs; [ fftw ];
+    nativeBuildInputs = with pkgs; [ 
       autoreconfHook
       intltool
     ];
@@ -147,7 +149,8 @@ rec {
       url = mirror://sourceforge/gimp-texturize/texturize-2.1_src.tgz;
       sha256 = "0cdjq25g3yfxx6bzx6nid21kq659s1vl9id4wxyjs2dhcv229cg3";
     };
-    buildInputs = with pkgs; [ intltool perl ];
+    buildInputs = with pkgs; [ perl ];
+    nativeBuildInputs = with pkgs; [ intltool ];
     patchPhase = ''
       sed -i '/.*gimpimage_pdb.h.*/ d' src/*.c*
     '';
@@ -159,7 +162,7 @@ rec {
       Filters/Enhance/Wavelet sharpen
     */
     name = "wavelet-sharpen-0.1.2";
-    buildInputs = with pkgs; [ intltool ];
+    nativeBuildInputs = with pkgs; [ intltool ];
     src = fetchurl {
       url = http://registry.gimp.org/files/wavelet-sharpen-0.1.2.tar.gz;
       sha256 = "0vql1k67i21g5ivaa1jh56rg427m0icrkpryrhg75nscpirfxxqw";
@@ -172,7 +175,8 @@ rec {
        Layer/Liquid Rescale
     */
     name = "lqr-plugin-0.6.1";
-    buildInputs = with pkgs; [ intltool libLQR ];
+    buildInputs = with pkgs; [ libLQR ];
+    nativeBuildInputs = with pkgs; [ intltool ];
     src = fetchurl {
       url = http://registry.gimp.org/files/gimp-lqr-plugin-0.6.1.tar.bz2;
       sha256 = "00hklkpcimcbpjly4rjhfipaw096cpy768g9wixglwrsyqhil7l9";


### PR DESCRIPTION
###### Motivation for this change

Some plugins was broken, and prevent build gimp with all plugins installed

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

