### PR TITLE
souper: 2017-03-07 -> 2017.03.23

### DIFF
--- a/pkgs/development/compilers/souper/default.nix
+++ b/pkgs/development/compilers/souper/default.nix
@@ -9,14 +9,15 @@ let
     rev   = "57cd3d43056b029d9da3c6b3c666c4153554c04f";
     sha256 = "197wb7nbirlfpx2jr3afpjjhcj7slc4dxxi02j3kmazz9kcqaygz";
   };
-in stdenv.mkDerivation {
-  name = "souper-unstable-2017-03-07";
+in stdenv.mkDerivation rec {
+  name = "souper-unstable-${version}";
+  version = "2017.03.23";
 
   src = fetchFromGitHub {
     owner  = "google";
     repo   = "souper";
-    rev    = "5faed54ddc4a0e0e12647a0eac1da455a1067a47";
-    sha256 = "1v8ml94ryw5wdls9syvicx4sc9l34yaq8r7cf7is6x7y1q677rps";
+    rev    = "cf2911d2eb1e7c8ab465df5a722fa5cdac06e6fc";
+    sha256 = "1kg08a1af4di729pn1pip2lzqzlvjign6av95214f5rr3cq2q0cl";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
* update to latest
* change version format for nix-env friendliness.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

