### PR TITLE
glibc: Clean up cross compilation

### DIFF
--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -1,21 +1,23 @@
-{ lib, stdenv, fetchurl, linuxHeaders
+{ lib, stdenv, fetchurl
 , installLocales ? true
 , profilingLibraries ? false
-, gccCross ? null
 , withGd ? false, gd ? null, libpng ? null
+, buildPlatform, hostPlatform
+, buildPackages
 }:
 
 assert stdenv.cc.isGNU;
 
 let
   build = import ./common.nix;
-  cross = if gccCross != null then gccCross.target else null;
+  cross = if buildPlatform != hostPlatform then hostPlatform else null;
+  inherit (buildPackages) linuxHeaders;
 in
   build cross ({
     name = "glibc" + lib.optionalString withGd "-gd";
 
-    inherit lib stdenv fetchurl linuxHeaders installLocales
-      profilingLibraries gccCross withGd gd libpng;
+    inherit lib stdenv buildPackages fetchurl linuxHeaders installLocales
+      profilingLibraries withGd gd libpng;
 
     NIX_NO_SELF_RPATH = true;
 

--- a/pkgs/development/libraries/glibc/info.nix
+++ b/pkgs/development/libraries/glibc/info.nix
@@ -1,12 +1,7 @@
-{ lib, stdenv, fetchurl, texinfo, perl }:
+{ callPackage, texinfo, perl }:
 
-let build = import ./common.nix; in
-
-/* null cross builder */
-build null {
+callPackage ./common.nix {} {
   name = "glibc-info";
-
-  inherit fetchurl stdenv lib;
 
   outputs = [ "out" ];
 

--- a/pkgs/development/libraries/glibc/locales.nix
+++ b/pkgs/development/libraries/glibc/locales.nix
@@ -6,14 +6,13 @@
    http://sourceware.org/cgi-bin/cvsweb.cgi/libc/localedata/SUPPORTED?cvsroot=glibc
 */
 
-{ lib, stdenv, fetchurl, writeText, allLocales ? true, locales ? ["en_US.UTF-8/UTF-8"] }:
+{ stdenv, callPackage, writeText
+, allLocales ? true, locales ? [ "en_US.UTF-8/UTF-8" ]
+}:
 
-let build = import ./common.nix; in
-
-build null {
+callPackage ./common.nix { inherit stdenv; } {
   name = "glibc-locales";
 
-  inherit fetchurl stdenv lib;
   installLocales = true;
 
   builder = ./locales-builder.sh;

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -92,7 +92,7 @@ let
 
   pkgs = pkgsFun ({inherit system;} // selectedCrossSystem);
 
-  glibc = pkgs.buildPackages.libcCross;
+  glibc = pkgs.libcCross;
   bash = pkgs.bash;
   findutils = pkgs.findutils;
   diffutils = pkgs.diffutils;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7700,7 +7700,6 @@ with pkgs;
 
   glibc = callPackage ../development/libraries/glibc {
     installLocales = config.glibc.locales or false;
-    gccCross = null;
   };
 
   glibc_memusage = callPackage ../development/libraries/glibc {
@@ -7708,13 +7707,23 @@ with pkgs;
     withGd = true;
   };
 
-  glibcCross = forcedNativePackages.glibc.override {
-    gccCross = gccCrossStageStatic;
-    inherit (forcedNativePackages) linuxHeaders;
+  # Being redundant to avoid cycles on boot. TODO: find a better way
+  glibcCross = callPackage ../development/libraries/glibc {
+    installLocales = config.glibc.locales or false;
+    # Can't just overrideCC, because then the stdenv-cross mkDerivation will be
+    # thrown away. TODO: find a better solution for this.
+    stdenv = buildPackages.makeStdenvCross
+      buildPackages.buildPackages.stdenv
+      buildPackages.targetPlatform
+      buildPackages.binutils
+      buildPackages.gccCrossStageStatic;
   };
 
   # We can choose:
-  libcCrossChooser = name: if name == "glibc" then glibcCross
+  libcCrossChooser = name:
+    # libc is hackily often used from the previous stage. This `or`
+    # hack fixes the hack, *sigh*.
+    /**/ if name == "glibc" then __targetPackages.glibcCross or glibcCross
     else if name == "uclibc" then uclibcCross
     else if name == "msvcrt" then windows.mingw_w64
     else if name == "libSystem" then darwin.xcode

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -15,6 +15,7 @@ let
   common = {
     buildPackages.binutils = nativePlatforms;
     gmp = nativePlatforms;
+    libcCross = nativePlatforms;
   };
 
   gnuCommon = lib.recursiveUpdate common {


### PR DESCRIPTION
Might it be possible to use `overrideAttrs` or something to make this cleaner still?

testing: http://hydra.nixos.org/eval/1359820