### PR TITLE
rdkafka: fixes darwin build

### DIFF
--- a/pkgs/development/libraries/rdkafka/default.nix
+++ b/pkgs/development/libraries/rdkafka/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-Wno-error=strict-overflow";
 
+  configureFlags = stdenv.lib.optionals stdenv.isDarwin [ "--disable-ssl" ];
+
   postPatch = ''
     patchShebangs .
   '';
@@ -23,7 +25,7 @@ stdenv.mkDerivation rec {
     description = "librdkafka - Apache Kafka C/C++ client library";
     homepage = "https://github.com/edenhill/librdkafka";
     license = licenses.bsd2;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ boothead wkennington ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Fixes build on macOS. It was failing because the `./configure` was erroneously detecting incompatible SSL library. Disabling it during that step means that the library can be successfully build. The lack of SSL support is the same as the default for Linux.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

