### PR TITLE
languagetool: 3.5 -> 3.7

### DIFF
--- a/pkgs/tools/text/languagetool/default.nix
+++ b/pkgs/tools/text/languagetool/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "LanguageTool";
-  version = "3.5";
+  version = "3.7";
   name = pname + "-" + version;
   src = fetchurl {
     url = "https://www.languagetool.org/download/${name}.zip";
-    sha256 = "1axw8fqg2wlkmv45s71q5pg44sg1s06szpkjhyscy704i7d2jc34";
+    sha256 = "04i49z022k3nyyr8hnlxima9k5id8qvh2nr3dv8zgcqm5sin6xx9";
   };
   buildInputs = [ unzip jdk ];
   installPhase =


### PR DESCRIPTION
###### Motivation for this change

Update languagetools to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

