### PR TITLE
sift: fix build for darwin

### DIFF
--- a/pkgs/tools/text/sift/default.nix
+++ b/pkgs/tools/text/sift/default.nix
@@ -16,11 +16,15 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -delete_rpath $out/lib -add_rpath $bin $bin/bin/sift
+  '';
+
   meta = with lib; {
     description = "sift is a fast and powerful alternative to grep";
     homepage = "https://sift-tool.org";
     maintainers = [ maintainers.carlsverre ];
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


This package can build on darwin but suffers from the same problem described here: https://github.com/NixOS/nixpkgs/issues/18131#issuecomment-252252209

Before:
```
$ nix-build -I nixpkgs=. -E 'with import <nixpkgs> {}; callPackage pkgs/tools/text/sift {}'
these derivations will be built:
  /nix/store/7ggs2rii2jz7viwcfsgd56ibw9i7s2fj-sift-0.8.0.drv
building path(s) ‘/nix/store/p1g7jzj6rsdxb3xay7612ykqi7bpnp8j-sift-0.8.0’, ‘/nix/store/xzfa87j2gb1fhwypd3hblgm4b3gn3m4w-sift-0.8.0-bin’
unpacking sources
unpacking source archive /nix/store/5ngj6nj90hjjsxpz3ynnkyzw5kzzhxmj-sift-v0.8.0-src
source root is sift-v0.8.0-src
patching sources
configuring
grep: Invalid range end
unpacking source archive /nix/store/ggc90hhc25jpymh4hx45qq7nldnyh7hb-crypto-575fdbe
unpacking source archive /nix/store/gd7l7hfks2011r91xr01bzm475bsgbpi-go-flags-4bcbad3
unpacking source archive /nix/store/zg6y9v9gkxyjb72rq0zranxf1zbms722-go-nbreader-7cef48d
building
github.com/svent/sift/gitignore
github.com/svent/go-flags
golang.org/x/crypto/ssh/terminal
github.com/svent/go-nbreader
github.com/svent/sift
# github.com/svent/sift
ld: warning: /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation, ignoring unexpected dylib file
installing
/private/var/folders/jt/qgrx8lp10ylbdlnb93t54r6c0000gn/T/nix-build-sift-0.8.0.drv-0/go /private/var/folders/jt/qgrx8lp10ylbdlnb93t54r6c0000gn/T/nix-build-sift-0.8.0.drv-0
/private/var/folders/jt/qgrx8lp10ylbdlnb93t54r6c0000gn/T/nix-build-sift-0.8.0.drv-0
post-installation fixup
stripping (with flags -S) in /nix/store/xzfa87j2gb1fhwypd3hblgm4b3gn3m4w-sift-0.8.0-bin/bin
patching script interpreter paths in /nix/store/xzfa87j2gb1fhwypd3hblgm4b3gn3m4w-sift-0.8.0-bin
patching script interpreter paths in /nix/store/p1g7jzj6rsdxb3xay7612ykqi7bpnp8j-sift-0.8.0
cycle detected in the references of ‘/nix/store/p1g7jzj6rsdxb3xay7612ykqi7bpnp8j-sift-0.8.0’
error: build of ‘/nix/store/7ggs2rii2jz7viwcfsgd56ibw9i7s2fj-sift-0.8.0.drv’ failed
nix-build -I nixpkgs=. -E   3.15s user 2.03s system 36% cpu 14.235 total
```

After:

```
$ nix-build -I nixpkgs=. -E 'with import <nixpkgs> {}; callPackage pkgs/tools/text/sift {}'
...
/nix/store/f8i8sqqs3k23pvviz7bb20l9356jzqbz-sift-0.8.0-bin
$ ./result-bin/bin/sift
Error: No pattern given. Try 'sift --help' for more information.
```

The problem in https://github.com/NixOS/nixpkgs/pull/16820 also seems to have gone away.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

