### PR TITLE
elementary-icon-theme: 4.0.3 -> 4.1.0

### DIFF
--- a/pkgs/data/icons/elementary-icon-theme/default.nix
+++ b/pkgs/data/icons/elementary-icon-theme/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "4.0.3";
+  version = "4.1.0";
 
   package-name = "elementary-icon-theme";
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://launchpad.net/elementaryicons/4.x/${version}/+download/${name}.tar.xz";
-    sha256 = "0i3cp0wiy4g6d6symyfv3hvmw97109lfakd4qyphabbqllc9xlxb";
+    sha256 = "08pkk4299dj442dby15lwxwz7bax5d3828v1f81mbll084k7vssm";
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).