### PR TITLE
mynewt-newt: init at 1.0.0

### DIFF
--- a/pkgs/tools/package-management/mynewt-newt/default.nix
+++ b/pkgs/tools/package-management/mynewt-newt/default.nix
@@ -24,6 +24,6 @@ buildGoPackage rec {
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ pjones ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/package-management/mynewt-newt/default.nix
+++ b/pkgs/tools/package-management/mynewt-newt/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "mynewt-newt-${version}";
+  version = "1.0.0";
+
+  goPackagePath = "mynewt.apache.org/newt";
+  goDeps = ./deps.nix;
+
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "incubator-mynewt-newt";
+    rev = "mynewt_${builtins.replaceStrings ["."] ["_"] version}_tag";
+    sha256 = "1ixqxqizd957prd4j2nijgnkv84rffj8cx5f7aqyjq9nkawjksf6";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://mynewt.apache.org/;
+    description = "Build and package management tool for embedded development.";
+    longDescription = ''
+      Apache Newt is a smart build and package management tool,
+      designed for C and C++ applications in embedded contexts. Newt
+      was developed as a part of the Apache Mynewt Operating System.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pjones ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/package-management/mynewt-newt/deps.nix
+++ b/pkgs/tools/package-management/mynewt-newt/deps.nix
@@ -1,0 +1,101 @@
+[
+  {
+    goPackagePath = "github.com/Sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus.git";
+      rev = "a437dfd2463eaedbec3dfe443e477d3b0a810b3f";
+      sha256 = "1904s2bbc7p88anzjp6fyj3jrbm5p6wbb8j4490674dq10kkcfbj";
+    };
+  }
+  {
+    goPackagePath = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap.git";
+      rev = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pretty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pretty.git";
+      rev = "cfb55aafdaf3ec08f0db22699ab822c50091b1c4";
+      sha256 = "0441yi9ah9892hxdslv2h35bkfr75g7ajma0q45lqks84pawrdkg";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/text";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/text.git";
+      rev = "7cafcd837844e784b526369c9bce262804aebc60";
+      sha256 = "0br693pf6vdr1sfvzdz6zxq7hjpdgci0il4wj0v636r8lyy21vsx";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/mapstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/mapstructure.git";
+      rev = "f3009df150dadf309fdee4a54ed65c124afad715";
+      sha256 = "1i08zzlsn1bwicjn8cvakv2h5wwicw8ijx0i0cipk49yfmd6ab4i";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cast";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cast.git";
+      rev = "24b6558033ffe202bf42f0f3b870dcc798dd2ba8";
+      sha256 = "10g8vzvffkd55ivkbaqcjj50z3iiqffl2p902rmbriz14znqyywl";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra.git";
+      rev = "9495bc009a56819bdb0ddbc1a373e29c140bc674";
+      sha256 = "0hphdnhpcmy2mngah81c700s2y43f5g9jckwgmh6xyb4f1zjj9nm";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/jwalterweatherman";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/jwalterweatherman.git";
+      rev = "33c24e77fb80341fe7130ee7c594256ff08ccc46";
+      sha256 = "1knvzspqzc2bh58q16zggzc8gcabjp5gr7zk4k7nx5ij4092cg0z";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag.git";
+      rev = "5ccb023bc27df288a957c5e994cd44fd19619465";
+      sha256 = "1r65j8sw15pz0iacwnf303p6s51vkv0k6qc5cyb2kybfraqd7f7z";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/fsnotify.v1";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify.git";
+      rev = "629574ca2a5df945712d3079857300b5e4da0236";
+      sha256 = "06wfg1mmzjj04z7d0q1x2fai9k6hm957brngsaf02fa9a3qqanv3";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys/unix";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/sys.git";
+      rev = "b699b7032584f0953262cb2788a0ca19bb494703";
+      sha256 = "172sw1bm581qwal9pbf9qj1sgivr74nabbj8qq4q4fhgpzams9ix";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18246,6 +18246,8 @@ with pkgs;
     stdenv = overrideCC stdenv gcc49;
   };
 
+  mynewt-newt = callPackage ../tools/package-management/mynewt-newt { };
+
   inherit (callPackages ../tools/package-management/nix {
       storeDir = config.nix.storeDir or "/nix/store";
       stateDir = config.nix.stateDir or "/nix/var";


### PR DESCRIPTION

###### Motivation for this change

Add package for mynewt-newt build manager.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

