### PR TITLE
staccato: init at 0.1.6

### DIFF
--- a/pkgs/tools/text/staccato/default.nix
+++ b/pkgs/tools/text/staccato/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "staccato-${version}";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner = "tshlabs";
+    repo = "staccato";
+    rev = version;
+    sha256 = "1zbd1gx0ik2r7bavcid776j37g6rzd3f6cs94kq1qar4gyf1gqjm";
+  };
+
+  depsSha256 = "1gwfkh3ck8n3zcy43ch2mnc28a6y10p3srhnx9dh8gwnwbpb733c";
+
+  meta = {
+    description = "A command line program that lets you compute statistics from values from a file or standard input";
+    longDescription = ''
+      Staccato (`st` for short) is a command line program that lets you
+      compute statistics from values from a file or standard input. It
+      computes things about the stream of numbers like min, max, mean, median,
+      and standard deviation. It can also compute these things about some
+      subset of the stream, for example the lower 95% of values.
+    '';
+    homepage = "https://docs.rs/crate/staccato";
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1028,6 +1028,8 @@ with pkgs;
 
   socklog = callPackage ../tools/system/socklog { };
 
+  staccato = callPackage ../tools/text/staccato { };
+
   syscall_limiter = callPackage ../os-specific/linux/syscall_limiter {};
 
   syslogng = callPackage ../tools/system/syslog-ng { };


### PR DESCRIPTION
Add the package `staccato`, "a command line program that lets you
compute statistics from values from a file or standard input".

I have tested this change per nixpkgs manual section 13.1 ("Making
patches").

