### PR TITLE
elastix: init at 4.8

### DIFF
--- a/pkgs/development/libraries/science/biology/elastix/default.nix
+++ b/pkgs/development/libraries/science/biology/elastix/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, cmake, itk, python }:
+
+stdenv.mkDerivation rec {
+  _name    = "elastix";
+  _version = "4.8";
+  name  = "${_name}-${_version}";
+
+  src = fetchFromGitHub {
+    owner  = "SuperElastix";
+    repo   = "elastix";
+    rev    = "ef057ff89233822b26b04b31c3c043af57d5deff";
+    sha256 = "0gm3a8dgqww50h6zld9ighjk92wlpybpimjwfz4s5h82vdjsvxrm";
+  };
+
+  nativeBuildInputs = [ cmake python ];
+  buildInputs = [ itk ];
+
+  cmakeFlags = [ "-DUSE_KNNGraphAlphaMutualInformationMetric=OFF" ];
+
+  checkPhase = "ctest";
+
+  meta = with stdenv.lib; {
+    homepage = http://elastix.isi.uu.nl/;
+    description = "Image registration toolkit based on ITK";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms = platforms.unix;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7520,6 +7520,8 @@ with pkgs;
 
   vmmlib = callPackage ../development/libraries/vmmlib {};
 
+  elastix = callPackage ../development/libraries/science/biology/elastix { };
+
   enchant = callPackage ../development/libraries/enchant { };
 
   enet = callPackage ../development/libraries/enet { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [na] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

