### PR TITLE
openmvs: init at current master

### DIFF
--- a/pkgs/applications/science/misc/openmvs/default.nix
+++ b/pkgs/applications/science/misc/openmvs/default.nix
@@ -18,12 +18,17 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
-  cmakeFlags = [
-    "-DCMAKE_CXX_FLAGS=-std=c++11"
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DVCG_DIR=${vcg}"
-    "-DCERES_DIR=${ceres-solver}/lib/cmake/Ceres/"
-  ];
+  preConfigure = ''
+    cmakeFlagsArray=(
+      $cmakeFlagsArray
+      "-DCMAKE_CXX_FLAGS=-std=c++11"
+      "-DBUILD_SHARED_LIBS=ON"
+      "-DBUILD_STATIC_RUNTIME=ON"
+      "-DINSTALL_BIN_DIR=$out/bin"
+      "-DVCG_DIR=${vcg}"
+      "-DCERES_DIR=${ceres-solver}/lib/cmake/Ceres/"
+    )
+  '';
 
   cmakeDir = "./";
 
@@ -31,18 +36,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  installPhase = ''
-    mkdir -p $out/bin $out/lib $out/include
-    make install
-    mv $out/bin/OpenMVS/* $out/bin/
-    rm -rf $out/bin/OpenMVS/
-  '';
-
-  meta = {
+  meta = with stdenv.lib; {
     description = "A library for computer-vision scientists and especially targeted to the Multi-View Stereo reconstruction community";
     homepage = http://cdcseacave.github.io/openMVS/;
-    license = stdenv.lib.licenses.agpl3;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ mdaiter ];
+    license = licenses.agpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mdaiter ];
   };
 }

--- a/pkgs/applications/science/misc/openmvs/default.nix
+++ b/pkgs/applications/science/misc/openmvs/default.nix
@@ -3,8 +3,7 @@
 , gmp, mpfr, glog, google-gflags, libjpeg_turbo }:
 
 stdenv.mkDerivation rec {
-  version = "a3b3600";
-  name = "openmvs-${version}";
+  name = "openmvs-unstable-2017-05-01";
 
   src = fetchFromGitHub {
     owner = "cdcseacave";

--- a/pkgs/applications/science/misc/openmvs/default.nix
+++ b/pkgs/applications/science/misc/openmvs/default.nix
@@ -1,0 +1,48 @@
+{ lib, stdenv, fetchFromGitHub, pkgconfig, cmake
+, eigen, opencv, ceres-solver, cgal, boost, vcg
+, gmp, mpfr, glog, google-gflags, libjpeg_turbo }:
+
+stdenv.mkDerivation rec {
+  version = "a3b3600";
+  name = "openmvs-${version}";
+
+  src = fetchFromGitHub {
+    owner = "cdcseacave";
+    repo = "openmvs";
+
+    rev = "a3b360016660a1397f6eb6c070c2c19bbb4c7590";
+    sha256 = "170ff4ipix2kqq5rhb1yrrcvc79im9qgp5hiwsdr23xxzdl21221";
+  };
+
+  buildInputs = [ eigen opencv ceres-solver cgal boost vcg gmp mpfr glog google-gflags libjpeg_turbo ];
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  cmakeFlags = [
+    "-DCMAKE_CXX_FLAGS=-std=c++11"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DVCG_DIR=${vcg}"
+    "-DCERES_DIR=${ceres-solver}/lib/cmake/Ceres/"
+  ];
+
+  cmakeDir = "./";
+
+  dontUseCmakeBuildDir = true;
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib $out/include
+    make install
+    mv $out/bin/OpenMVS/* $out/bin/
+    rm -rf $out/bin/OpenMVS/
+  '';
+
+  meta = {
+    description = "A library for computer-vision scientists and especially targeted to the Multi-View Stereo reconstruction community";
+    homepage = http://cdcseacave.github.io/openMVS/;
+    license = stdenv.lib.licenses.agpl3;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ mdaiter ];
+  };
+}

--- a/pkgs/development/libraries/vcg/default.nix
+++ b/pkgs/development/libraries/vcg/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchsvn, eigen }:
+{ stdenv, fetchFromGitHub, eigen }:
 
 stdenv.mkDerivation rec {
-  name = "vcg-2016-02-14";
+  name = "vcg-${version}";
+  version = "1.0.1";
 
-  src = fetchsvn {
-    url = "svn://svn.code.sf.net/p/vcg/code/trunk/vcglib";
-    rev = 5688;
-    sha256 = "0hkvz2d8prrjdcc7h0xhfd9hq86lmqg17ml045x4bkiciimx0w5s";
+  src = fetchFromGitHub {
+    owner = "cnr-isti-vclab";
+    repo = "vcglib";
+    rev = "v${version}";
+    sha256 = "0jh8jc8rn7rci8qr3q03q574fk2hsc3rllysck41j8xkr3rmxz2f";
   };
 
   propagatedBuildInputs = [ eigen ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3327,6 +3327,8 @@ with pkgs;
 
   openmvg = callPackage ../applications/science/misc/openmvg { };
 
+  openmvs = callPackage ../applications/science/misc/openmvs { };
+
   openntpd = callPackage ../tools/networking/openntpd { };
 
   openntpd_nixos = openntpd.override {


### PR DESCRIPTION
###### Motivation for this change
Let's add OpenMVS to nixpkgs. This change enables OpenMVS to be built in a sane and quick manner.

On top of this, this change fixes a minor bug that arises when attempting to compile libraries using VCG. Header files assume implicit `std::` prefixing for the `isnan` and `isinf` functions supplied by `<cmath>`. This commit should alter that, in order to more specifically reference that.

The reason why the VCG library expression has been altered in this commit to, say, a separate PR stems from its importance in relation to the OpenMVS package. While this commit won't break other packages that rely on it, OpenMVS needs this commit to the VCG library in order to compile and function properly.
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

