### PR TITLE
kdevelop: Fix shell integration (issue 25559)

### DIFF
--- a/pkgs/applications/editors/kdevelop5/kdevelop.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cmake, gettext, pkgconfig, extra-cmake-modules, makeQtWrapper
-, qtquickcontrols, qtwebkit, qttools
+, qtquickcontrols, qtwebkit, qttools, kde-cli-tools
 , kconfig, kdeclarative, kdoctools, kiconthemes, ki18n, kitemmodels, kitemviews
 , kjobwidgets, kcmutils, kio, knewstuff, knotifyconfig, kparts, ktexteditor
 , threadweaver, kxmlgui, kwindowsystem, grantlee
@@ -36,7 +36,16 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapQtProgram "$out/bin/kdevelop"
-    wrapProgram "$out/bin/kdevelop!" --prefix PATH ":" "${qttools}/bin"
+    
+    # The kdevelop! script (shell environment) needs qdbus and kioclient5 in PATH.
+    wrapProgram "$out/bin/kdevelop!" --prefix PATH ":" "${qttools}/bin:${kde-cli-tools}/bin"
+    
+    # Fix the (now wrapped) kdevelop! to find things in right places:
+    # - Make KDEV_BASEDIR point to bin directory of kdevplatform.
+    kdev_fixup_sed="s|^export KDEV_BASEDIR=.*$|export KDEV_BASEDIR=${kdevplatform}/bin|"
+    # - Fixup the one use where KDEV_BASEDIR is assumed to contain kdevelop.
+    kdev_fixup_sed+=";s|\\\$KDEV_BASEDIR/kdevelop|$out/bin/kdevelop|"
+    sed -E -i "$kdev_fixup_sed" "$out/bin/.kdevelop!-wrapped"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixes issue 25559.
Tested in release-17.03.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

