### PR TITLE
gnutls: 3.5.11 -> 3.5.12

### DIFF
--- a/pkgs/development/libraries/gnutls/3.5.nix
+++ b/pkgs/development/libraries/gnutls/3.5.nix
@@ -1,11 +1,11 @@
 { callPackage, fetchurl, libunistring, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "3.5.11";
+  version = "3.5.12";
 
   src = fetchurl {
     url = "ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5/gnutls-${version}.tar.xz";
-    sha256 = "13z2dxxyrsb7gfpl1k2kafqh2zaigi872y5xgykhs9cyaz2mqxji";
+    sha256 = "1jspvrmydqgz30c1ji94b55gr2dynz7p96p4y8fkhad0xajkkjv3";
   };
 
   # Skip two tests introduced in 3.5.11.  Probable reasons of failure:


### PR DESCRIPTION
###### Motivation for this change

Update gnutls to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

