### PR TITLE
tcptraceroute: init at 1.5beta7

### DIFF
--- a/pkgs/tools/networking/tcptraceroute/default.nix
+++ b/pkgs/tools/networking/tcptraceroute/default.nix
@@ -1,0 +1,28 @@
+{ stdenv , pkgs , fetchurl, libpcap, libnet
+}:
+
+stdenv.mkDerivation rec {
+   pkgname = "tcptraceroute";
+   name = "${pkgname}-${version}";
+   version = "1.5beta7";
+
+   src = fetchurl {
+     url = "https://github.com/mct/${pkgname}/archive/${name}.tar.gz";
+     sha256 = "1rz8bgc6r1isb40awv1siirpr2i1paa2jc1cd3l5pg1m9522xzap";
+   };
+
+   # for reasons unknown --disable-static configure flag doesn't disable static
+   # linking.. we instead override CFLAGS with -static omitted
+   preBuild = ''
+      makeFlagsArray=(CFLAGS=" -g -O2 -Wall")
+   '';
+
+   buildInputs = [ libpcap libnet ];
+
+   meta = {
+     description = "A traceroute implementation using TCP packets.";
+     homepage = https://github.com/mct/tcptraceroute;
+     license = stdenv.lib.licenses.gpl2;
+     maintainers = [ stdenv.lib.maintainers.pbogdan ];
+   };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4229,6 +4229,8 @@ with pkgs;
 
   tcpcrypt = callPackage ../tools/security/tcpcrypt { };
 
+  tcptraceroute = callPackage ../tools/networking/tcptraceroute { };
+
   tboot = callPackage ../tools/security/tboot { };
 
   tcpdump = callPackage ../tools/networking/tcpdump { };


### PR DESCRIPTION
###### Motivation for this change

Make tcptraceroute available in nixpkgs.

Notes:

- I'm unsure on version names with suffixes such as beta7. Is it fine as is or would 1.5-beta7 be more appropriate, or perhaps some other variation?
- I don't particularly like the `CFLAGS` hack but no matter what configure flags I try I can't disable static linking. Neither `--disable-static` nor `--enable-static=no` appears to work although I haven't looked into this further.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

