### PR TITLE
vimer: init at 0.2.0

### DIFF
--- a/pkgs/tools/misc/vimer/default.nix
+++ b/pkgs/tools/misc/vimer/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  version = "0.2.0";
+  name = "vimer-${version}";
+
+  src = fetchFromGitHub {
+    owner = "susam";
+    repo = "vimer";
+    rev = version;
+    sha256 = "01qhr3i7wasbaxvms39c81infpry2vk0nzh7r5m5b9p713p0phsi";
+  };
+
+  installPhase = ''
+    mkdir $out/bin/ -p
+    cp vimer $out/bin/
+    chmod +x $out/bin/vimer
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/susam/vimer";
+    description = ''
+      A convenience wrapper for gvim/mvim --remote(-tab)-silent to open files
+      in an existing instance of GVim or MacVim.
+    '';
+    license = licenses.mit;
+    maintainers = [ maintainers.matthiasbeyer ];
+    platforms = platforms.linux;
+  };
+
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4477,6 +4477,8 @@ with pkgs;
 
   vim-vint = callPackage ../development/tools/vim-vint { };
 
+  vimer = callPackage ../tools/misc/vimer { };
+
   vit = callPackage ../applications/misc/vit { };
 
   vnc2flv = callPackage ../tools/video/vnc2flv {};
@@ -13353,7 +13355,7 @@ with pkgs;
   clipit = callPackage ../applications/misc/clipit { };
 
   cloud-print-connector = callPackage ../servers/cloud-print-connector { };
-  
+
   cmatrix = callPackage ../applications/misc/cmatrix { };
 
   cmus = callPackage ../applications/audio/cmus {
@@ -17789,7 +17791,7 @@ with pkgs;
   coqPackages_8_5 = mkCoqPackages_8_5 coqPackages_8_5;
   coqPackages_8_6 = mkCoqPackages_8_6 coqPackages_8_6;
   coqPackages = coqPackages_8_6;
-  
+
   coq_8_4 = coqPackages_8_4.coq;
   coq_8_5 = coqPackages_8_5.coq;
   coq_8_6 = coqPackages_8_6.coq;


### PR DESCRIPTION
I'm using this for some weeks now and it works.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

