### PR TITLE
Android Studio Version Bump 2.2.3 -> 2.3.1

### DIFF
--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -33,8 +33,8 @@
 
 let
 
-  version = "2.2.3.0";
-  build = "145.3537739";
+  version = "2.3.1.0";
+  build = "162.3871768";
 
   androidStudio = stdenv.mkDerivation {
     name = "android-studio";
@@ -98,7 +98,7 @@ let
     '';
     src = fetchurl {
       url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";
-      sha256 = "10fmffkvvbnmgjxb4rq7rjwnn16jp5phw6div4n7hh2ad6spf8wq";
+      sha256 = "0cw483xxpc3alg5gv5gqfr2ri98pvdb5kzpmbn5jk04gcwhhylin";
     };
     meta = {
       description = "The Official IDE for Android";


### PR DESCRIPTION
###### Motivation for this change
The current version of Android Studio in Nixpkgs (2.2.3) has an error that prevents running developed 
apps on an Android phone. The latest version (2.3.1) fixes this issue.
###### Things done
Updated version number, build number, and sha256 hash. Warning: In order to get the lastest sha256 hash, I used the build error output. I could not find where the official sha256 hashes are published for Android Studio.
- [ ] Tested using sandboxing (http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`"0cw483xxpc3alg5gv5gqfr2ri98pvdb5kzpmbn5jk04gcwhhylin"nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux"0cw483xxpc3alg5gv5gqfr2ri98pvdb5kzpmbn5jk04gcwhhylin"
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

