### PR TITLE
lambda-mod-zsh-theme: 2015-12-15 -> 2017-04-05

### DIFF
--- a/pkgs/shells/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/lambda-mod-zsh-theme/default.nix
@@ -3,8 +3,9 @@
 let
   repo = "lambda-mod-zsh-theme";
   rev = "c6445c79cbc73b85cc18871c216fb28ddc8b3d96";
+  version = "2017-04-05";
 in stdenv.mkDerivation {
-  name = "${repo}-${rev}";
+  name = "${repo}-${version}";
 
   src = fetchFromGitHub {
     inherit rev repo;

--- a/pkgs/shells/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/lambda-mod-zsh-theme/default.nix
@@ -2,7 +2,7 @@
 
 let
   repo = "lambda-mod-zsh-theme";
-  rev = "eceee68cf46bba9f7f42887c2128b48e8861e31b";
+  rev = "c6445c79cbc73b85cc18871c216fb28ddc8b3d96";
 in stdenv.mkDerivation {
   name = "${repo}-${rev}";
 
@@ -10,7 +10,7 @@ in stdenv.mkDerivation {
     inherit rev repo;
 
     owner = "halfo";
-    sha256 = "1410ryc22i20na5ypa1q6f106lkjj8n1qfjmb77q4rspi0ydaiy4";
+    sha256 = "01c77s6fagycin6cpssif56ysbqaa8kiafjn9av12cacakldl84j";
   };
 
   buildPhases = [ "unpackPhase" "installPhase" ];


### PR DESCRIPTION
###### Motivation for this change

A newer version of `lambda-mod-zsh-theme` contains some fixes for several terminals:

- https://github.com/halfo/lambda-mod-zsh-theme/issues/5
- https://github.com/halfo/lambda-mod-zsh-theme/pull/10

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

