### PR TITLE
gitlab service: fix uploading artifacts from gitlab-runner

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -440,6 +440,7 @@ in {
       path = with pkgs; [
         gitAndTools.git
         openssh
+        gitlab-workhorse
       ];
       preStart = ''
         mkdir -p /run/gitlab


### PR DESCRIPTION
Add the binaries from gitlab-workhorse to the path of the
gitlab-workhorse service, as gitlab-zip-metadata is needed
by the service

###### Motivation for this change

Currently, `gitlab-runner` jobs that involve uploading artifacts fail with the following being displayed in the job log:

```
Uploading artifacts...
doc.pdf: found 1 matching files
WARNING: Uploading artifacts to coordinator... failed  id=116 responseStatus=500 Internal Server Error status=500 Internal Server Error token=9tdcH8zU
WARNING: Retrying...
WARNING: Uploading artifacts to coordinator... failed  id=116 responseStatus=500 Internal Server Error status=500 Internal Server Error token=9tdcH8zU
WARNING: Retrying...
WARNING: Uploading artifacts to coordinator... failed  id=116 responseStatus=500 Internal Server Error status=500 Internal Server Error token=9tdcH8zU
FATAL: invalid argument
ERROR: Job failed: exit code 1
```

Looking through the systemd logs yields additional error messages:

```
# journalctl -u gitlab-workhorse.service -S -10min|grep exec
May 12 06:45:47 gitlab gitlab-workhorse[4808]: 2017/05/12 06:45:47 error: POST "/ci/api/v1/builds/116/artifacts?": handleFileUploads: extract files from multipart: exec: "gitlab-zip-metadata": executable file not found in $PATH
May 12 06:45:48 gitlab gitlab-workhorse[4808]: 2017/05/12 06:45:48 error: POST "/ci/api/v1/builds/116/artifacts?": handleFileUploads: extract files from multipart: exec: "gitlab-zip-metadata": executable file not found in $PATH
May 12 06:45:49 gitlab gitlab-workhorse[4808]: 2017/05/12 06:45:49 error: POST "/ci/api/v1/builds/116/artifacts?": handleFileUploads: extract files from multipart: exec: "gitlab-zip-metadata": executable file not found in $PATH
```

Adding the `gitlab-workhorse` package to the path of the `gitlab-workhorse` service fixes the problem.

The problem was found with the `gitlab-runner_1_11` package and the docker executor, but I expect it to affect other configurations too.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
