### PR TITLE
corebird: 1.4.2 -> 1.5

### DIFF
--- a/pkgs/applications/networking/corebird/default.nix
+++ b/pkgs/applications/networking/corebird/default.nix
@@ -3,14 +3,14 @@
 , glib_networking }:
 
 stdenv.mkDerivation rec {
-  version = "1.4.2";
+  version = "1.5";
   name = "corebird-${version}";
 
   src = fetchFromGitHub {
     owner = "baedert";
     repo = "corebird";
     rev = version;
-    sha256 = "0s28q9c7p4p4jyhb1g6gdwdphlf6yhi6yg4yn8bkd0gmyf9acakb";
+    sha256 = "0nll3ns1riylxg33w6myz5x8h6ai39k5fw2bkf96g5rgmi6zsjma";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

Version update

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

