### PR TITLE
varnish: 5.0.0 -> 5.1.2

### DIFF
--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -49,7 +49,6 @@ with lib;
       postStop = ''
         rm -rf ${cfg.stateDir}
       '';
-      path = [ pkgs.gcc ];
       serviceConfig.ExecStart = "${pkgs.varnish}/sbin/varnishd -a ${cfg.http_address} -f ${pkgs.writeText "default.vcl" cfg.config} -n ${cfg.stateDir} -u varnish";
       serviceConfig.Type = "forking";
     };

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -1,22 +1,26 @@
 { stdenv, fetchurl, pcre, libxslt, groff, ncurses, pkgconfig, readline, libedit
-, python, pythonPackages }:
+, python, pythonPackages, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  version = "5.0.0";
+  version = "5.1.2";
   name = "varnish-${version}";
 
   src = fetchurl {
     url = "http://repo.varnish-cache.org/source/${name}.tar.gz";
-    sha256 = "0jizha1mwqk42zmkrh80y07vfl78mg1d9pp5w83qla4xn9ras0ai";
+    sha256 = "1qzwljdwp830l41nw4ils9hxly077zqn6wzhhmy8m516gq9min1r";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     pcre libxslt groff ncurses readline python libedit
-    pythonPackages.docutils
+    pythonPackages.docutils makeWrapper
   ];
 
   buildFlags = "localstatedir=/var/spool";
+
+  postInstall = ''
+    wrapProgram "$out/sbin/varnishd" --prefix PATH : "${stdenv.lib.makeBinPath [ stdenv.cc ]}"
+  '';
 
   # https://github.com/varnishcache/varnish-cache/issues/1875
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isi686 "-fexcess-precision=standard";


### PR DESCRIPTION
###### Motivation for this change

Varnish 5.0.0 is [retired](https://varnish-cache.org/releases/index.html), so updating a the latest fresh version.
This also add the gcc runtime dependency to `varnishd` so it can be used directly, and remove the gcc runtime dependency from the varnish module as it is not needed anymore.

cc @garbas @fpletz 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

