### PR TITLE
ripgrep: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -4,16 +4,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "ripgrep-${version}";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "BurntSushi";
     repo = "ripgrep";
     rev = "${version}";
-    sha256 = "1fbvc419gh1rix8v3bh9a63r993kvfizp49p5ps6y22wggpy0k77";
+    sha256 = "128sfczms14zgfbhgmf84jjlivd4q6i581rxirhz3kmpnnby18rz";
   };
 
-  depsSha256 = "0vyrcgcmlf3lbp15nip2cm8xv4n6qldfbl0iwy3jb69i2mazi6nm";
+  depsSha256 = "1kjmv4bn5sicx8g5gyzq2zhxmqsqlgckhcg4ypvnjmcyq1ifiv2m";
 
   preFixup = ''
     mkdir -p "$out/man/man1"

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,9 +7,9 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2017-05-03";
-  rev = "dbc41da97da0a504d83af656b5d354ab5cf033e6";
-  sha256 = "1kmy0hr155gcmilvwaj4ak5ppszrympyia7zxwhfihh00mip7xkb";
+  version = "2017-05-15";
+  rev = "c73d61e84a623168a1a9bfff9c71defcc3416631";
+  sha256 = "0c2f4f48bacx0lq33bjw806fq5r4nvbrxvl74n7gd2y44ldafnir";
 
   src = fetchFromGitHub {
       inherit rev;


### PR DESCRIPTION
###### Motivation for this change

Update ripgrep to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

