### PR TITLE
flat-plat: 20170323 -> 20170515

### DIFF
--- a/pkgs/misc/themes/flat-plat/default.nix
+++ b/pkgs/misc/themes/flat-plat/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "flat-plat-gtk-theme-${version}";
-  version = "20170323";
+  version = "20170515";
 
   src = fetchFromGitHub {
     owner = "nana-4";
     repo = "Flat-Plat";
     rev = "v${version}";
-    sha256 = "18s05x5qkl9cwywd01498xampyya1lnpjyyknj61qxxw5rsgay9y";
+    sha256 = "0z0l9ch6symcjhbfkj1q5i46ajbn7l7slhjgrcjm0ppqh05xc4y7";
   };
 
   nativeBuildInputs = [ gnome3.glib libxml2 ];


### PR DESCRIPTION
###### Motivation for this change

Update to a new [release](https://github.com/nana-4/Flat-Plat/releases/tag/v20170515).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).