### PR TITLE
znapzend service: fix autostart

### DIFF
--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -18,6 +18,7 @@ in
     systemd.services = {
       "znapzend" = {
         description = "ZnapZend - ZFS Backup System";
+        wantedBy    = [ "zfs.target" ];
         after       = [ "zfs.target" ];
 
         path = with pkgs; [ zfs mbuffer openssh ];
@@ -28,6 +29,5 @@ in
         };
       };
     };
-
   };
 }


### PR DESCRIPTION
###### Motivation for this change

PR #25009 fixed reload but autostart still didn't work (see https://github.com/NixOS/nixpkgs/issues/24438#issuecomment-294617200).

Turns out no systemd unit dependency was established.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

