### PR TITLE
fontconfig-penultimate: fix zenhei font priority

### DIFF
--- a/pkgs/data/fonts/fontconfig-penultimate/default.nix
+++ b/pkgs/data/fonts/fontconfig-penultimate/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/etc/fonts/conf.d
     cp *.conf $out/etc/fonts/conf.d
+    # fix font priority issue https://github.com/bohoomil/fontconfig-ultimate/issues/173
+    mv $out/etc/fonts/conf.d/{43,60}-wqy-zenhei-sharp.conf
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fix #16026
One of the fix introduced in #16730 was not ported to `fontconfig-penultimate` making #16026 problem reappear.

See also https://github.com/bohoomil/fontconfig-ultimate/issues/173

cc @ttuegel 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

