### PR TITLE
tcpreplay: init at 4.2.5

### DIFF
--- a/pkgs/tools/networking/tcpreplay/default.nix
+++ b/pkgs/tools/networking/tcpreplay/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A suite of utilities for editing and replaying network traffic";
     homepage = http://tcpreplay.appneta.com/;
-    license = with stdenv.lib.licenses; [ bsd gpl3 ];
+    license = [ "bsd" stdenv.lib.licenses.gpl3 ];
     maintainers = with stdenv.lib.maintainers; [ eleanor ];
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/tools/networking/tcpreplay/default.nix
+++ b/pkgs/tools/networking/tcpreplay/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, libpcap, tcpdump }:
+
+stdenv.mkDerivation rec {
+  name = "tcpreplay-${version}";
+  version = "4.2.5";
+
+  src = fetchurl {
+    url = "https://github.com/appneta/tcpreplay/releases/download/v${version}/tcpreplay-${version}.tar.gz";
+    sha256 = "1mw9r97blczm70rjf7p83sd1fxpzdzfvsbnjsc0m3nz16jz2c44l";
+  };
+
+  buildInputs = [ libpcap ];
+
+  configureFlags = [
+    "--disable-local-libopts"
+    "--disable-libopts-install"
+    "--enable-dynamic-link"
+    "--enable-shared"
+    "--enable-tcpreplay-edit"
+    "--with-libpcap=${libpcap}"
+    "--with-tcpdump=${tcpdump}/bin"
+  ];
+
+  meta = {
+    description = "A suite of utilities for editing and replaying network traffic";
+    homepage = http://tcpreplay.appneta.com/;
+    license = with stdenv.lib.licenses; [ bsd gpl3 ];
+    maintainers = with stdenv.lib.maintainers; [ eleanor ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/tcpreplay/default.nix
+++ b/pkgs/tools/networking/tcpreplay/default.nix
@@ -21,11 +21,11 @@ stdenv.mkDerivation rec {
     "--with-tcpdump=${tcpdump}/bin"
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A suite of utilities for editing and replaying network traffic";
     homepage = http://tcpreplay.appneta.com/;
-    license = [ "bsd" stdenv.lib.licenses.gpl3 ];
-    maintainers = with stdenv.lib.maintainers; [ eleanor ];
-    platforms = stdenv.lib.platforms.linux;
+    license = with licenses; [ bsd3 gpl3 ];
+    maintainers = with maintainers; [ eleanor ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4216,6 +4216,8 @@ with pkgs;
 
   tcpkali = callPackage ../applications/networking/tcpkali { };
 
+  tcpreplay = callPackage ../tools/networking/tcpreplay { };
+
   teamviewer = callPackage ../applications/networking/remote/teamviewer {
     stdenv = stdenv_32bit;
   };


### PR DESCRIPTION
###### Motivation for this change

Addition of tcpreplay into nixpkgs.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

