### PR TITLE
minisat: fix maintainer

### DIFF
--- a/nixos/modules/services/continuous-integration/buildbot/master.nix
+++ b/nixos/modules/services/continuous-integration/buildbot/master.nix
@@ -235,6 +235,6 @@ in {
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ nand0p Mic92 ];
+  meta.maintainers = with lib.maintainers; [ nand0p mic92 ];
 
 }

--- a/pkgs/applications/science/logic/minisat/unstable.nix
+++ b/pkgs/applications/science/logic/minisat/unstable.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Compact and readable SAT solver";
-    maintainers = with maintainers; [ Mic92 ];
+    maintainers = with maintainers; [ mic92 ];
     platforms = platforms.unix;
     license = licenses.mit;
     homepage = "http://minisat.se/";


### PR DESCRIPTION
###### Motivation for this change
Travis builds are breaking because maintainer string is wrong.

```
$ ./maintainers/scripts/travis-nox-review-pr.sh nixpkgs-verify nixpkgs-manual nixpkgs-tarball nixpkgs-unstable
=== Verifying that nixpkgs evaluates...
error: undefined variable ‘Mic92’ at /home/travis/build/NixOS/nixpkgs/pkgs/applications/science/logic/minisat/unstable.nix:18:39
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

