### PR TITLE
Electrum-LTC: init at 2.6.4.2

### DIFF
--- a/pkgs/applications/misc/electrum-ltc/default.nix
+++ b/pkgs/applications/misc/electrum-ltc/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, fetchurl
+, python2Packages
+}:
+
+python2Packages.buildPythonApplication rec {
+  name = "electrum-ltc-${version}";
+  version = "2.6.4.2";
+
+  src = fetchurl {
+    url = "https://electrum-ltc.org/download/Electrum-LTC-${version}.tar.gz";
+    sha256 = "0sqcyk6n6kgaiinnwh6mzbbn4whk3ga59r5bw5rqmnnfqk1xdnb4";
+  };
+
+  propagatedBuildInputs = with python2Packages; [
+    pyqt4
+    slowaes
+    ecdsa
+    pbkdf2
+    requests
+    qrcode
+    ltc_scrypt
+    protobuf3_0
+    dns
+    jsonrpclib
+  ];
+
+  preBuild = ''
+    sed -i 's,usr_share = .*,usr_share = "'$out'/share",g' setup.py
+    pyrcc4 icons.qrc -o gui/qt/icons_rc.py
+    # Recording the creation timestamps introduces indeterminism to the build
+    sed -i '/Created: .*/d' gui/qt/icons_rc.py
+  '';
+
+  checkPhase = ''
+    $out/bin/electrum-ltc help >/dev/null
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Litecoin thin client";
+    longDescription = ''
+      Electrum-LTC is a simple, but powerful Litecoin wallet. A twelve-word
+      security passphrase (or “seed”) leaves intruders stranded and your peace
+      of mind intact. Keep it on paper, or in your head... and never worry
+      about losing your litecoins to theft or hardware failure. No waiting, no
+      lengthy blockchain downloads and no syncing to the network.
+    '';
+    homepage = https://electrum-ltc.org/;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ asymmetric ];
+  };
+}
+

--- a/pkgs/development/python-modules/ltc_scrypt/default.nix
+++ b/pkgs/development/python-modules/ltc_scrypt/default.nix
@@ -1,0 +1,22 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "ltc_scrypt";
+  version = "1.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1h90hh3iw4i7zs7jgskdjlk8gi97b3v2zqsxdfwdvhrrnhpvv856";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Bindings for scrypt proof of work used by Litecoin";
+    homepage = https://pypi.python.org/pypi/ltc_scrypt;
+    maintainers = with maintainers; [ asymmetric ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13451,6 +13451,8 @@ with pkgs;
 
   electrum-dash = callPackage ../applications/misc/electrum-dash { };
 
+  electrum-ltc = callPackage ../applications/misc/electrum-ltc { };
+
   elinks = callPackage ../applications/networking/browsers/elinks { };
 
   elvis = callPackage ../applications/editors/elvis { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13940,6 +13940,8 @@ in {
     };
   });
 
+  ltc_scrypt = callPackage ../development/python-modules/ltc_scrypt/default.nix { };
+
   python_magic = buildPythonPackage rec {
     name = "python-magic-0.4.10";
 


### PR DESCRIPTION
###### Motivation for this change

Adds Electrum-LTC, a Litecoin lightweight wallet.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

