### PR TITLE
openmvg: init at v1.1

### DIFF
--- a/pkgs/applications/science/misc/openmvg/default.nix
+++ b/pkgs/applications/science/misc/openmvg/default.nix
@@ -1,0 +1,50 @@
+{ lib, stdenv, fetchgit, pkgconfig, cmake
+, libjpeg ? null
+, zlib ? null
+, libpng ? null
+, eigen ? null
+, libtiff ? null
+, enableExamples ? false
+, enableDocs ? false }:
+
+stdenv.mkDerivation rec {
+  version = "1.1";
+  name = "openmvg-${version}";
+
+  src = fetchgit {
+    url = "https://www.github.com/openmvg/openmvg.git";
+
+    # Tag v1.1
+    rev = "f5ecb48";
+    sha256 = "1di9i7yxnkdvl8lhflynmqw62gaxwv00r1sd7nzzs9qn63g0af0f";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ libjpeg zlib libpng eigen libtiff ];
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  cmakeFlags = [
+    "-DCMAKE_CXX_FLAGS=-std=c++11"
+    "-DOpenMVG_BUILD_EXAMPLES=${if enableExamples then "ON" else "OFF"}"
+    "-DOpenMVG_BUILD_DOC=${if enableDocs then "ON" else "OFF"}"
+  ];
+
+  cmakeDir = "./src";
+
+  dontUseCmakeBuildDir = true;
+
+  # This can be enabled, but it will exhause virtual memory on most machines.
+  enableParallelBuilding = false;
+
+  # Without hardeningDisable, certain flags are passed to the compile that break the build (primarily string format errors)
+  hardeningDisable = [ "all" ];
+
+  meta = {
+    description = "A library for computer-vision scientists and targeted for the Multiple View Geometry community";
+    homepage = http://openmvg.readthedocs.io/en/latest/;
+    license = stdenv.lib.licenses.mpl20;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ mdaiter ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3301,6 +3301,8 @@ with pkgs;
 
   openjade = callPackage ../tools/text/sgml/openjade { };
 
+  openmvg = callPackage ../applications/science/misc/openmvg { };
+
   openntpd = callPackage ../tools/networking/openntpd { };
 
   openntpd_nixos = openntpd.override {


### PR DESCRIPTION
###### Motivation for this change
Let's add OpenMVG to the NixOS ecosystem!
OpenMVG is a package for performing Structure-from-Motion on sets of images.
Currently, OpenMVG is a hassle to compile on NixOS; therefore, we should make an easy-to-use derivation for compiling this piece of software on NixOS.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

