### PR TITLE
lldb: fix on Darwin

### DIFF
--- a/pkgs/development/compilers/llvm/4/lldb.nix
+++ b/pkgs/development/compilers/llvm/4/lldb.nix
@@ -32,10 +32,14 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake python which swig ];
   buildInputs = [ ncurses zlib libedit libxml2 llvm ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.libobjc darwin.apple_sdk.libs.xpc ];
+    ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.libobjc darwin.apple_sdk.libs.xpc darwin.apple_sdk.frameworks.Foundation darwin.bootstrap_cmds darwin.apple_sdk.frameworks.Carbon darwin.apple_sdk.frameworks.Cocoa ];
 
   CXXFLAGS = "-fno-rtti";
   hardeningDisable = [ "format" ];
+
+  cmakeFlags = [
+    "-DLLDB_CODESIGN_IDENTITY=" # codesigning makes nondeterministic
+  ];
 
   enableParallelBuilding = true;
 
@@ -43,6 +47,6 @@ stdenv.mkDerivation {
     description = "A next-generation high-performance debugger";
     homepage    = http://llvm.org/;
     license     = licenses.ncsa;
-    platforms   = platforms.allBut platforms.darwin;
+    platforms   = platforms.all;
   };
 }


### PR DESCRIPTION
This gives a few fixes for LLDB on Darwin.

Note: you will have to do code signing for it to work outside of root!

###### Motivation for this change

LLDB was not supporting Darwin for some reason. This should make things work fine. Codesigning is of course not doable currently.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

