### PR TITLE
go: 1.8.2 -> 1.8.3

### DIFF
--- a/pkgs/development/compilers/go/1.8.nix
+++ b/pkgs/development/compilers/go/1.8.nix
@@ -25,13 +25,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.8.2";
+  version = "1.8.3";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "go";
     rev = "go${version}";
-    sha256 = "0haazh0sk1zys1gbmbi128rmcyrd6f32amp6a872jqhadjlvj9qv";
+    sha256 = "0g83xm9gb872rsqzwqr1zw5szq69xhynljj2nglg4yyfi7dm2r1c";
   };
 
   # perl is used for testing go vet


### PR DESCRIPTION
###### Motivation for this change

1.8.3 is a bugfix release.

###### Things done

note: nox-review passes on Linux after applying #26076

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

