### PR TITLE
nodePackages.lumo-cljs: init at 1.5.0

### DIFF
--- a/pkgs/development/node-packages/node-packages-v4.nix
+++ b/pkgs/development/node-packages/node-packages-v4.nix
@@ -76,13 +76,13 @@ let
         sha1 = "edbbe1888ba3525ded3a7bf836b30b3405d3161b";
       };
     };
-    "resolve-1.3.2" = {
+    "resolve-1.3.3" = {
       name = "resolve";
       packageName = "resolve";
-      version = "1.3.2";
+      version = "1.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz";
-        sha1 = "1f0442c9e0cbb8136e87b9305f932f46c7f28235";
+        url = "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz";
+        sha1 = "655907c3469a8680dc2de3a275a8fdd69691f0e5";
       };
     };
     "global-paths-0.1.2" = {
@@ -310,13 +310,13 @@ let
         sha1 = "a1d78fc3a50474cb80845d3b3b6e1da49a446e8e";
       };
     };
-    "kind-of-3.1.0" = {
+    "kind-of-3.2.0" = {
       name = "kind-of";
       packageName = "kind-of";
-      version = "3.1.0";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz";
-        sha1 = "475d698a5e49ff5e53d14e3e732429dc8bf4cf47";
+        url = "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz";
+        sha1 = "b58abe4d5c044ad33726a8c1525b48cf891bff07";
       };
     };
     "longest-1.0.1" = {
@@ -544,22 +544,22 @@ let
         sha1 = "f6d81c1e6093f4abae2d153a7b856963f5085e32";
       };
     };
-    "azure-arm-datalake-analytics-1.0.1-preview" = {
+    "azure-arm-datalake-analytics-1.0.2-preview" = {
       name = "azure-arm-datalake-analytics";
       packageName = "azure-arm-datalake-analytics";
-      version = "1.0.1-preview";
+      version = "1.0.2-preview";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-arm-datalake-analytics/-/azure-arm-datalake-analytics-1.0.1-preview.tgz";
-        sha1 = "75461904000427e12ce11d634d74c052c86de994";
+        url = "https://registry.npmjs.org/azure-arm-datalake-analytics/-/azure-arm-datalake-analytics-1.0.2-preview.tgz";
+        sha1 = "b34f868e98a972ec80e4408d209dc06c000dfb63";
       };
     };
-    "azure-arm-datalake-store-1.0.1-preview" = {
+    "azure-arm-datalake-store-1.0.2-preview" = {
       name = "azure-arm-datalake-store";
       packageName = "azure-arm-datalake-store";
-      version = "1.0.1-preview";
+      version = "1.0.2-preview";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-arm-datalake-store/-/azure-arm-datalake-store-1.0.1-preview.tgz";
-        sha1 = "bd07cbeb5eb355a00b7bed69e198a1a968115dd5";
+        url = "https://registry.npmjs.org/azure-arm-datalake-store/-/azure-arm-datalake-store-1.0.2-preview.tgz";
+        sha1 = "c8b7c113016c92703a84dc28d29ba518e8c64763";
       };
     };
     "azure-arm-hdinsight-0.2.2" = {
@@ -1714,13 +1714,13 @@ let
         sha1 = "49bd6331d7d02d0c09bc910a1075ba8165b56df9";
       };
     };
-    "minimatch-3.0.3" = {
+    "minimatch-3.0.4" = {
       name = "minimatch";
       packageName = "minimatch";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz";
-        sha1 = "2a4e4090b96b2db06a9d7df01055a62a77c9b774";
+        url = "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz";
+        sha1 = "5166e286457f03306064be5497e8dbb0c3d32083";
       };
     };
     "once-1.4.0" = {
@@ -1867,13 +1867,13 @@ let
         sha1 = "938370a57b4a51dea2c77c15d5c5fdf895164009";
       };
     };
-    "extend-3.0.0" = {
+    "extend-3.0.1" = {
       name = "extend";
       packageName = "extend";
-      version = "3.0.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz";
-        sha1 = "5a474353b9f3353ddd8176dfd37b91c83a46f1d4";
+        url = "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz";
+        sha1 = "a755ea7bc1adfcc5a31ce7e762dbaadc5e636444";
       };
     };
     "forever-agent-0.6.1" = {
@@ -2002,13 +2002,13 @@ let
         sha1 = "df3ae199acadfb7d440aaae0b29e2272b24ec619";
       };
     };
-    "async-2.3.0" = {
+    "async-2.4.0" = {
       name = "async";
       packageName = "async";
-      version = "2.3.0";
+      version = "2.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/async/-/async-2.3.0.tgz";
-        sha1 = "1013d1051047dd320fe24e494d5c66ecaf6147d9";
+        url = "https://registry.npmjs.org/async/-/async-2.4.0.tgz";
+        sha1 = "4990200f18ea5b837c2cc4f8c031a6985c385611";
       };
     };
     "lodash-4.17.4" = {
@@ -2290,13 +2290,13 @@ let
         sha1 = "853cfa0f7cbe2fed5de20326b8dd581035f6e2f0";
       };
     };
-    "getpass-0.1.6" = {
+    "getpass-0.1.7" = {
       name = "getpass";
       packageName = "getpass";
-      version = "0.1.6";
+      version = "0.1.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz";
-        sha1 = "283ffd9fc1256840875311c1b60e8c40187110e6";
+        url = "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz";
+        sha1 = "5eff8e3e684d569ae4cb2b1282604e8ba62149fa";
       };
     };
     "jsbn-0.1.1" = {
@@ -2659,13 +2659,13 @@ let
         sha1 = "04e6926f662895354f3dd015203633b857297e2c";
       };
     };
-    "deep-extend-0.4.1" = {
+    "deep-extend-0.4.2" = {
       name = "deep-extend";
       packageName = "deep-extend";
-      version = "0.4.1";
+      version = "0.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz";
-        sha1 = "efe4113d08085f4e6f9687759810f807469e2253";
+        url = "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz";
+        sha1 = "48b699c27e334bf89f10892be432f6e4c7d34a7f";
       };
     };
     "ext-name-3.0.0" = {
@@ -2893,13 +2893,13 @@ let
         sha1 = "a35008b20f41383eec1fb914f4cd5df79a264284";
       };
     };
-    "normalize-package-data-2.3.6" = {
+    "normalize-package-data-2.3.8" = {
       name = "normalize-package-data";
       packageName = "normalize-package-data";
-      version = "2.3.6";
+      version = "2.3.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz";
-        sha1 = "498fa420c96401f787402ba21e600def9f981fff";
+        url = "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz";
+        sha1 = "d819eda2a9dedbd1ffa563ea4071d936782295bb";
       };
     };
     "object-assign-4.1.1" = {
@@ -3253,22 +3253,22 @@ let
         sha1 = "dd01bac9d06d30e6f219aecb8253ee9ebdc308f1";
       };
     };
-    "debug-2.6.3" = {
+    "debug-2.6.6" = {
       name = "debug";
       packageName = "debug";
-      version = "2.6.3";
+      version = "2.6.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz";
-        sha1 = "0f7eb8c30965ec08c72accfa0130c8b79984141d";
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz";
+        sha1 = "a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a";
       };
     };
-    "ms-0.7.2" = {
+    "ms-0.7.3" = {
       name = "ms";
       packageName = "ms";
-      version = "0.7.2";
+      version = "0.7.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz";
-        sha1 = "ae25cf2512b3885a1d95d7f037868d8431124765";
+        url = "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz";
+        sha1 = "708155a5e44e33f5fd0fc53e81d0d40a91be1fff";
       };
     };
     "os-tmpdir-1.0.2" = {
@@ -3514,13 +3514,13 @@ let
         sha1 = "a0b870729aae214005b7d5032ec2cbbb0fb4451a";
       };
     };
-    "process-0.11.9" = {
+    "process-0.11.10" = {
       name = "process";
       packageName = "process";
-      version = "0.11.9";
+      version = "0.11.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/process/-/process-0.11.9.tgz";
-        sha1 = "7bd5ad21aa6253e7da8682264f1e11d11c0318c1";
+        url = "https://registry.npmjs.org/process/-/process-0.11.10.tgz";
+        sha1 = "7332300e840161bda3e69a1d1d91a7d4bc16f182";
       };
     };
     "querystring-es3-0.2.1" = {
@@ -3568,13 +3568,13 @@ let
         sha1 = "66266ee5f9bdb9940a4e4514cafb43bb71e5c9db";
       };
     };
-    "stream-http-2.7.0" = {
+    "stream-http-2.7.1" = {
       name = "stream-http";
       packageName = "stream-http";
-      version = "2.7.0";
+      version = "2.7.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stream-http/-/stream-http-2.7.0.tgz";
-        sha1 = "cec1f4e3b494bc4a81b451808970f8b20b4ed5f6";
+        url = "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz";
+        sha1 = "546a51741ad5a6b07e9e31b0b10441a917df528a";
       };
     };
     "subarg-1.0.0" = {
@@ -3649,13 +3649,13 @@ let
         sha1 = "5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73";
       };
     };
-    "jsonparse-1.3.0" = {
+    "jsonparse-1.3.1" = {
       name = "jsonparse";
       packageName = "jsonparse";
-      version = "1.3.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz";
-        sha1 = "85fc245b1d9259acc6941960b905adf64e7de0e8";
+        url = "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz";
+        sha1 = "3f4dae4a91fac315f71062f8521cc239f1366280";
       };
     };
     "through-2.3.8" = {
@@ -3784,22 +3784,22 @@ let
         sha1 = "888c723596cdf7612f6498233eebd7a35301737d";
       };
     };
-    "create-hash-1.1.2" = {
+    "create-hash-1.1.3" = {
       name = "create-hash";
       packageName = "create-hash";
-      version = "1.1.2";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz";
-        sha1 = "51210062d7bb7479f6c65bb41a92208b1d61abad";
+        url = "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz";
+        sha1 = "606042ac8b9262750f483caddab0f5819172d8fd";
       };
     };
-    "create-hmac-1.1.4" = {
+    "create-hmac-1.1.6" = {
       name = "create-hmac";
       packageName = "create-hmac";
-      version = "1.1.4";
+      version = "1.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz";
-        sha1 = "d3fb4ba253eb8b3f56e39ea2fbcb8af747bd3170";
+        url = "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz";
+        sha1 = "acb9e221a4e17bdb076e90657c42b93e3726cf06";
       };
     };
     "diffie-hellman-5.0.2" = {
@@ -3811,13 +3811,13 @@ let
         sha1 = "b5835739270cfe26acf632099fded2a07f209e5e";
       };
     };
-    "pbkdf2-3.0.9" = {
+    "pbkdf2-3.0.12" = {
       name = "pbkdf2";
       packageName = "pbkdf2";
-      version = "3.0.9";
+      version = "3.0.12";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz";
-        sha1 = "f2c4b25a600058b3c3773c086c37dbbee1ffe693";
+        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz";
+        sha1 = "be36785c5067ea48d806ff923288c5f750b6b8a2";
       };
     };
     "public-encrypt-4.0.0" = {
@@ -3982,13 +3982,13 @@ let
         sha1 = "48ba240b45a9280e94748990ba597d216617fd40";
       };
     };
-    "ripemd160-1.0.1" = {
+    "ripemd160-2.0.1" = {
       name = "ripemd160";
       packageName = "ripemd160";
-      version = "1.0.1";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz";
-        sha1 = "93a4bbd4942bc574b69a8fa57c71de10ecca7d6e";
+        url = "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz";
+        sha1 = "0f4584295c53a3628af7e6d79aca21ce57d1c6e7";
       };
     };
     "sha.js-2.4.8" = {
@@ -3998,6 +3998,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz";
         sha1 = "37068c2c476b6baf402d14a49c67f597921f634f";
+      };
+    };
+    "hash-base-2.0.2" = {
+      name = "hash-base";
+      packageName = "hash-base";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz";
+        sha1 = "66ea1d856db4e8a5470cadf6fce23ae5244ef2e1";
       };
     };
     "miller-rabin-4.0.0" = {
@@ -4270,13 +4279,13 @@ let
         sha1 = "1e80454250018dbad4c3fe94497d6e67b6269c77";
       };
     };
-    "mime-1.3.4" = {
+    "mime-1.3.6" = {
       name = "mime";
       packageName = "mime";
-      version = "1.3.4";
+      version = "1.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz";
-        sha1 = "115f9e3b6b3daf2959983cb38f149a2d40eb5d53";
+        url = "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz";
+        sha1 = "591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0";
       };
     };
     "peerflix-0.34.0" = {
@@ -4702,13 +4711,13 @@ let
         sha1 = "add2958d399319b6d8f2dde29bebac5e845e8b6d";
       };
     };
-    "plist-2.0.1" = {
+    "plist-2.1.0" = {
       name = "plist";
       packageName = "plist";
-      version = "2.0.1";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz";
-        sha1 = "0a32ca9481b1c364e92e18dc55c876de9d01da8b";
+        url = "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz";
+        sha1 = "57ccdb7a0821df21831217a3cad54e3e146a1025";
       };
     };
     "dns-js-0.2.1" = {
@@ -4736,15 +4745,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/qap/-/qap-3.1.3.tgz";
         sha1 = "394288bf07c8fe16cf36bb2e40a3bb947ed24963";
-      };
-    };
-    "base64-js-1.1.2" = {
-      name = "base64-js";
-      packageName = "base64-js";
-      version = "1.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz";
-        sha1 = "d6400cac1c4c660976d90d07a04351d89395f5e8";
       };
     };
     "xmlbuilder-8.2.2" = {
@@ -4846,13 +4846,13 @@ let
         sha1 = "122e161591e21ff4c52530305693f20e6393a398";
       };
     };
-    "magnet-uri-5.1.6" = {
+    "magnet-uri-5.1.7" = {
       name = "magnet-uri";
       packageName = "magnet-uri";
-      version = "5.1.6";
+      version = "5.1.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/magnet-uri/-/magnet-uri-5.1.6.tgz";
-        sha1 = "60e8fb5ea90488c8491701eb306970f3126480b3";
+        url = "https://registry.npmjs.org/magnet-uri/-/magnet-uri-5.1.7.tgz";
+        sha1 = "8f8016ab74c415f274f4fb1943faaf7e92030eff";
       };
     };
     "parse-torrent-file-4.0.2" = {
@@ -4864,13 +4864,13 @@ let
         sha1 = "981a22143832abbcd99052d889d31a39ae3f9bfe";
       };
     };
-    "simple-get-2.5.1" = {
+    "simple-get-2.6.0" = {
       name = "simple-get";
       packageName = "simple-get";
-      version = "2.5.1";
+      version = "2.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-get/-/simple-get-2.5.1.tgz";
-        sha1 = "eb418fb2c9e431631b4cd6c478af548da613ccd2";
+        url = "https://registry.npmjs.org/simple-get/-/simple-get-2.6.0.tgz";
+        sha1 = "bb01144db49b3d4c107615dcf48d3ee404b16e06";
       };
     };
     "thirty-two-1.0.2" = {
@@ -4909,13 +4909,13 @@ let
         sha1 = "9427bb96ff1263cc10a8414cedd51a18b919e8b3";
       };
     };
-    "rusha-0.8.5" = {
+    "rusha-0.8.6" = {
       name = "rusha";
       packageName = "rusha";
-      version = "0.8.5";
+      version = "0.8.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/rusha/-/rusha-0.8.5.tgz";
-        sha1 = "a30ae9bd5a4e80fbc96fbe7a13232b944be24f84";
+        url = "https://registry.npmjs.org/rusha/-/rusha-0.8.6.tgz";
+        sha1 = "b264ddaa4d49a1d67300061858ba9358c4adca14";
       };
     };
     "simple-concat-1.0.0" = {
@@ -5080,13 +5080,13 @@ let
         sha1 = "50346e42a43b35daf2a86f414afb153629a854be";
       };
     };
-    "random-access-file-1.6.1" = {
+    "random-access-file-1.7.2" = {
       name = "random-access-file";
       packageName = "random-access-file";
-      version = "1.6.1";
+      version = "1.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/random-access-file/-/random-access-file-1.6.1.tgz";
-        sha1 = "33358436f43076d34a058db47177a691319f0e99";
+        url = "https://registry.npmjs.org/random-access-file/-/random-access-file-1.7.2.tgz";
+        sha1 = "053e2e8ec7670370a8e8b10da962e45753f22dbc";
       };
     };
     "run-parallel-1.1.6" = {
@@ -5413,13 +5413,13 @@ let
         sha1 = "bbcd40c8451a7ed4ef5c373b8169a409dd1d11d9";
       };
     };
-    "ws-2.2.3" = {
+    "ws-2.3.1" = {
       name = "ws";
       packageName = "ws";
-      version = "2.2.3";
+      version = "2.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ws/-/ws-2.2.3.tgz";
-        sha1 = "f36c9719a56dff813f455af912a2078145bbd940";
+        url = "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz";
+        sha1 = "6b94b3e447cb6a363f785eaf94af6359e8e81c80";
       };
     };
     "ultron-1.1.0" = {
@@ -5737,31 +5737,49 @@ let
         sha1 = "aa58a3041a066f90eaa16c2f5389ff19f3f461a5";
       };
     };
-    "cordova-common-2.0.0" = {
+    "configstore-2.1.0" = {
+      name = "configstore";
+      packageName = "configstore";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz";
+        sha1 = "737a3a7036e9886102aa6099e47bb33ab1aba1a1";
+      };
+    };
+    "cordova-common-2.0.3" = {
       name = "cordova-common";
       packageName = "cordova-common";
-      version = "2.0.0";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-common/-/cordova-common-2.0.0.tgz";
-        sha1 = "125097eb4b50b7353cec226ed21649192293ae97";
+        url = "https://registry.npmjs.org/cordova-common/-/cordova-common-2.0.3.tgz";
+        sha1 = "2214ee04ae1c2ec012a52c7c185313e341a6fb38";
       };
     };
-    "cordova-lib-6.5.0" = {
+    "cordova-lib-7.0.1" = {
       name = "cordova-lib";
       packageName = "cordova-lib";
-      version = "6.5.0";
+      version = "7.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-lib/-/cordova-lib-6.5.0.tgz";
-        sha1 = "f7630a04c29d6cdee980190b1d93fb1536ac453f";
+        url = "https://registry.npmjs.org/cordova-lib/-/cordova-lib-7.0.1.tgz";
+        sha1 = "31cbb90daeb66a67a7d3091636ce729a22a4f7ff";
       };
     };
-    "insight-0.8.4" = {
+    "editor-1.0.0" = {
+      name = "editor";
+      packageName = "editor";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz";
+        sha1 = "60c7f87bd62bcc6a894fa8ccd6afb7823a24f742";
+      };
+    };
+    "insight-0.8.2" = {
       name = "insight";
       packageName = "insight";
-      version = "0.8.4";
+      version = "0.8.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/insight/-/insight-0.8.4.tgz";
-        sha1 = "671caf65b47c9fe8c3d1b3206cf45bb211b75884";
+        url = "https://registry.npmjs.org/insight/-/insight-0.8.2.tgz";
+        sha1 = "18c2acf1b6055491278fc7529f1f21d32e1f0eda";
       };
     };
     "nopt-3.0.1" = {
@@ -5782,15 +5800,6 @@ let
         sha1 = "11872aeedee89268110b10a718448ffb10112a14";
       };
     };
-    "underscore-1.7.0" = {
-      name = "underscore";
-      packageName = "underscore";
-      version = "1.7.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz";
-        sha1 = "6bbaf0877500d36be34ecaa584e0db9fef035209";
-      };
-    };
     "update-notifier-0.5.0" = {
       name = "update-notifier";
       packageName = "update-notifier";
@@ -5798,6 +5807,78 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz";
         sha1 = "07b5dc2066b3627ab3b4f530130f7eddda07a4cc";
+      };
+    };
+    "dot-prop-3.0.0" = {
+      name = "dot-prop";
+      packageName = "dot-prop";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz";
+        sha1 = "1b708af094a49c9a0e7dbcad790aba539dac1177";
+      };
+    };
+    "osenv-0.1.4" = {
+      name = "osenv";
+      packageName = "osenv";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz";
+        sha1 = "42fe6d5953df06c8064be6f176c3d05aaaa34644";
+      };
+    };
+    "uuid-2.0.3" = {
+      name = "uuid";
+      packageName = "uuid";
+      version = "2.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz";
+        sha1 = "67e2e863797215530dff318e5bf9dcebfd47b21a";
+      };
+    };
+    "write-file-atomic-1.3.4" = {
+      name = "write-file-atomic";
+      packageName = "write-file-atomic";
+      version = "1.3.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz";
+        sha1 = "f807a4f0b1d9e913ae7a48112e6cc3af1991b45f";
+      };
+    };
+    "xdg-basedir-2.0.0" = {
+      name = "xdg-basedir";
+      packageName = "xdg-basedir";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz";
+        sha1 = "edbc903cc385fc04523d966a335504b5504d1bd2";
+      };
+    };
+    "is-obj-1.0.1" = {
+      name = "is-obj";
+      packageName = "is-obj";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz";
+        sha1 = "3e4729ac1f5fde025cd7d83a896dab9f4f67db0f";
+      };
+    };
+    "imurmurhash-0.1.4" = {
+      name = "imurmurhash";
+      packageName = "imurmurhash";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz";
+        sha1 = "9218b9b2b928a238b13dc4fb6b6d576f231453ea";
+      };
+    };
+    "slide-1.1.6" = {
+      name = "slide";
+      packageName = "slide";
+      version = "1.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz";
+        sha1 = "56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707";
       };
     };
     "ansi-0.3.1" = {
@@ -5827,13 +5908,13 @@ let
         sha1 = "e244b9185b8175473bff6079324905115f83dc7c";
       };
     };
-    "elementtree-0.1.7" = {
+    "elementtree-0.1.6" = {
       name = "elementtree";
       packageName = "elementtree";
-      version = "0.1.7";
+      version = "0.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz";
-        sha1 = "9ac91be6e52fb6e6244c4e54a4ac3ed8ae8e29c0";
+        url = "https://registry.npmjs.org/elementtree/-/elementtree-0.1.6.tgz";
+        sha1 = "2ac4c46ea30516c8c4cbdb5e3ac7418e592de20c";
       };
     };
     "glob-5.0.15" = {
@@ -5843,15 +5924,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz";
         sha1 = "1bc936b9e02f4a603fcc222ecf7633d30b8b93b1";
-      };
-    };
-    "osenv-0.1.4" = {
-      name = "osenv";
-      packageName = "osenv";
-      version = "0.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz";
-        sha1 = "42fe6d5953df06c8064be6f176c3d05aaaa34644";
       };
     };
     "plist-1.2.0" = {
@@ -5890,22 +5962,22 @@ let
         sha1 = "364200d5f13646ca8bcd44490271335614792300";
       };
     };
-    "big-integer-1.6.19" = {
+    "big-integer-1.6.22" = {
       name = "big-integer";
       packageName = "big-integer";
-      version = "1.6.19";
+      version = "1.6.22";
       src = fetchurl {
-        url = "https://registry.npmjs.org/big-integer/-/big-integer-1.6.19.tgz";
-        sha1 = "4a5e915e3188c8708f254b356196f28542acc1e0";
+        url = "https://registry.npmjs.org/big-integer/-/big-integer-1.6.22.tgz";
+        sha1 = "487c95fce886022ea48ff5f19e388932df46dd2e";
       };
     };
-    "sax-1.1.4" = {
+    "sax-0.3.5" = {
       name = "sax";
       packageName = "sax";
-      version = "1.1.4";
+      version = "0.3.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz";
-        sha1 = "74b6d33c9ae1e001510f179a91168588f1aedaa9";
+        url = "https://registry.npmjs.org/sax/-/sax-0.3.5.tgz";
+        sha1 = "88fcfc1f73c0c8bbd5b7c776b6d3f3501eed073d";
       };
     };
     "base64-js-0.0.8" = {
@@ -5926,31 +5998,31 @@ let
         sha1 = "98b8f651ca30aa624036f127d11cc66dc7b907a3";
       };
     };
-    "aliasify-1.9.0" = {
+    "aliasify-2.1.0" = {
       name = "aliasify";
       packageName = "aliasify";
-      version = "1.9.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aliasify/-/aliasify-1.9.0.tgz";
-        sha1 = "03aa1a5fe5b4cac604e3b967bc4c7ceacf957030";
+        url = "https://registry.npmjs.org/aliasify/-/aliasify-2.1.0.tgz";
+        sha1 = "7c30825b9450b9e6185ba27533eaf6e2067d4b42";
       };
     };
-    "cordova-create-1.0.2" = {
+    "cordova-create-1.1.1" = {
       name = "cordova-create";
       packageName = "cordova-create";
-      version = "1.0.2";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-create/-/cordova-create-1.0.2.tgz";
-        sha1 = "cb9bba9817c62a645bacb6e00da8cc50936a0fa5";
+        url = "https://registry.npmjs.org/cordova-create/-/cordova-create-1.1.1.tgz";
+        sha1 = "55282493ab396d9303f72febbaf2f978fa764cd2";
       };
     };
-    "cordova-fetch-1.0.2" = {
+    "cordova-fetch-1.1.0" = {
       name = "cordova-fetch";
       packageName = "cordova-fetch";
-      version = "1.0.2";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-fetch/-/cordova-fetch-1.0.2.tgz";
-        sha1 = "b8f4903f39fe613888062552a96995413af16d35";
+        url = "https://registry.npmjs.org/cordova-fetch/-/cordova-fetch-1.1.0.tgz";
+        sha1 = "1549f9ff4e6345f3c6fb6bd6523e8b19311a7b54";
       };
     };
     "cordova-js-4.2.1" = {
@@ -5980,31 +6052,22 @@ let
         sha1 = "fade86a92799a813e9b42511cdf3dfa6cc8dbefe";
       };
     };
-    "elementtree-0.1.6" = {
-      name = "elementtree";
-      packageName = "elementtree";
-      version = "0.1.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/elementtree/-/elementtree-0.1.6.tgz";
-        sha1 = "2ac4c46ea30516c8c4cbdb5e3ac7418e592de20c";
-      };
-    };
-    "init-package-json-1.9.6" = {
+    "init-package-json-1.10.1" = {
       name = "init-package-json";
       packageName = "init-package-json";
-      version = "1.9.6";
+      version = "1.10.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.6.tgz";
-        sha1 = "789fc2b74466a4952b9ea77c0575bc78ebd60a61";
+        url = "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz";
+        sha1 = "cd873a167796befb99612b28762a0b6393fd8f6a";
       };
     };
-    "nopt-3.0.6" = {
+    "nopt-4.0.1" = {
       name = "nopt";
       packageName = "nopt";
-      version = "3.0.6";
+      version = "4.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz";
-        sha1 = "c6465dbf08abcd4db359317f79ac68a646b28ff9";
+        url = "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz";
+        sha1 = "d0d4685afd5415193c8c7505602d0d17cd64474d";
       };
     };
     "npm-2.15.12" = {
@@ -6016,40 +6079,40 @@ let
         sha1 = "df7c3ed5a277c3f9d4b5d819b05311d10a200ae6";
       };
     };
-    "opener-1.4.1" = {
+    "opener-1.4.2" = {
       name = "opener";
       packageName = "opener";
-      version = "1.4.1";
+      version = "1.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz";
-        sha1 = "897590acd1aed3311b703b58bccb4d43f56f2895";
+        url = "https://registry.npmjs.org/opener/-/opener-1.4.2.tgz";
+        sha1 = "b32582080042af8680c389a499175b4c54fff523";
       };
     };
-    "properties-parser-0.2.3" = {
+    "plist-2.0.1" = {
+      name = "plist";
+      packageName = "plist";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz";
+        sha1 = "0a32ca9481b1c364e92e18dc55c876de9d01da8b";
+      };
+    };
+    "properties-parser-0.3.1" = {
       name = "properties-parser";
       packageName = "properties-parser";
-      version = "0.2.3";
+      version = "0.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/properties-parser/-/properties-parser-0.2.3.tgz";
-        sha1 = "f7591255f707abbff227c7b56b637dbb0373a10f";
+        url = "https://registry.npmjs.org/properties-parser/-/properties-parser-0.3.1.tgz";
+        sha1 = "1316e9539ffbfd93845e369b211022abd478771a";
       };
     };
-    "request-2.47.0" = {
+    "request-2.79.0" = {
       name = "request";
       packageName = "request";
-      version = "2.47.0";
+      version = "2.79.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/request/-/request-2.47.0.tgz";
-        sha1 = "09e9fd1a4fed6593a805ef8202b20f0c5ecb485f";
-      };
-    };
-    "semver-4.3.6" = {
-      name = "semver";
-      packageName = "semver";
-      version = "4.3.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz";
-        sha1 = "300bc6e0e86374f7ba61068b5b1ecd57fc6532da";
+        url = "https://registry.npmjs.org/request/-/request-2.79.0.tgz";
+        sha1 = "4dfe5bf6be8b8cdc37fcf93e04b65577722710de";
       };
     };
     "shelljs-0.3.0" = {
@@ -6061,22 +6124,13 @@ let
         sha1 = "3596e6307a781544f591f37da618360f31db57b1";
       };
     };
-    "tar-1.0.2" = {
+    "tar-2.2.1" = {
       name = "tar";
       packageName = "tar";
-      version = "1.0.2";
+      version = "2.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tar/-/tar-1.0.2.tgz";
-        sha1 = "8b0f6740f9946259de26a3ed9c9a22890dff023f";
-      };
-    };
-    "unorm-1.3.3" = {
-      name = "unorm";
-      packageName = "unorm";
-      version = "1.3.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/unorm/-/unorm-1.3.3.tgz";
-        sha1 = "16a8772671ebd6f7cde6f8c5e49bb60ac47dba93";
+        url = "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz";
+        sha1 = "8e4d2a256c0e2185c6b18ad694aec968b83cb1d1";
       };
     };
     "valid-identifier-0.0.1" = {
@@ -6097,31 +6151,31 @@ let
         sha1 = "910a89c16aee6cc0b42ca805a6d0b4cf87211cf3";
       };
     };
-    "browserify-transform-tools-1.5.3" = {
+    "browserify-transform-tools-1.7.0" = {
       name = "browserify-transform-tools";
       packageName = "browserify-transform-tools";
-      version = "1.5.3";
+      version = "1.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.5.3.tgz";
-        sha1 = "509c9c652fb6b07bf0d21efceebb1d826f80754b";
+        url = "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.7.0.tgz";
+        sha1 = "83e277221f63259bed2e7eb2a283a970a501f4c4";
       };
     };
-    "falafel-1.2.0" = {
+    "falafel-2.1.0" = {
       name = "falafel";
       packageName = "falafel";
-      version = "1.2.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz";
-        sha1 = "c18d24ef5091174a497f318cd24b026a25cddab4";
+        url = "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz";
+        sha1 = "96bb17761daba94f46d001738b3cedf3a67fe06c";
       };
     };
-    "acorn-1.2.2" = {
+    "acorn-5.0.3" = {
       name = "acorn";
       packageName = "acorn";
-      version = "1.2.2";
+      version = "5.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz";
-        sha1 = "c8ce27de0acc76d896d2b1fad3df588d9e82f014";
+        url = "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz";
+        sha1 = "c460df08491463f028ccb82eab3730bf01087b3d";
       };
     };
     "foreach-2.0.5" = {
@@ -6142,22 +6196,22 @@ let
         sha1 = "c54601778ad560f1142ce0e01bcca8b56d13426d";
       };
     };
-    "cordova-app-hello-world-3.11.0" = {
+    "cordova-app-hello-world-3.12.0" = {
       name = "cordova-app-hello-world";
       packageName = "cordova-app-hello-world";
-      version = "3.11.0";
+      version = "3.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-app-hello-world/-/cordova-app-hello-world-3.11.0.tgz";
-        sha1 = "9214feb9dd713ca481a1cbabceeca60966c1c0cf";
+        url = "https://registry.npmjs.org/cordova-app-hello-world/-/cordova-app-hello-world-3.12.0.tgz";
+        sha1 = "270e06b67b2ae94bcfee6592ed39eb42303d186f";
       };
     };
-    "dependency-ls-1.0.0" = {
+    "dependency-ls-1.1.0" = {
       name = "dependency-ls";
       packageName = "dependency-ls";
-      version = "1.0.0";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dependency-ls/-/dependency-ls-1.0.0.tgz";
-        sha1 = "311dc9fa9a840bee4c6ca33954556e5cf09cb5c9";
+        url = "https://registry.npmjs.org/dependency-ls/-/dependency-ls-1.1.0.tgz";
+        sha1 = "94cfe674620f5e9f2924d0501f9c6e710fc90f55";
       };
     };
     "is-url-1.2.2" = {
@@ -6187,13 +6241,13 @@ let
         sha1 = "55705bcd93c5f3673530c2c2cbc0c2b3addc286e";
       };
     };
-    "interpret-1.0.2" = {
+    "interpret-1.0.3" = {
       name = "interpret";
       packageName = "interpret";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz";
-        sha1 = "f4f623f0bb7122f15f5717c8e254b8161b5c5b2d";
+        url = "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz";
+        sha1 = "cbc35c62eeee73f19ab7b10a801511401afc0f90";
       };
     };
     "rechoir-0.6.2" = {
@@ -6412,13 +6466,13 @@ let
         sha1 = "6f631aef336d6c46362b51764044ce216be3c051";
       };
     };
-    "finalhandler-1.0.1" = {
+    "finalhandler-1.0.2" = {
       name = "finalhandler";
       packageName = "finalhandler";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.1.tgz";
-        sha1 = "bcd15d1689c0e5ed729b6f7f541a6df984117db8";
+        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.2.tgz";
+        sha1 = "d0e36f9dbc557f2de14423df6261889e9d60c93a";
       };
     };
     "fresh-0.5.0" = {
@@ -6529,6 +6583,24 @@ let
         sha1 = "0294fb922bb9375153541c4f7096231f287c8af8";
       };
     };
+    "ms-0.7.2" = {
+      name = "ms";
+      packageName = "ms";
+      version = "0.7.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz";
+        sha1 = "ae25cf2512b3885a1d95d7f037868d8431124765";
+      };
+    };
+    "debug-2.6.4" = {
+      name = "debug";
+      packageName = "debug";
+      version = "2.6.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz";
+        sha1 = "7586a9b3c39741c0282ae33445c4e8ac74734fe0";
+      };
+    };
     "unpipe-1.0.0" = {
       name = "unpipe";
       packageName = "unpipe";
@@ -6574,6 +6646,15 @@ let
         sha1 = "5f8b8ed98aca545656bf572997387f904a722257";
       };
     };
+    "mime-1.3.4" = {
+      name = "mime";
+      packageName = "mime";
+      version = "1.3.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz";
+        sha1 = "115f9e3b6b3daf2959983cb38f149a2d40eb5d53";
+      };
+    };
     "media-typer-0.3.0" = {
       name = "media-typer";
       packageName = "media-typer";
@@ -6590,15 +6671,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/underscore/-/underscore-1.2.1.tgz";
         sha1 = "fc5c6b0765673d92a2d4ac8b4dc0aa88702e2bd4";
-      };
-    };
-    "sax-0.3.5" = {
-      name = "sax";
-      packageName = "sax";
-      version = "0.3.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sax/-/sax-0.3.5.tgz";
-        sha1 = "88fcfc1f73c0c8bbd5b7c776b6d3f3501eed073d";
       };
     };
     "npm-package-arg-5.0.1" = {
@@ -6790,15 +6862,6 @@ let
         sha1 = "7f742de066fc748bc8db820569dddce49bf0d456";
       };
     };
-    "editor-1.0.0" = {
-      name = "editor";
-      packageName = "editor";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz";
-        sha1 = "60c7f87bd62bcc6a894fa8ccd6afb7823a24f742";
-      };
-    };
     "fs-vacuum-1.2.10" = {
       name = "fs-vacuum";
       packageName = "fs-vacuum";
@@ -6871,6 +6934,15 @@ let
         sha1 = "0ba81d90da2e25ab34a332e6ec77936e1598118b";
       };
     };
+    "init-package-json-1.9.6" = {
+      name = "init-package-json";
+      packageName = "init-package-json";
+      version = "1.9.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.6.tgz";
+        sha1 = "789fc2b74466a4952b9ea77c0575bc78ebd60a61";
+      };
+    };
     "lockfile-1.0.3" = {
       name = "lockfile";
       packageName = "lockfile";
@@ -6889,13 +6961,22 @@ let
         sha1 = "1d17679c069cda5d040991a09dbc2c0db377e55e";
       };
     };
-    "node-gyp-3.6.0" = {
+    "node-gyp-3.6.1" = {
       name = "node-gyp";
       packageName = "node-gyp";
-      version = "3.6.0";
+      version = "3.6.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz";
-        sha1 = "7474f63a3a0501161dda0b6341f022f14c423fa6";
+        url = "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.1.tgz";
+        sha1 = "19561067ff185464aded478212681f47fd578cbc";
+      };
+    };
+    "nopt-3.0.6" = {
+      name = "nopt";
+      packageName = "nopt";
+      version = "3.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz";
+        sha1 = "c6465dbf08abcd4db359317f79ac68a646b28ff9";
       };
     };
     "normalize-git-url-3.0.2" = {
@@ -7024,15 +7105,6 @@ let
         sha1 = "6030822fbd2c9823949f8f72ed6411ee5cf25aae";
       };
     };
-    "slide-1.1.6" = {
-      name = "slide";
-      packageName = "slide";
-      version = "1.1.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz";
-        sha1 = "56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707";
-      };
-    };
     "sorted-object-2.0.1" = {
       name = "sorted-object";
       packageName = "sorted-object";
@@ -7040,15 +7112,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz";
         sha1 = "7d631f4bd3a798a24af1dffcfbfe83337a5df5fc";
-      };
-    };
-    "tar-2.2.1" = {
-      name = "tar";
-      packageName = "tar";
-      version = "2.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz";
-        sha1 = "8e4d2a256c0e2185c6b18ad694aec968b83cb1d1";
       };
     };
     "text-table-0.2.0" = {
@@ -7094,15 +7157,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz";
         sha1 = "b1f52dc2e8dc0e3cb04d187a25f758a38a90ca3b";
-      };
-    };
-    "imurmurhash-0.1.4" = {
-      name = "imurmurhash";
-      packageName = "imurmurhash";
-      version = "0.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz";
-        sha1 = "9218b9b2b928a238b13dc4fb6b6d576f231453ea";
       };
     };
     "wcwidth-1.0.1" = {
@@ -7177,13 +7231,13 @@ let
         sha1 = "1c11f9218f076089a47dd512f93c6699a6a81d52";
       };
     };
-    "are-we-there-yet-1.1.2" = {
+    "are-we-there-yet-1.1.4" = {
       name = "are-we-there-yet";
       packageName = "are-we-there-yet";
-      version = "1.1.2";
+      version = "1.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz";
-        sha1 = "80e470e95a084794fe1899262c5667c6e88de1b3";
+        url = "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz";
+        sha1 = "bb5dca382bb94f05e15194373d16fd3ba1ca110d";
       };
     };
     "gauge-1.2.7" = {
@@ -7276,157 +7330,49 @@ let
         sha1 = "355219cd6cf18dbe7c01cc7fd2dce765cfdc549a";
       };
     };
-    "bl-0.9.5" = {
-      name = "bl";
-      packageName = "bl";
-      version = "0.9.5";
+    "base64-js-1.1.2" = {
+      name = "base64-js";
+      packageName = "base64-js";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz";
-        sha1 = "c06b797af085ea00bc527afc8efcf11de2232054";
+        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz";
+        sha1 = "d6400cac1c4c660976d90d07a04351d89395f5e8";
       };
     };
-    "caseless-0.6.0" = {
-      name = "caseless";
-      packageName = "caseless";
-      version = "0.6.0";
+    "string.prototype.codepointat-0.2.0" = {
+      name = "string.prototype.codepointat";
+      packageName = "string.prototype.codepointat";
+      version = "0.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz";
-        sha1 = "8167c1ab8397fb5bb95f96d28e5a81c50f247ac4";
+        url = "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz";
+        sha1 = "6b26e9bd3afcaa7be3b4269b526de1b82000ac78";
       };
     };
-    "forever-agent-0.5.2" = {
-      name = "forever-agent";
-      packageName = "forever-agent";
-      version = "0.5.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz";
-        sha1 = "6d0e09c4921f94a27f63d3b49c5feff1ea4c5130";
-      };
-    };
-    "form-data-0.1.4" = {
+    "form-data-2.1.4" = {
       name = "form-data";
       packageName = "form-data";
-      version = "0.1.4";
+      version = "2.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz";
-        sha1 = "91abd788aba9702b1aabfa8bc01031a2ac9e3b12";
+        url = "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz";
+        sha1 = "33c183acf193276ecaa98143a69e94bfee1750d1";
       };
     };
-    "mime-types-1.0.2" = {
-      name = "mime-types";
-      packageName = "mime-types";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz";
-        sha1 = "995ae1392ab8affcbfcb2641dd054e943c0d5dce";
-      };
-    };
-    "qs-2.3.3" = {
+    "qs-6.3.2" = {
       name = "qs";
       packageName = "qs";
-      version = "2.3.3";
+      version = "6.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz";
-        sha1 = "e9e85adbe75da0bbe4c8e0476a086290f863b404";
+        url = "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz";
+        sha1 = "e75bd5f6e268122a2a0e0bda630b2550c166502c";
       };
     };
-    "http-signature-0.10.1" = {
-      name = "http-signature";
-      packageName = "http-signature";
-      version = "0.10.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz";
-        sha1 = "4fbdac132559aa8323121e540779c0a012b27e66";
-      };
-    };
-    "oauth-sign-0.4.0" = {
-      name = "oauth-sign";
-      packageName = "oauth-sign";
+    "asynckit-0.4.0" = {
+      name = "asynckit";
+      packageName = "asynckit";
       version = "0.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz";
-        sha1 = "f22956f31ea7151a821e5f2fb32c113cad8b9f69";
-      };
-    };
-    "hawk-1.1.1" = {
-      name = "hawk";
-      packageName = "hawk";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz";
-        sha1 = "87cd491f9b46e4e2aeaca335416766885d2d1ed9";
-      };
-    };
-    "aws-sign2-0.5.0" = {
-      name = "aws-sign2";
-      packageName = "aws-sign2";
-      version = "0.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz";
-        sha1 = "c57103f7a17fc037f02d7c2e64b602ea223f7d63";
-      };
-    };
-    "async-0.9.2" = {
-      name = "async";
-      packageName = "async";
-      version = "0.9.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/async/-/async-0.9.2.tgz";
-        sha1 = "aea74d5e61c1f899613bf64bda66d4c78f2fd17d";
-      };
-    };
-    "assert-plus-0.1.5" = {
-      name = "assert-plus";
-      packageName = "assert-plus";
-      version = "0.1.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz";
-        sha1 = "ee74009413002d84cec7219c6ac811812e723160";
-      };
-    };
-    "ctype-0.5.3" = {
-      name = "ctype";
-      packageName = "ctype";
-      version = "0.5.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz";
-        sha1 = "82c18c2461f74114ef16c135224ad0b9144ca12f";
-      };
-    };
-    "hoek-0.9.1" = {
-      name = "hoek";
-      packageName = "hoek";
-      version = "0.9.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz";
-        sha1 = "3d322462badf07716ea7eb85baf88079cddce505";
-      };
-    };
-    "boom-0.4.2" = {
-      name = "boom";
-      packageName = "boom";
-      version = "0.4.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz";
-        sha1 = "7a636e9ded4efcefb19cef4947a3c67dfaee911b";
-      };
-    };
-    "cryptiles-0.2.2" = {
-      name = "cryptiles";
-      packageName = "cryptiles";
-      version = "0.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz";
-        sha1 = "ed91ff1f17ad13d3748288594f8a48a0d26f325c";
-      };
-    };
-    "sntp-0.2.4" = {
-      name = "sntp";
-      packageName = "sntp";
-      version = "0.2.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz";
-        sha1 = "fb885f18b0f3aad189f824862536bceeec750900";
+        url = "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz";
+        sha1 = "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79";
       };
     };
     "pegjs-0.10.0" = {
@@ -7517,33 +7463,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/request/-/request-2.81.0.tgz";
         sha1 = "c6928946a0e06c5f8d6f8a9333469ffda46298a0";
-      };
-    };
-    "uuid-2.0.3" = {
-      name = "uuid";
-      packageName = "uuid";
-      version = "2.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz";
-        sha1 = "67e2e863797215530dff318e5bf9dcebfd47b21a";
-      };
-    };
-    "write-file-atomic-1.3.1" = {
-      name = "write-file-atomic";
-      packageName = "write-file-atomic";
-      version = "1.3.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz";
-        sha1 = "7d45ba32316328dd1ec7d90f60ebc0d845bb759a";
-      };
-    };
-    "xdg-basedir-2.0.0" = {
-      name = "xdg-basedir";
-      packageName = "xdg-basedir";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz";
-        sha1 = "edbc903cc385fc04523d966a335504b5504d1bd2";
       };
     };
     "ansi-escapes-1.4.0" = {
@@ -7681,15 +7600,6 @@ let
         sha1 = "1b681c21ff84033c826543090689420d187151dc";
       };
     };
-    "form-data-2.1.4" = {
-      name = "form-data";
-      packageName = "form-data";
-      version = "2.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz";
-        sha1 = "33c183acf193276ecaa98143a69e94bfee1750d1";
-      };
-    };
     "har-validator-4.2.1" = {
       name = "har-validator";
       packageName = "har-validator";
@@ -7717,22 +7627,13 @@ let
         sha1 = "27a5dea06b36b04a0a9966774b290868f0fc40fd";
       };
     };
-    "asynckit-0.4.0" = {
-      name = "asynckit";
-      packageName = "asynckit";
-      version = "0.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz";
-        sha1 = "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79";
-      };
-    };
-    "ajv-4.11.6" = {
+    "ajv-4.11.8" = {
       name = "ajv";
       packageName = "ajv";
-      version = "4.11.6";
+      version = "4.11.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ajv/-/ajv-4.11.6.tgz";
-        sha1 = "947e93049790942b2a2d60a8289b28924d39f987";
+        url = "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz";
+        sha1 = "82ffb02b29e662ae53bdc20af15947706739c536";
       };
     };
     "har-schema-1.0.5" = {
@@ -8150,6 +8051,15 @@ let
         sha1 = "0d40a82f801fc355567d2ecb65efe3f077f121c5";
       };
     };
+    "qs-2.3.3" = {
+      name = "qs";
+      packageName = "qs";
+      version = "2.3.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz";
+        sha1 = "e9e85adbe75da0bbe4c8e0476a086290f863b404";
+      };
+    };
     "range-parser-1.0.3" = {
       name = "range-parser";
       packageName = "range-parser";
@@ -8441,13 +8351,13 @@ let
         sha1 = "78a9a7f4343ae7d820a8999acc80de591e25a779";
       };
     };
-    "verror-1.9.0" = {
+    "verror-1.10.0" = {
       name = "verror";
       packageName = "verror";
-      version = "1.9.0";
+      version = "1.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/verror/-/verror-1.9.0.tgz";
-        sha1 = "107a8a2d14c33586fc4bb830057cd2d19ae2a6ee";
+        url = "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz";
+        sha1 = "3a105ca17053af55d6e270c1f8288682e18da400";
       };
     };
     "extsprintf-1.3.0" = {
@@ -8457,6 +8367,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz";
         sha1 = "96918440e3041a7a414f8c52e3c574eb3c3e1e05";
+      };
+    };
+    "async-0.9.2" = {
+      name = "async";
+      packageName = "async";
+      version = "0.9.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async/-/async-0.9.2.tgz";
+        sha1 = "aea74d5e61c1f899613bf64bda66d4c78f2fd17d";
       };
     };
     "qs-1.2.0" = {
@@ -8729,13 +8648,13 @@ let
         sha1 = "4d4e55f171356121b2c5f6559f944705ab28db15";
       };
     };
-    "tar-stream-1.5.2" = {
+    "tar-stream-1.5.4" = {
       name = "tar-stream";
       packageName = "tar-stream";
-      version = "1.5.2";
+      version = "1.5.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz";
-        sha1 = "fbc6c6e83c1a19d4cb48c7d96171fc248effc7bf";
+        url = "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz";
+        sha1 = "36549cf04ed1aee9b2a30c0143252238daf94016";
       };
     };
     "through2-0.6.5" = {
@@ -8810,13 +8729,13 @@ let
         sha1 = "9500635e257945d6feede185f5d7a24773455b17";
       };
     };
-    "pull-stream-3.5.0" = {
+    "pull-stream-3.6.0" = {
       name = "pull-stream";
       packageName = "pull-stream";
-      version = "3.5.0";
+      version = "3.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.5.0.tgz";
-        sha1 = "1ee5b6f76fd3b3a49a5afb6ded5c0320acb3cfc7";
+        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.0.tgz";
+        sha1 = "59d033a6815d4e3097d47c3d2b1893a9e58a2351";
       };
     };
     "typewiselite-1.0.0" = {
@@ -8936,13 +8855,13 @@ let
         sha1 = "a4ecee01e330155e9124bbbcf4761f21b38f51f5";
       };
     };
-    "pull-pushable-2.0.1" = {
+    "pull-pushable-2.1.0" = {
       name = "pull-pushable";
       packageName = "pull-pushable";
-      version = "2.0.1";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.0.1.tgz";
-        sha1 = "02bdca51a39cf585f483fbecde2fc9378076f212";
+        url = "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.1.0.tgz";
+        sha1 = "aa6c37cde7d54347c49762b4c8b467e814e52fbc";
       };
     };
     "pull-window-2.1.4" = {
@@ -9035,22 +8954,58 @@ let
         sha1 = "80ab4e919749351263ef14500d684e57c4202840";
       };
     };
-    "bl-1.2.0" = {
+    "bl-1.2.1" = {
       name = "bl";
       packageName = "bl";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz";
-        sha1 = "1397e7ec42c5f5dc387470c500e34a9f6be9ea98";
+        url = "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz";
+        sha1 = "cac328f7bee45730d404b692203fcb590e172d5e";
       };
     };
-    "awscred-1.2.0" = {
-      name = "awscred";
-      packageName = "awscred";
-      version = "1.2.0";
+    "aws-sdk-2.50.0" = {
+      name = "aws-sdk";
+      packageName = "aws-sdk";
+      version = "2.50.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/awscred/-/awscred-1.2.0.tgz";
-        sha1 = "9ba714a0d2feb625b848f15c62746c07aebdc3b5";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.50.0.tgz";
+        sha1 = "6b2855741f8efe064f824a3db0bf4f3bc5bde018";
+      };
+    };
+    "crypto-browserify-1.0.9" = {
+      name = "crypto-browserify";
+      packageName = "crypto-browserify";
+      version = "1.0.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz";
+        sha1 = "cc5449685dfb85eb11c9828acc7cb87ab5bbfcc0";
+      };
+    };
+    "jmespath-0.15.0" = {
+      name = "jmespath";
+      packageName = "jmespath";
+      version = "0.15.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz";
+        sha1 = "a3f222a9aae9f966f5d27c796510e28091764217";
+      };
+    };
+    "sax-1.2.1" = {
+      name = "sax";
+      packageName = "sax";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz";
+        sha1 = "7b8e656190b228e81a66aea748480d828cd2d37a";
+      };
+    };
+    "url-0.10.3" = {
+      name = "url";
+      packageName = "url";
+      version = "0.10.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/url/-/url-0.10.3.tgz";
+        sha1 = "021e4d9c7705f21bbf37d03ceb58767402774c64";
       };
     };
     "clipboardy-0.1.2" = {
@@ -9060,6 +9015,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/clipboardy/-/clipboardy-0.1.2.tgz";
         sha1 = "b82fffcf2828624afc1ec26530a66d6d1781a9cc";
+      };
+    };
+    "conf-1.1.1" = {
+      name = "conf";
+      packageName = "conf";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/conf/-/conf-1.1.1.tgz";
+        sha1 = "238d0a3090ac4916ed2d40c7e81d7a11667bc7ba";
       };
     };
     "got-6.7.1" = {
@@ -9096,6 +9060,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz";
         sha1 = "5edd52b485ca1d900fe64895505399a0dfa45f76";
+      };
+    };
+    "skin-tone-1.0.0" = {
+      name = "skin-tone";
+      packageName = "skin-tone";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/skin-tone/-/skin-tone-1.0.0.tgz";
+        sha1 = "d4ba3e8e5e92760e4d1d3b603d772805c6cb256f";
       };
     };
     "execa-0.5.1" = {
@@ -9159,6 +9132,87 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz";
         sha1 = "411cadb574c5a140d3a4b1910d40d80cc9f40b40";
+      };
+    };
+    "dot-prop-4.1.1" = {
+      name = "dot-prop";
+      packageName = "dot-prop";
+      version = "4.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz";
+        sha1 = "a8493f0b7b5eeec82525b5c7587fa7de7ca859c1";
+      };
+    };
+    "env-paths-1.0.0" = {
+      name = "env-paths";
+      packageName = "env-paths";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz";
+        sha1 = "4168133b42bb05c38a35b1ae4397c8298ab369e0";
+      };
+    };
+    "make-dir-1.0.0" = {
+      name = "make-dir";
+      packageName = "make-dir";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz";
+        sha1 = "97a011751e91dd87cfadef58832ebb04936de978";
+      };
+    };
+    "pkg-up-2.0.0" = {
+      name = "pkg-up";
+      packageName = "pkg-up";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz";
+        sha1 = "c819ac728059a461cab1c3889a2be3c49a004d7f";
+      };
+    };
+    "find-up-2.1.0" = {
+      name = "find-up";
+      packageName = "find-up";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz";
+        sha1 = "45d1b7e506c717ddd482775a2b77920a3c0c57a7";
+      };
+    };
+    "locate-path-2.0.0" = {
+      name = "locate-path";
+      packageName = "locate-path";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz";
+        sha1 = "2b568b265eec944c6d9c0de9c3dbbbca0354cd8e";
+      };
+    };
+    "p-locate-2.0.0" = {
+      name = "p-locate";
+      packageName = "p-locate";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz";
+        sha1 = "20a0103b222a70c8fd39cc2e580680f3dde5ec43";
+      };
+    };
+    "path-exists-3.0.0" = {
+      name = "path-exists";
+      packageName = "path-exists";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz";
+        sha1 = "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515";
+      };
+    };
+    "p-limit-1.1.0" = {
+      name = "p-limit";
+      packageName = "p-limit";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz";
+        sha1 = "b07ff2d9a5d88bec806035895a2bab66a27988bc";
       };
     };
     "create-error-class-3.0.2" = {
@@ -9233,6 +9287,15 @@ let
         sha1 = "e667783d92e89dbd342818b5230b9d62a672ad18";
       };
     };
+    "unicode-emoji-modifier-base-1.0.0" = {
+      name = "unicode-emoji-modifier-base";
+      packageName = "unicode-emoji-modifier-base";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz";
+        sha1 = "dbbd5b54ba30f287e2a8d5a249da6c0cef369459";
+      };
+    };
     "babel-code-frame-6.22.0" = {
       name = "babel-code-frame";
       packageName = "babel-code-frame";
@@ -9260,13 +9323,13 @@ let
         sha1 = "e01975e812781a163a6dadfdd80398dc64c889c3";
       };
     };
-    "espree-3.4.1" = {
+    "espree-3.4.3" = {
       name = "espree";
       packageName = "espree";
-      version = "3.4.1";
+      version = "3.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/espree/-/espree-3.4.1.tgz";
-        sha1 = "28a83ab4aaed71ed8fe0f5efe61b76a05c13c4d2";
+        url = "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz";
+        sha1 = "2910b5ccd49ce893c2ffffaab4fd8b3a31b82374";
       };
     };
     "esquery-1.0.0" = {
@@ -9314,13 +9377,13 @@ let
         sha1 = "0c0ca696d9b9bb694d2e5470bd37777caad50286";
       };
     };
-    "ignore-3.2.7" = {
+    "ignore-3.3.0" = {
       name = "ignore";
       packageName = "ignore";
-      version = "3.2.7";
+      version = "3.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz";
-        sha1 = "4810ca5f1d8eca5595213a34b94f2eb4ed926bbd";
+        url = "https://registry.npmjs.org/ignore/-/ignore-3.3.0.tgz";
+        sha1 = "3812d22cbe9125f2c2b4915755a1b8abd745a001";
       };
     };
     "inquirer-0.12.0" = {
@@ -9341,13 +9404,13 @@ let
         sha1 = "8df57c61ea2e3c501408d100fb013cf8d6e0cc62";
       };
     };
-    "js-yaml-3.8.3" = {
+    "js-yaml-3.8.4" = {
       name = "js-yaml";
       packageName = "js-yaml";
-      version = "3.8.3";
+      version = "3.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz";
-        sha1 = "33a05ec481c850c8875929166fe1beb61c728766";
+        url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz";
+        sha1 = "520b4564f86573ba96662af85a8cafa7b4b5a6f6";
       };
     };
     "levn-0.3.0" = {
@@ -9458,13 +9521,13 @@ let
         sha1 = "754bb5bfe55451da69a58b94d45f4c5b0462d58f";
       };
     };
-    "es5-ext-0.10.15" = {
+    "es5-ext-0.10.16" = {
       name = "es5-ext";
       packageName = "es5-ext";
-      version = "0.10.15";
+      version = "0.10.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz";
-        sha1 = "c330a5934c1ee21284a7c081a86e5fd937c91ea6";
+        url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.16.tgz";
+        sha1 = "1ef1b04f3d09db6a5d630226d62202f2e425e45a";
       };
     };
     "es6-iterator-2.0.1" = {
@@ -9510,15 +9573,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz";
         sha1 = "f6caca728933a850ef90661d0e17982ba47111a2";
-      };
-    };
-    "acorn-5.0.3" = {
-      name = "acorn";
-      packageName = "acorn";
-      version = "5.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz";
-        sha1 = "c460df08491463f028ccb82eab3730bf01087b3d";
       };
     };
     "acorn-jsx-3.0.1" = {
@@ -9935,13 +9989,13 @@ let
         sha1 = "8f61b75cde012b2e9eb284d4545583b5643b61ab";
       };
     };
-    "chokidar-1.6.1" = {
+    "chokidar-1.7.0" = {
       name = "chokidar";
       packageName = "chokidar";
-      version = "1.6.1";
+      version = "1.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz";
-        sha1 = "2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2";
+        url = "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz";
+        sha1 = "798e689778151c8076b4b360e5edd28cda2bb468";
       };
     };
     "ps-tree-0.0.3" = {
@@ -10061,13 +10115,13 @@ let
         sha1 = "2e18ff3d2f49ab2765cec9023f011daa8d8349a1";
       };
     };
-    "filename-regex-2.0.0" = {
+    "filename-regex-2.0.1" = {
       name = "filename-regex";
       packageName = "filename-regex";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz";
-        sha1 = "996e3e80479b98b9897f15a8a58b3d084e926775";
+        url = "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz";
+        sha1 = "c1c4b9bee3e09725ddb106b75c1e301fe2f18b26";
       };
     };
     "is-extglob-1.0.0" = {
@@ -10115,13 +10169,13 @@ let
         sha1 = "9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145";
       };
     };
-    "arr-flatten-1.0.2" = {
+    "arr-flatten-1.0.3" = {
       name = "arr-flatten";
       packageName = "arr-flatten";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.2.tgz";
-        sha1 = "1ec1e63439c54f67d6f72bb4299c3d4f73b2d996";
+        url = "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz";
+        sha1 = "a274ed85ac08849b6bd7847c4580745dc51adfb1";
       };
     };
     "expand-range-1.8.2" = {
@@ -10295,22 +10349,13 @@ let
         sha1 = "94ad1c798a11d7fc67381b50d47f8cc18d9799f7";
       };
     };
-    "nopt-4.0.1" = {
-      name = "nopt";
-      packageName = "nopt";
-      version = "4.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz";
-        sha1 = "d0d4685afd5415193c8c7505602d0d17cd64474d";
-      };
-    };
-    "npmlog-4.0.2" = {
+    "npmlog-4.1.0" = {
       name = "npmlog";
       packageName = "npmlog";
-      version = "4.0.2";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz";
-        sha1 = "d03950e0e78ce1527ba26d2a7592e9348ac3e75f";
+        url = "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz";
+        sha1 = "dc59bee85f64f00ed424efb2af0783df25d1c0b5";
       };
     };
     "tar-pack-3.4.0" = {
@@ -10331,13 +10376,13 @@ let
         sha1 = "3d7cf4464db6446ea644bf4b39507f9851008e8e";
       };
     };
-    "gauge-2.7.3" = {
+    "gauge-2.7.4" = {
       name = "gauge";
       packageName = "gauge";
-      version = "2.7.3";
+      version = "2.7.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz";
-        sha1 = "1c23855f962f17b3ad3d0dc7443f304542edfe09";
+        url = "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz";
+        sha1 = "2c03405c7538c39d7eb37b317022e325fb018bf7";
       };
     };
     "set-blocking-2.0.0" = {
@@ -10358,13 +10403,13 @@ let
         sha1 = "95d3600f07710aa0e9298c726ad5ecf2eacbabab";
       };
     };
-    "wide-align-1.1.0" = {
+    "wide-align-1.1.2" = {
       name = "wide-align";
       packageName = "wide-align";
-      version = "1.1.0";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz";
-        sha1 = "40edde802a71fea1f070da3e62dcda2e7add96ad";
+        url = "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz";
+        sha1 = "571e0f1b0604636ebc0dfc21b0339bbe31341710";
       };
     };
     "event-stream-0.5.3" = {
@@ -10466,13 +10511,13 @@ let
         sha1 = "21ffdc429be2b50cb361df990a40a7731288e935";
       };
     };
-    "simple-git-1.70.0" = {
+    "simple-git-1.72.0" = {
       name = "simple-git";
       packageName = "simple-git";
-      version = "1.70.0";
+      version = "1.72.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-git/-/simple-git-1.70.0.tgz";
-        sha1 = "62cfd90bb2628a13ff4fe704c840fcef56244a71";
+        url = "https://registry.npmjs.org/simple-git/-/simple-git-1.72.0.tgz";
+        sha1 = "e462ce8b46d4523f679e340000681582e9e965d2";
       };
     };
     "tabtab-git+https://github.com/mixu/node-tabtab.git" = {
@@ -10557,13 +10602,13 @@ let
         sha1 = "c0dde4ab182713b919b970959a123ecc1a30fcd6";
       };
     };
-    "clean-css-3.4.25" = {
+    "clean-css-3.4.26" = {
       name = "clean-css";
       packageName = "clean-css";
-      version = "3.4.25";
+      version = "3.4.26";
       src = fetchurl {
-        url = "https://registry.npmjs.org/clean-css/-/clean-css-3.4.25.tgz";
-        sha1 = "9e9a52d5c1e6bc5123e1b2783fa65fe958946ede";
+        url = "https://registry.npmjs.org/clean-css/-/clean-css-3.4.26.tgz";
+        sha1 = "55323b344ff3bcee684a2eac81c93df8fa73deeb";
       };
     };
     "commander-2.6.0" = {
@@ -10602,13 +10647,13 @@ let
         sha1 = "5d23cb35561dd85dc67fb8482309b47d53cce9a7";
       };
     };
-    "uglify-js-2.8.22" = {
+    "uglify-js-2.8.24" = {
       name = "uglify-js";
       packageName = "uglify-js";
-      version = "2.8.22";
+      version = "2.8.24";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz";
-        sha1 = "d54934778a8da14903fa29a326fb24c0ab51a1a0";
+        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.24.tgz";
+        sha1 = "48eb5175cf32e22ec11a47e638d7c8b4e0faf2dd";
       };
     };
     "void-elements-2.0.1" = {
@@ -10746,6 +10791,15 @@ let
         sha1 = "c90941ad59e4273328923074d2cf2e7cbc6ec0d9";
       };
     };
+    "acorn-1.2.2" = {
+      name = "acorn";
+      packageName = "acorn";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz";
+        sha1 = "c8ce27de0acc76d896d2b1fad3df588d9e82f014";
+      };
+    };
     "acorn-globals-1.0.9" = {
       name = "acorn-globals";
       packageName = "acorn-globals";
@@ -10818,6 +10872,15 @@ let
         sha1 = "b7e3ea42435a4c9b2759d99e0f201eb195802ee1";
       };
     };
+    "semver-4.3.6" = {
+      name = "semver";
+      packageName = "semver";
+      version = "4.3.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz";
+        sha1 = "300bc6e0e86374f7ba61068b5b1ecd57fc6532da";
+      };
+    };
     "tildify-1.2.0" = {
       name = "tildify";
       packageName = "tildify";
@@ -10827,13 +10890,13 @@ let
         sha1 = "dcec03f55dca9b7aa3e5b04f21817eb56e63588a";
       };
     };
-    "v8flags-2.0.12" = {
+    "v8flags-2.1.1" = {
       name = "v8flags";
       packageName = "v8flags";
-      version = "2.0.12";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/v8flags/-/v8flags-2.0.12.tgz";
-        sha1 = "73235d9f7176f8e8833fb286795445f7938d84e5";
+        url = "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz";
+        sha1 = "aab1a1fa30d45f88dd321148875ac02c0b55e5b4";
       };
     };
     "vinyl-fs-0.3.14" = {
@@ -11691,13 +11754,13 @@ let
         sha1 = "96e3b70d5779f6ad49cd032673d1c312767ba581";
       };
     };
-    "handlebars-4.0.6" = {
+    "handlebars-4.0.8" = {
       name = "handlebars";
       packageName = "handlebars";
-      version = "4.0.6";
+      version = "4.0.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz";
-        sha1 = "2ce4484850537f9c97a8026d5399b935c4ed4ed7";
+        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.0.8.tgz";
+        sha1 = "22b875cd3f0e6cbea30314f144e82bc7a72ff420";
       };
     };
     "supports-color-3.2.3" = {
@@ -11781,13 +11844,13 @@ let
         sha1 = "458c07e09e0d900fc28b70a3fec2dacd1d2cb7f6";
       };
     };
-    "connect-3.6.0" = {
+    "connect-3.6.1" = {
       name = "connect";
       packageName = "connect";
-      version = "3.6.0";
+      version = "3.6.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/connect/-/connect-3.6.0.tgz";
-        sha1 = "f09a4f7dcd17324b663b725c815bdb1c4158a46e";
+        url = "https://registry.npmjs.org/connect/-/connect-3.6.1.tgz";
+        sha1 = "b7760693a74f0454face1d9378edb3f885b43227";
       };
     };
     "core-js-2.4.1" = {
@@ -11916,13 +11979,22 @@ let
         sha1 = "994976cf6a5096a41162840492f0bdc5d6e7fb96";
       };
     };
-    "finalhandler-1.0.0" = {
+    "debug-2.6.3" = {
+      name = "debug";
+      packageName = "debug";
+      version = "2.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz";
+        sha1 = "0f7eb8c30965ec08c72accfa0130c8b79984141d";
+      };
+    };
+    "finalhandler-1.0.1" = {
       name = "finalhandler";
       packageName = "finalhandler";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.0.tgz";
-        sha1 = "b5691c2c0912092f18ac23e9416bde5cd7dc6755";
+        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.1.tgz";
+        sha1 = "bcd15d1689c0e5ed729b6f7f541a6df984117db8";
       };
     };
     "custom-event-1.0.1" = {
@@ -13104,22 +13176,22 @@ let
         sha1 = "f351d32969d32fa5d7a5567154263d928ae3bd1f";
       };
     };
-    "diff-1.4.0" = {
-      name = "diff";
-      packageName = "diff";
-      version = "1.4.0";
+    "debug-2.6.0" = {
+      name = "debug";
+      packageName = "debug";
+      version = "2.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz";
-        sha1 = "7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf";
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz";
+        sha1 = "bc596bcabe7617f11d9fa15361eded5608b8499b";
       };
     };
-    "glob-7.0.5" = {
-      name = "glob";
-      packageName = "glob";
-      version = "7.0.5";
+    "diff-3.2.0" = {
+      name = "diff";
+      packageName = "diff";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz";
-        sha1 = "b4202a69099bbb4d292a7c1b95b6682b67ebdc95";
+        url = "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz";
+        sha1 = "c9ce393a4b7cbd0b058a725c93df299027868ff9";
       };
     };
     "growl-1.9.2" = {
@@ -14058,6 +14130,24 @@ let
         sha1 = "9929acdf628fc2c41098deab82ac580cf149aae4";
       };
     };
+    "domhandler-2.4.1" = {
+      name = "domhandler";
+      packageName = "domhandler";
+      version = "2.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz";
+        sha1 = "892e47000a99be55bbf3774ffea0561d8879c259";
+      };
+    };
+    "domutils-1.6.2" = {
+      name = "domutils";
+      packageName = "domutils";
+      version = "1.6.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz";
+        sha1 = "1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff";
+      };
+    };
     "moment-timezone-0.5.13" = {
       name = "moment-timezone";
       packageName = "moment-timezone";
@@ -14238,13 +14328,13 @@ let
         sha1 = "6910bca5da8c95e784b5751b976cf5a10fee36d2";
       };
     };
-    "ordered-read-streams-1.0.0" = {
+    "ordered-read-streams-1.0.1" = {
       name = "ordered-read-streams";
       packageName = "ordered-read-streams";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.0.tgz";
-        sha1 = "d674a86ffcedf83d0ae06afa2918855e96d4033a";
+        url = "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz";
+        sha1 = "77c0cb37c41525d64166d990ffad7ec6a0e1363e";
       };
     };
     "to-absolute-glob-2.0.1" = {
@@ -14371,6 +14461,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-1.1.0.tgz";
         sha1 = "e6c37f31885ab3080e7ded3cf528c4ad7e691398";
+      };
+    };
+    "iconv-lite-0.4.17" = {
+      name = "iconv-lite";
+      packageName = "iconv-lite";
+      version = "0.4.17";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz";
+        sha1 = "4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d";
       };
     };
     "libbase64-0.1.0" = {
@@ -15111,6 +15210,15 @@ let
         sha1 = "9f557e08fc3b4d26ece9dd34f8fbf476b62585ad";
       };
     };
+    "underscore-1.7.0" = {
+      name = "underscore";
+      packageName = "underscore";
+      version = "1.7.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz";
+        sha1 = "6bbaf0877500d36be34ecaa584e0db9fef035209";
+      };
+    };
     "underscore.string-2.4.0" = {
       name = "underscore.string";
       packageName = "underscore.string";
@@ -15129,13 +15237,13 @@ let
         sha1 = "6fd61b03f3da42a2cd0ec2b60f02bd0e71991fea";
       };
     };
-    "fstream-npm-1.2.0" = {
+    "fstream-npm-1.2.1" = {
       name = "fstream-npm";
       packageName = "fstream-npm";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz";
-        sha1 = "d2c3c89101346982d64e57091c38487bda916fce";
+        url = "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz";
+        sha1 = "08c4a452f789dcbac4c89a4563c902b2c862fd5b";
       };
     };
     "lazy-property-1.0.0" = {
@@ -15226,6 +15334,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.1.1.tgz";
         sha1 = "831476455423ca0a265c6ffdb6100fcc042b36cf";
+      };
+    };
+    "npmlog-4.0.2" = {
+      name = "npmlog";
+      packageName = "npmlog";
+      version = "4.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz";
+        sha1 = "d03950e0e78ce1527ba26d2a7592e9348ac3e75f";
       };
     };
     "opener-1.4.3" = {
@@ -15399,22 +15516,22 @@ let
         sha1 = "db6676e7c7cc0629878ff196097c78855ae9f4ab";
       };
     };
-    "boxen-1.0.0" = {
+    "boxen-1.1.0" = {
       name = "boxen";
       packageName = "boxen";
-      version = "1.0.0";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/boxen/-/boxen-1.0.0.tgz";
-        sha1 = "b2694baf1f605f708ff0177c12193b22f29aaaab";
+        url = "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz";
+        sha1 = "b1b69dd522305e807a99deee777dbd6e5167b102";
       };
     };
-    "configstore-3.0.0" = {
+    "configstore-3.1.0" = {
       name = "configstore";
       packageName = "configstore";
-      version = "3.0.0";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/configstore/-/configstore-3.0.0.tgz";
-        sha1 = "e1b8669c1803ccc50b545e92f8e6e79aa80e0196";
+        url = "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz";
+        sha1 = "45df907073e26dfa1cf4b2d52f5b60545eaa11d1";
       };
     };
     "latest-version-3.1.0" = {
@@ -15444,13 +15561,13 @@ let
         sha1 = "496b2cc109eca8dbacfe2dc72b603c17c5870ad4";
       };
     };
-    "ansi-align-1.1.0" = {
+    "ansi-align-2.0.0" = {
       name = "ansi-align";
       packageName = "ansi-align";
-      version = "1.1.0";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz";
-        sha1 = "2f0c1658829739add5ebb15e6b0c6e3423f016ba";
+        url = "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz";
+        sha1 = "c36aeccba563b89ceb556f3690f0b1d9e3547f7f";
       };
     };
     "camelcase-4.1.0" = {
@@ -15525,15 +15642,6 @@ let
         sha1 = "5d53d578019646c0d68800db4e146e6bdc2ac7af";
       };
     };
-    "dot-prop-4.1.1" = {
-      name = "dot-prop";
-      packageName = "dot-prop";
-      version = "4.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz";
-        sha1 = "a8493f0b7b5eeec82525b5c7587fa7de7ca859c1";
-      };
-    };
     "unique-string-1.0.0" = {
       name = "unique-string";
       packageName = "unique-string";
@@ -15543,13 +15651,13 @@ let
         sha1 = "9e1057cca851abb93398f8b33ae187b99caec11a";
       };
     };
-    "is-obj-1.0.1" = {
-      name = "is-obj";
-      packageName = "is-obj";
-      version = "1.0.1";
+    "write-file-atomic-2.1.0" = {
+      name = "write-file-atomic";
+      packageName = "write-file-atomic";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz";
-        sha1 = "3e4729ac1f5fde025cd7d83a896dab9f4f67db0f";
+        url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz";
+        sha1 = "1769f4b551eedce419f0505deae2e26763542d37";
       };
     };
     "crypto-random-string-1.0.0" = {
@@ -15561,22 +15669,22 @@ let
         sha1 = "a230f64f568310e1498009940790ec99545bca7e";
       };
     };
-    "package-json-4.0.0" = {
+    "package-json-4.0.1" = {
       name = "package-json";
       packageName = "package-json";
-      version = "4.0.0";
+      version = "4.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/package-json/-/package-json-4.0.0.tgz";
-        sha1 = "f3c9dc8738f5b59304d54d2cfb3f91d08fdd7998";
+        url = "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz";
+        sha1 = "8869a0401253661c4c4ca3da6c2121ed555f5eed";
       };
     };
-    "registry-auth-token-3.1.2" = {
+    "registry-auth-token-3.3.1" = {
       name = "registry-auth-token";
       packageName = "registry-auth-token";
-      version = "3.1.2";
+      version = "3.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.2.tgz";
-        sha1 = "1b9e51a185c930da34a9894b12a52ea998f1adaf";
+        url = "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz";
+        sha1 = "fb0d3289ee0d9ada2cbb52af5dfe66cb070d3006";
       };
     };
     "argparse-0.1.15" = {
@@ -15831,13 +15939,13 @@ let
         sha1 = "27d92fec34d27cfa42707d3b40d025ae9855f2df";
       };
     };
-    "snyk-1.28.1" = {
+    "snyk-1.30.0" = {
       name = "snyk";
       packageName = "snyk";
-      version = "1.28.1";
+      version = "1.30.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk/-/snyk-1.28.1.tgz";
-        sha1 = "ae0faed0fcee7d5dbc0fa8a7a8c9ebacb03b6151";
+        url = "https://registry.npmjs.org/snyk/-/snyk-1.30.0.tgz";
+        sha1 = "a323809ea477d6aff0e325f5995cb491c0d7ca3d";
       };
     };
     "spawn-please-0.2.0" = {
@@ -16137,15 +16245,6 @@ let
         sha1 = "a7d898243ae622f7abb6bb604d740a76c6a5461b";
       };
     };
-    "configstore-2.1.0" = {
-      name = "configstore";
-      packageName = "configstore";
-      version = "2.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz";
-        sha1 = "737a3a7036e9886102aa6099e47bb33ab1aba1a1";
-      };
-    };
     "latest-version-2.0.0" = {
       name = "latest-version";
       packageName = "latest-version";
@@ -16162,15 +16261,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz";
         sha1 = "c3c4f6c663b923459a9aa29912d2d031f1507f84";
-      };
-    };
-    "dot-prop-3.0.0" = {
-      name = "dot-prop";
-      packageName = "dot-prop";
-      version = "3.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz";
-        sha1 = "1b708af094a49c9a0e7dbcad790aba539dac1177";
       };
     };
     "package-json-2.4.0" = {
@@ -16308,6 +16398,15 @@ let
         sha1 = "bdaebead30f8d824039ce0ce149d4daa07ba1fac";
       };
     };
+    "ansi-align-1.1.0" = {
+      name = "ansi-align";
+      packageName = "ansi-align";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz";
+        sha1 = "2f0c1658829739add5ebb15e6b0c6e3423f016ba";
+      };
+    };
     "babybird-0.0.1" = {
       name = "babybird";
       packageName = "babybird";
@@ -16334,6 +16433,15 @@ let
         url = "https://github.com/wikimedia/content-type.git";
         rev = "47b2632d0a2ee79a7d67268e2f6621becd95d05b";
         sha256 = "e583031138b98e2a09ce14dbd72afa0377201894092c941ef4cc07206c35ed04";
+      };
+    };
+    "diff-1.4.0" = {
+      name = "diff";
+      packageName = "diff";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz";
+        sha1 = "7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf";
       };
     };
     "domino-1.0.28" = {
@@ -16401,13 +16509,13 @@ let
         sha1 = "78717d9b718ce7cab55e20b9f24388d5fa51d5c0";
       };
     };
-    "service-runner-2.2.5" = {
+    "service-runner-2.3.0" = {
       name = "service-runner";
       packageName = "service-runner";
-      version = "2.2.5";
+      version = "2.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/service-runner/-/service-runner-2.2.5.tgz";
-        sha1 = "95a55084f939110b3f201549c1afedf900ec4850";
+        url = "https://registry.npmjs.org/service-runner/-/service-runner-2.3.0.tgz";
+        sha1 = "09039dfdcc40cdbd0259dd3f982916675838cb59";
       };
     };
     "simplediff-0.1.1" = {
@@ -16509,13 +16617,13 @@ let
         sha1 = "9cea9b6386ac301c741838ca3cb91e66dbfbf669";
       };
     };
-    "hot-shots-4.4.0" = {
+    "hot-shots-4.5.0" = {
       name = "hot-shots";
       packageName = "hot-shots";
-      version = "4.4.0";
+      version = "4.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hot-shots/-/hot-shots-4.4.0.tgz";
-        sha1 = "ab3f3b3df2f4b2ff0d716837569241ede81d9175";
+        url = "https://registry.npmjs.org/hot-shots/-/hot-shots-4.5.0.tgz";
+        sha1 = "d0b7c2ad367cbb2f8c062b26151c0949ad9271f9";
       };
     };
     "limitation-0.2.0" = {
@@ -16527,13 +16635,13 @@ let
         sha1 = "70ce102a972a0b79d4ca13a3ab62b8e6fe682a62";
       };
     };
-    "yargs-6.6.0" = {
+    "yargs-7.1.0" = {
       name = "yargs";
       packageName = "yargs";
-      version = "6.6.0";
+      version = "7.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz";
-        sha1 = "782ec21ef403345f830a808ca3d513af56065208";
+        url = "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz";
+        sha1 = "6ba318eb16961727f5d284f8ea003e8d6154d0c8";
       };
     };
     "dnscache-1.0.1" = {
@@ -16654,15 +16762,6 @@ let
         sha1 = "7531e39d4949c281a66b8c5a6e0265e8b05894da";
       };
     };
-    "ms-0.7.3" = {
-      name = "ms";
-      packageName = "ms";
-      version = "0.7.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz";
-        sha1 = "708155a5e44e33f5fd0fc53e81d0d40a91be1fff";
-      };
-    };
     "msgpack5-3.4.1" = {
       name = "msgpack5";
       packageName = "msgpack5";
@@ -16681,13 +16780,13 @@ let
         sha1 = "ed17cbf68abd10e0aef8182713e297c5e4b500b0";
       };
     };
-    "yargs-parser-4.2.1" = {
+    "yargs-parser-5.0.0" = {
       name = "yargs-parser";
       packageName = "yargs-parser";
-      version = "4.2.1";
+      version = "5.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz";
-        sha1 = "29cceac0dc4f03c6c87b4a9f217dd18c9f74871c";
+        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz";
+        sha1 = "275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a";
       };
     };
     "lodash.clone-4.3.2" = {
@@ -16969,6 +17068,15 @@ let
         sha1 = "af440e1ddad078934ec78241420b40bbc56dc2ad";
       };
     };
+    "socket.io-1.7.4" = {
+      name = "socket.io";
+      packageName = "socket.io";
+      version = "1.7.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz";
+        sha1 = "2f7ecedc3391bf2d5c73e291fe233e6e34d4dd00";
+      };
+    };
     "torrent-stream-0.18.1" = {
       name = "torrent-stream";
       packageName = "torrent-stream";
@@ -16978,13 +17086,13 @@ let
         sha1 = "e2e8ca44d81f16fbe5646e0ebb05f5418fea9bf6";
       };
     };
-    "fluent-ffmpeg-2.1.0" = {
+    "fluent-ffmpeg-2.1.2" = {
       name = "fluent-ffmpeg";
       packageName = "fluent-ffmpeg";
-      version = "2.1.0";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.0.tgz";
-        sha1 = "e6ab85e75ba8e49119a3900cd9df10d39831d392";
+        url = "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.2.tgz";
+        sha1 = "c952de2240f812ebda0aa8006d7776ee2acf7d74";
       };
     };
     "on-finished-2.1.1" = {
@@ -17338,6 +17446,33 @@ let
         sha1 = "0541ea91f0e503fdf0c5eed418a32550234967f0";
       };
     };
+    "engine.io-1.8.4" = {
+      name = "engine.io";
+      packageName = "engine.io";
+      version = "1.8.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/engine.io/-/engine.io-1.8.4.tgz";
+        sha1 = "77bce12b80e5d60429337fec3b0daf691ebc9003";
+      };
+    };
+    "socket.io-client-1.7.4" = {
+      name = "socket.io-client";
+      packageName = "socket.io-client";
+      version = "1.7.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz";
+        sha1 = "ec9f820356ed99ef6d357f0756d648717bdd4281";
+      };
+    };
+    "engine.io-client-1.8.4" = {
+      name = "engine.io-client";
+      packageName = "engine.io-client";
+      version = "1.8.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.4.tgz";
+        sha1 = "9fe85dee25853ca6babe25bd2ad68710863e91c2";
+      };
+    };
     "bittorrent-dht-3.2.6" = {
       name = "bittorrent-dht";
       packageName = "bittorrent-dht";
@@ -17608,13 +17743,13 @@ let
         sha1 = "2bdc5ae366041442c27e068cce6f0d7c06ea9949";
       };
     };
-    "flow-parser-0.43.0" = {
+    "flow-parser-0.45.0" = {
       name = "flow-parser";
       packageName = "flow-parser";
-      version = "0.43.0";
+      version = "0.45.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.43.0.tgz";
-        sha1 = "e2b8eb1ac83dd53f7b6b04a7c35b6a52c33479b7";
+        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.45.0.tgz";
+        sha1 = "aa29d4ae27f06aa02817772bba0fcbefef7e62f0";
       };
     };
     "jest-validate-19.0.0" = {
@@ -18203,6 +18338,15 @@ let
         sha1 = "e587c68580994ac67fc56ff86d3ac56bdbe810bc";
       };
     };
+    "assert-plus-0.1.5" = {
+      name = "assert-plus";
+      packageName = "assert-plus";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz";
+        sha1 = "ee74009413002d84cec7219c6ac811812e723160";
+      };
+    };
     "lru-cache-2.2.0" = {
       name = "lru-cache";
       packageName = "lru-cache";
@@ -18419,6 +18563,15 @@ let
         sha1 = "52cc3b3dfc197758c55ad325a95be85071f9e51b";
       };
     };
+    "ctype-0.5.3" = {
+      name = "ctype";
+      packageName = "ctype";
+      version = "0.5.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz";
+        sha1 = "82c18c2461f74114ef16c135224ad0b9144ca12f";
+      };
+    };
     "verror-1.6.0" = {
       name = "verror";
       packageName = "verror";
@@ -18554,6 +18707,33 @@ let
         sha1 = "321f6cf73782a6ff751111390fc05e2c657d8c9b";
       };
     };
+    "jszip-2.6.1" = {
+      name = "jszip";
+      packageName = "jszip";
+      version = "2.6.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz";
+        sha1 = "b88f3a7b2e67a2a048152982c7a3756d9c4828f0";
+      };
+    };
+    "progress-2.0.0" = {
+      name = "progress";
+      packageName = "progress";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz";
+        sha1 = "8a1be366bf8fc23db2bd23f10c6fe920b4389d1f";
+      };
+    };
+    "pako-1.0.5" = {
+      name = "pako";
+      packageName = "pako";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pako/-/pako-1.0.5.tgz";
+        sha1 = "d2205dfe5b9da8af797e7c163db4d1f84e4600bc";
+      };
+    };
     "coa-1.0.1" = {
       name = "coa";
       packageName = "coa";
@@ -18626,6 +18806,15 @@ let
         sha1 = "7bcc6b629e3a43e871d7e29aca6ae8a7f15cbb20";
       };
     };
+    "adm-zip-0.4.7" = {
+      name = "adm-zip";
+      packageName = "adm-zip";
+      version = "0.4.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz";
+        sha1 = "8606c2cbf1c426ce8c8ec00174447fd49b6eafc1";
+      };
+    };
     "async-2.1.2" = {
       name = "async";
       packageName = "async";
@@ -18680,15 +18869,6 @@ let
         sha1 = "f68cf5acb607c4903e2f63024383ae95ba1fdc52";
       };
     };
-    "request-2.79.0" = {
-      name = "request";
-      packageName = "request";
-      version = "2.79.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/request/-/request-2.79.0.tgz";
-        sha1 = "4dfe5bf6be8b8cdc37fcf93e04b65577722710de";
-      };
-    };
     "sprintf-0.1.5" = {
       name = "sprintf";
       packageName = "sprintf";
@@ -18734,15 +18914,6 @@ let
         sha1 = "c8b6c167797ba4740a8ea33252162ff08591b266";
       };
     };
-    "adm-zip-0.4.7" = {
-      name = "adm-zip";
-      packageName = "adm-zip";
-      version = "0.4.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz";
-        sha1 = "8606c2cbf1c426ce8c8ec00174447fd49b6eafc1";
-      };
-    };
     "async-2.1.4" = {
       name = "async";
       packageName = "async";
@@ -18750,15 +18921,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/async/-/async-2.1.4.tgz";
         sha1 = "2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4";
-      };
-    };
-    "diff-3.2.0" = {
-      name = "diff";
-      packageName = "diff";
-      version = "3.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz";
-        sha1 = "c9ce393a4b7cbd0b058a725c93df299027868ff9";
       };
     };
     "wrench-1.5.9" = {
@@ -18770,31 +18932,13 @@ let
         sha1 = "411691c63a9b2531b1700267279bdeca23b2142a";
       };
     };
-    "qs-6.3.2" = {
-      name = "qs";
-      packageName = "qs";
-      version = "6.3.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz";
-        sha1 = "e75bd5f6e268122a2a0e0bda630b2550c166502c";
-      };
-    };
-    "bluebird-3.4.7" = {
-      name = "bluebird";
-      packageName = "bluebird";
-      version = "3.4.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz";
-        sha1 = "f72d760be09b7f76d08ed8fae98b289a8d05fab3";
-      };
-    };
-    "blueimp-md5-2.6.0" = {
+    "blueimp-md5-2.7.0" = {
       name = "blueimp-md5";
       packageName = "blueimp-md5";
-      version = "2.6.0";
+      version = "2.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.6.0.tgz";
-        sha1 = "c96dd67f57db522da9a0c49b464ca44e20c04e0f";
+        url = "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.7.0.tgz";
+        sha1 = "7f518e0dd70467fefe28ecba398916092f2a02a9";
       };
     };
     "color-1.0.3" = {
@@ -18860,6 +19004,24 @@ let
         sha1 = "8b5341c3496124b0724ac8555fbb8ca363ebbb73";
       };
     };
+    "ignore-3.2.7" = {
+      name = "ignore";
+      packageName = "ignore";
+      version = "3.2.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz";
+        sha1 = "4810ca5f1d8eca5595213a34b94f2eb4ed926bbd";
+      };
+    };
+    "just-detect-adblock-1.0.0" = {
+      name = "just-detect-adblock";
+      packageName = "just-detect-adblock";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/just-detect-adblock/-/just-detect-adblock-1.0.0.tgz";
+        sha1 = "7bf8660cf15571fe7cf3b49c222e4716e1605a0c";
+      };
+    };
     "keen.io-0.1.3" = {
       name = "keen.io";
       packageName = "keen.io";
@@ -18887,13 +19049,22 @@ let
         sha1 = "08524645ee4039dedc3dcc1dd7c6b979e0619e44";
       };
     };
-    "npm-4.5.0" = {
+    "npm-4.6.1" = {
       name = "npm";
       packageName = "npm";
-      version = "4.5.0";
+      version = "4.6.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npm/-/npm-4.5.0.tgz";
-        sha1 = "dc6a31f28807e6db980ed5083315667dcc8d0475";
+        url = "https://registry.npmjs.org/npm/-/npm-4.6.1.tgz";
+        sha1 = "f8eb1ad00dc58a5514363b41ca5342817f0bd646";
+      };
+    };
+    "npm-registry-client-8.3.0" = {
+      name = "npm-registry-client";
+      packageName = "npm-registry-client";
+      version = "8.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.3.0.tgz";
+        sha1 = "a86d5b1f97945de8df73c471d33602d5cd15130f";
       };
     };
     "octicons-3.5.0" = {
@@ -18923,6 +19094,15 @@ let
         sha1 = "949c134db028a190b7bbf8f790aae541b7c020bd";
       };
     };
+    "serve-static-1.12.2" = {
+      name = "serve-static";
+      packageName = "serve-static";
+      version = "1.12.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz";
+        sha1 = "e546e2726081b81b4bcec8e90808ebcdd323afba";
+      };
+    };
     "signals-1.0.0" = {
       name = "signals";
       packageName = "signals";
@@ -18950,13 +19130,13 @@ let
         sha1 = "0b48420d978c01804cf0230b648861598225a119";
       };
     };
-    "yargs-7.1.0" = {
+    "yargs-8.0.1" = {
       name = "yargs";
       packageName = "yargs";
-      version = "7.1.0";
+      version = "8.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz";
-        sha1 = "6ba318eb16961727f5d284f8ea003e8d6154d0c8";
+        url = "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz";
+        sha1 = "420ef75e840c1457a80adcca9bc6fa3849de51aa";
       };
     };
     "color-string-1.5.2" = {
@@ -19139,6 +19319,15 @@ let
         sha1 = "1335c5e4f5e6d33bbb4b006ba8c86a00f556de08";
       };
     };
+    "ssri-4.1.2" = {
+      name = "ssri";
+      packageName = "ssri";
+      version = "4.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssri/-/ssri-4.1.2.tgz";
+        sha1 = "3d3c69b490d0b107772a9bf81881f38ae071f24b";
+      };
+    };
     "lsmod-1.0.0" = {
       name = "lsmod";
       packageName = "lsmod";
@@ -19157,22 +19346,85 @@ let
         sha1 = "6728fc0459c450d796a99c31837569bdf672d728";
       };
     };
-    "eve-0.5.3" = {
-      name = "eve";
-      packageName = "eve";
-      version = "0.5.3";
+    "send-0.15.2" = {
+      name = "send";
+      packageName = "send";
+      version = "0.15.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eve/-/eve-0.5.3.tgz";
-        sha1 = "6c2f6588f7d0b392044d245ba5af9d7cfe237f42";
+        url = "https://registry.npmjs.org/send/-/send-0.15.2.tgz";
+        sha1 = "f91fab4403bcf87e716f70ceb5db2f578bdc17d6";
       };
     };
-    "yargs-parser-5.0.0" = {
+    "eve-0.5.4" = {
+      name = "eve";
+      packageName = "eve";
+      version = "0.5.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/eve/-/eve-0.5.4.tgz";
+        sha1 = "67d080b9725291d7e389e34c26860dd97f1debaa";
+      };
+    };
+    "os-locale-2.0.0" = {
+      name = "os-locale";
+      packageName = "os-locale";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz";
+        sha1 = "15918ded510522b81ee7ae5a309d54f639fc39a4";
+      };
+    };
+    "read-pkg-up-2.0.0" = {
+      name = "read-pkg-up";
+      packageName = "read-pkg-up";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz";
+        sha1 = "6b72a8048984e0c41e79510fd5e9fa99b3b549be";
+      };
+    };
+    "which-module-2.0.0" = {
+      name = "which-module";
+      packageName = "which-module";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz";
+        sha1 = "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a";
+      };
+    };
+    "yargs-parser-7.0.0" = {
       name = "yargs-parser";
       packageName = "yargs-parser";
-      version = "5.0.0";
+      version = "7.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz";
-        sha1 = "275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a";
+        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz";
+        sha1 = "8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9";
+      };
+    };
+    "read-pkg-2.0.0" = {
+      name = "read-pkg";
+      packageName = "read-pkg";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz";
+        sha1 = "8ef1c0623c6a6db0dc6713c4bfac46332b2368f8";
+      };
+    };
+    "load-json-file-2.0.0" = {
+      name = "load-json-file";
+      packageName = "load-json-file";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz";
+        sha1 = "7947e42149af80d696cbf797bcaabcfe1fe29ca8";
+      };
+    };
+    "path-type-2.0.0" = {
+      name = "path-type";
+      packageName = "path-type";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz";
+        sha1 = "f012ccb8415b7096fc2daa1054c3d72389594c73";
       };
     };
     "kew-0.1.7" = {
@@ -19301,6 +19553,15 @@ let
         sha1 = "17c62bfaf13c707f9d02c479e0dcdde8380697fb";
       };
     };
+    "yargs-6.6.0" = {
+      name = "yargs";
+      packageName = "yargs";
+      version = "6.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz";
+        sha1 = "782ec21ef403345f830a808ca3d513af56065208";
+      };
+    };
     "big.js-3.1.3" = {
       name = "big.js";
       packageName = "big.js";
@@ -19346,13 +19607,22 @@ let
         sha1 = "290cbb232e306942d7d7ea9b83732ab7856f8285";
       };
     };
-    "source-list-map-1.1.1" = {
+    "source-list-map-1.1.2" = {
       name = "source-list-map";
       packageName = "source-list-map";
-      version = "1.1.1";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.1.tgz";
-        sha1 = "1a33ac210ca144d1e561f906ebccab5669ff4cb4";
+        url = "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz";
+        sha1 = "9889019d1024cce55cdc069498337ef6186a11a1";
+      };
+    };
+    "yargs-parser-4.2.1" = {
+      name = "yargs-parser";
+      packageName = "yargs-parser";
+      version = "4.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz";
+        sha1 = "29cceac0dc4f03c6c87b4a9f217dd18c9f74871c";
       };
     };
     "babel-runtime-6.23.0" = {
@@ -19389,6 +19659,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz";
         sha1 = "3871cc0a6a002e8c3e5b3cf7f336264675f06b9d";
+      };
+    };
+    "gunzip-maybe-1.4.0" = {
+      name = "gunzip-maybe";
+      packageName = "gunzip-maybe";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.0.tgz";
+        sha1 = "7d8316c8d0571e1d08a5a79e46fff0afe8172b19";
       };
     };
     "inquirer-3.0.6" = {
@@ -19436,13 +19715,13 @@ let
         sha1 = "370ae752fbf37de3ea70a861c23bba8915691949";
       };
     };
-    "proper-lockfile-2.0.0" = {
+    "proper-lockfile-2.0.1" = {
       name = "proper-lockfile";
       packageName = "proper-lockfile";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.0.tgz";
-        sha1 = "b21f5e79bcbb6b4e23eeeced15cfc7f63e8a2e55";
+        url = "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.1.tgz";
+        sha1 = "159fb06193d32003f4b3691dd2ec1a634aa80d1d";
       };
     };
     "request-capture-har-1.2.2" = {
@@ -19454,13 +19733,13 @@ let
         sha1 = "cd692cfb2cc744fd84a3358aac6ee51528cf720d";
       };
     };
-    "roadrunner-1.1.0" = {
-      name = "roadrunner";
-      packageName = "roadrunner";
-      version = "1.1.0";
+    "tar-fs-1.15.2" = {
+      name = "tar-fs";
+      packageName = "tar-fs";
+      version = "1.15.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/roadrunner/-/roadrunner-1.1.0.tgz";
-        sha1 = "1180a30d64e1970d8f55dd8cb0da8ffccecad71e";
+        url = "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.2.tgz";
+        sha1 = "761f5b32932c7b39461a60d537faea0d8084830c";
       };
     };
     "v8-compile-cache-1.1.0" = {
@@ -19472,13 +19751,40 @@ let
         sha1 = "1dc2a340fb8e5f800a32bcdbfb8c23cd747021b9";
       };
     };
-    "regenerator-runtime-0.10.3" = {
+    "regenerator-runtime-0.10.5" = {
       name = "regenerator-runtime";
       packageName = "regenerator-runtime";
-      version = "0.10.3";
+      version = "0.10.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz";
-        sha1 = "8c4367a904b51ea62a908ac310bf99ff90a82a3e";
+        url = "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz";
+        sha1 = "336c3efc1220adcedda2c9fab67b5a7955a33658";
+      };
+    };
+    "is-deflate-1.0.0" = {
+      name = "is-deflate";
+      packageName = "is-deflate";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz";
+        sha1 = "c862901c3c161fb09dac7cdc7e784f80e98f2f14";
+      };
+    };
+    "is-gzip-1.0.0" = {
+      name = "is-gzip";
+      packageName = "is-gzip";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz";
+        sha1 = "6ca8b07b99c77998025900e555ced8ed80879a83";
+      };
+    };
+    "peek-stream-1.1.2" = {
+      name = "peek-stream";
+      packageName = "peek-stream";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.2.tgz";
+        sha1 = "97eb76365bcfd8c89e287f55c8b69d4c3e9bcc52";
       };
     };
     "cli-cursor-2.1.0" = {
@@ -19542,15 +19848,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz";
         sha1 = "dc5285f2b4e251821683681c381c3388f46ec534";
-      };
-    };
-    "string.prototype.codepointat-0.2.0" = {
-      name = "string.prototype.codepointat";
-      packageName = "string.prototype.codepointat";
-      version = "0.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz";
-        sha1 = "6b26e9bd3afcaa7be3b4269b526de1b82000ac78";
       };
     };
     "cli-list-0.1.8" = {
@@ -20016,7 +20313,7 @@ in
                     dependencies = [
                       (sources."align-text-0.1.4" // {
                         dependencies = [
-                          (sources."kind-of-3.1.0" // {
+                          (sources."kind-of-3.2.0" // {
                             dependencies = [
                               sources."is-buffer-1.1.5"
                             ];
@@ -20032,7 +20329,7 @@ in
                     dependencies = [
                       (sources."align-text-0.1.4" // {
                         dependencies = [
-                          (sources."kind-of-3.1.0" // {
+                          (sources."kind-of-3.2.0" // {
                             dependencies = [
                               sources."is-buffer-1.1.5"
                             ];
@@ -20052,7 +20349,7 @@ in
           })
         ];
       })
-      (sources."resolve-1.3.2" // {
+      (sources."resolve-1.3.3" // {
         dependencies = [
           sources."path-parse-1.0.5"
         ];
@@ -20115,10 +20412,10 @@ in
   azure-cli = nodeEnv.buildNodePackage {
     name = "azure-cli";
     packageName = "azure-cli";
-    version = "0.10.12";
+    version = "0.10.13";
     src = fetchurl {
-      url = "https://registry.npmjs.org/azure-cli/-/azure-cli-0.10.12.tgz";
-      sha1 = "4446af5df8dda6c755a0bf7dfec2468a9f63f26d";
+      url = "https://registry.npmjs.org/azure-cli/-/azure-cli-0.10.13.tgz";
+      sha1 = "7e98a46b058f436fb2a3fbed982d143d49557348";
     };
     dependencies = [
       (sources."adal-node-0.1.21" // {
@@ -20158,8 +20455,8 @@ in
       sources."azure-arm-cdn-1.0.3"
       sources."azure-arm-commerce-0.2.0"
       sources."azure-arm-compute-0.20.0"
-      sources."azure-arm-datalake-analytics-1.0.1-preview"
-      sources."azure-arm-datalake-store-1.0.1-preview"
+      sources."azure-arm-datalake-analytics-1.0.2-preview"
+      sources."azure-arm-datalake-store-1.0.2-preview"
       sources."azure-arm-hdinsight-0.2.2"
       sources."azure-arm-hdinsight-jobs-0.1.0"
       sources."azure-arm-insights-0.11.3"
@@ -20337,7 +20634,7 @@ in
                         ];
                       })
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -20403,11 +20700,11 @@ in
               sources."delayed-stream-1.0.0"
             ];
           })
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           sources."forever-agent-0.6.1"
           (sources."form-data-1.0.1" // {
             dependencies = [
-              (sources."async-2.3.0" // {
+              (sources."async-2.4.0" // {
                 dependencies = [
                   sources."lodash-4.17.4"
                 ];
@@ -20481,7 +20778,7 @@ in
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.1"
-                  sources."getpass-0.1.6"
+                  sources."getpass-0.1.7"
                   sources."jsbn-0.1.1"
                   sources."tweetnacl-0.14.5"
                   sources."jodid25519-1.0.2"
@@ -20637,7 +20934,7 @@ in
       sources."bower-endpoint-parser-0.2.1"
       (sources."bower-json-0.6.0" // {
         dependencies = [
-          sources."deep-extend-0.4.1"
+          sources."deep-extend-0.4.2"
           (sources."ext-name-3.0.0" // {
             dependencies = [
               sources."ends-with-0.2.0"
@@ -20721,7 +21018,7 @@ in
                   })
                   sources."map-obj-1.0.1"
                   sources."minimist-1.2.0"
-                  (sources."normalize-package-data-2.3.6" // {
+                  (sources."normalize-package-data-2.3.8" // {
                     dependencies = [
                       sources."hosted-git-info-2.4.2"
                       (sources."is-builtin-module-1.0.0" // {
@@ -20858,7 +21155,7 @@ in
                     ];
                   })
                   sources."inherits-2.0.3"
-                  (sources."minimatch-3.0.3" // {
+                  (sources."minimatch-3.0.4" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.7" // {
                         dependencies = [
@@ -20883,9 +21180,9 @@ in
       (sources."promised-temp-0.1.0" // {
         dependencies = [
           sources."q-1.5.0"
-          (sources."debug-2.6.3" // {
+          (sources."debug-2.6.6" // {
             dependencies = [
-              sources."ms-0.7.2"
+              sources."ms-0.7.3"
             ];
           })
           (sources."mkdirp-0.5.1" // {
@@ -20910,7 +21207,7 @@ in
             ];
           })
           sources."inherits-2.0.3"
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -20948,7 +21245,7 @@ in
     dependencies = [
       (sources."JSONStream-1.3.1" // {
         dependencies = [
-          sources."jsonparse-1.3.0"
+          sources."jsonparse-1.3.1"
           sources."through-2.3.8"
         ];
       })
@@ -21070,14 +21367,29 @@ in
               })
             ];
           })
-          (sources."create-hash-1.1.2" // {
+          (sources."create-hash-1.1.3" // {
             dependencies = [
               sources."cipher-base-1.0.3"
-              sources."ripemd160-1.0.1"
+              (sources."ripemd160-2.0.1" // {
+                dependencies = [
+                  sources."hash-base-2.0.2"
+                ];
+              })
               sources."sha.js-2.4.8"
             ];
           })
-          sources."create-hmac-1.1.4"
+          (sources."create-hmac-1.1.6" // {
+            dependencies = [
+              sources."cipher-base-1.0.3"
+              (sources."ripemd160-2.0.1" // {
+                dependencies = [
+                  sources."hash-base-2.0.2"
+                ];
+              })
+              sources."safe-buffer-5.0.1"
+              sources."sha.js-2.4.8"
+            ];
+          })
           (sources."diffie-hellman-5.0.2" // {
             dependencies = [
               sources."bn.js-4.11.6"
@@ -21088,7 +21400,17 @@ in
               })
             ];
           })
-          sources."pbkdf2-3.0.9"
+          (sources."pbkdf2-3.0.12" // {
+            dependencies = [
+              (sources."ripemd160-2.0.1" // {
+                dependencies = [
+                  sources."hash-base-2.0.2"
+                ];
+              })
+              sources."safe-buffer-5.0.1"
+              sources."sha.js-2.4.8"
+            ];
+          })
           (sources."public-encrypt-4.0.0" // {
             dependencies = [
               sources."bn.js-4.11.6"
@@ -21127,7 +21449,7 @@ in
               sources."wrappy-1.0.2"
             ];
           })
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -21198,7 +21520,7 @@ in
         ];
       })
       sources."path-browserify-0.0.0"
-      sources."process-0.11.9"
+      sources."process-0.11.10"
       sources."punycode-1.4.1"
       sources."querystring-es3-0.2.1"
       sources."read-only-stream-2.0.0"
@@ -21212,7 +21534,7 @@ in
           sources."util-deprecate-1.0.2"
         ];
       })
-      (sources."resolve-1.3.2" // {
+      (sources."resolve-1.3.3" // {
         dependencies = [
           sources."path-parse-1.0.5"
         ];
@@ -21236,7 +21558,7 @@ in
         ];
       })
       sources."stream-browserify-2.0.1"
-      (sources."stream-http-2.7.0" // {
+      (sources."stream-http-2.7.1" // {
         dependencies = [
           sources."builtin-status-codes-3.0.0"
           sources."to-arraybuffer-1.0.1"
@@ -21362,9 +21684,9 @@ in
         ];
       })
       sources."debounced-seeker-1.0.0"
-      (sources."debug-2.6.3" // {
+      (sources."debug-2.6.6" // {
         dependencies = [
-          sources."ms-0.7.2"
+          sources."ms-0.7.3"
         ];
       })
       (sources."diveSync-0.3.0" // {
@@ -21398,7 +21720,7 @@ in
                 ];
               })
               sources."map-obj-1.0.1"
-              (sources."normalize-package-data-2.3.6" // {
+              (sources."normalize-package-data-2.3.8" // {
                 dependencies = [
                   sources."hosted-git-info-2.4.2"
                   (sources."is-builtin-module-1.0.0" // {
@@ -21502,7 +21824,7 @@ in
         ];
       })
       sources."keypress-0.2.1"
-      sources."mime-1.3.4"
+      sources."mime-1.3.6"
       sources."minimist-1.2.0"
       (sources."peerflix-0.34.0" // {
         dependencies = [
@@ -21518,9 +21840,9 @@ in
                   sources."semver-5.1.1"
                 ];
               })
-              (sources."plist-2.0.1" // {
+              (sources."plist-2.1.0" // {
                 dependencies = [
-                  sources."base64-js-1.1.2"
+                  sources."base64-js-1.2.0"
                   sources."xmlbuilder-8.2.2"
                   sources."xmldom-0.1.27"
                 ];
@@ -21562,8 +21884,9 @@ in
             dependencies = [
               sources."blob-to-buffer-1.2.6"
               sources."get-stdin-5.0.1"
-              (sources."magnet-uri-5.1.6" // {
+              (sources."magnet-uri-5.1.7" // {
                 dependencies = [
+                  sources."safe-buffer-5.0.1"
                   sources."thirty-two-1.0.2"
                   sources."uniq-1.0.1"
                 ];
@@ -21573,13 +21896,13 @@ in
                   sources."bencode-0.11.0"
                   (sources."simple-sha1-2.1.0" // {
                     dependencies = [
-                      sources."rusha-0.8.5"
+                      sources."rusha-0.8.6"
                     ];
                   })
                   sources."uniq-1.0.1"
                 ];
               })
-              (sources."simple-get-2.5.1" // {
+              (sources."simple-get-2.6.0" // {
                 dependencies = [
                   (sources."once-1.4.0" // {
                     dependencies = [
@@ -21634,7 +21957,7 @@ in
                       sources."minimist-0.0.8"
                     ];
                   })
-                  (sources."random-access-file-1.6.1" // {
+                  (sources."random-access-file-1.7.2" // {
                     dependencies = [
                       sources."buffer-alloc-unsafe-1.0.0"
                       sources."inherits-2.0.3"
@@ -21666,7 +21989,7 @@ in
                       sources."bencode-0.7.0"
                       (sources."simple-sha1-2.1.0" // {
                         dependencies = [
-                          sources."rusha-0.8.5"
+                          sources."rusha-0.8.6"
                         ];
                       })
                     ];
@@ -21713,7 +22036,7 @@ in
                         ];
                       })
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -21779,7 +22102,7 @@ in
                       })
                       sources."random-iterate-1.0.1"
                       sources."run-series-1.1.4"
-                      (sources."simple-get-2.5.1" // {
+                      (sources."simple-get-2.6.0" // {
                         dependencies = [
                           sources."simple-concat-1.0.0"
                           sources."unzip-response-2.0.1"
@@ -21814,7 +22137,7 @@ in
                               sources."util-deprecate-1.0.2"
                             ];
                           })
-                          (sources."ws-2.2.3" // {
+                          (sources."ws-2.3.1" // {
                             dependencies = [
                               sources."safe-buffer-5.0.1"
                               sources."ultron-1.1.0"
@@ -21893,7 +22216,7 @@ in
                   sources."bencode-0.7.0"
                   (sources."simple-sha1-2.1.0" // {
                     dependencies = [
-                      sources."rusha-0.8.5"
+                      sources."rusha-0.8.6"
                     ];
                   })
                 ];
@@ -22011,24 +22334,58 @@ in
   cordova = nodeEnv.buildNodePackage {
     name = "cordova";
     packageName = "cordova";
-    version = "6.5.0";
+    version = "7.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/cordova/-/cordova-6.5.0.tgz";
-      sha1 = "e6ec81b17dd50c17c40b4b87330f7ced38fb0b47";
+      url = "https://registry.npmjs.org/cordova/-/cordova-7.0.1.tgz";
+      sha1 = "69fd054300ce5105b092f67a1b286e80c4e88b9d";
     };
     dependencies = [
-      (sources."cordova-common-2.0.0" // {
+      (sources."configstore-2.1.0" // {
+        dependencies = [
+          (sources."dot-prop-3.0.0" // {
+            dependencies = [
+              sources."is-obj-1.0.1"
+            ];
+          })
+          sources."graceful-fs-4.1.11"
+          (sources."mkdirp-0.5.1" // {
+            dependencies = [
+              sources."minimist-0.0.8"
+            ];
+          })
+          sources."object-assign-4.1.1"
+          sources."os-tmpdir-1.0.2"
+          (sources."osenv-0.1.4" // {
+            dependencies = [
+              sources."os-homedir-1.0.2"
+            ];
+          })
+          sources."uuid-2.0.3"
+          (sources."write-file-atomic-1.3.4" // {
+            dependencies = [
+              sources."imurmurhash-0.1.4"
+              sources."slide-1.1.6"
+            ];
+          })
+          (sources."xdg-basedir-2.0.0" // {
+            dependencies = [
+              sources."os-homedir-1.0.2"
+            ];
+          })
+        ];
+      })
+      (sources."cordova-common-2.0.3" // {
         dependencies = [
           sources."ansi-0.3.1"
           (sources."bplist-parser-0.1.1" // {
             dependencies = [
-              sources."big-integer-1.6.19"
+              sources."big-integer-1.6.22"
             ];
           })
           sources."cordova-registry-mapper-1.1.15"
-          (sources."elementtree-0.1.7" // {
+          (sources."elementtree-0.1.6" // {
             dependencies = [
-              sources."sax-1.1.4"
+              sources."sax-0.3.5"
             ];
           })
           (sources."glob-5.0.15" // {
@@ -22047,7 +22404,7 @@ in
               sources."path-is-absolute-1.0.1"
             ];
           })
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -22082,15 +22439,15 @@ in
           sources."unorm-1.4.1"
         ];
       })
-      (sources."cordova-lib-6.5.0" // {
+      (sources."cordova-lib-7.0.1" // {
         dependencies = [
-          (sources."aliasify-1.9.0" // {
+          (sources."aliasify-2.1.0" // {
             dependencies = [
-              (sources."browserify-transform-tools-1.5.3" // {
+              (sources."browserify-transform-tools-1.7.0" // {
                 dependencies = [
-                  (sources."falafel-1.2.0" // {
+                  (sources."falafel-2.1.0" // {
                     dependencies = [
-                      sources."acorn-1.2.2"
+                      sources."acorn-5.0.3"
                       sources."foreach-2.0.5"
                       sources."isarray-0.0.1"
                       sources."object-keys-1.0.11"
@@ -22101,14 +22458,14 @@ in
               })
             ];
           })
-          (sources."cordova-create-1.0.2" // {
+          (sources."cordova-create-1.1.1" // {
             dependencies = [
-              sources."cordova-app-hello-world-3.11.0"
+              sources."cordova-app-hello-world-3.12.0"
             ];
           })
-          (sources."cordova-fetch-1.0.2" // {
+          (sources."cordova-fetch-1.1.0" // {
             dependencies = [
-              (sources."dependency-ls-1.0.0" // {
+              (sources."dependency-ls-1.1.0" // {
                 dependencies = [
                   sources."q-1.4.1"
                 ];
@@ -22117,37 +22474,10 @@ in
               sources."q-1.5.0"
               (sources."shelljs-0.7.7" // {
                 dependencies = [
-                  (sources."glob-7.1.1" // {
-                    dependencies = [
-                      sources."fs.realpath-1.0.0"
-                      (sources."inflight-1.0.6" // {
-                        dependencies = [
-                          sources."wrappy-1.0.2"
-                        ];
-                      })
-                      sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
-                        dependencies = [
-                          (sources."brace-expansion-1.1.7" // {
-                            dependencies = [
-                              sources."balanced-match-0.4.2"
-                              sources."concat-map-0.0.1"
-                            ];
-                          })
-                        ];
-                      })
-                      (sources."once-1.4.0" // {
-                        dependencies = [
-                          sources."wrappy-1.0.2"
-                        ];
-                      })
-                      sources."path-is-absolute-1.0.1"
-                    ];
-                  })
-                  sources."interpret-1.0.2"
+                  sources."interpret-1.0.3"
                   (sources."rechoir-0.6.2" // {
                     dependencies = [
-                      (sources."resolve-1.3.2" // {
+                      (sources."resolve-1.3.3" // {
                         dependencies = [
                           sources."path-parse-1.0.5"
                         ];
@@ -22164,7 +22494,7 @@ in
                 dependencies = [
                   (sources."JSONStream-1.3.1" // {
                     dependencies = [
-                      sources."jsonparse-1.3.0"
+                      sources."jsonparse-1.3.1"
                       sources."through-2.3.8"
                     ];
                   })
@@ -22287,14 +22617,29 @@ in
                           })
                         ];
                       })
-                      (sources."create-hash-1.1.2" // {
+                      (sources."create-hash-1.1.3" // {
                         dependencies = [
                           sources."cipher-base-1.0.3"
-                          sources."ripemd160-1.0.1"
+                          (sources."ripemd160-2.0.1" // {
+                            dependencies = [
+                              sources."hash-base-2.0.2"
+                            ];
+                          })
                           sources."sha.js-2.4.8"
                         ];
                       })
-                      sources."create-hmac-1.1.4"
+                      (sources."create-hmac-1.1.6" // {
+                        dependencies = [
+                          sources."cipher-base-1.0.3"
+                          (sources."ripemd160-2.0.1" // {
+                            dependencies = [
+                              sources."hash-base-2.0.2"
+                            ];
+                          })
+                          sources."safe-buffer-5.0.1"
+                          sources."sha.js-2.4.8"
+                        ];
+                      })
                       (sources."diffie-hellman-5.0.2" // {
                         dependencies = [
                           sources."bn.js-4.11.6"
@@ -22305,7 +22650,17 @@ in
                           })
                         ];
                       })
-                      sources."pbkdf2-3.0.9"
+                      (sources."pbkdf2-3.0.12" // {
+                        dependencies = [
+                          (sources."ripemd160-2.0.1" // {
+                            dependencies = [
+                              sources."hash-base-2.0.2"
+                            ];
+                          })
+                          sources."safe-buffer-5.0.1"
+                          sources."sha.js-2.4.8"
+                        ];
+                      })
                       (sources."public-encrypt-4.0.0" // {
                         dependencies = [
                           sources."bn.js-4.11.6"
@@ -22336,32 +22691,6 @@ in
                   sources."domain-browser-1.1.7"
                   sources."duplexer2-0.1.4"
                   sources."events-1.1.1"
-                  (sources."glob-7.1.1" // {
-                    dependencies = [
-                      sources."fs.realpath-1.0.0"
-                      (sources."inflight-1.0.6" // {
-                        dependencies = [
-                          sources."wrappy-1.0.2"
-                        ];
-                      })
-                      (sources."minimatch-3.0.3" // {
-                        dependencies = [
-                          (sources."brace-expansion-1.1.7" // {
-                            dependencies = [
-                              sources."balanced-match-0.4.2"
-                              sources."concat-map-0.0.1"
-                            ];
-                          })
-                        ];
-                      })
-                      (sources."once-1.4.0" // {
-                        dependencies = [
-                          sources."wrappy-1.0.2"
-                        ];
-                      })
-                      sources."path-is-absolute-1.0.1"
-                    ];
-                  })
                   (sources."has-1.0.1" // {
                     dependencies = [
                       sources."function-bind-1.1.0"
@@ -22415,7 +22744,7 @@ in
                     ];
                   })
                   sources."path-browserify-0.0.0"
-                  sources."process-0.11.9"
+                  sources."process-0.11.10"
                   sources."punycode-1.4.1"
                   sources."querystring-es3-0.2.1"
                   sources."read-only-stream-2.0.0"
@@ -22429,7 +22758,7 @@ in
                       sources."util-deprecate-1.0.2"
                     ];
                   })
-                  (sources."resolve-1.3.2" // {
+                  (sources."resolve-1.3.3" // {
                     dependencies = [
                       sources."path-parse-1.0.5"
                     ];
@@ -22453,7 +22782,7 @@ in
                     ];
                   })
                   sources."stream-browserify-2.0.1"
-                  (sources."stream-http-2.7.0" // {
+                  (sources."stream-http-2.7.1" // {
                     dependencies = [
                       sources."builtin-status-codes-3.0.0"
                       sources."to-arraybuffer-1.0.1"
@@ -22494,7 +22823,6 @@ in
               })
             ];
           })
-          sources."cordova-registry-mapper-1.1.15"
           (sources."cordova-serve-1.0.1" // {
             dependencies = [
               (sources."chalk-1.1.3" // {
@@ -22567,11 +22895,11 @@ in
                   sources."encodeurl-1.0.1"
                   sources."escape-html-1.0.3"
                   sources."etag-1.8.0"
-                  (sources."finalhandler-1.0.1" // {
+                  (sources."finalhandler-1.0.2" // {
                     dependencies = [
-                      (sources."debug-2.6.3" // {
+                      (sources."debug-2.6.4" // {
                         dependencies = [
-                          sources."ms-0.7.2"
+                          sources."ms-0.7.3"
                         ];
                       })
                       sources."unpipe-1.0.0"
@@ -22637,15 +22965,16 @@ in
               sources."sax-0.3.5"
             ];
           })
-          (sources."glob-5.0.15" // {
+          (sources."glob-7.1.1" // {
             dependencies = [
+              sources."fs.realpath-1.0.0"
               (sources."inflight-1.0.6" // {
                 dependencies = [
                   sources."wrappy-1.0.2"
                 ];
               })
               sources."inherits-2.0.3"
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -22663,35 +22992,8 @@ in
               sources."path-is-absolute-1.0.1"
             ];
           })
-          (sources."init-package-json-1.9.6" // {
+          (sources."init-package-json-1.10.1" // {
             dependencies = [
-              (sources."glob-7.1.1" // {
-                dependencies = [
-                  sources."fs.realpath-1.0.0"
-                  (sources."inflight-1.0.6" // {
-                    dependencies = [
-                      sources."wrappy-1.0.2"
-                    ];
-                  })
-                  sources."inherits-2.0.3"
-                  (sources."minimatch-3.0.3" // {
-                    dependencies = [
-                      (sources."brace-expansion-1.1.7" // {
-                        dependencies = [
-                          sources."balanced-match-0.4.2"
-                          sources."concat-map-0.0.1"
-                        ];
-                      })
-                    ];
-                  })
-                  (sources."once-1.4.0" // {
-                    dependencies = [
-                      sources."wrappy-1.0.2"
-                    ];
-                  })
-                  sources."path-is-absolute-1.0.1"
-                ];
-              })
               (sources."npm-package-arg-5.0.1" // {
                 dependencies = [
                   sources."hosted-git-info-2.4.2"
@@ -22701,7 +23003,6 @@ in
                       sources."os-tmpdir-1.0.2"
                     ];
                   })
-                  sources."semver-5.3.0"
                 ];
               })
               sources."promzard-0.3.0"
@@ -22717,7 +23018,7 @@ in
                       sources."jju-1.3.0"
                     ];
                   })
-                  (sources."normalize-package-data-2.3.6" // {
+                  (sources."normalize-package-data-2.3.8" // {
                     dependencies = [
                       sources."hosted-git-info-2.4.2"
                       (sources."is-builtin-module-1.0.0" // {
@@ -22747,9 +23048,15 @@ in
               })
             ];
           })
-          (sources."nopt-3.0.6" // {
+          (sources."nopt-4.0.1" // {
             dependencies = [
               sources."abbrev-1.1.0"
+              (sources."osenv-0.1.4" // {
+                dependencies = [
+                  sources."os-homedir-1.0.2"
+                  sources."os-tmpdir-1.0.2"
+                ];
+              })
             ];
           })
           (sources."npm-2.15.12" // {
@@ -22788,7 +23095,6 @@ in
                   sources."asap-2.0.5"
                 ];
               })
-              sources."editor-1.0.0"
               sources."fs-vacuum-1.2.10"
               (sources."fs-write-stream-atomic-1.0.10" // {
                 dependencies = [
@@ -22814,6 +23120,22 @@ in
               sources."inflight-1.0.6"
               sources."inherits-2.0.3"
               sources."ini-1.3.4"
+              (sources."init-package-json-1.9.6" // {
+                dependencies = [
+                  (sources."glob-7.1.1" // {
+                    dependencies = [
+                      sources."fs.realpath-1.0.0"
+                      sources."path-is-absolute-1.0.1"
+                    ];
+                  })
+                  sources."promzard-0.3.0"
+                  (sources."validate-npm-package-name-3.0.0" // {
+                    dependencies = [
+                      sources."builtins-1.0.3"
+                    ];
+                  })
+                ];
+              })
               sources."lockfile-1.0.3"
               (sources."lru-cache-4.0.2" // {
                 dependencies = [
@@ -22821,7 +23143,7 @@ in
                   sources."yallist-2.1.2"
                 ];
               })
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -22836,13 +23158,14 @@ in
                   sources."minimist-0.0.8"
                 ];
               })
-              (sources."node-gyp-3.6.0" // {
+              (sources."node-gyp-3.6.1" // {
                 dependencies = [
                   sources."semver-5.3.0"
                 ];
               })
+              sources."nopt-3.0.6"
               sources."normalize-git-url-3.0.2"
-              (sources."normalize-package-data-2.3.6" // {
+              (sources."normalize-package-data-2.3.8" // {
                 dependencies = [
                   (sources."is-builtin-module-1.0.0" // {
                     dependencies = [
@@ -22876,7 +23199,7 @@ in
               sources."npm-user-validate-0.1.5"
               (sources."npmlog-2.0.4" // {
                 dependencies = [
-                  (sources."are-we-there-yet-1.1.2" // {
+                  (sources."are-we-there-yet-1.1.4" // {
                     dependencies = [
                       sources."delegates-1.0.0"
                     ];
@@ -22960,11 +23283,11 @@ in
                       sources."delayed-stream-1.0.0"
                     ];
                   })
-                  sources."extend-3.0.0"
+                  sources."extend-3.0.1"
                   sources."forever-agent-0.6.1"
                   (sources."form-data-1.0.1" // {
                     dependencies = [
-                      (sources."async-2.3.0" // {
+                      (sources."async-2.4.0" // {
                         dependencies = [
                           sources."lodash-4.17.4"
                         ];
@@ -23029,7 +23352,7 @@ in
                           sources."asn1-0.2.3"
                           sources."assert-plus-1.0.0"
                           sources."dashdash-1.14.1"
-                          sources."getpass-0.1.6"
+                          sources."getpass-0.1.7"
                           sources."jsbn-0.1.1"
                           sources."tweetnacl-0.14.5"
                           sources."jodid25519-1.0.2"
@@ -23067,7 +23390,6 @@ in
               sources."sorted-object-2.0.1"
               sources."spdx-license-ids-1.2.2"
               sources."strip-ansi-3.0.1"
-              sources."tar-2.2.1"
               sources."text-table-0.2.0"
               sources."uid-number-0.0.6"
               sources."umask-1.1.0"
@@ -23093,80 +23415,136 @@ in
               sources."imurmurhash-0.1.4"
             ];
           })
-          sources."opener-1.4.1"
-          (sources."plist-1.2.0" // {
+          sources."opener-1.4.2"
+          (sources."plist-2.0.1" // {
             dependencies = [
-              sources."base64-js-0.0.8"
-              (sources."xmlbuilder-4.0.0" // {
-                dependencies = [
-                  sources."lodash-3.10.1"
-                ];
-              })
+              sources."base64-js-1.1.2"
+              sources."xmlbuilder-8.2.2"
               sources."xmldom-0.1.27"
-              sources."util-deprecate-1.0.2"
             ];
           })
-          sources."properties-parser-0.2.3"
-          (sources."request-2.47.0" // {
+          (sources."properties-parser-0.3.1" // {
             dependencies = [
-              (sources."bl-0.9.5" // {
+              sources."string.prototype.codepointat-0.2.0"
+            ];
+          })
+          (sources."request-2.79.0" // {
+            dependencies = [
+              sources."aws-sign2-0.6.0"
+              sources."aws4-1.6.0"
+              sources."caseless-0.11.0"
+              (sources."combined-stream-1.0.5" // {
                 dependencies = [
-                  (sources."readable-stream-1.0.34" // {
+                  sources."delayed-stream-1.0.0"
+                ];
+              })
+              sources."extend-3.0.1"
+              sources."forever-agent-0.6.1"
+              (sources."form-data-2.1.4" // {
+                dependencies = [
+                  sources."asynckit-0.4.0"
+                ];
+              })
+              (sources."har-validator-2.0.6" // {
+                dependencies = [
+                  (sources."chalk-1.1.3" // {
                     dependencies = [
-                      sources."core-util-is-1.0.2"
-                      sources."isarray-0.0.1"
-                      sources."string_decoder-0.10.31"
-                      sources."inherits-2.0.3"
+                      sources."ansi-styles-2.2.1"
+                      sources."escape-string-regexp-1.0.5"
+                      (sources."has-ansi-2.0.0" // {
+                        dependencies = [
+                          sources."ansi-regex-2.1.1"
+                        ];
+                      })
+                      (sources."strip-ansi-3.0.1" // {
+                        dependencies = [
+                          sources."ansi-regex-2.1.1"
+                        ];
+                      })
+                      sources."supports-color-2.0.0"
+                    ];
+                  })
+                  (sources."commander-2.9.0" // {
+                    dependencies = [
+                      sources."graceful-readlink-1.0.1"
+                    ];
+                  })
+                  (sources."is-my-json-valid-2.16.0" // {
+                    dependencies = [
+                      sources."generate-function-2.0.0"
+                      (sources."generate-object-property-1.2.0" // {
+                        dependencies = [
+                          sources."is-property-1.0.2"
+                        ];
+                      })
+                      sources."jsonpointer-4.0.1"
+                      sources."xtend-4.0.1"
+                    ];
+                  })
+                  (sources."pinkie-promise-2.0.1" // {
+                    dependencies = [
+                      sources."pinkie-2.0.4"
                     ];
                   })
                 ];
               })
-              sources."caseless-0.6.0"
-              sources."forever-agent-0.5.2"
-              (sources."form-data-0.1.4" // {
+              (sources."hawk-3.1.3" // {
                 dependencies = [
-                  sources."mime-1.2.11"
-                  sources."async-0.9.2"
+                  sources."hoek-2.16.3"
+                  sources."boom-2.10.1"
+                  sources."cryptiles-2.0.5"
+                  sources."sntp-1.0.9"
                 ];
               })
+              (sources."http-signature-1.1.1" // {
+                dependencies = [
+                  sources."assert-plus-0.2.0"
+                  (sources."jsprim-1.4.0" // {
+                    dependencies = [
+                      sources."assert-plus-1.0.0"
+                      sources."extsprintf-1.0.2"
+                      sources."json-schema-0.2.3"
+                      sources."verror-1.3.6"
+                    ];
+                  })
+                  (sources."sshpk-1.13.0" // {
+                    dependencies = [
+                      sources."asn1-0.2.3"
+                      sources."assert-plus-1.0.0"
+                      sources."dashdash-1.14.1"
+                      sources."getpass-0.1.7"
+                      sources."jsbn-0.1.1"
+                      sources."tweetnacl-0.14.5"
+                      sources."jodid25519-1.0.2"
+                      sources."ecc-jsbn-0.1.1"
+                      sources."bcrypt-pbkdf-1.0.1"
+                    ];
+                  })
+                ];
+              })
+              sources."is-typedarray-1.0.0"
+              sources."isstream-0.1.2"
               sources."json-stringify-safe-5.0.1"
-              sources."mime-types-1.0.2"
-              sources."node-uuid-1.4.8"
-              sources."qs-2.3.3"
-              sources."tunnel-agent-0.4.3"
+              (sources."mime-types-2.1.15" // {
+                dependencies = [
+                  sources."mime-db-1.27.0"
+                ];
+              })
+              sources."oauth-sign-0.8.2"
+              sources."qs-6.3.2"
+              sources."stringstream-0.0.5"
               (sources."tough-cookie-2.3.2" // {
                 dependencies = [
                   sources."punycode-1.4.1"
                 ];
               })
-              (sources."http-signature-0.10.1" // {
-                dependencies = [
-                  sources."assert-plus-0.1.5"
-                  sources."asn1-0.1.11"
-                  sources."ctype-0.5.3"
-                ];
-              })
-              sources."oauth-sign-0.4.0"
-              (sources."hawk-1.1.1" // {
-                dependencies = [
-                  sources."hoek-0.9.1"
-                  sources."boom-0.4.2"
-                  sources."cryptiles-0.2.2"
-                  sources."sntp-0.2.4"
-                ];
-              })
-              sources."aws-sign2-0.5.0"
-              sources."stringstream-0.0.5"
-              (sources."combined-stream-0.0.7" // {
-                dependencies = [
-                  sources."delayed-stream-0.0.5"
-                ];
-              })
+              sources."tunnel-agent-0.4.3"
+              sources."uuid-3.0.1"
             ];
           })
-          sources."semver-4.3.6"
+          sources."semver-5.3.0"
           sources."shelljs-0.3.0"
-          (sources."tar-1.0.2" // {
+          (sources."tar-2.2.1" // {
             dependencies = [
               sources."block-stream-0.0.9"
               (sources."fstream-1.0.11" // {
@@ -23177,42 +23555,14 @@ in
                       sources."minimist-0.0.8"
                     ];
                   })
-                  (sources."rimraf-2.6.1" // {
-                    dependencies = [
-                      (sources."glob-7.1.1" // {
-                        dependencies = [
-                          sources."fs.realpath-1.0.0"
-                          (sources."inflight-1.0.6" // {
-                            dependencies = [
-                              sources."wrappy-1.0.2"
-                            ];
-                          })
-                          (sources."minimatch-3.0.3" // {
-                            dependencies = [
-                              (sources."brace-expansion-1.1.7" // {
-                                dependencies = [
-                                  sources."balanced-match-0.4.2"
-                                  sources."concat-map-0.0.1"
-                                ];
-                              })
-                            ];
-                          })
-                          (sources."once-1.4.0" // {
-                            dependencies = [
-                              sources."wrappy-1.0.2"
-                            ];
-                          })
-                          sources."path-is-absolute-1.0.1"
-                        ];
-                      })
-                    ];
-                  })
+                  sources."rimraf-2.6.1"
                 ];
               })
               sources."inherits-2.0.3"
             ];
           })
-          sources."unorm-1.3.3"
+          sources."underscore-1.8.3"
+          sources."unorm-1.4.1"
           sources."valid-identifier-0.0.1"
           (sources."xcode-0.9.3" // {
             dependencies = [
@@ -23226,14 +23576,7 @@ in
                   })
                   (sources."bplist-parser-0.1.1" // {
                     dependencies = [
-                      sources."big-integer-1.6.19"
-                    ];
-                  })
-                  (sources."plist-2.0.1" // {
-                    dependencies = [
-                      sources."base64-js-1.1.2"
-                      sources."xmlbuilder-8.2.2"
-                      sources."xmldom-0.1.27"
+                      sources."big-integer-1.6.22"
                     ];
                   })
                 ];
@@ -23243,7 +23586,8 @@ in
           })
         ];
       })
-      (sources."insight-0.8.4" // {
+      sources."editor-1.0.0"
+      (sources."insight-0.8.2" // {
         dependencies = [
           sources."async-1.5.2"
           (sources."chalk-1.1.3" // {
@@ -23278,7 +23622,7 @@ in
                 ];
               })
               sources."uuid-2.0.3"
-              (sources."write-file-atomic-1.3.1" // {
+              (sources."write-file-atomic-1.3.4" // {
                 dependencies = [
                   sources."imurmurhash-0.1.4"
                   sources."slide-1.1.6"
@@ -23342,6 +23686,7 @@ in
               sources."lodash._getnative-3.9.1"
             ];
           })
+          sources."node-uuid-1.4.8"
           sources."object-assign-4.1.1"
           (sources."os-name-1.0.3" // {
             dependencies = [
@@ -23367,7 +23712,7 @@ in
                   sources."delayed-stream-1.0.0"
                 ];
               })
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               sources."forever-agent-0.6.1"
               (sources."form-data-2.1.4" // {
                 dependencies = [
@@ -23376,7 +23721,7 @@ in
               })
               (sources."har-validator-4.2.1" // {
                 dependencies = [
-                  (sources."ajv-4.11.6" // {
+                  (sources."ajv-4.11.8" // {
                     dependencies = [
                       sources."co-4.6.0"
                       (sources."json-stable-stringify-1.0.1" // {
@@ -23413,7 +23758,7 @@ in
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.1"
-                      sources."getpass-0.1.6"
+                      sources."getpass-0.1.7"
                       sources."jsbn-0.1.1"
                       sources."tweetnacl-0.14.5"
                       sources."jodid25519-1.0.2"
@@ -23437,6 +23782,7 @@ in
               sources."safe-buffer-5.0.1"
               sources."stringstream-0.0.5"
               sources."tunnel-agent-0.6.0"
+              sources."uuid-3.0.1"
             ];
           })
           (sources."tough-cookie-2.3.2" // {
@@ -23444,7 +23790,6 @@ in
               sources."punycode-1.4.1"
             ];
           })
-          sources."uuid-3.0.1"
         ];
       })
       (sources."nopt-3.0.1" // {
@@ -23453,7 +23798,6 @@ in
         ];
       })
       sources."q-1.0.1"
-      sources."underscore-1.7.0"
       (sources."update-notifier-0.5.0" // {
         dependencies = [
           (sources."chalk-1.1.3" // {
@@ -23489,7 +23833,7 @@ in
                 ];
               })
               sources."uuid-2.0.3"
-              (sources."write-file-atomic-1.3.1" // {
+              (sources."write-file-atomic-1.3.4" // {
                 dependencies = [
                   sources."imurmurhash-0.1.4"
                   sources."slide-1.1.6"
@@ -23572,7 +23916,7 @@ in
                     dependencies = [
                       (sources."rc-1.2.1" // {
                         dependencies = [
-                          sources."deep-extend-0.4.1"
+                          sources."deep-extend-0.4.2"
                           sources."ini-1.3.4"
                           sources."minimist-1.2.0"
                           sources."strip-json-comments-2.0.1"
@@ -23770,7 +24114,7 @@ in
                 dependencies = [
                   (sources."buffercursor-0.0.12" // {
                     dependencies = [
-                      (sources."verror-1.9.0" // {
+                      (sources."verror-1.10.0" // {
                         dependencies = [
                           sources."assert-plus-1.0.0"
                           sources."core-util-is-1.0.2"
@@ -23787,7 +24131,7 @@ in
             dependencies = [
               (sources."buffercursor-0.0.12" // {
                 dependencies = [
-                  (sources."verror-1.9.0" // {
+                  (sources."verror-1.10.0" // {
                     dependencies = [
                       sources."assert-plus-1.0.0"
                       sources."core-util-is-1.0.2"
@@ -23804,7 +24148,7 @@ in
         dependencies = [
           (sources."buffercursor-0.0.12" // {
             dependencies = [
-              (sources."verror-1.9.0" // {
+              (sources."verror-1.10.0" // {
                 dependencies = [
                   sources."assert-plus-1.0.0"
                   sources."core-util-is-1.0.2"
@@ -23849,9 +24193,9 @@ in
           sources."component-emitter-1.1.2"
           sources."methods-1.0.1"
           sources."cookiejar-2.0.1"
-          (sources."debug-2.6.3" // {
+          (sources."debug-2.6.6" // {
             dependencies = [
-              sources."ms-0.7.2"
+              sources."ms-0.7.3"
             ];
           })
           sources."reduce-component-1.0.1"
@@ -24009,7 +24353,7 @@ in
               sources."level-post-1.0.5"
               sources."pull-cat-1.1.11"
               sources."pull-live-1.0.1"
-              sources."pull-pushable-2.0.1"
+              sources."pull-pushable-2.1.0"
               (sources."pull-window-2.1.4" // {
                 dependencies = [
                   sources."looper-2.0.0"
@@ -24022,7 +24366,7 @@ in
               })
             ];
           })
-          sources."pull-stream-3.5.0"
+          sources."pull-stream-3.6.0"
           sources."typewiselite-1.0.0"
         ];
       })
@@ -24162,9 +24506,9 @@ in
           })
         ];
       })
-      (sources."tar-stream-1.5.2" // {
+      (sources."tar-stream-1.5.4" // {
         dependencies = [
-          sources."bl-1.2.0"
+          sources."bl-1.2.1"
           (sources."readable-stream-2.2.9" // {
             dependencies = [
               sources."buffer-shims-1.0.0"
@@ -24204,25 +24548,50 @@ in
   elasticdump = nodeEnv.buildNodePackage {
     name = "elasticdump";
     packageName = "elasticdump";
-    version = "3.1.0";
+    version = "3.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-3.1.0.tgz";
-      sha1 = "4bec1f64f7931b84884306fb5b37a0d269d81e8d";
+      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-3.3.0.tgz";
+      sha1 = "19aec66c4619e49a66dfa1106719819d9daecbc8";
     };
     dependencies = [
       (sources."JSONStream-1.3.1" // {
         dependencies = [
-          sources."jsonparse-1.3.0"
+          sources."jsonparse-1.3.1"
           sources."through-2.3.8"
         ];
       })
-      (sources."async-2.3.0" // {
+      (sources."async-2.4.0" // {
         dependencies = [
           sources."lodash-4.17.4"
         ];
       })
       sources."aws4-1.6.0"
-      sources."awscred-1.2.0"
+      (sources."aws-sdk-2.50.0" // {
+        dependencies = [
+          (sources."buffer-5.0.6" // {
+            dependencies = [
+              sources."base64-js-1.2.0"
+              sources."ieee754-1.1.8"
+            ];
+          })
+          sources."crypto-browserify-1.0.9"
+          sources."jmespath-0.15.0"
+          sources."querystring-0.2.0"
+          sources."sax-1.2.1"
+          (sources."url-0.10.3" // {
+            dependencies = [
+              sources."punycode-1.3.2"
+            ];
+          })
+          sources."uuid-3.0.1"
+          sources."xml2js-0.4.17"
+          (sources."xmlbuilder-4.2.1" // {
+            dependencies = [
+              sources."lodash-4.17.4"
+            ];
+          })
+        ];
+      })
       sources."ini-1.3.4"
       (sources."optimist-0.6.1" // {
         dependencies = [
@@ -24239,7 +24608,7 @@ in
               sources."delayed-stream-1.0.0"
             ];
           })
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           sources."forever-agent-0.6.1"
           (sources."form-data-2.1.4" // {
             dependencies = [
@@ -24248,7 +24617,7 @@ in
           })
           (sources."har-validator-4.2.1" // {
             dependencies = [
-              (sources."ajv-4.11.6" // {
+              (sources."ajv-4.11.8" // {
                 dependencies = [
                   sources."co-4.6.0"
                   (sources."json-stable-stringify-1.0.1" // {
@@ -24285,7 +24654,7 @@ in
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.1"
-                  sources."getpass-0.1.6"
+                  sources."getpass-0.1.7"
                   sources."jsbn-0.1.1"
                   sources."tweetnacl-0.14.5"
                   sources."jodid25519-1.0.2"
@@ -24329,10 +24698,10 @@ in
   emoj = nodeEnv.buildNodePackage {
     name = "emoj";
     packageName = "emoj";
-    version = "1.0.0";
+    version = "1.1.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/emoj/-/emoj-1.0.0.tgz";
-      sha1 = "3cccbeec420e2b45f73b923e880c220392c055bd";
+      url = "https://registry.npmjs.org/emoj/-/emoj-1.1.0.tgz";
+      sha1 = "5a43ae17f6bf672cd8e40891357f84b086c52509";
     };
     dependencies = [
       (sources."chalk-1.1.3" // {
@@ -24385,6 +24754,39 @@ in
               sources."p-finally-1.0.0"
               sources."signal-exit-3.0.2"
               sources."strip-eof-1.0.0"
+            ];
+          })
+        ];
+      })
+      (sources."conf-1.1.1" // {
+        dependencies = [
+          (sources."dot-prop-4.1.1" // {
+            dependencies = [
+              sources."is-obj-1.0.1"
+            ];
+          })
+          sources."env-paths-1.0.0"
+          (sources."make-dir-1.0.0" // {
+            dependencies = [
+              sources."pify-2.3.0"
+            ];
+          })
+          (sources."pkg-up-2.0.0" // {
+            dependencies = [
+              (sources."find-up-2.1.0" // {
+                dependencies = [
+                  (sources."locate-path-2.0.0" // {
+                    dependencies = [
+                      (sources."p-locate-2.0.0" // {
+                        dependencies = [
+                          sources."p-limit-1.1.0"
+                        ];
+                      })
+                      sources."path-exists-3.0.0"
+                    ];
+                  })
+                ];
+              })
             ];
           })
         ];
@@ -24458,7 +24860,7 @@ in
           })
           sources."map-obj-1.0.1"
           sources."minimist-1.2.0"
-          (sources."normalize-package-data-2.3.6" // {
+          (sources."normalize-package-data-2.3.8" // {
             dependencies = [
               sources."hosted-git-info-2.4.2"
               (sources."is-builtin-module-1.0.0" // {
@@ -24559,6 +24961,11 @@ in
           sources."trim-newlines-1.0.0"
         ];
       })
+      (sources."skin-tone-1.0.0" // {
+        dependencies = [
+          sources."unicode-emoji-modifier-base-1.0.0"
+        ];
+      })
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -24615,9 +25022,9 @@ in
           })
         ];
       })
-      (sources."debug-2.6.3" // {
+      (sources."debug-2.6.6" // {
         dependencies = [
-          sources."ms-0.7.2"
+          sources."ms-0.7.3"
         ];
       })
       (sources."doctrine-2.0.0" // {
@@ -24630,7 +25037,7 @@ in
           (sources."es6-map-0.1.5" // {
             dependencies = [
               sources."d-1.0.0"
-              sources."es5-ext-0.10.15"
+              sources."es5-ext-0.10.16"
               sources."es6-iterator-2.0.1"
               sources."es6-set-0.1.5"
               sources."es6-symbol-3.1.1"
@@ -24640,7 +25047,7 @@ in
           (sources."es6-weak-map-2.0.2" // {
             dependencies = [
               sources."d-1.0.0"
-              sources."es5-ext-0.10.15"
+              sources."es5-ext-0.10.16"
               sources."es6-iterator-2.0.1"
               sources."es6-symbol-3.1.1"
             ];
@@ -24653,7 +25060,7 @@ in
           })
         ];
       })
-      (sources."espree-3.4.1" // {
+      (sources."espree-3.4.3" // {
         dependencies = [
           sources."acorn-5.0.3"
           (sources."acorn-jsx-3.0.1" // {
@@ -24714,7 +25121,7 @@ in
             ];
           })
           sources."inherits-2.0.3"
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -24733,7 +25140,7 @@ in
         ];
       })
       sources."globals-9.17.0"
-      sources."ignore-3.2.7"
+      sources."ignore-3.3.0"
       sources."imurmurhash-0.1.4"
       (sources."inquirer-0.12.0" // {
         dependencies = [
@@ -24808,7 +25215,7 @@ in
           sources."tryit-1.0.3"
         ];
       })
-      (sources."js-yaml-3.8.3" // {
+      (sources."js-yaml-3.8.4" // {
         dependencies = [
           (sources."argparse-1.0.9" // {
             dependencies = [
@@ -24860,10 +25267,10 @@ in
       })
       (sources."shelljs-0.7.7" // {
         dependencies = [
-          sources."interpret-1.0.2"
+          sources."interpret-1.0.3"
           (sources."rechoir-0.6.2" // {
             dependencies = [
-              (sources."resolve-1.3.2" // {
+              (sources."resolve-1.3.3" // {
                 dependencies = [
                   sources."path-parse-1.0.5"
                 ];
@@ -24876,7 +25283,7 @@ in
       sources."strip-json-comments-2.0.1"
       (sources."table-3.8.3" // {
         dependencies = [
-          (sources."ajv-4.11.6" // {
+          (sources."ajv-4.11.8" // {
             dependencies = [
               sources."co-4.6.0"
             ];
@@ -24913,14 +25320,14 @@ in
   emojione = nodeEnv.buildNodePackage {
     name = "emojione";
     packageName = "emojione";
-    version = "2.2.7";
+    version = "3.0.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/emojione/-/emojione-2.2.7.tgz";
-      sha1 = "46457cf6b9b2f8da13ae8a2e4e547de06ee15e96";
+      url = "https://registry.npmjs.org/emojione/-/emojione-3.0.3.tgz";
+      sha1 = "7b4c61210bf6949f0ac16803889ea1abf2b285ea";
     };
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Emoji One is a complete set of emojis designed for the web. It includes libraries to easily convert unicode characters to shortnames (:smile:) and shortnames to our custom emoji images. PNG and SVG formats provided for the emoji images.";
+      description = "EmojiOne is a complete set of emojis designed for the web. It includes libraries to easily convert unicode characters to shortnames (:smile:) and shortnames to our custom emoji images. PNG formats provided for the emoji images.";
       homepage = http://www.emojione.com/;
     };
     production = true;
@@ -25035,7 +25442,7 @@ in
               })
             ];
           })
-          (sources."chokidar-1.6.1" // {
+          (sources."chokidar-1.7.0" // {
             dependencies = [
               (sources."anymatch-1.3.0" // {
                 dependencies = [
@@ -25044,7 +25451,7 @@ in
                     dependencies = [
                       (sources."arr-diff-2.0.0" // {
                         dependencies = [
-                          sources."arr-flatten-1.0.2"
+                          sources."arr-flatten-1.0.3"
                         ];
                       })
                       sources."array-unique-0.2.1"
@@ -25076,9 +25483,9 @@ in
                         ];
                       })
                       sources."extglob-0.3.2"
-                      sources."filename-regex-2.0.0"
+                      sources."filename-regex-2.0.1"
                       sources."is-extglob-1.0.0"
-                      (sources."kind-of-3.1.0" // {
+                      (sources."kind-of-3.2.0" // {
                         dependencies = [
                           sources."is-buffer-1.1.5"
                         ];
@@ -25164,9 +25571,9 @@ in
                           })
                         ];
                       })
-                      (sources."npmlog-4.0.2" // {
+                      (sources."npmlog-4.1.0" // {
                         dependencies = [
-                          (sources."are-we-there-yet-1.1.2" // {
+                          (sources."are-we-there-yet-1.1.4" // {
                             dependencies = [
                               sources."delegates-1.0.0"
                               (sources."readable-stream-2.2.9" // {
@@ -25182,7 +25589,7 @@ in
                             ];
                           })
                           sources."console-control-strings-1.1.0"
-                          (sources."gauge-2.7.3" // {
+                          (sources."gauge-2.7.4" // {
                             dependencies = [
                               sources."aproba-1.1.1"
                               sources."has-unicode-2.0.1"
@@ -25203,7 +25610,7 @@ in
                                   sources."ansi-regex-2.1.1"
                                 ];
                               })
-                              sources."wide-align-1.1.0"
+                              sources."wide-align-1.1.2"
                             ];
                           })
                           sources."set-blocking-2.0.0"
@@ -25211,7 +25618,7 @@ in
                       })
                       (sources."rc-1.2.1" // {
                         dependencies = [
-                          sources."deep-extend-0.4.1"
+                          sources."deep-extend-0.4.2"
                           sources."ini-1.3.4"
                           sources."minimist-1.2.0"
                           sources."strip-json-comments-2.0.1"
@@ -25227,7 +25634,7 @@ in
                               sources."delayed-stream-1.0.0"
                             ];
                           })
-                          sources."extend-3.0.0"
+                          sources."extend-3.0.1"
                           sources."forever-agent-0.6.1"
                           (sources."form-data-2.1.4" // {
                             dependencies = [
@@ -25236,7 +25643,7 @@ in
                           })
                           (sources."har-validator-4.2.1" // {
                             dependencies = [
-                              (sources."ajv-4.11.6" // {
+                              (sources."ajv-4.11.8" // {
                                 dependencies = [
                                   sources."co-4.6.0"
                                   (sources."json-stable-stringify-1.0.1" // {
@@ -25273,7 +25680,7 @@ in
                                   sources."asn1-0.2.3"
                                   sources."assert-plus-1.0.0"
                                   sources."dashdash-1.14.1"
-                                  sources."getpass-0.1.6"
+                                  sources."getpass-0.1.7"
                                   sources."jsbn-0.1.1"
                                   sources."tweetnacl-0.14.5"
                                   sources."jodid25519-1.0.2"
@@ -25337,9 +25744,9 @@ in
                       })
                       (sources."tar-pack-3.4.0" // {
                         dependencies = [
-                          (sources."debug-2.6.3" // {
+                          (sources."debug-2.6.6" // {
                             dependencies = [
-                              sources."ms-0.7.2"
+                              sources."ms-0.7.3"
                             ];
                           })
                           (sources."fstream-1.0.11" // {
@@ -25372,7 +25779,7 @@ in
               })
             ];
           })
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -25471,7 +25878,7 @@ in
                     ];
                   })
                   sources."inherits-2.0.3"
-                  (sources."minimatch-3.0.3" // {
+                  (sources."minimatch-3.0.4" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.7" // {
                         dependencies = [
@@ -25520,7 +25927,7 @@ in
       sha1 = "466a7253a54f526ca2f57ca78780895b95efaee4";
     };
     dependencies = [
-      (sources."async-2.3.0" // {
+      (sources."async-2.4.0" // {
         dependencies = [
           sources."lodash-4.17.4"
         ];
@@ -25531,7 +25938,7 @@ in
           sources."microee-0.0.2"
         ];
       })
-      sources."simple-git-1.70.0"
+      sources."simple-git-1.72.0"
       sources."tabtab-git+https://github.com/mixu/node-tabtab.git"
     ];
     buildInputs = globalBuildInputs;
@@ -25561,7 +25968,7 @@ in
                 ];
               })
               sources."inherits-2.0.3"
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -25611,7 +26018,7 @@ in
       (sources."jade-1.11.0" // {
         dependencies = [
           sources."character-parser-1.2.1"
-          (sources."clean-css-3.4.25" // {
+          (sources."clean-css-3.4.26" // {
             dependencies = [
               (sources."commander-2.8.1" // {
                 dependencies = [
@@ -25675,7 +26082,7 @@ in
               })
             ];
           })
-          (sources."uglify-js-2.8.22" // {
+          (sources."uglify-js-2.8.24" // {
             dependencies = [
               sources."source-map-0.5.6"
               (sources."yargs-3.10.0" // {
@@ -25687,7 +26094,7 @@ in
                         dependencies = [
                           (sources."align-text-0.1.4" // {
                             dependencies = [
-                              (sources."kind-of-3.1.0" // {
+                              (sources."kind-of-3.2.0" // {
                                 dependencies = [
                                   sources."is-buffer-1.1.5"
                                 ];
@@ -25703,7 +26110,7 @@ in
                         dependencies = [
                           (sources."align-text-0.1.4" // {
                             dependencies = [
-                              (sources."kind-of-3.1.0" // {
+                              (sources."kind-of-3.2.0" // {
                                 dependencies = [
                                   sources."is-buffer-1.1.5"
                                 ];
@@ -25887,10 +26294,10 @@ in
           })
         ];
       })
-      sources."interpret-1.0.2"
+      sources."interpret-1.0.3"
       (sources."liftoff-2.3.0" // {
         dependencies = [
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           (sources."findup-sync-0.4.3" // {
             dependencies = [
               (sources."detect-file-0.1.0" // {
@@ -25907,7 +26314,7 @@ in
                 dependencies = [
                   (sources."arr-diff-2.0.0" // {
                     dependencies = [
-                      sources."arr-flatten-1.0.2"
+                      sources."arr-flatten-1.0.3"
                     ];
                   })
                   sources."array-unique-0.2.1"
@@ -25939,9 +26346,9 @@ in
                     ];
                   })
                   sources."extglob-0.3.2"
-                  sources."filename-regex-2.0.0"
+                  sources."filename-regex-2.0.1"
                   sources."is-extglob-1.0.0"
-                  (sources."kind-of-3.1.0" // {
+                  (sources."kind-of-3.2.0" // {
                     dependencies = [
                       sources."is-buffer-1.1.5"
                     ];
@@ -26051,7 +26458,7 @@ in
           sources."lodash.isstring-4.0.1"
           sources."lodash.mapvalues-4.6.0"
           sources."rechoir-0.6.2"
-          (sources."resolve-1.3.2" // {
+          (sources."resolve-1.3.3" // {
             dependencies = [
               sources."path-parse-1.0.5"
             ];
@@ -26081,7 +26488,7 @@ in
           sources."os-homedir-1.0.2"
         ];
       })
-      (sources."v8flags-2.0.12" // {
+      (sources."v8flags-2.1.1" // {
         dependencies = [
           sources."user-home-1.1.1"
         ];
@@ -26251,7 +26658,7 @@ in
             ];
           })
           sources."inherits-2.0.3"
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -26410,7 +26817,7 @@ in
             ];
           })
           sources."inherits-2.0.3"
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -26423,7 +26830,7 @@ in
           sources."path-is-absolute-1.0.1"
         ];
       })
-      (sources."handlebars-4.0.6" // {
+      (sources."handlebars-4.0.8" // {
         dependencies = [
           (sources."optimist-0.6.1" // {
             dependencies = [
@@ -26436,7 +26843,7 @@ in
               sources."amdefine-1.0.1"
             ];
           })
-          (sources."uglify-js-2.8.22" // {
+          (sources."uglify-js-2.8.24" // {
             dependencies = [
               sources."source-map-0.5.6"
               (sources."yargs-3.10.0" // {
@@ -26448,7 +26855,7 @@ in
                         dependencies = [
                           (sources."align-text-0.1.4" // {
                             dependencies = [
-                              (sources."kind-of-3.1.0" // {
+                              (sources."kind-of-3.2.0" // {
                                 dependencies = [
                                   sources."is-buffer-1.1.5"
                                 ];
@@ -26464,7 +26871,7 @@ in
                         dependencies = [
                           (sources."align-text-0.1.4" // {
                             dependencies = [
-                              (sources."kind-of-3.1.0" // {
+                              (sources."kind-of-3.2.0" // {
                                 dependencies = [
                                   sources."is-buffer-1.1.5"
                                 ];
@@ -26487,7 +26894,7 @@ in
           })
         ];
       })
-      (sources."js-yaml-3.8.3" // {
+      (sources."js-yaml-3.8.4" // {
         dependencies = [
           (sources."argparse-1.0.9" // {
             dependencies = [
@@ -26609,7 +27016,7 @@ in
           sources."entities-1.0.0"
         ];
       })
-      (sources."minimatch-3.0.3" // {
+      (sources."minimatch-3.0.4" // {
         dependencies = [
           (sources."brace-expansion-1.1.7" // {
             dependencies = [
@@ -26664,10 +27071,10 @@ in
   js-yaml = nodeEnv.buildNodePackage {
     name = "js-yaml";
     packageName = "js-yaml";
-    version = "3.8.3";
+    version = "3.8.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz";
-      sha1 = "33a05ec481c850c8875929166fe1beb61c728766";
+      url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz";
+      sha1 = "520b4564f86573ba96662af85a8cafa7b4b5a6f6";
     };
     dependencies = [
       (sources."argparse-1.0.9" // {
@@ -26688,10 +27095,10 @@ in
   karma = nodeEnv.buildNodePackage {
     name = "karma";
     packageName = "karma";
-    version = "1.6.0";
+    version = "1.7.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/karma/-/karma-1.6.0.tgz";
-      sha1 = "0e871d4527d5eac56c41d181f03c5c0a7e6dbf3e";
+      url = "https://registry.npmjs.org/karma/-/karma-1.7.0.tgz";
+      sha1 = "6f7a1a406446fa2e187ec95398698f4cee476269";
     };
     dependencies = [
       sources."bluebird-3.5.0"
@@ -26736,7 +27143,7 @@ in
           })
         ];
       })
-      (sources."chokidar-1.6.1" // {
+      (sources."chokidar-1.7.0" // {
         dependencies = [
           (sources."anymatch-1.3.0" // {
             dependencies = [
@@ -26745,7 +27152,7 @@ in
                 dependencies = [
                   (sources."arr-diff-2.0.0" // {
                     dependencies = [
-                      sources."arr-flatten-1.0.2"
+                      sources."arr-flatten-1.0.3"
                     ];
                   })
                   sources."array-unique-0.2.1"
@@ -26777,9 +27184,9 @@ in
                     ];
                   })
                   sources."extglob-0.3.2"
-                  sources."filename-regex-2.0.0"
+                  sources."filename-regex-2.0.1"
                   sources."is-extglob-1.0.0"
-                  (sources."kind-of-3.1.0" // {
+                  (sources."kind-of-3.2.0" // {
                     dependencies = [
                       sources."is-buffer-1.1.5"
                     ];
@@ -26865,9 +27272,9 @@ in
                       })
                     ];
                   })
-                  (sources."npmlog-4.0.2" // {
+                  (sources."npmlog-4.1.0" // {
                     dependencies = [
-                      (sources."are-we-there-yet-1.1.2" // {
+                      (sources."are-we-there-yet-1.1.4" // {
                         dependencies = [
                           sources."delegates-1.0.0"
                           (sources."readable-stream-2.2.9" // {
@@ -26883,7 +27290,7 @@ in
                         ];
                       })
                       sources."console-control-strings-1.1.0"
-                      (sources."gauge-2.7.3" // {
+                      (sources."gauge-2.7.4" // {
                         dependencies = [
                           sources."aproba-1.1.1"
                           sources."has-unicode-2.0.1"
@@ -26904,7 +27311,7 @@ in
                               sources."ansi-regex-2.1.1"
                             ];
                           })
-                          sources."wide-align-1.1.0"
+                          sources."wide-align-1.1.2"
                         ];
                       })
                       sources."set-blocking-2.0.0"
@@ -26912,7 +27319,7 @@ in
                   })
                   (sources."rc-1.2.1" // {
                     dependencies = [
-                      sources."deep-extend-0.4.1"
+                      sources."deep-extend-0.4.2"
                       sources."ini-1.3.4"
                       sources."minimist-1.2.0"
                       sources."strip-json-comments-2.0.1"
@@ -26928,7 +27335,7 @@ in
                           sources."delayed-stream-1.0.0"
                         ];
                       })
-                      sources."extend-3.0.0"
+                      sources."extend-3.0.1"
                       sources."forever-agent-0.6.1"
                       (sources."form-data-2.1.4" // {
                         dependencies = [
@@ -26937,7 +27344,7 @@ in
                       })
                       (sources."har-validator-4.2.1" // {
                         dependencies = [
-                          (sources."ajv-4.11.6" // {
+                          (sources."ajv-4.11.8" // {
                             dependencies = [
                               sources."co-4.6.0"
                               (sources."json-stable-stringify-1.0.1" // {
@@ -26974,7 +27381,7 @@ in
                               sources."asn1-0.2.3"
                               sources."assert-plus-1.0.0"
                               sources."dashdash-1.14.1"
-                              sources."getpass-0.1.6"
+                              sources."getpass-0.1.7"
                               sources."jsbn-0.1.1"
                               sources."tweetnacl-0.14.5"
                               sources."jodid25519-1.0.2"
@@ -27014,9 +27421,9 @@ in
                   })
                   (sources."tar-pack-3.4.0" // {
                     dependencies = [
-                      (sources."debug-2.6.3" // {
+                      (sources."debug-2.6.6" // {
                         dependencies = [
-                          sources."ms-0.7.2"
+                          sources."ms-0.7.3"
                         ];
                       })
                       sources."fstream-1.0.11"
@@ -27051,14 +27458,14 @@ in
           sources."lodash-4.17.4"
         ];
       })
-      (sources."connect-3.6.0" // {
+      (sources."connect-3.6.1" // {
         dependencies = [
-          (sources."debug-2.6.1" // {
+          (sources."debug-2.6.3" // {
             dependencies = [
               sources."ms-0.7.2"
             ];
           })
-          (sources."finalhandler-1.0.0" // {
+          (sources."finalhandler-1.0.1" // {
             dependencies = [
               sources."encodeurl-1.0.1"
               sources."escape-html-1.0.3"
@@ -27081,7 +27488,7 @@ in
         dependencies = [
           sources."custom-event-1.0.1"
           sources."ent-2.2.0"
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           sources."void-elements-2.0.1"
         ];
       })
@@ -27140,8 +27547,8 @@ in
           sources."semver-4.3.6"
         ];
       })
-      sources."mime-1.3.4"
-      (sources."minimatch-3.0.3" // {
+      sources."mime-1.3.6"
+      (sources."minimatch-3.0.4" // {
         dependencies = [
           (sources."brace-expansion-1.1.7" // {
             dependencies = [
@@ -27662,7 +28069,7 @@ in
           })
           (sources."glob-stream-5.3.5" // {
             dependencies = [
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               (sources."glob-5.0.15" // {
                 dependencies = [
                   (sources."inflight-1.0.6" // {
@@ -27671,7 +28078,7 @@ in
                     ];
                   })
                   sources."inherits-2.0.3"
-                  (sources."minimatch-3.0.3" // {
+                  (sources."minimatch-3.0.4" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.7" // {
                         dependencies = [
@@ -27703,7 +28110,7 @@ in
                 dependencies = [
                   (sources."arr-diff-2.0.0" // {
                     dependencies = [
-                      sources."arr-flatten-1.0.2"
+                      sources."arr-flatten-1.0.3"
                     ];
                   })
                   sources."array-unique-0.2.1"
@@ -27735,10 +28142,10 @@ in
                     ];
                   })
                   sources."extglob-0.3.2"
-                  sources."filename-regex-2.0.0"
+                  sources."filename-regex-2.0.1"
                   sources."is-extglob-1.0.0"
                   sources."is-glob-2.0.1"
-                  (sources."kind-of-3.1.0" // {
+                  (sources."kind-of-3.2.0" // {
                     dependencies = [
                       sources."is-buffer-1.1.5"
                     ];
@@ -27918,10 +28325,10 @@ in
   mocha = nodeEnv.buildNodePackage {
     name = "mocha";
     packageName = "mocha";
-    version = "3.2.0";
+    version = "3.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/mocha/-/mocha-3.2.0.tgz";
-      sha1 = "7dc4f45e5088075171a68896814e6ae9eb7a85e3";
+      url = "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz";
+      sha1 = "d29b7428d3f52c82e2e65df1ecb7064e1aabbfb5";
     };
     dependencies = [
       sources."browser-stdout-1.3.0"
@@ -27930,14 +28337,14 @@ in
           sources."graceful-readlink-1.0.1"
         ];
       })
-      (sources."debug-2.2.0" // {
+      (sources."debug-2.6.0" // {
         dependencies = [
-          sources."ms-0.7.1"
+          sources."ms-0.7.2"
         ];
       })
-      sources."diff-1.4.0"
+      sources."diff-3.2.0"
       sources."escape-string-regexp-1.0.5"
-      (sources."glob-7.0.5" // {
+      (sources."glob-7.1.1" // {
         dependencies = [
           sources."fs.realpath-1.0.0"
           (sources."inflight-1.0.6" // {
@@ -27946,7 +28353,7 @@ in
             ];
           })
           sources."inherits-2.0.3"
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -28059,7 +28466,7 @@ in
               sources."minimist-0.0.8"
             ];
           })
-          (sources."normalize-package-data-2.3.6" // {
+          (sources."normalize-package-data-2.3.8" // {
             dependencies = [
               sources."hosted-git-info-2.4.2"
               (sources."is-builtin-module-1.0.0" // {
@@ -28099,7 +28506,7 @@ in
                   sources."delayed-stream-1.0.0"
                 ];
               })
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               sources."forever-agent-0.6.1"
               (sources."form-data-2.1.4" // {
                 dependencies = [
@@ -28108,7 +28515,7 @@ in
               })
               (sources."har-validator-4.2.1" // {
                 dependencies = [
-                  (sources."ajv-4.11.6" // {
+                  (sources."ajv-4.11.8" // {
                     dependencies = [
                       sources."co-4.6.0"
                       (sources."json-stable-stringify-1.0.1" // {
@@ -28145,7 +28552,7 @@ in
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.1"
-                      sources."getpass-0.1.6"
+                      sources."getpass-0.1.7"
                       sources."jsbn-0.1.1"
                       sources."tweetnacl-0.14.5"
                       sources."jodid25519-1.0.2"
@@ -28189,7 +28596,7 @@ in
                     ];
                   })
                   sources."inherits-2.0.3"
-                  (sources."minimatch-3.0.3" // {
+                  (sources."minimatch-3.0.4" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.7" // {
                         dependencies = [
@@ -28207,7 +28614,7 @@ in
           sources."slide-1.1.6"
           (sources."npmlog-3.1.2" // {
             dependencies = [
-              (sources."are-we-there-yet-1.1.2" // {
+              (sources."are-we-there-yet-1.1.4" // {
                 dependencies = [
                   sources."delegates-1.0.0"
                   (sources."readable-stream-2.2.9" // {
@@ -28246,7 +28653,7 @@ in
                       sources."ansi-regex-2.1.1"
                     ];
                   })
-                  sources."wide-align-1.1.0"
+                  sources."wide-align-1.1.2"
                 ];
               })
               sources."set-blocking-2.0.0"
@@ -28309,7 +28716,7 @@ in
                           sources."wrappy-1.0.2"
                         ];
                       })
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -28376,10 +28783,10 @@ in
   node-gyp = nodeEnv.buildNodePackage {
     name = "node-gyp";
     packageName = "node-gyp";
-    version = "3.6.0";
+    version = "3.6.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz";
-      sha1 = "7474f63a3a0501161dda0b6341f022f14c423fa6";
+      url = "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.1.tgz";
+      sha1 = "19561067ff185464aded478212681f47fd578cbc";
     };
     dependencies = [
       (sources."fstream-1.0.11" // {
@@ -28405,7 +28812,7 @@ in
         ];
       })
       sources."graceful-fs-4.1.11"
-      (sources."minimatch-3.0.3" // {
+      (sources."minimatch-3.0.4" // {
         dependencies = [
           (sources."brace-expansion-1.1.7" // {
             dependencies = [
@@ -28425,9 +28832,9 @@ in
           sources."abbrev-1.1.0"
         ];
       })
-      (sources."npmlog-4.0.2" // {
+      (sources."npmlog-4.1.0" // {
         dependencies = [
-          (sources."are-we-there-yet-1.1.2" // {
+          (sources."are-we-there-yet-1.1.4" // {
             dependencies = [
               sources."delegates-1.0.0"
               (sources."readable-stream-2.2.9" // {
@@ -28444,7 +28851,7 @@ in
             ];
           })
           sources."console-control-strings-1.1.0"
-          (sources."gauge-2.7.3" // {
+          (sources."gauge-2.7.4" // {
             dependencies = [
               sources."aproba-1.1.1"
               sources."has-unicode-2.0.1"
@@ -28465,7 +28872,7 @@ in
                   sources."ansi-regex-2.1.1"
                 ];
               })
-              sources."wide-align-1.1.0"
+              sources."wide-align-1.1.2"
             ];
           })
           sources."set-blocking-2.0.0"
@@ -28487,7 +28894,7 @@ in
               sources."delayed-stream-1.0.0"
             ];
           })
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           sources."forever-agent-0.6.1"
           (sources."form-data-2.1.4" // {
             dependencies = [
@@ -28496,7 +28903,7 @@ in
           })
           (sources."har-validator-4.2.1" // {
             dependencies = [
-              (sources."ajv-4.11.6" // {
+              (sources."ajv-4.11.8" // {
                 dependencies = [
                   sources."co-4.6.0"
                   (sources."json-stable-stringify-1.0.1" // {
@@ -28533,7 +28940,7 @@ in
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.1"
-                  sources."getpass-0.1.6"
+                  sources."getpass-0.1.7"
                   sources."jsbn-0.1.1"
                   sources."tweetnacl-0.14.5"
                   sources."jodid25519-1.0.2"
@@ -28590,10 +28997,10 @@ in
   node-inspector = nodeEnv.buildNodePackage {
     name = "node-inspector";
     packageName = "node-inspector";
-    version = "1.1.0";
+    version = "1.1.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/node-inspector/-/node-inspector-1.1.0.tgz";
-      sha1 = "0f8ffffbf9a9b86540eb33c1d64e7ba546457622";
+      url = "https://registry.npmjs.org/node-inspector/-/node-inspector-1.1.1.tgz";
+      sha1 = "e7851eb973f380543c058db564a9812055eac640";
     };
     dependencies = [
       sources."async-0.9.2"
@@ -28644,7 +29051,7 @@ in
                 dependencies = [
                   (sources."bplist-parser-0.1.1" // {
                     dependencies = [
-                      sources."big-integer-1.6.19"
+                      sources."big-integer-1.6.22"
                     ];
                   })
                   (sources."meow-3.7.0" // {
@@ -28666,7 +29073,7 @@ in
                         ];
                       })
                       sources."map-obj-1.0.1"
-                      (sources."normalize-package-data-2.3.6" // {
+                      (sources."normalize-package-data-2.3.8" // {
                         dependencies = [
                           sources."hosted-git-info-2.4.2"
                           (sources."is-builtin-module-1.0.0" // {
@@ -28777,9 +29184,9 @@ in
           })
         ];
       })
-      (sources."debug-2.6.3" // {
+      (sources."debug-2.6.6" // {
         dependencies = [
-          sources."ms-0.7.2"
+          sources."ms-0.7.3"
         ];
       })
       (sources."express-4.15.2" // {
@@ -28808,11 +29215,11 @@ in
           sources."encodeurl-1.0.1"
           sources."escape-html-1.0.3"
           sources."etag-1.8.0"
-          (sources."finalhandler-1.0.1" // {
+          (sources."finalhandler-1.0.2" // {
             dependencies = [
-              (sources."debug-2.6.3" // {
+              (sources."debug-2.6.4" // {
                 dependencies = [
-                  sources."ms-0.7.2"
+                  sources."ms-0.7.3"
                 ];
               })
               sources."unpipe-1.0.0"
@@ -28873,7 +29280,7 @@ in
             ];
           })
           sources."inherits-2.0.3"
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -28893,7 +29300,7 @@ in
       sources."path-is-absolute-1.0.1"
       (sources."rc-1.2.1" // {
         dependencies = [
-          sources."deep-extend-0.4.1"
+          sources."deep-extend-0.4.2"
           sources."ini-1.3.4"
           sources."minimist-1.2.0"
           sources."strip-json-comments-2.0.1"
@@ -28934,9 +29341,9 @@ in
                   })
                 ];
               })
-              (sources."npmlog-4.0.2" // {
+              (sources."npmlog-4.1.0" // {
                 dependencies = [
-                  (sources."are-we-there-yet-1.1.2" // {
+                  (sources."are-we-there-yet-1.1.4" // {
                     dependencies = [
                       sources."delegates-1.0.0"
                       (sources."readable-stream-2.2.9" // {
@@ -28953,7 +29360,7 @@ in
                     ];
                   })
                   sources."console-control-strings-1.1.0"
-                  (sources."gauge-2.7.3" // {
+                  (sources."gauge-2.7.4" // {
                     dependencies = [
                       sources."aproba-1.1.1"
                       sources."has-unicode-2.0.1"
@@ -28974,7 +29381,7 @@ in
                           sources."ansi-regex-2.1.1"
                         ];
                       })
-                      sources."wide-align-1.1.0"
+                      sources."wide-align-1.1.2"
                     ];
                   })
                   sources."set-blocking-2.0.0"
@@ -28990,7 +29397,7 @@ in
                       sources."delayed-stream-1.0.0"
                     ];
                   })
-                  sources."extend-3.0.0"
+                  sources."extend-3.0.1"
                   sources."forever-agent-0.6.1"
                   (sources."form-data-2.1.4" // {
                     dependencies = [
@@ -28999,7 +29406,7 @@ in
                   })
                   (sources."har-validator-4.2.1" // {
                     dependencies = [
-                      (sources."ajv-4.11.6" // {
+                      (sources."ajv-4.11.8" // {
                         dependencies = [
                           sources."co-4.6.0"
                           (sources."json-stable-stringify-1.0.1" // {
@@ -29036,7 +29443,7 @@ in
                           sources."asn1-0.2.3"
                           sources."assert-plus-1.0.0"
                           sources."dashdash-1.14.1"
-                          sources."getpass-0.1.6"
+                          sources."getpass-0.1.7"
                           sources."jsbn-0.1.1"
                           sources."tweetnacl-0.14.5"
                           sources."jodid25519-1.0.2"
@@ -29079,7 +29486,7 @@ in
                         ];
                       })
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -29121,7 +29528,7 @@ in
                   (sources."fstream-ignore-1.0.5" // {
                     dependencies = [
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -29177,9 +29584,9 @@ in
                   })
                 ];
               })
-              (sources."npmlog-4.0.2" // {
+              (sources."npmlog-4.1.0" // {
                 dependencies = [
-                  (sources."are-we-there-yet-1.1.2" // {
+                  (sources."are-we-there-yet-1.1.4" // {
                     dependencies = [
                       sources."delegates-1.0.0"
                       (sources."readable-stream-2.2.9" // {
@@ -29196,7 +29603,7 @@ in
                     ];
                   })
                   sources."console-control-strings-1.1.0"
-                  (sources."gauge-2.7.3" // {
+                  (sources."gauge-2.7.4" // {
                     dependencies = [
                       sources."aproba-1.1.1"
                       sources."has-unicode-2.0.1"
@@ -29217,7 +29624,7 @@ in
                           sources."ansi-regex-2.1.1"
                         ];
                       })
-                      sources."wide-align-1.1.0"
+                      sources."wide-align-1.1.2"
                     ];
                   })
                   sources."set-blocking-2.0.0"
@@ -29233,7 +29640,7 @@ in
                       sources."delayed-stream-1.0.0"
                     ];
                   })
-                  sources."extend-3.0.0"
+                  sources."extend-3.0.1"
                   sources."forever-agent-0.6.1"
                   (sources."form-data-2.1.4" // {
                     dependencies = [
@@ -29242,7 +29649,7 @@ in
                   })
                   (sources."har-validator-4.2.1" // {
                     dependencies = [
-                      (sources."ajv-4.11.6" // {
+                      (sources."ajv-4.11.8" // {
                         dependencies = [
                           sources."co-4.6.0"
                           (sources."json-stable-stringify-1.0.1" // {
@@ -29279,7 +29686,7 @@ in
                           sources."asn1-0.2.3"
                           sources."assert-plus-1.0.0"
                           sources."dashdash-1.14.1"
-                          sources."getpass-0.1.6"
+                          sources."getpass-0.1.7"
                           sources."jsbn-0.1.1"
                           sources."tweetnacl-0.14.5"
                           sources."jodid25519-1.0.2"
@@ -29322,7 +29729,7 @@ in
                         ];
                       })
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -29364,7 +29771,7 @@ in
                   (sources."fstream-ignore-1.0.5" // {
                     dependencies = [
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -29485,9 +29892,9 @@ in
           })
         ];
       })
-      (sources."npmlog-4.0.2" // {
+      (sources."npmlog-4.1.0" // {
         dependencies = [
-          (sources."are-we-there-yet-1.1.2" // {
+          (sources."are-we-there-yet-1.1.4" // {
             dependencies = [
               sources."delegates-1.0.0"
               (sources."readable-stream-2.2.9" // {
@@ -29504,7 +29911,7 @@ in
             ];
           })
           sources."console-control-strings-1.1.0"
-          (sources."gauge-2.7.3" // {
+          (sources."gauge-2.7.4" // {
             dependencies = [
               sources."aproba-1.1.1"
               sources."has-unicode-2.0.1"
@@ -29525,7 +29932,7 @@ in
                   sources."ansi-regex-2.1.1"
                 ];
               })
-              sources."wide-align-1.1.0"
+              sources."wide-align-1.1.2"
             ];
           })
           sources."set-blocking-2.0.0"
@@ -29533,7 +29940,7 @@ in
       })
       (sources."rc-1.2.1" // {
         dependencies = [
-          sources."deep-extend-0.4.1"
+          sources."deep-extend-0.4.2"
           sources."ini-1.3.4"
           sources."minimist-1.2.0"
           sources."strip-json-comments-2.0.1"
@@ -29549,7 +29956,7 @@ in
               sources."delayed-stream-1.0.0"
             ];
           })
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           sources."forever-agent-0.6.1"
           (sources."form-data-2.1.4" // {
             dependencies = [
@@ -29558,7 +29965,7 @@ in
           })
           (sources."har-validator-4.2.1" // {
             dependencies = [
-              (sources."ajv-4.11.6" // {
+              (sources."ajv-4.11.8" // {
                 dependencies = [
                   sources."co-4.6.0"
                   (sources."json-stable-stringify-1.0.1" // {
@@ -29595,7 +30002,7 @@ in
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.1"
-                  sources."getpass-0.1.6"
+                  sources."getpass-0.1.7"
                   sources."jsbn-0.1.1"
                   sources."tweetnacl-0.14.5"
                   sources."jodid25519-1.0.2"
@@ -29638,7 +30045,7 @@ in
                 ];
               })
               sources."inherits-2.0.3"
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -29672,9 +30079,9 @@ in
       })
       (sources."tar-pack-3.4.0" // {
         dependencies = [
-          (sources."debug-2.6.3" // {
+          (sources."debug-2.6.6" // {
             dependencies = [
-              sources."ms-0.7.2"
+              sources."ms-0.7.3"
             ];
           })
           (sources."fstream-1.0.11" // {
@@ -29686,7 +30093,7 @@ in
           (sources."fstream-ignore-1.0.5" // {
             dependencies = [
               sources."inherits-2.0.3"
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -29735,7 +30142,7 @@ in
       sha1 = "226c562bd2a7b13d3d7518b49ad4828a3623d06c";
     };
     dependencies = [
-      (sources."chokidar-1.6.1" // {
+      (sources."chokidar-1.7.0" // {
         dependencies = [
           (sources."anymatch-1.3.0" // {
             dependencies = [
@@ -29744,7 +30151,7 @@ in
                 dependencies = [
                   (sources."arr-diff-2.0.0" // {
                     dependencies = [
-                      sources."arr-flatten-1.0.2"
+                      sources."arr-flatten-1.0.3"
                     ];
                   })
                   sources."array-unique-0.2.1"
@@ -29776,9 +30183,9 @@ in
                     ];
                   })
                   sources."extglob-0.3.2"
-                  sources."filename-regex-2.0.0"
+                  sources."filename-regex-2.0.1"
                   sources."is-extglob-1.0.0"
-                  (sources."kind-of-3.1.0" // {
+                  (sources."kind-of-3.2.0" // {
                     dependencies = [
                       sources."is-buffer-1.1.5"
                     ];
@@ -29865,9 +30272,9 @@ in
                       })
                     ];
                   })
-                  (sources."npmlog-4.0.2" // {
+                  (sources."npmlog-4.1.0" // {
                     dependencies = [
-                      (sources."are-we-there-yet-1.1.2" // {
+                      (sources."are-we-there-yet-1.1.4" // {
                         dependencies = [
                           sources."delegates-1.0.0"
                           (sources."readable-stream-2.2.9" // {
@@ -29883,7 +30290,7 @@ in
                         ];
                       })
                       sources."console-control-strings-1.1.0"
-                      (sources."gauge-2.7.3" // {
+                      (sources."gauge-2.7.4" // {
                         dependencies = [
                           sources."aproba-1.1.1"
                           sources."has-unicode-2.0.1"
@@ -29904,7 +30311,7 @@ in
                               sources."ansi-regex-2.1.1"
                             ];
                           })
-                          sources."wide-align-1.1.0"
+                          sources."wide-align-1.1.2"
                         ];
                       })
                       sources."set-blocking-2.0.0"
@@ -29912,7 +30319,7 @@ in
                   })
                   (sources."rc-1.2.1" // {
                     dependencies = [
-                      sources."deep-extend-0.4.1"
+                      sources."deep-extend-0.4.2"
                       sources."ini-1.3.4"
                       sources."minimist-1.2.0"
                       sources."strip-json-comments-2.0.1"
@@ -29928,7 +30335,7 @@ in
                           sources."delayed-stream-1.0.0"
                         ];
                       })
-                      sources."extend-3.0.0"
+                      sources."extend-3.0.1"
                       sources."forever-agent-0.6.1"
                       (sources."form-data-2.1.4" // {
                         dependencies = [
@@ -29937,7 +30344,7 @@ in
                       })
                       (sources."har-validator-4.2.1" // {
                         dependencies = [
-                          (sources."ajv-4.11.6" // {
+                          (sources."ajv-4.11.8" // {
                             dependencies = [
                               sources."co-4.6.0"
                               (sources."json-stable-stringify-1.0.1" // {
@@ -29974,7 +30381,7 @@ in
                               sources."asn1-0.2.3"
                               sources."assert-plus-1.0.0"
                               sources."dashdash-1.14.1"
-                              sources."getpass-0.1.6"
+                              sources."getpass-0.1.7"
                               sources."jsbn-0.1.1"
                               sources."tweetnacl-0.14.5"
                               sources."jodid25519-1.0.2"
@@ -30068,9 +30475,9 @@ in
           })
         ];
       })
-      (sources."debug-2.6.3" // {
+      (sources."debug-2.6.6" // {
         dependencies = [
-          sources."ms-0.7.2"
+          sources."ms-0.7.3"
         ];
       })
       sources."es6-promise-3.3.1"
@@ -30102,7 +30509,7 @@ in
           sources."lodash.restparam-3.6.1"
         ];
       })
-      (sources."minimatch-3.0.3" // {
+      (sources."minimatch-3.0.4" // {
         dependencies = [
           (sources."brace-expansion-1.1.7" // {
             dependencies = [
@@ -30172,7 +30579,7 @@ in
                 ];
               })
               sources."uuid-2.0.3"
-              (sources."write-file-atomic-1.3.1" // {
+              (sources."write-file-atomic-1.3.4" // {
                 dependencies = [
                   sources."imurmurhash-0.1.4"
                   sources."slide-1.1.6"
@@ -30255,7 +30662,7 @@ in
                     dependencies = [
                       (sources."rc-1.2.1" // {
                         dependencies = [
-                          sources."deep-extend-0.4.1"
+                          sources."deep-extend-0.4.2"
                           sources."ini-1.3.4"
                           sources."minimist-1.2.0"
                           sources."strip-json-comments-2.0.1"
@@ -30375,8 +30782,8 @@ in
           (sources."htmlparser2-3.9.2" // {
             dependencies = [
               sources."domelementtype-1.3.0"
-              sources."domhandler-2.3.0"
-              sources."domutils-1.5.1"
+              sources."domhandler-2.4.1"
+              sources."domutils-1.6.2"
               sources."inherits-2.0.3"
               (sources."readable-stream-2.2.9" // {
                 dependencies = [
@@ -30522,9 +30929,9 @@ in
       })
       (sources."follow-redirects-1.2.1" // {
         dependencies = [
-          (sources."debug-2.6.3" // {
+          (sources."debug-2.6.6" // {
             dependencies = [
-              sources."ms-0.7.2"
+              sources."ms-0.7.3"
             ];
           })
         ];
@@ -30594,7 +31001,7 @@ in
               sources."callback-stream-1.1.0"
               (sources."glob-stream-6.1.0" // {
                 dependencies = [
-                  sources."extend-3.0.0"
+                  sources."extend-3.0.1"
                   (sources."glob-7.1.1" // {
                     dependencies = [
                       sources."fs.realpath-1.0.0"
@@ -30603,7 +31010,7 @@ in
                           sources."wrappy-1.0.2"
                         ];
                       })
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -30632,11 +31039,7 @@ in
                     ];
                   })
                   sources."is-negated-glob-1.0.0"
-                  (sources."ordered-read-streams-1.0.0" // {
-                    dependencies = [
-                      sources."is-stream-1.1.0"
-                    ];
-                  })
+                  sources."ordered-read-streams-1.0.1"
                   (sources."pumpify-1.3.5" // {
                     dependencies = [
                       (sources."duplexify-3.5.0" // {
@@ -30698,7 +31101,7 @@ in
           sources."minimist-1.2.0"
           (sources."mqtt-packet-5.3.0" // {
             dependencies = [
-              sources."bl-1.2.0"
+              sources."bl-1.2.1"
               sources."process-nextick-args-1.0.7"
               sources."safe-buffer-5.0.1"
             ];
@@ -30760,9 +31163,9 @@ in
         dependencies = [
           sources."uid2-0.0.3"
           sources."utils-merge-1.0.0"
-          (sources."debug-2.6.3" // {
+          (sources."debug-2.6.6" // {
             dependencies = [
-              sources."ms-0.7.2"
+              sources."ms-0.7.3"
             ];
           })
         ];
@@ -30807,7 +31210,7 @@ in
                     dependencies = [
                       (sources."align-text-0.1.4" // {
                         dependencies = [
-                          (sources."kind-of-3.1.0" // {
+                          (sources."kind-of-3.2.0" // {
                             dependencies = [
                               sources."is-buffer-1.1.5"
                             ];
@@ -30823,7 +31226,7 @@ in
                     dependencies = [
                       (sources."align-text-0.1.4" // {
                         dependencies = [
-                          (sources."kind-of-3.1.0" // {
+                          (sources."kind-of-3.2.0" // {
                             dependencies = [
                               sources."is-buffer-1.1.5"
                             ];
@@ -30901,11 +31304,11 @@ in
                   sources."delayed-stream-1.0.0"
                 ];
               })
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               sources."forever-agent-0.6.1"
               (sources."form-data-1.0.1" // {
                 dependencies = [
-                  (sources."async-2.3.0" // {
+                  (sources."async-2.4.0" // {
                     dependencies = [
                       sources."lodash-4.17.4"
                     ];
@@ -30979,7 +31382,7 @@ in
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.1"
-                      sources."getpass-0.1.6"
+                      sources."getpass-0.1.7"
                       sources."jsbn-0.1.1"
                       sources."tweetnacl-0.14.5"
                       sources."jodid25519-1.0.2"
@@ -31016,7 +31419,7 @@ in
             dependencies = [
               (sources."libmime-1.2.0" // {
                 dependencies = [
-                  sources."iconv-lite-0.4.15"
+                  sources."iconv-lite-0.4.17"
                   sources."libbase64-0.1.0"
                   sources."libqp-1.1.0"
                 ];
@@ -31030,12 +31433,12 @@ in
                       sources."libqp-1.1.0"
                       (sources."needle-0.10.0" // {
                         dependencies = [
-                          (sources."debug-2.6.3" // {
+                          (sources."debug-2.6.6" // {
                             dependencies = [
-                              sources."ms-0.7.2"
+                              sources."ms-0.7.3"
                             ];
                           })
-                          sources."iconv-lite-0.4.15"
+                          sources."iconv-lite-0.4.17"
                         ];
                       })
                     ];
@@ -31044,12 +31447,12 @@ in
               })
               (sources."needle-0.11.0" // {
                 dependencies = [
-                  (sources."debug-2.6.3" // {
+                  (sources."debug-2.6.6" // {
                     dependencies = [
-                      sources."ms-0.7.2"
+                      sources."ms-0.7.3"
                     ];
                   })
-                  sources."iconv-lite-0.4.15"
+                  sources."iconv-lite-0.4.17"
                 ];
               })
               (sources."nodemailer-direct-transport-1.1.0" // {
@@ -31085,13 +31488,13 @@ in
               })
               (sources."encoding-0.1.12" // {
                 dependencies = [
-                  sources."iconv-lite-0.4.15"
+                  sources."iconv-lite-0.4.17"
                 ];
               })
-              sources."mime-1.3.4"
+              sources."mime-1.3.6"
               (sources."uue-3.1.0" // {
                 dependencies = [
-                  sources."extend-3.0.0"
+                  sources."extend-3.0.1"
                 ];
               })
             ];
@@ -31125,7 +31528,7 @@ in
                   sources."delayed-stream-1.0.0"
                 ];
               })
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               sources."forever-agent-0.6.1"
               (sources."form-data-2.1.4" // {
                 dependencies = [
@@ -31134,7 +31537,7 @@ in
               })
               (sources."har-validator-4.2.1" // {
                 dependencies = [
-                  (sources."ajv-4.11.6" // {
+                  (sources."ajv-4.11.8" // {
                     dependencies = [
                       sources."co-4.6.0"
                       (sources."json-stable-stringify-1.0.1" // {
@@ -31171,7 +31574,7 @@ in
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.1"
-                      sources."getpass-0.1.6"
+                      sources."getpass-0.1.7"
                       sources."jsbn-0.1.1"
                       sources."tweetnacl-0.14.5"
                       sources."jodid25519-1.0.2"
@@ -31216,9 +31619,9 @@ in
                   sources."minimist-0.0.8"
                 ];
               })
-              (sources."npmlog-4.0.2" // {
+              (sources."npmlog-4.1.0" // {
                 dependencies = [
-                  (sources."are-we-there-yet-1.1.2" // {
+                  (sources."are-we-there-yet-1.1.4" // {
                     dependencies = [
                       sources."delegates-1.0.0"
                       (sources."readable-stream-2.2.9" // {
@@ -31235,7 +31638,7 @@ in
                     ];
                   })
                   sources."console-control-strings-1.1.0"
-                  (sources."gauge-2.7.3" // {
+                  (sources."gauge-2.7.4" // {
                     dependencies = [
                       sources."aproba-1.1.1"
                       sources."has-unicode-2.0.1"
@@ -31256,7 +31659,7 @@ in
                           sources."ansi-regex-2.1.1"
                         ];
                       })
-                      sources."wide-align-1.1.0"
+                      sources."wide-align-1.1.2"
                     ];
                   })
                   sources."set-blocking-2.0.0"
@@ -31264,7 +31667,7 @@ in
               })
               (sources."rc-1.1.7" // {
                 dependencies = [
-                  sources."deep-extend-0.4.1"
+                  sources."deep-extend-0.4.2"
                   sources."ini-1.3.4"
                   sources."minimist-1.2.0"
                   sources."strip-json-comments-2.0.1"
@@ -31280,7 +31683,7 @@ in
                       sources."delayed-stream-1.0.0"
                     ];
                   })
-                  sources."extend-3.0.0"
+                  sources."extend-3.0.1"
                   sources."forever-agent-0.6.1"
                   (sources."form-data-2.1.4" // {
                     dependencies = [
@@ -31289,7 +31692,7 @@ in
                   })
                   (sources."har-validator-4.2.1" // {
                     dependencies = [
-                      (sources."ajv-4.11.6" // {
+                      (sources."ajv-4.11.8" // {
                         dependencies = [
                           sources."co-4.6.0"
                           (sources."json-stable-stringify-1.0.1" // {
@@ -31326,7 +31729,7 @@ in
                           sources."asn1-0.2.3"
                           sources."assert-plus-1.0.0"
                           sources."dashdash-1.14.1"
-                          sources."getpass-0.1.6"
+                          sources."getpass-0.1.7"
                           sources."jsbn-0.1.1"
                           sources."tweetnacl-0.14.5"
                           sources."jodid25519-1.0.2"
@@ -31368,7 +31771,7 @@ in
                         ];
                       })
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -31415,7 +31818,7 @@ in
                   (sources."fstream-ignore-1.0.5" // {
                     dependencies = [
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -31513,9 +31916,9 @@ in
             ];
           })
           sources."cookie-signature-1.0.1"
-          (sources."debug-2.6.3" // {
+          (sources."debug-2.6.6" // {
             dependencies = [
-              sources."ms-0.7.2"
+              sources."ms-0.7.3"
             ];
           })
         ];
@@ -31661,7 +32064,7 @@ in
     dependencies = [
       (sources."JSONStream-1.3.1" // {
         dependencies = [
-          sources."jsonparse-1.3.0"
+          sources."jsonparse-1.3.1"
           sources."through-2.3.8"
         ];
       })
@@ -31699,11 +32102,11 @@ in
       sources."fs-vacuum-1.2.10"
       sources."fs-write-stream-atomic-1.0.10"
       sources."fstream-1.0.11"
-      (sources."fstream-npm-1.2.0" // {
+      (sources."fstream-npm-1.2.1" // {
         dependencies = [
           (sources."fstream-ignore-1.0.5" // {
             dependencies = [
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -31720,7 +32123,7 @@ in
       (sources."glob-7.1.1" // {
         dependencies = [
           sources."fs.realpath-1.0.0"
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -31807,9 +32210,9 @@ in
           sources."run-queue-1.0.3"
         ];
       })
-      (sources."node-gyp-3.6.0" // {
+      (sources."node-gyp-3.6.1" // {
         dependencies = [
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -31824,7 +32227,7 @@ in
       })
       sources."nopt-4.0.1"
       sources."normalize-git-url-3.0.2"
-      (sources."normalize-package-data-2.3.6" // {
+      (sources."normalize-package-data-2.3.8" // {
         dependencies = [
           (sources."is-builtin-module-1.0.0" // {
             dependencies = [
@@ -31848,13 +32251,13 @@ in
       sources."npm-user-validate-0.1.5"
       (sources."npmlog-4.0.2" // {
         dependencies = [
-          (sources."are-we-there-yet-1.1.2" // {
+          (sources."are-we-there-yet-1.1.4" // {
             dependencies = [
               sources."delegates-1.0.0"
             ];
           })
           sources."console-control-strings-1.1.0"
-          (sources."gauge-2.7.3" // {
+          (sources."gauge-2.7.4" // {
             dependencies = [
               sources."object-assign-4.1.1"
               sources."signal-exit-3.0.2"
@@ -31868,7 +32271,7 @@ in
                   })
                 ];
               })
-              sources."wide-align-1.1.0"
+              sources."wide-align-1.1.2"
             ];
           })
           sources."set-blocking-2.0.0"
@@ -31925,7 +32328,7 @@ in
               sources."delayed-stream-1.0.0"
             ];
           })
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           sources."forever-agent-0.6.1"
           (sources."form-data-2.1.4" // {
             dependencies = [
@@ -31934,7 +32337,7 @@ in
           })
           (sources."har-validator-4.2.1" // {
             dependencies = [
-              (sources."ajv-4.11.6" // {
+              (sources."ajv-4.11.8" // {
                 dependencies = [
                   sources."co-4.6.0"
                   (sources."json-stable-stringify-1.0.1" // {
@@ -31971,7 +32374,7 @@ in
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.1"
-                  sources."getpass-0.1.6"
+                  sources."getpass-0.1.7"
                   sources."jsbn-0.1.1"
                   sources."tweetnacl-0.14.5"
                   sources."jodid25519-1.0.2"
@@ -32045,22 +32448,9 @@ in
       sources."unpipe-1.0.0"
       (sources."update-notifier-2.1.0" // {
         dependencies = [
-          (sources."boxen-1.0.0" // {
+          (sources."boxen-1.1.0" // {
             dependencies = [
-              (sources."ansi-align-1.1.0" // {
-                dependencies = [
-                  (sources."string-width-1.0.2" // {
-                    dependencies = [
-                      sources."code-point-at-1.1.0"
-                      (sources."is-fullwidth-code-point-1.0.0" // {
-                        dependencies = [
-                          sources."number-is-nan-1.0.1"
-                        ];
-                      })
-                    ];
-                  })
-                ];
-              })
+              sources."ansi-align-2.0.0"
               sources."camelcase-4.1.0"
               sources."cli-boxes-1.0.0"
               (sources."string-width-2.0.0" // {
@@ -32115,11 +32505,16 @@ in
               sources."supports-color-2.0.0"
             ];
           })
-          (sources."configstore-3.0.0" // {
+          (sources."configstore-3.1.0" // {
             dependencies = [
               (sources."dot-prop-4.1.1" // {
                 dependencies = [
                   sources."is-obj-1.0.1"
+                ];
+              })
+              (sources."make-dir-1.0.0" // {
+                dependencies = [
+                  sources."pify-2.3.0"
                 ];
               })
               (sources."unique-string-1.0.0" // {
@@ -32127,12 +32522,13 @@ in
                   sources."crypto-random-string-1.0.0"
                 ];
               })
+              sources."write-file-atomic-2.1.0"
             ];
           })
           sources."is-npm-1.0.0"
           (sources."latest-version-3.1.0" // {
             dependencies = [
-              (sources."package-json-4.0.0" // {
+              (sources."package-json-4.0.1" // {
                 dependencies = [
                   (sources."got-6.7.1" // {
                     dependencies = [
@@ -32157,22 +32553,23 @@ in
                       })
                     ];
                   })
-                  (sources."registry-auth-token-3.1.2" // {
+                  (sources."registry-auth-token-3.3.1" // {
                     dependencies = [
                       (sources."rc-1.2.1" // {
                         dependencies = [
-                          sources."deep-extend-0.4.1"
+                          sources."deep-extend-0.4.2"
                           sources."minimist-1.2.0"
                           sources."strip-json-comments-2.0.1"
                         ];
                       })
+                      sources."safe-buffer-5.0.1"
                     ];
                   })
                   (sources."registry-url-3.1.0" // {
                     dependencies = [
                       (sources."rc-1.2.1" // {
                         dependencies = [
-                          sources."deep-extend-0.4.1"
+                          sources."deep-extend-0.4.2"
                           sources."minimist-1.2.0"
                           sources."strip-json-comments-2.0.1"
                         ];
@@ -32200,7 +32597,7 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."write-file-atomic-1.3.1"
+      sources."write-file-atomic-1.3.4"
       sources."debuglog-1.0.1"
       sources."imurmurhash-0.1.4"
       sources."lodash._baseindexof-3.1.0"
@@ -32258,7 +32655,7 @@ in
                   sources."delayed-stream-1.0.0"
                 ];
               })
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               sources."forever-agent-0.6.1"
               (sources."form-data-2.1.4" // {
                 dependencies = [
@@ -32267,7 +32664,7 @@ in
               })
               (sources."har-validator-4.2.1" // {
                 dependencies = [
-                  (sources."ajv-4.11.6" // {
+                  (sources."ajv-4.11.8" // {
                     dependencies = [
                       sources."co-4.6.0"
                       (sources."json-stable-stringify-1.0.1" // {
@@ -32304,7 +32701,7 @@ in
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.1"
-                      sources."getpass-0.1.6"
+                      sources."getpass-0.1.7"
                       sources."jsbn-0.1.1"
                       sources."tweetnacl-0.14.5"
                       sources."jodid25519-1.0.2"
@@ -32352,7 +32749,7 @@ in
                     ];
                   })
                   sources."inherits-2.0.3"
-                  (sources."minimatch-3.0.3" // {
+                  (sources."minimatch-3.0.4" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.7" // {
                         dependencies = [
@@ -32374,9 +32771,9 @@ in
           })
           sources."retry-0.6.0"
           sources."couch-login-0.1.20"
-          (sources."npmlog-4.0.2" // {
+          (sources."npmlog-4.1.0" // {
             dependencies = [
-              (sources."are-we-there-yet-1.1.2" // {
+              (sources."are-we-there-yet-1.1.4" // {
                 dependencies = [
                   sources."delegates-1.0.0"
                   (sources."readable-stream-2.2.9" // {
@@ -32393,7 +32790,7 @@ in
                 ];
               })
               sources."console-control-strings-1.1.0"
-              (sources."gauge-2.7.3" // {
+              (sources."gauge-2.7.4" // {
                 dependencies = [
                   sources."aproba-1.1.1"
                   sources."has-unicode-2.0.1"
@@ -32414,7 +32811,7 @@ in
                       sources."ansi-regex-2.1.1"
                     ];
                   })
-                  sources."wide-align-1.1.0"
+                  sources."wide-align-1.1.2"
                 ];
               })
               sources."set-blocking-2.0.0"
@@ -32474,7 +32871,7 @@ in
                           sources."wrappy-1.0.2"
                         ];
                       })
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -32538,10 +32935,10 @@ in
   npm-check-updates = nodeEnv.buildNodePackage {
     name = "npm-check-updates";
     packageName = "npm-check-updates";
-    version = "2.10.5";
+    version = "2.11.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-2.10.5.tgz";
-      sha1 = "2d047e3a24d676e0c99cf7221361088dcc247a6a";
+      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-2.11.1.tgz";
+      sha1 = "9f9e9f6d9e558165c52901924063fc70783cd9eb";
     };
     dependencies = [
       sources."bluebird-3.5.0"
@@ -32625,11 +33022,11 @@ in
           sources."fs-vacuum-1.2.10"
           sources."fs-write-stream-atomic-1.0.10"
           sources."fstream-1.0.11"
-          (sources."fstream-npm-1.2.0" // {
+          (sources."fstream-npm-1.2.1" // {
             dependencies = [
               (sources."fstream-ignore-1.0.5" // {
                 dependencies = [
-                  (sources."minimatch-3.0.3" // {
+                  (sources."minimatch-3.0.4" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.7" // {
                         dependencies = [
@@ -32646,7 +33043,7 @@ in
           (sources."glob-7.1.1" // {
             dependencies = [
               sources."fs.realpath-1.0.0"
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -32694,7 +33091,7 @@ in
           })
           (sources."node-gyp-3.4.0" // {
             dependencies = [
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -32706,7 +33103,7 @@ in
               })
               (sources."npmlog-3.1.2" // {
                 dependencies = [
-                  (sources."are-we-there-yet-1.1.2" // {
+                  (sources."are-we-there-yet-1.1.4" // {
                     dependencies = [
                       sources."delegates-1.0.0"
                     ];
@@ -32727,7 +33124,7 @@ in
                           })
                         ];
                       })
-                      sources."wide-align-1.1.0"
+                      sources."wide-align-1.1.2"
                     ];
                   })
                   sources."set-blocking-2.0.0"
@@ -32737,15 +33134,15 @@ in
                 dependencies = [
                   (sources."array-index-1.0.0" // {
                     dependencies = [
-                      (sources."debug-2.6.3" // {
+                      (sources."debug-2.6.6" // {
                         dependencies = [
-                          sources."ms-0.7.2"
+                          sources."ms-0.7.3"
                         ];
                       })
                       (sources."es6-symbol-3.1.1" // {
                         dependencies = [
                           sources."d-1.0.0"
-                          (sources."es5-ext-0.10.15" // {
+                          (sources."es5-ext-0.10.16" // {
                             dependencies = [
                               sources."es6-iterator-2.0.1"
                             ];
@@ -32760,7 +33157,7 @@ in
           })
           sources."nopt-3.0.6"
           sources."normalize-git-url-3.0.2"
-          (sources."normalize-package-data-2.3.6" // {
+          (sources."normalize-package-data-2.3.8" // {
             dependencies = [
               (sources."is-builtin-module-1.0.0" // {
                 dependencies = [
@@ -32791,7 +33188,7 @@ in
               })
               (sources."npmlog-3.1.2" // {
                 dependencies = [
-                  (sources."are-we-there-yet-1.1.2" // {
+                  (sources."are-we-there-yet-1.1.4" // {
                     dependencies = [
                       sources."delegates-1.0.0"
                     ];
@@ -32812,7 +33209,7 @@ in
                           })
                         ];
                       })
-                      sources."wide-align-1.1.0"
+                      sources."wide-align-1.1.2"
                     ];
                   })
                   sources."set-blocking-2.0.0"
@@ -32823,13 +33220,13 @@ in
           sources."npm-user-validate-0.1.5"
           (sources."npmlog-4.0.2" // {
             dependencies = [
-              (sources."are-we-there-yet-1.1.2" // {
+              (sources."are-we-there-yet-1.1.4" // {
                 dependencies = [
                   sources."delegates-1.0.0"
                 ];
               })
               sources."console-control-strings-1.1.0"
-              (sources."gauge-2.7.3" // {
+              (sources."gauge-2.7.4" // {
                 dependencies = [
                   sources."object-assign-4.1.1"
                   sources."signal-exit-3.0.2"
@@ -32843,7 +33240,7 @@ in
                       })
                     ];
                   })
-                  sources."wide-align-1.1.0"
+                  sources."wide-align-1.1.2"
                 ];
               })
               sources."set-blocking-2.0.0"
@@ -32905,7 +33302,7 @@ in
                   sources."delayed-stream-1.0.0"
                 ];
               })
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               sources."forever-agent-0.6.1"
               (sources."form-data-2.0.0" // {
                 dependencies = [
@@ -32957,7 +33354,7 @@ in
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.1"
-                      sources."getpass-0.1.6"
+                      sources."getpass-0.1.7"
                       sources."jsbn-0.1.1"
                       sources."tweetnacl-0.14.5"
                       sources."jodid25519-1.0.2"
@@ -33049,7 +33446,7 @@ in
       sources."require-dir-0.3.1"
       sources."semver-5.3.0"
       sources."semver-utils-1.1.1"
-      (sources."snyk-1.28.1" // {
+      (sources."snyk-1.30.0" // {
         dependencies = [
           sources."abbrev-1.1.0"
           sources."ansi-escapes-1.4.0"
@@ -33069,7 +33466,7 @@ in
                 ];
               })
               sources."uuid-2.0.3"
-              (sources."write-file-atomic-1.3.1" // {
+              (sources."write-file-atomic-1.3.4" // {
                 dependencies = [
                   sources."imurmurhash-0.1.4"
                   sources."slide-1.1.6"
@@ -33082,9 +33479,9 @@ in
               })
             ];
           })
-          (sources."debug-2.6.3" // {
+          (sources."debug-2.6.6" // {
             dependencies = [
-              sources."ms-0.7.2"
+              sources."ms-0.7.3"
             ];
           })
           sources."es6-promise-3.3.1"
@@ -33163,7 +33560,7 @@ in
                   sources."delayed-stream-1.0.0"
                 ];
               })
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               sources."forever-agent-0.6.1"
               (sources."form-data-2.1.4" // {
                 dependencies = [
@@ -33172,7 +33569,7 @@ in
               })
               (sources."har-validator-4.2.1" // {
                 dependencies = [
-                  (sources."ajv-4.11.6" // {
+                  (sources."ajv-4.11.8" // {
                     dependencies = [
                       sources."co-4.6.0"
                       (sources."json-stable-stringify-1.0.1" // {
@@ -33209,7 +33606,7 @@ in
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.1"
-                      sources."getpass-0.1.6"
+                      sources."getpass-0.1.7"
                       sources."jsbn-0.1.1"
                       sources."tweetnacl-0.14.5"
                       sources."jodid25519-1.0.2"
@@ -33255,7 +33652,7 @@ in
                             dependencies = [
                               (sources."align-text-0.1.4" // {
                                 dependencies = [
-                                  (sources."kind-of-3.1.0" // {
+                                  (sources."kind-of-3.2.0" // {
                                     dependencies = [
                                       sources."is-buffer-1.1.5"
                                     ];
@@ -33271,7 +33668,7 @@ in
                             dependencies = [
                               (sources."align-text-0.1.4" // {
                                 dependencies = [
-                                  (sources."kind-of-3.1.0" // {
+                                  (sources."kind-of-3.2.0" // {
                                     dependencies = [
                                       sources."is-buffer-1.1.5"
                                     ];
@@ -33301,7 +33698,7 @@ in
           })
           (sources."snyk-policy-1.7.1" // {
             dependencies = [
-              (sources."js-yaml-3.8.3" // {
+              (sources."js-yaml-3.8.4" // {
                 dependencies = [
                   (sources."argparse-1.0.9" // {
                     dependencies = [
@@ -33391,7 +33788,7 @@ in
                             ];
                           })
                           sources."uuid-2.0.3"
-                          (sources."write-file-atomic-1.3.1" // {
+                          (sources."write-file-atomic-1.3.4" // {
                             dependencies = [
                               sources."imurmurhash-0.1.4"
                               sources."slide-1.1.6"
@@ -33458,22 +33855,23 @@ in
                                   })
                                 ];
                               })
-                              (sources."registry-auth-token-3.1.2" // {
+                              (sources."registry-auth-token-3.3.1" // {
                                 dependencies = [
                                   (sources."rc-1.2.1" // {
                                     dependencies = [
-                                      sources."deep-extend-0.4.1"
+                                      sources."deep-extend-0.4.2"
                                       sources."ini-1.3.4"
                                       sources."strip-json-comments-2.0.1"
                                     ];
                                   })
+                                  sources."safe-buffer-5.0.1"
                                 ];
                               })
                               (sources."registry-url-3.1.0" // {
                                 dependencies = [
                                   (sources."rc-1.2.1" // {
                                     dependencies = [
-                                      sources."deep-extend-0.4.1"
+                                      sources."deep-extend-0.4.2"
                                       sources."ini-1.3.4"
                                       sources."strip-json-comments-2.0.1"
                                     ];
@@ -33540,7 +33938,7 @@ in
                                   })
                                 ];
                               })
-                              (sources."normalize-package-data-2.3.6" // {
+                              (sources."normalize-package-data-2.3.8" // {
                                 dependencies = [
                                   sources."hosted-git-info-2.4.2"
                                   (sources."is-builtin-module-1.0.0" // {
@@ -33718,7 +34116,7 @@ in
                         dependencies = [
                           (sources."rc-1.2.1" // {
                             dependencies = [
-                              sources."deep-extend-0.4.1"
+                              sources."deep-extend-0.4.2"
                               sources."ini-1.3.4"
                               sources."minimist-1.2.0"
                               sources."strip-json-comments-2.0.1"
@@ -33818,7 +34216,7 @@ in
                 ];
               })
               sources."uuid-2.0.3"
-              (sources."write-file-atomic-1.3.1" // {
+              (sources."write-file-atomic-1.3.4" // {
                 dependencies = [
                   sources."imurmurhash-0.1.4"
                   sources."slide-1.1.6"
@@ -33880,23 +34278,24 @@ in
                       })
                     ];
                   })
-                  (sources."registry-auth-token-3.1.2" // {
+                  (sources."registry-auth-token-3.3.1" // {
                     dependencies = [
                       (sources."rc-1.2.1" // {
                         dependencies = [
-                          sources."deep-extend-0.4.1"
+                          sources."deep-extend-0.4.2"
                           sources."ini-1.3.4"
                           sources."minimist-1.2.0"
                           sources."strip-json-comments-2.0.1"
                         ];
                       })
+                      sources."safe-buffer-5.0.1"
                     ];
                   })
                   (sources."registry-url-3.1.0" // {
                     dependencies = [
                       (sources."rc-1.2.1" // {
                         dependencies = [
-                          sources."deep-extend-0.4.1"
+                          sources."deep-extend-0.4.2"
                           sources."ini-1.3.4"
                           sources."minimist-1.2.0"
                           sources."strip-json-comments-2.0.1"
@@ -34060,11 +34459,11 @@ in
           sources."encodeurl-1.0.1"
           sources."escape-html-1.0.3"
           sources."etag-1.8.0"
-          (sources."finalhandler-1.0.1" // {
+          (sources."finalhandler-1.0.2" // {
             dependencies = [
-              (sources."debug-2.6.3" // {
+              (sources."debug-2.6.4" // {
                 dependencies = [
-                  sources."ms-0.7.2"
+                  sources."ms-0.7.3"
                 ];
               })
               sources."unpipe-1.0.0"
@@ -34127,7 +34526,7 @@ in
                 ];
               })
               sources."inherits-2.0.3"
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -34146,7 +34545,7 @@ in
             ];
           })
           sources."graceful-fs-4.1.11"
-          (sources."handlebars-4.0.6" // {
+          (sources."handlebars-4.0.8" // {
             dependencies = [
               sources."async-1.5.2"
               (sources."optimist-0.6.1" // {
@@ -34160,7 +34559,7 @@ in
                   sources."amdefine-1.0.1"
                 ];
               })
-              (sources."uglify-js-2.8.22" // {
+              (sources."uglify-js-2.8.24" // {
                 dependencies = [
                   sources."source-map-0.5.6"
                   (sources."yargs-3.10.0" // {
@@ -34172,7 +34571,7 @@ in
                             dependencies = [
                               (sources."align-text-0.1.4" // {
                                 dependencies = [
-                                  (sources."kind-of-3.1.0" // {
+                                  (sources."kind-of-3.2.0" // {
                                     dependencies = [
                                       sources."is-buffer-1.1.5"
                                     ];
@@ -34188,7 +34587,7 @@ in
                             dependencies = [
                               (sources."align-text-0.1.4" // {
                                 dependencies = [
-                                  (sources."kind-of-3.1.0" // {
+                                  (sources."kind-of-3.2.0" // {
                                     dependencies = [
                                       sources."is-buffer-1.1.5"
                                     ];
@@ -34246,7 +34645,7 @@ in
           sources."unpipe-1.0.0"
         ];
       })
-      (sources."js-yaml-3.8.3" // {
+      (sources."js-yaml-3.8.4" // {
         dependencies = [
           (sources."argparse-1.0.9" // {
             dependencies = [
@@ -34271,7 +34670,7 @@ in
               sources."delayed-stream-1.0.0"
             ];
           })
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           sources."forever-agent-0.6.1"
           (sources."form-data-2.1.4" // {
             dependencies = [
@@ -34280,7 +34679,7 @@ in
           })
           (sources."har-validator-4.2.1" // {
             dependencies = [
-              (sources."ajv-4.11.6" // {
+              (sources."ajv-4.11.8" // {
                 dependencies = [
                   sources."co-4.6.0"
                   (sources."json-stable-stringify-1.0.1" // {
@@ -34317,7 +34716,7 @@ in
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.1"
-                  sources."getpass-0.1.6"
+                  sources."getpass-0.1.7"
                   sources."jsbn-0.1.1"
                   sources."tweetnacl-0.14.5"
                   sources."jodid25519-1.0.2"
@@ -34358,7 +34757,7 @@ in
           sources."parseurl-1.3.1"
         ];
       })
-      (sources."service-runner-2.2.5" // {
+      (sources."service-runner-2.3.0" // {
         dependencies = [
           sources."bluebird-3.5.0"
           (sources."bunyan-1.8.10" // {
@@ -34386,7 +34785,7 @@ in
                             ];
                           })
                           sources."inherits-2.0.3"
-                          (sources."minimatch-3.0.3" // {
+                          (sources."minimatch-3.0.4" // {
                             dependencies = [
                               (sources."brace-expansion-1.1.7" // {
                                 dependencies = [
@@ -34413,13 +34812,13 @@ in
             ];
           })
           sources."bunyan-syslog-udp-0.1.0"
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           (sources."gelf-stream-1.1.1" // {
             dependencies = [
               sources."gelfling-0.3.1"
             ];
           })
-          sources."hot-shots-4.4.0"
+          sources."hot-shots-4.5.0"
           (sources."limitation-0.2.0" // {
             dependencies = [
               (sources."kad-git+https://github.com/gwicke/kad.git#master" // {
@@ -34439,7 +34838,7 @@ in
                   sources."ms-0.7.3"
                   (sources."msgpack5-3.4.1" // {
                     dependencies = [
-                      sources."bl-1.2.0"
+                      sources."bl-1.2.1"
                       sources."inherits-2.0.3"
                     ];
                   })
@@ -34458,7 +34857,7 @@ in
               })
             ];
           })
-          (sources."yargs-6.6.0" // {
+          (sources."yargs-7.1.0" // {
             dependencies = [
               sources."camelcase-3.0.0"
               (sources."cliui-3.2.0" // {
@@ -34521,7 +34920,7 @@ in
                           })
                         ];
                       })
-                      (sources."normalize-package-data-2.3.6" // {
+                      (sources."normalize-package-data-2.3.8" // {
                         dependencies = [
                           sources."hosted-git-info-2.4.2"
                           (sources."is-builtin-module-1.0.0" // {
@@ -34576,7 +34975,7 @@ in
               })
               sources."which-module-1.0.0"
               sources."y18n-3.2.1"
-              sources."yargs-parser-4.2.1"
+              sources."yargs-parser-5.0.0"
             ];
           })
           (sources."dnscache-1.0.1" // {
@@ -34655,7 +35054,7 @@ in
                       })
                     ];
                   })
-                  (sources."normalize-package-data-2.3.6" // {
+                  (sources."normalize-package-data-2.3.8" // {
                     dependencies = [
                       sources."hosted-git-info-2.4.2"
                       (sources."is-builtin-module-1.0.0" // {
@@ -34730,10 +35129,10 @@ in
   peerflix = nodeEnv.buildNodePackage {
     name = "peerflix";
     packageName = "peerflix";
-    version = "0.36.2";
+    version = "0.36.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/peerflix/-/peerflix-0.36.2.tgz";
-      sha1 = "93dd39e10a0a94b4f66ec19a42d8f5598a3eec01";
+      url = "https://registry.npmjs.org/peerflix/-/peerflix-0.36.3.tgz";
+      sha1 = "7100ab8190192a19633c98a2ea124e089a68c19e";
     };
     dependencies = [
       (sources."airplayer-2.0.0" // {
@@ -34747,7 +35146,7 @@ in
               })
               (sources."bplist-parser-0.1.1" // {
                 dependencies = [
-                  sources."big-integer-1.6.19"
+                  sources."big-integer-1.6.22"
                 ];
               })
               (sources."concat-stream-1.6.0" // {
@@ -34888,7 +35287,7 @@ in
                     ];
                   })
                   sources."map-obj-1.0.1"
-                  (sources."normalize-package-data-2.3.6" // {
+                  (sources."normalize-package-data-2.3.8" // {
                     dependencies = [
                       sources."hosted-git-info-2.4.2"
                       (sources."is-builtin-module-1.0.0" // {
@@ -35024,7 +35423,7 @@ in
           sources."cli-width-2.1.0"
           (sources."external-editor-1.1.1" // {
             dependencies = [
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               (sources."spawn-sync-1.0.15" // {
                 dependencies = [
                   (sources."concat-stream-1.6.0" // {
@@ -35091,7 +35490,7 @@ in
         ];
       })
       sources."keypress-0.2.1"
-      sources."mime-1.3.4"
+      sources."mime-1.3.6"
       sources."network-address-1.1.2"
       sources."numeral-1.5.6"
       sources."open-0.0.5"
@@ -35105,8 +35504,9 @@ in
         dependencies = [
           sources."blob-to-buffer-1.2.6"
           sources."get-stdin-5.0.1"
-          (sources."magnet-uri-5.1.6" // {
+          (sources."magnet-uri-5.1.7" // {
             dependencies = [
+              sources."safe-buffer-5.0.1"
               sources."thirty-two-1.0.2"
               sources."uniq-1.0.1"
             ];
@@ -35116,13 +35516,13 @@ in
               sources."bencode-0.11.0"
               (sources."simple-sha1-2.1.0" // {
                 dependencies = [
-                  sources."rusha-0.8.5"
+                  sources."rusha-0.8.6"
                 ];
               })
               sources."uniq-1.0.1"
             ];
           })
-          (sources."simple-get-2.5.1" // {
+          (sources."simple-get-2.6.0" // {
             dependencies = [
               (sources."once-1.4.0" // {
                 dependencies = [
@@ -35148,7 +35548,7 @@ in
       sources."range-parser-1.2.0"
       (sources."rc-1.2.1" // {
         dependencies = [
-          sources."deep-extend-0.4.1"
+          sources."deep-extend-0.4.2"
           sources."ini-1.3.4"
           sources."minimist-1.2.0"
           sources."strip-json-comments-2.0.1"
@@ -35174,12 +35574,12 @@ in
                   sources."minimist-0.0.8"
                 ];
               })
-              (sources."random-access-file-1.6.1" // {
+              (sources."random-access-file-1.7.2" // {
                 dependencies = [
                   sources."buffer-alloc-unsafe-1.0.0"
-                  (sources."debug-2.6.3" // {
+                  (sources."debug-2.6.6" // {
                     dependencies = [
-                      sources."ms-0.7.2"
+                      sources."ms-0.7.3"
                     ];
                   })
                   sources."inherits-2.0.3"
@@ -35211,7 +35611,7 @@ in
                   sources."bencode-0.7.0"
                   (sources."simple-sha1-2.1.0" // {
                     dependencies = [
-                      sources."rusha-0.8.5"
+                      sources."rusha-0.8.6"
                     ];
                   })
                 ];
@@ -35258,7 +35658,7 @@ in
                     ];
                   })
                   sources."inherits-2.0.3"
-                  (sources."minimatch-3.0.3" // {
+                  (sources."minimatch-3.0.4" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.7" // {
                         dependencies = [
@@ -35325,7 +35725,7 @@ in
                   })
                   sources."random-iterate-1.0.1"
                   sources."run-series-1.1.4"
-                  (sources."simple-get-2.5.1" // {
+                  (sources."simple-get-2.6.0" // {
                     dependencies = [
                       sources."simple-concat-1.0.0"
                       sources."unzip-response-2.0.1"
@@ -35360,7 +35760,7 @@ in
                           sources."util-deprecate-1.0.2"
                         ];
                       })
-                      (sources."ws-2.2.3" // {
+                      (sources."ws-2.3.1" // {
                         dependencies = [
                           sources."safe-buffer-5.0.1"
                           sources."ultron-1.1.0"
@@ -35383,9 +35783,9 @@ in
                   })
                 ];
               })
-              (sources."debug-2.6.3" // {
+              (sources."debug-2.6.6" // {
                 dependencies = [
-                  sources."ms-0.7.2"
+                  sources."ms-0.7.3"
                 ];
               })
               sources."inherits-2.0.3"
@@ -35581,7 +35981,7 @@ in
                   sources."bencode-0.7.0"
                   (sources."simple-sha1-2.1.0" // {
                     dependencies = [
-                      sources."rusha-0.8.5"
+                      sources."rusha-0.8.6"
                     ];
                   })
                 ];
@@ -35622,14 +36022,14 @@ in
           sources."xtend-4.0.1"
         ];
       })
-      (sources."socket.io-1.7.3" // {
+      (sources."socket.io-1.7.4" // {
         dependencies = [
           (sources."debug-2.3.3" // {
             dependencies = [
               sources."ms-0.7.2"
             ];
           })
-          (sources."engine.io-1.8.3" // {
+          (sources."engine.io-1.8.4" // {
             dependencies = [
               (sources."accepts-1.3.3" // {
                 dependencies = [
@@ -35651,7 +36051,7 @@ in
                   sources."wtf-8-1.0.0"
                 ];
               })
-              (sources."ws-1.1.2" // {
+              (sources."ws-1.1.4" // {
                 dependencies = [
                   sources."options-0.0.6"
                   sources."ultron-1.0.2"
@@ -35667,12 +36067,12 @@ in
           })
           sources."object-assign-4.1.0"
           sources."socket.io-adapter-0.5.0"
-          (sources."socket.io-client-1.7.3" // {
+          (sources."socket.io-client-1.7.4" // {
             dependencies = [
               sources."backo2-1.0.2"
               sources."component-bind-1.0.0"
               sources."component-emitter-1.2.1"
-              (sources."engine.io-client-1.8.3" // {
+              (sources."engine.io-client-1.8.4" // {
                 dependencies = [
                   sources."component-inherit-0.0.3"
                   (sources."engine.io-parser-1.3.2" // {
@@ -35749,9 +36149,9 @@ in
               sources."addr-to-ip-port-1.4.2"
               sources."bencode-0.7.0"
               sources."buffer-equal-0.0.1"
-              (sources."debug-2.6.3" // {
+              (sources."debug-2.6.6" // {
                 dependencies = [
-                  sources."ms-0.7.2"
+                  sources."ms-0.7.3"
                 ];
               })
               sources."inherits-2.0.3"
@@ -35786,9 +36186,9 @@ in
               sources."bencode-0.6.0"
               sources."bn.js-1.3.0"
               sources."buffer-equal-0.0.1"
-              (sources."debug-2.6.3" // {
+              (sources."debug-2.6.6" // {
                 dependencies = [
-                  sources."ms-0.7.2"
+                  sources."ms-0.7.3"
                 ];
               })
               sources."extend.js-0.0.2"
@@ -35860,7 +36260,7 @@ in
                   sources."bencode-0.7.0"
                   (sources."simple-sha1-2.1.0" // {
                     dependencies = [
-                      sources."rusha-0.8.5"
+                      sources."rusha-0.8.6"
                     ];
                   })
                 ];
@@ -35903,7 +36303,7 @@ in
                     ];
                   })
                   sources."inherits-2.0.3"
-                  (sources."minimatch-3.0.3" // {
+                  (sources."minimatch-3.0.4" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.7" // {
                         dependencies = [
@@ -35926,9 +36326,9 @@ in
           sources."thunky-0.1.0"
         ];
       })
-      (sources."fluent-ffmpeg-2.1.0" // {
+      (sources."fluent-ffmpeg-2.1.2" // {
         dependencies = [
-          (sources."async-2.3.0" // {
+          (sources."async-2.4.0" // {
             dependencies = [
               sources."lodash-4.17.4"
             ];
@@ -36009,7 +36409,7 @@ in
                     ];
                   })
                   sources."inherits-2.0.3"
-                  (sources."minimatch-3.0.3" // {
+                  (sources."minimatch-3.0.4" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.7" // {
                         dependencies = [
@@ -36059,11 +36459,11 @@ in
             ];
           })
           sources."caseless-0.11.0"
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           sources."forever-agent-0.6.1"
           (sources."form-data-1.0.1" // {
             dependencies = [
-              (sources."async-2.3.0" // {
+              (sources."async-2.4.0" // {
                 dependencies = [
                   sources."lodash-4.17.4"
                 ];
@@ -36096,7 +36496,7 @@ in
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.1"
-                  sources."getpass-0.1.6"
+                  sources."getpass-0.1.7"
                   sources."jsbn-0.1.1"
                   sources."tweetnacl-0.14.5"
                   sources."jodid25519-1.0.2"
@@ -36191,10 +36591,10 @@ in
   prettier = nodeEnv.buildNodePackage {
     name = "prettier";
     packageName = "prettier";
-    version = "1.1.0";
+    version = "1.3.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/prettier/-/prettier-1.1.0.tgz";
-      sha1 = "9d6ad005703efefa66b6999b8916bfc6afeaf9f8";
+      url = "https://registry.npmjs.org/prettier/-/prettier-1.3.1.tgz";
+      sha1 = "fa0ea84b45ac0ba6de6a1e4cecdcff900d563151";
     };
     dependencies = [
       sources."ast-types-0.9.8"
@@ -36222,7 +36622,7 @@ in
         ];
       })
       sources."esutils-2.0.2"
-      sources."flow-parser-0.43.0"
+      sources."flow-parser-0.45.0"
       sources."get-stdin-5.0.1"
       (sources."glob-7.1.1" // {
         dependencies = [
@@ -36233,7 +36633,7 @@ in
             ];
           })
           sources."inherits-2.0.3"
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -36310,7 +36710,7 @@ in
                 ];
               })
               sources."inherits-2.0.3"
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -36329,7 +36729,7 @@ in
             ];
           })
           sources."graceful-fs-4.1.11"
-          sources."iconv-lite-0.4.15"
+          sources."iconv-lite-0.4.17"
           (sources."mkdirp-0.5.1" // {
             dependencies = [
               sources."minimist-0.0.8"
@@ -36435,9 +36835,9 @@ in
             ];
           })
           sources."cookie-signature-1.0.1"
-          (sources."debug-2.6.3" // {
+          (sources."debug-2.6.6" // {
             dependencies = [
-              sources."ms-0.7.2"
+              sources."ms-0.7.3"
             ];
           })
         ];
@@ -36474,7 +36874,7 @@ in
                       sources."delayed-stream-1.0.0"
                     ];
                   })
-                  sources."extend-3.0.0"
+                  sources."extend-3.0.1"
                   sources."forever-agent-0.6.1"
                   (sources."form-data-2.1.4" // {
                     dependencies = [
@@ -36483,7 +36883,7 @@ in
                   })
                   (sources."har-validator-4.2.1" // {
                     dependencies = [
-                      (sources."ajv-4.11.6" // {
+                      (sources."ajv-4.11.8" // {
                         dependencies = [
                           sources."co-4.6.0"
                           (sources."json-stable-stringify-1.0.1" // {
@@ -36520,7 +36920,7 @@ in
                           sources."asn1-0.2.3"
                           sources."assert-plus-1.0.0"
                           sources."dashdash-1.14.1"
-                          sources."getpass-0.1.6"
+                          sources."getpass-0.1.7"
                           sources."jsbn-0.1.1"
                           sources."tweetnacl-0.14.5"
                           sources."jodid25519-1.0.2"
@@ -36633,11 +37033,11 @@ in
           sources."encodeurl-1.0.1"
           sources."escape-html-1.0.3"
           sources."etag-1.8.0"
-          (sources."finalhandler-1.0.1" // {
+          (sources."finalhandler-1.0.2" // {
             dependencies = [
-              (sources."debug-2.6.3" // {
+              (sources."debug-2.6.4" // {
                 dependencies = [
-                  sources."ms-0.7.2"
+                  sources."ms-0.7.3"
                 ];
               })
               sources."unpipe-1.0.0"
@@ -36763,7 +37163,7 @@ in
           sources."graceful-readlink-1.0.1"
         ];
       })
-      (sources."js-yaml-3.8.3" // {
+      (sources."js-yaml-3.8.4" // {
         dependencies = [
           (sources."argparse-1.0.9" // {
             dependencies = [
@@ -36789,7 +37189,7 @@ in
               sources."delayed-stream-1.0.0"
             ];
           })
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           sources."forever-agent-0.6.1"
           (sources."form-data-2.1.4" // {
             dependencies = [
@@ -36798,7 +37198,7 @@ in
           })
           (sources."har-validator-4.2.1" // {
             dependencies = [
-              (sources."ajv-4.11.6" // {
+              (sources."ajv-4.11.8" // {
                 dependencies = [
                   sources."co-4.6.0"
                   (sources."json-stable-stringify-1.0.1" // {
@@ -36835,7 +37235,7 @@ in
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.1"
-                  sources."getpass-0.1.6"
+                  sources."getpass-0.1.7"
                   sources."jsbn-0.1.1"
                   sources."tweetnacl-0.14.5"
                   sources."jodid25519-1.0.2"
@@ -36896,7 +37296,7 @@ in
                         ];
                       })
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -36963,8 +37363,8 @@ in
               (sources."htmlparser2-3.9.2" // {
                 dependencies = [
                   sources."domelementtype-1.3.0"
-                  sources."domhandler-2.3.0"
-                  (sources."domutils-1.5.1" // {
+                  sources."domhandler-2.4.1"
+                  (sources."domutils-1.6.2" // {
                     dependencies = [
                       (sources."dom-serializer-0.1.0" // {
                         dependencies = [
@@ -36996,7 +37396,7 @@ in
       sources."jju-1.3.0"
       (sources."JSONStream-1.3.1" // {
         dependencies = [
-          sources."jsonparse-1.3.0"
+          sources."jsonparse-1.3.1"
           sources."through-2.3.8"
         ];
       })
@@ -37071,7 +37471,7 @@ in
       (sources."readdirp-2.1.0" // {
         dependencies = [
           sources."graceful-fs-4.1.11"
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -37145,7 +37545,7 @@ in
           })
           sources."keep-alive-agent-0.0.1"
           sources."lru-cache-2.7.3"
-          sources."mime-1.3.4"
+          sources."mime-1.3.6"
           sources."negotiator-0.5.3"
           sources."node-uuid-1.4.8"
           (sources."once-1.4.0" // {
@@ -37166,7 +37566,7 @@ in
               })
             ];
           })
-          (sources."verror-1.9.0" // {
+          (sources."verror-1.10.0" // {
             dependencies = [
               sources."assert-plus-1.0.0"
               sources."core-util-is-1.0.2"
@@ -37205,7 +37605,7 @@ in
                         ];
                       })
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -37297,7 +37697,7 @@ in
       (sources."cmdln-3.2.1" // {
         dependencies = [
           sources."extsprintf-1.3.0"
-          (sources."verror-1.9.0" // {
+          (sources."verror-1.10.0" // {
             dependencies = [
               sources."assert-plus-1.0.0"
               sources."core-util-is-1.0.2"
@@ -37338,9 +37738,9 @@ in
           sources."minimist-0.0.8"
         ];
       })
-      (sources."debug-2.6.3" // {
+      (sources."debug-2.6.6" // {
         dependencies = [
-          sources."ms-0.7.2"
+          sources."ms-0.7.3"
         ];
       })
       sources."sax-0.5.8"
@@ -37353,7 +37753,7 @@ in
             ];
           })
           sources."inherits-2.0.3"
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -37382,6 +37782,118 @@ in
       description = "Robust, expressive, and feature-rich CSS superset";
       homepage = https://github.com/stylus/stylus;
       license = "MIT";
+    };
+    production = true;
+  };
+  lumo-cljs = nodeEnv.buildNodePackage {
+    name = "lumo-cljs";
+    packageName = "lumo-cljs";
+    version = "1.5.0";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/lumo-cljs/-/lumo-cljs-1.5.0.tgz";
+      sha1 = "93af1b9cfccc12edfd495d64aec1748d4145f8dc";
+    };
+    dependencies = [
+      (sources."jszip-2.6.1" // {
+        dependencies = [
+          sources."pako-1.0.5"
+        ];
+      })
+      sources."progress-2.0.0"
+      (sources."request-2.81.0" // {
+        dependencies = [
+          sources."aws-sign2-0.6.0"
+          sources."aws4-1.6.0"
+          sources."caseless-0.12.0"
+          (sources."combined-stream-1.0.5" // {
+            dependencies = [
+              sources."delayed-stream-1.0.0"
+            ];
+          })
+          sources."extend-3.0.1"
+          sources."forever-agent-0.6.1"
+          (sources."form-data-2.1.4" // {
+            dependencies = [
+              sources."asynckit-0.4.0"
+            ];
+          })
+          (sources."har-validator-4.2.1" // {
+            dependencies = [
+              (sources."ajv-4.11.8" // {
+                dependencies = [
+                  sources."co-4.6.0"
+                  (sources."json-stable-stringify-1.0.1" // {
+                    dependencies = [
+                      sources."jsonify-0.0.0"
+                    ];
+                  })
+                ];
+              })
+              sources."har-schema-1.0.5"
+            ];
+          })
+          (sources."hawk-3.1.3" // {
+            dependencies = [
+              sources."hoek-2.16.3"
+              sources."boom-2.10.1"
+              sources."cryptiles-2.0.5"
+              sources."sntp-1.0.9"
+            ];
+          })
+          (sources."http-signature-1.1.1" // {
+            dependencies = [
+              sources."assert-plus-0.2.0"
+              (sources."jsprim-1.4.0" // {
+                dependencies = [
+                  sources."assert-plus-1.0.0"
+                  sources."extsprintf-1.0.2"
+                  sources."json-schema-0.2.3"
+                  sources."verror-1.3.6"
+                ];
+              })
+              (sources."sshpk-1.13.0" // {
+                dependencies = [
+                  sources."asn1-0.2.3"
+                  sources."assert-plus-1.0.0"
+                  sources."dashdash-1.14.1"
+                  sources."getpass-0.1.7"
+                  sources."jsbn-0.1.1"
+                  sources."tweetnacl-0.14.5"
+                  sources."jodid25519-1.0.2"
+                  sources."ecc-jsbn-0.1.1"
+                  sources."bcrypt-pbkdf-1.0.1"
+                ];
+              })
+            ];
+          })
+          sources."is-typedarray-1.0.0"
+          sources."isstream-0.1.2"
+          sources."json-stringify-safe-5.0.1"
+          (sources."mime-types-2.1.15" // {
+            dependencies = [
+              sources."mime-db-1.27.0"
+            ];
+          })
+          sources."oauth-sign-0.8.2"
+          sources."performance-now-0.2.0"
+          sources."qs-6.4.0"
+          sources."safe-buffer-5.0.1"
+          sources."stringstream-0.0.5"
+          (sources."tough-cookie-2.3.2" // {
+            dependencies = [
+              sources."punycode-1.4.1"
+            ];
+          })
+          sources."tunnel-agent-0.6.0"
+          sources."uuid-3.0.1"
+        ];
+      })
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Fast, cross-platform, standalone ClojureScript REPL";
+      homepage = https://github.com/anmonteiro/lumo;
+      license = "EPL-1.0";
     };
     production = true;
   };
@@ -37506,7 +38018,7 @@ in
           sources."path-is-absolute-1.0.1"
         ];
       })
-      (sources."minimatch-3.0.3" // {
+      (sources."minimatch-3.0.4" // {
         dependencies = [
           (sources."brace-expansion-1.1.7" // {
             dependencies = [
@@ -37529,12 +38041,13 @@ in
   titanium = nodeEnv.buildNodePackage {
     name = "titanium";
     packageName = "titanium";
-    version = "5.0.12";
+    version = "5.0.14";
     src = fetchurl {
-      url = "https://registry.npmjs.org/titanium/-/titanium-5.0.12.tgz";
-      sha1 = "2bcfab6110ef0a91c9d54825052fd0db3e9dd942";
+      url = "https://registry.npmjs.org/titanium/-/titanium-5.0.14.tgz";
+      sha1 = "140bd332624acae65113a3ffec10b8cbb940ad0b";
     };
     dependencies = [
+      sources."adm-zip-0.4.7"
       (sources."async-2.1.2" // {
         dependencies = [
           sources."lodash-4.17.4"
@@ -37564,7 +38077,6 @@ in
       sources."moment-2.16.0"
       (sources."node-appc-0.2.41" // {
         dependencies = [
-          sources."adm-zip-0.4.7"
           (sources."async-2.1.4" // {
             dependencies = [
               sources."lodash-4.17.4"
@@ -37593,7 +38105,7 @@ in
                         dependencies = [
                           (sources."align-text-0.1.4" // {
                             dependencies = [
-                              (sources."kind-of-3.1.0" // {
+                              (sources."kind-of-3.2.0" // {
                                 dependencies = [
                                   sources."is-buffer-1.1.5"
                                 ];
@@ -37609,7 +38121,7 @@ in
                         dependencies = [
                           (sources."align-text-0.1.4" // {
                             dependencies = [
-                              (sources."kind-of-3.1.0" // {
+                              (sources."kind-of-3.2.0" // {
                                 dependencies = [
                                   sources."is-buffer-1.1.5"
                                 ];
@@ -37642,7 +38154,7 @@ in
               sources."delayed-stream-1.0.0"
             ];
           })
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           sources."forever-agent-0.6.1"
           (sources."form-data-2.1.4" // {
             dependencies = [
@@ -37716,7 +38228,7 @@ in
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.1"
-                  sources."getpass-0.1.6"
+                  sources."getpass-0.1.7"
                   sources."jsbn-0.1.1"
                   sources."tweetnacl-0.14.5"
                   sources."jodid25519-1.0.2"
@@ -37783,10 +38295,10 @@ in
   typescript = nodeEnv.buildNodePackage {
     name = "typescript";
     packageName = "typescript";
-    version = "2.2.2";
+    version = "2.3.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/typescript/-/typescript-2.2.2.tgz";
-      sha1 = "606022508479b55ffa368b58fee963a03dfd7b0c";
+      url = "https://registry.npmjs.org/typescript/-/typescript-2.3.2.tgz";
+      sha1 = "f0f045e196f69a72f06b25fd3bd39d01c3ce9984";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -37799,56 +38311,18 @@ in
   uglify-js = nodeEnv.buildNodePackage {
     name = "uglify-js";
     packageName = "uglify-js";
-    version = "2.8.22";
+    version = "3.0.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz";
-      sha1 = "d54934778a8da14903fa29a326fb24c0ab51a1a0";
+      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.4.tgz";
+      sha1 = "13da18bc4ecec20d29861b4ab7b60cb9ef9a9cc0";
     };
     dependencies = [
-      sources."source-map-0.5.6"
-      (sources."yargs-3.10.0" // {
+      (sources."commander-2.9.0" // {
         dependencies = [
-          sources."camelcase-1.2.1"
-          (sources."cliui-2.1.0" // {
-            dependencies = [
-              (sources."center-align-0.1.3" // {
-                dependencies = [
-                  (sources."align-text-0.1.4" // {
-                    dependencies = [
-                      (sources."kind-of-3.1.0" // {
-                        dependencies = [
-                          sources."is-buffer-1.1.5"
-                        ];
-                      })
-                      sources."longest-1.0.1"
-                      sources."repeat-string-1.6.1"
-                    ];
-                  })
-                  sources."lazy-cache-1.0.4"
-                ];
-              })
-              (sources."right-align-0.1.3" // {
-                dependencies = [
-                  (sources."align-text-0.1.4" // {
-                    dependencies = [
-                      (sources."kind-of-3.1.0" // {
-                        dependencies = [
-                          sources."is-buffer-1.1.5"
-                        ];
-                      })
-                      sources."longest-1.0.1"
-                      sources."repeat-string-1.6.1"
-                    ];
-                  })
-                ];
-              })
-              sources."wordwrap-0.0.2"
-            ];
-          })
-          sources."decamelize-1.2.0"
-          sources."window-size-0.1.0"
+          sources."graceful-readlink-1.0.1"
         ];
       })
+      sources."source-map-0.5.6"
       sources."uglify-to-browserify-1.0.2"
     ];
     buildInputs = globalBuildInputs;
@@ -37862,40 +38336,40 @@ in
   ungit = nodeEnv.buildNodePackage {
     name = "ungit";
     packageName = "ungit";
-    version = "1.1.14";
+    version = "1.1.16";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ungit/-/ungit-1.1.14.tgz";
-      sha1 = "e65f05f541bc8b829f9720f28e74c4a12c7b6dd2";
+      url = "https://registry.npmjs.org/ungit/-/ungit-1.1.16.tgz";
+      sha1 = "d19a80706583423f9895364dd20adf873b88d09e";
     };
     dependencies = [
-      sources."async-2.1.5"
-      sources."bluebird-3.4.7"
-      sources."blueimp-md5-2.6.0"
-      (sources."body-parser-1.15.2" // {
+      sources."async-2.4.0"
+      sources."bluebird-3.5.0"
+      sources."blueimp-md5-2.7.0"
+      (sources."body-parser-1.17.1" // {
         dependencies = [
           sources."bytes-2.4.0"
           sources."content-type-1.0.2"
-          (sources."debug-2.2.0" // {
+          (sources."debug-2.6.1" // {
             dependencies = [
-              sources."ms-0.7.1"
+              sources."ms-0.7.2"
             ];
           })
           sources."depd-1.1.0"
-          (sources."http-errors-1.5.1" // {
+          (sources."http-errors-1.6.1" // {
             dependencies = [
               sources."inherits-2.0.3"
-              sources."setprototypeof-1.0.2"
+              sources."setprototypeof-1.0.3"
               sources."statuses-1.3.1"
             ];
           })
-          sources."iconv-lite-0.4.13"
+          sources."iconv-lite-0.4.15"
           (sources."on-finished-2.3.0" // {
             dependencies = [
               sources."ee-first-1.1.1"
             ];
           })
-          sources."qs-6.2.0"
-          (sources."raw-body-2.1.7" // {
+          sources."qs-6.4.0"
+          (sources."raw-body-2.2.0" // {
             dependencies = [
               sources."unpipe-1.0.0"
             ];
@@ -37980,11 +38454,11 @@ in
           sources."encodeurl-1.0.1"
           sources."escape-html-1.0.3"
           sources."etag-1.8.0"
-          (sources."finalhandler-1.0.1" // {
+          (sources."finalhandler-1.0.2" // {
             dependencies = [
-              (sources."debug-2.6.3" // {
+              (sources."debug-2.6.4" // {
                 dependencies = [
-                  sources."ms-0.7.2"
+                  sources."ms-0.7.3"
                 ];
               })
               sources."unpipe-1.0.0"
@@ -38020,6 +38494,7 @@ in
               sources."ms-0.7.2"
             ];
           })
+          sources."serve-static-1.12.1"
           sources."setprototypeof-1.0.3"
           sources."statuses-1.3.1"
           (sources."type-is-1.6.15" // {
@@ -38183,6 +38658,7 @@ in
       })
       sources."hasher-1.2.0"
       sources."ignore-3.2.7"
+      sources."just-detect-adblock-1.0.0"
       (sources."keen.io-0.1.3" // {
         dependencies = [
           sources."underscore-1.5.2"
@@ -38201,11 +38677,11 @@ in
           sources."clone-2.1.1"
         ];
       })
-      (sources."npm-4.5.0" // {
+      (sources."npm-4.6.1" // {
         dependencies = [
           (sources."JSONStream-1.3.1" // {
             dependencies = [
-              sources."jsonparse-1.3.0"
+              sources."jsonparse-1.3.1"
               sources."through-2.3.8"
             ];
           })
@@ -38216,7 +38692,6 @@ in
           sources."aproba-1.1.1"
           sources."archy-1.0.0"
           sources."asap-2.0.5"
-          sources."bluebird-3.5.0"
           sources."call-limit-1.1.0"
           sources."chownr-1.0.1"
           sources."cmd-shim-2.0.2"
@@ -38243,11 +38718,11 @@ in
           sources."fs-vacuum-1.2.10"
           sources."fs-write-stream-atomic-1.0.10"
           sources."fstream-1.0.11"
-          (sources."fstream-npm-1.2.0" // {
+          (sources."fstream-npm-1.2.1" // {
             dependencies = [
               (sources."fstream-ignore-1.0.5" // {
                 dependencies = [
-                  (sources."minimatch-3.0.3" // {
+                  (sources."minimatch-3.0.4" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.7" // {
                         dependencies = [
@@ -38264,7 +38739,7 @@ in
           (sources."glob-7.1.1" // {
             dependencies = [
               sources."fs.realpath-1.0.0"
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -38284,7 +38759,7 @@ in
           sources."inflight-1.0.6"
           sources."inherits-2.0.3"
           sources."ini-1.3.4"
-          (sources."init-package-json-1.9.6" // {
+          (sources."init-package-json-1.10.1" // {
             dependencies = [
               sources."promzard-0.3.0"
             ];
@@ -38346,9 +38821,9 @@ in
               sources."run-queue-1.0.3"
             ];
           })
-          (sources."node-gyp-3.6.0" // {
+          (sources."node-gyp-3.6.1" // {
             dependencies = [
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -38363,7 +38838,7 @@ in
           })
           sources."nopt-4.0.1"
           sources."normalize-git-url-3.0.2"
-          (sources."normalize-package-data-2.3.6" // {
+          (sources."normalize-package-data-2.3.8" // {
             dependencies = [
               (sources."is-builtin-module-1.0.0" // {
                 dependencies = [
@@ -38375,16 +38850,25 @@ in
           sources."npm-cache-filename-1.0.2"
           sources."npm-install-checks-3.0.0"
           sources."npm-package-arg-4.2.1"
+          (sources."npm-registry-client-8.1.1" // {
+            dependencies = [
+              (sources."concat-stream-1.6.0" // {
+                dependencies = [
+                  sources."typedarray-0.0.6"
+                ];
+              })
+            ];
+          })
           sources."npm-user-validate-0.1.5"
           (sources."npmlog-4.0.2" // {
             dependencies = [
-              (sources."are-we-there-yet-1.1.2" // {
+              (sources."are-we-there-yet-1.1.4" // {
                 dependencies = [
                   sources."delegates-1.0.0"
                 ];
               })
               sources."console-control-strings-1.1.0"
-              (sources."gauge-2.7.3" // {
+              (sources."gauge-2.7.4" // {
                 dependencies = [
                   sources."object-assign-4.1.1"
                   sources."signal-exit-3.0.2"
@@ -38398,7 +38882,7 @@ in
                       })
                     ];
                   })
-                  sources."wide-align-1.1.0"
+                  sources."wide-align-1.1.2"
                 ];
               })
               sources."set-blocking-2.0.0"
@@ -38454,7 +38938,7 @@ in
                   sources."delayed-stream-1.0.0"
                 ];
               })
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               sources."forever-agent-0.6.1"
               (sources."form-data-2.1.4" // {
                 dependencies = [
@@ -38463,7 +38947,7 @@ in
               })
               (sources."har-validator-4.2.1" // {
                 dependencies = [
-                  (sources."ajv-4.11.6" // {
+                  (sources."ajv-4.11.8" // {
                     dependencies = [
                       sources."co-4.6.0"
                       (sources."json-stable-stringify-1.0.1" // {
@@ -38500,7 +38984,7 @@ in
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.1"
-                      sources."getpass-0.1.6"
+                      sources."getpass-0.1.7"
                       sources."jsbn-0.1.1"
                       sources."tweetnacl-0.14.5"
                       sources."jodid25519-1.0.2"
@@ -38572,22 +39056,9 @@ in
           sources."unpipe-1.0.0"
           (sources."update-notifier-2.1.0" // {
             dependencies = [
-              (sources."boxen-1.0.0" // {
+              (sources."boxen-1.1.0" // {
                 dependencies = [
-                  (sources."ansi-align-1.1.0" // {
-                    dependencies = [
-                      (sources."string-width-1.0.2" // {
-                        dependencies = [
-                          sources."code-point-at-1.1.0"
-                          (sources."is-fullwidth-code-point-1.0.0" // {
-                            dependencies = [
-                              sources."number-is-nan-1.0.1"
-                            ];
-                          })
-                        ];
-                      })
-                    ];
-                  })
+                  sources."ansi-align-2.0.0"
                   sources."camelcase-4.1.0"
                   sources."cli-boxes-1.0.0"
                   (sources."string-width-2.0.0" // {
@@ -38642,11 +39113,16 @@ in
                   sources."supports-color-2.0.0"
                 ];
               })
-              (sources."configstore-3.0.0" // {
+              (sources."configstore-3.1.0" // {
                 dependencies = [
                   (sources."dot-prop-4.1.1" // {
                     dependencies = [
                       sources."is-obj-1.0.1"
+                    ];
+                  })
+                  (sources."make-dir-1.0.0" // {
+                    dependencies = [
+                      sources."pify-2.3.0"
                     ];
                   })
                   (sources."unique-string-1.0.0" // {
@@ -38654,12 +39130,13 @@ in
                       sources."crypto-random-string-1.0.0"
                     ];
                   })
+                  sources."write-file-atomic-2.1.0"
                 ];
               })
               sources."is-npm-1.0.0"
               (sources."latest-version-3.1.0" // {
                 dependencies = [
-                  (sources."package-json-4.0.0" // {
+                  (sources."package-json-4.0.1" // {
                     dependencies = [
                       (sources."got-6.7.1" // {
                         dependencies = [
@@ -38684,7 +39161,11 @@ in
                           })
                         ];
                       })
-                      sources."registry-auth-token-3.1.2"
+                      (sources."registry-auth-token-3.3.1" // {
+                        dependencies = [
+                          sources."safe-buffer-5.0.1"
+                        ];
+                      })
                       sources."registry-url-3.1.0"
                     ];
                   })
@@ -38707,7 +39188,7 @@ in
             ];
           })
           sources."wrappy-1.0.2"
-          sources."write-file-atomic-1.3.1"
+          sources."write-file-atomic-1.3.4"
           sources."debuglog-1.0.1"
           sources."imurmurhash-0.1.4"
           sources."lodash._baseindexof-3.1.0"
@@ -38729,7 +39210,7 @@ in
           })
         ];
       })
-      (sources."npm-registry-client-8.1.1" // {
+      (sources."npm-registry-client-8.3.0" // {
         dependencies = [
           (sources."concat-stream-1.6.0" // {
             dependencies = [
@@ -38748,7 +39229,7 @@ in
             ];
           })
           sources."graceful-fs-4.1.11"
-          (sources."normalize-package-data-2.3.6" // {
+          (sources."normalize-package-data-2.3.8" // {
             dependencies = [
               sources."hosted-git-info-2.4.2"
               (sources."is-builtin-module-1.0.0" // {
@@ -38798,7 +39279,7 @@ in
                   sources."delayed-stream-1.0.0"
                 ];
               })
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               sources."forever-agent-0.6.1"
               (sources."form-data-2.1.4" // {
                 dependencies = [
@@ -38807,7 +39288,7 @@ in
               })
               (sources."har-validator-4.2.1" // {
                 dependencies = [
-                  (sources."ajv-4.11.6" // {
+                  (sources."ajv-4.11.8" // {
                     dependencies = [
                       sources."co-4.6.0"
                       (sources."json-stable-stringify-1.0.1" // {
@@ -38844,7 +39325,7 @@ in
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.1"
-                      sources."getpass-0.1.6"
+                      sources."getpass-0.1.7"
                       sources."jsbn-0.1.1"
                       sources."tweetnacl-0.14.5"
                       sources."jodid25519-1.0.2"
@@ -38878,9 +39359,10 @@ in
           })
           sources."retry-0.10.1"
           sources."slide-1.1.6"
-          (sources."npmlog-4.0.2" // {
+          sources."ssri-4.1.2"
+          (sources."npmlog-4.1.0" // {
             dependencies = [
-              (sources."are-we-there-yet-1.1.2" // {
+              (sources."are-we-there-yet-1.1.4" // {
                 dependencies = [
                   sources."delegates-1.0.0"
                   (sources."readable-stream-2.2.9" // {
@@ -38897,7 +39379,7 @@ in
                 ];
               })
               sources."console-control-strings-1.1.0"
-              (sources."gauge-2.7.3" // {
+              (sources."gauge-2.7.4" // {
                 dependencies = [
                   sources."aproba-1.1.1"
                   sources."has-unicode-2.0.1"
@@ -38918,7 +39400,7 @@ in
                       sources."ansi-regex-2.1.1"
                     ];
                   })
-                  sources."wide-align-1.1.0"
+                  sources."wide-align-1.1.2"
                 ];
               })
               sources."set-blocking-2.0.0"
@@ -38951,7 +39433,7 @@ in
       })
       (sources."rc-1.2.1" // {
         dependencies = [
-          sources."deep-extend-0.4.1"
+          sources."deep-extend-0.4.2"
           sources."ini-1.3.4"
           sources."minimist-1.2.0"
           sources."strip-json-comments-2.0.1"
@@ -38968,7 +39450,7 @@ in
                 ];
               })
               sources."inherits-2.0.3"
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -38989,14 +39471,18 @@ in
         ];
       })
       sources."semver-5.3.0"
-      (sources."serve-static-1.12.1" // {
+      (sources."serve-static-1.12.2" // {
         dependencies = [
           sources."encodeurl-1.0.1"
           sources."escape-html-1.0.3"
           sources."parseurl-1.3.1"
-          (sources."send-0.15.1" // {
+          (sources."send-0.15.2" // {
             dependencies = [
-              sources."debug-2.6.1"
+              (sources."debug-2.6.4" // {
+                dependencies = [
+                  sources."ms-0.7.3"
+                ];
+              })
               sources."depd-1.1.0"
               sources."destroy-1.0.4"
               sources."etag-1.8.0"
@@ -39008,7 +39494,7 @@ in
                 ];
               })
               sources."mime-1.3.4"
-              sources."ms-0.7.2"
+              sources."ms-1.0.0"
               (sources."on-finished-2.3.0" // {
                 dependencies = [
                   sources."ee-first-1.1.1"
@@ -39023,17 +39509,17 @@ in
       sources."signals-1.0.0"
       (sources."snapsvg-0.5.1" // {
         dependencies = [
-          sources."eve-0.5.3"
+          sources."eve-0.5.4"
         ];
       })
-      (sources."socket.io-1.7.3" // {
+      (sources."socket.io-1.7.4" // {
         dependencies = [
           (sources."debug-2.3.3" // {
             dependencies = [
               sources."ms-0.7.2"
             ];
           })
-          (sources."engine.io-1.8.3" // {
+          (sources."engine.io-1.8.4" // {
             dependencies = [
               (sources."accepts-1.3.3" // {
                 dependencies = [
@@ -39055,7 +39541,7 @@ in
                   sources."wtf-8-1.0.0"
                 ];
               })
-              (sources."ws-1.1.2" // {
+              (sources."ws-1.1.4" // {
                 dependencies = [
                   sources."options-0.0.6"
                   sources."ultron-1.0.2"
@@ -39071,12 +39557,12 @@ in
           })
           sources."object-assign-4.1.0"
           sources."socket.io-adapter-0.5.0"
-          (sources."socket.io-client-1.7.3" // {
+          (sources."socket.io-client-1.7.4" // {
             dependencies = [
               sources."backo2-1.0.2"
               sources."component-bind-1.0.0"
               sources."component-emitter-1.2.1"
-              (sources."engine.io-client-1.8.3" // {
+              (sources."engine.io-client-1.8.4" // {
                 dependencies = [
                   sources."component-inherit-0.0.3"
                   (sources."engine.io-parser-1.3.2" // {
@@ -39153,9 +39639,9 @@ in
           sources."component-emitter-1.1.2"
           sources."methods-1.0.1"
           sources."cookiejar-2.0.1"
-          (sources."debug-2.6.3" // {
+          (sources."debug-2.6.6" // {
             dependencies = [
-              sources."ms-0.7.2"
+              sources."ms-0.7.3"
             ];
           })
           sources."reduce-component-1.0.1"
@@ -39196,11 +39682,21 @@ in
           sources."stack-trace-0.0.9"
         ];
       })
-      (sources."yargs-7.1.0" // {
+      (sources."yargs-8.0.1" // {
         dependencies = [
-          sources."camelcase-3.0.0"
+          sources."camelcase-4.1.0"
           (sources."cliui-3.2.0" // {
             dependencies = [
+              (sources."string-width-1.0.2" // {
+                dependencies = [
+                  sources."code-point-at-1.1.0"
+                  (sources."is-fullwidth-code-point-1.0.0" // {
+                    dependencies = [
+                      sources."number-is-nan-1.0.1"
+                    ];
+                  })
+                ];
+              })
               (sources."strip-ansi-3.0.1" // {
                 dependencies = [
                   sources."ansi-regex-2.1.1"
@@ -39211,30 +39707,77 @@ in
           })
           sources."decamelize-1.2.0"
           sources."get-caller-file-1.0.2"
-          (sources."os-locale-1.4.0" // {
+          (sources."os-locale-2.0.0" // {
             dependencies = [
+              (sources."execa-0.5.1" // {
+                dependencies = [
+                  (sources."cross-spawn-4.0.2" // {
+                    dependencies = [
+                      (sources."lru-cache-4.0.2" // {
+                        dependencies = [
+                          sources."pseudomap-1.0.2"
+                          sources."yallist-2.1.2"
+                        ];
+                      })
+                      (sources."which-1.2.14" // {
+                        dependencies = [
+                          sources."isexe-2.0.0"
+                        ];
+                      })
+                    ];
+                  })
+                  (sources."get-stream-2.3.1" // {
+                    dependencies = [
+                      sources."object-assign-4.1.1"
+                      (sources."pinkie-promise-2.0.1" // {
+                        dependencies = [
+                          sources."pinkie-2.0.4"
+                        ];
+                      })
+                    ];
+                  })
+                  sources."is-stream-1.1.0"
+                  (sources."npm-run-path-2.0.2" // {
+                    dependencies = [
+                      sources."path-key-2.0.1"
+                    ];
+                  })
+                  sources."p-finally-1.0.0"
+                  sources."signal-exit-3.0.2"
+                  sources."strip-eof-1.0.0"
+                ];
+              })
               (sources."lcid-1.0.0" // {
                 dependencies = [
                   sources."invert-kv-1.0.0"
                 ];
               })
+              (sources."mem-1.1.0" // {
+                dependencies = [
+                  sources."mimic-fn-1.1.0"
+                ];
+              })
             ];
           })
-          (sources."read-pkg-up-1.0.1" // {
+          (sources."read-pkg-up-2.0.0" // {
             dependencies = [
-              (sources."find-up-1.1.2" // {
+              (sources."find-up-2.1.0" // {
                 dependencies = [
-                  sources."path-exists-2.1.0"
-                  (sources."pinkie-promise-2.0.1" // {
+                  (sources."locate-path-2.0.0" // {
                     dependencies = [
-                      sources."pinkie-2.0.4"
+                      (sources."p-locate-2.0.0" // {
+                        dependencies = [
+                          sources."p-limit-1.1.0"
+                        ];
+                      })
+                      sources."path-exists-3.0.0"
                     ];
                   })
                 ];
               })
-              (sources."read-pkg-1.1.0" // {
+              (sources."read-pkg-2.0.0" // {
                 dependencies = [
-                  (sources."load-json-file-1.1.0" // {
+                  (sources."load-json-file-2.0.0" // {
                     dependencies = [
                       sources."graceful-fs-4.1.11"
                       (sources."parse-json-2.2.0" // {
@@ -39247,19 +39790,10 @@ in
                         ];
                       })
                       sources."pify-2.3.0"
-                      (sources."pinkie-promise-2.0.1" // {
-                        dependencies = [
-                          sources."pinkie-2.0.4"
-                        ];
-                      })
-                      (sources."strip-bom-2.0.0" // {
-                        dependencies = [
-                          sources."is-utf8-0.2.1"
-                        ];
-                      })
+                      sources."strip-bom-3.0.0"
                     ];
                   })
-                  (sources."normalize-package-data-2.3.6" // {
+                  (sources."normalize-package-data-2.3.8" // {
                     dependencies = [
                       sources."hosted-git-info-2.4.2"
                       (sources."is-builtin-module-1.0.0" // {
@@ -39279,15 +39813,9 @@ in
                       })
                     ];
                   })
-                  (sources."path-type-1.1.0" // {
+                  (sources."path-type-2.0.0" // {
                     dependencies = [
-                      sources."graceful-fs-4.1.11"
                       sources."pify-2.3.0"
-                      (sources."pinkie-promise-2.0.1" // {
-                        dependencies = [
-                          sources."pinkie-2.0.4"
-                        ];
-                      })
                     ];
                   })
                 ];
@@ -39297,14 +39825,9 @@ in
           sources."require-directory-2.1.1"
           sources."require-main-filename-1.0.1"
           sources."set-blocking-2.0.0"
-          (sources."string-width-1.0.2" // {
+          (sources."string-width-2.0.0" // {
             dependencies = [
-              sources."code-point-at-1.1.0"
-              (sources."is-fullwidth-code-point-1.0.0" // {
-                dependencies = [
-                  sources."number-is-nan-1.0.1"
-                ];
-              })
+              sources."is-fullwidth-code-point-2.0.0"
               (sources."strip-ansi-3.0.1" // {
                 dependencies = [
                   sources."ansi-regex-2.1.1"
@@ -39312,9 +39835,9 @@ in
               })
             ];
           })
-          sources."which-module-1.0.0"
+          sources."which-module-2.0.0"
           sources."y18n-3.2.1"
-          sources."yargs-parser-5.0.0"
+          sources."yargs-parser-7.0.0"
         ];
       })
     ];
@@ -39415,7 +39938,7 @@ in
                         ];
                       })
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -39465,11 +39988,11 @@ in
                 ];
               })
               sources."caseless-0.11.0"
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               sources."forever-agent-0.6.1"
               (sources."form-data-1.0.1" // {
                 dependencies = [
-                  (sources."async-2.3.0" // {
+                  (sources."async-2.4.0" // {
                     dependencies = [
                       sources."lodash-4.17.4"
                     ];
@@ -39502,7 +40025,7 @@ in
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.1"
-                      sources."getpass-0.1.6"
+                      sources."getpass-0.1.7"
                       sources."jsbn-0.1.1"
                       sources."tweetnacl-0.14.5"
                       sources."jodid25519-1.0.2"
@@ -39609,10 +40132,10 @@ in
   webpack = nodeEnv.buildNodePackage {
     name = "webpack";
     packageName = "webpack";
-    version = "2.4.1";
+    version = "2.5.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack/-/webpack-2.4.1.tgz";
-      sha1 = "15a91dbe34966d8a4b99c7d656efd92a2e5a6f6a";
+      url = "https://registry.npmjs.org/webpack/-/webpack-2.5.1.tgz";
+      sha1 = "61742f0cf8af555b87460a9cd8bba2f1e3ee2fce";
     };
     dependencies = [
       sources."acorn-5.0.3"
@@ -39621,7 +40144,7 @@ in
           sources."acorn-4.0.11"
         ];
       })
-      (sources."ajv-4.11.6" // {
+      (sources."ajv-4.11.8" // {
         dependencies = [
           sources."co-4.6.0"
           (sources."json-stable-stringify-1.0.1" // {
@@ -39632,7 +40155,7 @@ in
         ];
       })
       sources."ajv-keywords-1.5.1"
-      (sources."async-2.3.0" // {
+      (sources."async-2.4.0" // {
         dependencies = [
           sources."lodash-4.17.4"
         ];
@@ -39643,7 +40166,7 @@ in
           sources."object-assign-4.1.1"
         ];
       })
-      sources."interpret-1.0.2"
+      sources."interpret-1.0.3"
       sources."json-loader-0.5.4"
       sources."json5-0.5.1"
       sources."loader-runner-2.3.0"
@@ -39768,14 +40291,29 @@ in
                   })
                 ];
               })
-              (sources."create-hash-1.1.2" // {
+              (sources."create-hash-1.1.3" // {
                 dependencies = [
                   sources."cipher-base-1.0.3"
-                  sources."ripemd160-1.0.1"
+                  (sources."ripemd160-2.0.1" // {
+                    dependencies = [
+                      sources."hash-base-2.0.2"
+                    ];
+                  })
                   sources."sha.js-2.4.8"
                 ];
               })
-              sources."create-hmac-1.1.4"
+              (sources."create-hmac-1.1.6" // {
+                dependencies = [
+                  sources."cipher-base-1.0.3"
+                  (sources."ripemd160-2.0.1" // {
+                    dependencies = [
+                      sources."hash-base-2.0.2"
+                    ];
+                  })
+                  sources."safe-buffer-5.0.1"
+                  sources."sha.js-2.4.8"
+                ];
+              })
               (sources."diffie-hellman-5.0.2" // {
                 dependencies = [
                   sources."bn.js-4.11.6"
@@ -39787,7 +40325,17 @@ in
                 ];
               })
               sources."inherits-2.0.3"
-              sources."pbkdf2-3.0.9"
+              (sources."pbkdf2-3.0.12" // {
+                dependencies = [
+                  (sources."ripemd160-2.0.1" // {
+                    dependencies = [
+                      sources."hash-base-2.0.2"
+                    ];
+                  })
+                  sources."safe-buffer-5.0.1"
+                  sources."sha.js-2.4.8"
+                ];
+              })
               (sources."public-encrypt-4.0.0" // {
                 dependencies = [
                   sources."bn.js-4.11.6"
@@ -39818,7 +40366,7 @@ in
           sources."https-browserify-0.0.1"
           sources."os-browserify-0.2.1"
           sources."path-browserify-0.0.0"
-          sources."process-0.11.9"
+          sources."process-0.11.10"
           sources."punycode-1.4.1"
           sources."querystring-es3-0.2.1"
           (sources."readable-stream-2.2.9" // {
@@ -39837,7 +40385,7 @@ in
               sources."inherits-2.0.3"
             ];
           })
-          (sources."stream-http-2.7.0" // {
+          (sources."stream-http-2.7.1" // {
             dependencies = [
               sources."builtin-status-codes-3.0.0"
               sources."inherits-2.0.3"
@@ -39877,7 +40425,7 @@ in
         ];
       })
       sources."tapable-0.2.6"
-      (sources."uglify-js-2.8.22" // {
+      (sources."uglify-js-2.8.24" // {
         dependencies = [
           (sources."yargs-3.10.0" // {
             dependencies = [
@@ -39888,7 +40436,7 @@ in
                     dependencies = [
                       (sources."align-text-0.1.4" // {
                         dependencies = [
-                          (sources."kind-of-3.1.0" // {
+                          (sources."kind-of-3.2.0" // {
                             dependencies = [
                               sources."is-buffer-1.1.5"
                             ];
@@ -39904,7 +40452,7 @@ in
                     dependencies = [
                       (sources."align-text-0.1.4" // {
                         dependencies = [
-                          (sources."kind-of-3.1.0" // {
+                          (sources."kind-of-3.2.0" // {
                             dependencies = [
                               sources."is-buffer-1.1.5"
                             ];
@@ -39927,7 +40475,7 @@ in
       })
       (sources."watchpack-1.3.1" // {
         dependencies = [
-          (sources."chokidar-1.6.1" // {
+          (sources."chokidar-1.7.0" // {
             dependencies = [
               (sources."anymatch-1.3.0" // {
                 dependencies = [
@@ -39936,7 +40484,7 @@ in
                     dependencies = [
                       (sources."arr-diff-2.0.0" // {
                         dependencies = [
-                          sources."arr-flatten-1.0.2"
+                          sources."arr-flatten-1.0.3"
                         ];
                       })
                       sources."array-unique-0.2.1"
@@ -39968,9 +40516,9 @@ in
                         ];
                       })
                       sources."extglob-0.3.2"
-                      sources."filename-regex-2.0.0"
+                      sources."filename-regex-2.0.1"
                       sources."is-extglob-1.0.0"
-                      (sources."kind-of-3.1.0" // {
+                      (sources."kind-of-3.2.0" // {
                         dependencies = [
                           sources."is-buffer-1.1.5"
                         ];
@@ -40022,7 +40570,7 @@ in
               sources."path-is-absolute-1.0.1"
               (sources."readdirp-2.1.0" // {
                 dependencies = [
-                  (sources."minimatch-3.0.3" // {
+                  (sources."minimatch-3.0.4" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.7" // {
                         dependencies = [
@@ -40061,9 +40609,9 @@ in
                           })
                         ];
                       })
-                      (sources."npmlog-4.0.2" // {
+                      (sources."npmlog-4.1.0" // {
                         dependencies = [
-                          (sources."are-we-there-yet-1.1.2" // {
+                          (sources."are-we-there-yet-1.1.4" // {
                             dependencies = [
                               sources."delegates-1.0.0"
                               (sources."readable-stream-2.2.9" // {
@@ -40079,7 +40627,7 @@ in
                             ];
                           })
                           sources."console-control-strings-1.1.0"
-                          (sources."gauge-2.7.3" // {
+                          (sources."gauge-2.7.4" // {
                             dependencies = [
                               sources."aproba-1.1.1"
                               sources."has-unicode-2.0.1"
@@ -40100,7 +40648,7 @@ in
                                   sources."ansi-regex-2.1.1"
                                 ];
                               })
-                              sources."wide-align-1.1.0"
+                              sources."wide-align-1.1.2"
                             ];
                           })
                           sources."set-blocking-2.0.0"
@@ -40108,7 +40656,7 @@ in
                       })
                       (sources."rc-1.2.1" // {
                         dependencies = [
-                          sources."deep-extend-0.4.1"
+                          sources."deep-extend-0.4.2"
                           sources."ini-1.3.4"
                           sources."minimist-1.2.0"
                           sources."strip-json-comments-2.0.1"
@@ -40124,7 +40672,7 @@ in
                               sources."delayed-stream-1.0.0"
                             ];
                           })
-                          sources."extend-3.0.0"
+                          sources."extend-3.0.1"
                           sources."forever-agent-0.6.1"
                           (sources."form-data-2.1.4" // {
                             dependencies = [
@@ -40160,7 +40708,7 @@ in
                                   sources."asn1-0.2.3"
                                   sources."assert-plus-1.0.0"
                                   sources."dashdash-1.14.1"
-                                  sources."getpass-0.1.6"
+                                  sources."getpass-0.1.7"
                                   sources."jsbn-0.1.1"
                                   sources."tweetnacl-0.14.5"
                                   sources."jodid25519-1.0.2"
@@ -40202,7 +40750,7 @@ in
                                   sources."wrappy-1.0.2"
                                 ];
                               })
-                              (sources."minimatch-3.0.3" // {
+                              (sources."minimatch-3.0.4" // {
                                 dependencies = [
                                   (sources."brace-expansion-1.1.7" // {
                                     dependencies = [
@@ -40230,15 +40778,15 @@ in
                       })
                       (sources."tar-pack-3.4.0" // {
                         dependencies = [
-                          (sources."debug-2.6.3" // {
+                          (sources."debug-2.6.6" // {
                             dependencies = [
-                              sources."ms-0.7.2"
+                              sources."ms-0.7.3"
                             ];
                           })
                           sources."fstream-1.0.11"
                           (sources."fstream-ignore-1.0.5" // {
                             dependencies = [
-                              (sources."minimatch-3.0.3" // {
+                              (sources."minimatch-3.0.4" // {
                                 dependencies = [
                                   (sources."brace-expansion-1.1.7" // {
                                     dependencies = [
@@ -40279,7 +40827,7 @@ in
       })
       (sources."webpack-sources-0.2.3" // {
         dependencies = [
-          sources."source-list-map-1.1.1"
+          sources."source-list-map-1.1.2"
         ];
       })
       (sources."yargs-6.6.0" // {
@@ -40345,7 +40893,7 @@ in
                       })
                     ];
                   })
-                  (sources."normalize-package-data-2.3.6" // {
+                  (sources."normalize-package-data-2.3.8" // {
                     dependencies = [
                       sources."hosted-git-info-2.4.2"
                       (sources."is-builtin-module-1.0.0" // {
@@ -40432,16 +40980,16 @@ in
   yarn = nodeEnv.buildNodePackage {
     name = "yarn";
     packageName = "yarn";
-    version = "0.22.0";
+    version = "0.24.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/yarn/-/yarn-0.22.0.tgz";
-      sha1 = "fd8511dc29225b925be967dc185772cc59de5888";
+      url = "https://registry.npmjs.org/yarn/-/yarn-0.24.4.tgz";
+      sha1 = "a4bfa3bb768192706771337f959721cfc0555093";
     };
     dependencies = [
       (sources."babel-runtime-6.23.0" // {
         dependencies = [
           sources."core-js-2.4.1"
-          sources."regenerator-runtime-0.10.3"
+          sources."regenerator-runtime-0.10.5"
         ];
       })
       sources."bytes-2.5.0"
@@ -40474,12 +41022,107 @@ in
         ];
       })
       sources."death-1.1.0"
-      (sources."debug-2.6.3" // {
+      (sources."debug-2.6.6" // {
         dependencies = [
-          sources."ms-0.7.2"
+          sources."ms-0.7.3"
         ];
       })
       sources."detect-indent-5.0.0"
+      (sources."gunzip-maybe-1.4.0" // {
+        dependencies = [
+          (sources."browserify-zlib-0.1.4" // {
+            dependencies = [
+              sources."pako-0.2.9"
+            ];
+          })
+          sources."is-deflate-1.0.0"
+          sources."is-gzip-1.0.0"
+          (sources."peek-stream-1.1.2" // {
+            dependencies = [
+              (sources."duplexify-3.5.0" // {
+                dependencies = [
+                  (sources."end-of-stream-1.0.0" // {
+                    dependencies = [
+                      (sources."once-1.3.3" // {
+                        dependencies = [
+                          sources."wrappy-1.0.2"
+                        ];
+                      })
+                    ];
+                  })
+                  sources."inherits-2.0.3"
+                  (sources."readable-stream-2.2.9" // {
+                    dependencies = [
+                      sources."buffer-shims-1.0.0"
+                      sources."core-util-is-1.0.2"
+                      sources."isarray-1.0.0"
+                      sources."process-nextick-args-1.0.7"
+                      sources."string_decoder-1.0.0"
+                      sources."util-deprecate-1.0.2"
+                    ];
+                  })
+                  sources."stream-shift-1.0.0"
+                ];
+              })
+            ];
+          })
+          (sources."pumpify-1.3.5" // {
+            dependencies = [
+              (sources."duplexify-3.5.0" // {
+                dependencies = [
+                  (sources."end-of-stream-1.0.0" // {
+                    dependencies = [
+                      (sources."once-1.3.3" // {
+                        dependencies = [
+                          sources."wrappy-1.0.2"
+                        ];
+                      })
+                    ];
+                  })
+                  (sources."readable-stream-2.2.9" // {
+                    dependencies = [
+                      sources."buffer-shims-1.0.0"
+                      sources."core-util-is-1.0.2"
+                      sources."isarray-1.0.0"
+                      sources."process-nextick-args-1.0.7"
+                      sources."string_decoder-1.0.0"
+                      sources."util-deprecate-1.0.2"
+                    ];
+                  })
+                  sources."stream-shift-1.0.0"
+                ];
+              })
+              sources."inherits-2.0.3"
+              (sources."pump-1.0.2" // {
+                dependencies = [
+                  sources."end-of-stream-1.4.0"
+                  (sources."once-1.4.0" // {
+                    dependencies = [
+                      sources."wrappy-1.0.2"
+                    ];
+                  })
+                ];
+              })
+            ];
+          })
+          (sources."through2-2.0.3" // {
+            dependencies = [
+              (sources."readable-stream-2.2.9" // {
+                dependencies = [
+                  sources."buffer-shims-1.0.0"
+                  sources."core-util-is-1.0.2"
+                  sources."isarray-1.0.0"
+                  sources."inherits-2.0.3"
+                  sources."process-nextick-args-1.0.7"
+                  sources."string_decoder-1.0.0"
+                  sources."util-deprecate-1.0.2"
+                ];
+              })
+              sources."xtend-4.0.1"
+            ];
+          })
+        ];
+      })
       sources."ini-1.3.4"
       (sources."inquirer-3.0.6" // {
         dependencies = [
@@ -40564,7 +41207,7 @@ in
           sources."signal-exit-3.0.2"
         ];
       })
-      (sources."minimatch-3.0.3" // {
+      (sources."minimatch-3.0.4" // {
         dependencies = [
           (sources."brace-expansion-1.1.7" // {
             dependencies = [
@@ -40584,97 +41227,8 @@ in
           sources."string.prototype.codepointat-0.2.0"
         ];
       })
-      (sources."node-gyp-3.6.0" // {
-        dependencies = [
-          (sources."fstream-1.0.11" // {
-            dependencies = [
-              sources."inherits-2.0.3"
-            ];
-          })
-          (sources."glob-7.1.1" // {
-            dependencies = [
-              sources."fs.realpath-1.0.0"
-              (sources."inflight-1.0.6" // {
-                dependencies = [
-                  sources."wrappy-1.0.2"
-                ];
-              })
-              sources."inherits-2.0.3"
-              (sources."once-1.4.0" // {
-                dependencies = [
-                  sources."wrappy-1.0.2"
-                ];
-              })
-              sources."path-is-absolute-1.0.1"
-            ];
-          })
-          sources."graceful-fs-4.1.11"
-          (sources."nopt-3.0.6" // {
-            dependencies = [
-              sources."abbrev-1.1.0"
-            ];
-          })
-          (sources."npmlog-4.0.2" // {
-            dependencies = [
-              (sources."are-we-there-yet-1.1.2" // {
-                dependencies = [
-                  sources."delegates-1.0.0"
-                  (sources."readable-stream-2.2.9" // {
-                    dependencies = [
-                      sources."buffer-shims-1.0.0"
-                      sources."core-util-is-1.0.2"
-                      sources."isarray-1.0.0"
-                      sources."inherits-2.0.3"
-                      sources."process-nextick-args-1.0.7"
-                      sources."string_decoder-1.0.0"
-                      sources."util-deprecate-1.0.2"
-                    ];
-                  })
-                ];
-              })
-              sources."console-control-strings-1.1.0"
-              (sources."gauge-2.7.3" // {
-                dependencies = [
-                  sources."aproba-1.1.1"
-                  sources."has-unicode-2.0.1"
-                  sources."object-assign-4.1.1"
-                  sources."signal-exit-3.0.2"
-                  (sources."string-width-1.0.2" // {
-                    dependencies = [
-                      sources."code-point-at-1.1.0"
-                      (sources."is-fullwidth-code-point-1.0.0" // {
-                        dependencies = [
-                          sources."number-is-nan-1.0.1"
-                        ];
-                      })
-                    ];
-                  })
-                  (sources."strip-ansi-3.0.1" // {
-                    dependencies = [
-                      sources."ansi-regex-2.1.1"
-                    ];
-                  })
-                  sources."wide-align-1.1.0"
-                ];
-              })
-              sources."set-blocking-2.0.0"
-            ];
-          })
-          (sources."osenv-0.1.4" // {
-            dependencies = [
-              sources."os-homedir-1.0.2"
-              sources."os-tmpdir-1.0.2"
-            ];
-          })
-          (sources."which-1.2.14" // {
-            dependencies = [
-              sources."isexe-2.0.0"
-            ];
-          })
-        ];
-      })
       sources."object-path-0.11.4"
-      (sources."proper-lockfile-2.0.0" // {
+      (sources."proper-lockfile-2.0.1" // {
         dependencies = [
           sources."graceful-fs-4.1.11"
           sources."retry-0.10.1"
@@ -40695,7 +41249,7 @@ in
               sources."delayed-stream-1.0.0"
             ];
           })
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
           sources."forever-agent-0.6.1"
           (sources."form-data-2.1.4" // {
             dependencies = [
@@ -40704,7 +41258,7 @@ in
           })
           (sources."har-validator-4.2.1" // {
             dependencies = [
-              (sources."ajv-4.11.6" // {
+              (sources."ajv-4.11.8" // {
                 dependencies = [
                   sources."co-4.6.0"
                   (sources."json-stable-stringify-1.0.1" // {
@@ -40741,7 +41295,7 @@ in
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.1"
-                  sources."getpass-0.1.6"
+                  sources."getpass-0.1.7"
                   sources."jsbn-0.1.1"
                   sources."tweetnacl-0.14.5"
                   sources."jodid25519-1.0.2"
@@ -40770,7 +41324,6 @@ in
             ];
           })
           sources."tunnel-agent-0.6.0"
-          sources."uuid-3.0.1"
         ];
       })
       sources."request-capture-har-1.2.2"
@@ -40795,23 +41348,26 @@ in
           })
         ];
       })
-      sources."roadrunner-1.1.0"
       sources."semver-5.3.0"
       sources."strip-bom-3.0.0"
-      (sources."tar-2.2.1" // {
+      (sources."tar-fs-1.15.2" // {
         dependencies = [
-          sources."block-stream-0.0.9"
-          (sources."fstream-1.0.11" // {
+          sources."chownr-1.0.1"
+          (sources."pump-1.0.2" // {
             dependencies = [
-              sources."graceful-fs-4.1.11"
+              sources."end-of-stream-1.4.0"
+              (sources."once-1.4.0" // {
+                dependencies = [
+                  sources."wrappy-1.0.2"
+                ];
+              })
             ];
           })
-          sources."inherits-2.0.3"
         ];
       })
-      (sources."tar-stream-1.5.2" // {
+      (sources."tar-stream-1.5.4" // {
         dependencies = [
-          sources."bl-1.2.0"
+          sources."bl-1.2.1"
           (sources."end-of-stream-1.4.0" // {
             dependencies = [
               (sources."once-1.4.0" // {
@@ -40835,6 +41391,7 @@ in
           sources."xtend-4.0.1"
         ];
       })
+      sources."uuid-3.0.1"
       sources."v8-compile-cache-1.1.0"
       (sources."validate-npm-package-license-3.0.1" // {
         dependencies = [
@@ -40899,7 +41456,7 @@ in
             ];
           })
           sources."uuid-2.0.3"
-          (sources."write-file-atomic-1.3.1" // {
+          (sources."write-file-atomic-1.3.4" // {
             dependencies = [
               sources."imurmurhash-0.1.4"
               sources."slide-1.1.6"
@@ -41153,7 +41710,7 @@ in
                   sources."delayed-stream-1.0.0"
                 ];
               })
-              sources."extend-3.0.0"
+              sources."extend-3.0.1"
               sources."forever-agent-0.6.1"
               (sources."form-data-2.1.4" // {
                 dependencies = [
@@ -41162,7 +41719,7 @@ in
               })
               (sources."har-validator-4.2.1" // {
                 dependencies = [
-                  (sources."ajv-4.11.6" // {
+                  (sources."ajv-4.11.8" // {
                     dependencies = [
                       sources."co-4.6.0"
                       (sources."json-stable-stringify-1.0.1" // {
@@ -41199,7 +41756,7 @@ in
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.1"
-                      sources."getpass-0.1.6"
+                      sources."getpass-0.1.7"
                       sources."jsbn-0.1.1"
                       sources."tweetnacl-0.14.5"
                       sources."jodid25519-1.0.2"
@@ -41254,7 +41811,7 @@ in
           })
           sources."map-obj-1.0.1"
           sources."minimist-1.2.0"
-          (sources."normalize-package-data-2.3.6" // {
+          (sources."normalize-package-data-2.3.8" // {
             dependencies = [
               sources."hosted-git-info-2.4.2"
               (sources."is-builtin-module-1.0.0" // {
@@ -41301,7 +41858,7 @@ in
             dependencies = [
               (sources."rc-1.2.1" // {
                 dependencies = [
-                  sources."deep-extend-0.4.1"
+                  sources."deep-extend-0.4.2"
                   sources."ini-1.3.4"
                   sources."minimist-1.2.0"
                   sources."strip-json-comments-2.0.1"
@@ -41318,23 +41875,24 @@ in
       })
       (sources."package-json-2.4.0" // {
         dependencies = [
-          (sources."registry-auth-token-3.1.2" // {
+          (sources."registry-auth-token-3.3.1" // {
             dependencies = [
               (sources."rc-1.2.1" // {
                 dependencies = [
-                  sources."deep-extend-0.4.1"
+                  sources."deep-extend-0.4.2"
                   sources."ini-1.3.4"
                   sources."minimist-1.2.0"
                   sources."strip-json-comments-2.0.1"
                 ];
               })
+              sources."safe-buffer-5.0.1"
             ];
           })
           (sources."registry-url-3.1.0" // {
             dependencies = [
               (sources."rc-1.2.1" // {
                 dependencies = [
-                  sources."deep-extend-0.4.1"
+                  sources."deep-extend-0.4.2"
                   sources."ini-1.3.4"
                   sources."minimist-1.2.0"
                   sources."strip-json-comments-2.0.1"
@@ -41398,7 +41956,7 @@ in
                   })
                 ];
               })
-              (sources."normalize-package-data-2.3.6" // {
+              (sources."normalize-package-data-2.3.8" // {
                 dependencies = [
                   sources."hosted-git-info-2.4.2"
                   (sources."is-builtin-module-1.0.0" // {
@@ -41480,9 +42038,9 @@ in
       })
       (sources."tabtab-1.3.2" // {
         dependencies = [
-          (sources."debug-2.6.3" // {
+          (sources."debug-2.6.6" // {
             dependencies = [
-              sources."ms-0.7.2"
+              sources."ms-0.7.3"
             ];
           })
           (sources."inquirer-1.2.3" // {
@@ -41501,7 +42059,7 @@ in
               sources."cli-width-2.1.0"
               (sources."external-editor-1.1.1" // {
                 dependencies = [
-                  sources."extend-3.0.0"
+                  sources."extend-3.0.1"
                   (sources."spawn-sync-1.0.15" // {
                     dependencies = [
                       (sources."concat-stream-1.6.0" // {
@@ -41570,7 +42128,7 @@ in
           (sources."npmlog-2.0.4" // {
             dependencies = [
               sources."ansi-0.3.1"
-              (sources."are-we-there-yet-1.1.2" // {
+              (sources."are-we-there-yet-1.1.4" // {
                 dependencies = [
                   sources."delegates-1.0.0"
                   (sources."readable-stream-2.2.9" // {
@@ -41645,7 +42203,7 @@ in
                 ];
               })
               sources."uuid-2.0.3"
-              (sources."write-file-atomic-1.3.1" // {
+              (sources."write-file-atomic-1.3.4" // {
                 dependencies = [
                   sources."imurmurhash-0.1.4"
                   sources."slide-1.1.6"
@@ -41721,7 +42279,7 @@ in
                   sources."foreachasync-3.0.0"
                 ];
               })
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -41737,9 +42295,9 @@ in
       })
       (sources."yeoman-environment-1.6.6" // {
         dependencies = [
-          (sources."debug-2.6.3" // {
+          (sources."debug-2.6.6" // {
             dependencies = [
-              sources."ms-0.7.2"
+              sources."ms-0.7.3"
             ];
           })
           sources."diff-2.2.3"
@@ -41760,7 +42318,7 @@ in
                     ];
                   })
                   sources."inherits-2.0.3"
-                  (sources."minimatch-3.0.3" // {
+                  (sources."minimatch-3.0.4" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.7" // {
                         dependencies = [
@@ -41804,7 +42362,7 @@ in
               sources."cli-width-2.1.0"
               (sources."external-editor-1.1.1" // {
                 dependencies = [
-                  sources."extend-3.0.0"
+                  sources."extend-3.0.1"
                   (sources."spawn-sync-1.0.15" // {
                     dependencies = [
                       (sources."concat-stream-1.6.0" // {

--- a/pkgs/development/node-packages/node-packages-v6.nix
+++ b/pkgs/development/node-packages/node-packages-v6.nix
@@ -76,13 +76,13 @@ let
         sha1 = "edbbe1888ba3525ded3a7bf836b30b3405d3161b";
       };
     };
-    "resolve-1.3.2" = {
+    "resolve-1.3.3" = {
       name = "resolve";
       packageName = "resolve";
-      version = "1.3.2";
+      version = "1.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz";
-        sha1 = "1f0442c9e0cbb8136e87b9305f932f46c7f28235";
+        url = "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz";
+        sha1 = "655907c3469a8680dc2de3a275a8fdd69691f0e5";
       };
     };
     "global-paths-0.1.2" = {
@@ -310,13 +310,13 @@ let
         sha1 = "a1d78fc3a50474cb80845d3b3b6e1da49a446e8e";
       };
     };
-    "kind-of-3.1.0" = {
+    "kind-of-3.2.0" = {
       name = "kind-of";
       packageName = "kind-of";
-      version = "3.1.0";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz";
-        sha1 = "475d698a5e49ff5e53d14e3e732429dc8bf4cf47";
+        url = "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz";
+        sha1 = "b58abe4d5c044ad33726a8c1525b48cf891bff07";
       };
     };
     "longest-1.0.1" = {
@@ -544,22 +544,22 @@ let
         sha1 = "f6d81c1e6093f4abae2d153a7b856963f5085e32";
       };
     };
-    "azure-arm-datalake-analytics-1.0.1-preview" = {
+    "azure-arm-datalake-analytics-1.0.2-preview" = {
       name = "azure-arm-datalake-analytics";
       packageName = "azure-arm-datalake-analytics";
-      version = "1.0.1-preview";
+      version = "1.0.2-preview";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-arm-datalake-analytics/-/azure-arm-datalake-analytics-1.0.1-preview.tgz";
-        sha1 = "75461904000427e12ce11d634d74c052c86de994";
+        url = "https://registry.npmjs.org/azure-arm-datalake-analytics/-/azure-arm-datalake-analytics-1.0.2-preview.tgz";
+        sha1 = "b34f868e98a972ec80e4408d209dc06c000dfb63";
       };
     };
-    "azure-arm-datalake-store-1.0.1-preview" = {
+    "azure-arm-datalake-store-1.0.2-preview" = {
       name = "azure-arm-datalake-store";
       packageName = "azure-arm-datalake-store";
-      version = "1.0.1-preview";
+      version = "1.0.2-preview";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-arm-datalake-store/-/azure-arm-datalake-store-1.0.1-preview.tgz";
-        sha1 = "bd07cbeb5eb355a00b7bed69e198a1a968115dd5";
+        url = "https://registry.npmjs.org/azure-arm-datalake-store/-/azure-arm-datalake-store-1.0.2-preview.tgz";
+        sha1 = "c8b7c113016c92703a84dc28d29ba518e8c64763";
       };
     };
     "azure-arm-hdinsight-0.2.2" = {
@@ -1705,13 +1705,13 @@ let
         sha1 = "49bd6331d7d02d0c09bc910a1075ba8165b56df9";
       };
     };
-    "minimatch-3.0.3" = {
+    "minimatch-3.0.4" = {
       name = "minimatch";
       packageName = "minimatch";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz";
-        sha1 = "2a4e4090b96b2db06a9d7df01055a62a77c9b774";
+        url = "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz";
+        sha1 = "5166e286457f03306064be5497e8dbb0c3d32083";
       };
     };
     "once-1.4.0" = {
@@ -1858,13 +1858,13 @@ let
         sha1 = "938370a57b4a51dea2c77c15d5c5fdf895164009";
       };
     };
-    "extend-3.0.0" = {
+    "extend-3.0.1" = {
       name = "extend";
       packageName = "extend";
-      version = "3.0.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz";
-        sha1 = "5a474353b9f3353ddd8176dfd37b91c83a46f1d4";
+        url = "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz";
+        sha1 = "a755ea7bc1adfcc5a31ce7e762dbaadc5e636444";
       };
     };
     "forever-agent-0.6.1" = {
@@ -1993,13 +1993,13 @@ let
         sha1 = "df3ae199acadfb7d440aaae0b29e2272b24ec619";
       };
     };
-    "async-2.3.0" = {
+    "async-2.4.0" = {
       name = "async";
       packageName = "async";
-      version = "2.3.0";
+      version = "2.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/async/-/async-2.3.0.tgz";
-        sha1 = "1013d1051047dd320fe24e494d5c66ecaf6147d9";
+        url = "https://registry.npmjs.org/async/-/async-2.4.0.tgz";
+        sha1 = "4990200f18ea5b837c2cc4f8c031a6985c385611";
       };
     };
     "lodash-4.17.4" = {
@@ -2281,13 +2281,13 @@ let
         sha1 = "853cfa0f7cbe2fed5de20326b8dd581035f6e2f0";
       };
     };
-    "getpass-0.1.6" = {
+    "getpass-0.1.7" = {
       name = "getpass";
       packageName = "getpass";
-      version = "0.1.6";
+      version = "0.1.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz";
-        sha1 = "283ffd9fc1256840875311c1b60e8c40187110e6";
+        url = "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz";
+        sha1 = "5eff8e3e684d569ae4cb2b1282604e8ba62149fa";
       };
     };
     "jsbn-0.1.1" = {
@@ -2632,13 +2632,13 @@ let
         sha1 = "04e6926f662895354f3dd015203633b857297e2c";
       };
     };
-    "deep-extend-0.4.1" = {
+    "deep-extend-0.4.2" = {
       name = "deep-extend";
       packageName = "deep-extend";
-      version = "0.4.1";
+      version = "0.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz";
-        sha1 = "efe4113d08085f4e6f9687759810f807469e2253";
+        url = "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz";
+        sha1 = "48b699c27e334bf89f10892be432f6e4c7d34a7f";
       };
     };
     "ext-name-3.0.0" = {
@@ -2866,13 +2866,13 @@ let
         sha1 = "a35008b20f41383eec1fb914f4cd5df79a264284";
       };
     };
-    "normalize-package-data-2.3.6" = {
+    "normalize-package-data-2.3.8" = {
       name = "normalize-package-data";
       packageName = "normalize-package-data";
-      version = "2.3.6";
+      version = "2.3.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz";
-        sha1 = "498fa420c96401f787402ba21e600def9f981fff";
+        url = "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz";
+        sha1 = "d819eda2a9dedbd1ffa563ea4071d936782295bb";
       };
     };
     "object-assign-4.1.1" = {
@@ -3226,22 +3226,22 @@ let
         sha1 = "dd01bac9d06d30e6f219aecb8253ee9ebdc308f1";
       };
     };
-    "debug-2.6.3" = {
+    "debug-2.6.6" = {
       name = "debug";
       packageName = "debug";
-      version = "2.6.3";
+      version = "2.6.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz";
-        sha1 = "0f7eb8c30965ec08c72accfa0130c8b79984141d";
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz";
+        sha1 = "a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a";
       };
     };
-    "ms-0.7.2" = {
+    "ms-0.7.3" = {
       name = "ms";
       packageName = "ms";
-      version = "0.7.2";
+      version = "0.7.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz";
-        sha1 = "ae25cf2512b3885a1d95d7f037868d8431124765";
+        url = "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz";
+        sha1 = "708155a5e44e33f5fd0fc53e81d0d40a91be1fff";
       };
     };
     "os-tmpdir-1.0.2" = {
@@ -3487,13 +3487,13 @@ let
         sha1 = "a0b870729aae214005b7d5032ec2cbbb0fb4451a";
       };
     };
-    "process-0.11.9" = {
+    "process-0.11.10" = {
       name = "process";
       packageName = "process";
-      version = "0.11.9";
+      version = "0.11.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/process/-/process-0.11.9.tgz";
-        sha1 = "7bd5ad21aa6253e7da8682264f1e11d11c0318c1";
+        url = "https://registry.npmjs.org/process/-/process-0.11.10.tgz";
+        sha1 = "7332300e840161bda3e69a1d1d91a7d4bc16f182";
       };
     };
     "querystring-es3-0.2.1" = {
@@ -3541,13 +3541,13 @@ let
         sha1 = "66266ee5f9bdb9940a4e4514cafb43bb71e5c9db";
       };
     };
-    "stream-http-2.7.0" = {
+    "stream-http-2.7.1" = {
       name = "stream-http";
       packageName = "stream-http";
-      version = "2.7.0";
+      version = "2.7.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stream-http/-/stream-http-2.7.0.tgz";
-        sha1 = "cec1f4e3b494bc4a81b451808970f8b20b4ed5f6";
+        url = "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz";
+        sha1 = "546a51741ad5a6b07e9e31b0b10441a917df528a";
       };
     };
     "subarg-1.0.0" = {
@@ -3622,13 +3622,13 @@ let
         sha1 = "5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73";
       };
     };
-    "jsonparse-1.3.0" = {
+    "jsonparse-1.3.1" = {
       name = "jsonparse";
       packageName = "jsonparse";
-      version = "1.3.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz";
-        sha1 = "85fc245b1d9259acc6941960b905adf64e7de0e8";
+        url = "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz";
+        sha1 = "3f4dae4a91fac315f71062f8521cc239f1366280";
       };
     };
     "through-2.3.8" = {
@@ -3757,22 +3757,22 @@ let
         sha1 = "888c723596cdf7612f6498233eebd7a35301737d";
       };
     };
-    "create-hash-1.1.2" = {
+    "create-hash-1.1.3" = {
       name = "create-hash";
       packageName = "create-hash";
-      version = "1.1.2";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz";
-        sha1 = "51210062d7bb7479f6c65bb41a92208b1d61abad";
+        url = "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz";
+        sha1 = "606042ac8b9262750f483caddab0f5819172d8fd";
       };
     };
-    "create-hmac-1.1.4" = {
+    "create-hmac-1.1.6" = {
       name = "create-hmac";
       packageName = "create-hmac";
-      version = "1.1.4";
+      version = "1.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz";
-        sha1 = "d3fb4ba253eb8b3f56e39ea2fbcb8af747bd3170";
+        url = "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz";
+        sha1 = "acb9e221a4e17bdb076e90657c42b93e3726cf06";
       };
     };
     "diffie-hellman-5.0.2" = {
@@ -3784,13 +3784,13 @@ let
         sha1 = "b5835739270cfe26acf632099fded2a07f209e5e";
       };
     };
-    "pbkdf2-3.0.9" = {
+    "pbkdf2-3.0.12" = {
       name = "pbkdf2";
       packageName = "pbkdf2";
-      version = "3.0.9";
+      version = "3.0.12";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz";
-        sha1 = "f2c4b25a600058b3c3773c086c37dbbee1ffe693";
+        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz";
+        sha1 = "be36785c5067ea48d806ff923288c5f750b6b8a2";
       };
     };
     "public-encrypt-4.0.0" = {
@@ -3955,13 +3955,13 @@ let
         sha1 = "48ba240b45a9280e94748990ba597d216617fd40";
       };
     };
-    "ripemd160-1.0.1" = {
+    "ripemd160-2.0.1" = {
       name = "ripemd160";
       packageName = "ripemd160";
-      version = "1.0.1";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz";
-        sha1 = "93a4bbd4942bc574b69a8fa57c71de10ecca7d6e";
+        url = "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz";
+        sha1 = "0f4584295c53a3628af7e6d79aca21ce57d1c6e7";
       };
     };
     "sha.js-2.4.8" = {
@@ -3971,6 +3971,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz";
         sha1 = "37068c2c476b6baf402d14a49c67f597921f634f";
+      };
+    };
+    "hash-base-2.0.2" = {
+      name = "hash-base";
+      packageName = "hash-base";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz";
+        sha1 = "66ea1d856db4e8a5470cadf6fce23ae5244ef2e1";
       };
     };
     "miller-rabin-4.0.0" = {
@@ -4243,13 +4252,13 @@ let
         sha1 = "1e80454250018dbad4c3fe94497d6e67b6269c77";
       };
     };
-    "mime-1.3.4" = {
+    "mime-1.3.6" = {
       name = "mime";
       packageName = "mime";
-      version = "1.3.4";
+      version = "1.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz";
-        sha1 = "115f9e3b6b3daf2959983cb38f149a2d40eb5d53";
+        url = "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz";
+        sha1 = "591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0";
       };
     };
     "peerflix-0.34.0" = {
@@ -4675,13 +4684,13 @@ let
         sha1 = "add2958d399319b6d8f2dde29bebac5e845e8b6d";
       };
     };
-    "plist-2.0.1" = {
+    "plist-2.1.0" = {
       name = "plist";
       packageName = "plist";
-      version = "2.0.1";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz";
-        sha1 = "0a32ca9481b1c364e92e18dc55c876de9d01da8b";
+        url = "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz";
+        sha1 = "57ccdb7a0821df21831217a3cad54e3e146a1025";
       };
     };
     "dns-js-0.2.1" = {
@@ -4709,15 +4718,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/qap/-/qap-3.1.3.tgz";
         sha1 = "394288bf07c8fe16cf36bb2e40a3bb947ed24963";
-      };
-    };
-    "base64-js-1.1.2" = {
-      name = "base64-js";
-      packageName = "base64-js";
-      version = "1.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz";
-        sha1 = "d6400cac1c4c660976d90d07a04351d89395f5e8";
       };
     };
     "xmlbuilder-8.2.2" = {
@@ -4819,13 +4819,13 @@ let
         sha1 = "122e161591e21ff4c52530305693f20e6393a398";
       };
     };
-    "magnet-uri-5.1.6" = {
+    "magnet-uri-5.1.7" = {
       name = "magnet-uri";
       packageName = "magnet-uri";
-      version = "5.1.6";
+      version = "5.1.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/magnet-uri/-/magnet-uri-5.1.6.tgz";
-        sha1 = "60e8fb5ea90488c8491701eb306970f3126480b3";
+        url = "https://registry.npmjs.org/magnet-uri/-/magnet-uri-5.1.7.tgz";
+        sha1 = "8f8016ab74c415f274f4fb1943faaf7e92030eff";
       };
     };
     "parse-torrent-file-4.0.2" = {
@@ -4837,13 +4837,13 @@ let
         sha1 = "981a22143832abbcd99052d889d31a39ae3f9bfe";
       };
     };
-    "simple-get-2.5.1" = {
+    "simple-get-2.6.0" = {
       name = "simple-get";
       packageName = "simple-get";
-      version = "2.5.1";
+      version = "2.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-get/-/simple-get-2.5.1.tgz";
-        sha1 = "eb418fb2c9e431631b4cd6c478af548da613ccd2";
+        url = "https://registry.npmjs.org/simple-get/-/simple-get-2.6.0.tgz";
+        sha1 = "bb01144db49b3d4c107615dcf48d3ee404b16e06";
       };
     };
     "thirty-two-1.0.2" = {
@@ -4882,13 +4882,13 @@ let
         sha1 = "9427bb96ff1263cc10a8414cedd51a18b919e8b3";
       };
     };
-    "rusha-0.8.5" = {
+    "rusha-0.8.6" = {
       name = "rusha";
       packageName = "rusha";
-      version = "0.8.5";
+      version = "0.8.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/rusha/-/rusha-0.8.5.tgz";
-        sha1 = "a30ae9bd5a4e80fbc96fbe7a13232b944be24f84";
+        url = "https://registry.npmjs.org/rusha/-/rusha-0.8.6.tgz";
+        sha1 = "b264ddaa4d49a1d67300061858ba9358c4adca14";
       };
     };
     "simple-concat-1.0.0" = {
@@ -5053,13 +5053,13 @@ let
         sha1 = "50346e42a43b35daf2a86f414afb153629a854be";
       };
     };
-    "random-access-file-1.6.1" = {
+    "random-access-file-1.7.2" = {
       name = "random-access-file";
       packageName = "random-access-file";
-      version = "1.6.1";
+      version = "1.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/random-access-file/-/random-access-file-1.6.1.tgz";
-        sha1 = "33358436f43076d34a058db47177a691319f0e99";
+        url = "https://registry.npmjs.org/random-access-file/-/random-access-file-1.7.2.tgz";
+        sha1 = "053e2e8ec7670370a8e8b10da962e45753f22dbc";
       };
     };
     "run-parallel-1.1.6" = {
@@ -5386,13 +5386,13 @@ let
         sha1 = "bbcd40c8451a7ed4ef5c373b8169a409dd1d11d9";
       };
     };
-    "ws-2.2.3" = {
+    "ws-2.3.1" = {
       name = "ws";
       packageName = "ws";
-      version = "2.2.3";
+      version = "2.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ws/-/ws-2.2.3.tgz";
-        sha1 = "f36c9719a56dff813f455af912a2078145bbd940";
+        url = "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz";
+        sha1 = "6b94b3e447cb6a363f785eaf94af6359e8e81c80";
       };
     };
     "ultron-1.1.0" = {
@@ -5728,31 +5728,49 @@ let
         sha1 = "aa58a3041a066f90eaa16c2f5389ff19f3f461a5";
       };
     };
-    "cordova-common-2.0.0" = {
+    "configstore-2.1.0" = {
+      name = "configstore";
+      packageName = "configstore";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz";
+        sha1 = "737a3a7036e9886102aa6099e47bb33ab1aba1a1";
+      };
+    };
+    "cordova-common-2.0.3" = {
       name = "cordova-common";
       packageName = "cordova-common";
-      version = "2.0.0";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-common/-/cordova-common-2.0.0.tgz";
-        sha1 = "125097eb4b50b7353cec226ed21649192293ae97";
+        url = "https://registry.npmjs.org/cordova-common/-/cordova-common-2.0.3.tgz";
+        sha1 = "2214ee04ae1c2ec012a52c7c185313e341a6fb38";
       };
     };
-    "cordova-lib-6.5.0" = {
+    "cordova-lib-7.0.1" = {
       name = "cordova-lib";
       packageName = "cordova-lib";
-      version = "6.5.0";
+      version = "7.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-lib/-/cordova-lib-6.5.0.tgz";
-        sha1 = "f7630a04c29d6cdee980190b1d93fb1536ac453f";
+        url = "https://registry.npmjs.org/cordova-lib/-/cordova-lib-7.0.1.tgz";
+        sha1 = "31cbb90daeb66a67a7d3091636ce729a22a4f7ff";
       };
     };
-    "insight-0.8.4" = {
+    "editor-1.0.0" = {
+      name = "editor";
+      packageName = "editor";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz";
+        sha1 = "60c7f87bd62bcc6a894fa8ccd6afb7823a24f742";
+      };
+    };
+    "insight-0.8.2" = {
       name = "insight";
       packageName = "insight";
-      version = "0.8.4";
+      version = "0.8.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/insight/-/insight-0.8.4.tgz";
-        sha1 = "671caf65b47c9fe8c3d1b3206cf45bb211b75884";
+        url = "https://registry.npmjs.org/insight/-/insight-0.8.2.tgz";
+        sha1 = "18c2acf1b6055491278fc7529f1f21d32e1f0eda";
       };
     };
     "nopt-3.0.1" = {
@@ -5773,15 +5791,6 @@ let
         sha1 = "11872aeedee89268110b10a718448ffb10112a14";
       };
     };
-    "underscore-1.7.0" = {
-      name = "underscore";
-      packageName = "underscore";
-      version = "1.7.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz";
-        sha1 = "6bbaf0877500d36be34ecaa584e0db9fef035209";
-      };
-    };
     "update-notifier-0.5.0" = {
       name = "update-notifier";
       packageName = "update-notifier";
@@ -5789,6 +5798,78 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz";
         sha1 = "07b5dc2066b3627ab3b4f530130f7eddda07a4cc";
+      };
+    };
+    "dot-prop-3.0.0" = {
+      name = "dot-prop";
+      packageName = "dot-prop";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz";
+        sha1 = "1b708af094a49c9a0e7dbcad790aba539dac1177";
+      };
+    };
+    "osenv-0.1.4" = {
+      name = "osenv";
+      packageName = "osenv";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz";
+        sha1 = "42fe6d5953df06c8064be6f176c3d05aaaa34644";
+      };
+    };
+    "uuid-2.0.3" = {
+      name = "uuid";
+      packageName = "uuid";
+      version = "2.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz";
+        sha1 = "67e2e863797215530dff318e5bf9dcebfd47b21a";
+      };
+    };
+    "write-file-atomic-1.3.4" = {
+      name = "write-file-atomic";
+      packageName = "write-file-atomic";
+      version = "1.3.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz";
+        sha1 = "f807a4f0b1d9e913ae7a48112e6cc3af1991b45f";
+      };
+    };
+    "xdg-basedir-2.0.0" = {
+      name = "xdg-basedir";
+      packageName = "xdg-basedir";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz";
+        sha1 = "edbc903cc385fc04523d966a335504b5504d1bd2";
+      };
+    };
+    "is-obj-1.0.1" = {
+      name = "is-obj";
+      packageName = "is-obj";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz";
+        sha1 = "3e4729ac1f5fde025cd7d83a896dab9f4f67db0f";
+      };
+    };
+    "imurmurhash-0.1.4" = {
+      name = "imurmurhash";
+      packageName = "imurmurhash";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz";
+        sha1 = "9218b9b2b928a238b13dc4fb6b6d576f231453ea";
+      };
+    };
+    "slide-1.1.6" = {
+      name = "slide";
+      packageName = "slide";
+      version = "1.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz";
+        sha1 = "56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707";
       };
     };
     "ansi-0.3.1" = {
@@ -5818,13 +5899,13 @@ let
         sha1 = "e244b9185b8175473bff6079324905115f83dc7c";
       };
     };
-    "elementtree-0.1.7" = {
+    "elementtree-0.1.6" = {
       name = "elementtree";
       packageName = "elementtree";
-      version = "0.1.7";
+      version = "0.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz";
-        sha1 = "9ac91be6e52fb6e6244c4e54a4ac3ed8ae8e29c0";
+        url = "https://registry.npmjs.org/elementtree/-/elementtree-0.1.6.tgz";
+        sha1 = "2ac4c46ea30516c8c4cbdb5e3ac7418e592de20c";
       };
     };
     "glob-5.0.15" = {
@@ -5834,15 +5915,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz";
         sha1 = "1bc936b9e02f4a603fcc222ecf7633d30b8b93b1";
-      };
-    };
-    "osenv-0.1.4" = {
-      name = "osenv";
-      packageName = "osenv";
-      version = "0.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz";
-        sha1 = "42fe6d5953df06c8064be6f176c3d05aaaa34644";
       };
     };
     "plist-1.2.0" = {
@@ -5881,22 +5953,22 @@ let
         sha1 = "364200d5f13646ca8bcd44490271335614792300";
       };
     };
-    "big-integer-1.6.19" = {
+    "big-integer-1.6.22" = {
       name = "big-integer";
       packageName = "big-integer";
-      version = "1.6.19";
+      version = "1.6.22";
       src = fetchurl {
-        url = "https://registry.npmjs.org/big-integer/-/big-integer-1.6.19.tgz";
-        sha1 = "4a5e915e3188c8708f254b356196f28542acc1e0";
+        url = "https://registry.npmjs.org/big-integer/-/big-integer-1.6.22.tgz";
+        sha1 = "487c95fce886022ea48ff5f19e388932df46dd2e";
       };
     };
-    "sax-1.1.4" = {
+    "sax-0.3.5" = {
       name = "sax";
       packageName = "sax";
-      version = "1.1.4";
+      version = "0.3.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz";
-        sha1 = "74b6d33c9ae1e001510f179a91168588f1aedaa9";
+        url = "https://registry.npmjs.org/sax/-/sax-0.3.5.tgz";
+        sha1 = "88fcfc1f73c0c8bbd5b7c776b6d3f3501eed073d";
       };
     };
     "base64-js-0.0.8" = {
@@ -5917,31 +5989,31 @@ let
         sha1 = "98b8f651ca30aa624036f127d11cc66dc7b907a3";
       };
     };
-    "aliasify-1.9.0" = {
+    "aliasify-2.1.0" = {
       name = "aliasify";
       packageName = "aliasify";
-      version = "1.9.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aliasify/-/aliasify-1.9.0.tgz";
-        sha1 = "03aa1a5fe5b4cac604e3b967bc4c7ceacf957030";
+        url = "https://registry.npmjs.org/aliasify/-/aliasify-2.1.0.tgz";
+        sha1 = "7c30825b9450b9e6185ba27533eaf6e2067d4b42";
       };
     };
-    "cordova-create-1.0.2" = {
+    "cordova-create-1.1.1" = {
       name = "cordova-create";
       packageName = "cordova-create";
-      version = "1.0.2";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-create/-/cordova-create-1.0.2.tgz";
-        sha1 = "cb9bba9817c62a645bacb6e00da8cc50936a0fa5";
+        url = "https://registry.npmjs.org/cordova-create/-/cordova-create-1.1.1.tgz";
+        sha1 = "55282493ab396d9303f72febbaf2f978fa764cd2";
       };
     };
-    "cordova-fetch-1.0.2" = {
+    "cordova-fetch-1.1.0" = {
       name = "cordova-fetch";
       packageName = "cordova-fetch";
-      version = "1.0.2";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-fetch/-/cordova-fetch-1.0.2.tgz";
-        sha1 = "b8f4903f39fe613888062552a96995413af16d35";
+        url = "https://registry.npmjs.org/cordova-fetch/-/cordova-fetch-1.1.0.tgz";
+        sha1 = "1549f9ff4e6345f3c6fb6bd6523e8b19311a7b54";
       };
     };
     "cordova-js-4.2.1" = {
@@ -5971,31 +6043,22 @@ let
         sha1 = "fade86a92799a813e9b42511cdf3dfa6cc8dbefe";
       };
     };
-    "elementtree-0.1.6" = {
-      name = "elementtree";
-      packageName = "elementtree";
-      version = "0.1.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/elementtree/-/elementtree-0.1.6.tgz";
-        sha1 = "2ac4c46ea30516c8c4cbdb5e3ac7418e592de20c";
-      };
-    };
-    "init-package-json-1.9.6" = {
+    "init-package-json-1.10.1" = {
       name = "init-package-json";
       packageName = "init-package-json";
-      version = "1.9.6";
+      version = "1.10.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.6.tgz";
-        sha1 = "789fc2b74466a4952b9ea77c0575bc78ebd60a61";
+        url = "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz";
+        sha1 = "cd873a167796befb99612b28762a0b6393fd8f6a";
       };
     };
-    "nopt-3.0.6" = {
+    "nopt-4.0.1" = {
       name = "nopt";
       packageName = "nopt";
-      version = "3.0.6";
+      version = "4.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz";
-        sha1 = "c6465dbf08abcd4db359317f79ac68a646b28ff9";
+        url = "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz";
+        sha1 = "d0d4685afd5415193c8c7505602d0d17cd64474d";
       };
     };
     "npm-2.15.12" = {
@@ -6007,40 +6070,40 @@ let
         sha1 = "df7c3ed5a277c3f9d4b5d819b05311d10a200ae6";
       };
     };
-    "opener-1.4.1" = {
+    "opener-1.4.2" = {
       name = "opener";
       packageName = "opener";
-      version = "1.4.1";
+      version = "1.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz";
-        sha1 = "897590acd1aed3311b703b58bccb4d43f56f2895";
+        url = "https://registry.npmjs.org/opener/-/opener-1.4.2.tgz";
+        sha1 = "b32582080042af8680c389a499175b4c54fff523";
       };
     };
-    "properties-parser-0.2.3" = {
+    "plist-2.0.1" = {
+      name = "plist";
+      packageName = "plist";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz";
+        sha1 = "0a32ca9481b1c364e92e18dc55c876de9d01da8b";
+      };
+    };
+    "properties-parser-0.3.1" = {
       name = "properties-parser";
       packageName = "properties-parser";
-      version = "0.2.3";
+      version = "0.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/properties-parser/-/properties-parser-0.2.3.tgz";
-        sha1 = "f7591255f707abbff227c7b56b637dbb0373a10f";
+        url = "https://registry.npmjs.org/properties-parser/-/properties-parser-0.3.1.tgz";
+        sha1 = "1316e9539ffbfd93845e369b211022abd478771a";
       };
     };
-    "request-2.47.0" = {
+    "request-2.79.0" = {
       name = "request";
       packageName = "request";
-      version = "2.47.0";
+      version = "2.79.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/request/-/request-2.47.0.tgz";
-        sha1 = "09e9fd1a4fed6593a805ef8202b20f0c5ecb485f";
-      };
-    };
-    "semver-4.3.6" = {
-      name = "semver";
-      packageName = "semver";
-      version = "4.3.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz";
-        sha1 = "300bc6e0e86374f7ba61068b5b1ecd57fc6532da";
+        url = "https://registry.npmjs.org/request/-/request-2.79.0.tgz";
+        sha1 = "4dfe5bf6be8b8cdc37fcf93e04b65577722710de";
       };
     };
     "shelljs-0.3.0" = {
@@ -6052,22 +6115,13 @@ let
         sha1 = "3596e6307a781544f591f37da618360f31db57b1";
       };
     };
-    "tar-1.0.2" = {
+    "tar-2.2.1" = {
       name = "tar";
       packageName = "tar";
-      version = "1.0.2";
+      version = "2.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tar/-/tar-1.0.2.tgz";
-        sha1 = "8b0f6740f9946259de26a3ed9c9a22890dff023f";
-      };
-    };
-    "unorm-1.3.3" = {
-      name = "unorm";
-      packageName = "unorm";
-      version = "1.3.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/unorm/-/unorm-1.3.3.tgz";
-        sha1 = "16a8772671ebd6f7cde6f8c5e49bb60ac47dba93";
+        url = "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz";
+        sha1 = "8e4d2a256c0e2185c6b18ad694aec968b83cb1d1";
       };
     };
     "valid-identifier-0.0.1" = {
@@ -6088,31 +6142,31 @@ let
         sha1 = "910a89c16aee6cc0b42ca805a6d0b4cf87211cf3";
       };
     };
-    "browserify-transform-tools-1.5.3" = {
+    "browserify-transform-tools-1.7.0" = {
       name = "browserify-transform-tools";
       packageName = "browserify-transform-tools";
-      version = "1.5.3";
+      version = "1.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.5.3.tgz";
-        sha1 = "509c9c652fb6b07bf0d21efceebb1d826f80754b";
+        url = "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.7.0.tgz";
+        sha1 = "83e277221f63259bed2e7eb2a283a970a501f4c4";
       };
     };
-    "falafel-1.2.0" = {
+    "falafel-2.1.0" = {
       name = "falafel";
       packageName = "falafel";
-      version = "1.2.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz";
-        sha1 = "c18d24ef5091174a497f318cd24b026a25cddab4";
+        url = "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz";
+        sha1 = "96bb17761daba94f46d001738b3cedf3a67fe06c";
       };
     };
-    "acorn-1.2.2" = {
+    "acorn-5.0.3" = {
       name = "acorn";
       packageName = "acorn";
-      version = "1.2.2";
+      version = "5.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz";
-        sha1 = "c8ce27de0acc76d896d2b1fad3df588d9e82f014";
+        url = "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz";
+        sha1 = "c460df08491463f028ccb82eab3730bf01087b3d";
       };
     };
     "foreach-2.0.5" = {
@@ -6133,22 +6187,22 @@ let
         sha1 = "c54601778ad560f1142ce0e01bcca8b56d13426d";
       };
     };
-    "cordova-app-hello-world-3.11.0" = {
+    "cordova-app-hello-world-3.12.0" = {
       name = "cordova-app-hello-world";
       packageName = "cordova-app-hello-world";
-      version = "3.11.0";
+      version = "3.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-app-hello-world/-/cordova-app-hello-world-3.11.0.tgz";
-        sha1 = "9214feb9dd713ca481a1cbabceeca60966c1c0cf";
+        url = "https://registry.npmjs.org/cordova-app-hello-world/-/cordova-app-hello-world-3.12.0.tgz";
+        sha1 = "270e06b67b2ae94bcfee6592ed39eb42303d186f";
       };
     };
-    "dependency-ls-1.0.0" = {
+    "dependency-ls-1.1.0" = {
       name = "dependency-ls";
       packageName = "dependency-ls";
-      version = "1.0.0";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dependency-ls/-/dependency-ls-1.0.0.tgz";
-        sha1 = "311dc9fa9a840bee4c6ca33954556e5cf09cb5c9";
+        url = "https://registry.npmjs.org/dependency-ls/-/dependency-ls-1.1.0.tgz";
+        sha1 = "94cfe674620f5e9f2924d0501f9c6e710fc90f55";
       };
     };
     "is-url-1.2.2" = {
@@ -6178,13 +6232,13 @@ let
         sha1 = "55705bcd93c5f3673530c2c2cbc0c2b3addc286e";
       };
     };
-    "interpret-1.0.2" = {
+    "interpret-1.0.3" = {
       name = "interpret";
       packageName = "interpret";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz";
-        sha1 = "f4f623f0bb7122f15f5717c8e254b8161b5c5b2d";
+        url = "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz";
+        sha1 = "cbc35c62eeee73f19ab7b10a801511401afc0f90";
       };
     };
     "rechoir-0.6.2" = {
@@ -6403,13 +6457,13 @@ let
         sha1 = "6f631aef336d6c46362b51764044ce216be3c051";
       };
     };
-    "finalhandler-1.0.1" = {
+    "finalhandler-1.0.2" = {
       name = "finalhandler";
       packageName = "finalhandler";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.1.tgz";
-        sha1 = "bcd15d1689c0e5ed729b6f7f541a6df984117db8";
+        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.2.tgz";
+        sha1 = "d0e36f9dbc557f2de14423df6261889e9d60c93a";
       };
     };
     "fresh-0.5.0" = {
@@ -6529,6 +6583,24 @@ let
         sha1 = "0294fb922bb9375153541c4f7096231f287c8af8";
       };
     };
+    "ms-0.7.2" = {
+      name = "ms";
+      packageName = "ms";
+      version = "0.7.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz";
+        sha1 = "ae25cf2512b3885a1d95d7f037868d8431124765";
+      };
+    };
+    "debug-2.6.4" = {
+      name = "debug";
+      packageName = "debug";
+      version = "2.6.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz";
+        sha1 = "7586a9b3c39741c0282ae33445c4e8ac74734fe0";
+      };
+    };
     "unpipe-1.0.0" = {
       name = "unpipe";
       packageName = "unpipe";
@@ -6574,6 +6646,15 @@ let
         sha1 = "5f8b8ed98aca545656bf572997387f904a722257";
       };
     };
+    "mime-1.3.4" = {
+      name = "mime";
+      packageName = "mime";
+      version = "1.3.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz";
+        sha1 = "115f9e3b6b3daf2959983cb38f149a2d40eb5d53";
+      };
+    };
     "media-typer-0.3.0" = {
       name = "media-typer";
       packageName = "media-typer";
@@ -6590,15 +6671,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/underscore/-/underscore-1.2.1.tgz";
         sha1 = "fc5c6b0765673d92a2d4ac8b4dc0aa88702e2bd4";
-      };
-    };
-    "sax-0.3.5" = {
-      name = "sax";
-      packageName = "sax";
-      version = "0.3.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sax/-/sax-0.3.5.tgz";
-        sha1 = "88fcfc1f73c0c8bbd5b7c776b6d3f3501eed073d";
       };
     };
     "npm-package-arg-5.0.1" = {
@@ -6790,15 +6862,6 @@ let
         sha1 = "7f742de066fc748bc8db820569dddce49bf0d456";
       };
     };
-    "editor-1.0.0" = {
-      name = "editor";
-      packageName = "editor";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz";
-        sha1 = "60c7f87bd62bcc6a894fa8ccd6afb7823a24f742";
-      };
-    };
     "fs-vacuum-1.2.10" = {
       name = "fs-vacuum";
       packageName = "fs-vacuum";
@@ -6871,6 +6934,15 @@ let
         sha1 = "0ba81d90da2e25ab34a332e6ec77936e1598118b";
       };
     };
+    "init-package-json-1.9.6" = {
+      name = "init-package-json";
+      packageName = "init-package-json";
+      version = "1.9.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.6.tgz";
+        sha1 = "789fc2b74466a4952b9ea77c0575bc78ebd60a61";
+      };
+    };
     "lockfile-1.0.3" = {
       name = "lockfile";
       packageName = "lockfile";
@@ -6889,13 +6961,22 @@ let
         sha1 = "1d17679c069cda5d040991a09dbc2c0db377e55e";
       };
     };
-    "node-gyp-3.6.0" = {
+    "node-gyp-3.6.1" = {
       name = "node-gyp";
       packageName = "node-gyp";
-      version = "3.6.0";
+      version = "3.6.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz";
-        sha1 = "7474f63a3a0501161dda0b6341f022f14c423fa6";
+        url = "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.1.tgz";
+        sha1 = "19561067ff185464aded478212681f47fd578cbc";
+      };
+    };
+    "nopt-3.0.6" = {
+      name = "nopt";
+      packageName = "nopt";
+      version = "3.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz";
+        sha1 = "c6465dbf08abcd4db359317f79ac68a646b28ff9";
       };
     };
     "normalize-git-url-3.0.2" = {
@@ -7024,15 +7105,6 @@ let
         sha1 = "6030822fbd2c9823949f8f72ed6411ee5cf25aae";
       };
     };
-    "slide-1.1.6" = {
-      name = "slide";
-      packageName = "slide";
-      version = "1.1.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz";
-        sha1 = "56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707";
-      };
-    };
     "sorted-object-2.0.1" = {
       name = "sorted-object";
       packageName = "sorted-object";
@@ -7040,15 +7112,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz";
         sha1 = "7d631f4bd3a798a24af1dffcfbfe83337a5df5fc";
-      };
-    };
-    "tar-2.2.1" = {
-      name = "tar";
-      packageName = "tar";
-      version = "2.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz";
-        sha1 = "8e4d2a256c0e2185c6b18ad694aec968b83cb1d1";
       };
     };
     "text-table-0.2.0" = {
@@ -7094,15 +7157,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz";
         sha1 = "b1f52dc2e8dc0e3cb04d187a25f758a38a90ca3b";
-      };
-    };
-    "imurmurhash-0.1.4" = {
-      name = "imurmurhash";
-      packageName = "imurmurhash";
-      version = "0.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz";
-        sha1 = "9218b9b2b928a238b13dc4fb6b6d576f231453ea";
       };
     };
     "wcwidth-1.0.1" = {
@@ -7186,112 +7240,13 @@ let
         sha1 = "593303fdea85f7c422775f17f9eb7670f680e3ec";
       };
     };
-    "request-2.81.0" = {
-      name = "request";
-      packageName = "request";
-      version = "2.81.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/request/-/request-2.81.0.tgz";
-        sha1 = "c6928946a0e06c5f8d6f8a9333469ffda46298a0";
-      };
-    };
-    "caseless-0.12.0" = {
-      name = "caseless";
-      packageName = "caseless";
-      version = "0.12.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz";
-        sha1 = "1b681c21ff84033c826543090689420d187151dc";
-      };
-    };
-    "form-data-2.1.4" = {
-      name = "form-data";
-      packageName = "form-data";
-      version = "2.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz";
-        sha1 = "33c183acf193276ecaa98143a69e94bfee1750d1";
-      };
-    };
-    "har-validator-4.2.1" = {
-      name = "har-validator";
-      packageName = "har-validator";
-      version = "4.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz";
-        sha1 = "33481d0f1bbff600dd203d75812a6a5fba002e2a";
-      };
-    };
-    "performance-now-0.2.0" = {
-      name = "performance-now";
-      packageName = "performance-now";
-      version = "0.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz";
-        sha1 = "33ef30c5c77d4ea21c5a53869d91b56d8f2555e5";
-      };
-    };
-    "tunnel-agent-0.6.0" = {
-      name = "tunnel-agent";
-      packageName = "tunnel-agent";
-      version = "0.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz";
-        sha1 = "27a5dea06b36b04a0a9966774b290868f0fc40fd";
-      };
-    };
-    "asynckit-0.4.0" = {
-      name = "asynckit";
-      packageName = "asynckit";
-      version = "0.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz";
-        sha1 = "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79";
-      };
-    };
-    "ajv-4.11.6" = {
-      name = "ajv";
-      packageName = "ajv";
-      version = "4.11.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ajv/-/ajv-4.11.6.tgz";
-        sha1 = "947e93049790942b2a2d60a8289b28924d39f987";
-      };
-    };
-    "har-schema-1.0.5" = {
-      name = "har-schema";
-      packageName = "har-schema";
-      version = "1.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz";
-        sha1 = "d263135f43307c02c602afc8fe95970c0151369e";
-      };
-    };
-    "co-4.6.0" = {
-      name = "co";
-      packageName = "co";
-      version = "4.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/co/-/co-4.6.0.tgz";
-        sha1 = "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184";
-      };
-    };
-    "json-stable-stringify-1.0.1" = {
-      name = "json-stable-stringify";
-      packageName = "json-stable-stringify";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz";
-        sha1 = "9a759d39c5f2ff503fd5300646ed445f88c4f9af";
-      };
-    };
-    "are-we-there-yet-1.1.2" = {
+    "are-we-there-yet-1.1.4" = {
       name = "are-we-there-yet";
       packageName = "are-we-there-yet";
-      version = "1.1.2";
+      version = "1.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz";
-        sha1 = "80e470e95a084794fe1899262c5667c6e88de1b3";
+        url = "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz";
+        sha1 = "bb5dca382bb94f05e15194373d16fd3ba1ca110d";
       };
     };
     "gauge-1.2.7" = {
@@ -7384,157 +7339,49 @@ let
         sha1 = "355219cd6cf18dbe7c01cc7fd2dce765cfdc549a";
       };
     };
-    "bl-0.9.5" = {
-      name = "bl";
-      packageName = "bl";
-      version = "0.9.5";
+    "base64-js-1.1.2" = {
+      name = "base64-js";
+      packageName = "base64-js";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz";
-        sha1 = "c06b797af085ea00bc527afc8efcf11de2232054";
+        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz";
+        sha1 = "d6400cac1c4c660976d90d07a04351d89395f5e8";
       };
     };
-    "caseless-0.6.0" = {
-      name = "caseless";
-      packageName = "caseless";
-      version = "0.6.0";
+    "string.prototype.codepointat-0.2.0" = {
+      name = "string.prototype.codepointat";
+      packageName = "string.prototype.codepointat";
+      version = "0.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz";
-        sha1 = "8167c1ab8397fb5bb95f96d28e5a81c50f247ac4";
+        url = "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz";
+        sha1 = "6b26e9bd3afcaa7be3b4269b526de1b82000ac78";
       };
     };
-    "forever-agent-0.5.2" = {
-      name = "forever-agent";
-      packageName = "forever-agent";
-      version = "0.5.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz";
-        sha1 = "6d0e09c4921f94a27f63d3b49c5feff1ea4c5130";
-      };
-    };
-    "form-data-0.1.4" = {
+    "form-data-2.1.4" = {
       name = "form-data";
       packageName = "form-data";
-      version = "0.1.4";
+      version = "2.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz";
-        sha1 = "91abd788aba9702b1aabfa8bc01031a2ac9e3b12";
+        url = "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz";
+        sha1 = "33c183acf193276ecaa98143a69e94bfee1750d1";
       };
     };
-    "mime-types-1.0.2" = {
-      name = "mime-types";
-      packageName = "mime-types";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz";
-        sha1 = "995ae1392ab8affcbfcb2641dd054e943c0d5dce";
-      };
-    };
-    "qs-2.3.3" = {
+    "qs-6.3.2" = {
       name = "qs";
       packageName = "qs";
-      version = "2.3.3";
+      version = "6.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz";
-        sha1 = "e9e85adbe75da0bbe4c8e0476a086290f863b404";
+        url = "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz";
+        sha1 = "e75bd5f6e268122a2a0e0bda630b2550c166502c";
       };
     };
-    "http-signature-0.10.1" = {
-      name = "http-signature";
-      packageName = "http-signature";
-      version = "0.10.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz";
-        sha1 = "4fbdac132559aa8323121e540779c0a012b27e66";
-      };
-    };
-    "oauth-sign-0.4.0" = {
-      name = "oauth-sign";
-      packageName = "oauth-sign";
+    "asynckit-0.4.0" = {
+      name = "asynckit";
+      packageName = "asynckit";
       version = "0.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz";
-        sha1 = "f22956f31ea7151a821e5f2fb32c113cad8b9f69";
-      };
-    };
-    "hawk-1.1.1" = {
-      name = "hawk";
-      packageName = "hawk";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz";
-        sha1 = "87cd491f9b46e4e2aeaca335416766885d2d1ed9";
-      };
-    };
-    "aws-sign2-0.5.0" = {
-      name = "aws-sign2";
-      packageName = "aws-sign2";
-      version = "0.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz";
-        sha1 = "c57103f7a17fc037f02d7c2e64b602ea223f7d63";
-      };
-    };
-    "async-0.9.2" = {
-      name = "async";
-      packageName = "async";
-      version = "0.9.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/async/-/async-0.9.2.tgz";
-        sha1 = "aea74d5e61c1f899613bf64bda66d4c78f2fd17d";
-      };
-    };
-    "assert-plus-0.1.5" = {
-      name = "assert-plus";
-      packageName = "assert-plus";
-      version = "0.1.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz";
-        sha1 = "ee74009413002d84cec7219c6ac811812e723160";
-      };
-    };
-    "ctype-0.5.3" = {
-      name = "ctype";
-      packageName = "ctype";
-      version = "0.5.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz";
-        sha1 = "82c18c2461f74114ef16c135224ad0b9144ca12f";
-      };
-    };
-    "hoek-0.9.1" = {
-      name = "hoek";
-      packageName = "hoek";
-      version = "0.9.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz";
-        sha1 = "3d322462badf07716ea7eb85baf88079cddce505";
-      };
-    };
-    "boom-0.4.2" = {
-      name = "boom";
-      packageName = "boom";
-      version = "0.4.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz";
-        sha1 = "7a636e9ded4efcefb19cef4947a3c67dfaee911b";
-      };
-    };
-    "cryptiles-0.2.2" = {
-      name = "cryptiles";
-      packageName = "cryptiles";
-      version = "0.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz";
-        sha1 = "ed91ff1f17ad13d3748288594f8a48a0d26f325c";
-      };
-    };
-    "sntp-0.2.4" = {
-      name = "sntp";
-      packageName = "sntp";
-      version = "0.2.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz";
-        sha1 = "fb885f18b0f3aad189f824862536bceeec750900";
+        url = "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz";
+        sha1 = "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79";
       };
     };
     "pegjs-0.10.0" = {
@@ -7616,24 +7463,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz";
         sha1 = "1b379f64835af7c5a7f498b357cb95215c159edf";
-      };
-    };
-    "uuid-2.0.3" = {
-      name = "uuid";
-      packageName = "uuid";
-      version = "2.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz";
-        sha1 = "67e2e863797215530dff318e5bf9dcebfd47b21a";
-      };
-    };
-    "xdg-basedir-2.0.0" = {
-      name = "xdg-basedir";
-      packageName = "xdg-basedir";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz";
-        sha1 = "edbc903cc385fc04523d966a335504b5504d1bd2";
       };
     };
     "ansi-escapes-1.4.0" = {
@@ -8150,6 +7979,15 @@ let
         sha1 = "0d40a82f801fc355567d2ecb65efe3f077f121c5";
       };
     };
+    "qs-2.3.3" = {
+      name = "qs";
+      packageName = "qs";
+      version = "2.3.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz";
+        sha1 = "e9e85adbe75da0bbe4c8e0476a086290f863b404";
+      };
+    };
     "range-parser-1.0.3" = {
       name = "range-parser";
       packageName = "range-parser";
@@ -8441,13 +8279,13 @@ let
         sha1 = "78a9a7f4343ae7d820a8999acc80de591e25a779";
       };
     };
-    "verror-1.9.0" = {
+    "verror-1.10.0" = {
       name = "verror";
       packageName = "verror";
-      version = "1.9.0";
+      version = "1.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/verror/-/verror-1.9.0.tgz";
-        sha1 = "107a8a2d14c33586fc4bb830057cd2d19ae2a6ee";
+        url = "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz";
+        sha1 = "3a105ca17053af55d6e270c1f8288682e18da400";
       };
     };
     "extsprintf-1.3.0" = {
@@ -8457,6 +8295,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz";
         sha1 = "96918440e3041a7a414f8c52e3c574eb3c3e1e05";
+      };
+    };
+    "async-0.9.2" = {
+      name = "async";
+      packageName = "async";
+      version = "0.9.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async/-/async-0.9.2.tgz";
+        sha1 = "aea74d5e61c1f899613bf64bda66d4c78f2fd17d";
       };
     };
     "qs-1.2.0" = {
@@ -8729,13 +8576,13 @@ let
         sha1 = "4d4e55f171356121b2c5f6559f944705ab28db15";
       };
     };
-    "tar-stream-1.5.2" = {
+    "tar-stream-1.5.4" = {
       name = "tar-stream";
       packageName = "tar-stream";
-      version = "1.5.2";
+      version = "1.5.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz";
-        sha1 = "fbc6c6e83c1a19d4cb48c7d96171fc248effc7bf";
+        url = "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz";
+        sha1 = "36549cf04ed1aee9b2a30c0143252238daf94016";
       };
     };
     "through2-0.6.5" = {
@@ -8810,13 +8657,13 @@ let
         sha1 = "9500635e257945d6feede185f5d7a24773455b17";
       };
     };
-    "pull-stream-3.5.0" = {
+    "pull-stream-3.6.0" = {
       name = "pull-stream";
       packageName = "pull-stream";
-      version = "3.5.0";
+      version = "3.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.5.0.tgz";
-        sha1 = "1ee5b6f76fd3b3a49a5afb6ded5c0320acb3cfc7";
+        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.0.tgz";
+        sha1 = "59d033a6815d4e3097d47c3d2b1893a9e58a2351";
       };
     };
     "typewiselite-1.0.0" = {
@@ -8936,13 +8783,13 @@ let
         sha1 = "a4ecee01e330155e9124bbbcf4761f21b38f51f5";
       };
     };
-    "pull-pushable-2.0.1" = {
+    "pull-pushable-2.1.0" = {
       name = "pull-pushable";
       packageName = "pull-pushable";
-      version = "2.0.1";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.0.1.tgz";
-        sha1 = "02bdca51a39cf585f483fbecde2fc9378076f212";
+        url = "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.1.0.tgz";
+        sha1 = "aa6c37cde7d54347c49762b4c8b467e814e52fbc";
       };
     };
     "pull-window-2.1.4" = {
@@ -9035,22 +8882,139 @@ let
         sha1 = "80ab4e919749351263ef14500d684e57c4202840";
       };
     };
-    "bl-1.2.0" = {
+    "bl-1.2.1" = {
       name = "bl";
       packageName = "bl";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz";
-        sha1 = "1397e7ec42c5f5dc387470c500e34a9f6be9ea98";
+        url = "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz";
+        sha1 = "cac328f7bee45730d404b692203fcb590e172d5e";
       };
     };
-    "awscred-1.2.0" = {
-      name = "awscred";
-      packageName = "awscred";
-      version = "1.2.0";
+    "aws-sdk-2.50.0" = {
+      name = "aws-sdk";
+      packageName = "aws-sdk";
+      version = "2.50.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/awscred/-/awscred-1.2.0.tgz";
-        sha1 = "9ba714a0d2feb625b848f15c62746c07aebdc3b5";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.50.0.tgz";
+        sha1 = "6b2855741f8efe064f824a3db0bf4f3bc5bde018";
+      };
+    };
+    "request-2.81.0" = {
+      name = "request";
+      packageName = "request";
+      version = "2.81.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/request/-/request-2.81.0.tgz";
+        sha1 = "c6928946a0e06c5f8d6f8a9333469ffda46298a0";
+      };
+    };
+    "crypto-browserify-1.0.9" = {
+      name = "crypto-browserify";
+      packageName = "crypto-browserify";
+      version = "1.0.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz";
+        sha1 = "cc5449685dfb85eb11c9828acc7cb87ab5bbfcc0";
+      };
+    };
+    "jmespath-0.15.0" = {
+      name = "jmespath";
+      packageName = "jmespath";
+      version = "0.15.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz";
+        sha1 = "a3f222a9aae9f966f5d27c796510e28091764217";
+      };
+    };
+    "sax-1.2.1" = {
+      name = "sax";
+      packageName = "sax";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz";
+        sha1 = "7b8e656190b228e81a66aea748480d828cd2d37a";
+      };
+    };
+    "url-0.10.3" = {
+      name = "url";
+      packageName = "url";
+      version = "0.10.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/url/-/url-0.10.3.tgz";
+        sha1 = "021e4d9c7705f21bbf37d03ceb58767402774c64";
+      };
+    };
+    "caseless-0.12.0" = {
+      name = "caseless";
+      packageName = "caseless";
+      version = "0.12.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz";
+        sha1 = "1b681c21ff84033c826543090689420d187151dc";
+      };
+    };
+    "har-validator-4.2.1" = {
+      name = "har-validator";
+      packageName = "har-validator";
+      version = "4.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz";
+        sha1 = "33481d0f1bbff600dd203d75812a6a5fba002e2a";
+      };
+    };
+    "performance-now-0.2.0" = {
+      name = "performance-now";
+      packageName = "performance-now";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz";
+        sha1 = "33ef30c5c77d4ea21c5a53869d91b56d8f2555e5";
+      };
+    };
+    "tunnel-agent-0.6.0" = {
+      name = "tunnel-agent";
+      packageName = "tunnel-agent";
+      version = "0.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz";
+        sha1 = "27a5dea06b36b04a0a9966774b290868f0fc40fd";
+      };
+    };
+    "ajv-4.11.8" = {
+      name = "ajv";
+      packageName = "ajv";
+      version = "4.11.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz";
+        sha1 = "82ffb02b29e662ae53bdc20af15947706739c536";
+      };
+    };
+    "har-schema-1.0.5" = {
+      name = "har-schema";
+      packageName = "har-schema";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz";
+        sha1 = "d263135f43307c02c602afc8fe95970c0151369e";
+      };
+    };
+    "co-4.6.0" = {
+      name = "co";
+      packageName = "co";
+      version = "4.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/co/-/co-4.6.0.tgz";
+        sha1 = "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184";
+      };
+    };
+    "json-stable-stringify-1.0.1" = {
+      name = "json-stable-stringify";
+      packageName = "json-stable-stringify";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz";
+        sha1 = "9a759d39c5f2ff503fd5300646ed445f88c4f9af";
       };
     };
     "clipboardy-0.1.2" = {
@@ -9060,6 +9024,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/clipboardy/-/clipboardy-0.1.2.tgz";
         sha1 = "b82fffcf2828624afc1ec26530a66d6d1781a9cc";
+      };
+    };
+    "conf-1.1.1" = {
+      name = "conf";
+      packageName = "conf";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/conf/-/conf-1.1.1.tgz";
+        sha1 = "238d0a3090ac4916ed2d40c7e81d7a11667bc7ba";
       };
     };
     "got-6.7.1" = {
@@ -9096,6 +9069,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz";
         sha1 = "5edd52b485ca1d900fe64895505399a0dfa45f76";
+      };
+    };
+    "skin-tone-1.0.0" = {
+      name = "skin-tone";
+      packageName = "skin-tone";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/skin-tone/-/skin-tone-1.0.0.tgz";
+        sha1 = "d4ba3e8e5e92760e4d1d3b603d772805c6cb256f";
       };
     };
     "execa-0.5.1" = {
@@ -9159,6 +9141,87 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz";
         sha1 = "411cadb574c5a140d3a4b1910d40d80cc9f40b40";
+      };
+    };
+    "dot-prop-4.1.1" = {
+      name = "dot-prop";
+      packageName = "dot-prop";
+      version = "4.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz";
+        sha1 = "a8493f0b7b5eeec82525b5c7587fa7de7ca859c1";
+      };
+    };
+    "env-paths-1.0.0" = {
+      name = "env-paths";
+      packageName = "env-paths";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz";
+        sha1 = "4168133b42bb05c38a35b1ae4397c8298ab369e0";
+      };
+    };
+    "make-dir-1.0.0" = {
+      name = "make-dir";
+      packageName = "make-dir";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz";
+        sha1 = "97a011751e91dd87cfadef58832ebb04936de978";
+      };
+    };
+    "pkg-up-2.0.0" = {
+      name = "pkg-up";
+      packageName = "pkg-up";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz";
+        sha1 = "c819ac728059a461cab1c3889a2be3c49a004d7f";
+      };
+    };
+    "find-up-2.1.0" = {
+      name = "find-up";
+      packageName = "find-up";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz";
+        sha1 = "45d1b7e506c717ddd482775a2b77920a3c0c57a7";
+      };
+    };
+    "locate-path-2.0.0" = {
+      name = "locate-path";
+      packageName = "locate-path";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz";
+        sha1 = "2b568b265eec944c6d9c0de9c3dbbbca0354cd8e";
+      };
+    };
+    "p-locate-2.0.0" = {
+      name = "p-locate";
+      packageName = "p-locate";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz";
+        sha1 = "20a0103b222a70c8fd39cc2e580680f3dde5ec43";
+      };
+    };
+    "path-exists-3.0.0" = {
+      name = "path-exists";
+      packageName = "path-exists";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz";
+        sha1 = "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515";
+      };
+    };
+    "p-limit-1.1.0" = {
+      name = "p-limit";
+      packageName = "p-limit";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz";
+        sha1 = "b07ff2d9a5d88bec806035895a2bab66a27988bc";
       };
     };
     "create-error-class-3.0.2" = {
@@ -9233,6 +9296,15 @@ let
         sha1 = "e667783d92e89dbd342818b5230b9d62a672ad18";
       };
     };
+    "unicode-emoji-modifier-base-1.0.0" = {
+      name = "unicode-emoji-modifier-base";
+      packageName = "unicode-emoji-modifier-base";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz";
+        sha1 = "dbbd5b54ba30f287e2a8d5a249da6c0cef369459";
+      };
+    };
     "babel-code-frame-6.22.0" = {
       name = "babel-code-frame";
       packageName = "babel-code-frame";
@@ -9260,13 +9332,13 @@ let
         sha1 = "e01975e812781a163a6dadfdd80398dc64c889c3";
       };
     };
-    "espree-3.4.1" = {
+    "espree-3.4.3" = {
       name = "espree";
       packageName = "espree";
-      version = "3.4.1";
+      version = "3.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/espree/-/espree-3.4.1.tgz";
-        sha1 = "28a83ab4aaed71ed8fe0f5efe61b76a05c13c4d2";
+        url = "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz";
+        sha1 = "2910b5ccd49ce893c2ffffaab4fd8b3a31b82374";
       };
     };
     "esquery-1.0.0" = {
@@ -9314,13 +9386,13 @@ let
         sha1 = "0c0ca696d9b9bb694d2e5470bd37777caad50286";
       };
     };
-    "ignore-3.2.7" = {
+    "ignore-3.3.0" = {
       name = "ignore";
       packageName = "ignore";
-      version = "3.2.7";
+      version = "3.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz";
-        sha1 = "4810ca5f1d8eca5595213a34b94f2eb4ed926bbd";
+        url = "https://registry.npmjs.org/ignore/-/ignore-3.3.0.tgz";
+        sha1 = "3812d22cbe9125f2c2b4915755a1b8abd745a001";
       };
     };
     "inquirer-0.12.0" = {
@@ -9341,13 +9413,13 @@ let
         sha1 = "8df57c61ea2e3c501408d100fb013cf8d6e0cc62";
       };
     };
-    "js-yaml-3.8.3" = {
+    "js-yaml-3.8.4" = {
       name = "js-yaml";
       packageName = "js-yaml";
-      version = "3.8.3";
+      version = "3.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz";
-        sha1 = "33a05ec481c850c8875929166fe1beb61c728766";
+        url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz";
+        sha1 = "520b4564f86573ba96662af85a8cafa7b4b5a6f6";
       };
     };
     "levn-0.3.0" = {
@@ -9458,13 +9530,13 @@ let
         sha1 = "754bb5bfe55451da69a58b94d45f4c5b0462d58f";
       };
     };
-    "es5-ext-0.10.15" = {
+    "es5-ext-0.10.16" = {
       name = "es5-ext";
       packageName = "es5-ext";
-      version = "0.10.15";
+      version = "0.10.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz";
-        sha1 = "c330a5934c1ee21284a7c081a86e5fd937c91ea6";
+        url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.16.tgz";
+        sha1 = "1ef1b04f3d09db6a5d630226d62202f2e425e45a";
       };
     };
     "es6-iterator-2.0.1" = {
@@ -9510,15 +9582,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz";
         sha1 = "f6caca728933a850ef90661d0e17982ba47111a2";
-      };
-    };
-    "acorn-5.0.3" = {
-      name = "acorn";
-      packageName = "acorn";
-      version = "5.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz";
-        sha1 = "c460df08491463f028ccb82eab3730bf01087b3d";
       };
     };
     "acorn-jsx-3.0.1" = {
@@ -9935,13 +9998,13 @@ let
         sha1 = "8f61b75cde012b2e9eb284d4545583b5643b61ab";
       };
     };
-    "chokidar-1.6.1" = {
+    "chokidar-1.7.0" = {
       name = "chokidar";
       packageName = "chokidar";
-      version = "1.6.1";
+      version = "1.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz";
-        sha1 = "2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2";
+        url = "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz";
+        sha1 = "798e689778151c8076b4b360e5edd28cda2bb468";
       };
     };
     "ps-tree-0.0.3" = {
@@ -10061,13 +10124,13 @@ let
         sha1 = "2e18ff3d2f49ab2765cec9023f011daa8d8349a1";
       };
     };
-    "filename-regex-2.0.0" = {
+    "filename-regex-2.0.1" = {
       name = "filename-regex";
       packageName = "filename-regex";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz";
-        sha1 = "996e3e80479b98b9897f15a8a58b3d084e926775";
+        url = "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz";
+        sha1 = "c1c4b9bee3e09725ddb106b75c1e301fe2f18b26";
       };
     };
     "is-extglob-1.0.0" = {
@@ -10115,13 +10178,13 @@ let
         sha1 = "9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145";
       };
     };
-    "arr-flatten-1.0.2" = {
+    "arr-flatten-1.0.3" = {
       name = "arr-flatten";
       packageName = "arr-flatten";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.2.tgz";
-        sha1 = "1ec1e63439c54f67d6f72bb4299c3d4f73b2d996";
+        url = "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz";
+        sha1 = "a274ed85ac08849b6bd7847c4580745dc51adfb1";
       };
     };
     "expand-range-1.8.2" = {
@@ -10295,22 +10358,13 @@ let
         sha1 = "94ad1c798a11d7fc67381b50d47f8cc18d9799f7";
       };
     };
-    "nopt-4.0.1" = {
-      name = "nopt";
-      packageName = "nopt";
-      version = "4.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz";
-        sha1 = "d0d4685afd5415193c8c7505602d0d17cd64474d";
-      };
-    };
-    "npmlog-4.0.2" = {
+    "npmlog-4.1.0" = {
       name = "npmlog";
       packageName = "npmlog";
-      version = "4.0.2";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz";
-        sha1 = "d03950e0e78ce1527ba26d2a7592e9348ac3e75f";
+        url = "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz";
+        sha1 = "dc59bee85f64f00ed424efb2af0783df25d1c0b5";
       };
     };
     "tar-pack-3.4.0" = {
@@ -10331,13 +10385,13 @@ let
         sha1 = "3d7cf4464db6446ea644bf4b39507f9851008e8e";
       };
     };
-    "gauge-2.7.3" = {
+    "gauge-2.7.4" = {
       name = "gauge";
       packageName = "gauge";
-      version = "2.7.3";
+      version = "2.7.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz";
-        sha1 = "1c23855f962f17b3ad3d0dc7443f304542edfe09";
+        url = "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz";
+        sha1 = "2c03405c7538c39d7eb37b317022e325fb018bf7";
       };
     };
     "set-blocking-2.0.0" = {
@@ -10358,13 +10412,13 @@ let
         sha1 = "95d3600f07710aa0e9298c726ad5ecf2eacbabab";
       };
     };
-    "wide-align-1.1.0" = {
+    "wide-align-1.1.2" = {
       name = "wide-align";
       packageName = "wide-align";
-      version = "1.1.0";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz";
-        sha1 = "40edde802a71fea1f070da3e62dcda2e7add96ad";
+        url = "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz";
+        sha1 = "571e0f1b0604636ebc0dfc21b0339bbe31341710";
       };
     };
     "event-stream-0.5.3" = {
@@ -10466,13 +10520,13 @@ let
         sha1 = "21ffdc429be2b50cb361df990a40a7731288e935";
       };
     };
-    "simple-git-1.70.0" = {
+    "simple-git-1.72.0" = {
       name = "simple-git";
       packageName = "simple-git";
-      version = "1.70.0";
+      version = "1.72.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-git/-/simple-git-1.70.0.tgz";
-        sha1 = "62cfd90bb2628a13ff4fe704c840fcef56244a71";
+        url = "https://registry.npmjs.org/simple-git/-/simple-git-1.72.0.tgz";
+        sha1 = "e462ce8b46d4523f679e340000681582e9e965d2";
       };
     };
     "tabtab-git+https://github.com/mixu/node-tabtab.git" = {
@@ -10557,13 +10611,13 @@ let
         sha1 = "c0dde4ab182713b919b970959a123ecc1a30fcd6";
       };
     };
-    "clean-css-3.4.25" = {
+    "clean-css-3.4.26" = {
       name = "clean-css";
       packageName = "clean-css";
-      version = "3.4.25";
+      version = "3.4.26";
       src = fetchurl {
-        url = "https://registry.npmjs.org/clean-css/-/clean-css-3.4.25.tgz";
-        sha1 = "9e9a52d5c1e6bc5123e1b2783fa65fe958946ede";
+        url = "https://registry.npmjs.org/clean-css/-/clean-css-3.4.26.tgz";
+        sha1 = "55323b344ff3bcee684a2eac81c93df8fa73deeb";
       };
     };
     "commander-2.6.0" = {
@@ -10602,13 +10656,13 @@ let
         sha1 = "5d23cb35561dd85dc67fb8482309b47d53cce9a7";
       };
     };
-    "uglify-js-2.8.22" = {
+    "uglify-js-2.8.24" = {
       name = "uglify-js";
       packageName = "uglify-js";
-      version = "2.8.22";
+      version = "2.8.24";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz";
-        sha1 = "d54934778a8da14903fa29a326fb24c0ab51a1a0";
+        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.24.tgz";
+        sha1 = "48eb5175cf32e22ec11a47e638d7c8b4e0faf2dd";
       };
     };
     "void-elements-2.0.1" = {
@@ -10746,6 +10800,15 @@ let
         sha1 = "c90941ad59e4273328923074d2cf2e7cbc6ec0d9";
       };
     };
+    "acorn-1.2.2" = {
+      name = "acorn";
+      packageName = "acorn";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz";
+        sha1 = "c8ce27de0acc76d896d2b1fad3df588d9e82f014";
+      };
+    };
     "acorn-globals-1.0.9" = {
       name = "acorn-globals";
       packageName = "acorn-globals";
@@ -10818,6 +10881,15 @@ let
         sha1 = "b7e3ea42435a4c9b2759d99e0f201eb195802ee1";
       };
     };
+    "semver-4.3.6" = {
+      name = "semver";
+      packageName = "semver";
+      version = "4.3.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz";
+        sha1 = "300bc6e0e86374f7ba61068b5b1ecd57fc6532da";
+      };
+    };
     "tildify-1.2.0" = {
       name = "tildify";
       packageName = "tildify";
@@ -10827,13 +10899,13 @@ let
         sha1 = "dcec03f55dca9b7aa3e5b04f21817eb56e63588a";
       };
     };
-    "v8flags-2.0.12" = {
+    "v8flags-2.1.1" = {
       name = "v8flags";
       packageName = "v8flags";
-      version = "2.0.12";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/v8flags/-/v8flags-2.0.12.tgz";
-        sha1 = "73235d9f7176f8e8833fb286795445f7938d84e5";
+        url = "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz";
+        sha1 = "aab1a1fa30d45f88dd321148875ac02c0b55e5b4";
       };
     };
     "vinyl-fs-0.3.14" = {
@@ -11691,13 +11763,13 @@ let
         sha1 = "96e3b70d5779f6ad49cd032673d1c312767ba581";
       };
     };
-    "handlebars-4.0.6" = {
+    "handlebars-4.0.8" = {
       name = "handlebars";
       packageName = "handlebars";
-      version = "4.0.6";
+      version = "4.0.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz";
-        sha1 = "2ce4484850537f9c97a8026d5399b935c4ed4ed7";
+        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.0.8.tgz";
+        sha1 = "22b875cd3f0e6cbea30314f144e82bc7a72ff420";
       };
     };
     "supports-color-3.2.3" = {
@@ -11781,13 +11853,13 @@ let
         sha1 = "458c07e09e0d900fc28b70a3fec2dacd1d2cb7f6";
       };
     };
-    "connect-3.6.0" = {
+    "connect-3.6.1" = {
       name = "connect";
       packageName = "connect";
-      version = "3.6.0";
+      version = "3.6.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/connect/-/connect-3.6.0.tgz";
-        sha1 = "f09a4f7dcd17324b663b725c815bdb1c4158a46e";
+        url = "https://registry.npmjs.org/connect/-/connect-3.6.1.tgz";
+        sha1 = "b7760693a74f0454face1d9378edb3f885b43227";
       };
     };
     "core-js-2.4.1" = {
@@ -11916,13 +11988,22 @@ let
         sha1 = "994976cf6a5096a41162840492f0bdc5d6e7fb96";
       };
     };
-    "finalhandler-1.0.0" = {
+    "debug-2.6.3" = {
+      name = "debug";
+      packageName = "debug";
+      version = "2.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz";
+        sha1 = "0f7eb8c30965ec08c72accfa0130c8b79984141d";
+      };
+    };
+    "finalhandler-1.0.1" = {
       name = "finalhandler";
       packageName = "finalhandler";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.0.tgz";
-        sha1 = "b5691c2c0912092f18ac23e9416bde5cd7dc6755";
+        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.1.tgz";
+        sha1 = "bcd15d1689c0e5ed729b6f7f541a6df984117db8";
       };
     };
     "custom-event-1.0.1" = {
@@ -13104,22 +13185,22 @@ let
         sha1 = "f351d32969d32fa5d7a5567154263d928ae3bd1f";
       };
     };
-    "diff-1.4.0" = {
-      name = "diff";
-      packageName = "diff";
-      version = "1.4.0";
+    "debug-2.6.0" = {
+      name = "debug";
+      packageName = "debug";
+      version = "2.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz";
-        sha1 = "7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf";
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz";
+        sha1 = "bc596bcabe7617f11d9fa15361eded5608b8499b";
       };
     };
-    "glob-7.0.5" = {
-      name = "glob";
-      packageName = "glob";
-      version = "7.0.5";
+    "diff-3.2.0" = {
+      name = "diff";
+      packageName = "diff";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz";
-        sha1 = "b4202a69099bbb4d292a7c1b95b6682b67ebdc95";
+        url = "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz";
+        sha1 = "c9ce393a4b7cbd0b058a725c93df299027868ff9";
       };
     };
     "growl-1.9.2" = {
@@ -13626,15 +13707,6 @@ let
         sha1 = "6ddd21bd2a31417b92727dd585f8a6f37608ebee";
       };
     };
-    "write-file-atomic-1.3.1" = {
-      name = "write-file-atomic";
-      packageName = "write-file-atomic";
-      version = "1.3.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz";
-        sha1 = "7d45ba32316328dd1ec7d90f60ebc0d845bb759a";
-      };
-    };
     "bcryptjs-2.4.0" = {
       name = "bcryptjs";
       packageName = "bcryptjs";
@@ -14058,6 +14130,15 @@ let
         sha1 = "9929acdf628fc2c41098deab82ac580cf149aae4";
       };
     };
+    "domhandler-2.4.1" = {
+      name = "domhandler";
+      packageName = "domhandler";
+      version = "2.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz";
+        sha1 = "892e47000a99be55bbf3774ffea0561d8879c259";
+      };
+    };
     "moment-timezone-0.5.13" = {
       name = "moment-timezone";
       packageName = "moment-timezone";
@@ -14238,13 +14319,13 @@ let
         sha1 = "6910bca5da8c95e784b5751b976cf5a10fee36d2";
       };
     };
-    "ordered-read-streams-1.0.0" = {
+    "ordered-read-streams-1.0.1" = {
       name = "ordered-read-streams";
       packageName = "ordered-read-streams";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.0.tgz";
-        sha1 = "d674a86ffcedf83d0ae06afa2918855e96d4033a";
+        url = "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz";
+        sha1 = "77c0cb37c41525d64166d990ffad7ec6a0e1363e";
       };
     };
     "to-absolute-glob-2.0.1" = {
@@ -15111,6 +15192,15 @@ let
         sha1 = "9f557e08fc3b4d26ece9dd34f8fbf476b62585ad";
       };
     };
+    "underscore-1.7.0" = {
+      name = "underscore";
+      packageName = "underscore";
+      version = "1.7.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz";
+        sha1 = "6bbaf0877500d36be34ecaa584e0db9fef035209";
+      };
+    };
     "underscore.string-2.4.0" = {
       name = "underscore.string";
       packageName = "underscore.string";
@@ -15129,13 +15219,13 @@ let
         sha1 = "6fd61b03f3da42a2cd0ec2b60f02bd0e71991fea";
       };
     };
-    "fstream-npm-1.2.0" = {
+    "fstream-npm-1.2.1" = {
       name = "fstream-npm";
       packageName = "fstream-npm";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz";
-        sha1 = "d2c3c89101346982d64e57091c38487bda916fce";
+        url = "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz";
+        sha1 = "08c4a452f789dcbac4c89a4563c902b2c862fd5b";
       };
     };
     "lazy-property-1.0.0" = {
@@ -15226,6 +15316,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.1.1.tgz";
         sha1 = "831476455423ca0a265c6ffdb6100fcc042b36cf";
+      };
+    };
+    "npmlog-4.0.2" = {
+      name = "npmlog";
+      packageName = "npmlog";
+      version = "4.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz";
+        sha1 = "d03950e0e78ce1527ba26d2a7592e9348ac3e75f";
       };
     };
     "opener-1.4.3" = {
@@ -15399,22 +15498,22 @@ let
         sha1 = "db6676e7c7cc0629878ff196097c78855ae9f4ab";
       };
     };
-    "boxen-1.0.0" = {
+    "boxen-1.1.0" = {
       name = "boxen";
       packageName = "boxen";
-      version = "1.0.0";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/boxen/-/boxen-1.0.0.tgz";
-        sha1 = "b2694baf1f605f708ff0177c12193b22f29aaaab";
+        url = "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz";
+        sha1 = "b1b69dd522305e807a99deee777dbd6e5167b102";
       };
     };
-    "configstore-3.0.0" = {
+    "configstore-3.1.0" = {
       name = "configstore";
       packageName = "configstore";
-      version = "3.0.0";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/configstore/-/configstore-3.0.0.tgz";
-        sha1 = "e1b8669c1803ccc50b545e92f8e6e79aa80e0196";
+        url = "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz";
+        sha1 = "45df907073e26dfa1cf4b2d52f5b60545eaa11d1";
       };
     };
     "latest-version-3.1.0" = {
@@ -15444,13 +15543,13 @@ let
         sha1 = "496b2cc109eca8dbacfe2dc72b603c17c5870ad4";
       };
     };
-    "ansi-align-1.1.0" = {
+    "ansi-align-2.0.0" = {
       name = "ansi-align";
       packageName = "ansi-align";
-      version = "1.1.0";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz";
-        sha1 = "2f0c1658829739add5ebb15e6b0c6e3423f016ba";
+        url = "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz";
+        sha1 = "c36aeccba563b89ceb556f3690f0b1d9e3547f7f";
       };
     };
     "camelcase-4.1.0" = {
@@ -15525,15 +15624,6 @@ let
         sha1 = "5d53d578019646c0d68800db4e146e6bdc2ac7af";
       };
     };
-    "dot-prop-4.1.1" = {
-      name = "dot-prop";
-      packageName = "dot-prop";
-      version = "4.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz";
-        sha1 = "a8493f0b7b5eeec82525b5c7587fa7de7ca859c1";
-      };
-    };
     "unique-string-1.0.0" = {
       name = "unique-string";
       packageName = "unique-string";
@@ -15543,13 +15633,13 @@ let
         sha1 = "9e1057cca851abb93398f8b33ae187b99caec11a";
       };
     };
-    "is-obj-1.0.1" = {
-      name = "is-obj";
-      packageName = "is-obj";
-      version = "1.0.1";
+    "write-file-atomic-2.1.0" = {
+      name = "write-file-atomic";
+      packageName = "write-file-atomic";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz";
-        sha1 = "3e4729ac1f5fde025cd7d83a896dab9f4f67db0f";
+        url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz";
+        sha1 = "1769f4b551eedce419f0505deae2e26763542d37";
       };
     };
     "crypto-random-string-1.0.0" = {
@@ -15561,22 +15651,22 @@ let
         sha1 = "a230f64f568310e1498009940790ec99545bca7e";
       };
     };
-    "package-json-4.0.0" = {
+    "package-json-4.0.1" = {
       name = "package-json";
       packageName = "package-json";
-      version = "4.0.0";
+      version = "4.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/package-json/-/package-json-4.0.0.tgz";
-        sha1 = "f3c9dc8738f5b59304d54d2cfb3f91d08fdd7998";
+        url = "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz";
+        sha1 = "8869a0401253661c4c4ca3da6c2121ed555f5eed";
       };
     };
-    "registry-auth-token-3.1.2" = {
+    "registry-auth-token-3.3.1" = {
       name = "registry-auth-token";
       packageName = "registry-auth-token";
-      version = "3.1.2";
+      version = "3.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.2.tgz";
-        sha1 = "1b9e51a185c930da34a9894b12a52ea998f1adaf";
+        url = "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz";
+        sha1 = "fb0d3289ee0d9ada2cbb52af5dfe66cb070d3006";
       };
     };
     "argparse-0.1.15" = {
@@ -15831,13 +15921,13 @@ let
         sha1 = "27d92fec34d27cfa42707d3b40d025ae9855f2df";
       };
     };
-    "snyk-1.28.1" = {
+    "snyk-1.30.0" = {
       name = "snyk";
       packageName = "snyk";
-      version = "1.28.1";
+      version = "1.30.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk/-/snyk-1.28.1.tgz";
-        sha1 = "ae0faed0fcee7d5dbc0fa8a7a8c9ebacb03b6151";
+        url = "https://registry.npmjs.org/snyk/-/snyk-1.30.0.tgz";
+        sha1 = "a323809ea477d6aff0e325f5995cb491c0d7ca3d";
       };
     };
     "spawn-please-0.2.0" = {
@@ -16137,15 +16227,6 @@ let
         sha1 = "a7d898243ae622f7abb6bb604d740a76c6a5461b";
       };
     };
-    "configstore-2.1.0" = {
-      name = "configstore";
-      packageName = "configstore";
-      version = "2.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz";
-        sha1 = "737a3a7036e9886102aa6099e47bb33ab1aba1a1";
-      };
-    };
     "latest-version-2.0.0" = {
       name = "latest-version";
       packageName = "latest-version";
@@ -16162,15 +16243,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz";
         sha1 = "c3c4f6c663b923459a9aa29912d2d031f1507f84";
-      };
-    };
-    "dot-prop-3.0.0" = {
-      name = "dot-prop";
-      packageName = "dot-prop";
-      version = "3.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz";
-        sha1 = "1b708af094a49c9a0e7dbcad790aba539dac1177";
       };
     };
     "package-json-2.4.0" = {
@@ -16308,6 +16380,15 @@ let
         sha1 = "bdaebead30f8d824039ce0ce149d4daa07ba1fac";
       };
     };
+    "ansi-align-1.1.0" = {
+      name = "ansi-align";
+      packageName = "ansi-align";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz";
+        sha1 = "2f0c1658829739add5ebb15e6b0c6e3423f016ba";
+      };
+    };
     "babybird-0.0.1" = {
       name = "babybird";
       packageName = "babybird";
@@ -16334,6 +16415,15 @@ let
         url = "https://github.com/wikimedia/content-type.git";
         rev = "47b2632d0a2ee79a7d67268e2f6621becd95d05b";
         sha256 = "e583031138b98e2a09ce14dbd72afa0377201894092c941ef4cc07206c35ed04";
+      };
+    };
+    "diff-1.4.0" = {
+      name = "diff";
+      packageName = "diff";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz";
+        sha1 = "7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf";
       };
     };
     "domino-1.0.28" = {
@@ -16401,13 +16491,13 @@ let
         sha1 = "78717d9b718ce7cab55e20b9f24388d5fa51d5c0";
       };
     };
-    "service-runner-2.2.5" = {
+    "service-runner-2.3.0" = {
       name = "service-runner";
       packageName = "service-runner";
-      version = "2.2.5";
+      version = "2.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/service-runner/-/service-runner-2.2.5.tgz";
-        sha1 = "95a55084f939110b3f201549c1afedf900ec4850";
+        url = "https://registry.npmjs.org/service-runner/-/service-runner-2.3.0.tgz";
+        sha1 = "09039dfdcc40cdbd0259dd3f982916675838cb59";
       };
     };
     "simplediff-0.1.1" = {
@@ -16509,13 +16599,13 @@ let
         sha1 = "9cea9b6386ac301c741838ca3cb91e66dbfbf669";
       };
     };
-    "hot-shots-4.4.0" = {
+    "hot-shots-4.5.0" = {
       name = "hot-shots";
       packageName = "hot-shots";
-      version = "4.4.0";
+      version = "4.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hot-shots/-/hot-shots-4.4.0.tgz";
-        sha1 = "ab3f3b3df2f4b2ff0d716837569241ede81d9175";
+        url = "https://registry.npmjs.org/hot-shots/-/hot-shots-4.5.0.tgz";
+        sha1 = "d0b7c2ad367cbb2f8c062b26151c0949ad9271f9";
       };
     };
     "limitation-0.2.0" = {
@@ -16527,13 +16617,13 @@ let
         sha1 = "70ce102a972a0b79d4ca13a3ab62b8e6fe682a62";
       };
     };
-    "yargs-6.6.0" = {
+    "yargs-7.1.0" = {
       name = "yargs";
       packageName = "yargs";
-      version = "6.6.0";
+      version = "7.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz";
-        sha1 = "782ec21ef403345f830a808ca3d513af56065208";
+        url = "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz";
+        sha1 = "6ba318eb16961727f5d284f8ea003e8d6154d0c8";
       };
     };
     "dnscache-1.0.1" = {
@@ -16672,13 +16762,13 @@ let
         sha1 = "ed17cbf68abd10e0aef8182713e297c5e4b500b0";
       };
     };
-    "yargs-parser-4.2.1" = {
+    "yargs-parser-5.0.0" = {
       name = "yargs-parser";
       packageName = "yargs-parser";
-      version = "4.2.1";
+      version = "5.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz";
-        sha1 = "29cceac0dc4f03c6c87b4a9f217dd18c9f74871c";
+        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz";
+        sha1 = "275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a";
       };
     };
     "lodash.clone-4.3.2" = {
@@ -16960,6 +17050,15 @@ let
         sha1 = "af440e1ddad078934ec78241420b40bbc56dc2ad";
       };
     };
+    "socket.io-1.7.4" = {
+      name = "socket.io";
+      packageName = "socket.io";
+      version = "1.7.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz";
+        sha1 = "2f7ecedc3391bf2d5c73e291fe233e6e34d4dd00";
+      };
+    };
     "torrent-stream-0.18.1" = {
       name = "torrent-stream";
       packageName = "torrent-stream";
@@ -16969,13 +17068,13 @@ let
         sha1 = "e2e8ca44d81f16fbe5646e0ebb05f5418fea9bf6";
       };
     };
-    "fluent-ffmpeg-2.1.0" = {
+    "fluent-ffmpeg-2.1.2" = {
       name = "fluent-ffmpeg";
       packageName = "fluent-ffmpeg";
-      version = "2.1.0";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.0.tgz";
-        sha1 = "e6ab85e75ba8e49119a3900cd9df10d39831d392";
+        url = "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.2.tgz";
+        sha1 = "c952de2240f812ebda0aa8006d7776ee2acf7d74";
       };
     };
     "on-finished-2.1.1" = {
@@ -17329,6 +17428,33 @@ let
         sha1 = "0541ea91f0e503fdf0c5eed418a32550234967f0";
       };
     };
+    "engine.io-1.8.4" = {
+      name = "engine.io";
+      packageName = "engine.io";
+      version = "1.8.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/engine.io/-/engine.io-1.8.4.tgz";
+        sha1 = "77bce12b80e5d60429337fec3b0daf691ebc9003";
+      };
+    };
+    "socket.io-client-1.7.4" = {
+      name = "socket.io-client";
+      packageName = "socket.io-client";
+      version = "1.7.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz";
+        sha1 = "ec9f820356ed99ef6d357f0756d648717bdd4281";
+      };
+    };
+    "engine.io-client-1.8.4" = {
+      name = "engine.io-client";
+      packageName = "engine.io-client";
+      version = "1.8.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.4.tgz";
+        sha1 = "9fe85dee25853ca6babe25bd2ad68710863e91c2";
+      };
+    };
     "bittorrent-dht-3.2.6" = {
       name = "bittorrent-dht";
       packageName = "bittorrent-dht";
@@ -17599,13 +17725,13 @@ let
         sha1 = "2bdc5ae366041442c27e068cce6f0d7c06ea9949";
       };
     };
-    "flow-parser-0.43.0" = {
+    "flow-parser-0.45.0" = {
       name = "flow-parser";
       packageName = "flow-parser";
-      version = "0.43.0";
+      version = "0.45.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.43.0.tgz";
-        sha1 = "e2b8eb1ac83dd53f7b6b04a7c35b6a52c33479b7";
+        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.45.0.tgz";
+        sha1 = "aa29d4ae27f06aa02817772bba0fcbefef7e62f0";
       };
     };
     "jest-validate-19.0.0" = {
@@ -17687,6 +17813,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz";
         sha1 = "b4c49bf63f162c108b0348399a8737c713b0a83a";
+      };
+    };
+    "iconv-lite-0.4.17" = {
+      name = "iconv-lite";
+      packageName = "iconv-lite";
+      version = "0.4.17";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz";
+        sha1 = "4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d";
       };
     };
     "private-0.1.7" = {
@@ -18185,6 +18320,15 @@ let
         sha1 = "1e0f4650c862dcbfed54fd42b148e9bb1721fcf2";
       };
     };
+    "domutils-1.6.2" = {
+      name = "domutils";
+      packageName = "domutils";
+      version = "1.6.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz";
+        sha1 = "1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff";
+      };
+    };
     "async-2.1.5" = {
       name = "async";
       packageName = "async";
@@ -18192,6 +18336,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/async/-/async-2.1.5.tgz";
         sha1 = "e587c68580994ac67fc56ff86d3ac56bdbe810bc";
+      };
+    };
+    "assert-plus-0.1.5" = {
+      name = "assert-plus";
+      packageName = "assert-plus";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz";
+        sha1 = "ee74009413002d84cec7219c6ac811812e723160";
       };
     };
     "lru-cache-2.2.0" = {
@@ -18410,6 +18563,15 @@ let
         sha1 = "52cc3b3dfc197758c55ad325a95be85071f9e51b";
       };
     };
+    "ctype-0.5.3" = {
+      name = "ctype";
+      packageName = "ctype";
+      version = "0.5.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz";
+        sha1 = "82c18c2461f74114ef16c135224ad0b9144ca12f";
+      };
+    };
     "verror-1.6.0" = {
       name = "verror";
       packageName = "verror";
@@ -18545,6 +18707,33 @@ let
         sha1 = "321f6cf73782a6ff751111390fc05e2c657d8c9b";
       };
     };
+    "jszip-2.6.1" = {
+      name = "jszip";
+      packageName = "jszip";
+      version = "2.6.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz";
+        sha1 = "b88f3a7b2e67a2a048152982c7a3756d9c4828f0";
+      };
+    };
+    "progress-2.0.0" = {
+      name = "progress";
+      packageName = "progress";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz";
+        sha1 = "8a1be366bf8fc23db2bd23f10c6fe920b4389d1f";
+      };
+    };
+    "pako-1.0.5" = {
+      name = "pako";
+      packageName = "pako";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pako/-/pako-1.0.5.tgz";
+        sha1 = "d2205dfe5b9da8af797e7c163db4d1f84e4600bc";
+      };
+    };
     "coa-1.0.1" = {
       name = "coa";
       packageName = "coa";
@@ -18617,6 +18806,15 @@ let
         sha1 = "7bcc6b629e3a43e871d7e29aca6ae8a7f15cbb20";
       };
     };
+    "adm-zip-0.4.7" = {
+      name = "adm-zip";
+      packageName = "adm-zip";
+      version = "0.4.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz";
+        sha1 = "8606c2cbf1c426ce8c8ec00174447fd49b6eafc1";
+      };
+    };
     "async-2.1.2" = {
       name = "async";
       packageName = "async";
@@ -18671,15 +18869,6 @@ let
         sha1 = "f68cf5acb607c4903e2f63024383ae95ba1fdc52";
       };
     };
-    "request-2.79.0" = {
-      name = "request";
-      packageName = "request";
-      version = "2.79.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/request/-/request-2.79.0.tgz";
-        sha1 = "4dfe5bf6be8b8cdc37fcf93e04b65577722710de";
-      };
-    };
     "sprintf-0.1.5" = {
       name = "sprintf";
       packageName = "sprintf";
@@ -18725,15 +18914,6 @@ let
         sha1 = "c8b6c167797ba4740a8ea33252162ff08591b266";
       };
     };
-    "adm-zip-0.4.7" = {
-      name = "adm-zip";
-      packageName = "adm-zip";
-      version = "0.4.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz";
-        sha1 = "8606c2cbf1c426ce8c8ec00174447fd49b6eafc1";
-      };
-    };
     "async-2.1.4" = {
       name = "async";
       packageName = "async";
@@ -18741,15 +18921,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/async/-/async-2.1.4.tgz";
         sha1 = "2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4";
-      };
-    };
-    "diff-3.2.0" = {
-      name = "diff";
-      packageName = "diff";
-      version = "3.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz";
-        sha1 = "c9ce393a4b7cbd0b058a725c93df299027868ff9";
       };
     };
     "wrench-1.5.9" = {
@@ -18761,31 +18932,13 @@ let
         sha1 = "411691c63a9b2531b1700267279bdeca23b2142a";
       };
     };
-    "qs-6.3.2" = {
-      name = "qs";
-      packageName = "qs";
-      version = "6.3.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz";
-        sha1 = "e75bd5f6e268122a2a0e0bda630b2550c166502c";
-      };
-    };
-    "bluebird-3.4.7" = {
-      name = "bluebird";
-      packageName = "bluebird";
-      version = "3.4.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz";
-        sha1 = "f72d760be09b7f76d08ed8fae98b289a8d05fab3";
-      };
-    };
-    "blueimp-md5-2.6.0" = {
+    "blueimp-md5-2.7.0" = {
       name = "blueimp-md5";
       packageName = "blueimp-md5";
-      version = "2.6.0";
+      version = "2.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.6.0.tgz";
-        sha1 = "c96dd67f57db522da9a0c49b464ca44e20c04e0f";
+        url = "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.7.0.tgz";
+        sha1 = "7f518e0dd70467fefe28ecba398916092f2a02a9";
       };
     };
     "color-1.0.3" = {
@@ -18851,6 +19004,24 @@ let
         sha1 = "8b5341c3496124b0724ac8555fbb8ca363ebbb73";
       };
     };
+    "ignore-3.2.7" = {
+      name = "ignore";
+      packageName = "ignore";
+      version = "3.2.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz";
+        sha1 = "4810ca5f1d8eca5595213a34b94f2eb4ed926bbd";
+      };
+    };
+    "just-detect-adblock-1.0.0" = {
+      name = "just-detect-adblock";
+      packageName = "just-detect-adblock";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/just-detect-adblock/-/just-detect-adblock-1.0.0.tgz";
+        sha1 = "7bf8660cf15571fe7cf3b49c222e4716e1605a0c";
+      };
+    };
     "keen.io-0.1.3" = {
       name = "keen.io";
       packageName = "keen.io";
@@ -18878,13 +19049,22 @@ let
         sha1 = "08524645ee4039dedc3dcc1dd7c6b979e0619e44";
       };
     };
-    "npm-4.5.0" = {
+    "npm-4.6.1" = {
       name = "npm";
       packageName = "npm";
-      version = "4.5.0";
+      version = "4.6.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npm/-/npm-4.5.0.tgz";
-        sha1 = "dc6a31f28807e6db980ed5083315667dcc8d0475";
+        url = "https://registry.npmjs.org/npm/-/npm-4.6.1.tgz";
+        sha1 = "f8eb1ad00dc58a5514363b41ca5342817f0bd646";
+      };
+    };
+    "npm-registry-client-8.3.0" = {
+      name = "npm-registry-client";
+      packageName = "npm-registry-client";
+      version = "8.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.3.0.tgz";
+        sha1 = "a86d5b1f97945de8df73c471d33602d5cd15130f";
       };
     };
     "octicons-3.5.0" = {
@@ -18914,6 +19094,15 @@ let
         sha1 = "949c134db028a190b7bbf8f790aae541b7c020bd";
       };
     };
+    "serve-static-1.12.2" = {
+      name = "serve-static";
+      packageName = "serve-static";
+      version = "1.12.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz";
+        sha1 = "e546e2726081b81b4bcec8e90808ebcdd323afba";
+      };
+    };
     "signals-1.0.0" = {
       name = "signals";
       packageName = "signals";
@@ -18941,13 +19130,13 @@ let
         sha1 = "0b48420d978c01804cf0230b648861598225a119";
       };
     };
-    "yargs-7.1.0" = {
+    "yargs-8.0.1" = {
       name = "yargs";
       packageName = "yargs";
-      version = "7.1.0";
+      version = "8.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz";
-        sha1 = "6ba318eb16961727f5d284f8ea003e8d6154d0c8";
+        url = "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz";
+        sha1 = "420ef75e840c1457a80adcca9bc6fa3849de51aa";
       };
     };
     "color-string-1.5.2" = {
@@ -19130,6 +19319,15 @@ let
         sha1 = "1335c5e4f5e6d33bbb4b006ba8c86a00f556de08";
       };
     };
+    "ssri-4.1.2" = {
+      name = "ssri";
+      packageName = "ssri";
+      version = "4.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssri/-/ssri-4.1.2.tgz";
+        sha1 = "3d3c69b490d0b107772a9bf81881f38ae071f24b";
+      };
+    };
     "lsmod-1.0.0" = {
       name = "lsmod";
       packageName = "lsmod";
@@ -19148,22 +19346,85 @@ let
         sha1 = "6728fc0459c450d796a99c31837569bdf672d728";
       };
     };
-    "eve-0.5.3" = {
-      name = "eve";
-      packageName = "eve";
-      version = "0.5.3";
+    "send-0.15.2" = {
+      name = "send";
+      packageName = "send";
+      version = "0.15.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eve/-/eve-0.5.3.tgz";
-        sha1 = "6c2f6588f7d0b392044d245ba5af9d7cfe237f42";
+        url = "https://registry.npmjs.org/send/-/send-0.15.2.tgz";
+        sha1 = "f91fab4403bcf87e716f70ceb5db2f578bdc17d6";
       };
     };
-    "yargs-parser-5.0.0" = {
+    "eve-0.5.4" = {
+      name = "eve";
+      packageName = "eve";
+      version = "0.5.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/eve/-/eve-0.5.4.tgz";
+        sha1 = "67d080b9725291d7e389e34c26860dd97f1debaa";
+      };
+    };
+    "os-locale-2.0.0" = {
+      name = "os-locale";
+      packageName = "os-locale";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz";
+        sha1 = "15918ded510522b81ee7ae5a309d54f639fc39a4";
+      };
+    };
+    "read-pkg-up-2.0.0" = {
+      name = "read-pkg-up";
+      packageName = "read-pkg-up";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz";
+        sha1 = "6b72a8048984e0c41e79510fd5e9fa99b3b549be";
+      };
+    };
+    "which-module-2.0.0" = {
+      name = "which-module";
+      packageName = "which-module";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz";
+        sha1 = "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a";
+      };
+    };
+    "yargs-parser-7.0.0" = {
       name = "yargs-parser";
       packageName = "yargs-parser";
-      version = "5.0.0";
+      version = "7.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz";
-        sha1 = "275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a";
+        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz";
+        sha1 = "8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9";
+      };
+    };
+    "read-pkg-2.0.0" = {
+      name = "read-pkg";
+      packageName = "read-pkg";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz";
+        sha1 = "8ef1c0623c6a6db0dc6713c4bfac46332b2368f8";
+      };
+    };
+    "load-json-file-2.0.0" = {
+      name = "load-json-file";
+      packageName = "load-json-file";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz";
+        sha1 = "7947e42149af80d696cbf797bcaabcfe1fe29ca8";
+      };
+    };
+    "path-type-2.0.0" = {
+      name = "path-type";
+      packageName = "path-type";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz";
+        sha1 = "f012ccb8415b7096fc2daa1054c3d72389594c73";
       };
     };
     "kew-0.1.7" = {
@@ -19292,6 +19553,15 @@ let
         sha1 = "17c62bfaf13c707f9d02c479e0dcdde8380697fb";
       };
     };
+    "yargs-6.6.0" = {
+      name = "yargs";
+      packageName = "yargs";
+      version = "6.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz";
+        sha1 = "782ec21ef403345f830a808ca3d513af56065208";
+      };
+    };
     "big.js-3.1.3" = {
       name = "big.js";
       packageName = "big.js";
@@ -19337,13 +19607,22 @@ let
         sha1 = "290cbb232e306942d7d7ea9b83732ab7856f8285";
       };
     };
-    "source-list-map-1.1.1" = {
+    "source-list-map-1.1.2" = {
       name = "source-list-map";
       packageName = "source-list-map";
-      version = "1.1.1";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.1.tgz";
-        sha1 = "1a33ac210ca144d1e561f906ebccab5669ff4cb4";
+        url = "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz";
+        sha1 = "9889019d1024cce55cdc069498337ef6186a11a1";
+      };
+    };
+    "yargs-parser-4.2.1" = {
+      name = "yargs-parser";
+      packageName = "yargs-parser";
+      version = "4.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz";
+        sha1 = "29cceac0dc4f03c6c87b4a9f217dd18c9f74871c";
       };
     };
     "babel-runtime-6.23.0" = {
@@ -19380,6 +19659,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz";
         sha1 = "3871cc0a6a002e8c3e5b3cf7f336264675f06b9d";
+      };
+    };
+    "gunzip-maybe-1.4.0" = {
+      name = "gunzip-maybe";
+      packageName = "gunzip-maybe";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.0.tgz";
+        sha1 = "7d8316c8d0571e1d08a5a79e46fff0afe8172b19";
       };
     };
     "inquirer-3.0.6" = {
@@ -19427,13 +19715,13 @@ let
         sha1 = "370ae752fbf37de3ea70a861c23bba8915691949";
       };
     };
-    "proper-lockfile-2.0.0" = {
+    "proper-lockfile-2.0.1" = {
       name = "proper-lockfile";
       packageName = "proper-lockfile";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.0.tgz";
-        sha1 = "b21f5e79bcbb6b4e23eeeced15cfc7f63e8a2e55";
+        url = "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.1.tgz";
+        sha1 = "159fb06193d32003f4b3691dd2ec1a634aa80d1d";
       };
     };
     "request-capture-har-1.2.2" = {
@@ -19445,13 +19733,13 @@ let
         sha1 = "cd692cfb2cc744fd84a3358aac6ee51528cf720d";
       };
     };
-    "roadrunner-1.1.0" = {
-      name = "roadrunner";
-      packageName = "roadrunner";
-      version = "1.1.0";
+    "tar-fs-1.15.2" = {
+      name = "tar-fs";
+      packageName = "tar-fs";
+      version = "1.15.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/roadrunner/-/roadrunner-1.1.0.tgz";
-        sha1 = "1180a30d64e1970d8f55dd8cb0da8ffccecad71e";
+        url = "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.2.tgz";
+        sha1 = "761f5b32932c7b39461a60d537faea0d8084830c";
       };
     };
     "v8-compile-cache-1.1.0" = {
@@ -19463,13 +19751,40 @@ let
         sha1 = "1dc2a340fb8e5f800a32bcdbfb8c23cd747021b9";
       };
     };
-    "regenerator-runtime-0.10.3" = {
+    "regenerator-runtime-0.10.5" = {
       name = "regenerator-runtime";
       packageName = "regenerator-runtime";
-      version = "0.10.3";
+      version = "0.10.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz";
-        sha1 = "8c4367a904b51ea62a908ac310bf99ff90a82a3e";
+        url = "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz";
+        sha1 = "336c3efc1220adcedda2c9fab67b5a7955a33658";
+      };
+    };
+    "is-deflate-1.0.0" = {
+      name = "is-deflate";
+      packageName = "is-deflate";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz";
+        sha1 = "c862901c3c161fb09dac7cdc7e784f80e98f2f14";
+      };
+    };
+    "is-gzip-1.0.0" = {
+      name = "is-gzip";
+      packageName = "is-gzip";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz";
+        sha1 = "6ca8b07b99c77998025900e555ced8ed80879a83";
+      };
+    };
+    "peek-stream-1.1.2" = {
+      name = "peek-stream";
+      packageName = "peek-stream";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.2.tgz";
+        sha1 = "97eb76365bcfd8c89e287f55c8b69d4c3e9bcc52";
       };
     };
     "cli-cursor-2.1.0" = {
@@ -19533,15 +19848,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz";
         sha1 = "dc5285f2b4e251821683681c381c3388f46ec534";
-      };
-    };
-    "string.prototype.codepointat-0.2.0" = {
-      name = "string.prototype.codepointat";
-      packageName = "string.prototype.codepointat";
-      version = "0.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz";
-        sha1 = "6b26e9bd3afcaa7be3b4269b526de1b82000ac78";
       };
     };
     "cli-list-0.1.8" = {
@@ -19982,7 +20288,7 @@ in
           sources."source-map-0.5.6"
         ];
       })
-      sources."resolve-1.3.2"
+      sources."resolve-1.3.3"
       sources."global-paths-0.1.2"
       sources."source-map-0.1.9"
       sources."xml2tss-0.0.5"
@@ -20007,7 +20313,7 @@ in
       sources."wordwrap-0.0.2"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.1.0"
+      sources."kind-of-3.2.0"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
@@ -20045,10 +20351,10 @@ in
   azure-cli = nodeEnv.buildNodePackage {
     name = "azure-cli";
     packageName = "azure-cli";
-    version = "0.10.12";
+    version = "0.10.13";
     src = fetchurl {
-      url = "https://registry.npmjs.org/azure-cli/-/azure-cli-0.10.12.tgz";
-      sha1 = "4446af5df8dda6c755a0bf7dfec2468a9f63f26d";
+      url = "https://registry.npmjs.org/azure-cli/-/azure-cli-0.10.13.tgz";
+      sha1 = "7e98a46b058f436fb2a3fbed982d143d49557348";
     };
     dependencies = [
       sources."adal-node-0.1.21"
@@ -20063,8 +20369,8 @@ in
       sources."azure-arm-cdn-1.0.3"
       sources."azure-arm-commerce-0.2.0"
       sources."azure-arm-compute-0.20.0"
-      sources."azure-arm-datalake-analytics-1.0.1-preview"
-      sources."azure-arm-datalake-store-1.0.1-preview"
+      sources."azure-arm-datalake-analytics-1.0.2-preview"
+      sources."azure-arm-datalake-store-1.0.2-preview"
       sources."azure-arm-hdinsight-0.2.2"
       sources."azure-arm-hdinsight-jobs-0.1.0"
       sources."azure-arm-insights-0.11.3"
@@ -20161,7 +20467,7 @@ in
       })
       (sources."request-2.74.0" // {
         dependencies = [
-          sources."extend-3.0.0"
+          sources."extend-3.0.1"
         ];
       })
       (sources."ssh-key-to-pem-0.11.0" // {
@@ -20249,7 +20555,7 @@ in
       sources."glob-7.1.1"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -20270,7 +20576,7 @@ in
       sources."forever-agent-0.6.1"
       (sources."form-data-1.0.1" // {
         dependencies = [
-          sources."async-2.3.0"
+          sources."async-2.4.0"
         ];
       })
       (sources."har-validator-2.0.6" // {
@@ -20330,7 +20636,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -20416,7 +20722,7 @@ in
       })
       sources."glob-6.0.4"
       sources."sprintf-js-1.0.3"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ext-name-3.0.0"
       sources."graceful-fs-3.0.11"
       sources."intersect-1.0.1"
@@ -20456,7 +20762,7 @@ in
       sources."loud-rejection-1.6.0"
       sources."map-obj-1.0.1"
       sources."minimist-1.2.0"
-      sources."normalize-package-data-2.3.6"
+      sources."normalize-package-data-2.3.8"
       sources."read-pkg-up-1.0.1"
       sources."redent-1.0.0"
       sources."trim-newlines-1.0.0"
@@ -20519,18 +20825,18 @@ in
       })
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
       sources."q-1.5.0"
-      sources."debug-2.6.3"
+      sources."debug-2.6.6"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
           sources."minimist-0.0.8"
         ];
       })
-      sources."ms-0.7.2"
+      sources."ms-0.7.3"
       sources."os-tmpdir-1.0.2"
     ];
     buildInputs = globalBuildInputs;
@@ -20589,7 +20895,7 @@ in
       sources."os-browserify-0.1.2"
       sources."parents-1.0.1"
       sources."path-browserify-0.0.0"
-      sources."process-0.11.9"
+      sources."process-0.11.10"
       sources."punycode-1.4.1"
       sources."querystring-es3-0.2.1"
       sources."read-only-stream-2.0.0"
@@ -20598,11 +20904,11 @@ in
           sources."string_decoder-1.0.0"
         ];
       })
-      sources."resolve-1.3.2"
+      sources."resolve-1.3.3"
       sources."shasum-1.0.2"
       sources."shell-quote-1.6.1"
       sources."stream-browserify-2.0.1"
-      sources."stream-http-2.7.0"
+      sources."stream-http-2.7.1"
       sources."string_decoder-0.10.31"
       sources."subarg-1.0.0"
       sources."syntax-error-1.3.0"
@@ -20621,7 +20927,7 @@ in
       })
       sources."vm-browserify-0.0.4"
       sources."xtend-4.0.1"
-      sources."jsonparse-1.3.0"
+      sources."jsonparse-1.3.1"
       sources."through-2.3.8"
       sources."combine-source-map-0.7.2"
       sources."umd-3.0.1"
@@ -20641,10 +20947,10 @@ in
       sources."browserify-cipher-1.0.0"
       sources."browserify-sign-4.0.4"
       sources."create-ecdh-4.0.0"
-      sources."create-hash-1.1.2"
-      sources."create-hmac-1.1.4"
+      sources."create-hash-1.1.3"
+      sources."create-hmac-1.1.6"
       sources."diffie-hellman-5.0.2"
-      sources."pbkdf2-3.0.9"
+      sources."pbkdf2-3.0.12"
       sources."public-encrypt-4.0.0"
       sources."randombytes-2.0.3"
       sources."browserify-aes-1.0.6"
@@ -20663,12 +20969,14 @@ in
       sources."hmac-drbg-1.0.1"
       sources."minimalistic-crypto-utils-1.0.1"
       sources."asn1.js-4.9.1"
-      sources."ripemd160-1.0.1"
+      sources."ripemd160-2.0.1"
       sources."sha.js-2.4.8"
+      sources."hash-base-2.0.2"
+      sources."safe-buffer-5.0.1"
       sources."miller-rabin-4.0.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -20720,12 +21028,12 @@ in
       sources."chalk-1.0.0"
       sources."chromecast-player-0.2.3"
       sources."debounced-seeker-1.0.0"
-      sources."debug-2.6.3"
+      sources."debug-2.6.6"
       sources."diveSync-0.3.0"
       sources."got-1.2.2"
       sources."internal-ip-1.2.0"
       sources."keypress-0.2.1"
-      sources."mime-1.3.4"
+      sources."mime-1.3.6"
       sources."minimist-1.2.0"
       sources."peerflix-0.34.0"
       (sources."playerui-1.2.0" // {
@@ -20789,7 +21097,7 @@ in
       sources."thunky-0.1.0"
       sources."wrap-fn-0.1.5"
       sources."co-3.1.0"
-      sources."ms-0.7.2"
+      sources."ms-0.7.3"
       sources."append-0.1.1"
       sources."object-assign-1.0.0"
       (sources."meow-3.7.0" // {
@@ -20801,7 +21109,7 @@ in
       sources."decamelize-1.2.0"
       sources."loud-rejection-1.6.0"
       sources."map-obj-1.0.1"
-      sources."normalize-package-data-2.3.6"
+      sources."normalize-package-data-2.3.8"
       sources."read-pkg-up-1.0.1"
       sources."redent-1.0.0"
       sources."trim-newlines-1.0.0"
@@ -20879,10 +21187,10 @@ in
           sources."semver-5.1.1"
         ];
       })
-      sources."plist-2.0.1"
+      sources."plist-2.1.0"
       sources."dns-js-0.2.1"
       sources."qap-3.1.3"
-      sources."base64-js-1.1.2"
+      sources."base64-js-1.2.0"
       sources."xmlbuilder-8.2.2"
       sources."xmldom-0.1.27"
       sources."cli-width-1.1.1"
@@ -20898,14 +21206,15 @@ in
       sources."mute-stream-0.0.4"
       sources."wordwrap-0.0.3"
       sources."blob-to-buffer-1.2.6"
-      sources."magnet-uri-5.1.6"
+      sources."magnet-uri-5.1.7"
       sources."parse-torrent-file-4.0.2"
-      sources."simple-get-2.5.1"
+      sources."simple-get-2.6.0"
+      sources."safe-buffer-5.0.1"
       sources."thirty-two-1.0.2"
       sources."uniq-1.0.1"
       sources."bencode-0.11.0"
       sources."simple-sha1-2.1.0"
-      sources."rusha-0.8.5"
+      sources."rusha-0.8.6"
       sources."once-1.4.0"
       sources."simple-concat-1.0.0"
       sources."unzip-response-2.0.1"
@@ -20935,7 +21244,7 @@ in
       sources."rimraf-2.6.1"
       sources."torrent-discovery-5.4.0"
       sources."torrent-piece-1.1.1"
-      (sources."random-access-file-1.6.1" // {
+      (sources."random-access-file-1.7.2" // {
         dependencies = [
           sources."mkdirp-0.5.1"
           sources."thunky-1.0.2"
@@ -20964,7 +21273,7 @@ in
       sources."glob-7.1.1"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -21004,7 +21313,7 @@ in
       (sources."simple-websocket-4.3.1" // {
         dependencies = [
           sources."readable-stream-2.2.9"
-          sources."ws-2.2.3"
+          sources."ws-2.3.1"
           sources."isarray-1.0.0"
           sources."string_decoder-1.0.0"
         ];
@@ -21020,7 +21329,6 @@ in
       sources."buffer-shims-1.0.0"
       sources."process-nextick-args-1.0.7"
       sources."util-deprecate-1.0.2"
-      sources."safe-buffer-5.0.1"
       sources."ultron-1.1.0"
       sources."addr-to-ip-port-1.4.2"
       sources."options-0.0.6"
@@ -21096,51 +21404,69 @@ in
   cordova = nodeEnv.buildNodePackage {
     name = "cordova";
     packageName = "cordova";
-    version = "6.5.0";
+    version = "7.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/cordova/-/cordova-6.5.0.tgz";
-      sha1 = "e6ec81b17dd50c17c40b4b87330f7ced38fb0b47";
+      url = "https://registry.npmjs.org/cordova/-/cordova-7.0.1.tgz";
+      sha1 = "69fd054300ce5105b092f67a1b286e80c4e88b9d";
     };
     dependencies = [
-      (sources."cordova-common-2.0.0" // {
+      sources."configstore-2.1.0"
+      (sources."cordova-common-2.0.3" // {
         dependencies = [
           sources."q-1.5.0"
-          sources."underscore-1.8.3"
         ];
       })
-      (sources."cordova-lib-6.5.0" // {
+      (sources."cordova-lib-7.0.1" // {
         dependencies = [
-          sources."elementtree-0.1.6"
-          sources."nopt-3.0.6"
-          sources."semver-4.3.6"
+          sources."glob-7.1.1"
+          sources."nopt-4.0.1"
+          sources."plist-2.0.1"
           sources."shelljs-0.3.0"
-          sources."unorm-1.3.3"
-          sources."sax-0.3.5"
+          sources."base64-js-1.1.2"
+          sources."xmlbuilder-8.2.2"
         ];
       })
-      (sources."insight-0.8.4" // {
+      sources."editor-1.0.0"
+      (sources."insight-0.8.2" // {
         dependencies = [
           sources."async-1.5.2"
-          sources."request-2.81.0"
+          sources."configstore-1.4.0"
         ];
       })
       sources."nopt-3.0.1"
       sources."q-1.0.1"
-      sources."underscore-1.7.0"
-      sources."update-notifier-0.5.0"
+      (sources."update-notifier-0.5.0" // {
+        dependencies = [
+          sources."configstore-1.4.0"
+        ];
+      })
+      sources."dot-prop-3.0.0"
+      sources."graceful-fs-4.1.11"
+      sources."mkdirp-0.5.1"
+      sources."object-assign-4.1.1"
+      sources."os-tmpdir-1.0.2"
+      sources."osenv-0.1.4"
+      sources."uuid-2.0.3"
+      sources."write-file-atomic-1.3.4"
+      sources."xdg-basedir-2.0.0"
+      sources."is-obj-1.0.1"
+      sources."minimist-0.0.8"
+      sources."os-homedir-1.0.2"
+      sources."imurmurhash-0.1.4"
+      sources."slide-1.1.6"
       sources."ansi-0.3.1"
       sources."bplist-parser-0.1.1"
       sources."cordova-registry-mapper-1.1.15"
-      sources."elementtree-0.1.7"
+      sources."elementtree-0.1.6"
       sources."glob-5.0.15"
-      sources."minimatch-3.0.3"
-      sources."osenv-0.1.4"
+      sources."minimatch-3.0.4"
       sources."plist-1.2.0"
       sources."semver-5.3.0"
       sources."shelljs-0.5.3"
+      sources."underscore-1.8.3"
       sources."unorm-1.4.1"
-      sources."big-integer-1.6.19"
-      sources."sax-1.1.4"
+      sources."big-integer-1.6.22"
+      sources."sax-0.3.5"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
       sources."once-1.4.0"
@@ -21149,20 +21475,18 @@ in
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
-      sources."os-homedir-1.0.2"
-      sources."os-tmpdir-1.0.2"
       sources."base64-js-0.0.8"
       sources."xmlbuilder-4.0.0"
       sources."xmldom-0.1.27"
       sources."util-deprecate-1.0.2"
       sources."lodash-3.10.1"
-      sources."aliasify-1.9.0"
-      (sources."cordova-create-1.0.2" // {
+      sources."aliasify-2.1.0"
+      (sources."cordova-create-1.1.1" // {
         dependencies = [
           sources."shelljs-0.3.0"
         ];
       })
-      (sources."cordova-fetch-1.0.2" // {
+      (sources."cordova-fetch-1.1.0" // {
         dependencies = [
           sources."q-1.5.0"
           sources."shelljs-0.7.7"
@@ -21180,7 +21504,7 @@ in
           sources."underscore-1.2.1"
         ];
       })
-      (sources."init-package-json-1.9.6" // {
+      (sources."init-package-json-1.10.1" // {
         dependencies = [
           sources."glob-7.1.1"
         ];
@@ -21190,71 +21514,58 @@ in
           sources."abbrev-1.0.9"
           sources."glob-7.0.6"
           sources."hosted-git-info-2.1.5"
+          (sources."init-package-json-1.9.6" // {
+            dependencies = [
+              sources."glob-7.1.1"
+              sources."validate-npm-package-name-3.0.0"
+            ];
+          })
           sources."nopt-3.0.6"
           sources."npm-package-arg-4.1.1"
           sources."readable-stream-2.1.5"
           sources."request-2.74.0"
           sources."semver-5.1.1"
-          sources."tar-2.2.1"
           sources."validate-npm-package-name-2.2.2"
+          sources."write-file-atomic-1.1.4"
           sources."isarray-1.0.0"
-          sources."caseless-0.11.0"
-          sources."form-data-1.0.1"
-          sources."har-validator-2.0.6"
           sources."qs-6.2.3"
-          sources."tunnel-agent-0.4.3"
           sources."builtins-0.0.7"
         ];
       })
-      sources."opener-1.4.1"
-      sources."properties-parser-0.2.3"
-      (sources."request-2.47.0" // {
+      sources."opener-1.4.2"
+      sources."properties-parser-0.3.1"
+      (sources."request-2.79.0" // {
         dependencies = [
-          sources."bl-0.9.5"
-          sources."caseless-0.6.0"
-          sources."forever-agent-0.5.2"
-          sources."form-data-0.1.4"
-          sources."mime-types-1.0.2"
-          sources."qs-2.3.3"
-          sources."tunnel-agent-0.4.3"
-          sources."http-signature-0.10.1"
-          sources."oauth-sign-0.4.0"
-          sources."hawk-1.1.1"
-          sources."aws-sign2-0.5.0"
-          sources."combined-stream-0.0.7"
-          sources."readable-stream-1.0.34"
-          sources."mime-1.2.11"
-          sources."async-0.9.2"
-          sources."assert-plus-0.1.5"
-          sources."asn1-0.1.11"
-          sources."hoek-0.9.1"
-          sources."boom-0.4.2"
-          sources."cryptiles-0.2.2"
-          sources."sntp-0.2.4"
-          sources."delayed-stream-0.0.5"
+          sources."form-data-2.1.4"
+          sources."qs-6.3.2"
+          sources."uuid-3.0.1"
         ];
       })
-      sources."tar-1.0.2"
+      sources."tar-2.2.1"
       sources."valid-identifier-0.0.1"
-      sources."xcode-0.9.3"
-      sources."browserify-transform-tools-1.5.3"
-      sources."falafel-1.2.0"
+      (sources."xcode-0.9.3" // {
+        dependencies = [
+          sources."uuid-3.0.1"
+        ];
+      })
+      sources."browserify-transform-tools-1.7.0"
+      sources."falafel-2.1.0"
       sources."through-2.3.8"
-      sources."acorn-1.2.2"
+      sources."acorn-5.0.3"
       sources."foreach-2.0.5"
       sources."isarray-0.0.1"
       sources."object-keys-1.0.11"
-      sources."cordova-app-hello-world-3.11.0"
-      (sources."dependency-ls-1.0.0" // {
+      sources."cordova-app-hello-world-3.12.0"
+      (sources."dependency-ls-1.1.0" // {
         dependencies = [
           sources."q-1.4.1"
         ];
       })
       sources."is-url-1.2.2"
-      sources."interpret-1.0.2"
+      sources."interpret-1.0.3"
       sources."rechoir-0.6.2"
       sources."fs.realpath-1.0.0"
-      sources."resolve-1.3.2"
+      sources."resolve-1.3.3"
       sources."path-parse-1.0.5"
       (sources."browserify-13.3.0" // {
         dependencies = [
@@ -21300,7 +21611,7 @@ in
       sources."os-browserify-0.1.2"
       sources."parents-1.0.1"
       sources."path-browserify-0.0.0"
-      sources."process-0.11.9"
+      sources."process-0.11.10"
       sources."punycode-1.4.1"
       sources."querystring-es3-0.2.1"
       sources."read-only-stream-2.0.0"
@@ -21313,9 +21624,13 @@ in
       sources."shasum-1.0.2"
       sources."shell-quote-1.6.1"
       sources."stream-browserify-2.0.1"
-      sources."stream-http-2.7.0"
+      sources."stream-http-2.7.1"
       sources."string_decoder-0.10.31"
-      sources."subarg-1.0.0"
+      (sources."subarg-1.0.0" // {
+        dependencies = [
+          sources."minimist-1.2.0"
+        ];
+      })
       (sources."syntax-error-1.3.0" // {
         dependencies = [
           sources."acorn-4.0.11"
@@ -21336,7 +21651,7 @@ in
       })
       sources."vm-browserify-0.0.4"
       sources."xtend-4.0.1"
-      sources."jsonparse-1.3.0"
+      sources."jsonparse-1.3.1"
       sources."combine-source-map-0.7.2"
       sources."umd-3.0.1"
       sources."convert-source-map-1.1.3"
@@ -21352,10 +21667,10 @@ in
       sources."browserify-cipher-1.0.0"
       sources."browserify-sign-4.0.4"
       sources."create-ecdh-4.0.0"
-      sources."create-hash-1.1.2"
-      sources."create-hmac-1.1.4"
+      sources."create-hash-1.1.3"
+      sources."create-hmac-1.1.6"
       sources."diffie-hellman-5.0.2"
-      sources."pbkdf2-3.0.9"
+      sources."pbkdf2-3.0.12"
       sources."public-encrypt-4.0.0"
       sources."randombytes-2.0.3"
       sources."browserify-aes-1.0.6"
@@ -21374,8 +21689,10 @@ in
       sources."hmac-drbg-1.0.1"
       sources."minimalistic-crypto-utils-1.0.1"
       sources."asn1.js-4.9.1"
-      sources."ripemd160-1.0.1"
+      sources."ripemd160-2.0.1"
       sources."sha.js-2.4.8"
+      sources."hash-base-2.0.2"
+      sources."safe-buffer-5.0.1"
       sources."miller-rabin-4.0.0"
       sources."function-bind-1.1.0"
       sources."is-buffer-1.1.5"
@@ -21401,7 +21718,6 @@ in
       sources."array-map-0.0.0"
       sources."builtin-status-codes-3.0.0"
       sources."to-arraybuffer-1.0.1"
-      sources."minimist-1.2.0"
       sources."querystring-0.2.0"
       sources."indexof-0.0.1"
       sources."chalk-1.1.3"
@@ -21437,10 +21753,10 @@ in
       sources."encodeurl-1.0.1"
       sources."escape-html-1.0.3"
       sources."etag-1.8.0"
-      (sources."finalhandler-1.0.1" // {
+      (sources."finalhandler-1.0.2" // {
         dependencies = [
-          sources."debug-2.6.3"
-          sources."ms-0.7.2"
+          sources."debug-2.6.4"
+          sources."ms-0.7.3"
         ];
       })
       sources."fresh-0.5.0"
@@ -21484,8 +21800,7 @@ in
       sources."hosted-git-info-2.4.2"
       sources."mute-stream-0.0.7"
       sources."json-parse-helpfulerror-1.0.3"
-      sources."normalize-package-data-2.3.6"
-      sources."graceful-fs-4.1.11"
+      sources."normalize-package-data-2.3.8"
       sources."jju-1.3.0"
       sources."is-builtin-module-1.0.0"
       sources."builtin-modules-1.1.1"
@@ -21506,7 +21821,6 @@ in
       sources."columnify-1.5.4"
       sources."config-chain-1.1.11"
       sources."dezalgo-1.0.3"
-      sources."editor-1.0.0"
       sources."fs-vacuum-1.2.10"
       sources."fs-write-stream-atomic-1.0.10"
       sources."fstream-1.0.11"
@@ -21516,15 +21830,9 @@ in
       sources."ini-1.3.4"
       sources."lockfile-1.0.3"
       sources."lru-cache-4.0.2"
-      (sources."mkdirp-0.5.1" // {
-        dependencies = [
-          sources."minimist-0.0.8"
-        ];
-      })
-      (sources."node-gyp-3.6.0" // {
+      (sources."node-gyp-3.6.1" // {
         dependencies = [
           sources."glob-7.1.1"
-          sources."tar-2.2.1"
         ];
       })
       sources."normalize-git-url-3.0.2"
@@ -21533,7 +21841,6 @@ in
       (sources."npm-registry-client-7.2.1" // {
         dependencies = [
           sources."npm-package-arg-4.2.1"
-          sources."request-2.81.0"
         ];
       })
       sources."npm-user-validate-0.1.5"
@@ -21552,14 +21859,11 @@ in
         ];
       })
       sources."sha-2.0.1"
-      sources."slide-1.1.6"
       sources."sorted-object-2.0.1"
       sources."text-table-0.2.0"
       sources."uid-number-0.0.6"
       sources."umask-1.1.0"
       sources."which-1.2.14"
-      sources."write-file-atomic-1.1.4"
-      sources."imurmurhash-0.1.4"
       sources."wcwidth-1.0.1"
       sources."defaults-1.0.3"
       sources."clone-1.0.2"
@@ -21569,35 +21873,55 @@ in
       sources."fstream-ignore-1.0.5"
       sources."pseudomap-1.0.2"
       sources."yallist-2.1.2"
+      sources."are-we-there-yet-1.1.4"
+      sources."gauge-1.2.7"
+      sources."delegates-1.0.0"
+      sources."has-unicode-2.0.1"
+      sources."lodash.pad-4.5.1"
+      sources."lodash.padend-4.6.1"
+      sources."lodash.padstart-4.6.1"
+      sources."debuglog-1.0.1"
+      sources."readdir-scoped-modules-1.0.2"
+      sources."util-extend-1.0.3"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
-      sources."caseless-0.12.0"
+      (sources."bl-1.1.2" // {
+        dependencies = [
+          sources."readable-stream-2.0.6"
+          sources."isarray-1.0.0"
+        ];
+      })
+      sources."caseless-0.11.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
-      sources."form-data-2.1.4"
-      sources."har-validator-4.2.1"
+      sources."form-data-1.0.1"
+      sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."json-stringify-safe-5.0.1"
+      sources."node-uuid-1.4.8"
       sources."oauth-sign-0.8.2"
-      sources."performance-now-0.2.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
-      sources."tunnel-agent-0.6.0"
-      sources."uuid-3.0.1"
+      sources."tunnel-agent-0.4.3"
       sources."delayed-stream-1.0.0"
-      sources."asynckit-0.4.0"
-      (sources."ajv-4.11.6" // {
+      (sources."async-2.4.0" // {
         dependencies = [
-          sources."json-stable-stringify-1.0.1"
+          sources."lodash-4.17.4"
         ];
       })
-      sources."har-schema-1.0.5"
-      sources."co-4.6.0"
+      sources."commander-2.9.0"
+      sources."is-my-json-valid-2.16.0"
+      sources."pinkie-promise-2.0.1"
+      sources."graceful-readlink-1.0.1"
+      sources."generate-function-2.0.0"
+      sources."generate-object-property-1.2.0"
+      sources."jsonpointer-4.0.1"
+      sources."is-property-1.0.2"
+      sources."pinkie-2.0.4"
       sources."hoek-2.16.3"
       sources."boom-2.10.1"
       sources."cryptiles-2.0.5"
@@ -21622,7 +21946,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -21632,39 +21956,9 @@ in
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
       sources."bcrypt-pbkdf-1.0.1"
-      sources."are-we-there-yet-1.1.2"
-      sources."gauge-1.2.7"
-      sources."delegates-1.0.0"
-      sources."has-unicode-2.0.1"
-      sources."lodash.pad-4.5.1"
-      sources."lodash.padend-4.6.1"
-      sources."lodash.padstart-4.6.1"
-      sources."debuglog-1.0.1"
-      sources."readdir-scoped-modules-1.0.2"
-      sources."util-extend-1.0.3"
-      (sources."bl-1.1.2" // {
-        dependencies = [
-          sources."readable-stream-2.0.6"
-          sources."isarray-1.0.0"
-        ];
-      })
-      sources."node-uuid-1.4.8"
-      (sources."async-2.3.0" // {
-        dependencies = [
-          sources."lodash-4.17.4"
-        ];
-      })
-      sources."commander-2.9.0"
-      sources."is-my-json-valid-2.16.0"
-      sources."pinkie-promise-2.0.1"
-      sources."graceful-readlink-1.0.1"
-      sources."generate-function-2.0.0"
-      sources."generate-object-property-1.2.0"
-      sources."jsonpointer-4.0.1"
-      sources."is-property-1.0.2"
-      sources."pinkie-2.0.4"
       sources."isexe-2.0.0"
-      sources."ctype-0.5.3"
+      sources."string.prototype.codepointat-0.2.0"
+      sources."asynckit-0.4.0"
       sources."pegjs-0.10.0"
       (sources."simple-plist-0.2.1" // {
         dependencies = [
@@ -21675,16 +21969,9 @@ in
       })
       sources."bplist-creator-0.0.7"
       sources."stream-buffers-2.2.0"
-      (sources."configstore-1.4.0" // {
-        dependencies = [
-          sources."uuid-2.0.3"
-        ];
-      })
       sources."inquirer-0.10.1"
       sources."lodash.debounce-3.1.1"
-      sources."object-assign-4.1.1"
       sources."os-name-1.0.3"
-      sources."xdg-basedir-2.0.0"
       sources."ansi-escapes-1.4.0"
       sources."cli-cursor-1.0.2"
       sources."cli-width-1.1.1"
@@ -21703,7 +21990,11 @@ in
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."lodash._getnative-3.9.1"
-      sources."osx-release-1.1.0"
+      (sources."osx-release-1.1.0" // {
+        dependencies = [
+          sources."minimist-1.2.0"
+        ];
+      })
       sources."win-release-1.1.1"
       sources."is-npm-1.0.0"
       sources."latest-version-1.0.1"
@@ -21732,8 +22023,12 @@ in
         ];
       })
       sources."stream-shift-1.0.0"
-      sources."rc-1.2.1"
-      sources."deep-extend-0.4.1"
+      (sources."rc-1.2.1" // {
+        dependencies = [
+          sources."minimist-1.2.0"
+        ];
+      })
+      sources."deep-extend-0.4.2"
       sources."strip-json-comments-2.0.1"
       sources."is-finite-1.0.2"
     ];
@@ -21869,7 +22164,7 @@ in
       })
       sources."binaryheap-0.0.3"
       sources."buffercursor-0.0.12"
-      sources."verror-1.9.0"
+      sources."verror-1.10.0"
       sources."assert-plus-1.0.0"
       sources."core-util-is-1.0.2"
       sources."extsprintf-1.3.0"
@@ -21969,9 +22264,9 @@ in
       sources."sorted-union-stream-1.0.2"
       sources."split2-0.2.1"
       sources."stream-collector-1.0.1"
-      (sources."tar-stream-1.5.2" // {
+      (sources."tar-stream-1.5.4" // {
         dependencies = [
-          sources."bl-1.2.0"
+          sources."bl-1.2.1"
           sources."readable-stream-2.2.9"
           sources."isarray-1.0.0"
           sources."string_decoder-1.0.0"
@@ -22013,7 +22308,7 @@ in
       sources."bytewise-1.1.0"
       sources."ltgt-2.1.3"
       sources."pull-level-2.0.3"
-      sources."pull-stream-3.5.0"
+      sources."pull-stream-3.6.0"
       sources."typewiselite-1.0.0"
       sources."bytewise-core-1.2.3"
       sources."typewise-1.0.3"
@@ -22035,7 +22330,7 @@ in
       sources."level-post-1.0.5"
       sources."pull-cat-1.1.11"
       sources."pull-live-1.0.1"
-      sources."pull-pushable-2.0.1"
+      sources."pull-pushable-2.1.0"
       sources."pull-window-2.1.4"
       (sources."stream-to-pull-stream-1.7.2" // {
         dependencies = [
@@ -22061,28 +22356,40 @@ in
   elasticdump = nodeEnv.buildNodePackage {
     name = "elasticdump";
     packageName = "elasticdump";
-    version = "3.1.0";
+    version = "3.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-3.1.0.tgz";
-      sha1 = "4bec1f64f7931b84884306fb5b37a0d269d81e8d";
+      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-3.3.0.tgz";
+      sha1 = "19aec66c4619e49a66dfa1106719819d9daecbc8";
     };
     dependencies = [
       sources."JSONStream-1.3.1"
-      sources."async-2.3.0"
+      sources."async-2.4.0"
       sources."aws4-1.6.0"
-      sources."awscred-1.2.0"
+      sources."aws-sdk-2.50.0"
       sources."ini-1.3.4"
       sources."optimist-0.6.1"
       sources."request-2.81.0"
-      sources."jsonparse-1.3.0"
+      sources."jsonparse-1.3.1"
       sources."through-2.3.8"
       sources."lodash-4.17.4"
+      sources."buffer-5.0.6"
+      sources."crypto-browserify-1.0.9"
+      sources."jmespath-0.15.0"
+      sources."querystring-0.2.0"
+      sources."sax-1.2.1"
+      sources."url-0.10.3"
+      sources."uuid-3.0.1"
+      sources."xml2js-0.4.17"
+      sources."xmlbuilder-4.2.1"
+      sources."base64-js-1.2.0"
+      sources."ieee754-1.1.8"
+      sources."punycode-1.3.2"
       sources."wordwrap-0.0.3"
       sources."minimist-0.0.10"
       sources."aws-sign2-0.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -22097,12 +22404,15 @@ in
       sources."qs-6.4.0"
       sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
-      sources."tough-cookie-2.3.2"
+      (sources."tough-cookie-2.3.2" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
-      sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -22131,7 +22441,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -22142,7 +22452,6 @@ in
       sources."ecc-jsbn-0.1.1"
       sources."bcrypt-pbkdf-1.0.1"
       sources."mime-db-1.27.0"
-      sources."punycode-1.4.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -22155,14 +22464,15 @@ in
   emoj = nodeEnv.buildNodePackage {
     name = "emoj";
     packageName = "emoj";
-    version = "1.0.0";
+    version = "1.1.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/emoj/-/emoj-1.0.0.tgz";
-      sha1 = "3cccbeec420e2b45f73b923e880c220392c055bd";
+      url = "https://registry.npmjs.org/emoj/-/emoj-1.1.0.tgz";
+      sha1 = "5a43ae17f6bf672cd8e40891357f84b086c52509";
     };
     dependencies = [
       sources."chalk-1.1.3"
       sources."clipboardy-0.1.2"
+      sources."conf-1.1.1"
       (sources."got-6.7.1" // {
         dependencies = [
           sources."get-stream-3.0.0"
@@ -22173,6 +22483,7 @@ in
       sources."log-update-1.0.2"
       sources."mem-1.1.0"
       sources."meow-3.7.0"
+      sources."skin-tone-1.0.0"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."strip-ansi-3.0.1"
@@ -22195,6 +22506,17 @@ in
       sources."pinkie-promise-2.0.1"
       sources."pinkie-2.0.4"
       sources."path-key-2.0.1"
+      sources."dot-prop-4.1.1"
+      sources."env-paths-1.0.0"
+      sources."make-dir-1.0.0"
+      sources."pkg-up-2.0.0"
+      sources."is-obj-1.0.1"
+      sources."pify-2.3.0"
+      sources."find-up-2.1.0"
+      sources."locate-path-2.0.0"
+      sources."p-locate-2.0.0"
+      sources."path-exists-3.0.0"
+      sources."p-limit-1.1.0"
       sources."create-error-class-3.0.2"
       sources."duplexer3-0.1.4"
       sources."is-redirect-1.0.0"
@@ -22217,8 +22539,13 @@ in
       sources."loud-rejection-1.6.0"
       sources."map-obj-1.0.1"
       sources."minimist-1.2.0"
-      sources."normalize-package-data-2.3.6"
-      sources."read-pkg-up-1.0.1"
+      sources."normalize-package-data-2.3.8"
+      (sources."read-pkg-up-1.0.1" // {
+        dependencies = [
+          sources."find-up-1.1.2"
+          sources."path-exists-2.1.0"
+        ];
+      })
       sources."redent-1.0.0"
       sources."trim-newlines-1.0.0"
       sources."camelcase-2.1.1"
@@ -22232,14 +22559,11 @@ in
       sources."spdx-correct-1.0.2"
       sources."spdx-expression-parse-1.0.4"
       sources."spdx-license-ids-1.2.2"
-      sources."find-up-1.1.2"
       sources."read-pkg-1.1.0"
-      sources."path-exists-2.1.0"
       sources."load-json-file-1.1.0"
       sources."path-type-1.1.0"
       sources."graceful-fs-4.1.11"
       sources."parse-json-2.2.0"
-      sources."pify-2.3.0"
       sources."strip-bom-2.0.0"
       sources."error-ex-1.3.1"
       sources."is-arrayish-0.2.1"
@@ -22250,6 +22574,7 @@ in
       sources."is-finite-1.0.2"
       sources."number-is-nan-1.0.1"
       sources."get-stdin-4.0.1"
+      sources."unicode-emoji-modifier-base-1.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -22271,22 +22596,22 @@ in
       sources."babel-code-frame-6.22.0"
       sources."chalk-1.1.3"
       sources."concat-stream-1.6.0"
-      sources."debug-2.6.3"
+      sources."debug-2.6.6"
       sources."doctrine-2.0.0"
       sources."escope-3.6.0"
-      sources."espree-3.4.1"
+      sources."espree-3.4.3"
       sources."esquery-1.0.0"
       sources."estraverse-4.2.0"
       sources."esutils-2.0.2"
       sources."file-entry-cache-2.0.0"
       sources."glob-7.1.1"
       sources."globals-9.17.0"
-      sources."ignore-3.2.7"
+      sources."ignore-3.3.0"
       sources."imurmurhash-0.1.4"
       sources."inquirer-0.12.0"
       sources."is-my-json-valid-2.16.0"
       sources."is-resolvable-1.0.0"
-      sources."js-yaml-3.8.3"
+      sources."js-yaml-3.8.4"
       sources."json-stable-stringify-1.0.1"
       sources."levn-0.3.0"
       sources."lodash-4.17.4"
@@ -22324,7 +22649,7 @@ in
       sources."process-nextick-args-1.0.7"
       sources."string_decoder-1.0.0"
       sources."util-deprecate-1.0.2"
-      sources."ms-0.7.2"
+      sources."ms-0.7.3"
       sources."es6-map-0.1.5"
       sources."es6-weak-map-2.0.2"
       (sources."esrecurse-4.1.0" // {
@@ -22333,7 +22658,7 @@ in
         ];
       })
       sources."d-1.0.0"
-      sources."es5-ext-0.10.15"
+      sources."es5-ext-0.10.16"
       sources."es6-iterator-2.0.1"
       sources."es6-set-0.1.5"
       sources."es6-symbol-3.1.1"
@@ -22363,7 +22688,7 @@ in
       sources."pinkie-2.0.4"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -22405,11 +22730,11 @@ in
       sources."caller-path-0.1.0"
       sources."resolve-from-1.0.1"
       sources."callsites-0.2.0"
-      sources."interpret-1.0.2"
+      sources."interpret-1.0.3"
       sources."rechoir-0.6.2"
-      sources."resolve-1.3.2"
+      sources."resolve-1.3.3"
       sources."path-parse-1.0.5"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."ajv-keywords-1.5.1"
       sources."slice-ansi-0.0.4"
       sources."co-4.6.0"
@@ -22426,14 +22751,14 @@ in
   emojione = nodeEnv.buildNodePackage {
     name = "emojione";
     packageName = "emojione";
-    version = "2.2.7";
+    version = "3.0.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/emojione/-/emojione-2.2.7.tgz";
-      sha1 = "46457cf6b9b2f8da13ae8a2e4e547de06ee15e96";
+      url = "https://registry.npmjs.org/emojione/-/emojione-3.0.3.tgz";
+      sha1 = "7b4c61210bf6949f0ac16803889ea1abf2b285ea";
     };
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Emoji One is a complete set of emojis designed for the web. It includes libraries to easily convert unicode characters to shortnames (:smile:) and shortnames to our custom emoji images. PNG and SVG formats provided for the emoji images.";
+      description = "EmojiOne is a complete set of emojis designed for the web. It includes libraries to easily convert unicode characters to shortnames (:smile:) and shortnames to our custom emoji images. PNG formats provided for the emoji images.";
       homepage = http://www.emojione.com/;
     };
     production = true;
@@ -22528,8 +22853,8 @@ in
       sources."read-1.0.7"
       sources."revalidator-0.1.8"
       sources."mute-stream-0.0.7"
-      sources."chokidar-1.6.1"
-      sources."minimatch-3.0.3"
+      sources."chokidar-1.7.0"
+      sources."minimatch-3.0.4"
       sources."ps-tree-0.0.3"
       sources."anymatch-1.3.0"
       sources."async-each-1.0.1"
@@ -22546,14 +22871,14 @@ in
       sources."braces-1.8.5"
       sources."expand-brackets-0.1.5"
       sources."extglob-0.3.2"
-      sources."filename-regex-2.0.0"
+      sources."filename-regex-2.0.1"
       sources."is-extglob-1.0.0"
-      sources."kind-of-3.1.0"
+      sources."kind-of-3.2.0"
       sources."normalize-path-2.1.1"
       sources."object.omit-2.0.1"
       sources."parse-glob-3.0.4"
       sources."regex-cache-0.4.3"
-      sources."arr-flatten-1.0.2"
+      sources."arr-flatten-1.0.3"
       sources."expand-range-1.8.2"
       sources."preserve-0.2.0"
       sources."repeat-element-1.1.2"
@@ -22590,7 +22915,7 @@ in
         ];
       })
       sources."nopt-4.0.1"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       (sources."rc-1.2.1" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -22605,9 +22930,9 @@ in
       sources."osenv-0.1.4"
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
-      (sources."gauge-2.7.3" // {
+      (sources."gauge-2.7.4" // {
         dependencies = [
           sources."object-assign-4.1.1"
         ];
@@ -22619,19 +22944,19 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."ansi-regex-2.1.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -22651,7 +22976,7 @@ in
       sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -22680,7 +23005,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -22699,10 +23024,10 @@ in
       sources."wrappy-1.0.2"
       sources."block-stream-0.0.9"
       sources."fstream-1.0.11"
-      sources."debug-2.6.3"
+      sources."debug-2.6.6"
       sources."fstream-ignore-1.0.5"
       sources."uid-number-0.0.6"
-      sources."ms-0.7.2"
+      sources."ms-0.7.3"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
@@ -22738,10 +23063,10 @@ in
       sha1 = "466a7253a54f526ca2f57ca78780895b95efaee4";
     };
     dependencies = [
-      sources."async-2.3.0"
+      sources."async-2.4.0"
       sources."lodash.groupby-4.6.0"
       sources."minilog-2.0.8"
-      sources."simple-git-1.70.0"
+      sources."simple-git-1.72.0"
       sources."tabtab-git+https://github.com/mixu/node-tabtab.git"
       sources."lodash-4.17.4"
       sources."microee-0.0.2"
@@ -22770,7 +23095,7 @@ in
       sources."glob-5.0.15"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -22807,7 +23132,7 @@ in
       sources."xml2js-0.4.17"
       sources."msgpack-1.0.2"
       sources."character-parser-1.2.1"
-      (sources."clean-css-3.4.25" // {
+      (sources."clean-css-3.4.26" // {
         dependencies = [
           sources."commander-2.8.1"
         ];
@@ -22824,7 +23149,7 @@ in
           sources."source-map-0.1.43"
         ];
       })
-      (sources."uglify-js-2.8.22" // {
+      (sources."uglify-js-2.8.24" // {
         dependencies = [
           sources."source-map-0.5.6"
         ];
@@ -22862,7 +23187,7 @@ in
       sources."right-align-0.1.3"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.1.0"
+      sources."kind-of-3.2.0"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
@@ -22894,14 +23219,14 @@ in
       sources."chalk-1.1.3"
       sources."deprecated-0.0.1"
       sources."gulp-util-3.0.8"
-      sources."interpret-1.0.2"
+      sources."interpret-1.0.3"
       sources."liftoff-2.3.0"
       sources."minimist-1.2.0"
       sources."orchestrator-0.3.8"
       sources."pretty-hrtime-1.0.3"
       sources."semver-4.3.6"
       sources."tildify-1.2.0"
-      sources."v8flags-2.0.12"
+      sources."v8flags-2.1.1"
       (sources."vinyl-fs-0.3.14" // {
         dependencies = [
           sources."through2-0.6.5"
@@ -22965,7 +23290,7 @@ in
       sources."util-deprecate-1.0.2"
       sources."clone-1.0.2"
       sources."clone-stats-0.0.1"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."findup-sync-0.4.3"
       sources."fined-1.0.2"
       sources."flagged-respawn-0.3.2"
@@ -22973,7 +23298,7 @@ in
       sources."lodash.isstring-4.0.1"
       sources."lodash.mapvalues-4.6.0"
       sources."rechoir-0.6.2"
-      sources."resolve-1.3.2"
+      sources."resolve-1.3.3"
       sources."detect-file-0.1.0"
       sources."is-glob-2.0.1"
       sources."micromatch-2.3.11"
@@ -22985,13 +23310,13 @@ in
       sources."braces-1.8.5"
       sources."expand-brackets-0.1.5"
       sources."extglob-0.3.2"
-      sources."filename-regex-2.0.0"
-      sources."kind-of-3.1.0"
+      sources."filename-regex-2.0.1"
+      sources."kind-of-3.2.0"
       sources."normalize-path-2.1.1"
       sources."object.omit-2.0.1"
       sources."parse-glob-3.0.4"
       sources."regex-cache-0.4.3"
-      sources."arr-flatten-1.0.2"
+      sources."arr-flatten-1.0.3"
       sources."expand-range-1.8.2"
       sources."preserve-0.2.0"
       sources."repeat-element-1.1.2"
@@ -23140,7 +23465,7 @@ in
       sources."parserlib-0.2.5"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -23219,12 +23544,12 @@ in
       sources."escodegen-1.8.1"
       sources."esprima-2.7.3"
       sources."glob-5.0.15"
-      (sources."handlebars-4.0.6" // {
+      (sources."handlebars-4.0.8" // {
         dependencies = [
           sources."source-map-0.4.4"
         ];
       })
-      (sources."js-yaml-3.8.3" // {
+      (sources."js-yaml-3.8.4" // {
         dependencies = [
           sources."esprima-3.1.3"
         ];
@@ -23252,7 +23577,7 @@ in
       sources."amdefine-1.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
       sources."brace-expansion-1.1.7"
@@ -23263,7 +23588,7 @@ in
           sources."wordwrap-0.0.3"
         ];
       })
-      (sources."uglify-js-2.8.22" // {
+      (sources."uglify-js-2.8.24" // {
         dependencies = [
           sources."source-map-0.5.6"
         ];
@@ -23283,7 +23608,7 @@ in
       sources."right-align-0.1.3"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.1.0"
+      sources."kind-of-3.2.0"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
@@ -23332,7 +23657,7 @@ in
       sources."console-browserify-1.1.0"
       sources."exit-0.1.2"
       sources."htmlparser2-3.8.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."shelljs-0.3.0"
       sources."strip-json-comments-1.0.4"
       sources."lodash-3.7.0"
@@ -23403,10 +23728,10 @@ in
   js-yaml = nodeEnv.buildNodePackage {
     name = "js-yaml";
     packageName = "js-yaml";
-    version = "3.8.3";
+    version = "3.8.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz";
-      sha1 = "33a05ec481c850c8875929166fe1beb61c728766";
+      url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz";
+      sha1 = "520b4564f86573ba96662af85a8cafa7b4b5a6f6";
     };
     dependencies = [
       sources."argparse-1.0.9"
@@ -23424,22 +23749,26 @@ in
   karma = nodeEnv.buildNodePackage {
     name = "karma";
     packageName = "karma";
-    version = "1.6.0";
+    version = "1.7.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/karma/-/karma-1.6.0.tgz";
-      sha1 = "0e871d4527d5eac56c41d181f03c5c0a7e6dbf3e";
+      url = "https://registry.npmjs.org/karma/-/karma-1.7.0.tgz";
+      sha1 = "6f7a1a406446fa2e187ec95398698f4cee476269";
     };
     dependencies = [
       sources."bluebird-3.5.0"
       sources."body-parser-1.17.1"
-      sources."chokidar-1.6.1"
+      sources."chokidar-1.7.0"
       sources."colors-1.1.2"
       (sources."combine-lists-1.0.1" // {
         dependencies = [
           sources."lodash-4.17.4"
         ];
       })
-      sources."connect-3.6.0"
+      (sources."connect-3.6.1" // {
+        dependencies = [
+          sources."debug-2.6.3"
+        ];
+      })
       sources."core-js-2.4.1"
       sources."di-0.0.1"
       sources."dom-serialize-2.2.1"
@@ -23464,8 +23793,8 @@ in
           sources."string_decoder-0.10.31"
         ];
       })
-      sources."mime-1.3.4"
-      sources."minimatch-3.0.3"
+      sources."mime-1.3.6"
+      sources."minimatch-3.0.4"
       sources."optimist-0.6.1"
       sources."qjobs-1.1.5"
       sources."range-parser-1.2.0"
@@ -23514,14 +23843,14 @@ in
       sources."braces-1.8.5"
       sources."expand-brackets-0.1.5"
       sources."extglob-0.3.2"
-      sources."filename-regex-2.0.0"
+      sources."filename-regex-2.0.1"
       sources."is-extglob-1.0.0"
-      sources."kind-of-3.1.0"
+      sources."kind-of-3.2.0"
       sources."normalize-path-2.1.1"
       sources."object.omit-2.0.1"
       sources."parse-glob-3.0.4"
       sources."regex-cache-0.4.3"
-      sources."arr-flatten-1.0.2"
+      sources."arr-flatten-1.0.3"
       sources."expand-range-1.8.2"
       sources."preserve-0.2.0"
       sources."repeat-element-1.1.2"
@@ -23553,7 +23882,7 @@ in
       sources."node-pre-gyp-0.6.34"
       sources."mkdirp-0.5.1"
       sources."nopt-4.0.1"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       (sources."rc-1.2.1" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -23568,9 +23897,9 @@ in
       sources."osenv-0.1.4"
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
-      sources."gauge-2.7.3"
+      sources."gauge-2.7.4"
       sources."set-blocking-2.0.0"
       sources."delegates-1.0.0"
       sources."aproba-1.1.1"
@@ -23579,19 +23908,19 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."ansi-regex-2.1.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -23608,7 +23937,7 @@ in
       sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -23637,7 +23966,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -23654,7 +23983,11 @@ in
       sources."once-1.4.0"
       sources."uid-number-0.0.6"
       sources."wrappy-1.0.2"
-      sources."finalhandler-1.0.0"
+      (sources."finalhandler-1.0.1" // {
+        dependencies = [
+          sources."debug-2.6.3"
+        ];
+      })
       sources."parseurl-1.3.1"
       sources."utils-merge-1.0.0"
       sources."encodeurl-1.0.1"
@@ -23950,7 +24283,7 @@ in
       sources."stream-shift-1.0.0"
       sources."once-1.3.3"
       sources."wrappy-1.0.2"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."glob-5.0.15"
       sources."glob-parent-3.1.0"
       (sources."micromatch-2.3.11" // {
@@ -23963,7 +24296,7 @@ in
       sources."to-absolute-glob-0.1.1"
       sources."unique-stream-2.2.1"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -23980,8 +24313,8 @@ in
           sources."is-extglob-1.0.0"
         ];
       })
-      sources."filename-regex-2.0.0"
-      sources."kind-of-3.1.0"
+      sources."filename-regex-2.0.1"
+      sources."kind-of-3.2.0"
       sources."normalize-path-2.1.1"
       sources."object.omit-2.0.1"
       (sources."parse-glob-3.0.4" // {
@@ -23991,7 +24324,7 @@ in
         ];
       })
       sources."regex-cache-0.4.3"
-      sources."arr-flatten-1.0.2"
+      sources."arr-flatten-1.0.3"
       sources."expand-range-1.8.2"
       sources."preserve-0.2.0"
       sources."repeat-element-1.1.2"
@@ -24071,29 +24404,29 @@ in
   mocha = nodeEnv.buildNodePackage {
     name = "mocha";
     packageName = "mocha";
-    version = "3.2.0";
+    version = "3.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/mocha/-/mocha-3.2.0.tgz";
-      sha1 = "7dc4f45e5088075171a68896814e6ae9eb7a85e3";
+      url = "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz";
+      sha1 = "d29b7428d3f52c82e2e65df1ecb7064e1aabbfb5";
     };
     dependencies = [
       sources."browser-stdout-1.3.0"
       sources."commander-2.9.0"
-      sources."debug-2.2.0"
-      sources."diff-1.4.0"
+      sources."debug-2.6.0"
+      sources."diff-3.2.0"
       sources."escape-string-regexp-1.0.5"
-      sources."glob-7.0.5"
+      sources."glob-7.1.1"
       sources."growl-1.9.2"
       sources."json3-3.3.2"
       sources."lodash.create-3.1.1"
       sources."mkdirp-0.5.1"
       sources."supports-color-3.1.2"
       sources."graceful-readlink-1.0.1"
-      sources."ms-0.7.1"
+      sources."ms-0.7.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -24175,7 +24508,7 @@ in
       sources."concat-stream-1.6.0"
       sources."graceful-fs-4.1.11"
       sources."mkdirp-0.5.1"
-      sources."normalize-package-data-2.3.6"
+      sources."normalize-package-data-2.3.8"
       sources."npm-package-arg-4.2.1"
       sources."once-1.4.0"
       sources."request-2.81.0"
@@ -24205,7 +24538,7 @@ in
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -24225,7 +24558,7 @@ in
       sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -24254,7 +24587,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -24269,12 +24602,12 @@ in
       sources."glob-7.1.1"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
       sources."gauge-2.6.0"
       sources."set-blocking-2.0.0"
@@ -24286,7 +24619,7 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
@@ -24325,19 +24658,19 @@ in
   node-gyp = nodeEnv.buildNodePackage {
     name = "node-gyp";
     packageName = "node-gyp";
-    version = "3.6.0";
+    version = "3.6.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz";
-      sha1 = "7474f63a3a0501161dda0b6341f022f14c423fa6";
+      url = "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.1.tgz";
+      sha1 = "19561067ff185464aded478212681f47fd578cbc";
     };
     dependencies = [
       sources."fstream-1.0.11"
       sources."glob-7.1.1"
       sources."graceful-fs-4.1.11"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."mkdirp-0.5.1"
       sources."nopt-3.0.6"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       sources."osenv-0.1.4"
       sources."request-2.81.0"
       sources."rimraf-2.6.1"
@@ -24355,9 +24688,9 @@ in
       sources."concat-map-0.0.1"
       sources."minimist-0.0.8"
       sources."abbrev-1.1.0"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
-      sources."gauge-2.7.3"
+      sources."gauge-2.7.4"
       sources."set-blocking-2.0.0"
       sources."delegates-1.0.0"
       sources."readable-stream-2.2.9"
@@ -24373,7 +24706,7 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
@@ -24384,7 +24717,7 @@ in
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -24404,7 +24737,7 @@ in
       sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -24433,7 +24766,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -24459,18 +24792,19 @@ in
   node-inspector = nodeEnv.buildNodePackage {
     name = "node-inspector";
     packageName = "node-inspector";
-    version = "1.1.0";
+    version = "1.1.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/node-inspector/-/node-inspector-1.1.0.tgz";
-      sha1 = "0f8ffffbf9a9b86540eb33c1d64e7ba546457622";
+      url = "https://registry.npmjs.org/node-inspector/-/node-inspector-1.1.1.tgz";
+      sha1 = "e7851eb973f380543c058db564a9812055eac640";
     };
     dependencies = [
       sources."async-0.9.2"
       sources."biased-opener-0.2.8"
-      sources."debug-2.6.3"
+      sources."debug-2.6.6"
       (sources."express-4.15.2" // {
         dependencies = [
           sources."debug-2.6.1"
+          sources."ms-0.7.2"
         ];
       })
       sources."glob-5.0.15"
@@ -24523,12 +24857,12 @@ in
       sources."bplist-parser-0.1.1"
       sources."meow-3.7.0"
       sources."untildify-2.1.0"
-      sources."big-integer-1.6.19"
+      sources."big-integer-1.6.22"
       sources."camelcase-keys-2.1.0"
       sources."decamelize-1.2.0"
       sources."loud-rejection-1.6.0"
       sources."map-obj-1.0.1"
-      sources."normalize-package-data-2.3.6"
+      sources."normalize-package-data-2.3.8"
       sources."object-assign-4.1.1"
       sources."read-pkg-up-1.0.1"
       sources."redent-1.0.0"
@@ -24564,7 +24898,7 @@ in
       sources."is-finite-1.0.2"
       sources."number-is-nan-1.0.1"
       sources."get-stdin-4.0.1"
-      sources."ms-0.7.2"
+      sources."ms-0.7.3"
       sources."accepts-1.3.3"
       sources."array-flatten-1.1.1"
       sources."content-disposition-0.5.2"
@@ -24575,7 +24909,11 @@ in
       sources."encodeurl-1.0.1"
       sources."escape-html-1.0.3"
       sources."etag-1.8.0"
-      sources."finalhandler-1.0.1"
+      (sources."finalhandler-1.0.2" // {
+        dependencies = [
+          sources."debug-2.6.4"
+        ];
+      })
       sources."fresh-0.5.0"
       sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
@@ -24588,6 +24926,7 @@ in
       (sources."send-0.15.1" // {
         dependencies = [
           sources."debug-2.6.1"
+          sources."ms-0.7.2"
         ];
       })
       sources."serve-static-1.12.1"
@@ -24609,13 +24948,13 @@ in
       sources."inherits-2.0.3"
       sources."media-typer-0.3.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."wrappy-1.0.2"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."truncate-1.0.5"
@@ -24628,7 +24967,7 @@ in
         ];
       })
       sources."nopt-4.0.1"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       sources."request-2.81.0"
       sources."tar-2.2.1"
       (sources."tar-pack-3.4.0" // {
@@ -24638,9 +24977,9 @@ in
         ];
       })
       sources."abbrev-1.1.0"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
-      sources."gauge-2.7.3"
+      sources."gauge-2.7.4"
       sources."set-blocking-2.0.0"
       sources."delegates-1.0.0"
       sources."readable-stream-2.2.9"
@@ -24653,7 +24992,7 @@ in
       sources."has-unicode-2.0.1"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."ansi-regex-2.1.1"
@@ -24661,7 +25000,7 @@ in
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -24679,7 +25018,7 @@ in
       sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -24708,7 +25047,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -24753,7 +25092,7 @@ in
     dependencies = [
       sources."mkdirp-0.5.1"
       sources."nopt-4.0.1"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       (sources."rc-1.2.1" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -24769,9 +25108,9 @@ in
       sources."osenv-0.1.4"
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
-      sources."gauge-2.7.3"
+      sources."gauge-2.7.4"
       sources."set-blocking-2.0.0"
       sources."delegates-1.0.0"
       sources."readable-stream-2.2.9"
@@ -24788,19 +25127,19 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."ansi-regex-2.1.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -24820,7 +25159,7 @@ in
       sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -24849,7 +25188,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -24864,7 +25203,7 @@ in
       sources."glob-7.1.1"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -24874,10 +25213,10 @@ in
       sources."block-stream-0.0.9"
       sources."fstream-1.0.11"
       sources."graceful-fs-4.1.11"
-      sources."debug-2.6.3"
+      sources."debug-2.6.6"
       sources."fstream-ignore-1.0.5"
       sources."uid-number-0.0.6"
-      sources."ms-0.7.2"
+      sources."ms-0.7.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -24896,12 +25235,12 @@ in
       sha1 = "226c562bd2a7b13d3d7518b49ad4828a3623d06c";
     };
     dependencies = [
-      sources."chokidar-1.6.1"
-      sources."debug-2.6.3"
+      sources."chokidar-1.7.0"
+      sources."debug-2.6.6"
       sources."es6-promise-3.3.1"
       sources."ignore-by-default-1.0.1"
       sources."lodash.defaults-3.1.2"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."ps-tree-1.1.0"
       (sources."touch-1.0.0" // {
         dependencies = [
@@ -24926,14 +25265,14 @@ in
       sources."braces-1.8.5"
       sources."expand-brackets-0.1.5"
       sources."extglob-0.3.2"
-      sources."filename-regex-2.0.0"
+      sources."filename-regex-2.0.1"
       sources."is-extglob-1.0.0"
-      sources."kind-of-3.1.0"
+      sources."kind-of-3.2.0"
       sources."normalize-path-2.1.1"
       sources."object.omit-2.0.1"
       sources."parse-glob-3.0.4"
       sources."regex-cache-0.4.3"
-      sources."arr-flatten-1.0.2"
+      sources."arr-flatten-1.0.3"
       sources."expand-range-1.8.2"
       sources."preserve-0.2.0"
       sources."repeat-element-1.1.2"
@@ -24966,7 +25305,7 @@ in
       sources."node-pre-gyp-0.6.34"
       sources."mkdirp-0.5.1"
       sources."nopt-4.0.1"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       (sources."rc-1.2.1" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -24982,9 +25321,9 @@ in
       sources."osenv-0.1.4"
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
-      sources."gauge-2.7.3"
+      sources."gauge-2.7.4"
       sources."set-blocking-2.0.0"
       sources."delegates-1.0.0"
       sources."aproba-1.1.1"
@@ -24993,19 +25332,19 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."ansi-regex-2.1.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -25025,7 +25364,7 @@ in
       sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -25054,7 +25393,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -25075,7 +25414,7 @@ in
       sources."fstream-1.0.11"
       sources."fstream-ignore-1.0.5"
       sources."uid-number-0.0.6"
-      sources."ms-0.7.2"
+      sources."ms-0.7.3"
       sources."lodash.assign-3.2.0"
       sources."lodash.restparam-3.6.1"
       sources."lodash._baseassign-3.2.0"
@@ -25113,7 +25452,7 @@ in
       sources."escape-string-regexp-1.0.5"
       sources."has-ansi-2.0.0"
       sources."supports-color-2.0.0"
-      sources."write-file-atomic-1.3.1"
+      sources."write-file-atomic-1.3.4"
       sources."xdg-basedir-2.0.0"
       sources."imurmurhash-0.1.4"
       sources."slide-1.1.6"
@@ -25175,8 +25514,8 @@ in
       sources."express-4.14.0"
       (sources."follow-redirects-1.2.1" // {
         dependencies = [
-          sources."debug-2.6.3"
-          sources."ms-0.7.2"
+          sources."debug-2.6.6"
+          sources."ms-0.7.3"
         ];
       })
       sources."fs-extra-1.0.0"
@@ -25266,7 +25605,7 @@ in
       sources."boolbase-1.0.0"
       sources."nth-check-1.0.1"
       sources."domelementtype-1.3.0"
-      sources."domhandler-2.3.0"
+      sources."domhandler-2.4.1"
       sources."readable-stream-2.2.9"
       sources."buffer-shims-1.0.0"
       sources."core-util-is-1.0.2"
@@ -25336,18 +25675,18 @@ in
       sources."callback-stream-1.1.0"
       sources."glob-stream-6.1.0"
       sources."through2-2.0.3"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."glob-7.1.1"
       sources."glob-parent-3.1.0"
       sources."is-negated-glob-1.0.0"
-      sources."ordered-read-streams-1.0.0"
+      sources."ordered-read-streams-1.0.1"
       sources."pumpify-1.3.5"
       sources."remove-trailing-separator-1.0.1"
       sources."to-absolute-glob-2.0.1"
       sources."unique-stream-2.2.1"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -25355,7 +25694,6 @@ in
       sources."is-glob-3.1.0"
       sources."path-dirname-1.0.2"
       sources."is-extglob-2.1.1"
-      sources."is-stream-1.1.0"
       (sources."duplexify-3.5.0" // {
         dependencies = [
           sources."end-of-stream-1.0.0"
@@ -25373,7 +25711,7 @@ in
       sources."json-stable-stringify-1.0.1"
       sources."through2-filter-2.0.0"
       sources."jsonify-0.0.0"
-      sources."bl-1.2.0"
+      sources."bl-1.2.1"
       sources."safe-buffer-5.0.1"
       sources."abbrev-1.1.0"
       sources."uid2-0.0.3"
@@ -25391,7 +25729,7 @@ in
       sources."wordwrap-0.0.2"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.1.0"
+      sources."kind-of-3.2.0"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
@@ -25424,7 +25762,7 @@ in
       sources."forever-agent-0.6.1"
       (sources."form-data-1.0.1" // {
         dependencies = [
-          sources."async-2.3.0"
+          sources."async-2.4.0"
         ];
       })
       sources."har-validator-2.0.6"
@@ -25478,7 +25816,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -25536,7 +25874,7 @@ in
       sources."performance-now-0.2.0"
       sources."uuid-3.0.1"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."bindings-1.2.1"
@@ -25556,7 +25894,7 @@ in
           sources."minimist-0.0.8"
         ];
       })
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       sources."rc-1.1.7"
       sources."rimraf-2.5.4"
       sources."tar-2.2.1"
@@ -25567,9 +25905,9 @@ in
           sources."string_decoder-0.10.31"
         ];
       })
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
-      sources."gauge-2.7.3"
+      sources."gauge-2.7.4"
       sources."set-blocking-2.0.0"
       sources."delegates-1.0.0"
       sources."aproba-1.1.1"
@@ -25577,11 +25915,11 @@ in
       sources."object-assign-4.1.1"
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."block-stream-0.0.9"
@@ -25651,9 +25989,9 @@ in
       sources."methods-0.0.1"
       sources."send-0.1.0"
       sources."cookie-signature-1.0.1"
-      (sources."debug-2.6.3" // {
+      (sources."debug-2.6.6" // {
         dependencies = [
-          sources."ms-0.7.2"
+          sources."ms-0.7.3"
         ];
       })
       sources."qs-0.5.1"
@@ -25751,7 +26089,7 @@ in
       sources."fs-vacuum-1.2.10"
       sources."fs-write-stream-atomic-1.0.10"
       sources."fstream-1.0.11"
-      sources."fstream-npm-1.2.0"
+      sources."fstream-npm-1.2.1"
       sources."glob-7.1.1"
       sources."graceful-fs-4.1.11"
       sources."has-unicode-2.0.1"
@@ -25771,14 +26109,14 @@ in
       sources."mississippi-1.3.0"
       sources."mkdirp-0.5.1"
       sources."move-concurrently-1.0.1"
-      (sources."node-gyp-3.6.0" // {
+      (sources."node-gyp-3.6.1" // {
         dependencies = [
           sources."nopt-3.0.6"
         ];
       })
       sources."nopt-4.0.1"
       sources."normalize-git-url-3.0.2"
-      sources."normalize-package-data-2.3.6"
+      sources."normalize-package-data-2.3.8"
       sources."npm-cache-filename-1.0.2"
       sources."npm-install-checks-3.0.0"
       sources."npm-package-arg-4.2.1"
@@ -25823,7 +26161,7 @@ in
       sources."validate-npm-package-name-3.0.0"
       sources."which-1.2.14"
       sources."wrappy-1.0.2"
-      sources."write-file-atomic-1.3.1"
+      sources."write-file-atomic-1.3.4"
       sources."debuglog-1.0.1"
       sources."imurmurhash-0.1.4"
       sources."lodash._baseindexof-3.1.0"
@@ -25834,14 +26172,14 @@ in
       sources."lodash.restparam-3.6.1"
       sources."readdir-scoped-modules-1.0.2"
       sources."validate-npm-package-license-3.0.1"
-      sources."jsonparse-1.3.0"
+      sources."jsonparse-1.3.1"
       sources."through-2.3.8"
       sources."wcwidth-1.0.1"
       sources."defaults-1.0.3"
       sources."clone-1.0.2"
       sources."proto-list-1.2.4"
       sources."fstream-ignore-1.0.5"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
@@ -25874,15 +26212,15 @@ in
       sources."run-queue-1.0.3"
       sources."is-builtin-module-1.0.0"
       sources."builtin-modules-1.1.1"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
-      sources."gauge-2.7.3"
+      sources."gauge-2.7.4"
       sources."set-blocking-2.0.0"
       sources."delegates-1.0.0"
       sources."object-assign-4.1.1"
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
@@ -25902,7 +26240,7 @@ in
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -25921,7 +26259,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -25950,7 +26288,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -25965,20 +26303,29 @@ in
       sources."stream-iterate-1.2.0"
       sources."block-stream-0.0.9"
       sources."unique-slug-2.0.0"
-      (sources."boxen-1.0.0" // {
+      (sources."boxen-1.1.0" // {
         dependencies = [
           sources."string-width-2.0.0"
           sources."is-fullwidth-code-point-2.0.0"
         ];
       })
       sources."chalk-1.1.3"
-      sources."configstore-3.0.0"
+      (sources."configstore-3.1.0" // {
+        dependencies = [
+          sources."write-file-atomic-2.1.0"
+        ];
+      })
       sources."is-npm-1.0.0"
       sources."latest-version-3.1.0"
       sources."lazy-req-2.0.0"
       sources."semver-diff-2.1.0"
       sources."xdg-basedir-3.0.0"
-      sources."ansi-align-1.1.0"
+      (sources."ansi-align-2.0.0" // {
+        dependencies = [
+          sources."string-width-2.0.0"
+          sources."is-fullwidth-code-point-2.0.0"
+        ];
+      })
       sources."camelcase-4.1.0"
       sources."cli-boxes-1.0.0"
       sources."term-size-0.1.1"
@@ -25997,12 +26344,14 @@ in
       sources."has-ansi-2.0.0"
       sources."supports-color-2.0.0"
       sources."dot-prop-4.1.1"
+      sources."make-dir-1.0.0"
       sources."unique-string-1.0.0"
       sources."is-obj-1.0.1"
+      sources."pify-2.3.0"
       sources."crypto-random-string-1.0.0"
-      sources."package-json-4.0.0"
+      sources."package-json-4.0.1"
       sources."got-6.7.1"
-      sources."registry-auth-token-3.1.2"
+      sources."registry-auth-token-3.3.1"
       sources."registry-url-3.1.0"
       sources."create-error-class-3.0.2"
       sources."duplexer3-0.1.4"
@@ -26020,7 +26369,7 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."strip-json-comments-2.0.1"
       sources."builtins-1.0.3"
       sources."isexe-2.0.0"
@@ -26084,12 +26433,12 @@ in
       sources."rimraf-2.6.1"
       sources."retry-0.6.0"
       sources."couch-login-0.1.20"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -26109,7 +26458,7 @@ in
       sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -26138,7 +26487,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -26154,16 +26503,16 @@ in
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
-      sources."gauge-2.7.3"
+      sources."gauge-2.7.4"
       sources."set-blocking-2.0.0"
       sources."delegates-1.0.0"
       sources."readable-stream-2.2.9"
@@ -26179,7 +26528,7 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
@@ -26223,10 +26572,10 @@ in
   npm-check-updates = nodeEnv.buildNodePackage {
     name = "npm-check-updates";
     packageName = "npm-check-updates";
-    version = "2.10.5";
+    version = "2.11.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-2.10.5.tgz";
-      sha1 = "2d047e3a24d676e0c99cf7221361088dcc247a6a";
+      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-2.11.1.tgz";
+      sha1 = "9f9e9f6d9e558165c52901924063fc70783cd9eb";
     };
     dependencies = [
       sources."bluebird-3.5.0"
@@ -26249,7 +26598,7 @@ in
       sources."require-dir-0.3.1"
       sources."semver-5.3.0"
       sources."semver-utils-1.1.1"
-      (sources."snyk-1.28.1" // {
+      (sources."snyk-1.30.0" // {
         dependencies = [
           sources."update-notifier-0.5.0"
           sources."latest-version-1.0.1"
@@ -26296,7 +26645,7 @@ in
       sources."fs-vacuum-1.2.10"
       sources."fs-write-stream-atomic-1.0.10"
       sources."fstream-1.0.11"
-      sources."fstream-npm-1.2.0"
+      sources."fstream-npm-1.2.1"
       sources."glob-7.1.1"
       sources."graceful-fs-4.1.11"
       sources."has-unicode-2.0.1"
@@ -26324,7 +26673,7 @@ in
       })
       sources."nopt-3.0.6"
       sources."normalize-git-url-3.0.2"
-      sources."normalize-package-data-2.3.6"
+      sources."normalize-package-data-2.3.8"
       sources."npm-cache-filename-1.0.2"
       sources."npm-install-checks-3.0.0"
       sources."npm-package-arg-4.2.1"
@@ -26336,7 +26685,7 @@ in
       sources."npm-user-validate-0.1.5"
       (sources."npmlog-4.0.2" // {
         dependencies = [
-          sources."gauge-2.7.3"
+          sources."gauge-2.7.4"
         ];
       })
       sources."once-1.4.0"
@@ -26389,7 +26738,7 @@ in
       sources."clone-1.0.2"
       sources."proto-list-1.2.4"
       sources."fstream-ignore-1.0.5"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
@@ -26401,7 +26750,7 @@ in
       sources."lodash._root-3.0.1"
       sources."minimist-0.0.8"
       sources."path-array-1.0.1"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
       sources."gauge-2.6.0"
       sources."set-blocking-2.0.0"
@@ -26410,16 +26759,16 @@ in
       sources."object-assign-4.1.1"
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."array-index-1.0.0"
-      sources."debug-2.6.3"
+      sources."debug-2.6.6"
       sources."es6-symbol-3.1.1"
-      sources."ms-0.7.2"
+      sources."ms-0.7.3"
       sources."d-1.0.0"
-      sources."es5-ext-0.10.15"
+      sources."es5-ext-0.10.16"
       sources."es6-iterator-2.0.1"
       sources."is-builtin-module-1.0.0"
       sources."builtin-modules-1.1.1"
@@ -26449,7 +26798,7 @@ in
       })
       sources."caseless-0.11.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
@@ -26497,7 +26846,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -26592,11 +26941,11 @@ in
       sources."wordwrap-0.0.2"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.1.0"
+      sources."kind-of-3.2.0"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
-      sources."js-yaml-3.8.3"
+      sources."js-yaml-3.8.4"
       sources."argparse-1.0.9"
       sources."esprima-3.1.3"
       sources."sprintf-js-1.0.3"
@@ -26626,7 +26975,7 @@ in
       sources."is-obj-1.0.1"
       sources."package-json-2.4.0"
       sources."got-5.7.1"
-      sources."registry-auth-token-3.1.2"
+      sources."registry-auth-token-3.3.1"
       sources."registry-url-3.1.0"
       sources."create-error-class-3.0.2"
       sources."duplexer2-0.1.4"
@@ -26649,7 +26998,8 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."deep-extend-0.4.1"
+      sources."safe-buffer-5.0.1"
+      sources."deep-extend-0.4.2"
       sources."strip-json-comments-2.0.1"
       sources."get-caller-file-1.0.2"
       sources."lodash.assign-4.2.0"
@@ -26731,11 +27081,12 @@ in
       (sources."express-4.15.2" // {
         dependencies = [
           sources."content-type-1.0.2"
-          (sources."finalhandler-1.0.1" // {
+          (sources."finalhandler-1.0.2" // {
             dependencies = [
-              sources."debug-2.6.3"
+              sources."debug-2.6.4"
             ];
           })
+          sources."ms-0.7.3"
         ];
       })
       sources."express-handlebars-3.0.0"
@@ -26745,7 +27096,7 @@ in
           sources."ms-0.7.1"
         ];
       })
-      sources."js-yaml-3.8.3"
+      sources."js-yaml-3.8.4"
       sources."mediawiki-title-0.5.6"
       sources."negotiator-git+https://github.com/arlolra/negotiator.git#full-parse-access"
       sources."node-uuid-1.4.8"
@@ -26758,9 +27109,9 @@ in
           sources."ms-1.0.0"
         ];
       })
-      (sources."service-runner-2.2.5" // {
+      (sources."service-runner-2.3.0" // {
         dependencies = [
-          sources."yargs-6.6.0"
+          sources."yargs-7.1.0"
           sources."camelcase-3.0.0"
           sources."cliui-3.2.0"
         ];
@@ -26828,7 +27179,7 @@ in
       sources."mime-1.3.4"
       sources."glob-6.0.4"
       sources."graceful-fs-4.1.11"
-      (sources."handlebars-4.0.6" // {
+      (sources."handlebars-4.0.8" // {
         dependencies = [
           sources."async-1.5.2"
         ];
@@ -26836,7 +27187,7 @@ in
       sources."object.assign-4.0.4"
       sources."promise-7.1.1"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -26845,7 +27196,7 @@ in
       sources."concat-map-0.0.1"
       sources."optimist-0.6.1"
       sources."source-map-0.4.4"
-      (sources."uglify-js-2.8.22" // {
+      (sources."uglify-js-2.8.24" // {
         dependencies = [
           sources."source-map-0.5.6"
           sources."yargs-3.10.0"
@@ -26867,7 +27218,7 @@ in
       sources."right-align-0.1.3"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.1.0"
+      sources."kind-of-3.2.0"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
@@ -26882,7 +27233,7 @@ in
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -26900,7 +27251,7 @@ in
       sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -26929,7 +27280,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -26944,7 +27295,7 @@ in
       sources."bunyan-1.8.10"
       sources."bunyan-syslog-udp-0.1.0"
       sources."gelf-stream-1.1.1"
-      sources."hot-shots-4.4.0"
+      sources."hot-shots-4.5.0"
       (sources."limitation-0.2.0" // {
         dependencies = [
           sources."readable-stream-2.2.9"
@@ -26998,7 +27349,7 @@ in
       sources."process-nextick-args-1.0.7"
       sources."util-deprecate-1.0.2"
       sources."dom-storage-2.0.2"
-      (sources."bl-1.2.0" // {
+      (sources."bl-1.2.1" // {
         dependencies = [
           sources."readable-stream-2.2.9"
           sources."isarray-1.0.0"
@@ -27014,7 +27365,7 @@ in
       sources."string-width-1.0.2"
       sources."which-module-1.0.0"
       sources."y18n-3.2.1"
-      (sources."yargs-parser-4.2.1" // {
+      (sources."yargs-parser-5.0.0" // {
         dependencies = [
           sources."camelcase-3.0.0"
         ];
@@ -27030,7 +27381,7 @@ in
       sources."pinkie-promise-2.0.1"
       sources."pinkie-2.0.4"
       sources."load-json-file-1.1.0"
-      sources."normalize-package-data-2.3.6"
+      sources."normalize-package-data-2.3.8"
       sources."path-type-1.1.0"
       sources."parse-json-2.2.0"
       sources."pify-2.3.0"
@@ -27063,10 +27414,10 @@ in
   peerflix = nodeEnv.buildNodePackage {
     name = "peerflix";
     packageName = "peerflix";
-    version = "0.36.2";
+    version = "0.36.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/peerflix/-/peerflix-0.36.2.tgz";
-      sha1 = "93dd39e10a0a94b4f66ec19a42d8f5598a3eec01";
+      url = "https://registry.npmjs.org/peerflix/-/peerflix-0.36.3.tgz";
+      sha1 = "7100ab8190192a19633c98a2ea124e089a68c19e";
     };
     dependencies = [
       sources."airplayer-2.0.0"
@@ -27077,7 +27428,7 @@ in
         ];
       })
       sources."keypress-0.2.1"
-      sources."mime-1.3.4"
+      sources."mime-1.3.6"
       sources."network-address-1.1.2"
       sources."numeral-1.5.6"
       sources."open-0.0.5"
@@ -27119,7 +27470,7 @@ in
       sources."plist-1.2.0"
       sources."reverse-http-1.2.0"
       sources."stream-buffers-2.2.0"
-      sources."big-integer-1.6.19"
+      sources."big-integer-1.6.22"
       sources."inherits-2.0.3"
       sources."typedarray-0.0.6"
       sources."readable-stream-2.2.9"
@@ -27167,7 +27518,7 @@ in
       sources."decamelize-1.2.0"
       sources."loud-rejection-1.6.0"
       sources."map-obj-1.0.1"
-      sources."normalize-package-data-2.3.6"
+      sources."normalize-package-data-2.3.8"
       sources."object-assign-4.1.1"
       sources."read-pkg-up-1.0.1"
       sources."redent-1.0.0"
@@ -27215,7 +27566,7 @@ in
       sources."restore-cursor-1.0.1"
       sources."exit-hook-1.1.1"
       sources."onetime-1.1.0"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."spawn-sync-1.0.15"
       sources."tmp-0.0.29"
       sources."os-shim-0.1.3"
@@ -27223,18 +27574,18 @@ in
       sources."is-promise-2.1.0"
       sources."wordwrap-0.0.3"
       sources."blob-to-buffer-1.2.6"
-      sources."magnet-uri-5.1.6"
+      sources."magnet-uri-5.1.7"
       sources."parse-torrent-file-4.0.2"
-      sources."simple-get-2.5.1"
+      sources."simple-get-2.6.0"
       sources."thirty-two-1.0.2"
       sources."uniq-1.0.1"
       sources."bencode-0.11.0"
       sources."simple-sha1-2.1.0"
-      sources."rusha-0.8.5"
+      sources."rusha-0.8.6"
       sources."simple-concat-1.0.0"
       sources."unzip-response-2.0.1"
       sources."end-of-stream-1.4.0"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."bitfield-0.1.0"
@@ -27254,7 +27605,7 @@ in
       sources."rimraf-2.6.1"
       sources."torrent-discovery-5.4.0"
       sources."torrent-piece-1.1.1"
-      (sources."random-access-file-1.6.1" // {
+      (sources."random-access-file-1.7.2" // {
         dependencies = [
           sources."mkdirp-0.5.1"
           sources."thunky-1.0.2"
@@ -27264,8 +27615,8 @@ in
       sources."randombytes-2.0.3"
       sources."run-parallel-1.1.6"
       sources."buffer-alloc-unsafe-1.0.0"
-      sources."debug-2.6.3"
-      sources."ms-0.7.2"
+      sources."debug-2.6.6"
+      sources."ms-0.7.3"
       sources."flatten-0.0.1"
       sources."fifo-0.1.4"
       (sources."peer-wire-protocol-0.7.0" // {
@@ -27282,7 +27633,7 @@ in
       sources."glob-7.1.1"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -27315,7 +27666,7 @@ in
       sources."simple-peer-6.4.4"
       (sources."simple-websocket-4.3.1" // {
         dependencies = [
-          sources."ws-2.2.3"
+          sources."ws-2.3.1"
         ];
       })
       sources."string2compact-1.2.2"
@@ -27359,7 +27710,7 @@ in
       sources."pump-1.0.2"
       sources."range-parser-1.2.0"
       sources."read-torrent-1.3.0"
-      (sources."socket.io-1.7.3" // {
+      (sources."socket.io-1.7.4" // {
         dependencies = [
           sources."debug-2.3.3"
         ];
@@ -27371,7 +27722,7 @@ in
           sources."once-1.3.3"
         ];
       })
-      sources."fluent-ffmpeg-2.1.0"
+      sources."fluent-ffmpeg-2.1.2"
       sources."multiparty-3.3.2"
       sources."on-finished-2.1.1"
       sources."qs-2.2.5"
@@ -27475,7 +27826,7 @@ in
       sources."flatten-0.0.1"
       sources."bencode-0.7.0"
       sources."simple-sha1-2.1.0"
-      sources."rusha-0.8.5"
+      sources."rusha-0.8.6"
       sources."form-data-0.0.10"
       sources."hawk-0.10.2"
       sources."node-uuid-1.4.8"
@@ -27492,7 +27843,7 @@ in
       sources."boom-0.3.8"
       sources."cryptiles-0.1.3"
       sources."sntp-0.1.4"
-      (sources."engine.io-1.8.3" // {
+      (sources."engine.io-1.8.4" // {
         dependencies = [
           sources."debug-2.3.3"
           sources."cookie-0.3.1"
@@ -27505,7 +27856,7 @@ in
           sources."debug-2.3.3"
         ];
       })
-      (sources."socket.io-client-1.7.3" // {
+      (sources."socket.io-client-1.7.4" // {
         dependencies = [
           sources."debug-2.3.3"
         ];
@@ -27527,7 +27878,7 @@ in
       })
       sources."base64id-1.0.0"
       sources."engine.io-parser-1.3.2"
-      sources."ws-1.1.2"
+      sources."ws-1.1.4"
       sources."after-0.8.2"
       sources."arraybuffer.slice-0.0.6"
       sources."base64-arraybuffer-0.1.5"
@@ -27538,9 +27889,10 @@ in
       sources."backo2-1.0.2"
       sources."component-bind-1.0.0"
       sources."component-emitter-1.2.1"
-      (sources."engine.io-client-1.8.3" // {
+      (sources."engine.io-client-1.8.4" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ws-1.1.2"
         ];
       })
       sources."indexof-0.0.1"
@@ -27559,13 +27911,15 @@ in
       sources."bitfield-0.1.0"
       (sources."bittorrent-dht-3.2.6" // {
         dependencies = [
-          sources."debug-2.6.3"
+          sources."debug-2.6.6"
+          sources."ms-0.7.3"
         ];
       })
       (sources."bittorrent-tracker-2.12.1" // {
         dependencies = [
           sources."bencode-0.6.0"
-          sources."debug-2.6.3"
+          sources."debug-2.6.6"
+          sources."ms-0.7.3"
         ];
       })
       sources."bncode-0.5.3"
@@ -27610,7 +27964,7 @@ in
       sources."glob-7.1.1"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -27666,7 +28020,7 @@ in
       sources."glob-7.1.1"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."wrappy-1.0.2"
       sources."brace-expansion-1.1.7"
@@ -27677,7 +28031,7 @@ in
       sources."pinkie-2.0.4"
       sources."bl-1.0.3"
       sources."caseless-0.11.0"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-1.0.1"
       sources."json-stringify-safe-5.0.1"
@@ -27695,7 +28049,7 @@ in
       sources."isstream-0.1.2"
       sources."is-typedarray-1.0.0"
       sources."har-validator-2.0.6"
-      sources."async-2.3.0"
+      sources."async-2.4.0"
       sources."lodash-4.17.4"
       sources."mime-db-1.27.0"
       sources."assert-plus-0.2.0"
@@ -27718,7 +28072,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -27762,10 +28116,10 @@ in
   prettier = nodeEnv.buildNodePackage {
     name = "prettier";
     packageName = "prettier";
-    version = "1.1.0";
+    version = "1.3.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/prettier/-/prettier-1.1.0.tgz";
-      sha1 = "9d6ad005703efefa66b6999b8916bfc6afeaf9f8";
+      url = "https://registry.npmjs.org/prettier/-/prettier-1.3.1.tgz";
+      sha1 = "fa0ea84b45ac0ba6de6a1e4cecdcff900d563151";
     };
     dependencies = [
       sources."ast-types-0.9.8"
@@ -27773,7 +28127,7 @@ in
       sources."babylon-7.0.0-beta.8"
       sources."chalk-1.1.3"
       sources."esutils-2.0.2"
-      sources."flow-parser-0.43.0"
+      sources."flow-parser-0.45.0"
       sources."get-stdin-5.0.1"
       sources."glob-7.1.1"
       sources."jest-validate-19.0.0"
@@ -27788,7 +28142,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -27832,7 +28186,7 @@ in
       sources."detective-4.5.0"
       sources."glob-5.0.15"
       sources."graceful-fs-4.1.11"
-      sources."iconv-lite-0.4.15"
+      sources."iconv-lite-0.4.17"
       sources."mkdirp-0.5.1"
       sources."private-0.1.7"
       sources."q-1.5.0"
@@ -27842,7 +28196,7 @@ in
       sources."defined-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -27915,7 +28269,7 @@ in
       sources."methods-0.1.0"
       sources."send-0.1.4"
       sources."cookie-signature-1.0.1"
-      sources."debug-2.6.3"
+      sources."debug-2.6.6"
       sources."qs-0.6.5"
       sources."bytes-0.2.1"
       sources."pause-0.0.1"
@@ -27931,7 +28285,7 @@ in
       sources."inherits-2.0.3"
       sources."keypress-0.1.0"
       sources."mime-1.2.11"
-      sources."ms-0.7.2"
+      sources."ms-0.7.3"
       sources."oauth-https://codeload.github.com/ciaranj/node-oauth/legacy.tar.gz/master"
       sources."request-2.9.203"
       (sources."openid-2.0.6" // {
@@ -27948,7 +28302,7 @@ in
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -27967,7 +28321,7 @@ in
       sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -27996,7 +28350,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -28057,7 +28411,7 @@ in
         ];
       })
       sources."commander-2.9.0"
-      sources."js-yaml-3.8.3"
+      sources."js-yaml-3.8.4"
       sources."cookies-0.7.0"
       sources."request-2.81.0"
       sources."async-0.9.2"
@@ -28093,9 +28447,10 @@ in
       sources."encodeurl-1.0.1"
       sources."escape-html-1.0.3"
       sources."etag-1.8.0"
-      (sources."finalhandler-1.0.1" // {
+      (sources."finalhandler-1.0.2" // {
         dependencies = [
-          sources."debug-2.6.3"
+          sources."debug-2.6.4"
+          sources."ms-0.7.3"
         ];
       })
       sources."fresh-0.5.0"
@@ -28141,7 +28496,7 @@ in
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -28159,7 +28514,7 @@ in
       sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -28188,7 +28543,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -28210,7 +28565,7 @@ in
       sources."rimraf-2.4.5"
       (sources."glob-6.0.4" // {
         dependencies = [
-          sources."minimatch-3.0.3"
+          sources."minimatch-3.0.4"
         ];
       })
       sources."inflight-1.0.6"
@@ -28243,8 +28598,8 @@ in
       sources."regexp-quote-0.0.0"
       sources."xtend-4.0.1"
       sources."domelementtype-1.3.0"
-      sources."domhandler-2.3.0"
-      sources."domutils-1.5.1"
+      sources."domhandler-2.4.1"
+      sources."domutils-1.6.2"
       (sources."dom-serializer-0.1.0" // {
         dependencies = [
           sources."domelementtype-1.1.3"
@@ -28256,7 +28611,7 @@ in
       sources."process-nextick-args-1.0.7"
       sources."string_decoder-1.0.0"
       sources."util-deprecate-1.0.2"
-      sources."jsonparse-1.3.0"
+      sources."jsonparse-1.3.1"
       sources."through-2.3.8"
       sources."minimist-0.0.8"
     ];
@@ -28288,7 +28643,7 @@ in
       sources."colors-1.0.3"
       sources."graceful-readlink-1.0.1"
       sources."graceful-fs-4.1.11"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."readable-stream-2.2.9"
       sources."set-immediate-shim-1.0.1"
       sources."brace-expansion-1.1.7"
@@ -28374,7 +28729,7 @@ in
       sources."formidable-1.1.1"
       sources."http-signature-0.11.0"
       sources."keep-alive-agent-0.0.1"
-      sources."mime-1.3.4"
+      sources."mime-1.3.6"
       sources."negotiator-0.5.3"
       sources."node-uuid-1.4.8"
       sources."once-1.4.0"
@@ -28382,7 +28737,7 @@ in
       sources."semver-4.3.6"
       sources."spdy-1.32.5"
       sources."tunnel-agent-0.4.3"
-      (sources."verror-1.9.0" // {
+      (sources."verror-1.10.0" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -28408,7 +28763,7 @@ in
       sources."glob-6.0.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -28462,16 +28817,16 @@ in
     dependencies = [
       sources."css-parse-1.7.0"
       sources."mkdirp-0.5.1"
-      sources."debug-2.6.3"
+      sources."debug-2.6.6"
       sources."sax-0.5.8"
       sources."glob-7.0.6"
       sources."source-map-0.1.43"
       sources."minimist-0.0.8"
-      sources."ms-0.7.2"
+      sources."ms-0.7.3"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -28485,6 +28840,93 @@ in
       description = "Robust, expressive, and feature-rich CSS superset";
       homepage = https://github.com/stylus/stylus;
       license = "MIT";
+    };
+    production = true;
+  };
+  lumo-cljs = nodeEnv.buildNodePackage {
+    name = "lumo-cljs";
+    packageName = "lumo-cljs";
+    version = "1.5.0";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/lumo-cljs/-/lumo-cljs-1.5.0.tgz";
+      sha1 = "93af1b9cfccc12edfd495d64aec1748d4145f8dc";
+    };
+    dependencies = [
+      sources."jszip-2.6.1"
+      sources."progress-2.0.0"
+      sources."request-2.81.0"
+      sources."pako-1.0.5"
+      sources."aws-sign2-0.6.0"
+      sources."aws4-1.6.0"
+      sources."caseless-0.12.0"
+      sources."combined-stream-1.0.5"
+      sources."extend-3.0.1"
+      sources."forever-agent-0.6.1"
+      sources."form-data-2.1.4"
+      sources."har-validator-4.2.1"
+      sources."hawk-3.1.3"
+      sources."http-signature-1.1.1"
+      sources."is-typedarray-1.0.0"
+      sources."isstream-0.1.2"
+      sources."json-stringify-safe-5.0.1"
+      sources."mime-types-2.1.15"
+      sources."oauth-sign-0.8.2"
+      sources."performance-now-0.2.0"
+      sources."qs-6.4.0"
+      sources."safe-buffer-5.0.1"
+      sources."stringstream-0.0.5"
+      sources."tough-cookie-2.3.2"
+      sources."tunnel-agent-0.6.0"
+      sources."uuid-3.0.1"
+      sources."delayed-stream-1.0.0"
+      sources."asynckit-0.4.0"
+      sources."ajv-4.11.8"
+      sources."har-schema-1.0.5"
+      sources."co-4.6.0"
+      sources."json-stable-stringify-1.0.1"
+      sources."jsonify-0.0.0"
+      sources."hoek-2.16.3"
+      sources."boom-2.10.1"
+      sources."cryptiles-2.0.5"
+      sources."sntp-1.0.9"
+      sources."assert-plus-0.2.0"
+      (sources."jsprim-1.4.0" // {
+        dependencies = [
+          sources."assert-plus-1.0.0"
+        ];
+      })
+      (sources."sshpk-1.13.0" // {
+        dependencies = [
+          sources."assert-plus-1.0.0"
+        ];
+      })
+      sources."extsprintf-1.0.2"
+      sources."json-schema-0.2.3"
+      sources."verror-1.3.6"
+      sources."asn1-0.2.3"
+      (sources."dashdash-1.14.1" // {
+        dependencies = [
+          sources."assert-plus-1.0.0"
+        ];
+      })
+      (sources."getpass-0.1.7" // {
+        dependencies = [
+          sources."assert-plus-1.0.0"
+        ];
+      })
+      sources."jsbn-0.1.1"
+      sources."tweetnacl-0.14.5"
+      sources."jodid25519-1.0.2"
+      sources."ecc-jsbn-0.1.1"
+      sources."bcrypt-pbkdf-1.0.1"
+      sources."mime-db-1.27.0"
+      sources."punycode-1.4.1"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Fast, cross-platform, standalone ClojureScript REPL";
+      homepage = https://github.com/anmonteiro/lumo;
+      license = "EPL-1.0";
     };
     production = true;
   };
@@ -28539,7 +28981,7 @@ in
       sources."acorn-4.0.11"
       sources."enhanced-resolve-2.3.0"
       sources."glob-7.1.1"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."resolve-from-2.0.0"
       sources."tapable-0.2.6"
       sources."memory-fs-0.3.0"
@@ -28575,12 +29017,13 @@ in
   titanium = nodeEnv.buildNodePackage {
     name = "titanium";
     packageName = "titanium";
-    version = "5.0.12";
+    version = "5.0.14";
     src = fetchurl {
-      url = "https://registry.npmjs.org/titanium/-/titanium-5.0.12.tgz";
-      sha1 = "2bcfab6110ef0a91c9d54825052fd0db3e9dd942";
+      url = "https://registry.npmjs.org/titanium/-/titanium-5.0.14.tgz";
+      sha1 = "140bd332624acae65113a3ffec10b8cbb940ad0b";
     };
     dependencies = [
+      sources."adm-zip-0.4.7"
       sources."async-2.1.2"
       sources."colors-1.1.2"
       (sources."fields-0.1.24" // {
@@ -28612,7 +29055,6 @@ in
       sources."source-map-support-0.3.2"
       sources."source-map-0.1.32"
       sources."amdefine-1.0.1"
-      sources."adm-zip-0.4.7"
       sources."diff-3.2.0"
       sources."node-uuid-1.4.7"
       sources."optimist-0.6.1"
@@ -28640,7 +29082,7 @@ in
       sources."right-align-0.1.3"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.1.0"
+      sources."kind-of-3.2.0"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
@@ -28648,7 +29090,7 @@ in
       sources."aws4-1.6.0"
       sources."caseless-0.11.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-2.0.6"
@@ -28707,7 +29149,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -28739,10 +29181,10 @@ in
   typescript = nodeEnv.buildNodePackage {
     name = "typescript";
     packageName = "typescript";
-    version = "2.2.2";
+    version = "2.3.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/typescript/-/typescript-2.2.2.tgz";
-      sha1 = "606022508479b55ffa368b58fee963a03dfd7b0c";
+      url = "https://registry.npmjs.org/typescript/-/typescript-2.3.2.tgz";
+      sha1 = "f0f045e196f69a72f06b25fd3bd39d01c3ce9984";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -28755,28 +29197,16 @@ in
   uglify-js = nodeEnv.buildNodePackage {
     name = "uglify-js";
     packageName = "uglify-js";
-    version = "2.8.22";
+    version = "3.0.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz";
-      sha1 = "d54934778a8da14903fa29a326fb24c0ab51a1a0";
+      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.4.tgz";
+      sha1 = "13da18bc4ecec20d29861b4ab7b60cb9ef9a9cc0";
     };
     dependencies = [
+      sources."commander-2.9.0"
       sources."source-map-0.5.6"
-      sources."yargs-3.10.0"
       sources."uglify-to-browserify-1.0.2"
-      sources."camelcase-1.2.1"
-      sources."cliui-2.1.0"
-      sources."decamelize-1.2.0"
-      sources."window-size-0.1.0"
-      sources."center-align-0.1.3"
-      sources."right-align-0.1.3"
-      sources."wordwrap-0.0.2"
-      sources."align-text-0.1.4"
-      sources."lazy-cache-1.0.4"
-      sources."kind-of-3.1.0"
-      sources."longest-1.0.1"
-      sources."repeat-string-1.6.1"
-      sources."is-buffer-1.1.5"
+      sources."graceful-readlink-1.0.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -28789,38 +29219,35 @@ in
   ungit = nodeEnv.buildNodePackage {
     name = "ungit";
     packageName = "ungit";
-    version = "1.1.14";
+    version = "1.1.16";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ungit/-/ungit-1.1.14.tgz";
-      sha1 = "e65f05f541bc8b829f9720f28e74c4a12c7b6dd2";
+      url = "https://registry.npmjs.org/ungit/-/ungit-1.1.16.tgz";
+      sha1 = "d19a80706583423f9895364dd20adf873b88d09e";
     };
     dependencies = [
-      sources."async-2.1.5"
-      sources."bluebird-3.4.7"
-      sources."blueimp-md5-2.6.0"
-      sources."body-parser-1.15.2"
+      sources."async-2.4.0"
+      sources."bluebird-3.5.0"
+      sources."blueimp-md5-2.7.0"
+      sources."body-parser-1.17.1"
       sources."color-1.0.3"
       sources."cookie-parser-1.4.3"
       sources."crossroads-0.12.2"
       sources."diff2html-2.3.0"
       (sources."express-4.15.2" // {
         dependencies = [
-          sources."debug-2.6.1"
-          sources."qs-6.4.0"
-          sources."setprototypeof-1.0.3"
-          sources."ms-0.7.2"
+          sources."serve-static-1.12.1"
         ];
       })
       (sources."express-session-1.15.2" // {
         dependencies = [
           sources."debug-2.6.3"
-          sources."ms-0.7.2"
         ];
       })
       sources."forever-monitor-1.1.0"
       sources."getmac-1.2.1"
       sources."hasher-1.2.0"
       sources."ignore-3.2.7"
+      sources."just-detect-adblock-1.0.0"
       sources."keen.io-0.1.3"
       sources."knockout-3.4.2"
       sources."lodash-4.17.4"
@@ -28831,10 +29258,10 @@ in
       })
       sources."moment-2.18.1"
       sources."node-cache-4.1.1"
-      (sources."npm-4.5.0" // {
+      (sources."npm-4.6.1" // {
         dependencies = [
-          sources."bluebird-3.5.0"
           sources."nopt-4.0.1"
+          sources."npm-registry-client-8.1.1"
           sources."request-2.81.0"
           sources."combined-stream-1.0.5"
           sources."forever-agent-0.6.1"
@@ -28842,7 +29269,6 @@ in
           sources."hawk-3.1.3"
           sources."json-stringify-safe-5.0.1"
           sources."oauth-sign-0.8.2"
-          sources."qs-6.4.0"
           sources."tunnel-agent-0.6.0"
           sources."delayed-stream-1.0.0"
           sources."hoek-2.16.3"
@@ -28851,7 +29277,7 @@ in
           sources."sntp-1.0.9"
         ];
       })
-      (sources."npm-registry-client-8.1.1" // {
+      (sources."npm-registry-client-8.3.0" // {
         dependencies = [
           sources."request-2.81.0"
           sources."combined-stream-1.0.5"
@@ -28860,7 +29286,6 @@ in
           sources."hawk-3.1.3"
           sources."json-stringify-safe-5.0.1"
           sources."oauth-sign-0.8.2"
-          sources."qs-6.4.0"
           sources."tunnel-agent-0.6.0"
           sources."delayed-stream-1.0.0"
           sources."hoek-2.16.3"
@@ -28887,14 +29312,23 @@ in
       })
       sources."rimraf-2.6.1"
       sources."semver-5.3.0"
-      sources."serve-static-1.12.1"
+      (sources."serve-static-1.12.2" // {
+        dependencies = [
+          sources."send-0.15.2"
+          (sources."debug-2.6.4" // {
+            dependencies = [
+              sources."ms-0.7.3"
+            ];
+          })
+          sources."ms-1.0.0"
+        ];
+      })
       sources."signals-1.0.0"
       sources."snapsvg-0.5.1"
-      (sources."socket.io-1.7.3" // {
+      (sources."socket.io-1.7.4" // {
         dependencies = [
           sources."debug-2.3.3"
           sources."object-assign-4.1.0"
-          sources."ms-0.7.2"
         ];
       })
       (sources."superagent-0.21.0" // {
@@ -28922,24 +29356,25 @@ in
           sources."colors-1.0.3"
         ];
       })
-      (sources."yargs-7.1.0" // {
+      (sources."yargs-8.0.1" // {
         dependencies = [
-          sources."camelcase-3.0.0"
+          sources."string-width-2.0.0"
+          sources."is-fullwidth-code-point-2.0.0"
         ];
       })
       sources."bytes-2.4.0"
       sources."content-type-1.0.2"
-      sources."debug-2.2.0"
+      sources."debug-2.6.1"
       sources."depd-1.1.0"
-      sources."http-errors-1.5.1"
-      sources."iconv-lite-0.4.13"
+      sources."http-errors-1.6.1"
+      sources."iconv-lite-0.4.15"
       sources."on-finished-2.3.0"
-      sources."qs-6.2.0"
-      sources."raw-body-2.1.7"
+      sources."qs-6.4.0"
+      sources."raw-body-2.2.0"
       sources."type-is-1.6.15"
-      sources."ms-0.7.1"
+      sources."ms-0.7.2"
       sources."inherits-2.0.3"
-      sources."setprototypeof-1.0.2"
+      sources."setprototypeof-1.0.3"
       sources."statuses-1.3.1"
       sources."ee-first-1.1.1"
       sources."unpipe-1.0.0"
@@ -28968,10 +29403,10 @@ in
       sources."encodeurl-1.0.1"
       sources."escape-html-1.0.3"
       sources."etag-1.8.0"
-      (sources."finalhandler-1.0.1" // {
+      (sources."finalhandler-1.0.2" // {
         dependencies = [
-          sources."debug-2.6.3"
-          sources."ms-0.7.2"
+          sources."debug-2.6.4"
+          sources."ms-0.7.3"
         ];
       })
       sources."fresh-0.5.0"
@@ -28981,14 +29416,7 @@ in
       sources."path-to-regexp-0.1.7"
       sources."proxy-addr-1.1.4"
       sources."range-parser-1.2.0"
-      (sources."send-0.15.1" // {
-        dependencies = [
-          sources."debug-2.6.1"
-          sources."http-errors-1.6.1"
-          sources."ms-0.7.2"
-          sources."setprototypeof-1.0.3"
-        ];
-      })
+      sources."send-0.15.1"
       sources."utils-merge-1.0.0"
       sources."vary-1.1.1"
       sources."negotiator-0.6.1"
@@ -29096,10 +29524,10 @@ in
       sources."fs-vacuum-1.2.10"
       sources."fs-write-stream-atomic-1.0.10"
       sources."fstream-1.0.11"
-      sources."fstream-npm-1.2.0"
+      sources."fstream-npm-1.2.1"
       (sources."glob-7.1.1" // {
         dependencies = [
-          sources."minimatch-3.0.3"
+          sources."minimatch-3.0.4"
         ];
       })
       sources."graceful-fs-4.1.11"
@@ -29107,7 +29535,7 @@ in
       sources."hosted-git-info-2.4.2"
       sources."iferr-0.1.5"
       sources."inflight-1.0.6"
-      sources."init-package-json-1.9.6"
+      sources."init-package-json-1.10.1"
       sources."lazy-property-1.0.0"
       sources."lockfile-1.0.3"
       sources."lodash._baseuniq-4.6.0"
@@ -29117,14 +29545,14 @@ in
       sources."lodash.without-4.4.0"
       sources."mississippi-1.3.0"
       sources."move-concurrently-1.0.1"
-      (sources."node-gyp-3.6.0" // {
+      (sources."node-gyp-3.6.1" // {
         dependencies = [
-          sources."minimatch-3.0.3"
+          sources."minimatch-3.0.4"
           sources."nopt-3.0.6"
         ];
       })
       sources."normalize-git-url-3.0.2"
-      sources."normalize-package-data-2.3.6"
+      sources."normalize-package-data-2.3.8"
       sources."npm-cache-filename-1.0.2"
       sources."npm-install-checks-3.0.0"
       sources."npm-package-arg-4.2.1"
@@ -29164,7 +29592,7 @@ in
       sources."validate-npm-package-name-3.0.0"
       sources."which-1.2.14"
       sources."wrappy-1.0.2"
-      sources."write-file-atomic-1.3.1"
+      sources."write-file-atomic-1.3.4"
       sources."debuglog-1.0.1"
       sources."imurmurhash-0.1.4"
       sources."lodash._baseindexof-3.1.0"
@@ -29175,7 +29603,7 @@ in
       sources."lodash.restparam-3.6.1"
       sources."readdir-scoped-modules-1.0.2"
       sources."validate-npm-package-license-3.0.1"
-      sources."jsonparse-1.3.0"
+      sources."jsonparse-1.3.1"
       sources."through-2.3.8"
       sources."wcwidth-1.0.1"
       (sources."defaults-1.0.3" // {
@@ -29186,7 +29614,7 @@ in
       sources."proto-list-1.2.4"
       (sources."fstream-ignore-1.0.5" // {
         dependencies = [
-          sources."minimatch-3.0.3"
+          sources."minimatch-3.0.4"
         ];
       })
       sources."brace-expansion-1.1.7"
@@ -29220,15 +29648,15 @@ in
       sources."run-queue-1.0.3"
       sources."is-builtin-module-1.0.0"
       sources."builtin-modules-1.1.1"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
-      sources."gauge-2.7.3"
+      sources."gauge-2.7.4"
       sources."set-blocking-2.0.0"
       sources."delegates-1.0.0"
       sources."object-assign-4.1.1"
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
@@ -29246,7 +29674,7 @@ in
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."har-validator-4.2.1"
       sources."http-signature-1.1.1"
       sources."is-typedarray-1.0.0"
@@ -29256,7 +29684,7 @@ in
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -29281,7 +29709,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -29295,20 +29723,29 @@ in
       sources."stream-iterate-1.2.0"
       sources."block-stream-0.0.9"
       sources."unique-slug-2.0.0"
-      (sources."boxen-1.0.0" // {
+      (sources."boxen-1.1.0" // {
         dependencies = [
           sources."string-width-2.0.0"
           sources."is-fullwidth-code-point-2.0.0"
         ];
       })
       sources."chalk-1.1.3"
-      sources."configstore-3.0.0"
+      (sources."configstore-3.1.0" // {
+        dependencies = [
+          sources."write-file-atomic-2.1.0"
+        ];
+      })
       sources."is-npm-1.0.0"
       sources."latest-version-3.1.0"
       sources."lazy-req-2.0.0"
       sources."semver-diff-2.1.0"
       sources."xdg-basedir-3.0.0"
-      sources."ansi-align-1.1.0"
+      (sources."ansi-align-2.0.0" // {
+        dependencies = [
+          sources."string-width-2.0.0"
+          sources."is-fullwidth-code-point-2.0.0"
+        ];
+      })
       sources."camelcase-4.1.0"
       sources."cli-boxes-1.0.0"
       sources."term-size-0.1.1"
@@ -29330,12 +29767,14 @@ in
       sources."has-ansi-2.0.0"
       sources."supports-color-2.0.0"
       sources."dot-prop-4.1.1"
+      sources."make-dir-1.0.0"
       sources."unique-string-1.0.0"
       sources."is-obj-1.0.1"
+      sources."pify-2.3.0"
       sources."crypto-random-string-1.0.0"
-      sources."package-json-4.0.0"
+      sources."package-json-4.0.1"
       sources."got-6.7.1"
-      sources."registry-auth-token-3.1.2"
+      sources."registry-auth-token-3.3.1"
       sources."registry-url-3.1.0"
       sources."create-error-class-3.0.2"
       sources."duplexer3-0.1.4"
@@ -29353,16 +29792,16 @@ in
       sources."spdx-correct-1.0.2"
       sources."spdx-expression-parse-1.0.4"
       sources."spdx-license-ids-1.2.2"
+      sources."ssri-4.1.2"
       sources."passport-strategy-1.0.0"
       sources."pause-0.0.1"
       sources."lsmod-1.0.0"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."strip-json-comments-2.0.1"
-      sources."eve-0.5.3"
-      (sources."engine.io-1.8.3" // {
+      sources."eve-0.5.4"
+      (sources."engine.io-1.8.4" // {
         dependencies = [
           sources."debug-2.3.3"
-          sources."ms-0.7.2"
         ];
       })
       (sources."has-binary-0.1.7" // {
@@ -29373,24 +29812,24 @@ in
       (sources."socket.io-adapter-0.5.0" // {
         dependencies = [
           sources."debug-2.3.3"
-          sources."ms-0.7.2"
         ];
       })
-      (sources."socket.io-client-1.7.3" // {
+      (sources."socket.io-client-1.7.4" // {
         dependencies = [
           sources."debug-2.3.3"
-          sources."ms-0.7.2"
         ];
       })
       (sources."socket.io-parser-2.3.1" // {
         dependencies = [
+          sources."debug-2.2.0"
           sources."component-emitter-1.1.2"
           sources."isarray-0.0.1"
+          sources."ms-0.7.1"
         ];
       })
       sources."base64id-1.0.0"
       sources."engine.io-parser-1.3.2"
-      sources."ws-1.1.2"
+      sources."ws-1.1.4"
       sources."after-0.8.2"
       sources."arraybuffer.slice-0.0.6"
       sources."base64-arraybuffer-0.1.5"
@@ -29401,10 +29840,10 @@ in
       sources."backo2-1.0.2"
       sources."component-bind-1.0.0"
       sources."component-emitter-1.2.1"
-      (sources."engine.io-client-1.8.3" // {
+      (sources."engine.io-client-1.8.4" // {
         dependencies = [
           sources."debug-2.3.3"
-          sources."ms-0.7.2"
+          sources."ws-1.1.2"
         ];
       })
       sources."indexof-0.0.1"
@@ -29426,36 +29865,48 @@ in
       sources."cliui-3.2.0"
       sources."decamelize-1.2.0"
       sources."get-caller-file-1.0.2"
-      sources."os-locale-1.4.0"
-      sources."read-pkg-up-1.0.1"
-      sources."require-directory-2.1.1"
-      sources."require-main-filename-1.0.1"
-      sources."which-module-1.0.0"
-      sources."y18n-3.2.1"
-      (sources."yargs-parser-5.0.0" // {
+      (sources."os-locale-2.0.0" // {
         dependencies = [
-          sources."camelcase-3.0.0"
+          sources."execa-0.5.1"
+          sources."get-stream-2.3.1"
+          sources."npm-run-path-2.0.2"
+          sources."path-key-2.0.1"
         ];
       })
+      sources."read-pkg-up-2.0.0"
+      sources."require-directory-2.1.1"
+      sources."require-main-filename-1.0.1"
+      sources."which-module-2.0.0"
+      sources."y18n-3.2.1"
+      sources."yargs-parser-7.0.0"
       sources."wrap-ansi-2.1.0"
       sources."lcid-1.0.0"
-      sources."invert-kv-1.0.0"
-      sources."find-up-1.1.2"
-      sources."read-pkg-1.1.0"
-      sources."path-exists-2.1.0"
+      sources."mem-1.1.0"
+      (sources."cross-spawn-4.0.2" // {
+        dependencies = [
+          sources."lru-cache-4.0.2"
+        ];
+      })
+      sources."p-finally-1.0.0"
       sources."pinkie-promise-2.0.1"
       sources."pinkie-2.0.4"
-      sources."load-json-file-1.1.0"
-      sources."path-type-1.1.0"
+      sources."invert-kv-1.0.0"
+      sources."mimic-fn-1.1.0"
+      sources."find-up-2.1.0"
+      sources."read-pkg-2.0.0"
+      sources."locate-path-2.0.0"
+      sources."p-locate-2.0.0"
+      sources."path-exists-3.0.0"
+      sources."p-limit-1.1.0"
+      sources."load-json-file-2.0.0"
+      sources."path-type-2.0.0"
       sources."parse-json-2.2.0"
-      sources."pify-2.3.0"
-      sources."strip-bom-2.0.0"
+      sources."strip-bom-3.0.0"
       (sources."error-ex-1.3.1" // {
         dependencies = [
           sources."is-arrayish-0.2.1"
         ];
       })
-      sources."is-utf8-0.2.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -29531,7 +29982,7 @@ in
       sources."glob-7.1.1"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
@@ -29540,7 +29991,7 @@ in
       sources."pinkie-2.0.4"
       sources."bl-1.0.3"
       sources."caseless-0.11.0"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-1.0.1"
       sources."json-stringify-safe-5.0.1"
@@ -29558,7 +30009,7 @@ in
       sources."isstream-0.1.2"
       sources."is-typedarray-1.0.0"
       sources."har-validator-2.0.6"
-      sources."async-2.3.0"
+      sources."async-2.4.0"
       sources."lodash-4.17.4"
       sources."mime-db-1.27.0"
       sources."assert-plus-0.2.0"
@@ -29581,7 +30032,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -29627,10 +30078,10 @@ in
   webpack = nodeEnv.buildNodePackage {
     name = "webpack";
     packageName = "webpack";
-    version = "2.4.1";
+    version = "2.5.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack/-/webpack-2.4.1.tgz";
-      sha1 = "15a91dbe34966d8a4b99c7d656efd92a2e5a6f6a";
+      url = "https://registry.npmjs.org/webpack/-/webpack-2.5.1.tgz";
+      sha1 = "61742f0cf8af555b87460a9cd8bba2f1e3ee2fce";
     };
     dependencies = [
       sources."acorn-5.0.3"
@@ -29639,11 +30090,11 @@ in
           sources."acorn-4.0.11"
         ];
       })
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."ajv-keywords-1.5.1"
-      sources."async-2.3.0"
+      sources."async-2.4.0"
       sources."enhanced-resolve-3.1.0"
-      sources."interpret-1.0.2"
+      sources."interpret-1.0.3"
       sources."json-loader-0.5.4"
       sources."json5-0.5.1"
       sources."loader-runner-2.3.0"
@@ -29658,7 +30109,7 @@ in
       sources."source-map-0.5.6"
       sources."supports-color-3.2.3"
       sources."tapable-0.2.6"
-      (sources."uglify-js-2.8.22" // {
+      (sources."uglify-js-2.8.24" // {
         dependencies = [
           sources."yargs-3.10.0"
         ];
@@ -29701,11 +30152,11 @@ in
       sources."https-browserify-0.0.1"
       sources."os-browserify-0.2.1"
       sources."path-browserify-0.0.0"
-      sources."process-0.11.9"
+      sources."process-0.11.10"
       sources."punycode-1.4.1"
       sources."querystring-es3-0.2.1"
       sources."stream-browserify-2.0.1"
-      sources."stream-http-2.7.0"
+      sources."stream-http-2.7.1"
       sources."timers-browserify-2.0.2"
       sources."tty-browserify-0.0.0"
       (sources."url-0.11.0" // {
@@ -29726,10 +30177,10 @@ in
       sources."browserify-cipher-1.0.0"
       sources."browserify-sign-4.0.4"
       sources."create-ecdh-4.0.0"
-      sources."create-hash-1.1.2"
-      sources."create-hmac-1.1.4"
+      sources."create-hash-1.1.3"
+      sources."create-hmac-1.1.6"
       sources."diffie-hellman-5.0.2"
-      sources."pbkdf2-3.0.9"
+      sources."pbkdf2-3.0.12"
       sources."public-encrypt-4.0.0"
       sources."randombytes-2.0.3"
       sources."browserify-aes-1.0.6"
@@ -29748,8 +30199,10 @@ in
       sources."hmac-drbg-1.0.1"
       sources."minimalistic-crypto-utils-1.0.1"
       sources."asn1.js-4.9.1"
-      sources."ripemd160-1.0.1"
+      sources."ripemd160-2.0.1"
       sources."sha.js-2.4.8"
+      sources."hash-base-2.0.2"
+      sources."safe-buffer-5.0.1"
       sources."miller-rabin-4.0.0"
       sources."builtin-status-codes-3.0.0"
       sources."to-arraybuffer-1.0.1"
@@ -29768,11 +30221,11 @@ in
       sources."wordwrap-0.0.2"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.1.0"
+      sources."kind-of-3.2.0"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
-      sources."chokidar-1.6.1"
+      sources."chokidar-1.7.0"
       sources."anymatch-1.3.0"
       sources."async-each-1.0.1"
       sources."glob-parent-2.0.0"
@@ -29788,13 +30241,13 @@ in
       sources."braces-1.8.5"
       sources."expand-brackets-0.1.5"
       sources."extglob-0.3.2"
-      sources."filename-regex-2.0.0"
+      sources."filename-regex-2.0.1"
       sources."is-extglob-1.0.0"
       sources."normalize-path-2.1.1"
       sources."object.omit-2.0.1"
       sources."parse-glob-3.0.4"
       sources."regex-cache-0.4.3"
-      sources."arr-flatten-1.0.2"
+      sources."arr-flatten-1.0.3"
       sources."expand-range-1.8.2"
       sources."preserve-0.2.0"
       sources."repeat-element-1.1.2"
@@ -29812,7 +30265,7 @@ in
       sources."is-equal-shallow-0.1.3"
       sources."is-primitive-2.0.0"
       sources."binary-extensions-1.8.0"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."set-immediate-shim-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -29820,7 +30273,7 @@ in
       sources."nan-2.6.2"
       sources."node-pre-gyp-0.6.34"
       sources."nopt-4.0.1"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       (sources."rc-1.2.1" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -29835,9 +30288,9 @@ in
       sources."osenv-0.1.4"
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."console-control-strings-1.1.0"
-      sources."gauge-2.7.3"
+      sources."gauge-2.7.4"
       sources."set-blocking-2.0.0"
       sources."delegates-1.0.0"
       sources."aproba-1.1.1"
@@ -29845,19 +30298,19 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."ansi-regex-2.1.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -29870,7 +30323,6 @@ in
       sources."oauth-sign-0.8.2"
       sources."performance-now-0.2.0"
       sources."qs-6.4.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."tunnel-agent-0.6.0"
@@ -29902,7 +30354,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -29920,11 +30372,11 @@ in
       sources."wrappy-1.0.2"
       sources."block-stream-0.0.9"
       sources."fstream-1.0.11"
-      sources."debug-2.6.3"
+      sources."debug-2.6.6"
       sources."fstream-ignore-1.0.5"
       sources."uid-number-0.0.6"
-      sources."ms-0.7.2"
-      sources."source-list-map-1.1.1"
+      sources."ms-0.7.3"
+      sources."source-list-map-1.1.2"
       sources."get-caller-file-1.0.2"
       sources."os-locale-1.4.0"
       sources."read-pkg-up-1.0.1"
@@ -29946,7 +30398,7 @@ in
       sources."pinkie-promise-2.0.1"
       sources."pinkie-2.0.4"
       sources."load-json-file-1.1.0"
-      sources."normalize-package-data-2.3.6"
+      sources."normalize-package-data-2.3.8"
       sources."path-type-1.1.0"
       sources."parse-json-2.2.0"
       sources."pify-2.3.0"
@@ -29989,10 +30441,10 @@ in
   yarn = nodeEnv.buildNodePackage {
     name = "yarn";
     packageName = "yarn";
-    version = "0.22.0";
+    version = "0.24.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/yarn/-/yarn-0.22.0.tgz";
-      sha1 = "fd8511dc29225b925be967dc185772cc59de5888";
+      url = "https://registry.npmjs.org/yarn/-/yarn-0.24.4.tgz";
+      sha1 = "a4bfa3bb768192706771337f959721cfc0555093";
     };
     dependencies = [
       sources."babel-runtime-6.23.0"
@@ -30002,8 +30454,9 @@ in
       sources."cmd-shim-2.0.2"
       sources."commander-2.9.0"
       sources."death-1.1.0"
-      sources."debug-2.6.3"
+      sources."debug-2.6.6"
       sources."detect-indent-5.0.0"
+      sources."gunzip-maybe-1.4.0"
       sources."ini-1.3.4"
       sources."inquirer-3.0.6"
       sources."invariant-2.2.2"
@@ -30011,25 +30464,24 @@ in
       sources."is-ci-1.0.10"
       sources."leven-2.1.0"
       sources."loud-rejection-1.6.0"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."mkdirp-0.5.1"
       sources."node-emoji-1.5.1"
-      sources."node-gyp-3.6.0"
       sources."object-path-0.11.4"
-      sources."proper-lockfile-2.0.0"
+      sources."proper-lockfile-2.0.1"
       sources."read-1.0.7"
       sources."request-2.81.0"
       sources."request-capture-har-1.2.2"
       sources."rimraf-2.6.1"
-      sources."roadrunner-1.1.0"
       sources."semver-5.3.0"
       sources."strip-bom-3.0.0"
-      sources."tar-2.2.1"
-      sources."tar-stream-1.5.2"
+      sources."tar-fs-1.15.2"
+      sources."tar-stream-1.5.4"
+      sources."uuid-3.0.1"
       sources."v8-compile-cache-1.1.0"
       sources."validate-npm-package-license-3.0.1"
       sources."core-js-2.4.1"
-      sources."regenerator-runtime-0.10.3"
+      sources."regenerator-runtime-0.10.5"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."has-ansi-2.0.0"
@@ -30038,7 +30490,37 @@ in
       sources."ansi-regex-2.1.1"
       sources."graceful-fs-4.1.11"
       sources."graceful-readlink-1.0.1"
-      sources."ms-0.7.2"
+      sources."ms-0.7.3"
+      sources."browserify-zlib-0.1.4"
+      sources."is-deflate-1.0.0"
+      sources."is-gzip-1.0.0"
+      sources."peek-stream-1.1.2"
+      sources."pumpify-1.3.5"
+      sources."through2-2.0.3"
+      sources."pako-0.2.9"
+      sources."duplexify-3.5.0"
+      sources."end-of-stream-1.0.0"
+      sources."inherits-2.0.3"
+      sources."readable-stream-2.2.9"
+      sources."stream-shift-1.0.0"
+      sources."once-1.3.3"
+      sources."wrappy-1.0.2"
+      sources."buffer-shims-1.0.0"
+      sources."core-util-is-1.0.2"
+      sources."isarray-1.0.0"
+      sources."process-nextick-args-1.0.7"
+      sources."string_decoder-1.0.0"
+      sources."util-deprecate-1.0.2"
+      (sources."pump-1.0.2" // {
+        dependencies = [
+          (sources."end-of-stream-1.4.0" // {
+            dependencies = [
+              sources."once-1.4.0"
+            ];
+          })
+        ];
+      })
+      sources."xtend-4.0.1"
       sources."ansi-escapes-1.4.0"
       sources."cli-cursor-2.1.0"
       sources."cli-width-2.1.0"
@@ -30069,55 +30551,12 @@ in
       sources."concat-map-0.0.1"
       sources."minimist-0.0.8"
       sources."string.prototype.codepointat-0.2.0"
-      sources."fstream-1.0.11"
-      sources."glob-7.1.1"
-      sources."nopt-3.0.6"
-      sources."npmlog-4.0.2"
-      sources."osenv-0.1.4"
-      sources."which-1.2.14"
-      sources."inherits-2.0.3"
-      sources."fs.realpath-1.0.0"
-      sources."inflight-1.0.6"
-      sources."once-1.4.0"
-      sources."path-is-absolute-1.0.1"
-      sources."wrappy-1.0.2"
-      sources."abbrev-1.1.0"
-      sources."are-we-there-yet-1.1.2"
-      sources."console-control-strings-1.1.0"
-      (sources."gauge-2.7.3" // {
-        dependencies = [
-          sources."string-width-1.0.2"
-          sources."is-fullwidth-code-point-1.0.0"
-        ];
-      })
-      sources."set-blocking-2.0.0"
-      sources."delegates-1.0.0"
-      sources."readable-stream-2.2.9"
-      sources."buffer-shims-1.0.0"
-      sources."core-util-is-1.0.2"
-      sources."isarray-1.0.0"
-      sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
-      sources."util-deprecate-1.0.2"
-      sources."aproba-1.1.1"
-      sources."has-unicode-2.0.1"
-      sources."object-assign-4.1.1"
-      (sources."wide-align-1.1.0" // {
-        dependencies = [
-          sources."string-width-1.0.2"
-          sources."is-fullwidth-code-point-1.0.0"
-        ];
-      })
-      sources."code-point-at-1.1.0"
-      sources."number-is-nan-1.0.1"
-      sources."os-homedir-1.0.2"
-      sources."isexe-2.0.0"
       sources."retry-0.10.1"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -30134,10 +30573,9 @@ in
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."tunnel-agent-0.6.0"
-      sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -30166,7 +30604,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -30178,10 +30616,12 @@ in
       sources."bcrypt-pbkdf-1.0.1"
       sources."mime-db-1.27.0"
       sources."punycode-1.4.1"
-      sources."block-stream-0.0.9"
-      sources."bl-1.2.0"
-      sources."end-of-stream-1.4.0"
-      sources."xtend-4.0.1"
+      sources."glob-7.1.1"
+      sources."fs.realpath-1.0.0"
+      sources."inflight-1.0.6"
+      sources."path-is-absolute-1.0.1"
+      sources."chownr-1.0.1"
+      sources."bl-1.2.1"
       sources."spdx-correct-1.0.2"
       sources."spdx-expression-parse-1.0.4"
       sources."spdx-license-ids-1.2.2"
@@ -30287,7 +30727,7 @@ in
       sources."os-tmpdir-1.0.2"
       sources."osenv-0.1.4"
       sources."uuid-2.0.3"
-      sources."write-file-atomic-1.3.1"
+      sources."write-file-atomic-1.3.4"
       sources."xdg-basedir-2.0.0"
       sources."minimist-0.0.8"
       sources."os-homedir-1.0.2"
@@ -30374,7 +30814,7 @@ in
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
       sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
+      sources."extend-3.0.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.1.4"
       sources."har-validator-4.2.1"
@@ -30392,7 +30832,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
-      sources."ajv-4.11.6"
+      sources."ajv-4.11.8"
       sources."har-schema-1.0.5"
       sources."co-4.6.0"
       sources."json-stable-stringify-1.0.1"
@@ -30421,7 +30861,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      (sources."getpass-0.1.6" // {
+      (sources."getpass-0.1.7" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -30436,7 +30876,7 @@ in
       sources."camelcase-keys-2.1.0"
       sources."loud-rejection-1.6.0"
       sources."map-obj-1.0.1"
-      sources."normalize-package-data-2.3.6"
+      sources."normalize-package-data-2.3.8"
       sources."redent-1.0.0"
       sources."trim-newlines-1.0.0"
       sources."camelcase-2.1.1"
@@ -30459,9 +30899,9 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."strip-json-comments-2.0.1"
-      sources."registry-auth-token-3.1.2"
+      sources."registry-auth-token-3.3.1"
       sources."execall-1.0.0"
       sources."clone-regexp-1.0.0"
       sources."is-regexp-1.0.0"
@@ -30482,9 +30922,9 @@ in
       sources."arrify-1.0.1"
       sources."dot-prop-2.4.0"
       sources."is-obj-1.0.1"
-      sources."debug-2.6.3"
+      sources."debug-2.6.6"
       sources."npmlog-2.0.4"
-      sources."ms-0.7.2"
+      sources."ms-0.7.3"
       sources."external-editor-1.1.1"
       sources."rx-4.1.0"
       sources."spawn-sync-1.0.15"
@@ -30494,7 +30934,7 @@ in
       sources."typedarray-0.0.6"
       sources."is-promise-2.1.0"
       sources."ansi-0.3.1"
-      sources."are-we-there-yet-1.1.2"
+      sources."are-we-there-yet-1.1.4"
       sources."gauge-1.2.7"
       sources."delegates-1.0.0"
       sources."has-unicode-2.0.1"
@@ -30532,7 +30972,7 @@ in
       sources."semver-regex-1.0.0"
       sources."set-immediate-shim-1.0.1"
       sources."walk-2.3.9"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."foreachasync-3.0.0"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -57,6 +57,7 @@
 , "sloc"
 , "smartdc"
 , "stylus"
+, "lumo-cljs"
 , "svgo"
 , "tern"
 , "titanium"


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

