### PR TITLE
Fix meta priority types

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -45,7 +45,7 @@ rec {
   /* Decrease the nix-env priority of the package, i.e., other
      versions/variants of the package will be preferred.
   */
-  lowPrio = drv: addMetaAttrs { priority = "10"; } drv;
+  lowPrio = drv: addMetaAttrs { priority = 10; } drv;
 
 
   /* Apply lowPrio to an attrset with derivations
@@ -56,7 +56,7 @@ rec {
   /* Increase the nix-env priority of the package, i.e., this
      version/variant of the package will be preferred.
   */
-  hiPrio = drv: addMetaAttrs { priority = "-10"; } drv;
+  hiPrio = drv: addMetaAttrs { priority = -10; } drv;
 
 
   /* Apply hiPrio to an attrset with derivations

--- a/pkgs/applications/science/biology/ncbi-tools/default.nix
+++ b/pkgs/applications/science/biology/ncbi-tools/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     longDescription = ''The NCBI Bioinformatics toolsbox, including command-line utilties, libraries and include files. No X11 support'';
     homepage = http://www.ncbi.nlm.nih.gov/IEB/ToolBox/; 
     license = "GPL";
-    priority = "5";   # zlib.so gives a conflict with zlib
+    priority = 5;   # zlib.so gives a conflict with zlib
     broken = true;
   };
 }

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -236,7 +236,7 @@ let
 
       checkMetaAttr = k: v:
         if metaTypes?${k} then
-          if metaTypes.${k}.check v then null else "key '${k}' has a value of an invalid type; expected ${metaTypes.${k}.description}"
+          if metaTypes.${k}.check v then null else "key '${k}' has a value ${v} of an invalid type ${builtins.typeOf v}; expected ${metaTypes.${k}.description}"
         else "key '${k}' is unrecognized; expected one of: \n\t      [${lib.concatMapStringsSep ", " (x: "'${x}'") (lib.attrNames metaTypes)}]";
       checkMeta = meta: if shouldCheckMeta then lib.remove null (lib.mapAttrsToList checkMetaAttr meta) else [];
 


### PR DESCRIPTION
###### Motivation for this change

See commit messages, I saw broken package evaluation after 90b9719f4fc95e54400a66bffcc8044c568cfa4b.

cc @copumpkin 
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

