### PR TITLE
Remove unused `local` command.

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -236,7 +236,6 @@ stdenv.mkDerivation ({
     # libraries) from all the dependencies.
     local dynamicLinksDir="$out/lib/links"
     mkdir -p $dynamicLinksDir
-    local foundDylib=false
     for d in $(grep dynamic-library-dirs $packageConfDir/*|awk '{print $2}'); do
       ln -s $d/*.dylib $dynamicLinksDir
     done


### PR DESCRIPTION
I missed removing this for #25537.

I tested it by building `stack` on Mac OS X Sierra.