### PR TITLE
shaarli: 0.8.1 -> 0.8.4

### DIFF
--- a/pkgs/servers/web-apps/shaarli/default.nix
+++ b/pkgs/servers/web-apps/shaarli/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "shaarli-${version}";
-  version = "0.8.1";
+  version = "0.8.4";
 
   src = fetchurl {
     url = "https://github.com/shaarli/Shaarli/releases/download/v${version}/shaarli-v${version}-full.tar.gz";
-    sha256 = "17p8bmkgmlan6vbvh955idddckr5kyf00gp8apjfcnm4b2awma8x";
+    sha256 = "1p6yljl8v8p74n71az1h68nnsvffw2hkcfk9p2dldspi4k51vnb7";
   };
 
   outputs = [ "out" "doc" ];


### PR DESCRIPTION
###### Motivation for this change

Update Shaarli version to 0.8.4 in order to fix a login bug (cf. https://github.com/shaarli/Shaarli/issues/711)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @schneefux 
---

