### PR TITLE
pythonPackages.ltc_scrypt: init at 1.0

### DIFF
--- a/pkgs/development/python-modules/ltc_scrypt/default.nix
+++ b/pkgs/development/python-modules/ltc_scrypt/default.nix
@@ -1,0 +1,22 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "ltc_scrypt";
+  version = "1.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1h90hh3iw4i7zs7jgskdjlk8gi97b3v2zqsxdfwdvhrrnhpvv856";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Bindings for scrypt proof of work used by Litecoin";
+    homepage = https://pypi.python.org/pypi/ltc_scrypt;
+    maintainers = with maintainers; [ asymmetric ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13940,6 +13940,8 @@ in {
     };
   });
 
+  ltc_scrypt = callPackage ../development/python-modules/ltc_scrypt/default.nix { };
+
   python_magic = buildPythonPackage rec {
     name = "python-magic-0.4.10";
 


### PR DESCRIPTION
library needed by the electrum-ltc lightweight litecoin wallet

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

