### PR TITLE
nbstripout: init at 0.3.0

### DIFF
--- a/pkgs/applications/version-management/nbstripout/default.nix
+++ b/pkgs/applications/version-management/nbstripout/default.nix
@@ -1,0 +1,32 @@
+{lib, python2Packages, git, mercurial}:
+
+with python2Packages;
+buildPythonApplication rec {
+  name = "${pname}-${version}";
+  version = "0.3.0";
+  pname = "nbstripout";
+
+  # Mercurial should be added as a build input but because it's a Python
+  # application, it would mess up the Python environment. Thus, don't add it
+  # here, instead add it to PATH when running unit tests
+  buildInputs = [ pytest pytest-flake8 pytest-cram git pytestrunner ];
+  propagatedBuildInputs = [ ipython nbformat ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "126xhjma4a0k7gq58hbqglhb3rai0a576azz7g8gmqjr3kl0264v";
+  };
+
+  # ignore flake8 tests for the nix wrapped setup.py
+  checkPhase = ''
+    PATH=$PATH:$out/bin:${mercurial}/bin pytest --ignore=nix_run_setup.py .
+  '';
+
+  meta = {
+    inherit version;
+    description = "Strip output from Jupyter and IPython notebooks";
+    homepage = https://github.com/kynan/nbstripout;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/cram/default.nix
+++ b/pkgs/development/python-modules/cram/default.nix
@@ -1,0 +1,38 @@
+{lib, buildPythonPackage, fetchPypi, coverage, bash, which, writeText}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "0.7";
+  pname = "cram";
+
+  buildInputs = [ coverage which ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0bvz6fwdi55rkrz3f50zsy35gvvwhlppki2yml5bj5ffy9d499vx";
+  };
+
+  postPatch = ''
+    substituteInPlace tests/test.t \
+      --replace "/bin/bash" "${bash}/bin/bash"
+  '';
+
+  # This testing is copied from Makefile. Simply using `make test` doesn't work
+  # because it uses the unpatched `scripts/cram` executable which has a bad
+  # shebang. Also, for some reason, coverage fails on one file so let's just
+  # ignore that one.
+  checkPhase = ''
+    # scripts/cram tests
+    #COVERAGE=${coverage}/bin/coverage $out/bin/cram tests
+    #${coverage}/bin/coverage report --fail-under=100
+    COVERAGE=coverage $out/bin/cram tests
+    coverage report --fail-under=100 --omit="*/_encoding.py"
+  '';
+
+  meta = {
+    description = "A simple testing framework for command line applications";
+    homepage = https://bitheap.org/cram/;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-cram/default.nix
+++ b/pkgs/development/python-modules/pytest-cram/default.nix
@@ -1,0 +1,34 @@
+{lib, buildPythonPackage, fetchPypi, pytest, cram, bash, writeText}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "0.1.1";
+  pname = "pytest-cram";
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ cram ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ad05999iqzyjay9y5lc0cnd3jv8qxqlzsvxzp76shslmhrv0c4f";
+  };
+
+  postPatch = ''
+    substituteInPlace pytest_cram/tests/test_options.py \
+      --replace "/bin/bash" "${bash}/bin/bash"
+  '';
+
+  # Remove __init__.py from tests folder, otherwise pytest raises an error that
+  # the imported and collected modules are different.
+  checkPhase = ''
+    rm pytest_cram/tests/__init__.py
+    pytest pytest_cram
+  '';
+
+  meta = {
+    description = "Test command-line applications with pytest and cram";
+    homepage = https://github.com/tbekolay/pytest-cram;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11382,7 +11382,7 @@ with pkgs;
   b43Firmware_6_30_163_46 = callPackage ../os-specific/linux/firmware/b43-firmware/6.30.163.46.nix { };
 
   b43FirmwareCutter = callPackage ../os-specific/linux/firmware/b43-firmware-cutter { };
-  
+
   bt-fw-converter = callPackage ../os-specific/linux/firmware/bt-fw-converter { };
 
   broadcom-bt-firmware = callPackage ../os-specific/linux/firmware/broadcom-bt-firmware { };
@@ -14850,6 +14850,8 @@ with pkgs;
   mpc_cli = callPackage ../applications/audio/mpc { };
 
   clerk = callPackage ../applications/audio/clerk { };
+
+  nbstripout = callPackage ../applications/version-management/nbstripout { };
 
   ncmpc = callPackage ../applications/audio/ncmpc { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2433,6 +2433,8 @@ in {
     doCheck = false; # lazy packager
   };
 
+  cram = callPackage ../development/python-modules/cram { };
+
   csscompressor = callPackage ../development/python-modules/csscompressor.nix {};
 
   csvkit =  callPackage ../development/python-modules/csvkit { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -677,15 +677,15 @@ in {
   aniso8601 = buildPythonPackage rec {
     name = "aniso8601-${version}";
     version = "1.2.0";
- 
+
     meta = {
       description = "Parses ISO 8601 strings.";
       homepage    = "https://bitbucket.org/nielsenb/aniso8601";
       license     = licenses.bsd3;
     };
- 
+
     propagatedBuildInputs = with self; [ dateutil ];
- 
+
     src = pkgs.fetchurl {
       url = "mirror://pypi/a/aniso8601/${name}.tar.gz";
       sha256 = "502400f82574afa804cc915d83f15c67533d364dcd594f8a6b9d2053f3404dd4";
@@ -5077,6 +5077,8 @@ in {
       description = "py.test plugin to catch log messages. This is a fork of pytest-capturelog.";
     };
   };
+
+  pytest-cram = callPackage ../development/python-modules/pytest-cram { };
 
   pytest-datafiles = callPackage ../development/python-modules/pytest-datafiles { };
 
@@ -22195,7 +22197,7 @@ in {
       homepage = "https://github.com/goinnn/django-multiselectfield";
     };
   };
-  
+
   reviewboard = buildPythonPackage rec {
     name = "ReviewBoard-2.5.1.1";
 


### PR DESCRIPTION
###### Motivation for this change

`nbstripout` is a useful filter for git when version controlling Jupyter notebooks.

This pull request also contains the required dependencies as separate commits. Is that ok, or should I open separate pull requests for each commit?

*NOTE: This is still work in progress. I'm getting a build error with nox-review. I opened this pull request to get some feedback how to fix that so I can finish this.*

When running nox-review, I get the following error:

```
Copying nbstripout.egg-info to build/bdist.linux-x86_64/wheel/nbstripout-0.3.0-py2.7.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/nbstripout-0.3.0.dist-info/WHEEL
installing
/tmp/nix-build-python2.7-nbstripout-0.3.0.drv-0/nbstripout-0.3.0/dist /tmp/nix-build-python2.7-nbstripout-0.3.0.drv-0/nbstripout-0.3.0
Download error on https://pypi.python.org/simple/pytest-runner/: [Errno -2] Name or service not known -- Some packages may not be found!
Couldn't find index page for 'pytest-runner' (maybe misspelled?)
Download error on https://pypi.python.org/simple/: [Errno -2] Name or service not known -- Some packages may not be found!
No local packages or working download links found for pytest-runner
Traceback (most recent call last):
  File "nix_run_setup.py", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "setup.py", line 52, in <module>
    "Topic :: Software Development :: Version Control",
  File "/nix/store/ngfvnb22lh72z8prslmfdd2aiis5z08p-python3-3.5.3/lib/python3.5/distutils/core.py", line 108, in setup
    _setup_distribution = dist = klass(attrs)
  File "/nix/store/1mbjrzsq7rc6jb4wkcvdjgnqbhcm41jm-python2.7-setuptools-30.2.0/lib/python2.7/site-packages/setuptools-30.2.0-py2.7.egg/setuptools/dist.py", line 315, in __init__
  File "/nix/store/1mbjrzsq7rc6jb4wkcvdjgnqbhcm41jm-python2.7-setuptools-30.2.0/lib/python2.7/site-packages/setuptools-30.2.0-py2.7.egg/setuptools/dist.py", line 361, in fetch_build_eggs
  File "/nix/store/1mbjrzsq7rc6jb4wkcvdjgnqbhcm41jm-python2.7-setuptools-30.2.0/lib/python2.7/site-packages/setuptools-30.2.0-py2.7.egg/pkg_resources/__init__.py", line 846, in resolve
  File "/nix/store/1mbjrzsq7rc6jb4wkcvdjgnqbhcm41jm-python2.7-setuptools-30.2.0/lib/python2.7/site-packages/setuptools-30.2.0-py2.7.egg/pkg_resources/__init__.py", line 1118, in best_match
  File "/nix/store/1mbjrzsq7rc6jb4wkcvdjgnqbhcm41jm-python2.7-setuptools-30.2.0/lib/python2.7/site-packages/setuptools-30.2.0-py2.7.egg/pkg_resources/__init__.py", line 1130, in obtain
  File "/nix/store/1mbjrzsq7rc6jb4wkcvdjgnqbhcm41jm-python2.7-setuptools-30.2.0/lib/python2.7/site-packages/setuptools-30.2.0-py2.7.egg/setuptools/dist.py", line 429, in fetch_build_egg
  File "/nix/store/1mbjrzsq7rc6jb4wkcvdjgnqbhcm41jm-python2.7-setuptools-30.2.0/lib/python2.7/site-packages/setuptools-30.2.0-py2.7.egg/setuptools/command/easy_install.py", line 659, in easy_install
distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('pytest-runner')
builder for ‘/nix/store/frdmmw910nm2hd6mplv3g365q50qy9xx-python3.5-nbstripout-0.3.0.drv’ failed with exit code 1
error: build of ‘/nix/store/frdmmw910nm2hd6mplv3g365q50qy9xx-python3.5-nbstripout-0.3.0.drv’ failed
The invocation of "nix-build -A python27Packages.cram -A python35Packages.cram -A python27Packages.pytest-cram -A python27Packages.nbstripout -A python35Packages.pytest-cram -A python35Packages.nbstripout /etc/nixpkgs" failed
```

Why is it trying to download `pytest-runner` with `easy_install` as the package is already defined in `buildInputs`? I looked at other packages that use `pytestrunner` as a build input and they don't seem to do anything special, just add `pytestrunner` as a build input.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

