### PR TITLE
znapzend service: Added options for logging and nodestroy

### DIFF
--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -46,7 +46,7 @@ in
         serviceConfig = {
           ExecStart = "${pkgs.znapzend}/bin/znapzend --logto=${cfg.logTo} --loglevel=${cfg.logLevel} ${optionalString cfg.noDestroy "--nodestroy"}";
           ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-          #Restart = "on-failure";
+          Restart = "on-failure";
         };
       };
     };

--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -19,7 +19,7 @@ in
 
       logTo = mkOption {
         type = types.str;
-        default = "";
+        default = "syslog::daemon";
         example = "/var/log/znapzend.log";
         description = "Where to log to (syslog::&lt;facility&gt; or &lt;filepath&gt;).";
       };

--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -26,7 +26,7 @@ in
 
       noDestroy = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = "Does all changes to the filesystem except destroy";
       };
     };

--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -9,6 +9,26 @@ in
   options = {
     services.znapzend = {
       enable = mkEnableOption "ZnapZend daemon";
+
+      logLevel = mkOption {
+        default = "debug";
+        example = "warning";
+        type = lib.types.enum ["debug" "info" "warning" "err" "alert"];
+        description = "The log level when logging to file. Any of debug, info, warning, err, alert. Default in daemonized form is debug.";
+      };
+
+      logTo = mkOption {
+        type = types.str;
+        default = "";
+        example = "/var/log/znapzend.log";
+        description = "Where to log to (syslog::&lt;facility&gt; or &lt;filepath&gt;).";
+      };
+
+      noDestroy = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Does all changes to the filesystem except destroy";
+      };
     };
   };
 
@@ -24,8 +44,9 @@ in
         path = with pkgs; [ zfs mbuffer openssh ];
 
         serviceConfig = {
-          ExecStart = "${pkgs.znapzend}/bin/znapzend";
+          ExecStart = "${pkgs.znapzend}/bin/znapzend --logto=${cfg.logTo} --loglevel=${cfg.logLevel} ${optionalString cfg.noDestroy "--nodestroy"}";
           ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+          #Restart = "on-failure";
         };
       };
     };


### PR DESCRIPTION
and service now restarts on failure

###### Motivation for this change

The znapzend program has some useful options that weren't accessible before.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

