### PR TITLE
simple-scan: fix #26054

### DIFF
--- a/pkgs/applications/graphics/simple-scan/default.nix
+++ b/pkgs/applications/graphics/simple-scan/default.nix
@@ -29,6 +29,17 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/share/icons
     mv $out/share/simple-scan/icons/* $out/share/icons/
+    (
+    cd ${gnome3.defaultIconTheme}/share/icons/Adwaita
+    for f in `find . | grep 'scanner\.'`
+    do
+      local outFile="`echo "$out/share/icons/hicolor/$f" | sed \
+        -e 's#/devices/#/apps/#g' \
+        -e 's#scanner\.#simple-scan\.#g'`"
+      mkdir -p "`realpath -m "$outFile/.."`"
+      cp "$f" "$outFile"
+    done
+    )
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Restore icon for simple-scan

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

