### PR TITLE
Libminc and minc tools fixes

### DIFF
--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -9,13 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "1d457vrwy2fl6ga2axnwn1cchkx2rmgixfzyb1zjxb06cxkfj1dm";
   };
 
-  nativeBuildInputs = [ cmake flex bison ] ++ (if doCheck then [ perl ] else [ ]);
+  nativeBuildInputs = [ cmake flex bison perl ];
   buildInputs = [ libminc ];
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/" ];
 
   checkPhase = "ctest";
-  doCheck = false;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/BIC-MNI/minc-tools;

--- a/pkgs/development/libraries/libminc/default.nix
+++ b/pkgs/development/libraries/libminc/default.nix
@@ -12,11 +12,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib netcdf hdf5 ];
 
-  cmakeFlags = [ "-DBUILD_TESTING=${if doCheck then "ON" else "OFF"}"
+  cmakeFlags = [ "-DLIBMINC_BUILD_SHARED_LIBS=ON"
                  "-DLIBMINC_MINC1_SUPPORT=ON" ];
 
   checkPhase = "ctest";
-  doCheck = true;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/BIC-MNI/libminc;


### PR DESCRIPTION
###### Motivation for this change

- libminc: build shared libraries 
- fix minc-tools tests

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [na] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

