### PR TITLE
enable hydra jobs for some of the darwin only packages

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -100,7 +100,7 @@ let
           # Test a full stdenv bootstrap from the bootstrap tools definition
           inherit (bootstrap.test-pkgs) stdenv;
         };
-    }) // (mapTestOn ((packagePlatforms pkgs) // rec {
+    }) // (mapTestOn ((packagePlatforms pkgs) // {
       haskell.compiler = packagePlatforms pkgs.haskell.compiler;
       haskellPackages = packagePlatforms pkgs.haskellPackages;
 
@@ -122,6 +122,39 @@ let
         pandas = unix;
         scikitlearn = unix;
       };
+
+      # Enable darwin only packages, see https://github.com/NixOS/nixpkgs/issues/25200
+      darwin = {
+        adv_cmds = darwin;
+        basic_cmds = darwin;
+        binutils = darwin;
+        bootstrap_cmds = darwin;
+        cctools = darwin;
+        configd = darwin;
+        developer_cmds = darwin;
+        libiconv = darwin;
+        libobjc = darwin;
+        libresolv = darwin;
+        libunwind = darwin;
+        network_cmds = darwin;
+        ps = darwin;
+        shell_cmds = darwin;
+      };
+      contacts = darwin;
+      emacsMacport = darwin;
+      gtk-mac-bundler = darwin;
+      gtk-mac-integration = darwin;
+      gtk-mac-integration-gtk3 = darwin;
+      iterm2 = darwin;
+      khd = darwin;
+      kwm = darwin;
+      macvim = darwin;
+      pinentry_mac = darwin;
+      quartz-wm = darwin;
+      reattach-to-user-namespace = darwin;
+      terminal-notifier = darwin;
+      xhyve = darwin;
+      xquartz = darwin;
     } ));
 
 in jobs


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/25200.

Maybe there's another/better way to fix this?

Due to the way packagePlatforms and the fact that it's not possible to
access drv.meta of a 'broken' package all of the darwin only packages
are filtered out of the job in release.nix.

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
