### PR TITLE
pvgrub_image: add package

### DIFF
--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -3,6 +3,7 @@
 , zfs ? null
 , efiSupport ? false
 , zfsSupport ? true
+, xenSupport ? false
 }:
 
 with stdenv.lib;
@@ -46,6 +47,7 @@ in (
 
 assert efiSupport -> canEfi;
 assert zfsSupport -> zfs != null;
+assert !(efiSupport && xenSupport);
 
 stdenv.mkDerivation rec {
   name = "grub-${version}";
@@ -98,7 +100,8 @@ stdenv.mkDerivation rec {
   patches = [ ./fix-bash-completion.patch ];
 
   configureFlags = optional zfsSupport "--enable-libzfs"
-    ++ optionals efiSupport [ "--with-platform=efi" "--target=${efiSystemsBuild.${stdenv.system}.target}" "--program-prefix=" ];
+    ++ optionals efiSupport [ "--with-platform=efi" "--target=${efiSystemsBuild.${stdenv.system}.target}" "--program-prefix=" ]
+    ++ optionals xenSupport [ "--with-platform=xen" "--target=${efiSystemsBuild.${stdenv.system}.target}"];
 
   # save target that grub is compiled for
   grubTarget = if efiSupport

--- a/pkgs/tools/misc/grub/pvgrub_image/configs/grub-bootstrap.cfg
+++ b/pkgs/tools/misc/grub/pvgrub_image/configs/grub-bootstrap.cfg
@@ -1,0 +1,1 @@
+normal (memdisk)/grub.cfg

--- a/pkgs/tools/misc/grub/pvgrub_image/configs/grub.cfg
+++ b/pkgs/tools/misc/grub/pvgrub_image/configs/grub.cfg
@@ -1,0 +1,10 @@
+# The parentheses around ${root} here to match Grub's config file syntax
+if search -s -f /boot/grub/grub.cfg ; then
+        echo "Reading (${root})/boot/grub/grub.cfg"
+	configfile /boot/grub/grub.cfg
+fi
+
+if search -s -f /grub/grub.cfg ; then
+	echo "Reading (${root})/grub/grub.cfg"
+	configfile /grub/grub.cfg
+fi

--- a/pkgs/tools/misc/grub/pvgrub_image/default.nix
+++ b/pkgs/tools/misc/grub/pvgrub_image/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, grub2_xen }:
+
+with stdenv.lib;
+let
+  efiSystemsBuild = {
+    "i686-linux".target = "i386";
+    "x86_64-linux".target = "x86_64";
+    "aarch64-linux".target = "aarch64";
+  };
+
+in (
+
+stdenv.mkDerivation rec {
+  name = "pvgrub-image";
+
+  configs = ./configs;
+
+  buildInputs = [ grub2_xen ];
+
+  buildCommand = ''
+    cp "${configs}"/* .
+    tar -cf memdisk.tar grub.cfg
+    # We include all modules except all_video.mod as otherwise grub will fail printing "no symbol table"
+    # if we include it.
+    grub-mkimage -O "${efiSystemsBuild.${stdenv.system}.target}-xen" -c grub-bootstrap.cfg \
+      -m memdisk.tar -o "grub-${efiSystemsBuild.${stdenv.system}.target}-xen.bin" \
+      $(ls "${grub2_xen}/lib/grub/${efiSystemsBuild.${stdenv.system}.target}-xen/" |grep 'mod''$'|grep -v '^all_video\.mod''$')
+    mkdir -p "$out/lib/grub-xen"
+    cp "grub-${efiSystemsBuild.${stdenv.system}.target}-xen.bin" $out/lib/grub-xen/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "PvGrub image for use for booting PV Xen guests";
+
+    longDescription =
+      '' This package provides a PvGrub image for booting Para-Virtualized (PV)
+         Xen guests
+      '';
+
+    platforms = platforms.gnu;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2258,6 +2258,12 @@ with pkgs;
     zfsSupport = false;
   };
 
+  grub2_xen = callPackage ../tools/misc/grub/2.0x.nix {
+    xenSupport = true;
+  };
+
+  grub2_pvgrub_image = callPackage ../tools/misc/grub/pvgrub_image { };
+
   grub4dos = callPackage ../tools/misc/grub4dos {
     stdenv = stdenv_32bit;
   };


### PR DESCRIPTION
Add a package containing a pvgrub image for xen generated from grub2

###### Motivation for this change

This package provides a `pvgrub` image for booting PV guests in xen. Currently, xen in NixOS also provides `pygrub`, but it can be used only to boot guests that use older grub utilising `menu.lst`, and fails with new NixOS guests, for example.

I would appreciate if someone takes a look at this before merging.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
