### PR TITLE
docker-edge: 17.04 to 17.05

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -157,14 +157,14 @@ rec {
     tiniSha256 = "0zj4kdis1vvc6dwn4gplqna0bs7v6d1y2zc8v80s3zi018inhznw";
   };
 
-  docker_17_04 = dockerGen rec {
-    version = "17.04.0-ce";
-    rev = "4845c56"; # git commit
-    sha256 = "04farary19ws7xzsyack0sbrxjzp5xwjh26frxbpdd0a88pxnbj7";
+  docker_17_05 = dockerGen rec {
+    version = "17.05.0-ce";
+    rev = "90d35abf7b3535c1c319c872900fbd76374e521c"; # git commit
+    sha256 = "1m4fcawjj14qws57813wjxjwgnrfxgxnnzlj61csklp0s9dhg7df";
     runcRev = "9c2d8d184e5da67c95d601382adf14862e4f2228";
     runcSha256 = "131jv8f77pbdlx88ar0zjwdsp0a5v8kydaw0w0cl3i0j3622ydjl";
-    containerdRev = "422e31ce907fd9c3833a38d7b8fdd023e5a76e73";
-    containerdSha256 = "1g0k82f1mk3vn57k130q776wp5c226d06qbiq1q148pqxxhym2r2";
+    containerdRev = "9048e5e50717ea4497b757314bad98ea3763c145";
+    containerdSha256 = "1r9xhvzzh7md08nqb0rbp5d1rdr7jylb3da954d0267i0kh2iksa";
     tiniRev = "949e6facb77383876aeff8a6944dde66b3089574";
     tiniSha256 = "0zj4kdis1vvc6dwn4gplqna0bs7v6d1y2zc8v80s3zi018inhznw";
   };

--- a/pkgs/applications/virtualization/docker/proxy.nix
+++ b/pkgs/applications/virtualization/docker/proxy.nix
@@ -4,13 +4,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "docker-proxy-${rev}";
-  rev = "0f534354b813003a754606689722fe253101bc4e";
+  rev = "7b2b1feb1de4817d522cc372af149ff48d25028e";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "docker";
     repo = "libnetwork";
-    sha256 = "1ah7h417llcq0xzdbp497pchb9m9qvjhrwajcjb0ybrs8v889m31";
+    sha256 = "1ng577k11cyv207bp0vaz5jjfcn2igd6w95zn4izcq1nldzp5935";
   };
 
   buildInputs = [ go ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13405,10 +13405,11 @@ with pkgs;
 
   inherit (callPackage ../applications/virtualization/docker { })
     docker_17_03
-    docker_17_04;
+    docker_17_04
+    docker_17_05;
 
   docker = docker_17_03;
-  docker-edge = docker_17_04;
+  docker-edge = docker_17_05;
 
   docker-proxy = callPackage ../applications/virtualization/docker/proxy.nix { };
 


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Updating docker-edge to 17.05 now it's released.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

