### PR TITLE
kdeApplications.ktnef: init at 17.04.0

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -62,6 +62,7 @@ let
       kate = callPackage ./kate.nix {};
       kdenlive = callPackage ./kdenlive.nix {};
       kcalc = callPackage ./kcalc.nix {};
+      kcalcore = callPackage ./kcalcore.nix {};
       kcachegrind = callPackage ./kcachegrind.nix {};
       kcolorchooser = callPackage ./kcolorchooser.nix {};
       kcontacts = callPackage ./kcontacts.nix {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -83,6 +83,7 @@ let
       konsole = callPackage ./konsole.nix {};
       kpimtextedit = callPackage ./kpimtextedit.nix {};
       krfb = callPackage ./krfb.nix {};
+      ktnef = callPackage ./ktnef.nix {};
       kwalletmanager = callPackage ./kwalletmanager.nix {};
       libkdcraw = callPackage ./libkdcraw.nix {};
       libkexiv2 = callPackage ./libkexiv2.nix {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -81,6 +81,7 @@ let
       kolourpaint = callPackage ./kolourpaint.nix {};
       kompare = callPackage ./kompare.nix {};
       konsole = callPackage ./konsole.nix {};
+      kpimtextedit = callPackage ./kpimtextedit.nix {};
       krfb = callPackage ./krfb.nix {};
       kwalletmanager = callPackage ./kwalletmanager.nix {};
       libkdcraw = callPackage ./libkdcraw.nix {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -63,6 +63,7 @@ let
       kdenlive = callPackage ./kdenlive.nix {};
       kcalc = callPackage ./kcalc.nix {};
       kcalcore = callPackage ./kcalcore.nix {};
+      kcalutils = callPackage ./kcalutils.nix {};
       kcachegrind = callPackage ./kcachegrind.nix {};
       kcolorchooser = callPackage ./kcolorchooser.nix {};
       kcontacts = callPackage ./kcontacts.nix {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -73,6 +73,7 @@ let
       kdf = callPackage ./kdf.nix {};
       kgpg = callPackage ./kgpg.nix {};
       khelpcenter = callPackage ./khelpcenter.nix {};
+      kidentitymanagement = callPackage ./kidentitymanagement.nix {};
       kig = callPackage ./kig.nix {};
       kio-extras = callPackage ./kio-extras.nix {};
       kmime = callPackage ./kmime.nix {};

--- a/pkgs/applications/kde/kcalcore.nix
+++ b/pkgs/applications/kde/kcalcore.nix
@@ -1,0 +1,16 @@
+{ kdeApp, lib, kdeWrapper
+, extra-cmake-modules, kdoctools
+, kdelibs4support, libical
+}:
+
+kdeApp {
+  name = "kcalcore";
+  meta.license = with lib.licenses; [ lgpl21 gpl3 ];
+
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  propagatedBuildInputs = [
+    kdelibs4support libical
+  ];
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/applications/kde/kcalutils.nix
+++ b/pkgs/applications/kde/kcalutils.nix
@@ -1,0 +1,18 @@
+{ kdeApp, lib, kdeWrapper
+, extra-cmake-modules, kdoctools
+, kcalcore, kdelibs4support, kidentitymanagement, grantlee
+}:
+
+kdeApp {
+  name = "kcalutils";
+  meta.license = with lib.licenses; [ lgpl21 gpl3 ];
+
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  propagatedBuildInputs = [
+    kidentitymanagement
+    grantlee
+    kcalcore kdelibs4support
+  ];
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/applications/kde/kidentitymanagement.nix
+++ b/pkgs/applications/kde/kidentitymanagement.nix
@@ -1,0 +1,16 @@
+{ kdeApp, lib, kdeWrapper
+, extra-cmake-modules, kdoctools
+, kcoreaddons, kcompletion, kemoticons, kio, kpimtextedit, ktextwidgets, kxmlgui
+}:
+
+kdeApp {
+  name = "kidentitymanagement";
+  meta.license = with lib.licenses; [ lgpl21 gpl3 ];
+
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  propagatedBuildInputs = [
+    kcoreaddons kcompletion kemoticons kio kpimtextedit ktextwidgets kxmlgui
+  ];
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/applications/kde/kpimtextedit.nix
+++ b/pkgs/applications/kde/kpimtextedit.nix
@@ -1,0 +1,18 @@
+{ kdeApp, lib, kdeWrapper
+, extra-cmake-modules, kdoctools
+, kcodecs, kconfig, kconfigwidgets, kdesignerplugin, kemoticons, kiconthemes, kio
+, grantlee, syntax-highlighting
+}:
+
+kdeApp {
+  name = "kpimtextedit";
+  meta.license = with lib.licenses; [ lgpl21 gpl3 ];
+
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  propagatedBuildInputs = [
+    kcodecs kconfig kconfigwidgets kdesignerplugin kemoticons kiconthemes kio
+    grantlee syntax-highlighting
+  ];
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/applications/kde/ktnef.nix
+++ b/pkgs/applications/kde/ktnef.nix
@@ -1,0 +1,17 @@
+{ kdeApp, lib, kdeWrapper
+, extra-cmake-modules, kdoctools
+, kcalcore, kcalutils, kcontacts, kdelibs4support
+}:
+
+kdeApp {
+  name = "ktnef";
+  meta.license = with lib.licenses; [ lgpl21 gpl3 ];
+
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  propagatedBuildInputs = [
+    kcalcore kcalutils kcontacts
+    kdelibs4support
+  ];
+
+  enableParallelBuilding = true;
+}


### PR DESCRIPTION
###### Motivation for this change

I actually needed the KDE tnef VIEWER while this is the tnef LIBRARY which was pretty stupid of me...

ktnef (the viewer) is part if kdepim it seems.

@ttuegel: is this the proper way to package kdeApplication components?

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
