### PR TITLE
pythonPackages.requests: point to requests2

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21897,8 +21897,10 @@ in {
     };
   };
 
+  requests = self.requests2;
 
-  requests = buildPythonPackage rec {
+  # Remove before release of 17.09
+  requests_1 = buildPythonPackage rec {
     name = "requests-1.2.3";
     disabled = !pythonOlder "3.4";
 
@@ -21912,7 +21914,6 @@ in {
       homepage = http://docs.python-requests.org/en/latest/;
     };
   };
-
 
   requests2 = buildPythonPackage rec {
     name = "requests-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25996,6 +25996,7 @@ in {
       description = "Ultra fast memcache client written in highly optimized C++ with Python bindings";
       homepage = https://github.com/esnme/ultramemcache;
       license = licenses.bsdOriginal;
+      broken = true;
     };
   };
 


### PR DESCRIPTION
The Python package has two packages for requests, `requests`
corresponding to version 1.2.3, and `requests2` corresponding to version
2.13.0. Version 1.2.3 is almost 4 years old, and by now all software
should have transitioned.

This commit aliases `requests` to `requests2`. Packages that stop to
function should be upgraded. In the rare case that that is not possible,
version 1.2.3 is still available as `requests_1` but I plan to drop
that before the release of 17.09.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

