### PR TITLE
lib: introduce imap0, imap1

### DIFF
--- a/lib/deprecated.nix
+++ b/lib/deprecated.nix
@@ -423,4 +423,12 @@ rec {
       else if isInt x then "int"
       else "string";
 
+  /* deprecated:
+
+     For historical reasons, imap has an index starting at 1.
+
+     But for consistency with the rest of the library we want an index
+     starting at zero.
+  */
+  imap = imap1;
 }

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -77,15 +77,30 @@ rec {
   */
   foldl' = builtins.foldl' or foldl;
 
-  /* Map with index
-
-     FIXME(zimbatm): why does this start to count at 1?
+  /* Map with index starting from 0
 
      Example:
-       imap (i: v: "${v}-${toString i}") ["a" "b"]
+       imap0 (i: v: "${v}-${toString i}") ["a" "b"]
+       => [ "a-0" "b-1" ]
+  */
+  imap0 = f: list: genList (n: f n (elemAt list n)) (length list);
+
+  /* Map with index starting from 1
+
+     Example:
+       imap1 (i: v: "${v}-${toString i}") ["a" "b"]
        => [ "a-1" "b-2" ]
   */
-  imap = f: list: genList (n: f (n + 1) (elemAt list n)) (length list);
+  imap1 = f: list: genList (n: f (n + 1) (elemAt list n)) (length list);
+
+  /* deprecated:
+
+     For historical reasons, imap has an index starting at 1.
+
+     But for consistency with the rest of the library we want an index
+     starting at zero.
+  */
+  imap = imap1;
 
   /* Map and concatenate the result.
 

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -93,15 +93,6 @@ rec {
   */
   imap1 = f: list: genList (n: f (n + 1) (elemAt list n)) (length list);
 
-  /* deprecated:
-
-     For historical reasons, imap has an index starting at 1.
-
-     But for consistency with the rest of the library we want an index
-     starting at zero.
-  */
-  imap = imap1;
-
   /* Map and concatenate the result.
 
      Example:

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -98,7 +98,7 @@ rec {
   /* Close a set of modules under the ‘imports’ relation. */
   closeModules = modules: args:
     let
-      toClosureList = file: parentKey: imap (n: x:
+      toClosureList = file: parentKey: imap1 (n: x:
         if isAttrs x || isFunction x then
           let key = "${parentKey}:anon-${toString n}"; in
           unifyModuleSyntax file key (unpackSubmodule (applyIfFunction key) x args)

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -33,7 +33,7 @@ rec {
        concatImapStrings (pos: x: "${toString pos}-${x}") ["foo" "bar"]
        => "1-foo2-bar"
   */
-  concatImapStrings = f: list: concatStrings (lib.imap f list);
+  concatImapStrings = f: list: concatStrings (lib.imap1 f list);
 
   /* Place an element between each element of a list
 
@@ -70,7 +70,7 @@ rec {
        concatImapStringsSep "-" (pos: x: toString (x / pos)) [ 6 6 6 ]
        => "6-3-2"
   */
-  concatImapStringsSep = sep: f: list: concatStringsSep sep (lib.imap f list);
+  concatImapStringsSep = sep: f: list: concatStringsSep sep (lib.imap1 f list);
 
   /* Construct a Unix-style search path consisting of each `subDir"
      directory of the given list of packages.

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -177,9 +177,9 @@ rec {
       description = "list of ${elemType.description}s";
       check = isList;
       merge = loc: defs:
-        map (x: x.value) (filter (x: x ? value) (concatLists (imap (n: def:
+        map (x: x.value) (filter (x: x ? value) (concatLists (imap1 (n: def:
           if isList def.value then
-            imap (m: def':
+            imap1 (m: def':
               (mergeDefinitions
                 (loc ++ ["[definition ${toString n}-entry ${toString m}]"])
                 elemType
@@ -218,7 +218,7 @@ rec {
           if isList def.value then
             { inherit (def) file;
               value = listToAttrs (
-                imap (elemIdx: elem:
+                imap1 (elemIdx: elem:
                   { name = elem.name or "unnamed-${toString defIdx}.${toString elemIdx}";
                     value = elem;
                   }) def.value);
@@ -231,7 +231,7 @@ rec {
         name = "loaOf";
         description = "list or attribute set of ${elemType.description}s";
         check = x: isList x || isAttrs x;
-        merge = loc: defs: attrOnly.merge loc (imap convertIfList defs);
+        merge = loc: defs: attrOnly.merge loc (imap1 convertIfList defs);
         getSubOptions = prefix: elemType.getSubOptions (prefix ++ ["<name?>"]);
         getSubModules = elemType.getSubModules;
         substSubModules = m: loaOf (elemType.substSubModules m);

--- a/nixos/modules/misc/meta.nix
+++ b/nixos/modules/misc/meta.nix
@@ -17,7 +17,7 @@ let
     #   }
     merge = loc: defs:
       zipAttrs
-        (flatten (imap (n: def: imap (m: def':
+        (flatten (imap1 (n: def: imap1 (m: def':
           maintainer.merge (loc ++ ["[${toString n}-${toString m}]"])
             [{ inherit (def) file; value = def'; }]) def.value) defs));
   };

--- a/nixos/modules/services/cluster/kubernetes.nix
+++ b/nixos/modules/services/cluster/kubernetes.nix
@@ -44,7 +44,7 @@ let
 
   cniConfig = pkgs.buildEnv {
     name = "kubernetes-cni-config";
-    paths = imap (i: entry:
+    paths = imap1 (i: entry:
       pkgs.writeTextDir "${toString (10+i)}-${entry.type}.conf" (builtins.toJSON entry)
     ) cfg.kubelet.cni.config;
   };

--- a/nixos/modules/services/networking/libreswan.nix
+++ b/nixos/modules/services/networking/libreswan.nix
@@ -11,7 +11,7 @@ let
 
   trim = chars: str: let
       nonchars = filter (x : !(elem x.value chars))
-                  (imap (i: v: {ind = (sub i 1); value = v;}) (stringToCharacters str));
+                  (imap0 (i: v: {ind = i; value = v;}) (stringToCharacters str));
     in
       if length nonchars == 0 then ""
       else substring (head nonchars).ind (add 1 (sub (last nonchars).ind (head nonchars).ind)) str;

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -235,7 +235,7 @@ in {
            { source = overrideNameserversScript;
              target = "NetworkManager/dispatcher.d/02overridedns";
            }
-      ++ lib.imap (i: s: {
+      ++ lib.imap1 (i: s: {
         inherit (s) source;
         target = "NetworkManager/dispatcher.d/${dispatcherTypesSubdirMap.${s.type}}03userscript${lib.fixedWidthNumber 4 i}";
       }) cfg.dispatcherScripts;

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -71,7 +71,7 @@ let
       name = "multihead${toString num}";
       inherit config;
     };
-  in imap mkHead cfg.xrandrHeads;
+  in imap1 mkHead cfg.xrandrHeads;
 
   xrandrDeviceSection = let
     monitors = flip map xrandrHeads (h: ''

--- a/pkgs/games/uqm/default.nix
+++ b/pkgs/games/uqm/default.nix
@@ -18,7 +18,7 @@ let
     inherit stdenv requireFile writeText fetchurl haskellPackages;
   };
 
-  remixPacks = imap (num: sha256: fetchurl rec {
+  remixPacks = imap1 (num: sha256: fetchurl rec {
     name = "uqm-remix-disc${toString num}.uqm";
     url = "mirror://sourceforge/sc2/${name}";
     inherit sha256;


### PR DESCRIPTION
###### Motivation for this change

For historical reasons, imap starts counting at 1 and it's not
consistent with the rest of the lib.

So for now we split imap into imap0 that starts counting at zero and
imap1 that starts counting at 1. And imap is marked as deprecated.

See https://github.com/NixOS/nixpkgs/commit/c71e2d42359f9900ea2c290d141c0d606471da16#commitcomment-21873221

Also:
```
$ ag "imap " | wc -l
115
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
