### PR TITLE
Set clac.meta.platforms to "unix" instead of "linux"

### DIFF
--- a/pkgs/tools/misc/clac/default.nix
+++ b/pkgs/tools/misc/clac/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "Interactive stack-based calculator";
     license = stdenv.lib.licenses.bsd2;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     homepage = "https://github.com/soveran/clac";
   };
 }


### PR DESCRIPTION
It doesn't have anything Linux specific, and works on OSX without any modification.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

