### PR TITLE
proofgeneral: revert bad modification from previous commit

### DIFF
--- a/pkgs/applications/editors/emacs-modes/proofgeneral/pg.patch
+++ b/pkgs/applications/editors/emacs-modes/proofgeneral/pg.patch
@@ -1,0 +1,16 @@
+diff -r c7d8bfff4c0a bin/proofgeneral
+--- a/bin/proofgeneral	Sat Sep 27 02:25:15 2014 +0100
++++ b/bin/proofgeneral	Sat Sep 27 02:28:16 2014 +0100
+@@ -73,11 +73,7 @@
+ 
+ # Try to find Proof General directory
+ if [ -z "$PGHOME" ] || [ ! -d "$PGHOME" ]; then
+-    # default relative to this script, otherwise PGHOMEDEFAULT
+-    MYDIR="`readlink --canonicalize "$0" | sed -ne 's,/bin/proofgeneral$,,p'`"
+-    if [ -d "$MYDIR/generic" ]; then
+-	PGHOME="$MYDIR"
+-    elif [ -d "$PGHOMEDEFAULT" ]; then
++    if [ -d "$PGHOMEDEFAULT" ]; then
+ 	PGHOME="$PGHOMEDEFAULT"
+     else
+ 	echo "Cannot find the Proof General lisp files: Set PGHOME or use --pghome."


### PR DESCRIPTION
As mentioned in:
https://github.com/NixOS/nixpkgs/pull/25905

I had mistakenly removed the `pg.patch` file thinking it was unneeded anymore, failing to realize the stable derivation still used it.

This reverts this file deletion.