### PR TITLE
Add `*Platform.is*` predicates and alias `stdenv.is*` to `hostPlatform`'s

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -1,6 +1,9 @@
+let inherit (import ../attrsets.nix) mapAttrs; in
+
 rec {
   doubles = import ./doubles.nix;
   parse = import ./parse.nix;
+  inspect = import ./inspect.nix;
   platforms = import ./platforms.nix;
 
   # Elaborate a `localSystem` or `crossSystem` so that it contains everything
@@ -18,6 +21,7 @@ rec {
       config = parse.tripleFromSystem final.parsed;
       # Just a guess, based on `system`
       platform = platforms.selectBySystem final.system;
-    } // args;
+    } // mapAttrs (n: v: v final.parsed) inspect.predicates
+      // args;
   in final;
 }

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -21,6 +21,12 @@ rec {
       config = parse.tripleFromSystem final.parsed;
       # Just a guess, based on `system`
       platform = platforms.selectBySystem final.system;
+      libc =
+        /**/ if final.isDarwin then "libSystem"
+        else if final.isMinGW  then "msvcrt"
+        else if final.isLinux  then "glibc"
+        # TODO(@Ericson2314) think more about other operating systems
+        else                        "native/impure";
     } // mapAttrs (n: v: v final.parsed) inspect.predicates
       // args;
   in final;

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -1,8 +1,9 @@
-let lists = import ../lists.nix; in
-let parse = import ./parse.nix; in
-let inherit (import ../attrsets.nix) matchAttrs; in
-
 let
+  lists = import ../lists.nix;
+  parse = import ./parse.nix;
+  inherit (import ./inspect.nix) predicates;
+  inherit (import ../attrsets.nix) matchAttrs;
+
   all = [
     "aarch64-linux"
     "armv5tel-linux" "armv6l-linux" "armv7l-linux"
@@ -25,20 +26,21 @@ in rec {
   allBut = platforms: lists.filter (x: !(builtins.elem x platforms)) all;
   none = [];
 
-  arm = filterDoubles (matchAttrs { cpu = { family = "arm"; bits = 32; }; });
-  i686 = filterDoubles parse.isi686;
-  mips = filterDoubles (matchAttrs { cpu = { family = "mips"; }; });
-  x86_64 = filterDoubles parse.isx86_64;
+  arm     = filterDoubles predicates.isArm32;
+  i686    = filterDoubles predicates.isi686;
+  mips    = filterDoubles predicates.isMips;
+  x86_64  = filterDoubles predicates.isx86_64;
 
-  cygwin = filterDoubles parse.isCygwin;
-  darwin = filterDoubles parse.isDarwin;
-  freebsd = filterDoubles (matchAttrs { kernel = parse.kernels.freebsd; });
-  gnu = filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnu; }); # Should be better
-  illumos = filterDoubles (matchAttrs { kernel = parse.kernels.solaris; });
-  linux = filterDoubles parse.isLinux;
-  netbsd = filterDoubles (matchAttrs { kernel = parse.kernels.netbsd; });
-  openbsd = filterDoubles (matchAttrs { kernel = parse.kernels.openbsd; });
-  unix = filterDoubles parse.isUnix;
+  cygwin  = filterDoubles predicates.isCygwin;
+  darwin  = filterDoubles predicates.isDarwin;
+  freebsd = filterDoubles predicates.isFreeBSD;
+  # Should be better, but MinGW is unclear, and HURD is bit-rotted.
+  gnu     = filterDoubles (matchAttrs { kernel = parse.kernels.linux;  abi = parse.abis.gnu; });
+  illumos = filterDoubles predicates.isSunOS;
+  linux   = filterDoubles predicates.isLinux;
+  netbsd  = filterDoubles predicates.isNetBSD;
+  openbsd = filterDoubles predicates.isOpenBSD;
+  unix    = filterDoubles predicates.isUnix;
 
   mesaPlatforms = ["i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "aarch64-linux"];
 }

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -1,0 +1,36 @@
+with import ./parse.nix;
+with import ../attrsets.nix;
+
+rec {
+  patterns = {
+    "32bit"      = { cpu = { bits = 32; }; };
+    "64bit"      = { cpu = { bits = 64; }; };
+    i686         = { cpu = cpuTypes.i686; };
+    x86_64       = { cpu = cpuTypes.x86_64; };
+    Arm          = { cpu = { family = "arm"; }; };
+    Mips         = { cpu = { family = "mips"; }; };
+    BigEndian    = { cpu = { significantByte = significantBytes.bigEndian; }; };
+    LittleEndian = { cpu = { significantByte = significantBytes.littleEndian; }; };
+
+    Unix         = { kernel = { families = { inherit (kernelFamilies) unix; }; }; };
+    BSD          = { kernel = { families = { inherit (kernelFamilies) bsd; }; }; };
+
+    Darwin       = { kernel = kernels.darwin; };
+    Linux        = { kernel = kernels.linux; };
+    SunOS        = { kernel = kernels.solaris; };
+    FreeBSD      = { kernel = kernels.freebsd; };
+    NetBSD       = { kernel = kernels.netbsd; };
+    OpenBSD      = { kernel = kernels.openbsd; };
+    Windows      = { kernel = kernels.windows; };
+    Cygwin       = { kernel = kernels.windows; abi = abis.cygnus; };
+    MinGW        = { kernel = kernels.windows; abi = abis.gnu; };
+
+    Arm32        = recursiveUpdate patterns.Arm patterns."32bit";
+    Arm64        = recursiveUpdate patterns.Arm patterns."64bit";
+
+  };
+
+  predicates = mapAttrs'
+    (name: value: nameValuePair ("is" + name) (matchAttrs value))
+    patterns;
+}

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -8,6 +8,7 @@
 with import ../lists.nix;
 with import ../types.nix;
 with import ../attrsets.nix;
+with (import ./inspect.nix).predicates;
 
 let
   lib = import ../default.nix;
@@ -109,19 +110,6 @@ rec {
       inherit cpu vendor kernel abi;
     };
 
-  is64Bit = matchAttrs { cpu = { bits = 64; }; };
-  is32Bit = matchAttrs { cpu = { bits = 32; }; };
-  isi686 = matchAttrs { cpu = cpuTypes.i686; };
-  isx86_64 = matchAttrs { cpu = cpuTypes.x86_64; };
-
-  isDarwin = matchAttrs { kernel = kernels.darwin; };
-  isLinux = matchAttrs { kernel = kernels.linux; };
-  isUnix = matchAttrs { kernel = { families = { inherit (kernelFamilies) unix; }; }; };
-  isWindows = matchAttrs { kernel = kernels.windows; };
-  isCygwin = matchAttrs { kernel = kernels.windows; abi = abis.cygnus; };
-  isMinGW = matchAttrs { kernel = kernels.windows; abi = abis.gnu; };
-
-
   mkSkeletonFromList = l: {
     "2" = # We only do 2-part hacks for things Nix already supports
       if elemAt l 1 == "cygwin"
@@ -153,22 +141,22 @@ rec {
     getKernel = name:  kernels.${name} or (throw "Unknown kernel: ${name}");
     getAbi    = name:     abis.${name} or (throw "Unknown ABI: ${name}");
 
-    system = rec {
+    parsed = rec {
       cpu = getCpu args.cpu;
       vendor =
         /**/ if args ? vendor    then getVendor args.vendor
-        else if isDarwin  system then vendors.apple
-        else if isWindows system then vendors.pc
+        else if isDarwin  parsed then vendors.apple
+        else if isWindows parsed then vendors.pc
         else                     vendors.unknown;
       kernel = getKernel args.kernel;
       abi =
         /**/ if args ? abi       then getAbi args.abi
-        else if isLinux   system then abis.gnu
-        else if isWindows system then abis.gnu
+        else if isLinux   parsed then abis.gnu
+        else if isWindows parsed then abis.gnu
         else                     abis.unknown;
     };
 
-  in mkSystem system;
+  in mkSystem parsed;
 
   mkSystemFromString = s: mkSystemFromSkeleton (mkSkeletonFromList (lib.splitString "-" s));
 

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ((import ../../lib).cleanSource ../..) {} }:
+{ pkgs ? import ((import ../.).cleanSource ../..) {} }:
 
 pkgs.stdenv.mkDerivation {
   name = "nixpkgs-lib-tests";

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -5,17 +5,15 @@
 }:
 
 let
-  inherit (stdenv.lib.systems.parse) isDarwin;
-
   prefix = stdenv.lib.optionalString
     (targetPlatform != hostPlatform)
     "${targetPlatform.config}-";
 in
 
-assert isDarwin targetPlatform.parsed;
+assert targetPlatform.isDarwin;
 
 # Non-Darwin alternatives
-assert (!isDarwin hostPlatform.parsed) -> (maloader != null && xctoolchain != null);
+assert (!hostPlatform.isDarwin) -> (maloader != null && xctoolchain != null);
 
 let
   baseParams = rec {
@@ -91,7 +89,7 @@ let
     '';
 
     postInstall =
-      if isDarwin hostPlatform.parsed
+      if hostPlatform.isDarwin
       then ''
         cat >$out/bin/dsymutil << EOF
         #!${stdenv.shell}

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -61,7 +61,7 @@ in rec {
                           allowedRequisites ? null}:
     let
       thisStdenv = import ../generic {
-        inherit system config shell extraBuildInputs allowedRequisites;
+        inherit config shell extraBuildInputs allowedRequisites;
 
         name = "stdenv-darwin-boot-${toString step}";
 
@@ -87,6 +87,10 @@ in rec {
           ${extraPreHook}
         '';
         initialPath  = [ bootstrapTools ];
+
+        hostPlatform = localSystem;
+        targetPlatform = localSystem;
+
         fetchurlBoot = import ../../build-support/fetchurl {
           stdenv = stage0.stdenv;
           curl   = bootstrapTools;
@@ -268,7 +272,7 @@ in rec {
   };
 
   stdenvDarwin = prevStage: let pkgs = prevStage; in import ../generic rec {
-    inherit system config;
+    inherit config;
     inherit (pkgs.stdenv) fetchurlBoot;
 
     name = "stdenv-darwin";
@@ -279,6 +283,9 @@ in rec {
 
     stdenvSandboxProfile = binShClosure + libSystemProfile;
     extraSandboxProfile  = binShClosure + libSystemProfile;
+
+    hostPlatform = localSystem;
+    targetPlatform = localSystem;
 
     initialPath = import ../common-path.nix { inherit pkgs; };
     shell       = "${pkgs.bash}/bin/bash";

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -35,8 +35,10 @@ let inherit (localSystem) system; in
 
     stdenv = import ../generic {
       name = "stdenv-freebsd-boot-1";
-      inherit system config;
+      inherit config;
       initialPath = [ "/" "/usr" ];
+      hostPlatform = localSystem;
+      targetPlatform = localSystem;
       shell = "${bootstrapTools}/bin/bash";
       fetchurlBoot = null;
       cc = null;
@@ -50,9 +52,10 @@ let inherit (localSystem) system; in
 
     stdenv = import ../generic {
       name = "stdenv-freebsd-boot-0";
-      inherit system config;
+      inherit config;
       initialPath = [ prevStage.bootstrapTools ];
-      inherit (prevStage.stdenv) shell;
+      inherit (prevStage.stdenv)
+        hostPlatform targetPlatform shell;
       fetchurlBoot = prevStage.fetchurl;
       cc = null;
     };
@@ -65,10 +68,10 @@ let inherit (localSystem) system; in
     inherit config overlays;
     stdenv = import ../generic {
       name = "stdenv-freebsd-boot-3";
-      inherit system config;
+      inherit config;
 
       inherit (prevStage.stdenv)
-        initialPath shell fetchurlBoot;
+        hostPlatform targetPlatform initialPath shell fetchurlBoot;
 
       cc = import ../../build-support/cc-wrapper {
         nativeTools  = true;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -1,6 +1,6 @@
 let lib = import ../../../lib; in lib.makeOverridable (
 
-{ system, name ? "stdenv", preHook ? "", initialPath, cc, shell
+{ name ? "stdenv", preHook ? "", initialPath, cc, shell
 , allowedRequisites ? null, extraAttrs ? {}, overrides ? (self: super: {}), config
 
 , # The `fetchurl' to use for downloading curl and its dependencies
@@ -14,9 +14,18 @@ let lib = import ../../../lib; in lib.makeOverridable (
 , __extraImpureHostDeps ? []
 , stdenvSandboxProfile ? ""
 , extraSandboxProfile ? ""
+
+, # The platforms here do *not* correspond to the stage the stdenv is
+  # used in, but rather the previous one, in which it was built. We
+  # use the latter two platforms, like a cross compiler, because the
+  # stand environment is a build tool if you squint at it, and because
+  # neither of these are used when building stdenv so we know the
+  # build platform is irrelevant.
+  hostPlatform, targetPlatform
 }:
 
 let
+  inherit (targetPlatform) system;
 
   # See discussion at https://github.com/NixOS/nixpkgs/pull/25304#issuecomment-298385426
   # for why this defaults to false, but I (@copumpkin) want to default it to true soon.
@@ -265,7 +274,7 @@ let
 
       outputs' =
         outputs ++
-        (if separateDebugInfo then assert result.isLinux; [ "debug" ] else []);
+        (if separateDebugInfo then assert targetPlatform.isLinux; [ "debug" ] else []);
 
       buildInputs' = lib.chooseDevOutputs buildInputs ++
         (if separateDebugInfo then [ ../../build-support/setup-hooks/separate-debug-info.sh ] else []);
@@ -311,7 +320,7 @@ let
           # Inputs built by the usual native compiler.
           nativeBuildInputs = nativeBuildInputs'
             ++ lib.optional
-                (result.isCygwin
+                (hostPlatform.isCygwin
                   || (crossConfig != null && lib.hasSuffix "mingw32" crossConfig))
                 ../../build-support/setup-hooks/win-dll-link.sh
             ;
@@ -392,51 +401,14 @@ let
       };
 
       # Utility flags to test the type of platform.
-      isDarwin = system == "x86_64-darwin";
-      isLinux = system == "i686-linux"
-             || system == "x86_64-linux"
-             || system == "powerpc-linux"
-             || system == "armv5tel-linux"
-             || system == "armv6l-linux"
-             || system == "armv7l-linux"
-             || system == "aarch64-linux"
-             || system == "mips64el-linux";
-      isGNU = system == "i686-gnu"; # GNU/Hurd
-      isSunOS = system == "i686-solaris"
-             || system == "x86_64-solaris";
-      isCygwin = system == "i686-cygwin"
-              || system == "x86_64-cygwin";
-      isFreeBSD = system == "i686-freebsd"
-               || system == "x86_64-freebsd";
-      isOpenBSD = system == "i686-openbsd"
-               || system == "x86_64-openbsd";
-      isi686 = system == "i686-linux"
-            || system == "i686-gnu"
-            || system == "i686-freebsd"
-            || system == "i686-openbsd"
-            || system == "i686-cygwin"
-            || system == "i386-sunos";
-      isx86_64 = system == "x86_64-linux"
-              || system == "x86_64-darwin"
-              || system == "x86_64-freebsd"
-              || system == "x86_64-openbsd"
-              || system == "x86_64-cygwin"
-              || system == "x86_64-solaris";
-      is64bit = system == "x86_64-linux"
-             || system == "x86_64-darwin"
-             || system == "x86_64-freebsd"
-             || system == "x86_64-openbsd"
-             || system == "x86_64-cygwin"
-             || system == "x86_64-solaris"
-             || system == "aarch64-linux"
-             || system == "mips64el-linux";
-      isMips = system == "mips-linux"
-            || system == "mips64el-linux";
-      isArm = system == "armv5tel-linux"
-           || system == "armv6l-linux"
-           || system == "armv7l-linux";
-      isAarch64 = system == "aarch64-linux";
-      isBigEndian = system == "powerpc-linux";
+      inherit (hostPlatform)
+        isDarwin isLinux isSunOS isCygwin isFreeBSD isOpenBSD isi686 isx86_64
+        is64bit isMips isBigEndian;
+      isArm = hostPlatform.isArm32;
+      isAarch64 = hostPlatform.isArm64;
+      # Other code instead checks for anything using GNU userland,
+      # e.g. GNU/linux. This refers just to GNU Hurd.
+      isGNU = system == "i686-gnu";
 
       # Whether we should run paxctl to pax-mark binaries.
       needsPax = isLinux;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -402,9 +402,6 @@ let
              || system == "aarch64-linux"
              || system == "mips64el-linux";
       isGNU = system == "i686-gnu"; # GNU/Hurd
-      isGlibc = isGNU # useful for `stdenvNative'
-             || isLinux
-             || system == "x86_64-kfreebsd-gnu";
       isSunOS = system == "i686-solaris"
              || system == "x86_64-solaris";
       isCygwin = system == "i686-cygwin"

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -52,7 +52,7 @@ let
     let
 
       thisStdenv = import ../generic {
-        inherit system config extraBuildInputs;
+        inherit config extraBuildInputs;
         name = "stdenv-linux-boot";
         preHook =
           ''
@@ -63,6 +63,9 @@ let
           '';
         shell = "${bootstrapTools}/bin/bash";
         initialPath = [bootstrapTools];
+
+        hostPlatform = localSystem;
+        targetPlatform = localSystem;
 
         fetchurlBoot = import ../../build-support/fetchurl/boot.nix {
           inherit system;
@@ -261,7 +264,7 @@ in
     targetPlatform = localSystem;
     inherit config overlays;
     stdenv = import ../generic rec {
-      inherit system config;
+      inherit config;
 
       preHook = ''
         # Make "strip" produce deterministic output, by setting
@@ -272,6 +275,9 @@ in
 
       initialPath =
         ((import ../common-path.nix) {pkgs = prevStage;});
+
+      hostPlatform = localSystem;
+      targetPlatform = localSystem;
 
       extraBuildInputs = [ prevStage.patchelf prevStage.paxctl ] ++
         # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -81,6 +81,9 @@ let
     { cc, fetchurl, extraPath ? [], overrides ? (self: super: { }) }:
 
     import ../generic {
+      hostPlatform = localSystem;
+      targetPlatform = localSystem;
+
       preHook =
         if system == "i686-freebsd" then prehookFreeBSD else
         if system == "x86_64-freebsd" then prehookFreeBSD else

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -24,11 +24,11 @@ bootStages ++ [
 
       initialPath = (import ../common-path.nix) { pkgs = prevStage; };
 
-      system = stdenv.system;
+      inherit (prevStage.stdenv) hostPlatform targetPlatform;
 
       cc = import ../../build-support/cc-wrapper {
         nativeTools = false;
-        nativePrefix = stdenv.lib.optionalString stdenv.isSunOS "/usr";
+        nativePrefix = stdenv.lib.optionalString hostPlatform.isSunOS "/usr";
         nativeLibc = true;
         inherit stdenv;
         inherit (prevStage) binutils coreutils gnugrep;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6397,7 +6397,7 @@ with pkgs;
   bin_replace_string = callPackage ../development/tools/misc/bin_replace_string { };
 
   binutils =
-    if lib.systems.parse.isDarwin targetPlatform.parsed
+    if targetPlatform.isDarwin
     then darwin.binutils
     else binutils-raw;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8653,15 +8653,19 @@ with pkgs;
 
   libgsf = callPackage ../development/libraries/libgsf { };
 
-  # glibc provides libiconv so systems with glibc don't need to build libiconv
-  # separately, but we also provide libiconvReal, which will always be a
-  # standalone libiconv, just in case you want it
-  libiconv = if stdenv ? cross then
-    (if stdenv.cross.libc == "glibc" then libcCross
-      else if stdenv.cross.libc == "libSystem" then darwin.libiconv
-      else libiconvReal)
-    else if stdenv.isGlibc then glibcIconv stdenv.cc.libc
-    else if stdenv.isDarwin then darwin.libiconv
+  # GNU libc provides libiconv so systems with glibc don't need to build
+  # libiconv separately. Additionally, Apple forked/repackaged libiconv so we
+  # use that instead of the vanilla version on that OS.
+  #
+  # We also provide `libiconvReal`, which will always be a standalone libiconv,
+  # just in case you want it regardless of platform.
+  libiconv =
+    if hostPlatform.libc == "glibc"
+      then glibcIconv (if hostPlatform != buildPlatform
+                       then libcCross
+                       else stdenv.cc.libc)
+    else if hostPlatform.isDarwin
+      then darwin.libiconv
     else libiconvReal;
 
   glibcIconv = libc: let


### PR DESCRIPTION
###### Motivation for this change

As discussed in https://github.com/NixOS/nixpkgs/issues/14965, The old notation is vague on which platform is being inspected. Worse, users probably mean the host platform, but in fact are inspecting the build platform.

This PR doesn't actually replace the old notation, but sets everything up so a simple/stupid replace can be done as a follow-up:

 - `*Platform.is*` shorthand is now defined
 - `stdenv.is*` is just taken from `hostPlatform.is*`

Also infer `{build,host,target}.libc`, which is a first step for the ideas in https://github.com/NixOS/nixpkgs/issues/6221

CC @vcunat @copumpkin 

[@kmicklas Your branch we paired on the other day should be rebased on this one, once it's merged. (Otherwise will be lots of merge conflicts.)]

###### Things done

~~No hashes should be changed; need to check that.~~ I assume cause travis completed there was no-mass rebuild.

