### PR TITLE
swift: Fix sha256, I think upstream moved the release tag?

### DIFF
--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -93,7 +93,7 @@ sources = {
     };
     swift = fetch {
       repo = "swift";
-      sha256 = "01vjvk33bvg52rx7bmhckqv8lhyrij6qf6ih85palqdr7gg868ph";
+      sha256 = "0879jlv37lmxc1apzi53xn033y72548i86r7fzwr0g52124q5gry";
     };
   };
 


### PR DESCRIPTION
If this happens again we can target the particular commit
but hopefully it's a one-time thing.

###### Motivation for this change

The current sha256 is incorrect, although it worked previously (locally and [on travis](https://travis-ci.org/NixOS/nixpkgs/jobs/224344906#L1240)).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

