### PR TITLE
znc module: Fix error with bitlbee channel closing tag missing a newline

### DIFF
--- a/nixos/modules/services/networking/znc.nix
+++ b/nixos/modules/services/networking/znc.nix
@@ -53,7 +53,8 @@ let
                   Server = ${net.server} ${lib.optionalString net.useSSL "+"}${toString net.port} ${net.password}
                   ${concatMapStrings (c: "<Chan #${c}>\n</Chan>\n") net.channels}
                   ${lib.optionalString net.hasBitlbeeControlChannel ''
-                    <Chan &bitlbee></Chan>
+                    <Chan &bitlbee>
+                    </Chan>
                   ''}
                   ${net.extraConf}
               </Network>


### PR DESCRIPTION
###### Motivation for this change

The special bitlbee control channel did not use a newline between the channel tags as required for channel definitions in the ZNC configuration file.  This results in an error  (#26082).  I had not originally tested it in conjunction with a concurrent Bitlbee installation.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

