### PR TITLE
Make zshrc more predictable

### DIFF
--- a/nixos/modules/programs/zsh/oh-my-zsh.nix
+++ b/nixos/modules/programs/zsh/oh-my-zsh.nix
@@ -42,6 +42,10 @@ in
     };
 
     config = mkIf cfg.enable {
+
+      # Prevent zsh from overwriting oh-my-zsh's prompt
+      programs.zsh.promptInit = mkDefault "";
+
       environment.systemPackages = with pkgs; [ oh-my-zsh ];
 
       programs.zsh.interactiveShellInit = with pkgs; with builtins; ''

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -97,45 +97,6 @@ in
 
   config = mkIf cfg.enable {
 
-    programs.zsh = {
-
-      shellInit = ''
-        . ${config.system.build.setEnvironment}
-
-        ${cfge.shellInit}
-      '';
-
-      loginShellInit = cfge.loginShellInit;
-
-      interactiveShellInit = ''
-        # history defaults
-        SAVEHIST=2000
-        HISTSIZE=2000
-        HISTFILE=$HOME/.zsh_history
-
-        setopt HIST_IGNORE_DUPS SHARE_HISTORY HIST_FCNTL_LOCK
-
-        # Tell zsh how to find installed completions
-        for p in ''${(z)NIX_PROFILES}; do
-          fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions $p/share/zsh/vendor-completions)
-        done
-
-        ${if cfg.enableCompletion then "autoload -U compinit && compinit" else ""}
-
-        ${optionalString (cfg.enableAutosuggestions)
-          "source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
-        }
-
-        ${zshAliases}
-        ${cfg.promptInit}
-
-        ${cfge.interactiveShellInit}
-
-        HELPDIR="${pkgs.zsh}/share/zsh/$ZSH_VERSION/help"
-      '';
-
-    };
-
     environment.etc."zshenv".text =
       ''
         # /etc/zshenv: DO NOT EDIT -- this file has been generated automatically.
@@ -145,6 +106,10 @@ in
         # But don't clobber the environment of interactive non-login children!
         if [ -n "$__ETC_ZSHENV_SOURCED" ]; then return; fi
         export __ETC_ZSHENV_SOURCED=1
+
+        . ${config.system.build.setEnvironment}
+
+        ${cfge.shellInit}
 
         ${cfg.shellInit}
 
@@ -162,6 +127,8 @@ in
         # Only execute this file once per shell.
         if [ -n "$__ETC_ZPROFILE_SOURCED" ]; then return; fi
         __ETC_ZPROFILE_SOURCED=1
+
+        ${cfge.loginShellInit}
 
         ${cfg.loginShellInit}
 
@@ -182,7 +149,33 @@ in
 
         . /etc/zinputrc
 
+        # history defaults
+        SAVEHIST=2000
+        HISTSIZE=2000
+        HISTFILE=$HOME/.zsh_history
+
+        setopt HIST_IGNORE_DUPS SHARE_HISTORY HIST_FCNTL_LOCK
+
+        HELPDIR="${pkgs.zsh}/share/zsh/$ZSH_VERSION/help"
+
+        ${optionalString cfg.enableCompletion "autoload -U compinit && compinit"}
+
+        ${optionalString (cfg.enableAutosuggestions)
+          "source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
+        }
+
+        ${zshAliases}
+
+        ${cfge.interactiveShellInit}
+
         ${cfg.interactiveShellInit}
+
+        ${cfg.promptInit}
+
+        # Tell zsh how to find installed completions
+        for p in ''${(z)NIX_PROFILES}; do
+          fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions $p/share/zsh/vendor-completions)
+        done
 
         # Read system-wide modifications.
         if test -f /etc/zshrc.local; then


### PR DESCRIPTION
Make zshrc more predictable by modifying the initialization scripts.

###### Motivation for this change

Originally, `programs.zsh` sets default values for some initialization scripts.
Nix resolves the case of multiple values by concatenating them all.
It is however impossible to predict where the default script will be inserted; but we never want the default value to override the user-specified ones.

I encountered the problem when trying to augment nix-shell with zsh-specific hooks. As the hooks were inserted at unpredictable points in the scripts, it would sometimes fail.

###### Things done

Now, it doesn't set default values; almost everything is hardcoded at the beginning of the initialization file. Apart from predictability, it doesn't change anything.

Note that the point at which the `promptInit` script is evaluated has changed. For reasons I didn't investigate it seems to want to be evaluated last.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

