### PR TITLE
on error, add a reference to the configuration file

### DIFF
--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -30,6 +30,7 @@ let
       cd $out/zones
 
       for zoneFile in *; do
+        echo "|- checking zone '$out/zones/$zoneFile'"
         ${nsdPkg}/sbin/nsd-checkzone "$zoneFile" "$zoneFile" || {
           if grep -q \\\\\\$ "$zoneFile"; then
             echo zone "$zoneFile" contains escaped dollar signes \\\$


### PR DESCRIPTION
###### Motivation for this change
error statement now includes the `zone file` in question which enables 'reasonable' debugging!

```
[root@nixdoc:~/nixpkgs_nsd]# nixos-rebuild -I nixpkgs=. switch
building Nix...
building the system configuration...
these derivations will be built:
  /nix/store/318a7mhwlz1x0cy4hl1259n8x9z0jacy-nsd-env.drv
  /nix/store/fnbhk8grwk7vfdk3gby49bv6kml8hjcc-unit-script.drv
  /nix/store/xf80mq1f1c3pm37fci0vi5ixy4gb1rcp-unit-nsd.service.drv
  /nix/store/bfmkkykqksmvkhvh3ppl36k86lbw9v4i-system-units.drv
  /nix/store/ja97mwl2r0wdrxccl82dx8jln7jlmnyb-etc.drv
  /nix/store/yh8m6b3j8vapz2r1wzffq8zq09j56q8p-nixos-system-nixdoc.io-17.09.git.0afb6d7.drv
building path(s) ‘/nix/store/sg7w3k6qg2yr02a0sbrgbv5yiqn9pzcq-nsd-env’
created 2 symlinks in user environment
checking zone files
|- checking zone '/nix/store/sg7w3k6qg2yr02a0sbrgbv5yiqn9pzcq-nsd-env/zones/lastlog.de.'
[2017-05-16 10:30:34.628] nsd-checkzone[27696]: error: lastlog.de.:17: syntax error
[2017-05-16 10:30:34.628] nsd-checkzone[27696]: error: lastlog.de.:17: unrecognized RR type 'lastlog'
zone lastlog.de. file lastlog.de. has 2 errors
builder for ‘/nix/store/318a7mhwlz1x0cy4hl1259n8x9z0jacy-nsd-env.drv’ failed with exit code 1
cannot build derivation ‘/nix/store/xf80mq1f1c3pm37fci0vi5ixy4gb1rcp-unit-nsd.service.drv’: 1 dependencies couldn't be built
cannot build derivation ‘/nix/store/bfmkkykqksmvkhvh3ppl36k86lbw9v4i-system-units.drv’: 1 dependencies couldn't be built
cannot build derivation ‘/nix/store/ja97mwl2r0wdrxccl82dx8jln7jlmnyb-etc.drv’: 1 dependencies couldn't be built
cannot build derivation ‘/nix/store/yh8m6b3j8vapz2r1wzffq8zq09j56q8p-nixos-system-nixdoc.io-17.09.git.0afb6d7.drv’: 1 dependencies couldn't be built
error: build of ‘/nix/store/yh8m6b3j8vapz2r1wzffq8zq09j56q8p-nixos-system-nixdoc.io-17.09.git.0afb6d7.drv’ failed
```
