### PR TITLE
rdesktop: enable IPv6 support

### DIFF
--- a/pkgs/applications/networking/remote/rdesktop/default.nix
+++ b/pkgs/applications/networking/remote/rdesktop/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation (rec {
   buildInputs = [openssl libX11];
 
   configureFlags = [
+    "--with-ipv6"
     "--with-openssl=${openssl.dev}"
     "--disable-credssp"
     "--disable-smartcard"


### PR DESCRIPTION
###### Motivation for this change

This enables rdesktop to connect to hosts over IPv6.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
