### PR TITLE
rdkafka: 2015-11-03 -> 0.9.5

### DIFF
--- a/pkgs/development/libraries/rdkafka/default.nix
+++ b/pkgs/development/libraries/rdkafka/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, fetchFromGitHub, zlib, perl }:
+{ stdenv, fetchFromGitHub, zlib, perl, pkgconfig, python }:
 
 stdenv.mkDerivation rec {
-  name = "rdkafka-2015-11-03";
+  name = "rdkafka-${version}";
+  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner = "edenhill";
     repo = "librdkafka";
-    rev = "3e1babf4f26a7d12bbd272c1cdf4aa6a44000d4a";
-    sha256 = "1vmbbkgdwxr25wz60hi6rhqb843ipz34r9baygv87fwh3lwwkqwl";
+    rev = "v${version}";
+    sha256 = "0yp8vmj3yc564hcmhx46ssyn8qayywnsrg4wg67qk6jw967qgwsn";
   };
 
-  buildInputs = [ zlib perl ];
+  buildInputs = [ zlib perl pkgconfig python ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error=strict-overflow";
 


### PR DESCRIPTION
###### Motivation for this change

The old package version did not have `pkgconfig` files, and it was making `haskellPackages.haskakafka` fail. With this change, it compiles successfully.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

