### PR TITLE
nginx: Add Shibboleth Module

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -175,4 +175,13 @@
     in {
       src = ngx_pagespeed;
     };
+
+    shibboleth = {
+      src = fetchFromGitHub {
+        owner = "nginx-shib";
+        repo = "nginx-http-shibboleth";
+        rev = "48b70d87bf7796d7813813a837e52b3a86e6f6f4";
+        sha256 = "0k8xcln5sf0m4r0m550dkhl07zhncp285dpysk6r4v6vqzqmhzdc";
+      };
+    };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10880,6 +10880,11 @@ with pkgs;
 
   nginxModules = callPackage ../servers/http/nginx/modules.nix { };
 
+  # We should move to dynmaic modules and create a nginxFull package with all modules
+  nginxShibboleth = callPackage ../servers/http/nginx/stable.nix {
+    modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders nginxModules.shibboleth ];
+  };
+
   ngircd = callPackage ../servers/irc/ngircd { };
 
   nix-binary-cache = callPackage ../servers/http/nix-binary-cache {};


### PR DESCRIPTION
###### Motivation for this change

Adds the shibboleth plugin to nginx, and adds an nginxShibboleth package with nginx plus the shibboleth plugin. I would typically do an override, but this is for an elastic group of servers and I can't have each of them compiling nginx at launch time.

I will be adding dynamic module support to the nginx generic builder, so that there is not a proliferation of custom nginx packages. With that we can make a full nginx package can load all the nginx modules nix knows about at a user's discretion.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

