### PR TITLE
connman-gtk: init at 1.1.1

### DIFF
--- a/pkgs/tools/networking/connman-gtk/default.nix
+++ b/pkgs/tools/networking/connman-gtk/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, intltool, pkgconfig,
+gtk3, connman, openconnect, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "connman-gtk-${version}";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "jgke";
+    repo = "connman-gtk";
+    rev = "v${version}";
+    sha256 = "09k0hx5hxpbykvslv12l2fq9pxdwpd311mxj038hbqzjghcyidyr";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    intltool
+    pkgconfig
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    openconnect
+    connman
+  ];
+
+  preConfigure = ''
+    # m4/intltool.m4 is an invalid symbolic link
+    rm m4/intltool.m4
+    ln -s ${intltool}/share/aclocal/intltool.m4 m4/
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GTK GUI for Connman";
+    homepage = https://github.com/jgke/connman-gtk;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1259,6 +1259,8 @@ with pkgs;
 
   connman = callPackage ../tools/networking/connman { };
 
+  connman-gtk = callPackage ../tools/networking/connman-gtk { };
+
   connman-notify = callPackage ../tools/networking/connman-notify { };
 
   connmanui = callPackage ../tools/networking/connmanui { };


### PR DESCRIPTION
###### Motivation for this change

A GTK+ client for connman.

https://github.com/jgke/connman-gtk

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).