### PR TITLE
pythonPackages.pytest-flake8: init at 0.8.1

### DIFF
--- a/pkgs/development/python-modules/pytest-flake8/default.nix
+++ b/pkgs/development/python-modules/pytest-flake8/default.nix
@@ -1,0 +1,29 @@
+{lib, buildPythonPackage, fetchPypi, pytest, flake8}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "pytest-flake8";
+  version = "0.8.1";
+
+  # although pytest is a runtime dependency, do not add it as
+  # propagatedBuildInputs in order to allow packages depend on another version
+  # of pytest more easily
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ flake8 ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1za5i09gz127yraigmcl443w6149714l279rmlfxg1bl2kdsc45a";
+  };
+
+  checkPhase = ''
+    pytest --ignore=nix_run_setup.py .
+  '';
+
+  meta = {
+    description = "py.test plugin for efficiently checking PEP8 compliance";
+    homepage = https://github.com/tholo/pytest-flake8;
+    maintainers = with lib.maintainers; [ jluttine ];
+    license = lib.licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5129,6 +5129,8 @@ in {
     };
   };
 
+  pytest-flake8 = callPackage ../development/python-modules/pytest-flake8 { };
+
   pytestflakes = buildPythonPackage rec {
     name = "pytest-flakes-${version}";
     version = "1.0.1";


### PR DESCRIPTION
###### Motivation for this change

Add pytest-flake8 Python package. This is a build-time dependency for another package that I'm going to pull request soon.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

