### PR TITLE
csound: add liblo to buildinputs to enable osc capabilities

### DIFF
--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -2,6 +2,7 @@
 , alsaLib ? null
 , libpulseaudio ? null
 , tcltk ? null
+, liblo ? null
 
 # maybe csound can be compiled with support for those, see configure output
 # , ladspa ? null
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake flex bison ];
-  buildInputs = [ libsndfile alsaLib libpulseaudio tcltk boost ];
+  buildInputs = [ libsndfile alsaLib libpulseaudio tcltk boost liblo ];
 
   meta = with stdenv.lib; {
     description = "Sound design, audio synthesis, and signal processing system, providing facilities for music composition and performance on all major operating systems and platforms";


### PR DESCRIPTION
###### Motivation for this change
We probably wanna have OSC support in csound on nixos, this will enable it.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

