### PR TITLE
WIP: atril: init at 1.19.0

### DIFF
--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, pkgconfig, intltool, gtk3, libxml2, libsecret, poppler, itstool, mate, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "atril-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.19";
+  minor-ver = "0";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "0v829yvr738y5s2knyvimcgqv351qzb0rpw5il19qc27rbzyri1r";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    itstool
+    libsecret
+    libxml2
+    poppler
+    mate.mate-desktop
+  ];
+
+  configureFlags = [ "--disable-caja" ];
+  
+  meta = {
+    description = "Atril is a simple multi-page document viewer for the MATE desktop";
+    homepage = "http://mate-desktop.org";
+    license = with stdenv.lib.licenses; [ gpl2 ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Atril is a simple multi-page document viewer for the MATE desktop";
     homepage = "http://mate-desktop.org";
-    license = with stdenv.lib.licenses; [ gpl2 ];
+    license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--disable-caja" ];
   
   meta = {
-    description = "Atril is a simple multi-page document viewer for the MATE desktop";
+    description = "A simple multi-page document viewer for the MATE desktop";
     homepage = "http://mate-desktop.org";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -1,5 +1,6 @@
 { callPackage, pkgs }:
 rec {
+  atril = callPackage ./atril { };
   caja = callPackage ./caja { };
   mate-common = callPackage ./mate-common { };
   mate-desktop = callPackage ./mate-desktop { };


### PR DESCRIPTION
###### Motivation for this change

add atril from MATE desktop. Compiles fine on Fedora 25, but for some reason cannot display PDF documents yet.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

