### PR TITLE
nylas-mail: 2.0.32

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -249,6 +249,7 @@
   joelmo = "Joel Moberg <joel.moberg@gmail.com>";
   joelteon = "Joel Taylor <me@joelt.io>";
   johbo = "Johannes Bornhold <johannes@bornhold.name>";
+  johnramsden = "John Ramsden <johnramsden@riseup.net>"
   joko = "Ioannis Koutras <ioannis.koutras@gmail.com>";
   jonafato = "Jon Banafato <jon@jonafato.com>";
   jpbernardy = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -249,7 +249,7 @@
   joelmo = "Joel Moberg <joel.moberg@gmail.com>";
   joelteon = "Joel Taylor <me@joelt.io>";
   johbo = "Johannes Bornhold <johannes@bornhold.name>";
-  johnramsden = "John Ramsden <johnramsden@riseup.net>"
+  johnramsden = "John Ramsden <johnramsden@riseup.net>";
   joko = "Ioannis Koutras <ioannis.koutras@gmail.com>";
   jonafato = "Jon Banafato <jon@jonafato.com>";
   jpbernardy = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";

--- a/nixos/modules/programs/nylas-mail.nix
+++ b/nixos/modules/programs/nylas-mail.nix
@@ -19,16 +19,6 @@ in {
         default = true;
         description = "Enable gnome3 keyring for nylas-mail.";
       };
-
-      package = mkOption {
-        type = types.package;
-        default = pkgs.nylas-mail;
-        defaultText = "pkgs.nylas-mail";
-        example = literalExample "pkgs.nylas-mail";
-        description = ''
-          nylas-mail package to use.
-        '';
-      };
     };
   };
 
@@ -37,7 +27,11 @@ in {
 
   config = mkIf cfg.enable {
 
+    environment.systemPackages = [pkgs.nylas-mail];
 
+    services.gnome3.gnome-keyring = mkIf cfg.gnome3-keyring {
+      enable = true;
+    };
 
   };
 }

--- a/nixos/modules/programs/nylas-mail.nix
+++ b/nixos/modules/programs/nylas-mail.nix
@@ -27,7 +27,7 @@ in {
 
   config = mkIf cfg.enable {
 
-    environment.systemPackages = [pkgs.nylas-mail];
+    environment.systemPackages = [ pkgs.nylas-mail-bin ];
 
     services.gnome3.gnome-keyring = mkIf cfg.gnome3-keyring {
       enable = true;

--- a/nixos/modules/programs/nylas-mail.nix
+++ b/nixos/modules/programs/nylas-mail.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.nylas-mail;
+  defaultUser = "nylas-mail";
+in {
+  ###### interface
+  options = {
+    services.nylas-mail = {
+
+      enable = mkEnableOption ''
+        nylas-mail - Open-source mail client built on the modern web with Electron, React, and Flux
+      '';
+
+      gnome3-keyring = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Enable gnome3 keyring for nylas-mail.";
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.nylas-mail;
+        defaultText = "pkgs.nylas-mail";
+        example = literalExample "pkgs.nylas-mail";
+        description = ''
+          nylas-mail package to use.
+        '';
+      };
+    };
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+
+
+  };
+}

--- a/pkgs/applications/networking/mailreaders/nylas-mail-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/nylas-mail-bin/default.nix
@@ -29,7 +29,7 @@
 
 stdenv.mkDerivation rec {
   name = "${pkgname}-${version}";
-  pkgname = "nylas-mail";
+  pkgname = "nylas-mail-bin";
   version = "2.0.32";
   subVersion = "fec7941";
 
@@ -126,7 +126,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Open-source mail client built on the modern web with Electron, React, and Flux";
     longDescription = ''
-      Nylas Mail is an open-source mail client built on the modern web with Electron, React, and Flux. It is designed to be extensible, so it's easy to create new experiences and workflows around email. To run nylas-mail, an additional manual step is required. Make sure to have services.gnome3.gnome-keyring.enable = true; in your configuration.nix before running nylas-mail. If you happen to miss this step, you should remove ~/.nylas-mail and "~/.config/Nylas Mail" for a blank setup".
+      Nylas Mail is an open-source mail client built on the modern web with Electron, React, and Flux. It is designed to be extensible, so it's easy to create new experiences and workflows around email. Nylas Mail can be enabled with it's requirements by enabling 'services.nylas-mail.enable=true'. Alternatively, make sure to have services.gnome3.gnome-keyring.enable = true; in your configuration.nix before running nylas-mail. If you happen to miss this step, you should remove ~/.nylas-mail and "~/.config/Nylas Mail" for a blank setup".
     '';
     license = licenses.gpl3;
     maintainers = with maintainers; [ johnramsden ];

--- a/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
@@ -126,9 +126,12 @@ stdenv.mkDerivation rec {
         $out/share/nylas-mail/resources/apm/bin/node
    '';
 
-   meta = {
-     description = "Nylas Mail is an open-source mail client built on the modern web with Electron, React, and Flux. It is designed to be extensible, so it's easy to create new experiences and workflows around email.";
-     license = stdenv.lib.licenses.gpl3;
+   meta = with stdenv.lib; {
+     description = "pen-source mail client built on the modern web with Electron, React, and Flux";
+     longDescription = ''
+        Nylas Mail is an open-source mail client built on the modern web with Electron, React, and Flux. It is designed to be extensible, so it's easy to create new experiences and workflows around email. Nylas-Mail requires gnome3 keyring. It can be enabled with "services.gnome3.gnome-keyring.enable = true;".
+     '';
+     license = licenses.gpl3;
      maintainers = with maintainers; [ johnramsden ];
      homepage = https://nylas.com;
    };

--- a/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
@@ -1,0 +1,134 @@
+{ config
+, stdenv
+, pkgs
+, fetchurl
+, dpkg
+, lib
+, gnome2
+, libgnome_keyring
+, desktop_file_utils
+, python2
+, nodejs
+, libnotify
+, alsaLib
+, atk
+, glib
+, pango
+, gdk_pixbuf
+, cairo
+, freetype
+, fontconfig
+, dbus
+, nss
+, nspr
+, cups
+, expat
+, wget
+, udev
+, xorg
+, libgcrypt
+, makeWrapper
+, gcc-unwrapped
+, coreutils
+}:
+
+stdenv.mkDerivation rec {
+   name = "${pkgname}-${version}";
+   pkgname = "nylas-mail";
+   version = "2.0.31";
+   subVersion = "e675deb";
+
+   src = fetchurl {
+     url = "https://edgehill.s3-us-west-2.amazonaws.com/${version}-${subVersion}/linux-deb/x64/NylasMail.deb";
+     sha256 = "b036956174f998bd4a2662a1f59cb4a302465b3ed06c487de88ff2721e372f6e";
+   };
+
+   # Build dependencies
+   propagatedBuildInputs = [
+     gnome2.gtk
+     gnome2.GConf
+     libgnome_keyring
+     desktop_file_utils
+     python2
+     nodejs
+     libnotify
+     alsaLib
+     atk
+     glib
+     pango
+     gdk_pixbuf
+     cairo
+     freetype
+     fontconfig
+     dbus
+     nss
+     nspr
+     cups
+     expat
+     wget
+     udev
+     gcc-unwrapped
+     coreutils
+     xorg.libXScrnSaver
+     xorg.libXi
+     xorg.libXtst
+     xorg.libXcursor
+     xorg.libXdamage
+     xorg.libXrandr
+     xorg.libXcomposite
+     xorg.libXext
+     xorg.libXfixes
+     xorg.libXrender
+     xorg.libX11
+     xorg.libxkbfile
+   ];
+
+   # Runtime dependencies
+   buildInputs = [ makeWrapper gnome2.gnome_keyring ];
+
+   phases = [ "unpackPhase" ];
+
+   unpackPhase = ''
+    mkdir -p $out
+
+    ${dpkg}/bin/dpkg-deb -x $src unpacked
+    mv unpacked/usr/* $out/
+
+    # Fix path in desktop file
+    substituteInPlace $out/share/applications/nylas-mail.desktop \
+        --replace /usr/bin/nylas-mail $out/bin/nylas-mail
+
+     # Patch librariess
+     noderp=$(patchelf --print-rpath $out/share/nylas-mail/libnode.so)
+     patchelf --set-rpath $noderp:$out/lib:${stdenv.cc.cc.lib}/lib:${xorg.libxkbfile.out}/lib:${lib.makeLibraryPath propagatedBuildInputs } \
+         $out/share/nylas-mail/libnode.so
+
+     ffrp=$(patchelf --print-rpath $out/share/nylas-mail/libffmpeg.so)
+     patchelf --set-rpath $ffrp:$out/lib:${stdenv.cc.cc.lib}/lib:${lib.makeLibraryPath propagatedBuildInputs } \
+         $out/share/nylas-mail/libffmpeg.so
+
+     # Patch binaries
+     binrp=$(patchelf --print-rpath $out/share/nylas-mail/nylas)
+     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+         --set-rpath $binrp:$out/lib:${stdenv.cc.cc.lib}/lib:${lib.makeLibraryPath propagatedBuildInputs } \
+         $out/share/nylas-mail/nylas
+
+    wrapProgram $out/share/nylas-mail/nylas --set LD_LIBRARY_PATH "${xorg.libxkbfile}/lib:${pkgs.gnome3.libgnome_keyring}/lib";
+
+    # Fix path to bash so apm can install plugins.
+    substituteInPlace $out/share/nylas-mail/resources/apm/bin/apm \
+          --replace /bin/bash ${stdenv.shell}
+
+    wrapProgram $out/share/nylas-mail/resources/apm/bin/apm \
+        --set PATH "${coreutils}/bin"
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+             --set-rpath ${gcc-unwrapped.lib}/lib \
+        $out/share/nylas-mail/resources/apm/bin/node
+   '';
+
+   meta = {
+     description = "Nylas Mail is an open-source mail client built on the modern web with Electron, React, and Flux. It is designed to be extensible, so it's easy to create new experiences and workflows around email.";
+     license = stdenv.lib.licenses.gpl3;
+     homepage = https://nylas.com;
+   };
+}

--- a/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
@@ -129,6 +129,7 @@ stdenv.mkDerivation rec {
    meta = {
      description = "Nylas Mail is an open-source mail client built on the modern web with Electron, React, and Flux. It is designed to be extensible, so it's easy to create new experiences and workflows around email.";
      license = stdenv.lib.licenses.gpl3;
+     maintainers = with maintainers; [ johnramsden ];
      homepage = https://nylas.com;
    };
 }

--- a/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
@@ -127,9 +127,9 @@ stdenv.mkDerivation rec {
    '';
 
    meta = with stdenv.lib; {
-     description = "pen-source mail client built on the modern web with Electron, React, and Flux";
+     description = "Open-source mail client built on the modern web with Electron, React, and Flux";
      longDescription = ''
-        Nylas Mail is an open-source mail client built on the modern web with Electron, React, and Flux. It is designed to be extensible, so it's easy to create new experiences and workflows around email. Nylas-Mail requires gnome3 keyring. It can be enabled with "services.gnome3.gnome-keyring.enable = true;".
+        Nylas Mail is an open-source mail client built on the modern web with Electron, React, and Flux. It is designed to be extensible, so it's easy to create new experiences and workflows around email. To run nylas-mail, an additional manual step is required. Make sure to have services.gnome3.gnome-keyring.enable = true; in your configuration.nix before running nylas-mail. If you happen to miss this step, you should remove ~/.nylas-mail and "~/.config/Nylas Mail" for a blank setup".
      '';
      license = licenses.gpl3;
      maintainers = with maintainers; [ johnramsden ];

--- a/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
@@ -1,94 +1,93 @@
-{ config
-, stdenv
-, pkgs
-, fetchurl
-, dpkg
-, lib
-, gnome2
-, libgnome_keyring
-, desktop_file_utils
-, python2
-, nodejs
-, libnotify
+{ dpkg, fetchurl, lib, pkgs, stdenv, config
 , alsaLib
 , atk
-, glib
-, pango
-, gdk_pixbuf
 , cairo
-, freetype
-, fontconfig
-, dbus
-, nss
-, nspr
-, cups
-, expat
-, wget
-, udev
-, xorg
-, libgcrypt
-, makeWrapper
-, gcc-unwrapped
 , coreutils
+, cups
+, dbus
+, desktop_file_utils
+, expat
+, fontconfig
+, freetype
+, gcc-unwrapped
+, gdk_pixbuf
+, glib
+, gnome2
+, libgcrypt
+, libgnome_keyring
+, libnotify
+, makeWrapper
+, nodejs
+, nspr
+, nss
+, pango
+, python2
+, udev
+, wget
+, xorg
 }:
 
 stdenv.mkDerivation rec {
-   name = "${pkgname}-${version}";
-   pkgname = "nylas-mail";
-   version = "2.0.31";
-   subVersion = "e675deb";
+  name = "${pkgname}-${version}";
+  pkgname = "nylas-mail";
+  version = "2.0.32";
+  subVersion = "fec7941";
 
-   src = fetchurl {
-     url = "https://edgehill.s3-us-west-2.amazonaws.com/${version}-${subVersion}/linux-deb/x64/NylasMail.deb";
-     sha256 = "b036956174f998bd4a2662a1f59cb4a302465b3ed06c487de88ff2721e372f6e";
-   };
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://edgehill.s3-us-west-2.amazonaws.com/${version}-${subVersion}/linux-deb/x64/NylasMail.deb";
+        sha256 = "40060aa1dc3b5187b8ed4a07b9de3427e3c5a291df98c2c82395647fa2aa4ada";
+      }
+    else
+      throw "NylasMail is not supported on ${stdenv.system}";
 
-   # Build dependencies
-   propagatedBuildInputs = [
-     gnome2.gtk
-     gnome2.GConf
-     libgnome_keyring
-     desktop_file_utils
-     python2
-     nodejs
-     libnotify
-     alsaLib
-     atk
-     glib
-     pango
-     gdk_pixbuf
-     cairo
-     freetype
-     fontconfig
-     dbus
-     nss
-     nspr
-     cups
-     expat
-     wget
-     udev
-     gcc-unwrapped
-     coreutils
-     xorg.libXScrnSaver
-     xorg.libXi
-     xorg.libXtst
-     xorg.libXcursor
-     xorg.libXdamage
-     xorg.libXrandr
-     xorg.libXcomposite
-     xorg.libXext
-     xorg.libXfixes
-     xorg.libXrender
-     xorg.libX11
-     xorg.libxkbfile
-   ];
+  # Build dependencies
+  propagatedBuildInputs = [
+    alsaLib
+    atk
+    cairo
+    coreutils
+    cups
+    dbus
+    desktop_file_utils
+    expat
+    fontconfig
+    freetype
+    gcc-unwrapped
+    gdk_pixbuf
+    glib
+    gnome2.GConf
+    gnome2.gtk
+    libgnome_keyring
+    libnotify
+    nodejs
+    nspr
+    nss
+    pango
+    python2
+    udev
+    wget
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libxkbfile
+  ];
 
-   # Runtime dependencies
-   buildInputs = [ makeWrapper gnome2.gnome_keyring ];
+  # Runtime dependencies
+  buildInputs = [ makeWrapper gnome2.gnome_keyring ];
 
-   phases = [ "unpackPhase" ];
+  phases = [ "unpackPhase" ];
 
-   unpackPhase = ''
+  unpackPhase = ''
     mkdir -p $out
 
     ${dpkg}/bin/dpkg-deb -x $src unpacked
@@ -96,43 +95,43 @@ stdenv.mkDerivation rec {
 
     # Fix path in desktop file
     substituteInPlace $out/share/applications/nylas-mail.desktop \
-        --replace /usr/bin/nylas-mail $out/bin/nylas-mail
+      --replace /usr/bin/nylas-mail $out/bin/nylas-mail
 
-     # Patch librariess
-     noderp=$(patchelf --print-rpath $out/share/nylas-mail/libnode.so)
-     patchelf --set-rpath $noderp:$out/lib:${stdenv.cc.cc.lib}/lib:${xorg.libxkbfile.out}/lib:${lib.makeLibraryPath propagatedBuildInputs } \
-         $out/share/nylas-mail/libnode.so
+    # Patch librariess
+    noderp=$(patchelf --print-rpath $out/share/nylas-mail/libnode.so)
+    patchelf --set-rpath $noderp:$out/lib:${stdenv.cc.cc.lib}/lib:${xorg.libxkbfile.out}/lib:${lib.makeLibraryPath propagatedBuildInputs } \
+      $out/share/nylas-mail/libnode.so
 
-     ffrp=$(patchelf --print-rpath $out/share/nylas-mail/libffmpeg.so)
-     patchelf --set-rpath $ffrp:$out/lib:${stdenv.cc.cc.lib}/lib:${lib.makeLibraryPath propagatedBuildInputs } \
-         $out/share/nylas-mail/libffmpeg.so
+    ffrp=$(patchelf --print-rpath $out/share/nylas-mail/libffmpeg.so)
+    patchelf --set-rpath $ffrp:$out/lib:${stdenv.cc.cc.lib}/lib:${lib.makeLibraryPath propagatedBuildInputs } \
+      $out/share/nylas-mail/libffmpeg.so
 
-     # Patch binaries
-     binrp=$(patchelf --print-rpath $out/share/nylas-mail/nylas)
-     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-         --set-rpath $binrp:$out/lib:${stdenv.cc.cc.lib}/lib:${lib.makeLibraryPath propagatedBuildInputs } \
-         $out/share/nylas-mail/nylas
+    # Patch binaries
+    binrp=$(patchelf --print-rpath $out/share/nylas-mail/nylas)
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath $binrp:$out/lib:${stdenv.cc.cc.lib}/lib:${lib.makeLibraryPath propagatedBuildInputs } \
+      $out/share/nylas-mail/nylas
 
     wrapProgram $out/share/nylas-mail/nylas --set LD_LIBRARY_PATH "${xorg.libxkbfile}/lib:${pkgs.gnome3.libgnome_keyring}/lib";
 
     # Fix path to bash so apm can install plugins.
     substituteInPlace $out/share/nylas-mail/resources/apm/bin/apm \
-          --replace /bin/bash ${stdenv.shell}
+      --replace /bin/bash ${stdenv.shell}
 
     wrapProgram $out/share/nylas-mail/resources/apm/bin/apm \
-        --set PATH "${coreutils}/bin"
+      --set PATH "${coreutils}/bin"
     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-             --set-rpath ${gcc-unwrapped.lib}/lib \
-        $out/share/nylas-mail/resources/apm/bin/node
-   '';
+      --set-rpath ${gcc-unwrapped.lib}/lib $out/share/nylas-mail/resources/apm/bin/node
+  '';
 
-   meta = with stdenv.lib; {
-     description = "Open-source mail client built on the modern web with Electron, React, and Flux";
-     longDescription = ''
-        Nylas Mail is an open-source mail client built on the modern web with Electron, React, and Flux. It is designed to be extensible, so it's easy to create new experiences and workflows around email. To run nylas-mail, an additional manual step is required. Make sure to have services.gnome3.gnome-keyring.enable = true; in your configuration.nix before running nylas-mail. If you happen to miss this step, you should remove ~/.nylas-mail and "~/.config/Nylas Mail" for a blank setup".
-     '';
-     license = licenses.gpl3;
-     maintainers = with maintainers; [ johnramsden ];
-     homepage = https://nylas.com;
-   };
+  meta = with stdenv.lib; {
+    description = "Open-source mail client built on the modern web with Electron, React, and Flux";
+    longDescription = ''
+      Nylas Mail is an open-source mail client built on the modern web with Electron, React, and Flux. It is designed to be extensible, so it's easy to create new experiences and workflows around email. To run nylas-mail, an additional manual step is required. Make sure to have services.gnome3.gnome-keyring.enable = true; in your configuration.nix before running nylas-mail. If you happen to miss this step, you should remove ~/.nylas-mail and "~/.config/Nylas Mail" for a blank setup".
+    '';
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ johnramsden ];
+    homepage = https://nylas.com;
+    platforms = [ "x86_64-linux" ];
+  };
 }

--- a/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
 
     # Patch binaries
     binrp=$(patchelf --print-rpath $out/share/nylas-mail/nylas)
-    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+    patchelf --interpreter $(cat "$NIX_CC"/nix-support/dynamic-linker) \
       --set-rpath $binrp:$out/lib:${stdenv.cc.cc.lib}/lib:${lib.makeLibraryPath propagatedBuildInputs } \
       $out/share/nylas-mail/nylas
 
@@ -119,7 +119,7 @@ stdenv.mkDerivation rec {
 
     wrapProgram $out/share/nylas-mail/resources/apm/bin/apm \
       --set PATH "${coreutils}/bin"
-    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+    patchelf --interpreter $(cat "$NIX_CC"/nix-support/dynamic-linker) \
       --set-rpath ${gcc-unwrapped.lib}/lib $out/share/nylas-mail/resources/apm/bin/node
   '';
 

--- a/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/nylas-mail/default.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation rec {
     else
       throw "NylasMail is not supported on ${stdenv.system}";
 
-  # Build dependencies
   propagatedBuildInputs = [
     alsaLib
     atk
@@ -82,12 +81,12 @@ stdenv.mkDerivation rec {
     xorg.libxkbfile
   ];
 
-  # Runtime dependencies
-  buildInputs = [ makeWrapper gnome2.gnome_keyring ];
 
-  phases = [ "unpackPhase" ];
+  buildInputs = [ gnome2.gnome_keyring ];
 
-  unpackPhase = ''
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildCommand = ''
     mkdir -p $out
 
     ${dpkg}/bin/dpkg-deb -x $src unpacked

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1022,10 +1022,7 @@ with pkgs;
 
   mpdris2 = callPackage ../tools/audio/mpdris2 { };
 
-
   nfdump = callPackage ../tools/networking/nfdump { };
-
-  onboard = callPackage ../applications/misc/onboard { };
 
   playerctl = callPackage ../tools/audio/playerctl { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1022,7 +1022,10 @@ with pkgs;
 
   mpdris2 = callPackage ../tools/audio/mpdris2 { };
 
+
   nfdump = callPackage ../tools/networking/nfdump { };
+
+  onboard = callPackage ../applications/misc/onboard { };
 
   playerctl = callPackage ../tools/audio/playerctl { };
 
@@ -15910,6 +15913,8 @@ with pkgs;
 
   thinkingRock = callPackage ../applications/misc/thinking-rock { };
 
+  nylas-mail = callPackage ../applications/networking/mailreaders/nylas-mail { };
+
   thunderbird = callPackage ../applications/networking/mailreaders/thunderbird {
     inherit (gnome2) libIDL;
     libpng = libpng_apng;
@@ -17011,7 +17016,7 @@ with pkgs;
   quake3pointrelease = callPackage ../games/quake3/content/pointrelease.nix { };
 
   quakespasm = callPackage ../games/quakespasm { };
-  
+
   ioquake3 = callPackage ../games/quake3/ioquake { };
 
   quantumminigolf = callPackage ../games/quantumminigolf {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15910,7 +15910,7 @@ with pkgs;
 
   thinkingRock = callPackage ../applications/misc/thinking-rock { };
 
-  nylas-mail = callPackage ../applications/networking/mailreaders/nylas-mail { };
+  nylas-mail-bin = callPackage ../applications/networking/mailreaders/nylas-mail-bin { };
 
   thunderbird = callPackage ../applications/networking/mailreaders/thunderbird {
     inherit (gnome2) libIDL;


### PR DESCRIPTION
## Nylas-Mail

Packaged up the email client [Nylas-Mail](https://nylas.com/).  

> An open-source mail client built on the modern web with Electron, React, and Flux. It is designed to be extensible, so it's easy to create new experiences and workflows around email

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

