### PR TITLE
Fix #25723: Remove old GNU libstdc++ for qtbase

### DIFF
--- a/pkgs/development/libraries/qt-5/5.8/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtbase/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
       AGL AppKit ApplicationServices Carbon Cocoa
       CoreAudio CoreBluetooth CoreLocation CoreServices
       DiskArbitration Foundation OpenGL
-      darwin.cf-private darwin.apple_sdk.sdk darwin.libobjc libiconv
+      darwin.cf-private darwin.libobjc libiconv
     ]);
 
   buildInputs = [ ]


### PR DESCRIPTION
###### Motivation for this change
Fix for issue #25723 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

