### PR TITLE
lnav: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/tools/misc/lnav/default.nix
+++ b/pkgs/tools/misc/lnav/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, pcre-cpp, sqlite, ncurses,
-  readline, zlib, bzip2, autoconf, automake }:
+{ stdenv, fetchFromGitHub, pcre-cpp, sqlite, ncurses
+, readline, zlib, bzip2, autoconf, automake, curl }:
 
 stdenv.mkDerivation rec {
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "tstack";
     repo = "lnav";
     rev = "v${meta.version}";
-    sha256 = "0pag2rl7b6s2xfl80c629vhwsdvvlhcdy6732yvpgfv94w0zyjp9";
+    sha256 = "1jdjn64cxgbhhyg73cisrfrk7vjg1hr9nvkmfdk8gxc4g82y3xxc";
     inherit name;
   };
 
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     pcre-cpp
     readline
     sqlite
+    curl
   ];
 
   preConfigure = ''
@@ -42,7 +43,7 @@ stdenv.mkDerivation rec {
     '';
     downloadPage = "https://github.com/tstack/lnav/releases";
     license = licenses.bsd2;
-    version = "0.8.1";
+    version = "0.8.2";
     maintainers = [ maintainers.dochang ];
   };
 


### PR DESCRIPTION
###### Motivation for this change

Bump version

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

