### PR TITLE
weka: 3.8.0 -> 3.8.1

### DIFF
--- a/pkgs/applications/science/math/weka/default.nix
+++ b/pkgs/applications/science/math/weka/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "weka-${version}";
-  version = "3.8.0";
+  version = "3.8.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/weka/${stdenv.lib.replaceChars ["."]["-"] name}.zip";
-    sha256 = "2586298688059a025e2810b1ffc73f4fb3cf81ebf2183d8d19b0763d33857f61";
+    sha256 = "16n1a74d1cispp0a22zyiivi78izi354y67gmbyvv2lv9sc45wmk";
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

Update weka to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

