### PR TITLE
mb2md: init at 3.20

### DIFF
--- a/pkgs/tools/text/mb2md/default.nix
+++ b/pkgs/tools/text/mb2md/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, fetchurl, perl, makeWrapper, perlPackages }:
+
+let
+  perlDeps = with perlPackages; [ TimeDate ];
+in
+stdenv.mkDerivation rec {
+  version = "3.20";
+  name = "mb2md-${version}";
+
+  src = fetchurl {
+    url = "http://batleth.sapienti-sat.org/projects/mb2md/mb2md-${version}.pl.gz";
+    sha256 = "0bvkky3c90738h3skd2f1b2yy5xzhl25cbh9w2dy97rs86ssjidg";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ perl ];
+
+  unpackPhase = ''
+    sourceRoot=.
+    gzip -d < $src > mb2md.pl
+  '';
+
+  installPhase = ''
+    install -D $sourceRoot/mb2md.pl $out/bin/mb2md
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/mb2md \
+      --set PERL5LIB "${lib.makePerlPath perlDeps}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "mbox to maildir tool";
+    license = licenses.publicDomain;
+    platforms = platforms.all;
+    maintainers = [ maintainers.jb55 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2919,6 +2919,8 @@ with pkgs;
 
   mawk = callPackage ../tools/text/mawk { };
 
+  mb2md = callPackage ../tools/text/mb2md { };
+
   mbox = callPackage ../tools/security/mbox { };
 
   mbuffer = callPackage ../tools/misc/mbuffer { };


### PR DESCRIPTION
###### Motivation for this change

mbox to maildir tool

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

