### PR TITLE
timelapse-deflicker: init at 142acd1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -561,6 +561,7 @@
   vlstill = "Vladimír Štill <xstill@fi.muni.cz>";
   vmandela = "Venkateswara Rao Mandela <venkat.mandela@gmail.com>";
   vmchale = "Vanessa McHale <tmchale@wisc.edu>";
+  valeriangalliat = "Valérian Galliat <val@codejam.info>";
   volhovm = "Mikhail Volkhov <volhovm.cs@gmail.com>";
   volth = "Jaroslavas Pocepko <jaroslavas@volth.com>";
   vozz = "Oliver Hunt <oliver.huntuk@gmail.com>";

--- a/pkgs/applications/graphics/timelapse-deflicker/default.nix
+++ b/pkgs/applications/graphics/timelapse-deflicker/default.nix
@@ -1,37 +1,31 @@
-{ stdenv, fetchgit, makeWrapper, perl, perlPackages }:
+{ stdenv, fetchFromGitHub, makeWrapper, perl, perlPackages }:
 
 stdenv.mkDerivation rec {
   name = "timelapse-deflicker-${version}";
-  version = "142acd1";
+  version = "0.1.0";
 
-  src = fetchgit {
-    url = "https://github.com/cyberang3l/timelapse-deflicker.git";
-    rev = "142acd1";
+  src = fetchFromGitHub {
+    owner = "cyberang3l";
+    repo = "timelapse-deflicker";
+    rev = "v${version}";
     sha256 = "0bbfnrdycrpyz7rqrql5ib9qszny7z5xpqp65c1mxqd2876gv960";
   };
 
   installPhase = ''
-    mkdir -p $out/bin
-    mv timelapse-deflicker.pl $out/bin/timelapse-deflicker
-
-    wrapProgram $out/bin/timelapse-deflicker --prefix PERL5LIB : \
-      "${with perlPackages; stdenv.lib.makePerlPath [
-        PerlMagick
-        TermProgressBar
-        ImageExifTool
-        FileType
-        ClassMethodMaker
-      ]}"
+    install -m755 -D timelapse-deflicker.pl $out/bin/timelapse-deflicker
+    wrapProgram $out/bin/timelapse-deflicker --set PERL5LIB $PERL5LIB
   '';
 
-  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
-
-  buildInputs = [ makeWrapper perl ];
+  buildInputs = with perlPackages; [
+    makeWrapper perl
+    PerlMagick TermProgressBar ImageExifTool
+    FileType ClassMethodMaker
+  ];
 
   meta = with stdenv.lib; {
     description = "Simple script to deflicker images taken for timelapses";
     homepage = https://github.com/cyberang3l/timelapse-deflicker;
-    license = stdenv.lib.licenses.gpl3;
+    license = licenses.gpl3;
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/graphics/timelapse-deflicker/default.nix
+++ b/pkgs/applications/graphics/timelapse-deflicker/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchgit, makeWrapper, perl, perlPackages }:
+
+stdenv.mkDerivation rec {
+  name = "timelapse-deflicker-${version}";
+  version = "142acd1";
+
+  src = fetchgit {
+    url = "https://github.com/cyberang3l/timelapse-deflicker.git";
+    rev = "142acd1";
+    sha256 = "0bbfnrdycrpyz7rqrql5ib9qszny7z5xpqp65c1mxqd2876gv960";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv timelapse-deflicker.pl $out/bin/timelapse-deflicker
+
+    wrapProgram $out/bin/timelapse-deflicker --prefix PERL5LIB : \
+      "${with perlPackages; stdenv.lib.makePerlPath [
+        PerlMagick
+        TermProgressBar
+        ImageExifTool
+        FileType
+        ClassMethodMaker
+      ]}"
+  '';
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  buildInputs = [ makeWrapper perl ];
+
+  meta = with stdenv.lib; {
+    description = "Simple script to deflicker images taken for timelapses";
+    homepage = https://github.com/cyberang3l/timelapse-deflicker;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/graphics/timelapse-deflicker/default.nix
+++ b/pkgs/applications/graphics/timelapse-deflicker/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     description = "Simple script to deflicker images taken for timelapses";
     homepage = https://github.com/cyberang3l/timelapse-deflicker;
     license = licenses.gpl3;
+    maintainers = with maintainers; [ valeriangalliat ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4243,6 +4243,8 @@ with pkgs;
 
   timemachine = callPackage ../applications/audio/timemachine { };
 
+  timelapse-deflicker = callPackage ../applications/graphics/timelapse-deflicker { };
+
   timetrap = callPackage ../applications/office/timetrap { };
 
   tinc = callPackage ../tools/networking/tinc { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5535,6 +5535,19 @@ let self = _self // overrides; _self = with self; {
 
   FileTemp = null;
 
+  FileType = buildPerlPackage {
+    name = "File-Type-0.22";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/P/PM/PMISON/File-Type-0.22.tar.gz;
+      sha256 = "0hfkaafp6wb0nw19x47wc6wc9mwlw8s2rxiii3ylvzapxxgxjp6k";
+    };
+    meta = {
+      description = "File::Type uses magic numbers (typically at the start of a file) to determine the MIME type of that file.";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
+    };
+  };
+
   FileSlurp = buildPerlPackage {
     name = "File-Slurp-9999.19";
     # WARNING: check on next update if deprecation warning is gone


### PR DESCRIPTION
Add a package for [timelapse-deflicker](https://github.com/cyberang3l/timelapse-deflicker).

Tested on macOS and NixOS.

The `ClassMethodMaker` Perl library is not a dependency of timelapse-deflicker but it's needed by `TermProgressBar`. But even though it's in its `propagatedBuildInputs`, I had an error running the program on how `ClassMethod` was not found, and adding `ClassMethodMaker` to the direct dependencies fixed it. Any idea what I'm doing wrong?