### PR TITLE
ovmf: split firmware image files

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -15,7 +15,7 @@ let
   '';
   qemuConfigFile = pkgs.writeText "qemu.conf" ''
     ${optionalString cfg.qemuOvmf ''
-      nvram = ["${pkgs.OVMF}/FV/OVMF_CODE.fd:${pkgs.OVMF}/FV/OVMF_VARS.fd"]
+      nvram = ["${pkgs.OVMF.fd}/FV/OVMF_CODE.fd:${pkgs.OVMF.fd}/FV/OVMF_VARS.fd"]
     ''}
     ${cfg.qemuVerbatimConfig}
   '';

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -126,7 +126,7 @@ let
               bootFlash=$out/bios.bin
               ${qemu}/bin/qemu-img create -f qcow2 $diskImage "40M"
               ${if cfg.useEFIBoot then ''
-                cp ${pkgs.OVMF-CSM}/FV/OVMF.fd $bootFlash
+                cp ${pkgs.OVMF-CSM.fd}/FV/OVMF.fd $bootFlash
                 chmod 0644 $bootFlash
               '' else ''
               ''}

--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -40,12 +40,12 @@ in {
 
     uefiCdrom = makeBootTest "uefi-cdrom" ''
         cdrom => glob("${iso}/iso/*.iso"),
-        bios => '${pkgs.OVMF}/FV/OVMF.fd'
+        bios => '${pkgs.OVMF.fd}/FV/OVMF.fd'
       '';
 
     uefiUsb = makeBootTest "uefi-usb" ''
         usb => glob("${iso}/iso/*.iso"),
-        bios => '${pkgs.OVMF}/FV/OVMF.fd'
+        bios => '${pkgs.OVMF.fd}/FV/OVMF.fd'
       '';
 
     netboot = let

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -63,7 +63,7 @@ let
         (if system == "x86_64-linux" then "-m 768 " else "-m 512 ") +
         (optionalString (system == "x86_64-linux") "-cpu kvm64 ");
       hdFlags = ''hda => "vm-state-machine/machine.qcow2", hdaInterface => "${iface}", ''
-        + optionalString (bootLoader == "systemd-boot") ''bios => "${pkgs.OVMF}/FV/OVMF.fd", '';
+        + optionalString (bootLoader == "systemd-boot") ''bios => "${pkgs.OVMF.fd}/FV/OVMF.fd", '';
     in
     ''
       $machine->start;

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -15,6 +15,8 @@ in
 stdenv.mkDerivation (edk2.setup "OvmfPkg/OvmfPkg${targetArch}.dsc" {
   name = "OVMF-${version}";
 
+  outputs = [ "out" "fd" ];
+
   # TODO: properly include openssl for secureBoot
   buildInputs = [nasm iasl] ++ stdenv.lib.optionals (secureBoot == true) [ openssl ];
 
@@ -47,6 +49,13 @@ stdenv.mkDerivation (edk2.setup "OvmfPkg/OvmfPkg${targetArch}.dsc" {
     '' else ''
       build -D CSM_ENABLE -D FD_SIZE_2MB ${if secureBoot then "-DSECURE_BOOT_ENABLE=TRUE" else ""}
     '';
+
+  postFixup = ''
+    mkdir -p $fd/FV
+    mv $out/FV/OVMF{,_CODE,_VARS}.fd $fd/FV
+  '';
+
+  dontPatchELF = true;
 
   meta = {
     description = "Sample UEFI firmware for QEMU and KVM";

--- a/pkgs/applications/virtualization/xen/4.5.nix
+++ b/pkgs/applications/virtualization/xen/4.5.nix
@@ -167,7 +167,7 @@ callPackage (import ./generic.nix (rec {
     ++ optional (withSeabios) "--with-system-seabios=${seabios}"
     ++ optional (!withInternalSeabios && !withSeabios) "--disable-seabios"
 
-    ++ optional (withOVMF) "--with-system-ovmf=${OVMF}"
+    ++ optional (withOVMF) "--with-system-ovmf=${OVMF.fd}/FV/OVMF.fd"
     ++ optional (withInternalOVMF) "--enable-ovmf";
 
   patches =


### PR DESCRIPTION
The OVMF closure is huge, while we often only need `OVMF{,_CODE,VARS}.fd`.

See https://github.com/NixOS/nixpkgs/issues/25854

Not sure about why `dontPatchELF` now seems to be necessary for the build to pass, nor have I tested with Xen, so this is still WIP.