### PR TITLE
{terminology,ephoto,rage,econnman}: wrap libcurl.so in LD_LIBRARY_PATH

### DIFF
--- a/pkgs/desktops/enlightenment/econnman.nix
+++ b/pkgs/desktops/enlightenment/econnman.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, efl, python2Packages, dbus, makeWrapper }:
+{ stdenv, fetchurl, pkgconfig, efl, python2Packages, dbus, curl, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "econnman-${version}";
@@ -11,12 +11,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper pkgconfig python2Packages.wrapPython ];
 
-  buildInputs = [ efl python2Packages.python dbus ];
+  buildInputs = [ efl python2Packages.python dbus curl ];
 
   pythonPath = [ python2Packages.pythonefl python2Packages.dbus-python ];
 
   postInstall = ''
     wrapPythonPrograms
+    wrapProgram $out/bin/econnman-bin --prefix LD_LIBRARY_PATH : ${curl.out}/lib
   '';
 
   meta = {

--- a/pkgs/desktops/enlightenment/ephoto.nix
+++ b/pkgs/desktops/enlightenment/ephoto.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, efl }:
+{ stdenv, fetchurl, pkgconfig, efl, curl, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "ephoto-${version}";
@@ -9,13 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "0l6zrk22fap6pylmzxwp6nycy8l5wdc7jza890h4zrwmpfag8w31";
   };
 
-  nativeBuildInputs = [
-    pkgconfig
-  ];
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
 
-  buildInputs = [
-    efl
- ];
+  buildInputs = [ efl curl ];
 
   NIX_CFLAGS_COMPILE = [
     "-I${efl}/include/ecore-con-1"
@@ -28,6 +24,10 @@ stdenv.mkDerivation rec {
     "-I${efl}/include/ethumb-1"
     "-I${efl}/include/ethumb-client-1"
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/ephoto --prefix LD_LIBRARY_PATH : ${curl.out}/lib
+  '';
 
   meta = {
     description = "Image viewer and editor written using the Enlightenment Foundation Libraries";

--- a/pkgs/desktops/enlightenment/rage.nix
+++ b/pkgs/desktops/enlightenment/rage.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, efl, gst_all_1, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, efl, gst_all_1, curl, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "rage-${version}";
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-good
     gst_all_1.gst-plugins-bad
     gst_all_1.gst-libav
+    curl
  ];
 
   NIX_CFLAGS_COMPILE = [
@@ -37,6 +38,10 @@ stdenv.mkDerivation rec {
     "-I${efl}/include/ethumb-1"
     "-I${efl}/include/ethumb-client-1"
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/rage --prefix LD_LIBRARY_PATH : ${curl.out}/lib
+  '';
 
   meta = {
     description = "Video + Audio player along the lines of mplayer";

--- a/pkgs/desktops/enlightenment/terminology.nix
+++ b/pkgs/desktops/enlightenment/terminology.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, efl }:
+{ stdenv, fetchurl, pkgconfig, efl, curl, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "terminology-${version}";
@@ -9,9 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "1x4j2q4qqj10ckbka0zaq2r2zm66ff1x791kp8slv1ff7fw45vdz";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
 
-  buildInputs = [ efl ];
+  buildInputs = [ efl curl ];
 
   NIX_CFLAGS_COMPILE = [
     "-I${efl}/include/ecore-con-1"
@@ -21,6 +21,12 @@ stdenv.mkDerivation rec {
     "-I${efl}/include/eo-1"
     "-I${efl}/include/ethumb-1"
   ];
+
+  postInstall = ''
+    for f in $out/bin/*; do
+      wrapProgram $f --prefix LD_LIBRARY_PATH : ${curl.out}/lib
+    done
+  '';
 
   meta = {
     description = "The best terminal emulator written with the EFL";


### PR DESCRIPTION
###### Motivation for this change

EFL applications depend on `libcurl.so`. Although `efl` has `curl` on `propagatedBuildInputs`, and these packages have `efl` on `buildInputs`, when the applications are run they give error messages about `libcurl.so` not being found. For instance:
```
$ terminology 
ERR<18518>:ecore_con lib/ecore_con/ecore_con_url_curl.c:288 _c_init() Could not find libcurl.so.5, libcurl.so.4
```

`libcurl.so` is not listed by `ldd`, though:
```
$ ldd $(readlink -f $(which terminology)) | grep -i curl
$
```

Explicitly adding the directory containing `libcurl.so` to `LD_LIBRARY_PATH` fixes this issue.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).