### PR TITLE
solvespace: 2.0 -> 2.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -152,6 +152,7 @@
   e-user = "Alexander Kahl <nixos@sodosopa.io>";
   ebzzry = "Rommel Martinez <ebzzry@gmail.com>";
   edanaher = "Evan Danaher <nixos@edanaher.net>";
+  edef = "edef <edef@edef.eu>";
   ederoyd46 = "Matthew Brown <matt@ederoyd.co.uk>";
   eduarrrd = "Eduard Bachmakov <e.bachmakov@gmail.com>";
   edwtjo = "Edward Tjörnhammar <ed@cflags.cc>";

--- a/pkgs/applications/graphics/solvespace/default.nix
+++ b/pkgs/applications/graphics/solvespace/default.nix
@@ -1,38 +1,41 @@
-{ stdenv, fetchgit, autoreconfHook, fltk13
-, libjpeg, libpng, mesa, pkgconfig }:
-
-stdenv.mkDerivation {
-  name = "solvespace-2.0";
+{ stdenv, fetchgit, cmake, pkgconfig, zlib, libpng, cairo, freetype
+, json_c, fontconfig, gtkmm2, pangomm, glew, mesa_glu, xlibs, pcre
+}:
+stdenv.mkDerivation rec {
+  name = "solvespace-2.3-20170416";
+  rev = "b1d87bf284b32e875c8edba592113e691ea10bcd";
   src = fetchgit {
-    url = "https://github.com/jwesthues/solvespace.git";
-    sha256 = "0m6zlx1kiqxkm6szdsnywwr6spnb7xjg6vqsq30nrr44cx37w861";
-    rev = "e587d0e";
+    url = https://github.com/solvespace/solvespace;
+    inherit rev;
+    sha256 = "160qam04pfrwkh9qskfmjkj01wrjwhl09xi6jjxi009yqg3cff9l";
+    fetchSubmodules = true;
   };
 
-  # Fixup build after glibc-2.25.
-  postPatch = ''
-    sed 's/\<CHAR_WIDTH\>/CHARWIDTH/g' \
-      -i src/{fltk/fltkmain.cpp,glhelper.cpp,textwin.cpp,toolbar.cpp,ui.h}
-  '';
-
-  # e587d0e fails with undefined reference errors if make is called
-  # twice. Ugly workaround: Build while installing.
-  dontBuild = true;
-  enableParallelBuilding = false;
-
   buildInputs = [
-    autoreconfHook
-    fltk13
-    libjpeg
-    libpng
-    mesa
-    pkgconfig
+    cmake pkgconfig zlib libpng cairo freetype
+    json_c fontconfig gtkmm2 pangomm glew mesa_glu
+    xlibs.libpthreadstubs xlibs.libXdmcp pcre
   ];
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    patch CMakeLists.txt <<EOF
+    @@ -20,9 +20,9 @@
+     # NOTE TO PACKAGERS: The embedded git commit hash is critical for rapid bug triage when the builds
+     # can come from a variety of sources. If you are mirroring the sources or otherwise build when
+     # the .git directory is not present, please comment the following line:
+    -include(GetGitCommitHash)
+    +# include(GetGitCommitHash)
+     # and instead uncomment the following, adding the complete git hash of the checkout you are using:
+    -# set(GIT_COMMIT_HASH 0000000000000000000000000000000000000000)
+    +set(GIT_COMMIT_HASH $rev)
+    EOF
+  '';
 
   meta = {
     description = "A parametric 3d CAD program";
     license = stdenv.lib.licenses.gpl3;
-    maintainers = with stdenv.lib.maintainers; [ the-kenny ];
+    maintainers = with stdenv.lib.maintainers; [ edef ];
     platforms = stdenv.lib.platforms.linux;
     homepage = http://solvespace.com;
   };


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Remaining question: figure out if the version marker should include the commit hash
I'm not sure what the relevant nixpkgs conventions are, and SolveSpace doesn't have an official patch version number.
@whitequark (the maintainer) suggests including the git hash, although this doesn't provide ordering (does nix-env use version ordering?)