### PR TITLE
openmvg: clarify Git version

### DIFF
--- a/pkgs/applications/science/misc/openmvg/default.nix
+++ b/pkgs/applications/science/misc/openmvg/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     url = "https://www.github.com/openmvg/openmvg.git";
 
     # Tag v1.1
-    rev = "f5ecb48";
+    rev = "refs/tags/${version}";
     sha256 = "1di9i7yxnkdvl8lhflynmqw62gaxwv00r1sd7nzzs9qn63g0af0f";
     fetchSubmodules = true;
   };


### PR DESCRIPTION
###### Motivation for this change
We should clarify exactly which version of OpenMVG is being used.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

