### PR TITLE
broadcom-bt-firmware: init at 12.0.1.1011

### DIFF
--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -23,6 +23,7 @@ with lib;
 
   config = mkIf config.hardware.enableAllFirmware {
     hardware.firmware = with pkgs; [
+      broadcom-bt-firmware
       firmwareLinuxNonfree
       intel2200BGFirmware
       rtl8723bs-firmware

--- a/pkgs/os-specific/linux/firmware/broadcom-bt-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/broadcom-bt-firmware/default.nix
@@ -1,5 +1,8 @@
 { stdenv, fetchurl, cabextract, bt-fw-converter }:
 
+# Kernels between 4.2 and 4.7 will not work with
+# this packages as they expect the firmware to be named "BCM.hcd"
+# see: https://github.com/NixOS/nixpkgs/pull/25478#issuecomment-299034865
 stdenv.mkDerivation rec {
   name = "broadcom-bt-firmware-${version}";
   version = "12.0.1.1011";

--- a/pkgs/os-specific/linux/firmware/broadcom-bt-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/broadcom-bt-firmware/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, cabextract, bt-fw-converter }:
+
+stdenv.mkDerivation rec {
+  name = "broadcom-bt-firmware-${version}";
+  version = "12.0.1.1011";
+
+  src = fetchurl {
+    url = "http://download.windowsupdate.com/d/msdownload/update/driver/drvs/2016/11/200033618_94cfea9130b30c04bc602cd3dcc1f9a793fc75bb.cab";
+    sha256 = "6091e49c9d9c71cbe3aed2db3c0d60994ff562804c3b40e1e8bcbb818180987b";
+  };
+
+  nativeBuildInputs = [ cabextract bt-fw-converter ];
+
+  unpackCmd = ''
+    mkdir -p ${name}
+    cabextract $src --directory ${name}
+  '';
+  
+  installPhase = ''
+    mkdir -p $out/lib/firmware/brcm
+    bt-fw-converter -f bcbtums.inf -o $out/lib/firmware/brcm
+    for filename in $out/lib/firmware/brcm/*.hcd
+    do
+      linkname=$(basename $filename | awk 'match($0,/^(BCM)[0-9A-Z]+(-[0-9a-z]{4}-[0-9a-z]{4}\.hcd)$/,c) { print c[1]c[2] }')
+      if ! [ -z $linkname ]
+      then
+        ln -s -T $filename $out/lib/firmware/brcm/$linkname
+      fi
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Firmware for Broadcom WIDCOMM® Bluetooth devices";
+    homepage = http://www.catalog.update.microsoft.com/Search.aspx?q=Broadcom+bluetooth;
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zraexy ];
+  };
+} 

--- a/pkgs/os-specific/linux/firmware/bt-fw-converter/default.nix
+++ b/pkgs/os-specific/linux/firmware/bt-fw-converter/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, makeWrapper, perl, perlPackages, bluez }:
+
+stdenv.mkDerivation  rec {
+  name = "bt-fw-converter-${version}";
+  version = "2017-02-19";
+  rev = "2d8b34402df01c6f7f4b8622de9e8b82fadf4153";
+
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/winterheart/broadcom-bt-firmware/${rev}/tools/bt-fw-converter.pl";
+    sha256 = "c259b414a4a273c89a0fa7159b3ef73d1ea62b6de91c3a7c2fcc832868e39f4b";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ perl perlPackages.RegexpGrammars bluez ];
+
+  unpackCmd = ''
+    mkdir -p ${name}
+    cp $src ${name}/bt-fw-converter.pl
+  '';
+
+  installPhase = ''
+    install -D -m755 bt-fw-converter.pl $out/bin/bt-fw-converter
+    substituteInPlace $out/bin/bt-fw-converter --replace /usr/bin/hex2hcd ${bluez}/bin/hex2hcd
+    wrapProgram $out/bin/bt-fw-converter --set PERL5LIB $PERL5LIB
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/winterheart/broadcom-bt-firmware/;
+    description = "A tool that converts hex to hcd based on inf file";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zraexy ];
+  };
+} 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11352,6 +11352,8 @@ with pkgs;
   b43Firmware_6_30_163_46 = callPackage ../os-specific/linux/firmware/b43-firmware/6.30.163.46.nix { };
 
   b43FirmwareCutter = callPackage ../os-specific/linux/firmware/b43-firmware-cutter { };
+  
+  bt-fw-converter = callPackage ../os-specific/linux/firmware/bt-fw-converter { };
 
   batctl = callPackage ../os-specific/linux/batman-adv/batctl.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11355,6 +11355,8 @@ with pkgs;
   
   bt-fw-converter = callPackage ../os-specific/linux/firmware/bt-fw-converter { };
 
+  broadcom-bt-firmware = callPackage ../os-specific/linux/firmware/broadcom-bt-firmware { };
+
   batctl = callPackage ../os-specific/linux/batman-adv/batctl.nix { };
 
   blktrace = callPackage ../os-specific/linux/blktrace { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11317,6 +11317,19 @@ let self = _self // overrides; _self = with self; {
       sha256 = "09c8xb43p1s6ala6g4274az51mf33phyjkp66dpvgkgbi1xfnawp";
     };
   };
+  
+  RegexpGrammars = buildPerlPackage rec {
+    name = "Regexp-Grammars-1.045";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DC/DCONWAY/${name}.tar.gz";
+      sha256 = "8ab001f5641d03f7acce09ca5826b219b02ce40f8e56c2066737228a9232b594";
+    };
+    meta = {
+      homepage = http://search.cpan.org/~dconway/Regexp-Grammars-1.045/lib/Regexp/Grammars.pm;
+      description = "Add grammatical parsing features to Perl 5.10 regexes";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
 
   RegexpIPv6 = buildPerlPackage {
     name = "Regexp-IPv6-0.03";


### PR DESCRIPTION
###### Motivation for this change

Add Broadcomm's WIDCOMM® bluetooth firmware

`broadcom-bt-firmware` can be renamed if need be. I named it that simply because it contains firmware for multiple devices and `broadcom-bt-firmware` is `bt-fw-converter`'s [repository](https://github.com/winterheart/broadcom-bt-firmware)'s name. (It also amusingly contains the firmware and the license that is being violated by redistributing the firmware.)
Adding `broadcom-bt-firmware` to `NixOS`'s `hardware.firmware` should work all with kernels except `4.4`. Making it work for `4.4` would require moving the firmware for each device into a separate package. in order for the firmware to be loaded it must have the non unique name:`BCM.hcd`.

Fixes #21797

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

