### PR TITLE
gtk2: search for themes in XDG_DATA_DIRS

### DIFF
--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ setupHook perl pkgconfig gettext ];
 
-  patches = [ ./2.0-immodules.cache.patch ];
+  patches = [ ./2.0-immodules.cache.patch ./gtk2-theme-paths.patch ];
 
   propagatedBuildInputs = with xorg;
     [ glib cairo pango gdk_pixbuf atk ]

--- a/pkgs/development/libraries/gtk+/gtk2-theme-paths.patch
+++ b/pkgs/development/libraries/gtk+/gtk2-theme-paths.patch
@@ -1,0 +1,40 @@
+Subject: [PATCHv2] gtk: Patch GTK+ to look for themes in profiles.
+To: guix-devel@gnu.org
+Date: Sun, 13 Mar 2016 15:17:37 +1100
+Url: https://lists.gnu.org/archive/html/guix-devel/2016-03/msg00492.html
+
+diff -Naur gtk+-2.24.28.new/gtk/gtkrc.c gtk+-2.24.28/gtk/gtkrc.c
+--- gtk+-2.24.28.new/gtk/gtkrc.c	2016-03-13 10:31:14.413644362 +1100
++++ gtk+-2.24.28/gtk/gtkrc.c	2016-03-13 12:51:34.723398423 +1100
+@@ -808,6 +808,8 @@
+   gchar *path = NULL;
+   const gchar *home_dir;
+   gchar *subpath;
++  const gchar * const *xdg_data_dirs;
++  gint i;
+ 
+   if (type)
+     subpath = g_strconcat ("gtk-2.0-", type,
+@@ -830,6 +832,22 @@
+     }
+ 
+   if (!path)
++    {
++      xdg_data_dirs = g_get_system_data_dirs ();
++      for (i = 0; xdg_data_dirs[i]; i++)
++        {
++          path = g_build_filename (xdg_data_dirs[i], "themes", name, subpath, NULL);
++          if (g_file_test (path, G_FILE_TEST_EXISTS))
++            break;
++          else
++            {
++              g_free (path);
++              path = NULL;
++            }
++        }
++    }
++
++  if (!path)
+     {
+       gchar *theme_dir = gtk_rc_get_theme_dir ();
+       path = g_build_filename (theme_dir, name, subpath, NULL);


### PR DESCRIPTION
###### Motivation for this change

This patch was adapted from GUIX.
At the moment we still have to rely on GTK_DATA_PREFIX, which can only
point to one profile at the time and is also not set in all desktop
environments. This patch makes it possible to use installed themes, no
matter if system-wide or by in a user profile.
Benefit: Old GTK2 applications looks much better with the theme from Gnome 3. 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

