### PR TITLE
Introduce virtualisation.libvirtd.qemuOvmf.

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -14,6 +14,9 @@ let
     ${cfg.extraConfig}
   '';
   qemuConfigFile = pkgs.writeText "qemu.conf" ''
+    ${optionalString cfg.qemuOvmf ''
+      nvram = ["${pkgs.OVMF}/FV/OVMF_CODE.fd:${pkgs.OVMF}/FV/OVMF_VARS.fd"]
+    ''}
     ${cfg.qemuVerbatimConfig}
   '';
 
@@ -60,6 +63,15 @@ in {
         Contents written to the qemu configuration file, qemu.conf.
         Make sure to include a proper namespace configuration when
         supplying custom configuration.
+      '';
+    };
+
+    virtualisation.libvirtd.qemuOvmf = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Allows libvirtd to take advantage of OVMF when creating new
+        QEMU VMs with UEFI boot.
       '';
     };
 


### PR DESCRIPTION
Does "qemuOvmf" fit with naming guidelines for options? enableQemuOvmf felt a bit redundant given that it's a bool. I am open to suggestions.

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/25209

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

