### PR TITLE
desktopManager service: Add wallpaper options

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -32,7 +32,10 @@ in
           default = "scale";
           example = "fill";
           description = ''
-            Wallpaper image mode:
+            The file <filename>~/.background-image</filename> is used as a background image.
+            This option specifies the placement of this image onto your desktop.
+
+            Possible values:
             <literal>center</literal>: Center the image on the background. If it is too small, it will be surrounded by a black border.
             <literal>fill</literal>: Like <literal>scale</literal>, but preserves aspect ratio by zooming the image until it fits. Either a horizontal or a vertical part of the image will be cut off.
             <literal>max</literal>: Like <literal>fill</literal>, but scale the image to the maximum size that fits the screen with black borders on one side.

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -26,6 +26,31 @@ in
 
     services.xserver.desktopManager = {
 
+      wallpaper = {
+        mode = mkOption {
+          type = types.enum [ "center" "fill" "max" "scale" "tile" ];
+          default = "scale";
+          example = "fill";
+          description = ''
+            Wallpaper image mode:
+            <literal>center</literal>: Center the image on the background. If it is too small, it will be surrounded by a black border.
+            <literal>fill</literal>: Like <literal>scale</literal>, but preserves aspect ratio by zooming the image until it fits. Either a horizontal or a vertical part of the image will be cut off.
+            <literal>max</literal>: Like <literal>fill</literal>, but scale the image to the maximum size that fits the screen with black borders on one side.
+            <literal>scale</literal>: Fit the file into the background without repeating it, cutting off stuff or using borders. But the aspect ratio is not preserved either.
+            <literal>tile</literal>: Tile (repeat) the image in case it is too small for the screen.
+          '';
+        };
+
+        combineScreens = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            When set to <literal>true</literal> the wallpaper will stretch across all screens.
+            When set to <literal>false</literal> the wallpaper is duplicated to all screens.
+          '';
+        };
+      };
+
       session = mkOption {
         internal = true;
         default = [];
@@ -45,7 +70,7 @@ in
             start = d.start
             + optionalString (needBGCond d) ''
               if [ -e $HOME/.background-image ]; then
-                ${pkgs.feh}/bin/feh --bg-scale $HOME/.background-image
+                ${pkgs.feh}/bin/feh --bg-${cfg.wallpaper.mode} ${optionalString cfg.wallpaper.combineScreens "--no-xinerama"} $HOME/.background-image
               else
                 # Use a solid black background as fallback
                 ${pkgs.xorg.xsetroot}/bin/xsetroot -solid black


### PR DESCRIPTION
These changes won't affect desktop-managers that have set `bgSupport` to `true`.

###### Motivation for this change
I'd like to have my wallpaper stretch across multiple screens. (I'm not using a desktop manager)

###### Things done
This is why I added the `combineScreens` option.
This makes feh use `--no-xinerama` such that the wallpaper is set in the root-window that stretches across multiple monitors.

I also added a `mode` option for completeness, this provides more control on the image scale method.

I set the default values such that existing configurations wont be affected.

###### Feedback
I'm not sure about the name of the `combineScreens` option.
I'd love to receive feedback on this.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  (this is a module change and produces no binaries.)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
