### PR TITLE
gnome-disks: add D-Bus service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -187,6 +187,7 @@
   ./services/desktops/geoclue2.nix
   ./services/desktops/gnome3/at-spi2-core.nix
   ./services/desktops/gnome3/evolution-data-server.nix
+  ./services/desktops/gnome3/gnome-disks.nix
   ./services/desktops/gnome3/gnome-documents.nix
   ./services/desktops/gnome3/gnome-keyring.nix
   ./services/desktops/gnome3/gnome-online-accounts.nix

--- a/nixos/modules/services/desktops/gnome3/gnome-disks.nix
+++ b/nixos/modules/services/desktops/gnome3/gnome-disks.nix
@@ -1,0 +1,42 @@
+# GNOME Disks daemon.
+
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  gnome3 = config.environment.gnome3.packageSet;
+in
+{
+
+  ###### interface
+
+  options = {
+
+    services.gnome3.gnome-disks = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable GNOME Disks daemon, a service designed to
+          be a UDisks2 graphical front-end.
+        '';
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.gnome3.gnome-disks.enable {
+
+    environment.systemPackages = [ gnome3.gnome-disk-utility ];
+
+    services.dbus.packages = [ gnome3.gnome-disk-utility ];
+
+  };
+
+}

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -104,6 +104,7 @@ in {
     services.geoclue2.enable = mkDefault true;
     services.gnome3.at-spi2-core.enable = true;
     services.gnome3.evolution-data-server.enable = true;
+    services.gnome3.gnome-disks.enable = mkDefault true;
     services.gnome3.gnome-documents.enable = mkDefault true;
     services.gnome3.gnome-keyring.enable = true;
     services.gnome3.gnome-online-accounts.enable = mkDefault true;


### PR DESCRIPTION
###### Motivation for this change
Gnome Disks can't be launched from Gnome Shell because its desktop file contains **DBusActivatable=true** but its D-Bus service is not enabled. This pull request enable the D-Bus service of Gnome Disks

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

