### PR TITLE
lldb-4: Patch to fix libedit usage on Linux

### DIFF
--- a/pkgs/development/compilers/llvm/4/lldb-libedit.patch
+++ b/pkgs/development/compilers/llvm/4/lldb-libedit.patch
@@ -1,0 +1,30 @@
+From 94764369222a8e6c65420a6981d7f179a18a5417 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Thu, 25 May 2017 15:03:42 -0500
+Subject: [PATCH] EditLine.h: libedit supports wide chars on NixOS
+
+---
+ include/lldb/Host/Editline.h | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/include/lldb/Host/Editline.h b/include/lldb/Host/Editline.h
+index faed373bc..b248cdee1 100644
+--- a/include/lldb/Host/Editline.h
++++ b/include/lldb/Host/Editline.h
+@@ -43,12 +43,9 @@
+ // will only be
+ // used in cases where this is true.  This is a compile time dependecy, for now
+ // selected per target Platform
+-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
++// (libedit on NixOS is always wide-char capable)
+ #define LLDB_EDITLINE_USE_WCHAR 1
+ #include <codecvt>
+-#else
+-#define LLDB_EDITLINE_USE_WCHAR 0
+-#endif
+ 
+ #include "lldb/Host/ConnectionFileDescriptor.h"
+ #include "lldb/lldb-private.h"
+-- 
+2.13.0
+

--- a/pkgs/development/compilers/llvm/4/lldb.nix
+++ b/pkgs/development/compilers/llvm/4/lldb.nix
@@ -19,7 +19,8 @@ stdenv.mkDerivation {
 
   src = fetch "lldb" "0g83hbw1r4gd0z8hlph9i34xs6dlcc69vz3h2bqwkhb2qq2qzg9d";
 
-  patchPhase = ''
+  patches = [ ./lldb-libedit.patch ];
+  postPatch = ''
     # Fix up various paths that assume llvm and clang are installed in the same place
     sed -i 's,".*ClangConfig.cmake","${clang-unwrapped}/lib/cmake/clang/ClangConfig.cmake",' \
       cmake/modules/LLDBStandalone.cmake
@@ -34,10 +35,6 @@ stdenv.mkDerivation {
 
   CXXFLAGS = "-fno-rtti";
   hardeningDisable = [ "format" ];
-
-  cmakeFlags = [
-    "-DLLDB_DISABLE_LIBEDIT=ON"
-  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Idea from:
https://bugs.llvm.org//show_bug.cgi?id=28898#c7

Fixes ability to use arrow keys.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

