### PR TITLE
vms-empire: init at 1.14

### DIFF
--- a/pkgs/games/vms-empire/default.nix
+++ b/pkgs/games/vms-empire/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, ncurses, xmlto }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec{
+
+  name = "vms-empire-${version}";
+  version = "1.14";
+
+  src = fetchurl{
+    url = "http://www.catb.org/~esr/vms-empire/${name}.tar.gz";
+    sha256 = "0cymzhivvaahgqz0p11w25a710ls4w0jhyqj789jas5s07nvd890";
+  };
+
+  buildInputs =
+  [ ncurses xmlto ];
+
+  patchPhase = ''
+    sed -i -e 's|^install: empire\.6 uninstall|install: empire.6|' -e 's|usr/||g' Makefile
+  '';
+
+  hardeningDisable = [ "format" ];
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  meta = {
+    description = "The ancestor of all expand/explore/exploit/exterminate games";
+    longDescription = ''
+      Empire is a simulation of a full-scale war between two emperors, the
+      computer and you. Naturally, there is only room for one, so the object of
+      the game is to destroy the other. The computer plays by the same rules
+      that you do. This game was ancestral to all later
+      expand/explore/exploit/exterminate games, including Civilization and
+      Master of Orion.
+    '';
+    homepage = http://catb.org/~esr/vms-empire/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.AndersonTorres ];
+    platforms = platforms.linux;
+  };
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17276,6 +17276,8 @@ with pkgs;
 
   vessel = callPackage_i686 ../games/vessel { };
 
+  vms-empire = callPackage ../games/vms-empire { };
+
   voxelands = callPackage ../games/voxelands {
     libpng = libpng12;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

