### PR TITLE
fcitx service: add QT_PLUGIN_PATH to env

### DIFF
--- a/nixos/modules/i18n/input-method/fcitx.nix
+++ b/nixos/modules/i18n/input-method/fcitx.nix
@@ -34,10 +34,12 @@ in
     i18n.inputMethod.package = fcitxPackage;
 
     environment.variables = {
-      GTK_IM_MODULE = "fcitx";
-      QT_IM_MODULE  = "fcitx";
-      XMODIFIERS    = "@im=fcitx";
+      GTK_IM_MODULE  = "fcitx";
+      QT_IM_MODULE   = "fcitx";
+      XMODIFIERS     = "@im=fcitx";
+      QT_PLUGIN_PATH = "${fcitxPackage}/lib/qt5/plugins";
     };
+
     services.xserver.displayManager.sessionCommands = "${fcitxPackage}/bin/fcitx";
   };
 }


### PR DESCRIPTION
PR #25285 removed the auto-detection of qt plugins from NIX_PROFILE,
explicitly declaring QT_PLUGIN_PATH in the module solve the problem

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

