### PR TITLE
hpx: restrict architecture to x86_64

### DIFF
--- a/pkgs/development/libraries/hpx/default.nix
+++ b/pkgs/development/libraries/hpx/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     description = "C++ standard library for concurrency and parallelism";
     homepage = "https://github.com/STEllAR-GROUP/hpx";
     license = stdenv.lib.licenses.boost;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = [ "x86_64-linux" ]; # stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ bobakker ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Hydra spits out some build errors on aarch64, so I've set the architecture to x86_64 for now.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

