### PR TITLE
linux_samus_4_11: init at 4.11.1

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-samus-4.11.nix
+++ b/pkgs/os-specific/linux/kernel/linux-samus-4.11.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, perl, buildLinux, ncurses, ... } @ args:
+
+assert stdenv.is64bit;
+
+import ./generic.nix (args // rec {
+  version = "4.11.1";
+  extraMeta.branch = "4.11-2";
+
+  src =
+    let upstream = fetchFromGitHub {
+      owner = "raphael";
+      repo = "linux-samus";
+      rev = "v${extraMeta.branch}";
+      sha256 = "0b95mzadz8jd4pzizgdz6rkli1lh83kdc1zyrs44yin0xg9phxy4";
+    }; in "${upstream}/build/linux";
+
+  features.iwlwifi = true;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.netfilterRPFilter = true;
+
+  extraMeta.hydraPlatforms = [];
+} // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11891,6 +11891,21 @@ with pkgs;
     ];
   };
 
+
+  linux_samus_4_11 = callPackage ../os-specific/linux/kernel/linux-samus-4.11.nix {
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        kernelPatches.p9_fixes
+        # See pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/README.md
+        # when adding a new linux version
+        kernelPatches.cpu-cgroup-v2."4.11"
+        kernelPatches.modinst_arg_list_too_long
+    ];
+  };
+
+  linux_samus_latest = linux_samus_4_11;
+
+
   linux_chromiumos_3_18 = callPackage ../os-specific/linux/kernel/linux-chromiumos-3.18.nix {
     kernelPatches = [ kernelPatches.chromiumos_Kconfig_fix_entries_3_18
                       kernelPatches.chromiumos_no_link_restrictions
@@ -12090,6 +12105,10 @@ with pkgs;
     recurseIntoAttrs (linuxPackagesFor linux_grsec_nixos);
 
   linux_grsec_server_xen = linux_grsec_nixos;
+
+  # Samus kernels
+  linuxPackages_samus_4_11 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_samus_4_11);
+  linuxPackages_samus_latest = recurseIntoAttrs (linuxPackagesFor pkgs.linux_samus_latest);
 
   # ChromiumOS kernels
   linuxPackages_chromiumos_3_18 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_chromiumos_3_18);


### PR DESCRIPTION
This patch contains an expression for linux-samus kernel [1].

I've been using it for a few days and had no major problems so far.
Specific lines in `configuration.nix` the one might want to add are the following:

```shell
services.xserver.wacom.enable = true;
services.xserver.synaptics.enable = true;

boot.initrd.kernelModules = [ "i915" ];

boot.extraModprobeConfig = ''
  options snd_soc_sst_bdw_rt5677_mach index=0
  options snd-hda-intel index=1
'';
```

The sound can be controlled by the following instructions (without `-D pulse` as in original instruction):
```shell
amixer -q sset Master toggle
amixer -q sset Master 5%-
amixer -q sset Master 5%+
```

I have a problem with suspension: the led doesn't change it's colors and the touchscreen stops working after wake-up.
`mxt-app` doesn't seem to help here, so I turned it off:
```
services.logind.extraConfig = ''
  HandleLidSwitch = ignore
''
```

PS. I don't think we should build it in hydra, since there is not so many users and the build process takes about one hour on this laptop.
PPS. And again, many thanks to @abbradar for assistance in this pr!


[1] https://github.com/raphael/linux-samus

