### PR TITLE
xapian: fixup darwin

### DIFF
--- a/pkgs/development/libraries/xapian/default.nix
+++ b/pkgs/development/libraries/xapian/default.nix
@@ -18,6 +18,13 @@ let
 
     doCheck = true;
 
+    # the configure script thinks that Darwin has ___exp10
+    # but it’s not available on my systems (or hydra apparently)
+    postConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+      substituteInPlace config.h \
+        --replace "#define HAVE___EXP10 1" "#undef HAVE___EXP10"
+    '';
+
     meta = with stdenv.lib; {
       description = "Search engine library";
       homepage = http://xapian.org/;


### PR DESCRIPTION
The configure script is detecting that __exp10 is available even
though it isn’t on latest versions. This is the best fix I can find
for now.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

