### PR TITLE
nodePackages.bootlint: init, regenerate nodePackages

### DIFF
--- a/pkgs/development/node-packages/node-packages-v4.nix
+++ b/pkgs/development/node-packages/node-packages-v4.nix
@@ -67,13 +67,13 @@ let
         sha1 = "633c2c83e3da42a502f52466022480f4208261de";
       };
     };
-    "minimatch-3.0.3" = {
+    "minimatch-3.0.4" = {
       name = "minimatch";
       packageName = "minimatch";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz";
-        sha1 = "2a4e4090b96b2db06a9d7df01055a62a77c9b774";
+        url = "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz";
+        sha1 = "5166e286457f03306064be5497e8dbb0c3d32083";
       };
     };
     "once-1.4.0" = {
@@ -454,13 +454,13 @@ let
         sha1 = "b0455b38fc5e0cf30d4325132e461970c2091cde";
       };
     };
-    "time-stamp-1.0.1" = {
+    "time-stamp-1.1.0" = {
       name = "time-stamp";
       packageName = "time-stamp";
-      version = "1.0.1";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz";
-        sha1 = "9f4bd23559c9365966f3302dbba2b07c6b99b151";
+        url = "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz";
+        sha1 = "764a5a11af50561921b133f3b44e618687e0f5c3";
       };
     };
     "glogg-1.0.0" = {
@@ -679,13 +679,13 @@ let
         sha1 = "150e20b756590ad3f91093f25a4f2ad8bff30ba3";
       };
     };
-    "string_decoder-1.0.0" = {
+    "string_decoder-1.0.1" = {
       name = "string_decoder";
       packageName = "string_decoder";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz";
-        sha1 = "f06f41157b664d86069f84bdbdc9b0d8ab281667";
+        url = "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz";
+        sha1 = "62e200f039955a6810d8df0a33ffc0f013662d98";
       };
     };
     "util-deprecate-1.0.2" = {
@@ -695,6 +695,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz";
         sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
+      };
+    };
+    "safe-buffer-5.0.1" = {
+      name = "safe-buffer";
+      packageName = "safe-buffer";
+      version = "5.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz";
+        sha1 = "d263ca54696cd8a306b5ca6551e92de57918fbe7";
       };
     };
     "clone-1.0.2" = {
@@ -904,13 +913,13 @@ let
         sha1 = "c1c4b9bee3e09725ddb106b75c1e301fe2f18b26";
       };
     };
-    "kind-of-3.2.0" = {
+    "kind-of-3.2.2" = {
       name = "kind-of";
       packageName = "kind-of";
-      version = "3.2.0";
+      version = "3.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz";
-        sha1 = "b58abe4d5c044ad33726a8c1525b48cf891bff07";
+        url = "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz";
+        sha1 = "31ea21a734bab9bbb0f32466d893aea51e4a3c64";
       };
     };
     "normalize-path-2.1.1" = {
@@ -1642,13 +1651,13 @@ let
         sha1 = "5c1fb1f117477114f0632a0eb4b71b3cb0fd3171";
       };
     };
-    "glob-7.1.1" = {
+    "glob-7.1.2" = {
       name = "glob";
       packageName = "glob";
-      version = "7.1.1";
+      version = "7.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz";
-        sha1 = "805211df04faaf1c63a3600306cdf5ade50b2ec8";
+        url = "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz";
+        sha1 = "c19c9df9a028702d678612384a6552404c636d15";
       };
     };
     "graceful-fs-4.1.11" = {
@@ -1660,13 +1669,13 @@ let
         sha1 = "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658";
       };
     };
-    "npmlog-4.0.2" = {
+    "npmlog-4.1.0" = {
       name = "npmlog";
       packageName = "npmlog";
-      version = "4.0.2";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz";
-        sha1 = "d03950e0e78ce1527ba26d2a7592e9348ac3e75f";
+        url = "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz";
+        sha1 = "dc59bee85f64f00ed424efb2af0783df25d1c0b5";
       };
     };
     "osenv-0.1.4" = {
@@ -1813,13 +1822,13 @@ let
         sha1 = "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3";
       };
     };
-    "wide-align-1.1.0" = {
+    "wide-align-1.1.2" = {
       name = "wide-align";
       packageName = "wide-align";
-      version = "1.1.0";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz";
-        sha1 = "40edde802a71fea1f070da3e62dcda2e7add96ad";
+        url = "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz";
+        sha1 = "571e0f1b0604636ebc0dfc21b0339bbe31341710";
       };
     };
     "code-point-at-1.1.0" = {
@@ -2000,15 +2009,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz";
         sha1 = "13e26d28ad6b0ffaa91312cd3bf708ed351e7233";
-      };
-    };
-    "safe-buffer-5.0.1" = {
-      name = "safe-buffer";
-      packageName = "safe-buffer";
-      version = "5.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz";
-        sha1 = "d263ca54696cd8a306b5ca6551e92de57918fbe7";
       };
     };
     "stringstream-0.0.5" = {
@@ -2326,22 +2326,22 @@ let
         sha1 = "159a49b9a9714c1fb102f2e0ed1906fab6a450f4";
       };
     };
-    "debug-2.6.6" = {
+    "debug-2.6.8" = {
       name = "debug";
       packageName = "debug";
-      version = "2.6.6";
+      version = "2.6.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz";
-        sha1 = "a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a";
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz";
+        sha1 = "e731531ca2ede27d188222427da17821d68ff4fc";
       };
     };
-    "express-4.15.2" = {
+    "express-4.15.3" = {
       name = "express";
       packageName = "express";
-      version = "4.15.2";
+      version = "4.15.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/express/-/express-4.15.2.tgz";
-        sha1 = "af107fc148504457f2dca9a6f2571d7129b97b35";
+        url = "https://registry.npmjs.org/express/-/express-4.15.3.tgz";
+        sha1 = "bab65d0f03aa80c358408972fc700f916944b662";
       };
     };
     "rc-1.2.1" = {
@@ -2353,13 +2353,13 @@ let
         sha1 = "2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95";
       };
     };
-    "serve-favicon-2.4.2" = {
+    "serve-favicon-2.4.3" = {
       name = "serve-favicon";
       packageName = "serve-favicon";
-      version = "2.4.2";
+      version = "2.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.2.tgz";
-        sha1 = "aed1d8de67d5b83192cf31fdf53d2ea29464363e";
+        url = "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.3.tgz";
+        sha1 = "5986b17b0502642b641c21f818b1acce32025d23";
       };
     };
     "strong-data-uri-1.0.4" = {
@@ -2893,13 +2893,13 @@ let
         sha1 = "b968c6b0a04384324902e8bf1a5df32579a450fe";
       };
     };
-    "ms-0.7.3" = {
+    "ms-2.0.0" = {
       name = "ms";
       packageName = "ms";
-      version = "0.7.3";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz";
-        sha1 = "708155a5e44e33f5fd0fc53e81d0d40a91be1fff";
+        url = "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz";
+        sha1 = "5608aeadfc00be6c2901df5f9861788de0d597c8";
       };
     };
     "accepts-1.3.3" = {
@@ -2956,13 +2956,13 @@ let
         sha1 = "e303a882b342cc3ee8ca513a79999734dab3ae2c";
       };
     };
-    "debug-2.6.1" = {
+    "debug-2.6.7" = {
       name = "debug";
       packageName = "debug";
-      version = "2.6.1";
+      version = "2.6.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz";
-        sha1 = "79855090ba2c4e3115cc7d8769491d58f0491351";
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz";
+        sha1 = "92bad1f6d05bbb6bba22cca88bcd0ec894c2861e";
       };
     };
     "depd-1.1.0" = {
@@ -3001,13 +3001,13 @@ let
         sha1 = "6f631aef336d6c46362b51764044ce216be3c051";
       };
     };
-    "finalhandler-1.0.2" = {
+    "finalhandler-1.0.3" = {
       name = "finalhandler";
       packageName = "finalhandler";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.2.tgz";
-        sha1 = "d0e36f9dbc557f2de14423df6261889e9d60c93a";
+        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz";
+        sha1 = "ef47e77950e999780e86022a560e3217e0d0cc89";
       };
     };
     "fresh-0.5.0" = {
@@ -3082,22 +3082,22 @@ let
         sha1 = "f49be6b487894ddc40dcc94a322f611092e00d5e";
       };
     };
-    "send-0.15.1" = {
+    "send-0.15.3" = {
       name = "send";
       packageName = "send";
-      version = "0.15.1";
+      version = "0.15.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/send/-/send-0.15.1.tgz";
-        sha1 = "8a02354c26e6f5cca700065f5f0cdeba90ec7b5f";
+        url = "https://registry.npmjs.org/send/-/send-0.15.3.tgz";
+        sha1 = "5013f9f99023df50d1bd9892c19e3defd1d53309";
       };
     };
-    "serve-static-1.12.1" = {
+    "serve-static-1.12.3" = {
       name = "serve-static";
       packageName = "serve-static";
-      version = "1.12.1";
+      version = "1.12.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/serve-static/-/serve-static-1.12.1.tgz";
-        sha1 = "7443a965e3ced647aceb5639fa06bf4d1bbe0039";
+        url = "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz";
+        sha1 = "9f4ba19e2f3030c547f8af99107838ec38d5b1e2";
       };
     };
     "setprototypeof-1.0.3" = {
@@ -3152,24 +3152,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz";
         sha1 = "2b327184e8992101177b28563fb5e7102acd0ca9";
-      };
-    };
-    "ms-0.7.2" = {
-      name = "ms";
-      packageName = "ms";
-      version = "0.7.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz";
-        sha1 = "ae25cf2512b3885a1d95d7f037868d8431124765";
-      };
-    };
-    "debug-2.6.4" = {
-      name = "debug";
-      packageName = "debug";
-      version = "2.6.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz";
-        sha1 = "7586a9b3c39741c0282ae33445c4e8ac74734fe0";
       };
     };
     "unpipe-1.0.0" = {
@@ -3244,13 +3226,13 @@ let
         sha1 = "8710d7af0aa626f8fffa1ce00168545263255748";
       };
     };
-    "deep-extend-0.4.1" = {
+    "deep-extend-0.4.2" = {
       name = "deep-extend";
       packageName = "deep-extend";
-      version = "0.4.1";
+      version = "0.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz";
-        sha1 = "efe4113d08085f4e6f9687759810f807469e2253";
+        url = "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz";
+        sha1 = "48b699c27e334bf89f10892be432f6e4c7d34a7f";
       };
     };
     "strip-json-comments-2.0.1" = {
@@ -3260,15 +3242,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz";
         sha1 = "3c531942e908c2697c0ec344858c286c7ca0a60a";
-      };
-    };
-    "ms-1.0.0" = {
-      name = "ms";
-      packageName = "ms";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ms/-/ms-1.0.0.tgz";
-        sha1 = "59adcd22edc543f7b5381862d31387b1f4bc9473";
       };
     };
     "truncate-1.0.5" = {
@@ -3541,13 +3514,13 @@ let
         sha1 = "b47df53493ef911df75731e70a9ded0189db40c9";
       };
     };
-    "fstream-npm-1.2.0" = {
+    "fstream-npm-1.2.1" = {
       name = "fstream-npm";
       packageName = "fstream-npm";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz";
-        sha1 = "d2c3c89101346982d64e57091c38487bda916fce";
+        url = "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz";
+        sha1 = "08c4a452f789dcbac4c89a4563c902b2c862fd5b";
       };
     };
     "iferr-0.1.5" = {
@@ -3559,13 +3532,13 @@ let
         sha1 = "c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501";
       };
     };
-    "init-package-json-1.9.6" = {
+    "init-package-json-1.10.1" = {
       name = "init-package-json";
       packageName = "init-package-json";
-      version = "1.9.6";
+      version = "1.10.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.6.tgz";
-        sha1 = "789fc2b74466a4952b9ea77c0575bc78ebd60a61";
+        url = "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz";
+        sha1 = "cd873a167796befb99612b28762a0b6393fd8f6a";
       };
     };
     "lazy-property-1.0.0" = {
@@ -3710,6 +3683,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz";
         sha1 = "52465d50c2d20294a57125b996baedbf56c5004b";
+      };
+    };
+    "npmlog-4.0.2" = {
+      name = "npmlog";
+      packageName = "npmlog";
+      version = "4.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz";
+        sha1 = "d03950e0e78ce1527ba26d2a7592e9348ac3e75f";
       };
     };
     "opener-1.4.3" = {
@@ -3946,13 +3928,13 @@ let
         sha1 = "9fafa37d286be5d92cbaebdee030dc9b5f406747";
       };
     };
-    "jsonparse-1.3.0" = {
+    "jsonparse-1.3.1" = {
       name = "jsonparse";
       packageName = "jsonparse";
-      version = "1.3.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz";
-        sha1 = "85fc245b1d9259acc6941960b905adf64e7de0e8";
+        url = "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz";
+        sha1 = "3f4dae4a91fac315f71062f8521cc239f1366280";
       };
     };
     "through-2.3.8" = {
@@ -4198,22 +4180,22 @@ let
         sha1 = "db6676e7c7cc0629878ff196097c78855ae9f4ab";
       };
     };
-    "boxen-1.0.0" = {
+    "boxen-1.1.0" = {
       name = "boxen";
       packageName = "boxen";
-      version = "1.0.0";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/boxen/-/boxen-1.0.0.tgz";
-        sha1 = "b2694baf1f605f708ff0177c12193b22f29aaaab";
+        url = "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz";
+        sha1 = "b1b69dd522305e807a99deee777dbd6e5167b102";
       };
     };
-    "configstore-3.0.0" = {
+    "configstore-3.1.0" = {
       name = "configstore";
       packageName = "configstore";
-      version = "3.0.0";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/configstore/-/configstore-3.0.0.tgz";
-        sha1 = "e1b8669c1803ccc50b545e92f8e6e79aa80e0196";
+        url = "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz";
+        sha1 = "45df907073e26dfa1cf4b2d52f5b60545eaa11d1";
       };
     };
     "is-npm-1.0.0" = {
@@ -4261,13 +4243,13 @@ let
         sha1 = "496b2cc109eca8dbacfe2dc72b603c17c5870ad4";
       };
     };
-    "ansi-align-1.1.0" = {
+    "ansi-align-2.0.0" = {
       name = "ansi-align";
       packageName = "ansi-align";
-      version = "1.1.0";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz";
-        sha1 = "2f0c1658829739add5ebb15e6b0c6e3423f016ba";
+        url = "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz";
+        sha1 = "c36aeccba563b89ceb556f3690f0b1d9e3547f7f";
       };
     };
     "camelcase-4.1.0" = {
@@ -4414,6 +4396,15 @@ let
         sha1 = "a8493f0b7b5eeec82525b5c7587fa7de7ca859c1";
       };
     };
+    "make-dir-1.0.0" = {
+      name = "make-dir";
+      packageName = "make-dir";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz";
+        sha1 = "97a011751e91dd87cfadef58832ebb04936de978";
+      };
+    };
     "unique-string-1.0.0" = {
       name = "unique-string";
       packageName = "unique-string";
@@ -4421,6 +4412,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz";
         sha1 = "9e1057cca851abb93398f8b33ae187b99caec11a";
+      };
+    };
+    "write-file-atomic-2.1.0" = {
+      name = "write-file-atomic";
+      packageName = "write-file-atomic";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz";
+        sha1 = "1769f4b551eedce419f0505deae2e26763542d37";
       };
     };
     "is-obj-1.0.1" = {
@@ -5089,13 +5089,13 @@ let
         sha1 = "5b29f6a81f70717142e09e765bbeab97b4f81e21";
       };
     };
-    "stack-trace-0.0.9" = {
+    "stack-trace-0.0.10" = {
       name = "stack-trace";
       packageName = "stack-trace";
-      version = "0.0.9";
+      version = "0.0.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz";
-        sha1 = "a8f6eaeca90674c333e7c43953f275b451510695";
+        url = "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz";
+        sha1 = "547c70b347e8d32b4e108ea1a2a159e5fdde19c0";
       };
     };
     "jsonfile-2.4.0" = {
@@ -5113,10 +5113,10 @@ in
   coffee-script = nodeEnv.buildNodePackage {
     name = "coffee-script";
     packageName = "coffee-script";
-    version = "1.12.5";
+    version = "1.12.6";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.5.tgz";
-      sha1 = "809f4585419112bbfe46a073ad7543af18c27346";
+      url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.6.tgz";
+      sha1 = "285a3f7115689065064d6bf9ef4572db66695cbf";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -5145,7 +5145,7 @@ in
                 ];
               })
               sources."inherits-2.0.3"
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -5217,7 +5217,7 @@ in
           sources."dateformat-2.0.0"
           (sources."fancy-log-1.3.0" // {
             dependencies = [
-              sources."time-stamp-1.0.1"
+              sources."time-stamp-1.1.0"
             ];
           })
           (sources."gulplog-1.0.0" // {
@@ -5286,7 +5286,11 @@ in
                   sources."isarray-1.0.0"
                   sources."inherits-2.0.3"
                   sources."process-nextick-args-1.0.7"
-                  sources."string_decoder-1.0.0"
+                  (sources."string_decoder-1.0.1" // {
+                    dependencies = [
+                      sources."safe-buffer-5.0.1"
+                    ];
+                  })
                   sources."util-deprecate-1.0.2"
                 ];
               })
@@ -5355,7 +5359,7 @@ in
                   sources."extglob-0.3.2"
                   sources."filename-regex-2.0.1"
                   sources."is-extglob-1.0.0"
-                  (sources."kind-of-3.2.0" // {
+                  (sources."kind-of-3.2.2" // {
                     dependencies = [
                       sources."is-buffer-1.1.5"
                     ];
@@ -5628,7 +5632,7 @@ in
           sources."inherits-2.0.3"
         ];
       })
-      (sources."glob-7.1.1" // {
+      (sources."glob-7.1.2" // {
         dependencies = [
           sources."fs.realpath-1.0.0"
           (sources."inflight-1.0.6" // {
@@ -5646,7 +5650,7 @@ in
         ];
       })
       sources."graceful-fs-4.1.11"
-      (sources."minimatch-3.0.3" // {
+      (sources."minimatch-3.0.4" // {
         dependencies = [
           (sources."brace-expansion-1.1.7" // {
             dependencies = [
@@ -5666,7 +5670,7 @@ in
           sources."abbrev-1.1.0"
         ];
       })
-      (sources."npmlog-4.0.2" // {
+      (sources."npmlog-4.1.0" // {
         dependencies = [
           (sources."are-we-there-yet-1.1.4" // {
             dependencies = [
@@ -5678,7 +5682,11 @@ in
                   sources."isarray-1.0.0"
                   sources."inherits-2.0.3"
                   sources."process-nextick-args-1.0.7"
-                  sources."string_decoder-1.0.0"
+                  (sources."string_decoder-1.0.1" // {
+                    dependencies = [
+                      sources."safe-buffer-5.0.1"
+                    ];
+                  })
                   sources."util-deprecate-1.0.2"
                 ];
               })
@@ -5706,7 +5714,7 @@ in
                   sources."ansi-regex-2.1.1"
                 ];
               })
-              sources."wide-align-1.1.0"
+              sources."wide-align-1.1.2"
             ];
           })
           sources."set-blocking-2.0.0"
@@ -6018,12 +6026,12 @@ in
           })
         ];
       })
-      (sources."debug-2.6.6" // {
+      (sources."debug-2.6.8" // {
         dependencies = [
-          sources."ms-0.7.3"
+          sources."ms-2.0.0"
         ];
       })
-      (sources."express-4.15.2" // {
+      (sources."express-4.15.3" // {
         dependencies = [
           (sources."accepts-1.3.3" // {
             dependencies = [
@@ -6040,22 +6048,17 @@ in
           sources."content-type-1.0.2"
           sources."cookie-0.3.1"
           sources."cookie-signature-1.0.6"
-          (sources."debug-2.6.1" // {
+          (sources."debug-2.6.7" // {
             dependencies = [
-              sources."ms-0.7.2"
+              sources."ms-2.0.0"
             ];
           })
           sources."depd-1.1.0"
           sources."encodeurl-1.0.1"
           sources."escape-html-1.0.3"
           sources."etag-1.8.0"
-          (sources."finalhandler-1.0.2" // {
+          (sources."finalhandler-1.0.3" // {
             dependencies = [
-              (sources."debug-2.6.4" // {
-                dependencies = [
-                  sources."ms-0.7.3"
-                ];
-              })
               sources."unpipe-1.0.0"
             ];
           })
@@ -6077,7 +6080,7 @@ in
           })
           sources."qs-6.4.0"
           sources."range-parser-1.2.0"
-          (sources."send-0.15.1" // {
+          (sources."send-0.15.3" // {
             dependencies = [
               sources."destroy-1.0.4"
               (sources."http-errors-1.6.1" // {
@@ -6086,10 +6089,10 @@ in
                 ];
               })
               sources."mime-1.3.4"
-              sources."ms-0.7.2"
+              sources."ms-2.0.0"
             ];
           })
-          sources."serve-static-1.12.1"
+          sources."serve-static-1.12.3"
           sources."setprototypeof-1.0.3"
           sources."statuses-1.3.1"
           (sources."type-is-1.6.15" // {
@@ -6114,7 +6117,7 @@ in
             ];
           })
           sources."inherits-2.0.3"
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -6134,19 +6137,20 @@ in
       sources."path-is-absolute-1.0.1"
       (sources."rc-1.2.1" // {
         dependencies = [
-          sources."deep-extend-0.4.1"
+          sources."deep-extend-0.4.2"
           sources."ini-1.3.4"
           sources."minimist-1.2.0"
           sources."strip-json-comments-2.0.1"
         ];
       })
       sources."semver-4.3.6"
-      (sources."serve-favicon-2.4.2" // {
+      (sources."serve-favicon-2.4.3" // {
         dependencies = [
           sources."etag-1.8.0"
           sources."fresh-0.5.0"
-          sources."ms-1.0.0"
+          sources."ms-2.0.0"
           sources."parseurl-1.3.1"
+          sources."safe-buffer-5.0.1"
         ];
       })
       (sources."strong-data-uri-1.0.4" // {
@@ -6175,7 +6179,7 @@ in
                   })
                 ];
               })
-              (sources."npmlog-4.0.2" // {
+              (sources."npmlog-4.1.0" // {
                 dependencies = [
                   (sources."are-we-there-yet-1.1.4" // {
                     dependencies = [
@@ -6187,7 +6191,11 @@ in
                           sources."isarray-1.0.0"
                           sources."inherits-2.0.3"
                           sources."process-nextick-args-1.0.7"
-                          sources."string_decoder-1.0.0"
+                          (sources."string_decoder-1.0.1" // {
+                            dependencies = [
+                              sources."safe-buffer-5.0.1"
+                            ];
+                          })
                           sources."util-deprecate-1.0.2"
                         ];
                       })
@@ -6215,7 +6223,7 @@ in
                           sources."ansi-regex-2.1.1"
                         ];
                       })
-                      sources."wide-align-1.1.0"
+                      sources."wide-align-1.1.2"
                     ];
                   })
                   sources."set-blocking-2.0.0"
@@ -6311,7 +6319,7 @@ in
               })
               (sources."rimraf-2.6.1" // {
                 dependencies = [
-                  (sources."glob-7.1.1" // {
+                  (sources."glob-7.1.2" // {
                     dependencies = [
                       sources."fs.realpath-1.0.0"
                       (sources."inflight-1.0.6" // {
@@ -6320,7 +6328,7 @@ in
                         ];
                       })
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -6362,7 +6370,7 @@ in
                   (sources."fstream-ignore-1.0.5" // {
                     dependencies = [
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -6386,7 +6394,11 @@ in
                       sources."isarray-1.0.0"
                       sources."inherits-2.0.3"
                       sources."process-nextick-args-1.0.7"
-                      sources."string_decoder-1.0.0"
+                      (sources."string_decoder-1.0.1" // {
+                        dependencies = [
+                          sources."safe-buffer-5.0.1"
+                        ];
+                      })
                       sources."util-deprecate-1.0.2"
                     ];
                   })
@@ -6418,7 +6430,7 @@ in
                   })
                 ];
               })
-              (sources."npmlog-4.0.2" // {
+              (sources."npmlog-4.1.0" // {
                 dependencies = [
                   (sources."are-we-there-yet-1.1.4" // {
                     dependencies = [
@@ -6430,7 +6442,11 @@ in
                           sources."isarray-1.0.0"
                           sources."inherits-2.0.3"
                           sources."process-nextick-args-1.0.7"
-                          sources."string_decoder-1.0.0"
+                          (sources."string_decoder-1.0.1" // {
+                            dependencies = [
+                              sources."safe-buffer-5.0.1"
+                            ];
+                          })
                           sources."util-deprecate-1.0.2"
                         ];
                       })
@@ -6458,7 +6474,7 @@ in
                           sources."ansi-regex-2.1.1"
                         ];
                       })
-                      sources."wide-align-1.1.0"
+                      sources."wide-align-1.1.2"
                     ];
                   })
                   sources."set-blocking-2.0.0"
@@ -6554,7 +6570,7 @@ in
               })
               (sources."rimraf-2.6.1" // {
                 dependencies = [
-                  (sources."glob-7.1.1" // {
+                  (sources."glob-7.1.2" // {
                     dependencies = [
                       sources."fs.realpath-1.0.0"
                       (sources."inflight-1.0.6" // {
@@ -6563,7 +6579,7 @@ in
                         ];
                       })
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -6605,7 +6621,7 @@ in
                   (sources."fstream-ignore-1.0.5" // {
                     dependencies = [
                       sources."inherits-2.0.3"
-                      (sources."minimatch-3.0.3" // {
+                      (sources."minimatch-3.0.4" // {
                         dependencies = [
                           (sources."brace-expansion-1.1.7" // {
                             dependencies = [
@@ -6629,7 +6645,11 @@ in
                       sources."isarray-1.0.0"
                       sources."inherits-2.0.3"
                       sources."process-nextick-args-1.0.7"
-                      sources."string_decoder-1.0.0"
+                      (sources."string_decoder-1.0.1" // {
+                        dependencies = [
+                          sources."safe-buffer-5.0.1"
+                        ];
+                      })
                       sources."util-deprecate-1.0.2"
                     ];
                   })
@@ -6726,7 +6746,7 @@ in
           })
         ];
       })
-      (sources."npmlog-4.0.2" // {
+      (sources."npmlog-4.1.0" // {
         dependencies = [
           (sources."are-we-there-yet-1.1.4" // {
             dependencies = [
@@ -6738,7 +6758,11 @@ in
                   sources."isarray-1.0.0"
                   sources."inherits-2.0.3"
                   sources."process-nextick-args-1.0.7"
-                  sources."string_decoder-1.0.0"
+                  (sources."string_decoder-1.0.1" // {
+                    dependencies = [
+                      sources."safe-buffer-5.0.1"
+                    ];
+                  })
                   sources."util-deprecate-1.0.2"
                 ];
               })
@@ -6766,7 +6790,7 @@ in
                   sources."ansi-regex-2.1.1"
                 ];
               })
-              sources."wide-align-1.1.0"
+              sources."wide-align-1.1.2"
             ];
           })
           sources."set-blocking-2.0.0"
@@ -6774,7 +6798,7 @@ in
       })
       (sources."rc-1.2.1" // {
         dependencies = [
-          sources."deep-extend-0.4.1"
+          sources."deep-extend-0.4.2"
           sources."ini-1.3.4"
           sources."minimist-1.2.0"
           sources."strip-json-comments-2.0.1"
@@ -6870,7 +6894,7 @@ in
       })
       (sources."rimraf-2.6.1" // {
         dependencies = [
-          (sources."glob-7.1.1" // {
+          (sources."glob-7.1.2" // {
             dependencies = [
               sources."fs.realpath-1.0.0"
               (sources."inflight-1.0.6" // {
@@ -6879,7 +6903,7 @@ in
                 ];
               })
               sources."inherits-2.0.3"
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -6913,9 +6937,9 @@ in
       })
       (sources."tar-pack-3.4.0" // {
         dependencies = [
-          (sources."debug-2.6.6" // {
+          (sources."debug-2.6.8" // {
             dependencies = [
-              sources."ms-0.7.3"
+              sources."ms-2.0.0"
             ];
           })
           (sources."fstream-1.0.11" // {
@@ -6927,7 +6951,7 @@ in
           (sources."fstream-ignore-1.0.5" // {
             dependencies = [
               sources."inherits-2.0.3"
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -6951,7 +6975,11 @@ in
               sources."isarray-1.0.0"
               sources."inherits-2.0.3"
               sources."process-nextick-args-1.0.7"
-              sources."string_decoder-1.0.0"
+              (sources."string_decoder-1.0.1" // {
+                dependencies = [
+                  sources."safe-buffer-5.0.1"
+                ];
+              })
               sources."util-deprecate-1.0.2"
             ];
           })
@@ -6970,15 +6998,15 @@ in
   npm = nodeEnv.buildNodePackage {
     name = "npm";
     packageName = "npm";
-    version = "4.5.0";
+    version = "4.6.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm/-/npm-4.5.0.tgz";
-      sha1 = "dc6a31f28807e6db980ed5083315667dcc8d0475";
+      url = "https://registry.npmjs.org/npm/-/npm-4.6.1.tgz";
+      sha1 = "f8eb1ad00dc58a5514363b41ca5342817f0bd646";
     };
     dependencies = [
       (sources."JSONStream-1.3.1" // {
         dependencies = [
-          sources."jsonparse-1.3.0"
+          sources."jsonparse-1.3.1"
           sources."through-2.3.8"
         ];
       })
@@ -7016,11 +7044,11 @@ in
       sources."fs-vacuum-1.2.10"
       sources."fs-write-stream-atomic-1.0.10"
       sources."fstream-1.0.11"
-      (sources."fstream-npm-1.2.0" // {
+      (sources."fstream-npm-1.2.1" // {
         dependencies = [
           (sources."fstream-ignore-1.0.5" // {
             dependencies = [
-              (sources."minimatch-3.0.3" // {
+              (sources."minimatch-3.0.4" // {
                 dependencies = [
                   (sources."brace-expansion-1.1.7" // {
                     dependencies = [
@@ -7034,10 +7062,10 @@ in
           })
         ];
       })
-      (sources."glob-7.1.1" // {
+      (sources."glob-7.1.2" // {
         dependencies = [
           sources."fs.realpath-1.0.0"
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -7057,7 +7085,7 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
       sources."ini-1.3.4"
-      (sources."init-package-json-1.9.6" // {
+      (sources."init-package-json-1.10.1" // {
         dependencies = [
           sources."promzard-0.3.0"
         ];
@@ -7126,7 +7154,7 @@ in
       })
       (sources."node-gyp-3.6.1" // {
         dependencies = [
-          (sources."minimatch-3.0.3" // {
+          (sources."minimatch-3.0.4" // {
             dependencies = [
               (sources."brace-expansion-1.1.7" // {
                 dependencies = [
@@ -7185,7 +7213,7 @@ in
                   })
                 ];
               })
-              sources."wide-align-1.1.0"
+              sources."wide-align-1.1.2"
             ];
           })
           sources."set-blocking-2.0.0"
@@ -7227,7 +7255,11 @@ in
           sources."core-util-is-1.0.2"
           sources."isarray-1.0.0"
           sources."process-nextick-args-1.0.7"
-          sources."string_decoder-1.0.0"
+          (sources."string_decoder-1.0.1" // {
+            dependencies = [
+              sources."safe-buffer-5.0.1"
+            ];
+          })
           sources."util-deprecate-1.0.2"
         ];
       })
@@ -7362,22 +7394,9 @@ in
       sources."unpipe-1.0.0"
       (sources."update-notifier-2.1.0" // {
         dependencies = [
-          (sources."boxen-1.0.0" // {
+          (sources."boxen-1.1.0" // {
             dependencies = [
-              (sources."ansi-align-1.1.0" // {
-                dependencies = [
-                  (sources."string-width-1.0.2" // {
-                    dependencies = [
-                      sources."code-point-at-1.1.0"
-                      (sources."is-fullwidth-code-point-1.0.0" // {
-                        dependencies = [
-                          sources."number-is-nan-1.0.1"
-                        ];
-                      })
-                    ];
-                  })
-                ];
-              })
+              sources."ansi-align-2.0.0"
               sources."camelcase-4.1.0"
               sources."cli-boxes-1.0.0"
               (sources."string-width-2.0.0" // {
@@ -7432,11 +7451,16 @@ in
               sources."supports-color-2.0.0"
             ];
           })
-          (sources."configstore-3.0.0" // {
+          (sources."configstore-3.1.0" // {
             dependencies = [
               (sources."dot-prop-4.1.1" // {
                 dependencies = [
                   sources."is-obj-1.0.1"
+                ];
+              })
+              (sources."make-dir-1.0.0" // {
+                dependencies = [
+                  sources."pify-2.3.0"
                 ];
               })
               (sources."unique-string-1.0.0" // {
@@ -7444,6 +7468,7 @@ in
                   sources."crypto-random-string-1.0.0"
                 ];
               })
+              sources."write-file-atomic-2.1.0"
             ];
           })
           sources."is-npm-1.0.0"
@@ -7478,7 +7503,7 @@ in
                     dependencies = [
                       (sources."rc-1.2.1" // {
                         dependencies = [
-                          sources."deep-extend-0.4.1"
+                          sources."deep-extend-0.4.2"
                           sources."minimist-1.2.0"
                           sources."strip-json-comments-2.0.1"
                         ];
@@ -7490,7 +7515,7 @@ in
                     dependencies = [
                       (sources."rc-1.2.1" // {
                         dependencies = [
-                          sources."deep-extend-0.4.1"
+                          sources."deep-extend-0.4.2"
                           sources."minimist-1.2.0"
                           sources."strip-json-comments-2.0.1"
                         ];
@@ -7550,10 +7575,10 @@ in
   titanium = nodeEnv.buildNodePackage {
     name = "titanium";
     packageName = "titanium";
-    version = "5.0.13";
+    version = "5.0.14";
     src = fetchurl {
-      url = "https://registry.npmjs.org/titanium/-/titanium-5.0.13.tgz";
-      sha1 = "a7bfb383643fd93126cf6ac454dcc81e48be6d6d";
+      url = "https://registry.npmjs.org/titanium/-/titanium-5.0.14.tgz";
+      sha1 = "140bd332624acae65113a3ffec10b8cbb940ad0b";
     };
     dependencies = [
       sources."adm-zip-0.4.7"
@@ -7614,7 +7639,7 @@ in
                         dependencies = [
                           (sources."align-text-0.1.4" // {
                             dependencies = [
-                              (sources."kind-of-3.2.0" // {
+                              (sources."kind-of-3.2.2" // {
                                 dependencies = [
                                   sources."is-buffer-1.1.5"
                                 ];
@@ -7630,7 +7655,7 @@ in
                         dependencies = [
                           (sources."align-text-0.1.4" // {
                             dependencies = [
-                              (sources."kind-of-3.2.0" // {
+                              (sources."kind-of-3.2.2" // {
                                 dependencies = [
                                   sources."is-buffer-1.1.5"
                                 ];
@@ -7783,7 +7808,7 @@ in
           sources."eyes-0.1.8"
           sources."isstream-0.1.2"
           sources."pkginfo-0.3.1"
-          sources."stack-trace-0.0.9"
+          sources."stack-trace-0.0.10"
         ];
       })
       (sources."fs-extra-2.1.2" // {

--- a/pkgs/development/node-packages/node-packages-v6.json
+++ b/pkgs/development/node-packages/node-packages-v6.json
@@ -1,6 +1,7 @@
 [
   "alloy"
 , "azure-cli"
+, "bootlint"
 , "bower"
 , "bower2nix"
 , "browserify"

--- a/pkgs/development/node-packages/node-packages-v6.nix
+++ b/pkgs/development/node-packages/node-packages-v6.nix
@@ -4,6 +4,60 @@
 
 let
   sources = {
+    "async-2.4.1" = {
+      name = "async";
+      packageName = "async";
+      version = "2.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async/-/async-2.4.1.tgz";
+        sha1 = "62a56b279c98a11d0987096a01cc3eeb8eb7bbd7";
+      };
+    };
+    "babel-core-6.24.1" = {
+      name = "babel-core";
+      packageName = "babel-core";
+      version = "6.24.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz";
+        sha1 = "8c428564dce1e1f41fb337ec34f4c3b022b5ad83";
+      };
+    };
+    "babel-preset-babili-0.0.12" = {
+      name = "babel-preset-babili";
+      packageName = "babel-preset-babili";
+      version = "0.0.12";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-preset-babili/-/babel-preset-babili-0.0.12.tgz";
+        sha1 = "74d79205d54feae6470bc84231da0b9ac9fc7de9";
+      };
+    };
+    "babel-traverse-6.24.1" = {
+      name = "babel-traverse";
+      packageName = "babel-traverse";
+      version = "6.24.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz";
+        sha1 = "ab36673fd356f9a0948659e7b338d5feadb31695";
+      };
+    };
+    "babel-types-6.24.1" = {
+      name = "babel-types";
+      packageName = "babel-types";
+      version = "6.24.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz";
+        sha1 = "a136879dc15b3606bda0d90c1fc74304c2ff0975";
+      };
+    };
+    "babylon-6.17.1" = {
+      name = "babylon";
+      packageName = "babylon";
+      version = "6.17.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz";
+        sha1 = "17f14fddf361b695981fe679385e4f1c01ebd86f";
+      };
+    };
     "colors-0.6.0-1" = {
       name = "colors";
       packageName = "colors";
@@ -11,24 +65,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz";
         sha1 = "6dbb68ceb8bc60f2b313dcc5ce1599f06d19e67a";
-      };
-    };
-    "ejs-2.3.4" = {
-      name = "ejs";
-      packageName = "ejs";
-      version = "2.3.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ejs/-/ejs-2.3.4.tgz";
-        sha1 = "3c76caa09664b3583b0037af9dc136e79ec68b98";
-      };
-    };
-    "pkginfo-0.2.2" = {
-      name = "pkginfo";
-      packageName = "pkginfo";
-      version = "0.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.2.tgz";
-        sha1 = "97e1100dbbb275ff6fab583a256a7eea85120c8e";
       };
     };
     "commander-0.6.1" = {
@@ -40,49 +76,22 @@ let
         sha1 = "fa68a14f6a945d54dbbe50d8cdb3320e9e3b1a06";
       };
     };
-    "wrench-1.3.9" = {
-      name = "wrench";
-      packageName = "wrench";
-      version = "1.3.9";
+    "deasync-0.1.9" = {
+      name = "deasync";
+      packageName = "deasync";
+      version = "0.1.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz";
-        sha1 = "6f13ec35145317eb292ca5f6531391b244111411";
+        url = "https://registry.npmjs.org/deasync/-/deasync-0.1.9.tgz";
+        sha1 = "f58dd49fa63110c74bea8405a90a828be26d3a24";
       };
     };
-    "xmldom-0.1.19" = {
-      name = "xmldom";
-      packageName = "xmldom";
-      version = "0.1.19";
+    "ejs-2.3.4" = {
+      name = "ejs";
+      packageName = "ejs";
+      version = "2.3.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz";
-        sha1 = "631fc07776efd84118bf25171b37ed4d075a0abc";
-      };
-    };
-    "jsonlint-1.5.1" = {
-      name = "jsonlint";
-      packageName = "jsonlint";
-      version = "1.5.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/jsonlint/-/jsonlint-1.5.1.tgz";
-        sha1 = "3cf436dcc9f3477ef3d7fa55a5bdf6d893f1c6c6";
-      };
-    };
-    "uglify-js-2.6.1" = {
-      name = "uglify-js";
-      packageName = "uglify-js";
-      version = "2.6.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz";
-        sha1 = "edbbe1888ba3525ded3a7bf836b30b3405d3161b";
-      };
-    };
-    "resolve-1.3.3" = {
-      name = "resolve";
-      packageName = "resolve";
-      version = "1.3.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz";
-        sha1 = "655907c3469a8680dc2de3a275a8fdd69691f0e5";
+        url = "https://registry.npmjs.org/ejs/-/ejs-2.3.4.tgz";
+        sha1 = "3c76caa09664b3583b0037af9dc136e79ec68b98";
       };
     };
     "global-paths-0.1.2" = {
@@ -94,22 +103,13 @@ let
         sha1 = "8869ecb2a8c80995be8a459f27ae5db7a0b03299";
       };
     };
-    "source-map-0.1.9" = {
-      name = "source-map";
-      packageName = "source-map";
-      version = "0.1.9";
+    "jsonlint-1.5.1" = {
+      name = "jsonlint";
+      packageName = "jsonlint";
+      version = "1.5.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/source-map/-/source-map-0.1.9.tgz";
-        sha1 = "250224e4e9ef7e91f4cad76cae714b90f6218599";
-      };
-    };
-    "xml2tss-0.0.5" = {
-      name = "xml2tss";
-      packageName = "xml2tss";
-      version = "0.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/xml2tss/-/xml2tss-0.0.5.tgz";
-        sha1 = "d76a310d6b8a7ba9e4825bb3d43f5427e9fe8f6e";
+        url = "https://registry.npmjs.org/jsonlint/-/jsonlint-1.5.1.tgz";
+        sha1 = "3cf436dcc9f3477ef3d7fa55a5bdf6d893f1c6c6";
       };
     };
     "moment-2.17.1" = {
@@ -130,76 +130,193 @@ let
         sha1 = "3269bddf81c54535f408abc784c32b0d2bd55f6f";
       };
     };
-    "nomnom-1.8.1" = {
-      name = "nomnom";
-      packageName = "nomnom";
-      version = "1.8.1";
+    "pkginfo-0.2.2" = {
+      name = "pkginfo";
+      packageName = "pkginfo";
+      version = "0.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz";
-        sha1 = "2151f722472ba79e50a76fc125bb8c8f2e4dc2a7";
+        url = "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.2.tgz";
+        sha1 = "97e1100dbbb275ff6fab583a256a7eea85120c8e";
       };
     };
-    "JSV-4.0.2" = {
-      name = "JSV";
-      packageName = "JSV";
-      version = "4.0.2";
+    "resolve-1.3.3" = {
+      name = "resolve";
+      packageName = "resolve";
+      version = "1.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz";
-        sha1 = "d077f6825571f82132f9dffaed587b4029feff57";
+        url = "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz";
+        sha1 = "655907c3469a8680dc2de3a275a8fdd69691f0e5";
       };
     };
-    "underscore-1.6.0" = {
-      name = "underscore";
-      packageName = "underscore";
-      version = "1.6.0";
+    "source-map-0.1.9" = {
+      name = "source-map";
+      packageName = "source-map";
+      version = "0.1.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz";
-        sha1 = "8b38b10cacdef63337b8b24e4ff86d45aea529a8";
+        url = "https://registry.npmjs.org/source-map/-/source-map-0.1.9.tgz";
+        sha1 = "250224e4e9ef7e91f4cad76cae714b90f6218599";
       };
     };
-    "chalk-0.4.0" = {
-      name = "chalk";
-      packageName = "chalk";
-      version = "0.4.0";
+    "wrench-1.3.9" = {
+      name = "wrench";
+      packageName = "wrench";
+      version = "1.3.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz";
-        sha1 = "5199a3ddcd0c1efe23bc08c1b027b06176e0c64f";
+        url = "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz";
+        sha1 = "6f13ec35145317eb292ca5f6531391b244111411";
       };
     };
-    "has-color-0.1.7" = {
-      name = "has-color";
-      packageName = "has-color";
+    "xml2tss-0.0.5" = {
+      name = "xml2tss";
+      packageName = "xml2tss";
+      version = "0.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xml2tss/-/xml2tss-0.0.5.tgz";
+        sha1 = "d76a310d6b8a7ba9e4825bb3d43f5427e9fe8f6e";
+      };
+    };
+    "xmldom-0.1.19" = {
+      name = "xmldom";
+      packageName = "xmldom";
+      version = "0.1.19";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz";
+        sha1 = "631fc07776efd84118bf25171b37ed4d075a0abc";
+      };
+    };
+    "lodash-4.17.4" = {
+      name = "lodash";
+      packageName = "lodash";
+      version = "4.17.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz";
+        sha1 = "78203a4d1c328ae1d86dca6460e369b57f4055ae";
+      };
+    };
+    "babel-code-frame-6.22.0" = {
+      name = "babel-code-frame";
+      packageName = "babel-code-frame";
+      version = "6.22.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz";
+        sha1 = "027620bee567a88c32561574e7fd0801d33118e4";
+      };
+    };
+    "babel-generator-6.24.1" = {
+      name = "babel-generator";
+      packageName = "babel-generator";
+      version = "6.24.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz";
+        sha1 = "e715f486c58ded25649d888944d52aa07c5d9497";
+      };
+    };
+    "babel-helpers-6.24.1" = {
+      name = "babel-helpers";
+      packageName = "babel-helpers";
+      version = "6.24.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz";
+        sha1 = "3471de9caec388e5c850e597e58a26ddf37602b2";
+      };
+    };
+    "babel-messages-6.23.0" = {
+      name = "babel-messages";
+      packageName = "babel-messages";
+      version = "6.23.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz";
+        sha1 = "f3cdf4703858035b2a2951c6ec5edf6c62f2630e";
+      };
+    };
+    "babel-template-6.24.1" = {
+      name = "babel-template";
+      packageName = "babel-template";
+      version = "6.24.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz";
+        sha1 = "04ae514f1f93b3a2537f2a0f60a5a45fb8308333";
+      };
+    };
+    "babel-runtime-6.23.0" = {
+      name = "babel-runtime";
+      packageName = "babel-runtime";
+      version = "6.23.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz";
+        sha1 = "0a9489f144de70efb3ce4300accdb329e2fc543b";
+      };
+    };
+    "babel-register-6.24.1" = {
+      name = "babel-register";
+      packageName = "babel-register";
+      version = "6.24.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz";
+        sha1 = "7e10e13a2f71065bdfad5a1787ba45bca6ded75f";
+      };
+    };
+    "convert-source-map-1.5.0" = {
+      name = "convert-source-map";
+      packageName = "convert-source-map";
+      version = "1.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz";
+        sha1 = "9acd70851c6d5dfdd93d9282e5edf94a03ff46b5";
+      };
+    };
+    "debug-2.6.8" = {
+      name = "debug";
+      packageName = "debug";
+      version = "2.6.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz";
+        sha1 = "e731531ca2ede27d188222427da17821d68ff4fc";
+      };
+    };
+    "json5-0.5.1" = {
+      name = "json5";
+      packageName = "json5";
+      version = "0.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz";
+        sha1 = "1eade7acc012034ad84e2396767ead9fa5495821";
+      };
+    };
+    "minimatch-3.0.4" = {
+      name = "minimatch";
+      packageName = "minimatch";
+      version = "3.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz";
+        sha1 = "5166e286457f03306064be5497e8dbb0c3d32083";
+      };
+    };
+    "path-is-absolute-1.0.1" = {
+      name = "path-is-absolute";
+      packageName = "path-is-absolute";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz";
+        sha1 = "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f";
+      };
+    };
+    "private-0.1.7" = {
+      name = "private";
+      packageName = "private";
       version = "0.1.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz";
-        sha1 = "67144a5260c34fc3cca677d041daf52fe7b78b2f";
+        url = "https://registry.npmjs.org/private/-/private-0.1.7.tgz";
+        sha1 = "68ce5e8a1ef0a23bb570cc28537b5332aba63ef1";
       };
     };
-    "ansi-styles-1.0.0" = {
-      name = "ansi-styles";
-      packageName = "ansi-styles";
+    "slash-1.0.0" = {
+      name = "slash";
+      packageName = "slash";
       version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz";
-        sha1 = "cb102df1c56f5123eab8b67cd7b98027a0279178";
-      };
-    };
-    "strip-ansi-0.1.1" = {
-      name = "strip-ansi";
-      packageName = "strip-ansi";
-      version = "0.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz";
-        sha1 = "39e8a98d044d150660abe4a6808acf70bb7bc991";
-      };
-    };
-    "async-0.2.10" = {
-      name = "async";
-      packageName = "async";
-      version = "0.2.10";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/async/-/async-0.2.10.tgz";
-        sha1 = "b6bbe0b0674b9d719708ca38de8c237cb526c3d1";
+        url = "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz";
+        sha1 = "c41f2f6c39fc16d1cd17ad4b5d896114ae470d55";
       };
     };
     "source-map-0.5.6" = {
@@ -211,148 +328,598 @@ let
         sha1 = "75ce38f52bf0733c5a7f0c118d81334a2bb5f412";
       };
     };
-    "uglify-to-browserify-1.0.2" = {
-      name = "uglify-to-browserify";
-      packageName = "uglify-to-browserify";
-      version = "1.0.2";
+    "chalk-1.1.3" = {
+      name = "chalk";
+      packageName = "chalk";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz";
-        sha1 = "6e0924d6bda6b5afe349e39a6d632850a0f882b7";
+        url = "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz";
+        sha1 = "a8115c55e4a702fe4d150abd3872822a7e09fc98";
       };
     };
-    "yargs-3.10.0" = {
-      name = "yargs";
-      packageName = "yargs";
-      version = "3.10.0";
+    "esutils-2.0.2" = {
+      name = "esutils";
+      packageName = "esutils";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz";
-        sha1 = "f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1";
+        url = "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz";
+        sha1 = "0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b";
       };
     };
-    "camelcase-1.2.1" = {
-      name = "camelcase";
-      packageName = "camelcase";
-      version = "1.2.1";
+    "js-tokens-3.0.1" = {
+      name = "js-tokens";
+      packageName = "js-tokens";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz";
-        sha1 = "9bb5304d2e0b56698b2c758b08a3eaa9daa58a39";
+        url = "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz";
+        sha1 = "08e9f132484a2c45a30907e9dc4d5567b7f114d7";
       };
     };
-    "cliui-2.1.0" = {
-      name = "cliui";
-      packageName = "cliui";
-      version = "2.1.0";
+    "ansi-styles-2.2.1" = {
+      name = "ansi-styles";
+      packageName = "ansi-styles";
+      version = "2.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz";
-        sha1 = "4b475760ff80264c762c3a1719032e91c7fea0d1";
+        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz";
+        sha1 = "b432dd3358b634cf75e1e4664368240533c1ddbe";
       };
     };
-    "decamelize-1.2.0" = {
-      name = "decamelize";
-      packageName = "decamelize";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz";
-        sha1 = "f6534d15148269b20352e7bee26f501f9a191290";
-      };
-    };
-    "window-size-0.1.0" = {
-      name = "window-size";
-      packageName = "window-size";
-      version = "0.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz";
-        sha1 = "5438cd2ea93b202efa3a19fe8887aee7c94f9c9d";
-      };
-    };
-    "center-align-0.1.3" = {
-      name = "center-align";
-      packageName = "center-align";
-      version = "0.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz";
-        sha1 = "aa0d32629b6ee972200411cbd4461c907bc2b7ad";
-      };
-    };
-    "right-align-0.1.3" = {
-      name = "right-align";
-      packageName = "right-align";
-      version = "0.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz";
-        sha1 = "61339b722fe6a3515689210d24e14c96148613ef";
-      };
-    };
-    "wordwrap-0.0.2" = {
-      name = "wordwrap";
-      packageName = "wordwrap";
-      version = "0.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz";
-        sha1 = "b79669bb42ecb409f83d583cad52ca17eaa1643f";
-      };
-    };
-    "align-text-0.1.4" = {
-      name = "align-text";
-      packageName = "align-text";
-      version = "0.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz";
-        sha1 = "0cd90a561093f35d0a99256c22b7069433fad117";
-      };
-    };
-    "lazy-cache-1.0.4" = {
-      name = "lazy-cache";
-      packageName = "lazy-cache";
-      version = "1.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz";
-        sha1 = "a1d78fc3a50474cb80845d3b3b6e1da49a446e8e";
-      };
-    };
-    "kind-of-3.2.0" = {
-      name = "kind-of";
-      packageName = "kind-of";
-      version = "3.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz";
-        sha1 = "b58abe4d5c044ad33726a8c1525b48cf891bff07";
-      };
-    };
-    "longest-1.0.1" = {
-      name = "longest";
-      packageName = "longest";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz";
-        sha1 = "30a0b2da38f73770e8294a0d22e6625ed77d0097";
-      };
-    };
-    "repeat-string-1.6.1" = {
-      name = "repeat-string";
-      packageName = "repeat-string";
-      version = "1.6.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz";
-        sha1 = "8dcae470e1c88abc2d600fff4a776286da75e637";
-      };
-    };
-    "is-buffer-1.1.5" = {
-      name = "is-buffer";
-      packageName = "is-buffer";
-      version = "1.1.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz";
-        sha1 = "1f3b26ef613b214b88cbca23cc6c01d87961eecc";
-      };
-    };
-    "path-parse-1.0.5" = {
-      name = "path-parse";
-      packageName = "path-parse";
+    "escape-string-regexp-1.0.5" = {
+      name = "escape-string-regexp";
+      packageName = "escape-string-regexp";
       version = "1.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz";
-        sha1 = "3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1";
+        url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
+        sha1 = "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4";
+      };
+    };
+    "has-ansi-2.0.0" = {
+      name = "has-ansi";
+      packageName = "has-ansi";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz";
+        sha1 = "34f5049ce1ecdf2b0649af3ef24e45ed35416d91";
+      };
+    };
+    "strip-ansi-3.0.1" = {
+      name = "strip-ansi";
+      packageName = "strip-ansi";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz";
+        sha1 = "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf";
+      };
+    };
+    "supports-color-2.0.0" = {
+      name = "supports-color";
+      packageName = "supports-color";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz";
+        sha1 = "535d045ce6b6363fa40117084629995e9df324c7";
+      };
+    };
+    "ansi-regex-2.1.1" = {
+      name = "ansi-regex";
+      packageName = "ansi-regex";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz";
+        sha1 = "c3b33ab5ee360d86e0e628f0468ae7ef27d654df";
+      };
+    };
+    "detect-indent-4.0.0" = {
+      name = "detect-indent";
+      packageName = "detect-indent";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz";
+        sha1 = "f76d064352cdf43a1cb6ce619c4ee3a9475de208";
+      };
+    };
+    "jsesc-1.3.0" = {
+      name = "jsesc";
+      packageName = "jsesc";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz";
+        sha1 = "46c3fec8c1892b12b0833db9bc7622176dbab34b";
+      };
+    };
+    "trim-right-1.0.1" = {
+      name = "trim-right";
+      packageName = "trim-right";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz";
+        sha1 = "cb2e1203067e0c8de1f614094b9fe45704ea6003";
+      };
+    };
+    "repeating-2.0.1" = {
+      name = "repeating";
+      packageName = "repeating";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz";
+        sha1 = "5214c53a926d3552707527fbab415dbc08d06dda";
+      };
+    };
+    "is-finite-1.0.2" = {
+      name = "is-finite";
+      packageName = "is-finite";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz";
+        sha1 = "cc6677695602be550ef11e8b4aa6305342b6d0aa";
+      };
+    };
+    "number-is-nan-1.0.1" = {
+      name = "number-is-nan";
+      packageName = "number-is-nan";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz";
+        sha1 = "097b602b53422a522c1afb8790318336941a011d";
+      };
+    };
+    "core-js-2.4.1" = {
+      name = "core-js";
+      packageName = "core-js";
+      version = "2.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz";
+        sha1 = "4de911e667b0eae9124e34254b53aea6fc618d3e";
+      };
+    };
+    "regenerator-runtime-0.10.5" = {
+      name = "regenerator-runtime";
+      packageName = "regenerator-runtime";
+      version = "0.10.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz";
+        sha1 = "336c3efc1220adcedda2c9fab67b5a7955a33658";
+      };
+    };
+    "home-or-tmp-2.0.0" = {
+      name = "home-or-tmp";
+      packageName = "home-or-tmp";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz";
+        sha1 = "e36c3f2d2cae7d746a857e38d18d5f32a7882db8";
+      };
+    };
+    "mkdirp-0.5.1" = {
+      name = "mkdirp";
+      packageName = "mkdirp";
+      version = "0.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz";
+        sha1 = "30057438eac6cf7f8c4767f38648d6697d75c903";
+      };
+    };
+    "source-map-support-0.4.15" = {
+      name = "source-map-support";
+      packageName = "source-map-support";
+      version = "0.4.15";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz";
+        sha1 = "03202df65c06d2bd8c7ec2362a193056fef8d3b1";
+      };
+    };
+    "os-homedir-1.0.2" = {
+      name = "os-homedir";
+      packageName = "os-homedir";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz";
+        sha1 = "ffbc4988336e0e833de0c168c7ef152121aa7fb3";
+      };
+    };
+    "os-tmpdir-1.0.2" = {
+      name = "os-tmpdir";
+      packageName = "os-tmpdir";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz";
+        sha1 = "bbe67406c79aa85c5cfec766fe5734555dfa1274";
+      };
+    };
+    "minimist-0.0.8" = {
+      name = "minimist";
+      packageName = "minimist";
+      version = "0.0.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz";
+        sha1 = "857fcabfc3397d2625b8228262e86aa7a011b05d";
+      };
+    };
+    "ms-2.0.0" = {
+      name = "ms";
+      packageName = "ms";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz";
+        sha1 = "5608aeadfc00be6c2901df5f9861788de0d597c8";
+      };
+    };
+    "brace-expansion-1.1.7" = {
+      name = "brace-expansion";
+      packageName = "brace-expansion";
+      version = "1.1.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz";
+        sha1 = "3effc3c50e000531fb720eaff80f0ae8ef23cf59";
+      };
+    };
+    "balanced-match-0.4.2" = {
+      name = "balanced-match";
+      packageName = "balanced-match";
+      version = "0.4.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz";
+        sha1 = "cb3f3e3c732dc0f01ee70b403f302e61d7709838";
+      };
+    };
+    "concat-map-0.0.1" = {
+      name = "concat-map";
+      packageName = "concat-map";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz";
+        sha1 = "d8a96bd77fd68df7793a73036a3ba0d5405d477b";
+      };
+    };
+    "babel-plugin-minify-builtins-0.0.2" = {
+      name = "babel-plugin-minify-builtins";
+      packageName = "babel-plugin-minify-builtins";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.0.2.tgz";
+        sha1 = "f3be6121763c0c518d5ef82067cef4b615c9498c";
+      };
+    };
+    "babel-plugin-minify-constant-folding-0.0.4" = {
+      name = "babel-plugin-minify-constant-folding";
+      packageName = "babel-plugin-minify-constant-folding";
+      version = "0.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.0.4.tgz";
+        sha1 = "b6e231026a6035e88ceadd206128d7db2b5c15e6";
+      };
+    };
+    "babel-plugin-minify-dead-code-elimination-0.1.6" = {
+      name = "babel-plugin-minify-dead-code-elimination";
+      packageName = "babel-plugin-minify-dead-code-elimination";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.1.6.tgz";
+        sha1 = "c5471346fb0a1046863fd765c784cba97d7b22e3";
+      };
+    };
+    "babel-plugin-minify-flip-comparisons-0.0.2" = {
+      name = "babel-plugin-minify-flip-comparisons";
+      packageName = "babel-plugin-minify-flip-comparisons";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.0.2.tgz";
+        sha1 = "7d0953aa5876ede6118966bda9edecc63bf346ab";
+      };
+    };
+    "babel-plugin-minify-guarded-expressions-0.0.4" = {
+      name = "babel-plugin-minify-guarded-expressions";
+      packageName = "babel-plugin-minify-guarded-expressions";
+      version = "0.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.0.4.tgz";
+        sha1 = "957104a760e6a7ffd967005a7a11621bb42fd11c";
+      };
+    };
+    "babel-plugin-minify-infinity-0.0.3" = {
+      name = "babel-plugin-minify-infinity";
+      packageName = "babel-plugin-minify-infinity";
+      version = "0.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.0.3.tgz";
+        sha1 = "4cc99b61d12b434ce80ad675103335c589cba9a1";
+      };
+    };
+    "babel-plugin-minify-mangle-names-0.0.8" = {
+      name = "babel-plugin-minify-mangle-names";
+      packageName = "babel-plugin-minify-mangle-names";
+      version = "0.0.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.0.8.tgz";
+        sha1 = "1e2fea856dd742d5697aa26b427e41258a8c5b79";
+      };
+    };
+    "babel-plugin-minify-numeric-literals-0.0.1" = {
+      name = "babel-plugin-minify-numeric-literals";
+      packageName = "babel-plugin-minify-numeric-literals";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.0.1.tgz";
+        sha1 = "9597e6c31154d7daf3744d0bd417c144b275bd53";
+      };
+    };
+    "babel-plugin-minify-replace-0.0.1" = {
+      name = "babel-plugin-minify-replace";
+      packageName = "babel-plugin-minify-replace";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.0.1.tgz";
+        sha1 = "5d5aea7cb9899245248d1ee9ce7a2fe556a8facc";
+      };
+    };
+    "babel-plugin-minify-simplify-0.0.8" = {
+      name = "babel-plugin-minify-simplify";
+      packageName = "babel-plugin-minify-simplify";
+      version = "0.0.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.0.8.tgz";
+        sha1 = "597b23327bba4373fed1c51461a689bce9ff4979";
+      };
+    };
+    "babel-plugin-minify-type-constructors-0.0.4" = {
+      name = "babel-plugin-minify-type-constructors";
+      packageName = "babel-plugin-minify-type-constructors";
+      version = "0.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.0.4.tgz";
+        sha1 = "52d8b623775107523227719ade2d0b7458758b5f";
+      };
+    };
+    "babel-plugin-transform-inline-consecutive-adds-0.0.2" = {
+      name = "babel-plugin-transform-inline-consecutive-adds";
+      packageName = "babel-plugin-transform-inline-consecutive-adds";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.0.2.tgz";
+        sha1 = "a58fcecfc09c08fbf9373a5a3e70746c03d01fc1";
+      };
+    };
+    "babel-plugin-transform-member-expression-literals-6.8.3" = {
+      name = "babel-plugin-transform-member-expression-literals";
+      packageName = "babel-plugin-transform-member-expression-literals";
+      version = "6.8.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.8.3.tgz";
+        sha1 = "4eefa7fa1d3a86d05ac220bc3fdf96d5ed1835d6";
+      };
+    };
+    "babel-plugin-transform-merge-sibling-variables-6.8.4" = {
+      name = "babel-plugin-transform-merge-sibling-variables";
+      packageName = "babel-plugin-transform-merge-sibling-variables";
+      version = "6.8.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.8.4.tgz";
+        sha1 = "813a433f2d8c6989ee3a9c5e0cb46d3752d367a9";
+      };
+    };
+    "babel-plugin-transform-minify-booleans-6.8.2" = {
+      name = "babel-plugin-transform-minify-booleans";
+      packageName = "babel-plugin-transform-minify-booleans";
+      version = "6.8.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.8.2.tgz";
+        sha1 = "8451579f706e702c1e1ab2756de5c8ea369cf07c";
+      };
+    };
+    "babel-plugin-transform-property-literals-6.8.3" = {
+      name = "babel-plugin-transform-property-literals";
+      packageName = "babel-plugin-transform-property-literals";
+      version = "6.8.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.8.3.tgz";
+        sha1 = "0dcd2ecf0486c54c23f84817f911c4ab0e8d4b99";
+      };
+    };
+    "babel-plugin-transform-regexp-constructors-0.0.6" = {
+      name = "babel-plugin-transform-regexp-constructors";
+      packageName = "babel-plugin-transform-regexp-constructors";
+      version = "0.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.0.6.tgz";
+        sha1 = "0d92607f0d26268296980cb7c1dea5f2dd3e1e20";
+      };
+    };
+    "babel-plugin-transform-remove-console-6.8.3" = {
+      name = "babel-plugin-transform-remove-console";
+      packageName = "babel-plugin-transform-remove-console";
+      version = "6.8.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.8.3.tgz";
+        sha1 = "313441720324ad20af0fb009fa59e8102364626b";
+      };
+    };
+    "babel-plugin-transform-remove-debugger-6.8.3" = {
+      name = "babel-plugin-transform-remove-debugger";
+      packageName = "babel-plugin-transform-remove-debugger";
+      version = "6.8.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.8.3.tgz";
+        sha1 = "5064f2d843b77ce660ebaa7760be30eb925bb93f";
+      };
+    };
+    "babel-plugin-transform-remove-undefined-0.0.5" = {
+      name = "babel-plugin-transform-remove-undefined";
+      packageName = "babel-plugin-transform-remove-undefined";
+      version = "0.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.0.5.tgz";
+        sha1 = "12ef11805e06e861dd2eb0c7cc041d2184b8f410";
+      };
+    };
+    "babel-plugin-transform-simplify-comparison-operators-6.8.3" = {
+      name = "babel-plugin-transform-simplify-comparison-operators";
+      packageName = "babel-plugin-transform-simplify-comparison-operators";
+      version = "6.8.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.8.3.tgz";
+        sha1 = "2e47e11e5f8dc33e97476e0263151d5fd57e1c4c";
+      };
+    };
+    "babel-plugin-transform-undefined-to-void-6.8.2" = {
+      name = "babel-plugin-transform-undefined-to-void";
+      packageName = "babel-plugin-transform-undefined-to-void";
+      version = "6.8.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.8.2.tgz";
+        sha1 = "fe2b1d294eb05e87524eb93724dea6e2c3d66fa1";
+      };
+    };
+    "lodash.isplainobject-4.0.6" = {
+      name = "lodash.isplainobject";
+      packageName = "lodash.isplainobject";
+      version = "4.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz";
+        sha1 = "7c526a52d89b45c45cc690b88163be0497f550cb";
+      };
+    };
+    "babel-helper-evaluate-path-0.0.3" = {
+      name = "babel-helper-evaluate-path";
+      packageName = "babel-helper-evaluate-path";
+      version = "0.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.0.3.tgz";
+        sha1 = "1d103ac9d4a59e5d431842212f151785f7ac547b";
+      };
+    };
+    "jsesc-2.5.1" = {
+      name = "jsesc";
+      packageName = "jsesc";
+      version = "2.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz";
+        sha1 = "e421a2a8e20d6b0819df28908f782526b96dd1fe";
+      };
+    };
+    "babel-helper-mark-eval-scopes-0.1.1" = {
+      name = "babel-helper-mark-eval-scopes";
+      packageName = "babel-helper-mark-eval-scopes";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.1.1.tgz";
+        sha1 = "4554345edf9f2549427bd2098e530253f8af2992";
+      };
+    };
+    "babel-helper-remove-or-void-0.1.1" = {
+      name = "babel-helper-remove-or-void";
+      packageName = "babel-helper-remove-or-void";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.1.1.tgz";
+        sha1 = "9d7e1856dc6fafcb41b283a416730dc1844f66d7";
+      };
+    };
+    "lodash.some-4.6.0" = {
+      name = "lodash.some";
+      packageName = "lodash.some";
+      version = "4.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz";
+        sha1 = "1bb9f314ef6b8baded13b549169b2a945eb68e4d";
+      };
+    };
+    "babel-helper-is-void-0-0.0.1" = {
+      name = "babel-helper-is-void-0";
+      packageName = "babel-helper-is-void-0";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.0.1.tgz";
+        sha1 = "ed74553b883e68226ae45f989a99b02c190f105a";
+      };
+    };
+    "babel-helper-flip-expressions-0.0.2" = {
+      name = "babel-helper-flip-expressions";
+      packageName = "babel-helper-flip-expressions";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.0.2.tgz";
+        sha1 = "7bab2cf61162bc92703e9b298ef512bcf77d6787";
+      };
+    };
+    "babel-helper-mark-eval-scopes-0.0.3" = {
+      name = "babel-helper-mark-eval-scopes";
+      packageName = "babel-helper-mark-eval-scopes";
+      version = "0.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.0.3.tgz";
+        sha1 = "902f75aeb537336edc35eb9f52b6f09db7785328";
+      };
+    };
+    "babel-helper-is-nodes-equiv-0.0.1" = {
+      name = "babel-helper-is-nodes-equiv";
+      packageName = "babel-helper-is-nodes-equiv";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz";
+        sha1 = "34e9b300b1479ddd98ec77ea0bbe9342dfe39684";
+      };
+    };
+    "babel-helper-to-multiple-sequence-expressions-0.0.4" = {
+      name = "babel-helper-to-multiple-sequence-expressions";
+      packageName = "babel-helper-to-multiple-sequence-expressions";
+      version = "0.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.0.4.tgz";
+        sha1 = "d94414b386b6286fbaad77f073dea9b34324b01c";
+      };
+    };
+    "globals-9.17.0" = {
+      name = "globals";
+      packageName = "globals";
+      version = "9.17.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz";
+        sha1 = "0c0ca696d9b9bb694d2e5470bd37777caad50286";
+      };
+    };
+    "invariant-2.2.2" = {
+      name = "invariant";
+      packageName = "invariant";
+      version = "2.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz";
+        sha1 = "9e1f56ac0acdb6bf303306f338be3b204ae60360";
+      };
+    };
+    "loose-envify-1.3.1" = {
+      name = "loose-envify";
+      packageName = "loose-envify";
+      version = "1.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz";
+        sha1 = "d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848";
+      };
+    };
+    "to-fast-properties-1.0.3" = {
+      name = "to-fast-properties";
+      packageName = "to-fast-properties";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz";
+        sha1 = "b83571fa4d8c25b82e231b06e3a3055de4ca1a47";
+      };
+    };
+    "bindings-1.2.1" = {
+      name = "bindings";
+      packageName = "bindings";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz";
+        sha1 = "14ad6113812d2d37d72e67b4cacb4bb726505f11";
+      };
+    };
+    "nan-2.6.2" = {
+      name = "nan";
+      packageName = "nan";
+      version = "2.6.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz";
+        sha1 = "e4ff34e6c95fdfb5aecc08de6596f43605a7db45";
       };
     };
     "array-unique-0.2.1" = {
@@ -445,6 +1012,87 @@ let
         sha1 = "e8fbf374dc556ff8947a10dcb0572d633f2cfa10";
       };
     };
+    "nomnom-1.8.1" = {
+      name = "nomnom";
+      packageName = "nomnom";
+      version = "1.8.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz";
+        sha1 = "2151f722472ba79e50a76fc125bb8c8f2e4dc2a7";
+      };
+    };
+    "JSV-4.0.2" = {
+      name = "JSV";
+      packageName = "JSV";
+      version = "4.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz";
+        sha1 = "d077f6825571f82132f9dffaed587b4029feff57";
+      };
+    };
+    "underscore-1.6.0" = {
+      name = "underscore";
+      packageName = "underscore";
+      version = "1.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz";
+        sha1 = "8b38b10cacdef63337b8b24e4ff86d45aea529a8";
+      };
+    };
+    "chalk-0.4.0" = {
+      name = "chalk";
+      packageName = "chalk";
+      version = "0.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz";
+        sha1 = "5199a3ddcd0c1efe23bc08c1b027b06176e0c64f";
+      };
+    };
+    "has-color-0.1.7" = {
+      name = "has-color";
+      packageName = "has-color";
+      version = "0.1.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz";
+        sha1 = "67144a5260c34fc3cca677d041daf52fe7b78b2f";
+      };
+    };
+    "ansi-styles-1.0.0" = {
+      name = "ansi-styles";
+      packageName = "ansi-styles";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz";
+        sha1 = "cb102df1c56f5123eab8b67cd7b98027a0279178";
+      };
+    };
+    "strip-ansi-0.1.1" = {
+      name = "strip-ansi";
+      packageName = "strip-ansi";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz";
+        sha1 = "39e8a98d044d150660abe4a6808acf70bb7bc991";
+      };
+    };
+    "is-0.3.0" = {
+      name = "is";
+      packageName = "is";
+      version = "0.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is/-/is-0.3.0.tgz";
+        sha1 = "a8f71dfc8a6e28371627f26c929098c6f4d5d5d7";
+      };
+    };
+    "path-parse-1.0.5" = {
+      name = "path-parse";
+      packageName = "path-parse";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz";
+        sha1 = "3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1";
+      };
+    };
     "amdefine-1.0.1" = {
       name = "amdefine";
       packageName = "amdefine";
@@ -470,15 +1118,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz";
         sha1 = "d472db228eb331c2506b0e8c15524adb939d12c1";
-      };
-    };
-    "is-0.3.0" = {
-      name = "is";
-      packageName = "is";
-      version = "0.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is/-/is-0.3.0.tgz";
-        sha1 = "a8f71dfc8a6e28371627f26c929098c6f4d5d5d7";
       };
     };
     "adal-node-0.1.21" = {
@@ -544,22 +1183,22 @@ let
         sha1 = "f6d81c1e6093f4abae2d153a7b856963f5085e32";
       };
     };
-    "azure-arm-datalake-analytics-1.0.1-preview" = {
+    "azure-arm-datalake-analytics-1.0.2-preview" = {
       name = "azure-arm-datalake-analytics";
       packageName = "azure-arm-datalake-analytics";
-      version = "1.0.1-preview";
+      version = "1.0.2-preview";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-arm-datalake-analytics/-/azure-arm-datalake-analytics-1.0.1-preview.tgz";
-        sha1 = "75461904000427e12ce11d634d74c052c86de994";
+        url = "https://registry.npmjs.org/azure-arm-datalake-analytics/-/azure-arm-datalake-analytics-1.0.2-preview.tgz";
+        sha1 = "b34f868e98a972ec80e4408d209dc06c000dfb63";
       };
     };
-    "azure-arm-datalake-store-1.0.1-preview" = {
+    "azure-arm-datalake-store-1.0.2-preview" = {
       name = "azure-arm-datalake-store";
       packageName = "azure-arm-datalake-store";
-      version = "1.0.1-preview";
+      version = "1.0.2-preview";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-arm-datalake-store/-/azure-arm-datalake-store-1.0.1-preview.tgz";
-        sha1 = "bd07cbeb5eb355a00b7bed69e198a1a968115dd5";
+        url = "https://registry.npmjs.org/azure-arm-datalake-store/-/azure-arm-datalake-store-1.0.2-preview.tgz";
+        sha1 = "c8b7c113016c92703a84dc28d29ba518e8c64763";
       };
     };
     "azure-arm-hdinsight-0.2.2" = {
@@ -1183,6 +1822,15 @@ let
         sha1 = "3c9349d196207fd1bdff9d4bc43ef72510e3a12e";
       };
     };
+    "wordwrap-0.0.2" = {
+      name = "wordwrap";
+      packageName = "wordwrap";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz";
+        sha1 = "b79669bb42ecb409f83d583cad52ca17eaa1643f";
+      };
+    };
     "xml2js-0.1.14" = {
       name = "xml2js";
       packageName = "xml2js";
@@ -1480,13 +2128,13 @@ let
         sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
       };
     };
-    "stack-trace-0.0.9" = {
+    "stack-trace-0.0.10" = {
       name = "stack-trace";
       packageName = "stack-trace";
-      version = "0.0.9";
+      version = "0.0.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz";
-        sha1 = "a8f6eaeca90674c333e7c43953f275b451510695";
+        url = "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz";
+        sha1 = "547c70b347e8d32b4e108ea1a2a159e5fdde19c0";
       };
     };
     "keypress-0.1.0" = {
@@ -1624,6 +2272,15 @@ let
         sha1 = "64b6abf4cd01adcaefd5009393b1d8e8bec19db0";
       };
     };
+    "async-0.2.10" = {
+      name = "async";
+      packageName = "async";
+      version = "0.2.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async/-/async-0.2.10.tgz";
+        sha1 = "b6bbe0b0674b9d719708ca38de8c237cb526c3d1";
+      };
+    };
     "deep-equal-1.0.1" = {
       name = "deep-equal";
       packageName = "deep-equal";
@@ -1640,15 +2297,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/i/-/i-0.3.5.tgz";
         sha1 = "1d2b854158ec8169113c6cb7f6b6801e99e211d5";
-      };
-    };
-    "mkdirp-0.5.1" = {
-      name = "mkdirp";
-      packageName = "mkdirp";
-      version = "0.5.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz";
-        sha1 = "30057438eac6cf7f8c4767f38648d6697d75c903";
       };
     };
     "ncp-0.4.2" = {
@@ -1669,22 +2317,13 @@ let
         sha1 = "c2338ec643df7a1b7fe5c54fa86f57428a55f33d";
       };
     };
-    "minimist-0.0.8" = {
-      name = "minimist";
-      packageName = "minimist";
-      version = "0.0.8";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz";
-        sha1 = "857fcabfc3397d2625b8228262e86aa7a011b05d";
-      };
-    };
-    "glob-7.1.1" = {
+    "glob-7.1.2" = {
       name = "glob";
       packageName = "glob";
-      version = "7.1.1";
+      version = "7.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz";
-        sha1 = "805211df04faaf1c63a3600306cdf5ade50b2ec8";
+        url = "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz";
+        sha1 = "c19c9df9a028702d678612384a6552404c636d15";
       };
     };
     "fs.realpath-1.0.0" = {
@@ -1705,15 +2344,6 @@ let
         sha1 = "49bd6331d7d02d0c09bc910a1075ba8165b56df9";
       };
     };
-    "minimatch-3.0.3" = {
-      name = "minimatch";
-      packageName = "minimatch";
-      version = "3.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz";
-        sha1 = "2a4e4090b96b2db06a9d7df01055a62a77c9b774";
-      };
-    };
     "once-1.4.0" = {
       name = "once";
       packageName = "once";
@@ -1723,15 +2353,6 @@ let
         sha1 = "583b1aa775961d4b113ac17d9c50baef9dd76bd1";
       };
     };
-    "path-is-absolute-1.0.1" = {
-      name = "path-is-absolute";
-      packageName = "path-is-absolute";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz";
-        sha1 = "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f";
-      };
-    };
     "wrappy-1.0.2" = {
       name = "wrappy";
       packageName = "wrappy";
@@ -1739,33 +2360,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz";
         sha1 = "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f";
-      };
-    };
-    "brace-expansion-1.1.7" = {
-      name = "brace-expansion";
-      packageName = "brace-expansion";
-      version = "1.1.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz";
-        sha1 = "3effc3c50e000531fb720eaff80f0ae8ef23cf59";
-      };
-    };
-    "balanced-match-0.4.2" = {
-      name = "balanced-match";
-      packageName = "balanced-match";
-      version = "0.4.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz";
-        sha1 = "cb3f3e3c732dc0f01ee70b403f302e61d7709838";
-      };
-    };
-    "concat-map-0.0.1" = {
-      name = "concat-map";
-      packageName = "concat-map";
-      version = "0.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz";
-        sha1 = "d8a96bd77fd68df7793a73036a3ba0d5405d477b";
       };
     };
     "colors-0.6.2" = {
@@ -1993,33 +2587,6 @@ let
         sha1 = "df3ae199acadfb7d440aaae0b29e2272b24ec619";
       };
     };
-    "async-2.4.0" = {
-      name = "async";
-      packageName = "async";
-      version = "2.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/async/-/async-2.4.0.tgz";
-        sha1 = "4990200f18ea5b837c2cc4f8c031a6985c385611";
-      };
-    };
-    "lodash-4.17.4" = {
-      name = "lodash";
-      packageName = "lodash";
-      version = "4.17.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz";
-        sha1 = "78203a4d1c328ae1d86dca6460e369b57f4055ae";
-      };
-    };
-    "chalk-1.1.3" = {
-      name = "chalk";
-      packageName = "chalk";
-      version = "1.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz";
-        sha1 = "a8115c55e4a702fe4d150abd3872822a7e09fc98";
-      };
-    };
     "commander-2.9.0" = {
       name = "commander";
       packageName = "commander";
@@ -2045,60 +2612,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz";
         sha1 = "2135d6dfa7a358c069ac9b178776288228450ffa";
-      };
-    };
-    "ansi-styles-2.2.1" = {
-      name = "ansi-styles";
-      packageName = "ansi-styles";
-      version = "2.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz";
-        sha1 = "b432dd3358b634cf75e1e4664368240533c1ddbe";
-      };
-    };
-    "escape-string-regexp-1.0.5" = {
-      name = "escape-string-regexp";
-      packageName = "escape-string-regexp";
-      version = "1.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
-        sha1 = "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4";
-      };
-    };
-    "has-ansi-2.0.0" = {
-      name = "has-ansi";
-      packageName = "has-ansi";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz";
-        sha1 = "34f5049ce1ecdf2b0649af3ef24e45ed35416d91";
-      };
-    };
-    "strip-ansi-3.0.1" = {
-      name = "strip-ansi";
-      packageName = "strip-ansi";
-      version = "3.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz";
-        sha1 = "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf";
-      };
-    };
-    "supports-color-2.0.0" = {
-      name = "supports-color";
-      packageName = "supports-color";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz";
-        sha1 = "535d045ce6b6363fa40117084629995e9df324c7";
-      };
-    };
-    "ansi-regex-2.1.1" = {
-      name = "ansi-regex";
-      packageName = "ansi-regex";
-      version = "2.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz";
-        sha1 = "c3b33ab5ee360d86e0e628f0468ae7ef27d654df";
       };
     };
     "graceful-readlink-1.0.1" = {
@@ -2452,13 +2965,13 @@ let
         sha1 = "9978ce317388c649ad8793028c3477ef044a8b51";
       };
     };
-    "string_decoder-1.0.0" = {
+    "string_decoder-1.0.1" = {
       name = "string_decoder";
       packageName = "string_decoder";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz";
-        sha1 = "f06f41157b664d86069f84bdbdc9b0d8ab281667";
+        url = "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz";
+        sha1 = "62e200f039955a6810d8df0a33ffc0f013662d98";
       };
     };
     "http-basic-2.5.1" = {
@@ -2488,15 +3001,6 @@ let
         sha1 = "522765b50c3510490e52d7dcfe085ef9ba96958f";
       };
     };
-    "os-homedir-1.0.2" = {
-      name = "os-homedir";
-      packageName = "os-homedir";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz";
-        sha1 = "ffbc4988336e0e833de0c168c7ef152121aa7fb3";
-      };
-    };
     "async-1.0.0" = {
       name = "async";
       packageName = "async";
@@ -2522,6 +3026,618 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz";
         sha1 = "3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab";
+      };
+    };
+    "binary-search-1.3.2" = {
+      name = "binary-search";
+      packageName = "binary-search";
+      version = "1.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/binary-search/-/binary-search-1.3.2.tgz";
+        sha1 = "88c9b7bd2b7221d352da78ec887f5af2549e4de2";
+      };
+    };
+    "bluebird-3.5.0" = {
+      name = "bluebird";
+      packageName = "bluebird";
+      version = "3.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz";
+        sha1 = "791420d7f551eea2897453a8a77653f96606d67c";
+      };
+    };
+    "body-parser-1.17.2" = {
+      name = "body-parser";
+      packageName = "body-parser";
+      version = "1.17.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz";
+        sha1 = "f8892abc8f9e627d42aedafbca66bf5ab99104ee";
+      };
+    };
+    "cheerio-0.19.0" = {
+      name = "cheerio";
+      packageName = "cheerio";
+      version = "0.19.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz";
+        sha1 = "772e7015f2ee29965096d71ea4175b75ab354925";
+      };
+    };
+    "express-4.15.3" = {
+      name = "express";
+      packageName = "express";
+      version = "4.15.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/express/-/express-4.15.3.tgz";
+        sha1 = "bab65d0f03aa80c358408972fc700f916944b662";
+      };
+    };
+    "glob-6.0.4" = {
+      name = "glob";
+      packageName = "glob";
+      version = "6.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz";
+        sha1 = "0f08860f6a155127b2fadd4f9ce24b1aab6e4d22";
+      };
+    };
+    "morgan-1.8.1" = {
+      name = "morgan";
+      packageName = "morgan";
+      version = "1.8.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/morgan/-/morgan-1.8.1.tgz";
+        sha1 = "f93023d3887bd27b78dfd6023cea7892ee27a4b1";
+      };
+    };
+    "semver-5.3.0" = {
+      name = "semver";
+      packageName = "semver";
+      version = "5.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz";
+        sha1 = "9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f";
+      };
+    };
+    "void-elements-2.0.1" = {
+      name = "void-elements";
+      packageName = "void-elements";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz";
+        sha1 = "c066afb582bb1cb4128d60ea92392e94d5e9dbec";
+      };
+    };
+    "bytes-2.4.0" = {
+      name = "bytes";
+      packageName = "bytes";
+      version = "2.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz";
+        sha1 = "7d97196f9d5baf7f6935e25985549edd2a6c2339";
+      };
+    };
+    "content-type-1.0.2" = {
+      name = "content-type";
+      packageName = "content-type";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz";
+        sha1 = "b7d113aee7a8dd27bd21133c4dc2529df1721eed";
+      };
+    };
+    "debug-2.6.7" = {
+      name = "debug";
+      packageName = "debug";
+      version = "2.6.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz";
+        sha1 = "92bad1f6d05bbb6bba22cca88bcd0ec894c2861e";
+      };
+    };
+    "depd-1.1.0" = {
+      name = "depd";
+      packageName = "depd";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz";
+        sha1 = "e1bd82c6aab6ced965b97b88b17ed3e528ca18c3";
+      };
+    };
+    "http-errors-1.6.1" = {
+      name = "http-errors";
+      packageName = "http-errors";
+      version = "1.6.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz";
+        sha1 = "5f8b8ed98aca545656bf572997387f904a722257";
+      };
+    };
+    "iconv-lite-0.4.15" = {
+      name = "iconv-lite";
+      packageName = "iconv-lite";
+      version = "0.4.15";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz";
+        sha1 = "fe265a218ac6a57cfe854927e9d04c19825eddeb";
+      };
+    };
+    "on-finished-2.3.0" = {
+      name = "on-finished";
+      packageName = "on-finished";
+      version = "2.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz";
+        sha1 = "20f1336481b083cd75337992a16971aa2d906947";
+      };
+    };
+    "qs-6.4.0" = {
+      name = "qs";
+      packageName = "qs";
+      version = "6.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz";
+        sha1 = "13e26d28ad6b0ffaa91312cd3bf708ed351e7233";
+      };
+    };
+    "raw-body-2.2.0" = {
+      name = "raw-body";
+      packageName = "raw-body";
+      version = "2.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz";
+        sha1 = "994976cf6a5096a41162840492f0bdc5d6e7fb96";
+      };
+    };
+    "type-is-1.6.15" = {
+      name = "type-is";
+      packageName = "type-is";
+      version = "1.6.15";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz";
+        sha1 = "cab10fb4909e441c82842eafe1ad646c81804410";
+      };
+    };
+    "setprototypeof-1.0.3" = {
+      name = "setprototypeof";
+      packageName = "setprototypeof";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz";
+        sha1 = "66567e37043eeb4f04d91bd658c0cbefb55b8e04";
+      };
+    };
+    "statuses-1.3.1" = {
+      name = "statuses";
+      packageName = "statuses";
+      version = "1.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz";
+        sha1 = "faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e";
+      };
+    };
+    "ee-first-1.1.1" = {
+      name = "ee-first";
+      packageName = "ee-first";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz";
+        sha1 = "590c61156b0ae2f4f0255732a158b266bc56b21d";
+      };
+    };
+    "unpipe-1.0.0" = {
+      name = "unpipe";
+      packageName = "unpipe";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz";
+        sha1 = "b2bf4ee8514aae6165b4817829d21b2ef49904ec";
+      };
+    };
+    "media-typer-0.3.0" = {
+      name = "media-typer";
+      packageName = "media-typer";
+      version = "0.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz";
+        sha1 = "8710d7af0aa626f8fffa1ce00168545263255748";
+      };
+    };
+    "css-select-1.0.0" = {
+      name = "css-select";
+      packageName = "css-select";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz";
+        sha1 = "b1121ca51848dd264e2244d058cee254deeb44b0";
+      };
+    };
+    "entities-1.1.1" = {
+      name = "entities";
+      packageName = "entities";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz";
+        sha1 = "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0";
+      };
+    };
+    "htmlparser2-3.8.3" = {
+      name = "htmlparser2";
+      packageName = "htmlparser2";
+      version = "3.8.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz";
+        sha1 = "996c28b191516a8be86501a7d79757e5c70c1068";
+      };
+    };
+    "dom-serializer-0.1.0" = {
+      name = "dom-serializer";
+      packageName = "dom-serializer";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz";
+        sha1 = "073c697546ce0780ce23be4a28e293e40bc30c82";
+      };
+    };
+    "lodash-3.10.1" = {
+      name = "lodash";
+      packageName = "lodash";
+      version = "3.10.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz";
+        sha1 = "5bf45e8e49ba4189e17d482789dfd15bd140b7b6";
+      };
+    };
+    "css-what-1.0.0" = {
+      name = "css-what";
+      packageName = "css-what";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz";
+        sha1 = "d7cc2df45180666f99d2b14462639469e00f736c";
+      };
+    };
+    "domutils-1.4.3" = {
+      name = "domutils";
+      packageName = "domutils";
+      version = "1.4.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz";
+        sha1 = "0865513796c6b306031850e175516baf80b72a6f";
+      };
+    };
+    "boolbase-1.0.0" = {
+      name = "boolbase";
+      packageName = "boolbase";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz";
+        sha1 = "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e";
+      };
+    };
+    "nth-check-1.0.1" = {
+      name = "nth-check";
+      packageName = "nth-check";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz";
+        sha1 = "9929acdf628fc2c41098deab82ac580cf149aae4";
+      };
+    };
+    "domelementtype-1.3.0" = {
+      name = "domelementtype";
+      packageName = "domelementtype";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz";
+        sha1 = "b17aed82e8ab59e52dd9c19b1756e0fc187204c2";
+      };
+    };
+    "domhandler-2.3.0" = {
+      name = "domhandler";
+      packageName = "domhandler";
+      version = "2.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz";
+        sha1 = "2de59a0822d5027fabff6f032c2b25a2a8abe738";
+      };
+    };
+    "domutils-1.5.1" = {
+      name = "domutils";
+      packageName = "domutils";
+      version = "1.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz";
+        sha1 = "dcd8488a26f563d61079e48c9f7b7e32373682cf";
+      };
+    };
+    "readable-stream-1.1.14" = {
+      name = "readable-stream";
+      packageName = "readable-stream";
+      version = "1.1.14";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz";
+        sha1 = "7cf4c54ef648e3813084c636dd2079e166c081d9";
+      };
+    };
+    "entities-1.0.0" = {
+      name = "entities";
+      packageName = "entities";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz";
+        sha1 = "b2987aa3821347fcde642b24fdfc9e4fb712bf26";
+      };
+    };
+    "domelementtype-1.1.3" = {
+      name = "domelementtype";
+      packageName = "domelementtype";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz";
+        sha1 = "bd28773e2642881aec51544924299c5cd822185b";
+      };
+    };
+    "accepts-1.3.3" = {
+      name = "accepts";
+      packageName = "accepts";
+      version = "1.3.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz";
+        sha1 = "c3ca7434938648c3e0d9c1e328dd68b622c284ca";
+      };
+    };
+    "array-flatten-1.1.1" = {
+      name = "array-flatten";
+      packageName = "array-flatten";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz";
+        sha1 = "9a5f699051b1e7073328f2a008968b64ea2955d2";
+      };
+    };
+    "content-disposition-0.5.2" = {
+      name = "content-disposition";
+      packageName = "content-disposition";
+      version = "0.5.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz";
+        sha1 = "0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4";
+      };
+    };
+    "cookie-0.3.1" = {
+      name = "cookie";
+      packageName = "cookie";
+      version = "0.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz";
+        sha1 = "e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb";
+      };
+    };
+    "cookie-signature-1.0.6" = {
+      name = "cookie-signature";
+      packageName = "cookie-signature";
+      version = "1.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz";
+        sha1 = "e303a882b342cc3ee8ca513a79999734dab3ae2c";
+      };
+    };
+    "encodeurl-1.0.1" = {
+      name = "encodeurl";
+      packageName = "encodeurl";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz";
+        sha1 = "79e3d58655346909fe6f0f45a5de68103b294d20";
+      };
+    };
+    "escape-html-1.0.3" = {
+      name = "escape-html";
+      packageName = "escape-html";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz";
+        sha1 = "0258eae4d3d0c0974de1c169188ef0051d1d1988";
+      };
+    };
+    "etag-1.8.0" = {
+      name = "etag";
+      packageName = "etag";
+      version = "1.8.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz";
+        sha1 = "6f631aef336d6c46362b51764044ce216be3c051";
+      };
+    };
+    "finalhandler-1.0.3" = {
+      name = "finalhandler";
+      packageName = "finalhandler";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz";
+        sha1 = "ef47e77950e999780e86022a560e3217e0d0cc89";
+      };
+    };
+    "fresh-0.5.0" = {
+      name = "fresh";
+      packageName = "fresh";
+      version = "0.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz";
+        sha1 = "f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e";
+      };
+    };
+    "merge-descriptors-1.0.1" = {
+      name = "merge-descriptors";
+      packageName = "merge-descriptors";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz";
+        sha1 = "b00aaa556dd8b44568150ec9d1b953f3f90cbb61";
+      };
+    };
+    "methods-1.1.2" = {
+      name = "methods";
+      packageName = "methods";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz";
+        sha1 = "5529a4d67654134edcc5266656835b0f851afcee";
+      };
+    };
+    "parseurl-1.3.1" = {
+      name = "parseurl";
+      packageName = "parseurl";
+      version = "1.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz";
+        sha1 = "c8ab8c9223ba34888aa64a297b28853bec18da56";
+      };
+    };
+    "path-to-regexp-0.1.7" = {
+      name = "path-to-regexp";
+      packageName = "path-to-regexp";
+      version = "0.1.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz";
+        sha1 = "df604178005f522f15eb4490e7247a1bfaa67f8c";
+      };
+    };
+    "proxy-addr-1.1.4" = {
+      name = "proxy-addr";
+      packageName = "proxy-addr";
+      version = "1.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz";
+        sha1 = "27e545f6960a44a627d9b44467e35c1b6b4ce2f3";
+      };
+    };
+    "range-parser-1.2.0" = {
+      name = "range-parser";
+      packageName = "range-parser";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz";
+        sha1 = "f49be6b487894ddc40dcc94a322f611092e00d5e";
+      };
+    };
+    "send-0.15.3" = {
+      name = "send";
+      packageName = "send";
+      version = "0.15.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/send/-/send-0.15.3.tgz";
+        sha1 = "5013f9f99023df50d1bd9892c19e3defd1d53309";
+      };
+    };
+    "serve-static-1.12.3" = {
+      name = "serve-static";
+      packageName = "serve-static";
+      version = "1.12.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz";
+        sha1 = "9f4ba19e2f3030c547f8af99107838ec38d5b1e2";
+      };
+    };
+    "utils-merge-1.0.0" = {
+      name = "utils-merge";
+      packageName = "utils-merge";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz";
+        sha1 = "0294fb922bb9375153541c4f7096231f287c8af8";
+      };
+    };
+    "vary-1.1.1" = {
+      name = "vary";
+      packageName = "vary";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz";
+        sha1 = "67535ebb694c1d52257457984665323f587e8d37";
+      };
+    };
+    "negotiator-0.6.1" = {
+      name = "negotiator";
+      packageName = "negotiator";
+      version = "0.6.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz";
+        sha1 = "2b327184e8992101177b28563fb5e7102acd0ca9";
+      };
+    };
+    "forwarded-0.1.0" = {
+      name = "forwarded";
+      packageName = "forwarded";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz";
+        sha1 = "19ef9874c4ae1c297bcf078fde63a09b66a84363";
+      };
+    };
+    "ipaddr.js-1.3.0" = {
+      name = "ipaddr.js";
+      packageName = "ipaddr.js";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz";
+        sha1 = "1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec";
+      };
+    };
+    "destroy-1.0.4" = {
+      name = "destroy";
+      packageName = "destroy";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz";
+        sha1 = "978857442c44749e4206613e37946205826abd80";
+      };
+    };
+    "mime-1.3.4" = {
+      name = "mime";
+      packageName = "mime";
+      version = "1.3.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz";
+        sha1 = "115f9e3b6b3daf2959983cb38f149a2d40eb5d53";
+      };
+    };
+    "basic-auth-1.1.0" = {
+      name = "basic-auth";
+      packageName = "basic-auth";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz";
+        sha1 = "45221ee429f7ee1e5035be3f51533f1cdfd29884";
+      };
+    };
+    "debug-2.6.1" = {
+      name = "debug";
+      packageName = "debug";
+      version = "2.6.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz";
+        sha1 = "79855090ba2c4e3115cc7d8769491d58f0491351";
+      };
+    };
+    "on-headers-1.0.1" = {
+      name = "on-headers";
+      packageName = "on-headers";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz";
+        sha1 = "928f5d0f470d49342651ea6794b0857c100693f7";
+      };
+    };
+    "ms-0.7.2" = {
+      name = "ms";
+      packageName = "ms";
+      version = "0.7.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz";
+        sha1 = "ae25cf2512b3885a1d95d7f037868d8431124765";
       };
     };
     "argparse-1.0.4" = {
@@ -2596,15 +3712,6 @@ let
         sha1 = "5f8a704ccdf5f2ac23996fcafe2b301bc2a8d0eb";
       };
     };
-    "semver-5.3.0" = {
-      name = "semver";
-      packageName = "semver";
-      version = "5.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz";
-        sha1 = "9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f";
-      };
-    };
     "temp-0.8.3" = {
       name = "temp";
       packageName = "temp";
@@ -2612,15 +3719,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz";
         sha1 = "e0c6bc4d26b903124410e4fed81103014dfc1f59";
-      };
-    };
-    "glob-6.0.4" = {
-      name = "glob";
-      packageName = "glob";
-      version = "6.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz";
-        sha1 = "0f08860f6a155127b2fadd4f9ce24b1aab6e4d22";
       };
     };
     "sprintf-js-1.0.3" = {
@@ -2632,13 +3730,13 @@ let
         sha1 = "04e6926f662895354f3dd015203633b857297e2c";
       };
     };
-    "deep-extend-0.4.1" = {
+    "deep-extend-0.4.2" = {
       name = "deep-extend";
       packageName = "deep-extend";
-      version = "0.4.1";
+      version = "0.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz";
-        sha1 = "efe4113d08085f4e6f9687759810f807469e2253";
+        url = "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz";
+        sha1 = "48b699c27e334bf89f10892be432f6e4c7d34a7f";
       };
     };
     "ext-name-3.0.0" = {
@@ -2785,15 +3883,6 @@ let
         sha1 = "6b83370546c55ab6ade2bf75e83c66e45989bbf0";
       };
     };
-    "statuses-1.3.1" = {
-      name = "statuses";
-      packageName = "statuses";
-      version = "1.3.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz";
-        sha1 = "faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e";
-      };
-    };
     "timed-out-2.0.0" = {
       name = "timed-out";
       packageName = "timed-out";
@@ -2837,6 +3926,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz";
         sha1 = "308beeaffdf28119051efa1d932213c91b8f92e7";
+      };
+    };
+    "decamelize-1.2.0" = {
+      name = "decamelize";
+      packageName = "decamelize";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz";
+        sha1 = "f6534d15148269b20352e7bee26f501f9a191290";
       };
     };
     "loud-rejection-1.6.0" = {
@@ -3136,33 +4234,6 @@ let
         sha1 = "0c7962a6adefa7bbd4ac366460a638552ae1a0a2";
       };
     };
-    "repeating-2.0.1" = {
-      name = "repeating";
-      packageName = "repeating";
-      version = "2.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz";
-        sha1 = "5214c53a926d3552707527fbab415dbc08d06dda";
-      };
-    };
-    "is-finite-1.0.2" = {
-      name = "is-finite";
-      packageName = "is-finite";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz";
-        sha1 = "cc6677695602be550ef11e8b4aa6305342b6d0aa";
-      };
-    };
-    "number-is-nan-1.0.1" = {
-      name = "number-is-nan";
-      packageName = "number-is-nan";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz";
-        sha1 = "097b602b53422a522c1afb8790318336941a011d";
-      };
-    };
     "get-stdin-4.0.1" = {
       name = "get-stdin";
       packageName = "get-stdin";
@@ -3224,33 +4295,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/q/-/q-1.5.0.tgz";
         sha1 = "dd01bac9d06d30e6f219aecb8253ee9ebdc308f1";
-      };
-    };
-    "debug-2.6.6" = {
-      name = "debug";
-      packageName = "debug";
-      version = "2.6.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz";
-        sha1 = "a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a";
-      };
-    };
-    "ms-0.7.3" = {
-      name = "ms";
-      packageName = "ms";
-      version = "0.7.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz";
-        sha1 = "708155a5e44e33f5fd0fc53e81d0d40a91be1fff";
-      };
-    };
-    "os-tmpdir-1.0.2" = {
-      name = "os-tmpdir";
-      packageName = "os-tmpdir";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz";
-        sha1 = "bbe67406c79aa85c5cfec766fe5734555dfa1274";
       };
     };
     "rimraf-2.2.8" = {
@@ -3541,13 +4585,13 @@ let
         sha1 = "66266ee5f9bdb9940a4e4514cafb43bb71e5c9db";
       };
     };
-    "stream-http-2.7.0" = {
+    "stream-http-2.7.1" = {
       name = "stream-http";
       packageName = "stream-http";
-      version = "2.7.0";
+      version = "2.7.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stream-http/-/stream-http-2.7.0.tgz";
-        sha1 = "cec1f4e3b494bc4a81b451808970f8b20b4ed5f6";
+        url = "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz";
+        sha1 = "546a51741ad5a6b07e9e31b0b10441a917df528a";
       };
     };
     "subarg-1.0.0" = {
@@ -3622,13 +4666,13 @@ let
         sha1 = "5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73";
       };
     };
-    "jsonparse-1.3.0" = {
+    "jsonparse-1.3.1" = {
       name = "jsonparse";
       packageName = "jsonparse";
-      version = "1.3.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz";
-        sha1 = "85fc245b1d9259acc6941960b905adf64e7de0e8";
+        url = "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz";
+        sha1 = "3f4dae4a91fac315f71062f8521cc239f1366280";
       };
     };
     "through-2.3.8" = {
@@ -3757,22 +4801,22 @@ let
         sha1 = "888c723596cdf7612f6498233eebd7a35301737d";
       };
     };
-    "create-hash-1.1.2" = {
+    "create-hash-1.1.3" = {
       name = "create-hash";
       packageName = "create-hash";
-      version = "1.1.2";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz";
-        sha1 = "51210062d7bb7479f6c65bb41a92208b1d61abad";
+        url = "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz";
+        sha1 = "606042ac8b9262750f483caddab0f5819172d8fd";
       };
     };
-    "create-hmac-1.1.4" = {
+    "create-hmac-1.1.6" = {
       name = "create-hmac";
       packageName = "create-hmac";
-      version = "1.1.4";
+      version = "1.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz";
-        sha1 = "d3fb4ba253eb8b3f56e39ea2fbcb8af747bd3170";
+        url = "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz";
+        sha1 = "acb9e221a4e17bdb076e90657c42b93e3726cf06";
       };
     };
     "diffie-hellman-5.0.2" = {
@@ -3784,13 +4828,13 @@ let
         sha1 = "b5835739270cfe26acf632099fded2a07f209e5e";
       };
     };
-    "pbkdf2-3.0.9" = {
+    "pbkdf2-3.0.12" = {
       name = "pbkdf2";
       packageName = "pbkdf2";
-      version = "3.0.9";
+      version = "3.0.12";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz";
-        sha1 = "f2c4b25a600058b3c3773c086c37dbbee1ffe693";
+        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz";
+        sha1 = "be36785c5067ea48d806ff923288c5f750b6b8a2";
       };
     };
     "public-encrypt-4.0.0" = {
@@ -3955,13 +4999,13 @@ let
         sha1 = "48ba240b45a9280e94748990ba597d216617fd40";
       };
     };
-    "ripemd160-1.0.1" = {
+    "ripemd160-2.0.1" = {
       name = "ripemd160";
       packageName = "ripemd160";
-      version = "1.0.1";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz";
-        sha1 = "93a4bbd4942bc574b69a8fa57c71de10ecca7d6e";
+        url = "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz";
+        sha1 = "0f4584295c53a3628af7e6d79aca21ce57d1c6e7";
       };
     };
     "sha.js-2.4.8" = {
@@ -3971,6 +5015,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz";
         sha1 = "37068c2c476b6baf402d14a49c67f597921f634f";
+      };
+    };
+    "hash-base-2.0.2" = {
+      name = "hash-base";
+      packageName = "hash-base";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz";
+        sha1 = "66ea1d856db4e8a5470cadf6fce23ae5244ef2e1";
       };
     };
     "miller-rabin-4.0.0" = {
@@ -3989,6 +5042,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz";
         sha1 = "16176714c801798e4e8f2cf7f7529467bb4a5771";
+      };
+    };
+    "is-buffer-1.1.5" = {
+      name = "is-buffer";
+      packageName = "is-buffer";
+      version = "1.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz";
+        sha1 = "1f3b26ef613b214b88cbca23cc6c01d87961eecc";
       };
     };
     "lexical-scope-1.2.0" = {
@@ -4243,13 +5305,13 @@ let
         sha1 = "1e80454250018dbad4c3fe94497d6e67b6269c77";
       };
     };
-    "mime-1.3.4" = {
+    "mime-1.3.6" = {
       name = "mime";
       packageName = "mime";
-      version = "1.3.4";
+      version = "1.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz";
-        sha1 = "115f9e3b6b3daf2959983cb38f149a2d40eb5d53";
+        url = "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz";
+        sha1 = "591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0";
       };
     };
     "peerflix-0.34.0" = {
@@ -4277,15 +5339,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/query-string/-/query-string-1.0.1.tgz";
         sha1 = "63ac953352499ad670a9681a75680f6bf3dd1faf";
-      };
-    };
-    "range-parser-1.2.0" = {
-      name = "range-parser";
-      packageName = "range-parser";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz";
-        sha1 = "f49be6b487894ddc40dcc94a322f611092e00d5e";
       };
     };
     "read-torrent-1.3.0" = {
@@ -4738,15 +5791,6 @@ let
         sha1 = "cbe1e3affcf1cd44b80cadfed28dc793a9701d2e";
       };
     };
-    "lodash-3.10.1" = {
-      name = "lodash";
-      packageName = "lodash";
-      version = "3.10.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz";
-        sha1 = "5bf45e8e49ba4189e17d482789dfd15bd140b7b6";
-      };
-    };
     "readline2-0.1.1" = {
       name = "readline2";
       packageName = "readline2";
@@ -5170,15 +6214,6 @@ let
         sha1 = "ae43eb7745f5fe63dcc2f277cb4164ad27087f30";
       };
     };
-    "readable-stream-1.1.14" = {
-      name = "readable-stream";
-      packageName = "readable-stream";
-      version = "1.1.14";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz";
-        sha1 = "7cf4c54ef648e3813084c636dd2079e166c081d9";
-      };
-    };
     "bncode-0.2.3" = {
       name = "bncode";
       packageName = "bncode";
@@ -5357,15 +6392,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz";
         sha1 = "57f40d036832e5f5055662a397c4de76ed66bf61";
-      };
-    };
-    "ipaddr.js-1.3.0" = {
-      name = "ipaddr.js";
-      packageName = "ipaddr.js";
-      version = "1.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz";
-        sha1 = "1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec";
       };
     };
     "get-browser-rtc-1.0.2" = {
@@ -5737,13 +6763,13 @@ let
         sha1 = "2214ee04ae1c2ec012a52c7c185313e341a6fb38";
       };
     };
-    "cordova-lib-7.0.0" = {
+    "cordova-lib-7.0.1" = {
       name = "cordova-lib";
       packageName = "cordova-lib";
-      version = "7.0.0";
+      version = "7.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-lib/-/cordova-lib-7.0.0.tgz";
-        sha1 = "aa3f0a9be0e2cf4de797f394eff4ad31ac067d0f";
+        url = "https://registry.npmjs.org/cordova-lib/-/cordova-lib-7.0.1.tgz";
+        sha1 = "31cbb90daeb66a67a7d3091636ce729a22a4f7ff";
       };
     };
     "editor-1.0.0" = {
@@ -5989,13 +7015,13 @@ let
         sha1 = "7c30825b9450b9e6185ba27533eaf6e2067d4b42";
       };
     };
-    "cordova-create-1.1.0" = {
+    "cordova-create-1.1.1" = {
       name = "cordova-create";
       packageName = "cordova-create";
-      version = "1.1.0";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-create/-/cordova-create-1.1.0.tgz";
-        sha1 = "9ac3f9d418db3c09c75859324b05561d4d635e70";
+        url = "https://registry.npmjs.org/cordova-create/-/cordova-create-1.1.1.tgz";
+        sha1 = "55282493ab396d9303f72febbaf2f978fa764cd2";
       };
     };
     "cordova-fetch-1.1.0" = {
@@ -6032,6 +7058,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/dep-graph/-/dep-graph-1.1.0.tgz";
         sha1 = "fade86a92799a813e9b42511cdf3dfa6cc8dbefe";
+      };
+    };
+    "glob-7.1.1" = {
+      name = "glob";
+      packageName = "glob";
+      version = "7.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz";
+        sha1 = "805211df04faaf1c63a3600306cdf5ade50b2ec8";
       };
     };
     "init-package-json-1.10.1" = {
@@ -6277,24 +7312,6 @@ let
         sha1 = "cceb121ecc9d09c52d7ad0c3350ea93ddd402bc3";
       };
     };
-    "express-4.15.2" = {
-      name = "express";
-      packageName = "express";
-      version = "4.15.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/express/-/express-4.15.2.tgz";
-        sha1 = "af107fc148504457f2dca9a6f2571d7129b97b35";
-      };
-    };
-    "accepts-1.3.3" = {
-      name = "accepts";
-      packageName = "accepts";
-      version = "1.3.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz";
-        sha1 = "c3ca7434938648c3e0d9c1e328dd68b622c284ca";
-      };
-    };
     "bytes-2.3.0" = {
       name = "bytes";
       packageName = "bytes";
@@ -6322,33 +7339,6 @@ let
         sha1 = "f87057e995b1a1f6ae6a4960664137bc56f039da";
       };
     };
-    "on-headers-1.0.1" = {
-      name = "on-headers";
-      packageName = "on-headers";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz";
-        sha1 = "928f5d0f470d49342651ea6794b0857c100693f7";
-      };
-    };
-    "vary-1.1.1" = {
-      name = "vary";
-      packageName = "vary";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz";
-        sha1 = "67535ebb694c1d52257457984665323f587e8d37";
-      };
-    };
-    "negotiator-0.6.1" = {
-      name = "negotiator";
-      packageName = "negotiator";
-      version = "0.6.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz";
-        sha1 = "2b327184e8992101177b28563fb5e7102acd0ca9";
-      };
-    };
     "ms-0.7.1" = {
       name = "ms";
       packageName = "ms";
@@ -6356,294 +7346,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz";
         sha1 = "9cd13c03adbff25b65effde7ce864ee952017098";
-      };
-    };
-    "array-flatten-1.1.1" = {
-      name = "array-flatten";
-      packageName = "array-flatten";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz";
-        sha1 = "9a5f699051b1e7073328f2a008968b64ea2955d2";
-      };
-    };
-    "content-disposition-0.5.2" = {
-      name = "content-disposition";
-      packageName = "content-disposition";
-      version = "0.5.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz";
-        sha1 = "0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4";
-      };
-    };
-    "content-type-1.0.2" = {
-      name = "content-type";
-      packageName = "content-type";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz";
-        sha1 = "b7d113aee7a8dd27bd21133c4dc2529df1721eed";
-      };
-    };
-    "cookie-0.3.1" = {
-      name = "cookie";
-      packageName = "cookie";
-      version = "0.3.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz";
-        sha1 = "e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb";
-      };
-    };
-    "cookie-signature-1.0.6" = {
-      name = "cookie-signature";
-      packageName = "cookie-signature";
-      version = "1.0.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz";
-        sha1 = "e303a882b342cc3ee8ca513a79999734dab3ae2c";
-      };
-    };
-    "debug-2.6.1" = {
-      name = "debug";
-      packageName = "debug";
-      version = "2.6.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz";
-        sha1 = "79855090ba2c4e3115cc7d8769491d58f0491351";
-      };
-    };
-    "depd-1.1.0" = {
-      name = "depd";
-      packageName = "depd";
-      version = "1.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz";
-        sha1 = "e1bd82c6aab6ced965b97b88b17ed3e528ca18c3";
-      };
-    };
-    "encodeurl-1.0.1" = {
-      name = "encodeurl";
-      packageName = "encodeurl";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz";
-        sha1 = "79e3d58655346909fe6f0f45a5de68103b294d20";
-      };
-    };
-    "escape-html-1.0.3" = {
-      name = "escape-html";
-      packageName = "escape-html";
-      version = "1.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz";
-        sha1 = "0258eae4d3d0c0974de1c169188ef0051d1d1988";
-      };
-    };
-    "etag-1.8.0" = {
-      name = "etag";
-      packageName = "etag";
-      version = "1.8.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz";
-        sha1 = "6f631aef336d6c46362b51764044ce216be3c051";
-      };
-    };
-    "finalhandler-1.0.2" = {
-      name = "finalhandler";
-      packageName = "finalhandler";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.2.tgz";
-        sha1 = "d0e36f9dbc557f2de14423df6261889e9d60c93a";
-      };
-    };
-    "fresh-0.5.0" = {
-      name = "fresh";
-      packageName = "fresh";
-      version = "0.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz";
-        sha1 = "f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e";
-      };
-    };
-    "merge-descriptors-1.0.1" = {
-      name = "merge-descriptors";
-      packageName = "merge-descriptors";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz";
-        sha1 = "b00aaa556dd8b44568150ec9d1b953f3f90cbb61";
-      };
-    };
-    "methods-1.1.2" = {
-      name = "methods";
-      packageName = "methods";
-      version = "1.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz";
-        sha1 = "5529a4d67654134edcc5266656835b0f851afcee";
-      };
-    };
-    "on-finished-2.3.0" = {
-      name = "on-finished";
-      packageName = "on-finished";
-      version = "2.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz";
-        sha1 = "20f1336481b083cd75337992a16971aa2d906947";
-      };
-    };
-    "parseurl-1.3.1" = {
-      name = "parseurl";
-      packageName = "parseurl";
-      version = "1.3.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz";
-        sha1 = "c8ab8c9223ba34888aa64a297b28853bec18da56";
-      };
-    };
-    "path-to-regexp-0.1.7" = {
-      name = "path-to-regexp";
-      packageName = "path-to-regexp";
-      version = "0.1.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz";
-        sha1 = "df604178005f522f15eb4490e7247a1bfaa67f8c";
-      };
-    };
-    "proxy-addr-1.1.4" = {
-      name = "proxy-addr";
-      packageName = "proxy-addr";
-      version = "1.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz";
-        sha1 = "27e545f6960a44a627d9b44467e35c1b6b4ce2f3";
-      };
-    };
-    "qs-6.4.0" = {
-      name = "qs";
-      packageName = "qs";
-      version = "6.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz";
-        sha1 = "13e26d28ad6b0ffaa91312cd3bf708ed351e7233";
-      };
-    };
-    "send-0.15.1" = {
-      name = "send";
-      packageName = "send";
-      version = "0.15.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/send/-/send-0.15.1.tgz";
-        sha1 = "8a02354c26e6f5cca700065f5f0cdeba90ec7b5f";
-      };
-    };
-    "serve-static-1.12.1" = {
-      name = "serve-static";
-      packageName = "serve-static";
-      version = "1.12.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/serve-static/-/serve-static-1.12.1.tgz";
-        sha1 = "7443a965e3ced647aceb5639fa06bf4d1bbe0039";
-      };
-    };
-    "setprototypeof-1.0.3" = {
-      name = "setprototypeof";
-      packageName = "setprototypeof";
-      version = "1.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz";
-        sha1 = "66567e37043eeb4f04d91bd658c0cbefb55b8e04";
-      };
-    };
-    "type-is-1.6.15" = {
-      name = "type-is";
-      packageName = "type-is";
-      version = "1.6.15";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz";
-        sha1 = "cab10fb4909e441c82842eafe1ad646c81804410";
-      };
-    };
-    "utils-merge-1.0.0" = {
-      name = "utils-merge";
-      packageName = "utils-merge";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz";
-        sha1 = "0294fb922bb9375153541c4f7096231f287c8af8";
-      };
-    };
-    "ms-0.7.2" = {
-      name = "ms";
-      packageName = "ms";
-      version = "0.7.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz";
-        sha1 = "ae25cf2512b3885a1d95d7f037868d8431124765";
-      };
-    };
-    "debug-2.6.4" = {
-      name = "debug";
-      packageName = "debug";
-      version = "2.6.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz";
-        sha1 = "7586a9b3c39741c0282ae33445c4e8ac74734fe0";
-      };
-    };
-    "unpipe-1.0.0" = {
-      name = "unpipe";
-      packageName = "unpipe";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz";
-        sha1 = "b2bf4ee8514aae6165b4817829d21b2ef49904ec";
-      };
-    };
-    "ee-first-1.1.1" = {
-      name = "ee-first";
-      packageName = "ee-first";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz";
-        sha1 = "590c61156b0ae2f4f0255732a158b266bc56b21d";
-      };
-    };
-    "forwarded-0.1.0" = {
-      name = "forwarded";
-      packageName = "forwarded";
-      version = "0.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz";
-        sha1 = "19ef9874c4ae1c297bcf078fde63a09b66a84363";
-      };
-    };
-    "destroy-1.0.4" = {
-      name = "destroy";
-      packageName = "destroy";
-      version = "1.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz";
-        sha1 = "978857442c44749e4206613e37946205826abd80";
-      };
-    };
-    "http-errors-1.6.1" = {
-      name = "http-errors";
-      packageName = "http-errors";
-      version = "1.6.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz";
-        sha1 = "5f8b8ed98aca545656bf572997387f904a722257";
-      };
-    };
-    "media-typer-0.3.0" = {
-      name = "media-typer";
-      packageName = "media-typer";
-      version = "0.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz";
-        sha1 = "8710d7af0aa626f8fffa1ce00168545263255748";
       };
     };
     "underscore-1.2.1" = {
@@ -8105,24 +8807,6 @@ let
         sha1 = "3d0c63180f458eb10d325aaa37d7c58ae312e9d7";
       };
     };
-    "bindings-1.2.1" = {
-      name = "bindings";
-      packageName = "bindings";
-      version = "1.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz";
-        sha1 = "14ad6113812d2d37d72e67b4cacb4bb726505f11";
-      };
-    };
-    "nan-2.6.2" = {
-      name = "nan";
-      packageName = "nan";
-      version = "2.6.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz";
-        sha1 = "e4ff34e6c95fdfb5aecc08de6596f43605a7db45";
-      };
-    };
     "jsonparse-0.0.6" = {
       name = "jsonparse";
       packageName = "jsonparse";
@@ -8369,15 +9053,6 @@ let
         sha1 = "91657dfe6ff857483066132b4618b62e8f4887bd";
       };
     };
-    "basic-auth-1.1.0" = {
-      name = "basic-auth";
-      packageName = "basic-auth";
-      version = "1.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz";
-        sha1 = "45221ee429f7ee1e5035be3f51533f1cdfd29884";
-      };
-    };
     "cors-2.8.3" = {
       name = "cors";
       packageName = "cors";
@@ -8558,13 +9233,13 @@ let
         sha1 = "4d4e55f171356121b2c5f6559f944705ab28db15";
       };
     };
-    "tar-stream-1.5.2" = {
+    "tar-stream-1.5.4" = {
       name = "tar-stream";
       packageName = "tar-stream";
-      version = "1.5.2";
+      version = "1.5.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz";
-        sha1 = "fbc6c6e83c1a19d4cb48c7d96171fc248effc7bf";
+        url = "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz";
+        sha1 = "36549cf04ed1aee9b2a30c0143252238daf94016";
       };
     };
     "through2-0.6.5" = {
@@ -8639,13 +9314,13 @@ let
         sha1 = "9500635e257945d6feede185f5d7a24773455b17";
       };
     };
-    "pull-stream-3.5.0" = {
+    "pull-stream-3.6.0" = {
       name = "pull-stream";
       packageName = "pull-stream";
-      version = "3.5.0";
+      version = "3.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.5.0.tgz";
-        sha1 = "1ee5b6f76fd3b3a49a5afb6ded5c0320acb3cfc7";
+        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.0.tgz";
+        sha1 = "59d033a6815d4e3097d47c3d2b1893a9e58a2351";
       };
     };
     "typewiselite-1.0.0" = {
@@ -8765,13 +9440,13 @@ let
         sha1 = "a4ecee01e330155e9124bbbcf4761f21b38f51f5";
       };
     };
-    "pull-pushable-2.0.1" = {
+    "pull-pushable-2.1.1" = {
       name = "pull-pushable";
       packageName = "pull-pushable";
-      version = "2.0.1";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.0.1.tgz";
-        sha1 = "02bdca51a39cf585f483fbecde2fc9378076f212";
+        url = "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.1.1.tgz";
+        sha1 = "86666abbe3f5402f1f7ead03eefd69b785eca5b8";
       };
     };
     "pull-window-2.1.4" = {
@@ -8873,13 +9548,13 @@ let
         sha1 = "cac328f7bee45730d404b692203fcb590e172d5e";
       };
     };
-    "awscred-1.2.0" = {
-      name = "awscred";
-      packageName = "awscred";
-      version = "1.2.0";
+    "aws-sdk-2.55.0" = {
+      name = "aws-sdk";
+      packageName = "aws-sdk";
+      version = "2.55.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/awscred/-/awscred-1.2.0.tgz";
-        sha1 = "9ba714a0d2feb625b848f15c62746c07aebdc3b5";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.55.0.tgz";
+        sha1 = "7528f3729ecbc8e5aea42ac89e1ff2537086f7c2";
       };
     };
     "request-2.81.0" = {
@@ -8889,6 +9564,42 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/request/-/request-2.81.0.tgz";
         sha1 = "c6928946a0e06c5f8d6f8a9333469ffda46298a0";
+      };
+    };
+    "crypto-browserify-1.0.9" = {
+      name = "crypto-browserify";
+      packageName = "crypto-browserify";
+      version = "1.0.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz";
+        sha1 = "cc5449685dfb85eb11c9828acc7cb87ab5bbfcc0";
+      };
+    };
+    "jmespath-0.15.0" = {
+      name = "jmespath";
+      packageName = "jmespath";
+      version = "0.15.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz";
+        sha1 = "a3f222a9aae9f966f5d27c796510e28091764217";
+      };
+    };
+    "sax-1.2.1" = {
+      name = "sax";
+      packageName = "sax";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz";
+        sha1 = "7b8e656190b228e81a66aea748480d828cd2d37a";
+      };
+    };
+    "url-0.10.3" = {
+      name = "url";
+      packageName = "url";
+      version = "0.10.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/url/-/url-0.10.3.tgz";
+        sha1 = "021e4d9c7705f21bbf37d03ceb58767402774c64";
       };
     };
     "caseless-0.12.0" = {
@@ -8972,6 +9683,15 @@ let
         sha1 = "b82fffcf2828624afc1ec26530a66d6d1781a9cc";
       };
     };
+    "conf-1.1.1" = {
+      name = "conf";
+      packageName = "conf";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/conf/-/conf-1.1.1.tgz";
+        sha1 = "238d0a3090ac4916ed2d40c7e81d7a11667bc7ba";
+      };
+    };
     "got-6.7.1" = {
       name = "got";
       packageName = "got";
@@ -9006,6 +9726,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz";
         sha1 = "5edd52b485ca1d900fe64895505399a0dfa45f76";
+      };
+    };
+    "skin-tone-1.0.0" = {
+      name = "skin-tone";
+      packageName = "skin-tone";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/skin-tone/-/skin-tone-1.0.0.tgz";
+        sha1 = "d4ba3e8e5e92760e4d1d3b603d772805c6cb256f";
       };
     };
     "execa-0.5.1" = {
@@ -9069,6 +9798,87 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz";
         sha1 = "411cadb574c5a140d3a4b1910d40d80cc9f40b40";
+      };
+    };
+    "dot-prop-4.1.1" = {
+      name = "dot-prop";
+      packageName = "dot-prop";
+      version = "4.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz";
+        sha1 = "a8493f0b7b5eeec82525b5c7587fa7de7ca859c1";
+      };
+    };
+    "env-paths-1.0.0" = {
+      name = "env-paths";
+      packageName = "env-paths";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz";
+        sha1 = "4168133b42bb05c38a35b1ae4397c8298ab369e0";
+      };
+    };
+    "make-dir-1.0.0" = {
+      name = "make-dir";
+      packageName = "make-dir";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz";
+        sha1 = "97a011751e91dd87cfadef58832ebb04936de978";
+      };
+    };
+    "pkg-up-2.0.0" = {
+      name = "pkg-up";
+      packageName = "pkg-up";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz";
+        sha1 = "c819ac728059a461cab1c3889a2be3c49a004d7f";
+      };
+    };
+    "find-up-2.1.0" = {
+      name = "find-up";
+      packageName = "find-up";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz";
+        sha1 = "45d1b7e506c717ddd482775a2b77920a3c0c57a7";
+      };
+    };
+    "locate-path-2.0.0" = {
+      name = "locate-path";
+      packageName = "locate-path";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz";
+        sha1 = "2b568b265eec944c6d9c0de9c3dbbbca0354cd8e";
+      };
+    };
+    "p-locate-2.0.0" = {
+      name = "p-locate";
+      packageName = "p-locate";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz";
+        sha1 = "20a0103b222a70c8fd39cc2e580680f3dde5ec43";
+      };
+    };
+    "path-exists-3.0.0" = {
+      name = "path-exists";
+      packageName = "path-exists";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz";
+        sha1 = "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515";
+      };
+    };
+    "p-limit-1.1.0" = {
+      name = "p-limit";
+      packageName = "p-limit";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz";
+        sha1 = "b07ff2d9a5d88bec806035895a2bab66a27988bc";
       };
     };
     "create-error-class-3.0.2" = {
@@ -9143,13 +9953,13 @@ let
         sha1 = "e667783d92e89dbd342818b5230b9d62a672ad18";
       };
     };
-    "babel-code-frame-6.22.0" = {
-      name = "babel-code-frame";
-      packageName = "babel-code-frame";
-      version = "6.22.0";
+    "unicode-emoji-modifier-base-1.0.0" = {
+      name = "unicode-emoji-modifier-base";
+      packageName = "unicode-emoji-modifier-base";
+      version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz";
-        sha1 = "027620bee567a88c32561574e7fd0801d33118e4";
+        url = "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz";
+        sha1 = "dbbd5b54ba30f287e2a8d5a249da6c0cef369459";
       };
     };
     "doctrine-2.0.0" = {
@@ -9170,13 +9980,13 @@ let
         sha1 = "e01975e812781a163a6dadfdd80398dc64c889c3";
       };
     };
-    "espree-3.4.2" = {
+    "espree-3.4.3" = {
       name = "espree";
       packageName = "espree";
-      version = "3.4.2";
+      version = "3.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz";
-        sha1 = "38dbdedbedc95b8961a1fbf04734a8f6a9c8c592";
+        url = "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz";
+        sha1 = "2910b5ccd49ce893c2ffffaab4fd8b3a31b82374";
       };
     };
     "esquery-1.0.0" = {
@@ -9197,15 +10007,6 @@ let
         sha1 = "0dee3fed31fcd469618ce7342099fc1afa0bdb13";
       };
     };
-    "esutils-2.0.2" = {
-      name = "esutils";
-      packageName = "esutils";
-      version = "2.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz";
-        sha1 = "0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b";
-      };
-    };
     "file-entry-cache-2.0.0" = {
       name = "file-entry-cache";
       packageName = "file-entry-cache";
@@ -9215,22 +10016,13 @@ let
         sha1 = "c392990c3e684783d838b8c84a45d8a048458361";
       };
     };
-    "globals-9.17.0" = {
-      name = "globals";
-      packageName = "globals";
-      version = "9.17.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz";
-        sha1 = "0c0ca696d9b9bb694d2e5470bd37777caad50286";
-      };
-    };
-    "ignore-3.3.0" = {
+    "ignore-3.3.3" = {
       name = "ignore";
       packageName = "ignore";
-      version = "3.3.0";
+      version = "3.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ignore/-/ignore-3.3.0.tgz";
-        sha1 = "3812d22cbe9125f2c2b4915755a1b8abd745a001";
+        url = "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz";
+        sha1 = "432352e57accd87ab3110e82d3fea0e47812156d";
       };
     };
     "inquirer-0.12.0" = {
@@ -9251,13 +10043,13 @@ let
         sha1 = "8df57c61ea2e3c501408d100fb013cf8d6e0cc62";
       };
     };
-    "js-yaml-3.8.3" = {
+    "js-yaml-3.8.4" = {
       name = "js-yaml";
       packageName = "js-yaml";
-      version = "3.8.3";
+      version = "3.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz";
-        sha1 = "33a05ec481c850c8875929166fe1beb61c728766";
+        url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz";
+        sha1 = "520b4564f86573ba96662af85a8cafa7b4b5a6f6";
       };
     };
     "levn-0.3.0" = {
@@ -9323,15 +10115,6 @@ let
         sha1 = "2bbc542f0fda9861a755d3947fefd8b3f513855f";
       };
     };
-    "js-tokens-3.0.1" = {
-      name = "js-tokens";
-      packageName = "js-tokens";
-      version = "3.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz";
-        sha1 = "08e9f132484a2c45a30907e9dc4d5567b7f114d7";
-      };
-    };
     "es6-map-0.1.5" = {
       name = "es6-map";
       packageName = "es6-map";
@@ -9368,13 +10151,13 @@ let
         sha1 = "754bb5bfe55451da69a58b94d45f4c5b0462d58f";
       };
     };
-    "es5-ext-0.10.15" = {
+    "es5-ext-0.10.21" = {
       name = "es5-ext";
       packageName = "es5-ext";
-      version = "0.10.15";
+      version = "0.10.21";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz";
-        sha1 = "c330a5934c1ee21284a7c081a86e5fd937c91ea6";
+        url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.21.tgz";
+        sha1 = "19a725f9e51d0300bbc1e8e821109fd9daf55925";
       };
     };
     "es6-iterator-2.0.1" = {
@@ -9836,13 +10619,13 @@ let
         sha1 = "8f61b75cde012b2e9eb284d4545583b5643b61ab";
       };
     };
-    "chokidar-1.6.1" = {
+    "chokidar-1.7.0" = {
       name = "chokidar";
       packageName = "chokidar";
-      version = "1.6.1";
+      version = "1.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz";
-        sha1 = "2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2";
+        url = "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz";
+        sha1 = "798e689778151c8076b4b360e5edd28cda2bb468";
       };
     };
     "ps-tree-0.0.3" = {
@@ -9980,6 +10763,15 @@ let
         sha1 = "ac468177c4943405a092fc8f29760c6ffc6206c0";
       };
     };
+    "kind-of-3.2.2" = {
+      name = "kind-of";
+      packageName = "kind-of";
+      version = "3.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz";
+        sha1 = "31ea21a734bab9bbb0f32466d893aea51e4a3c64";
+      };
+    };
     "normalize-path-2.1.1" = {
       name = "normalize-path";
       packageName = "normalize-path";
@@ -10086,6 +10878,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz";
         sha1 = "110dcabff397e9dcff7c0789ccc0a49adf1ec5bb";
+      };
+    };
+    "repeat-string-1.6.1" = {
+      name = "repeat-string";
+      packageName = "repeat-string";
+      version = "1.6.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz";
+        sha1 = "8dcae470e1c88abc2d600fff4a776286da75e637";
       };
     };
     "is-posix-bracket-0.1.1" = {
@@ -10196,13 +10997,13 @@ let
         sha1 = "94ad1c798a11d7fc67381b50d47f8cc18d9799f7";
       };
     };
-    "npmlog-4.0.2" = {
+    "npmlog-4.1.0" = {
       name = "npmlog";
       packageName = "npmlog";
-      version = "4.0.2";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz";
-        sha1 = "d03950e0e78ce1527ba26d2a7592e9348ac3e75f";
+        url = "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz";
+        sha1 = "dc59bee85f64f00ed424efb2af0783df25d1c0b5";
       };
     };
     "tar-pack-3.4.0" = {
@@ -10250,13 +11051,13 @@ let
         sha1 = "95d3600f07710aa0e9298c726ad5ecf2eacbabab";
       };
     };
-    "wide-align-1.1.0" = {
+    "wide-align-1.1.2" = {
       name = "wide-align";
       packageName = "wide-align";
-      version = "1.1.0";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz";
-        sha1 = "40edde802a71fea1f070da3e62dcda2e7add96ad";
+        url = "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz";
+        sha1 = "571e0f1b0604636ebc0dfc21b0339bbe31341710";
       };
     };
     "event-stream-0.5.3" = {
@@ -10358,13 +11159,13 @@ let
         sha1 = "21ffdc429be2b50cb361df990a40a7731288e935";
       };
     };
-    "simple-git-1.70.0" = {
+    "simple-git-1.73.0" = {
       name = "simple-git";
       packageName = "simple-git";
-      version = "1.70.0";
+      version = "1.73.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-git/-/simple-git-1.70.0.tgz";
-        sha1 = "62cfd90bb2628a13ff4fe704c840fcef56244a71";
+        url = "https://registry.npmjs.org/simple-git/-/simple-git-1.73.0.tgz";
+        sha1 = "87683a729b1bee016a3182f95a2ab72317bb0230";
       };
     };
     "tabtab-git+https://github.com/mixu/node-tabtab.git" = {
@@ -10404,13 +11205,13 @@ let
         sha1 = "a4274eeb32fa765da5a7a3b1712617ce3b144149";
       };
     };
-    "coffee-script-1.12.5" = {
+    "coffee-script-1.12.6" = {
       name = "coffee-script";
       packageName = "coffee-script";
-      version = "1.12.5";
+      version = "1.12.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.5.tgz";
-        sha1 = "809f4585419112bbfe46a073ad7543af18c27346";
+        url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.6.tgz";
+        sha1 = "285a3f7115689065064d6bf9ef4572db66695cbf";
       };
     };
     "jade-1.11.0" = {
@@ -10449,13 +11250,13 @@ let
         sha1 = "c0dde4ab182713b919b970959a123ecc1a30fcd6";
       };
     };
-    "clean-css-3.4.25" = {
+    "clean-css-3.4.26" = {
       name = "clean-css";
       packageName = "clean-css";
-      version = "3.4.25";
+      version = "3.4.26";
       src = fetchurl {
-        url = "https://registry.npmjs.org/clean-css/-/clean-css-3.4.25.tgz";
-        sha1 = "9e9a52d5c1e6bc5123e1b2783fa65fe958946ede";
+        url = "https://registry.npmjs.org/clean-css/-/clean-css-3.4.26.tgz";
+        sha1 = "55323b344ff3bcee684a2eac81c93df8fa73deeb";
       };
     };
     "commander-2.6.0" = {
@@ -10494,22 +11295,13 @@ let
         sha1 = "5d23cb35561dd85dc67fb8482309b47d53cce9a7";
       };
     };
-    "uglify-js-2.8.22" = {
+    "uglify-js-2.8.27" = {
       name = "uglify-js";
       packageName = "uglify-js";
-      version = "2.8.22";
+      version = "2.8.27";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz";
-        sha1 = "d54934778a8da14903fa29a326fb24c0ab51a1a0";
-      };
-    };
-    "void-elements-2.0.1" = {
-      name = "void-elements";
-      packageName = "void-elements";
-      version = "2.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz";
-        sha1 = "c066afb582bb1cb4128d60ea92392e94d5e9dbec";
+        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz";
+        sha1 = "47787f912b0f242e5b984343be8e35e95f694c9c";
       };
     };
     "with-4.0.3" = {
@@ -10636,6 +11428,96 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz";
         sha1 = "c90941ad59e4273328923074d2cf2e7cbc6ec0d9";
+      };
+    };
+    "yargs-3.10.0" = {
+      name = "yargs";
+      packageName = "yargs";
+      version = "3.10.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz";
+        sha1 = "f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1";
+      };
+    };
+    "uglify-to-browserify-1.0.2" = {
+      name = "uglify-to-browserify";
+      packageName = "uglify-to-browserify";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz";
+        sha1 = "6e0924d6bda6b5afe349e39a6d632850a0f882b7";
+      };
+    };
+    "camelcase-1.2.1" = {
+      name = "camelcase";
+      packageName = "camelcase";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz";
+        sha1 = "9bb5304d2e0b56698b2c758b08a3eaa9daa58a39";
+      };
+    };
+    "cliui-2.1.0" = {
+      name = "cliui";
+      packageName = "cliui";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz";
+        sha1 = "4b475760ff80264c762c3a1719032e91c7fea0d1";
+      };
+    };
+    "window-size-0.1.0" = {
+      name = "window-size";
+      packageName = "window-size";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz";
+        sha1 = "5438cd2ea93b202efa3a19fe8887aee7c94f9c9d";
+      };
+    };
+    "center-align-0.1.3" = {
+      name = "center-align";
+      packageName = "center-align";
+      version = "0.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz";
+        sha1 = "aa0d32629b6ee972200411cbd4461c907bc2b7ad";
+      };
+    };
+    "right-align-0.1.3" = {
+      name = "right-align";
+      packageName = "right-align";
+      version = "0.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz";
+        sha1 = "61339b722fe6a3515689210d24e14c96148613ef";
+      };
+    };
+    "align-text-0.1.4" = {
+      name = "align-text";
+      packageName = "align-text";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz";
+        sha1 = "0cd90a561093f35d0a99256c22b7069433fad117";
+      };
+    };
+    "lazy-cache-1.0.4" = {
+      name = "lazy-cache";
+      packageName = "lazy-cache";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz";
+        sha1 = "a1d78fc3a50474cb80845d3b3b6e1da49a446e8e";
+      };
+    };
+    "longest-1.0.1" = {
+      name = "longest";
+      packageName = "longest";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz";
+        sha1 = "30a0b2da38f73770e8294a0d22e6625ed77d0097";
       };
     };
     "acorn-1.2.2" = {
@@ -10872,13 +11754,13 @@ let
         sha1 = "b0455b38fc5e0cf30d4325132e461970c2091cde";
       };
     };
-    "time-stamp-1.0.1" = {
+    "time-stamp-1.1.0" = {
       name = "time-stamp";
       packageName = "time-stamp";
-      version = "1.0.1";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz";
-        sha1 = "9f4bd23559c9365966f3302dbba2b07c6b99b151";
+        url = "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz";
+        sha1 = "764a5a11af50561921b133f3b44e618687e0f5c3";
       };
     };
     "glogg-1.0.0" = {
@@ -11041,15 +11923,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz";
         sha1 = "ff191eddcd7088a675b2610fffc976be9b8074b5";
-      };
-    };
-    "lodash.isplainobject-4.0.6" = {
-      name = "lodash.isplainobject";
-      packageName = "lodash.isplainobject";
-      version = "4.0.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz";
-        sha1 = "7c526a52d89b45c45cc690b88163be0497f550cb";
       };
     };
     "lodash.isstring-4.0.1" = {
@@ -11502,15 +12375,6 @@ let
         sha1 = "0632638f8d877cc82107d30a0fff1a17cba1cd0c";
       };
     };
-    "htmlparser2-3.8.3" = {
-      name = "htmlparser2";
-      packageName = "htmlparser2";
-      version = "3.8.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz";
-        sha1 = "996c28b191516a8be86501a7d79757e5c70c1068";
-      };
-    };
     "lodash-3.7.0" = {
       name = "lodash";
       packageName = "lodash";
@@ -11518,69 +12382,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz";
         sha1 = "3678bd8ab995057c07ade836ed2ef087da811d45";
-      };
-    };
-    "domhandler-2.3.0" = {
-      name = "domhandler";
-      packageName = "domhandler";
-      version = "2.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz";
-        sha1 = "2de59a0822d5027fabff6f032c2b25a2a8abe738";
-      };
-    };
-    "domutils-1.5.1" = {
-      name = "domutils";
-      packageName = "domutils";
-      version = "1.5.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz";
-        sha1 = "dcd8488a26f563d61079e48c9f7b7e32373682cf";
-      };
-    };
-    "domelementtype-1.3.0" = {
-      name = "domelementtype";
-      packageName = "domelementtype";
-      version = "1.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz";
-        sha1 = "b17aed82e8ab59e52dd9c19b1756e0fc187204c2";
-      };
-    };
-    "entities-1.0.0" = {
-      name = "entities";
-      packageName = "entities";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz";
-        sha1 = "b2987aa3821347fcde642b24fdfc9e4fb712bf26";
-      };
-    };
-    "dom-serializer-0.1.0" = {
-      name = "dom-serializer";
-      packageName = "dom-serializer";
-      version = "0.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz";
-        sha1 = "073c697546ce0780ce23be4a28e293e40bc30c82";
-      };
-    };
-    "domelementtype-1.1.3" = {
-      name = "domelementtype";
-      packageName = "domelementtype";
-      version = "1.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz";
-        sha1 = "bd28773e2642881aec51544924299c5cd822185b";
-      };
-    };
-    "entities-1.1.1" = {
-      name = "entities";
-      packageName = "entities";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz";
-        sha1 = "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0";
       };
     };
     "escodegen-1.8.1" = {
@@ -11601,13 +12402,13 @@ let
         sha1 = "96e3b70d5779f6ad49cd032673d1c312767ba581";
       };
     };
-    "handlebars-4.0.8" = {
+    "handlebars-4.0.10" = {
       name = "handlebars";
       packageName = "handlebars";
-      version = "4.0.8";
+      version = "4.0.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.0.8.tgz";
-        sha1 = "22b875cd3f0e6cbea30314f144e82bc7a72ff420";
+        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz";
+        sha1 = "3d30c718b09a3d96f23ea4cc1f403c4d3ba9ff4f";
       };
     };
     "supports-color-3.2.3" = {
@@ -11664,24 +12465,6 @@ let
         sha1 = "22817534f24bfa4950c34d532d48ecbc621b8c14";
       };
     };
-    "bluebird-3.5.0" = {
-      name = "bluebird";
-      packageName = "bluebird";
-      version = "3.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz";
-        sha1 = "791420d7f551eea2897453a8a77653f96606d67c";
-      };
-    };
-    "body-parser-1.17.1" = {
-      name = "body-parser";
-      packageName = "body-parser";
-      version = "1.17.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/body-parser/-/body-parser-1.17.1.tgz";
-        sha1 = "75b3bc98ddd6e7e0d8ffe750dfaca5c66993fa47";
-      };
-    };
     "combine-lists-1.0.1" = {
       name = "combine-lists";
       packageName = "combine-lists";
@@ -11691,22 +12474,13 @@ let
         sha1 = "458c07e09e0d900fc28b70a3fec2dacd1d2cb7f6";
       };
     };
-    "connect-3.6.1" = {
+    "connect-3.6.2" = {
       name = "connect";
       packageName = "connect";
-      version = "3.6.1";
+      version = "3.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/connect/-/connect-3.6.1.tgz";
-        sha1 = "b7760693a74f0454face1d9378edb3f885b43227";
-      };
-    };
-    "core-js-2.4.1" = {
-      name = "core-js";
-      packageName = "core-js";
-      version = "2.4.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz";
-        sha1 = "4de911e667b0eae9124e34254b53aea6fc618d3e";
+        url = "https://registry.npmjs.org/connect/-/connect-3.6.2.tgz";
+        sha1 = "694e8d20681bfe490282c8ab886be98f09f42fe7";
       };
     };
     "di-0.0.1" = {
@@ -11797,51 +12571,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/useragent/-/useragent-2.1.13.tgz";
         sha1 = "bba43e8aa24d5ceb83c2937473e102e21df74c10";
-      };
-    };
-    "bytes-2.4.0" = {
-      name = "bytes";
-      packageName = "bytes";
-      version = "2.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz";
-        sha1 = "7d97196f9d5baf7f6935e25985549edd2a6c2339";
-      };
-    };
-    "iconv-lite-0.4.15" = {
-      name = "iconv-lite";
-      packageName = "iconv-lite";
-      version = "0.4.15";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz";
-        sha1 = "fe265a218ac6a57cfe854927e9d04c19825eddeb";
-      };
-    };
-    "raw-body-2.2.0" = {
-      name = "raw-body";
-      packageName = "raw-body";
-      version = "2.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz";
-        sha1 = "994976cf6a5096a41162840492f0bdc5d6e7fb96";
-      };
-    };
-    "debug-2.6.3" = {
-      name = "debug";
-      packageName = "debug";
-      version = "2.6.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz";
-        sha1 = "0f7eb8c30965ec08c72accfa0130c8b79984141d";
-      };
-    };
-    "finalhandler-1.0.1" = {
-      name = "finalhandler";
-      packageName = "finalhandler";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.1.tgz";
-        sha1 = "bcd15d1689c0e5ed729b6f7f541a6df984117db8";
       };
     };
     "custom-event-1.0.1" = {
@@ -12420,13 +13149,13 @@ let
         sha1 = "197e22cdebd4198585e8694ef6786197b91ed942";
       };
     };
-    "method-override-2.3.8" = {
+    "method-override-2.3.9" = {
       name = "method-override";
       packageName = "method-override";
-      version = "2.3.8";
+      version = "2.3.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/method-override/-/method-override-2.3.8.tgz";
-        sha1 = "178234bf4bab869f89df9444b06fc6147b44828c";
+        url = "https://registry.npmjs.org/method-override/-/method-override-2.3.9.tgz";
+        sha1 = "bd151f2ce34cf01a76ca400ab95c012b102d8f71";
       };
     };
     "morgan-1.6.1" = {
@@ -12888,15 +13617,6 @@ let
         sha1 = "51af7d614ad9a9f610ea1bafbb989d6b1c56890f";
       };
     };
-    "convert-source-map-1.5.0" = {
-      name = "convert-source-map";
-      packageName = "convert-source-map";
-      version = "1.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz";
-        sha1 = "9acd70851c6d5dfdd93d9282e5edf94a03ff46b5";
-      };
-    };
     "express-2.5.11" = {
       name = "express";
       packageName = "express";
@@ -13248,13 +13968,13 @@ let
         sha1 = "159a49b9a9714c1fb102f2e0ed1906fab6a450f4";
       };
     };
-    "serve-favicon-2.4.2" = {
+    "serve-favicon-2.4.3" = {
       name = "serve-favicon";
       packageName = "serve-favicon";
-      version = "2.4.2";
+      version = "2.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.2.tgz";
-        sha1 = "aed1d8de67d5b83192cf31fdf53d2ea29464363e";
+        url = "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.3.tgz";
+        sha1 = "5986b17b0502642b641c21f818b1acce32025d23";
       };
     };
     "strong-data-uri-1.0.4" = {
@@ -13363,15 +14083,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz";
         sha1 = "17eb2807987f76952e9c0485fc311d06a826a2e0";
-      };
-    };
-    "ms-1.0.0" = {
-      name = "ms";
-      packageName = "ms";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ms/-/ms-1.0.0.tgz";
-        sha1 = "59adcd22edc543f7b5381862d31387b1f4bc9473";
       };
     };
     "truncate-1.0.5" = {
@@ -13932,15 +14643,6 @@ let
         sha1 = "80d6492dc1470864bbf583533b651f42a9f52415";
       };
     };
-    "lodash.some-4.6.0" = {
-      name = "lodash.some";
-      packageName = "lodash.some";
-      version = "4.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz";
-        sha1 = "1bb9f314ef6b8baded13b549169b2a945eb68e4d";
-      };
-    };
     "css-what-2.1.0" = {
       name = "css-what";
       packageName = "css-what";
@@ -13950,22 +14652,13 @@ let
         sha1 = "9467d032c38cfaefb9f2d79501253062f87fa1bd";
       };
     };
-    "boolbase-1.0.0" = {
-      name = "boolbase";
-      packageName = "boolbase";
-      version = "1.0.0";
+    "domhandler-2.4.1" = {
+      name = "domhandler";
+      packageName = "domhandler";
+      version = "2.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz";
-        sha1 = "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e";
-      };
-    };
-    "nth-check-1.0.1" = {
-      name = "nth-check";
-      packageName = "nth-check";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz";
-        sha1 = "9929acdf628fc2c41098deab82ac580cf149aae4";
+        url = "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz";
+        sha1 = "892e47000a99be55bbf3774ffea0561d8879c259";
       };
     };
     "moment-timezone-0.5.13" = {
@@ -14148,13 +14841,13 @@ let
         sha1 = "6910bca5da8c95e784b5751b976cf5a10fee36d2";
       };
     };
-    "ordered-read-streams-1.0.0" = {
+    "ordered-read-streams-1.0.1" = {
       name = "ordered-read-streams";
       packageName = "ordered-read-streams";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.0.tgz";
-        sha1 = "d674a86ffcedf83d0ae06afa2918855e96d4033a";
+        url = "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz";
+        sha1 = "77c0cb37c41525d64166d990ffad7ec6a0e1363e";
       };
     };
     "to-absolute-glob-2.0.1" = {
@@ -15048,13 +15741,13 @@ let
         sha1 = "6fd61b03f3da42a2cd0ec2b60f02bd0e71991fea";
       };
     };
-    "fstream-npm-1.2.0" = {
+    "fstream-npm-1.2.1" = {
       name = "fstream-npm";
       packageName = "fstream-npm";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz";
-        sha1 = "d2c3c89101346982d64e57091c38487bda916fce";
+        url = "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz";
+        sha1 = "08c4a452f789dcbac4c89a4563c902b2c862fd5b";
       };
     };
     "lazy-property-1.0.0" = {
@@ -15145,6 +15838,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.1.1.tgz";
         sha1 = "831476455423ca0a265c6ffdb6100fcc042b36cf";
+      };
+    };
+    "npmlog-4.0.2" = {
+      name = "npmlog";
+      packageName = "npmlog";
+      version = "4.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz";
+        sha1 = "d03950e0e78ce1527ba26d2a7592e9348ac3e75f";
       };
     };
     "opener-1.4.3" = {
@@ -15318,22 +16020,22 @@ let
         sha1 = "db6676e7c7cc0629878ff196097c78855ae9f4ab";
       };
     };
-    "boxen-1.0.0" = {
+    "boxen-1.1.0" = {
       name = "boxen";
       packageName = "boxen";
-      version = "1.0.0";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/boxen/-/boxen-1.0.0.tgz";
-        sha1 = "b2694baf1f605f708ff0177c12193b22f29aaaab";
+        url = "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz";
+        sha1 = "b1b69dd522305e807a99deee777dbd6e5167b102";
       };
     };
-    "configstore-3.0.0" = {
+    "configstore-3.1.0" = {
       name = "configstore";
       packageName = "configstore";
-      version = "3.0.0";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/configstore/-/configstore-3.0.0.tgz";
-        sha1 = "e1b8669c1803ccc50b545e92f8e6e79aa80e0196";
+        url = "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz";
+        sha1 = "45df907073e26dfa1cf4b2d52f5b60545eaa11d1";
       };
     };
     "latest-version-3.1.0" = {
@@ -15363,13 +16065,13 @@ let
         sha1 = "496b2cc109eca8dbacfe2dc72b603c17c5870ad4";
       };
     };
-    "ansi-align-1.1.0" = {
+    "ansi-align-2.0.0" = {
       name = "ansi-align";
       packageName = "ansi-align";
-      version = "1.1.0";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz";
-        sha1 = "2f0c1658829739add5ebb15e6b0c6e3423f016ba";
+        url = "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz";
+        sha1 = "c36aeccba563b89ceb556f3690f0b1d9e3547f7f";
       };
     };
     "camelcase-4.1.0" = {
@@ -15444,15 +16146,6 @@ let
         sha1 = "5d53d578019646c0d68800db4e146e6bdc2ac7af";
       };
     };
-    "dot-prop-4.1.1" = {
-      name = "dot-prop";
-      packageName = "dot-prop";
-      version = "4.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz";
-        sha1 = "a8493f0b7b5eeec82525b5c7587fa7de7ca859c1";
-      };
-    };
     "unique-string-1.0.0" = {
       name = "unique-string";
       packageName = "unique-string";
@@ -15460,6 +16153,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz";
         sha1 = "9e1057cca851abb93398f8b33ae187b99caec11a";
+      };
+    };
+    "write-file-atomic-2.1.0" = {
+      name = "write-file-atomic";
+      packageName = "write-file-atomic";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz";
+        sha1 = "1769f4b551eedce419f0505deae2e26763542d37";
       };
     };
     "crypto-random-string-1.0.0" = {
@@ -15741,13 +16443,13 @@ let
         sha1 = "27d92fec34d27cfa42707d3b40d025ae9855f2df";
       };
     };
-    "snyk-1.30.0" = {
+    "snyk-1.30.1" = {
       name = "snyk";
       packageName = "snyk";
-      version = "1.30.0";
+      version = "1.30.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk/-/snyk-1.30.0.tgz";
-        sha1 = "a323809ea477d6aff0e325f5995cb491c0d7ca3d";
+        url = "https://registry.npmjs.org/snyk/-/snyk-1.30.1.tgz";
+        sha1 = "0cf14c1d73c7b6f63ca4e275ac8c2a090ec2ad52";
       };
     };
     "spawn-please-0.2.0" = {
@@ -16200,6 +16902,15 @@ let
         sha1 = "bdaebead30f8d824039ce0ce149d4daa07ba1fac";
       };
     };
+    "ansi-align-1.1.0" = {
+      name = "ansi-align";
+      packageName = "ansi-align";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz";
+        sha1 = "2f0c1658829739add5ebb15e6b0c6e3423f016ba";
+      };
+    };
     "babybird-0.0.1" = {
       name = "babybird";
       packageName = "babybird";
@@ -16555,6 +17266,15 @@ let
         sha1 = "7531e39d4949c281a66b8c5a6e0265e8b05894da";
       };
     };
+    "ms-0.7.3" = {
+      name = "ms";
+      packageName = "ms";
+      version = "0.7.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz";
+        sha1 = "708155a5e44e33f5fd0fc53e81d0d40a91be1fff";
+      };
+    };
     "msgpack5-3.4.1" = {
       name = "msgpack5";
       packageName = "msgpack5";
@@ -16690,13 +17410,13 @@ let
         sha1 = "fef069bee85975b2ddcc2264aaa7c50dc17a3c7e";
       };
     };
-    "reverse-http-1.2.0" = {
+    "reverse-http-1.3.0" = {
       name = "reverse-http";
       packageName = "reverse-http";
-      version = "1.2.0";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/reverse-http/-/reverse-http-1.2.0.tgz";
-        sha1 = "d5bd826506425a3b3eacadf1e0e2c1ac3e289728";
+        url = "https://registry.npmjs.org/reverse-http/-/reverse-http-1.3.0.tgz";
+        sha1 = "61a9644bdea483aa281ffb62706e642f1a73a239";
       };
     };
     "consume-http-header-1.0.0" = {
@@ -16843,31 +17563,22 @@ let
         sha1 = "6b62c3791cf7909ea35ed46e17658bb417cb3917";
       };
     };
-    "connect-multiparty-1.2.5" = {
+    "connect-multiparty-2.0.0" = {
       name = "connect-multiparty";
       packageName = "connect-multiparty";
-      version = "1.2.5";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/connect-multiparty/-/connect-multiparty-1.2.5.tgz";
-        sha1 = "2fabecfdc1a8a774ba19484dce660c818a8555e7";
+        url = "https://registry.npmjs.org/connect-multiparty/-/connect-multiparty-2.0.0.tgz";
+        sha1 = "57a7b61cc7b31b6eef4a62878d60d771b23699ab";
       };
     };
-    "express-3.5.3" = {
-      name = "express";
-      packageName = "express";
-      version = "3.5.3";
+    "socket.io-1.7.4" = {
+      name = "socket.io";
+      packageName = "socket.io";
+      version = "1.7.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/express/-/express-3.5.3.tgz";
-        sha1 = "af440e1ddad078934ec78241420b40bbc56dc2ad";
-      };
-    };
-    "torrent-stream-0.18.1" = {
-      name = "torrent-stream";
-      packageName = "torrent-stream";
-      version = "0.18.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/torrent-stream/-/torrent-stream-0.18.1.tgz";
-        sha1 = "e2e8ca44d81f16fbe5646e0ebb05f5418fea9bf6";
+        url = "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz";
+        sha1 = "2f7ecedc3391bf2d5c73e291fe233e6e34d4dd00";
       };
     };
     "fluent-ffmpeg-2.1.2" = {
@@ -16879,481 +17590,58 @@ let
         sha1 = "c952de2240f812ebda0aa8006d7776ee2acf7d74";
       };
     };
-    "on-finished-2.1.1" = {
-      name = "on-finished";
-      packageName = "on-finished";
-      version = "2.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz";
-        sha1 = "f82ca1c9e3a4f3286b1b9938610e5b8636bd3cb2";
-      };
-    };
-    "qs-2.2.5" = {
-      name = "qs";
-      packageName = "qs";
-      version = "2.2.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-2.2.5.tgz";
-        sha1 = "1088abaf9dcc0ae5ae45b709e6c6b5888b23923c";
-      };
-    };
-    "connect-2.14.5" = {
-      name = "connect";
-      packageName = "connect";
-      version = "2.14.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/connect/-/connect-2.14.5.tgz";
-        sha1 = "73217513152c152ebe049c499fa09211b8c476f4";
-      };
-    };
-    "commander-1.3.2" = {
-      name = "commander";
-      packageName = "commander";
-      version = "1.3.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz";
-        sha1 = "8a8f30ec670a6fdd64af52f1914b907d79ead5b5";
-      };
-    };
-    "range-parser-1.0.0" = {
-      name = "range-parser";
-      packageName = "range-parser";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz";
-        sha1 = "a4b264cfe0be5ce36abe3765ac9c2a248746dbc0";
-      };
-    };
-    "mkdirp-0.4.0" = {
-      name = "mkdirp";
-      packageName = "mkdirp";
-      version = "0.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mkdirp/-/mkdirp-0.4.0.tgz";
-        sha1 = "291ac2a2d43a19c478662577b5be846fe83b5923";
-      };
-    };
-    "buffer-crc32-0.2.1" = {
-      name = "buffer-crc32";
-      packageName = "buffer-crc32";
-      version = "0.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz";
-        sha1 = "be3e5382fc02b6d6324956ac1af98aa98b08534c";
-      };
-    };
-    "fresh-0.2.2" = {
-      name = "fresh";
-      packageName = "fresh";
-      version = "0.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz";
-        sha1 = "9731dcf5678c7faeb44fb903c4f72df55187fa77";
-      };
-    };
-    "methods-0.1.0" = {
-      name = "methods";
-      packageName = "methods";
-      version = "0.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz";
-        sha1 = "335d429eefd21b7bacf2e9c922a8d2bd14a30e4f";
-      };
-    };
-    "send-0.3.0" = {
-      name = "send";
-      packageName = "send";
-      version = "0.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/send/-/send-0.3.0.tgz";
-        sha1 = "9718324634806fc75bc4f8f5e51f57d9d66606e7";
-      };
-    };
-    "cookie-signature-1.0.3" = {
-      name = "cookie-signature";
-      packageName = "cookie-signature";
-      version = "1.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz";
-        sha1 = "91cd997cc51fb641595738c69cda020328f50ff9";
-      };
-    };
-    "debug-0.8.1" = {
-      name = "debug";
-      packageName = "debug";
-      version = "0.8.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz";
-        sha1 = "20ff4d26f5e422cb68a1bacbbb61039ad8c1c130";
-      };
-    };
-    "cookie-parser-1.0.1" = {
-      name = "cookie-parser";
-      packageName = "cookie-parser";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.0.1.tgz";
-        sha1 = "17bd622c9717cd0858a912a9fef4c0362360a7b0";
-      };
-    };
-    "compression-1.0.0" = {
-      name = "compression";
-      packageName = "compression";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/compression/-/compression-1.0.0.tgz";
-        sha1 = "8aeb85d48db5145d38bc8b181b6352d8eab26020";
-      };
-    };
-    "connect-timeout-1.0.0" = {
-      name = "connect-timeout";
-      packageName = "connect-timeout";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.0.0.tgz";
-        sha1 = "12054799f90bb9566f8b274efe7842d6465d10bb";
-      };
-    };
-    "csurf-1.1.0" = {
-      name = "csurf";
-      packageName = "csurf";
-      version = "1.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/csurf/-/csurf-1.1.0.tgz";
-        sha1 = "5dd459df40df43b9eb828284d6d03132f42cb8b2";
-      };
-    };
-    "errorhandler-1.0.0" = {
-      name = "errorhandler";
-      packageName = "errorhandler";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/errorhandler/-/errorhandler-1.0.0.tgz";
-        sha1 = "d74b37e8dc38c99afb3f5a79edcebaea022d042a";
-      };
-    };
-    "express-session-1.0.2" = {
-      name = "express-session";
-      packageName = "express-session";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/express-session/-/express-session-1.0.2.tgz";
-        sha1 = "004478c742561774411ceb79733155a56b6d49eb";
-      };
-    };
-    "method-override-1.0.0" = {
-      name = "method-override";
-      packageName = "method-override";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/method-override/-/method-override-1.0.0.tgz";
-        sha1 = "9e5bfbd80f3b9e043801dd3fe60bbab0f15b5f61";
-      };
-    };
-    "morgan-1.0.0" = {
-      name = "morgan";
-      packageName = "morgan";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/morgan/-/morgan-1.0.0.tgz";
-        sha1 = "83cf74b9f2d841901f1a9a6b8fa7a468d2e47a8d";
-      };
-    };
-    "qs-0.6.6" = {
-      name = "qs";
-      packageName = "qs";
-      version = "0.6.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz";
-        sha1 = "6e015098ff51968b8a3c819001d5f2c89bc4b107";
-      };
-    };
-    "raw-body-1.1.4" = {
-      name = "raw-body";
-      packageName = "raw-body";
-      version = "1.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/raw-body/-/raw-body-1.1.4.tgz";
-        sha1 = "f0b5624388d031f63da07f870c86cb9ccadcb67d";
-      };
-    };
-    "response-time-1.0.0" = {
-      name = "response-time";
-      packageName = "response-time";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/response-time/-/response-time-1.0.0.tgz";
-        sha1 = "c2bc8d08f3c359f97eae1d6da86eead175fabdc9";
-      };
-    };
-    "setimmediate-1.0.1" = {
-      name = "setimmediate";
-      packageName = "setimmediate";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.1.tgz";
-        sha1 = "a9ca56ccbd6a4c3334855f060abcdece5c42ebb7";
-      };
-    };
-    "serve-index-1.0.1" = {
-      name = "serve-index";
-      packageName = "serve-index";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/serve-index/-/serve-index-1.0.1.tgz";
-        sha1 = "2782ee8ede6cccaae54957962c4715e8ce1921a6";
-      };
-    };
-    "serve-static-1.1.0" = {
-      name = "serve-static";
-      packageName = "serve-static";
-      version = "1.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/serve-static/-/serve-static-1.1.0.tgz";
-        sha1 = "454dfa05bb3ddd4e701a8915b83a278aa91c5643";
-      };
-    };
-    "static-favicon-1.0.2" = {
-      name = "static-favicon";
-      packageName = "static-favicon";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/static-favicon/-/static-favicon-1.0.2.tgz";
-        sha1 = "7c15920dda2bf33f414b0e60aebbd65cdd2a1d2f";
-      };
-    };
-    "vhost-1.0.0" = {
-      name = "vhost";
-      packageName = "vhost";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vhost/-/vhost-1.0.0.tgz";
-        sha1 = "654513f289a4f898aab745bbd633e40180c9c4c0";
-      };
-    };
-    "bytes-0.3.0" = {
-      name = "bytes";
-      packageName = "bytes";
-      version = "0.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bytes/-/bytes-0.3.0.tgz";
-        sha1 = "78e2e0e28c7f9c7b988ea8aee0db4d5fa9941935";
-      };
-    };
-    "multiparty-2.2.0" = {
+    "multiparty-4.1.3" = {
       name = "multiparty";
       packageName = "multiparty";
-      version = "2.2.0";
+      version = "4.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz";
-        sha1 = "a567c2af000ad22dc8f2a653d91978ae1f5316f4";
+        url = "https://registry.npmjs.org/multiparty/-/multiparty-4.1.3.tgz";
+        sha1 = "3c43c7fcb1896e17460436a9dd0b6ef1668e4f94";
       };
     };
-    "cookie-0.1.0" = {
-      name = "cookie";
-      packageName = "cookie";
-      version = "0.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz";
-        sha1 = "90eb469ddce905c866de687efc43131d8801f9d0";
-      };
-    };
-    "bytes-0.2.1" = {
-      name = "bytes";
-      packageName = "bytes";
-      version = "0.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz";
-        sha1 = "555b08abcb063f8975905302523e4cd4ffdfdf31";
-      };
-    };
-    "negotiator-0.3.0" = {
-      name = "negotiator";
-      packageName = "negotiator";
-      version = "0.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz";
-        sha1 = "706d692efeddf574d57ea9fb1ab89a4fa7ee8f60";
-      };
-    };
-    "compressible-1.0.0" = {
-      name = "compressible";
-      packageName = "compressible";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/compressible/-/compressible-1.0.0.tgz";
-        sha1 = "f83e49c1cb61421753545125a8011d68b492427d";
-      };
-    };
-    "scmp-0.0.3" = {
-      name = "scmp";
-      packageName = "scmp";
-      version = "0.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz";
-        sha1 = "3648df2d7294641e7f78673ffc29681d9bad9073";
-      };
-    };
-    "batch-0.5.0" = {
-      name = "batch";
-      packageName = "batch";
-      version = "0.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz";
-        sha1 = "fd2e05a7a5d696b4db9314013e285d8ff3557ec3";
-      };
-    };
-    "negotiator-0.4.2" = {
-      name = "negotiator";
-      packageName = "negotiator";
-      version = "0.4.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/negotiator/-/negotiator-0.4.2.tgz";
-        sha1 = "8c43ea7e4c40ddfe40c3c0234c4ef77500b8fd37";
-      };
-    };
-    "parseurl-1.0.1" = {
-      name = "parseurl";
-      packageName = "parseurl";
+    "fd-slicer-1.0.1" = {
+      name = "fd-slicer";
+      packageName = "fd-slicer";
       version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz";
-        sha1 = "2e57dce6efdd37c3518701030944c22bf388b7b4";
+        url = "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz";
+        sha1 = "8b5bcbd9ec327c5041bf9ab023fd6750f1177e65";
       };
     };
-    "debug-0.8.0" = {
-      name = "debug";
-      packageName = "debug";
-      version = "0.8.0";
+    "pend-1.2.0" = {
+      name = "pend";
+      packageName = "pend";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-0.8.0.tgz";
-        sha1 = "0541ea91f0e503fdf0c5eed418a32550234967f0";
+        url = "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz";
+        sha1 = "7a57eb550a6783f9115331fcf4663d5c8e007a50";
       };
     };
-    "bittorrent-dht-3.2.6" = {
-      name = "bittorrent-dht";
-      packageName = "bittorrent-dht";
-      version = "3.2.6";
+    "engine.io-1.8.4" = {
+      name = "engine.io";
+      packageName = "engine.io";
+      version = "1.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-3.2.6.tgz";
-        sha1 = "8d6f64f002525951536ca403ddd040c03009b7d5";
+        url = "https://registry.npmjs.org/engine.io/-/engine.io-1.8.4.tgz";
+        sha1 = "77bce12b80e5d60429337fec3b0daf691ebc9003";
       };
     };
-    "bittorrent-tracker-2.12.1" = {
-      name = "bittorrent-tracker";
-      packageName = "bittorrent-tracker";
-      version = "2.12.1";
+    "socket.io-client-1.7.4" = {
+      name = "socket.io-client";
+      packageName = "socket.io-client";
+      version = "1.7.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-2.12.1.tgz";
-        sha1 = "562f0e43c6340d003b08c5dad3d4bff0eb3fd64d";
+        url = "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz";
+        sha1 = "ec9f820356ed99ef6d357f0756d648717bdd4281";
       };
     };
-    "ip-0.3.3" = {
-      name = "ip";
-      packageName = "ip";
-      version = "0.3.3";
+    "engine.io-client-1.8.4" = {
+      name = "engine.io-client";
+      packageName = "engine.io-client";
+      version = "1.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz";
-        sha1 = "8ee8309e92f0b040d287f72efaca1a21702d3fb4";
-      };
-    };
-    "peer-wire-swarm-0.9.2" = {
-      name = "peer-wire-swarm";
-      packageName = "peer-wire-swarm";
-      version = "0.9.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/peer-wire-swarm/-/peer-wire-swarm-0.9.2.tgz";
-        sha1 = "092848005607d8ca94e69f9bc9ebe52956ec3048";
-      };
-    };
-    "random-access-file-0.3.2" = {
-      name = "random-access-file";
-      packageName = "random-access-file";
-      version = "0.3.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/random-access-file/-/random-access-file-0.3.2.tgz";
-        sha1 = "cbca246e131db7b68a1c6bb6328dd4d0997100a0";
-      };
-    };
-    "is-ip-1.0.0" = {
-      name = "is-ip";
-      packageName = "is-ip";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-ip/-/is-ip-1.0.0.tgz";
-        sha1 = "2bb6959f797ccd6f9fdc812758bcbc87c4c59074";
-      };
-    };
-    "k-bucket-0.5.0" = {
-      name = "k-bucket";
-      packageName = "k-bucket";
-      version = "0.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/k-bucket/-/k-bucket-0.5.0.tgz";
-        sha1 = "31d462d86cdb2e8d245528acfe5e71382f552e1d";
-      };
-    };
-    "simple-get-1.4.3" = {
-      name = "simple-get";
-      packageName = "simple-get";
-      version = "1.4.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz";
-        sha1 = "e9755eda407e96da40c5e5158c9ea37b33becbeb";
-      };
-    };
-    "ip-regex-1.0.3" = {
-      name = "ip-regex";
-      packageName = "ip-regex";
-      version = "1.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz";
-        sha1 = "dc589076f659f419c222039a33316f1c7387effd";
-      };
-    };
-    "bencode-0.6.0" = {
-      name = "bencode";
-      packageName = "bencode";
-      version = "0.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bencode/-/bencode-0.6.0.tgz";
-        sha1 = "04d6190e1d7467c56a969e1a94d1668076eac050";
-      };
-    };
-    "bn.js-1.3.0" = {
-      name = "bn.js";
-      packageName = "bn.js";
-      version = "1.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz";
-        sha1 = "0db4cbf96f8f23b742f5bcb9d1aa7a9994a05e83";
-      };
-    };
-    "extend.js-0.0.2" = {
-      name = "extend.js";
-      packageName = "extend.js";
-      version = "0.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/extend.js/-/extend.js-0.0.2.tgz";
-        sha1 = "0f9c7a81a1f208b703eb0c3131fe5716ac6ecd15";
-      };
-    };
-    "portfinder-0.3.0" = {
-      name = "portfinder";
-      packageName = "portfinder";
-      version = "0.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/portfinder/-/portfinder-0.3.0.tgz";
-        sha1 = "f9f2c96894440c5b5113b84e0ad1013042b7c2a0";
-      };
-    };
-    "mkdirp-0.0.7" = {
-      name = "mkdirp";
-      packageName = "mkdirp";
-      version = "0.0.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mkdirp/-/mkdirp-0.0.7.tgz";
-        sha1 = "d89b4f0e4c3e5e5ca54235931675e094fe1a5072";
+        url = "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.4.tgz";
+        sha1 = "9fe85dee25853ca6babe25bd2ad68710863e91c2";
       };
     };
     "extract-zip-1.5.0" = {
@@ -17426,24 +17714,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz";
         sha1 = "9528f442dab1b2284e58b4379bb194e22e0c4005";
-      };
-    };
-    "fd-slicer-1.0.1" = {
-      name = "fd-slicer";
-      packageName = "fd-slicer";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz";
-        sha1 = "8b5bcbd9ec327c5041bf9ab023fd6750f1177e65";
-      };
-    };
-    "pend-1.2.0" = {
-      name = "pend";
-      packageName = "pend";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz";
-        sha1 = "7a57eb550a6783f9115331fcf4663d5c8e007a50";
       };
     };
     "bl-1.0.3" = {
@@ -17597,15 +17867,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz";
         sha1 = "4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d";
-      };
-    };
-    "private-0.1.7" = {
-      name = "private";
-      packageName = "private";
-      version = "0.1.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/private/-/private-0.1.7.tgz";
-        sha1 = "68ce5e8a1ef0a23bb570cc28537b5332aba63ef1";
       };
     };
     "recast-0.11.23" = {
@@ -17770,6 +18031,33 @@ let
         sha1 = "9991ce09ff9b85d9ead27f9d41d0b2a2df2f9284";
       };
     };
+    "commander-1.3.2" = {
+      name = "commander";
+      packageName = "commander";
+      version = "1.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz";
+        sha1 = "8a8f30ec670a6fdd64af52f1914b907d79ead5b5";
+      };
+    };
+    "cookie-0.1.0" = {
+      name = "cookie";
+      packageName = "cookie";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz";
+        sha1 = "90eb469ddce905c866de687efc43131d8801f9d0";
+      };
+    };
+    "buffer-crc32-0.2.1" = {
+      name = "buffer-crc32";
+      packageName = "buffer-crc32";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz";
+        sha1 = "be3e5382fc02b6d6324956ac1af98aa98b08534c";
+      };
+    };
     "fresh-0.2.0" = {
       name = "fresh";
       packageName = "fresh";
@@ -17777,6 +18065,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz";
         sha1 = "bfd9402cf3df12c4a4c310c79f99a3dde13d34a7";
+      };
+    };
+    "methods-0.1.0" = {
+      name = "methods";
+      packageName = "methods";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz";
+        sha1 = "335d429eefd21b7bacf2e9c922a8d2bd14a30e4f";
       };
     };
     "send-0.1.4" = {
@@ -17797,6 +18094,15 @@ let
         sha1 = "294b268e4b0d4250f6dde19b3b8b34935dff14ef";
       };
     };
+    "bytes-0.2.1" = {
+      name = "bytes";
+      packageName = "bytes";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz";
+        sha1 = "555b08abcb063f8975905302523e4cd4ffdfdf31";
+      };
+    };
     "raw-body-0.0.3" = {
       name = "raw-body";
       packageName = "raw-body";
@@ -17804,6 +18110,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/raw-body/-/raw-body-0.0.3.tgz";
         sha1 = "0cb3eb22ced1ca607d32dd8fd94a6eb383f3eb8a";
+      };
+    };
+    "negotiator-0.3.0" = {
+      name = "negotiator";
+      packageName = "negotiator";
+      version = "0.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz";
+        sha1 = "706d692efeddf574d57ea9fb1ab89a4fa7ee8f60";
+      };
+    };
+    "multiparty-2.2.0" = {
+      name = "multiparty";
+      packageName = "multiparty";
+      version = "2.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz";
+        sha1 = "a567c2af000ad22dc8f2a653d91978ae1f5316f4";
       };
     };
     "oauth-https://codeload.github.com/ciaranj/node-oauth/legacy.tar.gz/master" = {
@@ -17996,13 +18320,31 @@ let
         sha1 = "4bd28e0770fad421fc807745c1ef3010905b2332";
       };
     };
-    "router-1.3.0" = {
+    "router-1.3.1" = {
       name = "router";
       packageName = "router";
-      version = "1.3.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/router/-/router-1.3.0.tgz";
-        sha1 = "15b24075c1de4a3d3f39808c5d7344a1564417c8";
+        url = "https://registry.npmjs.org/router/-/router-1.3.1.tgz";
+        sha1 = "e59ef64fafc22194a196986834d887058d76af47";
+      };
+    };
+    "send-0.15.1" = {
+      name = "send";
+      packageName = "send";
+      version = "0.15.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/send/-/send-0.15.1.tgz";
+        sha1 = "8a02354c26e6f5cca700065f5f0cdeba90ec7b5f";
+      };
+    };
+    "serve-static-1.12.1" = {
+      name = "serve-static";
+      packageName = "serve-static";
+      version = "1.12.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/serve-static/-/serve-static-1.12.1.tgz";
+        sha1 = "7443a965e3ced647aceb5639fa06bf4d1bbe0039";
       };
     };
     "raw-body-1.3.4" = {
@@ -18095,13 +18437,13 @@ let
         sha1 = "1e0f4650c862dcbfed54fd42b148e9bb1721fcf2";
       };
     };
-    "domutils-1.6.0" = {
+    "domutils-1.6.2" = {
       name = "domutils";
       packageName = "domutils";
-      version = "1.6.0";
+      version = "1.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/domutils/-/domutils-1.6.0.tgz";
-        sha1 = "853de07f013287f976b7fe0461740222ea14ecbb";
+        url = "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz";
+        sha1 = "1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff";
       };
     };
     "async-2.1.5" = {
@@ -18482,13 +18824,13 @@ let
         sha1 = "321f6cf73782a6ff751111390fc05e2c657d8c9b";
       };
     };
-    "coa-1.0.1" = {
+    "coa-1.0.2" = {
       name = "coa";
       packageName = "coa";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz";
-        sha1 = "7f959346cfc8719e3f7233cd6852854a7c67d8a3";
+        url = "https://registry.npmjs.org/coa/-/coa-1.0.2.tgz";
+        sha1 = "2ba9fec3b4aa43d7a49d7e6c3561e92061b6bcec";
       };
     };
     "whet.extend-0.9.9" = {
@@ -18590,13 +18932,13 @@ let
         sha1 = "375fb0783ca8fa90307749399bc9c75eb7cf6580";
       };
     };
-    "express-session-1.15.2" = {
+    "express-session-1.15.3" = {
       name = "express-session";
       packageName = "express-session";
-      version = "1.15.2";
+      version = "1.15.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/express-session/-/express-session-1.15.2.tgz";
-        sha1 = "d98516443a4ccb8688e1725ae584c02daa4093d4";
+        url = "https://registry.npmjs.org/express-session/-/express-session-1.15.3.tgz";
+        sha1 = "db545f0435a7b1b228ae02da8197f65141735c67";
       };
     };
     "forever-monitor-1.1.0" = {
@@ -18714,15 +19056,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/raven/-/raven-1.2.1.tgz";
         sha1 = "949c134db028a190b7bbf8f790aae541b7c020bd";
-      };
-    };
-    "serve-static-1.12.2" = {
-      name = "serve-static";
-      packageName = "serve-static";
-      version = "1.12.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz";
-        sha1 = "e546e2726081b81b4bcec8e90808ebcdd323afba";
       };
     };
     "signals-1.0.0" = {
@@ -18968,13 +19301,13 @@ let
         sha1 = "6728fc0459c450d796a99c31837569bdf672d728";
       };
     };
-    "send-0.15.2" = {
-      name = "send";
-      packageName = "send";
-      version = "0.15.2";
+    "stack-trace-0.0.9" = {
+      name = "stack-trace";
+      packageName = "stack-trace";
+      version = "0.0.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/send/-/send-0.15.2.tgz";
-        sha1 = "f91fab4403bcf87e716f70ceb5db2f578bdc17d6";
+        url = "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz";
+        sha1 = "a8f6eaeca90674c333e7c43953f275b451510695";
       };
     };
     "eve-0.5.4" = {
@@ -19022,15 +19355,6 @@ let
         sha1 = "8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9";
       };
     };
-    "find-up-2.1.0" = {
-      name = "find-up";
-      packageName = "find-up";
-      version = "2.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz";
-        sha1 = "45d1b7e506c717ddd482775a2b77920a3c0c57a7";
-      };
-    };
     "read-pkg-2.0.0" = {
       name = "read-pkg";
       packageName = "read-pkg";
@@ -19038,42 +19362,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz";
         sha1 = "8ef1c0623c6a6db0dc6713c4bfac46332b2368f8";
-      };
-    };
-    "locate-path-2.0.0" = {
-      name = "locate-path";
-      packageName = "locate-path";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz";
-        sha1 = "2b568b265eec944c6d9c0de9c3dbbbca0354cd8e";
-      };
-    };
-    "p-locate-2.0.0" = {
-      name = "p-locate";
-      packageName = "p-locate";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz";
-        sha1 = "20a0103b222a70c8fd39cc2e580680f3dde5ec43";
-      };
-    };
-    "path-exists-3.0.0" = {
-      name = "path-exists";
-      packageName = "path-exists";
-      version = "3.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz";
-        sha1 = "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515";
-      };
-    };
-    "p-limit-1.1.0" = {
-      name = "p-limit";
-      packageName = "p-limit";
-      version = "1.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz";
-        sha1 = "b07ff2d9a5d88bec806035895a2bab66a27988bc";
       };
     };
     "load-json-file-2.0.0" = {
@@ -19164,15 +19452,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz";
         sha1 = "8baa1365a632f58a3c46d20175fc6002c96e37de";
-      };
-    };
-    "json5-0.5.1" = {
-      name = "json5";
-      packageName = "json5";
-      version = "0.5.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz";
-        sha1 = "1eade7acc012034ad84e2396767ead9fa5495821";
       };
     };
     "loader-runner-2.3.0" = {
@@ -19301,15 +19580,6 @@ let
         sha1 = "29cceac0dc4f03c6c87b4a9f217dd18c9f74871c";
       };
     };
-    "babel-runtime-6.23.0" = {
-      name = "babel-runtime";
-      packageName = "babel-runtime";
-      version = "6.23.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz";
-        sha1 = "0a9489f144de70efb3ce4300accdb329e2fc543b";
-      };
-    };
     "bytes-2.5.0" = {
       name = "bytes";
       packageName = "bytes";
@@ -19337,6 +19607,15 @@ let
         sha1 = "3871cc0a6a002e8c3e5b3cf7f336264675f06b9d";
       };
     };
+    "gunzip-maybe-1.4.0" = {
+      name = "gunzip-maybe";
+      packageName = "gunzip-maybe";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.0.tgz";
+        sha1 = "7d8316c8d0571e1d08a5a79e46fff0afe8172b19";
+      };
+    };
     "inquirer-3.0.6" = {
       name = "inquirer";
       packageName = "inquirer";
@@ -19344,15 +19623,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz";
         sha1 = "e04aaa9d05b7a3cb9b0f407d04375f0447190347";
-      };
-    };
-    "invariant-2.2.2" = {
-      name = "invariant";
-      packageName = "invariant";
-      version = "2.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz";
-        sha1 = "9e1f56ac0acdb6bf303306f338be3b204ae60360";
       };
     };
     "is-ci-1.0.10" = {
@@ -19400,15 +19670,6 @@ let
         sha1 = "cd692cfb2cc744fd84a3358aac6ee51528cf720d";
       };
     };
-    "roadrunner-1.1.0" = {
-      name = "roadrunner";
-      packageName = "roadrunner";
-      version = "1.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/roadrunner/-/roadrunner-1.1.0.tgz";
-        sha1 = "1180a30d64e1970d8f55dd8cb0da8ffccecad71e";
-      };
-    };
     "tar-fs-1.15.2" = {
       name = "tar-fs";
       packageName = "tar-fs";
@@ -19427,13 +19688,31 @@ let
         sha1 = "1dc2a340fb8e5f800a32bcdbfb8c23cd747021b9";
       };
     };
-    "regenerator-runtime-0.10.5" = {
-      name = "regenerator-runtime";
-      packageName = "regenerator-runtime";
-      version = "0.10.5";
+    "is-deflate-1.0.0" = {
+      name = "is-deflate";
+      packageName = "is-deflate";
+      version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz";
-        sha1 = "336c3efc1220adcedda2c9fab67b5a7955a33658";
+        url = "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz";
+        sha1 = "c862901c3c161fb09dac7cdc7e784f80e98f2f14";
+      };
+    };
+    "is-gzip-1.0.0" = {
+      name = "is-gzip";
+      packageName = "is-gzip";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz";
+        sha1 = "6ca8b07b99c77998025900e555ced8ed80879a83";
+      };
+    };
+    "peek-stream-1.1.2" = {
+      name = "peek-stream";
+      packageName = "peek-stream";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.2.tgz";
+        sha1 = "97eb76365bcfd8c89e287f55c8b69d4c3e9bcc52";
       };
     };
     "cli-cursor-2.1.0" = {
@@ -19445,13 +19724,13 @@ let
         sha1 = "b35dac376479facc3e94747d41d0d0f5238ffcb5";
       };
     };
-    "external-editor-2.0.1" = {
+    "external-editor-2.0.2" = {
       name = "external-editor";
       packageName = "external-editor";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/external-editor/-/external-editor-2.0.1.tgz";
-        sha1 = "4c597c6c88fa6410e41dbbaa7b1be2336aa31095";
+        url = "https://registry.npmjs.org/external-editor/-/external-editor-2.0.2.tgz";
+        sha1 = "384f6d8ae02054235c19e0a142c6d6fc36ad9363";
       };
     };
     "figures-2.0.0" = {
@@ -19479,15 +19758,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz";
         sha1 = "067428230fd67443b2794b22bba528b6867962d4";
-      };
-    };
-    "loose-envify-1.3.1" = {
-      name = "loose-envify";
-      packageName = "loose-envify";
-      version = "1.3.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz";
-        sha1 = "d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848";
       };
     };
     "ci-info-1.0.0" = {
@@ -19919,54 +20189,131 @@ in
   alloy = nodeEnv.buildNodePackage {
     name = "alloy";
     packageName = "alloy";
-    version = "1.9.11";
+    version = "1.10.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/alloy/-/alloy-1.9.11.tgz";
-      sha1 = "6e185c5c3211b5a86d272caec63b8daf80e5b186";
+      url = "https://registry.npmjs.org/alloy/-/alloy-1.10.0.tgz";
+      sha1 = "5b2d51bb622f60a808c4625e539562e802a274e1";
     };
     dependencies = [
-      sources."colors-0.6.0-1"
-      sources."ejs-2.3.4"
-      sources."pkginfo-0.2.2"
-      sources."commander-0.6.1"
-      sources."wrench-1.3.9"
-      sources."xmldom-0.1.19"
-      sources."jsonlint-1.5.1"
-      (sources."uglify-js-2.6.1" // {
+      sources."async-2.4.1"
+      (sources."babel-core-6.24.1" // {
         dependencies = [
           sources."source-map-0.5.6"
         ];
       })
-      sources."resolve-1.3.3"
+      sources."babel-preset-babili-0.0.12"
+      sources."babel-traverse-6.24.1"
+      sources."babel-types-6.24.1"
+      sources."babylon-6.17.1"
+      sources."colors-0.6.0-1"
+      sources."commander-0.6.1"
+      sources."deasync-0.1.9"
+      sources."ejs-2.3.4"
       sources."global-paths-0.1.2"
-      sources."source-map-0.1.9"
-      sources."xml2tss-0.0.5"
+      sources."jsonlint-1.5.1"
       sources."moment-2.17.1"
       sources."node.extend-1.0.10"
-      sources."nomnom-1.8.1"
-      sources."JSV-4.0.2"
-      sources."underscore-1.6.0"
-      sources."chalk-0.4.0"
-      sources."has-color-0.1.7"
-      sources."ansi-styles-1.0.0"
-      sources."strip-ansi-0.1.1"
-      sources."async-0.2.10"
-      sources."uglify-to-browserify-1.0.2"
-      sources."yargs-3.10.0"
-      sources."camelcase-1.2.1"
-      sources."cliui-2.1.0"
-      sources."decamelize-1.2.0"
-      sources."window-size-0.1.0"
-      sources."center-align-0.1.3"
-      sources."right-align-0.1.3"
-      sources."wordwrap-0.0.2"
-      sources."align-text-0.1.4"
-      sources."lazy-cache-1.0.4"
-      sources."kind-of-3.2.0"
-      sources."longest-1.0.1"
-      sources."repeat-string-1.6.1"
-      sources."is-buffer-1.1.5"
-      sources."path-parse-1.0.5"
+      sources."pkginfo-0.2.2"
+      sources."resolve-1.3.3"
+      sources."source-map-0.1.9"
+      sources."wrench-1.3.9"
+      sources."xml2tss-0.0.5"
+      sources."xmldom-0.1.19"
+      sources."lodash-4.17.4"
+      sources."babel-code-frame-6.22.0"
+      (sources."babel-generator-6.24.1" // {
+        dependencies = [
+          sources."source-map-0.5.6"
+        ];
+      })
+      sources."babel-helpers-6.24.1"
+      sources."babel-messages-6.23.0"
+      sources."babel-template-6.24.1"
+      sources."babel-runtime-6.23.0"
+      sources."babel-register-6.24.1"
+      sources."convert-source-map-1.5.0"
+      sources."debug-2.6.8"
+      sources."json5-0.5.1"
+      sources."minimatch-3.0.4"
+      sources."path-is-absolute-1.0.1"
+      sources."private-0.1.7"
+      sources."slash-1.0.0"
+      sources."chalk-1.1.3"
+      sources."esutils-2.0.2"
+      sources."js-tokens-3.0.1"
+      sources."ansi-styles-2.2.1"
+      sources."escape-string-regexp-1.0.5"
+      sources."has-ansi-2.0.0"
+      sources."strip-ansi-3.0.1"
+      sources."supports-color-2.0.0"
+      sources."ansi-regex-2.1.1"
+      sources."detect-indent-4.0.0"
+      sources."jsesc-1.3.0"
+      sources."trim-right-1.0.1"
+      sources."repeating-2.0.1"
+      sources."is-finite-1.0.2"
+      sources."number-is-nan-1.0.1"
+      sources."core-js-2.4.1"
+      sources."regenerator-runtime-0.10.5"
+      sources."home-or-tmp-2.0.0"
+      sources."mkdirp-0.5.1"
+      (sources."source-map-support-0.4.15" // {
+        dependencies = [
+          sources."source-map-0.5.6"
+        ];
+      })
+      sources."os-homedir-1.0.2"
+      sources."os-tmpdir-1.0.2"
+      sources."minimist-0.0.8"
+      sources."ms-2.0.0"
+      sources."brace-expansion-1.1.7"
+      sources."balanced-match-0.4.2"
+      sources."concat-map-0.0.1"
+      sources."babel-plugin-minify-builtins-0.0.2"
+      (sources."babel-plugin-minify-constant-folding-0.0.4" // {
+        dependencies = [
+          sources."jsesc-2.5.1"
+        ];
+      })
+      sources."babel-plugin-minify-dead-code-elimination-0.1.6"
+      sources."babel-plugin-minify-flip-comparisons-0.0.2"
+      sources."babel-plugin-minify-guarded-expressions-0.0.4"
+      sources."babel-plugin-minify-infinity-0.0.3"
+      (sources."babel-plugin-minify-mangle-names-0.0.8" // {
+        dependencies = [
+          sources."babel-helper-mark-eval-scopes-0.0.3"
+        ];
+      })
+      sources."babel-plugin-minify-numeric-literals-0.0.1"
+      sources."babel-plugin-minify-replace-0.0.1"
+      sources."babel-plugin-minify-simplify-0.0.8"
+      sources."babel-plugin-minify-type-constructors-0.0.4"
+      sources."babel-plugin-transform-inline-consecutive-adds-0.0.2"
+      sources."babel-plugin-transform-member-expression-literals-6.8.3"
+      sources."babel-plugin-transform-merge-sibling-variables-6.8.4"
+      sources."babel-plugin-transform-minify-booleans-6.8.2"
+      sources."babel-plugin-transform-property-literals-6.8.3"
+      sources."babel-plugin-transform-regexp-constructors-0.0.6"
+      sources."babel-plugin-transform-remove-console-6.8.3"
+      sources."babel-plugin-transform-remove-debugger-6.8.3"
+      sources."babel-plugin-transform-remove-undefined-0.0.5"
+      sources."babel-plugin-transform-simplify-comparison-operators-6.8.3"
+      sources."babel-plugin-transform-undefined-to-void-6.8.2"
+      sources."lodash.isplainobject-4.0.6"
+      sources."babel-helper-evaluate-path-0.0.3"
+      sources."babel-helper-mark-eval-scopes-0.1.1"
+      sources."babel-helper-remove-or-void-0.1.1"
+      sources."lodash.some-4.6.0"
+      sources."babel-helper-is-void-0-0.0.1"
+      sources."babel-helper-flip-expressions-0.0.2"
+      sources."babel-helper-is-nodes-equiv-0.0.1"
+      sources."babel-helper-to-multiple-sequence-expressions-0.0.4"
+      sources."globals-9.17.0"
+      sources."invariant-2.2.2"
+      sources."loose-envify-1.3.1"
+      sources."to-fast-properties-1.0.3"
+      sources."bindings-1.2.1"
+      sources."nan-2.6.2"
       sources."array-unique-0.2.1"
       (sources."global-modules-0.2.3" // {
         dependencies = [
@@ -19984,10 +20331,21 @@ in
       sources."which-1.2.14"
       sources."parse-passwd-1.0.0"
       sources."isexe-2.0.0"
+      (sources."nomnom-1.8.1" // {
+        dependencies = [
+          sources."chalk-0.4.0"
+          sources."ansi-styles-1.0.0"
+          sources."strip-ansi-0.1.1"
+        ];
+      })
+      sources."JSV-4.0.2"
+      sources."underscore-1.6.0"
+      sources."has-color-0.1.7"
+      sources."is-0.3.0"
+      sources."path-parse-1.0.5"
       sources."amdefine-1.0.1"
       sources."xml2js-0.2.8"
       sources."sax-0.5.8"
-      sources."is-0.3.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -20000,10 +20358,10 @@ in
   azure-cli = nodeEnv.buildNodePackage {
     name = "azure-cli";
     packageName = "azure-cli";
-    version = "0.10.12";
+    version = "0.10.13";
     src = fetchurl {
-      url = "https://registry.npmjs.org/azure-cli/-/azure-cli-0.10.12.tgz";
-      sha1 = "4446af5df8dda6c755a0bf7dfec2468a9f63f26d";
+      url = "https://registry.npmjs.org/azure-cli/-/azure-cli-0.10.13.tgz";
+      sha1 = "7e98a46b058f436fb2a3fbed982d143d49557348";
     };
     dependencies = [
       sources."adal-node-0.1.21"
@@ -20018,8 +20376,8 @@ in
       sources."azure-arm-cdn-1.0.3"
       sources."azure-arm-commerce-0.2.0"
       sources."azure-arm-compute-0.20.0"
-      sources."azure-arm-datalake-analytics-1.0.1-preview"
-      sources."azure-arm-datalake-store-1.0.1-preview"
+      sources."azure-arm-datalake-analytics-1.0.2-preview"
+      sources."azure-arm-datalake-store-1.0.2-preview"
       sources."azure-arm-hdinsight-0.2.2"
       sources."azure-arm-hdinsight-jobs-0.1.0"
       sources."azure-arm-insights-0.11.3"
@@ -20169,7 +20527,7 @@ in
       sources."process-nextick-args-1.0.7"
       sources."string_decoder-0.10.31"
       sources."util-deprecate-1.0.2"
-      sources."stack-trace-0.0.9"
+      sources."stack-trace-0.0.10"
       sources."keypress-0.1.0"
       sources."from-0.1.7"
       sources."map-stream-0.1.0"
@@ -20201,10 +20559,10 @@ in
       sources."ncp-0.4.2"
       sources."rimraf-2.6.1"
       sources."minimist-0.0.8"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -20225,7 +20583,7 @@ in
       sources."forever-agent-0.6.1"
       (sources."form-data-1.0.1" // {
         dependencies = [
-          sources."async-2.4.0"
+          sources."async-2.4.1"
         ];
       })
       (sources."har-validator-2.0.6" // {
@@ -20305,7 +20663,7 @@ in
       (sources."concat-stream-1.6.0" // {
         dependencies = [
           sources."readable-stream-2.2.9"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."http-response-object-1.1.0"
@@ -20323,6 +20681,141 @@ in
       description = "Microsoft Azure Cross Platform Command Line tool";
       homepage = https://github.com/Azure/azure-xplat-cli;
       license = "Apache-2.0";
+    };
+    production = true;
+  };
+  bootlint = nodeEnv.buildNodePackage {
+    name = "bootlint";
+    packageName = "bootlint";
+    version = "0.14.2";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/bootlint/-/bootlint-0.14.2.tgz";
+      sha1 = "c04c373d65dfd0a4d0df7c2dbb3e29a6e150cb70";
+    };
+    dependencies = [
+      sources."binary-search-1.3.2"
+      sources."bluebird-3.5.0"
+      (sources."body-parser-1.17.2" // {
+        dependencies = [
+          sources."debug-2.6.7"
+        ];
+      })
+      sources."chalk-1.1.3"
+      sources."cheerio-0.19.0"
+      sources."commander-2.9.0"
+      sources."debug-2.6.8"
+      (sources."express-4.15.3" // {
+        dependencies = [
+          sources."debug-2.6.7"
+        ];
+      })
+      sources."glob-6.0.4"
+      (sources."morgan-1.8.1" // {
+        dependencies = [
+          sources."debug-2.6.1"
+          sources."ms-0.7.2"
+        ];
+      })
+      sources."semver-5.3.0"
+      sources."void-elements-2.0.1"
+      sources."bytes-2.4.0"
+      sources."content-type-1.0.2"
+      sources."depd-1.1.0"
+      sources."http-errors-1.6.1"
+      sources."iconv-lite-0.4.15"
+      sources."on-finished-2.3.0"
+      sources."qs-6.4.0"
+      sources."raw-body-2.2.0"
+      sources."type-is-1.6.15"
+      sources."ms-2.0.0"
+      sources."inherits-2.0.3"
+      sources."setprototypeof-1.0.3"
+      sources."statuses-1.3.1"
+      sources."ee-first-1.1.1"
+      sources."unpipe-1.0.0"
+      sources."media-typer-0.3.0"
+      sources."mime-types-2.1.15"
+      sources."mime-db-1.27.0"
+      sources."ansi-styles-2.2.1"
+      sources."escape-string-regexp-1.0.5"
+      sources."has-ansi-2.0.0"
+      sources."strip-ansi-3.0.1"
+      sources."supports-color-2.0.0"
+      sources."ansi-regex-2.1.1"
+      sources."css-select-1.0.0"
+      sources."entities-1.1.1"
+      (sources."htmlparser2-3.8.3" // {
+        dependencies = [
+          sources."domutils-1.5.1"
+          sources."entities-1.0.0"
+        ];
+      })
+      (sources."dom-serializer-0.1.0" // {
+        dependencies = [
+          sources."domelementtype-1.1.3"
+        ];
+      })
+      sources."lodash-3.10.1"
+      sources."css-what-1.0.0"
+      sources."domutils-1.4.3"
+      sources."boolbase-1.0.0"
+      sources."nth-check-1.0.1"
+      sources."domelementtype-1.3.0"
+      sources."domhandler-2.3.0"
+      sources."readable-stream-1.1.14"
+      sources."core-util-is-1.0.2"
+      sources."isarray-0.0.1"
+      sources."string_decoder-0.10.31"
+      sources."graceful-readlink-1.0.1"
+      sources."accepts-1.3.3"
+      sources."array-flatten-1.1.1"
+      sources."content-disposition-0.5.2"
+      sources."cookie-0.3.1"
+      sources."cookie-signature-1.0.6"
+      sources."encodeurl-1.0.1"
+      sources."escape-html-1.0.3"
+      sources."etag-1.8.0"
+      (sources."finalhandler-1.0.3" // {
+        dependencies = [
+          sources."debug-2.6.7"
+        ];
+      })
+      sources."fresh-0.5.0"
+      sources."merge-descriptors-1.0.1"
+      sources."methods-1.1.2"
+      sources."parseurl-1.3.1"
+      sources."path-to-regexp-0.1.7"
+      sources."proxy-addr-1.1.4"
+      sources."range-parser-1.2.0"
+      (sources."send-0.15.3" // {
+        dependencies = [
+          sources."debug-2.6.7"
+        ];
+      })
+      sources."serve-static-1.12.3"
+      sources."utils-merge-1.0.0"
+      sources."vary-1.1.1"
+      sources."negotiator-0.6.1"
+      sources."forwarded-0.1.0"
+      sources."ipaddr.js-1.3.0"
+      sources."destroy-1.0.4"
+      sources."mime-1.3.4"
+      sources."inflight-1.0.6"
+      sources."minimatch-3.0.4"
+      sources."once-1.4.0"
+      sources."path-is-absolute-1.0.1"
+      sources."wrappy-1.0.2"
+      sources."brace-expansion-1.1.7"
+      sources."balanced-match-0.4.2"
+      sources."concat-map-0.0.1"
+      sources."basic-auth-1.1.0"
+      sources."on-headers-1.0.1"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "HTML linter for Bootstrap projects";
+      homepage = https://github.com/twbs/bootlint;
+      license = "MIT";
     };
     production = true;
   };
@@ -20371,7 +20864,7 @@ in
       })
       sources."glob-6.0.4"
       sources."sprintf-js-1.0.3"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ext-name-3.0.0"
       sources."graceful-fs-3.0.11"
       sources."intersect-1.0.1"
@@ -20404,8 +20897,9 @@ in
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."camelcase-keys-2.1.0"
       sources."decamelize-1.2.0"
       sources."loud-rejection-1.6.0"
@@ -20469,23 +20963,23 @@ in
       sources."path-is-absolute-1.0.1"
       (sources."rimraf-2.6.1" // {
         dependencies = [
-          sources."glob-7.1.1"
+          sources."glob-7.1.2"
         ];
       })
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
       sources."q-1.5.0"
-      sources."debug-2.6.6"
+      sources."debug-2.6.8"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
           sources."minimist-0.0.8"
         ];
       })
-      sources."ms-0.7.3"
+      sources."ms-2.0.0"
       sources."os-tmpdir-1.0.2"
     ];
     buildInputs = globalBuildInputs;
@@ -20529,7 +21023,7 @@ in
       sources."domain-browser-1.1.7"
       sources."duplexer2-0.1.4"
       sources."events-1.1.1"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."has-1.0.1"
       sources."htmlescape-1.1.1"
       sources."https-browserify-1.0.0"
@@ -20550,14 +21044,14 @@ in
       sources."read-only-stream-2.0.0"
       (sources."readable-stream-2.2.9" // {
         dependencies = [
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."resolve-1.3.3"
       sources."shasum-1.0.2"
       sources."shell-quote-1.6.1"
       sources."stream-browserify-2.0.1"
-      sources."stream-http-2.7.0"
+      sources."stream-http-2.7.1"
       sources."string_decoder-0.10.31"
       sources."subarg-1.0.0"
       sources."syntax-error-1.3.0"
@@ -20576,7 +21070,7 @@ in
       })
       sources."vm-browserify-0.0.4"
       sources."xtend-4.0.1"
-      sources."jsonparse-1.3.0"
+      sources."jsonparse-1.3.1"
       sources."through-2.3.8"
       sources."combine-source-map-0.7.2"
       sources."umd-3.0.1"
@@ -20596,10 +21090,10 @@ in
       sources."browserify-cipher-1.0.0"
       sources."browserify-sign-4.0.4"
       sources."create-ecdh-4.0.0"
-      sources."create-hash-1.1.2"
-      sources."create-hmac-1.1.4"
+      sources."create-hash-1.1.3"
+      sources."create-hmac-1.1.6"
       sources."diffie-hellman-5.0.2"
-      sources."pbkdf2-3.0.9"
+      sources."pbkdf2-3.0.12"
       sources."public-encrypt-4.0.0"
       sources."randombytes-2.0.3"
       sources."browserify-aes-1.0.6"
@@ -20618,12 +21112,14 @@ in
       sources."hmac-drbg-1.0.1"
       sources."minimalistic-crypto-utils-1.0.1"
       sources."asn1.js-4.9.1"
-      sources."ripemd160-1.0.1"
+      sources."ripemd160-2.0.1"
       sources."sha.js-2.4.8"
+      sources."hash-base-2.0.2"
+      sources."safe-buffer-5.0.1"
       sources."miller-rabin-4.0.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -20675,12 +21171,12 @@ in
       sources."chalk-1.0.0"
       sources."chromecast-player-0.2.3"
       sources."debounced-seeker-1.0.0"
-      sources."debug-2.6.6"
+      sources."debug-2.6.8"
       sources."diveSync-0.3.0"
       sources."got-1.2.2"
       sources."internal-ip-1.2.0"
       sources."keypress-0.2.1"
-      sources."mime-1.3.4"
+      sources."mime-1.3.6"
       sources."minimist-1.2.0"
       sources."peerflix-0.34.0"
       (sources."playerui-1.2.0" // {
@@ -20744,7 +21240,7 @@ in
       sources."thunky-0.1.0"
       sources."wrap-fn-0.1.5"
       sources."co-3.1.0"
-      sources."ms-0.7.3"
+      sources."ms-2.0.0"
       sources."append-0.1.1"
       sources."object-assign-1.0.0"
       (sources."meow-3.7.0" // {
@@ -20917,10 +21413,10 @@ in
       sources."isarray-0.0.1"
       sources."string_decoder-0.10.31"
       sources."cyclist-0.1.1"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -20954,7 +21450,7 @@ in
         dependencies = [
           sources."readable-stream-2.2.9"
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       (sources."simple-websocket-4.3.1" // {
@@ -20962,7 +21458,7 @@ in
           sources."readable-stream-2.2.9"
           sources."ws-2.3.1"
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."string2compact-1.2.2"
@@ -21014,7 +21510,7 @@ in
         dependencies = [
           sources."readable-stream-2.2.9"
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."exit-on-epipe-1.0.0"
@@ -21035,10 +21531,10 @@ in
   coffee-script = nodeEnv.buildNodePackage {
     name = "coffee-script";
     packageName = "coffee-script";
-    version = "1.12.5";
+    version = "1.12.6";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.5.tgz";
-      sha1 = "809f4585419112bbfe46a073ad7543af18c27346";
+      url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.6.tgz";
+      sha1 = "285a3f7115689065064d6bf9ef4572db66695cbf";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -21051,10 +21547,10 @@ in
   cordova = nodeEnv.buildNodePackage {
     name = "cordova";
     packageName = "cordova";
-    version = "7.0.0";
+    version = "7.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/cordova/-/cordova-7.0.0.tgz";
-      sha1 = "425b79539784c728149ee0b7668af0e63f4720b2";
+      url = "https://registry.npmjs.org/cordova/-/cordova-7.0.1.tgz";
+      sha1 = "69fd054300ce5105b092f67a1b286e80c4e88b9d";
     };
     dependencies = [
       sources."configstore-2.1.0"
@@ -21063,7 +21559,7 @@ in
           sources."q-1.5.0"
         ];
       })
-      (sources."cordova-lib-7.0.0" // {
+      (sources."cordova-lib-7.0.1" // {
         dependencies = [
           sources."glob-7.1.1"
           sources."nopt-4.0.1"
@@ -21106,7 +21602,7 @@ in
       sources."cordova-registry-mapper-1.1.15"
       sources."elementtree-0.1.6"
       sources."glob-5.0.15"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."plist-1.2.0"
       sources."semver-5.3.0"
       sources."shelljs-0.5.3"
@@ -21128,7 +21624,7 @@ in
       sources."util-deprecate-1.0.2"
       sources."lodash-3.10.1"
       sources."aliasify-2.1.0"
-      (sources."cordova-create-1.1.0" // {
+      (sources."cordova-create-1.1.1" // {
         dependencies = [
           sources."shelljs-0.3.0"
         ];
@@ -21137,7 +21633,7 @@ in
         dependencies = [
           sources."q-1.5.0"
           sources."shelljs-0.7.7"
-          sources."glob-7.1.1"
+          sources."glob-7.1.2"
         ];
       })
       sources."cordova-js-4.2.1"
@@ -21153,7 +21649,7 @@ in
       })
       (sources."init-package-json-1.10.1" // {
         dependencies = [
-          sources."glob-7.1.1"
+          sources."glob-7.1.2"
         ];
       })
       (sources."npm-2.15.12" // {
@@ -21163,7 +21659,7 @@ in
           sources."hosted-git-info-2.1.5"
           (sources."init-package-json-1.9.6" // {
             dependencies = [
-              sources."glob-7.1.1"
+              sources."glob-7.1.2"
               sources."validate-npm-package-name-3.0.0"
             ];
           })
@@ -21216,7 +21712,7 @@ in
       sources."path-parse-1.0.5"
       (sources."browserify-13.3.0" // {
         dependencies = [
-          sources."glob-7.1.1"
+          sources."glob-7.1.2"
         ];
       })
       sources."JSONStream-1.3.1"
@@ -21265,13 +21761,13 @@ in
       (sources."readable-stream-2.2.9" // {
         dependencies = [
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."shasum-1.0.2"
       sources."shell-quote-1.6.1"
       sources."stream-browserify-2.0.1"
-      sources."stream-http-2.7.0"
+      sources."stream-http-2.7.1"
       sources."string_decoder-0.10.31"
       (sources."subarg-1.0.0" // {
         dependencies = [
@@ -21298,7 +21794,7 @@ in
       })
       sources."vm-browserify-0.0.4"
       sources."xtend-4.0.1"
-      sources."jsonparse-1.3.0"
+      sources."jsonparse-1.3.1"
       sources."combine-source-map-0.7.2"
       sources."umd-3.0.1"
       sources."convert-source-map-1.1.3"
@@ -21314,10 +21810,10 @@ in
       sources."browserify-cipher-1.0.0"
       sources."browserify-sign-4.0.4"
       sources."create-ecdh-4.0.0"
-      sources."create-hash-1.1.2"
-      sources."create-hmac-1.1.4"
+      sources."create-hash-1.1.3"
+      sources."create-hmac-1.1.6"
       sources."diffie-hellman-5.0.2"
-      sources."pbkdf2-3.0.9"
+      sources."pbkdf2-3.0.12"
       sources."public-encrypt-4.0.0"
       sources."randombytes-2.0.3"
       sources."browserify-aes-1.0.6"
@@ -21336,8 +21832,10 @@ in
       sources."hmac-drbg-1.0.1"
       sources."minimalistic-crypto-utils-1.0.1"
       sources."asn1.js-4.9.1"
-      sources."ripemd160-1.0.1"
+      sources."ripemd160-2.0.1"
       sources."sha.js-2.4.8"
+      sources."hash-base-2.0.2"
+      sources."safe-buffer-5.0.1"
       sources."miller-rabin-4.0.0"
       sources."function-bind-1.1.0"
       sources."is-buffer-1.1.5"
@@ -21367,10 +21865,10 @@ in
       sources."indexof-0.0.1"
       sources."chalk-1.1.3"
       sources."compression-1.6.2"
-      (sources."express-4.15.2" // {
+      (sources."express-4.15.3" // {
         dependencies = [
-          sources."debug-2.6.1"
-          sources."ms-0.7.2"
+          sources."debug-2.6.7"
+          sources."ms-2.0.0"
         ];
       })
       sources."ansi-styles-2.2.1"
@@ -21398,10 +21896,10 @@ in
       sources."encodeurl-1.0.1"
       sources."escape-html-1.0.3"
       sources."etag-1.8.0"
-      (sources."finalhandler-1.0.2" // {
+      (sources."finalhandler-1.0.3" // {
         dependencies = [
-          sources."debug-2.6.4"
-          sources."ms-0.7.3"
+          sources."debug-2.6.7"
+          sources."ms-2.0.0"
         ];
       })
       sources."fresh-0.5.0"
@@ -21413,13 +21911,13 @@ in
       sources."proxy-addr-1.1.4"
       sources."qs-6.4.0"
       sources."range-parser-1.2.0"
-      (sources."send-0.15.1" // {
+      (sources."send-0.15.3" // {
         dependencies = [
-          sources."debug-2.6.1"
-          sources."ms-0.7.2"
+          sources."debug-2.6.7"
+          sources."ms-2.0.0"
         ];
       })
-      sources."serve-static-1.12.1"
+      sources."serve-static-1.12.3"
       sources."setprototypeof-1.0.3"
       sources."statuses-1.3.1"
       sources."type-is-1.6.15"
@@ -21437,7 +21935,7 @@ in
       sources."read-1.0.7"
       (sources."read-package-json-2.0.5" // {
         dependencies = [
-          sources."glob-7.1.1"
+          sources."glob-7.1.2"
         ];
       })
       sources."validate-npm-package-license-3.0.1"
@@ -21477,7 +21975,7 @@ in
       sources."lru-cache-4.0.2"
       (sources."node-gyp-3.6.1" // {
         dependencies = [
-          sources."glob-7.1.1"
+          sources."glob-7.1.2"
         ];
       })
       sources."normalize-git-url-3.0.2"
@@ -21500,7 +21998,7 @@ in
       sources."retry-0.10.1"
       (sources."rimraf-2.5.4" // {
         dependencies = [
-          sources."glob-7.1.1"
+          sources."glob-7.1.2"
         ];
       })
       sources."sha-2.0.1"
@@ -21553,7 +22051,7 @@ in
       sources."tough-cookie-2.3.2"
       sources."tunnel-agent-0.4.3"
       sources."delayed-stream-1.0.0"
-      (sources."async-2.4.0" // {
+      (sources."async-2.4.1" // {
         dependencies = [
           sources."lodash-4.17.4"
         ];
@@ -21673,7 +22171,7 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."strip-json-comments-2.0.1"
       sources."is-finite-1.0.2"
     ];
@@ -21822,7 +22320,7 @@ in
       sources."cycle-1.0.3"
       sources."eyes-0.1.8"
       sources."pkginfo-0.3.1"
-      sources."stack-trace-0.0.9"
+      sources."stack-trace-0.0.10"
       sources."formidable-1.0.14"
       sources."component-emitter-1.1.2"
       sources."cookiejar-2.0.1"
@@ -21899,7 +22397,7 @@ in
           sources."through2-2.0.3"
           sources."readable-stream-2.2.9"
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."pump-1.0.2"
@@ -21909,12 +22407,12 @@ in
       sources."sorted-union-stream-1.0.2"
       sources."split2-0.2.1"
       sources."stream-collector-1.0.1"
-      (sources."tar-stream-1.5.2" // {
+      (sources."tar-stream-1.5.4" // {
         dependencies = [
           sources."bl-1.2.1"
           sources."readable-stream-2.2.9"
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       (sources."through2-0.6.5" // {
@@ -21941,7 +22439,7 @@ in
           sources."readable-stream-2.2.9"
           sources."once-1.3.3"
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."lru-cache-2.7.3"
@@ -21949,11 +22447,12 @@ in
       sources."buffer-shims-1.0.0"
       sources."process-nextick-args-1.0.7"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."level-packager-0.18.0"
       sources."bytewise-1.1.0"
       sources."ltgt-2.1.3"
       sources."pull-level-2.0.3"
-      sources."pull-stream-3.5.0"
+      sources."pull-stream-3.6.0"
       sources."typewiselite-1.0.0"
       sources."bytewise-core-1.2.3"
       sources."typewise-1.0.3"
@@ -21975,7 +22474,7 @@ in
       sources."level-post-1.0.5"
       sources."pull-cat-1.1.11"
       sources."pull-live-1.0.1"
-      sources."pull-pushable-2.0.1"
+      sources."pull-pushable-2.1.1"
       sources."pull-window-2.1.4"
       (sources."stream-to-pull-stream-1.7.2" // {
         dependencies = [
@@ -22001,22 +22500,34 @@ in
   elasticdump = nodeEnv.buildNodePackage {
     name = "elasticdump";
     packageName = "elasticdump";
-    version = "3.2.0";
+    version = "3.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-3.2.0.tgz";
-      sha1 = "e2b430a7ac456512e1a34bdae7ac125c2566a998";
+      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-3.3.0.tgz";
+      sha1 = "19aec66c4619e49a66dfa1106719819d9daecbc8";
     };
     dependencies = [
       sources."JSONStream-1.3.1"
-      sources."async-2.4.0"
+      sources."async-2.4.1"
       sources."aws4-1.6.0"
-      sources."awscred-1.2.0"
+      sources."aws-sdk-2.55.0"
       sources."ini-1.3.4"
       sources."optimist-0.6.1"
       sources."request-2.81.0"
-      sources."jsonparse-1.3.0"
+      sources."jsonparse-1.3.1"
       sources."through-2.3.8"
       sources."lodash-4.17.4"
+      sources."buffer-5.0.6"
+      sources."crypto-browserify-1.0.9"
+      sources."jmespath-0.15.0"
+      sources."querystring-0.2.0"
+      sources."sax-1.2.1"
+      sources."url-0.10.3"
+      sources."uuid-3.0.1"
+      sources."xml2js-0.4.17"
+      sources."xmlbuilder-4.2.1"
+      sources."base64-js-1.2.0"
+      sources."ieee754-1.1.8"
+      sources."punycode-1.3.2"
       sources."wordwrap-0.0.3"
       sources."minimist-0.0.10"
       sources."aws-sign2-0.6.0"
@@ -22037,9 +22548,12 @@ in
       sources."qs-6.4.0"
       sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
-      sources."tough-cookie-2.3.2"
+      (sources."tough-cookie-2.3.2" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
-      sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
       sources."ajv-4.11.8"
@@ -22082,7 +22596,6 @@ in
       sources."ecc-jsbn-0.1.1"
       sources."bcrypt-pbkdf-1.0.1"
       sources."mime-db-1.27.0"
-      sources."punycode-1.4.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -22095,14 +22608,15 @@ in
   emoj = nodeEnv.buildNodePackage {
     name = "emoj";
     packageName = "emoj";
-    version = "1.0.0";
+    version = "1.1.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/emoj/-/emoj-1.0.0.tgz";
-      sha1 = "3cccbeec420e2b45f73b923e880c220392c055bd";
+      url = "https://registry.npmjs.org/emoj/-/emoj-1.1.0.tgz";
+      sha1 = "5a43ae17f6bf672cd8e40891357f84b086c52509";
     };
     dependencies = [
       sources."chalk-1.1.3"
       sources."clipboardy-0.1.2"
+      sources."conf-1.1.1"
       (sources."got-6.7.1" // {
         dependencies = [
           sources."get-stream-3.0.0"
@@ -22113,6 +22627,7 @@ in
       sources."log-update-1.0.2"
       sources."mem-1.1.0"
       sources."meow-3.7.0"
+      sources."skin-tone-1.0.0"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."strip-ansi-3.0.1"
@@ -22135,6 +22650,17 @@ in
       sources."pinkie-promise-2.0.1"
       sources."pinkie-2.0.4"
       sources."path-key-2.0.1"
+      sources."dot-prop-4.1.1"
+      sources."env-paths-1.0.0"
+      sources."make-dir-1.0.0"
+      sources."pkg-up-2.0.0"
+      sources."is-obj-1.0.1"
+      sources."pify-2.3.0"
+      sources."find-up-2.1.0"
+      sources."locate-path-2.0.0"
+      sources."p-locate-2.0.0"
+      sources."path-exists-3.0.0"
+      sources."p-limit-1.1.0"
       sources."create-error-class-3.0.2"
       sources."duplexer3-0.1.4"
       sources."is-redirect-1.0.0"
@@ -22158,7 +22684,12 @@ in
       sources."map-obj-1.0.1"
       sources."minimist-1.2.0"
       sources."normalize-package-data-2.3.8"
-      sources."read-pkg-up-1.0.1"
+      (sources."read-pkg-up-1.0.1" // {
+        dependencies = [
+          sources."find-up-1.1.2"
+          sources."path-exists-2.1.0"
+        ];
+      })
       sources."redent-1.0.0"
       sources."trim-newlines-1.0.0"
       sources."camelcase-2.1.1"
@@ -22172,14 +22703,11 @@ in
       sources."spdx-correct-1.0.2"
       sources."spdx-expression-parse-1.0.4"
       sources."spdx-license-ids-1.2.2"
-      sources."find-up-1.1.2"
       sources."read-pkg-1.1.0"
-      sources."path-exists-2.1.0"
       sources."load-json-file-1.1.0"
       sources."path-type-1.1.0"
       sources."graceful-fs-4.1.11"
       sources."parse-json-2.2.0"
-      sources."pify-2.3.0"
       sources."strip-bom-2.0.0"
       sources."error-ex-1.3.1"
       sources."is-arrayish-0.2.1"
@@ -22190,6 +22718,7 @@ in
       sources."is-finite-1.0.2"
       sources."number-is-nan-1.0.1"
       sources."get-stdin-4.0.1"
+      sources."unicode-emoji-modifier-base-1.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -22211,22 +22740,22 @@ in
       sources."babel-code-frame-6.22.0"
       sources."chalk-1.1.3"
       sources."concat-stream-1.6.0"
-      sources."debug-2.6.6"
+      sources."debug-2.6.8"
       sources."doctrine-2.0.0"
       sources."escope-3.6.0"
-      sources."espree-3.4.2"
+      sources."espree-3.4.3"
       sources."esquery-1.0.0"
       sources."estraverse-4.2.0"
       sources."esutils-2.0.2"
       sources."file-entry-cache-2.0.0"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."globals-9.17.0"
-      sources."ignore-3.3.0"
+      sources."ignore-3.3.3"
       sources."imurmurhash-0.1.4"
       sources."inquirer-0.12.0"
       sources."is-my-json-valid-2.16.0"
       sources."is-resolvable-1.0.0"
-      sources."js-yaml-3.8.3"
+      sources."js-yaml-3.8.4"
       sources."json-stable-stringify-1.0.1"
       sources."levn-0.3.0"
       sources."lodash-4.17.4"
@@ -22262,9 +22791,10 @@ in
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
-      sources."ms-0.7.3"
+      sources."safe-buffer-5.0.1"
+      sources."ms-2.0.0"
       sources."es6-map-0.1.5"
       sources."es6-weak-map-2.0.2"
       (sources."esrecurse-4.1.0" // {
@@ -22273,7 +22803,7 @@ in
         ];
       })
       sources."d-1.0.0"
-      sources."es5-ext-0.10.15"
+      sources."es5-ext-0.10.21"
       sources."es6-iterator-2.0.1"
       sources."es6-set-0.1.5"
       sources."es6-symbol-3.1.1"
@@ -22303,7 +22833,7 @@ in
       sources."pinkie-2.0.4"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -22462,14 +22992,14 @@ in
       sources."async-0.2.10"
       sources."cycle-1.0.3"
       sources."pkginfo-0.3.1"
-      sources."stack-trace-0.0.9"
+      sources."stack-trace-0.0.10"
       sources."wordwrap-0.0.3"
       sources."minimist-0.0.10"
       sources."read-1.0.7"
       sources."revalidator-0.1.8"
       sources."mute-stream-0.0.7"
-      sources."chokidar-1.6.1"
-      sources."minimatch-3.0.3"
+      sources."chokidar-1.7.0"
+      sources."minimatch-3.0.4"
       sources."ps-tree-0.0.3"
       sources."anymatch-1.3.0"
       sources."async-each-1.0.1"
@@ -22488,7 +23018,7 @@ in
       sources."extglob-0.3.2"
       sources."filename-regex-2.0.1"
       sources."is-extglob-1.0.0"
-      sources."kind-of-3.2.0"
+      sources."kind-of-3.2.2"
       sources."normalize-path-2.1.1"
       sources."object.omit-2.0.1"
       sources."parse-glob-3.0.4"
@@ -22520,8 +23050,9 @@ in
       sources."buffer-shims-1.0.0"
       sources."core-util-is-1.0.2"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."nan-2.6.2"
       sources."node-pre-gyp-0.6.34"
       (sources."mkdirp-0.5.1" // {
@@ -22530,7 +23061,7 @@ in
         ];
       })
       sources."nopt-4.0.1"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       (sources."rc-1.2.1" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -22559,12 +23090,12 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."ansi-regex-2.1.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."aws-sign2-0.6.0"
@@ -22584,7 +23115,6 @@ in
       sources."oauth-sign-0.8.2"
       sources."performance-now-0.2.0"
       sources."qs-6.4.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."tunnel-agent-0.6.0"
@@ -22632,17 +23162,17 @@ in
       sources."bcrypt-pbkdf-1.0.1"
       sources."mime-db-1.27.0"
       sources."punycode-1.4.1"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."once-1.4.0"
       sources."wrappy-1.0.2"
       sources."block-stream-0.0.9"
       sources."fstream-1.0.11"
-      sources."debug-2.6.6"
+      sources."debug-2.6.8"
       sources."fstream-ignore-1.0.5"
       sources."uid-number-0.0.6"
-      sources."ms-0.7.3"
+      sources."ms-2.0.0"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
@@ -22678,13 +23208,15 @@ in
       sha1 = "466a7253a54f526ca2f57ca78780895b95efaee4";
     };
     dependencies = [
-      sources."async-2.4.0"
+      sources."async-2.4.1"
       sources."lodash.groupby-4.6.0"
       sources."minilog-2.0.8"
-      sources."simple-git-1.70.0"
+      sources."simple-git-1.73.0"
       sources."tabtab-git+https://github.com/mixu/node-tabtab.git"
       sources."lodash-4.17.4"
       sources."microee-0.0.2"
+      sources."debug-2.6.8"
+      sources."ms-2.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -22710,7 +23242,7 @@ in
       sources."glob-5.0.15"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -22737,7 +23269,7 @@ in
       sha256 = "a51a5beef55c14c68630275d51cf66c44a4462d1b20c0f08aef6d88a62ca077c";
     };
     dependencies = [
-      sources."coffee-script-1.12.5"
+      sources."coffee-script-1.12.6"
       sources."jade-1.11.0"
       (sources."q-2.0.3" // {
         dependencies = [
@@ -22747,7 +23279,7 @@ in
       sources."xml2js-0.4.17"
       sources."msgpack-1.0.2"
       sources."character-parser-1.2.1"
-      (sources."clean-css-3.4.25" // {
+      (sources."clean-css-3.4.26" // {
         dependencies = [
           sources."commander-2.8.1"
         ];
@@ -22764,7 +23296,7 @@ in
           sources."source-map-0.1.43"
         ];
       })
-      (sources."uglify-js-2.8.22" // {
+      (sources."uglify-js-2.8.27" // {
         dependencies = [
           sources."source-map-0.5.6"
         ];
@@ -22802,7 +23334,7 @@ in
       sources."right-align-0.1.3"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.2.0"
+      sources."kind-of-3.2.2"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
@@ -22874,11 +23406,11 @@ in
         dependencies = [
           sources."readable-stream-2.2.9"
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."vinyl-0.5.3"
-      sources."time-stamp-1.0.1"
+      sources."time-stamp-1.1.0"
       sources."glogg-1.0.0"
       sources."sparkles-1.0.0"
       sources."lodash._basecopy-3.0.1"
@@ -22903,6 +23435,7 @@ in
       sources."buffer-shims-1.0.0"
       sources."process-nextick-args-1.0.7"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."clone-1.0.2"
       sources."clone-stats-0.0.1"
       sources."extend-3.0.1"
@@ -22926,7 +23459,7 @@ in
       sources."expand-brackets-0.1.5"
       sources."extglob-0.3.2"
       sources."filename-regex-2.0.1"
-      sources."kind-of-3.2.0"
+      sources."kind-of-3.2.2"
       sources."normalize-path-2.1.1"
       sources."object.omit-2.0.1"
       sources."parse-glob-3.0.4"
@@ -23080,7 +23613,7 @@ in
       sources."parserlib-0.2.5"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -23159,12 +23692,12 @@ in
       sources."escodegen-1.8.1"
       sources."esprima-2.7.3"
       sources."glob-5.0.15"
-      (sources."handlebars-4.0.8" // {
+      (sources."handlebars-4.0.10" // {
         dependencies = [
           sources."source-map-0.4.4"
         ];
       })
-      (sources."js-yaml-3.8.3" // {
+      (sources."js-yaml-3.8.4" // {
         dependencies = [
           sources."esprima-3.1.3"
         ];
@@ -23192,7 +23725,7 @@ in
       sources."amdefine-1.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
       sources."brace-expansion-1.1.7"
@@ -23203,7 +23736,7 @@ in
           sources."wordwrap-0.0.3"
         ];
       })
-      (sources."uglify-js-2.8.22" // {
+      (sources."uglify-js-2.8.27" // {
         dependencies = [
           sources."source-map-0.5.6"
         ];
@@ -23223,7 +23756,7 @@ in
       sources."right-align-0.1.3"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.2.0"
+      sources."kind-of-3.2.2"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
@@ -23272,11 +23805,11 @@ in
       sources."console-browserify-1.1.0"
       sources."exit-0.1.2"
       sources."htmlparser2-3.8.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."shelljs-0.3.0"
       sources."strip-json-comments-1.0.4"
       sources."lodash-3.7.0"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
@@ -23343,10 +23876,10 @@ in
   js-yaml = nodeEnv.buildNodePackage {
     name = "js-yaml";
     packageName = "js-yaml";
-    version = "3.8.3";
+    version = "3.8.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz";
-      sha1 = "33a05ec481c850c8875929166fe1beb61c728766";
+      url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz";
+      sha1 = "520b4564f86573ba96662af85a8cafa7b4b5a6f6";
     };
     dependencies = [
       sources."argparse-1.0.9"
@@ -23364,26 +23897,22 @@ in
   karma = nodeEnv.buildNodePackage {
     name = "karma";
     packageName = "karma";
-    version = "1.6.0";
+    version = "1.7.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/karma/-/karma-1.6.0.tgz";
-      sha1 = "0e871d4527d5eac56c41d181f03c5c0a7e6dbf3e";
+      url = "https://registry.npmjs.org/karma/-/karma-1.7.0.tgz";
+      sha1 = "6f7a1a406446fa2e187ec95398698f4cee476269";
     };
     dependencies = [
       sources."bluebird-3.5.0"
-      sources."body-parser-1.17.1"
-      sources."chokidar-1.6.1"
+      sources."body-parser-1.17.2"
+      sources."chokidar-1.7.0"
       sources."colors-1.1.2"
       (sources."combine-lists-1.0.1" // {
         dependencies = [
           sources."lodash-4.17.4"
         ];
       })
-      (sources."connect-3.6.1" // {
-        dependencies = [
-          sources."debug-2.6.3"
-        ];
-      })
+      sources."connect-3.6.2"
       sources."core-js-2.4.1"
       sources."di-0.0.1"
       sources."dom-serialize-2.2.1"
@@ -23395,7 +23924,7 @@ in
           sources."repeat-string-0.2.2"
         ];
       })
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."graceful-fs-4.1.11"
       sources."http-proxy-1.16.2"
       sources."isbinaryfile-3.0.2"
@@ -23408,8 +23937,8 @@ in
           sources."string_decoder-0.10.31"
         ];
       })
-      sources."mime-1.3.4"
-      sources."minimatch-3.0.3"
+      sources."mime-1.3.6"
+      sources."minimatch-3.0.4"
       sources."optimist-0.6.1"
       sources."qjobs-1.1.5"
       sources."range-parser-1.2.0"
@@ -23419,6 +23948,7 @@ in
         dependencies = [
           sources."debug-2.3.3"
           sources."object-assign-4.1.0"
+          sources."ms-0.7.2"
         ];
       })
       sources."source-map-0.5.6"
@@ -23426,7 +23956,7 @@ in
       sources."useragent-2.1.13"
       sources."bytes-2.4.0"
       sources."content-type-1.0.2"
-      sources."debug-2.6.1"
+      sources."debug-2.6.7"
       sources."depd-1.1.0"
       sources."http-errors-1.6.1"
       sources."iconv-lite-0.4.15"
@@ -23434,7 +23964,7 @@ in
       sources."qs-6.4.0"
       sources."raw-body-2.2.0"
       sources."type-is-1.6.15"
-      sources."ms-0.7.2"
+      sources."ms-2.0.0"
       sources."inherits-2.0.3"
       sources."setprototypeof-1.0.3"
       sources."statuses-1.3.1"
@@ -23460,7 +23990,7 @@ in
       sources."extglob-0.3.2"
       sources."filename-regex-2.0.1"
       sources."is-extglob-1.0.0"
-      sources."kind-of-3.2.0"
+      sources."kind-of-3.2.2"
       sources."normalize-path-2.1.1"
       sources."object.omit-2.0.1"
       sources."parse-glob-3.0.4"
@@ -23491,13 +24021,13 @@ in
       sources."buffer-shims-1.0.0"
       sources."core-util-is-1.0.2"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
       sources."nan-2.6.2"
       sources."node-pre-gyp-0.6.34"
       sources."mkdirp-0.5.1"
       sources."nopt-4.0.1"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       (sources."rc-1.2.1" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -23523,12 +24053,12 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."ansi-regex-2.1.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."aws-sign2-0.6.0"
@@ -23598,11 +24128,7 @@ in
       sources."once-1.4.0"
       sources."uid-number-0.0.6"
       sources."wrappy-1.0.2"
-      (sources."finalhandler-1.0.1" // {
-        dependencies = [
-          sources."debug-2.6.3"
-        ];
-      })
+      sources."finalhandler-1.0.3"
       sources."parseurl-1.3.1"
       sources."utils-merge-1.0.0"
       sources."encodeurl-1.0.1"
@@ -23622,6 +24148,7 @@ in
       (sources."engine.io-1.8.3" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ms-0.7.2"
         ];
       })
       (sources."has-binary-0.1.7" // {
@@ -23632,11 +24159,13 @@ in
       (sources."socket.io-adapter-0.5.0" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ms-0.7.2"
         ];
       })
       (sources."socket.io-client-1.7.3" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ms-0.7.2"
         ];
       })
       (sources."socket.io-parser-2.3.1" // {
@@ -23666,6 +24195,7 @@ in
       (sources."engine.io-client-1.8.3" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ms-0.7.2"
         ];
       })
       sources."indexof-0.0.1"
@@ -23757,11 +24287,11 @@ in
       })
       sources."finalhandler-0.4.0"
       sources."http-errors-1.3.1"
-      (sources."method-override-2.3.8" // {
+      (sources."method-override-2.3.9" // {
         dependencies = [
-          sources."debug-2.6.3"
+          sources."debug-2.6.8"
           sources."vary-1.1.1"
-          sources."ms-0.7.2"
+          sources."ms-2.0.0"
         ];
       })
       sources."morgan-1.6.1"
@@ -23868,8 +24398,9 @@ in
       sources."isarray-1.0.0"
       sources."inherits-2.0.3"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."clone-1.0.2"
       sources."clone-stats-0.0.1"
       sources."replace-ext-0.0.1"
@@ -23911,7 +24442,7 @@ in
       sources."to-absolute-glob-0.1.1"
       sources."unique-stream-2.2.1"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -23929,7 +24460,7 @@ in
         ];
       })
       sources."filename-regex-2.0.1"
-      sources."kind-of-3.2.0"
+      sources."kind-of-3.2.2"
       sources."normalize-path-2.1.1"
       sources."object.omit-2.0.1"
       (sources."parse-glob-3.0.4" // {
@@ -24007,7 +24538,7 @@ in
       sources."eyes-0.1.8"
       sources."pkginfo-0.2.3"
       sources."request-2.9.203"
-      sources."stack-trace-0.0.9"
+      sources."stack-trace-0.0.10"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -24019,10 +24550,10 @@ in
   mocha = nodeEnv.buildNodePackage {
     name = "mocha";
     packageName = "mocha";
-    version = "3.3.0";
+    version = "3.4.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz";
-      sha1 = "d29b7428d3f52c82e2e65df1ecb7064e1aabbfb5";
+      url = "https://registry.npmjs.org/mocha/-/mocha-3.4.1.tgz";
+      sha1 = "a3802b4aa381934cacb38de70cf771621da8f9af";
     };
     dependencies = [
       sources."browser-stdout-1.3.0"
@@ -24041,7 +24572,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -24138,8 +24669,9 @@ in
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."minimist-0.0.8"
       sources."hosted-git-info-2.4.2"
       sources."is-builtin-module-1.0.0"
@@ -24166,7 +24698,6 @@ in
       sources."oauth-sign-0.8.2"
       sources."performance-now-0.2.0"
       sources."qs-6.4.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."tunnel-agent-0.6.0"
@@ -24214,10 +24745,10 @@ in
       sources."bcrypt-pbkdf-1.0.1"
       sources."mime-db-1.27.0"
       sources."punycode-1.4.1"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -24234,7 +24765,7 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
@@ -24280,12 +24811,12 @@ in
     };
     dependencies = [
       sources."fstream-1.0.11"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."graceful-fs-4.1.11"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."mkdirp-0.5.1"
       sources."nopt-3.0.6"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       sources."osenv-0.1.4"
       sources."request-2.81.0"
       sources."rimraf-2.6.1"
@@ -24313,15 +24844,16 @@ in
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."aproba-1.1.1"
       sources."has-unicode-2.0.1"
       sources."object-assign-4.1.1"
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
@@ -24345,7 +24877,6 @@ in
       sources."oauth-sign-0.8.2"
       sources."performance-now-0.2.0"
       sources."qs-6.4.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."tunnel-agent-0.6.0"
@@ -24415,22 +24946,17 @@ in
     dependencies = [
       sources."async-0.9.2"
       sources."biased-opener-0.2.8"
-      sources."debug-2.6.6"
-      (sources."express-4.15.2" // {
+      sources."debug-2.6.8"
+      (sources."express-4.15.3" // {
         dependencies = [
-          sources."debug-2.6.1"
-          sources."ms-0.7.2"
+          sources."debug-2.6.7"
         ];
       })
       sources."glob-5.0.15"
       sources."path-is-absolute-1.0.1"
       sources."rc-1.2.1"
       sources."semver-4.3.6"
-      (sources."serve-favicon-2.4.2" // {
-        dependencies = [
-          sources."ms-1.0.0"
-        ];
-      })
+      sources."serve-favicon-2.4.3"
       sources."strong-data-uri-1.0.4"
       sources."v8-debug-1.0.1"
       sources."v8-profiler-5.7.0"
@@ -24513,7 +25039,7 @@ in
       sources."is-finite-1.0.2"
       sources."number-is-nan-1.0.1"
       sources."get-stdin-4.0.1"
-      sources."ms-0.7.3"
+      sources."ms-2.0.0"
       sources."accepts-1.3.3"
       sources."array-flatten-1.1.1"
       sources."content-disposition-0.5.2"
@@ -24524,9 +25050,9 @@ in
       sources."encodeurl-1.0.1"
       sources."escape-html-1.0.3"
       sources."etag-1.8.0"
-      (sources."finalhandler-1.0.2" // {
+      (sources."finalhandler-1.0.3" // {
         dependencies = [
-          sources."debug-2.6.4"
+          sources."debug-2.6.7"
         ];
       })
       sources."fresh-0.5.0"
@@ -24538,13 +25064,12 @@ in
       sources."proxy-addr-1.1.4"
       sources."qs-6.4.0"
       sources."range-parser-1.2.0"
-      (sources."send-0.15.1" // {
+      (sources."send-0.15.3" // {
         dependencies = [
-          sources."debug-2.6.1"
-          sources."ms-0.7.2"
+          sources."debug-2.6.7"
         ];
       })
-      sources."serve-static-1.12.1"
+      sources."serve-static-1.12.3"
       sources."setprototypeof-1.0.3"
       sources."statuses-1.3.1"
       sources."type-is-1.6.15"
@@ -24563,32 +25088,33 @@ in
       sources."inherits-2.0.3"
       sources."media-typer-0.3.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."wrappy-1.0.2"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
+      sources."safe-buffer-5.0.1"
       sources."truncate-1.0.5"
       sources."nan-2.6.2"
       (sources."node-pre-gyp-0.6.34" // {
         dependencies = [
           sources."rimraf-2.6.1"
           sources."semver-5.3.0"
-          sources."glob-7.1.1"
+          sources."glob-7.1.2"
         ];
       })
       sources."nopt-4.0.1"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       sources."request-2.81.0"
       sources."tar-2.2.1"
       (sources."tar-pack-3.4.0" // {
         dependencies = [
           sources."rimraf-2.6.1"
-          sources."glob-7.1.1"
+          sources."glob-7.1.2"
         ];
       })
       sources."abbrev-1.1.0"
@@ -24602,12 +25128,12 @@ in
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."aproba-1.1.1"
       sources."has-unicode-2.0.1"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."ansi-regex-2.1.1"
@@ -24626,7 +25152,6 @@ in
       sources."json-stringify-safe-5.0.1"
       sources."oauth-sign-0.8.2"
       sources."performance-now-0.2.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."tunnel-agent-0.6.0"
@@ -24707,7 +25232,7 @@ in
     dependencies = [
       sources."mkdirp-0.5.1"
       sources."nopt-4.0.1"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       (sources."rc-1.2.1" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -24734,20 +25259,21 @@ in
       sources."isarray-1.0.0"
       sources."inherits-2.0.3"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."aproba-1.1.1"
       sources."has-unicode-2.0.1"
       sources."object-assign-4.1.1"
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."ansi-regex-2.1.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."aws-sign2-0.6.0"
@@ -24767,7 +25293,6 @@ in
       sources."oauth-sign-0.8.2"
       sources."performance-now-0.2.0"
       sources."qs-6.4.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."tunnel-agent-0.6.0"
@@ -24815,10 +25340,10 @@ in
       sources."bcrypt-pbkdf-1.0.1"
       sources."mime-db-1.27.0"
       sources."punycode-1.4.1"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -24828,10 +25353,10 @@ in
       sources."block-stream-0.0.9"
       sources."fstream-1.0.11"
       sources."graceful-fs-4.1.11"
-      sources."debug-2.6.6"
+      sources."debug-2.6.8"
       sources."fstream-ignore-1.0.5"
       sources."uid-number-0.0.6"
-      sources."ms-0.7.3"
+      sources."ms-2.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -24850,12 +25375,12 @@ in
       sha1 = "226c562bd2a7b13d3d7518b49ad4828a3623d06c";
     };
     dependencies = [
-      sources."chokidar-1.6.1"
-      sources."debug-2.6.6"
+      sources."chokidar-1.7.0"
+      sources."debug-2.6.8"
       sources."es6-promise-3.3.1"
       sources."ignore-by-default-1.0.1"
       sources."lodash.defaults-3.1.2"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."ps-tree-1.1.0"
       (sources."touch-1.0.0" // {
         dependencies = [
@@ -24882,7 +25407,7 @@ in
       sources."extglob-0.3.2"
       sources."filename-regex-2.0.1"
       sources."is-extglob-1.0.0"
-      sources."kind-of-3.2.0"
+      sources."kind-of-3.2.2"
       sources."normalize-path-2.1.1"
       sources."object.omit-2.0.1"
       sources."parse-glob-3.0.4"
@@ -24914,13 +25439,14 @@ in
       sources."buffer-shims-1.0.0"
       sources."core-util-is-1.0.2"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."nan-2.6.2"
       sources."node-pre-gyp-0.6.34"
       sources."mkdirp-0.5.1"
       sources."nopt-4.0.1"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       (sources."rc-1.2.1" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -24947,12 +25473,12 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."ansi-regex-2.1.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."aws-sign2-0.6.0"
@@ -24972,7 +25498,6 @@ in
       sources."oauth-sign-0.8.2"
       sources."performance-now-0.2.0"
       sources."qs-6.4.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."tunnel-agent-0.6.0"
@@ -25020,7 +25545,7 @@ in
       sources."bcrypt-pbkdf-1.0.1"
       sources."mime-db-1.27.0"
       sources."punycode-1.4.1"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."once-1.4.0"
@@ -25029,7 +25554,7 @@ in
       sources."fstream-1.0.11"
       sources."fstream-ignore-1.0.5"
       sources."uid-number-0.0.6"
-      sources."ms-0.7.3"
+      sources."ms-2.0.0"
       sources."lodash.assign-3.2.0"
       sources."lodash.restparam-3.6.1"
       sources."lodash._baseassign-3.2.0"
@@ -25129,8 +25654,8 @@ in
       sources."express-4.14.0"
       (sources."follow-redirects-1.2.1" // {
         dependencies = [
-          sources."debug-2.6.6"
-          sources."ms-0.7.3"
+          sources."debug-2.6.8"
+          sources."ms-2.0.0"
         ];
       })
       sources."fs-extra-1.0.0"
@@ -25220,14 +25745,15 @@ in
       sources."boolbase-1.0.0"
       sources."nth-check-1.0.1"
       sources."domelementtype-1.3.0"
-      sources."domhandler-2.3.0"
+      sources."domhandler-2.4.1"
       sources."readable-stream-2.2.9"
       sources."buffer-shims-1.0.0"
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."cookie-0.3.1"
       sources."cookie-signature-1.0.6"
       sources."vary-1.1.1"
@@ -25291,17 +25817,17 @@ in
       sources."glob-stream-6.1.0"
       sources."through2-2.0.3"
       sources."extend-3.0.1"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."glob-parent-3.1.0"
       sources."is-negated-glob-1.0.0"
-      sources."ordered-read-streams-1.0.0"
+      sources."ordered-read-streams-1.0.1"
       sources."pumpify-1.3.5"
       sources."remove-trailing-separator-1.0.1"
       sources."to-absolute-glob-2.0.1"
       sources."unique-stream-2.2.1"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -25309,7 +25835,6 @@ in
       sources."is-glob-3.1.0"
       sources."path-dirname-1.0.2"
       sources."is-extglob-2.1.1"
-      sources."is-stream-1.1.0"
       (sources."duplexify-3.5.0" // {
         dependencies = [
           sources."end-of-stream-1.0.0"
@@ -25328,7 +25853,6 @@ in
       sources."through2-filter-2.0.0"
       sources."jsonify-0.0.0"
       sources."bl-1.2.1"
-      sources."safe-buffer-5.0.1"
       sources."abbrev-1.1.0"
       sources."uid2-0.0.3"
       sources."passport-strategy-1.0.0"
@@ -25345,7 +25869,7 @@ in
       sources."wordwrap-0.0.2"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.2.0"
+      sources."kind-of-3.2.2"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
@@ -25378,7 +25902,7 @@ in
       sources."forever-agent-0.6.1"
       (sources."form-data-1.0.1" // {
         dependencies = [
-          sources."async-2.4.0"
+          sources."async-2.4.1"
         ];
       })
       sources."har-validator-2.0.6"
@@ -25510,7 +26034,7 @@ in
           sources."minimist-0.0.8"
         ];
       })
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       sources."rc-1.1.7"
       sources."rimraf-2.5.4"
       sources."tar-2.2.1"
@@ -25531,11 +26055,11 @@ in
       sources."object-assign-4.1.1"
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."block-stream-0.0.9"
@@ -25605,9 +26129,9 @@ in
       sources."methods-0.0.1"
       sources."send-0.1.0"
       sources."cookie-signature-1.0.1"
-      (sources."debug-2.6.6" // {
+      (sources."debug-2.6.8" // {
         dependencies = [
-          sources."ms-0.7.3"
+          sources."ms-2.0.0"
         ];
       })
       sources."qs-0.5.1"
@@ -25615,7 +26139,7 @@ in
       sources."bytes-0.2.0"
       sources."pause-0.0.1"
       sources."mime-1.2.6"
-      sources."coffee-script-1.12.5"
+      sources."coffee-script-1.12.6"
       sources."vows-0.8.1"
       sources."eyes-0.1.8"
       sources."diff-1.0.8"
@@ -25680,10 +26204,10 @@ in
   npm = nodeEnv.buildNodePackage {
     name = "npm";
     packageName = "npm";
-    version = "4.5.0";
+    version = "4.6.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm/-/npm-4.5.0.tgz";
-      sha1 = "dc6a31f28807e6db980ed5083315667dcc8d0475";
+      url = "https://registry.npmjs.org/npm/-/npm-4.6.1.tgz";
+      sha1 = "f8eb1ad00dc58a5514363b41ca5342817f0bd646";
     };
     dependencies = [
       sources."JSONStream-1.3.1"
@@ -25705,8 +26229,8 @@ in
       sources."fs-vacuum-1.2.10"
       sources."fs-write-stream-atomic-1.0.10"
       sources."fstream-1.0.11"
-      sources."fstream-npm-1.2.0"
-      sources."glob-7.1.1"
+      sources."fstream-npm-1.2.1"
+      sources."glob-7.1.2"
       sources."graceful-fs-4.1.11"
       sources."has-unicode-2.0.1"
       sources."hosted-git-info-2.4.2"
@@ -25714,7 +26238,7 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
       sources."ini-1.3.4"
-      sources."init-package-json-1.9.6"
+      sources."init-package-json-1.10.1"
       sources."lazy-property-1.0.0"
       sources."lockfile-1.0.3"
       sources."lodash._baseuniq-4.6.0"
@@ -25788,14 +26312,14 @@ in
       sources."lodash.restparam-3.6.1"
       sources."readdir-scoped-modules-1.0.2"
       sources."validate-npm-package-license-3.0.1"
-      sources."jsonparse-1.3.0"
+      sources."jsonparse-1.3.1"
       sources."through-2.3.8"
       sources."wcwidth-1.0.1"
       sources."defaults-1.0.3"
       sources."clone-1.0.2"
       sources."proto-list-1.2.4"
       sources."fstream-ignore-1.0.5"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
@@ -25836,7 +26360,7 @@ in
       sources."object-assign-4.1.1"
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
@@ -25850,8 +26374,9 @@ in
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
@@ -25869,7 +26394,6 @@ in
       sources."oauth-sign-0.8.2"
       sources."performance-now-0.2.0"
       sources."qs-6.4.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."tunnel-agent-0.6.0"
@@ -25919,20 +26443,29 @@ in
       sources."stream-iterate-1.2.0"
       sources."block-stream-0.0.9"
       sources."unique-slug-2.0.0"
-      (sources."boxen-1.0.0" // {
+      (sources."boxen-1.1.0" // {
         dependencies = [
           sources."string-width-2.0.0"
           sources."is-fullwidth-code-point-2.0.0"
         ];
       })
       sources."chalk-1.1.3"
-      sources."configstore-3.0.0"
+      (sources."configstore-3.1.0" // {
+        dependencies = [
+          sources."write-file-atomic-2.1.0"
+        ];
+      })
       sources."is-npm-1.0.0"
       sources."latest-version-3.1.0"
       sources."lazy-req-2.0.0"
       sources."semver-diff-2.1.0"
       sources."xdg-basedir-3.0.0"
-      sources."ansi-align-1.1.0"
+      (sources."ansi-align-2.0.0" // {
+        dependencies = [
+          sources."string-width-2.0.0"
+          sources."is-fullwidth-code-point-2.0.0"
+        ];
+      })
       sources."camelcase-4.1.0"
       sources."cli-boxes-1.0.0"
       sources."term-size-0.1.1"
@@ -25951,8 +26484,10 @@ in
       sources."has-ansi-2.0.0"
       sources."supports-color-2.0.0"
       sources."dot-prop-4.1.1"
+      sources."make-dir-1.0.0"
       sources."unique-string-1.0.0"
       sources."is-obj-1.0.1"
+      sources."pify-2.3.0"
       sources."crypto-random-string-1.0.0"
       sources."package-json-4.0.1"
       sources."got-6.7.1"
@@ -25974,7 +26509,7 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."strip-json-comments-2.0.1"
       sources."builtins-1.0.3"
       sources."isexe-2.0.0"
@@ -26027,7 +26562,7 @@ in
       })
       sources."fs.extra-1.3.2"
       sources."findit-1.2.0"
-      sources."coffee-script-1.12.5"
+      sources."coffee-script-1.12.6"
       sources."underscore-1.4.4"
       sources."underscore.string-2.3.3"
       sources."request-2.81.0"
@@ -26038,7 +26573,7 @@ in
       sources."rimraf-2.6.1"
       sources."retry-0.6.0"
       sources."couch-login-0.1.20"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
@@ -26104,11 +26639,11 @@ in
       sources."bcrypt-pbkdf-1.0.1"
       sources."mime-db-1.27.0"
       sources."punycode-1.4.1"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -26125,7 +26660,7 @@ in
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
       sources."aproba-1.1.1"
       sources."has-unicode-2.0.1"
@@ -26133,7 +26668,7 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
@@ -26177,10 +26712,10 @@ in
   npm-check-updates = nodeEnv.buildNodePackage {
     name = "npm-check-updates";
     packageName = "npm-check-updates";
-    version = "2.11.0";
+    version = "2.11.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-2.11.0.tgz";
-      sha1 = "6073a2c022eaf27352e2a8b08de931776207b818";
+      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-2.11.1.tgz";
+      sha1 = "9f9e9f6d9e558165c52901924063fc70783cd9eb";
     };
     dependencies = [
       sources."bluebird-3.5.0"
@@ -26203,7 +26738,7 @@ in
       sources."require-dir-0.3.1"
       sources."semver-5.3.0"
       sources."semver-utils-1.1.1"
-      (sources."snyk-1.30.0" // {
+      (sources."snyk-1.30.1" // {
         dependencies = [
           sources."update-notifier-0.5.0"
           sources."latest-version-1.0.1"
@@ -26250,8 +26785,8 @@ in
       sources."fs-vacuum-1.2.10"
       sources."fs-write-stream-atomic-1.0.10"
       sources."fstream-1.0.11"
-      sources."fstream-npm-1.2.0"
-      sources."glob-7.1.1"
+      sources."fstream-npm-1.2.1"
+      sources."glob-7.1.2"
       sources."graceful-fs-4.1.11"
       sources."has-unicode-2.0.1"
       sources."hosted-git-info-2.1.5"
@@ -26343,7 +26878,7 @@ in
       sources."clone-1.0.2"
       sources."proto-list-1.2.4"
       sources."fstream-ignore-1.0.5"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
@@ -26364,16 +26899,16 @@ in
       sources."object-assign-4.1.1"
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."array-index-1.0.0"
-      sources."debug-2.6.6"
+      sources."debug-2.6.8"
       sources."es6-symbol-3.1.1"
-      sources."ms-0.7.3"
+      sources."ms-2.0.0"
       sources."d-1.0.0"
-      sources."es5-ext-0.10.15"
+      sources."es5-ext-0.10.21"
       sources."es6-iterator-2.0.1"
       sources."is-builtin-module-1.0.0"
       sources."builtin-modules-1.1.1"
@@ -26387,8 +26922,9 @@ in
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
       sources."mute-stream-0.0.7"
@@ -26546,11 +27082,11 @@ in
       sources."wordwrap-0.0.2"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.2.0"
+      sources."kind-of-3.2.2"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
-      sources."js-yaml-3.8.3"
+      sources."js-yaml-3.8.4"
       sources."argparse-1.0.9"
       sources."esprima-3.1.3"
       sources."sprintf-js-1.0.3"
@@ -26603,8 +27139,7 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."safe-buffer-5.0.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."strip-json-comments-2.0.1"
       sources."get-caller-file-1.0.2"
       sources."lodash.assign-4.2.0"
@@ -26665,7 +27200,7 @@ in
     dependencies = [
       sources."async-0.9.2"
       sources."babybird-0.0.1"
-      (sources."body-parser-1.17.1" // {
+      (sources."body-parser-1.17.2" // {
         dependencies = [
           sources."content-type-1.0.2"
         ];
@@ -26683,15 +27218,10 @@ in
       sources."diff-1.4.0"
       sources."domino-1.0.28"
       sources."entities-1.1.1"
-      (sources."express-4.15.2" // {
+      (sources."express-4.15.3" // {
         dependencies = [
           sources."content-type-1.0.2"
-          (sources."finalhandler-1.0.2" // {
-            dependencies = [
-              sources."debug-2.6.4"
-            ];
-          })
-          sources."ms-0.7.3"
+          sources."finalhandler-1.0.3"
         ];
       })
       sources."express-handlebars-3.0.0"
@@ -26701,7 +27231,7 @@ in
           sources."ms-0.7.1"
         ];
       })
-      sources."js-yaml-3.8.3"
+      sources."js-yaml-3.8.4"
       sources."mediawiki-title-0.5.6"
       sources."negotiator-git+https://github.com/arlolra/negotiator.git#full-parse-access"
       sources."node-uuid-1.4.8"
@@ -26709,11 +27239,7 @@ in
       sources."prfun-2.1.4"
       sources."request-2.81.0"
       sources."semver-5.3.0"
-      (sources."serve-favicon-2.4.2" // {
-        dependencies = [
-          sources."ms-1.0.0"
-        ];
-      })
+      sources."serve-favicon-2.4.3"
       (sources."service-runner-2.3.0" // {
         dependencies = [
           sources."yargs-7.1.0"
@@ -26733,7 +27259,7 @@ in
       sources."asap-2.0.5"
       sources."is-arguments-1.0.2"
       sources."bytes-2.4.0"
-      sources."debug-2.6.1"
+      sources."debug-2.6.7"
       sources."depd-1.1.0"
       sources."http-errors-1.6.1"
       sources."iconv-lite-0.4.15"
@@ -26741,7 +27267,7 @@ in
       sources."qs-6.4.0"
       sources."raw-body-2.2.0"
       sources."type-is-1.6.15"
-      sources."ms-0.7.2"
+      sources."ms-2.0.0"
       sources."inherits-2.0.3"
       sources."setprototypeof-1.0.3"
       sources."statuses-1.3.1"
@@ -26775,8 +27301,8 @@ in
       sources."path-to-regexp-0.1.7"
       sources."proxy-addr-1.1.4"
       sources."range-parser-1.2.0"
-      sources."send-0.15.1"
-      sources."serve-static-1.12.1"
+      sources."send-0.15.3"
+      sources."serve-static-1.12.3"
       sources."utils-merge-1.0.0"
       sources."forwarded-0.1.0"
       sources."ipaddr.js-1.3.0"
@@ -26784,7 +27310,7 @@ in
       sources."mime-1.3.4"
       sources."glob-6.0.4"
       sources."graceful-fs-4.1.11"
-      (sources."handlebars-4.0.8" // {
+      (sources."handlebars-4.0.10" // {
         dependencies = [
           sources."async-1.5.2"
         ];
@@ -26792,7 +27318,7 @@ in
       sources."object.assign-4.0.4"
       sources."promise-7.1.1"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -26801,7 +27327,7 @@ in
       sources."concat-map-0.0.1"
       sources."optimist-0.6.1"
       sources."source-map-0.4.4"
-      (sources."uglify-js-2.8.22" // {
+      (sources."uglify-js-2.8.27" // {
         dependencies = [
           sources."source-map-0.5.6"
           sources."yargs-3.10.0"
@@ -26823,7 +27349,7 @@ in
       sources."right-align-0.1.3"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.2.0"
+      sources."kind-of-3.2.2"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
@@ -26905,7 +27431,7 @@ in
         dependencies = [
           sources."readable-stream-2.2.9"
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."dnscache-1.0.1"
@@ -26922,7 +27448,11 @@ in
       sources."ncp-2.0.0"
       sources."rimraf-2.4.5"
       sources."gelfling-0.3.1"
-      sources."kad-git+https://github.com/gwicke/kad.git#master"
+      (sources."kad-git+https://github.com/gwicke/kad.git#master" // {
+        dependencies = [
+          sources."ms-0.7.3"
+        ];
+      })
       sources."clarinet-0.11.0"
       sources."colors-1.1.2"
       sources."hat-0.0.3"
@@ -26930,7 +27460,7 @@ in
         dependencies = [
           sources."readable-stream-2.2.9"
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."kad-localstorage-0.0.7"
@@ -26938,7 +27468,7 @@ in
         dependencies = [
           sources."readable-stream-2.2.9"
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."lodash-3.10.1"
@@ -26947,7 +27477,7 @@ in
         dependencies = [
           sources."readable-stream-2.2.9"
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."buffer-shims-1.0.0"
@@ -26958,7 +27488,7 @@ in
         dependencies = [
           sources."readable-stream-2.2.9"
           sources."isarray-1.0.0"
-          sources."string_decoder-1.0.0"
+          sources."string_decoder-1.0.1"
         ];
       })
       sources."get-caller-file-1.0.2"
@@ -27033,7 +27563,7 @@ in
         ];
       })
       sources."keypress-0.2.1"
-      sources."mime-1.3.4"
+      sources."mime-1.3.6"
       sources."network-address-1.1.2"
       sources."numeral-1.5.6"
       sources."open-0.0.5"
@@ -27073,7 +27603,7 @@ in
       sources."bplist-parser-0.1.1"
       sources."concat-stream-1.6.0"
       sources."plist-1.2.0"
-      sources."reverse-http-1.2.0"
+      sources."reverse-http-1.3.0"
       sources."stream-buffers-2.2.0"
       sources."big-integer-1.6.22"
       sources."inherits-2.0.3"
@@ -27083,8 +27613,9 @@ in
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."base64-js-0.0.8"
       sources."xmlbuilder-4.0.0"
       sources."xmldom-0.1.27"
@@ -27117,7 +27648,6 @@ in
       sources."dns-packet-1.1.1"
       sources."thunky-0.1.0"
       sources."ip-1.1.5"
-      sources."safe-buffer-5.0.1"
       sources."meow-3.7.0"
       sources."camelcase-keys-2.1.0"
       sources."decamelize-1.2.0"
@@ -27190,7 +27720,7 @@ in
       sources."simple-concat-1.0.0"
       sources."unzip-response-2.0.1"
       sources."end-of-stream-1.4.0"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."bitfield-0.1.0"
@@ -27220,8 +27750,8 @@ in
       sources."randombytes-2.0.3"
       sources."run-parallel-1.1.6"
       sources."buffer-alloc-unsafe-1.0.0"
-      sources."debug-2.6.6"
-      sources."ms-0.7.3"
+      sources."debug-2.6.8"
+      sources."ms-2.0.0"
       sources."flatten-0.0.1"
       sources."fifo-0.1.4"
       (sources."peer-wire-protocol-0.7.0" // {
@@ -27235,10 +27765,10 @@ in
       sources."speedometer-0.1.4"
       sources."utp-0.0.7"
       sources."cyclist-0.1.1"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -27297,17 +27827,16 @@ in
   peerflix-server = nodeEnv.buildNodePackage {
     name = "peerflix-server";
     packageName = "peerflix-server";
-    version = "0.1.3";
+    version = "0.2.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/peerflix-server/-/peerflix-server-0.1.3.tgz";
-      sha1 = "1f3c2b81188de82482f64cf89d015f5428e4c4e5";
+      url = "https://registry.npmjs.org/peerflix-server/-/peerflix-server-0.2.0.tgz";
+      sha1 = "1848fdc14036f013af7489a39e8a5f0f9da48b87";
     };
     dependencies = [
-      sources."connect-multiparty-1.2.5"
-      (sources."express-3.5.3" // {
+      sources."connect-multiparty-2.0.0"
+      (sources."express-3.21.2" // {
         dependencies = [
-          sources."range-parser-1.0.0"
-          sources."mkdirp-0.4.0"
+          sources."range-parser-1.0.3"
         ];
       })
       sources."lodash-2.4.2"
@@ -27315,12 +27844,13 @@ in
       sources."pump-1.0.2"
       sources."range-parser-1.2.0"
       sources."read-torrent-1.3.0"
-      (sources."socket.io-1.7.3" // {
+      (sources."socket.io-1.7.4" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ms-0.7.2"
         ];
       })
-      (sources."torrent-stream-0.18.1" // {
+      (sources."torrent-stream-1.0.3" // {
         dependencies = [
           sources."end-of-stream-0.1.5"
           sources."mkdirp-0.3.5"
@@ -27328,88 +27858,132 @@ in
         ];
       })
       sources."fluent-ffmpeg-2.1.2"
-      sources."multiparty-3.3.2"
-      sources."on-finished-2.1.1"
-      sources."qs-2.2.5"
-      sources."type-is-1.5.7"
+      sources."multiparty-4.1.3"
+      sources."on-finished-2.3.0"
+      sources."qs-4.0.0"
+      sources."type-is-1.6.15"
+      sources."fd-slicer-1.0.1"
+      sources."pend-1.2.0"
+      sources."ee-first-1.1.1"
+      sources."media-typer-0.3.0"
+      sources."mime-types-2.1.15"
+      sources."mime-db-1.27.0"
+      sources."basic-auth-1.0.4"
+      (sources."connect-2.30.2" // {
+        dependencies = [
+          sources."multiparty-3.3.2"
+        ];
+      })
+      sources."content-disposition-0.5.0"
+      sources."content-type-1.0.2"
+      sources."commander-2.6.0"
+      sources."cookie-0.1.3"
+      sources."cookie-signature-1.0.6"
+      sources."debug-2.2.0"
+      sources."depd-1.0.1"
+      sources."escape-html-1.0.2"
+      sources."etag-1.7.0"
+      sources."fresh-0.3.0"
+      sources."merge-descriptors-1.0.0"
+      sources."methods-1.1.2"
+      sources."parseurl-1.3.1"
+      sources."proxy-addr-1.0.10"
+      (sources."send-0.13.0" // {
+        dependencies = [
+          sources."destroy-1.0.3"
+          sources."range-parser-1.0.3"
+          sources."statuses-1.2.1"
+        ];
+      })
+      sources."utils-merge-1.0.0"
+      sources."vary-1.0.1"
+      sources."basic-auth-connect-1.0.0"
+      sources."body-parser-1.13.3"
+      sources."bytes-2.1.0"
+      sources."cookie-parser-1.3.5"
+      sources."compression-1.5.2"
+      sources."connect-timeout-1.6.2"
+      sources."csurf-1.8.3"
+      (sources."errorhandler-1.4.3" // {
+        dependencies = [
+          sources."accepts-1.3.3"
+          sources."escape-html-1.0.3"
+          sources."negotiator-0.6.1"
+        ];
+      })
+      (sources."express-session-1.11.3" // {
+        dependencies = [
+          sources."uid-safe-2.0.0"
+        ];
+      })
+      sources."finalhandler-0.4.0"
+      sources."http-errors-1.3.1"
+      (sources."method-override-2.3.9" // {
+        dependencies = [
+          sources."debug-2.6.8"
+          sources."vary-1.1.1"
+          sources."ms-2.0.0"
+        ];
+      })
+      sources."morgan-1.6.1"
+      sources."on-headers-1.0.1"
+      sources."pause-0.1.0"
+      (sources."response-time-2.3.2" // {
+        dependencies = [
+          sources."depd-1.1.0"
+        ];
+      })
+      (sources."serve-favicon-2.3.2" // {
+        dependencies = [
+          sources."ms-0.7.2"
+        ];
+      })
+      (sources."serve-index-1.7.3" // {
+        dependencies = [
+          sources."escape-html-1.0.3"
+        ];
+      })
+      (sources."serve-static-1.10.3" // {
+        dependencies = [
+          sources."escape-html-1.0.3"
+          sources."send-0.13.2"
+          sources."depd-1.1.0"
+          sources."range-parser-1.0.3"
+          sources."statuses-1.2.1"
+        ];
+      })
+      sources."vhost-3.0.2"
+      sources."iconv-lite-0.4.11"
+      (sources."raw-body-2.1.7" // {
+        dependencies = [
+          sources."bytes-2.4.0"
+          sources."iconv-lite-0.4.13"
+        ];
+      })
+      sources."unpipe-1.0.0"
+      sources."accepts-1.2.13"
+      sources."compressible-2.0.10"
+      sources."negotiator-0.5.3"
+      sources."ms-0.7.1"
+      sources."csrf-3.0.6"
+      sources."rndm-1.2.0"
+      sources."tsscmp-1.0.5"
+      sources."uid-safe-2.1.4"
+      sources."random-bytes-1.0.0"
+      sources."crc-3.3.0"
+      sources."base64-url-1.2.1"
+      sources."inherits-2.0.3"
+      sources."statuses-1.3.1"
       sources."readable-stream-1.1.14"
       sources."stream-counter-0.2.0"
       sources."core-util-is-1.0.2"
       sources."isarray-0.0.1"
       sources."string_decoder-0.10.31"
-      sources."inherits-2.0.3"
-      sources."ee-first-1.1.0"
-      sources."media-typer-0.3.0"
-      sources."mime-types-2.0.14"
-      sources."mime-db-1.12.0"
-      (sources."connect-2.14.5" // {
-        dependencies = [
-          sources."qs-0.6.6"
-          sources."multiparty-2.2.0"
-        ];
-      })
-      sources."commander-1.3.2"
-      sources."cookie-0.1.2"
-      sources."buffer-crc32-0.2.1"
-      sources."fresh-0.2.2"
-      sources."methods-0.1.0"
-      (sources."send-0.3.0" // {
-        dependencies = [
-          sources."debug-0.8.0"
-          sources."range-parser-1.0.3"
-        ];
-      })
-      sources."cookie-signature-1.0.3"
-      sources."merge-descriptors-0.0.2"
-      sources."debug-0.8.1"
-      sources."basic-auth-connect-1.0.0"
-      (sources."cookie-parser-1.0.1" // {
-        dependencies = [
-          sources."cookie-0.1.0"
-        ];
-      })
-      (sources."compression-1.0.0" // {
-        dependencies = [
-          sources."bytes-0.2.1"
-        ];
-      })
-      sources."connect-timeout-1.0.0"
-      sources."csurf-1.1.0"
-      sources."errorhandler-1.0.0"
-      (sources."express-session-1.0.2" // {
-        dependencies = [
-          sources."cookie-0.1.0"
-          sources."debug-0.7.4"
-        ];
-      })
-      sources."method-override-1.0.0"
-      (sources."morgan-1.0.0" // {
-        dependencies = [
-          sources."bytes-0.2.1"
-        ];
-      })
-      sources."raw-body-1.1.4"
-      sources."response-time-1.0.0"
-      sources."setimmediate-1.0.1"
-      (sources."serve-index-1.0.1" // {
-        dependencies = [
-          sources."negotiator-0.4.2"
-        ];
-      })
-      sources."serve-static-1.1.0"
-      sources."static-favicon-1.0.2"
-      sources."vhost-1.0.0"
-      sources."bytes-0.3.0"
-      sources."pause-0.0.1"
-      sources."negotiator-0.3.0"
-      sources."compressible-1.0.0"
-      sources."uid2-0.0.3"
-      sources."scmp-0.0.3"
-      sources."utils-merge-1.0.0"
-      sources."batch-0.5.0"
-      sources."parseurl-1.0.1"
-      sources."keypress-0.1.0"
-      sources."mime-1.2.11"
+      sources."batch-0.5.3"
+      sources."destroy-1.0.4"
+      sources."mime-1.3.4"
+      sources."forwarded-0.1.0"
+      sources."ipaddr.js-1.0.5"
       sources."minimist-0.0.8"
       sources."end-of-stream-1.4.0"
       sources."once-1.4.0"
@@ -27422,6 +27996,7 @@ in
       })
       (sources."request-2.16.6" // {
         dependencies = [
+          sources."mime-1.2.11"
           sources."qs-0.5.6"
         ];
       })
@@ -27432,7 +28007,11 @@ in
       sources."bencode-0.7.0"
       sources."simple-sha1-2.1.0"
       sources."rusha-0.8.6"
-      sources."form-data-0.0.10"
+      (sources."form-data-0.0.10" // {
+        dependencies = [
+          sources."mime-1.2.11"
+        ];
+      })
       sources."hawk-0.10.2"
       sources."node-uuid-1.4.8"
       sources."cookie-jar-0.2.0"
@@ -27448,10 +28027,13 @@ in
       sources."boom-0.3.8"
       sources."cryptiles-0.1.3"
       sources."sntp-0.1.4"
-      (sources."engine.io-1.8.3" // {
+      (sources."engine.io-1.8.4" // {
         dependencies = [
+          sources."accepts-1.3.3"
           sources."debug-2.3.3"
           sources."cookie-0.3.1"
+          sources."negotiator-0.6.1"
+          sources."ms-0.7.2"
         ];
       })
       sources."has-binary-0.1.7"
@@ -27459,31 +28041,23 @@ in
       (sources."socket.io-adapter-0.5.0" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ms-0.7.2"
         ];
       })
-      (sources."socket.io-client-1.7.3" // {
+      (sources."socket.io-client-1.7.4" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ms-0.7.2"
         ];
       })
       (sources."socket.io-parser-2.3.1" // {
         dependencies = [
-          sources."debug-2.2.0"
           sources."component-emitter-1.1.2"
-          sources."ms-0.7.1"
-        ];
-      })
-      sources."ms-0.7.2"
-      (sources."accepts-1.3.3" // {
-        dependencies = [
-          sources."mime-types-2.1.15"
-          sources."negotiator-0.6.1"
-          sources."mime-db-1.27.0"
         ];
       })
       sources."base64id-1.0.0"
       sources."engine.io-parser-1.3.2"
-      sources."ws-1.1.2"
+      sources."ws-1.1.4"
       sources."after-0.8.2"
       sources."arraybuffer.slice-0.0.6"
       sources."base64-arraybuffer-0.1.5"
@@ -27494,9 +28068,11 @@ in
       sources."backo2-1.0.2"
       sources."component-bind-1.0.0"
       sources."component-emitter-1.2.1"
-      (sources."engine.io-client-1.8.3" // {
+      (sources."engine.io-client-1.8.4" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ws-1.1.2"
+          sources."ms-0.7.2"
         ];
       })
       sources."indexof-0.0.1"
@@ -27513,66 +28089,96 @@ in
       sources."callsite-1.0.0"
       sources."json3-3.3.2"
       sources."bitfield-0.1.0"
-      (sources."bittorrent-dht-3.2.6" // {
-        dependencies = [
-          sources."debug-2.6.6"
-          sources."ms-0.7.3"
-        ];
-      })
-      (sources."bittorrent-tracker-2.12.1" // {
-        dependencies = [
-          sources."bencode-0.6.0"
-          sources."debug-2.6.6"
-          sources."ms-0.7.3"
-        ];
-      })
       sources."bncode-0.5.3"
-      sources."compact2string-1.4.0"
+      sources."fs-chunk-store-1.6.5"
       sources."hat-0.0.3"
-      sources."ip-0.3.3"
-      (sources."ip-set-1.0.1" // {
-        dependencies = [
-          sources."ip-1.1.5"
-        ];
-      })
-      sources."peer-wire-swarm-0.9.2"
-      sources."random-access-file-0.3.2"
+      sources."immediate-chunk-store-1.0.8"
+      sources."ip-set-1.0.1"
+      sources."peer-wire-swarm-0.12.1"
       sources."rimraf-2.6.1"
-      sources."thunky-0.1.0"
-      sources."addr-to-ip-port-1.4.2"
-      sources."buffer-equal-0.0.1"
-      sources."is-ip-1.0.0"
-      sources."k-bucket-0.5.0"
-      sources."network-address-1.1.2"
-      sources."run-parallel-1.1.6"
-      sources."simple-get-1.4.3"
-      sources."string2compact-1.2.2"
-      sources."ip-regex-1.0.3"
-      sources."unzip-response-1.0.2"
-      sources."ipaddr.js-1.3.0"
-      sources."bn.js-1.3.0"
-      sources."extend.js-0.0.2"
-      (sources."portfinder-0.3.0" // {
+      sources."torrent-discovery-5.4.0"
+      sources."torrent-piece-1.1.1"
+      (sources."random-access-file-1.7.2" // {
         dependencies = [
-          sources."mkdirp-0.0.7"
+          sources."debug-2.6.8"
+          sources."ms-2.0.0"
         ];
       })
-      sources."run-series-1.1.4"
+      sources."randombytes-2.0.3"
+      sources."run-parallel-1.1.6"
+      sources."thunky-1.0.2"
+      sources."buffer-alloc-unsafe-1.0.0"
+      sources."ip-1.1.5"
+      sources."fifo-0.1.4"
       (sources."peer-wire-protocol-0.7.0" // {
         dependencies = [
           sources."bncode-0.2.3"
         ];
       })
-      sources."fifo-0.1.4"
       sources."speedometer-0.1.4"
-      sources."glob-7.1.1"
+      sources."utp-0.0.7"
+      sources."cyclist-0.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
+      sources."bittorrent-dht-6.4.2"
+      (sources."bittorrent-tracker-7.7.0" // {
+        dependencies = [
+          sources."bencode-0.8.0"
+          sources."minimist-1.2.0"
+        ];
+      })
+      sources."re-emitter-1.1.3"
+      sources."buffer-equals-1.0.4"
+      sources."k-bucket-0.6.0"
+      (sources."k-rpc-3.7.0" // {
+        dependencies = [
+          sources."k-bucket-2.0.1"
+        ];
+      })
+      sources."lru-2.0.1"
+      sources."buffer-equal-0.0.1"
+      (sources."k-rpc-socket-1.6.2" // {
+        dependencies = [
+          sources."bencode-0.11.0"
+        ];
+      })
+      sources."bn.js-4.11.6"
+      sources."compact2string-1.4.0"
+      sources."random-iterate-1.0.1"
+      sources."run-series-1.1.4"
+      sources."simple-get-2.6.0"
+      (sources."simple-peer-6.4.4" // {
+        dependencies = [
+          sources."readable-stream-2.2.9"
+          sources."isarray-1.0.0"
+          sources."string_decoder-1.0.1"
+        ];
+      })
+      (sources."simple-websocket-4.3.1" // {
+        dependencies = [
+          sources."readable-stream-2.2.9"
+          sources."ws-2.3.1"
+          sources."isarray-1.0.0"
+          sources."string_decoder-1.0.1"
+          sources."ultron-1.1.0"
+        ];
+      })
+      sources."string2compact-1.2.2"
+      sources."uniq-1.0.1"
+      sources."simple-concat-1.0.0"
+      sources."unzip-response-2.0.1"
+      sources."get-browser-rtc-1.0.2"
+      sources."buffer-shims-1.0.0"
+      sources."process-nextick-args-1.0.7"
+      sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
+      sources."addr-to-ip-port-1.4.2"
       sources."which-1.2.14"
       sources."isexe-2.0.0"
     ];
@@ -27621,10 +28227,10 @@ in
       sources."klaw-1.3.1"
       sources."path-is-absolute-1.0.1"
       sources."rimraf-2.6.1"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."wrappy-1.0.2"
       sources."brace-expansion-1.1.7"
@@ -27653,7 +28259,7 @@ in
       sources."isstream-0.1.2"
       sources."is-typedarray-1.0.0"
       sources."har-validator-2.0.6"
-      sources."async-2.4.0"
+      sources."async-2.4.1"
       sources."lodash-4.17.4"
       sources."mime-db-1.27.0"
       sources."assert-plus-0.2.0"
@@ -27746,7 +28352,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -27800,7 +28406,7 @@ in
       sources."defined-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -27873,7 +28479,7 @@ in
       sources."methods-0.1.0"
       sources."send-0.1.4"
       sources."cookie-signature-1.0.1"
-      sources."debug-2.6.6"
+      sources."debug-2.6.8"
       sources."qs-0.6.5"
       sources."bytes-0.2.1"
       sources."pause-0.0.1"
@@ -27889,7 +28495,7 @@ in
       sources."inherits-2.0.3"
       sources."keypress-0.1.0"
       sources."mime-1.2.11"
-      sources."ms-0.7.3"
+      sources."ms-2.0.0"
       sources."oauth-https://codeload.github.com/ciaranj/node-oauth/legacy.tar.gz/master"
       sources."request-2.9.203"
       (sources."openid-2.0.6" // {
@@ -28000,11 +28606,13 @@ in
     dependencies = [
       sources."express-5.0.0-alpha.5"
       sources."express-json5-0.1.0"
-      (sources."body-parser-1.17.1" // {
+      (sources."body-parser-1.17.2" // {
         dependencies = [
           sources."bytes-2.4.0"
+          sources."debug-2.6.7"
           sources."iconv-lite-0.4.15"
           sources."raw-body-2.2.0"
+          sources."ms-2.0.0"
         ];
       })
       (sources."compression-1.6.2" // {
@@ -28015,7 +28623,7 @@ in
         ];
       })
       sources."commander-2.9.0"
-      sources."js-yaml-3.8.3"
+      sources."js-yaml-3.8.4"
       sources."cookies-0.7.0"
       sources."request-2.81.0"
       sources."async-0.9.2"
@@ -28051,10 +28659,10 @@ in
       sources."encodeurl-1.0.1"
       sources."escape-html-1.0.3"
       sources."etag-1.8.0"
-      (sources."finalhandler-1.0.2" // {
+      (sources."finalhandler-1.0.3" // {
         dependencies = [
-          sources."debug-2.6.4"
-          sources."ms-0.7.3"
+          sources."debug-2.6.7"
+          sources."ms-2.0.0"
         ];
       })
       sources."fresh-0.5.0"
@@ -28067,7 +28675,12 @@ in
       sources."proxy-addr-1.1.4"
       sources."qs-6.4.0"
       sources."range-parser-1.2.0"
-      sources."router-1.3.0"
+      (sources."router-1.3.1" // {
+        dependencies = [
+          sources."debug-2.6.8"
+          sources."ms-2.0.0"
+        ];
+      })
       sources."send-0.15.1"
       sources."serve-static-1.12.1"
       sources."setprototypeof-1.0.3"
@@ -28169,7 +28782,7 @@ in
       sources."rimraf-2.4.5"
       (sources."glob-6.0.4" // {
         dependencies = [
-          sources."minimatch-3.0.3"
+          sources."minimatch-3.0.4"
         ];
       })
       sources."inflight-1.0.6"
@@ -28202,8 +28815,8 @@ in
       sources."regexp-quote-0.0.0"
       sources."xtend-4.0.1"
       sources."domelementtype-1.3.0"
-      sources."domhandler-2.3.0"
-      sources."domutils-1.6.0"
+      sources."domhandler-2.4.1"
+      sources."domutils-1.6.2"
       (sources."dom-serializer-0.1.0" // {
         dependencies = [
           sources."domelementtype-1.1.3"
@@ -28213,9 +28826,9 @@ in
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
-      sources."jsonparse-1.3.0"
+      sources."jsonparse-1.3.1"
       sources."through-2.3.8"
       sources."minimist-0.0.8"
     ];
@@ -28247,7 +28860,7 @@ in
       sources."colors-1.0.3"
       sources."graceful-readlink-1.0.1"
       sources."graceful-fs-4.1.11"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."readable-stream-2.2.9"
       sources."set-immediate-shim-1.0.1"
       sources."brace-expansion-1.1.7"
@@ -28258,8 +28871,9 @@ in
       sources."isarray-1.0.0"
       sources."inherits-2.0.3"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -28333,7 +28947,7 @@ in
       sources."formidable-1.1.1"
       sources."http-signature-0.11.0"
       sources."keep-alive-agent-0.0.1"
-      sources."mime-1.3.4"
+      sources."mime-1.3.6"
       sources."negotiator-0.5.3"
       sources."node-uuid-1.4.8"
       sources."once-1.4.0"
@@ -28367,7 +28981,7 @@ in
       sources."glob-6.0.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."path-is-absolute-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -28396,8 +29010,9 @@ in
       sources."buffer-shims-1.0.0"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."jsbn-0.1.1"
       sources."tweetnacl-0.14.5"
       sources."jodid25519-1.0.2"
@@ -28421,16 +29036,16 @@ in
     dependencies = [
       sources."css-parse-1.7.0"
       sources."mkdirp-0.5.1"
-      sources."debug-2.6.6"
+      sources."debug-2.6.8"
       sources."sax-0.5.8"
       sources."glob-7.0.6"
       sources."source-map-0.1.43"
       sources."minimist-0.0.8"
-      sources."ms-0.7.3"
+      sources."ms-2.0.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."wrappy-1.0.2"
@@ -28457,7 +29072,7 @@ in
     };
     dependencies = [
       sources."sax-1.2.2"
-      sources."coa-1.0.1"
+      sources."coa-1.0.2"
       sources."js-yaml-3.7.0"
       sources."colors-1.1.2"
       sources."whet.extend-0.9.9"
@@ -28497,8 +29112,8 @@ in
     dependencies = [
       sources."acorn-4.0.11"
       sources."enhanced-resolve-2.3.0"
-      sources."glob-7.1.1"
-      sources."minimatch-3.0.3"
+      sources."glob-7.1.2"
+      sources."minimatch-3.0.4"
       sources."resolve-from-2.0.0"
       sources."tapable-0.2.6"
       sources."memory-fs-0.3.0"
@@ -28512,8 +29127,9 @@ in
       sources."isarray-1.0.0"
       sources."inherits-2.0.3"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."once-1.4.0"
@@ -28534,10 +29150,10 @@ in
   typescript = nodeEnv.buildNodePackage {
     name = "typescript";
     packageName = "typescript";
-    version = "2.3.2";
+    version = "2.3.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/typescript/-/typescript-2.3.2.tgz";
-      sha1 = "f0f045e196f69a72f06b25fd3bd39d01c3ce9984";
+      url = "https://registry.npmjs.org/typescript/-/typescript-2.3.3.tgz";
+      sha1 = "9639f3c3b40148e8ca97fe08a51dd1891bb6be22";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -28550,28 +29166,15 @@ in
   uglify-js = nodeEnv.buildNodePackage {
     name = "uglify-js";
     packageName = "uglify-js";
-    version = "2.8.22";
+    version = "3.0.10";
     src = fetchurl {
-      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz";
-      sha1 = "d54934778a8da14903fa29a326fb24c0ab51a1a0";
+      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.10.tgz";
+      sha1 = "e220e7dbc05ce1f9bb08268b221aa0cf152fb4e2";
     };
     dependencies = [
+      sources."commander-2.9.0"
       sources."source-map-0.5.6"
-      sources."yargs-3.10.0"
-      sources."uglify-to-browserify-1.0.2"
-      sources."camelcase-1.2.1"
-      sources."cliui-2.1.0"
-      sources."decamelize-1.2.0"
-      sources."window-size-0.1.0"
-      sources."center-align-0.1.3"
-      sources."right-align-0.1.3"
-      sources."wordwrap-0.0.2"
-      sources."align-text-0.1.4"
-      sources."lazy-cache-1.0.4"
-      sources."kind-of-3.2.0"
-      sources."longest-1.0.1"
-      sources."repeat-string-1.6.1"
-      sources."is-buffer-1.1.5"
+      sources."graceful-readlink-1.0.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -28584,30 +29187,22 @@ in
   ungit = nodeEnv.buildNodePackage {
     name = "ungit";
     packageName = "ungit";
-    version = "1.1.16";
+    version = "1.1.19";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ungit/-/ungit-1.1.16.tgz";
-      sha1 = "d19a80706583423f9895364dd20adf873b88d09e";
+      url = "https://registry.npmjs.org/ungit/-/ungit-1.1.19.tgz";
+      sha1 = "83e0c9d79c808f7acb5f2da5a1ea77e3db571558";
     };
     dependencies = [
-      sources."async-2.4.0"
+      sources."async-2.4.1"
       sources."bluebird-3.5.0"
       sources."blueimp-md5-2.7.0"
-      sources."body-parser-1.17.1"
+      sources."body-parser-1.17.2"
       sources."color-1.0.3"
       sources."cookie-parser-1.4.3"
       sources."crossroads-0.12.2"
       sources."diff2html-2.3.0"
-      (sources."express-4.15.2" // {
-        dependencies = [
-          sources."serve-static-1.12.1"
-        ];
-      })
-      (sources."express-session-1.15.2" // {
-        dependencies = [
-          sources."debug-2.6.3"
-        ];
-      })
+      sources."express-4.15.3"
+      sources."express-session-1.15.3"
       sources."forever-monitor-1.1.0"
       sources."getmac-1.2.1"
       sources."hasher-1.2.0"
@@ -28668,6 +29263,7 @@ in
         dependencies = [
           sources."json-stringify-safe-5.0.1"
           sources."uuid-3.0.0"
+          sources."stack-trace-0.0.9"
         ];
       })
       (sources."rc-1.2.1" // {
@@ -28677,23 +29273,14 @@ in
       })
       sources."rimraf-2.6.1"
       sources."semver-5.3.0"
-      (sources."serve-static-1.12.2" // {
-        dependencies = [
-          sources."send-0.15.2"
-          (sources."debug-2.6.4" // {
-            dependencies = [
-              sources."ms-0.7.3"
-            ];
-          })
-          sources."ms-1.0.0"
-        ];
-      })
+      sources."serve-static-1.12.3"
       sources."signals-1.0.0"
       sources."snapsvg-0.5.1"
-      (sources."socket.io-1.7.3" // {
+      (sources."socket.io-1.7.4" // {
         dependencies = [
           sources."debug-2.3.3"
           sources."object-assign-4.1.0"
+          sources."ms-0.7.2"
         ];
       })
       (sources."superagent-0.21.0" // {
@@ -28729,7 +29316,7 @@ in
       })
       sources."bytes-2.4.0"
       sources."content-type-1.0.2"
-      sources."debug-2.6.1"
+      sources."debug-2.6.7"
       sources."depd-1.1.0"
       sources."http-errors-1.6.1"
       sources."iconv-lite-0.4.15"
@@ -28737,7 +29324,7 @@ in
       sources."qs-6.4.0"
       sources."raw-body-2.2.0"
       sources."type-is-1.6.15"
-      sources."ms-0.7.2"
+      sources."ms-2.0.0"
       sources."inherits-2.0.3"
       sources."setprototypeof-1.0.3"
       sources."statuses-1.3.1"
@@ -28768,12 +29355,7 @@ in
       sources."encodeurl-1.0.1"
       sources."escape-html-1.0.3"
       sources."etag-1.8.0"
-      (sources."finalhandler-1.0.2" // {
-        dependencies = [
-          sources."debug-2.6.4"
-          sources."ms-0.7.3"
-        ];
-      })
+      sources."finalhandler-1.0.3"
       sources."fresh-0.5.0"
       sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
@@ -28781,7 +29363,7 @@ in
       sources."path-to-regexp-0.1.7"
       sources."proxy-addr-1.1.4"
       sources."range-parser-1.2.0"
-      sources."send-0.15.1"
+      sources."send-0.15.3"
       sources."utils-merge-1.0.0"
       sources."vary-1.1.1"
       sources."negotiator-0.6.1"
@@ -28832,7 +29414,7 @@ in
       sources."eyes-0.1.8"
       sources."cycle-1.0.3"
       sources."request-2.9.203"
-      sources."stack-trace-0.0.9"
+      sources."stack-trace-0.0.10"
       sources."ini-1.3.4"
       sources."optimist-0.6.0"
       sources."wordwrap-0.0.3"
@@ -28889,10 +29471,10 @@ in
       sources."fs-vacuum-1.2.10"
       sources."fs-write-stream-atomic-1.0.10"
       sources."fstream-1.0.11"
-      sources."fstream-npm-1.2.0"
-      (sources."glob-7.1.1" // {
+      sources."fstream-npm-1.2.1"
+      (sources."glob-7.1.2" // {
         dependencies = [
-          sources."minimatch-3.0.3"
+          sources."minimatch-3.0.4"
         ];
       })
       sources."graceful-fs-4.1.11"
@@ -28912,7 +29494,7 @@ in
       sources."move-concurrently-1.0.1"
       (sources."node-gyp-3.6.1" // {
         dependencies = [
-          sources."minimatch-3.0.3"
+          sources."minimatch-3.0.4"
           sources."nopt-3.0.6"
         ];
       })
@@ -28968,7 +29550,7 @@ in
       sources."lodash.restparam-3.6.1"
       sources."readdir-scoped-modules-1.0.2"
       sources."validate-npm-package-license-3.0.1"
-      sources."jsonparse-1.3.0"
+      sources."jsonparse-1.3.1"
       sources."through-2.3.8"
       sources."wcwidth-1.0.1"
       (sources."defaults-1.0.3" // {
@@ -28979,7 +29561,7 @@ in
       sources."proto-list-1.2.4"
       (sources."fstream-ignore-1.0.5" // {
         dependencies = [
-          sources."minimatch-3.0.3"
+          sources."minimatch-3.0.4"
         ];
       })
       sources."brace-expansion-1.1.7"
@@ -29021,7 +29603,7 @@ in
       sources."object-assign-4.1.1"
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
@@ -29034,8 +29616,9 @@ in
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
       sources."caseless-0.12.0"
@@ -29045,7 +29628,6 @@ in
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."performance-now-0.2.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."asynckit-0.4.0"
@@ -29088,20 +29670,29 @@ in
       sources."stream-iterate-1.2.0"
       sources."block-stream-0.0.9"
       sources."unique-slug-2.0.0"
-      (sources."boxen-1.0.0" // {
+      (sources."boxen-1.1.0" // {
         dependencies = [
           sources."string-width-2.0.0"
           sources."is-fullwidth-code-point-2.0.0"
         ];
       })
       sources."chalk-1.1.3"
-      sources."configstore-3.0.0"
+      (sources."configstore-3.1.0" // {
+        dependencies = [
+          sources."write-file-atomic-2.1.0"
+        ];
+      })
       sources."is-npm-1.0.0"
       sources."latest-version-3.1.0"
       sources."lazy-req-2.0.0"
       sources."semver-diff-2.1.0"
       sources."xdg-basedir-3.0.0"
-      sources."ansi-align-1.1.0"
+      (sources."ansi-align-2.0.0" // {
+        dependencies = [
+          sources."string-width-2.0.0"
+          sources."is-fullwidth-code-point-2.0.0"
+        ];
+      })
       sources."camelcase-4.1.0"
       sources."cli-boxes-1.0.0"
       sources."term-size-0.1.1"
@@ -29123,8 +29714,10 @@ in
       sources."has-ansi-2.0.0"
       sources."supports-color-2.0.0"
       sources."dot-prop-4.1.1"
+      sources."make-dir-1.0.0"
       sources."unique-string-1.0.0"
       sources."is-obj-1.0.1"
+      sources."pify-2.3.0"
       sources."crypto-random-string-1.0.0"
       sources."package-json-4.0.1"
       sources."got-6.7.1"
@@ -29150,12 +29743,13 @@ in
       sources."passport-strategy-1.0.0"
       sources."pause-0.0.1"
       sources."lsmod-1.0.0"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."strip-json-comments-2.0.1"
       sources."eve-0.5.4"
-      (sources."engine.io-1.8.3" // {
+      (sources."engine.io-1.8.4" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ms-0.7.2"
         ];
       })
       (sources."has-binary-0.1.7" // {
@@ -29166,11 +29760,13 @@ in
       (sources."socket.io-adapter-0.5.0" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ms-0.7.2"
         ];
       })
-      (sources."socket.io-client-1.7.3" // {
+      (sources."socket.io-client-1.7.4" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ms-0.7.2"
         ];
       })
       (sources."socket.io-parser-2.3.1" // {
@@ -29183,7 +29779,7 @@ in
       })
       sources."base64id-1.0.0"
       sources."engine.io-parser-1.3.2"
-      sources."ws-1.1.2"
+      sources."ws-1.1.4"
       sources."after-0.8.2"
       sources."arraybuffer.slice-0.0.6"
       sources."base64-arraybuffer-0.1.5"
@@ -29194,9 +29790,11 @@ in
       sources."backo2-1.0.2"
       sources."component-bind-1.0.0"
       sources."component-emitter-1.2.1"
-      (sources."engine.io-client-1.8.3" // {
+      (sources."engine.io-client-1.8.4" // {
         dependencies = [
           sources."debug-2.3.3"
+          sources."ws-1.1.2"
+          sources."ms-0.7.2"
         ];
       })
       sources."indexof-0.0.1"
@@ -29254,7 +29852,6 @@ in
       sources."load-json-file-2.0.0"
       sources."path-type-2.0.0"
       sources."parse-json-2.2.0"
-      sources."pify-2.3.0"
       sources."strip-bom-3.0.0"
       (sources."error-ex-1.3.1" // {
         dependencies = [
@@ -29333,10 +29930,10 @@ in
       sources."klaw-1.3.1"
       sources."path-is-absolute-1.0.1"
       sources."rimraf-2.6.1"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
@@ -29363,7 +29960,7 @@ in
       sources."isstream-0.1.2"
       sources."is-typedarray-1.0.0"
       sources."har-validator-2.0.6"
-      sources."async-2.4.0"
+      sources."async-2.4.1"
       sources."lodash-4.17.4"
       sources."mime-db-1.27.0"
       sources."assert-plus-0.2.0"
@@ -29432,10 +30029,10 @@ in
   webpack = nodeEnv.buildNodePackage {
     name = "webpack";
     packageName = "webpack";
-    version = "2.5.0";
+    version = "2.6.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack/-/webpack-2.5.0.tgz";
-      sha1 = "5a17089f8d0e43442e606d6cf9b2a146c8ed9911";
+      url = "https://registry.npmjs.org/webpack/-/webpack-2.6.0.tgz";
+      sha1 = "7e650a92816abff5db5f43316b0b8b19b13d76c1";
     };
     dependencies = [
       sources."acorn-5.0.3"
@@ -29446,7 +30043,7 @@ in
       })
       sources."ajv-4.11.8"
       sources."ajv-keywords-1.5.1"
-      sources."async-2.4.0"
+      sources."async-2.4.1"
       sources."enhanced-resolve-3.1.0"
       sources."interpret-1.0.3"
       sources."json-loader-0.5.4"
@@ -29463,7 +30060,7 @@ in
       sources."source-map-0.5.6"
       sources."supports-color-3.2.3"
       sources."tapable-0.2.6"
-      (sources."uglify-js-2.8.22" // {
+      (sources."uglify-js-2.8.27" // {
         dependencies = [
           sources."yargs-3.10.0"
         ];
@@ -29492,8 +30089,9 @@ in
       sources."isarray-1.0.0"
       sources."inherits-2.0.3"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."minimist-0.0.8"
       sources."assert-1.4.1"
       sources."browserify-zlib-0.1.4"
@@ -29510,7 +30108,7 @@ in
       sources."punycode-1.4.1"
       sources."querystring-es3-0.2.1"
       sources."stream-browserify-2.0.1"
-      sources."stream-http-2.7.0"
+      sources."stream-http-2.7.1"
       sources."timers-browserify-2.0.2"
       sources."tty-browserify-0.0.0"
       (sources."url-0.11.0" // {
@@ -29531,10 +30129,10 @@ in
       sources."browserify-cipher-1.0.0"
       sources."browserify-sign-4.0.4"
       sources."create-ecdh-4.0.0"
-      sources."create-hash-1.1.2"
-      sources."create-hmac-1.1.4"
+      sources."create-hash-1.1.3"
+      sources."create-hmac-1.1.6"
       sources."diffie-hellman-5.0.2"
-      sources."pbkdf2-3.0.9"
+      sources."pbkdf2-3.0.12"
       sources."public-encrypt-4.0.0"
       sources."randombytes-2.0.3"
       sources."browserify-aes-1.0.6"
@@ -29553,8 +30151,9 @@ in
       sources."hmac-drbg-1.0.1"
       sources."minimalistic-crypto-utils-1.0.1"
       sources."asn1.js-4.9.1"
-      sources."ripemd160-1.0.1"
+      sources."ripemd160-2.0.1"
       sources."sha.js-2.4.8"
+      sources."hash-base-2.0.2"
       sources."miller-rabin-4.0.0"
       sources."builtin-status-codes-3.0.0"
       sources."to-arraybuffer-1.0.1"
@@ -29573,11 +30172,11 @@ in
       sources."wordwrap-0.0.2"
       sources."align-text-0.1.4"
       sources."lazy-cache-1.0.4"
-      sources."kind-of-3.2.0"
+      sources."kind-of-3.2.2"
       sources."longest-1.0.1"
       sources."repeat-string-1.6.1"
       sources."is-buffer-1.1.5"
-      sources."chokidar-1.6.1"
+      sources."chokidar-1.7.0"
       sources."anymatch-1.3.0"
       sources."async-each-1.0.1"
       sources."glob-parent-2.0.0"
@@ -29617,7 +30216,7 @@ in
       sources."is-equal-shallow-0.1.3"
       sources."is-primitive-2.0.0"
       sources."binary-extensions-1.8.0"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."set-immediate-shim-1.0.1"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"
@@ -29625,7 +30224,7 @@ in
       sources."nan-2.6.2"
       sources."node-pre-gyp-0.6.34"
       sources."nopt-4.0.1"
-      sources."npmlog-4.0.2"
+      sources."npmlog-4.1.0"
       (sources."rc-1.2.1" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -29650,12 +30249,12 @@ in
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
       sources."strip-ansi-3.0.1"
-      sources."wide-align-1.1.0"
+      sources."wide-align-1.1.2"
       sources."code-point-at-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."number-is-nan-1.0.1"
       sources."ansi-regex-2.1.1"
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."ini-1.3.4"
       sources."strip-json-comments-2.0.1"
       sources."aws-sign2-0.6.0"
@@ -29675,7 +30274,6 @@ in
       sources."oauth-sign-0.8.2"
       sources."performance-now-0.2.0"
       sources."qs-6.4.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."tunnel-agent-0.6.0"
@@ -29718,17 +30316,17 @@ in
       sources."ecc-jsbn-0.1.1"
       sources."bcrypt-pbkdf-1.0.1"
       sources."mime-db-1.27.0"
-      sources."glob-7.1.1"
+      sources."glob-7.1.2"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.6"
       sources."once-1.4.0"
       sources."wrappy-1.0.2"
       sources."block-stream-0.0.9"
       sources."fstream-1.0.11"
-      sources."debug-2.6.6"
+      sources."debug-2.6.8"
       sources."fstream-ignore-1.0.5"
       sources."uid-number-0.0.6"
-      sources."ms-0.7.3"
+      sources."ms-2.0.0"
       sources."source-list-map-1.1.2"
       sources."get-caller-file-1.0.2"
       sources."os-locale-1.4.0"
@@ -29794,10 +30392,10 @@ in
   yarn = nodeEnv.buildNodePackage {
     name = "yarn";
     packageName = "yarn";
-    version = "0.23.4";
+    version = "0.24.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/yarn/-/yarn-0.23.4.tgz";
-      sha1 = "f428c75ca27ad4910bc822174f586187c790c5db";
+      url = "https://registry.npmjs.org/yarn/-/yarn-0.24.4.tgz";
+      sha1 = "a4bfa3bb768192706771337f959721cfc0555093";
     };
     dependencies = [
       sources."babel-runtime-6.23.0"
@@ -29807,8 +30405,9 @@ in
       sources."cmd-shim-2.0.2"
       sources."commander-2.9.0"
       sources."death-1.1.0"
-      sources."debug-2.6.6"
+      sources."debug-2.6.8"
       sources."detect-indent-5.0.0"
+      sources."gunzip-maybe-1.4.0"
       sources."ini-1.3.4"
       sources."inquirer-3.0.6"
       sources."invariant-2.2.2"
@@ -29816,21 +30415,20 @@ in
       sources."is-ci-1.0.10"
       sources."leven-2.1.0"
       sources."loud-rejection-1.6.0"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."mkdirp-0.5.1"
       sources."node-emoji-1.5.1"
-      sources."node-gyp-3.6.1"
       sources."object-path-0.11.4"
       sources."proper-lockfile-2.0.1"
       sources."read-1.0.7"
       sources."request-2.81.0"
       sources."request-capture-har-1.2.2"
       sources."rimraf-2.6.1"
-      sources."roadrunner-1.1.0"
       sources."semver-5.3.0"
       sources."strip-bom-3.0.0"
       sources."tar-fs-1.15.2"
-      sources."tar-stream-1.5.2"
+      sources."tar-stream-1.5.4"
+      sources."uuid-3.0.1"
       sources."v8-compile-cache-1.1.0"
       sources."validate-npm-package-license-3.0.1"
       sources."core-js-2.4.1"
@@ -29843,11 +30441,42 @@ in
       sources."ansi-regex-2.1.1"
       sources."graceful-fs-4.1.11"
       sources."graceful-readlink-1.0.1"
-      sources."ms-0.7.3"
+      sources."ms-2.0.0"
+      sources."browserify-zlib-0.1.4"
+      sources."is-deflate-1.0.0"
+      sources."is-gzip-1.0.0"
+      sources."peek-stream-1.1.2"
+      sources."pumpify-1.3.5"
+      sources."through2-2.0.3"
+      sources."pako-0.2.9"
+      sources."duplexify-3.5.0"
+      sources."end-of-stream-1.0.0"
+      sources."inherits-2.0.3"
+      sources."readable-stream-2.2.9"
+      sources."stream-shift-1.0.0"
+      sources."once-1.3.3"
+      sources."wrappy-1.0.2"
+      sources."buffer-shims-1.0.0"
+      sources."core-util-is-1.0.2"
+      sources."isarray-1.0.0"
+      sources."process-nextick-args-1.0.7"
+      sources."string_decoder-1.0.1"
+      sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
+      (sources."pump-1.0.2" // {
+        dependencies = [
+          (sources."end-of-stream-1.4.0" // {
+            dependencies = [
+              sources."once-1.4.0"
+            ];
+          })
+        ];
+      })
+      sources."xtend-4.0.1"
       sources."ansi-escapes-1.4.0"
       sources."cli-cursor-2.1.0"
       sources."cli-width-2.1.0"
-      sources."external-editor-2.0.1"
+      sources."external-editor-2.0.2"
       sources."figures-2.0.0"
       sources."lodash-4.17.4"
       sources."mute-stream-0.0.7"
@@ -29874,51 +30503,6 @@ in
       sources."concat-map-0.0.1"
       sources."minimist-0.0.8"
       sources."string.prototype.codepointat-0.2.0"
-      sources."fstream-1.0.11"
-      sources."glob-7.1.1"
-      sources."nopt-3.0.6"
-      sources."npmlog-4.0.2"
-      sources."osenv-0.1.4"
-      sources."tar-2.2.1"
-      sources."which-1.2.14"
-      sources."inherits-2.0.3"
-      sources."fs.realpath-1.0.0"
-      sources."inflight-1.0.6"
-      sources."once-1.4.0"
-      sources."path-is-absolute-1.0.1"
-      sources."wrappy-1.0.2"
-      sources."abbrev-1.1.0"
-      sources."are-we-there-yet-1.1.4"
-      sources."console-control-strings-1.1.0"
-      (sources."gauge-2.7.4" // {
-        dependencies = [
-          sources."string-width-1.0.2"
-          sources."is-fullwidth-code-point-1.0.0"
-        ];
-      })
-      sources."set-blocking-2.0.0"
-      sources."delegates-1.0.0"
-      sources."readable-stream-2.2.9"
-      sources."buffer-shims-1.0.0"
-      sources."core-util-is-1.0.2"
-      sources."isarray-1.0.0"
-      sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
-      sources."util-deprecate-1.0.2"
-      sources."aproba-1.1.1"
-      sources."has-unicode-2.0.1"
-      sources."object-assign-4.1.1"
-      (sources."wide-align-1.1.0" // {
-        dependencies = [
-          sources."string-width-1.0.2"
-          sources."is-fullwidth-code-point-1.0.0"
-        ];
-      })
-      sources."code-point-at-1.1.0"
-      sources."number-is-nan-1.0.1"
-      sources."os-homedir-1.0.2"
-      sources."block-stream-0.0.9"
-      sources."isexe-2.0.0"
       sources."retry-0.10.1"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.6.0"
@@ -29937,11 +30521,9 @@ in
       sources."oauth-sign-0.8.2"
       sources."performance-now-0.2.0"
       sources."qs-6.4.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.2"
       sources."tunnel-agent-0.6.0"
-      sources."uuid-3.0.1"
       sources."delayed-stream-1.0.0"
       sources."asynckit-0.4.0"
       sources."ajv-4.11.8"
@@ -29985,11 +30567,12 @@ in
       sources."bcrypt-pbkdf-1.0.1"
       sources."mime-db-1.27.0"
       sources."punycode-1.4.1"
+      sources."glob-7.1.2"
+      sources."fs.realpath-1.0.0"
+      sources."inflight-1.0.6"
+      sources."path-is-absolute-1.0.1"
       sources."chownr-1.0.1"
-      sources."pump-1.0.2"
-      sources."end-of-stream-1.4.0"
       sources."bl-1.2.1"
-      sources."xtend-4.0.1"
       sources."spdx-correct-1.0.2"
       sources."spdx-expression-parse-1.0.4"
       sources."spdx-license-ids-1.2.2"
@@ -30140,8 +30723,9 @@ in
       sources."core-util-is-1.0.2"
       sources."isarray-1.0.0"
       sources."process-nextick-args-1.0.7"
-      sources."string_decoder-1.0.0"
+      sources."string_decoder-1.0.1"
       sources."util-deprecate-1.0.2"
+      sources."safe-buffer-5.0.1"
       sources."prepend-http-1.0.4"
       sources."decamelize-1.2.0"
       sources."ansi-escapes-1.4.0"
@@ -30195,7 +30779,6 @@ in
       sources."oauth-sign-0.8.2"
       sources."performance-now-0.2.0"
       sources."qs-6.4.0"
-      sources."safe-buffer-5.0.1"
       sources."stringstream-0.0.5"
       sources."tunnel-agent-0.6.0"
       sources."delayed-stream-1.0.0"
@@ -30267,7 +30850,7 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."deep-extend-0.4.1"
+      sources."deep-extend-0.4.2"
       sources."strip-json-comments-2.0.1"
       sources."registry-auth-token-3.3.1"
       sources."execall-1.0.0"
@@ -30290,9 +30873,9 @@ in
       sources."arrify-1.0.1"
       sources."dot-prop-2.4.0"
       sources."is-obj-1.0.1"
-      sources."debug-2.6.6"
+      sources."debug-2.6.8"
       sources."npmlog-2.0.4"
-      sources."ms-0.7.3"
+      sources."ms-2.0.0"
       sources."external-editor-1.1.1"
       sources."rx-4.1.0"
       sources."spawn-sync-1.0.15"
@@ -30340,7 +30923,7 @@ in
       sources."semver-regex-1.0.0"
       sources."set-immediate-shim-1.0.1"
       sources."walk-2.3.9"
-      sources."minimatch-3.0.3"
+      sources."minimatch-3.0.4"
       sources."foreachasync-3.0.0"
       sources."brace-expansion-1.1.7"
       sources."balanced-match-0.4.2"


### PR DESCRIPTION
###### Motivation for this change

Adding 'bootlint': https://github.com/twbs/bootlint

Regenerated using `generate.sh` per documentation.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

