### PR TITLE
mozjpeg: 3.1 -> 3.2

### DIFF
--- a/pkgs/applications/graphics/mozjpeg/default.nix
+++ b/pkgs/applications/graphics/mozjpeg/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, file, pkgconfig, libpng, nasm }:
 
 stdenv.mkDerivation rec {
-  version = "3.1";
+  version = "3.2";
   name = "mozjpeg-${version}";
 
   src = fetchurl {
     url = "https://github.com/mozilla/mozjpeg/releases/download/v${version}/mozjpeg-${version}-release-source.tar.gz";
-    sha256 = "07vs0xq9di7bv3y68daig8dvxvjqrn8a5na702gj3nn58a1xivfy";
+    sha256 = "0wvv5qh1jasz8apq93c3j9d5wd22j7lld9dr06p76yj4mpnc3v4a";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Upgrade mozjpeg to latest version

cc @vcunat 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

