### PR TITLE
pythonPackages.natsort: refactor, update and fix

### DIFF
--- a/pkgs/development/python-modules/natsort/default.nix
+++ b/pkgs/development/python-modules/natsort/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, hypothesis
+, pytestcache
+, pytestcov
+, pytestflakes
+, pytestpep8
+, pytest
+, mock
+, pathlib ? null
+}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "natsort";
+  version = "5.0.1";
+
+  buildInputs = [
+    hypothesis
+    pytestcache
+    pytestcov
+    pytestflakes
+    pytestpep8
+    pytest
+    mock
+  ]
+  # pathlib was made part of standard library in 3.5:
+  ++ (lib.optionals (pythonOlder "3.4") [ pathlib ]);
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4ad6b4d1153451e345967989bd3ca30abf33f615b116eeadfcc51a456e6974a9";
+  };
+
+  meta = {
+    description = "Natural sorting for python";
+    homepage = https://github.com/SethMMorton/natsort;
+    license = lib.licenses.mit;
+    broken = true;
+  };
+}

--- a/pkgs/development/python-modules/natsort/default.nix
+++ b/pkgs/development/python-modules/natsort/default.nix
@@ -8,7 +8,8 @@
 , pytestflakes
 , pytestpep8
 , pytest
-, mock
+, glibcLocales
+, mock ? null
 , pathlib ? null
 }:
 
@@ -24,20 +25,30 @@ buildPythonPackage rec {
     pytestflakes
     pytestpep8
     pytest
-    mock
+    glibcLocales
   ]
   # pathlib was made part of standard library in 3.5:
-  ++ (lib.optionals (pythonOlder "3.4") [ pathlib ]);
+  ++ (lib.optionals (pythonOlder "3.4") [ pathlib ])
+  # based on testing-requirements.txt:
+  ++ (lib.optionals (pythonOlder "3.3") [ mock ]);
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "1h87n0jcsi6mgjx1pws6g1lmcn8jwabwxj8hq334jvziaq0plyym";
   };
 
+  # do not run checks on nix_run_setup.py
+  patches = [ ./setup.patch ];
+
+  # testing based on project's tox.ini
+  checkPhase = ''
+    pytest --doctest-modules natsort
+    pytest --flakes --pep8 --cov natsort --cov-report term-missing
+  '';
+
   meta = {
     description = "Natural sorting for python";
     homepage = https://github.com/SethMMorton/natsort;
     license = lib.licenses.mit;
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/natsort/default.nix
+++ b/pkgs/development/python-modules/natsort/default.nix
@@ -15,7 +15,7 @@
 buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "natsort";
-  version = "5.0.1";
+  version = "5.0.3";
 
   buildInputs = [
     hypothesis
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4ad6b4d1153451e345967989bd3ca30abf33f615b116eeadfcc51a456e6974a9";
+    sha256 = "1h87n0jcsi6mgjx1pws6g1lmcn8jwabwxj8hq334jvziaq0plyym";
   };
 
   meta = {

--- a/pkgs/development/python-modules/natsort/setup.patch
+++ b/pkgs/development/python-modules/natsort/setup.patch
@@ -1,0 +1,20 @@
+diff --git a/setup.cfg b/setup.cfg
+index 604994d..e38c3ec 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -6,6 +6,7 @@ formats = gztar
+ 
+ [tool:pytest]
+ flakes-ignore = 
++	nix_run_setup.py ALL
+ 	natsort/compat/py23.py UndefinedName
+ 	natsort/__init__.py UnusedImport
+ 	natsort/compat/* UnusedImport
+@@ -14,6 +15,7 @@ flakes-ignore =
+ 	test_natsort/test_locale_help.py UnusedImport RedefinedWhileUnused
+ 	test_natsort/compat/* UnusedImport
+ pep8ignore = 
++	nix_run_setup.py ALL
+ 	natsort/ns_enum.py E126 E241 E123 E221
+ 	test_natsort/test_*.py E501 E241 E221
+ 	test_natsort/test_natsort_keygen.py E501 E241 E221 E701

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8193,34 +8193,7 @@ in {
     };
   };
 
-  natsort = buildPythonPackage rec {
-    name = "natsort-5.0.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/n/natsort/${name}.tar.gz";
-      sha256 = "4ad6b4d1153451e345967989bd3ca30abf33f615b116eeadfcc51a456e6974a9";
-    };
-
-    buildInputs = with self;
-      [
-        hypothesis
-        pytestcache
-        pytestcov
-        pytestflakes
-        pytestpep8
-        pytest
-        mock
-      ]
-      # pathlib was made part of standard library in 3.5:
-      ++ (optionals (pythonOlder "3.4") [ pathlib ]);
-
-    meta = {
-      description = "Natural sorting for python";
-      homepage = https://github.com/SethMMorton/natsort;
-      license = licenses.mit;
-      broken = true;
-    };
-  };
+  natsort = callPackage ../development/python-modules/natsort { };
 
   logster = buildPythonPackage {
     name = "logster-7475c53822";


### PR DESCRIPTION
###### Motivation for this change

Move natsort from python-packages.nix to a separate file under python-modules. Update the version. Fix broken status (though not sure why it was marked broken originally by @FRidh).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

