### PR TITLE
Adding some Jane Street packages at version 0.9 (in progress)

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/bin_prot-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/bin_prot-0.9.nix
@@ -1,0 +1,12 @@
+{newBuildOcamlJane, base, ppx_compare, ppx_custom_printf, ppx_driver,
+ ppx_fields_conv, ppx_sexp_conv, ppx_variants_conv, sexplib, ocaml-migrate-parsetree}:
+
+newBuildOcamlJane {
+  name = "bin_prot";
+  hash = "0cy6lhksx4jypkrnj3ha31p97ghslki0bx5rpnzc2v28mfp6pzh1";
+
+  propagatedBuildInputs = [ base ppx_compare ppx_custom_printf ppx_driver
+    ppx_fields_conv ppx_sexp_conv ppx_variants_conv sexplib ocaml-migrate-parsetree ];
+
+  meta.description = "Binary protocol generator";
+}

--- a/pkgs/development/ocaml-modules/janestreet/fieldslib-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/fieldslib-0.9.nix
@@ -1,0 +1,11 @@
+{newBuildOcamlJane, base, ppx_driver, ocaml-migrate-parsetree}:
+
+newBuildOcamlJane {
+  name = "fieldslib";
+  hash = "1wxh59888l1bfz9ipnbcas58gwg744icaixzdbsg4v8f7wymc501";
+
+  propagatedBuildInputs =
+   [ base ppx_driver ocaml-migrate-parsetree ];
+
+  meta.description = "OCaml record fields as first class values";
+}

--- a/pkgs/development/ocaml-modules/janestreet/newBuildOcamlJane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/newBuildOcamlJane.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, ocaml, jbuilder, findlib }:
+
+{ name, version ? "0.9.0", buildInputs ? [], hash, ...}@args:
+
+stdenv.mkDerivation (args // {
+  name = "ocaml${ocaml.version}-${name}-${version}";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "janestreet";
+    repo = name;
+    rev = "v${version}";
+    sha256 = hash;
+  };
+
+  buildInputs = [ ocaml jbuilder findlib ] ++ buildInputs;
+
+  inherit (jbuilder) installPhase;
+
+  meta = {
+    license = stdenv.lib.licenses.asl20;
+    inherit (ocaml.meta) platforms;
+    homepage = "https://github.com/janestreet/${name}";
+  };
+})

--- a/pkgs/development/ocaml-modules/janestreet/ppx_compare-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx_compare-0.9.nix
@@ -1,0 +1,12 @@
+{newBuildOcamlJane, base, ppx_core, ppx_driver, ppx_metaquot, ppx_type_conv,
+ ocaml-migrate-parsetree}:
+
+newBuildOcamlJane {
+  name = "ppx_compare";
+  hash = "0wrszpvn1nms5sb5rb29p7z1wmqyd15gfzdj4ax8f843p5ywx3w9";
+
+  propagatedBuildInputs =
+   [ base ppx_core ppx_driver ppx_metaquot ppx_type_conv ocaml-migrate-parsetree ];
+
+  meta.description = "Generation of comparison functions from types";
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx_core-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx_core-0.9.nix
@@ -1,0 +1,12 @@
+{newBuildOcamlJane, base, ocaml-compiler-libs, ppx_ast,
+ ppx_traverse_builtins, stdio}:
+
+newBuildOcamlJane {
+  name = "ppx_core";
+  hash = "15400zxxkqdimmjpdjcs36gcbxbrhylmaczlzwd6x65v1h9aydz3";
+
+  propagatedBuildInputs =
+   [ base ocaml-compiler-libs ppx_ast ppx_traverse_builtins stdio ];
+
+  meta.description = "Jane Street's standard library for ppx rewriters";
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx_custom_printf-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx_custom_printf-0.9.nix
@@ -1,0 +1,12 @@
+{newBuildOcamlJane, ppx_core, ppx_driver, ppx_metaquot, ppx_sexp_conv,
+ ppx_traverse, ocaml-migrate-parsetree}:
+
+newBuildOcamlJane {
+  name = "ppx_custom_printf";
+  hash = "0cjy2c2c5g3qxqvwx1yb6p7kbmmpnpb1hll55f7a44x215lg8x19";
+
+  propagatedBuildInputs = [ ppx_core ppx_driver ppx_metaquot
+    ppx_sexp_conv ppx_traverse ocaml-migrate-parsetree ];
+
+  meta.description = "Printf-style format-strings for user-defined string conversion";
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx_driver-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx_driver-0.9.nix
@@ -1,0 +1,12 @@
+{newBuildOcamlJane, ocamlbuild, ppx_core, ppx_optcomp, ocaml-migrate-parsetree}:
+
+newBuildOcamlJane {
+  name = "ppx_driver";
+  hash = "1w3khwnvy18nkh673zrbhcs6051hs7z5z5dib7npkvpxndw22hwj";
+
+  buildInputs = [ ocamlbuild ];
+
+  propagatedBuildInputs = [ ppx_core ppx_optcomp ocaml-migrate-parsetree ];
+
+  meta.description = "Feature-full driver for OCaml AST transformers";
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx_fields_conv-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx_fields_conv-0.9.nix
@@ -1,0 +1,12 @@
+{newBuildOcamlJane, fieldslib, ppx_core, ppx_driver, ppx_metaquot,
+ ppx_type_conv, ocaml-migrate-parsetree}:
+
+newBuildOcamlJane {
+  name = "ppx_fields_conv";
+  hash = "0qp8zgmk58iskzrkf4g06i471kg6lrh3wqpy9klrb8pp9mg0xr9z";
+
+  propagatedBuildInputs = [ fieldslib ppx_core ppx_driver ppx_metaquot
+    ppx_type_conv ocaml-migrate-parsetree ];
+
+  meta.description = "Generation of accessor and iteration functions for OCaml records";
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx_metaquot-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx_metaquot-0.9.nix
@@ -1,0 +1,10 @@
+{newBuildOcamlJane, ppx_core, ppx_driver, ppx_traverse_builtins, ocaml-migrate-parsetree}:
+
+newBuildOcamlJane {
+  name = "ppx_metaquot";
+  hash = "15qfd3s4x2pz006nx5316laxd3gqqi472x432qg4rfx4yh3vn31k";
+
+  propagatedBuildInputs = [ ppx_core ppx_driver ppx_traverse_builtins ocaml-migrate-parsetree ];
+
+  meta.description = "Metaquotations for ppx_ast";
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx_optcomp-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx_optcomp-0.9.nix
@@ -1,0 +1,10 @@
+{newBuildOcamlJane, ppx_core}:
+
+newBuildOcamlJane {
+  name = "ppx_optcomp";
+  hash = "1wfj6fnh92s81yncq7yyhmax7j6zpjj1sg1f3qa1f9c5kf4kkzrd";
+
+  propagatedBuildInputs = [ ppx_core ];
+
+  meta.description = "Optional compilation for OCaml";
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx_sexp_conv-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx_sexp_conv-0.9.nix
@@ -1,0 +1,12 @@
+{newBuildOcamlJane, ppx_core, ppx_driver, ppx_metaquot, ppx_type_conv,
+ sexplib, ocaml-migrate-parsetree}:
+
+newBuildOcamlJane {
+  name = "ppx_sexp_conv";
+  hash = "03cg2sym0wvpd5l7q4w9bclp589z5byygwsmnnq9h1ih56cmd55l";
+
+  propagatedBuildInputs =
+   [ ppx_core ppx_driver ppx_metaquot ppx_type_conv sexplib ocaml-migrate-parsetree ];
+
+  meta.description = "Generation of S-expression conversion functions from type definitions";
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx_traverse-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx_traverse-0.9.nix
@@ -1,0 +1,11 @@
+{newBuildOcamlJane, ppx_core, ppx_driver, ppx_metaquot, ppx_type_conv, ocaml-migrate-parsetree}:
+
+newBuildOcamlJane {
+  name = "ppx_traverse";
+  hash = "1sdqgwyq0w71i03vhc5jq4jk6rsbgwhvain48fnrllpkb5kj2la2";
+
+  propagatedBuildInputs =
+   [ ppx_core ppx_driver ppx_metaquot ppx_type_conv ocaml-migrate-parsetree ];
+
+  meta.description = "Automatic generation of open recursion classes";
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx_type_conv-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx_type_conv-0.9.nix
@@ -1,0 +1,10 @@
+{newBuildOcamlJane, ppx_core, ppx_driver, ppx_metaquot, ocaml-migrate-parsetree}:
+
+newBuildOcamlJane {
+  name = "ppx_type_conv";
+  hash = "0a0gxjvjiql9vg37k0akn8xr5724nv3xb7v37xpidv7ld927ks7p";
+
+  propagatedBuildInputs = [ ppx_core ppx_driver ppx_metaquot ocaml-migrate-parsetree ];
+
+  meta.description = "Support Library for type-driven code generators";
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx_variants_conv-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx_variants_conv-0.9.nix
@@ -1,0 +1,12 @@
+{newBuildOcamlJane, ppx_core, ppx_driver, ppx_metaquot, ppx_type_conv,
+ variantslib, ocaml-migrate-parsetree}:
+
+newBuildOcamlJane {
+  name = "ppx_variants_conv";
+  hash = "1xayhyglgbdjqvb9123kjbwjcv0a3n3302nb0j7g8gmja8w5y834";
+
+  propagatedBuildInputs = [ ppx_core ppx_driver ppx_metaquot ppx_type_conv
+    variantslib ocaml-migrate-parsetree ];
+
+  meta.description = "Generation of accessor and iteration functions for OCaml variant types";
+}

--- a/pkgs/development/ocaml-modules/janestreet/sexplib-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/sexplib-0.9.nix
@@ -1,0 +1,10 @@
+{newBuildOcamlJane, base}:
+
+newBuildOcamlJane {
+  name = "sexplib";
+  hash = "1cj0sv7zwy6njckiszym57zjwdkay78r9fncblsacqijzsdjl6dd";
+
+  propagatedBuildInputs = [ base ];
+
+  meta.description = "Automated S-expression conversion";
+}

--- a/pkgs/development/ocaml-modules/janestreet/variantslib-0.9.nix
+++ b/pkgs/development/ocaml-modules/janestreet/variantslib-0.9.nix
@@ -1,0 +1,10 @@
+{newBuildOcamlJane, ppx_driver, ocaml-migrate-parsetree}:
+
+newBuildOcamlJane {
+  name = "variantslib";
+  hash = "0kj53n62193j58q9vip8lfhhyf6w9d25wyvxzc163hx5m68yw0fz";
+
+  propagatedBuildInputs = [ ppx_driver ocaml-migrate-parsetree ];
+
+  meta.description = "OCaml variants as first class values";
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -669,6 +669,11 @@ let
       then callPackage ../development/ocaml-modules/janestreet/ppx_custom_printf-113_33_00.nix {}
       else callPackage ../development/ocaml-modules/janestreet/ppx-custom-printf.nix {};
 
+    ppx_custom_printf_0_9 = callPackage ../development/ocaml-modules/janestreet/ppx_custom_printf-0.9.nix {
+      ppx_core = ppx_core_0_9;
+      ppx_driver = ppx_driver_0_9;
+      ppx_sexp_conv = ppx_sexp_conv_0_9; };
+
     ppx_enumerate =
       if lib.versionOlder "4.03" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/ppx_enumerate-113_33_00.nix {}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -743,6 +743,9 @@ let
       then callPackage ../development/ocaml-modules/janestreet/fieldslib.nix {}
       else fieldslib_p4;
 
+    fieldslib_0_9 = callPackage ../development/ocaml-modules/janestreet/fieldslib-0.9.nix {
+      ppx_driver = ppx_driver_0_9; };
+
     sexplib =
       if lib.versionOlder "4.03" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/sexplib-113_33_00.nix {}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -725,6 +725,12 @@ let
       then callPackage ../development/ocaml-modules/janestreet/ppx_variants_conv-113_33_00.nix {}
       else callPackage ../development/ocaml-modules/janestreet/ppx-variants-conv.nix {};
 
+    ppx_variants_conv_0_9 = callPackage ../development/ocaml-modules/janestreet/ppx_variants_conv-0.9.nix {
+      ppx_core = ppx_core_0_9;
+      ppx_driver = ppx_driver_0_9;
+      ppx_type_conv = ppx_type_conv_0_9;
+      variantslib = variantslib_0_9; };
+
     ppx_expect =
       if lib.versionOlder "4.03" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/ppx_expect-113_33_01.nix {}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -780,6 +780,15 @@ let
       then callPackage ../development/ocaml-modules/janestreet/bin_prot.nix {}
       else bin_prot_p4;
 
+    bin_prot_0_9 = callPackage ../development/ocaml-modules/janestreet/bin_prot-0.9.nix {
+      ppx_compare = ppx_compare_0_9;
+      ppx_custom_printf = ppx_custom_printf_0_9;
+      ppx_driver = ppx_driver_0_9;
+      ppx_fields_conv = ppx_fields_conv_0_9;
+      ppx_sexp_conv = ppx_sexp_conv_0_9;
+      ppx_variants_conv = ppx_variants_conv_0_9;
+      sexplib = sexplib_0_9; };
+
     core_kernel =
       if lib.versionOlder "4.03" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/core_kernel-113_33_01.nix {}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -597,6 +597,9 @@ let
         oasis = ocaml_oasis; }
       else callPackage ../development/ocaml-modules/janestreet/ppx-optcomp.nix {};
 
+    ppx_optcomp_0_9 = callPackage ../development/ocaml-modules/janestreet/ppx_optcomp-0.9.nix {
+      ppx_core = ppx_core_0_9; };
+
     ppx_driver = callPackage ../development/ocaml-modules/janestreet/ppx-driver.nix {};
 
     ppx_type_conv =

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -615,6 +615,10 @@ let
       then callPackage ../development/ocaml-modules/janestreet/ppx_type_conv-113_33_02.nix { }
       else callPackage ../development/ocaml-modules/janestreet/ppx-type-conv.nix {};
 
+    ppx_type_conv_0_9 = callPackage ../development/ocaml-modules/janestreet/ppx_type_conv-0.9.nix {
+      ppx_core = ppx_core_0_9;
+      ppx_driver = ppx_driver_0_9; };
+
     ppx_compare =
       if lib.versionOlder "4.03" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/ppx_compare-113_33_00.nix {}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -689,6 +689,12 @@ let
       then callPackage ../development/ocaml-modules/janestreet/ppx_fields_conv-113_33_00.nix {}
       else callPackage ../development/ocaml-modules/janestreet/ppx-fields-conv.nix {};
 
+    ppx_fields_conv_0_9 = callPackage ../development/ocaml-modules/janestreet/ppx_fields_conv-0.9.nix {
+      ppx_core = ppx_core_0_9;
+      ppx_driver = ppx_driver_0_9;
+      ppx_type_conv = ppx_type_conv_0_9;
+      fieldslib = fieldslib_0_9; };
+
     ppx_let =
       if lib.versionOlder "4.03" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/ppx_let-113_33_00.nix {}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -602,6 +602,10 @@ let
 
     ppx_driver = callPackage ../development/ocaml-modules/janestreet/ppx-driver.nix {};
 
+    ppx_driver_0_9 = callPackage ../development/ocaml-modules/janestreet/ppx_driver-0.9.nix {
+      ppx_core = ppx_core_0_9;
+      ppx_optcomp = ppx_optcomp_0_9; };
+
     ppx_type_conv =
       if lib.versionOlder "4.03" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/ppx_type_conv-113_33_02.nix { }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -606,6 +606,10 @@ let
       ppx_core = ppx_core_0_9;
       ppx_optcomp = ppx_optcomp_0_9; };
 
+    ppx_metaquot = callPackage ../development/ocaml-modules/janestreet/ppx_metaquot-0.9.nix {
+      ppx_core = ppx_core_0_9;
+      ppx_driver = ppx_driver_0_9; };
+
     ppx_type_conv =
       if lib.versionOlder "4.03" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/ppx_type_conv-113_33_02.nix { }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -659,6 +659,11 @@ let
       then callPackage ../development/ocaml-modules/janestreet/ppx_bin_prot-113_33_00.nix {}
       else callPackage ../development/ocaml-modules/janestreet/ppx-bin-prot.nix {};
 
+    ppx_traverse = callPackage ../development/ocaml-modules/janestreet/ppx_traverse-0.9.nix {
+      ppx_core = ppx_core_0_9;
+      ppx_driver = ppx_driver_0_9;
+      ppx_type_conv = ppx_type_conv_0_9; };
+
     ppx_custom_printf =
       if lib.versionOlder "4.03" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/ppx_custom_printf-113_33_00.nix {}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -589,6 +589,8 @@ let
       then callPackage ../development/ocaml-modules/janestreet/ppx_core-113_33_01.nix {}
       else callPackage ../development/ocaml-modules/janestreet/ppx-core.nix {};
 
+    ppx_core_0_9  = callPackage ../development/ocaml-modules/janestreet/ppx_core-0.9.nix {};
+
     ppx_optcomp =
       if lib.versionOlder "4.03" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/ppx_optcomp-113_33_01.nix {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -631,6 +631,12 @@ let
       then callPackage ../development/ocaml-modules/janestreet/ppx_sexp_conv-113_33_01.nix { }
       else callPackage ../development/ocaml-modules/janestreet/ppx-sexp-conv.nix {};
 
+    ppx_sexp_conv_0_9 = callPackage ../development/ocaml-modules/janestreet/ppx_sexp_conv-0.9.nix {
+      ppx_core = ppx_core_0_9;
+      ppx_driver = ppx_driver_0_9;
+      ppx_type_conv = ppx_type_conv_0_9;
+      sexplib = sexplib_0_9; };
+
     ppx_assert = callPackage ../development/ocaml-modules/janestreet/ppx-assert.nix {};
 
     ppx_inline_test =

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -766,6 +766,9 @@ let
       then callPackage ../development/ocaml-modules/janestreet/variantslib.nix {}
       else variantslib_p4;
 
+    variantslib_0_9 = callPackage ../development/ocaml-modules/janestreet/variantslib-0.9.nix {
+      ppx_driver = ppx_driver_0_9; };
+
     bin_prot =
       if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/bin_prot.nix {}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -712,6 +712,8 @@ let
       then callPackage ../development/ocaml-modules/janestreet/sexplib.nix {}
       else sexplib_p4;
 
+    sexplib_0_9 = callPackage ../development/ocaml-modules/janestreet/sexplib-0.9.nix {};
+
     variantslib =
       if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/variantslib.nix {}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -624,6 +624,11 @@ let
       then callPackage ../development/ocaml-modules/janestreet/ppx_compare-113_33_00.nix {}
       else callPackage ../development/ocaml-modules/janestreet/ppx-compare.nix {};
 
+    ppx_compare_0_9 = callPackage ../development/ocaml-modules/janestreet/ppx_compare-0.9.nix {
+      ppx_core = ppx_core_0_9;
+      ppx_driver = ppx_driver_0_9;
+      ppx_type_conv = ppx_type_conv_0_9; };
+
     ppx_here = callPackage ../development/ocaml-modules/janestreet/ppx-here.nix {};
 
     ppx_sexp_conv =

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -578,6 +578,8 @@ let
 
     buildOcamlJane = callPackage ../development/ocaml-modules/janestreet/buildOcamlJane.nix {};
 
+    newBuildOcamlJane = callPackage ../development/ocaml-modules/janestreet/newBuildOcamlJane.nix {};
+
     ocaml-compiler-libs = callPackage ../development/ocaml-modules/janestreet/ocaml-compiler-libs.nix {};
 
     ppx_ast = callPackage ../development/ocaml-modules/janestreet/ppx_ast.nix {};


### PR DESCRIPTION
This pull request is mostly to get comments from OCaml packages (especially Jane Street packages) maintainers.

It seems that Nixpkgs contains lots of Jane Street packages at version 113.33.03.
Recently they have been moving to 0.9 with (it seems) quite a few differences in the way those are compiled / installed.
I need a few of these packages at version 0.9+, among them sexplib.
I have created the builder `newBuildOcamlJane` to generically build any of those packages. I'd appreciate feedback on that.
I've also added a package for sexplib version 0.9.1: at first I just wanted to replace version 113.33.03 with version 0.9.1 but a lot of packages depend on it, so it implies updating many many packages. Also some of the new versions of these packages have new dependencies, so it requires adding new packages as well. I am ready to do it, but I'd like feedback before.

Do you mind the new builder and does it seem OK to you? I probably could have modified the current builder to check if the version is before or after v0.9 but that would have been more complex and would have created unnecessary dependencies.

Do you confirm that updating all those packages (at once) is the way to go?

cc @maurer @ericbmerritt @vbgl