### PR TITLE
kbfs service: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -429,6 +429,7 @@
   ./services/networking/iodine.nix
   ./services/networking/ircd-hybrid/default.nix
   ./services/networking/keepalived/default.nix
+  ./services/networking/keybase.nix
   ./services/networking/kippo.nix
   ./services/networking/kresd.nix
   ./services/networking/lambdabot.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -367,6 +367,7 @@
   ./services/network-filesystems/cachefilesd.nix
   ./services/network-filesystems/drbd.nix
   ./services/network-filesystems/glusterfs.nix
+  ./services/network-filesystems/kbfs.nix
   ./services/network-filesystems/ipfs.nix
   ./services/network-filesystems/netatalk.nix
   ./services/network-filesystems/nfsd.nix

--- a/nixos/modules/services/network-filesystems/kbfs.nix
+++ b/nixos/modules/services/network-filesystems/kbfs.nix
@@ -69,7 +69,6 @@ in {
       postStop = "fusermount -u ${cfg.mountPoint}";
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/kbfsfuse ${toString cfg.extraFlags} ${cfg.mountPoint}";
-        RestartSec = 3;
         Restart = "on-failure";
       };
     };

--- a/nixos/modules/services/network-filesystems/kbfs.nix
+++ b/nixos/modules/services/network-filesystems/kbfs.nix
@@ -1,0 +1,79 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.kbfs;
+
+in {
+
+  ###### interface
+
+  options = {
+
+    services.kbfs = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to mount the Keybase filesystem.";
+      };
+
+      mountPoint = mkOption {
+        type = types.str;
+        default = "/keybase";
+        example = "/home/user/keybase";
+        description = "Mountpoint for the Keybase filesystem.";
+      };
+
+      createMountPoint = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to create the mount point directory at startup time.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.kbfs;
+        defaultText = "pkgs.kbfs";
+        example = literalExample "pkgs.kbfs";
+        description = "Keybase filesystem derivation to use.";
+      };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [
+          "-label kbfs"
+          "-mount-type normal"
+        ];
+        description = ''
+          Additional flags to pass to the Keybase filesystem on launch.
+        '';
+      };
+
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    systemd.user.services.kbfs = {
+      description = "Keybase File System";
+      path = [ "/run/wrappers" ];
+      preStart = ''
+      ${optionalString cfg.createMountPoint
+      "test -d ${cfg.mountPoint} || mkdir -p ${cfg.mountPoint}"
+      }'';
+      postStop = "fusermount -u ${cfg.mountPoint}";
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/kbfsfuse ${toString cfg.extraFlags} ${cfg.mountPoint}";
+        RestartSec = 3;
+        Restart = "always";
+      };
+    };
+
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/nixos/modules/services/network-filesystems/kbfs.nix
+++ b/nixos/modules/services/network-filesystems/kbfs.nix
@@ -70,7 +70,7 @@ in {
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/kbfsfuse ${toString cfg.extraFlags} ${cfg.mountPoint}";
         RestartSec = 3;
-        Restart = "always";
+        Restart = "on-failure";
       };
     };
 

--- a/nixos/modules/services/network-filesystems/kbfs.nix
+++ b/nixos/modules/services/network-filesystems/kbfs.nix
@@ -61,6 +61,7 @@ in {
 
     systemd.user.services.kbfs = {
       description = "Keybase File System";
+      requires = [ "keybase.service" ];
       path = [ "/run/wrappers" ];
       preStart = ''
       ${optionalString cfg.createMountPoint
@@ -74,5 +75,6 @@ in {
     };
 
     environment.systemPackages = [ cfg.package ];
+    services.keybase.enable = true;
   };
 }

--- a/nixos/modules/services/network-filesystems/kbfs.nix
+++ b/nixos/modules/services/network-filesystems/kbfs.nix
@@ -19,25 +19,9 @@ in {
 
       mountPoint = mkOption {
         type = types.str;
-        default = "/keybase";
-        example = "/home/user/keybase";
+        default = "%h/keybase";
+        example = "/keybase";
         description = "Mountpoint for the Keybase filesystem.";
-      };
-
-      createMountPoint = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to create the mount point directory at startup time.
-        '';
-      };
-
-      package = mkOption {
-        type = types.package;
-        default = pkgs.kbfs;
-        defaultText = "pkgs.kbfs";
-        example = literalExample "pkgs.kbfs";
-        description = "Keybase filesystem derivation to use.";
       };
 
       extraFlags = mkOption {
@@ -62,19 +46,17 @@ in {
     systemd.user.services.kbfs = {
       description = "Keybase File System";
       requires = [ "keybase.service" ];
+      after = [ "keybase.service" ];
       path = [ "/run/wrappers" ];
-      preStart = ''
-      ${optionalString cfg.createMountPoint
-      "test -d ${cfg.mountPoint} || mkdir -p ${cfg.mountPoint}"
-      }'';
-      postStop = "fusermount -u ${cfg.mountPoint}";
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/kbfsfuse ${toString cfg.extraFlags} ${cfg.mountPoint}";
+        ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${cfg.mountPoint}";
+        ExecStart = "${pkgs.kbfs}/bin/kbfsfuse ${toString cfg.extraFlags} ${cfg.mountPoint}";
+        ExecStopPost = "/run/wrappers/bin/fusermount -u ${cfg.mountPoint}";
         Restart = "on-failure";
+        PrivateTmp = true;
       };
     };
 
-    environment.systemPackages = [ cfg.package ];
     services.keybase.enable = true;
   };
 }

--- a/nixos/modules/services/networking/keybase.nix
+++ b/nixos/modules/services/networking/keybase.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.keybase;
+
+in {
+
+  ###### interface
+
+  options = {
+
+    services.keybase = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to start the Keybase service.";
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.keybase;
+        defaultText = "pkgs.keybase";
+        example = literalExample "pkgs.keybase";
+        description = "Keybase derivation to use.";
+      };
+
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    systemd.user.services.keybase = {
+      description = "Keybase service";
+      serviceConfig = {
+        ExecStart = ''
+	  ${cfg.package}/bin/keybase service --auto-forked
+	'';
+        Restart = "on-failure";
+      };
+    };
+
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/nixos/modules/services/networking/keybase.nix
+++ b/nixos/modules/services/networking/keybase.nix
@@ -17,14 +17,6 @@ in {
         description = "Whether to start the Keybase service.";
       };
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.keybase;
-        defaultText = "pkgs.keybase";
-        example = literalExample "pkgs.keybase";
-        description = "Keybase derivation to use.";
-      };
-
     };
   };
 
@@ -36,12 +28,13 @@ in {
       description = "Keybase service";
       serviceConfig = {
         ExecStart = ''
-          ${cfg.package}/bin/keybase service --auto-forked
+          ${pkgs.keybase}/bin/keybase service
         '';
         Restart = "on-failure";
+        PrivateTmp = true;
       };
     };
 
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [ pkgs.keybase ];
   };
 }

--- a/nixos/modules/services/networking/keybase.nix
+++ b/nixos/modules/services/networking/keybase.nix
@@ -36,8 +36,8 @@ in {
       description = "Keybase service";
       serviceConfig = {
         ExecStart = ''
-	  ${cfg.package}/bin/keybase service --auto-forked
-	'';
+          ${cfg.package}/bin/keybase service --auto-forked
+        '';
         Restart = "on-failure";
       };
     };


### PR DESCRIPTION
###### Motivation for this change
It'd be nice to have a Keybase File System service on NixOS.  
There's already been interest expressed (#22603).  

These changes will lend themselves to those using any Keybase clients (CLI or GUI) by providing a `kbfs` mount. 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

