### PR TITLE
zsh-git-prompt: Init at 0.5

### DIFF
--- a/pkgs/shells/zsh-git-prompt/default.nix
+++ b/pkgs/shells/zsh-git-prompt/default.nix
@@ -1,0 +1,70 @@
+# zsh-git-prompt -- Informative git prompt for zsh
+#
+# Usage: to enable this plugin for all users, you could
+# add it to configuration.nix like this:
+#
+#   programs.zsh.interactiveShellInit = ''
+#     source ${pkgs.zsh-git-prompt}/share/zsh-git-prompt/zshrc.sh
+#   '';
+#
+# Or you can install it globally but only enable it in individual
+# users' ~/.zshrc files:
+#
+#   source /run/current-system/sw/share/zsh-git-prompt/zshrc.sh
+#
+# Or if installed locally:
+#
+#   source ~/.nix-profile/share/zsh-git-prompt/zshrc.sh
+#
+# Either way, you then have to set a prompt that incorporates
+# git_super_status, for example:
+#
+#   PROMPT='%B%m%~%b$(git_super_status) %# '
+#
+# More details are in share/doc/zsh-git-prompt/README.md, once
+# installed.
+#
+{ fetchgit
+, haskell
+, python
+, git
+, lib
+, ghcVersion ? "ghc802"
+}:
+
+haskell.packages.${ghcVersion}.callPackage
+  ({ mkDerivation, base, HUnit, parsec, process, QuickCheck, stdenv }:
+   mkDerivation rec {
+     pname = "zsh-git-prompt";
+     version = "0.5";
+     src = fetchgit {
+       url = "https://github.com/olivierverdier/zsh-git-prompt.git";
+       rev = "0a6c8b610e799040b612db8888945f502a2ddd9d";
+       sha256 = "19x1gf1r6l7r6i7vhhsgzcbdlnr648jx8j84nk2zv1b8igh205hw";
+     };
+     prePatch = ''
+        substituteInPlace zshrc.sh                       \
+          --replace ':-"python"' ':-"haskell"'           \
+          --replace 'python '    '${python.interpreter} ' \
+          --replace 'git '       '${git}/bin/git '
+     '';
+     preCompileBuildDriver = "cd src";
+     postInstall = ''
+        cd ..
+        gpshare=$out/share/${pname}
+        gpdoc=$out/share/doc/${pname}
+        mkdir -p $gpshare/src $gpdoc
+        cp README.md $gpdoc
+        cp zshrc.sh gitstatus.py $gpshare
+        mv $out/bin $gpshare/src/.bin
+     '';
+     isLibrary = false;
+     isExecutable = true;
+     libraryHaskellDepends = [ base parsec process QuickCheck ];
+     executableHaskellDepends = libraryHaskellDepends;
+     testHaskellDepends = [HUnit] ++ libraryHaskellDepends;
+     homepage = "http://github.com/olivierverdier/zsh-git-prompt#readme";
+     description = "Informative git prompt for zsh";
+     license = stdenv.lib.licenses.mit;
+     maintainers = [lib.maintainers.league];
+   }) {}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4801,6 +4801,8 @@ with pkgs;
   zpaq = callPackage ../tools/archivers/zpaq { };
   zpaqd = callPackage ../tools/archivers/zpaq/zpaqd.nix { };
 
+  zsh-git-prompt = callPackage ../shells/zsh-git-prompt { };
+
   zsh-navigation-tools = callPackage ../tools/misc/zsh-navigation-tools { };
 
   zsh-syntax-highlighting = callPackage ../shells/zsh-syntax-highlighting { };


### PR DESCRIPTION
###### Motivation for this change

This is a plugin of sorts for your `.zshrc` that can add status information about the current git repository to your prompt. By default it uses a python script and is thus easy on the dependencies and not really worth packaging. But there's also a Haskell implementation. I set it up sometime back, but then it died when the libgmp version it was compiled with disappeared in a garbage collection. So I decided that the Haskell version of zsh-git-prompt might be worth packaging after all.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

