### PR TITLE
Update/htslib 1.4

### DIFF
--- a/pkgs/applications/science/biology/bcftools/default.nix
+++ b/pkgs/applications/science/biology/bcftools/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, fetchurl, zlib, htslib }:
+{ stdenv, fetchurl, htslib, zlib, bzip2, lzma, perl }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "bcftools";
-  version = "1.3.1";
+  major = "1.4";
+  version = "${major}.0";
 
   src = fetchurl {
-    url = "https://github.com/samtools/${pname}/releases/download/${version}/${name}.tar.bz2";
-    sha256 = "095ry68vmz9q5s1scjsa698dhgyvgw5aicz24c19iwfbai07mhqj";
+    url = "https://github.com/samtools/bcftools/releases/download/${major}/bcftools-${major}.tar.bz2";
+    sha256 = "0k93mq3lf73dch81p4zxi0bdll567acxfa81qzbzkqflgsjb1ccg";
   };
 
-  buildInputs = [ zlib ];
+  buildInputs = [ zlib bzip2 lzma perl ];
 
   makeFlags = [
     "HSTDIR=${htslib}"

--- a/pkgs/applications/science/biology/samtools/default.nix
+++ b/pkgs/applications/science/biology/samtools/default.nix
@@ -3,14 +3,15 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "samtools";
-  version = "1.3.1";
+  major = "1.4";
+  version = "${major}.0";
 
   src = fetchurl {
-    url = "https://github.com/samtools/${pname}/releases/download/${version}/${name}.tar.bz2";
-    sha256 = "0znnnxc467jbf1as2dpskrjhfh8mbll760j6w6rdkwlwbqsp8gbc";
+    url = "https://github.com/samtools/samtools/releases/download/${major}/samtools-${major}.tar.bz2";
+    sha256 = "1x73c0lxvd58ghrmaqqyp56z7bkmp28a71fk4ap82j976pw5pbls";
   };
 
-  buildInputs = [ zlib ncurses htslib ];
+  buildInputs = [ zlib ncurses ];
 
   configureFlags = [ "--with-htslib=${htslib}" ]
     ++ stdenv.lib.optional (ncurses == null) "--without-curses";

--- a/pkgs/development/libraries/science/biology/htslib/default.nix
+++ b/pkgs/development/libraries/science/biology/htslib/default.nix
@@ -1,16 +1,21 @@
-{ stdenv, fetchurl, zlib }:
+{ stdenv, fetchurl, zlib, bzip2, lzma, curl }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "${major}.0";
   pname = "htslib";
-  version = "1.3.2";
+  major = "1.4";
 
   src = fetchurl {
-    url = "https://github.com/samtools/${pname}/releases/download/${version}/${name}.tar.bz2";
-    sha256 = "0iq3blw23s55vkr1z88p9y2dqrb2dybzhl6hz2nlk53ncihrxcdr";
+    url = "https://github.com/samtools/htslib/releases/download/${major}/htslib-${major}.tar.bz2";
+    sha256 = "0l1ki3sqfhawfn7fx9v7i2pm725jki4c5zij9j96xka5zwc8iz2w";
   };
 
-  buildInputs = [ zlib ];
+  buildInputs = [ zlib bzip2 lzma curl ];
+
+  configureFlags = "--enable-libcurl"; # optional but strongly recommended
+
+  installFlags = "prefix=$(out)";
 
   meta = with stdenv.lib; {
     description = "A C library for reading/writing high-throughput sequencing data";


### PR DESCRIPTION
###### Motivation for this change

Update htslib, samtools and bcftools to the last versions

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

