### PR TITLE
draftsight: init at 2017-SP1

### DIFF
--- a/pkgs/applications/graphics/draftsight/default.nix
+++ b/pkgs/applications/graphics/draftsight/default.nix
@@ -1,0 +1,76 @@
+{ stdenv, requireFile, dpkg, makeWrapper, gcc, mesa, xdg_utils,
+  dbus_tools, alsaLib, cups, fontconfig, glib, icu, libpng12,
+  xkeyboard_config, gstreamer, zlib, libxslt, libxml2, sqlite, orc,
+  libX11, libXcursor, libXrandr, libxcb, libXi, libSM, libICE,
+  libXrender, libXcomposite }:
+
+assert stdenv.system == "x86_64-linux";
+
+let version = "2017-SP1"; in
+stdenv.mkDerivation {
+  name = "draftsight-${version}";
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  unpackPhase = ''
+    mkdir $out
+    mkdir $out/draftsight
+    dpkg -x $src $out/draftsight
+  '';
+
+  # Both executables and bundled libraries need patching to find their
+  # dependencies.  The makeWrapper & QT_XKB_CONFIG_ROOT is to
+  # alleviate "xkbcommon: ERROR: failed to add default include path
+  # /usr/share/X11/xkb" and "Qt: Failed to create XKB context!".
+  installPhase = ''
+    mkdir $out/bin
+    for exe in DraftSight dsHttpApiController dsHttpApiService FxCrashRptApp HelpGuide; do
+      echo "Patching $exe..."
+      patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+               --set-rpath $libPath:\$ORIGIN/../Libraries \
+               $out/draftsight/opt/dassault-systemes/DraftSight/Linux/$exe
+      makeWrapper $out/draftsight/opt/dassault-systemes/DraftSight/Linux/$exe \
+          $out/bin/$exe \
+          --prefix "QT_XKB_CONFIG_ROOT" ":" "${xkeyboard_config}/share/X11/xkb"
+    done
+    for lib in $out/draftsight/opt/dassault-systemes/DraftSight/Libraries/*.so; do
+      # DraftSight ships with broken symlinks for some reason
+      if [ -f $(readlink -f $lib) ]
+      then
+        echo "Patching $lib..."
+        patchelf --set-rpath $libPath:\$ORIGIN/../Libraries $lib
+      else
+        echo "Ignoring broken link $lib"
+      fi
+    done
+  '';
+
+  # TODO: Figure out why HelpGuide segfaults at startup.
+
+  # This must be here for main window graphics to appear (without it
+  # it also gives the error: "QXcbIntegration: Cannot create platform
+  # OpenGL context, neither GLX nor EGL are enabled"). My guess is
+  # that it dlopen()'s libraries in paths removed by shrinking RPATH.
+  dontPatchELF = true;
+
+  src = requireFile {
+    name = "draftSight.deb";
+    url = "https://www.3ds.com/?eID=3ds_brand_download&uid=41&pidDown=13426&L=0";
+    sha256 = "0s7b74685r0961kd59hxpdp9s5yhvzx8307imsxm66f99s8rswdv";
+  };
+
+  libPath = stdenv.lib.makeLibraryPath [ gcc.cc mesa xdg_utils
+    dbus_tools alsaLib cups.lib fontconfig glib icu libpng12
+    xkeyboard_config gstreamer zlib libxslt libxml2 sqlite orc libX11
+    libXcursor libXrandr libxcb libXi libSM libICE libXrender
+    libXcomposite ];
+
+  meta = with stdenv.lib; {
+    description = "2D design & drafting application, meant to be similar to AutoCAD";
+    longDescription = "Professional-grade 2D design and drafting solution from Dassault Systèmes that lets you create, edit, view and mark up any kind of 2D CAD drawing.";
+    homepage = https://www.3ds.com/products-services/draftsight-cad-software/;
+    license = stdenv.lib.licenses.unfree;
+    maintainers = with maintainers; [ hodapp ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13385,6 +13385,8 @@ with pkgs;
 
   doodle = callPackage ../applications/search/doodle { };
 
+  draftsight = callPackage ../applications/graphics/draftsight { };
+  
   droopy = callPackage ../applications/networking/droopy {
     inherit (python3Packages) wrapPython;
   };


### PR DESCRIPTION
###### Motivation for this change

I'm unaware of any other decent-quality CAD package in Nixpkgs. This adds a package for DraftSight, "a professional-grade 2D design and drafting solution that lets you create, edit, view and markup any kind of 2D drawing." from Dassault Systèmes that is basically a clone of AutoCAD.

It is available as a binary .deb package for Linux. This package jumps through the necessary hoops to make it run properly.

I know `requireFile` is frowned upon, but I don't know what else to do here. The package is ~500 MB and is available through clicking the license agreement, and while I could probably determine the actual URL and hotlink to it, that would involve bypassing the license agreement.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS _(N/A, package is Linux-only)_
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
  - `HelpGuide` segfaults at startup; this needs resolving. The main binary `DraftSight` runs, and the associated ones (like the crash reporter) appear to.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

