### PR TITLE
Set virtualisation.libvirtd.qemuOvmf to false as the OVMF closure-siz…

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -68,7 +68,7 @@ in {
 
     virtualisation.libvirtd.qemuOvmf = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = ''
         Allows libvirtd to take advantage of OVMF when creating new
         QEMU VMs with UEFI boot.


### PR DESCRIPTION
…e is too large for true to be the default.

###### Motivation for this change
https://github.com/NixOS/nixpkgs/commit/df5d588f13674bbe4be63a05e533c8303ea5a465#commitcomment-22166176 motivated this change.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

