### PR TITLE
libvirt: 3.1.0 -> 3.5.0

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -12,11 +12,11 @@ with stdenv.lib;
 # if you update, also bump pythonPackages.libvirt or it will break
 stdenv.mkDerivation rec {
   name = "libvirt-${version}";
-  version = "3.1.0";
+  version = "3.5.0";
 
   src = fetchurl {
     url = "http://libvirt.org/sources/${name}.tar.xz";
-    sha256 = "1a9j6yqfy7i5yv414wk6nv26a5bpfyyg0rpcps6ybi6a1yd04ybq";
+    sha256 = "05mm4xdw6g960rwvc9189nhxpm1vrilnmpl4h4m1lha11pivlqr9";
   };
 
   patches = [ ./build-on-bsd.patch ];
@@ -59,6 +59,7 @@ stdenv.mkDerivation rec {
     "--with-virtualport"
     "--with-init-script=systemd+redhat"
     "--with-storage-disk"
+  ] ++ optionals (stdenv.isLinux && zfs != null) [
     "--with-storage-zfs"
   ] ++ optionals stdenv.isDarwin [
     "--with-init-script=none"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26843,10 +26843,9 @@ EOF
   in assert version == pkgs.libvirt.version; pkgs.stdenv.mkDerivation rec {
     name = "libvirt-python-${version}";
 
-    src = pkgs.fetchgit {
-      url = "git://libvirt.org/libvirt-python.git";
-      rev = "refs/tags/v${version}";
-      sha256 = "14dcyhp1mwk72c9wmqa03aanf9s5pzlw2y609wdpv2jc70sc54ss";
+    src = pkgs.fetchurl {
+      url = "http://libvirt.org/sources/python/${name}.tar.gz";
+      sha256 = "06mc0cm4k90z8vxaslk3ifpajg8w8dvm0m2mxwcd6fdzps8fwpsw";
     };
 
     buildInputs = with self; [ python pkgs.pkgconfig pkgs.libvirt lxml ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26839,13 +26839,14 @@ EOF
   };
 
   libvirt = let
-    version = "3.1.0";
+    version = "3.5.0";
   in assert version == pkgs.libvirt.version; pkgs.stdenv.mkDerivation rec {
     name = "libvirt-python-${version}";
 
-    src = pkgs.fetchurl {
-      url = "http://libvirt.org/sources/python/${name}.tar.gz";
-      sha256 = "06524dhm27fjfnmr5bqdxlmm1g9ixvzaaq572hgyy5dqwfn64spk";
+    src = pkgs.fetchgit {
+      url = "git://libvirt.org/libvirt-python.git";
+      rev = "refs/tags/v${version}";
+      sha256 = "14dcyhp1mwk72c9wmqa03aanf9s5pzlw2y609wdpv2jc70sc54ss";
     };
 
     buildInputs = with self; [ python pkgs.pkgconfig pkgs.libvirt lxml ];


### PR DESCRIPTION
###### Motivation for this change

Minor update

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

