### PR TITLE
pharo-vm: Add third-party libraries to LD_LIBRARY_PATH

### DIFF
--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, makeDesktopItem }:
+{ stdenv, fetchurl, cmake, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, makeDesktopItem, makeWrapper }:
 
 { name, src, binary-basename, ... }:
 
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
     cd build/
   '';
   resources = ./resources;
+
+  LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath [ cairo freetype ];
   installPhase = ''
     mkdir -p "$prefix/lib/$name"
 
@@ -67,10 +69,15 @@ stdenv.mkDerivation rec {
 
     chmod +x $prefix/bin/${binary-basename}-x $prefix/bin/${binary-basename}-nox
 
+    # Add cairo library to the library path.
+    wrapProgram $prefix/bin/${binary-basename}-x --prefix LD_LIBRARY_PATH : ${LD_LIBRARY_PATH}
+    wrapProgram $prefix/bin/${binary-basename}-nox --prefix LD_LIBRARY_PATH : ${LD_LIBRARY_PATH}
+
     ln -s "${pharo-share}/lib/"*.sources $prefix/lib/$name
   '';
 
-  buildInputs = [ bash unzip cmake glibc openssl gcc mesa freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share ];
+  nativeBuildInputs = [ bash unzip cmake gcc makeWrapper ];
+  buildInputs = [ glibc openssl mesa freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share ];
 
   meta = {
     description = "Clean and innovative Smalltalk-inspired environment";

--- a/pkgs/development/pharo/vm/default.nix
+++ b/pkgs/development/pharo/vm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, makeDesktopItem } @args:
+{ stdenv, fetchurl, cmake, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, makeDesktopItem, makeWrapper } @args:
 
 rec {
   pharo-vm-build = import ./build-vm.nix args;


### PR DESCRIPTION
###### Motivation for this change
The default Pharo image has code which uses the freetype and cairo libraries. When that code was executed it threw an error saying that it couldn't find these libraries. This PR fixes it by putting the libraries in `LD_LIBRARY_PATH ` using a wrapper.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

