### PR TITLE
neovim: neovim-ruby 0.3.1 -> 0.4.0

### DIFF
--- a/pkgs/applications/editors/neovim/ruby_provider/Gemfile.lock
+++ b/pkgs/applications/editors/neovim/ruby_provider/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    msgpack (1.0.2)
-    neovim (0.3.1)
+    msgpack (1.1.0)
+    neovim (0.5.0)
       msgpack (~> 1.0)
 
 PLATFORMS
@@ -12,4 +12,4 @@ DEPENDENCIES
   neovim
 
 BUNDLED WITH
-   1.12.5
+   1.15.1

--- a/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
+++ b/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
@@ -2,18 +2,18 @@
   msgpack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1fb2my91j08plsbbry5kilsrh7slmzgbbf6f55zy6xk28p9036lg";
+      sha256 = "0ck7w17d6b4jbb8inh1q57bghi9cjkiaxql1d3glmj1yavbpmlh7";
       type = "gem";
     };
-    version = "1.0.2";
+    version = "1.1.0";
   };
   neovim = {
     dependencies = ["msgpack"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1gvwa1zkirai7605x4hn2lynbw1caviga272iyy472jv7hs2zn92";
+      sha256 = "1da0ha3mz63iyihldp7185b87wx86jg07023xjhbng6i28y1ksn7";
       type = "gem";
     };
-    version = "0.4.0";
+    version = "0.5.0";
   };
 }

--- a/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
+++ b/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
@@ -11,9 +11,9 @@
     dependencies = ["msgpack"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "018mk4vqaxzbk4anq558h2rgj8prbn2rmi777iwrg3n0v8k5nxqw";
+      sha256 = "1gvwa1zkirai7605x4hn2lynbw1caviga272iyy472jv7hs2zn92";
       type = "gem";
     };
-    version = "0.3.1";
+    version = "0.4.0";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upgrade `neovim` ruby gem from 0.3.1 to 0.4.0.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

