### PR TITLE
fira-code-symbols: init at 20160811

### DIFF
--- a/pkgs/data/fonts/fira-code/symbols.nix
+++ b/pkgs/data/fonts/fira-code/symbols.nix
@@ -1,0 +1,24 @@
+{ stdenv, runCommand, fetchurl, unzip }:
+
+runCommand "fira-code-symbols-20160811" {
+  src = fetchurl {
+    url = "https://github.com/tonsky/FiraCode/files/412440/FiraCode-Regular-Symbol.zip";
+    sha256 = "01sk8cmm50xg2vwf0ff212yi5gd2sxcb5l4i9g004alfrp7qaqxg";
+  };
+  buildInputs = [ unzip ];
+
+  meta = with stdenv.lib; {
+    description = "FiraCode unicode ligature glyphs in private use area";
+    longDescription = ''
+      FiraCode uses ligatures, which some editors don’t support.
+      This addition adds them as glyphs to the private unicode use area.
+      See https://github.com/tonsky/FiraCode/issues/211.
+    '';
+    license = licenses.ofl;
+    maintainers = [ maintainers.profpatsch ];
+    homepage = "https://github.com/tonsky/FiraCode/issues/211#issuecomment-239058632";
+  };
+} ''
+  mkdir -p $out/share/fonts/opentype
+  unzip "$src" -d $out/share/fonts/opentype
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12559,6 +12559,7 @@ with pkgs;
   fira = callPackage ../data/fonts/fira { };
 
   fira-code = callPackage ../data/fonts/fira-code { };
+  fira-code-symbols = callPackage ../data/fonts/fira-code/symbols.nix { };
 
   fira-mono = callPackage ../data/fonts/fira-mono { };
 


### PR DESCRIPTION
- [x] tested manually