### PR TITLE
pythonPackages.cram: mark i686 broken

### DIFF
--- a/pkgs/development/python-modules/cram/default.nix
+++ b/pkgs/development/python-modules/cram/default.nix
@@ -1,4 +1,4 @@
-{lib, buildPythonPackage, fetchPypi, coverage, bash, which, writeText}:
+{stdenv, lib, buildPythonPackage, fetchPypi, coverage, bash, which, writeText}:
 
 buildPythonPackage rec {
   name = "${pname}-${version}";
@@ -34,5 +34,7 @@ buildPythonPackage rec {
     homepage = https://bitheap.org/cram/;
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ jluttine ];
+    # Tests fail on i686: https://hydra.nixos.org/build/52896671/nixlog/4
+    broken = stdenv.isi686;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

For some reason, build fails on i686: https://hydra.nixos.org/build/52896671/nixlog/4

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

