### PR TITLE
clblas-cuda: requires ocl-icd now for libOpenCL.so.1 #25902

### DIFF
--- a/pkgs/development/libraries/science/math/clblas/cuda/default.nix
+++ b/pkgs/development/libraries/science/math/clblas/cuda/default.nix
@@ -5,6 +5,7 @@
 , blas
 , boost
 , python
+, ocl-icd
 , cudatoolkit
 , nvidia_x11
 , gtest
@@ -51,6 +52,7 @@ stdenv.mkDerivation rec {
     gfortran
     blas
     python
+    ocl-icd
     cudatoolkit
     nvidia_x11
     gtest


### PR DESCRIPTION
###### Motivation for this change

Closes #25902

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

