### PR TITLE
programs.zsh: rename oh-my-zsh to ohMyZsh

### DIFF
--- a/nixos/modules/programs/zsh/oh-my-zsh.nix
+++ b/nixos/modules/programs/zsh/oh-my-zsh.nix
@@ -3,11 +3,11 @@
 with lib;
 
 let
-  cfg = config.programs.zsh.oh-my-zsh;
+  cfg = config.programs.zsh.ohMyZsh;
 in
   {
     options = {
-      programs.zsh.oh-my-zsh = {
+      programs.zsh.ohMyZsh = {
         enable = mkOption {
           default = false;
           description = ''

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -210,5 +210,9 @@ with lib;
     (mkRenamedOptionModule [ "programs" "zsh" "syntax-highlighting" "enable" ] [ "programs" "zsh" "syntaxHighlighting" "enable" ])
     (mkRenamedOptionModule [ "programs" "zsh" "syntax-highlighting" "highlighters" ] [ "programs" "zsh" "syntaxHighlighting" "highlighters" ])
     (mkRenamedOptionModule [ "programs" "zsh" "syntax-highlighting" "patterns" ] [ "programs" "zsh" "syntaxHighlighting" "patterns" ])
+    (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "enable" ] [ "programs" "zsh" "ohMyZsh" "enable" ])
+    (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "theme" ] [ "programs" "zsh" "ohMyZsh" "theme" ])
+    (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "custom" ] [ "programs" "zsh" "ohMyZsh" "custom" ])
+    (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "plugins" ] [ "programs" "zsh" "ohMyZsh" "plugins" ])
   ];
 }


### PR DESCRIPTION
###### Motivation for this change

This is intended to provide better consistency with other NixOS modules.
Please refer to mayflower/nixpkgs#21 for further information. (/cc @WilliButz @fpletz)

I checked this change using the following configuration:

``` nix
{
  # ...
  programs.zsh = {
    enable = true;

    ohMyZsh = {
      enable = true;
      theme = "norm";
    };
  };
}
```

I booted the VM using the following command:

```
NIXOS_CONFIG=`pwd`/vmtest.nix nixos-rebuild -I nixpkgs=$HOME/Projects/nixpkgs/ build-vm
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

