### PR TITLE
systemd-boot: sync efi filesystem after update

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -2,12 +2,15 @@
 import argparse
 import shutil
 import os
+import sys
 import errno
 import subprocess
 import glob
 import tempfile
 import errno
 import warnings
+import ctypes
+libc = ctypes.CDLL("libc.so.6")
 
 def copy_if_not_exists(source, dest):
     if not os.path.exists(dest):
@@ -144,6 +147,10 @@ def main():
         write_entry(gen, machine_id)
         if os.readlink(system_dir(gen)) == args.default_config:
             write_loader_conf(gen)
+
+    rc = libc.syncfs(os.open("@efiSysMountPoint@", os.O_RDONLY))
+    if rc != 0:
+        print("could not sync @efiSysMountPoint@: {}".format(os.strerror(rc)), file=sys.stderr)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
###### Motivation for this change

Since fat32 provides little recovery facilities after a crash,
it can leave the system in an unbootable state, when a crash/outage
happens shortly after an update. To decrease the likelihood of this
event sync the efi file-system after each update.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

