### PR TITLE
lightworks: init at 14.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -43,6 +43,7 @@
   andsild = "Anders Sildnes <andsild@gmail.com>";
   aneeshusa = "Aneesh Agrawal <aneeshusa@gmail.com>";
   antono = "Antono Vasiljev <self@antono.info>";
+  antonxy = "Anton Schirg <anton.schirg@posteo.de>";
   apeschar = "Albert Peschar <albert@peschar.net>";
   apeyroux = "Alexandre Peyroux <alex@px.io>";
   ardumont = "Antoine R. Dumont <eniotna.t@gmail.com>";

--- a/pkgs/applications/video/lightworks/default.nix
+++ b/pkgs/applications/video/lightworks/default.nix
@@ -1,0 +1,87 @@
+{ stdenv, fetchurl, dpkg, makeWrapper, patchelf, buildFHSUserEnv
+, gtk3, gnome3, gdk_pixbuf, cairo, libjpeg_original, glib, gnome2, mesa_glu
+, nvidia_cg_toolkit, zlib, openssl, portaudio
+}:
+let
+  fullPath = stdenv.lib.makeLibraryPath [
+    stdenv.cc.cc
+    gnome3.gtk
+    gdk_pixbuf
+    cairo
+    libjpeg_original
+    glib
+    gnome2.pango
+    mesa_glu
+    nvidia_cg_toolkit
+    zlib
+    openssl
+    portaudio
+  ];
+
+  lightworks = stdenv.mkDerivation rec {
+    version = "14.0.0";
+    name = "lightworks-${version}";
+    
+    src =
+      if stdenv.system == "x86_64-linux" then
+        fetchurl {
+          url = "http://downloads.lwks.com/v14/lwks-14.0.0-amd64.deb";
+          sha256 = "66eb9f9678d979db76199f1c99a71df0ddc017bb47dfda976b508849ab305033";
+        }
+      else throw "${name} is not supported on ${stdenv.system}";
+
+    buildInputs = [ dpkg makeWrapper ];
+
+    phases = [ "unpackPhase" "installPhase" ];
+    unpackPhase = "dpkg-deb -x ${src} ./";
+
+    installPhase = ''
+      mkdir -p $out/bin
+      substitute usr/bin/lightworks $out/bin/lightworks \
+        --replace "/usr/lib/lightworks" "$out/lib/lightworks"
+      chmod +x $out/bin/lightworks
+
+      cp -r usr/lib $out
+
+      # /usr/share/fonts is not normally searched
+      # This adds it to lightworks' search path while keeping the default
+      # using the FONTCONFIG_FILE env variable
+      echo "<?xml version='1.0'?>
+      <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+      <fontconfig>
+          <dir>/usr/share/fonts/truetype</dir>
+          <include>/etc/fonts/fonts.conf</include>
+      </fontconfig>" > $out/lib/lightworks/fonts.conf
+
+      patchelf \
+        --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        $out/lib/lightworks/ntcardvt
+
+      wrapProgram $out/lib/lightworks/ntcardvt \
+        --prefix LD_LIBRARY_PATH : ${fullPath}:$out/lib/lightworks \
+        --set FONTCONFIG_FILE $out/lib/lightworks/fonts.conf
+       
+      cp -r usr/share $out/share
+    '';
+
+    dontPatchELF = true;
+
+    meta = {
+      description = "Professional Non-Linear Video Editor";
+      homepage = "https://www.lwks.com/";
+      license = stdenv.lib.licenses.unfree;
+      maintainers = [ stdenv.lib.maintainers.antonxy ];
+      platforms = [ "x86_64-linux" ];
+    };
+  };
+
+# Lightworks expects some files in /usr/share/lightworks
+in buildFHSUserEnv rec {
+  name = "lightworks";
+
+  targetPkgs = pkgs: [
+      lightworks
+  ];
+
+  runScript = "lightworks";
+}

--- a/pkgs/development/libraries/portaudio/default.nix
+++ b/pkgs/development/libraries/portaudio/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig ]
     ++ stdenv.lib.optional (!stdenv.isDarwin) alsaLib;
 
-  configureFlags = [ "--disable-mac-universal" ];
+  configureFlags = [ "--disable-mac-universal --enable-cxx" ];
 
   propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin [ AudioUnit AudioToolbox CoreAudio CoreServices Carbon ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14611,6 +14611,8 @@ with pkgs;
     inherit (gnome3) libpeas gsettings_desktop_schemas dconf;
   };
 
+  lightworks = callPackage ../applications/video/lightworks { };
+
   lingot = callPackage ../applications/audio/lingot {
     inherit (gnome2) libglade;
   };


### PR DESCRIPTION
###### Motivation for this change
add Lightworks (Commercial Video Editor)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is my first PR so please let me know if anything does not fit.
Especially: Is it ok to add --enable-cxx in portaudio? According to nox-review 40 packages are affected