### PR TITLE
nbstripout: fix build on darwin

### DIFF
--- a/pkgs/applications/version-management/nbstripout/default.nix
+++ b/pkgs/applications/version-management/nbstripout/default.nix
@@ -1,4 +1,4 @@
-{lib, python2Packages, git, mercurial}:
+{lib, python2Packages, git, mercurial, coreutils}:
 
 with python2Packages;
 buildPythonApplication rec {
@@ -16,6 +16,12 @@ buildPythonApplication rec {
     inherit pname version;
     sha256 = "126xhjma4a0k7gq58hbqglhb3rai0a576azz7g8gmqjr3kl0264v";
   };
+
+  # for some reason, darwin uses /bin/sh echo native instead of echo binary, so
+  # force using the echo binary
+  postPatch = ''
+    substituteInPlace tests/test-git.t --replace "echo" "${coreutils}/bin/echo"
+  '';
 
   # ignore flake8 tests for the nix wrapped setup.py
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Build fails on darwin because, for some reason, `echo -n` isn't handled properly: https://hydra.nixos.org/build/52896770/nixlog/14

I patched the failing test on darwin to use `\c` at the end of the string instead of `-n` flag.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

