### PR TITLE
lightdm: allow cursor theme customisation. [WIP]

### DIFF
--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
@@ -30,7 +30,7 @@ let
         --set GTK_DATA_PREFIX "${theme}" \
         --set XDG_DATA_DIRS "${theme}/share:${icons}/share" \
         --set XDG_CONFIG_HOME "${theme}/share" \
-        --set XCURSOR_PATH "${cursors}/share/icons"
+        ${lib.optionalString (cursors != null) ''--set XCURSOR_PATH ${cursors}/share/icons''}
 
       cat - > $out/lightdm-gtk-greeter.desktop << EOF
       [Desktop Entry]
@@ -46,9 +46,13 @@ let
     [greeter]
     theme-name = ${cfg.theme.name}
     icon-theme-name = ${cfg.iconTheme.name}
-    cursor-theme-name = ${cfg.cursorTheme.name}
-    cursor-theme-size = ${toString cfg.cursorTheme.size}
     background = ${ldmcfg.background}
+    ${lib.optionalString (cfg.cursorTheme.name != null) ''
+    cursor-theme-name = ${cfg.cursorTheme.name}
+    ''}
+    ${lib.optionalString (cfg.cursorTheme.size != null) ''
+    cursor-theme-size = ${toString cfg.cursorTheme.size}
+    ''}
     ${cfg.extraConfig}
     '';
 
@@ -111,25 +115,24 @@ in
       cursorTheme = {
 
         package = mkOption {
-          type = types.package;
-          default = pkgs.gnome3.defaultIconTheme;
-          defaultText = "pkgs.gnome3.defaultCursorTheme";
+          type = types.nullOr types.package;
+          default = null;
           description = ''
             The package path that contains the cursor theme given in the name option.
           '';
         };
 
         name = mkOption {
-          type = types.str;
-          default = "Adwaita";
+          type = types.nullOr types.str;
+          default = null;
           description = ''
             Name of the cursor theme to use for the lightdm-gtk-greeter.
           '';
         };
 
         size = mkOption {
-          type = types.int;
-          default = 32;
+          type = types.nullOr types.int;
+          default = null;
           description = ''
             Size of the cursor theme to use for the lightdm-gtk-greeter.
           '';
@@ -151,6 +154,13 @@ in
   };
 
   config = mkIf (ldmcfg.enable && cfg.enable) {
+    assertions = [
+      { assertion = cfg.cursorTheme.name != null
+          -> cfg.cursorTheme.package != null;
+        message  =
+          "Using cfg.cursorTheme.name requires cfg.cursorTheme.package to be set.";
+      }
+    ];
 
     services.xserver.displayManager.lightdm.greeter = mkDefault {
       package = wrappedGtkGreeter;

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
@@ -12,6 +12,7 @@ let
 
   theme = cfg.theme.package;
   icons = cfg.iconTheme.package;
+  cursors = cfg.cursorTheme.package;
 
   # The default greeter provided with this expression is the GTK greeter.
   # Again, we need a few things in the environment for the greeter to run with
@@ -28,7 +29,8 @@ let
         --set GTK_EXE_PREFIX "${theme}" \
         --set GTK_DATA_PREFIX "${theme}" \
         --set XDG_DATA_DIRS "${theme}/share:${icons}/share" \
-        --set XDG_CONFIG_HOME "${theme}/share"
+        --set XDG_CONFIG_HOME "${theme}/share" \
+        --set XCURSOR_PATH "${cursors}/share/icons"
 
       cat - > $out/lightdm-gtk-greeter.desktop << EOF
       [Desktop Entry]
@@ -44,6 +46,8 @@ let
     [greeter]
     theme-name = ${cfg.theme.name}
     icon-theme-name = ${cfg.iconTheme.name}
+    cursor-theme-name = ${cfg.cursorTheme.name}
+    cursor-theme-size = ${toString cfg.cursorTheme.size}
     background = ${ldmcfg.background}
     ${cfg.extraConfig}
     '';
@@ -99,6 +103,35 @@ in
           default = "Adwaita";
           description = ''
             Name of the icon theme to use for the lightdm-gtk-greeter.
+          '';
+        };
+
+      };
+
+      cursorTheme = {
+
+        package = mkOption {
+          type = types.package;
+          default = pkgs.gnome3.defaultIconTheme;
+          defaultText = "pkgs.gnome3.defaultCursorTheme";
+          description = ''
+            The package path that contains the cursor theme given in the name option.
+          '';
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = "Adwaita";
+          description = ''
+            Name of the cursor theme to use for the lightdm-gtk-greeter.
+          '';
+        };
+
+        size = mkOption {
+          type = types.int;
+          default = 32;
+          description = ''
+            Size of the cursor theme to use for the lightdm-gtk-greeter.
           '';
         };
 

--- a/pkgs/applications/display-managers/lightdm-gtk-greeter/cursors.patch
+++ b/pkgs/applications/display-managers/lightdm-gtk-greeter/cursors.patch
@@ -1,0 +1,46 @@
+--- a/src/greeterconfiguration.h        2016-10-06 02:13:23.000000000 +0100
++++ b/src/greeterconfiguration.h        2017-03-22 19:20:44.913861615 +0000
+@@ -11,6 +11,8 @@
+ #define CONFIG_KEY_SCREENSAVER_TIMEOUT  "screensaver-timeout"
+ #define CONFIG_KEY_THEME                "theme-name"
+ #define CONFIG_KEY_ICON_THEME           "icon-theme-name"
++#define CONFIG_KEY_CURSOR_THEME         "cursor-theme-name"
++#define CONFIG_KEY_CURSOR_THEME_SIZE    "cursor-theme-size"
+ #define CONFIG_KEY_FONT                 "font-name"
+ #define CONFIG_KEY_DPI                  "xft-dpi"
+ #define CONFIG_KEY_ANTIALIAS            "xft-antialias"
+diff -Naur a/src/lightdm-gtk-greeter.c b/src/lightdm-gtk-greeter.c
+--- a/src/lightdm-gtk-greeter.c 2016-10-06 10:31:54.000000000 +0100
++++ b/src/lightdm-gtk-greeter.c 2017-03-23 20:39:40.476678709 +0000
+@@ -275,7 +275,8 @@
+ /* a11y indicator */
+ static gchar *default_font_name,
+              *default_theme_name,
+-             *default_icon_theme_name;
++             *default_icon_theme_name,
++             *default_cursor_theme_name;
+ void a11y_font_cb (GtkCheckMenuItem *item);
+ void a11y_contrast_cb (GtkCheckMenuItem *item);
+ void a11y_keyboard_cb (GtkCheckMenuItem *item, gpointer user_data);
+@@ -2745,6 +2746,21 @@
+     g_object_get (gtk_settings_get_default (), "gtk-icon-theme-name", &default_icon_theme_name, NULL);
+     g_debug ("[Configuration] Icons theme: '%s'", default_icon_theme_name);
+ 
++    value = config_get_string (NULL, CONFIG_KEY_CURSOR_THEME, NULL);
++    if (value)
++    {
++        g_debug ("[Configuration] Changing cursor theme to '%s'", value);
++        g_object_set (gtk_settings_get_default (), "gtk-cursor-theme-name", value, NULL);
++        g_free (value);
++    }
++    g_object_get (gtk_settings_get_default (), "gtk-cursor-theme-name", &default_cursor_theme_name, NULL);
++    g_debug ("[Configuration] Cursor theme: '%s'", default_cursor_theme_name);
++
++    if (config_has_key(NULL, CONFIG_KEY_CURSOR_THEME_SIZE))
++    {
++        g_object_set (gtk_settings_get_default (), "gtk-cursor-theme-size", config_get_int (NULL, CONFIG_KEY_CURSOR_THEME_SIZE, 16), NULL);
++    }
++
+     value = config_get_string (NULL, CONFIG_KEY_FONT, "Sans 10");
+     if (value)
+     {

--- a/pkgs/applications/display-managers/lightdm-gtk-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-gtk-greeter/default.nix
@@ -12,7 +12,6 @@ let
 in
 stdenv.mkDerivation rec {
   name = "lightdm-gtk-greeter-${version}";
-
   src = fetchurl {
     url = "${meta.homepage}/${ver_branch}/${version}/+download/${name}.tar.gz";
     sha256 = "031iv7zrpv27zsvahvfyrm75zdrh7591db56q89k8cjiiy600r1j";
@@ -24,6 +23,7 @@ stdenv.mkDerivation rec {
       url = "https://588764.bugs.gentoo.org/attachment.cgi?id=442616";
       sha256 = "0r383kjkvq9yanjc1lk878xc5g8993pjgxylqhhjb5rkpi1mbfsv";
     })
+    ./cursors.patch
   ];
 
   buildInputs = [ pkgconfig lightdm intltool makeWrapper ]


### PR DESCRIPTION
###### Motivation for this change

Allow customisation of cursor theme (both theme and cursor size as well) in lightdm's gtk greeter.
With this change one can configure both the greeter and the desktop environment to have a consistent cursor theme. Also comes handy on a hidpi display where lightdm by default was using tiny cursor size.

This is both work in progress as well as a request for feedback to see whether there is interest in those changes.

In terms of things that would still need to be done: I would like to make the new settings optional so they don't affect existing setups unless users explicitly opt in.

Also to note - outside of changes to the nixos module itself this PR includes [a patch to lightdm's sources](https://github.com/NixOS/nixpkgs/compare/master...pbogdan:lightdm?expand=1#diff-936b708c2703c3e4cee18d748a2e167f)

Perhaps there is a less invasive way to accomplish what this PR is trying to do in which case I would like to hear about it 😄 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

