### PR TITLE
pysrt: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/pysrt/default.nix
+++ b/pkgs/development/python-modules/pysrt/default.nix
@@ -1,0 +1,23 @@
+{ stdenv
+, buildPythonApplication
+, fetchurl
+, chardet
+}:
+
+buildPythonApplication rec {
+  name = "pysrt-${version}";
+  version = "1.1.1";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/pysrt/${name}.tar.gz";
+    sha256 = "1anhfilhamdv15w9mmzwc5a8fsri00ghkmcws4r5mz298m110k7v";
+  };
+
+  propagatedBuildInputs = [ chardet ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/byroot/pysrt;
+    license = licenses.gpl3;
+    description = "Python library used to edit or create SubRip files";
+  };
+}

--- a/pkgs/development/python-modules/pysrt/default.nix
+++ b/pkgs/development/python-modules/pysrt/default.nix
@@ -1,17 +1,25 @@
 { stdenv
 , buildPythonApplication
-, fetchurl
+, fetchFromGitHub
 , chardet
+, nose
 }:
 
 buildPythonApplication rec {
   name = "pysrt-${version}";
   version = "1.1.1";
 
-  src = fetchurl {
-    url = "mirror://pypi/p/pysrt/${name}.tar.gz";
-    sha256 = "1anhfilhamdv15w9mmzwc5a8fsri00ghkmcws4r5mz298m110k7v";
+  src = fetchFromGitHub {
+    owner = "byroot";
+    repo = "pysrt";
+    rev = "v${version}";
+    sha256 = "0rwjaf26885vxhxnas5d8zwasvj7x88y4y2pdivjd4vdcpqrqdjn";
   };
+
+  buildInputs = [ nose ];
+  checkPhase = ''
+    nosetests -v
+  '';
 
   propagatedBuildInputs = [ chardet ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9148,6 +9148,8 @@ in {
     };
   };
 
+  pysrt = callPackage ../development/python-modules/pysrt { };
+
   pytools = buildPythonPackage rec {
     name = "pytools-${version}";
     version = "2016.2.1";


### PR DESCRIPTION
###### Motivation for this change

Dependency of subliminal, which I want to add later.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

