### PR TITLE
psensor: init at 1.2.0

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -1,18 +1,43 @@
 nvidia_x11: sha256:
 
-{ stdenv, lib, fetchurl, pkgconfig, m4, jansson, gtk2, dbus, gtk3, libXv, libXrandr, libvdpau
+{ stdenv, lib, fetchurl, pkgconfig, m4, jansson, gtk2, dbus, gtk3, libXv, libXrandr, libvdpau, libXext
 , librsvg, wrapGAppsHook
 , withGtk2 ? false, withGtk3 ? true
 }:
 
+let
+  src = fetchurl {
+    url = "https://download.nvidia.com/XFree86/nvidia-settings/nvidia-settings-${nvidia_x11.version}.tar.bz2";
+    inherit sha256;
+  };
+
+  libXNVCtrl = stdenv.mkDerivation {
+    name = "libXNVCtrl-${nvidia_x11.version}";
+    inherit (nvidia_x11) version;
+    inherit src;
+
+    buildInputs = [ libXrandr libXext ];
+
+    preBuild = ''
+      cd src/libXNVCtrl
+    '';
+
+    installPhase = ''
+      mkdir -p $out/lib
+      mkdir -p $out/include/NVCtrl
+
+      cp libXNVCtrl.a $out/lib
+      cp NVCtrl.h     $out/include/NVCtrl
+      cp NVCtrlLib.h  $out/include/NVCtrl
+    '';
+  };
+
+in
+
 stdenv.mkDerivation rec {
   name = "nvidia-settings-${nvidia_x11.version}";
   inherit (nvidia_x11) version;
-
-  src = fetchurl {
-    url = "https://download.nvidia.com/XFree86/nvidia-settings/${name}.tar.bz2";
-    inherit sha256;
-  };
+  inherit src;
 
   nativeBuildInputs = [ pkgconfig m4 ];
 
@@ -51,6 +76,10 @@ stdenv.mkDerivation rec {
     patchelf --set-rpath "$(patchelf --print-rpath $out/bin/$binaryName):$out/lib" \
       $out/bin/$binaryName
   '';
+
+  passthru = {
+    inherit libXNVCtrl;
+  };
 
   meta = with stdenv.lib; {
     homepage = "http://www.nvidia.com/object/unix.html";

--- a/pkgs/tools/system/psensor/default.nix
+++ b/pkgs/tools/system/psensor/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchurl, pkgconfig, lm_sensors, libgtop, libatasmart, gtk3
+, libnotify, udisks2, libXNVCtrl, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  name = "psensor-${version}";
+
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "http://wpitchoune.net/psensor/files/psensor-${version}.tar.gz";
+    sha256 = "1smbidbby4rh14jnh9kn7y64qf486aqnmyxcgacjvkz27cqqnw4r";
+  };
+
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+
+  buildInputs = [
+    lm_sensors libgtop libatasmart gtk3 libnotify udisks2
+  ];
+
+  preConfigure = ''
+    NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${libXNVCtrl}/include"
+    NIX_LDFLAGS="$NIX_LDFLAGS -L${libXNVCtrl}/lib"
+  '';
+
+  meta = with lib; {
+    description = "Graphical hardware monitoring application for Linux";
+    homepage = "https://wpitchoune.net/psensor/";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3716,6 +3716,10 @@ with pkgs;
 
   psutils = callPackage ../tools/typesetting/psutils { };
 
+  psensor = callPackage ../tools/system/psensor {
+    libXNVCtrl = linuxPackages.nvidia_x11.settings.libXNVCtrl;
+  };
+
   pv = callPackage ../tools/misc/pv { };
 
   pwgen = callPackage ../tools/security/pwgen { };


### PR DESCRIPTION
psensor is a graphical hardware monitoring application for Linux.

###### Motivation for this change

I wanted a decent way of tracking my CPU/GPU temps/fans.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

