### PR TITLE
loadlibrary: init at 2551be

### DIFF
--- a/pkgs/tools/misc/loadlibrary/default.nix
+++ b/pkgs/tools/misc/loadlibrary/default.nix
@@ -1,0 +1,31 @@
+{ cabextract, glibc_multi, fetchFromGitHub, readline, stdenv_32bit }:
+
+# stdenv_32bit is needed because the program depends upon 32-bit libraries and does not have
+# support for 64-bit yet: it requires libc6-dev:i386, libreadline-dev:i386.
+
+stdenv_32bit.mkDerivation rec {
+  name = "loadlibrary-${version}";
+  version = "20170525-${stdenv_32bit.lib.strings.substring 0 7 rev}";
+  rev = "721b084c088d779075405b7f20c77c2578e2a961";
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "taviso";
+    repo = "loadlibrary";
+    sha256 = "01hb7wzfh1s5b8cvmrmr1gqknpq5zpzj9prq3wrpsgg129jpsjkb";
+  };
+
+  buildInputs = [ glibc_multi cabextract readline stdenv_32bit.cc.libc ];
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    cp mpclient $out/bin/
+  '';
+
+  meta = with stdenv_32bit.lib; {
+    homepage = "https://github.com/taviso/loadlibrary";
+    description = "Porting Windows Dynamic Link Libraries to Linux";
+    platforms = platforms.linux;
+    maintainers = [ maintainers.eleanor ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2653,6 +2653,8 @@ with pkgs;
 
   lnav = callPackage ../tools/misc/lnav { };
 
+  loadlibrary = callPackage ../tools/misc/loadlibrary { };
+
   loc = callPackage ../development/misc/loc { };
 
   lockfileProgs = callPackage ../tools/misc/lockfile-progs { };
@@ -13355,7 +13357,7 @@ with pkgs;
   clipit = callPackage ../applications/misc/clipit { };
 
   cloud-print-connector = callPackage ../servers/cloud-print-connector { };
-  
+
   cmatrix = callPackage ../applications/misc/cmatrix { };
 
   cmus = callPackage ../applications/audio/cmus {
@@ -17791,7 +17793,7 @@ with pkgs;
   coqPackages_8_5 = mkCoqPackages_8_5 coqPackages_8_5;
   coqPackages_8_6 = mkCoqPackages_8_6 coqPackages_8_6;
   coqPackages = coqPackages_8_6;
-  
+
   coq_8_4 = coqPackages_8_4.coq;
   coq_8_5 = coqPackages_8_5.coq;
   coq_8_6 = coqPackages_8_6.coq;


### PR DESCRIPTION
###### Motivation for this change

Addition of loadlibrary to nixpkgs.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

