### PR TITLE
efl: 1.19.0 -> 1.19.1

### DIFF
--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   name = "efl-${version}";
-  version = "1.19.0";
+  version = "1.19.1";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/efl/${name}.tar.xz";
-    sha256 = "1pza8lacqh3bgsvcm4h2hyc577bvnzix932g87dhg03ph4839q54";
+    sha256 = "0fndwraca9rg0bz3al4isdprvyw56szr88qiyvglb4j8ygsylscc";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Update to new release.

[News](https://www.enlightenment.org/news/efl-1.19.1):

Fixes:
- elm_image: Fix file_set when preload is disabled
- elm_code: Fix selection,start signal
- build: bump minimum version requirement of gnutls to 3.3.6 (T5437)
- bump minimum version requirement of freetype2 to 16.2.10 which equals release 2.5.0.1 (T5437)
- evas/elm: Fix bad propagation of ON_HOLD flag
- evas render: Fix issue with map render
- nstate: correct the legacy class name
- check: fix efl_ui_check_selected_set() API
- elm_code : LINE_APPEND Render fix
- elm_code: Fix crash on tabs in long lines

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).