### PR TITLE
samba: 4.5.8 -> 4.6.3

### DIFF
--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -19,11 +19,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "samba-${version}";
-  version = "4.5.8";
+  version = "4.6.3";
 
   src = fetchurl {
     url = "mirror://samba/pub/samba/stable/${name}.tar.gz";
-    sha256 = "1w41pxszv5z6gjclg6zymn47mk8n51lnpgcx1k2q18i3i1nnafzn";
+    sha256 = "0q8m9cp76vx0x7zhvbfamqvh8hmmlki8ih9zb2hcn2bqlwyyyf1a";
   };
 
   outputs = [ "out" "dev" "man" ];


### PR DESCRIPTION
###### Motivation for this change

Update to latest samba version

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Used samba service with 4.6.3 for a week.

---

