### PR TITLE
fwup: init at 0.14.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -196,6 +196,7 @@
   garrison = "Jim Garrison <jim@garrison.cc>";
   gavin = "Gavin Rogers <gavin@praxeology.co.uk>";
   gebner = "Gabriel Ebner <gebner@gebner.org>";
+  georgewhewell = "George Whewell <georgerw@gmail.com>";
   gilligan = "Tobias Pflug <tobias.pflug@gmail.com>";
   giogadi = "Luis G. Torres <lgtorres42@gmail.com>";
   gleber = "Gleb Peregud <gleber.p@gmail.com>";

--- a/pkgs/tools/misc/fwup/default.nix
+++ b/pkgs/tools/misc/fwup/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, makeWrapper, pkgconfig
+, zlib, lzma, bzip2, mtools, dosfstools, zip, unzip, libconfuse, libsodium
+, libarchive, darwin, coreutils }:
+
+stdenv.mkDerivation rec {
+  name = "fwup-${version}";
+  version = "0.14.2";
+
+  src = fetchFromGitHub {
+    owner = "fhunleth";
+    repo = "fwup";
+    rev = "v${version}";
+    sha256 = "0ddyiprq4qnqpdhh48bivl8c5yrh21p4r99qs0d1rjiwx5h9p21l";
+  };
+
+  doCheck = true;
+  patches = lib.optional stdenv.isDarwin [ ./fix-testrunner-darwin.patch ];
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook makeWrapper ];
+  buildInputs = [ zlib lzma bzip2 libconfuse libsodium libarchive ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.DiskArbitration
+    ];
+  propagatedBuildInputs = [ zip unzip mtools dosfstools coreutils ];
+
+  # segfaults on darwin without
+  NIX_LDFLAGS = lib.optional stdenv.isDarwin "-F/System/Library/Frameworks";
+
+  meta = with stdenv.lib; {
+    description = "Configurable embedded Linux firmware update creator and runner";
+    homepage = https://github.com/fhunleth/fwup;
+    license = licenses.asl20;
+    maintainers = [ maintainers.georgewhewell ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/fwup/fix-testrunner-darwin.patch
+++ b/pkgs/tools/misc/fwup/fix-testrunner-darwin.patch
@@ -1,0 +1,25 @@
+diff --git a/tests/common-orig.sh b/tests/common.sh
+index 1f2673f..79dcf74 100755
+--- a/tests/common-orig.sh
++++ b/tests/common.sh
+@@ -21,20 +21,6 @@ else
+ fi
+ 
+ case "$HOST_OS" in
+-    Darwin)
+-	# BSD stat
+-        STAT_FILESIZE_FLAGS="-f %z"
+-
+-	# Not -d?
+-        BASE64_DECODE=-D
+-
+-        READLINK=/usr/local/bin/greadlink
+-        [ -e $READLINK ] || ( echo "Please run 'brew install coreutils' to install greadlink"; exit 1 )
+-        [ -e /usr/local/bin/mdir ] || ( echo "Please run 'brew install mtools' to install mdir"; exit 1 )
+-
+-        FSCK_FAT=fsck_msdos
+-        TIMEOUT=gtimeout
+-        ;;
+     FreeBSD|NetBSD|OpenBSD|DragonFly)
+ 	# BSD stat
+         STAT_FILESIZE_FLAGS="-f %z"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -952,6 +952,8 @@ with pkgs;
 
   fsmark = callPackage ../tools/misc/fsmark { };
 
+  fwup = callPackage ../tools/misc/fwup { };
+
   fzf = callPackage ../tools/misc/fzf { };
 
   fzy = callPackage ../tools/misc/fzy { };


### PR DESCRIPTION
###### Motivation for this change

adds fwup package

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

