### PR TITLE
cups: mount private /tmp

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -324,6 +324,8 @@ in
               fi
             ''}
           '';
+
+          serviceConfig.PrivateTmp = true;
       };
 
     systemd.services.cups-browsed = mkIf avahiEnabled


### PR DESCRIPTION
###### Motivation for this change

printer driver and wrapper are often not written with security in mind.

While reviewing https://github.com/NixOS/nixpkgs/pull/25654 I found
a symlink-race vulnerability within the wrapper code, when writing
unique files in /tmp.
I expect this script to be reused in other models as well
as similar vulnerabilities in the code of other vendors. Therefore
I propose to make /tmp of cups.service private so that only processes
with the same privileges are able to access these files.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note that I have not tested actual printing with cups, because I currently have no hardware access.
The service itself works. I suspect if anything would require access to /tmp of cups outside of cups, this would be a security vulnerability on its own.