### PR TITLE
openshift: copy symlinks into $bin/bin

### DIFF
--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -36,7 +36,7 @@ in buildGoPackage rec {
 
   installPhase = ''
     mkdir -p "$bin/bin"
-    cp "_output/local/bin/$(go env GOOS)/$(go env GOARCH)/"* "$bin/bin/"
+    cp -a "_output/local/bin/$(go env GOOS)/$(go env GOARCH)/"* "$bin/bin/"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixes the size issue mentioned in https://github.com/NixOS/nixpkgs/pull/25369 by @Mic92 and reported from hydra: https://hydra.nixos.org/build/52313947

It brings down the size to around 250 MiB by propery compying symlinks instead of duplicating the binaries.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

