### PR TITLE
libscrypt: init at 1.21

### DIFF
--- a/pkgs/development/libraries/libscrypt/default.nix
+++ b/pkgs/development/libraries/libscrypt/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "libscrypt-${version}";
+  version = "1.21";
+
+  src = fetchFromGitHub {
+    owner = "technion";
+    repo = "libscrypt";
+    rev = "v${version}";
+    sha256 = "1d76ys6cp7fi4ng1w3mz2l0p9dbr7ljbk33dcywyimzjz8bahdng";
+  };
+
+  buildFlags = stdenv.lib.optional stdenv.isDarwin "LDFLAGS= CFLAGS_EXTRA=";
+
+  installFlags = [ "PREFIX=$(out)" ];
+  installTargets = if stdenv.isDarwin then "install-osx" else "install";
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Shared library that implements scrypt() functionality";
+    homepage = "https://lolware.net/2014/04/29/libscrypt.html";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ davidak ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2594,6 +2594,8 @@ with pkgs;
 
   libcpuid = callPackage ../tools/misc/libcpuid { };
 
+  libscrypt = callPackage ../development/libraries/libscrypt { };
+
   libsmi = callPackage ../development/libraries/libsmi { };
 
   lesspipe = callPackage ../tools/misc/lesspipe { };


### PR DESCRIPTION
###### Motivation for this change

i need it for the bcachefs-tools package :)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

