### PR TITLE
linux-testing-bcachefs: init at 87a9a6e

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -680,6 +680,7 @@
   ./tasks/cpu-freq.nix
   ./tasks/encrypted-devices.nix
   ./tasks/filesystems.nix
+  ./tasks/filesystems/bcachefs.nix
   ./tasks/filesystems/btrfs.nix
   ./tasks/filesystems/cifs.nix
   ./tasks/filesystems/exfat.nix

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -221,6 +221,9 @@ checkFS() {
     # Don't check resilient COWs as they validate the fs structures at mount time
     if [ "$fsType" = btrfs -o "$fsType" = zfs ]; then return 0; fi
 
+    # Skip fsck for bcachefs - not implemented yet.
+    if [ "$fsType" = bcachefs ]; then return 0; fi
+
     # Skip fsck for inherently readonly filesystems.
     if [ "$fsType" = squashfs ]; then return 0; fi
 

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -13,6 +13,8 @@ in
 
     system.fsPackages = [ pkgs.bcachefs-tools ];
 
+    # use kernel package with bcachefs support until it's in mainline
+    boot.kernelPackages = pkgs.linuxPackages_testing_bcachefs;
     boot.initrd.availableKernelModules = mkIf inInitrd [ "bcachefs" ];
 
     boot.initrd.extraUtilsCommands = mkIf inInitrd

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  inInitrd = any (fs: fs == "bcachefs") config.boot.initrd.supportedFilesystems;
+
+in
+
+{
+  config = mkIf (any (fs: fs == "bcachefs") config.boot.supportedFilesystems) {
+
+    system.fsPackages = [ pkgs.bcachefs-tools ];
+
+    boot.initrd.availableKernelModules = mkIf inInitrd [ "bcachefs" ];
+
+    boot.initrd.extraUtilsCommands = mkIf inInitrd
+      ''
+        copy_bin_and_libs ${pkgs.bcachefs-tools}/bin/fsck.bcachefs
+      '';
+
+  };
+}

--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, perl, buildLinux, ... } @ args:
+{ stdenv, hostPlatform, fetchgit, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.11-git";

--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -8,8 +8,8 @@ import ./generic.nix (args // rec {
 
   src = fetchgit {
     url = "https://evilpiepirate.org/git/bcachefs.git";
-    rev = "43e3159567958ea70c8a95d98fdb6e881153a656";
-    sha256 = "1595l2wabf74q8fb7fk14mz5iv7x7wk9nhjddyd9v3v5nw9krm4v";
+    rev = "87a9a6efd0ab602fc8d429fe75c427f1ac278f41";
+    sha256 = "0h73r7ypqcwcsfzkxdwcvli96cig3gmnyhfw251fv2bsyq26ik9f";
   };
 
   extraConfig = ''

--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchgit, perl, buildLinux, ... } @ args:
+
+import ./generic.nix (args // rec {
+  version = "4.11-git";
+  modDirVersion = "4.11.0";
+  extraMeta.branch = "master";
+  extraMeta.maintainers = [ stdenv.lib.maintainers.davidak ];
+
+  src = fetchgit {
+    url = "https://evilpiepirate.org/git/bcachefs.git";
+    rev = "43e3159567958ea70c8a95d98fdb6e881153a656";
+    sha256 = "1595l2wabf74q8fb7fk14mz5iv7x7wk9nhjddyd9v3v5nw9krm4v";
+  };
+
+  extraConfig = ''
+    BCACHEFS_FS m
+  '';
+
+  features.iwlwifi = true;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.netfilterRPFilter = true;
+
+  # Should the testing kernels ever be built on Hydra?
+  extraMeta.hydraPlatforms = [];
+
+} // (args.argsOverride or {}))
+

--- a/pkgs/tools/filesystems/bcachefs-tools/default.nix
+++ b/pkgs/tools/filesystems/bcachefs-tools/default.nix
@@ -1,12 +1,12 @@
 { stdenv, pkgs, fetchgit, pkgconfig, attr, libuuid, libscrypt, libsodium, keyutils, liburcu, zlib, libaio }:
 
 stdenv.mkDerivation rec {
-  name = "bcachefs-tools-unstable-2016-05-13";
+  name = "bcachefs-tools-unstable-2017-06-14";
 
   src = fetchgit {
     url = "https://evilpiepirate.org/git/bcachefs-tools.git";
-    rev = "565b4a74d6c25c78b0d2b82d9529595fc6269308";
-    sha256 = "1wnis26hq67vxqkxzck6wm6caq4c1rfmy9blmmgkzlhdd2nzisbx";
+    rev = "851e945db88322153df06bd8a9db506217a6029f";
+    sha256 = "0dqwrrsxiszvdi060krxlvdvk1v33ac1jmi9rx6jvhlavs3fxl4m";
   };
 
   buildInputs = [ pkgconfig attr libuuid libscrypt libsodium keyutils liburcu zlib libaio ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12164,16 +12164,23 @@ with pkgs;
         # when adding a new linux version
         kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
-    ];
-  };
-
-  linux_samus_4_12 = callPackage ../os-specific/linux/kernel/linux-samus-4.12.nix {
       ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu
         kernelPatches.mips_fpu_sigill
         kernelPatches.mips_ext3_n32
       ];
+  };
+
+  linux_samus_4_12 = callPackage ../os-specific/linux/kernel/linux-samus-4.12.nix {
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        kernelPatches.p9_fixes
+        # See pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/README.md
+        # when adding a new linux version
+        kernelPatches.cpu-cgroup-v2."4.11"
+        kernelPatches.modinst_arg_list_too_long
+    ];
   };
 
   linux_samus_latest = linux_samus_4_12;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12156,8 +12156,7 @@ with pkgs;
     ];
   };
 
-
-  linux_samus_4_12 = callPackage ../os-specific/linux/kernel/linux-samus-4.12.nix {
+  linux_testing_bcachefs = callPackage ../os-specific/linux/kernel/linux-testing-bcachefs.nix {
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
         kernelPatches.p9_fixes
@@ -12166,6 +12165,15 @@ with pkgs;
         kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
     ];
+  };
+
+  linux_samus_4_12 = callPackage ../os-specific/linux/kernel/linux-samus-4.12.nix {
+      ]
+      ++ lib.optionals ((platform.kernelArch or null) == "mips")
+      [ kernelPatches.mips_fpureg_emu
+        kernelPatches.mips_fpu_sigill
+        kernelPatches.mips_ext3_n32
+      ];
   };
 
   linux_samus_latest = linux_samus_4_12;
@@ -12343,6 +12351,9 @@ with pkgs;
       inherit version src configfile stdenv;
       allowImportFromDerivation = true;
     }));
+
+  # Build a kernel with bcachefs module
+  linuxPackages_testing_bcachefs = recurseIntoAttrs (linuxPackagesFor pkgs.linux_testing_bcachefs);
 
   # Build a kernel for Xen dom0
   linuxPackages_latest_xen_dom0 = recurseIntoAttrs (linuxPackagesFor (pkgs.linux_latest.override { features.xen_dom0=true; }));


### PR DESCRIPTION
###### Motivation for this change

I want to test the bcachefs filesystem and maybe use it when it seams stable. Could be a good alternative to Btrfs/ZFS/ext4 in the near future.

This PR needs https://github.com/NixOS/nixpkgs/pull/25580

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

