### PR TITLE
dale: 20170419 -> 20170519

### DIFF
--- a/pkgs/development/compilers/dale/default.nix
+++ b/pkgs/development/compilers/dale/default.nix
@@ -1,19 +1,27 @@
-{ stdenv, fetchFromGitHub, cmake, libffi, llvm_35, perl }:
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkgconfig
+, libffi
+, llvm_35
+, doCheck ? false
+, perl
+}:
 
-let version = "20170419";
-    doCheck = false;
+let version = "20170519";
+
 in stdenv.mkDerivation {
   name = "dale-${version}";
 
   src = fetchFromGitHub {
     owner = "tomhrr";
     repo = "dale";
-    rev = "64e072d0520a134b9ae8038104fa977776b6e0af";
-    sha256 = "1apvq3v6ra8x0sj8gg9yavqsyxiggh2wnh1zbw2ccpg723bssl4a";
+    rev = "39e16d8e89fa070de65a673d4462e783d530f95a";
+    sha256 = "0dc5cjahv7lzlp92hidlh83rwgrpgb6xz2pnba2pm5xrv2pnsskl";
   };
 
-  buildInputs = [ cmake libffi llvm_35 ] ++
-                stdenv.lib.optional doCheck perl;
+  buildInputs = [ cmake pkgconfig libffi llvm_35 ]
+             ++ stdenv.lib.optional doCheck perl;
 
   inherit doCheck;
 


### PR DESCRIPTION
Includes some stability/predictability and portability improvements.

###### Motivation for this change

Incorporate some essential upstream changes, and maybe make it build on Darwin.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [x] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).