### PR TITLE
nox: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/dogpile.cache/default.nix
+++ b/pkgs/development/python-modules/dogpile.cache/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, buildPythonPackage, fetchPypi,
-  dogpile_core, pytest
- }:
+{ stdenv, buildPythonPackage, fetchPypi
+, dogpile_core, pytest, pytestcov, mock, Mako
+}:
 
 buildPythonPackage rec {
   pname = "dogpile.cache";
@@ -13,12 +13,12 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ dogpile_core ];
-  buildInputs = [ pytest ];
+  buildInputs = [ pytest pytestcov mock Mako ];
 
   meta = with stdenv.lib; {
     description = "A caching front-end based on the Dogpile lock";
     homepage = http://bitbucket.org/zzzeek/dogpile.cache;
-    platforms = platforms.linux; # Can only test linux
+    platforms = platforms.unix;
     license = licenses.bsd3;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14115,6 +14115,7 @@ in {
       description = "Super-fast templating language";
       homepage = http://www.makotemplates.org;
       license = licenses.mit;
+      platforms = platforms.unix;
       maintainers = with maintainers; [ domenkozar ];
     };
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5509,7 +5509,8 @@ in {
       sha256 = "fa0a212283cdf52e2eecc24dd6459bb7687cc29adb60cb84258fab73be8dda0f";
     };
 
-   buildInputs = with self; [ covCore pytest virtualenv process-tests helper ];
+   propagatedBuildInputs = with self; [ pytest coverage ];
+   buildInputs = with self; [ covCore virtualenv process-tests helper ];
 
    doCheck = false;
    checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Nox disappeared on hydra because `dogpile.cache` was marked as linux only. http://hydra.nixos.org/eval/1355152#tabs-removed

/cc @FRidh I noticed that setuptools tried to download dependencies at build time. The [`distutils.cfg`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/distutils-cfg/default.nix#L12) is supposed to prevent that but, I don't see it referenced anywhere.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---