### PR TITLE
dosfstools: fix build on darwin

### DIFF
--- a/pkgs/tools/filesystems/dosfstools/default.nix
+++ b/pkgs/tools/filesystems/dosfstools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "dosfstools-${version}";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1a2zn1655d5f1m6jp9vpn3bp8yfxhcmxx3mx23ai9hmxiydiykr1";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ]
+    ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
   configureFlags = [ "--enable-compat-symlinks" ];
 
@@ -19,6 +20,6 @@ stdenv.mkDerivation rec {
     description = "Utilities for creating and checking FAT and VFAT file systems";
     repositories.git = git://daniel-baumann.ch/git/software/dosfstools.git;
     homepage = http://www.daniel-baumann.ch/software/dosfstools/;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

before: `charconv.c:2:10: fatal error: 'iconv.h' file not found`
after: build works

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
