### PR TITLE
elasticsearch_kopf: 1.5.7 -> 2.1.1

### DIFF
--- a/pkgs/servers/search/elasticsearch/plugins.nix
+++ b/pkgs/servers/search/elasticsearch/plugins.nix
@@ -94,10 +94,10 @@ in {
   elasticsearch_kopf = esPlugin rec {
     name = "elasticsearch-kopf-${version}";
     pluginName = "elasticsearch-kopf";
-    version = "1.5.7";
+    version = "2.1.1";
     src = fetchurl {
       url = "https://github.com/lmenezes/elasticsearch-kopf/archive/v${version}.zip";
-      sha256 = "0mq6jmjb4ldi03m431kzr7ly0bf7mdim7s5dx4wplb85gyhscns1";
+      sha256 = "1nwwd92g0jxhfpkxb1a9z5a62naa1y7hvlx400dm6mwwav3mrf4v";
     };
     meta = {
       homepage = https://github.com/lmenezes/elasticsearch-kopf;


### PR DESCRIPTION
###### Motivation for this change
Version 1.5.7 is not working with elastic 2.x


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

