### PR TITLE
v8: fixes darwin build

### DIFF
--- a/pkgs/development/libraries/v8/no-xcode.patch
+++ b/pkgs/development/libraries/v8/no-xcode.patch
@@ -1,0 +1,64 @@
+--- a/tools/gyp/pylib/gyp/xcode_emulation.py
++++ a/tools/gyp/pylib/gyp/xcode_emulation.py
+@@ -473,10 +473,16 @@
+ 
+   def _XcodeSdkPath(self, sdk_root):
+     if sdk_root not in XcodeSettings._sdk_path_cache:
+-      sdk_path = self._GetSdkVersionInfoItem(sdk_root, '--show-sdk-path')
+-      XcodeSettings._sdk_path_cache[sdk_root] = sdk_path
+-      if sdk_root:
+-        XcodeSettings._sdk_root_cache[sdk_path] = sdk_root
++      try:
++        sdk_path = self._GetSdkVersionInfoItem(sdk_root, '--show-sdk-path')
++        XcodeSettings._sdk_path_cache[sdk_root] = sdk_path
++        if sdk_root:
++          XcodeSettings._sdk_root_cache[sdk_path] = sdk_root
++      except:
++        # if this fails it's because xcodebuild failed, which means
++        # the user is probably on a CLT-only system, where there
++        # is no valid SDK root
++        XcodeSettings._sdk_path_cache[sdk_root] = None
+     return XcodeSettings._sdk_path_cache[sdk_root]
+ 
+   def _AppendPlatformVersionMinFlags(self, lst):
+@@ -606,10 +612,11 @@
+       framework_root = sdk_root
+     else:
+       framework_root = ''
+-    config = self.spec['configurations'][self.configname]
+-    framework_dirs = config.get('mac_framework_dirs', [])
+-    for directory in framework_dirs:
+-      cflags.append('-F' + directory.replace('$(SDKROOT)', framework_root))
++    if 'SDKROOT' in self._Settings():
++      config = self.spec['configurations'][self.configname]
++      framework_dirs = config.get('mac_framework_dirs', [])
++      for directory in framework_dirs:
++        cflags.append('-F' + directory.replace('$(SDKROOT)', framework_root))
+ 
+     self.configname = None
+     return cflags
+@@ -861,10 +868,11 @@
+     sdk_root = self._SdkPath()
+     if not sdk_root:
+       sdk_root = ''
+-    config = self.spec['configurations'][self.configname]
+-    framework_dirs = config.get('mac_framework_dirs', [])
+-    for directory in framework_dirs:
+-      ldflags.append('-F' + directory.replace('$(SDKROOT)', sdk_root))
++    if 'SDKROOT' in self._Settings():
++      config = self.spec['configurations'][self.configname]
++      framework_dirs = config.get('mac_framework_dirs', [])
++      for directory in framework_dirs:
++        ldflags.append('-F' + directory.replace('$(SDKROOT)', sdk_root))
+ 
+     platform_root = self._XcodePlatformPath(configname)
+     if sdk_root and platform_root and self._IsXCTest():
+@@ -1358,7 +1366,7 @@
+     if version:
+       version = re.match(r'(\d\.\d\.?\d*)', version).groups()[0]
+     else:
+-      raise GypError("No Xcode or CLT version detected!")
++      version = "7.0.0"
+     # The CLT has no build information, so we return an empty string.
+     version_list = [version, '']
+   version = version_list[0]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10198,6 +10198,7 @@ with pkgs;
 
   v8 = callPackage ../development/libraries/v8 {
     inherit (python2Packages) python gyp;
+    cctools = darwin.cctools;
   };
 
   v8_static = lowPrio (self.v8.override { static = true; });


### PR DESCRIPTION
###### Motivation for this change
v8 compilation on macOS was failing because of missing dependency and wrong linker. This PR fixes those problems.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

