### PR TITLE
hardware: add enableRedistributalFirmware

### DIFF
--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -2,7 +2,9 @@
 
 with lib;
 
-{
+let
+  cfg = config.hardware;
+in {
 
   ###### interface
 
@@ -12,7 +14,16 @@ with lib;
       default = false;
       type = types.bool;
       description = ''
-        Turn on this option if you want to enable all the firmware shipped in linux-firmware.
+        Turn on this option if you want to enable all the firmware.
+      '';
+    };
+
+    hardware.enableRedistributalFirmware = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Turn on this option if you want to enable all the firmware with a license allowing redistribution.
+        (i.e. free firmware and <literal>firmware-linux-nonfree</literal>)
       '';
     };
 
@@ -21,15 +32,27 @@ with lib;
 
   ###### implementation
 
-  config = mkIf config.hardware.enableAllFirmware {
-    hardware.firmware = with pkgs; [
-      firmwareLinuxNonfree
-      intel2200BGFirmware
-      rtl8723bs-firmware
-      rtl8192su-firmware
-    ] ++ optionals config.nixpkgs.config.allowUnfree [
-      broadcom-bt-firmware
-    ];
-  };
-
+  config = mkMerge [
+    (mkIf (cfg.enableAllFirmware || cfg.enableRedistributalFirmware) {
+      hardware.firmware = with pkgs; [
+        firmwareLinuxNonfree
+        intel2200BGFirmware
+        rtl8723bs-firmware
+        rtl8192su-firmware
+      ];
+    })
+    (mkIf cfg.enableAllFirmware {
+      assertions = [{
+        assertion = !cfg.enableAllFirmware || (config.nixpkgs.config.allowUnfree or false);
+        message = ''
+          the list of hardware.enableAllFirmware contains non-redistributable licensed firmware files.
+            This requires nixpkgs.config.allowUnfree to be true.
+            An alternative is to use the hardware.enableRedistributalFirmware option.
+        '';
+      }];
+      hardware.firmware = with pkgs; [
+        broadcom-bt-firmware
+      ];
+    })
+  ];
 }

--- a/nixos/modules/hardware/network/broadcom-43xx.nix
+++ b/nixos/modules/hardware/network/broadcom-43xx.nix
@@ -1,3 +1,3 @@
 {
-  hardware.enableAllFirmware = true;
+  hardware.enableRedistributalFirmware = true;
 }

--- a/nixos/modules/hardware/network/intel-2030.nix
+++ b/nixos/modules/hardware/network/intel-2030.nix
@@ -1,3 +1,3 @@
 {
-  hardware.enableAllFirmware = true;
+  hardware.enableRedistributalFirmware = true;
 }

--- a/nixos/modules/hardware/network/intel-2100bg.nix
+++ b/nixos/modules/hardware/network/intel-2100bg.nix
@@ -23,7 +23,7 @@
 
   config = lib.mkIf config.networking.enableIntel2100BGFirmware {
 
-    hardware.enableAllFirmware = true;
+    hardware.enableRedistributalFirmware = true;
 
   };
 

--- a/nixos/modules/hardware/network/intel-3945abg.nix
+++ b/nixos/modules/hardware/network/intel-3945abg.nix
@@ -22,7 +22,7 @@
 
   config = lib.mkIf config.networking.enableIntel3945ABGFirmware {
 
-    hardware.enableAllFirmware = true;
+    hardware.enableRedistributalFirmware = true;
 
   };
 

--- a/nixos/modules/hardware/network/intel-4965agn.nix
+++ b/nixos/modules/hardware/network/intel-4965agn.nix
@@ -1,3 +1,3 @@
 {
-  hardware.enableAllFirmware = true;
+  hardware.enableRedistributalFirmware = true;
 }

--- a/nixos/modules/hardware/network/intel-5000.nix
+++ b/nixos/modules/hardware/network/intel-5000.nix
@@ -1,3 +1,3 @@
 {
-  hardware.enableAllFirmware = true;
+  hardware.enableRedistributalFirmware = true;
 }

--- a/nixos/modules/hardware/network/intel-5150.nix
+++ b/nixos/modules/hardware/network/intel-5150.nix
@@ -1,3 +1,3 @@
 {
-  hardware.enableAllFirmware = true;
+  hardware.enableRedistributalFirmware = true;
 }

--- a/nixos/modules/hardware/network/intel-6000.nix
+++ b/nixos/modules/hardware/network/intel-6000.nix
@@ -1,3 +1,3 @@
 {
-  hardware.enableAllFirmware = true;
+  hardware.enableRedistributalFirmware = true;
 }

--- a/nixos/modules/hardware/network/intel-6000g2a.nix
+++ b/nixos/modules/hardware/network/intel-6000g2a.nix
@@ -1,3 +1,3 @@
 {
-  hardware.enableAllFirmware = true;
+  hardware.enableRedistributalFirmware = true;
 }

--- a/nixos/modules/hardware/network/intel-6000g2b.nix
+++ b/nixos/modules/hardware/network/intel-6000g2b.nix
@@ -1,3 +1,3 @@
 {
-  hardware.enableAllFirmware = true;
+  hardware.enableRedistributalFirmware = true;
 }

--- a/nixos/modules/hardware/network/ralink.nix
+++ b/nixos/modules/hardware/network/ralink.nix
@@ -20,7 +20,7 @@
   ###### implementation
 
   config = lib.mkIf config.networking.enableRalinkFirmware {
-    hardware.enableAllFirmware = true;
+    hardware.enableRedistributalFirmware = true;
   };
 
 }

--- a/nixos/modules/hardware/network/rtl8192c.nix
+++ b/nixos/modules/hardware/network/rtl8192c.nix
@@ -20,7 +20,7 @@
   ###### implementation
 
   config = lib.mkIf config.networking.enableRTL8192cFirmware {
-    hardware.enableAllFirmware = true;
+    hardware.enableRedistributalFirmware = true;
   };
 
 }

--- a/nixos/modules/hardware/video/radeon.nix
+++ b/nixos/modules/hardware/video/radeon.nix
@@ -1,3 +1,3 @@
 {
-  hardware.enableAllFirmware = true;
+  hardware.enableRedistributalFirmware = true;
 }

--- a/nixos/modules/installer/scan/not-detected.nix
+++ b/nixos/modules/installer/scan/not-detected.nix
@@ -5,5 +5,5 @@
 with lib;
 
 {
-  hardware.enableAllFirmware = true;
+  hardware.enableRedistributalFirmware = true;
 }

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -50,7 +50,7 @@
     ];
 
   # Include lots of firmware.
-  hardware.enableAllFirmware = true;
+  hardware.enableRedistributalFirmware = true;
 
   imports =
     [ ../hardware/network/zydas-zd1211.nix ];


### PR DESCRIPTION
###### Motivation for this change

Due the recent inclusion of broadcom-bt-firmware in enableAllFirmware,
it was required to set `nixpkgs.config.allowUnfree` to obtain the full
list. To make this dependency more explicit an assertion is added and an
alternative option `enableRedistributalFirmware` is provided to only
obtain firmware with an license allowing redistribution.

see https://github.com/NixOS/nixpkgs/pull/25567 for previous discussion.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

