### PR TITLE
salt: 2016.11.4 -> 2016.11.5

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -1,5 +1,5 @@
 {
-  stdenv, fetchurl, python2Packages, openssl,
+  stdenv, python2Packages, openssl,
 
   # Many Salt modules require various Python modules to be installed,
   # passing them in this array enables Salt to find them.
@@ -7,12 +7,13 @@
 }:
 
 python2Packages.buildPythonApplication rec {
-  name = "salt-${version}";
-  version = "2016.11.4";
+  pname = "salt";
+  version = "2016.11.5";
+  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "mirror://pypi/s/salt/${name}.tar.gz";
-    sha256 = "0pvn0pkndwx81xkpah14awz4rg9zhkpl4bhn3hlrin1zinr0jhgv";
+  src = python2Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1gpq6s87vy782z4b5h6s7zwndcxnllbdr2wldxr9hyp4lfj2f55q";
   };
 
   propagatedBuildInputs = with python2Packages; [


### PR DESCRIPTION
###### Motivation for this change

Release notes: https://docs.saltstack.com/en/latest/topics/releases/2016.11.5.html
This fixes a regression in 2016.11.4.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).