### PR TITLE
Fix typo in manual about options without defaults

### DIFF
--- a/nixos/doc/manual/development/option-declarations.xml
+++ b/nixos/doc/manual/development/option-declarations.xml
@@ -41,8 +41,9 @@ options = {
     <term><varname>default</varname></term>
     <listitem>
       <para>The default value used if no value is defined by any
-      module.  A default is not required; in that case, if the option
-      value is never used, an error will be thrown.</para>
+      module.  A default is not required; but if a default is not given,
+      then users of the module will have to define the value of the
+      option, otherwise an error will be thrown.</para>
     </listitem>
   </varlistentry>
 


### PR DESCRIPTION
###### Motivation for this change

Manual seems to have this the wrong way
