### PR TITLE
xonotic: fix xonotic not finding libcurl at runtime

### DIFF
--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , # required for both
-  unzip, libjpeg, zlib, libvorbis, curl
+  unzip, libjpeg, zlib, libvorbis, curl, patchelf
 , # glx
   libX11, mesa, libXpm, libXext, libXxf86vm, alsaLib
 , # sdl
@@ -48,7 +48,13 @@ stdenv.mkDerivation rec {
     ln -s "$out/bin/xonotic-sdl" "$out/bin/xonotic"
   '';
 
+  # Xonotic needs to find libcurl.so at runtime for map downloads
   dontPatchELF = true;
+  postFixup = ''
+    patchelf --add-needed ${curl.out}/lib/libcurl.so $out/bin/xonotic-dedicated
+    patchelf --add-needed ${curl.out}/lib/libcurl.so $out/bin/xonotic-sdl
+    patchelf --add-needed ${curl.out}/lib/libcurl.so $out/bin/xonotic-glx
+  '';
 
   meta = {
     description = "A free fast-paced first-person shooter";


### PR DESCRIPTION
###### Motivation for this change

Xonotic needs to be able to find libcurl at runtime so that it can download game maps.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

