### PR TITLE
camlp5: fix install with ocaml 4.04

### DIFF
--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation {
 
   postInstall = "cp ${metafile} $out/lib/ocaml/${ocaml.version}/site-lib/camlp5/META";
 
+  dontStrip = true;
+
   meta = with stdenv.lib; {
     description = "Preprocessor-pretty-printer for OCaml";
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change

As reported in #25367, camlp5 doesn't work with `ocamlPackages_latest`.
I managed, with the help of the author of the software, to track down the problem to the shrink phase, during installation. The problem was that bytecode executables were stripped.

This commit fixes the problem but there might be a bigger issue that bytecode executables are not detected as such and thus incorrectly stripped. So maybe a better fix is possible.

Maybe some OCaml expert can help here (cc @vbgl).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

