### PR TITLE
subliminal: init at 2.0.5

### DIFF
--- a/pkgs/development/python-modules/subliminal/default.nix
+++ b/pkgs/development/python-modules/subliminal/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchurl
+, buildPythonApplication
+, guessit
+, babelfish
+, enzyme
+, beautifulsoup4
+, requests
+, click
+, dogpile_cache
+, stevedore
+, chardet
+, pysrt
+, six
+, appdirs
+, rarfile
+, pytz
+, futures
+}:
+
+buildPythonApplication rec {
+  name = "subliminal-${version}";
+  version = "2.0.5";
+
+  src = fetchurl {
+    url = "mirror://pypi/s/subliminal/${name}.tar.gz";
+    sha256 = "1dzv5csjcwgz69aimarx2c6606ckm2gbn4x2mzydcqnyai7sayhl";
+  };
+
+  # Too many test dependencies
+  doCheck = false;
+  propagatedBuildInputs = [ guessit babelfish enzyme beautifulsoup4 requests
+                            click dogpile_cache stevedore chardet pysrt six
+                            appdirs rarfile pytz futures ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Diaoul/subliminal;
+    description = "Python library to search and download subtitles";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9345,6 +9345,8 @@ in {
     };
   };
 
+  subliminal = callPackage ../development/python-modules/subliminal {};
+
   hyp = buildPythonPackage rec {
     name = "hyp-server-${version}";
     version = "1.2.0";


### PR DESCRIPTION
###### Motivation for this change

Add subliminal -- library and cli tool for finding and downloading subtitles for shows and moves.

###### Work in progress

This commit is blocked until the following PRs get accepted:

- #25885
- #25884
- #25883

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

