### PR TITLE
fwup: 0.14.2 -> 0.14.3

### DIFF
--- a/pkgs/tools/misc/fwup/default.nix
+++ b/pkgs/tools/misc/fwup/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "fwup-${version}";
-  version = "0.14.2";
+  version = "0.14.3";
 
   src = fetchFromGitHub {
     owner = "fhunleth";
     repo = "fwup";
     rev = "v${version}";
-    sha256 = "0ddyiprq4qnqpdhh48bivl8c5yrh21p4r99qs0d1rjiwx5h9p21l";
+    sha256 = "15sjpxw1llpipshriivpha6470lkvhcgs5wh5mlaabjbvrgxygqh";
   };
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

Update has fixes for failing tests on ZFS, should fix issues identified in https://github.com/NixOS/nixpkgs/pull/25760

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
