### PR TITLE
solc: 0.4.8 -> 0.4.11

### DIFF
--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -5,19 +5,22 @@ let jsoncpp = fetchzip {
   sha256 = "0jz93zv17ir7lbxb3dv8ph2n916rajs8i96immwx9vb45pqid3n0";
 }; in
 
+let commit = "68ef5810593e7c8092ed41d5f474dd43141624eb"; in
+
 stdenv.mkDerivation rec {
-  version = "0.4.8";
+  version = "0.4.11";
   name = "solc-${version}";
 
   # Cannot use `fetchFromGitHub' because of submodules
   src = fetchgit {
     url = "https://github.com/ethereum/solidity";
-    rev = "60cc1668517f56ce6ca8225555472e7a27eab8b0";
-    sha256 = "09mwah7c5ca1bgnqp5qgghsi6mbsi7p16z8yxm0aylsn2cjk23na";
+    rev = commit;
+    sha256 = "13zycybf23yvf3hkf9zgw9gbc1y4ifzxaf7sll69bsn24fcyq961";
   };
 
   patchPhase = ''
-    echo >commit_hash.txt 2dabbdf06f414750ef0425c664f861aeb3e470b8
+    echo >commit_hash.txt ${commit}
+    echo >prerelease.txt
     substituteInPlace deps/jsoncpp.cmake \
       --replace https://github.com/open-source-parsers/jsoncpp/archive/1.7.7.tar.gz ${jsoncpp}
     substituteInPlace cmake/EthCompilerSettings.cmake \


### PR DESCRIPTION
###### Motivation for this change

> This release fixes a bug in the optimizer (more about this on the blog), introduces the standard JSON interface, adds interface contracts and implements some additional safety checks.

https://github.com/ethereum/solidity/releases/tag/v0.4.11

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
