### PR TITLE
stdenv: Rename `isGNU` to `isHurd` as GNU is a userland

### DIFF
--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -7,6 +7,7 @@ rec {
     "64bit"      = { cpu = { bits = 64; }; };
     i686         = { cpu = cpuTypes.i686; };
     x86_64       = { cpu = cpuTypes.x86_64; };
+    x86          = { cpu = { family = "x86"; }; };
     Arm          = { cpu = { family = "arm"; }; };
     Mips         = { cpu = { family = "mips"; }; };
     BigEndian    = { cpu = { significantByte = significantBytes.bigEndian; }; };

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -19,6 +19,7 @@ rec {
     Linux        = { kernel = kernels.linux; };
     SunOS        = { kernel = kernels.solaris; };
     FreeBSD      = { kernel = kernels.freebsd; };
+    Hurd         = { kernel = kernels.hurd; };
     NetBSD       = { kernel = kernels.netbsd; };
     OpenBSD      = { kernel = kernels.openbsd; };
     Windows      = { kernel = kernels.windows; };
@@ -27,7 +28,6 @@ rec {
 
     Arm32        = recursiveUpdate patterns.Arm patterns."32bit";
     Arm64        = recursiveUpdate patterns.Arm patterns."64bit";
-
   };
 
   predicates = mapAttrs'

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -77,6 +77,7 @@ rec {
   {
     darwin  = { execFormat = macho;   families = { inherit unix; }; };
     freebsd = { execFormat = elf;     families = { inherit unix bsd; }; };
+    hurd    = { execFormat = elf;     families = { inherit unix; }; };
     linux   = { execFormat = elf;     families = { inherit unix; }; };
     netbsd  = { execFormat = elf;     families = { inherit unix bsd; }; };
     none    = { execFormat = unknown; families = { inherit unix; }; };
@@ -113,7 +114,9 @@ rec {
   mkSkeletonFromList = l: {
     "2" = # We only do 2-part hacks for things Nix already supports
       if elemAt l 1 == "cygwin"
-        then { cpu = elemAt l 0;                      kernel = "windows"; abi = "cygnus";    }
+        then { cpu = elemAt l 0;                      kernel = "windows";  abi = "cygnus";   }
+      else if elemAt l 1 == "gnu"
+        then { cpu = elemAt l 0;                      kernel = "hurd";     abi = "gnu";      }
       else   { cpu = elemAt l 0;                      kernel = elemAt l 1;                   };
     "3" = # Awkwards hacks, beware!
       if elemAt l 1 == "apple"

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -226,7 +226,7 @@ stdenv.mkDerivation ({
   libc_dev = stdenv.cc.libc_dev;
 
   postPatch =
-    if (stdenv.isGNU
+    if (stdenv.isHurd
         || (libcCross != null                  # e.g., building `gcc.crossDrv'
             && libcCross ? crossConfig
             && libcCross.crossConfig == "i586-pc-gnu")

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -230,7 +230,7 @@ stdenv.mkDerivation ({
   libc_dev = stdenv.cc.libc_dev;
 
   postPatch =
-    if (stdenv.isGNU
+    if (stdenv.isHurd
         || (libcCross != null                  # e.g., building `gcc.crossDrv'
             && libcCross ? crossConfig
             && libcCross.crossConfig == "i586-pc-gnu")

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -247,7 +247,7 @@ stdenv.mkDerivation ({
   '';
 
   postPatch =
-    if (stdenv.isGNU
+    if (stdenv.isHurd
         || (libcCross != null                  # e.g., building `gcc.crossDrv'
             && libcCross ? crossConfig
             && libcCross.crossConfig == "i586-pc-gnu")

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -229,7 +229,7 @@ stdenv.mkDerivation ({
   hardeningDisable = [ "format" ];
 
   postPatch =
-    if (stdenv.isGNU
+    if (stdenv.isHurd
         || (libcCross != null                  # e.g., building `gcc.crossDrv'
             && libcCross ? crossConfig
             && libcCross.crossConfig == "i586-pc-gnu")

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -230,7 +230,7 @@ stdenv.mkDerivation ({
   hardeningDisable = [ "format" ];
 
   postPatch =
-    if (stdenv.isGNU
+    if (stdenv.isHurd
         || (libcCross != null                  # e.g., building `gcc.crossDrv'
             && libcCross ? crossConfig
             && libcCross.crossConfig == "i586-pc-gnu")

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -1,33 +1,31 @@
 { fetchurl, stdenv, ncurses, readline, gmp, mpfr, expat, texinfo, zlib
 , dejagnu, perl, pkgconfig
-, python ? null
+
+, buildPlatform, hostPlatform, targetPlatform
+
+, pythonSupport ? hostPlatform == buildPlatform && !hostPlatform.isCygwin, python ? null
 , guile ? null
-, target ? null
+
 # Support all known targets in one gdb binary.
 , multitarget ? false
+
 # Additional dependencies for GNU/Hurd.
 , mig ? null, hurd ? null
-
 }:
 
 let
-
-  basename = "gdb-7.12.1";
-
-  # Whether (cross-)building for GNU/Hurd.  This is an approximation since
-  # having `stdenv ? cross' doesn't tell us if we're building `crossDrv' and
-  # `nativeDrv'.
-  isGNU =
-      stdenv.system == "i686-gnu"
-      || (stdenv ? cross && stdenv.cross.config == "i586-pc-gnu");
-
+  basename = "gdb-${version}";
+  version = "7.12.1";
 in
 
-assert isGNU -> mig != null && hurd != null;
+assert targetPlatform.isHurd -> mig != null && hurd != null;
+assert pythonSupport -> python != null;
 
 stdenv.mkDerivation rec {
-  name = basename + stdenv.lib.optionalString (target != null)
-      ("-" + target.config);
+  name =
+    stdenv.lib.optionalString (targetPlatform != hostPlatform)
+                              (targetPlatform.config + "-")
+    + basename;
 
   src = fetchurl {
     url = "mirror://gnu/gdb/${basename}.tar.xz";
@@ -35,10 +33,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig texinfo perl ]
-    ++ stdenv.lib.optional isGNU mig;
+    # TODO(@Ericson2314) not sure if should be host or target
+    ++ stdenv.lib.optional targetPlatform.isHurd mig;
 
-  buildInputs = [ ncurses readline gmp mpfr expat zlib python guile ]
-    ++ stdenv.lib.optional isGNU hurd
+  buildInputs = [ ncurses readline gmp mpfr expat zlib guile ]
+    ++ stdenv.lib.optional pythonSupport python
+    ++ stdenv.lib.optional targetPlatform.isHurd hurd
     ++ stdenv.lib.optional doCheck dejagnu;
 
   enableParallelBuilding = true;
@@ -46,24 +46,16 @@ stdenv.mkDerivation rec {
   # darwin build fails with format hardening since v7.12
   hardeningDisable = stdenv.lib.optionals stdenv.isDarwin [ "format" ];
 
-  configureFlags = with stdenv.lib;
-    [ "--with-gmp=${gmp.dev}" "--with-mpfr=${mpfr.dev}" "--with-system-readline"
-      "--with-system-zlib" "--with-expat" "--with-libexpat-prefix=${expat.dev}"
+  configureFlags = with stdenv.lib; [
+    "--with-gmp=${gmp.dev}" "--with-mpfr=${mpfr.dev}" "--with-system-readline"
+    "--with-system-zlib" "--with-expat" "--with-libexpat-prefix=${expat.dev}"
+  ] ++ stdenv.lib.optional hostPlatform.isLinux
+      # TODO(@Ericson2314): make this conditional on whether host platform is NixOS
       "--with-separate-debug-dir=/run/current-system/sw/lib/debug"
-    ]
-    ++ optional (target != null) "--target=${target.config}"
-    ++ optional multitarget "--enable-targets=all"
-    ++ optional (elem stdenv.system platforms.cygwin) "--without-python";
-
-  crossAttrs = {
-    # Do not add --with-python here to avoid cross building it.
-    configureFlags = with stdenv.lib;
-      [ "--with-gmp=${gmp.crossDrv}" "--with-mpfr=${mpfr.crossDrv}" "--with-system-readline"
-        "--with-system-zlib" "--with-expat" "--with-libexpat-prefix=${expat.crossDrv}" "--without-python"
-      ]
-      ++ optional (target != null) "--target=${target.config}"
-      ++ optional multitarget "--enable-targets=all";
-  };
+    ++ stdenv.lib.optional (!pythonSupport) "--without-python"
+    # TODO(@Ericson2314): This should be done in stdenv, not per-package
+    ++ stdenv.lib.optional (targetPlatform != hostPlatform) "--target=${target.config}"
+    ++ stdenv.lib.optional multitarget "--enable-targets=all";
 
   postInstall =
     '' # Remove Info files already provided by Binutils and other packages.

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -402,13 +402,10 @@ let
 
       # Utility flags to test the type of platform.
       inherit (hostPlatform)
-        isDarwin isLinux isSunOS isCygwin isFreeBSD isOpenBSD isi686 isx86_64
-        is64bit isMips isBigEndian;
+        isDarwin isLinux isSunOS isHurd isCygwin isFreeBSD isOpenBSD
+        isi686 isx86_64 is64bit isMips isBigEndian;
       isArm = hostPlatform.isArm32;
       isAarch64 = hostPlatform.isArm64;
-      # Other code instead checks for anything using GNU userland,
-      # e.g. GNU/linux. This refers just to GNU Hurd.
-      isGNU = system == "i686-gnu";
 
       # Whether we should run paxctl to pax-mark binaries.
       needsPax = isLinux;

--- a/pkgs/tools/archivers/zpaq/zpaqd.nix
+++ b/pkgs/tools/archivers/zpaq/zpaqd.nix
@@ -1,7 +1,10 @@
-{ stdenv, fetchurl, unzip }:
+{ stdenv, fetchurl, unzip
+, buildPlatform, hostPlatform
+}:
+
 let
-  s = # Generated upstream information
-  rec {
+  # Generated upstream information
+  s = rec {
     baseName="zpaqd";
     version="715";
     name="${baseName}-${version}";
@@ -9,15 +12,12 @@ let
     url="http://mattmahoney.net/dc/zpaqd715.zip";
     sha256="0868lynb45lm79yvx5f10lj5h6bfv0yck8whcls2j080vmk3n7rk";
   };
-  isUnix = with stdenv; isLinux || isGNU || isDarwin || isFreeBSD || isOpenBSD;
-  isx86 = stdenv.isi686 || stdenv.isx86_64;
-  compileFlags = with stdenv; ""
-    + (lib.optionalString (isUnix) " -Dunix -pthread")
-    + (lib.optionalString (isi686) " -march=i686")
-    + (lib.optionalString (isx86_64) " -march=nocona")
-    + (lib.optionalString (!isx86) " -DNOJIT")
-    + " -O3 -mtune=generic -DNDEBUG"
-    ;
+
+  compileFlags = stdenv.lib.concatStringsSep " " ([ "-O3" "-mtune=generic" "-DNDEBUG" ]
+    ++ stdenv.lib.optional (hostPlatform.isUnix) "-Dunix -pthread"
+    ++ stdenv.lib.optional (hostPlatform.isi686) "-march=i686"
+    ++ stdenv.lib.optional (hostPlatform.isx86_64) "-march=nocona"
+    ++ stdenv.lib.optional (!hostPlatform.isx86) "-DNOJIT");
 in
 stdenv.mkDerivation {
   inherit (s) name version;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7076,10 +7076,6 @@ with pkgs;
 
   gdbGuile = lowPrio (gdb.override { inherit guile; });
 
-  gdbCross = lowPrio (callPackage ../development/tools/misc/gdb {
-    target = if targetPlatform != buildPlatform then targetPlatform else null;
-  });
-
   gdb-multitarget = lowPrio (gdb.override { multitarget = true; });
 
   valgrind = callPackage ../development/tools/analysis/valgrind {

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -24,7 +24,7 @@ let
   };
 
   linuxCommon = lib.recursiveUpdate gnuCommon {
-    buildPackages.gdbCross = nativePlatforms;
+    buildPackages.gdb = nativePlatforms;
 
     bison = nativePlatforms;
     busybox = nativePlatforms;


### PR DESCRIPTION
###### Motivation for this change

Elsewhere, things called GNU indeed includes GNU/Linux or GNU/Hurd, but this predicate was defined excluding Linux regardless of userland.


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @matthewbauer (it won't let me request a review)