### PR TITLE
terraform-inventory: init at 0.7-pre

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -220,6 +220,7 @@
   hinton = "Tom Hinton <t@larkery.com>";
   hodapp = "Chris Hodapp <hodapp87@gmail.com>";
   hrdinka = "Christoph Hrdinka <c.nix@hrdinka.at>";
+  htr = "Hugo Tavares Reis <hugo@linux.com>";
   iand675 = "Ian Duncan <ian@iankduncan.com>";
   ianwookim = "Ian-Woo Kim <ianwookim@gmail.com>";
   igsha = "Igor Sharonov <igor.sharonov@gmail.com>";

--- a/pkgs/applications/networking/cluster/terraform-inventory/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-inventory/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildGoPackage, fetchFromGitHub}:
+
+buildGoPackage rec {
+  name = "terraform-inventory-${version}";
+  version = "0.7-pre";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/adammck/terraform-inventory";
+
+  subPackages = [ "./" ];
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "adammck";
+    repo = "terraform-inventory";
+    sha256 = "0wwyi2nfyn3wfpmvj8aabn0cjba0lpr5nw3rgd6qdywy7sc3rmb1";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = {
+    homepage = https://github.com/adammck/terraform-inventory;
+    description = "Terraform state to ansible inventory adapter";
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/applications/networking/cluster/terraform-inventory/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-inventory/default.nix
@@ -18,10 +18,11 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/adammck/terraform-inventory;
     description = "Terraform state to ansible inventory adapter";
-    platforms = stdenv.lib.platforms.all;
-    license = stdenv.lib.licenses.mit;
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ htr ];
   };
 }

--- a/pkgs/applications/networking/cluster/terraform-inventory/deps.nix
+++ b/pkgs/applications/networking/cluster/terraform-inventory/deps.nix
@@ -1,0 +1,20 @@
+[
+  {
+    goPackagePath = "github.com/adammck/venv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/adammck/venv";
+      rev = "8a9c907a37d36a8f34fa1c5b81aaf80c2554a306";
+      sha256 = "1fzk3j4q59kpd2ks2aw8rmic6b123p5mh981cjh0kzs716grc6y8";
+    };
+  }
+  {
+    goPackagePath = "github.com/blang/vfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/blang/vfs";
+      rev = "c14afcac17253ce7418da751ec6b1988790cdc8f";
+      sha256 = "00q5qzxpn9n59nrmrljz4w9lljxvrr8i5j8i8b4iw86j0alcx53b";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18492,6 +18492,8 @@ with pkgs;
   terraform_0_9 = terraform_0_9_4;
   terraform = terraform_0_9;
 
+  terraform-inventory = callPackage ../applications/networking/cluster/terraform-inventory {};
+
   terragrunt = callPackage ../applications/networking/cluster/terragrunt {};
 
   terragrunt_0_11_1 = callPackage ../applications/networking/cluster/terragrunt/0.11.1.nix {


### PR DESCRIPTION
###### Motivation for this change
adds terraform-inventory

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

