### PR TITLE
hpx: init at 1.0.0

### DIFF
--- a/pkgs/development/libraries/hpx/default.nix
+++ b/pkgs/development/libraries/hpx/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, boost, cmake, hwloc, gperftools, pkgconfig, python }:
+
+stdenv.mkDerivation rec {
+  name = "hpx-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "STEllAR-GROUP";
+    repo = "hpx";
+    rev = "${version}";
+    sha256 = "0k79gw4c0v4i7ps1hw6x4m7svxbfml5xm6ly7p00dvg7z9521zsk";
+  };
+
+  buildInputs = [ boost hwloc gperftools ];
+  nativeBuildInputs = [ cmake pkgconfig python ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "C++ standard library for concurrency and parallelism";
+    homepage = "https://github.com/STEllAR-GROUP/hpx";
+    license = stdenv.lib.licenses.boost;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ bobakker ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8012,6 +8012,8 @@ with pkgs;
 
   hound = callPackage ../development/tools/misc/hound { };
 
+  hpx = callPackage ../development/libraries/hpx { };
+
   hspell = callPackage ../development/libraries/hspell { };
 
   hspellDicts = callPackage ../development/libraries/hspell/dicts.nix { };
@@ -17011,7 +17013,7 @@ with pkgs;
   quake3pointrelease = callPackage ../games/quake3/content/pointrelease.nix { };
 
   quakespasm = callPackage ../games/quakespasm { };
-  
+
   ioquake3 = callPackage ../games/quake3/ioquake { };
 
   quantumminigolf = callPackage ../games/quantumminigolf {};


### PR DESCRIPTION
###### Motivation for this change

HPX is a useful C++ library for concurrency and distributed computing.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

