### PR TITLE
Charybdis: Read MOTD files from /etc/charybdis. Add option to configure MOTD.

### DIFF
--- a/pkgs/servers/irc/charybdis/default.nix
+++ b/pkgs/servers/irc/charybdis/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     "--enable-ipv6"
     "--enable-openssl=${openssl.dev}"
     "--with-program-prefix=charybdis-"
+    "--sysconfdir=/etc/charybdis"
   ];
 
   buildInputs = [ bison flex openssl ];


### PR DESCRIPTION
###### Motivation for this change
The current charybdis build hardcodes the path to the MOTD file to the default file produced by the install in the nix store.
Charybdis doesn't have any option to override this path via cmdline flags or ircd.conf entries; this makes it exceedingly hard to configure.
We point this path at /etc/charybdis/ircd.motd instead and add a config option to write this file, for convenient configurability.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

