### PR TITLE
linux: support using gcc plugins

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -1,4 +1,6 @@
-{ stdenv, runCommand, nettools, bc, perl, kmod, openssl, writeTextFile, ubootChooser }:
+{ stdenv, runCommand, nettools, bc, perl, gmp, libmpc, mpfr, kmod, openssl
+, writeTextFile, ubootChooser
+}:
 
 let
   readConfig = configfile: import (runCommand "config.nix" {} ''
@@ -219,7 +221,7 @@ stdenv.mkDerivation ((drvAttrs config stdenv.platform (kernelPatches ++ nativeKe
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ perl bc nettools openssl ] ++ optional (stdenv.platform.uboot != null)
+  nativeBuildInputs = [ perl bc nettools openssl gmp libmpc mpfr ] ++ optional (stdenv.platform.uboot != null)
     (ubootChooser stdenv.platform.uboot);
 
   hardeningDisable = [ "bindnow" "format" "fortify" "stackprotector" "pic" ];


### PR DESCRIPTION
linux 4.8 onwards support gcc plugins.  This patch adds build inputs required to make use of gcc plugins to the generic kernel build environment.

I plan to use this, but thought it'd be good to see if there are any objections to adding this to the generic builder.