### PR TITLE
syncthing: correct path for systemd units

### DIFF
--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -25,20 +25,20 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin $out/etc/systemd/{system,user}
+    mkdir -p $out/bin $out/lib/systemd/{system,user}
 
     cp bin/* $out/bin
   '' + lib.optionalString (stdenv.isLinux) ''
     substitute etc/linux-systemd/system/syncthing-resume.service \
-               $out/etc/systemd/system/syncthing-resume.service \
+               $out/lib/systemd/system/syncthing-resume.service \
                --replace /usr/bin/pkill ${pkgs.procps}/bin/pkill
 
     substitute etc/linux-systemd/system/syncthing@.service \
-               $out/etc/systemd/system/syncthing@.service \
+               $out/lib/systemd/system/syncthing@.service \
                --replace /usr/bin/syncthing $out/bin/syncthing
 
     substitute etc/linux-systemd/user/syncthing.service \
-               $out/etc/systemd/user/syncthing.service \
+               $out/lib/systemd/user/syncthing.service \
                --replace /usr/bin/syncthing $out/bin/syncthing
   '';
 

--- a/pkgs/applications/networking/syncthing/inotify.nix
+++ b/pkgs/applications/networking/syncthing/inotify.nix
@@ -16,14 +16,14 @@ buildGoPackage rec {
   goDeps = ./inotify-deps.nix;
 
   postInstall = ''
-    mkdir -p $bin/etc/systemd/{system,user}
+    mkdir -p $bin/lib/systemd/{system,user}
 
     substitute $src/etc/linux-systemd/system/syncthing-inotify@.service \
-               $bin/etc/systemd/system/syncthing-inotify@.service \
+               $bin/lib/systemd/system/syncthing-inotify@.service \
                --replace /usr/bin/syncthing-inotify $bin/bin/syncthing-inotify
 
     substitute $src/etc/linux-systemd/user/syncthing-inotify.service \
-               $bin/etc/systemd/user/syncthing-inotify.service \
+               $bin/lib/systemd/user/syncthing-inotify.service \
                --replace /usr/bin/syncthing-inotify $bin/bin/syncthing-inotify
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     install_name_tool -delete_rpath $out/lib -add_rpath $bin $bin/bin/syncthing-inotify


### PR DESCRIPTION
The systemd files included with syncthing are "library" and not
"configuration" units, so they should be placed in lib/systemd
rather than etc/systemd, so that they can be customised by creating
unit files in etc/. This also corresponds to how syncthing's own
build script installs them.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

