### PR TITLE
pass: 1.7 -> 1.7.1

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -13,15 +13,15 @@ assert x11Support -> xclip != null
                   && dmenu != null;
 
 stdenv.mkDerivation rec {
-  version = "1.7";
+  version = "1.7.1";
   name    = "password-store-${version}";
 
   src = fetchurl {
     url    = "http://git.zx2c4.com/password-store/snapshot/${name}.tar.xz";
-    sha256 = "002mw7j0m33bw483rllzhcf41wp3ixka8yma6kqrfaj57jyw66hn";
+    sha256 = "0scqkpll2q8jhzcgcsh9kqz0gwdpvynivqjmmbzax2irjfaiklpn";
   };
 
-  patches = [ ./set-correct-program-name-for-sleep.patch 
+  patches = [ ./set-correct-program-name-for-sleep.patch
             ] ++ stdenv.lib.optional stdenv.isDarwin ./no-darwin-getopt.patch;
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Package bump.

Also, some trailing whitespace removed.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

