### PR TITLE
cmst: 2016.10.03 -> 2017.03.18

### DIFF
--- a/pkgs/tools/networking/cmst/default.nix
+++ b/pkgs/tools/networking/cmst/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "cmst-${version}";
-  version = "2016.10.03";
+  version = "2017.03.18";
 
   src = fetchFromGitHub {
     repo = "cmst";
     owner = "andrew-bibb";
     rev = name;
-    sha256 = "1pvk1jg0fiw0j4f1wrnhgirgziliwa44sxfdmcq9ans4zbig4izh";
+    sha256 = "0lsg8ya36df48ij0jawgli3f63hy6mn9zcla48whb1l4r7cih545";
   };
 
   nativeBuildInputs = [ makeWrapper qmakeHook ];


### PR DESCRIPTION
###### Motivation for this change

Update to the [March 2017 Release](https://github.com/andrew-bibb/cmst/releases/tag/cmst-2017.03.18)

*A few small enhancements and bug fixes:*

- Added Keywords to .desktop files.
- Fixed missing send destination in dbus policy file.
- Fixed segfault where system tray icon could be used uninitialized.
- Disable vpn tab and vpn icon menu if we cannot connect to the connman-vpn daemon.
- Notifications use system theme icons if available.
- New local icon for wifi tab (wifi_tab_state_not_ready).
- Modify cmst.pro for Fedora build.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).