### PR TITLE
pythonPackages.elasticsearch: 1.9.0 -> 2.4.1

### DIFF
--- a/pkgs/development/python-modules/elasticsearch/default.nix
+++ b/pkgs/development/python-modules/elasticsearch/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "elasticsearch";
+  version = "2.4.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fead47ebfcaabd1c53dbfc21403eb99ac207eef76de8002fe11a1c8ec9589ce2";
+  };
+
+  # Tests are not distributed
+  doCheck = false;
+
+  propagatedBuildInputs = [ urllib3 ];
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/elastic/elasticsearch-py";
+    license = licenses.asl20;
+    description = "Python client for Elasticsearch";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6418,7 +6418,7 @@ in {
 
   edward = callPackage ../development/python-modules/edward { };
 
-  elasticsearch = buildPythonPackage (rec {
+  elasticsearch_1 = buildPythonPackage (rec {
     name = "elasticsearch-1.9.0";
 
     src = pkgs.fetchurl {
@@ -6440,6 +6440,7 @@ in {
     };
   });
 
+  elasticsearch = callPackage ../development/python-modules/elasticsearch{ };
 
   elasticsearchdsl = buildPythonPackage (rec {
     name = "elasticsearch-dsl-0.0.9";
@@ -19588,7 +19589,7 @@ in {
 
     # Tests require a local instance of elasticsearch
     doCheck = false;
-    propagatedBuildInputs = with self; [ elasticsearch six simplejson certifi ];
+    propagatedBuildInputs = with self; [ elasticsearch_1 six simplejson certifi ];
     buildInputs = with self; [ nose mock ];
 
     meta = {


### PR DESCRIPTION
Since the latest version of pythonPackages.pyelasticsearch requires
pythonPackages.elasticsearch < 2, we preserve the old version.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

