### PR TITLE
rarfile: 2.6 -> 3.0

### DIFF
--- a/pkgs/development/python-modules/rarfile/default.nix
+++ b/pkgs/development/python-modules/rarfile/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, pytest, nose, unrar, glibcLocales }:
+
+buildPythonPackage rec {
+  name = "rarfile-${version}";
+  version = "3.0";
+
+  src = fetchFromGitHub {
+    owner = "markokr";
+    repo = "rarfile";
+    rev = "rarfile_3_0";
+    sha256 = "07yliz6p1bxzhipnrgz133gl8laic35gl4rqfay7f1vc384ch7sn";
+  };
+  buildInputs = [ pytest nose glibcLocales ];
+
+  prePatch = ''
+    substituteInPlace rarfile.py \
+      --replace 'UNRAR_TOOL = "unrar"' "UNRAR_TOOL = \"${unrar}/bin/unrar\""
+  '';
+  LC_ALL = "en_US.UTF-8";
+  checkPhase = ''
+    py.test test -k "not test_printdir"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "RAR archive reader for Python";
+    homepage = https://github.com/markokr/rarfile;
+    license = licenses.isc;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2619,21 +2619,7 @@ in {
 
   };
 
-  rarfile = self.buildPythonPackage rec {
-    name = "rarfile-${version}";
-    version = "3.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/r/rarfile/${name}.tar.gz";
-      sha256 = "0dbcqvyxc3ji38hgkxy529s3sw74sfz7idp0rc3lay9n7fg405p8";
-    };
-
-    meta = {
-      description = "rarfile - RAR archive reader for Python";
-      homepage = https://github.com/markokr/rarfile;
-      license = licenses.isc;
-    };
-  };
+  rarfile = callPackage ../development/python-modules/rarfile {};
 
   proboscis = buildPythonPackage rec {
     name = "proboscis-1.2.6.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2620,16 +2620,18 @@ in {
   };
 
   rarfile = self.buildPythonPackage rec {
-    name = "rarfile-2.6";
+    name = "rarfile-${version}";
+    version = "3.0";
 
     src = pkgs.fetchurl {
-      url = "mirror://pypi/r/rarfile/rarfile-2.6.tar.gz";
-      sha256 = "326700c5450cfb367f612e918866ea27551bac02f4656f340003c88873fa1a56";
+      url = "mirror://pypi/r/rarfile/${name}.tar.gz";
+      sha256 = "0dbcqvyxc3ji38hgkxy529s3sw74sfz7idp0rc3lay9n7fg405p8";
     };
 
     meta = {
       description = "rarfile - RAR archive reader for Python";
       homepage = https://github.com/markokr/rarfile;
+      license = licenses.isc;
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Subliminal (which I want to add) requires rarfile >2.7

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

