### PR TITLE
go: 1.8.1 -> 1.8.2

### DIFF
--- a/pkgs/development/compilers/go/1.8.nix
+++ b/pkgs/development/compilers/go/1.8.nix
@@ -25,13 +25,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.8.1";
+  version = "1.8.2";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "go";
     rev = "go${version}";
-    sha256 = "1157mmzjpk887cpcpn2qy9c69anc22c4p3cjpl84zl7an41x660j";
+    sha256 = "0haazh0sk1zys1gbmbi128rmcyrd6f32amp6a872jqhadjlvj9qv";
   };
 
   # perl is used for testing go vet


### PR DESCRIPTION
###### Motivation for this change
security fix release, to address CVE-2017-8932
This contains a single patch in addition to 1.8.1: https://go-review.googlesource.com/c/41070/

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

