### PR TITLE
nginx: enableSSL description: clarify that HTTP is disabled; #25533

### DIFF
--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -59,7 +59,11 @@ with lib;
     enableSSL = mkOption {
       type = types.bool;
       default = false;
-      description = "Whether to enable SSL (https) support.";
+      description = ''
+        Whether to enable SSL (https) support.  This disables non-SSL (http);
+        consider using forceSSL or extraConfig = "listen 80; listen [::]:80;"
+        to also support standard http on port 80 via redirects or as an
+        alternative.  '';
     };
 
     forceSSL = mkOption {


### PR DESCRIPTION
###### Motivation for this change

#25533.  I'm not the only one that's been confused by the fact that "enableSSL" also disables non-SSL; changing it would require a bit of refactoring and break backwards compatibility, so I'm taking the easy way and documenting existing behavior, along with providing @danbst's trivial workaround.

And while I really shouldn't, I find it somewhat magical that changing that description actually changes `man configuration.nix`.  That's the "testing" I did; I didn't bother with the rest since that should be the only change.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

