### PR TITLE
robotfindskitten: init at 2.7182818.701

### DIFF
--- a/pkgs/games/robotfindskitten/default.nix
+++ b/pkgs/games/robotfindskitten/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pkgconfig, ncurses }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+
+  name = "robotfindskitten-${version}";
+  version = "2.7182818.701";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/rfk/robotfindskitten-POSIX/mayan_apocalypse_edition/${name}.tar.gz";
+    sha256 = "06fp6b4li50mzw83j3pkzqspm6dpgxgxw03b60xkxlkgg5qa6jbp";
+  };
+
+  buildInputs = 
+  [ pkgconfig ncurses ];
+
+  meta = {
+    description = "Yet another zen simulation; A simple find-the-kitten game";
+    homepage = http://robotfindskitten.org/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17116,6 +17116,8 @@ with pkgs;
 
   rogue = callPackage ../games/rogue { };
 
+  robotfindskitten = callPackage ../games/robotfindskitten { };
+
   saga = callPackage ../applications/gis/saga { };
 
   samplv1 = callPackage ../applications/audio/samplv1 { };


### PR DESCRIPTION
###### Motivation for this change

A new terminal game

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

