### PR TITLE
Updates Yakuake to version 3.0.3 and exposes the .desktop

### DIFF
--- a/pkgs/applications/misc/yakuake/default.nix
+++ b/pkgs/applications/misc/yakuake/default.nix
@@ -20,13 +20,13 @@
 let
   unwrapped = let
     pname = "yakuake";
-    version = "3.0.2";
+    version = "3.0.3";
   in kdeDerivation rec {
     name = "${pname}-${version}";
 
     src = fetchurl {
       url = "http://download.kde.org/stable/${pname}/${version}/src/${name}.tar.xz";
-      sha256 = "0vcdji1k8d3pz7k6lkw8ighkj94zff2l2cf9v1avf83f4hjyfhg5";
+      sha256 = "ef51aa3325916d352fde17870cf706397e41105103e4c9289cc4032a1b8609a7";
     };
 
     buildInputs = [
@@ -58,6 +58,6 @@ in
 kdeWrapper
 {
   inherit unwrapped;
-  targets = [ "bin/yakuake" ];
+  targets = [ "bin/yakuake" "share/applications/org.kde.yakuake.desktop" ];
   paths = [ konsole.unwrapped ];
 }


### PR DESCRIPTION
###### Motivation for this change
I wanted to autostart Yakuake with makeAutostartItem, but that requires the .desktop file. By adding the .desktop as target you can create an autostart entry with:

(pkgs.makeAutostartItem { name = "yakuake"; package = yakuake; srcPrefix = "org.kde.";  });

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

