### PR TITLE
git: 2.12.2 -> 2.13.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  version = "2.12.2";
+  version = "2.13.0";
   svn = subversionClient.override { perlBindings = true; };
 in
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "0jlccxx7l4c76h830y8lhrxr4kqksrxqlnmj3xb8sqbfa0irw6nj";
+    sha256 = "0n0j36rapw31zb0sabap88ffncv8jg3nwc4miyim64ilyav2mgsb";
   };
 
   hardeningDisable = [ "format" ];

--- a/pkgs/applications/version-management/git-and-tools/git/ssh-path.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/ssh-path.patch
@@ -2,20 +2,20 @@ diff --git a/connect.c b/connect.c
 index fd7ffe1..20cd992 100644
 --- a/connect.c
 +++ b/connect.c
-@@ -768,7 +768,7 @@ struct child_process *git_connect(int fd[2], const char *url,
- 
+@@ -768,7 +768,7 @@
+
  				ssh = getenv("GIT_SSH");
  				if (!ssh)
 -					ssh = "ssh";
 +					ssh = "@ssh@";
- 
- 				ssh_dup = xstrdup(ssh);
- 				base = basename(ssh_dup);
+				else
+					handle_ssh_variant(ssh, 0,
+								&port_option,
 diff --git a/git-gui/lib/remote_add.tcl b/git-gui/lib/remote_add.tcl
 index 50029d0..17b9594 100644
 --- a/git-gui/lib/remote_add.tcl
 +++ b/git-gui/lib/remote_add.tcl
-@@ -139,7 +139,7 @@ method _add {} {
+@@ -139,7 +139,7 @@
  		# Parse the location
  		if { [regexp {(?:git\+)?ssh://([^/]+)(/.+)} $location xx host path]
  		     || [regexp {([^:][^:]+):(.+)} $location xx host path]} {


### PR DESCRIPTION
###### Motivation for this change
Update

https://github.com/blog/2360-git-2-13-has-been-released

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

