### PR TITLE
poppler: Include poppler encoding data by default

### DIFF
--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, fetchpatch, pkgconfig, libiconv, libintlOrEmpty
 , zlib, curl, cairo, freetype, fontconfig, lcms, libjpeg, openjpeg
-, withData ? false, poppler_data
+, withData ? true, poppler_data
 , qt4Support ? false, qt4 ? null
 , qt5Support ? false, qtbase ? null
 , introspectionSupport ? false, gobjectIntrospection ? null

--- a/pkgs/tools/typesetting/pdf2htmlEX/default.nix
+++ b/pkgs/tools/typesetting/pdf2htmlEX/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     glib
     cairo
     pango
-    (poppler.override { withData = true; })
+    poppler
     fontforge
     openjdk8
   ];


### PR DESCRIPTION
###### Motivation for this change
poppler-data contains encoding data needed to view some PDF documents. Without it, some characters will not  be rendered unless the fonts are embedded into the document. This includes CJK characters, so many documents written in those languages is unviewable with the current defaults. Since many popular packages depend on poppler for PDF rendering, multi-language support should be enabled by default.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

