### PR TITLE
tomb: 2.2 -> 2.4

### DIFF
--- a/pkgs/os-specific/linux/tomb/default.nix
+++ b/pkgs/os-specific/linux/tomb/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, zsh, pinentry, cryptsetup, gnupg1orig, makeWrapper }:
 
 let
-    version = "2.2";
+    version = "2.4";
 in
 
 stdenv.mkDerivation rec {
   name = "tomb-${version}";
 
   src = fetchurl {
-    url = "https://files.dyne.org/tomb/tomb-${version}.tar.gz";
-    sha256 = "11msj38fdmymiqcmwq1883kjqi5zr01ybdjj58rfjjrw4zw2w5y0";
+    url = "https://files.dyne.org/tomb/Tomb-${version}.tar.gz";
+    sha256 = "1hv1w79as7swqj0n137vz8n8mwvcgwlvd91sdyssz41jarg7f1vr";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Version bump.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

