### PR TITLE
autotrace: init at 0.31.1

### DIFF
--- a/pkgs/applications/graphics/autotrace/autofig.nix
+++ b/pkgs/applications/graphics/autotrace/autofig.nix
@@ -1,0 +1,10 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "autofig-0.1";
+
+  src = fetchurl {
+    url = "http://autotrace.sourceforge.net/tools/autofig.tar.gz";
+    sha256 = "11cs9hdbgcl3aamcs3149i8kvyyldmnjf6yq81kbcf8fdmfk2zdq";
+  };
+}

--- a/pkgs/applications/graphics/autotrace/default.nix
+++ b/pkgs/applications/graphics/autotrace/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchurl, callPackage, libpng12, imagemagick,
+  autoreconfHook, glib, pstoedit, pkgconfig, gettext, darwin }:
+
+# TODO: Solve that it cannot find pstoedit (as it is unable to find
+# pstoedit-config)
+
+# TODO: Figure out why the resultant binary is somehow linked against
+# libpng16.so.16 rather than libpng12.
+
+stdenv.mkDerivation rec {
+  name = "autotrace-${version}";
+  version = "0.31.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/autotrace/AutoTrace/0.31.1/${name}.tar.gz";
+    sha256 = "1xmgja5fv48mdbsa51inf7ksz36nqd6bsaybrk5xgprm6cy946js";
+  };
+
+  # The below commented out part is for an identically-named project
+  # on GitHub which appears to derive somehow from the Sourceforge
+  # version, but I have no idea what the lineage is of this project.
+  # It will build, but it segfaults when I attempt to run -centerline.
+  # Someone may need this for some reason, so I've left it here.
+  #
+  #src = fetchFromGitHub {
+  #  owner = "autotrace";
+  #  repo = "autotrace";
+  #  rev = "b3ac8818d86943102cb4f13734e0b527c42dc45a";
+  #  sha256 = "0z5h2mvxwckk2msi361zk1nc9fdcvxyimyc2hlyqd6h8k3p7zdi4";
+  #};
+  #postConfigure = ''
+  #  sed -i -e "s/at_string/gchar */g" *.c
+  #  sed -i -e "s/at_address/gpointer/g" *.c
+  #  sed -i -e "s/at_bitmap_type/struct _at_bitmap/g" *.c
+  #  sed -i -e "s/AT_BITMAP_BITS(bitmap)/AT_BITMAP_BITS(\&bitmap)/g" input-magick.c
+  #'';
+
+  autofig = callPackage ./autofig.nix {};
+  nativeBuildInputs = [ autoreconfHook glib autofig pkgconfig gettext ];
+  buildInputs = [ libpng12 imagemagick pstoedit ]
+    ++ stdenv.lib.optionals stdenv.isDarwin
+       (with darwin.apple_sdk.frameworks; [ApplicationServices]);
+    
+  postUnpack = ''
+    pushd $sourceRoot
+    autofig autotrace-config.af
+    popd
+  '';
+
+  # This complains about various m4 files, but it appears to not be an
+  # actual error.
+  preConfigure = "glib-gettextize --copy --force";
+
+  meta = with stdenv.lib; {
+    homepage = http://autotrace.sourceforge.net/;
+    description = "Utility for converting bitmap into vector graphics";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ hodapp ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13181,6 +13181,8 @@ with pkgs;
 
   audio-recorder = callPackage ../applications/audio/audio-recorder { };
 
+  autotrace = callPackage ../applications/graphics/autotrace {};
+  
   milkytracker = callPackage ../applications/audio/milkytracker { };
 
   schismtracker = callPackage ../applications/audio/schismtracker { };


### PR DESCRIPTION
###### Motivation for this change

autotrace isn't in nixpkgs, and the process of building it is a bit weird due to the package being fairly old.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

