### PR TITLE
Pycharm 2017 -> 2017.1.2

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -305,12 +305,12 @@ in
 
   pycharm-community = buildPycharm rec {
     name = "pycharm-community-${version}";
-    version = "2017.1";
+    version = "2017.1.2";
     description = "PyCharm Community Edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "14p6f15n0927awgpsdsdqgmdfbbwkykrw5xggz5hnfl7d05i4sb6";
+      sha256 = "03c352lj6vnc7cs5ch8p12i4f95qadnibzbrxmxv5xqglpdrp7g9";
     };
     wmClass = "jetbrains-pycharm-ce";
   };

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -317,12 +317,12 @@ in
 
   pycharm-professional = buildPycharm rec {
     name = "pycharm-professional-${version}";
-    version = "2017.1";
+    version = "2017.1.2";
     description = "PyCharm Professional Edition";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "1rvic3njsq480pslhw6rxld7jngchihkplq3dfnmkr2h9gx26lkf";
+      sha256 = "0jrrlrkwi6f70nqrrz2vv1wdjpwjbh2in1g658dsbr9gpmkdmy0q";
     };
     wmClass = "jetbrains-pycharm";
   };


### PR DESCRIPTION
###### Motivation for this change

PyCharm was updated with a new release 2017.1.2. The commits here are pretty much minimal - just version and sha256 updates.

There's one thing, though - URL for pycharm-professional 2017.1 currently [responds with 403 error](https://download-cf.jetbrains.com/python/pycharm-professional-2017.1.tar.gz) for some reason (no issues for pycharm-community, that one works), which currently breaks `release-17.03` if someone has `idea.pycharm-professional` in their `configuration.nix`. So, I'd ask to please backport the changes to 17.03. This could be slightly inconvenient, as the directory was renamed since then (from `idea` to `jetbrains`), so unless that change is also merged there probably will be a merge conflict. To save time, you may want to check my branch [`pycharm-2017.1.2-release-17.03`](https://github.com/drdaeman/nixpkgs/tree/pycharm-2017.1.2-release-17.03), which does similar changes from current `release-17.03` branch. Please tell if you'd want me to make a PR for this.

Thanks!

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

