### PR TITLE
sgtpuzzles: fix broken gtk3 file dialog

### DIFF
--- a/pkgs/games/sgt-puzzles/default.nix
+++ b/pkgs/games/sgt-puzzles/default.nix
@@ -1,8 +1,8 @@
-{stdenv, gtk3, pkgconfig, libX11, perl, fetchurl, automake115x, autoconf}:
+{stdenv, gtk3, makeWrapper, pkgconfig, libX11, perl, fetchurl, automake115x, autoconf}:
 let
   version = "20170228.1f613ba";
   buildInputs = [
-    gtk3 pkgconfig libX11 perl automake115x autoconf
+    gtk3 pkgconfig libX11 perl automake115x autoconf makeWrapper
   ];
 in
 stdenv.mkDerivation {
@@ -17,6 +17,12 @@ stdenv.mkDerivation {
     mkdir -p "$out"/{bin,share/doc/sgtpuzzles}
     cp gamedesc.txt LICENCE README "$out/share/doc/sgtpuzzles"
     cp LICENCE "$out/share/doc/sgtpuzzles/LICENSE"
+  '';
+  # gtk3 file dialog needs XDG_DATA_DIRS set correctly
+  preFixup = ''
+    for FILE in "$out"/bin/*; do
+      wrapProgram "$FILE" --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+    done
   '';
   # SGT Puzzles use generic names like net, map, etc.
   # Create symlinks with sgt-puzzle- prefix for possibility of

--- a/pkgs/games/sgt-puzzles/default.nix
+++ b/pkgs/games/sgt-puzzles/default.nix
@@ -1,28 +1,25 @@
-{stdenv, gtk3, makeWrapper, pkgconfig, libX11, perl, fetchurl, automake115x, autoconf}:
-let
+{ stdenv, fetchurl
+, gtk3, libX11
+, makeWrapper, pkgconfig, perl, autoreconfHook, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  name = "sgt-puzzles-r${version}";
   version = "20170228.1f613ba";
-  buildInputs = [
-    gtk3 pkgconfig libX11 perl automake115x autoconf makeWrapper
-  ];
-in
-stdenv.mkDerivation {
+
   src = fetchurl {
    url = "http://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles-${version}.tar.gz";
    sha256 = "02nqc18fhvxr545wgk55ly61fi0a06q61ljzwadprqxa1n0g0fz5";
   };
-  name = "sgt-puzzles-r" + version;
-  inherit buildInputs;
+
+  nativeBuildInputs = [ autoreconfHook makeWrapper pkgconfig perl wrapGAppsHook ];
+
+  buildInputs = [ gtk3 libX11 ];
+
   makeFlags = ["prefix=$(out)" "gamesdir=$(out)/bin"];
   preInstall = ''
     mkdir -p "$out"/{bin,share/doc/sgtpuzzles}
     cp gamedesc.txt LICENCE README "$out/share/doc/sgtpuzzles"
-    cp LICENCE "$out/share/doc/sgtpuzzles/LICENSE"
-  '';
-  # gtk3 file dialog needs XDG_DATA_DIRS set correctly
-  preFixup = ''
-    for FILE in "$out"/bin/*; do
-      wrapProgram "$FILE" --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-    done
   '';
   # SGT Puzzles use generic names like net, map, etc.
   # Create symlinks with sgt-puzzle- prefix for possibility of
@@ -39,12 +36,11 @@ stdenv.mkDerivation {
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-error"
     cp Makefile.gtk Makefile
   '';
-  meta = {
-    inherit version;
+  meta = with stdenv.lib; {
     description = "Simon Tatham's portable puzzle collection";
-    license = stdenv.lib.licenses.mit ;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.mit;
+    maintainers = [ maintainers.raskin ];
+    platforms = platforms.linux;
     homepage = "http://www.chiark.greenend.org.uk/~sgtatham/puzzles/";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Start any puzzle (eg. `loopy`) and try to save. The program crash with

    GLib-GIO-ERROR **: No GSettings schemas are installed on the system

###### Things done

Wrap all binaries with XDG_DATA_DIRS prefixed to $GSETTINGS_SCHEMAS_PATH.

Note: I see that's there's quite some variety in how this issue [has been fixed](https://github.com/NixOS/nixpkgs/issues?utf8=%E2%9C%93&q=is%3Aissue%20%20No%20GSettings%20schemas%20are%20installed%20on%20the%20system).

(Some suggest)[https://github.com/NixOS/nixpkgs/issues/23474#issuecomment-287562402] using `wrapGAppsHook`? (but that might increase the closure size for simple programs that only need file dialogs?)

Seems less than ideal to have to wrap (almost) every gtk program, at least if it requires writing a fixUp shell code snippet.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)  **\*** Lot's of bin files, tested a few.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

