### PR TITLE
gimp: 2.8.20 -> 2.8.22

### DIFF
--- a/pkgs/applications/graphics/gimp/2.8.nix
+++ b/pkgs/applications/graphics/gimp/2.8.nix
@@ -8,7 +8,7 @@ let
   inherit (python2Packages) pygtk wrapPython python;
 in stdenv.mkDerivation rec {
   name = "gimp-${version}";
-  version = "2.8.20";
+  version = "2.8.22";
 
   # This declarations for `gimp-with-plugins` wrapper,
   # (used for determining $out/lib/gimp/${majorVersion}/ paths)
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.gimp.org/pub/gimp/v2.8/${name}.tar.bz2";
-    sha256 = "939ca1df70be865c672ffd654f4e20f188121d01601c5c90237214101533c805";
+    sha256 = "12k3lp938qdc9cqj29scg55f3bb8iav2fysd29w0s49bqmfa71wi";
   };
 
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change

new version

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

