### PR TITLE
intero-nix-shim: fix runtime dependencies

### DIFF
--- a/pkgs/development/tools/haskell/intero-nix-shim/default.nix
+++ b/pkgs/development/tools/haskell/intero-nix-shim/default.nix
@@ -1,5 +1,6 @@
-{ mkDerivation, base, directory, filepath, optparse-applicative
-, posix-escape, split, stdenv, unix, fetchFromGitHub
+{ mkDerivation, base, cabal-install, directory, fetchFromGitHub
+, filepath, intero, optparse-applicative, posix-escape, split
+, stdenv, unix
 }:
 mkDerivation {
   pname = "intero-nix-shim";
@@ -16,6 +17,11 @@ mkDerivation {
     base directory filepath optparse-applicative posix-escape split
     unix
   ];
+  postInstall = ''
+    mkdir -p $out/libexec
+    ln -s ${cabal-install}/bin/cabal  $out/libexec
+    ln -s ${intero       }/bin/intero $out/libexec
+  '';
   homepage = "https://github.com/michalrus/intero-nix-shim";
   license = stdenv.lib.licenses.asl20;
 }


### PR DESCRIPTION
###### Motivation for this change

@shlevy, in the initial PR, #24853, I forgot to include this part: https://github.com/michalrus/intero-nix-shim/blob/72677fb3a9f475f7f53715b18dc251ed83026410/default.nix#L13-L17

Partly due to “copying code” (having similar `default.nix` in both repos) and forgetting to retest it, but that’s no excuse, I’m terribly sorry! :crying_cat_face: 

Do you think you could backport this to 17.03 as well? Without those two links, the version there is useless.

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).