### PR TITLE
enzyme: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/enzyme/default.nix
+++ b/pkgs/development/python-modules/enzyme/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, fetchurl, buildPythonPackage }:
+{ stdenv, fetchPypi, buildPythonPackage }:
 
 buildPythonPackage rec {
-  name = "enzyme-${version}";
+  name = "${pname}-${version}";
+  pname = "enzyme";
   version = "0.4.1";
 
   # Tests rely on files obtained over the network
   doCheck = false;
 
-  src = fetchurl {
-    url = "mirror://pypi/e/enzyme/${name}.tar.gz";
+  src = fetchPypi {
+    inherit pname version;
     sha256 = "1fv2kh2v4lwj0hhrhj9pib1pdjh01yr4xgyljhx11l94gjlpy5pj";
   };
 

--- a/pkgs/development/python-modules/enzyme/default.nix
+++ b/pkgs/development/python-modules/enzyme/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, buildPythonPackage }:
+
+buildPythonPackage rec {
+  name = "enzyme-${version}";
+  version = "0.4.1";
+
+  # Tests rely on files obtained over the network
+  doCheck = false;
+
+  src = fetchurl {
+    url = "mirror://pypi/e/enzyme/${name}.tar.gz";
+    sha256 = "1fv2kh2v4lwj0hhrhj9pib1pdjh01yr4xgyljhx11l94gjlpy5pj";
+  };
+
+  meta = {
+    homepage = https://github.com/Diaoul/enzyme;
+    license = with stdenv.lib; licenses.asl20;
+    description = "Python video metadata parser";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6471,6 +6471,8 @@ in {
     propagatedBuildInputs = with self; [ configparser ];
   };
 
+  enzyme = callPackage ../development/python-modules/enzyme {};
+
   escapism = buildPythonPackage rec {
     name = "escapism-${version}";
     version = "0.0.1";


### PR DESCRIPTION
###### Motivation for this change

Subliminal (small subtitle fetching utility) depends on enzyme.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

