### PR TITLE
treewide: meta.platform -> meta.platforms

### DIFF
--- a/pkgs/applications/misc/urh/default.nix
+++ b/pkgs/applications/misc/urh/default.nix
@@ -22,7 +22,7 @@ python3Packages.buildPythonApplication rec {
     inherit (src.meta) homepage;
     description = "Universal Radio Hacker: investigate wireless protocols like a boss";
     license = licenses.asl20;
-    platform = platforms.all;
+    platforms = platforms.all;
     maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/applications/networking/feedreaders/rawdog/default.nix
+++ b/pkgs/applications/networking/feedreaders/rawdog/default.nix
@@ -12,12 +12,12 @@ python2Packages.buildPythonApplication rec {
   propagatedBuildInputs = with python2Packages; [ feedparser ];
 
   namePrefix = "";
-  
+
   meta = with stdenv.lib; {
     homepage = "http://offog.org/code/rawdog/";
     description = "RSS Aggregator Without Delusions Of Grandeur";
     license = licenses.gpl2;
-    platform = platforms.unix;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ nckx ];
   };
 }

--- a/pkgs/applications/networking/irc/qweechat/default.nix
+++ b/pkgs/applications/networking/irc/qweechat/default.nix
@@ -26,6 +26,6 @@ python27Packages.buildPythonApplication rec {
     description = "Qt remote GUI for WeeChat";
     license = licenses.gpl3;
     maintainers = with maintainers; [ ramkromberg ];
-    platform = with platforms; linux;
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/development/python-modules/pyroute2/default.nix
+++ b/pkgs/development/python-modules/pyroute2/default.nix
@@ -16,6 +16,6 @@ buildPythonPackage rec {
     homepage = https://github.com/svinota/pyroute2;
     license = licenses.asl20;
     maintainers = [maintainers.mic92];
-    platform = platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/radicale/default.nix
+++ b/pkgs/servers/radicale/default.nix
@@ -28,7 +28,7 @@ pythonPackages.buildPythonApplication rec {
       on mobile phones or computers.
     '';
     license = licenses.gpl3Plus;
-    platform = platforms.all;
+    platforms = platforms.all;
     maintainers = with maintainers; [ edwtjo pSub aneeshusa ];
   };
 }

--- a/pkgs/tools/networking/fakeroute/default.nix
+++ b/pkgs/tools/networking/fakeroute/default.nix
@@ -16,6 +16,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://moxie.org/software/fakeroute/;
     license = licenses.bsd3;
-    platform = platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/security/encryptr/default.nix
+++ b/pkgs/tools/security/encryptr/default.nix
@@ -52,6 +52,6 @@ in stdenv.mkDerivation rec {
     description = "Free, private and secure password management tool and e-wallet";
     license = licenses.unfree;
     maintainers = with maintainers; [ guillaumekoenig ];
-    platform = platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/text/grin/default.nix
+++ b/pkgs/tools/text/grin/default.nix
@@ -15,7 +15,7 @@ python2Packages.buildPythonApplication rec {
   meta = {
     homepage = https://pypi.python.org/pypi/grin;
     description = "A grep program configured the way I like it";
-    platform = stdenv.lib.platforms.all;
+    platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.sjagoe ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Another follow-up after 90b9719f4fc95e54400a66bffcc8044c568cfa4b;
`radicale` broke for me so I fixed this up treewide.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).