### PR TITLE
xfce4-volumed-pulse: 0.2.0 -> 0.2.2.

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-volumed-pulse.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-volumed-pulse.nix
@@ -4,12 +4,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.2.0";
-  name = "xfce4-volumed-pulse-${version}";
+  p_name  = "xfce4-volumed-pulse";
+  ver_maj = "0.2";
+  ver_min = "2";
+  name = "${p_name}-${ver_maj}.${ver_min}";
 
   src = fetchurl {
-    url = "https://launchpad.net/xfce4-volumed-pulse/trunk/${version}/+download/${name}.tar.bz2";
-    sha256 = "0l75gl96skm0zn10w70mwvsjd12p1zjshvn7yc3439dz61506c39";
+    url = "mirror://xfce/src/apps/${p_name}/${ver_maj}/${name}.tar.bz2";
+    sha256 = "0xjcs1b6ix6rwj9xgr9n89h315r3yhdm8wh5bkincd4lhz6ibhqf";
   };
 
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change

Update xfce4-volumed-pulse to the latest release. 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

