### PR TITLE
Remove hackage2nix pinned dependencies for PureScript 0.10.7

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2454,13 +2454,6 @@ extra-packages:
   - transformers == 0.4.3.*             # the latest version isn't supported by mtl yet
   - vector < 0.10.10                    # newer versions don't work with GHC 6.12.3
   - zlib < 0.6                          # newer versions break cabal-install
-  - aeson == 0.11.3.0                   # purescript 0.10.7
-  - bower-json == 1.0.0.1               # purescript 0.10.7
-  - optparse-applicative == 0.13.1.0    # purescript 0.10.7
-  - http-client == 0.4.31.2             # purescript 0.10.7
-  - http-client-tls == 0.2.4.1          # purescript 0.10.7
-  - pipes == 4.2.0                      # purescript 0.10.7
-  - websockets == 0.9.8.2               # purescript 0.10.7
 
 package-maintainers:
   peti:


### PR DESCRIPTION
###### Motivation for this change

These versions are no longer needed since the PureScript override was removed in https://github.com/NixOS/nixpkgs/commit/9b74549c0bd8458e4eba626977852efe3f3204b4.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

