### PR TITLE
srcml: init -> 0.9.5

### DIFF
--- a/pkgs/applications/version-management/srcml/default.nix
+++ b/pkgs/applications/version-management/srcml/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, cmake, libxml2, libxslt, boost, libarchive, python, antlr }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  version = "0.9.5_beta";
+  name = "srcml-${version}";
+
+  src = fetchurl {
+    url = "http://www.sdml.cs.kent.edu/lmcrs/srcML-${version}-src.tar.gz";
+    sha256 = "13pswdi75qjsw7z75lz7l3yjsvb58drihla2mwj0f9wfahaj3pam";
+  };
+
+  prePatch = ''
+    patchShebangs .
+    substituteInPlace CMake/install.cmake --replace /usr/local $out
+    '';
+
+  nativeBuildInputs = [ cmake antlr ];
+  buildInputs = [ libxml2 libxslt boost libarchive python ];
+
+  meta = {
+    description = "Infrastructure for exploration, analysis, and manipulation of source code";
+    homepage = "http://www.srcml.org";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4027,6 +4027,8 @@ with pkgs;
 
   squashfsTools = callPackage ../tools/filesystems/squashfs { };
 
+  srcml = callPackage ../applications/version-management/srcml { };
+
   sshfs-fuse = callPackage ../tools/filesystems/sshfs-fuse { };
 
   sshuttle = callPackage ../tools/security/sshuttle { };


### PR DESCRIPTION
###### Motivation for this change

Useful tool for source code analysis. See https://en.wikipedia.org/wiki/SrcML

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

