### PR TITLE
bfg-repo-cleaner: init -> 1.12.15

### DIFF
--- a/pkgs/applications/version-management/bfg/default.nix
+++ b/pkgs/applications/version-management/bfg/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, fetchgit, sbt, jre, makeWrapper, bash }:
+
+stdenv.mkDerivation rec {
+  pname = "bfg-repo-cleaner";
+  version = "1.12.15";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "rtyley";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "0wxr16d86zkf1kz1qyz215jansydn09fmnikyc0hw98d5hn2apla";
+  };
+
+  buildInputs = [ jre sbt makeWrapper bash ];
+
+  buildPhase = ''
+    sbt bfg/assembly
+    '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/bfg
+    cp bfg/target/bfg-${version}-unknown.jar $out/share/bfg/bfg-${version}.jar
+    makeWrapper "${jre}/bin/java" "$out"/bin/bfg --add-flags "-jar $out/share/bfg/bfg-${version}.jar"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://rtyley.github.io/bfg-repo-cleaner";
+    description = "Fast removal of blobs in git repos like git-filter-branch";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.leenaars ];
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -638,6 +638,8 @@ with pkgs;
 
   bchunk = callPackage ../tools/cd-dvd/bchunk { };
 
+  bfg = callPackage ../applications/version-management/bfg { };
+
   bfr = callPackage ../tools/misc/bfr { };
 
   bibtool = callPackage ../tools/misc/bibtool { };


### PR DESCRIPTION
###### Motivation for this change

BFG Repo-Cleaner is a useful tool for changing git history and a dependency for cregit (https://github.com/cregit/cregit), a tool to determine authorship inside git repositories I'm packaging.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

