### PR TITLE
far2l: add .desktop file

### DIFF
--- a/pkgs/applications/misc/far2l/default.nix
+++ b/pkgs/applications/misc/far2l/default.nix
@@ -1,19 +1,19 @@
 { stdenv, fetchFromGitHub, makeWrapper, cmake, pkgconfig, wxGTK30, glib, pcre, m4, bash,
-  xdg_utils, xterm, gvfs, zip, unzip, gzip, bzip2, gnutar, p7zip, xz }:
+  xdg_utils, xterm, gvfs, zip, unzip, gzip, bzip2, gnutar, p7zip, xz, imagemagick }:
 
 stdenv.mkDerivation rec {
-  rev = "c2f2b89db31b1c3cb9bed53267873f4cd7bc996d";
-  build = "2017-03-18-${builtins.substring 0 10 rev}";
+  rev = "94b09a84db803a2e7071094e7fa776948c6a64f2";
+  build = "2017-04-05-${builtins.substring 0 10 rev}";
   name = "far2l-2.1.${build}";
 
   src = fetchFromGitHub {
     owner = "elfmz";
     repo = "far2l";
     rev = rev;
-    sha256 = "1172ajg4n8g4ag14b6nb9lclwh2r6v7ccndmvhnj066w35ixnqgb";
+    sha256 = "05yaynwn88m1vv15ww50rasjwhcrfgkha4z51qmm2v06638kbxhl";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig m4 makeWrapper ];
+  nativeBuildInputs = [ cmake pkgconfig m4 makeWrapper imagemagick ];
 
   buildInputs = [ wxGTK30 glib pcre ];
 
@@ -41,12 +41,20 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/{bin,share}
-    rm install/{far2l_askpass,far2l_sudoapp}
-    mv install/far2l $out/bin/far2l
-    mv install $out/share/far2l
-    ln -s -r $out/bin/far2l $out/share/far2l/far2l_askpass
-    ln -s -r $out/bin/far2l $out/share/far2l/far2l_sudoapp
+    mkdir -p $out/bin $out/share/applications $out/share/icons/hicolor/scalable/apps
+    cp -dpR install $out/share/far2l
+    mv $out/share/far2l/far2l $out/bin/
+    ln -s -r --force $out/bin/far2l $out/share/far2l/far2l_askpass
+    ln -s -r --force $out/bin/far2l $out/share/far2l/far2l_sudoapp
+
+    sed "s,/usr/bin/,$out/bin/," ../far2l/DE/far2l.desktop > $out/share/applications/far2l.desktop
+
+    cp ../far2l/DE/icons/hicolor/1024x1024/apps/far2l.svg $out/share/icons/hicolor/scalable/apps/
+    convert -size 128x128 ../far2l/DE/icons/far2l.svg $out/share/icons/far2l.png
+    for size in 16x16 24x24 32x32 48x48 64x64 72x72 96x96 128x128 192x192 256x256 512x512 1024x1024; do
+      mkdir -p $out/share/icons/hicolor/$size/apps
+      convert -size $size ../far2l/DE/icons/hicolor/$size/apps/far2l.svg $out/share/icons/hicolor/$size/apps/far2l.png
+    done
   '';
 
   stripDebugList = "bin share";

--- a/pkgs/applications/misc/far2l/default.nix
+++ b/pkgs/applications/misc/far2l/default.nix
@@ -2,15 +2,15 @@
   xdg_utils, gvfs, zip, unzip, gzip, bzip2, gnutar, p7zip, xz, imagemagick }:
 
 stdenv.mkDerivation rec {
-  rev = "94b09a84db803a2e7071094e7fa776948c6a64f2";
-  build = "2017-04-05-${builtins.substring 0 10 rev}";
+  rev = "ab240373f69824c56e9255d452b689cff3b1ecfb";
+  build = "2017-05-09-${builtins.substring 0 10 rev}";
   name = "far2l-2.1.${build}";
 
   src = fetchFromGitHub {
     owner = "elfmz";
     repo = "far2l";
     rev = rev;
-    sha256 = "05yaynwn88m1vv15ww50rasjwhcrfgkha4z51qmm2v06638kbxhl";
+    sha256 = "1b6w6xhja3xkfzhrdy8a8qpbhxws75khm1zhwz8sc8la9ykd541q";
   };
 
   nativeBuildInputs = [ cmake pkgconfig m4 makeWrapper imagemagick ];

--- a/pkgs/applications/misc/far2l/default.nix
+++ b/pkgs/applications/misc/far2l/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, makeWrapper, cmake, pkgconfig, wxGTK30, glib, pcre, m4, bash,
-  xdg_utils, xterm, gvfs, zip, unzip, gzip, bzip2, gnutar, p7zip, xz, imagemagick }:
+  xdg_utils, gvfs, zip, unzip, gzip, bzip2, gnutar, p7zip, xz, imagemagick }:
 
 stdenv.mkDerivation rec {
   rev = "94b09a84db803a2e7071094e7fa776948c6a64f2";
@@ -23,8 +23,7 @@ stdenv.mkDerivation rec {
     substituteInPlace far2l/bootstrap/open.sh              \
       --replace 'gvfs-trash'  '${gvfs}/bin/gvfs-trash'
     substituteInPlace far2l/bootstrap/open.sh              \
-      --replace 'xdg-open'    '${xdg_utils}/bin/xdg-open'  \
-      --replace 'xterm'       '${xterm}/bin/xterm'
+      --replace 'xdg-open'    '${xdg_utils}/bin/xdg-open'
     substituteInPlace far2l/vtcompletor.cpp                \
       --replace '"/bin/bash"' '"${bash}/bin/bash"'
     substituteInPlace multiarc/src/formats/zip/zip.cpp     \


### PR DESCRIPTION
###### Motivation for this change

Add .desktop file and icons.
removed unnecessary dependency on ```xterm```.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

