### PR TITLE
rust-bindgen: 0.23.0 -> 0.24.0

### DIFF
--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -1,25 +1,30 @@
-{ stdenv, fetchFromGitHub, rustPlatform, llvmPackages }:
+{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper, llvmPackages }:
 
 # Future work: Automatically communicate NIX_CFLAGS_COMPILE to bindgen's tests and the bindgen executable itself.
 
 rustPlatform.buildRustPackage rec {
   name = "rust-bindgen-${version}";
-  version = "0.23.0";
+  version = "0.24.0";
 
   src = fetchFromGitHub {
     owner = "servo";
     repo = "rust-bindgen";
     rev = "v${version}";
-    sha256 = "1cr7wgb13pavjpv2glq02wf5sqigcl1k0qgf3cqi9c5mjca2cg5y";
+    sha256 = "1nzva8g5nj7m2w8vax86p4rd02ci8793nhnm7sf76ajr4hfnx323";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ llvmPackages.clang-unwrapped ];
 
   configurePhase = ''
     export LIBCLANG_PATH="${llvmPackages.clang-unwrapped}/lib"
   '';
 
-  depsSha256 = "1qrnd9a73vxr7572byjjlhwbax3z4slc7qmwjx3aiwjix3r250dh";
+  postInstall = ''
+    wrapProgram $out/bin/bindgen --set LIBCLANG_PATH "${llvmPackages.clang-unwrapped}/lib"
+  '';
+
+  depsSha256 = "1l8c48y67azzwmv4hzghia1c53b5dw6qiv22cgv8zbyrg20aj8as";
 
   doCheck = false; # A test fails because it can't find standard headers in NixOS
 


### PR DESCRIPTION
###### Motivation for this change
Updated and added a needed wrapper.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

