### PR TITLE
gdal: add GeoPDF support via poppler

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, composableDerivation, unzip, libjpeg, libtiff, zlib
 , postgresql, mysql, libgeotiff, pythonPackages, proj, geos, openssl
-, libpng, sqlite, libspatialite
+, libpng, sqlite, libspatialite, poppler
 , libiconv
 , netcdfSupport ? true, netcdf, hdf5 , curl
 }:
@@ -16,7 +16,8 @@ composableDerivation.composableDerivation {} (fixed: rec {
     sha256 = "0jh7filpf5dk5iz5acj7y3y49ihnzqypxckdlj0sjigbqq6hlsmf";
   };
 
-  buildInputs = [ unzip libjpeg libtiff libpng proj openssl sqlite libspatialite ]
+  buildInputs = [ unzip libjpeg libtiff libpng proj openssl sqlite
+    libspatialite poppler ]
   ++ (with pythonPackages; [ python numpy wrapPython ])
   ++ stdenv.lib.optional stdenv.isDarwin libiconv
   ++ stdenv.lib.optionals netcdfSupport [ netcdf hdf5 curl ];
@@ -30,6 +31,7 @@ composableDerivation.composableDerivation {} (fixed: rec {
     "--with-jpeg=${libjpeg.dev}"
     "--with-libtiff=${libtiff.dev}" # optional (without largetiff support)
     "--with-png=${libpng.dev}"      # optional
+    "--with-poppler=${poppler.dev}" # optional
     "--with-libz=${zlib.dev}"       # optional
     "--with-pg=${postgresql}/bin/pg_config"
     "--with-mysql=${mysql.lib.dev}/bin/mysql_config"


### PR DESCRIPTION
###### Motivation for this change

GDAL is unable to load GeoPDF files without having the poppler library available.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

