### PR TITLE
eventstore 3.5.0 -> 3.9.4

### DIFF
--- a/pkgs/servers/nosql/eventstore/default.nix
+++ b/pkgs/servers/nosql/eventstore/default.nix
@@ -5,12 +5,12 @@
 
 stdenv.mkDerivation rec {
   name = "EventStore-${version}";
-  version = "3.5.0";
+  version = "3.9.4";
   src = fetchFromGitHub {
     owner  = "EventStore";
     repo   = "EventStore";
     rev    = "oss-v${version}";
-    sha256 = "0dp5914hxwdzw62q49wavqfqkw3jy0dvml09y7gh8frnbiajcxq9";
+    sha256 = "1mi0qzxpc8342dikx039qgy3wqyskk67c8awbsx7x3ljxkifi807";
   };
 
   buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Need a more current version of EventStore (3.5.0 is outdated).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

