### PR TITLE
emojione: Fix typo in meta.license attribute name

### DIFF
--- a/pkgs/data/fonts/emojione/default.nix
+++ b/pkgs/data/fonts/emojione/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Open source emoji set";
     homepage = "http://emojione.com/";
-    licenses = licenses.cc-by-40;
+    license = licenses.cc-by-40;
     platforms = platforms.all;
     maintainers = with maintainers; [ abbradar ];
   };


### PR DESCRIPTION
###### Motivation for this change
When installing this package, it broke because there was no meta.license attribute.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

