### PR TITLE
asn1c: 0.9.27 -> 0.9.28

### DIFF
--- a/pkgs/development/compilers/asn1c/default.nix
+++ b/pkgs/development/compilers/asn1c/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "asn1c-${version}";
-  version = "0.9.27";
+  version = "0.9.28";
 
   src = fetchurl {
     url = "http://lionet.info/soft/asn1c-${version}.tar.gz";
-    sha256 = "17nvn2kzvlryasr9dzqg6gs27b9lvqpval0k31pb64bjqbhn8pq2";
+    sha256 = "1fc64g45ykmv73kdndr4zdm4wxhimhrir4rxnygxvwkych5l81w0";
   };
 
   outputs = [ "out" "doc" "man" ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

