### PR TITLE
metar: init at 20161013.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -587,6 +587,7 @@
   yurrriq = "Eric Bailey <eric@ericb.me>";
   z77z = "Marco Maggesi <maggesi@math.unifi.it>";
   zagy = "Christian Zagrodnick <cz@flyingcircus.io>";
+  zalakain = "Unai Zalakain <contact@unaizalakain.info>";
   zauberpony = "Elmar Athmer <elmar@athmer.org>";
   zef = "Zef Hemel <zef@zef.me>";
   zimbatm = "zimbatm <zimbatm@zimbatm.com>";

--- a/pkgs/applications/misc/metar/default.nix
+++ b/pkgs/applications/misc/metar/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchgit, curl }:
+
+stdenv.mkDerivation {
+  name = "metar-20161013.1";
+
+  src = fetchgit {
+    url = "https://github.com/keesL/metar.git";
+    rev = "20e9ca69faea330f6c2493b6829131c24cb55147";
+    sha256 = "1fgrlnpasqf1ihh9y6zy6mzzybqx0lxvh7gmv03rjdb55dr42dxj";
+  };
+
+  buildInputs = [ curl ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/keesL/metar;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.zalakain ];
+    description = "Downloads weather reports and optionally decodes them";
+    longDescription = ''
+      METAR reports are meteorogical weather reports for aviation. Metar is a small
+      program which downloads weather reports for user-specified stations and
+      optionally decodes them into a human-readable format.
+
+      Currently, metar supports decoding date/time, wind, visibility, cloud layers,
+      temperature, air pressure and weather phenomena, such as rain, fog, etc. Also,
+      more work in the area of clouds need to be done, as support for Cumulus or
+      Cumulunimbus is not yet decoded.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3020,6 +3020,8 @@ with pkgs;
 
   metamorphose2 = callPackage ../applications/misc/metamorphose2 { };
 
+  metar = callPackage ../applications/misc/metar { };
+
   mfcuk = callPackage ../tools/security/mfcuk { };
 
   mfoc = callPackage ../tools/security/mfoc { };


### PR DESCRIPTION
###### Motivation for this change

Add metar -- library for downloading and decoding airport METARs.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

