### PR TITLE
mawled: init at 20170517

### DIFF
--- a/pkgs/applications/window-managers/mawled/default.nix
+++ b/pkgs/applications/window-managers/mawled/default.nix
@@ -29,7 +29,6 @@ in stdenv.mkDerivation {
     homepage = "https://github.com/tomhrr/mawled";
     license = licenses.bsd3;
     maintainers = with maintainers; [ amiloradovsky ];
-    platforms = with platforms; [ "i686-linux" "x86_64-linux" ];
-    # The Dale port is currently present only on these platforms
+    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/window-managers/mawled/default.nix
+++ b/pkgs/applications/window-managers/mawled/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, dale, libX11 }:
+
+let version = "20170517";
+
+in stdenv.mkDerivation {
+  name = "mawled-${version}";
+
+  src = fetchFromGitHub {
+    owner = "tomhrr";
+    repo = "mawled";
+    rev = "d8e9714cf1d4b739ceeb4ed16b8adf1dccc12484";
+    sha256 = "0py00lgw0cj9c9lvxqc0852g7mvhz2gjp4x0dybwyfcb8kj5nc0w";
+  };
+
+  buildInputs = [ dale libX11 ];
+
+  postPatch = ''
+    substituteInPlace ./Makefile --replace /usr/local $out
+  '';
+
+  hardeningDisable = "bindnow";  # Dale utilizes RTLD_LAZY dlopen flag
+
+  meta = with stdenv.lib; {
+    description = "A minimalist window manager written in Dale";
+    longDescription = ''
+      Mawled is a basic X11 tiling window manager,
+      inspired by XMonad, though with fewer features.
+    '';
+    homepage = "https://github.com/tomhrr/mawled";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ amiloradovsky ];
+    platforms = with platforms; [ "i686-linux" "x86_64-linux" ];
+    # The Dale port is currently present only on these platforms
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1012,6 +1012,8 @@ with pkgs;
 
   masscan = callPackage ../tools/security/masscan { };
 
+  mawled = callPackage ../applications/window-managers/mawled { };
+
   meson = callPackage ../development/tools/build-managers/meson { };
 
   metricbeat = callPackage ../misc/logging/metricbeat { };


### PR DESCRIPTION
A minimalist window manager written in Dale.
Mawled is a basic X11 tiling window manager, inspired by XMonad, though with fewer features.

###### Motivation for this change

It has been requested.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).