### PR TITLE
teensy-loader-cli: Update to latest git.

### DIFF
--- a/pkgs/development/tools/misc/teensy-loader-cli/default.nix
+++ b/pkgs/development/tools/misc/teensy-loader-cli/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation {
   name = "teensy-loader-cli-${version}";
   src = fetchgit {
     url = "git://github.com/PaulStoffregen/teensy_loader_cli.git";
-    rev = "001da416bc362ff24485ff97e3a729bd921afe98";
-    sha256 = "36aed0a725055e36d71183ff57a023993099fdc380072177cffc7676da3c3966";
+    rev = "f5b6d7aafda9a8b014b4bb08660833ca45c136d2";
+    sha256 = "1a663bv3lvm7bsf2wcaj2c0vpmniak7w5hwix5qgz608bvm2v781";
   };
 
   buildInputs = [ unzip libusb ];


### PR DESCRIPTION
This fixes uploading programs greater than 128k to Teensy 3.1/3.2.

###### Motivation for this change
Broken uploading of larger files (`Warning, HEX parse error line 8193`).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

