### PR TITLE
pngquant: restored 'patchShebangs' because build failed on Hydra

### DIFF
--- a/pkgs/tools/graphics/pngquant/default.nix
+++ b/pkgs/tools/graphics/pngquant/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  preConfigure = "patchShebangs .";
+
   buildInputs = [ pkgconfig libpng zlib lcms2 ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

restored 'patchShebangs' because build [failed on Hydra](https://hydra.nixos.org/build/52569452)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

