### PR TITLE
jing-trang: supports all unix

### DIFF
--- a/pkgs/tools/text/xml/jing-trang/default.nix
+++ b/pkgs/tools/text/xml/jing-trang/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     # The homepage is www.thaiopensource.com, but it links to googlecode.com
     # for downloads and call it the "project site".
     homepage = http://www.thaiopensource.com/relaxng/jing.html;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This is needed to build the manual on macOS.

