### PR TITLE
planner: 20170429 -> split (into three versions)

### DIFF
--- a/pkgs/applications/office/planner/default.nix
+++ b/pkgs/applications/office/planner/default.nix
@@ -1,69 +1,18 @@
-{ stdenv
-, fetchgit
-, pkgconfig
-, intltool
-, automake111x
-, autoconf
-, libtool
-, gnome2
-, libxslt
-, python
-}:
+{ newScope, stdenv }:
 
-let version = "20170425";
-
-in stdenv.mkDerivation {
-  name = "planner-${version}";
-
-  src = fetchgit {
-    url = "https://git.gnome.org/browse/planner";
-    rev = "6a79647e5711b2b8d7435cacc3452e643d2f05e6";
-    sha256 = "18k40s0f665qclrzvkgyfqmvjk0nqdc8aj3m8n4ky85di4qbqlwd";
-  };
-
-  buildInputs = with gnome2; [
-    pkgconfig
-    intltool
-    automake111x
-    autoconf
-    libtool
-
-    gnome_common
-    gtk_doc
-
-    GConf
-    gtk
-    libgnomecanvas
-    libgnomeui
-    libglade
-    scrollkeeper
-
-    libxslt
-    python
-  ];
-
-  preConfigure = ''./autogen.sh'';
-
-  enableParallelBuilding = true;
+let
+  callPackage = newScope stdenv;
 
   meta = with stdenv.lib; {
     homepage = "https://wiki.gnome.org/Apps/Planner";
     description = "Project management application for GNOME";
-    longDescription = ''
-      Planner is the GNOME project management tool.
-      Its goal is to be an easy-to-use no-nonsense cross-platform
-      project management application.
-
-      Planner is a GTK+ application written in C and licensed under the
-      GPLv2 or any later version. It can store its data in either xml
-      files or in a postgresql database. Projects can also be printed
-      to PDF or exported to HTML for easy viewing from any web browser.
-
-      Planner was originally created by Richard Hult and Mikael Hallendal
-      at Imendio.
-    '';
     license = licenses.gpl2Plus;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ rasendubi amiloradovsky ];
   };
-}
+in
+  {
+    stable = callPackage ./stable.nix { basicmeta = meta; };
+
+    unstable = callPackage ./unstable.nix { basicmeta = meta; };
+
+    unofficial = callPackage ./unofficial.nix { basicmeta = meta; };
+  }

--- a/pkgs/applications/office/planner/stable.nix
+++ b/pkgs/applications/office/planner/stable.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, fetchurl
+, pkgconfig
+, intltool
+, gnome2
+, libxslt
+, python
+, basicmeta
+}:
+
+let
+  version = "${major}.${minor}.${patch}";
+  major = "0";
+  minor = "14";
+  patch = "6";
+
+in stdenv.mkDerivation {
+  name = "planner-${version}";
+
+  src = fetchurl {
+    url = "http://ftp.gnome.org/pub/GNOME/sources/planner/${major}.${minor}/planner-${version}.tar.xz";
+    sha256 = "15h6ps58giy5r1g66sg1l4xzhjssl362mfny2x09khdqsvk2j38k";
+  };
+
+  buildInputs = [
+    pkgconfig
+    intltool
+  ] ++ (with gnome2; [
+    GConf
+    gtk
+    libgnomecanvas
+    libgnomeui
+    libglade
+    scrollkeeper
+  ]) ++ [
+    libxslt
+    python
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    longDescription = ''
+      Planner is the GNOME project management tool.
+      Its goal is to be an easy-to-use no-nonsense cross-platform
+      project management application.
+    '';
+    platforms = platforms.all;
+    maintainers = with maintainers; [ rasendubi amiloradovsky ];
+  } // basicmeta;
+}

--- a/pkgs/applications/office/planner/unofficial.nix
+++ b/pkgs/applications/office/planner/unofficial.nix
@@ -1,0 +1,86 @@
+{ stdenv
+, fetchFromGitLab
+, pkgconfig
+, intltool
+, automake111x
+, autoconf
+, libtool
+, gnome2
+, gnome3
+, libxslt
+, docbook_xsl
+, python
+, pythonPackages
+, file
+, basicmeta
+}:
+
+let version = "20170514+";
+    doCheck = false;
+
+in stdenv.mkDerivation {
+  name = "planner-${version}";
+
+  src = fetchFromGitLab {
+    owner = "amiloradovsky";
+    repo = "planner";
+    rev = "d9bc19ad4451ec67de90e80a0ffa6637010d8d00";
+    sha256 = "1is3jf86kzqf9641a2vm9z1v820jsh2bg2ys6d5rpdsbx8h5q3il";
+  };
+
+  buildInputs = [
+    pkgconfig
+    intltool
+    automake111x
+    autoconf
+    libtool
+  ] ++ (with gnome2; [
+    gnome_common
+    gtk_doc
+
+    GConf
+    gtk
+    libgnome
+    libgnomecanvas
+    libgnomeui
+    libglade
+    scrollkeeper
+  ]) ++ (with gnome3; [
+    libgda
+  ]) ++ [
+    libxslt
+    docbook_xsl
+    python
+    pythonPackages.pygtk
+    file
+  ];
+
+  configureScript = "./autogen.sh";
+  configureFlags = [ "--enable-gtk-doc" "--with-database"
+                     "--enable-compile-warnings=yes"
+                     "--enable-python-plugin"
+                     "--enable-simple-priority-scheduling" ];
+  # simple priority scheduling is experimental, not yet for production
+
+  inherit doCheck;
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    longDescription = ''
+      Planner is the GNOME project management tool.
+      Its goal is to be an easy-to-use no-nonsense cross-platform
+      project management application.
+
+      Planner is a GTK+ application written in C and licensed under the
+      GPLv2 or any later version. It can store its data in either xml
+      files or in a postgresql database. Projects can also be printed
+      to PDF or exported to HTML for easy viewing from any web browser.
+
+      Planner was originally created by Richard Hult and Mikael Hallendal
+      at Imendio.
+    '';
+    platforms = platforms.all;
+    maintainers = with maintainers; [ amiloradovsky ];
+  } // basicmeta;
+}

--- a/pkgs/applications/office/planner/unstable.nix
+++ b/pkgs/applications/office/planner/unstable.nix
@@ -1,0 +1,70 @@
+{ stdenv
+, fetchgit
+, pkgconfig
+, intltool
+, automake111x
+, autoconf
+, libtool
+, gnome2
+, libxslt
+, python
+, basicmeta
+}:
+
+let version = "20170514";
+    doCheck = false;
+
+in stdenv.mkDerivation {
+  name = "planner-${version}";
+
+  src = fetchgit {
+    url = "https://git.gnome.org/browse/planner";
+    rev = "23699814d5cc425b89baa20236a802f28dca7c2c";
+    sha256 = "107y4nw4jfcabykcrc9q9vb2wwqk421aq5wnyk4xamycc2zlqfcf";
+  };
+
+  buildInputs = [
+    pkgconfig
+    intltool
+    automake111x
+    autoconf
+    libtool
+  ] ++ (with gnome2; [
+    gnome_common
+    gtk_doc
+
+    GConf
+    gtk
+    libgnomecanvas
+    libgnomeui
+    libglade
+    scrollkeeper
+  ]) ++ [
+    libxslt
+    python
+  ];
+
+  configureScript = "./autogen.sh";
+
+  inherit doCheck;
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    longDescription = ''
+      Planner is the GNOME project management tool.
+      Its goal is to be an easy-to-use no-nonsense cross-platform
+      project management application.
+
+      Planner is a GTK+ application written in C and licensed under the
+      GPLv2 or any later version. It stores its data in XML files.
+      Projects can also be printed to PDF or exported to HTML
+      for easy viewing from any web browser.
+
+      Planner was originally created by Richard Hult and Mikael Hallendal
+      at Imendio.
+    '';
+    platforms = platforms.all;
+    maintainers = with maintainers; [ amiloradovsky rasendubi ];
+  } // basicmeta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14995,6 +14995,9 @@ with pkgs;
   pijul = callPackage ../applications/version-management/pijul {};
 
   planner = callPackage ../applications/office/planner { };
+  planner_stable = planner.stable;  # from the tarball on FTP
+  planner_unstable = planner.unstable;  # official GNOME Git
+  planner_unofficial = planner.unofficial;  # with more patches
 
   playonlinux = callPackage ../applications/misc/playonlinux {
      stdenv = stdenv_32bit;


### PR DESCRIPTION
Provide several versions of the package, trade-off preferences:

- stable: the official stable release, based on the tarball
- unstable: the official Git repository, very conservative
- unofficial: including few more of the proposed patches
  and enabling few more of the available features

###### Motivation for this change

Provide more choice.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).