### PR TITLE
fonttools: 3.0 -> 3.13.0

### DIFF
--- a/pkgs/development/python-modules/fonttools/default.nix
+++ b/pkgs/development/python-modules/fonttools/default.nix
@@ -1,0 +1,32 @@
+{ buildPythonPackage
+, fetchPypi
+, numpy
+, pytest
+, pytestrunner
+}:
+
+buildPythonPackage rec {
+  pname = "fonttools";
+  version = "3.13.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5ec278ff231d0c88afe8266e911ee0f8e66c8501c53f5f144a1a0abbc936c6b8";
+    extension = "zip";
+  };
+
+  buildInputs = [
+    numpy
+  ];
+
+  checkInputs = [
+    pytest
+    pytestrunner
+  ];
+
+  meta = {
+    homepage = "https://github.com/fonttools/fonttools";
+    description = "A library to manipulate font files from Python";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11418,21 +11418,28 @@ in {
   };
 
   fonttools = buildPythonPackage (rec {
-    version = "3.0";
-    name = "fonttools-${version}";
+    pname = "fonttools";
+    version = "3.13.0";
+    name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/F/FontTools/fonttools-${version}.tar.gz";
-      sha256 = "0f4iblpbf3y3ghajiccvdwk2f46cim6dsj6fq1kkrbqfv05dr4nz";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "5ec278ff231d0c88afe8266e911ee0f8e66c8501c53f5f144a1a0abbc936c6b8";
+      extension = "zip";
     };
 
     buildInputs = with self; [
       numpy
     ];
 
+    checkInputs = with self; [
+      pytest
+      pytestrunner
+    ];
+
     meta = {
-      homepage = "https://github.com/behdad/fonttools";
-      description = "Font file processing tools";
+      homepage = "https://github.com/fonttools/fonttools";
+      description = "A library to manipulate font files from Python";
     };
   });
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11417,31 +11417,7 @@ in {
     inherit python;
   };
 
-  fonttools = buildPythonPackage (rec {
-    pname = "fonttools";
-    version = "3.13.0";
-    name = "${pname}-${version}";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "5ec278ff231d0c88afe8266e911ee0f8e66c8501c53f5f144a1a0abbc936c6b8";
-      extension = "zip";
-    };
-
-    buildInputs = with self; [
-      numpy
-    ];
-
-    checkInputs = with self; [
-      pytest
-      pytestrunner
-    ];
-
-    meta = {
-      homepage = "https://github.com/fonttools/fonttools";
-      description = "A library to manipulate font files from Python";
-    };
-  });
+  fonttools = callPackage ../development/python-modules/fonttools { };
 
   foolscap = buildPythonPackage (rec {
     name = "foolscap-${version}";


### PR DESCRIPTION
###### Motivation for this change

version bump

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

