### PR TITLE
git-series: init at 0.9.1

### DIFF
--- a/pkgs/development/tools/git-series/default.nix
+++ b/pkgs/development/tools/git-series/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, rustPlatform, openssl, cmake, perl, pkgconfig, zlib }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  version = "0.9.1";
+  name = "git-series-${version}";
+
+  src = fetchFromGitHub {
+    owner = "git-series";
+    repo = "git-series";
+    rev = version;
+    sha256 = "07mgq5h6r1gf3jflbv2khcz32bdazw7z1s8xcsafdarnm13ps014";
+  };
+
+  depsSha256 = "1xypk9ck7znca0nqm61m5ngpz6q7c0wydlpwxq4mnkd1np27xn53";
+
+  nativeBuildInputs = [ cmake pkgconfig perl ];
+  buildInputs = [ openssl zlib ];
+
+  meta = with stdenv.lib; {
+    description = "A tool to help with formatting git patches for review on mailing lists";
+    longDescription = ''
+          git series tracks changes to a patch series over time. git
+          series also tracks a cover letter for the patch series,
+          formats the series for email, and prepares pull requests.
+    '';
+    homepage = https://github.com/git-series/git-series;
+
+    license = licenses.mit;
+    maintainer = [ maintainers.vmandela ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2021,6 +2021,8 @@ with pkgs;
 
   git-lfs = callPackage ../applications/version-management/git-lfs { };
 
+  git-series = callPackage ../development/tools/git-series { };
+
   git-up = callPackage ../applications/version-management/git-up { };
 
   gitfs = callPackage ../tools/filesystems/gitfs { };


### PR DESCRIPTION
git series tracks changes to a patch series over time. git series also
tracks a cover letter for the patch series, formats the series for
email, and prepares pull requests.

https://github.com/git-series/git-series

###### Motivation for this change

This tool will be helpful in formatting git patches for mailing list review and 
tracking the changes to the patches over time. 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

