### PR TITLE
google-app-engine-go-sdk: init at 1.9.53

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -296,6 +296,7 @@
   lsix = "Lancelot SIX <lsix@lancelotsix.com>";
   lucas8 = "Luc Chabassier <luc.linux@mailoo.org>";
   ludo = "Ludovic Courtès <ludo@gnu.org>";
+  lufia = "Kyohei Kadota <lufia@lufia.org>";
   luispedro = "Luis Pedro Coelho <luis@luispedro.org>";
   lukego = "Luke Gorrie <luke@snabb.co>";
   lw = "Sergey Sofeychuk <lw@fmap.me>";

--- a/pkgs/development/tools/google-app-engine-go-sdk/default.nix
+++ b/pkgs/development/tools/google-app-engine-go-sdk/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, unzip, python27, python27Packages, makeWrapper }:
+
+with python27Packages;
+
+assert stdenv.system == "x86_64-linux" || stdenv.system == "x86_64-darwin";
+
+stdenv.mkDerivation rec {
+  name = "google-app-engine-go-sdk-${version}";
+  version = "1.9.53";
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-${version}.zip";
+        sha1 = "9152e132bfe00ecc7605ca8b4c233f8656ada8a6";
+      }
+    else
+      fetchurl {
+        url = "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_amd64-${version}.zip";
+        sha1 = "9f352b81a3f4eb97937c45431a7a955f3ba77fc2";
+      };
+
+  buildInputs = [python27 unzip makeWrapper];
+
+  phases = [ "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p "$out"
+    unzip -d "$out" "$src"
+
+    # create wrappers with correct env
+    for i in goapp appcfg.py
+	do
+        prog="$out/go_appengine/$i"
+        wrapper="$out/bin/$i"
+        makeWrapper "$prog" "$wrapper" \
+            --prefix PATH : "${python27}/bin" \
+            --prefix PYTHONPATH : "$(toPythonPath ${cffi}):$(toPythonPath ${cryptography}):$(toPythonPath ${pyopenssl})"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google App Engine SDK for Go";
+    version = version;
+    homepage = "https://cloud.google.com/appengine/docs/go/";
+    license = licenses.asl20;
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/development/tools/google-app-engine-go-sdk/default.nix
+++ b/pkgs/development/tools/google-app-engine-go-sdk/default.nix
@@ -37,5 +37,6 @@ stdenv.mkDerivation rec {
     homepage = "https://cloud.google.com/appengine/docs/go/";
     license = licenses.asl20;
     platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ lufia ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2098,6 +2098,8 @@ with pkgs;
   # rename to upower-notify?
   go-upower-notify = callPackage ../tools/misc/upower-notify { };
 
+  google-app-engine-go-sdk = callPackage ../development/tools/google-app-engine-go-sdk { };
+
   google-authenticator = callPackage ../os-specific/linux/google-authenticator { };
 
   google-cloud-sdk = callPackage ../tools/admin/google-cloud-sdk { };


### PR DESCRIPTION
###### Motivation for this change

AppEngine SDK for Go is tools for developing, deploying, and managing apps in Google App Engine.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

