### PR TITLE
i3lock-pixeled: init at 1.1.0

### DIFF
--- a/pkgs/misc/screensavers/i3lock-pixeled/default.nix
+++ b/pkgs/misc/screensavers/i3lock-pixeled/default.nix
@@ -22,11 +22,11 @@ stdenv.mkDerivation rec {
   ];
 
   patchPhase = ''
-    # patch paths
-    sed -i -e "s#i3lock#${pkgs.i3lock}/bin/i3lock#" i3lock-pixeled
-    sed -i -e "s#convert#${pkgs.imagemagick}/bin/convert#" i3lock-pixeled
-    sed -i -e "s#scrot#${pkgs.scrot}/bin/scrot#" i3lock-pixeled
-    sed -i -e "s#playerctl#${pkgs.playerctl}/bin/playerctl#" i3lock-pixeled
+    substituteInPlace i3lock-pixeled \
+       --replace i3lock    "${pkgs.i3lock}/bin/i3lock" \
+       --replace convert   "${pkgs.imagemagick}/bin/convert" \
+       --replace scrot     "${pkgs.scrot}/bin/scrot" \
+       --replace playerctl "${pkgs.playerctl}/bin/playerctl#"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/misc/screensavers/i3lock-pixeled/default.nix
+++ b/pkgs/misc/screensavers/i3lock-pixeled/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, pkgs, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "i3lock-pixeled-${version}";
+  version = "1.1.0";
+
+  src = fetchurl {
+    url = "https://github.com/Ma27/i3lock-pixeled/archive/${version}.tar.gz";
+    sha256 = "046qbx4qvcc66h53h4mm9pyjj9gjc6dzy38a0f0jc5a84xbivh7k";
+  };
+
+  propagatedBuildInputs = with pkgs; [
+    i3lock
+    imagemagick
+    scrot
+    playerctl
+  ];
+
+  buildPhases = [ "unpackPhase" "patchPhase" "installPhase" ];
+  makeFlags = [
+    "PREFIX=$(out)/bin"
+  ];
+
+  patchPhase = ''
+    # patch paths
+    sed -i -e "s#i3lock#${pkgs.i3lock}/bin/i3lock#" i3lock-pixeled
+    sed -i -e "s#convert#${pkgs.imagemagick}/bin/convert#" i3lock-pixeled
+    sed -i -e "s#scrot#${pkgs.scrot}/bin/scrot#" i3lock-pixeled
+    sed -i -e "s#playerctl#${pkgs.playerctl}/bin/playerctl#" i3lock-pixeled
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple i3lock helper which pixels a screenshot by scaling it down and up to get a pixeled version of the screen when the lock is active.";
+    homepage = "https://github.com/Ma27/i3lock-pixeled";
+    license = licenses.mit;
+    platform = platforms.linux;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14308,6 +14308,8 @@ with pkgs;
 
   i3lock-fancy = callPackage ../applications/window-managers/i3/lock-fancy.nix { };
 
+  i3lock-pixeled = callPackage ../misc/screensavers/i3lock-pixeled/default.nix { };
+
   i3minator = callPackage ../tools/misc/i3minator { };
 
   i3pystatus = callPackage ../applications/window-managers/i3/pystatus.nix { };


### PR DESCRIPTION
###### Motivation for this change

Simple derivation for my `i3lock` helper.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

