### PR TITLE
gitAndTools.gitflow: fix runtime dependencies #25487

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitflow/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitflow/default.nix
@@ -14,15 +14,16 @@ stdenv.mkDerivation rec {
     sha256 = "1i8bwi83qcqvi8zrkjn4mp2v8v7y11fd520wpg2jgy5hqyz34chg";
   };
 
-  buildInputs = optionals (stdenv.isDarwin) [ pkgs.makeWrapper ];
+  buildInputs = [ pkgs.makeWrapper ];
 
   preBuild = ''
     makeFlagsArray+=(prefix="$out")
   '';
 
-  postInstall = optional (stdenv.isDarwin) ''
+  postInstall = ''
     wrapProgram $out/bin/git-flow \
-      --set FLAGS_GETOPT_CMD ${pkgs.getopt}/bin/getopt
+      --set FLAGS_GETOPT_CMD ${pkgs.getopt}/bin/getopt \
+      --suffix PATH : ${pkgs.git}/bin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

See #25487.

If `git-flow` was installed without explicitly installing `getopt` and `git` too, it couldn't find those executables. Now it can find those and it can be used as `git-flow` executable. Note, however, that in order to use `git-flow` as git subcommand (`git flow`), one needs to install `git` too.

cc: @jgeerds

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

