### PR TITLE
go: 1.8 -> 1.8.1

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5340,11 +5340,9 @@ with pkgs;
     stdenv = stdenvAdapters.overrideCC pkgs.stdenv pkgs.clang_38;
   });
 
-  go_1_8 = callPackage ../development/compilers/go/1.8.nix ({
+  go_1_8 = callPackage ../development/compilers/go/1.8.nix {
     inherit (darwin.apple_sdk.frameworks) Security Foundation;
-  } // stdenv.lib.optionalAttrs stdenv.isDarwin {
-    stdenv = stdenvAdapters.overrideCC pkgs.stdenv pkgs.clang_38;
-  });
+  };
 
   go = go_1_8;
 


### PR DESCRIPTION
###### Motivation for this change

1.8.1 fixes some issues with MacOS Sierra (https://github.com/golang/go/issues/19734)
as part of this, a fix for https://github.com/golang/go/issues/19772 is bringing to light a bug in the way we invoke `dsymutil`, which happens to be a stub in darwin `cctools` (during the build), and generally `/usr/bin/dsymutil` at runtime.
I'm not entirely sure of the correctness of the fix though, so feedback highly welcome !

I ran `nox-review` on both MacOS and NixOS, and some compilations failed (like `gcsfuse` and `qsyncthingtray` on NixOS, `consul`, `heroku` and `cadvisor` on MacOS) but as far as I can tell are already failing in master.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

