### PR TITLE
pythonPackages.PyRSS2Gen: fix sha256

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20511,7 +20511,7 @@ in {
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "4929d022713129401160fd47550d5158931e4ea6a7136b5d8dfe3b13ac16f2f0";
+      sha256 = "1rvf5jw9hknqz02rp1vg8abgb1lpa0bc65l7ylmlillqx7bswq3r";
     };
 
     # No tests in archive


### PR DESCRIPTION

###### Motivation for this change

The old hash caused version 1.0 version to be installed instead of 1.1, for some
reason.

With old hash:
```
$ nix-shell --pure -p pythonPackages.PyRSS2Gen -p pythonPackages.pip --run "pip freeze"
PyRSS2Gen==1.0
```

With this fix:
```
$ nix-shell --pure -p pythonPackages.PyRSS2Gen -p pythonPackages.pip --run "pip freeze"
PyRSS2Gen==1.1
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

