### PR TITLE
openafs: 1.6.20 -> 1.6.20.2

### DIFF
--- a/pkgs/servers/openafs-client/default.nix
+++ b/pkgs/servers/openafs-client/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "openafs-${version}-${kernel.version}";
-  version = "1.6.20";
+  version = "1.6.20.2";
 
   src = fetchurl {
     url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    sha256 = "0qar94k9x9dkws4clrnlw789q1ha9qjk06356s86hh78qwywc1ki";
+    sha256 = "50234820c3da9752d2ca05fb7e83b7dc5c96a0e96a0b875ebc7ae3c835607614";
   };
 
   nativeBuildInputs = [ autoconf automake flex yacc perl which ];
@@ -47,7 +47,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = [ maintainers.z77z ];
     broken =
-      (builtins.compareVersions kernel.version  "3.18" == -1) ||
-      (builtins.compareVersions kernel.version "4.4" != -1);
+      (builtins.compareVersions kernel.version  "3.18" == -1);
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

