### PR TITLE
common-updater-script: fix error handling

### DIFF
--- a/pkgs/common-updater/scripts.nix
+++ b/pkgs/common-updater/scripts.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, coreutils, gawk, gnused, nix }:
+{ stdenv, makeWrapper, coreutils, gawk, gnused, diffutils, nix }:
 
 stdenv.mkDerivation {
   name = "common-updater-scripts";
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     cp ${./scripts}/* $out/bin
 
     for f in $out/bin/*; do
-      wrapProgram $f --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gawk gnused nix ]}
+      wrapProgram $f --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gawk gnused nix diffutils ]}
     done
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

`common-updater-script` uses `cmp` command to check errors, but it cannot find `cmp`, so results in the following log file:

```
/nix/store/ys5l41pwfja3lyjaw9mf9ia9ivi8y8kl-common-updater-scripts/bin/.update-source-version-wrapped: line 55: cmp: command not found
/nix/store/ys5l41pwfja3lyjaw9mf9ia9ivi8y8kl-common-updater-scripts/bin/.update-source-version-wrapped: line 69: cmp: command not found
/nix/store/ys5l41pwfja3lyjaw9mf9ia9ivi8y8kl-common-updater-scripts/bin/.update-source-version-wrapped: line 86: cmp: command not found
```

This PR adds `diffutils` as a dependency to fix it.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc: @dezgeg 

---

