### PR TITLE
pmenu: 2016-05-13 -> 2017-04-10

### DIFF
--- a/pkgs/applications/misc/pmenu/default.nix
+++ b/pkgs/applications/misc/pmenu/default.nix
@@ -1,29 +1,25 @@
-{ stdenv, fetchFromGitLab, python2Packages, gnome2 }:
+{ stdenv, fetchFromGitLab, python2Packages, gnome3 }:
 
 stdenv.mkDerivation rec {
   name = "pmenu-${version}";
-  version = "2016-05-13";
+  version = "2017-04-10";
 
   src = fetchFromGitLab {
     owner = "o9000";
     repo = "pmenu";
-    rev = "90b722de345cff56f8ec0908a0e8a7d733c0c671";
-    sha256 = "15bkvadr7ab44mc8gkdqs3w14cm498mwf72w5rjm2rdh55357jjh";
+    rev = "87fec9ddf594f1046d03348de2bafcfa6e94cfd1";
+    sha256 = "0ynhml46bi5k52v7fw2pjpcac9dswkmlvh6gynvnyqjp4p153fl4";
   };
 
   nativeBuildInputs = [ python2Packages.wrapPython ];
 
-  buildInputs = [ python2Packages.pygtk gnome2.gnome_menus ];
+  buildInputs = [ python2Packages.pygtk gnome3.gnome-menus ];
 
   pythonPath = [ python2Packages.pygtk ];
-  
-  patchPhase = ''
-    substituteInPlace install.sh --replace "/usr/local" "$out"
-  '';
     
   installPhase = ''
     mkdir -p $out/bin $out/share/applications
-    ./install.sh
+    ./install.sh $out
   '';
 
   postFixup = ''


### PR DESCRIPTION
###### Motivation for this change

Update to current snapshot.

[Commit history:](https://gitlab.com/o9000/pmenu/commits/master)

- 10 Apr, 2017 2 commits

    Icon theme name helper
    Use correct names for tint2 variables

- 09 Apr, 2017 1 commit

    Terminal=true support

- 08 Apr, 2017 1 commit

    Add option to turn off icons

- 05 Apr, 2017 2 commits

    Add menu item to reload settigns
    Add menu item to reload settigns

- 04 Apr, 2017 1 commit

    Support for generating the openbox static menu

- 02 Apr, 2017 7 commits

    Positioning
    Positioning
    Update readme
    Update readme
    Change --wm parameter behaviour
    Update readme
    Tidy up install script

- 01 Apr, 2017 12 commits

    Respect NoDisplay
    Escape xml properly
    Fix tooltip for builtin items
    xfce support
    Configuration option for lock/logout buttons
    Show default icon for missing icons
    Load alignment variables for menu
    Make gtk and openbox modes consistent
    Fix gtk import, add openbox settings
    Merge
    Merge branch 'master' of https://gitlab.com/o9000/pmenu
    Backport from jgmenu

- 22 Jul, 2016 2 commits

    jgmenu wrapper: cleanup
    jgmenu wrapper


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).