### PR TITLE
release-cross: Be less absurd in `ensureUnaffected` tests

### DIFF
--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -59,8 +59,8 @@ in
     # there probably a good idea to try to be "more parametric" --- i.e. avoid
     # any special casing.
     crossSystem = {
-      config = "foosys";
-      libc = "foolibc";
+      config = "mips64el-apple-windows-gnu";
+      libc = "glibc";
     };
 
     # Converting to a string (drv path) before checking equality is probably a


### PR DESCRIPTION
###### Motivation for this change
We need to at least used a valid 4-part LLVM target "triple" and libc. Otherwise we'll get assertion errors during parsing.

###### Things done

- http://hydra.nixos.org/eval/1361430

---

