### PR TITLE
google-cloud-sdk: Upgrade to 155.0.0 and fix calling itself

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -37,10 +37,13 @@ stdenv.mkDerivation rec {
     # create wrappers with correct env
     for program in gcloud bq gsutil git-credential-gcloud.sh; do
         programPath="$out/google-cloud-sdk/bin/$program"
-        wrapper="$out/bin/$program"
-        makeWrapper "$programPath" "$wrapper" \
+        binaryPath="$out/bin/$program"
+        wrapProgram "$programPath" \
             --set CLOUDSDK_PYTHON "${python27}/bin/python" \
             --prefix PYTHONPATH : "$(toPythonPath ${cffi}):$(toPythonPath ${cryptography}):$(toPythonPath ${pyopenssl}):$(toPythonPath ${crcmod})"
+
+        mkdir -p $out/bin
+        ln -s $programPath $binaryPath
     done
 
     # install man pages

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -7,23 +7,23 @@ assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux" || stden
 
 stdenv.mkDerivation rec {
   name = "google-cloud-sdk-${version}";
-  version = "151.0.0";
+  version = "155.0.0";
 
   src =
     if stdenv.system == "i686-linux" then
       fetchurl {
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-linux-x86.tar.gz";
-        sha256 = "1d1h6jiqs3grsb6c61v6dkb4l2qv6v8g7wbzgaqkmn09xdbaq40l";
+        sha256 = "1xh8xy9p3qqmirvhih7vf96i5xn0z0zr5mmbqr6vfzx16r47bi2z";
       }
     else if stdenv.system == "x86_64-darwin" then
       fetchurl {
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-darwin-x86_64.tar.gz";
-        sha256 = "05idf0g505s8diaz28ij9yqig2wwn43lyppfs483m7vnx5hk62j5";
+        sha256 = "19pr1pld6vdp5ig5i7zddfl1l5xjv9nx5sn00va4l1nnb410ac69";
       }
     else
       fetchurl {
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-linux-x86_64.tar.gz";
-        sha256 = "01hf7pp1v57dxx6f2pz7j13fjdnrfp7gjmzjdlhlx4rnvxrd6i3f";
+        sha256 = "18hnabhdlrprhg8micy2z63jxyah3qr3pv9pgb64i7lbv6lznr2b";
       };
 
   buildInputs = [python27 makeWrapper];


### PR DESCRIPTION
###### Motivation for this change

Gcloud sometimes calls itself from `google-cloud-sdk/bin` which results in errors because necessary arguments / env variables are not set anymore.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

