### PR TITLE
nixos/security/acme: fix acme folder permissions

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -185,12 +185,15 @@ in
                   path = [ pkgs.simp_le ];
                   preStart = ''
                     mkdir -p '${cfg.directory}'
-                    chown -R '${data.user}:${data.group}' '${cfg.directory}'
+                    chown 'root:root' '${cfg.directory}'
+                    chmod 755 '${cfg.directory}'
                     if [ ! -d '${cpath}' ]; then
                       mkdir '${cpath}'
                     fi
                     chmod ${rights} '${cpath}'
                     chown -R '${data.user}:${data.group}' '${cpath}'
+                    mkdir -p '${data.webroot}/.well-known/acme-challenge'
+                    chown -R '${data.user}:${data.group}' '${data.webroot}/.well-known/acme-challenge'
                   '';
                   script = ''
                     cd '${cpath}'


### PR DESCRIPTION
###### Motivation for this change
I try to fix https://github.com/NixOS/nixpkgs/issues/25182 and implement @nh2 suggestion from the issue. Feedback is appreciated. 