### PR TITLE
seth: init at 0.5.0

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -36,6 +36,7 @@ rec {
 
   ethabi = callPackage ./ethabi.nix { };
   ethrun = callPackage ./ethrun.nix { };
+  seth = callPackage ./seth.nix { };
 
   primecoin  = callPackage ./primecoin.nix { withGui = true; };
   primecoind = callPackage ./primecoin.nix { withGui = false; };

--- a/pkgs/applications/altcoins/seth.nix
+++ b/pkgs/applications/altcoins/seth.nix
@@ -1,0 +1,31 @@
+{ stdenv, makeWrapper, lib, fetchFromGitHub
+, bc, coreutils, curl, ethabi, git, gnused, jshon, solc, which }:
+
+stdenv.mkDerivation rec {
+  name = "seth-${version}";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "dapphub";
+    repo = "seth";
+    rev = "v${version}";
+    sha256 = "0bgygvilhbabb0y9pv9cn8cx7cj513w9is4vh6v69h2czknrjmgz";
+  };
+
+  nativeBuildInputs = [makeWrapper];
+  buildPhase = "true";
+  makeFlags = ["prefix=$(out)"];
+  postInstall = let path = lib.makeBinPath [
+    bc coreutils curl ethabi git gnused jshon solc which
+  ]; in ''
+    wrapProgram "$out/bin/seth" --prefix PATH : "${path}"
+  '';
+
+  meta = {
+    description = "Command-line client for talking to Ethereum nodes";
+    homepage = https://github.com/dapphub/seth/;
+    maintainers = [stdenv.lib.maintainers.dbrock];
+    license = lib.licenses.gpl3;
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13062,6 +13062,7 @@ with pkgs;
   go-ethereum = self.altcoins.go-ethereum;
   ethabi = self.altcoins.ethabi;
   ethrun = self.altcoins.ethrun;
+  seth = self.altcoins.seth;
 
   stellar-core = self.altcoins.stellar-core;
 


### PR DESCRIPTION
###### Motivation for this change

Seth is a command-line utility for working with the Ethereum blockchain. It is a dependency for some other Ethereum-related programs as well as being useful in its own right.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

