### PR TITLE
confluent-kafka: init at 0.9.4

### DIFF
--- a/pkgs/development/python-modules/confluent-kafka/default.nix
+++ b/pkgs/development/python-modules/confluent-kafka/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, rdkafka, requests, avro3k, avro}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "0.9.4";
+  pname = "confluent-kafka";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1v8apw9f8l01ql42jg1sfqv41yxvcbxn1a3ar01y0ni428swq6wk";
+  };
+
+  buildInputs = [ rdkafka requests ] ++ (if isPy3k then [ avro3k ] else [ avro ]) ;
+
+  # Tests fail for python3 under this pypi release
+  doCheck = if isPy3k then false else true;
+
+  meta = with stdenv.lib; {
+    description = "Confluent's Apache Kafka client for Python";
+    homepage = "https://github.com/confluentinc/confluent-kafka-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mlieberman85 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4071,6 +4071,8 @@ in {
     };
   };
 
+  confluent-kafka = callPackage ../development/python-modules/confluent-kafka {};
+
 
   construct = buildPythonPackage rec {
     name = "construct-${version}";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

