### PR TITLE
gdb: s/target/tagetPlatform

### DIFF
--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
       "--with-separate-debug-dir=/run/current-system/sw/lib/debug"
     ++ stdenv.lib.optional (!pythonSupport) "--without-python"
     # TODO(@Ericson2314): This should be done in stdenv, not per-package
-    ++ stdenv.lib.optional (targetPlatform != hostPlatform) "--target=${target.config}"
+    ++ stdenv.lib.optional (targetPlatform != hostPlatform) "--target=${targetPlatform.config}"
     ++ stdenv.lib.optional multitarget "--enable-targets=all";
 
   postInstall =


### PR DESCRIPTION
Oops, missed this when cleaning up derivation recently

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

