### PR TITLE
Use consistent package naming for HEAD.nix files

### DIFF
--- a/pkgs/applications/editors/emacs-modes/proofgeneral/HEAD.nix
+++ b/pkgs/applications/editors/emacs-modes/proofgeneral/HEAD.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchgit, emacs, texinfo, texLive, perl, which, automake, enableDoc ? false }:
 
 stdenv.mkDerivation (rec {
-  name = "ProofGeneral-HEAD";
+  name = "ProofGeneral-unstable-${version}";
+  version = "2017-03-13";
 
   src = fetchgit {
     url = "https://github.com/ProofGeneral/PG.git";

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -12,7 +12,7 @@ let
 
   commonBuildInputs = [ ghc perl autoconf automake happy alex python3 ];
 
-  version = "8.1.20170106";
+  version = "2017-01-06";
   rev = "b4f2afe70ddbd0576b4eba3f82ba1ddc52e9b3bd";
 
   commonPreConfigure =  ''
@@ -29,7 +29,7 @@ let
   '';
 in stdenv.mkDerivation (rec {
   inherit version rev;
-  name = "ghc-${version}";
+  name = "ghc-unstable-${version}";
 
   src = fetchgit {
     url = "git://git.haskell.org/ghc.git";

--- a/pkgs/development/compilers/ghcjs/head.nix
+++ b/pkgs/development/compilers/ghcjs/head.nix
@@ -1,7 +1,7 @@
 { fetchgit, fetchFromGitHub, bootPkgs }:
 
 bootPkgs.callPackage ./base.nix {
-  version = "0.2.020170323";
+  version = "2017-03-23";
 
   inherit bootPkgs;
 

--- a/pkgs/development/coq-modules/fiat/HEAD.nix
+++ b/pkgs/development/coq-modules/fiat/HEAD.nix
@@ -2,8 +2,8 @@
 
 stdenv.mkDerivation rec {
 
-  name = "coq-fiat-${coq.coq-version}-${version}";
-  version = "20161024";
+  name = "coq-fiat-${coq.coq-version}-unstable-${version}";
+  version = "2016-10-24";
 
   src = fetchgit {
     url = "https://github.com/mit-plv/fiat.git";

--- a/pkgs/development/libraries/xcb-util-cursor/HEAD.nix
+++ b/pkgs/development/libraries/xcb-util-cursor/HEAD.nix
@@ -2,7 +2,8 @@
 , git, xorg, gnum4, libxcb, gperf }:
 
 stdenv.mkDerivation rec {
-  name = "xcb-util-cursor-0.1.1-3-gf03cc27";
+  name = "xcb-util-cursor-0.1.1-3-unstable-${version}";
+  version = "2017-04-05";
 
   src = fetchgit {
     url    = http://anongit.freedesktop.org/git/xcb/util-cursor.git;


### PR DESCRIPTION
###### Motivation for this change

This is a continuation of https://github.com/NixOS/nixpkgs/pull/21822#issuecomment-274345923. Naming is based on https://nixos.org/nixpkgs/manual/#sec-package-naming.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

