### PR TITLE
ipfs: 0.4.6 -> 0.4.9

### DIFF
--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -2,15 +2,15 @@
 
 buildGoPackage rec {
   name = "ipfs-${version}";
-  version = "0.4.6";
-  rev = "ed729423ce548785834cdcaa21aab11ebc3a1b1a";
+  version = "0.4.9";
+  rev = "7ea34c6c6ed18e886f869a1fbe725a848d13695c";
 
   goPackagePath = "github.com/ipfs/go-ipfs";
 
   extraSrcPaths = [
     (fetchgx {
       inherit name src;
-      sha256 = "1wwzbps3ry3vlrr0iqhvxd44x0wi99dcp5hlxvh79dc0g9r7myfk";
+      sha256 = "1xgk9gdnlcxkrpj98h2mrnlpr9b8084k4q926i4pbmxipwxkwl4b";
     })
   ];
 
@@ -18,7 +18,7 @@ buildGoPackage rec {
     owner = "ipfs";
     repo = "go-ipfs";
     inherit rev;
-    sha256 = "1b262k1lhb1g68l8hghly4pdrxx1c6wbv6ij6dg399zdwqzczl13";
+    sha256 = "1n2m2yah54cx4i9nlcsmljrwqi3wqxih517y8jpyjij6wraa334j";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/build-support/fetchgx/default.nix
+++ b/pkgs/build-support/fetchgx/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
   phases = [ "unpackPhase" "buildPhase" "installPhase" ];
 
-  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   buildPhase = ''
     export GOPATH=$(pwd)/vendor


### PR DESCRIPTION
###### Motivation for this change

IPFS was updated, this version fixes directory sharding, adds an experimental filestore implementation, and contains many bug fixes, and more.
Issue #24704 should not happen with this PR, as I updated fetchgx to use `NIX_SSL_CERT_FILE`, but please test this independently, as I couldn't reproduce this issue last time (#24523).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

