### PR TITLE
znc service: refactor config generation

### DIFF
--- a/nixos/modules/services/networking/znc.nix
+++ b/nixos/modules/services/networking/znc.nix
@@ -37,7 +37,7 @@ let
             IPv6 = true
             SSL = ${boolToString confOpts.useSSL}
     </Listener>
-    
+
     <User ${confOpts.userName}>
             ${confOpts.passBlock}
             Admin = true
@@ -50,9 +50,12 @@ let
             ${ lib.concatStringsSep "\n" (lib.mapAttrsToList (name: net: ''
               <Network ${name}>
                   ${concatMapStrings (m: "LoadModule = ${m}\n") net.modules}
-                  Server = ${net.server} ${if net.useSSL then "+" else ""}${toString net.port}
-
+                  Server = ${net.server} ${lib.optionalString net.useSSL "+"}${toString net.port} ${net.password}
                   ${concatMapStrings (c: "<Chan #${c}>\n</Chan>\n") net.channels}
+                  ${lib.optionalString net.hasBitlbeeControlChannel ''
+                    <Chan &bitlbee></Chan>
+                  ''}
+                  ${net.extraConf}
               </Network>
               '') confOpts.networks) }
     </User>
@@ -82,6 +85,23 @@ let
         example = 6697;
         description = ''
           IRC server port.
+        '';
+      };
+
+      userName = mkOption {
+        default = "";
+        example = "johntron";
+        type = types.string;
+        description = ''
+          A nick identity specific to the IRC server.
+        '';
+      };
+
+      password = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          IRC server password, such as for a Slack gateway.
         '';
       };
 
@@ -117,6 +137,31 @@ let
         example = [ "nixos" ];
         description = ''
           IRC channels to join.
+        '';
+      };
+
+      hasBitlbeeControlChannel = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to add the special Bitlbee operations channel.
+        '';
+      };
+
+      extraConf = mkOption {
+        default = "";
+        type = types.lines;
+        example = ''
+          Encoding = ^UTF-8
+          FloodBurst = 4
+          FloodRate = 1.00
+          IRCConnectEnabled = true
+          Ident = johntron
+          JoinDelay = 0
+          Nick = johntron
+        '';
+        description = ''
+          Extra config for the network.
         '';
       };
     };
@@ -273,21 +318,21 @@ in
           A list of global znc module packages to add to znc.
         '';
       };
- 
+
       mutable = mkOption {
         default = false;
         type = types.bool;
         description = ''
           Indicates whether to allow the contents of the `dataDir` directory to be changed
           by the user at run-time.
-          If true, modifications to the ZNC configuration after its initial creation are not 
+          If true, modifications to the ZNC configuration after its initial creation are not
             overwritten by a NixOS system rebuild.
           If false, the ZNC configuration is rebuilt by every system rebuild.
           If the user wants to manage the ZNC service using the web admin interface, this value
             should be set to true.
         '';
       };
- 
+
       extraFlags = mkOption {
         default = [ ];
         example = [ "--debug" ];
@@ -334,7 +379,7 @@ in
 
         if [[ ! -f ${cfg.dataDir}/znc.pem ]]; then
           ${pkgs.coreutils}/bin/echo "No znc.pem file found in ${cfg.dataDir}. Creating one now."
-          ${pkgs.znc}/bin/znc --makepem --datadir ${cfg.dataDir} 
+          ${pkgs.znc}/bin/znc --makepem --datadir ${cfg.dataDir}
         fi
 
         # Symlink modules
@@ -352,7 +397,7 @@ in
         home = cfg.dataDir;
         createHome = true;
       };
- 
+
     users.extraGroups = optional (cfg.user == defaultUser)
       { name = defaultUser;
         gid = config.ids.gids.znc;


### PR DESCRIPTION
###### Motivation for this change

The current config generation system does not allow for the option of an IRC server password with the network information (see #25876).  Also the Bitlbee control channel, &bitlbee, cannot be set because it doesn't start with a hash (see #25874); rather than change how channels must be defined in configuration by removing the auto-prefixed hash (and thus force everyone who has existing ZNC configuration to need to refactor their config values) I instead allowed the insertion of the specific Bitlbee control channel based upon a boolean value.  I'm not certain if this is the best approach for this channel and welcome better solutions.

Tested all values and their absence and checked the created configuration file to ensure it was built correctly with the proper syntax.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---