### PR TITLE
nss-pam-ldapd: 0.8.13 -> 0.9.7

### DIFF
--- a/pkgs/tools/networking/nss-pam-ldapd/default.nix
+++ b/pkgs/tools/networking/nss-pam-ldapd/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "nss-pam-ldapd-${version}";
-  version = "0.8.13";
+  version = "0.9.7";
   
   src = fetchurl {
     url = "http://arthurdejong.org/nss-pam-ldapd/${name}.tar.gz";
-    sha256 = "08jxxskzv983grc28zksk9fd8q5qad64rma9vcjsq0l4r6cax4mp";
+    sha256 = "1sw36w6zkzvabvjckqick032j5p5xi0qi3sgnh0znzxz31jqvf0d";
   };
   
   buildInputs = [ makeWrapper pkgconfig python openldap pam ];


### PR DESCRIPTION
###### Motivation for this change

The version in nixpkgs is very old (> 3 years). The new version has seen a lot of bug fixes and support new functionalities (e.g ppolicy)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

