### PR TITLE
lambda-mod-zsh-theme: 2017-04-05 -> 2017-05-21

### DIFF
--- a/pkgs/shells/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/lambda-mod-zsh-theme/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  name = "lambda-mod-zsh-theme-unstable-2017-04-05";
+  name = "lambda-mod-zsh-theme-unstable-2017-05-21";
 
   src = fetchFromGitHub {
     owner = "halfo";
     repo = "lambda-mod-zsh-theme";
-    sha256 = "01c77s6fagycin6cpssif56ysbqaa8kiafjn9av12cacakldl84j";
-    rev = "c6445c79cbc73b85cc18871c216fb28ddc8b3d96";
+    sha256 = "1410ryc22i20na5ypa1q6f106lkjj8n1qfjmb77q4rspi0ydaiy4";
+    rev = "6fa277361ec2c84e612b5b6d876797ebe72102a5";
   };
 
   buildPhases = [ "unpackPhase" "installPhase" ];


### PR DESCRIPTION
###### Motivation for this change

`lambda-mod-zsh-theme` contains a new fix which reverts the latest bugfix as it broke with several shells. (see https://github.com/halfo/lambda-mod-zsh-theme/commit/6fa277361ec2c84e612b5b6d876797ebe72102a5)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

