### PR TITLE
opencv: Fix OpenCV build on non NixOS platform

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -78,6 +78,12 @@ stdenv.mkDerivation rec {
         ln -s "${bootdescFiles}/$name" "$NIX_BUILD_TOP/opencv_contrib/xfeatures2d/src/$name"
       done
     '');
+
+  # This prevents cmake from using libraries in impure paths (which causes build failure on non NixOS)
+  postPatch = ''
+    sed -i '/Add these standard paths to the search paths for FIND_LIBRARY/,/^\s*$/{d}' CMakeLists.txt
+  '';
+
   preConfigure =
     (let version  = "20151201";
          md5      = "808b791a6eac9ed78d32a7666804320e";

--- a/pkgs/development/libraries/opencv/default.nix
+++ b/pkgs/development/libraries/opencv/default.nix
@@ -35,6 +35,11 @@ stdenv.mkDerivation rec {
       ./no-build-info.patch
     ];
 
+  # This prevents cmake from using libraries in impure paths (which causes build failure on non NixOS)
+  postPatch = ''
+    sed -i '/Add these standard paths to the search paths for FIND_LIBRARY/,/^\s*$/{d}' CMakeLists.txt
+  '';
+
   outputs = [ "out" "dev" ];
 
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change

Fixes #21994

I solve this issue by deleting [this paragraph](https://github.com/opencv/opencv/blob/f34b2f7b8d10271d0e16bcab174bdacd51365f4f/CMakeLists.txt#L137-L163)

To reproduce this issue, a distro which have libraries symlinked in `/lib` and `/lib64` is needed. (i.e Arch Linux)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Edit: I forgot to put opencv in title, now fixed.