### PR TITLE
pngquant: 2.6.0 -> 2.9.1

### DIFF
--- a/pkgs/tools/graphics/pngquant/default.nix
+++ b/pkgs/tools/graphics/pngquant/default.nix
@@ -1,29 +1,23 @@
-{ stdenv, fetchFromGitHub, pkgconfig, libpng, zlib, lcms2 }:
+{ stdenv, fetchgit, pkgconfig, libpng, zlib, lcms2 }:
 
 stdenv.mkDerivation rec {
   name = "pngquant-${version}";
-  version = "2.6.0";
+  version = "2.9.1";
 
-  src = fetchFromGitHub {
-    owner = "pornel";
-    repo = "pngquant";
-    rev = version;
-    sha256 = "0sdh9cz330rhj6xvqk3sdhy0393qwyl349klk9r55g88rjp774s5";
+  src = fetchgit {
+    url = "https://www.github.com/pornel/pngquant.git";
+    rev = "refs/tags/${version}";
+    sha256 = "0xhnrjsk55jy5q68f81y7l61c6x18i4fzkm3i4dgndrhri5g4n1q";
+    fetchSubmodules = true;
   };
 
-  preConfigure = "patchShebangs .";
-
   buildInputs = [ pkgconfig libpng zlib lcms2 ];
-
-  preInstall = ''
-    mkdir -p $out/bin
-    export PREFIX=$out
-  '';
 
   meta = with stdenv.lib; {
     homepage = https://pngquant.org/;
     description = "A tool to convert 24/32-bit RGBA PNGs to 8-bit palette with alpha channel preserved";
     platforms = platforms.linux;
-    license = licenses.bsd2; # Not exactly bsd2, but alike
+    license = licenses.gpl3;
+    maintainers = [ maintainers.volth ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

version update

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

