### PR TITLE
3to2: refactor to use fetchpypi

### DIFF
--- a/pkgs/development/python-modules/3to2/default.nix
+++ b/pkgs/development/python-modules/3to2/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchurl
+, fetchPypi
 , pytest
 }:
 
@@ -9,8 +9,9 @@ buildPythonPackage rec {
   version = "1.1.1";
   name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/8f/ab/58a363eca982c40e9ee5a7ca439e8ffc5243dde2ae660ba1ffdd4868026b/${pname}-${version}.zip";
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
     sha256 = "fef50b2b881ef743f269946e1090b77567b71bb9a9ce64b7f8e699b562ff685c";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Using fetchPypi is preferred for python packages (as per https://github.com/NixOS/nixpkgs/pull/25202#discussion_r113117919) but was deferred due to lack of support for zip distributions. This was fixed with https://github.com/NixOS/nixpkgs/pull/26059, so this PR replaces fetchurl with fetchPypi.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
