### PR TITLE
emby service: allow changing data directory

### DIFF
--- a/nixos/modules/services/misc/emby.nix
+++ b/nixos/modules/services/misc/emby.nix
@@ -22,6 +22,12 @@ in
         default = "emby";
         description = "Group under which emby runs.";
       };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/emby/ProgramData-Server";
+        description = "Location where Emby stores its data.";
+      };
     };
   };
 
@@ -31,10 +37,10 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       preStart = ''
-        test -d /var/lib/emby/ProgramData-Server || {
-          echo "Creating initial Emby data directory in /var/lib/emby/ProgramData-Server"
-          mkdir -p /var/lib/emby/ProgramData-Server
-          chown -R ${cfg.user}:${cfg.group} /var/lib/emby/ProgramData-Server
+        test -d ${cfg.dataDir} || {
+          echo "Creating initial Emby data directory in ${cfg.dataDir}"
+          mkdir -p ${cfg.dataDir}
+          chown -R ${cfg.user}:${cfg.group} ${cfg.dataDir}
           }
       '';
 


### PR DESCRIPTION
###### Motivation for this change

It's usefull to move the datadirectory to a different location, maybe on a different disk.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

