### PR TITLE
lib platform parsing: Fix windows support to conform to LLVM, take 2

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -30,7 +30,7 @@ in rec {
   mips = filterDoubles (matchAttrs { cpu = { family = "mips"; }; });
   x86_64 = filterDoubles parse.isx86_64;
 
-  cygwin = filterDoubles (matchAttrs { kernel = parse.kernels.cygwin; });
+  cygwin = filterDoubles parse.isCygwin;
   darwin = filterDoubles parse.isDarwin;
   freebsd = filterDoubles (matchAttrs { kernel = parse.kernels.freebsd; });
   gnu = filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnu; }); # Should be better

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -1,5 +1,9 @@
-# Define the list of system with their properties.  Only systems tested for
-# Nixpkgs are listed below
+# Define the list of system with their properties.
+#
+# See https://clang.llvm.org/docs/CrossCompilation.html and
+# http://llvm.org/docs/doxygen/html/Triple_8cpp_source.html especially
+# Triple::normalize. Parsing should essentially act as a more conservative
+# version of that last function.
 
 with import ../lists.nix;
 with import ../types.nix;
@@ -9,7 +13,7 @@ let
   lib = import ../default.nix;
   setTypesAssert = type: pred:
     mapAttrs (name: value:
-      #assert pred value;
+      assert pred value;
       setType type ({ inherit name; } // value));
   setTypes = type: setTypesAssert type (_: true);
 
@@ -22,7 +26,6 @@ rec {
     bigEndian = {};
     littleEndian = {};
   };
-
 
   isCpuType = isType "cpu-type";
   cpuTypes = with significantBytes; setTypesAssert "cpu-type"
@@ -47,6 +50,7 @@ rec {
   vendors = setTypes "vendor" {
     apple = {};
     pc = {};
+
     unknown = {};
   };
 
@@ -56,6 +60,7 @@ rec {
     elf = {};
     macho = {};
     pe = {};
+
     unknown = {};
   };
 
@@ -63,15 +68,12 @@ rec {
   kernelFamilies = setTypes "kernel-family" {
     bsd = {};
     unix = {};
-    windows-nt = {};
-    dos = {};
   };
 
   isKernel = x: isType "kernel" x;
   kernels = with execFormats; with kernelFamilies; setTypesAssert "kernel"
     (x: isExecFormat x.execFormat && all isKernelFamily (attrValues x.families))
   {
-    cygwin  = { execFormat = pe;      families = { inherit /*unix*/ windows-nt; }; };
     darwin  = { execFormat = macho;   families = { inherit unix; }; };
     freebsd = { execFormat = elf;     families = { inherit unix bsd; }; };
     linux   = { execFormat = elf;     families = { inherit unix; }; };
@@ -79,18 +81,21 @@ rec {
     none    = { execFormat = unknown; families = { inherit unix; }; };
     openbsd = { execFormat = elf;     families = { inherit unix bsd; }; };
     solaris = { execFormat = elf;     families = { inherit unix; }; };
-    win32   = { execFormat = pe;      families = { inherit dos; }; };
+    windows = { execFormat = pe;      families = { }; };
+  } // { # aliases
+    win32 = kernels.windows;
   };
-
 
   isAbi = isType "abi";
   abis = setTypes "abi" {
+    cygnus = {};
     gnu = {};
     msvc = {};
     eabi = {};
     androideabi = {};
     gnueabi = {};
     gnueabihf = {};
+
     unknown = {};
   };
 
@@ -109,19 +114,25 @@ rec {
   isDarwin = matchAttrs { kernel = kernels.darwin; };
   isLinux = matchAttrs { kernel = kernels.linux; };
   isUnix = matchAttrs { kernel = { families = { inherit (kernelFamilies) unix; }; }; };
-  isWindows = s: matchAttrs { kernel = { families = { inherit (kernelFamilies) windows-nt; }; }; } s
-              || matchAttrs { kernel = { families = { inherit (kernelFamilies) dos; }; }; } s;
+  isWindows = matchAttrs { kernel = kernels.windows; };
+  isCygwin = matchAttrs { kernel = kernels.windows; abi = abis.cygnus; };
+  isMinGW = matchAttrs { kernel = kernels.windows; abi = abis.gnu; };
 
 
   mkSkeletonFromList = l: {
-    "2" =    { cpu = elemAt l 0;                      kernel = elemAt l 1;                   };
-    "4" =    { cpu = elemAt l 0; vendor = elemAt l 1; kernel = elemAt l 2; abi = elemAt l 3; };
+    "2" = # We only do 2-part hacks for things Nix already supports
+      if elemAt l 1 == "cygwin"
+        then { cpu = elemAt l 0;                      kernel = "windows"; abi = "cygnus";    }
+      else   { cpu = elemAt l 0;                      kernel = elemAt l 1;                   };
     "3" = # Awkwards hacks, beware!
       if elemAt l 1 == "apple"
         then { cpu = elemAt l 0; vendor = "apple";    kernel = elemAt l 2;                   }
       else if (elemAt l 1 == "linux") || (elemAt l 2 == "gnu")
         then { cpu = elemAt l 0;                      kernel = elemAt l 1; abi = elemAt l 2; }
+      else if (elemAt l 2 == "mingw32") # autotools breaks on -gnu for window
+        then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = "windows";  abi = "gnu"; }
       else throw "Target specification with 3 components is ambiguous";
+    "4" =    { cpu = elemAt l 0; vendor = elemAt l 1; kernel = elemAt l 2; abi = elemAt l 3; };
   }.${toString (length l)}
     or (throw "system string has invalid number of hyphen-separated components");
 
@@ -134,18 +145,10 @@ rec {
                          , # Also inferred below
                            abi    ? assert false; null
                          } @ args: let
-    getCpu = name:
-      attrByPath [name] (throw "Unknown CPU type: ${name}")
-        cpuTypes;
-    getVendor = name:
-      attrByPath [name] (throw "Unknown vendor: ${name}")
-        vendors;
-    getKernel = name:
-      attrByPath [name] (throw "Unknown kernel: ${name}")
-        kernels;
-    getAbi = name:
-      attrByPath [name] (throw "Unknown ABI: ${name}")
-        abis;
+    getCpu    = name: cpuTypes.${name} or (throw "Unknown CPU type: ${name}");
+    getVendor = name:  vendors.${name} or (throw "Unknown vendor: ${name}");
+    getKernel = name:  kernels.${name} or (throw "Unknown kernel: ${name}");
+    getAbi    = name:     abis.${name} or (throw "Unknown ABI: ${name}");
 
     system = rec {
       cpu = getCpu args.cpu;
@@ -166,7 +169,10 @@ rec {
 
   mkSystemFromString = s: mkSystemFromSkeleton (mkSkeletonFromList (lib.splitString "-" s));
 
-  doubleFromSystem = { cpu, vendor, kernel, abi, ... }: "${cpu.name}-${kernel.name}";
+  doubleFromSystem = { cpu, vendor, kernel, abi, ... }:
+    if vendor == kernels.windows && abi == abis.cygnus
+    then "${cpu.name}-cygwin"
+    else "${cpu.name}-${kernel.name}";
 
   tripleFromSystem = { cpu, vendor, kernel, abi, ... } @ sys: assert isSystem sys; let
     optAbi = lib.optionalString (abi != abis.unknown) "-${abi.name}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5068,9 +5068,6 @@ with pkgs;
       cross = targetPlatform;
       crossStageStatic = false;
 
-      # XXX: We have troubles cross-compiling libstdc++ on MinGW (see
-      # <http://hydra.nixos.org/build/4268232>), so don't even try.
-      langCC = targetPlatform.config != "i686-pc-mingw32";
       # Why is this needed?
       inherit (forcedNativePackages) binutils;
     };

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -20,11 +20,26 @@ let
   /* Basic list of packages to be natively built,
      but need a crossSystem defined to get meaning */
   basicNativeDrv = {
+    buildPackages.binutils = nativePlatforms;
     buildPackages.gccCrossStageFinal = nativePlatforms;
     buildPackages.gdbCross = nativePlatforms;
   };
 
   basic = basicCrossDrv // basicNativeDrv;
+
+  windows = {
+    buildPackages.binutils = nativePlatforms;
+    buildPackages.gccCrossStageFinal = nativePlatforms;
+
+    coreutils = nativePlatforms;
+    boehmgc = nativePlatforms;
+    gmp = nativePlatforms;
+    guile_1_8 = nativePlatforms;
+    libffi = nativePlatforms;
+    libtool = nativePlatforms;
+    libunistring = nativePlatforms;
+    windows.wxMSW = nativePlatforms;
+  };
 
 in
 
@@ -89,48 +104,30 @@ in
   /* Test some cross builds on 32 bit mingw-w64 */
   crossMingw32 = let
     crossSystem = {
-      config = "i686-w64-mingw32";
+      config = "i686-pc-mingw32";
       arch = "x86"; # Irrelevant
       libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
       platform = {};
     };
-  in mapTestOnCross crossSystem {
-    coreutils = nativePlatforms;
-    boehmgc = nativePlatforms;
-    gmp = nativePlatforms;
-    guile_1_8 = nativePlatforms;
-    libffi = nativePlatforms;
-    libtool = nativePlatforms;
-    libunistring = nativePlatforms;
-    windows.wxMSW = nativePlatforms;
-  };
+  in mapTestOnCross crossSystem windows;
 
 
   /* Test some cross builds on 64 bit mingw-w64 */
   crossMingwW64 = let
     crossSystem = {
       # That's the triplet they use in the mingw-w64 docs.
-      config = "x86_64-w64-mingw32";
+      config = "x86_64-pc-mingw32";
       arch = "x86_64"; # Irrelevant
       libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
       platform = {};
     };
-  in mapTestOnCross crossSystem {
-    coreutils = nativePlatforms;
-    boehmgc = nativePlatforms;
-    gmp = nativePlatforms;
-    guile_1_8 = nativePlatforms;
-    libffi = nativePlatforms;
-    libtool = nativePlatforms;
-    libunistring = nativePlatforms;
-    windows.wxMSW = nativePlatforms;
-  };
+  in mapTestOnCross crossSystem windows;
 
 
   /* Linux on the fuloong */
   fuloongminipc = let
     crossSystem = {
-      config = "mips64el-unknown-linux";
+      config = "mips64el-unknown-linux-gnu";
       bigEndian = false;
       arch = "mips";
       float = "hard";


### PR DESCRIPTION
###### Motivation for this change

Second attempt at pull request #25275

This reverts commit b70924bd80918d153a5e2023afd7647ae7b24a12,
reapplying 2282a5774cd80567644a44d31585bf965a55f9ec

#25275 ensures regression will not happen again, as lib tests are now run as part of Travis job.

###### Things done

- Evaluated tests locally

---

