### PR TITLE
python metaphone: init at 0.6

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -451,6 +451,7 @@
   rht = "rht <rhtbot@protonmail.com>";
   rick68 = "Wei-Ming Yang <rick68@gmail.com>";
   rickynils = "Rickard Nilsson <rickynils@gmail.com>";
+  ris = "Robert Scott <code@humanleg.org.uk>";
   rlupton20 = "Richard Lupton <richard.lupton@gmail.com>";
   rnhmjoj = "Michele Guerini Rocco <micheleguerinirocco@me.com>";
   rob = "Rob Vermaas <rob.vermaas@gmail.com>";

--- a/pkgs/development/python-modules/metaphone/default.nix
+++ b/pkgs/development/python-modules/metaphone/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, isPy3k, fetchPypi, nose }:
+
+buildPythonPackage rec {
+  pname = "Metaphone";
+  version = "0.6";
+  name  = "metaphone-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09ysaczwh2rlsqq9j5fz7m4pq2fs0axp5vvivrpfrdvclvffl2xd";
+  };
+
+  disabled = isPy3k;
+
+  buildInputs = [ nose ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/oubiwann/metaphone;
+    description = "A Python implementation of the metaphone and double metaphone algorithms";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/metaphone/default.nix
+++ b/pkgs/development/python-modules/metaphone/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     homepage = https://github.com/oubiwann/metaphone;
     description = "A Python implementation of the metaphone and double metaphone algorithms";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ ris ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14036,6 +14036,8 @@ in {
     };
   };
 
+  metaphone = callPackage ../development/python-modules/metaphone { };
+
   mezzanine = buildPythonPackage rec {
     version = "3.1.10";
     name = "mezzanine-${version}";


### PR DESCRIPTION
###### Motivation for this change
If you _really_ want I'll add myself as maintainer of this...

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

