### PR TITLE
bcachefs-tools: init at a588eb0

### DIFF
--- a/pkgs/tools/filesystems/bcachefs-tools/default.nix
+++ b/pkgs/tools/filesystems/bcachefs-tools/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, pkgs, fetchgit, pkgconfig, attr, libuuid, libscrypt, libsodium, keyutils, liburcu, zlib, libaio }:
+
+stdenv.mkDerivation rec {
+  name = "bcachefs-tools-${version}";
+  version = "git";
+
+  src = fetchgit {
+    url = "https://evilpiepirate.org/git/bcachefs-tools.git";
+    rev = "a588eb0d9e30dffa4b319a4715c1454ee1d911f1 ";
+    sha256 = "1xpiwp6n6jp3zc70i648xpp54cd5yay4si28czn350bxwljbwpsy";
+  };
+
+  buildInputs = [ pkgconfig attr libuuid libscrypt libsodium keyutils liburcu zlib libaio ];
+
+  preConfigure = ''
+    substituteInPlace cmd_migrate.c --replace /usr/include/dirent.h ${stdenv.glibc.dev}/include/dirent.h
+  '';
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Tool for managing bcachefs filesystems";
+    homepage = "http://bcachefs.org/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ davidak ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -518,6 +518,8 @@ with pkgs;
 
   autorevision = callPackage ../tools/misc/autorevision { };
 
+  bcachefs-tools = callPackage ../tools/filesystems/bcachefs-tools { };
+
   bonnie = callPackage ../tools/filesystems/bonnie { };
 
   djmount = callPackage ../tools/filesystems/djmount { };


### PR DESCRIPTION
###### Motivation for this change

I want to test the [bcachefs](http://bcachefs.org/) filesystem and maybe use it when it seams stable. Could be a good alternative to Btrfs/ZFS/ext4 in the near future.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

