### PR TITLE
Add support for Brother MFC-L2700DN

### DIFF
--- a/pkgs/misc/cups/drivers/mfcl2700dncupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl2700dncupswrapper/default.nix
@@ -1,0 +1,44 @@
+{ coreutils, dpkg, fetchurl, gnugrep, gnused, makeWrapper, mfcl2700dnlpr, perl, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "mfcl2700dncupswrapper-${meta.version}";
+
+  src = fetchurl {
+    url = "http://download.brother.com/welcome/dlf102086/${name}.i386.deb";
+    sha256 = "07w48mah0xbv4h8vsh1qd5cd4b463bx8y6gc5x9pfgsxsy6h6da1";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+
+    basedir=${mfcl2700dnlpr}/opt/brother/Printers/MFCL2700DN
+    dir=$out/opt/brother/Printers/MFCL2700DN
+
+    substituteInPlace $dir/cupswrapper/brother_lpdwrapper_MFCL2700DN \
+      --replace /usr/bin/perl ${perl}/bin/perl \
+      --replace "basedir =~" "basedir = \"$basedir\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"MFCL2700DN\"; #"
+
+    wrapProgram $dir/cupswrapper/brother_lpdwrapper_MFCL2700DN \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gnugrep gnused ]}
+
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+
+    ln $dir/cupswrapper/brother_lpdwrapper_MFCL2700DN $out/lib/cups/filter
+    ln $dir/cupswrapper/brother-MFCL2700DN-cups-en.ppd $out/share/cups/model
+  '';
+
+  meta = {
+    description = "Brother MFC-L2700DN CUPS wrapper driver";
+    homepage = "http://www.brother.com/";
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = [ stdenv.lib.maintainers.tv ];
+    platforms = stdenv.lib.platforms.linux;
+    version = "3.2.0-1";
+  };
+}

--- a/pkgs/misc/cups/drivers/mfcl2700dnlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl2700dnlpr/default.nix
@@ -1,0 +1,44 @@
+{ coreutils, dpkg, fetchurl, ghostscript, gnugrep, gnused, makeWrapper, perl, stdenv, which }:
+
+stdenv.mkDerivation rec {
+  name = "mfcl2700dnlpr-${meta.version}";
+
+  src = fetchurl {
+    url = "http://download.brother.com/welcome/dlf102085/${name}.i386.deb";
+    sha256 = "170qdzxlqikzvv2wphvfb37m19mn13az4aj88md87ka3rl5knk4m";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+
+    dir=$out/opt/brother/Printers/MFCL2700DN
+
+    substituteInPlace $dir/lpd/filter_MFCL2700DN \
+      --replace /usr/bin/perl ${perl}/bin/perl \
+      --replace "BR_PRT_PATH =~" "BR_PRT_PATH = \"$dir\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"MFCL2700DN\"; #"
+
+    wrapProgram $dir/lpd/filter_MFCL2700DN \
+      --prefix PATH : ${stdenv.lib.makeBinPath [
+        coreutils ghostscript gnugrep gnused which
+      ]}
+
+    interpreter=$(cat $NIX_CC/nix-support/dynamic-linker)
+    patchelf --set-interpreter "$interpreter" $dir/inf/braddprinter
+    patchelf --set-interpreter "$interpreter" $dir/lpd/brprintconflsr3
+    patchelf --set-interpreter "$interpreter" $dir/lpd/rawtobr3
+  '';
+
+  meta = {
+    description = "Brother MFC-L2700DN LPR driver";
+    homepage = "http://www.brother.com/";
+    license = stdenv.lib.licenses.unfree;
+    maintainers = [ stdenv.lib.maintainers.tv ];
+    platforms = [ "i686-linux" ];
+    version = "3.2.0-1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18379,6 +18379,8 @@ with pkgs;
   mfcj6510dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj6510dwcupswrapper { };
   mfcj6510dwlpr = callPackage_i686 ../misc/cups/drivers/mfcj6510dwlpr { };
 
+  mfcl2700dnlpr = callPackage_i686 ../misc/cups/drivers/mfcl2700dnlpr { };
+
   samsung-unified-linux-driver_1_00_37 = callPackage ../misc/cups/drivers/samsung { };
   samsung-unified-linux-driver_4_01_17 = callPackage ../misc/cups/drivers/samsung/4.01.17.nix { };
   samsung-unified-linux-driver = callPackage ../misc/cups/drivers/samsung/4.00.39 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18379,6 +18379,7 @@ with pkgs;
   mfcj6510dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj6510dwcupswrapper { };
   mfcj6510dwlpr = callPackage_i686 ../misc/cups/drivers/mfcj6510dwlpr { };
 
+  mfcl2700dncupswrapper = callPackage ../misc/cups/drivers/mfcl2700dncupswrapper { };
   mfcl2700dnlpr = callPackage_i686 ../misc/cups/drivers/mfcl2700dnlpr { };
 
   samsung-unified-linux-driver_1_00_37 = callPackage ../misc/cups/drivers/samsung { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

