### PR TITLE
networkmanager_fortisslvpn: init at 1.2.4

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -124,7 +124,7 @@ in {
         type = types.attrsOf types.package;
         default = { inherit networkmanager modemmanager wpa_supplicant
                             networkmanager_openvpn networkmanager_vpnc
-                            networkmanager_openconnect
+                            networkmanager_openconnect networkmanager_fortisslvpn
                             networkmanager_pptp networkmanager_l2tp; };
         internal = true;
       };
@@ -221,6 +221,9 @@ in {
       }
       { source = "${networkmanager_openconnect}/etc/NetworkManager/VPN/nm-openconnect-service.name";
         target = "NetworkManager/VPN/nm-openconnect-service.name";
+      }
+      { source = "${networkmanager_fortisslvpn}/etc/NetworkManager/VPN/nm-fortisslvpn-service.name";
+        target = "NetworkManager/VPN/nm-fortisslvpn-service.name";
       }
       { source = "${networkmanager_pptp}/etc/NetworkManager/VPN/nm-pptp-service.name";
         target = "NetworkManager/VPN/nm-pptp-service.name";

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -186,7 +186,7 @@ in {
     networking.networkmanager.basePackages =
       { inherit (pkgs) networkmanager modemmanager wpa_supplicant;
         inherit (gnome3) networkmanager_openvpn networkmanager_vpnc
-                         networkmanager_openconnect networkmanager_pptp
+                         networkmanager_openconnect networkmanager_fortisslvpn networkmanager_pptp
                          networkmanager_l2tp; };
 
     # Needed for themes and backgrounds

--- a/pkgs/desktops/gnome-3/3.22/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/default.nix
@@ -212,6 +212,10 @@ let
     inherit gnome3;
   };
 
+  networkmanager_fortisslvpn = pkgs.networkmanager_fortisslvpn.override {
+    inherit gnome3;
+  };
+
   networkmanager_l2tp = pkgs.networkmanager_l2tp.override {
     inherit gnome3;
   };

--- a/pkgs/tools/networking/network-manager/fortisslvpn.nix
+++ b/pkgs/tools/networking/network-manager/fortisslvpn.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, openfortivpn, automake, autoconf, libtool, intltool, pkgconfig,
+networkmanager, ppp, lib, libsecret, withGnome ? true, gnome3, procps, kmod }:
+
+stdenv.mkDerivation rec {
+  name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
+  pname   = "NetworkManager-fortisslvpn";
+  major   = "1.2";
+  version = "${major}.4";
+
+  src = fetchurl {
+    url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
+    sha256 = "0wsbj5lvf9l1w8k5nmaqnzmldilh482bn4z4k8a3wnm62xfxgscr";
+  };
+
+  buildInputs = [ openfortivpn networkmanager ppp libtool libsecret ]
+    ++ stdenv.lib.optionals withGnome [ gnome3.gtk gnome3.libgnome_keyring gnome3.gconf gnome3.networkmanagerapplet ];
+
+  nativeBuildInputs = [ automake autoconf intltool pkgconfig ];
+
+  configureFlags = [
+    "${if withGnome then "--with-gnome" else "--without-gnome"}"
+    "--disable-static"
+    "--localstatedir=/tmp"
+  ];
+
+  preConfigure = ''
+     substituteInPlace "src/nm-fortisslvpn-service.c" \
+       --replace "/bin/openfortivpn" "${openfortivpn}/bin/openfortivpn"
+  '';
+
+  meta = {
+    description = "NetworkManager's FortiSSL plugin";
+    inherit (networkmanager.meta) maintainers platforms;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3192,6 +3192,8 @@ with pkgs;
 
   networkmanager_openconnect = callPackage ../tools/networking/network-manager/openconnect.nix { };
 
+  networkmanager_fortisslvpn = callPackage ../tools/networking/network-manager/fortisslvpn.nix { };
+
   networkmanager_strongswan = callPackage ../tools/networking/network-manager/strongswan.nix { };
 
   networkmanagerapplet = newScope gnome2 ../tools/networking/network-manager-applet { };


### PR DESCRIPTION
###### Motivation for this change

Useful for people who use this type of VPN.

I could connect to the VPN using this. Unfortunately some nm frontends dont support this yet, e.g. kde, but works with networkmanagerapplet.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

