### PR TITLE
ethabi: add cli feature

### DIFF
--- a/pkgs/applications/altcoins/ethabi.nix
+++ b/pkgs/applications/altcoins/ethabi.nix
@@ -15,6 +15,8 @@ buildRustPackage rec {
 
   depsSha256 = "1n4rxipna307r4xppb2iaads7kpa3yjv99fimvpn8l0f999ir2rz";
 
+  cargoBuildFlags = ["--features cli"];
+
   meta = {
     description = "Ethereum function call encoding (ABI) utility";
     homepage = https://github.com/ethcore/ethabi/;


### PR DESCRIPTION
###### Motivation for this change

This flag makes the CLI binary do anything at all, and without it
the package is completely useless.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

