### PR TITLE
llvmPackages_34.llvm: fix output of llvm-config

### DIFF
--- a/pkgs/development/compilers/llvm/3.4/fix-llvm-config.patch
+++ b/pkgs/development/compilers/llvm/3.4/fix-llvm-config.patch
@@ -1,0 +1,13 @@
+diff --git a/utils/llvm-build/llvmbuild/main.py b/utils/llvm-build/llvmbuild/main.py
+index eacefdf60bf..40d25f5cef8 100644
+--- a/utils/llvm-build/llvmbuild/main.py
++++ b/utils/llvm-build/llvmbuild/main.py
+@@ -412,7 +412,7 @@ subdirectories = %s
+             if library_name is None:
+                 library_name_as_cstr = '0'
+             else:
+-                library_name_as_cstr = '"lib%s.a"' % library_name
++                library_name_as_cstr = '"lib%s.so"' % library_name
+             f.write('  { "%s", %s, %d, { %s } },\n' % (
+                 name, library_name_as_cstr, is_installed,
+                 ', '.join('"%s"' % dep

--- a/pkgs/development/compilers/llvm/3.4/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.4/llvm.nix
@@ -29,11 +29,15 @@ in stdenv.mkDerivation rec {
   '';
 
   buildInputs =
-    [ perl groff cmake libxml2 libffi ]
-    ++ stdenv.lib.optional (!stdenv.isDarwin) python2 /*
+    [ perl groff cmake libxml2 libffi python2 ] /*
     ++ stdenv.lib.optional stdenv.isLinux valgrind */;
 
   propagatedBuildInputs = [ ncurses zlib ];
+
+  patches = stdenv.lib.optionals (!stdenv.isDarwin) [
+    # llvm-config --libfiles returns (non-existing) static libs
+    ./fix-llvm-config.patch
+  ];
 
   # hacky fix: created binaries need to be run before installation
   preBuild = ''
@@ -48,7 +52,7 @@ in stdenv.mkDerivation rec {
     "-DLLVM_REQUIRES_RTTI=1"
     "-DLLVM_BINUTILS_INCDIR=${binutils.dev or binutils}/include"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
-  ] ++ stdenv.lib.optional (!isDarwin) "-DBUILD_SHARED_LIBS=ON";
+  ] ++ stdenv.lib.optional (!stdenv.isDarwin) "-DBUILD_SHARED_LIBS=ON";
 
   postBuild = ''
     rm -fR $out


### PR DESCRIPTION
###### Motivation for this change

Now llvm-config --libnames and llvm-config --libfiles output the proper
files (shared libraries). Other llvm version have a same similar problem, but need to address slightly different. So I want to keep the scope small and fix it version by version.

~~Only affects ghc742 at the moment in nixpkgs.~~

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

