### PR TITLE
pythonPackages.phpserialize: init at 1.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -242,6 +242,7 @@
   jhhuh = "Ji-Haeng Huh <jhhuh.note@gmail.com>";
   jirkamarsik = "Jirka Marsik <jiri.marsik89@gmail.com>";
   jlesquembre = "José Luis Lafuente <jl@lafuente.me>";
+  jluttine = "Jaakko Luttinen <jaakko.luttinen@iki.fi>";
   joachifm = "Joachim Fasting <joachifm@fastmail.fm>";
   joamaki = "Jussi Maki <joamaki@gmail.com>";
   joelmo = "Joel Moberg <joel.moberg@gmail.com>";

--- a/pkgs/development/python-modules/phpserialize/default.nix
+++ b/pkgs/development/python-modules/phpserialize/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "19qgkb9z4zjbjxlpwh2w6pxkz2j3iymnydi69jl0jg905lqjsrxz";
   };
 
-  # PyPI source tarball doesn't contain the tests
+  # project does not have tests at the moment
   doCheck = false;
 
   meta = {

--- a/pkgs/development/python-modules/phpserialize/default.nix
+++ b/pkgs/development/python-modules/phpserialize/default.nix
@@ -1,0 +1,22 @@
+{lib, buildPythonPackage, fetchPypi}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "phpserialize";
+  version = "1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19qgkb9z4zjbjxlpwh2w6pxkz2j3iymnydi69jl0jg905lqjsrxz";
+  };
+
+  # PyPI source tarball doesn't contain the tests
+  doCheck = false;
+
+  meta = {
+    description = "A port of the serialize and unserialize functions of PHP to Python";
+    homepage = http://github.com/mitsuhiko/phpserialize;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8833,6 +8833,8 @@ in {
     };
   };
 
+  phpserialize = callPackage ../development/python-modules/phpserialize { };
+
   pies = buildPythonPackage rec {
     name = "pies-2.6.5";
 


### PR DESCRIPTION
###### Motivation for this change

`phpserialize` is a dependency of another Python package of which I'll make a separate pull request.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I also ran the unit tests which are available at the project's github repo in a nix-shell launched with `nix-shell -p python35Packages.phpserialize --pure`.

---

