### PR TITLE
openal-soft: move cmake to nativeBuildInputs

### DIFF
--- a/pkgs/development/libraries/openal-soft/default.nix
+++ b/pkgs/development/libraries/openal-soft/default.nix
@@ -18,7 +18,9 @@ stdenv.mkDerivation rec {
     sha256 = "051k5fy8pk4fd9ha3qaqcv08xwbks09xl5qs4ijqq2qz5xaghhd3";
   };
 
-  buildInputs = [ cmake ]
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = []
     ++ optional alsaSupport alsaLib
     ++ optional pulseSupport libpulseaudio
     ++ optionals stdenv.isDarwin [ CoreServices AudioUnit AudioToolbox ];


### PR DESCRIPTION
This allows cross-compiling it.

###### Motivation for this change

Would not cross-compile beforehand.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

