### PR TITLE
skypeforlinux hash mismatch

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -4,7 +4,7 @@
 
 let
 
-  version = "5.1.0.1";
+  version = "5.2.0.1";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -49,8 +49,8 @@ let
   src =
     if stdenv.system == "x86_64-linux" then
       fetchurl {
-        url = "https://repo.skype.com/latest/skypeforlinux-64.deb";
-        sha256 = "18v861x0n2q2jaglap8193sia476dwkwr0ccfzl29mi5ijma24ml";
+        url = "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_5.2.0.1_amd64.deb";
+        sha256 = "1dwyj5wm2amkysbnzxsskq6sl7rbqggm6n4sabnq7wd5xnbq4i06";
       }
     else
       throw "Skype for linux is not supported on ${stdenv.system}";


### PR DESCRIPTION
###### Motivation for this change
skypeforlinux hash mismatch #25729
Also upgraded skypeforlinux to 5.2.0.1

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

