### PR TITLE
filezilla: 3.25.1 -> 3.25.2

### DIFF
--- a/pkgs/applications/networking/ftp/filezilla/default.nix
+++ b/pkgs/applications/networking/ftp/filezilla/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, dbus, gnutls, wxGTK30, libidn, tinyxml, gettext
 , pkgconfig, xdg_utils, gtk2, sqlite, pugixml, libfilezilla, nettle }:
 
-let version = "3.25.1"; in
+let version = "3.25.2"; in
 stdenv.mkDerivation {
   name = "filezilla-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/filezilla/FileZilla_Client/${version}/FileZilla_${version}_src.tar.bz2";
-    sha256 = "1h9g26i16wvc3yjavd39lxifr8d21q9mvfidnwjp9ksrc1qvwww8";
+    sha256 = "1kdah69lbgpam7xrxrqxbcjplk459a5fv5ffvgfn5y5gq7dhm6sm";
   };
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

Update filezilla to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

