### PR TITLE
astroid: 0.8 -> 0.9.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/astroid/default.nix
+++ b/pkgs/applications/networking/mailreaders/astroid/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "astroid-${version}";
-  version = "0.8";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "astroidmail";
     repo = "astroid";
     rev = "v${version}";
-    sha256 = "1gjrdls1mz8y8bca7s8l965l0m7s2sb6g7a90gy848admjsyav7h";
+    sha256 = "0ha2jd3fvc54amh0x8f58s9ac4r8xgyhvkwd4jvs0h4mfh6cg496";
   };
 
   nativeBuildInputs = [ scons pkgconfig wrapGAppsHook ];


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Updating `astroid` as it's been bumped 👼 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

