### PR TITLE
haxe: introduce haxePackages

### DIFF
--- a/pkgs/development/compilers/haxe/hashlink.nix
+++ b/pkgs/development/compilers/haxe/hashlink.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, cmake, SDL2, zlib, libjpeg, libpng, libvorbis, mesa_glu, haxe }:
+
+stdenv.mkDerivation rec {
+  name = "hashlink-${version}";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "HaxeFoundation";
+    repo = "hashlink";
+    rev = version;
+    sha256 = "000k7a88fdkavy0x43hrggwck3zn1g61pc9m1nal5nfj1qi4r8qf";
+  };
+
+  nativeBuildInputs = [ cmake haxe ];
+  buildInputs = [ SDL2 zlib libjpeg libpng libvorbis mesa_glu ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,include,lib}
+    cp -dpR bin/* $out/lib/
+    mv $out/lib/{hl,hello.hl} $out/bin/
+
+    # generated C-code #includes the sources
+    cp -dpR ../src/* $out/include/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Virtual machine for Haxe";
+    homepage = http://hashlink.haxe.org/;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ volth ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/haxe-modules/flixel.nix
+++ b/pkgs/development/haxe-modules/flixel.nix
@@ -1,0 +1,63 @@
+{ neko, buildHaxeLib, withCommas, firetongue, spinehaxe, nape, poly2trihx, hscript, systools, task, openfl_3_6 }:
+
+rec {
+  flixel = buildHaxeLib {
+    libname = "flixel";
+    version = "4.2.1";
+    sha256 = "00c0rg6myj1nwhgwsvqqpj0fsbvfz8piza7fl3mm69adcf4661fr";
+    propagatedBuildInputs = [ openfl_3_6 ];
+    meta.description = "HaxeFlixel is a 2D game engine based on OpenFL that delivers cross-platform games";
+  };
+
+  flixel-ui = buildHaxeLib {
+    libname = "flixel-ui";
+    version = "2.2.0";
+    sha256 = "0b0rs6xfzfhnljsq4vgi74m8hzbsv79z14rsrl1dg6r5xfd69rgl";
+    propagatedBuildInputs = [ flixel ];
+    meta.description = "UI library for Flixel";
+  };
+
+  flixel-tools = buildHaxeLib {
+    libname = "flixel-tools";
+    version = "1.3.0";
+    sha256 = "1w1x53g82aq9c93wh109nc4l6ggn7q0cpcakm69zx7wf93cq49kc";
+    propagatedBuildInputs = [ flixel ];
+    meta.description = "Command-Line tools for the HaxeFlixel game engine";
+  };
+
+  flixel-templates = buildHaxeLib {
+    libname = "flixel-templates";
+    version = "2.4.1";
+    sha256 = "08a62gbx5r79819c69dhyzxh3cgm1w34ic1z3fihhl5ik4wdyc8n";
+    propagatedBuildInputs = [ flixel ];
+    meta.description = "Templates for HaxeFlixel projects";
+  };
+
+  flixel-addons = buildHaxeLib {
+    libname = "flixel-addons";
+    version = "2.4.1";
+    sha256 = "0322vpkcvnzv35famp240p2lz6x65kkirns5qmvaqxbj845q09bi";
+    propagatedBuildInputs = [ flixel ];
+    meta.description = "Set of useful, additional classes for HaxeFlixel";
+  };
+
+  flixel-demos = buildHaxeLib rec {
+    libname = "flixel-demos";
+    version = "2.4.0";
+    sha256 = "01dxknl4gr5dq8m9xwmdsp83vdkv4iirwg6w908cqx5254wn0hyr";
+    meta.description = "Demo Projects for HaxeFlixel";
+    propagatedBuildInputs = [ neko flixel flixel-ui flixel-addons firetongue nape spinehaxe poly2trihx hscript systools task ];
+    postFixup = ''
+      export HOME=$(mktemp -d)       # for "lime" to create working dir
+
+      for demo in */*; do
+        ( cd "$out/lib/haxe/${withCommas libname}/${withCommas version}/$demo"
+          lime build html5 -verbose
+          #lime build linux -verbose # works but compiles too slow
+          lime build neko -verbose
+          rm -rf Export/linux*/cpp/release/obj )
+      done
+    '';
+  };
+
+}

--- a/pkgs/development/haxe-modules/haxeui.nix
+++ b/pkgs/development/haxe-modules/haxeui.nix
@@ -1,0 +1,259 @@
+{ stdenv, fetchFromGitHub, haxe, hxcpp, hxcs, flixel, openfl, lime, luxe, pixijs, flambe, nme, hscript, installLibHaxe, simulateHaxelibDev, wxGTK30, mesa_noglu, libX11 }:
+
+let
+  meta = with stdenv.lib; {
+    description = "Styleable application centric rich UI";
+    homepage = http://haxeui.org;
+    license = licenses.mit;
+    platforms = platforms.linux; # might work on mac and windows too
+  };
+in rec {
+  hxWidgets = let
+    libname = "hxWidgets";
+    version = "2017-05-23-unstable";
+  in stdenv.mkDerivation rec {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxeui";
+      repo = "hxWidgets";
+      rev = "141ccde";
+      sha256 = "0qg7ffzs6a00raw2rygh6zbws67wk4kflxin9mbyq7dgj4g8kwg6";
+    };
+    buildInputs = [ haxe hxcpp ];
+    propagatedBuildInputs = [ (wxGTK30.override { withWebKit = true; }) mesa_noglu libX11 ];
+    doCheck = true; # it compiles demo project
+    checkPhase = ''
+      ${simulateHaxelibDev libname}
+
+      (cd samples/00-Showcase ; haxe build.hxml ; rm -rf bin/obj )
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  haxeui-core = let
+    libname = "haxeui-core";
+    version = "2017-05-24-unstable";
+  in stdenv.mkDerivation {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxeui";
+      repo = "haxeui-core";
+      rev = "ec20b7d";
+      sha256 = "1z4ckfykpkdfdagg5lg11dygfsbr65pzxwvwdpa3xhnzq9n5ipqz";
+    };
+    propagatedBuildInputs = [ hscript ];
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  haxeui-hxwidgets = let
+    libname = "haxeui-hxwidgets";
+    version = "2017-05-21-unstable";
+  in stdenv.mkDerivation {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxeui";
+      repo = "haxeui-hxwidgets";
+      rev = "9f0aa7c";
+      sha256 = "0qd3y4zddhgp0m6a9drwmcz455s1qyah7p1by680xinafh18wmdm";
+    };
+    buildInputs = [ haxe hxcpp ];
+    propagatedBuildInputs = [ haxeui-core hxWidgets ];
+    doCheck = true; # it compiles empty project
+    checkPhase = ''
+      ${simulateHaxelibDev libname}
+
+      haxe linux.hxml ; rm -rf bin/{src,include,obj}
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  haxeui-openfl = let
+    libname = "haxeui-openfl";
+    version = "2015-05-23-unstable";
+  in stdenv.mkDerivation {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxeui";
+      repo = "haxeui-openfl";
+      rev = "2587400";
+      sha256 = "0qm44yw2kk5049m6jq5xip6wggmdp6139ilry4hyjmcz6rqxb1wc";
+    };
+    buildInputs = [ haxe hxcpp ];
+    propagatedBuildInputs = [ haxeui-core openfl ];
+    doCheck = true; # compiles empty project
+    checkPhase = ''
+      ${simulateHaxelibDev libname}
+
+      haxe linux.hxml ; rm -rf bin/openfl/linux64/cpp/obj/{src,include,obj}
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  haxeui-flixel = let
+    libname = "haxeui-flixel";
+    version = "2017-05-24-unstable";
+  in stdenv.mkDerivation {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxeui";
+      repo = "haxeui-flixel";
+      rev = "26df77b";
+      sha256 = "153l6rk21lkl93h6fimrs4rclh080rl3x801sf0gcg0z63j664pr";
+    };
+    propagatedBuildInputs = [ haxeui-core flixel ];
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  haxeui-luxe = let
+    libname = "haxeui-luxe";
+    version = "2017-03-28-unstable";
+  in stdenv.mkDerivation {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxeui";
+      repo = "haxeui-luxe";
+      rev = "4104b47";
+      sha256 = "0w58js8n6fdki8sbpwsid3k8x16sjss26krjnhhv3hbx2kmy14pv";
+    };
+    propagatedBuildInputs = [ haxeui-core luxe ];
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  haxeui-pixijs = let
+    libname = "haxeui-pixijs";
+    version = "2017-04-29-unstable";
+  in stdenv.mkDerivation {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxeui";
+      repo = "haxeui-pixijs";
+      rev = "1bc4558";
+      sha256 = "01azrzdza5ij9x1cspsy88fjv8d7cczmq7sjar06919bsbv39wg3";
+    };
+    buildInputs = [ haxe ];
+    propagatedBuildInputs = [ haxeui-core pixijs ];
+    doCheck = true;
+    checkPhase = ''
+      ${simulateHaxelibDev libname}
+
+      haxe build.hxml
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  haxeui-flambe = let
+    libname = "haxeui-flambe";
+    version = "2017-04-29-unstable";
+  in stdenv.mkDerivation {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxeui";
+      repo = "haxeui-flambe";
+      rev = "797e7f3";
+      sha256 = "07h80zsnmcyqiyf91v6pbpfljsp38jwlmrfizrhs9qpyrnrlmkdw";
+    };
+    buildInputs = [ haxe ];
+    propagatedBuildInputs = [ haxeui-core flambe ];
+    doCheck = true;
+    checkPhase = ''
+      ${simulateHaxelibDev libname}
+
+      haxe build.hxml
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  haxeui-html5 = let
+    libname = "haxeui-html5";
+    version = "2017-04-29-unstable";
+  in stdenv.mkDerivation {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxeui";
+      repo = "haxeui-html5";
+      rev = "36faffb";
+      sha256 = "0h8nwn6c4iihx87hb7zgskwimd14p5dmxyszffcyw7y8fwxi3br7";
+    };
+    buildInputs = [ haxe ];
+    propagatedBuildInputs = [ haxeui-core ];
+    doCheck = true;
+    checkPhase = ''
+      ${simulateHaxelibDev libname}
+
+      haxe build.hxml
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  haxeui-nme = let
+    libname = "haxeui-nme";
+    version = "2017-05-23-unstable";
+  in stdenv.mkDerivation {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxeui";
+      repo = "haxeui-nme";
+      rev = "6f69b90";
+      sha256 = "1k02yqqgl480kncxnc794dnzg6ydh3kk8bzavjrfxhk21wi5fzs0";
+    };
+    buildInputs = [ haxe hxcpp ];
+    propagatedBuildInputs = [ haxeui-core nme ];
+    doCheck = true; # it compiles empty project
+    checkPhase = ''
+      ${simulateHaxelibDev libname}
+
+      haxe linux.hxml ; rm -rf bin/nme/*/cpp/{src,include,obj}
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  haxeui-kha = let
+    libname = "haxeui-kha";
+    version = "2017-04-29-unstable";
+  in stdenv.mkDerivation {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxeui";
+      repo = "haxeui-kha";
+      rev = "c51eb80";
+      sha256 = "0k0ip742cl19m8krwh2hnspaly4j3z5wz047swlbhs5f0rwc1jdp";
+    };
+    propagatedBuildInputs = [ haxeui-core /*kha*/ ];
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  haxeui-xwt = let
+    libname = "haxeui-xwt";
+    version = "2017-05-21-unstable";
+  in stdenv.mkDerivation {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxeui";
+      repo = "haxeui-xwt";
+      rev = "d1de5ea";
+      sha256 = "05j1vi914mqplfc59k32qp7hhqyrjgfvan3n198h1hs5yvmcnygd";
+    };
+    buildInputs = [ haxe hxcs ];
+    propagatedBuildInputs = [ haxeui-core ];
+    installPhase = installLibHaxe { inherit libname version; };
+    doCheck = true; # it compiles empty project
+    checkPhase = ''
+      ${simulateHaxelibDev libname}
+
+      haxe test.hxml
+     '';
+    inherit meta;
+  };
+
+}

--- a/pkgs/development/haxe-modules/nme.nix
+++ b/pkgs/development/haxe-modules/nme.nix
@@ -1,0 +1,66 @@
+{ stdenv, haxe, neko, hxcpp, format, buildHaxeLib, fetchFromGitHub, simulateHaxelibDev, withCommas, installLibHaxe, libX11, libXext, libXinerama, libXi, libXrandr, mesa_noglu }:
+
+let
+  meta = with stdenv.lib; {
+    description = "NME provides a backend for native iOS, Android, Windows, Mac and Linux applications, using a Flash inspired API";
+    homepage = http://nmehost.com;
+    license = licenses.mit;
+    platforms = platforms.linux; # might work on mac and windows too
+  };
+
+  nme-toolkit = buildHaxeLib rec {
+    libname = "nme-toolkit";
+    version = "6.1.0";
+    sha256 = "1jqxvn1i1q3r13lyyzsb2k4l9i4n9zkap0j6lvmfql4wq753yy76";
+    propagatedBuildInputs = [ libX11 libXext libXinerama libXi libXrandr mesa_noglu ];
+    postFixup = ''
+      # dynamicaly load libraries
+      substituteInPlace $out/lib/haxe/${withCommas libname}/${withCommas version}/sdl/include/configs/linux/SDL_config.h \
+        --replace '"libX11.so.6"'       '"${libX11     }/lib/libX11.so.6"'      \
+        --replace '"libXext.so.6"'      '"${libXext    }/lib/libXext.so.6"'     \
+        --replace '"libXinerama.so.1"'  '"${libXinerama}/lib/libXinerama.so.1"' \
+        --replace '"libXi.so.6"'        '"${libXi      }/lib/libXi.so.6"'       \
+        --replace '"libxrandr.so.2"'    '"${libXrandr  }/lib/libXrandr.so.6"'
+    '';
+    inherit meta;
+  };
+in rec {
+  gm2d = buildHaxeLib {
+    libname = "gm2d";
+    version = "3.3.24";
+    sha256 = "0lvy2y3n6dxj527sipwb2hs1fc7mqv6bkkm0r49603l0fw6rc6d9";
+    meta = meta // { description = "GM2D helper classes for rapid game making in 2D"; };
+  };
+
+  nme = let
+    libname = "nme";
+    version = "6.0.45";
+  in stdenv.mkDerivation {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "haxenme";
+      repo = "nme";
+      rev = "652f0a9"; # there are no tags on github, version -> git_revision table is at http://nmehost.com/nme/
+      sha256 = "0pvanf1gfd8dhd3z7gcbppnrl6dk6j1jvxh2sc38kcss5sjs26q9";
+    };
+    buildInputs = [ haxe neko hxcpp format gm2d ];
+    propagatedBuildInputs = [ nme-toolkit ];
+    buildPhase = ''
+      ${simulateHaxelibDev "nme"}
+      ( cd tools/nme
+        haxe compile.hxml )
+      ( cd project
+        neko build.n ndll-linux${ if stdenv.is64bit then "-m64" else "-m32" }
+        rm -rf obj )
+    '';
+    doCheck = false; # too slow
+    checkPhase = ''
+      for demo in samples/*; do
+       ( cd $demo
+         haxelib run nme build )
+      done
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+}

--- a/pkgs/development/haxe-modules/openfl/3.6.nix
+++ b/pkgs/development/haxe-modules/openfl/3.6.nix
@@ -1,0 +1,85 @@
+{ stdenv, fetchgit, bash, nodejs, haxe, neko, hxcpp, libX11, libXinerama, libXrandr, libXext, libXi, alsaLib, mesa_noglu,
+  simulateHaxelibDev, installLibHaxe, buildHaxeLib, withCommas,
+  lime, openfl, actuate, box2d, layout, munit, mcover, mconsole, mlib, hamcrest, format, webify,
+  haxe_3_2, glibc, boehmgc, pcre, zlib }:
+
+rec {
+  lime_2_9 = let
+    libname = "lime";
+    version = "2.9.1";
+  in stdenv.mkDerivation rec {
+    name = "${libname}-${version}";
+    src = fetchgit {
+      url = https://github.com/openfl/lime.git;
+      rev = "refs/tags/${version}";
+      fetchSubmodules = true;
+      sha256 = "01yyjn9s3fldxswvprhw7d2bg7p8c6bnq294ci9sg9bc5kiwya4q";
+    };
+    propagatedBuildInputs = [ munit mcover mconsole mlib hamcrest format ];
+    buildInputs = [ haxe_3_2 neko hxcpp libX11 libXinerama libXrandr libXext libXi alsaLib mesa_noglu ];
+    postPatch = ''
+      # those pre-compiled binaries do not work on NixOS anyway, and patchelf does not cure them
+      rm templates/bin/{node/node,webify}-{linux32,linux64,mac,windows.exe}
+      substituteInPlace lime/tools/helpers/NodeJSHelper.hx --replace 'var node = PathHelper.findTemplate (templatePaths, "bin/node/node" + suffix);' 'var node = "${nodejs}/bin/node";'
+      substituteInPlace lime/tools/helpers/HTML5Helper.hx  --replace 'var node = PathHelper.findTemplate (templatePaths, "bin/node/node" + suffix);' 'var node = "${nodejs}/bin/node";'
+      substituteInPlace lime/tools/helpers/HTML5Helper.hx  --replace 'var webify = PathHelper.findTemplate (templatePaths, "bin/webify" + suffix);'  'var webify = "${webify}/bin/webify";'
+
+      # dynamicaly load libraries
+      substituteInPlace project/lib/sdl/include/configs/linux/SDL_config.h      \
+        --replace '"libX11.so.6"'       '"${libX11     }/lib/libX11.so.6"'      \
+        --replace '"libXext.so.6"'      '"${libXext    }/lib/libXext.so.6"'     \
+        --replace '"libXinerama.so.1"'  '"${libXinerama}/lib/libXinerama.so.1"' \
+        --replace '"libXi.so.6"'        '"${libXi      }/lib/libXi.so.6"'       \
+        --replace '"libxrandr.so.2"'    '"${libXrandr  }/lib/libXrandr.so.6"'
+      substituteInPlace project/lib/openal/Alc/backends/alsa.c                  \
+        --replace '"libasound.so.2"'    '"${alsaLib    }/lib/libasound.so.2"'
+    '';
+    buildPhase = ''
+      ${simulateHaxelibDev "lime"}
+
+      haxelib run lime rebuild linux ${if stdenv.is64bit then "-64" else ""} -Dlegacy
+
+      # replace pre-compiled neko-2.0.0 binaries
+      rm {,legacy/}templates/neko/{bin/neko-linux{,64},ndll/linux{,64}/*}
+      ln -s ${neko}/bin/neko        templates/neko/bin/neko-linux${if stdenv.is64bit then "64" else ""}
+      ln -s ${neko}/bin/neko legacy/templates/neko/bin/neko-linux${if stdenv.is64bit then "64" else ""}
+
+      rm -rf project
+      find . -regex '.+\(\.gitignore\|\.gitmodules\)' -delete
+    '';
+    installPhase = ''
+      ${installLibHaxe { inherit libname version; }}
+
+      mkdir -p $out/bin
+      cat > $out/bin/lime <<EOF
+      #!${bash}/bin/bash
+
+      export HAXELIB_PATH="\$HAXELIB_PATH\''${HAXELIB_PATH:+:}$HAXELIB_PATH:$out/lib/haxe"
+      echo "HAXELIB_PATH=\$HAXELIB_PATH"
+      export PATH="\$PATH:${haxe}/bin:${neko}/bin"
+      exec haxelib run lime "\$@"
+      EOF
+      chmod +x $out/bin/lime
+    '';
+    inherit (lime) meta;
+  };
+
+  openfl_3_6 = buildHaxeLib {
+    libname = "openfl";
+    version = "3.6.1";
+    sha256 = "1f3v6m4fdsq77a74633qq4lfc1nm3i7dqc5zj70gg1306a0wrwxy";
+    propagatedBuildInputs = [ lime_2_9 ];
+    postFixup = ''
+      mkdir -p $out/bin
+      cat > $out/bin/openfl <<EOF
+      #!${bash}/bin/bash
+
+      export HAXELIB_PATH="\$HAXELIB_PATH\''${HAXELIB_PATH:+:}$HAXELIB_PATH:$out/lib/haxe"
+      export PATH="\$PATH:${haxe}/bin:${neko}/bin"
+      exec haxelib run openfl "\$@"
+      EOF
+      chmod +x $out/bin/openfl
+    '';
+    inherit (openfl) meta;
+  };
+}

--- a/pkgs/development/haxe-modules/openfl/default.nix
+++ b/pkgs/development/haxe-modules/openfl/default.nix
@@ -1,0 +1,117 @@
+{ stdenv, fetchgit, bash, nodejs, haxe, neko, hxcpp, libX11, libXinerama, libXrandr, libXext, libXi, alsaLib, mesa_noglu,
+  simulateHaxelibDev, installLibHaxe, buildHaxeLib, withCommas,
+  actuate, box2d, layout, munit, mcover, mconsole, mlib, hamcrest, format, webify }:
+
+rec {
+  lime = let
+    libname = "lime";
+    version = "5.0.2";
+  in stdenv.mkDerivation rec {
+    name = "${libname}-${version}";
+    src = fetchgit {
+      url = https://github.com/openfl/lime.git;
+      rev = "refs/tags/${version}";
+      fetchSubmodules = true;
+      sha256 = "1jwz6phj7mgm8n3bhjiq98zrjsmxbyr64qzcmhlqddxnsxxzrr2l";
+    };
+    propagatedBuildInputs = [ munit mcover mconsole mlib hamcrest format ];
+    buildInputs = [ haxe neko hxcpp libX11 libXinerama libXrandr libXext libXi alsaLib mesa_noglu ];
+    postPatch = ''
+      # those pre-compiled binaries do not work on NixOS anyway, and patchelf does not cure them
+      rm templates/bin/{node/node,webify}-{linux32,linux64,mac,windows.exe}
+      substituteInPlace lime/tools/helpers/NodeJSHelper.hx --replace 'var node = PathHelper.findTemplate (templatePaths, "bin/node/node" + suffix);' 'var node = "${nodejs}/bin/node";'
+      substituteInPlace lime/tools/helpers/HTML5Helper.hx  --replace 'var node = PathHelper.findTemplate (templatePaths, "bin/node/node" + suffix);' 'var node = "${nodejs}/bin/node";'
+      substituteInPlace lime/tools/helpers/HTML5Helper.hx  --replace 'var webify = PathHelper.findTemplate (templatePaths, "bin/webify" + suffix);'  'var webify = "${webify}/bin/webify";'
+
+      # dynamicaly load libraries
+      substituteInPlace project/lib/sdl/include/configs/linux/SDL_config.h      \
+        --replace '"libX11.so.6"'       '"${libX11     }/lib/libX11.so.6"'      \
+        --replace '"libXext.so.6"'      '"${libXext    }/lib/libXext.so.6"'     \
+        --replace '"libXinerama.so.1"'  '"${libXinerama}/lib/libXinerama.so.1"' \
+        --replace '"libXi.so.6"'        '"${libXi      }/lib/libXi.so.6"'       \
+        --replace '"libxrandr.so.2"'    '"${libXrandr  }/lib/libXrandr.so.6"'
+      substituteInPlace project/lib/openal/Alc/backends/alsa.c                  \
+        --replace '"libasound.so.2"'    '"${alsaLib    }/lib/libasound.so.2"'
+    '';
+    buildPhase = ''
+      ${simulateHaxelibDev "lime"}
+
+      haxelib run lime
+
+      rm -rf project
+      find . -regex '.+\(\.gitignore\|\.gitmodules\)' -delete
+    '';
+    installPhase = ''
+      ${installLibHaxe { inherit libname version; }}
+
+      mkdir -p $out/bin
+      cat > $out/bin/lime <<EOF
+      #!${bash}/bin/bash
+
+      export HAXELIB_PATH="\$HAXELIB_PATH\''${HAXELIB_PATH:+:}$HAXELIB_PATH:$out/lib/haxe"
+      export PATH="\$PATH:${haxe}/bin:${neko}/bin"
+      exec haxelib run lime "\$@"
+      EOF
+      chmod +x $out/bin/lime
+    '';
+    meta = with stdenv.lib; {
+      description = "A foundational Haxe framework for cross-platform development";
+      homepage = http://openfl.org;
+      license = licenses.mit;
+      platforms = platforms.linux; # might work on mac and windows too
+    };
+  };
+
+  lime-samples = buildHaxeLib rec {
+    libname = "lime-samples";
+    version = "4.0.1";
+    sha256 = "03nqbvnzwmdqqzfwx8nnfxfw63w1b9fi3abn0llqs5ycylxn7rlg";
+    meta = lime.meta // { description = "Lime samples"; };
+    propagatedBuildInputs = [ hxcpp lime ];
+    postFixup = ''
+      export HOME=$(mktemp -d)          # for "lime" to create working dir
+      for demo in BunnyMark HerokuShaders GameOfLife HelloWorld; do
+        ( cd "$out/lib/haxe/${withCommas libname}/${withCommas version}/demos/$demo"
+          lime build html5
+          lime build linux
+          rm -rf Export/linux*/cpp/release/obj )
+      done
+    '';
+  };
+
+  openfl = buildHaxeLib {
+    libname = "openfl";
+    version = "5.1.2";
+    sha256 = "0qpsxbxv0hy99jlmyv3qia1xayjbk6vzxz0jshz9cbwr5yn93n99";
+    meta = lime.meta // { description = ''The "Open Flash Library" for fast 2D development''; };
+    propagatedBuildInputs = [ lime actuate box2d layout ];
+    postFixup = ''
+      mkdir -p $out/bin
+      cat > $out/bin/openfl <<EOF
+      #!${bash}/bin/bash
+
+      export HAXELIB_PATH="\$HAXELIB_PATH\''${HAXELIB_PATH:+:}$HAXELIB_PATH:$out/lib/haxe"
+      export PATH="\$PATH:${haxe}/bin:${neko}/bin"
+      exec haxelib run openfl "\$@"
+      EOF
+      chmod +x $out/bin/openfl
+    '';
+  };
+
+  openfl-samples = buildHaxeLib rec {
+    libname = "openfl-samples";
+    version = "4.9.0";
+    sha256 = "0lgjmnc0r7467w7bcxygbx2ka834sc8l238nsdazsvqilqnh3bx8";
+    meta = lime.meta // { description = "OpenFL samples"; };
+    propagatedBuildInputs = [ hxcpp openfl ];
+    postFixup = ''
+      export HOME=$(mktemp -d)          # for "openfl" to create working dir
+      for demo in BunnyMark HerokuShaders NyanCat PiratePig TextAlignment TextMetrics; do
+        ( cd "$out/lib/haxe/${withCommas libname}/${withCommas version}/demos/$demo"
+          openfl build html5
+          openfl build linux
+          rm -rf Export/linux*/cpp/release/obj )
+      done
+    '';
+  };
+}

--- a/pkgs/development/haxe-modules/snowkit.nix
+++ b/pkgs/development/haxe-modules/snowkit.nix
@@ -1,0 +1,238 @@
+{ stdenv, fetchFromGitHub, fetchgit, bash, nodejs, haxe, neko, hxcpp, openal, mesa_glu, libX11, libXext, libXinerama, libXrandr, installLibHaxe, simulateHaxelibDev }:
+
+let
+  meta = with stdenv.lib; {
+    description = "Low level cross platform framework";
+    homepage = http://snowkit.org;
+    license = licenses.mit;
+    platforms = platforms.linux; # might work on mac and windows too
+  };
+in rec {
+  flow = let
+    libname = "flow";
+    version = "2017-05-04-unstable";
+  in stdenv.mkDerivation rec {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "snowkit";
+      repo = "flow";
+      rev = "16bc999";
+      sha256 = "19zcds93i6v6p92nzkvcx5df8342x47mb635iczidzjwig21n1wv";
+    };
+    propagatedBuildInputs = [ hxcpp ];
+    buildInputs = [ haxe neko ];
+    buildPhase = ''
+      substituteInPlace src/Flow.hx --replace 'Sys.command(node_path' 'Sys.command("${nodejs}/bin/node"'
+      (cd src; haxe compile.hxml)
+    '';
+    installPhase = installLibHaxe { inherit libname version; files = "src flow.png haxelib.json LICENSE.md readme.md run.n"; };
+    postFixup = ''
+      mkdir -p $out/bin
+      cat > $out/bin/flow <<EOF
+      #!${bash}/bin/bash
+
+      export HAXELIB_PATH="\$HAXELIB_PATH\''${HAXELIB_PATH:+:}$HAXELIB_PATH:$out/lib/haxe"
+      export PATH="\$PATH:${haxe}/bin:${neko}/bin"
+      exec haxelib run flow "\$@"
+      EOF
+      chmod +x $out/bin/flow
+    '';
+    inherit meta;
+  };
+
+  linc_openal = let
+    libname = "linc_openal";
+    version = "2017-02-13-unstable";
+  in stdenv.mkDerivation rec {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "snowkit";
+      repo = "linc_openal";
+      rev = "8231209";
+      sha256 = "0pwfv4lz2p1802a4dr9jrqns5gdvnfailj3y75vvllmsdn4309vc";
+    };
+    propagatedBuildInputs = [ openal ];
+    buildInputs = [ haxe hxcpp ];
+    buildPhase = ''
+      substituteInPlace linc/linc_openal.h --replace '#include <hxcpp.h>' ""
+    '';
+    doCheck = false; # fails with "Failed to create /homeless-shelter/.config/pulse"
+    checkPhase = ''
+      (cd test; haxe -main Test.hx -resource sound.pcm@sound.pcm -cpp cpp/ -cp ../ -D linux && ./cpp/Test && rm -rf cpp)
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  linc_timestamp = let
+    libname = "linc_timestamp";
+    version = "2017-02-01-unstable";
+  in stdenv.mkDerivation rec {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "snowkit";
+      repo = "linc_timestamp";
+      rev = "37c4285";
+      sha256 = "1awax5gvrlbas7m7i8im4iyd8hdnjz7hyc488ysp9ccnvxjrcjwk";
+    };
+    buildInputs = [ haxe hxcpp ];
+    doCheck = true;
+    checkPhase = ''
+      ( cd test && haxe -main Test.hx -cpp cpp/ -cp ../ -debug -D linux && cpp/Test-debug && rm -rf cpp )
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  linc_stb = let
+    libname = "linc_stb";
+    version = "2017-02-01-unstable";
+  in stdenv.mkDerivation rec {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "snowkit";
+      repo = "linc_stb";
+      rev = "5a9f8fe";
+      sha256 = "0nscnh3x09nkymn7i0a48jpkg7s17sj5ybxqqwypckv2k2xbmvlh";
+    };
+    buildInputs = [ haxe hxcpp ];
+    buildPhase = ''
+      substituteInPlace linc/linc_stb_image.h       --replace '#include <hxcpp.h>' ""
+      substituteInPlace linc/linc_stb_image_write.h --replace '#include <hxcpp.h>' ""
+      substituteInPlace linc/linc_stb_truetype.h    --replace '#include <hxcpp.h>' ""
+    '';
+    doCheck = true;
+    checkPhase = ''
+      ( cd tests/Image      && haxe -main Test.hx -resource image.png@image.png -cpp cpp/ -cp ../../ -debug -D linux && cpp/Test-debug && rm -rf cpp )
+      ( cd tests/ImageWrite && haxe -main Test.hx                               -cpp cpp/ -cp ../../ -debug -D linux && cpp/Test-debug && rm -rf cpp )
+      #(cd tests/TrueType   && haxe -main Test.hx                               -cpp cpp/ -cp ../../ -debug -D linux && cpp/Test-debug && rm -rf cpp )
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  linc_ogg = let
+    libname = "linc_ogg";
+    version = "2017-02-13-unstable";
+  in stdenv.mkDerivation rec {
+    name = "${libname}-${version}";
+    src = fetchgit {
+      url = https://github.com/snowkit/linc_ogg.git;
+      rev = "92ebeb9";
+      fetchSubmodules = true; # lib/ogg lib/vorbis lib/theora
+      sha256 = "15w5fsmcg5ffk0frrynq0hqmdq07863knkg87i0jw6bb02iwg31w";
+    };
+    buildInputs = [ haxe hxcpp ];
+    buildPhase = ''
+      substituteInPlace linc/linc_ogg.h --replace '#include <hxcpp.h>' ""
+    '';
+    doCheck = true;
+    checkPhase = ''
+      ( cd test && haxe -main Test.hx -cpp cpp/ -cp ../ -debug -D linux && cpp/Test-debug && rm -rf cpp )
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  linc_sdl = let
+    libname = "linc_sdl";
+    version = "2017-02-13-unstable";
+  in stdenv.mkDerivation rec {
+    name = "${libname}-${version}";
+    src = fetchgit {
+      url = https://github.com/snowkit/linc_sdl.git;
+      rev = "622c44d";
+      fetchSubmodules = true; # lib/sdl
+      sha256 = "1n6z783rkam4bg4glj6b84ia8bsaqrh2mim3a8fznqf799d2asas";
+    };
+    propagatedBuildInputs = [ mesa_glu libX11 libXext libXinerama libXrandr ];
+    buildInputs = [ haxe hxcpp ];
+    buildPhase = ''
+      substituteInPlace linc/linc_sdl.h --replace '#include <hxcpp.h>' ""
+    '';
+    doCheck = false; # the test fails on my machine
+    checkPhase = ''
+      ( cd test && haxe -main Test.hx -cpp cpp/ -cp ../ -debug -D linux && cpp/Test-debug && rm -rf cpp )
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  linc_opengl = let
+    libname = "linc_opengl";
+    version = "2017-02-13-unstable";
+  in stdenv.mkDerivation rec {
+    name = "${libname}-${version}";
+    src = fetchgit {
+      url = https://github.com/snowkit/linc_opengl.git;
+      rev = "21c1dfd";
+      fetchSubmodules = true; # lib/glew
+      sha256 = "1iy3c12qh31wa6yms7wixl1pya890i1b8psi6vqcvy7xfvvm3dhw";
+    };
+    buildInputs = [ haxe hxcpp ];
+    buildPhase = ''
+      substituteInPlace linc/linc_opengl.h --replace '#include <hxcpp.h>' ""
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  snow = let
+    libname = "snow";
+    version = "2017-05-24-unstable";
+  in stdenv.mkDerivation rec {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "snowkit";
+      repo = "snow";
+      rev = "b933401";
+      sha256 = "131vgbzhrah5qy4zbn923x7aa2priwiygl1p38ncscz267mrfmf8";
+    };
+    propagatedBuildInputs = [ linc_openal linc_timestamp linc_stb linc_ogg linc_sdl linc_opengl ];
+    buildInputs = [ haxe neko flow ];
+    doCheck = false; # too slow
+    checkPhase = ''
+      ${simulateHaxelibDev "snow"}
+      (cd samples/basic               ; flow build ; rm -rf bin/*.build)
+      (cd samples/audio               ; flow build ; rm -rf bin/*.build)
+      (cd samples/window              ; flow build ; rm -rf bin/*.build)
+      (cd samples/empty               ; flow build ; rm -rf bin/*.build)
+      (cd samples/config              ; flow build ; rm -rf bin/*.build)
+      (cd samples/audio_custom_stream ; flow build ; rm -rf bin/*.build)
+      (cd samples/assets              ; flow build ; rm -rf bin/*.build)
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+
+  luxe = let
+    libname = "luxe";
+    version = "2017-04-18-unstable";
+  in stdenv.mkDerivation rec {
+    name = "${libname}-${version}";
+    src = fetchFromGitHub {
+      owner = "underscorediscovery";
+      repo = "luxe";
+      rev = "7345f6f";
+      sha256 = "1yi4x4q9wns4gnvckw54h5yddr6xm3cqdxby1vkymrhm9d45mc66";
+    };
+    buildInputs = [ haxe neko flow snow ];
+    doCheck = false; # too slow
+    checkPhase = ''
+      ${simulateHaxelibDev "luxe"}
+
+      (cd samples/empty                      ; flow build ; rm -rf bin/*.build)
+      (cd samples/examples/platformer        ; flow build ; rm -rf bin/*.build)
+      (cd samples/alphas/1_0_parrott         ; flow build ; rm -rf bin/*.build)
+      (cd samples/alphas/2_0_0010            ; flow build ; rm -rf bin/*.build)
+      (cd samples/alphas/3_0_powell          ; flow build ; rm -rf bin/*.build)
+      (cd samples/guides/1_getting_started   ; flow build ; rm -rf bin/*.build)
+      (cd samples/guides/2_sprites           ; flow build ; rm -rf bin/*.build)
+      (cd samples/guides/3_sprite_animation  ; flow build ; rm -rf bin/*.build)
+      (cd samples/guides/4_text_and_tweening ; flow build ; rm -rf bin/*.build)
+      (cd samples/guides/5_components        ; flow build ; rm -rf bin/*.build)
+    '';
+    installPhase = installLibHaxe { inherit libname version; };
+    inherit meta;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5480,6 +5480,7 @@ with pkgs;
   haxe = haxe_3_4;
   haxePackages = recurseIntoAttrs (callPackage ./haxe-packages.nix { });
   inherit (haxePackages) hxcpp;
+  hashlink = callPackage ../development/compilers/haxe/hashlink.nix { };
 
   hhvm = callPackage ../development/compilers/hhvm {
     boost = boost160;

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -116,5 +116,449 @@ let
         description = "Extern definitions for node.js 6.9";
       };
     };
+
+    actuate = buildHaxeLib {
+      libname = "actuate";
+      version = "1.8.7";
+      sha256 = "1qqdmlfsxj79h3mgy71j5c5w3bf0pnidazkwwpjlq9rgnsg97i3a";
+      meta.description = ''Actuate is a fast and flexible tween library that uses a jQuery-style "chaining" syntax'';
+    };
+
+    firetongue = buildHaxeLib {
+      libname = "firetongue";
+      version = "2.0.0";
+      sha256 = "0s8z6agqsiylfpfh1jxz36da9ljz5gj271z8dcasiv64gn7r4vsa";
+      meta.description = "Framework-agnostic translation/localization library";
+    };
+
+    msgpack-haxe = buildHaxeLib {
+      libname = "msgpack-haxe";
+      version = "1.15.1";
+      sha256 = "1synzy59h89pnz0svdpvxksqpbmr5mxqiclbwcc45pk04s0rb9wc";
+      meta.description = "MessagePack (http://msgpack.org) for HaXe";
+    };
+
+    format = buildHaxeLib {
+      libname = "format";
+      version = "3.3.0";
+      sha256 = "05hkdvkhf0xz02rfafdq414m7a84albalpccn1vyq1kh9j8d5ydg";
+      meta.description = "A Haxe Library for supporting different file formats";
+    };
+
+    hamcrest = buildHaxeLib {
+      libname = "hamcrest";
+      version = "2.0.1";
+      sha256 = "06fb0mhvxz57js9ywaqx1addz0xrc92968w5ph0gkwrq2mrmv786";
+      meta.description = "Library of Matchers (also known as constraints or predicates) allowing 'match' rules to be defined declaratively, to be used in other frameworks";
+    };
+
+    mlib = buildHaxeLib {
+      libname = "mlib";
+      version = "2.0.2";
+      sha256 = "1gnyk19kfhmyssj9c2cfb4mh7vp67h2pifhmcayr2dx3860sp28h";
+      meta.description = "Cross platform unit testing framework for Haxe with metadata test markup and tools for generating, compiling and running tests from the command line";
+    };
+
+    mconsole = buildHaxeLib {
+      libname = "mconsole";
+      version = "1.6.0";
+      sha256 = "11s40dhfzxqq3vydprhh2iw62gff6h2w25xl1jz2vzs5ng9h64l2";
+      meta.description = "Cross platform Haxe implementation of the WebKit console API";
+    };
+
+    mcover = buildHaxeLib {
+      libname = "mcover";
+      version = "2.1.1";
+      sha256 = "09agn0la9pc0nbhw0slnzy7cdizpabqy3maarmjkdg7a30hc9idy";
+      meta.description = "Cross platform code coverage framework for Haxe with testing and profiling applications";
+    };
+
+    munit = buildHaxeLib {
+      libname = "munit";
+      version = "2.1.2";
+      sha256 = "1dagsv871ky0crwpx8w3dqnz1kmcnfpz029bl62hryyq16dpn86d";
+      meta.description = "Cross platform unit testing framework";
+    };
+
+    hashlink = buildHaxeLib {
+      libname = "hashlink";
+      version = "0.1.0";
+      sha256 = "0agb7snxwh74mkjif6vk2i5jf224acd13dcn3090krxphyvc9jj6";
+      meta.description = "Hashlink support library";
+    };
+
+    box2d = buildHaxeLib {
+      libname = "box2d";
+      version = "1.2.3";
+      sha256 = "14ws3qsiajahz5f4cxnc0qc7cpr8a4j2pk59mcfb80wlhxf9wfmv";
+      meta.description = "Tremendously popular physics engine for most platforms";
+    };
+
+    layout = buildHaxeLib {
+      libname = "layout";
+      version = "1.2.1";
+      sha256 = "0ns8h060d4nx7pri1b1ydkb9d1523aj9ja5gmjq2x54r07vkhcny";
+      meta.description = "Flexible system for fluid resizing layouts";
+    };
+
+    electron = buildHaxeLib {
+      libname = "electron";
+      version = "1.1.1";
+      sha256 = "1yppx9z0li7iv3kcb8sgzb4cwkzg8z6nxsn3ihiq8wxbc0na2jjv";
+      meta.description = "Externs for the electron framework";
+    };
+
+    slambda = buildHaxeLib {
+      libname = "slambda";
+      version = "0.8.5";
+      sha256 = "1419vwmmdmkfmdzw4z5z0xyql2rm0bc06gg2sshl1ibgawcjvc5s";
+      meta.description = "Short Lambda expressions in a tiny library";
+    };
+
+    unifill = buildHaxeLib {
+      libname = "unifill";
+      version = "0.4.1";
+      sha256 = "1l4cvq01amdsxrjfzrl8s1jnlqckfl4znxxi4cdxk25hdyra73sw";
+      meta.description = "Library for Unicode string support";
+    };
+
+    haxe-strings = buildHaxeLib {
+      libname = "haxe-strings";
+      version = "4.0.0";
+      sha256 = "1g0g9ljwbp2cla3mq3ha35z5mwj2k1c1zf25iw1f5743asbag8f8";
+      meta.description = "Library for consistent cross-platform UTF-8 string manipulation";
+    };
+
+    spinehaxe = buildHaxeLib {
+      libname = "spinehaxe";
+      version = "3.5.0";
+      sha256 = "1sqvyl1p8a13xgd9d4pvm8cmhkq13rf6yc639lanajris0zwisx7";
+      meta.description = "Spine runtime for Haxe";
+    };
+
+    nape = buildHaxeLib {
+      libname = "nape";
+      version = "2.0.20";
+      sha256 = "16aa787yjymnv1l17hb5p45m148nnd5ayfi083i34z7kfi7yxg32";
+      meta.description = "Nape 2D Physics Engine";
+    };
+
+    poly2trihx = buildHaxeLib {
+      libname = "poly2trihx";
+      version = "0.1.4";
+      sha256 = "0s9iyqrfyxqmp0hvp3lg702rrqbyp5b9iwayh6g6rab22cs99h4i";
+      meta.description = "Haxe port of the poly2tri library, an excellent Delaunay triangulation library, which supports constrained edges and holes";
+    };
+
+    systools = buildHaxeLib {
+      libname = "systools";
+      version = "1.1.0";
+      sha256 = "10rajqqzmyb606dpjrjqivvj3kl5gpcl9hccscpa24xp0ijnx38n";
+      meta.description = "Cross-platform extension to the Neko VM for accessing system APIs";
+    };
+
+    task = buildHaxeLib {
+      libname = "task";
+      version = "1.0.7";
+      sha256 = "1kr9gv842dk5xiqaaly67lrxi9fq6dayfhipj12aww23337h015n";
+      meta.description = "Use the Task and TaskList API to simplify asynchronous tasks";
+    };
+
+    air3 = buildHaxeLib {
+      libname = "air3";
+      version = "0.0.1";
+      sha256 = "0x8riacldqrg881jyzvx1j4wq095dlspkc5zh8jz4vdzmknadid0";
+      meta.description = "Externs for Adobe AIR3";
+    };
+
+    hxsl = buildHaxeLib {
+      libname = "hxsl";
+      version = "2.0.5";
+      sha256 = "09pxixgcnbs8197v11vwwrm0xcaznqz40ar2i2jybb293fm9yl85";
+      meta.description = "Haxe high level shader library";
+      propagatedBuildInputs = [ format ];
+    };
+
+    flambe = buildHaxeLib {
+      libname = "flambe";
+      version = "4.1.0";
+      sha256 = "184ra0hbxnsnyhzqycvbzycw0f64bcaj2jdwyqcp46jk50v55bb7";
+      meta.description = "Fast, expressive, and cross-platform engine for HTML5 and Flash games";
+      propagatedBuildInputs = [ air3 hxsl ];
+    };
+
+    perf_js = buildHaxeLib {
+      libname = "perf.js";
+      version = "1.1.8";
+      sha256 = "1zd25zrjrvriq7hrg3vlays9is7296imk21csf669pmplzfl4sfc";
+      meta.description = "Simple FPS and Memory monitor";
+    };
+
+    pixijs = buildHaxeLib {
+      libname = "pixijs";
+      version = "4.5.1";
+      sha256 = "19kllv67bh5vdvagnqvpqd5jmvm9m8krx33kmy425acvfnhslaxk";
+      meta.description = "Externs of pixi.js v4.x for Haxe - JavaScript 2D webGL renderer with canvas fallback";
+      propagatedBuildInputs = [ perf_js ];
+    };
+
+    HtmlParser = buildHaxeLib {
+      libname = "HtmlParser";
+      version = "3.3.0";
+      sha256 = "0bw18cgxng33avwmcbxpjxk75k2grxpa1sp693b65by2y3k3gv8w";
+      meta.description = "HTML/XML parser with a jQuery-like find() method";
+    };
+
+    stdlib = buildHaxeLib {
+      libname = "stdlib";
+      version = "2.2.0";
+      sha256 = "1yk6n00wrpa0zjw3nx3627mzn4g17fd4k6ngw5a5gmn20r8ql41s";
+      meta.description = "Standard library improvements: exceptions, string triming with a trimed chars specified, min/max for integers and so on";
+    };
+
+    mcli = buildHaxeLib {
+      libname = "mcli";
+      version = "0.1.6";
+      sha256 = "0chq5gs7pkqqnh2fl7i8h16kv3dqrhnpbvjyil33ig9ddn3vnkad";
+      meta.description = "A simple command-line object mapper";
+    };
+
+    waud = buildHaxeLib {
+      libname = "waud";
+      version = "0.9.9";
+      sha256 = "013d45mqc0by0irmb5fhzbv23lpd4ji3pzvmp9zhwrz3a55gdwqx";
+      meta.description = "Web Audio Library";
+    };
+
+    struct = buildHaxeLib {
+      libname = "struct";
+      version = "0.11.0";
+      sha256 = "1dj5zjgfzvxsbbrf3fha0rc5bz7ib1n9ci92v457gdmgp7sbbwav";
+      meta.description = "Data Structures and Algorithms";
+    };
+
+    compiletime = buildHaxeLib {
+      libname = "compiletime";
+      version = "2.7.0";
+      sha256 = "06mhd8rwxxmflj6g2x0rffr9li6dalxvbm2zvncfgq1rsa9zyg0s";
+      meta.description = "Simple Haxe Macro Helpers that let you do or get things at compile-time";
+    };
+
+    thx_core = buildHaxeLib {
+      libname = "thx.core";
+      version = "0.42.1";
+      sha256 = "1wan3w1avi5c9w2gaph6alidvhpwz6jpgl3yqd92hwivlsh558qn";
+      meta.homepage = http://thx-lib.org/;
+      meta.description = "General purpose library. It contains extensions to many of the types contained in the standard library as well as new complementary types";
+    };
+
+    thx_color = buildHaxeLib {
+      libname = "thx.color";
+      version = "0.19.1";
+      sha256 = "0r0rq0gsky9n4pm6ridvb8brx8358v7y9kdd6nhas3ckzg3z7g5z";
+      meta.description = "Library for color manipulation";
+      propagatedBuildInputs = [ thx_core ];
+    };
+
+    thx_csv = buildHaxeLib {
+      libname = "thx.csv";
+      version = "0.2.0";
+      sha256 = "1q9nfgq8mhiqqsavz4jb0kl7r31gm2xl6g5888k24m8fwhhn5yas";
+      meta.description = "CSV parsing and writing libraries. Also supports DSV and TSV";
+      propagatedBuildInputs = [ thx_core ];
+    };
+
+    thx_culture = buildHaxeLib {
+      libname = "thx.culture";
+      version = "0.5.0";
+      sha256 = "1jz6lnw4yh932lwy5jws0dlf7ca5dl3by0gbxncgl54z5mn032qh";
+      meta.description = "Localization library";
+      propagatedBuildInputs = [ thx_core ];
+    };
+
+    thx_format = buildHaxeLib {
+      libname = "thx.format";
+      version = "0.6.0";
+      sha256 = "0zj9kxl1dzli34vc8av2xwkj73iqf7rfzdp0hs1603kp9i901wfi";
+      meta.description = "Formatting library (Numbers and Dates)";
+      propagatedBuildInputs = [ thx_culture ];
+    };
+
+    thx_promise = buildHaxeLib {
+      libname = "thx.promise";
+      version = "0.6.0";
+      sha256 = "15yizzmf32n0092bfnjr3g1zlqqy7q5x03scabhi5cvnimvadhap";
+      meta.description = "Library for lightweight promises and futures.";
+      propagatedBuildInputs = [ thx_core ];
+    };
+
+    thx_stream = buildHaxeLib {
+      libname = "thx.stream";
+      version = "0.6.1";
+      sha256 = "0vgwgw7xcnfqnnvid33q5h8i53ipjl2msw9w4nfykia4hhxjxl3p";
+      meta.description = "Stream library for Haxe";
+      propagatedBuildInputs = [ thx_promise ];
+    };
+
+    thx_semver = buildHaxeLib {
+      libname = "thx.semver";
+      version = "0.2.2";
+      sha256 = "0jykj6kxfxycn2dhyyqpn051z8qnbzzghbiv25b96l9wlf0xivq4";
+      meta.description = "Semantic version library for Haxe";
+    };
+
+    thx_unit = buildHaxeLib {
+      libname = "thx.unit";
+      version = "0.8.0";
+      sha256 = "1478g2xyvqv5ggnsq7vmqdxm2n5rigsd0r56p7mi04wwb1hrhzca";
+      meta.description = "Library for unit of measurements";
+      propagatedBuildInputs = [ thx_core ];
+    };
+
+    hscript = let
+      libname = "hscript";
+      version = "2.0.7";
+    in stdenv.mkDerivation rec {
+      name = "${libname}-${version}";
+      src = fetchFromGitHub {
+        owner = "HaxeFoundation";
+        repo = "hscript";
+        rev = "7708159";
+        sha256 = "1j7f4m8wmw0c2zjz7m96q2mwl22dg7m9bl1byqysjmj83gy9nj7k";
+      };
+      buildInputs = [ haxe neko hxcpp hxjava hxcs nodejs wine php python3 ];
+      buildPhase = ''
+        ${simulateHaxelibDev "hscript"}
+        (cd script; haxe build.hxml)
+      '';
+      doCheck = true;
+      checkPhase = ''
+        haxe bin/build-interp.hxml
+        haxe bin/build-neko.hxml         && neko bin/Test.n
+        haxe bin/build-js.hxml           && node bin/Test.js
+        haxe bin/build-java.hxml         && java -jar bin/Test.jar
+        ( export HOME=$(mktemp -d)
+          haxe bin/build-cs.hxml           && wine bin/bin/Test.exe )
+        haxe bin/build-cpp.hxml          && bin/Test
+        #BROKEN# haxe bin/build-flash.hxml -D fdb && haxe flash/run.hxml bin/Test.swf
+        haxe bin/build-php.hxml          && php bin/index.php
+        haxe bin/build-python.hxml       && python bin/Test.py
+      '';
+      installPhase = installLibHaxe { inherit libname version; files = "hscript script extraParams.hxml haxelib.json README.md run.n"; };
+      meta = {
+        homepage = "http://lib.haxe.org/p/${libname}";
+        license = stdenv.lib.licenses.bsd2;
+        platforms = stdenv.lib.platforms.all;
+        description = "Haxe Script is a scripting engine for a subset of the Haxe language";
+      };
+    };
+
+    hxparse = let
+      libname = "hxparse";
+      version = "3.2.1.0";
+    in stdenv.mkDerivation rec {
+      name = "${libname}-${version}";
+      src = fetchFromGitHub {
+        owner = "Simn";
+        repo = "hxparse";
+        rev = "1343cc9";
+        sha256 = "04nj7g3viiqmdijk6ssginx4khz5b80minzbk98s1fyvadj1frx5";
+      };
+      buildInputs = [ haxe neko unifill hxcpp hxjava hxcs ];
+      doCheck = false;
+      checkPhase = ''
+        ${simulateHaxelibDev "hxparse"}
+        haxe -cp src -cp test -main Test -dce full -lib unifill  -D dump=pretty -neko bin/hxparse.n
+        haxe -cp src -cp test -main Test -dce full -lib unifill  -swf bin/hxparse.swf
+        haxe -cp src -cp test -main Test -dce full -lib unifill  -swf-version 8 -swf bin/hxparse8.swf
+        haxe -cp src -cp test -main Test -dce full -lib unifill  -js bin/hxparse.js
+        haxe -cp src -cp test -main Test -dce full -lib unifill  -php bin/php
+        haxe -cp src -cp test -main Test -dce full -lib unifill  -cpp bin/cpp
+        #BROKEN# haxe -cp src -cp test -main Test -dce full -lib unifill  -java bin/java
+        haxe -cp src -cp test -main Test -dce full -lib unifill  -cs bin/cs
+        haxe -cp src -cp test -main Test -dce full -lib unifill  -python bin/hxparse.py
+      '';
+      installPhase = installLibHaxe { inherit libname version; };
+      meta = {
+        homepage = "http://lib.haxe.org/p/${libname}";
+        license = stdenv.lib.licenses.bsd2;
+        platforms = stdenv.lib.platforms.all;
+        description = "This library provides tools for creating lexers and parsers in haxe";
+      };
+    };
+
+    haxeparser = let
+      libname = "haxeparser";
+      version = "3.3.0";
+    in stdenv.mkDerivation rec {
+      name = "${libname}-${version}";
+      src = fetchFromGitHub {
+        owner = "Simn";
+        repo = "haxeparser";
+        rev = "9be07a2";
+        sha256 = "11272lnyk4ilf9qlkfgnirsmjy681gmaaw0wzaaypchidj0mm7xv";
+      };
+      buildInputs = [ haxe neko hxparse ];
+      doCheck = true;
+      checkPhase = ''
+        ${simulateHaxelibDev "haxeparser"}
+        haxe build.hxml
+      '';
+      installPhase = installLibHaxe { inherit libname version; };
+      meta = {
+        homepage = "http://lib.haxe.org/p/${libname}";
+        license = stdenv.lib.licenses.bsd2;
+        platforms = stdenv.lib.platforms.all;
+        description = "A Haxe parser";
+      };
+    };
+
+    inherit (callPackage ../development/haxe-modules/snowkit.nix { })
+      flow
+      linc_openal
+      linc_timestamp
+      linc_stb
+      linc_ogg
+      linc_sdl
+      linc_opengl
+      snow
+      luxe;
+
+    inherit (callPackage ../development/haxe-modules/openfl { webify = haskellPackages.webify; })
+      lime
+      lime-samples
+      openfl
+      openfl-samples;
+
+    inherit (callPackage ../development/haxe-modules/openfl/3.6.nix { webify = haskellPackages.webify; })
+      lime_2_9
+      openfl_3_6;
+
+    inherit (callPackage ../development/haxe-modules/nme.nix { })
+      gm2d
+      nme;
+
+    inherit (callPackage ../development/haxe-modules/flixel.nix { })
+      flixel
+      flixel-ui
+      flixel-addons
+      flixel-tools
+      flixel-templates
+      flixel-demos;
+
+    inherit (callPackage ../development/haxe-modules/haxeui.nix { })
+      haxeui-core
+      haxeui-flixel
+      haxeui-openfl
+      haxeui-luxe
+      haxeui-flambe
+      haxeui-pixijs
+      haxeui-html5
+      haxeui-nme
+      haxeui-kha
+      haxeui-xwt
+      haxeui-hxwidgets
+      hxWidgets;
+
   };
 in self


### PR DESCRIPTION
###### Motivation for this change

```hxcpp``` (runtime for Haxe->C++ translator) is broken after [upgrade ](https://github.com/NixOS/nixpkgs/pull/25538).

This fix ```hxcpp``` and also allows to use more than one library directory (that in nix world means more than one library). Added some popular Haxe libs including ```hxjava``` and ```hxcs``` (runtimes for Haxe->Java and haxe->C# translators).

Cross-compilation in ```hxcpp``` is currently broken (including compilation of 32-bit apps on x86_64).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

