### PR TITLE
pythonPackages.piexif: init at 1.0.12

### DIFF
--- a/pkgs/development/python-modules/piexif/default.nix
+++ b/pkgs/development/python-modules/piexif/default.nix
@@ -1,0 +1,24 @@
+{lib, buildPythonPackage, fetchurl, pillow}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "piexif";
+  version = "1.0.12";
+
+  # pillow needed for unit tests
+  buildInputs = [ pillow ];
+
+  # No .tar.gz source available at PyPI, only .zip source, so need to use
+  # fetchurl because fetchPypi doesn't support .zip.
+  src = fetchurl {
+    url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.zip";
+    sha256 = "15dvdr7b5xxsbsq5k6kq8h0xnzrkqzc08dzlih48a21x27i02bii";
+  };
+
+  meta = {
+    description = "Simplify Exif manipulations with Python";
+    homepage = https://github.com/hMatoba/Piexif;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18371,6 +18371,8 @@ in {
     };
   };
 
+  piexif = callPackage ../development/python-modules/piexif { };
+
   pip = buildPythonPackage rec {
     pname = "pip";
     version = "9.0.1";


### PR DESCRIPTION
###### Motivation for this change

`piexif` is a dependency for another package that I'm going to pull request soon.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

