### PR TITLE
buildRebar3 and buildMix depend less on hex registry

### DIFF
--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -61,8 +61,9 @@ let
         export HEX_OFFLINE=1
         export HEX_HOME=`pwd`
         export MIX_ENV=prod
+        export MIX_NO_DEPS=1
 
-        MIX_ENV=prod mix compile ${debugInfoFlag} --no-deps-check
+        mix compile ${debugInfoFlag}
 
         runHook postBuild
     ''


### PR DESCRIPTION
###### Motivation for this change

I was trying to build one of my own projects using packages newer than those in the hex registry and found it was impossible because both Mix and rebar3 were trying to pull in the updated registry after failing to find the requested versions.

Mix has a new environment flag that fixes the behavior, so that change was easy.

Rebar3, on the other hand, still insists on updating the registry even when the built dependencies are present in `./_build/default/lib`. The best solution I could come up with short of fixing this in upstream (https://github.com/erlang/rebar3/issues/958) was to change the rebar3 bootstrap to have it generate all of what was symlinked said directory to `./_checkouts` instead, sans `src` subdirs, since rebar3 will try to recompile the source (always, because the derivations lack `.rebar3/erlcinfo` metadata) into a RO store directory.

My changes to the rebar3 bootstrapping could use review and probably more testing, but as it stands, `./pkgs/development/beam-modules/hex-packages.nix` is plenty broken. Does anyone know where is the script that generated this package listing? I need to make a fix there so that packages that depend on broken, elided packages are also elided. It could use a refresh, too.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

