### PR TITLE
pytables: Fix build on darwin by using external c-blosc

### DIFF
--- a/pkgs/development/libraries/c-blosc/default.nix
+++ b/pkgs/development/libraries/c-blosc/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "c-blosc";
+  version = "1.11.3";
+
+  src = fetchFromGitHub {
+    owner = "Blosc";
+    repo = "c-blosc";
+    rev = "v${version}";
+    sha256 = "18665lwszwbb48pxgisyxxjh92sr764hv6h7jw8zzsmzdkgzrmcw";
+  };
+
+  buildInputs = [ cmake ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A blocking, shuffling and loss-less compression library";
+    homepage = http://www.blosc.org;
+    license = licenses.bsd3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/tables/default.nix
+++ b/pkgs/development/python-modules/tables/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python, buildPythonPackage
-, cython, bzip2, lzo, numpy, numexpr, hdf5, six }:
+, cython, bzip2, lzo, numpy, numexpr, hdf5, six, c-blosc }:
 
 buildPythonPackage rec {
   version = "3.3.0";
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "0b4211s0zzdmh74k49ss0m9lc2ql2iazq2aa95ams6h45vqcr0w3";
   };
 
-  buildInputs = [ hdf5 cython bzip2 lzo ];
+  buildInputs = [ hdf5 cython bzip2 lzo c-blosc ];
   propagatedBuildInputs = [ numpy numexpr six ];
 
   # The setup script complains about missing run-paths, but they are
@@ -19,6 +19,7 @@ buildPythonPackage rec {
     [ "--hdf5=${hdf5}"
       "--lzo=${lzo}"
       "--bzip2=${bzip2.dev}"
+      "--blosc=${c-blosc}"
     ];
 
   # Run the test suite.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7239,6 +7239,8 @@ with pkgs;
     fetchurl = fetchurlBoot;
   };
 
+  c-blosc = callPackage ../development/libraries/c-blosc { };
+
   capnproto = callPackage ../development/libraries/capnproto { };
 
   ccnx = callPackage ../development/libraries/ccnx { };


### PR DESCRIPTION
Using the pytables internal c-blosc lead to a compilation error on
darwin, as the installer uses cpuinfo.get_cpu_info(), which (unexpectedly
for pytables) returns None in the current darwin-python.
See e.g. https://hydra.nixos.org/build/52274326

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

