### PR TITLE
pythonPackages.ablog: init at 0.8.4

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -363,6 +363,28 @@ in {
 
   # packages defined here
 
+  ablog = buildPythonPackage rec {
+    pname = "ablog";
+    version = "0.8.4";
+    name = pname + "-" + version;
+
+    propagatedBuildInputs = with self; [ sphinx alabaster invoke dateutil werkzeug ];
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+      sha256 = "1aapxswzlr920yg0k324xwdvsrdx8kydpxg8rrha1xbq62ll7fdb";
+    };
+
+    # Tests not distributed
+    doCheck = false;
+
+    meta = {
+      description = "A Sphinx extension that converts any documentation or personal website project into a full-fledged blog.";
+      license = licenses.mit;
+      homepage = http://ablog.readthedocs.org/;
+    };
+  };
+
   aafigure = buildPythonPackage rec {
     name = "aafigure-0.5";
 
@@ -5499,6 +5521,23 @@ in {
       homepage = http://stutzbachenterprises.com;
       license = licenses.bsd3;
       maintainers = with maintainers; [ teh ];
+    };
+  };
+
+  invoke = buildPythonPackage rec {
+    pname = "invoke";
+    version = "0.17.0";
+    name = pname + "-" + version;
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+      sha256 = "0lgaz07x22m0a5flgc6fklx05i3fwyds0pa1gaisv9raivq064cq";
+    };
+
+    meta = {
+      description = "Pythonic task execution";
+      license = licenses.bsd2;
+      homepage = http://docs.pyinvoke.org;
     };
   };
 


### PR DESCRIPTION
added also the necessary package

pythonPackages.invoke: init at 0.17.0

###### Motivation for this change

I need to use the package in production, so I added and tested it.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

