### PR TITLE
unetbootin: fix bug where nothing renders in the window

### DIFF
--- a/pkgs/tools/cd-dvd/unetbootin/default.nix
+++ b/pkgs/tools/cd-dvd/unetbootin/default.nix
@@ -46,7 +46,8 @@ stdenv.mkDerivation rec {
     cp unetbootin.desktop $out/share/applications
 
     wrapProgram $out/bin/unetbootin \
-      --prefix PATH : ${stdenv.lib.makeBinPath [ which p7zip mtools ]}
+      --prefix PATH : ${stdenv.lib.makeBinPath [ which p7zip mtools ]} \
+      --set QT_X11_NO_MITSHM 1
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Unetbootin shows up as a blank window.

This fix from https://github.com/unetbootin/unetbootin/issues/67 fixes it.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

