### PR TITLE
xen service: Add the possibility to override configuration of xendomains

### DIFF
--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -111,6 +111,19 @@ in
           '';
       };
 
+    virtualisation.xen.domains = {
+        extraConfig = mkOption {
+          type = types.string;
+          default = "";
+          description =
+            ''
+              Options defined here will override the defaults for xendomains.
+              The default options can be seen in the file included from
+              /etc/default/xendomains.
+            '';
+          };
+      };
+
     virtualisation.xen.trace =
       mkOption {
         default = false;
@@ -216,7 +229,11 @@ in
         { source = "${cfg.package}/etc/xen/scripts";
           target = "xen/scripts";
         }
-        { source = "${cfg.package}/etc/default/xendomains";
+        { text = ''
+            source ${cfg.package}/etc/default/xendomains
+
+            ${cfg.domains.extraConfig}
+          '';
           target = "default/xendomains";
         }
       ];


### PR DESCRIPTION
Add the option virtualisation.xen.domain.extraConfig, which
allows overriding options passed to xendomains.

###### Motivation for this change

I found this useful for my own setup, where I wanted to prevent the automatic
saving of VMs on shutdown. This can be done by setting the `XENDOMAINS_SAVE`
environment variable to the empty string in `/etc/default/xendomains`. With this change,
the setting can be configured in `/etc/nix/configuration.nix`.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
