### PR TITLE
bitcoin-unlimited: 1.0.1.4 -> 1.0.2.0

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-unlimited.nix
+++ b/pkgs/applications/altcoins/bitcoin-unlimited.nix
@@ -7,13 +7,13 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-unlimited-" + version;
-  version = "1.0.1.4";
+  version = "1.0.2.0";
 
   src = fetchFromGitHub {
     owner = "bitcoinunlimited";
     repo = "bitcoinunlimited";
     rev = "v${version}";
-    sha256 = "1awsgkgqvb57grrsq6k99009rzhpfaplh2lbf5sy36v3bh7p5mw5";
+    sha256 = "0rhk6xvzvzyfppg0pgq72nqgm2rmkiw0nhg3rwnzcvvj90nrz3da";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change
This fixes the latest node crash vulnerability, among other things.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

