### PR TITLE
services.xserver.xautolock: add module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -610,6 +610,7 @@
   ./services/x11/window-managers/windowlab.nix
   ./services/x11/window-managers/wmii.nix
   ./services/x11/window-managers/xmonad.nix
+  ./services/x11/xautolock.nix
   ./services/x11/xbanish.nix
   ./services/x11/xfs.nix
   ./services/x11/xserver.nix

--- a/nixos/modules/services/x11/xautolock.nix
+++ b/nixos/modules/services/x11/xautolock.nix
@@ -1,0 +1,72 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.xautolock;
+in
+  {
+    options = {
+      services.xserver.xautolock = {
+        enable = mkEnableOption "xautolock";
+        enableNotifier = mkEnableOption "xautolock.notify" // {
+          description = ''
+            Whether to enable the notifier feature of xautolock.
+            This publishes a notification before the autolock.
+          '';
+        };
+
+        time = mkOption {
+          default = 15;
+          type = types.int;
+
+          description = ''
+            Idle time to wait until xautolock locks the computer.
+          '';
+        };
+
+        locker = mkOption {
+          default = "xlock"; # default according to `man xautolock`
+          example = "i3lock -i /path/to/img";
+          type = types.string;
+
+          description = ''
+            The script to use when locking the computer.
+          '';
+        };
+
+        notify = mkOption {
+          default = 10;
+          type = types.int;
+
+          description = ''
+            Time (in seconds) before the actual lock when the notification about the pending lock should be published.
+          '';
+        };
+
+        notifier = mkOption {
+          default = "notify-send 'Locking in 10 seconds'";
+          type = types.string;
+
+          description = ''
+            Notification script to be used to warn about the pending autolock.
+          '';
+        };
+      };
+    };
+
+    config = mkIf cfg.enable {
+      environment.systemPackages = with pkgs; [ xautolock ];
+
+      services.xserver.displayManager.sessionCommands = with builtins; with pkgs; ''
+        ${xautolock}/bin/xautolock \
+          ${concatStringsSep " \\\n" ([
+            "-time ${toString(cfg.time)}"
+            "-locker ${cfg.locker}"
+          ] ++ optional cfg.enableNotifier (concatStringsSep " " [ 
+            "-notify ${toString(cfg.notify)}"
+            "-notifier \"${cfg.notifier}\""
+          ]))} &
+      '';
+    };
+  }


### PR DESCRIPTION
###### Motivation for this change

I currently use `xautolock` for autolocking things.
However I'd like to have a declarative module rather than a hacked configuration in the `sessionCommands` option of the `displayManager`.

I tested it using the following configurations:

``` nix
{ #...
  services.xserver = {
    # configuration with disabled notifier (no notification published before autolock)
    enable = true;
    displayManager.slim.enable = false;
    displayManager.sddm.enable = true;
    desktopManager.default = "xfce";
    desktopManager.xterm.enable = false;
    desktopManager.xfce.enable = true;
    xautolock = {
      enable = true;
      time = 1;
      enableNotifier = false;
    };
  };
}
```

``` nix
{
  # ...
  services.xserver = {
    # configuration with enabled notifier (notification published before autolock)
    enable = true;
    displayManager.slim.enable = false;
    displayManager.sddm.enable = true;
    desktopManager.default = "xfce";
    desktopManager.xterm.enable = false;
    desktopManager.xfce.enable = true;
    xautolock = {
      enable = true;
      time = 1;
      locker = "i3lock";
      enableNotifier = true;
      notifier = "notify-send 'foo'";
    };
  };
}
```

I tested it using the following command:

```
NIXOS_CONFIG=`pwd`/vmtest.nix nixos-rebuild -I nixpkgs=$HOME/Projects/nixpkgs/ build-vm
```

#### Note:

I checked the `xsession` file and it seemed to work for me, however it would be nice if someone could **test** it **before** merging :-)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

