### PR TITLE
FeedReader 2.0

### DIFF
--- a/pkgs/applications/networking/feedreaders/feedreader/default.nix
+++ b/pkgs/applications/networking/feedreaders/feedreader/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, vala_0_40, gettext
+, appstream-glib, desktop-file-utils, glibcLocales, wrapGAppsHook
+, curl, glib, gnome3, gst_all_1, json-glib, libnotify, libsecret, sqlite
+}:
+
+let
+  pname = "FeedReader";
+  version = "2.2";
+in stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "jangernert";
+    repo = pname;
+    rev = "v" + version;
+    sha256 = "17588hsa7xv92ba55kmbyvnijypp373yrly48kbc391wadp1z939";
+  };
+
+  nativeBuildInputs = [
+    meson ninja pkgconfig vala_0_40 gettext appstream-glib desktop-file-utils
+    glibcLocales wrapGAppsHook
+  ];
+
+  buildInputs = [
+    curl glib json-glib libnotify libsecret sqlite
+  ] ++ (with gnome3; [
+    gtk libgee libpeas libsoup rest webkitgtk gnome_online_accounts
+    gsettings_desktop_schemas
+  ]) ++ (with gst_all_1; [
+    gstreamer gst-plugins-base gst-plugins-good
+  ]);
+
+  # TODO: fix https://github.com/NixOS/nixpkgs/issues/39547
+  LIBRARY_PATH = stdenv.lib.makeLibraryPath [ curl ];
+
+  # vcs_tag function fails with UnicodeDecodeError
+  LC_ALL = "en_US.UTF-8";
+
+  postPatch = ''
+    patchShebangs meson_post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A modern desktop application designed to complement existing web-based RSS accounts.";
+    homepage = https://jangernert.github.io/FeedReader/;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ edwtjo ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2311,6 +2311,8 @@ with pkgs;
 
   fdm = callPackage ../tools/networking/fdm {};
 
+  feedreader = callPackage ../applications/networking/feedreaders/feedreader {};
+
   ferm = callPackage ../tools/networking/ferm { };
 
   fgallery = callPackage ../tools/graphics/fgallery {


### PR DESCRIPTION
###### Motivation for this change

Didn't push this package addition since it needs to add vala bindings for gnome_online_accounts.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

