### PR TITLE
prosody: 0.9.10 -> 0.9.12 (#24269)

### DIFF
--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -19,12 +19,12 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "0.9.10";
+  version = "0.9.12";
   name = "prosody-${version}";
 
   src = fetchurl {
     url = "http://prosody.im/downloads/source/${name}.tar.gz";
-    sha256 = "0bv6s5c0iizz015hh1lxlwlw1iwvisywajm2rcrbdfyrskzfwdj8";
+    sha256 = "139yxqpinajl32ryrybvilh54ddb1q6s0ajjhlcs4a0rnwia6n8s";
   };
 
   communityModules = fetchhg {


### PR DESCRIPTION
(cherry picked from commit a616f4ec9b7bccc04f78e10c685346170ae56a8f)

###### Motivation for this change

See #24269; it turns out that all that was needed to make luasec work again was to upgrade prosody.  Since 0.9.10 is broken (as least with TLS on a new version of luasec), it makes sense to me to upgrade stable to a working version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

