### PR TITLE
mypy: 0.501 -> 0.511

### DIFF
--- a/pkgs/development/python-modules/typed-ast/default.nix
+++ b/pkgs/development/python-modules/typed-ast/default.nix
@@ -1,19 +1,24 @@
-{ buildPythonPackage, fetchPypi, isPy3k, lib, pythonOlder }:
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, pythonOlder }:
+
 buildPythonPackage rec {
   pname = "typed-ast";
-  version = "1.0.2";
+  version = "1.0.3";
   name = "${pname}-${version}";
-  src = fetchPypi{
+
+  src = fetchPypi {
     inherit pname version;
-    sha256 = "13e02b10479ddff07eb546f9638743702ab9b175bfa3cdf2482688df91b5766d";
+    sha256 = "0qlq60jb191xdr66gd7axjidchbbwasd7hgym27i5abyd5wl2637";
   };
+
   # Only works with Python 3.3 and newer;
   disabled = pythonOlder "3.3";
+
   # No tests in archive
   doCheck = false;
-  meta = {
+
+  meta = with stdenv.lib; {
     homepage = "https://pypi.python.org/pypi/typed-ast";
     description = "a fork of Python 2 and 3 ast modules with type comment support";
-    license = lib.licenses.asl20;
+    license = licenses.asl20;
   };
 }

--- a/pkgs/development/tools/mypy/default.nix
+++ b/pkgs/development/tools/mypy/default.nix
@@ -1,22 +1,24 @@
-{ stdenv, fetchurl, python35Packages }:
-python35Packages.buildPythonApplication rec {
-  name = "mypy-${version}";
-  version = "0.501";
+{ stdenv, fetchPypi, buildPythonApplication, lxml, typed-ast }:
+
+buildPythonApplication rec {
+  name = "${pname}-${version}";
+  pname = "mypy";
+  version = "0.511";
 
   # Tests not included in pip package.
   doCheck = false;
 
-  src = fetchurl {
-    url = "mirror://pypi/m/mypy/${name}.tar.gz";
-    sha256 = "164g3dq2vzxa53n9lgvmbapg41qiwcxk1w9mvzmnqksvql5vm60h";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vmfyi6zh49mi7rmns5hjgpqshq7islxwsgp80j1izf82r8xgx1z";
   };
 
-  propagatedBuildInputs = with python35Packages; [ lxml typed-ast ];
+  propagatedBuildInputs = [ lxml typed-ast ];
 
   meta = with stdenv.lib; {
     description = "Optional static typing for Python";
     homepage    = "http://www.mypy-lang.org";
     license     = licenses.mit;
-    maintainers = with maintainers; [ martingms ];
+    maintainers = with maintainers; [ martingms lnl7 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7148,7 +7148,9 @@ with pkgs;
 
   grabserial = callPackage ../development/tools/grabserial { };
 
-  mypy = callPackage ../development/tools/mypy { };
+  mypy = callPackage ../development/tools/mypy {
+    inherit (python3Packages) fetchPypi buildPythonApplication lxml typed-ast;
+  };
 
 
   ### DEVELOPMENT / LIBRARIES


### PR DESCRIPTION
###### Motivation for this change

Update and the expression uses the python callPackage now.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

