### PR TITLE
clang: fix libclang on darwin

### DIFF
--- a/pkgs/development/compilers/llvm/4/clang/default.nix
+++ b/pkgs/development/compilers/llvm/4/clang/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetch, cmake, libxml2, libedit, llvm, version, release_version, clang-tools-extra_src, python }:
+{ stdenv, fetch, cmake, libxml2, libedit, llvm, version, release_version, clang-tools-extra_src, python
+, fixDarwinDylibNames
+}:
 
 let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
@@ -14,7 +16,8 @@ let
     '';
 
     nativeBuildInputs = [ cmake python python.pkgs.sphinx ];
-    buildInputs = [ libedit libxml2 llvm ];
+    buildInputs = [ libedit libxml2 llvm ]
+      ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
     cmakeFlags = [
       "-DCMAKE_CXX_FLAGS=-std=c++11"

--- a/pkgs/development/tools/rtags/default.nix
+++ b/pkgs/development/tools/rtags/default.nix
@@ -22,12 +22,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  postInstall = lib.optionalString stdenv.isDarwin ''
-    for f in $out/bin/{rc,rdm,rp}; do
-      install_name_tool -change @rpath/libclang.dylib ${llvmPackages.clang.cc}/lib/libclang.dylib ''${f}
-    done
-  '';
-
   meta = {
     description = "C/C++ client-server indexer based on clang";
     homepage = https://github.com/andersbakken/rtags;


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nixpkgs/pull/25309. I did some more testing and didn't notice any issues.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] macOS
   - [x] No changes for other platforms
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

