### PR TITLE
nixStable: remove old patches

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -8,8 +8,8 @@
 
 let
 
-  common = { name, suffix ? "", src, patchPhase ? "", fromGit ? false }: stdenv.mkDerivation rec {
-    inherit name src patchPhase;
+  common = { name, suffix ? "", src, fromGit ? false }: stdenv.mkDerivation rec {
+    inherit name src;
     version = lib.getVersion name;
 
     VERSION_SUFFIX = lib.optionalString fromGit suffix;
@@ -134,15 +134,6 @@ in rec {
       url = "http://nixos.org/releases/nix/${name}/${name}.tar.xz";
       sha256 = "0e943e277f37843f9196b0293cc31d828613ad7a328ee77cd5be01935dc6e7e1";
     };
-
-    # Until 1.11.9 is released, we do this :)
-    patchPhase = ''
-      substituteInPlace src/libexpr/json-to-value.cc \
-        --replace 'std::less<Symbol>, gc_allocator<Value *>' \
-                  'std::less<Symbol>, gc_allocator<std::pair<const Symbol, Value *> >'
-
-      sed -i '/if (settings.readOnlyMode) {/a curSchema = getSchema();' src/libstore/local-store.cc
-    '';
   }) // { perl-bindings = nixStable; };
 
   nixUnstable = (lib.lowPrio (common rec {


### PR DESCRIPTION
The patches in question already made into 1.11.9 and have no effect in nixpkgs now
https://github.com/NixOS/nix/commit/773313591f167888718228bf5ada44a81f3fa32e
https://github.com/NixOS/nix/commit/ad9e6037a4558c6fd5a2fcaf9d81a4725a1dd82f
Also setting patchPhase breaks user's custom patches.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

