### PR TITLE
gnu-cobol: init at 2.0rc-2

### DIFF
--- a/pkgs/development/compilers/gnu-cobol/default.nix
+++ b/pkgs/development/compilers/gnu-cobol/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, gcc, makeWrapper
+, db, gmp, ncurses }:
+
+let version = {
+  maj = "2.0";
+  min = "rc-2";
+};
+in 
+stdenv.mkDerivation rec {
+  name = "gnu-cobol-${version.maj}${version.min}";
+
+  src = fetchurl {
+    url = "https://sourceforge.com/projects/open-cobol/files/gnu-cobol/${version.maj}/gnu-cobol-${version.maj}_${version.min}.tar.gz";
+    sha256 = "1pj7mjnp3l76zvzrh1xa6d4kw3jkvzqh39sbf02kiinq4y65s7zj";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ db gmp ncurses ];
+
+  postInstall = with stdenv.lib; ''
+    wrapProgram "$out/bin/cobc" \
+      --prefix PATH ':' "${gcc}/bin" \
+      --prefix NIX_LDFLAGS ' ' "'$NIX_LDFLAGS'" \
+      --prefix NIX_CFLAGS_COMPILE ' ' "'$NIX_CFLAGS_COMPILE'"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An open-source COBOL compiler";
+    homepage = http://sourceforge.net/projects/open-cobol/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ericsagnes ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2039,6 +2039,8 @@ with pkgs;
 
   gnuapl = callPackage ../development/interpreters/gnu-apl { };
 
+  gnu-cobol = callPackage ../development/compilers/gnu-cobol { };
+
   gnufdisk = callPackage ../tools/system/fdisk {
     guile = guile_1_8;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

