### PR TITLE
awesome: Allows awesome to load svg images.

### DIFF
--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub, luaPackages, cairo, cmake, imagemagick, pkgconfig, gdk_pixbuf
+{ stdenv, fetchurl, fetchFromGitHub, luaPackages, cairo, librsvg, cmake, imagemagick, pkgconfig, gdk_pixbuf
 , xorg, libstartup_notification, libxdg_basedir, libpthreadstubs
 , xcb-util-cursor, makeWrapper, pango, gobjectIntrospection, unclutter
 , compton, procps, iproute, coreutils, curl, alsaUtils, findutils, xterm
@@ -30,7 +30,7 @@ with luaPackages; stdenv.mkDerivation rec {
   ];
    
   propagatedUserEnvPkgs = [ hicolor_icon_theme ];
-  buildInputs = [ cairo dbus gdk_pixbuf gobjectIntrospection
+  buildInputs = [ cairo librsvg dbus gdk_pixbuf gobjectIntrospection
                   git lgi libpthreadstubs libstartup_notification
                   libxdg_basedir lua nettools pango xcb-util-cursor
                   xorg.libXau xorg.libXdmcp xorg.libxcb xorg.libxshmfence
@@ -54,6 +54,7 @@ with luaPackages; stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/awesome \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
       --prefix LUA_CPATH ";" '"${lgi}/lib/lua/${lua.luaversion}/?.so"' \
       --prefix LUA_PATH ";" '"${lgi}/share/lua/${lua.luaversion}/?.lua;${lgi}/share/lua/${lua.luaversion}/lgi/?.lua"' \
       --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \


### PR DESCRIPTION
> Awesome can load SVG images, just like it can do PNG, through gdk.
> 
> The support for SVG images through GDK needs librvsg.
> 
> This commits adds the plumbing necessary in the wrapper that makes
> awesome be able to load SVG images.
> 
> Without this, awesome will not load SVG images. The related error message is:
> 
>  > Couldn't recognize the image file format for file
> 
> Which comes from gdk.

###### Motivation for this change

My `awesome` configuration uses SVG images. Awesome does support SVG images. Adding librsvg as an input and the GDK thing to the wrapper makes it work.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

