### PR TITLE
removing the advise to add virtualbox's guest additions in configuration.nix

### DIFF
--- a/nixos/doc/manual/installation/installing-virtualbox-guest.xml
+++ b/nixos/doc/manual/installation/installing-virtualbox-guest.xml
@@ -37,15 +37,7 @@
 </orderedlist>
 
 <para>
-  There are a few modifications you should make in configuration.nix. Enable
-  the virtualbox guest service in the main block:
-</para>
-
-<programlisting>
-virtualisation.virtualbox.guest.enable = true;
-</programlisting>
-
-<para>
+  There are a few modifications you should make in configuration.nix.
   Enable booting:
 </para>
 


### PR DESCRIPTION
... because `nixos-generate-config` currently understand it's running under virtualbox, and correctly adds the configuration in `/etc/nixos/hardware-configuration.nix`

###### Motivation for this change

clarity of manual

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

