### PR TITLE
pythonPackages.pika-pool: init at 0.1.3

### DIFF
--- a/pkgs/development/python-modules/pika-pool/default.nix
+++ b/pkgs/development/python-modules/pika-pool/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pika
+}:
+
+buildPythonPackage rec {
+  pname = "pika-pool";
+  version = "0.1.3";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f3985888cc2788cdbd293a68a8b5702a9c955db6f7b8b551aeac91e7f32da397";
+  };
+
+  # Tests are not distributed
+  doCheck = false;
+
+  propagatedBuildInputs = [ pika ];
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/bninja/pika-pool";
+    license = licenses.bsdOriginal;
+    description = "Pools for pikas.";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18427,6 +18427,8 @@ in {
     };
   };
 
+  pika-pool = callPackage ../development/python-modules/pika-pool { };
+
   platformio =  buildPythonPackage rec {
     name = "platformio-${version}";
     version="2.10.3";


### PR DESCRIPTION
###### Motivation for this change
Dependency of next Keystone release

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

