### PR TITLE
darwin: trash 0.9.0

### DIFF
--- a/pkgs/os-specific/darwin/trash/default.nix
+++ b/pkgs/os-specific/darwin/trash/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, frameworks, perl } :
+stdenv.mkDerivation rec {
+  version = "0.9.0";
+  name = "trash-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ali-rantakari";
+    repo = "trash";
+    rev = "f68ad25a02e24cc58eb8ef9a493d6dc0122bcd8f";
+    sha256 = "0ylkf7jxfy1pj7i1s48w28kzqjdfd57m2pw0jycsgcj5bkzwll41";
+  };
+
+  buildInputs = with frameworks; [
+    Cocoa
+    AppKit
+    ScriptingBridge
+    perl
+  ];
+
+  patches = [ ./trash.diff ];
+
+  buildPhase = ''make all docs'';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1
+    install -m 0755 trash $out/bin
+    install -m 0444 trash.1 $out/share/man/man1
+  '';
+
+  meta = {
+    homepage = https://github.com/ali-rantakari/trash;
+    description = "Small command-line program for OS X that moves files or
+    folders to the trash.";
+    platforms = stdenv.lib.platforms.darwin;
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/os-specific/darwin/trash/trash.diff
+++ b/pkgs/os-specific/darwin/trash/trash.diff
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 5e4306f..9c975fc 100644
+--- a/Makefile
++++ b/Makefile
+@@ -10,7 +10,7 @@ trash: $(SOURCE_FILES)
+ 	@echo
+ 	@echo ---- Compiling:
+ 	@echo ======================================
+-	$(CC) -O2 -Wall -Wextra -Wpartial-availability -force_cpusubtype_ALL -mmacosx-version-min=10.7 -arch i386 -arch x86_64 -framework AppKit -framework ScriptingBridge -o $@ $(SOURCE_FILES)
++	$(CC) -O2 -Wall -Wextra -Wpartial-availability -force_cpusubtype_ALL -mmacosx-version-min=10.7 -arch x86_64 -framework AppKit -framework ScriptingBridge -o $@ $(SOURCE_FILES)
+ 
+ analyze:
+ 	@echo

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -49,6 +49,8 @@ in
 
   swift-corefoundation = callPackage ../os-specific/darwin/swift-corefoundation { };
 
+  trash = callPackage ../os-specific/darwin/trash { inherit (darwin.apple_sdk) frameworks; };
+
   usr-include = callPackage ../os-specific/darwin/usr-include { };
 
   xcode = callPackage ../os-specific/darwin/xcode { };


### PR DESCRIPTION
###### Motivation for this change

Add the [`trash` command](https://github.com/ali-rantakari/trash) for darwin.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] macOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
