### PR TITLE
libvirtd: remove `onShutdown` option

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -204,6 +204,7 @@ with lib;
       "Set the option `services.xserver.displayManager.sddm.package' instead.")
     (mkRemovedOptionModule [ "fonts" "fontconfig" "forceAutohint" ] "")
     (mkRemovedOptionModule [ "fonts" "fontconfig" "renderMonoTTFAsBitmap" ] "")
+    (mkRemovedOptionModule [ "virtualisation" "libvirtd" "onShutdown" ] "")
 
     # ZSH
     (mkRenamedOptionModule [ "programs" "zsh" "enableSyntaxHighlighting" ] [ "programs" "zsh" "syntaxHighlighting" "enable" ])

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -84,17 +84,6 @@ in {
       '';
     };
 
-    virtualisation.libvirtd.onShutdown = mkOption {
-      type = types.enum ["shutdown" "suspend" ];
-      default = "suspend";
-      description = ''
-        When shutting down / restarting the host what method should
-        be used to gracefully halt the guests. Setting to "shutdown"
-        will cause an ACPI shutdown of each guest. "suspend" will
-        attempt to save the state of the guests ready to restore on boot.
-      '';
-    };
-
   };
 
 


### PR DESCRIPTION
It hasn’t been influencing the module implementation for a long time.

cc @fpletz 