### PR TITLE
Fish: source NixOS environment on non-login shells + source shell init on NixOS even when parent shell has done so

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -45,10 +45,15 @@ let
   '';
 
   fishPreInitHooks = ''
-    # source nixos environment if we're a login shell
+    # source nixos environment
+    # note that this is required:
+    #   1. For all shells, not just login shells (mosh needs this as do some other command-line utilities)
+    #   2. Before the shell is initialized, so that config snippets can find the commands they use on the PATH
     builtin status --is-login
+    or test -z "$__fish_nixos_env_preinit_sourced" -a -z "$ETC_PROFILE_SOURCED" -a -z "$ETC_ZSHENV_SOURCED"
     and test -f /etc/fish/nixos-env-preinit.fish
     and source /etc/fish/nixos-env-preinit.fish
+    and set -gx __fish_nixos_env_preinit_sourced 1
 
     test -n "$NIX_PROFILES"
     and begin


### PR DESCRIPTION
###### Motivation for this change
This fixes two new issues (#25800 and #25789) related to fish initialization (they are mentioned in the commit names)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This will need to be cherry-picked ahead to the master branch; I am on vacation and with shoddy/expensive/intermittent internet access, so I can't rebase and test on master right now because I'm running nixos-17.03 on this laptop and my connection is too slow for me to rebuild everything and test.