### PR TITLE
epson-alc1100: init at version 1.2-0

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -170,6 +170,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "DOC License";
   };
 
+  eapl = {
+    fullName = "EPSON AVASYS PUBLIC LICENSE";
+    url = http://avasys.jp/hp/menu000000700/hpg000000603.htm;
+    free = false;
+  };
+
   efl10 = spdx {
     spdxId = "EFL-1.0";
     fullName = "Eiffel Forum License v1.0";

--- a/pkgs/misc/drivers/epson-alc1100/cups-data-dir.patch
+++ b/pkgs/misc/drivers/epson-alc1100/cups-data-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 0053441..9a6b855 100755
+--- a/configure
++++ b/configure
+@@ -2833,7 +2833,7 @@ if test $have_cups_config = yes; then
+    CUPS_LIBS=`cups-config --libs`
+    CUPS_IMAGE_LIBS=`cups-config --image --libs`
+    CUPS_SERVER_DIR=`cups-config --serverbin`
+-   CUPS_DATA_DIR=`cups-config --datadir`
++   CUPS_DATA_DIR="${prefix}/share/cups"
+ else
+    { { echo "$as_me:$LINENO: error: *** 'cups-config' missing, please install CUPS or fix your \$PATH ***" >&5
+ echo "$as_me: error: *** 'cups-config' missing, please install CUPS or fix your \$PATH ***" >&2;}

--- a/pkgs/misc/drivers/epson-alc1100/default.nix
+++ b/pkgs/misc/drivers/epson-alc1100/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, stdenv_32bit, fetchurl, cups, pkgsi686Linux, dpkg, psutils, makeWrapper, ghostscript, bash }:
+
+let
+  version = "1.2-0";
+
+  libstdcpp5 = fetchurl {
+    url = "http://old-releases.ubuntu.com/ubuntu/pool/universe/g/gcc-3.3/libstdc++5_3.3.6-17ubuntu1_i386.deb";
+    sha256 = "10f8zcmqaa7skvg2bz94mnlgqpan4iscvi8913r6iawjh7hiisjy";
+  };
+in
+  stdenv.mkDerivation {
+    name = "epson-alc1100-${version}";
+
+    src = fetchurl {
+      url = "http://a1227.g.akamai.net/f/1227/40484/7d/download.ebz.epson.net/dsc/f/01/00/01/58/65/cd71929d2bf41ebf7e96f68fa9f1279556545ef1/Epson-ALC1100-filter-1.2.tar.gz";
+      sha256 = "0q0bf4dfm4v69l7xg6sgkh7rwb0h77i8j9kplq1dfkd208g7y81p";
+    };
+
+    patches = [ ./cups-data-dir.patch ./ppd.patch ];
+
+    nativeBuildInputs = [ dpkg makeWrapper ];
+
+    buildInputs = [ cups pkgsi686Linux.glibc psutils ghostscript bash ];
+
+    postUnpack = ''
+      dpkg -x ${libstdcpp5} libstdcpp5_i386;
+
+      mkdir -p $out/lib;
+
+      mv libstdcpp5_i386/usr/lib/* $out/lib;
+    '';
+
+    postFixup = ''
+      patchelf --set-interpreter ${pkgsi686Linux.glibc}/lib/ld-linux.so.2 \
+        --set-rpath "${stdenv.lib.makeLibraryPath [
+          pkgsi686Linux.glibc
+          "$out"
+        ]}" $out/bin/alc1100
+
+      patchelf --set-rpath "${stdenv.lib.makeLibraryPath [
+          pkgsi686Linux.glibc
+        ]}" $out/lib/libstdc++.so.5.0.7
+
+      wrapProgram $out/bin/alc1100_lprwrapper.sh \
+        --suffix PATH : "\$PATH:${psutils}/bin:/var/lib/cups/path/bin"
+
+      wrapProgram $out/bin/pstoalc1100.sh \
+        --suffix PATH : "\$PATH:${psutils}/bin:${ghostscript}/bin:${bash}/bin:/var/lib/cups/path/bin"
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = "http://download.ebz.epson.net/dsc/search/01/search/";
+      description = "Epson AcuLaser C1100 Driver";
+      longDescription = ''
+        This package provides a print filter for printing to EPSON AL-C1100
+        printers on Linux systems.
+
+        To use the driver adjust your configuration.nix file:
+          services.printing = {
+            enable = true;
+            drivers = [ pkgs.epson-alc1100 ];
+          };
+      '';
+
+      license = with licenses; [ mit eapl ];
+      maintainers = [ maintainers.eperuffo ];
+      platforms = platforms.linux;
+    };
+
+  }

--- a/pkgs/misc/drivers/epson-alc1100/ppd.patch
+++ b/pkgs/misc/drivers/epson-alc1100/ppd.patch
@@ -1,0 +1,13 @@
+diff --git a/ppd/Epson-AL-C1100-fm3.ppd b/ppd/Epson-AL-C1100-fm3.ppd
+index 75c7fff..ecd04c8 100644
+--- a/ppd/Epson-AL-C1100-fm3.ppd
++++ b/ppd/Epson-AL-C1100-fm3.ppd
+@@ -68,7 +68,7 @@
+ *%*********** Foomatic Configulations ************
+ *%pprRIP:        foomatic-rip other
+ *FoomaticIDs: Epson-AL-C1100 alc1100
+-*FoomaticRIPCommandLine: "pstoalc1100.sh %C"
++*FoomaticRIPCommandLine: "/var/lib/cups/path/bin/pstoalc1100.sh %C"
+ 
+ *%**************** Paper Handling ******************
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18009,6 +18009,8 @@ with pkgs;
 
   e17gtk = callPackage ../misc/themes/e17gtk { };
 
+  epson-alc1100 = callPackage ../misc/drivers/epson-alc1100 { };
+
   epson-escpr = callPackage ../misc/drivers/epson-escpr { };
 
   epson_201207w = callPackage ../misc/drivers/epson_201207w { };


### PR DESCRIPTION
Driver for printer Epson AcuLaser C1100

###### Motivation for this change
I need this driver for printing.
It works except for Duplex printing, which worked only on Windows XP for me.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Regarding the licence, I have not found the licence around and that link now redirects to the home page.
A copy of that licence is in the package the build script downloads. I have no idea if it's free so I've marked it as non free because I didn't know the right thing to do.