### PR TITLE
go: 1.7.5 -> 1.7.6

### DIFF
--- a/pkgs/development/compilers/go/1.7.nix
+++ b/pkgs/development/compilers/go/1.7.nix
@@ -24,13 +24,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.7.5";
+  version = "1.7.6";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "go";
     rev = "go${version}";
-    sha256 = "00radlwbrssn0x3naamb33cfx7ap2jv7s51bqr705nmn2j5yyblk";
+    sha256 = "1gacjwbs1qbx8x84746qdxx2xwylirvd31ybgagfglfsl77vi4m2";
   };
 
   # perl is used for testing go vet


### PR DESCRIPTION
###### Motivation for this change
security fix release, to address CVE-2017-8932
This contains a single patch in addition to 1.7.5: https://go-review.googlesource.com/c/41070/

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

