### PR TITLE
libsmi: init at 0.5.0

### DIFF
--- a/pkgs/development/libraries/libsmi/default.nix
+++ b/pkgs/development/libraries/libsmi/default.nix
@@ -10,7 +10,9 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    desc = "A Library to Access SMI MIB Information";
+    description = "A Library to Access SMI MIB Information";
+    homepage = "https://www.ibr.cs.tu-bs.de/projects/libsmi/index.html";
+    license = licenses.free;
     platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
   };
 }

--- a/pkgs/tools/misc/libsmi/default.nix
+++ b/pkgs/tools/misc/libsmi/default.nix
@@ -1,0 +1,16 @@
+{ stdenv , fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "libsmi-${version}";
+  version = "0.5.0";
+
+  src = fetchurl {
+    url = "https://www.ibr.cs.tu-bs.de/projects/libsmi/download/${name}.tar.gz";
+    sha256 = "1lslaxr2qcj6hf4naq5n5mparfhmswsgq4wa7zm2icqvvgdcq6pj";
+  };
+
+  meta = with stdenv.lib; {
+    desc = "A Library to Access SMI MIB Information";
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2578,6 +2578,8 @@ with pkgs;
 
   libcpuid = callPackage ../tools/misc/libcpuid { };
 
+  libsmi = callPackage ../tools/misc/libsmi { };
+
   lesspipe = callPackage ../tools/misc/lesspipe { };
 
   liquidsoap = callPackage ../tools/audio/liquidsoap/full.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2578,7 +2578,7 @@ with pkgs;
 
   libcpuid = callPackage ../tools/misc/libcpuid { };
 
-  libsmi = callPackage ../tools/misc/libsmi { };
+  libsmi = callPackage ../development/libraries/libsmi { };
 
   lesspipe = callPackage ../tools/misc/lesspipe { };
 


### PR DESCRIPTION
###### Motivation for this change

Add libsmi

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

