### PR TITLE
neo4j: 3.1.2 -> 3.1.4

### DIFF
--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "neo4j-${version}";
-  version = "3.1.2";
+  version = "3.1.4";
 
   src = fetchurl {
     url = "http://dist.neo4j.org/neo4j-community-${version}-unix.tar.gz";
-    sha256 = "0kvbsm9mjwqyl3q2myif28a0f11i4rfq3hik07w9cdnrwyd75s40";
+    sha256 = "0pnq13bn5zyfx3cv54qi47373d73vmprib3vqxyxcjgfd61py4pc";
   };
 
   buildInputs = [ makeWrapper jre8 which gawk ];


### PR DESCRIPTION
###### Motivation for this change

new version available. Note. 3.2.0 has also been released. I couldn't test this because of #25746 which means errors on Fedora.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

