### PR TITLE
mysql service: change default data directory for 17.09

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -72,7 +72,7 @@ in
 
       dataDir = mkOption {
         type = types.path;
-        default = "/var/mysql"; # !!! should be /var/db/mysql
+        example = "/var/lib/mysql";
         description = "Location where MySQL stores its table files";
       };
 
@@ -165,6 +165,10 @@ in
   ###### implementation
 
   config = mkIf config.services.mysql.enable {
+
+    services.mysql.dataDir =
+      mkDefault (if versionAtLeast config.system.stateVersion "17.09" then "/var/lib/mysql"
+                 else "/var/mysql");
 
     users.extraUsers.mysql = {
       description = "MySQL server user";


### PR DESCRIPTION
###### Motivation for this change

The new directory is now moved to /var/db/mysql. This makes it consistent with
most other databases like postgresql and mongodb.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

