### PR TITLE
lib.{or,and} -> lib.{bor,band}

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -2,7 +2,7 @@
 
 let
   inherit (builtins) head tail length;
-  inherit (import ./trivial.nix) and or;
+  inherit (import ./trivial.nix) band bor;
   inherit (import ./default.nix) fold;
   inherit (import ./strings.nix) concatStringsSep;
   inherit (import ./lists.nix) concatMap concatLists all deepSeqList;
@@ -422,7 +422,7 @@ rec {
        => true
    */
   matchAttrs = pattern: attrs: assert isAttrs pattern;
-    fold and true (attrValues (zipAttrsWithNames (attrNames pattern) (n: values:
+    fold band true (attrValues (zipAttrsWithNames (attrNames pattern) (n: values:
       let pat = head values; val = head (tail values); in
       if length values == 1 then false
       else if isAttrs pat then isAttrs val && matchAttrs pat val

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -54,7 +54,7 @@ rec {
     else if all isFunction list then x: mergeDefaultOption loc (map (f: f x) list)
     else if all isList list then concatLists list
     else if all isAttrs list then foldl' lib.mergeAttrs {} list
-    else if all isBool list then foldl' lib.or false list
+    else if all isBool list then foldl' lib.bor false list
     else if all isString list then lib.concatStrings list
     else if all isInt list && all (x: x == head list) list then head list
     else throw "Cannot merge definitions of `${showOption loc}' given in ${showFiles (getFiles defs)}.";

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -16,15 +16,13 @@ runTests {
     expected = 2;
   };
 
-  /*
   testOr = {
-    expr = or true false;
+    expr = bor true false;
     expected = true;
   };
-  */
 
   testAnd = {
-    expr = and true false;
+    expr = band true false;
     expected = false;
   };
 

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -25,10 +25,10 @@ rec {
   concat = x: y: x ++ y;
 
   /* boolean “or” */
-  or = x: y: x || y;
+  bor = x: y: x || y;
 
   /* boolean “and” */
-  and = x: y: x && y;
+  band = x: y: x && y;
 
   /* Convert a boolean to a string.
      Note that toString on a bool returns "1" and "".


### PR DESCRIPTION
Using `or` requires a special and hacky case on nix parser (because `or`
is also a keyword), which isn't worth the pain, given that this function
is hardly used in all of nixpkgs.

I can't certify that I replaced every occurence of the `or` and `and` functions
because I couldn't find any better way of tracking them than grep, which in
this case is pretty useless.