### PR TITLE
stalonetray: 0.8.1 -> 0.8.3

### DIFF
--- a/pkgs/applications/window-managers/stalonetray/default.nix
+++ b/pkgs/applications/window-managers/stalonetray/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "stalonetray-${version}";
-  version = "0.8.1";
+  version = "0.8.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/stalonetray/${name}.tar.bz2";
-    sha256 = "1wp8pnlv34w7xizj1vivnc3fkwqq4qgb9dbrsg15598iw85gi8ll";
+    sha256 = "0k7xnpdb6dvx25d67v0crlr32cdnzykdsi9j889njiididc8lm1n";
   };
 
   buildInputs = [ libX11 xproto ];
@@ -15,8 +15,10 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Stand alone tray";
-    maintainers = with maintainers; [ raskin ];
+    homepage = http://stalonetray.sourceforge.net;
+    license = licenses.gpl2;
     platforms = platforms.linux;
+    maintainers = with maintainers; [ raskin ];
   };
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

Update to new version.

[Changes](http://stalonetray.sourceforge.net/news.html)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).