### PR TITLE
libtiff fix 404 Error on build 4.0.7-5 to 4.0.7-6

### DIFF
--- a/pkgs/applications/science/logic/cvc4/default.nix
+++ b/pkgs/applications/science/logic/cvc4/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://cvc4.cs.nyu.edu/builds/src/cvc4-${version}.tar.gz";
-    sha256 = "15wz0plfc9q8acrwq1ljgsgqmh8pyz5alzv5xpchvv9w76lvj2zf";
+    sha256 = "13dzigync44pfd3ppdapyd7zamfqv6kgiwcrvnds0piyar87g5w4";
   };
 
   buildInputs = [ gmp cln pkgconfig readline swig libantlr3c boost jdk autoreconfHook python2 ];

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
       # https://lwn.net/Vulnerabilities/711777/
       debian = fetchurl {
         url = http://http.debian.net/debian/pool/main/t/tiff/tiff_4.0.7-6.debian.tar.xz;
-        sha256 = "9c9048c28205bdbeb5ba36c7a194d0cd604bd137c70961607bfc8a079be5fa31";
+        sha256 = "0cgswndhg2pwgdh622f76z8lnq6ds2aa3irnpasvxg85hb14i44w";
       };
     in ''
       tar xf '${debian}'

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
   prePatch =let
       # https://lwn.net/Vulnerabilities/711777/
       debian = fetchurl {
-        url = http://http.debian.net/debian/pool/main/t/tiff/tiff_4.0.7-5.debian.tar.xz;
-        sha256 = "1ribxdn89wx3nllcyh7ql3dx6wpr1h7z3waglz1w7dklxm43q67l";
+        url = http://http.debian.net/debian/pool/main/t/tiff/tiff_4.0.7-6.debian.tar.xz;
+        sha256 = "9c9048c28205bdbeb5ba36c7a194d0cd604bd137c70961607bfc8a079be5fa31";
       };
     in ''
       tar xf '${debian}'


### PR DESCRIPTION
###### Motivation for this change

404 Error on build

###### Things done

tested using nix-env -i libtiff -f PATH


- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

