### PR TITLE
rustRegistry: 2017-04-13 -> 2017-05-03

### DIFF
--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,9 +7,9 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2017-04-13";
-  rev = "5758a926a647716bd650978ad53aeb4a0c5f9b45";
-  sha256 = "1fnwh62k8fbflciv1qg3r9fsqn1xy72flyv15ii3mpja2vqzkdi2";
+  version = "2017-05-03";
+  rev = "dbc41da97da0a504d83af656b5d354ab5cf033e6";
+  sha256 = "1kmy0hr155gcmilvwaj4ak5ppszrympyia7zxwhfihh00mip7xkb";
 
   src = fetchFromGitHub {
       inherit rev;


### PR DESCRIPTION
###### Motivation for this change

Have more packages available.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

