### PR TITLE
phwmon: 2016-03-13 -> 2017-04-10

### DIFF
--- a/pkgs/applications/misc/phwmon/default.nix
+++ b/pkgs/applications/misc/phwmon/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "phwmon-${version}";
-  version = "2016-03-13";
+  version = "2017-04-10";
 
   src = fetchFromGitLab {
     owner = "o9000";
     repo = "phwmon";
-    rev = "90247ceaff915ad1040352c5cc9195e4153472d4";
-    sha256 = "1gkjfmd8rai7bl1j7jz9drmzlw72n7mczl0akv39ya4l6k8plzvv";
+    rev = "b162e53dccc4adf8f11f49408d05fd85d9c6c909";
+    sha256 = "1hqmsq66y8bqkpvszw84jyk8haxq3cjnz105hlkmp7786vfmkisq";
   };
 
   nativeBuildInputs = [ pythonPackages.wrapPython ];


### PR DESCRIPTION
###### Motivation for this change

Update to current snapshot.

[Commit history:](https://gitlab.com/o9000/phwmon/commits/master)

- 10 Apr, 2017 3 commits

    Hide swap icon when there is no swap available
    Consistent indentation
    Merge branch 'master' into 'master'

- 09 Apr, 2017 7 commits

    Change default swap fg color 
    Fix fg colors usage info
    Add option to (try and) invert icon ordering
    [tooltip] Add option to display RAM/Swap usage in percents
    Allow specifying refresh interval
    Add ability to launch system monitor on left click
    Add swap usage


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).