### PR TITLE
Mark ghcjs as fixed

### DIFF
--- a/pkgs/development/compilers/ghcjs/base.nix
+++ b/pkgs/development/compilers/ghcjs/base.nix
@@ -190,6 +190,6 @@ in mkDerivation (rec {
   description = "A Haskell to JavaScript compiler that uses the GHC API";
   license = stdenv.lib.licenses.bsd3;
   platforms = ghc.meta.platforms;
-  maintainers = with stdenv.lib.maintainers; [ jwiegley cstrahan ];
+  maintainers = with stdenv.lib.maintainers; [ jwiegley cstrahan dmjio ];
   inherit broken;
 })

--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -2,5 +2,5 @@
 
 bootPkgs.callPackage ./base.nix {
   inherit bootPkgs;
-  broken = true; # http://hydra.nixos.org/build/45110274
+  broken = false;
 }


### PR DESCRIPTION
###### Motivation for this change
`GHCJS` seems to be already be fixed, but not marked as unbroken. I plan on playing with it, so would like to be notified of further broken notifications (hence why I've added myself to the maintainers list)

cc @cstrahan @jwiegley 

Original error: http://hydra.nixos.org/build/45110274

```
λ nixos ~ → nix-build '<nixpkgs>' -A haskell.compiler.ghcjs 
/nix/store/gp9zkvzs36kbzfrziqka82a2iik8cw0y-ghcjs-0.2.0
```

This was built off a hash close to master. The original error seems to be related to a broken test dependency of a boot library.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

