### PR TITLE
virt-manager: add requests as dependency

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -28,7 +28,7 @@ python2Packages.buildPythonApplication rec {
     [ eventlet greenlet gflags netaddr carrot routes PasteDeploy
       m2crypto ipy twisted distutils_extra simplejson
       cheetah lockfile httplib2 urlgrabber pyGtkGlade dbus-python
-      pygobject3 ipaddr mox libvirt libxml2
+      pygobject3 ipaddr mox libvirt libxml2 requests
     ];
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

https://bugs.archlinux.org/task/47187

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

