### PR TITLE
cleanup homepage metadata

### DIFF
--- a/pkgs/data/fonts/droid/default.nix
+++ b/pkgs/data/fonts/droid/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Droid Family fonts by Google Android";
-    homepage = [ https://github.com/google/fonts ];
+    homepage = "https://github.com/google/fonts";
     license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.all;
     maintainers = [];


### PR DESCRIPTION
###### Motivation for this change

homepage element was not consistent with other packages

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

