### PR TITLE
spacy: added Explosion AI spaCy, thinc and related tools 

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -478,6 +478,7 @@
   schneefux = "schneefux <schneefux+nixos_pkg@schneefux.xyz>";
   schristo = "Scott Christopher <schristopher@konputa.com>";
   scolobb = "Sergiu Ivanov <sivanov@colimite.fr>";
+  sdll = "Sasha Illarionov <sasha.delly@gmail.com>";
   sepi = "Raffael Mancini <raffael@mancini.lu>";
   seppeljordan = "Sebastian Jordan <sebastian.jordan.mail@googlemail.com>";
   shanemikel = "Shane Pearlman <shanemikel1@gmail.com>";

--- a/pkgs/development/python-modules/cymem/default.nix
+++ b/pkgs/development/python-modules/cymem/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, cython
+, python
+}:
+buildPythonPackage rec {
+  name = "cymem-${version}";
+  version = "1.31.2";
+
+  src = fetchFromGitHub {
+    owner = "explosion";
+    repo = "cymem";
+    rev = "1.31.2";
+    sha256 = "0miznr4kbdzw8yik3m96jmrlmln4qv7z3i3qdp7wjqr51zpqfm1k";
+  };
+
+  propagatedBuildInputs = [
+   cython   
+  ];
+    
+  checkPhase = ''
+    cd cymem/tests
+    ${python.interpreter} -m unittest discover -p "*test*"
+  '';
+  
+  meta = with stdenv.lib; {
+    description = "Cython memory pool for RAII-style memory management";
+    homepage = https://github.com/explosion/cymem;
+    license = licenses.mit;
+    maintainers = with maintainers; [ sdll ];
+    };
+}

--- a/pkgs/development/python-modules/ftfy/default.nix
+++ b/pkgs/development/python-modules/ftfy/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, html5lib
+, wcwidth
+, nose
+, python
+}:
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "ftfy";
+  version = "4.4.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "152xdb56rhs1q4r0ck1n557sbphw7zq18r75a7kkd159ckdnc01w";        
+  };
+
+  propagatedBuildInputs = [ html5lib wcwidth];
+
+  buildInputs = [
+    nose
+  ];
+
+  checkPhase = ''
+    nosetests -v
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Given Unicode text, make its representation consistent and possibly less broken.";
+    homepage = https://github.com/LuminosoInsight/python-ftfy/tree/master/tests;
+    license = licenses.mit;
+    maintainers = with maintainers; [ sdll ];    
+    };
+}

--- a/pkgs/development/python-modules/murmurhash/default.nix
+++ b/pkgs/development/python-modules/murmurhash/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, cython
+, python
+}:
+
+buildPythonPackage rec {
+  name = "murmurhash-${version}";
+  version = "0.26.4";
+  
+  src = fetchFromGitHub {
+    owner = "explosion";
+    repo = "murmurhash";
+    rev = "0.26.4";
+    sha256 = "0n2j0glhlv2yh3fjgbg4d79j1c1fpchgjd4vnpw908l9mzchhmdv";    
+  };
+
+  buildInputs = [
+   cython
+  ];
+  
+  checkPhase = ''
+    cd murmurhash/tests
+    ${python.interpreter} -m unittest discover -p "*test*"
+  '';
+  
+  meta = with stdenv.lib; {
+    description = "Cython bindings for MurmurHash2";
+    homepage = https://github.com/explosion/murmurhash;
+    license = licenses.mit;
+    maintainers = with maintainers; [ sdll ];
+    };
+}

--- a/pkgs/development/python-modules/plac/default.nix
+++ b/pkgs/development/python-modules/plac/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, python
+}:
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "plac";
+  version = "0.9.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16zqpalx4i1n1hrcvaj8sdixapy2g76fc13bbahz0xc106d72gxs";
+  };
+
+  checkPhase = ''
+      cd doc
+      ${python.interpreter} -m unittest discover -p "*test_plac*"
+    '';
+  
+  meta = with stdenv.lib; {
+    description = "Parsing the Command Line the Easy Way";
+    homepage = https://github.com/micheles/plac;
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ sdll ];
+    };
+}

--- a/pkgs/development/python-modules/preshed/default.nix
+++ b/pkgs/development/python-modules/preshed/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pytest
+, cython
+, cymem
+, python
+}:
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "preshed";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1pdl4p2d32ficfh18xdkgsj6ajzdxc6mxhhf84z0wq1l8viskcx6";
+  };
+
+  propagatedBuildInputs = [
+   cython
+   cymem
+  ];
+  buildInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} setup.py test
+  '';
+  
+  meta = with stdenv.lib; {
+    description = "Cython hash tables that assume keys are pre-hashed";
+    homepage = https://github.com/explosion/preshed;
+    license = licenses.mit;
+    maintainers = with maintainers; [ sdll ];
+    };
+}

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -1,0 +1,76 @@
+{ stdenv
+, pkgs
+, buildPythonPackage
+, python
+, fetchPypi
+, fetchFromGitHub
+, pytest 
+, cython
+, cymem
+, preshed
+, pathlib2
+, numpy
+, murmurhash
+, plac
+, six
+, ujson
+, dill
+, requests
+, ftfy
+, thinc
+, pip
+}:
+let
+  enableDebugging = true;
+  regexLocked = buildPythonPackage rec {
+    name = "${pname}-${version}";
+    pname = "regex";
+    version = "2017.04.05";
+
+    src = fetchPypi {
+      inherit pname version;      
+      sha256 = "0c95gf3jzz8mv52lkgq0h7sbasjwvdhghm4s0phmy5k9sr78f4fq";
+    };
+  };
+in buildPythonPackage rec {
+  name = "spacy-${version}";
+  version = "1.8.2";
+
+  src = fetchFromGitHub {
+    owner = "explosion";
+    repo = "spaCy";
+    rev = "v${version}";
+    sha256 = "0v3bmmar31a6968y4wl0lmgnc3829l2mnwd8s959m4pqw1y1w648";    
+  };  
+
+  propagatedBuildInputs = [
+   cython
+   cymem
+   pathlib2
+   preshed
+   numpy
+   murmurhash
+   plac
+   six
+   ujson
+   dill
+   requests
+   regexLocked
+   ftfy
+   thinc
+   pytest
+   pip
+  ];
+
+  doCheck = false;
+  # checkPhase = ''
+  #   ${python.interpreter} -m pytest spacy/tests --vectors --models --slow
+  # '';  
+  
+  meta = with stdenv.lib; {
+    description = "Industrial-strength Natural Language Processing (NLP) with Python and Cython";
+    homepage = https://github.com/explosion/spaCy;
+    license = licenses.mit;
+    maintainers = with maintainers; [ sdll ];
+    };
+}

--- a/pkgs/development/python-modules/thinc/default.nix
+++ b/pkgs/development/python-modules/thinc/default.nix
@@ -1,0 +1,84 @@
+{ stdenv
+, pkgs
+, buildPythonPackage
+, fetchPypi
+, fetchFromGitHub
+, pytest
+, cython
+, cymem
+, preshed
+, numpy
+, python
+, murmurhash
+, hypothesis
+, tqdm
+, cytoolz
+, plac
+, six
+, mock
+, termcolor
+, wrapt
+, dill
+}:
+
+let
+  enableDebugging = true;
+
+  pathlibLocked = buildPythonPackage rec {
+    name = "${pname}-${version}";
+    pname = "pathlib";
+    version = "1.0.1";
+
+    src = fetchPypi {
+      inherit pname version;      
+      sha256 = "17zajiw4mjbkkv6ahp3xf025qglkj0805m9s41c45zryzj6p2h39";
+    };
+
+    doCheck = false; # fails to import support from test
+  };
+in buildPythonPackage rec {
+  name = "thinc-${version}";
+  version = "6.5.1";
+
+  src = fetchFromGitHub {
+    owner = "explosion";
+    repo = "thinc";
+    rev = "v${version}";
+    sha256 = "008kmjsvanh6qgnpvsn3qacfcyprxirxbw4yfd8flyg7mxw793ws";    
+  };
+
+  propagatedBuildInputs = [
+   cython
+   cymem
+   preshed
+   numpy
+   murmurhash
+   pytest
+   hypothesis
+   tqdm
+   cytoolz
+   plac
+   six
+   mock
+   termcolor
+   wrapt
+   dill
+   pathlibLocked
+  ];
+
+  doCheck = false;
+  
+  # fails to import some modules
+  # checkPhase = ''
+  #   ${python.interpreter} -m pytest thinc/tests
+  #   # cd thinc/tests
+  #   # ${python.interpreter} -m unittest discover -p "*test*"
+  # '';
+  
+  meta = with stdenv.lib; {
+    description = "Practical Machine Learning for NLP in Python";
+    homepage = https://github.com/explosion/thinc;
+    license = licenses.mit;
+    maintainers = with maintainers; [ sdll ];
+    };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31346,6 +31346,8 @@ EOF
 
   distro = callPackage ../development/python-modules/distro { };
 
+  cymem = callPackage ../development/python-modules/cymem { };    
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31348,6 +31348,8 @@ EOF
 
   cymem = callPackage ../development/python-modules/cymem { };    
 
+  ftfy = callPackage ../development/python-modules/ftfy { };    
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31350,6 +31350,8 @@ EOF
 
   ftfy = callPackage ../development/python-modules/ftfy { };    
 
+  murmurhash = callPackage ../development/python-modules/murmurhash { };      
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31352,11 +31352,11 @@ EOF
 
   murmurhash = callPackage ../development/python-modules/murmurhash { };      
 
-
   plac = callPackage ../development/python-modules/plac { };        
-
-
+  
   preshed = callPackage ../development/python-modules/preshed { };
+
+  thinc = callPackage ../development/python-modules/thinc { };  
 
 });
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31358,6 +31358,7 @@ EOF
 
   thinc = callPackage ../development/python-modules/thinc { };  
 
+  spacy = callPackage ../development/python-modules/spacy { };  
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31352,7 +31352,11 @@ EOF
 
   murmurhash = callPackage ../development/python-modules/murmurhash { };      
 
+
   plac = callPackage ../development/python-modules/plac { };        
+
+
+  preshed = callPackage ../development/python-modules/preshed { };
 
 });
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31352,6 +31352,8 @@ EOF
 
   murmurhash = callPackage ../development/python-modules/murmurhash { };      
 
+  plac = callPackage ../development/python-modules/plac { };        
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

Making NLP analysis easier with Nix.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

