### PR TITLE
xsv: fixup

### DIFF
--- a/pkgs/tools/text/xsv/default.nix
+++ b/pkgs/tools/text/xsv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper }:
+{ stdenv, fetchFromGitHub, rustPlatform }:
 
 with rustPlatform;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4708,7 +4708,7 @@ with pkgs;
 
   xsel = callPackage ../tools/misc/xsel { };
 
-  xsv = callPackages ../tools/text/xsv { };
+  xsv = callPackage ../tools/text/xsv { };
 
   xtreemfs = callPackage ../tools/filesystems/xtreemfs {};
 


### PR DESCRIPTION
###### Motivation for this change

Without this there's an eval error, when running ```nix-env -f '<nixpkgs>' --query --available --json```.

```
derivation ‘xsv-0.11.0’ has invalid meta attribute ‘override’
derivation ‘xsv-0.11.0’ has invalid meta attribute ‘overrideDerivation’
```
