### PR TITLE
chromedriver: Update and make available for linux-i686 and darwin

### DIFF
--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -1,19 +1,20 @@
 { stdenv, fetchurl, cairo, fontconfig, freetype, gdk_pixbuf, glib
 , glibc, gtk2, libX11, makeWrapper, nspr, nss, pango, unzip, gconf
-, libXi, libXrender, libXext
+, libXi, libXrender, libXext, lib
 }:
-
-# note: there is a i686 version available as well
-assert stdenv.system == "x86_64-linux";
-
+let
+  spec = if stdenv.system == "i686-linux" then { system="linux32"; sha256="5d267a8d59f18f1134966e312997b75976f8d816318b5b79b8357a3ac2c022da"; }
+    else if stdenv.system == "x86_64-linux" then { system="linux64"; sha256="d011749e76305b5591b5500897939b33fac460d705d9815b8c03c53b0e1ecc7c"; }
+    else if stdenv.system == "x86_64-darwin" then { system="mac64"; sha256="e95fb36ab85264e16c51d58dd9766624eca6b6339569da0460088f4c788c67ad"; }
+    else abort "missing chromedriver binary for ${stdenv.system}";
+in
 stdenv.mkDerivation rec {
-  product = "chromedriver_linux64";
-  name = "${product}-2.25";
+  name = "chromedriver-${version}";
   version = "2.25";
 
   src = fetchurl {
-    url = "http://chromedriver.storage.googleapis.com/${version}/${product}.zip";
-    sha256 = "0z6c3q73pi83iidq3n85sxhc9yikkf9rf22hnn8manrhfsg784fh";
+    url = "http://chromedriver.storage.googleapis.com/${version}/chromedriver_${spec.system}.zip";
+    sha256 = spec.sha256;
   };
 
   buildInputs = [ unzip makeWrapper ];
@@ -23,9 +24,9 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     mv chromedriver $out/bin
-    patchelf --set-interpreter ${glibc.out}/lib/ld-linux-x86-64.so.2 $out/bin/chromedriver
-    wrapProgram "$out/bin/chromedriver" \
-      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib cairo fontconfig freetype gdk_pixbuf glib gtk2 libX11 nspr nss pango libXrender gconf libXext libXi ]}:\$LD_LIBRARY_PATH"
+    ${lib.optionalString (!stdenv.isDarwin) "patchelf --set-interpreter ${glibc.out}/lib/ld-linux-x86-64.so.2 $out/bin/chromedriver"}
+    ${lib.optionalString (!stdenv.isDarwin) ''wrapProgram "$out/bin/chromedriver" \
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib cairo fontconfig freetype gdk_pixbuf glib gtk2 libX11 nspr nss pango libXrender gconf libXext libXi ]}:\$LD_LIBRARY_PATH"''}
   '';
 
   meta = with stdenv.lib; {
@@ -33,6 +34,6 @@ stdenv.mkDerivation rec {
     description = "A WebDriver server for running Selenium tests on Chrome";
     license = licenses.bsd3;
     maintainers = [ maintainers.goibhniu ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- Chromedriver was outdated
- Chromedriver is available on all systems so it can be packaged for all systems as well

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

