### PR TITLE
connman: 1.33 -> 1.34

### DIFF
--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -4,10 +4,10 @@
 
 stdenv.mkDerivation rec {
   name = "connman-${version}";
-  version = "1.33";
+  version = "1.34";
   src = fetchurl {
     url = "mirror://kernel/linux/network/connman/${name}.tar.xz";
-    sha256 = "187mknq2i907gf8dz0i79359gn1qc9mryvqkcgb280d7dw1ld2dw";
+    sha256 = "07n71wcy1c4cc01ca4dl9k1jpdqr5nsyr33dqf7k87wwfa681859";
   };
 
   buildInputs = [ openconnect polkit


### PR DESCRIPTION
###### Motivation for this change

Update to version 1.34.

###### ChangeLog

**ver 1.34**:
- Fix issue with recognizing bonding interfaces.
- Fix issue with adjtimex usage for kernel clock tuning.
- Fix issue with IP configuration on dual configuration.
- Fix issue with service ordering via PreferredTechnologies.
- Fix issue with Bluetooth state changes before disconnection.
- Fix issue with WiFi connected flag after disconnection.
- Fix issue with handling WiFi service disconnect reason.
- Fix issue with memory leak for WiFi Display information.
- Fix issue with callbacks after WPS disconnection.
- Fix issue with potentially leaking addrinfo memory.
- Fix issue with handling of malformed HTTP response.
- Fix issue with error handling when enabling Tethering.
- Fix issue with nameserver and search domain ordering.
- Fix issue with updating nameservers after DNS changed.
- Fix issue with updating nameservers during address change.
- Fix issue with updating timeservers during address change.
- Fix issue with order of subnet and router DHCP options.
- Fix issue with socket creating and bind latency for DHCP.
- Add support for DHCP Vendor Class ID configuration setting.
- Add support for configuration for service online check handling.
- Add support for additional 802.1X certificate options.
- Add support for automatically detecting root NFS.
- Add support for nftables based firewalls.
- Add support for new Wireless Daemon (iwd).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).