### PR TITLE
kicad: 4.0.2 -> 4.0.6

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, fetchurl, fetchbzr, cmake, mesa, wxGTK, zlib, libX11, gettext, glew, cairo, openssl, boost, pkgconfig, doxygen }:
+{ stdenv, fetchurl, fetchbzr, cmake, mesa, wxGTK30, zlib, libX11, gettext, glew, cairo, curl, openssl, boost160, pkgconfig, doxygen }:
 
 stdenv.mkDerivation rec {
   name = "kicad-${series}";
   series = "4.0";
-  version = "4.0.2";
+  version = "4.0.6";
 
   srcs = [
     (fetchurl {
       url = "https://code.launchpad.net/kicad/${series}/${version}/+download/kicad-${version}.tar.xz";
-      sha256 = "1fcf91fmxj6ha3mm6gzdb0px50j58m80p8wrncm8ca9shj36kbif";
+      sha256 = "1612lkr1p5sii2c4q8zdm6m4kmdylcq8hkd1mzr6b7l3g70sqz79";
     })
 
     (fetchurl {
       url = "http://downloads.kicad-pcb.org/libraries/kicad-library-${version}.tar.gz";
-      sha256 = "1xk9sxxb3d42chdysqmvizrjcbm0467q7nsq5cahq3j1hci49m6l";
+      sha256 = "16f47pd6f0ddsdxdrp327nr9v05gl8c24d0qypq2aqx5hdjmkp7f";
     })
 
     (fetchurl {
       url = "http://downloads.kicad-pcb.org/libraries/kicad-footprints-${version}.tar.gz";
-      sha256 = "0vrzykgxx423iwgz6186bi8724kmbi5wfl92gfwb3r6mqammgwpg";
+      sha256 = "0vmgqhdw05k5fdnqv42grnvlz7v75g9md82jp2d3dvw2zw050lfb";
     })
   ];
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true; # often fails on Hydra: fatal error: pcb_plot_params_lexer.h: No such file or directory
 
-  buildInputs = [ cmake mesa wxGTK zlib libX11 gettext glew cairo openssl boost pkgconfig doxygen ];
+  buildInputs = [ cmake mesa wxGTK30 zlib libX11 gettext glew cairo curl openssl boost160 pkgconfig doxygen ];
 
   # They say they only support installs to /usr or /usr/local,
   # so we have to handle this.

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchbzr, cmake, mesa, wxGTK30, zlib, libX11, gettext, glew, cairo, curl, openssl, boost160, pkgconfig, doxygen }:
+{ stdenv, fetchurl, fetchbzr, cmake, mesa, wxGTK, zlib, libX11, gettext, glew, cairo, curl, openssl, boost, pkgconfig, doxygen }:
 
 stdenv.mkDerivation rec {
   name = "kicad-${series}";
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true; # often fails on Hydra: fatal error: pcb_plot_params_lexer.h: No such file or directory
 
-  buildInputs = [ cmake mesa wxGTK30 zlib libX11 gettext glew cairo curl openssl boost160 pkgconfig doxygen ];
+  buildInputs = [ cmake mesa wxGTK zlib libX11 gettext glew cairo curl openssl boost pkgconfig doxygen ];
 
   # They say they only support installs to /usr or /usr/local,
   # so we have to handle this.


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

