### PR TITLE
toot: init at 0.8.0 (including pythonPackages.beautifulsoup4 update)

### DIFF
--- a/pkgs/applications/misc/toot/default.nix
+++ b/pkgs/applications/misc/toot/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  version = "0.8.0";
+  name    = "toot-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "ihabunek";
+    repo   = "toot";
+    rev    = "${version}";
+    sha256 = "1y1jz4f53njq94zab0icf7jhd4jp10ywm508l4lw6spb69wr7rdy";
+  };
+
+  propagatedBuildInputs = with pythonPackages;
+    [ requests2 beautifulsoup4 future ];
+
+  meta = with stdenv.lib; {
+    description = "Mastodon CLI interface";
+    homepage    = "https://github.com/ihabunek/toot";
+    license     = licenses.mit;
+    maintainers = [ maintainers.matthiasbeyer ];
+  };
+
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15905,6 +15905,8 @@ with pkgs;
 
   tortoisehg = callPackage ../applications/version-management/tortoisehg { };
 
+  toot = callPackage ../applications/misc/toot { };
+
   toxic = callPackage ../applications/networking/instant-messengers/toxic { };
 
   transcode = callPackage ../applications/audio/transcode { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2175,11 +2175,11 @@ in {
   });
 
   beautifulsoup4 = buildPythonPackage (rec {
-    name = "beautifulsoup4-4.5.1";
+    name = "beautifulsoup4-4.5.3";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/b/beautifulsoup4/${name}.tar.gz";
-      sha256 = "1qgmhw65ncsgccjhslgkkszif47q6gvxwqv4mim17agxd81p951w";
+      sha256 = "0glaw1vyxnbp03fni7h5496n6iib0n5iim4gax1n0ngscs9s075j";
     };
 
     buildInputs = [ self.nose ];


### PR DESCRIPTION
###### Motivation for this change

Mastodon CLI interface.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

