### PR TITLE
cyrus_sasl: fix version

### DIFF
--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "cyrus-sasl-${version}${optionalString (kerberos == null) "-without-kerberos"}";
-  version = "2.5.10";
+  version = "2.1.26";
 
   src = fetchurl {
     url = "ftp://ftp.cyrusimap.org/cyrus-sasl/${name}.tar.gz";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/commit/a60500ce7028a1888aa2e367cf69c53dd93e01b6 changed sasl version but did not update sha256, and there never were sasl 2.5.10, this is a version of cyrus imap.