### PR TITLE
pythonPackages.dulwich: 0.14.1 -> 0.17.3

### DIFF
--- a/pkgs/development/python-modules/dulwich.nix
+++ b/pkgs/development/python-modules/dulwich.nix
@@ -1,14 +1,15 @@
-{ stdenv, buildPythonPackage, fetchurl
+{ stdenv, buildPythonPackage, fetchPypi
 , gevent, geventhttpclient, mock, fastimport
 , git, glibcLocales }:
 
 buildPythonPackage rec {
-  name = "dulwich-${version}";
-  version = "0.14.1";
+  pname = "dulwich";
+  version = "0.17.3";
+  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "mirror://pypi/d/dulwich/${name}.tar.gz";
-    sha256 = "14xsyxha6qyxxyf0ma3zv1sy31iy22vzwayk519n7a1gwzk4j7vw";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0c3eccac93823e172b05d57aaeab3d6f03c6c0f1867613606d1909a3ab4100ca";
   };
 
   LC_ALL = "en_US.UTF-8";


### PR DESCRIPTION
###### Motivation for this change
Upgrade

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I run nox but it seems some reverse dependencies are broken before this patch (in particular `pythonPackages.pygit2`).
