### PR TITLE
emby: 3.2.13.0 -> 3.2.15.0

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
-  version = "3.2.13.0";
+  version = "3.2.15.0";
 
   src = fetchurl {
     url = "https://github.com/MediaBrowser/Emby/releases/download/${version}/Emby.Mono.zip";
-    sha256 = "180prfbc1lv35cqwamzzgl30c0j89nh18jr1nwjancq0s0wkiksp";
+    sha256 = "0xfjj899l7xmmiwwbfj4j9dwgrq10911nls06viz793bflmxw082";
   };
 
   buildInputs = with pkgs; [


### PR DESCRIPTION
###### Motivation for this change
https://github.com/MediaBrowser/Emby/releases/tag/3.2.14.0
https://github.com/MediaBrowser/Emby/releases/tag/3.2.15.0


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

