### PR TITLE
ecm-tools: init at github master

### DIFF
--- a/pkgs/applications/misc/ecm-tools/default.nix
+++ b/pkgs/applications/misc/ecm-tools/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchgit }:
+stdenv.mkDerivation rec {
+  name = "ecm-tools";
+  version = "master";
+
+  src = fetchgit {
+    url = "https://github.com/alucryd/ecm-tools";
+    rev = "55365b02f237f079334f207133dd85b45270ecd9";
+    sha256 = "1arbwnwggkc7ssf0cwwq97k13h7xf2ryjxvf8y028bxaq4xxfchg";
+    fetchSubmodules = true;
+  };
+
+  preInstall = ''
+    mkdir -p "$out/bin"
+    substituteInPlace Makefile --replace "$(DESTDIR)/usr/bin" "$out/bin"
+  '';
+  
+  meta = {
+    description = "Error Code Modeler";
+    longDescription = ''
+      Error Code Modeler
+      Fork of ECM primarily to host the code because upstream seems dead, 
+      with a minor change to how binaries are called to avoid conflicts with 
+      Sage Mathematics' ECM.
+    '';
+  
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.m3tti ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -914,6 +914,8 @@ with pkgs;
 
   ecasound = callPackage ../applications/audio/ecasound { };
 
+  ecm-tools = callPackage ../applications/misc/ecm-tools { };
+
   edac-utils = callPackage ../os-specific/linux/edac-utils { };
 
   eggdrop = callPackage ../tools/networking/eggdrop { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

