### PR TITLE
kubernetes-helm: 2.2.3 -> 2.3.1

### DIFF
--- a/pkgs/applications/networking/cluster/helm/default.nix
+++ b/pkgs/applications/networking/cluster/helm/default.nix
@@ -4,12 +4,12 @@ let
          then "linux-amd64"
          else "darwin-amd64";
   checksum = if stdenv.isLinux
-             then "fa434644d1afd92637369a033fd65b717d8dfa910127d335e8a82c8fad74cc35"
-             else "64420d467e03ceb666a4f22b89e08b93c06f76f5917fe539860b04cd5e5e515f";
+             then "17fya0d1v2w44df5n5xb99vr8qjbnbfjvicsi9p7yz4iz2mcymd6"
+             else "0299ffws37d60wim8kvdp4xrvqxa93sggrprgrsiclcp8bab0dcr";
 in
 stdenv.mkDerivation rec {
   pname = "helm";
-  version = "2.2.3";
+  version = "2.3.1";
   name = "${pname}-${version}";
 
   src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
New version

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

