### PR TITLE
yarn: 0.23.2 -> 0.23.4

### DIFF
--- a/pkgs/development/tools/yarn/default.nix
+++ b/pkgs/development/tools/yarn/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "yarn-${version}";
-  version = "0.23.2";
+  version = "0.23.4";
 
   src = fetchzip {
     url = "https://github.com/yarnpkg/yarn/releases/download/v${version}/yarn-v${version}.tar.gz";
-    sha256 = "06vqi78q1wsybr4nsh8xjnqmjynljmb36h21j2ffmni1adxf4syq";
+    sha256 = "1jv2fbi10rx6whqn1krn9lrgwpnmzlbfym23m0df4y6k9pfyc9pz";
   };
 
   buildInputs = [makeWrapper nodejs];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

