### PR TITLE
bitcoin-classic: 1.2.3 -> 1.2.5

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-classic.nix
+++ b/pkgs/applications/altcoins/bitcoin-classic.nix
@@ -7,13 +7,13 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-classic-" + version;
-  version = "1.2.3";
+  version = "1.2.5";
 
   src = fetchFromGitHub {
     owner = "bitcoinclassic";
     repo = "bitcoinclassic";
     rev = "v${version}";
-    sha256 = "0y99c8zv42ps3pxp46p3fqj9sir580v7s5qyi3cxva12mq2z0cql";
+    sha256 = "1z6g930csvx49krl34207yqwlr8dkxpi72k3msh15p1kjvv90nvz";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
@@ -32,11 +32,13 @@ stdenv.mkDerivation rec {
       parties. Users hold the crypto keys to their own money and transact directly
       with each other, with the help of a P2P network to check for double-spending.
 
-      We call our code repository Bitcoin Classic. It starts as a one-feature patch
-      to bitcoin-core that increases the blocksize limit to 2 MB. We will have
-      ports for master and 0.11.2, so that miners and businesses can upgrade to 2 MB
-      blocks from any recent bitcoin software version they run. In the future we will
-      continue to release updates that are in line with Satoshi’s whitepaper &
+      Bitcoin Classic stands for the original Bitcoin as Satoshi described it, 
+      "A Peer-to-Peer Electronic Cash System". We are writing the software that 
+      miners and users say they want. We will make sure it solves their needs, help
+      them deploy it, and gracefully upgrade the bitcoin network's capacity 
+      together. The data shows that Bitcoin can grow, on-chain, to welcome many
+      more users onto our coin in a safe and distributed manner. In the future we 
+      will continue to release updates that are in line with Satoshi’s whitepaper &
       vision, and are agreed upon by the community.
     '';
     homepage = https://bitcoinclassic.com/;


### PR DESCRIPTION
###### Motivation for this change
Keeping up to date with all the recent stability fixes.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

