### PR TITLE
pythonPackages.setuptools_scm: 1.15.0 -> 1.15.6

### DIFF
--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -10,8 +10,8 @@ buildPythonPackage rec {
   };
 
   LC_ALL = "en_US.UTF-8";
-  buildInputs = [ pytest glibcLocales ];
-  propagatedBuildInputs = [ pip click six first setuptools_scm ];
+  buildInputs = [ pytest glibcLocales setuptools_scm ];
+  propagatedBuildInputs = [ pip click six first ];
 
   checkPhase = ''
     export HOME=$(mktemp -d)

--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -14,7 +14,8 @@ pythonPackages.buildPythonApplication rec {
     $out/bin/simp_le --test
   '';
 
-  propagatedBuildInputs = with pythonPackages; [ acme setuptools_scm ];
+  buildInputs = with pythonPackages; [ setuptools_scm ];
+  propagatedBuildInputs = with pythonPackages; [ acme ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/zenhack/simp_le";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22865,7 +22865,8 @@ in {
       sha256 = "0fyniq37nnmhrk4j7mzvg6vfcpb624hb9x70g6mccyw4xrnhadv6";
     };
 
-    propagatedBuildInputs = with self; [setuptools_scm pyyaml jsonschema sphinxcontrib_httpdomain];
+    buildInputs = [ setuptools_scm ];
+    propagatedBuildInputs = with self; [pyyaml jsonschema sphinxcontrib_httpdomain];
   });
 
   sphinxcontrib_httpdomain = buildPythonPackage (rec {
@@ -25057,7 +25058,8 @@ EOF
     # Tests require `pyutil' so disable them to avoid circular references.
     doCheck = false;
 
-    propagatedBuildInputs = with self; [ six setuptools_scm pkgs.xorg.libX11 ];
+    buildInputs = [ setuptools_scm ];
+    propagatedBuildInputs = with self; [ six pkgs.xorg.libX11 ];
 
     meta = {
       description = "Fully functional X client library for Python programs";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21564,20 +21564,19 @@ in {
 
   setuptools_scm = buildPythonPackage rec {
     name = "setuptools_scm-${version}";
-    version = "1.15.0";
+    version = "1.15.6";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/s/setuptools_scm/${name}.tar.gz";
-      sha256 = "0bwyc5markib0i7i2qlyhdzxhiywzxbkfiapldma8m91m82jvwfs";
+      sha256 = "0pzvfmx8s20yrgkgwfbxaspz2x1g38qv61jpm0ns91lrb22ldas9";
     };
 
     buildInputs = with self; [ pip ];
+    propagatedBuildInputs = [ pkgs.gitMinimal ] ++ optional (!isPy3k) pkgs.mercurial;
     checkInputs = with self; [ pytest ];
-    # Seems to fail due to chroot
-    doCheck = false;
 
     checkPhase = ''
-      py.test
+      py.test ${optionalString isPy3k "-k 'not test_mercurial'"}
     '';
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
Also add missing dependencies

###### Motivation for this change

The packages is broken as it stands.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

