### PR TITLE
Add salt master module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -129,6 +129,7 @@
   ./security/rtkit.nix
   ./security/wrappers/default.nix
   ./security/sudo.nix
+  ./services/admin/salt/master.nix
   ./services/amqp/activemq/default.nix
   ./services/amqp/rabbitmq.nix
   ./services/audio/alsa.nix

--- a/nixos/modules/services/admin/salt/master.nix
+++ b/nixos/modules/services/admin/salt/master.nix
@@ -1,0 +1,60 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+
+  cfg  = config.services.salt.master;
+
+  fullConfig = lib.recursiveUpdate {
+    # Provide defaults for some directories to allow an immutable config dir
+
+    # Default is equivalent to /etc/salt/master.d/*.conf
+    default_include = "/var/lib/salt/master.d/*.conf";
+    # Default is in /etc/salt/pki/master
+    pki_dir = "/var/lib/salt/pki/master";
+  } cfg.configuration;
+
+in
+
+{
+  options = {
+    services.salt.master = {
+      enable = mkEnableOption "Salt master service";
+      configuration = mkOption {
+        type = types.attrs;
+        default = {};
+        description = "Salt master configuration as Nix attribute set.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment = {
+      # Set this up in /etc/salt/master so `salt`, `salt-key`, etc. work.
+      # The alternatives are
+      # - passing --config-dir to all salt commands, not just the master unit,
+      # - setting a global environment variable,
+      etc."salt/master".source = pkgs.writeText "master" (
+        builtins.toJSON fullConfig
+      );
+      systemPackages = with pkgs; [ salt ];
+    };
+    systemd.services.salt-master = {
+      description = "Salt Master";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      path = with pkgs; [
+        utillinux  # for dmesg
+      ];
+      serviceConfig = {
+        ExecStart = "${pkgs.salt}/bin/salt-master";
+        LimitNOFILE = 16384;
+        Type = "notify";
+        NotifyAccess = "all";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ aneeshusa ];
+}

--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -8,11 +8,11 @@
 
 python2Packages.buildPythonApplication rec {
   name = "salt-${version}";
-  version = "2016.11.2";
+  version = "2016.11.4";
 
   src = fetchurl {
     url = "mirror://pypi/s/salt/${name}.tar.gz";
-    sha256 = "0hrss5x47cr7ffyjl8jlkhf9j88lqvg7c33rjc5bimck8b7x7hzm";
+    sha256 = "0pvn0pkndwx81xkpah14awz4rg9zhkpl4bhn3hlrin1zinr0jhgv";
   };
 
   propagatedBuildInputs = with python2Packages; [


### PR DESCRIPTION
###### Motivation for this change
Add Salt master module.
Bump Salt to the newest version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).