### PR TITLE
cytoscape: 3.4.0 -> 3.5.1

### DIFF
--- a/pkgs/applications/science/misc/cytoscape/default.nix
+++ b/pkgs/applications/science/misc/cytoscape/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "cytoscape-${version}";
-  version = "3.4.0";
+  version = "3.5.1";
 
   src = fetchurl {
     url = "http://chianti.ucsd.edu/${name}/${name}.tar.gz";
-    sha256 = "065fsqa01w7j85nljwwc0677lfw112xphnyn1c4hb04166q082p2";
+    sha256 = "1dvv0f7sc7q7lwmpd7xkcx86dd8lxh2il3wiwkij44gh7ni1qkfm";
   };
 
   buildInputs = [jre makeWrapper];


### PR DESCRIPTION
###### Motivation for this change

Update cytoscape to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

