### PR TITLE
[WIP] One way to do other types of services

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -129,6 +129,8 @@
   ./security/rtkit.nix
   ./security/wrappers/default.nix
   ./security/sudo.nix
+  ./service-managers/docker.nix
+  ./service-managers/trivial.nix
   ./services/admin/salt/master.nix
   ./services/admin/salt/minion.nix
   ./services/amqp/activemq/default.nix

--- a/nixos/modules/service-managers/docker.nix
+++ b/nixos/modules/service-managers/docker.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.docker-containers;
+
+  containerModule = {
+    script = mkOption {
+      type = types.lines;
+      description = "Shell commands executed as the service's main process.";
+    };
+  };
+
+  toContainer = name: value: pkgs.dockerTools.buildImage {
+    inherit name;
+    config = {
+      Cmd = [ value.script ];
+    };
+  };
+in {
+  options.docker-containers = mkOption {
+    default = {};
+    type = with types; attrsOf (types.submodule containerModule);
+    description = "Definition of docker containers";
+  };
+
+  config.system.build.toplevel-docker = lib.mapAttrs toContainer cfg;
+}

--- a/nixos/modules/service-managers/trivial.nix
+++ b/nixos/modules/service-managers/trivial.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.trivial-services;
+
+  serviceModule.options = {
+    script = mkOption {
+      type = types.lines;
+      description = "Shell commands executed as the service's main process.";
+    };
+
+    environment = mkOption {
+      default = {};
+      type = types.attrs; # FIXME
+      example = { PATH = "/foo/bar/bin"; LANG = "nl_NL.UTF-8"; };
+      description = "Environment variables passed to the service's processes.";
+    };
+  };
+
+  launcher = name: value: pkgs.writeScript name ''
+    #!${pkgs.stdenv.shell} -eu
+
+    ${pkgs.writeScript "${name}-entry" value.script}
+  '';
+in {
+  options.trivial-services = mkOption {
+    default = {};
+    type = with types; attrsOf (types.submodule serviceModule);
+    description = "Definition of trivial services";
+  };
+
+  config.system.build.toplevel-trivial = lib.mapAttrs launcher cfg;
+}

--- a/nixos/modules/services/security/hologram-server.nix
+++ b/nixos/modules/services/security/hologram-server.nix
@@ -23,6 +23,8 @@ let
     stats  = cfg.statsAddress;
     listen = cfg.listenAddress;
   });
+
+  script = "${pkgs.hologram.bin}/bin/hologram-server --debug --conf ${cfgFile}";
 in {
   options = {
     services.hologram-server = {
@@ -94,9 +96,15 @@ in {
       after       = [ "network.target" ];
       wantedBy    = [ "multi-user.target" ];
 
-      serviceConfig = {
-        ExecStart = "${pkgs.hologram.bin}/bin/hologram-server --debug --conf ${cfgFile}";
-      };
+      inherit script;
+    };
+
+    docker-containers.hologram-server = {
+      inherit script;
+    };
+
+    trivial-services.hologram-server = {
+      inherit script;
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

See #26067. Not quite sure how to expose this, and I'd be tempted to move the service modules out of the `nixos` folder if this catches on.

Here's how I use it:

```nix
(import ./nixos/lib/eval-config.nix {
  modules = [
    {
      services.hologram-server = {
        enable = true;
        awsAccount = "123456";
        awsDefaultRole = "foo";
        ldapBaseDN = "foobar";
        ldapBindDN = "baaz";
        ldapBindPassword = "quuux";
        ldapHost = "zomg";
      };
    }
  ];
}).config.system.build.toplevel-trivial
```

Then just `nix-build` that and you get a runner script that launches your service on any platform supported by the package.

Also, `toplevel-docker` will contain as many `dockerTools`-style containers as your config has docker-flavored services enabled.