### PR TITLE
nikola: init at 7.8.4

### DIFF
--- a/pkgs/development/python-modules/Nikola/default.nix
+++ b/pkgs/development/python-modules/Nikola/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, isPy3k
+, fetchPypi
+, doit
+, glibcLocales
+, pytest
+, pytestcov
+, pytest-mock
+, pygments
+, pillow
+, dateutil
+, docutils
+, Mako
+, unidecode
+, lxml
+, Yapsy
+, PyRSS2Gen
+, Logbook
+, blinker
+, setuptools
+, natsort
+, requests
+, piexif
+, markdown
+, phpserialize
+, jinja2
+}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "Nikola";
+  version = "7.8.4";
+
+  # Nix contains only Python 3 supported version of doit, which is a dependency
+  # of Nikola. Python 2 support would require older doit 0.29.0 (which on the
+  # other hand doesn't support Python 3.3). So, just disable Python 2.
+  disabled = !isPy3k;
+
+  buildInputs = [ pytest pytestcov pytest-mock glibcLocales ];
+
+  propagatedBuildInputs = [
+    pygments pillow dateutil docutils Mako unidecode lxml Yapsy PyRSS2Gen
+    Logbook blinker setuptools natsort requests piexif markdown phpserialize
+    jinja2 doit
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14pd5zk6l6f58snq9n9zpxwhqcc3xz8b1gz31zsrqajggg1i8fn8";
+  };
+
+  meta = {
+    homepage = "https://getnikola.com/";
+    description = "A modular, fast, simple, static website and blog generator";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8198,6 +8198,8 @@ in {
 
   netcdf4 = callPackage ../development/python-modules/netcdf4.nix { };
 
+  Nikola = callPackage ../development/python-modules/Nikola { };
+
   nxt-python = buildPythonPackage rec {
     version = "unstable-20160819";
     pname = "nxt-python";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27899,23 +27899,21 @@ EOF
   };
 
   ws4py = buildPythonPackage rec {
-    name = "ws4py-${version}";
+    name = "${pname}-${version}";
+    pname = "ws4py";
+    version = "0.4.2";
 
-    version = "git-20130303";
-
-    src = pkgs.fetchgit {
-      url = "https://github.com/Lawouach/WebSocket-for-Python.git";
-      rev = "ace276500ca7e4c357595e3773be151d37bcd6e2";
-      sha256 = "1g7nmhjjxjf6vx75dyzns8bpid3b5i02kakk2lh1i297b5rw2rjq";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "0zr3254ky6r7q15l3dhdczfa8i723055zdkqssjifsgcwvirriks";
     };
 
-    # python zip complains about old timestamps
-    preConfigure = ''
-      find -print0 | xargs -0 touch
-    '';
+    buildInputs = with self; [ pytest mock ];
+    propagatedBuildInputs = with self; [ asyncio cherrypy gevent tornado ];
 
-    # Tests depend on other packages
-    doCheck = false;
+    checkPhase = ''
+      pytest test
+    '';
 
     meta = {
       homepage = https://ws4py.readthedocs.org;


### PR DESCRIPTION
###### Motivation for this change

Nikola is a static site generator written in Python. I added it as a Python application, not Python module, because it's used as an application, not as a library.

Nikola has a bunch of extra dependencies that enable some additional features. Is there some nice way to support installing Nikola with optionally all the extra dependencies? With pip, this would be done as `pip install nikola[extras]`, is there any similar support in nix or would it even be desirable?

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

