### PR TITLE
kops: fix hash

### DIFF
--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -10,7 +10,7 @@ buildGoPackage rec {
     rev = version;
     owner = "kubernetes";
     repo = "kops";
-    sha256 = "0varn38v2vybmahzpgbk73ma368bkdz09wmx2mmqikfppmzszkv3";
+    sha256 = "1z890kjgsdnghg71v4sp7lljvw14dhzr23m2qjmk6wndyssscykr";
   };
 
   buildInputs = [go-bindata];


### PR DESCRIPTION
###### Motivation for this change

The hash submitted in #26005 seems to have been wrong from the start according to travis logs
(see https://travis-ci.org/NixOS/nixpkgs/jobs/235378365 for example)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

