### PR TITLE
diary: init at 0.3

### DIFF
--- a/pkgs/applications/misc/diary/default.nix
+++ b/pkgs/applications/misc/diary/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, ncurses, readline }:
+
+stdenv.mkDerivation rec {
+  version = "0.3";
+  name = "diary-${version}";
+
+  src = fetchFromGitHub {
+    owner = "in0rdr";
+    repo = "diary";
+    rev = "v${version}";
+    sha256 = "0sda8hrnhs7zvl10iri6srllcimi719yvzn22g9jmiryi9sllay6";
+  };
+
+  buildInputs = [ ncurses readline ];
+
+  installPhase = ''
+    mkdir $out/bin -p
+    mkdir $out/share/man/ -p
+    PREFIX=$out make install
+  '';
+
+  meta = {
+    homepage = "https://github.com/in0rdr/diary";
+    description = "Simple CLI diary";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/applications/misc/diary/default.nix
+++ b/pkgs/applications/misc/diary/default.nix
@@ -13,11 +13,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses readline ];
 
-  installPhase = ''
+  preInstalledPhase = ''
     mkdir $out/bin -p
     mkdir $out/share/man/ -p
-    PREFIX=$out make install
   '';
+
+  installFlags = [ "PREFIX=\${out}" ];
 
   meta = {
     homepage = "https://github.com/in0rdr/diary";

--- a/pkgs/applications/misc/diary/default.nix
+++ b/pkgs/applications/misc/diary/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation rec {
     description = "Simple CLI diary";
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/misc/diary/default.nix
+++ b/pkgs/applications/misc/diary/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses readline ];
 
-  preInstalledPhase = ''
+  preInstall = ''
     mkdir $out/bin -p
     mkdir $out/share/man/ -p
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -94,6 +94,8 @@ with pkgs;
 
   cmark = callPackage ../development/libraries/cmark { };
 
+  diary = callPackage ../applications/misc/diary { };
+
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {
     inherit (haskellPackages) dhall-nix;
   };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

