### PR TITLE
pythonPackages.rfc3986: 0.2.2 -> 0.4.1

### DIFF
--- a/pkgs/development/python-modules/rfc3986/default.nix
+++ b/pkgs/development/python-modules/rfc3986/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi,
+  pytest }:
+
+buildPythonPackage rec {
+  pname = "rfc3986";
+  version = "0.4.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5ac85eb132fae7bbd811fa48d11984ae3104be30d44d397a351d004c633a68d2";
+  };
+
+  buildInputs = [ pytest ];
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://rfc3986.readthedocs.org";
+    license = licenses.asl20;
+    description = "Validating URI References per RFC 3986";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16442,23 +16442,7 @@ in {
     buildInputs = with self; [ oslotest mock coverage simplejson oslo-i18n ];
   };
 
-  rfc3986 = buildPythonPackage rec {
-    name = "rfc3986-${version}";
-    version = "0.2.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/r/rfc3986/rfc3986-0.2.2.tar.gz";
-      sha256 = "0yvzz7gp84qqdadbjdh9ch7dz4w19nmhwa704s9m11bljgp3hqmn";
-    };
-
-    LC_ALL = "en_US.UTF-8";
-    buildInputs = [ pkgs.glibcLocales ];
-
-    meta = with stdenv.lib; {
-      description = "rfc3986";
-      homepage = https://rfc3986.rtfd.org;
-    };
-  };
+  rfc3986 = callPackage ../development/python-modules/rfc3986 { };
 
   pycadf = buildPythonPackage rec {
     name = "pycadf-${version}";


### PR DESCRIPTION
###### Motivation for this change
Dependency of next Keystone release

###### Things done

- [] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

nox failed due to `pythonPackages.cinderclient` (which is tagged as broken)