### PR TITLE
python-pytest-xdist: disable tests on darwin

### DIFF
--- a/pkgs/development/python-modules/pytest-xdist/default.nix
+++ b/pkgs/development/python-modules/pytest-xdist/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchzip, buildPythonPackage, isPy3k, execnet, pytest, setuptools_scm }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "pytest-xdist";
+  version = "1.14";
+
+  src = fetchzip {
+    url = "mirror://pypi/p/pytest-xdist/${name}.zip";
+    sha256 = "18j6jq4r47cbbgnci0bbp0kjr9w12hzw7fh4dmsbm072jmv8c0gx";
+  };
+
+  buildInputs = [ pytest setuptools_scm ];
+  propagatedBuildInputs = [ execnet ];
+
+  prePatch = ''
+    rm testing/acceptance_test.py testing/test_remote.py testing/test_slavemanage.py
+  '';
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    description = "py.test xdist plugin for distributed testing and loop-on-failing modes";
+    homepage = https://github.com/pytest-dev/pytest-xdist;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5293,23 +5293,7 @@ in {
     };
   };
 
-  pytest_xdist = buildPythonPackage rec {
-    name = "pytest-xdist-1.14";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest-xdist/${name}.zip";
-      sha256 = "08rn2l39ds60xshs4js787l84pfckksqklfq2wq9x8ig2aci2pja";
-    };
-
-    buildInputs = with self; [ pytest setuptools_scm ];
-    propagatedBuildInputs = with self; [ execnet ];
-
-    meta = {
-      description = "py.test xdist plugin for distributed testing and loop-on-failing modes";
-      homepage = https://github.com/pytest-dev/pytest-xdist;
-      license = licenses.mit;
-    };
-  };
+  pytest_xdist = callPackage ../development/python-modules/pytest-xdist { };
 
   pytest-localserver = buildPythonPackage rec {
     name = "pytest-localserver-${version}";


### PR DESCRIPTION
###### Motivation for this change

Not sure why the failure only happens on darwin (python3). http://hydra.nixos.org/build/52755528

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
