### PR TITLE
lua packages: propagate libs with a setupHook

### DIFF
--- a/pkgs/development/lua-modules/generic/default.nix
+++ b/pkgs/development/lua-modules/generic/default.nix
@@ -1,4 +1,4 @@
-lua:
+{ lua, writeText }:
 
 { buildInputs ? [], disabled ? false, ... } @ attrs:
 
@@ -6,19 +6,32 @@ if disabled then
   throw "${attrs.name} not supported by interpreter lua-${lua.luaversion}"
 else
   lua.stdenv.mkDerivation ({
+    preBuild = ''
+      makeFlagsArray=(
+        PREFIX=$out
+        LUA_LIBDIR="$out/lib/lua/${lua.luaversion}"
+        LUA_INC="-I${lua}/include");
+    '';
+  } //
+  attrs // {
+    name = "lua${lua.luaversion}-" + attrs.name;
+    buildInputs = buildInputs ++ [ lua ];
 
-      preBuild = ''
-        makeFlagsArray=(
-          PREFIX=$out
-          LUA_LIBDIR="$out/lib/lua/${lua.luaversion}"
-          LUA_INC="-I${lua}/include");
-      '';
-    }
-    //
-    attrs
-    //
-    {
-      name = "lua${lua.luaversion}-" + attrs.name;
-      buildInputs = buildInputs ++ [ lua ];
-    }
-  )
+    # The function addToSearchPathWithCustomDelimiter breaks with ";" in
+    # the search path.
+    setupHook = writeText "setup-hook.sh" ''
+      addLuaPath() {
+        if [[ -d "$1/lib/lua/${lua.luaversion}" ]]; then
+          LUA_PATH="$1/lib/lua/${lua.luaversion}/?.lua;$LUA_PATH"
+          LUA_CPATH="$1/lib/lua/${lua.luaversion}/?.so;$LUA_CPATH"
+        fi
+        if [[ -d "$1/share/lua/${lua.luaversion}" ]]; then
+          LUA_PATH="$1/share/lua/${lua.luaversion}/?.lua;$LUA_PATH"
+          LUA_CPATH="$1/share/lua/${lua.luaversion}/?.so;$LUA_CPATH"
+        fi
+        export LUA_PATH
+        export LUA_CPATH
+      }
+      envHooks+=(addLuaPath)
+    '';
+  })

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -8,7 +8,7 @@
 { fetchurl, fetchzip, stdenv, lua, callPackage, unzip, zziplib, pkgconfig, libtool
 , pcre, oniguruma, gnulib, tre, glibc, sqlite, openssl, expat, cairo
 , perl, gtk2, python, glib, gobjectIntrospection, libevent, zlib, autoreconfHook
-, fetchFromGitHub, libmpack
+, fetchFromGitHub, libmpack, writeText
 }:
 
 let
@@ -33,7 +33,9 @@ let
   getLuaCPath   = lib : getPath lib "so";
 
   #define build lua package function
-  buildLuaPackage = callPackage ../development/lua-modules/generic lua;
+  buildLuaPackage = callPackage ../development/lua-modules/generic {
+    inherit lua writeText;
+  };
 
   luarocks = callPackage ../development/tools/misc/luarocks {
     inherit lua;


### PR DESCRIPTION
The LUA_PATH and LUA_CPATH variables are needed to load libraries. Export them with a setupHook.

This allows using installed libraries directly, e.g.,

nix-shell -p lua -p luaPackages.cjson --command "lua -e '(require \"cjson\").encode(1)'"

Also fixes some indentation in the lua-modules/generic/default.nix
file as it was inconsistent.

###### Motivation for this change

Using lua libraries without having to update LUA_PATH and LUA_CPATH manually.

https://github.com/NixOS/nixpkgs/issues/25830

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` See below for breakages.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The failures are either broken or not visible on hydra.nixos.org:

luajitPackages.cjson - already broken on hydra
luajitPackages.luaexpat - already broken on hydra
luajitPackages.luazip - already broken on hydra
luajitPackages.lrexlib fail - not on hydra
lua52Packages.lrexlib fail - not on hydra
luajitPackages.mpack fail - disabled on hydra
mudlet fail - disabled on hydra
lua51Packages.lrexlib fail - not on hydra


