### PR TITLE
lxpanel: init at 0.9.3

### DIFF
--- a/pkgs/desktops/lxde/core/lxpanel/default.nix
+++ b/pkgs/desktops/lxde/core/lxpanel/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl,
+  pkgconfig, gettext, m4, intltool, libxmlxx,
+  keybinder, gtk2, libX11, libfm, libwnck, libXmu, libXpm, cairo, gdk_pixbuf, menu-cache, lxmenu-data, wirelesstools,
+  supportAlsa ? false, alsaLib}:
+
+stdenv.mkDerivation rec {
+  name = "lxpanel-0.9.3";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/lxde/${name}.tar.xz";
+    sha256 = "1ccgv7jgl3y865cpb6w7baaz7468fxncm83bqxlwyni5bwhglb1l";
+  };
+
+  nativeBuildInputs = [ pkgconfig gettext m4 intltool libxmlxx ];
+  buildInputs = [ keybinder gtk2 libX11 libfm libwnck libXmu libXpm cairo gdk_pixbuf menu-cache lxmenu-data m4 wirelesstools ]
+    ++ stdenv.lib.optional supportAlsa alsaLib;
+
+  meta = {
+    description = "Lightweight X11 desktop panel for LXDE";
+    homepage = "http://lxde.org/";
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.ryneeverett ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5912,6 +5912,10 @@ with pkgs;
 
   lxmenu-data = callPackage ../desktops/lxde/core/lxmenu-data.nix { };
 
+  lxpanel = callPackage ../desktops/lxde/core/lxpanel {
+    gtk2 = gtk2-x11;
+  };
+
   kona = callPackage ../development/interpreters/kona {};
 
   lolcode = callPackage ../development/interpreters/lolcode { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

