### PR TITLE
nixos/xsession: use graphical systemd user target

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -240,11 +240,14 @@ in {
       };
       systemd.user = {
         services.pulseaudio = {
+          restartIfChanged = true;
           serviceConfig = {
             RestartSec = "500ms";
+            PassEnvironment = "DISPLAY";
           };
-          environment = { DISPLAY = ":${toString config.services.xserver.display}"; };
-          restartIfChanged = true;
+        };
+        sockets.pulseaudio = {
+          wantedBy = [ "sockets.target" ];
         };
       };
     })

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -80,6 +80,7 @@
   ./programs/environment.nix
   ./programs/fish.nix
   ./programs/freetds.nix
+  ./programs/gnupg.nix
   ./programs/gphoto2.nix
   ./programs/info.nix
   ./programs/java.nix

--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -1,0 +1,75 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.gnupg;
+
+in
+
+{
+
+  options.programs.gnupg = {
+    agent.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enables GnuPG agent with socket-activation for every user session.
+      '';
+    };
+
+    agent.enableSSHSupport = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Enable SSH agent support in GnuPG agent. Also sets SSH_AUTH_SOCK
+        environment variable correctly. This will disable socket-activation
+        and thus always start a GnuPG agent per user session.
+      '';
+    };
+  };
+
+  config = mkIf cfg.agent.enable {
+    systemd.user.services.gpg-agent = {
+      serviceConfig = {
+        ExecStart = [
+          ""
+          ("${pkgs.gnupg}/bin/gpg-agent --supervised "
+            + optionalString cfg.agent.enableSSHSupport "--enable-ssh-support")
+        ];
+      };
+    };
+
+    systemd.user.sockets.gpg-agent = {
+      wantedBy = [ "sockets.target" ];
+    };
+
+    systemd.user.sockets.gpg-agent-ssh = mkIf cfg.agent.enableSSHSupport {
+      wantedBy = [ "sockets.target" ];
+    };
+
+    systemd.packages = [ pkgs.gnupg ];
+
+    environment.extraInit = ''
+      # Bind gpg-agent to this TTY if gpg commands are used.
+      export GPG_TTY=$(tty)
+
+    '' + (optionalString cfg.agent.enableSSHSupport ''
+      # SSH agent protocol doesn't support changing TTYs, so bind the agent
+      # to every new TTY.
+      ${pkgs.gnupg}/bin/gpg-connect-agent --quiet updatestartuptty /bye > /dev/null
+
+      if [ -z "$SSH_AUTH_SOCK" ]; then
+        export SSH_AUTH_SOCK=$(${pkgs.gnupg}/bin/gpgconf --list-dirs agent-ssh-socket)
+      fi
+    '');
+
+    assertions = [
+      { assertion = cfg.agent.enableSSHSupport && !config.programs.ssh.startAgent;
+        message = "You can't use ssh-agent and GnuPG agent with SSH support enabled at the same time!";
+      }
+    ];
+  };
+
+}

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -199,9 +199,8 @@ in
     environment.etc."ssh/ssh_known_hosts".text = knownHostsText;
 
     # FIXME: this should really be socket-activated for über-awesomeness.
-    systemd.user.services.ssh-agent =
-      { enable = cfg.startAgent;
-        description = "SSH Agent";
+    systemd.user.services.ssh-agent = mkIf cfg.startAgent
+      { description = "SSH Agent";
         wantedBy = [ "default.target" ];
         serviceConfig =
           { ExecStartPre = "${pkgs.coreutils}/bin/rm -f %t/ssh-agent";

--- a/nixos/modules/services/monitoring/arbtt.nix
+++ b/nixos/modules/services/monitoring/arbtt.nix
@@ -48,7 +48,8 @@ in {
   config = mkIf cfg.enable {
     systemd.user.services.arbtt = {
       description = "arbtt statistics capture service";
-      wantedBy = [ "default.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
 
       serviceConfig = {
         Type = "simple";

--- a/nixos/modules/services/x11/compton.nix
+++ b/nixos/modules/services/x11/compton.nix
@@ -208,13 +208,13 @@ in {
   config = mkIf cfg.enable {
     systemd.user.services.compton = {
       description = "Compton composite manager";
-      wantedBy = [ "default.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/compton --config ${configFile}";
         RestartSec = 3;
         Restart = "always";
       };
-      environment.DISPLAY = ":0";
     };
 
     environment.systemPackages = [ cfg.package ];

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -122,6 +122,9 @@ let
           source ~/.xprofile
       fi
 
+      # Start systemd user services for graphical sessions
+      ${config.systemd.package}/bin/systemctl --user start graphical-session.target
+
       # Allow the user to setup a custom session type.
       if test -x ~/.xsession; then
           exec ~/.xsession
@@ -164,6 +167,9 @@ let
       ''}
 
       test -n "$waitPID" && wait "$waitPID"
+
+      ${config.systemd.package}/bin/systemctl --user stop graphical-session.target
+
       exit 0
     '';
 
@@ -325,6 +331,13 @@ in
 
   config = {
     services.xserver.displayManager.xserverBin = "${xorg.xorgserver.out}/bin/X";
+
+    systemd.user.targets.graphical-session = {
+      unitConfig = {
+        RefuseManualStart = false;
+        StopWhenUnneeded = false;
+      };
+    };
   };
 
   imports = [

--- a/nixos/modules/services/x11/redshift.nix
+++ b/nixos/modules/services/x11/redshift.nix
@@ -95,7 +95,8 @@ in {
   config = mkIf cfg.enable {
     systemd.user.services.redshift = {
       description = "Redshift colour temperature adjuster";
-      wantedBy = [ "default.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
       serviceConfig = {
         ExecStart = ''
           ${cfg.package}/bin/redshift \
@@ -106,12 +107,6 @@ in {
         '';
         RestartSec = 3;
         Restart = "always";
-      };
-      environment = {
-        DISPLAY = ":${toString (
-          let display = config.services.xserver.display;
-          in if display != null then display else 0
-        )}";
       };
     };
   };

--- a/nixos/modules/services/x11/unclutter-xfixes.nix
+++ b/nixos/modules/services/x11/unclutter-xfixes.nix
@@ -43,7 +43,8 @@ in {
   config = mkIf cfg.enable {
     systemd.user.services.unclutter-xfixes = {
       description = "unclutter-xfixes";
-      wantedBy = [ "graphical.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
       serviceConfig.ExecStart = ''
         ${cfg.package}/bin/unclutter \
           --timeout ${toString cfg.timeout} \

--- a/nixos/modules/services/x11/unclutter.nix
+++ b/nixos/modules/services/x11/unclutter.nix
@@ -56,19 +56,17 @@ in {
   config = mkIf cfg.enable {
     systemd.user.services.unclutter = {
       description = "unclutter";
-      wantedBy = [ "default.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
       serviceConfig.ExecStart = ''
         ${cfg.package}/bin/unclutter \
           -idle ${toString cfg.timeout} \
-          -display :${toString (
-             let display = config.services.xserver.display;
-             in if display != null then display else 0
-          )} \
           -jitter ${toString (cfg.threeshold - 1)} \
           ${optionalString cfg.keystroke "-keystroke"} \
           ${concatMapStrings (x: " -"+x) cfg.extraOptions} \
           -not ${concatStringsSep " " cfg.excluded} \
       '';
+      serviceConfig.PassEnvironment = "DISPLAY";
       serviceConfig.RestartSec = 3;
       serviceConfig.Restart = "always";
     };

--- a/nixos/modules/services/x11/urxvtd.nix
+++ b/nixos/modules/services/x11/urxvtd.nix
@@ -21,9 +21,8 @@ in {
     systemd.user = {
       sockets.urxvtd = {
         description = "socket for urxvtd, the urxvt terminal daemon";
-        after = [ "graphical.target" ];
-        wants = [ "graphical.target" ];
-        wantedBy = [ "sockets.target" ];
+        wantedBy = [ "graphical-session.target" ];
+        partOf = [ "graphical-session.target" ];
         socketConfig = {
           ListenStream = "%t/urxvtd-socket";
         };

--- a/nixos/modules/services/x11/xbanish.nix
+++ b/nixos/modules/services/x11/xbanish.nix
@@ -20,7 +20,8 @@ in {
   config = mkIf cfg.enable {
     systemd.user.services.xbanish = {
       description = "xbanish hides the mouse pointer";
-      wantedBy = [ "default.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
       serviceConfig.ExecStart = ''
         ${pkgs.xbanish}/bin/xbanish ${cfg.arguments}
       '';


### PR DESCRIPTION
###### Motivation for this change

While systemd suggests using the pre-defined graphical-session user
target, I found that this interface is difficult to use. Additionally,
no other major distribution, even in their unstable versions, currently
use this mechanism.

The window or desktop manager is supposed to run in a systemd user service
which activates graphical-session.target and the user services that are
binding to this target. The issue is that we can't elegantly pass the
xsession environment to the window manager session, in particular
whereas the PassEnvironment option does work for DISPLAY, it for some
mysterious reason won't for PATH.

This commit implements a new graphical user target that works just like
default.target. Services which should be run in a graphical session just
need to declare wantedBy graphical.target. The graphical target will be
activated in the xsession before executing the window or display manager.

Fixes #17858.

###### Things done

Only tested with i3 and slim right now but will test other window and desktop managers before merging.