### PR TITLE
Fix: GlusterFS python tools all have import errors

### DIFF
--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  inherit (pkgs) glusterfs;
+  inherit (pkgs) glusterfs rsync;
 
   cfg = config.services.glusterfs;
 
@@ -50,8 +50,11 @@ in
       after = [ "rpcbind.service" "network.target" "local-fs.target" ];
       before = [ "network-online.target" ];
 
+      # The copying of hooks is due to upstream bug https://bugzilla.redhat.com/show_bug.cgi?id=1452761
       preStart = ''
         install -m 0755 -d /var/log/glusterfs
+        mkdir -p /var/lib/glusterd/hooks/
+        ${rsync}/bin/rsync -a ${glusterfs}/var/lib/glusterd/hooks/ /var/lib/glusterd/hooks/
       '';
 
       serviceConfig = {

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -1,30 +1,75 @@
 {stdenv, fetchurl, fuse, bison, flex_2_5_35, openssl, python2, ncurses, readline,
- autoconf, automake, libtool, pkgconfig, zlib, libaio, libxml2, acl, sqlite
- , liburcu, attr, makeWrapper, coreutils, gnused, gnugrep, which
+ autoconf, automake, libtool, pkgconfig, zlib, libaio, libxml2, acl, sqlite,
+ liburcu, attr, makeWrapper, coreutils, gnused, gnugrep, which, python2Packages,
+ openssh, gawk, findutils, utillinux, lvm2, btrfs-progs, e2fsprogs, xfsprogs, systemd,
+ rsync, glibc
 }:
 let
   s =
   rec {
     baseName="glusterfs";
+    # NOTE: On each glusterfs release, it should be checked if gluster added
+    #       new, or changed, Python scripts whose PYTHONPATH has to be set in
+    #       `postFixup` below, and whose runtime deps need to go into
+    #       `nativeBuildInputs`.
+    #       The command
+    #         find /nix/store/...-glusterfs-.../ -name '*.py' -executable
+    #       can help with finding new Python scripts.
     version = "3.10.1";
     name="${baseName}-${version}";
     url="https://github.com/gluster/glusterfs/archive/v${version}.tar.gz";
     sha256 = "0gmb3m98djljcycjggi1qv99ai6k4cvn2rqym2q9f58q8n8kdhh7";
   };
   buildInputs = [
-    fuse bison flex_2_5_35 openssl python2 ncurses readline
+    fuse bison flex_2_5_35 openssl ncurses readline
     autoconf automake libtool pkgconfig zlib libaio libxml2
     acl sqlite liburcu attr makeWrapper
+    (python2.withPackages (pkgs: [
+      pkgs.flask
+      pkgs.prettytable
+      pkgs.requests
+      pkgs.xattr
+    ]))
+    # NOTE: `python2` has to be *AFTER* the above `python2.withPackages`,
+    #       to ensure that the packages are available but the `toPythonPath`
+    #       shell function used in `postFixup` is also still available.
+    python2
   ];
   # Some of the headers reference acl
   propagatedBuildInputs = [
     acl
+  ];
+  # Packages from which GlusterFS calls binaries at run-time from PATH,
+  # with comments on which commands are known to be called by it.
+  runtimePATHdeps = [
+    attr # getfattr setfattr
+    btrfs-progs # btrfs
+    coreutils # lots of commands in bash scripts
+    e2fsprogs # tune2fs
+    findutils # find
+    gawk # awk
+    glibc # getent
+    gnugrep # grep
+    gnused # sed
+    lvm2 # lvs
+    openssh # ssh
+    rsync # rsync, e.g. for geo-replication
+    systemd # systemctl
+    utillinux # mount umount
+    which # which
+    xfsprogs # xfs_info
   ];
 in
 stdenv.mkDerivation
 rec {
   inherit (s) name version;
   inherit buildInputs propagatedBuildInputs;
+
+  patches = [
+    ./glusterfs-use-PATH-instead-of-hardcodes.patch
+    ./glusterfs-fix-unsubstituted-autoconf-macros.patch
+    ./glusterfs-python-remove-find_library.patch
+  ];
 
    # Note that the VERSION file is something that is present in release tarballs
    # but not in git tags (at least not as of writing in v3.10.1).
@@ -49,7 +94,73 @@ rec {
   postInstall = ''
     cp -r $out/$out/* $out
     rm -r $out/nix
-    wrapProgram $out/sbin/mount.glusterfs --set PATH "${stdenv.lib.makeBinPath [ coreutils gnused attr gnugrep which]}"
+    '';
+
+  postFixup = ''
+    # glusterd invokes `gluster` and other utilities when telling other glusterd nodes to run commands.
+    # For example for `peer_georep-sshkey` key generation, so `$out/bin` is needed in the PATH.
+    # It also invokes bash scripts like `gverify.sh`.
+    # It also invokes executable Python scripts in `$out/libexec/glusterfs`, which is why we set up PYTHONPATH accordingly.
+    # We set up the paths for the main entry point executables.
+
+    GLUSTER_PATH="${stdenv.lib.makeBinPath runtimePATHdeps}:$out/bin"
+    GLUSTER_PYTHONPATH="$(toPythonPath $out):$out/libexec/glusterfs"
+    GLUSTER_LD_LIBRARY_PATH="$out/lib"
+
+    wrapProgram $out/bin/glusterd --set PATH "$GLUSTER_PATH" --set PYTHONPATH "$GLUSTER_PYTHONPATH" --set LD_LIBRARY_PATH "$GLUSTER_LD_LIBRARY_PATH"
+    wrapProgram $out/bin/gluster --set PATH "$GLUSTER_PATH" --set PYTHONPATH "$GLUSTER_PYTHONPATH" --set LD_LIBRARY_PATH "$GLUSTER_LD_LIBRARY_PATH"
+    wrapProgram $out/sbin/mount.glusterfs --set PATH "$GLUSTER_PATH" --set PYTHONPATH "$GLUSTER_PYTHONPATH" --set LD_LIBRARY_PATH "$GLUSTER_LD_LIBRARY_PATH"
+
+    # Set Python environment for the Python based utilities.
+    # It would be nice if there was a better way to do this, automatically for all of them.
+    # Also, this is brittle: If we forget a dependency or gluster adds a new one, things will break deep inside gluster.
+    # We should better try to get an explicit list of Python dependencies from gluster and ensure all of them are in the PYTHONPATH of all these python scripts.
+    # But at the time of writing (gluster 3.10), gluster only provides this in form of a gluster.spec file for RPM creation,
+    # and even that one is not complete (for example it doesn't mention the `flask` dependency).
+
+    wrapProgram $out/bin/gluster-eventsapi --set PATH "$GLUSTER_PATH" --set PYTHONPATH "$GLUSTER_PYTHONPATH" --set LD_LIBRARY_PATH "$GLUSTER_LD_LIBRARY_PATH"
+    wrapProgram $out/bin/gluster-georep-sshkey --set PATH "$GLUSTER_PATH" --set PYTHONPATH "$GLUSTER_PYTHONPATH" --set LD_LIBRARY_PATH "$GLUSTER_LD_LIBRARY_PATH"
+    wrapProgram $out/bin/gluster-mountbroker --set PATH "$GLUSTER_PATH" --set PYTHONPATH "$GLUSTER_PYTHONPATH" --set LD_LIBRARY_PATH "$GLUSTER_LD_LIBRARY_PATH"
+    wrapProgram $out/bin/glusterfind --set PATH "$GLUSTER_PATH" --set PYTHONPATH "$GLUSTER_PYTHONPATH" --set LD_LIBRARY_PATH "$GLUSTER_LD_LIBRARY_PATH"
+
+    # Note that we only wrap the symlinks in $out/bin, not the actual executable scripts in $out/libexec/glusterfs.
+    # This is because those scripts use `__file__` in their program logic
+    # (see https://github.com/gluster/glusterfs/blob/v3.10.1/extras/cliutils/cliutils.py#L116)
+    # which would break if we changed the file name (which is what `wrapProgram` does).
+    # Luckily, `libexec` scripts are never supposed to be invoked straight from PATH,
+    # instead they are invoked directly from `gluster` or `glusterd`, which is why it is
+    # sufficient to set PYTHONPATH for those executables.
+
+    wrapProgram $out/share/glusterfs/scripts/eventsdash.py --set PATH "$GLUSTER_PATH" --set PYTHONPATH "$GLUSTER_PYTHONPATH" --set LD_LIBRARY_PATH "$GLUSTER_LD_LIBRARY_PATH"
+    '';
+
+  doInstallCheck = true;
+
+  # Below we run Python programs. That generates .pyc/.pyo files.
+  # By default they are indeterministic because such files contain time stamps
+  # (see https://nedbatchelder.com/blog/200804/the_structure_of_pyc_files.html).
+  # So we use the same environment variables as in
+  #   https://github.com/NixOS/nixpkgs/blob/249b34aadca7038207492f29142a3456d0cecec3/pkgs/development/interpreters/python/mk-python-derivation.nix#L61
+  # to make these files deterministic.
+  # A general solution to this problem might be brought by #25707.
+  DETERMINISTIC_BUILD = 1;
+  PYTHONHASHSEED = 0;
+
+  installCheckPhase = ''
+    # Tests that the above programs work without import errors.
+    # For testing it manually in a shell you may want to substitute `$out` with `$(dirname $(readlink -f $(which gluster)))/../`.
+    $out/bin/glusterd --help
+    # $out/bin/gluster help # can't do this because even `gluster help` tries to write to `/var/log/glusterfs/cli.log`
+    $out/bin/gluster-eventsapi --help
+    $out/bin/gluster-georep-sshkey --help
+    $out/bin/gluster-mountbroker --help
+    $out/bin/glusterfind --help
+    # gfid_to_path.py doesn't accept --help, and it requires different arguments
+    # (a dir as single argument) than the usage prints when stdin is not a TTY.
+    # The `echo ""` is just so that stdin is not a TTY even if you try this line
+    # on a real TTY for testing purposes.
+    echo "" | (mkdir -p nix-test-dir-for-gfid_to_path && touch b && $out/libexec/glusterfs/gfind_missing_files/gfid_to_path.py nix-test-dir-for-gfid_to_path)
+    $out/share/glusterfs/scripts/eventsdash.py --help
     '';
 
   src = fetchurl {

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -36,14 +36,6 @@ rec {
 
   makeFlags = "DESTDIR=$(out)";
 
-  preInstall = ''
-    substituteInPlace api/examples/Makefile --replace '$(DESTDIR)' $out
-    substituteInPlace geo-replication/syncdaemon/Makefile --replace '$(DESTDIR)' $out
-    substituteInPlace geo-replication/syncdaemon/Makefile --replace '$(DESTDIR)' $out
-    substituteInPlace xlators/features/glupy/examples/Makefile --replace '$(DESTDIR)' $out
-    substituteInPlace xlators/features/glupy/src/Makefile --replace '$(DESTDIR)' $out
-    '';
-
   postInstall = ''
     cp -r $out/$out/* $out
     rm -r $out/nix

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -91,6 +91,8 @@ rec {
 
   makeFlags = "DESTDIR=$(out)";
 
+  enableParallelBuilding = true;
+
   postInstall = ''
     cp -r $out/$out/* $out
     rm -r $out/nix

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -15,10 +15,10 @@ let
     #       The command
     #         find /nix/store/...-glusterfs-.../ -name '*.py' -executable
     #       can help with finding new Python scripts.
-    version = "3.10.1";
+    version = "3.10.2";
     name="${baseName}-${version}";
     url="https://github.com/gluster/glusterfs/archive/v${version}.tar.gz";
-    sha256 = "0gmb3m98djljcycjggi1qv99ai6k4cvn2rqym2q9f58q8n8kdhh7";
+    sha256 = "09hpvw42sc77nc3bfv7395wjn7fxvp0n8qnmrlyxq83hf0w81gfs";
   };
   buildInputs = [
     fuse bison flex_2_5_35 openssl ncurses readline

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -2,14 +2,14 @@
  autoconf, automake, libtool, pkgconfig, zlib, libaio, libxml2, acl, sqlite
  , liburcu, attr, makeWrapper, coreutils, gnused, gnugrep, which
 }:
-let 
+let
   s =
   rec {
     baseName="glusterfs";
     version = "3.10.1";
     name="${baseName}-${version}";
-    url="http://download.gluster.org/pub/gluster/glusterfs/3.10/${version}/glusterfs-${version}.tar.gz";
-    sha256 = "05qmn85lg3d1gz0fhn1v2z7nwl2qwbflvjc8nvkfyr4r57rkvhnk";
+    url="https://github.com/gluster/glusterfs/archive/v${version}.tar.gz";
+    sha256 = "0gmb3m98djljcycjggi1qv99ai6k4cvn2rqym2q9f58q8n8kdhh7";
   };
   buildInputs = [
     fuse bison flex_2_5_35 openssl python2 ncurses readline
@@ -26,7 +26,17 @@ rec {
   inherit (s) name version;
   inherit buildInputs propagatedBuildInputs;
 
-  preConfigure = ''
+   # Note that the VERSION file is something that is present in release tarballs
+   # but not in git tags (at least not as of writing in v3.10.1).
+   # That's why we have to create it.
+   # Without this, gluster (at least 3.10.1) will fail very late and cryptically,
+   # for example when setting up geo-replication, with a message like
+   #   Staging of operation 'Volume Geo-replication Create' failed on localhost : Unable to fetch master volume details. Please check the master cluster and master volume.
+   # What happens here is that the gverify.sh script tries to compare the versions,
+   # but fails when the version is empty.
+   # See upstream GlusterFS bug https://bugzilla.redhat.com/show_bug.cgi?id=1452705
+   preConfigure = ''
+     echo "v${s.version}" > VERSION
     ./autogen.sh
     '';
 
@@ -52,7 +62,7 @@ rec {
     maintainers = [
       stdenv.lib.maintainers.raskin
     ];
-    platforms = with stdenv.lib.platforms; 
+    platforms = with stdenv.lib.platforms;
       linux ++ freebsd;
   };
 }

--- a/pkgs/tools/filesystems/glusterfs/glusterfs-fix-unsubstituted-autoconf-macros.patch
+++ b/pkgs/tools/filesystems/glusterfs/glusterfs-fix-unsubstituted-autoconf-macros.patch
@@ -1,0 +1,236 @@
+From b37e0222a6a60505868a6fbb8591608cdc4bba57 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Niklas=20Hamb=C3=BCchen?= <mail@nh2.me>
+Date: Sat, 13 May 2017 15:33:27 +0200
+Subject: [PATCH] Revert "build/packaging: Debian and Ubuntu don't have
+ /usr/libexec". Fixes #1450588
+
+This reverts commit 18509e436f8a728ef522f3e76e2f2dc30e1bd8ac.
+
+This fixes autoconf unsubstituted strings to appear in generated source code.
+---
+ cli/src/Makefile.am                      |  2 +-
+ configure.ac                             | 12 ++++++------
+ events/src/Makefile.am                   |  8 ++++----
+ extras/Makefile.am                       |  2 +-
+ geo-replication/src/Makefile.am          |  8 ++++----
+ geo-replication/syncdaemon/Makefile.am   |  2 +-
+ tools/gfind_missing_files/Makefile.am    |  4 ++--
+ tools/glusterfind/Makefile.am            |  4 ++--
+ tools/glusterfind/src/Makefile.am        |  2 +-
+ xlators/features/ganesha/src/Makefile.am |  2 +-
+ xlators/mgmt/glusterd/src/Makefile.am    |  2 +-
+ 11 files changed, 24 insertions(+), 24 deletions(-)
+
+diff --git a/cli/src/Makefile.am b/cli/src/Makefile.am
+index 5ef9389..f5b8d00 100644
+--- a/cli/src/Makefile.am
++++ b/cli/src/Makefile.am
+@@ -18,7 +18,7 @@ AM_CPPFLAGS = $(GF_CPPFLAGS) \
+ 	-I$(top_builddir)/rpc/xdr/src\
+ 	-DDATADIR=\"$(localstatedir)\" \
+ 	-DCONFDIR=\"$(sysconfdir)/glusterfs\" \
+-	-DGSYNCD_PREFIX=\"$(GLUSTERFS_LIBEXECDIR)\"\
++	-DGSYNCD_PREFIX=\"$(libexecdir)/glusterfs\"\
+ 	-DSYNCDAEMON_COMPILE=$(SYNCDAEMON_COMPILE) -DSBIN_DIR=\"$(sbindir)\"\
+ 	$(XML_CPPFLAGS)
+ 
+diff --git a/configure.ac b/configure.ac
+index c9742e2..0c3a386 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1056,24 +1056,24 @@ old_prefix=$prefix
+ if test "x$prefix" = xNONE; then
+ 	prefix=$ac_default_prefix
+ fi
+-GLUSTERFS_LIBEXECDIR="$libexecdir/glusterfs"
+-GLUSTERFSD_MISCDIR="$prefix/var/lib/misc/glusterfsd"
++GLUSTERFS_LIBEXECDIR="$(eval echo $prefix)/libexec/glusterfs"
++GLUSTERFSD_MISCDIR="$(eval echo $prefix)/var/lib/misc/glusterfsd"
+ prefix=$old_prefix
+ 
+ ### Dirty hacky stuff to make LOCALSTATEDIR work
+ if test "x$prefix" = xNONE; then
+-   test $localstatedir = '$prefix/var' && localstatedir=$ac_default_prefix/var
++   test $localstatedir = '${prefix}/var' && localstatedir=$ac_default_prefix/var
+    localstatedir=/var
+-   LOCALSTATEDIR=$localstatedir
++   LOCALSTATEDIR=$(eval echo ${localstatedir})
+ else
+-   LOCALSTATEDIR=$localstatedir
++   LOCALSTATEDIR=$(eval echo ${localstatedir})
+ fi
+ 
+ old_prefix=$prefix
+ if test "x$prefix" = xNONE; then
+     prefix=$ac_default_prefix
+ fi
+-GLUSTERD_VOLFILE="$sysconfdir/glusterfs/glusterd.vol"
++GLUSTERD_VOLFILE="$(eval echo ${sysconfdir})/glusterfs/glusterd.vol"
+ prefix=$old_prefix
+ 
+ 
+diff --git a/events/src/Makefile.am b/events/src/Makefile.am
+index 8493abd..87282c6 100644
+--- a/events/src/Makefile.am
++++ b/events/src/Makefile.am
+@@ -5,7 +5,7 @@ EXTRA_DIST = glustereventsd.py __init__.py  eventsapiconf.py.in \
+ BUILT_SOURCES = eventtypes.py
+ CLEANFILES = eventtypes.py
+ 
+-eventsdir = $(GLUSTERFS_LIBEXECDIR)/events
++eventsdir = $(libexecdir)/glusterfs/events
+ events_PYTHON = __init__.py gf_event.py eventsapiconf.py eventtypes.py \
+ 	utils.py
+ 
+@@ -13,7 +13,7 @@ eventtypes.py: $(top_srcdir)/events/eventskeygen.py
+ 	$(PYTHON) $(top_srcdir)/events/eventskeygen.py PY_HEADER
+ 
+ if BUILD_EVENTS
+-eventspeerscriptdir = $(GLUSTERFS_LIBEXECDIR)
++eventspeerscriptdir = $(libexecdir)/glusterfs
+ eventsconfdir = $(sysconfdir)/glusterfs
+ eventsconf_DATA = eventsconfig.json
+ 
+@@ -24,10 +24,10 @@ eventspeerscript_SCRIPTS = peer_eventsapi.py
+ install-exec-hook:
+ 	$(mkdir_p) $(DESTDIR)$(sbindir)
+ 	rm -f $(DESTDIR)$(sbindir)/glustereventsd
+-	ln -s $(GLUSTERFS_LIBEXECDIR)/events/glustereventsd.py \
++	ln -s $(libexecdir)/glusterfs/events/glustereventsd.py \
+ 		$(DESTDIR)$(sbindir)/glustereventsd
+ 	rm -f $(DESTDIR)$(sbindir)/gluster-eventsapi
+-	ln -s $(GLUSTERFS_LIBEXECDIR)/peer_eventsapi.py \
++	ln -s $(libexecdir)/glusterfs/peer_eventsapi.py \
+ 		$(DESTDIR)$(sbindir)/gluster-eventsapi
+ 
+ uninstall-hook:
+diff --git a/extras/Makefile.am b/extras/Makefile.am
+index 9dfc93d..53ac476 100644
+--- a/extras/Makefile.am
++++ b/extras/Makefile.am
+@@ -1,4 +1,4 @@
+-addonexecdir = $(GLUSTERFS_LIBEXECDIR)
++addonexecdir = $(libexecdir)/glusterfs
+ addonexec_SCRIPTS = peer_add_secret_pub
+ 
+ EditorModedir = $(docdir)
+diff --git a/geo-replication/src/Makefile.am b/geo-replication/src/Makefile.am
+index 9937a0b..87435d5 100644
+--- a/geo-replication/src/Makefile.am
++++ b/geo-replication/src/Makefile.am
+@@ -1,4 +1,4 @@
+-gsyncddir = $(GLUSTERFS_LIBEXECDIR)
++gsyncddir = $(libexecdir)/glusterfs
+ 
+ gsyncd_SCRIPTS = gverify.sh peer_gsec_create \
+ 	set_geo_rep_pem_keys.sh peer_mountbroker peer_mountbroker.py \
+@@ -21,7 +21,7 @@ noinst_HEADERS = procdiggy.h
+ 
+ AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
+ 	-I$(top_srcdir)/rpc/xdr/src -I$(top_builddir)/rpc/xdr/src \
+-	-DGSYNCD_PREFIX=\"$(GLUSTERFS_LIBEXECDIR)\" -DUSE_LIBGLUSTERFS \
++	-DGSYNCD_PREFIX=\"$(libexecdir)/glusterfs\" -DUSE_LIBGLUSTERFS \
+ 	-DSBIN_DIR=\"$(sbindir)\" -DPYTHON=\"$(PYTHON)\"
+ 
+ AM_CFLAGS = -Wall $(GF_CFLAGS)
+@@ -35,11 +35,11 @@ $(top_builddir)/libglusterfs/src/libglusterfs.la:
+ install-exec-hook:
+ 	$(mkdir_p) $(DESTDIR)$(sbindir)
+ 	rm -f $(DESTDIR)$(sbindir)/gluster-mountbroker
+-	ln -s $(GLUSTERFS_LIBEXECDIR)/peer_mountbroker.py \
++	ln -s $(libexecdir)/glusterfs/peer_mountbroker.py \
+ 		$(DESTDIR)$(sbindir)/gluster-mountbroker
+ 
+ 	rm -f $(DESTDIR)$(sbindir)/gluster-georep-sshkey
+-	ln -s $(GLUSTERFS_LIBEXECDIR)/peer_georep-sshkey.py \
++	ln -s $(libexecdir)/glusterfs/peer_georep-sshkey.py \
+ 		$(DESTDIR)$(sbindir)/gluster-georep-sshkey
+ 
+ 
+diff --git a/geo-replication/syncdaemon/Makefile.am b/geo-replication/syncdaemon/Makefile.am
+index f80fb26..7cdaf45 100644
+--- a/geo-replication/syncdaemon/Makefile.am
++++ b/geo-replication/syncdaemon/Makefile.am
+@@ -1,4 +1,4 @@
+-syncdaemondir = $(GLUSTERFS_LIBEXECDIR)/python/syncdaemon
++syncdaemondir = $(libexecdir)/glusterfs/python/syncdaemon
+ 
+ syncdaemon_PYTHON = gconf.py gsyncd.py __init__.py master.py README.md repce.py \
+ 	resource.py configinterface.py syncdutils.py monitor.py libcxattr.py \
+diff --git a/tools/gfind_missing_files/Makefile.am b/tools/gfind_missing_files/Makefile.am
+index f77f789..043c34c 100644
+--- a/tools/gfind_missing_files/Makefile.am
++++ b/tools/gfind_missing_files/Makefile.am
+@@ -1,4 +1,4 @@
+-gfindmissingfilesdir = $(GLUSTERFS_LIBEXECDIR)/gfind_missing_files
++gfindmissingfilesdir = $(libexecdir)/glusterfs/gfind_missing_files
+ 
+ gfindmissingfiles_SCRIPTS = gfind_missing_files.sh gfid_to_path.sh \
+ 	gfid_to_path.py
+@@ -21,6 +21,6 @@ uninstall-local:
+ 
+ install-data-local:
+ 	rm -f $(DESTDIR)$(sbindir)/gfind_missing_files
+-	ln -s $(GLUSTERFS_LIBEXECDIR)/gfind_missing_files/gfind_missing_files.sh $(DESTDIR)$(sbindir)/gfind_missing_files
++	ln -s $(libexecdir)/glusterfs/gfind_missing_files/gfind_missing_files.sh $(DESTDIR)$(sbindir)/gfind_missing_files
+ 
+ CLEANFILES =
+diff --git a/tools/glusterfind/Makefile.am b/tools/glusterfind/Makefile.am
+index 92fa614..37f23be 100644
+--- a/tools/glusterfind/Makefile.am
++++ b/tools/glusterfind/Makefile.am
+@@ -6,7 +6,7 @@ bin_SCRIPTS = glusterfind
+ 
+ CLEANFILES = $(bin_SCRIPTS)
+ 
+-deletehookscriptsdir = $(GLUSTERFS_LIBEXECDIR)/glusterfind/
++deletehookscriptsdir = $(libexecdir)/glusterfs/glusterfind/
+ deletehookscripts_SCRIPTS = S57glusterfind-delete-post.py
+ 
+ uninstall-local:
+@@ -16,5 +16,5 @@ install-data-local:
+ 	$(mkdir_p) $(DESTDIR)$(GLUSTERD_WORKDIR)/glusterfind/.keys
+ 	$(mkdir_p) $(DESTDIR)$(GLUSTERD_WORKDIR)/hooks/1/delete/post/
+ 	rm -f $(DESTDIR)$(GLUSTERD_WORKDIR)/hooks/1/delete/post/S57glusterfind-delete-post
+-	ln -s $(GLUSTERFS_LIBEXECDIR)/glusterfind/S57glusterfind-delete-post.py \
++	ln -s $(libexecdir)/glusterfs/glusterfind/S57glusterfind-delete-post.py \
+ 		$(DESTDIR)$(GLUSTERD_WORKDIR)/hooks/1/delete/post/S57glusterfind-delete-post
+diff --git a/tools/glusterfind/src/Makefile.am b/tools/glusterfind/src/Makefile.am
+index e4469c1..541ff94 100644
+--- a/tools/glusterfind/src/Makefile.am
++++ b/tools/glusterfind/src/Makefile.am
+@@ -1,4 +1,4 @@
+-glusterfinddir = $(GLUSTERFS_LIBEXECDIR)/glusterfind
++glusterfinddir = $(libexecdir)/glusterfs/glusterfind
+ 
+ glusterfind_PYTHON = conf.py utils.py __init__.py \
+ 	main.py libgfchangelog.py changelogdata.py
+diff --git a/xlators/features/ganesha/src/Makefile.am b/xlators/features/ganesha/src/Makefile.am
+index 78715d6..54cfcb3 100644
+--- a/xlators/features/ganesha/src/Makefile.am
++++ b/xlators/features/ganesha/src/Makefile.am
+@@ -12,7 +12,7 @@ AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
+ 	-fPIC -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D$(GF_HOST_OS)\
+ 	-I$(top_srcdir)/rpc/xdr/src -I$(top_builddir)/rpc/xdr/src \
+ 	-DGANESHA_DIR=\"$(sysconfdir)/ganesha\" \
+-	-DGYSNCD_PREFIX=\"$(GLUSTERFS_LIBEXECDIR)\"
++	-DGYSNCD_PREFIX=\"$(libexecdir)/glusterfs\"
+ 
+ AM_CFLAGS = -Wall $(GF_CFLAGS)
+ 
+diff --git a/xlators/mgmt/glusterd/src/Makefile.am b/xlators/mgmt/glusterd/src/Makefile.am
+index 23ebf37..4f2fffd 100644
+--- a/xlators/mgmt/glusterd/src/Makefile.am
++++ b/xlators/mgmt/glusterd/src/Makefile.am
+@@ -47,7 +47,7 @@ AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
+ 	-I$(CONTRIBDIR)/rbtree -I$(top_srcdir)/rpc/rpc-lib/src \
+ 	-I$(CONTRIBDIR)/mount -I$(CONTRIBDIR)/userspace-rcu \
+ 	-DSBIN_DIR=\"$(sbindir)\" -DDATADIR=\"$(localstatedir)\" \
+-	-DGSYNCD_PREFIX=\"$(GLUSTERFS_LIBEXECDIR)\" \
++	-DGSYNCD_PREFIX=\"$(libexecdir)/glusterfs\" \
+ 	-DCONFDIR=\"$(localstatedir)/run/gluster/shared_storage/nfs-ganesha\" \
+ 	-DGANESHA_PREFIX=\"$(libexecdir)/ganesha\" \
+ 	-DSYNCDAEMON_COMPILE=$(SYNCDAEMON_COMPILE) $(XML_CPPFLAGS)
+-- 
+2.7.4
+

--- a/pkgs/tools/filesystems/glusterfs/glusterfs-python-remove-find_library.patch
+++ b/pkgs/tools/filesystems/glusterfs/glusterfs-python-remove-find_library.patch
@@ -1,0 +1,151 @@
+From d321df349d10f038f0c89b9c11f8059572264f1b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Niklas=20Hamb=C3=BCchen?= <mail@nh2.me>
+Date: Sat, 13 May 2017 18:54:36 +0200
+Subject: [PATCH] python: Remove all uses of find_library. Fixes #1450593
+
+`find_library()` doesn't consider LD_LIBRARY_PATH on Python < 3.6.
+---
+ api/examples/getvolfile.py                                     |  2 +-
+ geo-replication/syncdaemon/libcxattr.py                        |  3 +--
+ geo-replication/syncdaemon/libgfchangelog.py                   |  3 +--
+ tests/features/ipctest.py                                      | 10 ++--------
+ tests/utils/libcxattr.py                                       |  5 ++---
+ tools/glusterfind/src/libgfchangelog.py                        |  3 +--
+ .../features/changelog/lib/examples/python/libgfchangelog.py   |  3 +--
+ 7 files changed, 9 insertions(+), 20 deletions(-)
+
+diff --git a/api/examples/getvolfile.py b/api/examples/getvolfile.py
+index 0c95213..32c2268 100755
+--- a/api/examples/getvolfile.py
++++ b/api/examples/getvolfile.py
+@@ -3,7 +3,7 @@
+ import ctypes
+ import ctypes.util
+ 
+-api = ctypes.CDLL(ctypes.util.find_library("gfapi"))
++api = ctypes.CDLL("libgfapi.so")
+ api.glfs_get_volfile.argtypes = [ctypes.c_void_p,
+                                  ctypes.c_void_p,
+                                  ctypes.c_ulong]
+diff --git a/geo-replication/syncdaemon/libcxattr.py b/geo-replication/syncdaemon/libcxattr.py
+index 3671e10..f576648 100644
+--- a/geo-replication/syncdaemon/libcxattr.py
++++ b/geo-replication/syncdaemon/libcxattr.py
+@@ -10,7 +10,6 @@
+ 
+ import os
+ from ctypes import CDLL, create_string_buffer, get_errno
+-from ctypes.util import find_library
+ 
+ 
+ class Xattr(object):
+@@ -25,7 +24,7 @@ class Xattr(object):
+          sizes we expect
+     """
+ 
+-    libc = CDLL(find_library("c"), use_errno=True)
++    libc = CDLL("libc.so.6", use_errno=True)
+ 
+     @classmethod
+     def geterrno(cls):
+diff --git a/geo-replication/syncdaemon/libgfchangelog.py b/geo-replication/syncdaemon/libgfchangelog.py
+index d87b56c..003c28c 100644
+--- a/geo-replication/syncdaemon/libgfchangelog.py
++++ b/geo-replication/syncdaemon/libgfchangelog.py
+@@ -10,12 +10,11 @@
+ 
+ import os
+ from ctypes import CDLL, RTLD_GLOBAL, create_string_buffer, get_errno, byref, c_ulong
+-from ctypes.util import find_library
+ from syncdutils import ChangelogException, ChangelogHistoryNotAvailable
+ 
+ 
+ class Changes(object):
+-    libgfc = CDLL(find_library("gfchangelog"), mode=RTLD_GLOBAL, use_errno=True)
++    libgfc = CDLL("libgfchangelog.so", mode=RTLD_GLOBAL, use_errno=True)
+ 
+     @classmethod
+     def geterrno(cls):
+diff --git a/tests/features/ipctest.py b/tests/features/ipctest.py
+index 5aff319..9339248 100755
+--- a/tests/features/ipctest.py
++++ b/tests/features/ipctest.py
+@@ -1,14 +1,8 @@
+ #!/usr/bin/python
+ 
+ import ctypes
+-import ctypes.util
+-
+-# find_library does not lookup LD_LIBRARY_PATH and may miss the
+-# function. In that case, retry with less portable but explicit name.
+-libgfapi = ctypes.util.find_library("gfapi")
+-if libgfapi == None:
+-	libgfapi = "libgfapi.so"
+-api = ctypes.CDLL(libgfapi,mode=ctypes.RTLD_GLOBAL)
++
++api = ctypes.CDLL("libgfapi.so",mode=ctypes.RTLD_GLOBAL)
+ 
+ api.glfs_ipc.argtypes = [ ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p ]
+ api.glfs_ipc.restype = ctypes.c_int
+diff --git a/tests/utils/libcxattr.py b/tests/utils/libcxattr.py
+index 149db72..4e6e6c4 100644
+--- a/tests/utils/libcxattr.py
++++ b/tests/utils/libcxattr.py
+@@ -11,7 +11,6 @@
+ import os
+ import sys
+ from ctypes import CDLL, c_int, create_string_buffer
+-from ctypes.util import find_library
+ 
+ 
+ class Xattr(object):
+@@ -28,9 +27,9 @@ class Xattr(object):
+ 
+     if sys.hexversion >= 0x02060000:
+         from ctypes import DEFAULT_MODE
+-        libc = CDLL(find_library("libc"), DEFAULT_MODE, None, True)
++        libc = CDLL("libc.so.6", DEFAULT_MODE, None, True)
+     else:
+-        libc = CDLL(find_library("libc"))
++        libc = CDLL("libc.so.6")
+ 
+     @classmethod
+     def geterrno(cls):
+diff --git a/tools/glusterfind/src/libgfchangelog.py b/tools/glusterfind/src/libgfchangelog.py
+index dd8153e..da822cf 100644
+--- a/tools/glusterfind/src/libgfchangelog.py
++++ b/tools/glusterfind/src/libgfchangelog.py
+@@ -12,14 +12,13 @@
+ import os
+ from ctypes import CDLL, get_errno, create_string_buffer, c_ulong, byref
+ from ctypes import RTLD_GLOBAL
+-from ctypes.util import find_library
+ 
+ 
+ class ChangelogException(OSError):
+     pass
+ 
+ 
+-libgfc = CDLL(find_library("gfchangelog"), use_errno=True, mode=RTLD_GLOBAL)
++libgfc = CDLL("libgfchangelog.so", use_errno=True, mode=RTLD_GLOBAL)
+ 
+ 
+ def raise_oserr():
+diff --git a/xlators/features/changelog/lib/examples/python/libgfchangelog.py b/xlators/features/changelog/lib/examples/python/libgfchangelog.py
+index 10e73c0..2cdbf11 100644
+--- a/xlators/features/changelog/lib/examples/python/libgfchangelog.py
++++ b/xlators/features/changelog/lib/examples/python/libgfchangelog.py
+@@ -1,9 +1,8 @@
+ import os
+ from ctypes import *
+-from ctypes.util import find_library
+ 
+ class Changes(object):
+-    libgfc = CDLL(find_library("gfchangelog"), mode=RTLD_GLOBAL, use_errno=True)
++    libgfc = CDLL("libgfchangelog.so", mode=RTLD_GLOBAL, use_errno=True)
+ 
+     @classmethod
+     def geterrno(cls):
+-- 
+2.7.4
+

--- a/pkgs/tools/filesystems/glusterfs/glusterfs-use-PATH-instead-of-hardcodes.patch
+++ b/pkgs/tools/filesystems/glusterfs/glusterfs-use-PATH-instead-of-hardcodes.patch
@@ -1,4 +1,4 @@
-From 67fbd3aadc2c4caeb14418609f5c7af6de36081b Mon Sep 17 00:00:00 2001
+From 616381bc25b0e90198683fb049f994e82d467d96 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Niklas=20Hamb=C3=BCchen?= <mail@nh2.me>
 Date: Sat, 13 May 2017 02:45:49 +0200
 Subject: [PATCH] Don't use hardcoded /sbin, /usr/bin etc. paths. Fixes
@@ -6,16 +6,18 @@ Subject: [PATCH] Don't use hardcoded /sbin, /usr/bin etc. paths. Fixes
 
 Instead, rely on programs to be in PATH, as gluster already
 does in many places across its code base.
+
+Change-Id: Id21152fe42f5b67205d8f1571b0656c4d5f74246
 ---
  contrib/fuse-lib/mount-common.c               |  8 ++++----
- xlators/mgmt/glusterd/src/glusterd-ganesha.c  |  8 ++++----
+ xlators/mgmt/glusterd/src/glusterd-ganesha.c  |  6 +++---
  xlators/mgmt/glusterd/src/glusterd-quota.c    |  6 +++---
  xlators/mgmt/glusterd/src/glusterd-snapshot.c |  4 ++--
- xlators/mgmt/glusterd/src/glusterd-utils.c    | 13 +------------
- 5 files changed, 14 insertions(+), 25 deletions(-)
+ xlators/mgmt/glusterd/src/glusterd-utils.c    | 14 +-------------
+ 5 files changed, 13 insertions(+), 25 deletions(-)
 
 diff --git a/contrib/fuse-lib/mount-common.c b/contrib/fuse-lib/mount-common.c
-index e9f80fe..6380dd8 100644
+index e9f80fe81..6380dd867 100644
 --- a/contrib/fuse-lib/mount-common.c
 +++ b/contrib/fuse-lib/mount-common.c
 @@ -255,16 +255,16 @@ fuse_mnt_umount (const char *progname, const char *abs_mnt,
@@ -40,14 +42,14 @@ index e9f80fe..6380dd8 100644
  #endif /* GF_LINUX_HOST_OS */
                  exit (1);
 diff --git a/xlators/mgmt/glusterd/src/glusterd-ganesha.c b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
-index 8dde82e..0038e69 100644
+index da1fee066..dcb9e5725 100644
 --- a/xlators/mgmt/glusterd/src/glusterd-ganesha.c
 +++ b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
-@@ -123,15 +123,15 @@ manage_service (char *action)
+@@ -122,15 +122,15 @@ manage_service (char *action)
          int     i               = 0;
          int     ret             = 0;
          struct service_command sc_list[] = {
--                { .binary  = "/usr/bin/systemctl",
+-                { .binary  = "/bin/systemctl",
 +                { .binary  = "systemctl",
                    .service = "nfs-ganesha",
                    .action  = sc_systemctl_action
@@ -62,17 +64,8 @@ index 8dde82e..0038e69 100644
                    .service = "nfs-ganesha",
                    .action  = sc_service_action
                  },
-@@ -144,7 +144,7 @@ manage_service (char *action)
-                 if (ret == 0) {
-                         gf_msg_debug (THIS->name, 0,
-                                 "%s found.", sc_list[i].binary);
--                        if (strcmp (sc_list[i].binary, "/usr/bin/systemctl") == 0)
-+                        if (strcmp (sc_list[i].binary, "systemctl") == 0)
-                                 ret = sc_systemctl_action (&sc_list[i], action);
-                         else
-                                 ret = sc_service_action (&sc_list[i], action);
 diff --git a/xlators/mgmt/glusterd/src/glusterd-quota.c b/xlators/mgmt/glusterd/src/glusterd-quota.c
-index c1c95ae..a6eeb69 100644
+index 0e6629cf0..fcb4738b7 100644
 --- a/xlators/mgmt/glusterd/src/glusterd-quota.c
 +++ b/xlators/mgmt/glusterd/src/glusterd-quota.c
 @@ -30,7 +30,7 @@
@@ -103,7 +96,7 @@ index c1c95ae..a6eeb69 100644
                                           VIRTUAL_QUOTA_XATTR_CLEANUP_KEY, "-v",
                                           "1", "{}", "\\", ";", NULL);
 diff --git a/xlators/mgmt/glusterd/src/glusterd-snapshot.c b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
-index c75a101..b7b659e 100644
+index da0152366..f0d135350 100644
 --- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
 +++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
 @@ -121,7 +121,7 @@ glusterd_build_snap_device_path (char *device, char *snapname,
@@ -125,10 +118,10 @@ index c75a101..b7b659e 100644
          runner_redir (&runner, STDOUT_FILENO, RUN_PIPE);
          runner_log (&runner, this->name, GF_LOG_DEBUG, msg);
 diff --git a/xlators/mgmt/glusterd/src/glusterd-utils.c b/xlators/mgmt/glusterd/src/glusterd-utils.c
-index 8f8447a..63d8add 100644
+index 51db13df0..6fa7b92f9 100644
 --- a/xlators/mgmt/glusterd/src/glusterd-utils.c
 +++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
-@@ -5899,7 +5899,6 @@ static struct fs_info {
+@@ -6027,7 +6027,6 @@ static struct fs_info {
          char *fs_tool_pattern;
          char *fs_tool_pkg;
  } glusterd_fs[] = {
@@ -136,7 +129,15 @@ index 8f8447a..63d8add 100644
          { "xfs", "xfs_info", NULL, "isize=", "xfsprogs" },
          { "ext3", "tune2fs", "-l", "Inode size:", "e2fsprogs" },
          { "ext4", "tune2fs", "-l", "Inode size:", "e2fsprogs" },
-@@ -5957,17 +5956,7 @@ glusterd_add_inode_size_to_dict (dict_t *dict, int count)
+@@ -6048,7 +6047,6 @@ glusterd_add_inode_size_to_dict (dict_t *dict, int count)
+         char           *trail             = NULL;
+         runner_t        runner            = {0, };
+         struct fs_info *fs                = NULL;
+-        char            fs_tool_name[256] = {0, };
+         static dict_t  *cached_fs         = NULL;
+ 
+         memset (key, 0, sizeof (key));
+@@ -6085,17 +6083,7 @@ glusterd_add_inode_size_to_dict (dict_t *dict, int count)
                                  cur_word = "N/A";
                                  goto cached;
                          }
@@ -156,5 +157,5 @@ index 8f8447a..63d8add 100644
                  }
          }
 -- 
-2.7.4
+2.12.0
 

--- a/pkgs/tools/filesystems/glusterfs/glusterfs-use-PATH-instead-of-hardcodes.patch
+++ b/pkgs/tools/filesystems/glusterfs/glusterfs-use-PATH-instead-of-hardcodes.patch
@@ -1,0 +1,160 @@
+From 67fbd3aadc2c4caeb14418609f5c7af6de36081b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Niklas=20Hamb=C3=BCchen?= <mail@nh2.me>
+Date: Sat, 13 May 2017 02:45:49 +0200
+Subject: [PATCH] Don't use hardcoded /sbin, /usr/bin etc. paths. Fixes
+ #1450546.
+
+Instead, rely on programs to be in PATH, as gluster already
+does in many places across its code base.
+---
+ contrib/fuse-lib/mount-common.c               |  8 ++++----
+ xlators/mgmt/glusterd/src/glusterd-ganesha.c  |  8 ++++----
+ xlators/mgmt/glusterd/src/glusterd-quota.c    |  6 +++---
+ xlators/mgmt/glusterd/src/glusterd-snapshot.c |  4 ++--
+ xlators/mgmt/glusterd/src/glusterd-utils.c    | 13 +------------
+ 5 files changed, 14 insertions(+), 25 deletions(-)
+
+diff --git a/contrib/fuse-lib/mount-common.c b/contrib/fuse-lib/mount-common.c
+index e9f80fe..6380dd8 100644
+--- a/contrib/fuse-lib/mount-common.c
++++ b/contrib/fuse-lib/mount-common.c
+@@ -255,16 +255,16 @@ fuse_mnt_umount (const char *progname, const char *abs_mnt,
+                         exit (1);
+                 }
+ #ifdef GF_LINUX_HOST_OS
+-                execl ("/bin/umount", "/bin/umount", "-i", rel_mnt,
++                execl ("umount", "umount", "-i", rel_mnt,
+                        lazy ? "-l" : NULL, NULL);
+-                GFFUSE_LOGERR ("%s: failed to execute /bin/umount: %s",
++                GFFUSE_LOGERR ("%s: failed to execute umount: %s",
+                                progname, strerror (errno));
+ #elif __NetBSD__
+                 /* exitting the filesystem causes the umount */
+                 exit (0);
+ #else
+-                execl ("/sbin/umount", "/sbin/umount", "-f", rel_mnt, NULL);
+-                GFFUSE_LOGERR ("%s: failed to execute /sbin/umount: %s",
++                execl ("umount", "umount", "-f", rel_mnt, NULL);
++                GFFUSE_LOGERR ("%s: failed to execute umount: %s",
+                                progname, strerror (errno));
+ #endif /* GF_LINUX_HOST_OS */
+                 exit (1);
+diff --git a/xlators/mgmt/glusterd/src/glusterd-ganesha.c b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
+index 8dde82e..0038e69 100644
+--- a/xlators/mgmt/glusterd/src/glusterd-ganesha.c
++++ b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
+@@ -123,15 +123,15 @@ manage_service (char *action)
+         int     i               = 0;
+         int     ret             = 0;
+         struct service_command sc_list[] = {
+-                { .binary  = "/usr/bin/systemctl",
++                { .binary  = "systemctl",
+                   .service = "nfs-ganesha",
+                   .action  = sc_systemctl_action
+                 },
+-                { .binary  = "/sbin/invoke-rc.d",
++                { .binary  = "invoke-rc.d",
+                   .service = "nfs-ganesha",
+                   .action  = sc_service_action
+                 },
+-                { .binary  = "/sbin/service",
++                { .binary  = "service",
+                   .service = "nfs-ganesha",
+                   .action  = sc_service_action
+                 },
+@@ -144,7 +144,7 @@ manage_service (char *action)
+                 if (ret == 0) {
+                         gf_msg_debug (THIS->name, 0,
+                                 "%s found.", sc_list[i].binary);
+-                        if (strcmp (sc_list[i].binary, "/usr/bin/systemctl") == 0)
++                        if (strcmp (sc_list[i].binary, "systemctl") == 0)
+                                 ret = sc_systemctl_action (&sc_list[i], action);
+                         else
+                                 ret = sc_service_action (&sc_list[i], action);
+diff --git a/xlators/mgmt/glusterd/src/glusterd-quota.c b/xlators/mgmt/glusterd/src/glusterd-quota.c
+index c1c95ae..a6eeb69 100644
+--- a/xlators/mgmt/glusterd/src/glusterd-quota.c
++++ b/xlators/mgmt/glusterd/src/glusterd-quota.c
+@@ -30,7 +30,7 @@
+ 
+ #ifndef _PATH_SETFATTR
+ # ifdef GF_LINUX_HOST_OS
+-#  define _PATH_SETFATTR "/usr/bin/setfattr"
++#  define _PATH_SETFATTR "setfattr"
+ # endif
+ # ifdef __NetBSD__
+ #  define _PATH_SETFATTR "/usr/pkg/bin/setfattr"
+@@ -335,7 +335,7 @@ _glusterd_quota_initiate_fs_crawl (glusterd_conf_t *priv,
+ 
+                 if (type == GF_QUOTA_OPTION_TYPE_ENABLE ||
+                     type == GF_QUOTA_OPTION_TYPE_ENABLE_OBJECTS)
+-                        runner_add_args (&runner, "/usr/bin/find", ".", NULL);
++                        runner_add_args (&runner, "find", ".", NULL);
+ 
+                 else if (type == GF_QUOTA_OPTION_TYPE_DISABLE) {
+ 
+@@ -351,7 +351,7 @@ _glusterd_quota_initiate_fs_crawl (glusterd_conf_t *priv,
+                                          VIRTUAL_QUOTA_XATTR_CLEANUP_KEY, "1",
+                                          "{}", "\\", ";", NULL);
+ #else
+-                        runner_add_args (&runner, "/usr/bin/find", ".",
++                        runner_add_args (&runner, "find", ".",
+                                          "-exec", _PATH_SETFATTR, "-n",
+                                          VIRTUAL_QUOTA_XATTR_CLEANUP_KEY, "-v",
+                                          "1", "{}", "\\", ";", NULL);
+diff --git a/xlators/mgmt/glusterd/src/glusterd-snapshot.c b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+index c75a101..b7b659e 100644
+--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
++++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+@@ -121,7 +121,7 @@ glusterd_build_snap_device_path (char *device, char *snapname,
+         }
+ 
+         runinit (&runner);
+-        runner_add_args (&runner, "/sbin/lvs", "--noheadings", "-o", "vg_name",
++        runner_add_args (&runner, "lvs", "--noheadings", "-o", "vg_name",
+                          device, NULL);
+         runner_redir (&runner, STDOUT_FILENO, RUN_PIPE);
+         snprintf (msg, sizeof (msg), "Get volume group for device %s", device);
+@@ -1982,7 +1982,7 @@ glusterd_is_thinp_brick (char *device, uint32_t *op_errno)
+ 
+         runinit (&runner);
+ 
+-        runner_add_args (&runner, "/sbin/lvs", "--noheadings", "-o", "pool_lv",
++        runner_add_args (&runner, "lvs", "--noheadings", "-o", "pool_lv",
+                          device, NULL);
+         runner_redir (&runner, STDOUT_FILENO, RUN_PIPE);
+         runner_log (&runner, this->name, GF_LOG_DEBUG, msg);
+diff --git a/xlators/mgmt/glusterd/src/glusterd-utils.c b/xlators/mgmt/glusterd/src/glusterd-utils.c
+index 8f8447a..63d8add 100644
+--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
++++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
+@@ -5899,7 +5899,6 @@ static struct fs_info {
+         char *fs_tool_pattern;
+         char *fs_tool_pkg;
+ } glusterd_fs[] = {
+-        /* some linux have these in /usr/sbin/and others in /sbin/? */
+         { "xfs", "xfs_info", NULL, "isize=", "xfsprogs" },
+         { "ext3", "tune2fs", "-l", "Inode size:", "e2fsprogs" },
+         { "ext4", "tune2fs", "-l", "Inode size:", "e2fsprogs" },
+@@ -5957,17 +5956,7 @@ glusterd_add_inode_size_to_dict (dict_t *dict, int count)
+                                 cur_word = "N/A";
+                                 goto cached;
+                         }
+-
+-                        snprintf (fs_tool_name, sizeof (fs_tool_name),
+-                                  "/usr/sbin/%s", fs->fs_tool_name);
+-                        if (sys_access (fs_tool_name, R_OK|X_OK) == 0)
+-                                runner_add_arg (&runner, fs_tool_name);
+-                        else {
+-                                snprintf (fs_tool_name, sizeof (fs_tool_name),
+-                                          "/sbin/%s", fs->fs_tool_name);
+-                                if (sys_access (fs_tool_name, R_OK|X_OK) == 0)
+-                                        runner_add_arg (&runner, fs_tool_name);
+-                        }
++                        runner_add_arg (&runner, fs->fs_tool_name);
+                         break;
+                 }
+         }
+-- 
+2.7.4
+


### PR DESCRIPTION
###### Motivation for this change

Fixes #25620 - [GlusterFS python tools all have import errors](https://github.com/NixOS/nixpkgs/issues/25620)

Also enables parallel building, after I have checked it (see last commit).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

