### PR TITLE
samsung-unified-linux-drive: Fix sane driver by patching rpaths

### DIFF
--- a/pkgs/misc/cups/drivers/samsung/default.nix
+++ b/pkgs/misc/cups/drivers/samsung/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glibc, cups, libusb, ghostscript }:
+{ stdenv, fetchurl, glibc, cups, libusb, libxml2, ghostscript }:
 
 let
 
@@ -18,6 +18,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     cups
     libusb
+    libxml2
   ];
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
@@ -76,6 +77,8 @@ in stdenv.mkDerivation rec {
   done
 
   patchelf --set-rpath "$out/lib:${stdenv.lib.getLib cups}/lib" "$out/lib/libscmssc.so"
+
+  patchelf --set-rpath "$out/lib:${libxml2.out}/lib:${libusb.out}/lib" "$out/lib/sane/libsane-smfp.so.1.0.1"
 
   ln -s ${stdenv.cc.cc.lib}/lib/libstdc++.so.6 $out/lib/
 


### PR DESCRIPTION
Patch rpaths to libxml2 and libusb. Makes the sane driver usable with my Samsung printer.