### PR TITLE
openpa: init -> 1.0.4

### DIFF
--- a/pkgs/development/libraries/openpa/default.nix
+++ b/pkgs/development/libraries/openpa/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, file }:
+
+stdenv.mkDerivation rec {
+  pname = "openpa";
+  version = "1.0.4";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://trac.mpich.org/projects/${pname}/raw-attachment/wiki/Downloads/${name}.tar.gz";
+    sha256 = "0flyi596hm6fv7xyw2iykx3s65p748s62bf15624xcnwpfrh8ncy";
+  };
+
+  prePatch = ''substituteInPlace configure --replace /usr/bin/file ${file}/bin/file'';
+
+  doCheck = true;
+
+  meta = {
+    description = "Atomic primitives for high performance, concurrent software";
+    homepage = "https://trac.mpich.org/projects/openpa";
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ leenaars ];
+    platforms = with stdenv.lib.platforms; linux;
+    longDescription = ''
+      OPA (or sometimes OpenPA or Open Portable Atomics) is an
+      open source library intended to provide a consistent C API for performing
+      atomic operations on a variety of platforms. The main goal of the project is to
+      enable the portable usage of atomic operations in concurrent software.
+      Developers of client software can worry about implementing and improving their
+      concurrent algorithms instead of fiddling with inline assembly syntax and
+      learning new assembly dialects in order improve or maintain application
+      portability.
+    '';
+   };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9457,6 +9457,8 @@ with pkgs;
   openjpeg_2_1 = callPackage ../development/libraries/openjpeg/2.1.nix { };
   openjpeg = openjpeg_2_1;
 
+  openpa = callPackage ../development/libraries/openpa { };
+
   opensaml-cpp = callPackage ../development/libraries/opensaml-cpp { };
 
   openscenegraph = callPackage ../development/libraries/openscenegraph { };


### PR DESCRIPTION
###### Motivation for this change

High performance scientific library which also happens to be a dependency for another project I'm packaging.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

