### PR TITLE
Typora: init at 0.9.29

### DIFF
--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Typora - a minimal Markdown reading & writing app.";
+    description = "A minimal Markdown reading & writing app";
     homepage = "https://typora.io";
     license = licenses.free;
     maintainers = with stdenv.lib.maintainers; [ jensbin ];

--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -1,0 +1,89 @@
+{ stdenv, fetchurl, dpkg, lib, glib, dbus, makeWrapper, gnome2, atk, cairo
+, freetype, fontconfig, nspr, nss, xorg, alsaLib, cups, expat, udev }:
+
+stdenv.mkDerivation rec {
+  name = "typora-${version}";
+  version = "0.9.29";
+
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://www.typora.io/linux/typora_${version}_amd64.deb";
+        sha256 = "1d7a02ee603be871d6f8c25b5c11069267ec11644a4f513635c0769ce46a44a7";
+      }
+    else
+      fetchurl {
+        url = "https://www.typora.io/linux/typora_${version}_i386.deb";
+        sha256 = "79834b0ccd2257c030aec850ebc81fe115f46891b482f1ffa41fcc19c5f29659";
+      }
+    ;
+
+    rpath = stdenv.lib.makeLibraryPath [
+      alsaLib
+      gnome2.GConf
+      gnome2.gtk
+      gnome2.gdk_pixbuf
+      gnome2.pango
+      expat
+      atk
+      nspr
+      nss
+      stdenv.cc.cc
+      glib
+      cairo
+      cups
+      dbus
+      udev
+      fontconfig
+      freetype
+      xorg.libX11
+      xorg.libXi
+      xorg.libXext
+      xorg.libXtst
+      xorg.libXfixes
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXrender
+      xorg.libXrandr
+      xorg.libXcomposite
+      xorg.libxcb
+      xorg.libXScrnSaver
+  ];
+
+
+  buildInputs = [ dpkg makeWrapper ];
+
+  unpackPhase = "true";
+  installPhase = ''
+    mkdir -p $out
+    dpkg -x $src $out
+    cp -av $out/usr/* $out
+    rm $out/bin/typora
+
+    # Otherwise it looks "suspicious"
+    chmod -R g-w $out
+  '';
+
+  postFixup = ''
+     patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "$out/share/typora:${rpath}" "$out/share/typora/Typora"
+
+    ln -s "$out/share/typora/Typora" "$out/bin/typora"
+
+    # Fix the desktop link
+    substituteInPlace $out/share/applications/typora.desktop \
+      --replace /usr/bin/ $out/bin/ \
+      --replace /usr/share/ $out/share/
+
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Typora - a minimal Markdown reading & writing app.";
+    homepage = "https://typora.io";
+    license = licenses.free;
+    maintainers = with stdenv.lib.maintainers; [ jensbin ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15030,6 +15030,8 @@ with pkgs;
     inherit (gnome3) defaultIconTheme;
   };
 
+  typora = callPackage ../applications/editors/typora { };
+
   librep = callPackage ../development/libraries/librep { };
 
   rep-gtk = callPackage ../development/libraries/rep-gtk { };


### PR DESCRIPTION
###### Motivation for this change
Typora (https://typora.io) is markdown viewer and editor.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

