### PR TITLE
gdal: Add hdf4 support

### DIFF
--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -1,0 +1,76 @@
+{ stdenv
+, fetchurl
+, cmake
+, libjpeg
+, szip
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  name = "hdf-${version}";
+  version = "4.2.12";
+  src = fetchurl {
+    url = "https://support.hdfgroup.org/ftp/HDF/releases/HDF${version}/src/hdf-${version}.tar.bz2";
+    sha256 = "020jh563sjyxsgml8l809d2i1d4ms9shivwj3gbm7n0ilxbll8id";
+  };
+
+  buildInputs = [
+    cmake
+    libjpeg
+    szip
+    zlib
+  ];
+
+  preConfigure = "export SZIP_INSTALL=${szip}";
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DBUILD_TESTING=ON"
+    "-DHDF4_BUILD_TOOLS=ON"
+    "-DHDF4_BUILD_UTILS=ON"
+    "-DHDF4_BUILD_WITH_INSTALL_NAME=OFF"
+    "-DHDF4_ENABLE_JPEG_LIB_SUPPORT=ON"
+    "-DHDF4_ENABLE_NETCDF=OFF"
+    "-DHDF4_ENABLE_SZIP_ENCODING=ON"
+    "-DHDF4_ENABLE_SZIP_SUPPORT=ON"
+    "-DHDF4_ENABLE_Z_LIB_SUPPORT=ON"
+    "-DHDF4_BUILD_FORTRAN=OFF"
+    "-DJPEG_DIR=${libjpeg}"
+  ];
+
+  doCheck = true;
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=$(pwd)/bin
+  '' + stdenv.lib.optionalString (stdenv.isDarwin) ''
+    export DYLD_LIBRARY_PATH=$(pwd)/bin
+  '';
+
+  excludedTests = [
+    "MFHDF_TEST-hdftest"
+    "MFHDF_TEST-hdftest-shared"
+    "HDP-dumpsds-18"
+    "NC_TEST-nctest"
+  ];
+
+  checkPhase = let excludedTestsRegex = if (excludedTests != [])
+    then "(" + (stdenv.lib.concatStringsSep "|" excludedTests) + ")"
+    else ""; in ''
+    runHook preCheck
+    ctest -E "${excludedTestsRegex}" --output-on-failure
+    runHook postCheck
+  '';
+
+  outputs = [ "bin" "dev" "out" ];
+
+  postInstall = ''
+    moveToOutput bin "$bin"
+  '';
+
+  meta = {
+    description = "Data model, library, and file format for storing and managing data";
+    homepage = https://support.hdfgroup.org/products/hdf4/;
+    maintainers = with stdenv.lib.maintainers; [ knedlsepp ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2277,6 +2277,8 @@ with pkgs;
 
   hddtemp = callPackage ../tools/misc/hddtemp { };
 
+  hdf4 = callPackage ../tools/misc/hdf4 { };
+
   hdf5 = callPackage ../tools/misc/hdf5 {
     gfortran = null;
     szip = null;


### PR DESCRIPTION
###### Motivation for this change
I want to add hdf4 support to the gdal library.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

