### PR TITLE
libressl: 2.5.3 -> 2.5.4

### DIFF
--- a/pkgs/development/libraries/libressl/2.5.nix
+++ b/pkgs/development/libraries/libressl/2.5.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libressl-${version}";
-  version = "2.5.3";
+  version = "2.5.4";
 
   src = fetchurl {
     url    = "mirror://openbsd/LibreSSL/${name}.tar.gz";
-    sha256 = "0c4awq45cl757fv7f7f75i5i0ibc6v7ns13n7xvfak7chv2lrqql";
+    sha256 = "1ykf6dqlbafafhbdfmcj19pjj1z6wmsq0rmyqga1i0xv5x95nyhh";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Contains a fix for CVE-2017-8301: TLS verification vulnerability in
LibreSSL 2.5.1 - 2.5.3 [1] [2]

[1]: http://seclists.org/oss-sec/2017/q2/145
[2]: https://github.com/libressl-portable/portable/issues/307