### PR TITLE
Update terragrunt to latest release 0.12.5

### DIFF
--- a/pkgs/applications/networking/cluster/terragrunt/0.11.1.nix
+++ b/pkgs/applications/networking/cluster/terragrunt/0.11.1.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, terraform, makeWrapper }:
+
+buildGoPackage rec {
+  name = "terragrunt-${version}";
+  version = "0.11.1";
+
+  goPackagePath = "github.com/gruntwork-io/terragrunt";
+
+  src = fetchFromGitHub {
+    rev    = "v${version}";
+    owner  = "gruntwork-io";
+    repo   = "terragrunt";
+    sha256 = "061ix4m64i8bvjpqm6hn83nnkvqrp5y0hh5gzmxiik2nz3by1rx5";
+  };
+
+  goDeps = ./deps.nix;
+
+  buildInputs = [ makeWrapper ];
+
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-X main.VERSION=v${version}")
+  '';
+
+  postInstall = ''
+    wrapProgram $bin/bin/terragrunt \
+      --set TERRAGRUNT_TFPATH ${lib.getBin terraform}/bin/terraform
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A thin wrapper for Terraform that supports locking for Terraform state and enforces best practices.";
+    homepage = https://github.com/gruntwork-io/terragrunt/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/applications/networking/cluster/terragrunt/default.nix
+++ b/pkgs/applications/networking/cluster/terragrunt/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "terragrunt-${version}";
-  version = "0.11.1";
+  version = "0.12.15";
 
   goPackagePath = "github.com/gruntwork-io/terragrunt";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     rev    = "v${version}";
     owner  = "gruntwork-io";
     repo   = "terragrunt";
-    sha256 = "061ix4m64i8bvjpqm6hn83nnkvqrp5y0hh5gzmxiik2nz3by1rx5";
+    sha256 = "1khmxqzhhkr6km4zfn0q3zm55wgc92hrayvqkf9snzr816c1qzp3";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18390,6 +18390,10 @@ with pkgs;
     terraform = terraform;
   };
 
+  terragrunt_0_11_1 = callPackage ../applications/networking/cluster/terragrunt/0.11.1.nix {
+    terraform = terraform_0_8;
+  };
+
   terragrunt_0_9_8 = callPackage ../applications/networking/cluster/terragrunt/0.9.8.nix {
     terraform = terraform_0_8_5;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18387,7 +18387,7 @@ with pkgs;
   terraform = terraform_0_9;
 
   terragrunt = callPackage ../applications/networking/cluster/terragrunt {
-    terraform = terraform_0_8;
+    terraform = terraform;
   };
 
   terragrunt_0_9_8 = callPackage ../applications/networking/cluster/terragrunt/0.9.8.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18386,9 +18386,7 @@ with pkgs;
   terraform_0_9 = terraform_0_9_4;
   terraform = terraform_0_9;
 
-  terragrunt = callPackage ../applications/networking/cluster/terragrunt {
-    terraform = terraform;
-  };
+  terragrunt = callPackage ../applications/networking/cluster/terragrunt {};
 
   terragrunt_0_11_1 = callPackage ../applications/networking/cluster/terragrunt/0.11.1.nix {
     terraform = terraform_0_8;


### PR DESCRIPTION
This updates the terragrunt version, sets its sha256 sum and sets a dependency
on the latest Terraform 0.9.4

This is still a WIP with @shlevy 

###### Motivation for this change

Terraform 0.8 has some broken stuff with respect to modules, to use terragrunt with 0.9.x, you've got to update to the bleeding edge latest release.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
