### PR TITLE
iwd: init at unstable-2017-04-21

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -430,6 +430,7 @@
   ./services/networking/i2p.nix
   ./services/networking/iodine.nix
   ./services/networking/ircd-hybrid/default.nix
+  ./services/networking/iwd.nix
   ./services/networking/keepalived/default.nix
   ./services/networking/kippo.nix
   ./services/networking/kresd.nix

--- a/nixos/modules/services/networking/iwd.nix
+++ b/nixos/modules/services/networking/iwd.nix
@@ -1,0 +1,34 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.networking.wireless.iwd;
+in {
+  options.networking.wireless.iwd.enable = mkEnableOption "iwd";
+
+  config = mkIf cfg.enable {
+    assertions = [{
+      assertion = !config.networking.wireless.enable;
+      message = ''
+        Only one wireless daemon is allowed at the time: networking.wireless.enable and networking.wireless.iwd.enable are mutually exclusive.
+      '';
+    }];
+
+    # for iwctl
+    environment.systemPackages =  [ pkgs.iwd ];
+
+    services.dbus.packages = [ pkgs.iwd ];
+
+    systemd.services.iwd = {
+      description = "Wireless daemon";
+      before = [ "network.target" ];
+      wants = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig.ExecStart = "${pkgs.iwd}/bin/iwd";
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ mic92 ];
+}

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchgit, autoreconfHook, readline }:
+
+let
+  ell = fetchgit {
+     url = https://git.kernel.org/pub/scm/libs/ell/ell.git;
+     rev = "58e873d7463f3a7f91e02260585bfa50cbc77668";
+     sha256 = "12k1f1iarm29j8k16mhw83xx7r3bama4lp0fchhnj7iwxrpgs4gh";
+  };
+in stdenv.mkDerivation rec {
+  name = "iwd-unstable-2017-04-21";
+
+  src = fetchgit {
+    url = https://git.kernel.org/pub/scm/network/wireless/iwd.git;
+    rev = "f64dea81b8490e5e09888be645a4325419bb269c";
+    sha256 = "0maqhx5264ykgmwaf90s2806i1kx2028if34ph2axlirxrhdd3lg";
+  };
+
+  configureFlags = [
+    "--with-dbusconfdir=$(out)/etc/"
+  ];
+
+  postUnpack = ''
+    ln -s ${ell} ell
+  '';
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ readline ];
+
+  meta = with stdenv.lib; {
+    homepage = https://git.kernel.org/pub/scm/network/wireless/iwd.git;
+    description = "Wireless daemon for Linux";
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11714,6 +11714,8 @@ with pkgs;
 
   iw = callPackage ../os-specific/linux/iw { };
 
+  iwd = callPackage ../os-specific/linux/iwd { };
+
   jfbview = callPackage ../os-specific/linux/jfbview { };
   jfbpdf = callPackage ../os-specific/linux/jfbview {
     imageSupport = false;


### PR DESCRIPTION
###### Motivation for this change

iwd is a new wireless daemon mainly developed by Intel.
The module added is pretty basic and not very practical at the moment due missing external agents (for wifi password callbacks). However it might serve well as a technical preview.

Usage:

```
# /etc/nixos/configuration.nix
network.wireless.enable = false; # if it was enabled before
network.wireless.iwd.enable = true;
```

```
$ iwctl
[iwd]# help
....
[iwd]# device list
                                    Devices
--------------------------------------------------------------------------------
  Name                Address             State          Adapter   
--------------------------------------------------------------------------------
  wlp3s0              34:02:86:1a:7b:47   disconnected   phy0
```


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

