### PR TITLE
gnome: Fix the issue `Using the 'memory' GSettings backend issue`

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -176,7 +176,7 @@ in {
 
     services.xserver.updateDbusEnvironment = true;
 
-    environment.variables.GIO_EXTRA_MODULES = [ "${gnome3.dconf}/lib/gio/modules"
+    environment.variables.GIO_EXTRA_MODULES = [ "${lib.getLib gnome3.dconf}/lib/gio/modules"
                                                 "${gnome3.glib_networking.out}/lib/gio/modules"
                                                 "${gnome3.gvfs}/lib/gio/modules" ];
     environment.systemPackages = gnome3.corePackages ++ cfg.sessionPath

--- a/pkgs/applications/audio/audio-recorder/default.nix
+++ b/pkgs/applications/audio/audio-recorder/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   patches = [ ./icon-names.diff ];
 
   buildInputs = with gst_all_1; [
-    glib dbus gtk3 librsvg libdbusmenu-gtk3 libappindicator-gtk3 gnome3.dconf
+    glib dbus gtk3 librsvg libdbusmenu-gtk3 libappindicator-gtk3 (stdenv.lib.getLib gnome3.dconf)
     gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav
   ] ++ optional pulseaudioSupport libpulseaudio;
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   preFixup = ''
     gappsWrapperArgs+=('--prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"'
       '--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"'
-      '--prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"')
+      '--prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib gnome3.dconf}/lib/gio/modules"')
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/easytag/default.nix
+++ b/pkgs/applications/audio/easytag/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   preFixup = ''
     wrapProgram $out/bin/easytag \
       --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:$out/share" \
-      --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
+      --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib gnome3.dconf}/lib/gio/modules"
   '';
 
   NIX_LDFLAGS = "-lid3tag -lz";
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper pkgconfig intltool ];
   buildInputs = [
     gtk3 glib libid3tag id3lib taglib libvorbis libogg flac
-    itstool libxml2 gsettings_desktop_schemas gnome3.defaultIconTheme gnome3.dconf
+    itstool libxml2 gsettings_desktop_schemas gnome3.defaultIconTheme (stdenv.lib.getLib gnome3.dconf)
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/sound-juicer/default.nix
+++ b/pkgs/applications/audio/sound-juicer/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig gtk3 intltool itstool libxml2 brasero libcanberra_gtk3
                   gnome3.gsettings_desktop_schemas libmusicbrainz5 libdiscid isocodes
-                  makeWrapper gnome3.dconf
+                  makeWrapper (stdenv.lib.getLib gnome3.dconf)
                   gst_all_1.gstreamer gst_all_1.gst-plugins-base
                   gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad
                   gst_all_1.gst-libav
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
       wrapProgram "$f" \
         --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
         --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
-        --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
+        --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib gnome3.dconf}/lib/gio/modules"
     done
   '';
 

--- a/pkgs/applications/misc/finalterm/default.nix
+++ b/pkgs/applications/misc/finalterm/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
   postFixup = ''
     wrapProgram "$out/bin/finalterm" \
       --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules" \
+      --prefix GIO_EXTRA_MODULES : "${getLib gnome3.dconf}/lib/gio/modules" \
       --prefix XDG_DATA_DIRS : "${gnome3.defaultIconTheme}/share:${gnome3.gtk.out}/share:$out/share:$GSETTINGS_SCHEMAS_PATH"
   '';
 

--- a/pkgs/applications/networking/browsers/dwb/default.nix
+++ b/pkgs/applications/networking/browsers/dwb/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   preFixup=''
     wrapProgram "$out/bin/dwb" \
-     --prefix GIO_EXTRA_MODULES : "${glib_networking.out}/lib/gio/modules:${dconf}/lib/gio/modules" \
+     --prefix GIO_EXTRA_MODULES : "${glib_networking.out}/lib/gio/modules:${stdenv.lib.getLib dconf}/lib/gio/modules" \
      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share"
     wrapProgram "$out/bin/dwbem" \
      --prefix GIO_EXTRA_MODULES : "${glib_networking.out}/lib/gio/modules"

--- a/pkgs/applications/networking/instant-messengers/telepathy/idle/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/idle/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, pkgconfig, dbus_glib, telepathy_glib, libxslt }:
+{ stdenv, fetchurl, glib, gnome3, pkgconfig, dbus_glib, telepathy_glib, libxslt, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "telepathy-idle";
@@ -10,7 +10,12 @@ stdenv.mkDerivation rec {
     sha256 = "1argdzbif1vdmwp5vqbgkadq9ancjmgdm2ncp0qfckni715ss4rh";
   };
 
-  buildInputs = [ pkgconfig glib telepathy_glib dbus_glib libxslt telepathy_glib.python ];
+  buildInputs = [ pkgconfig glib telepathy_glib dbus_glib libxslt telepathy_glib.python (stdenv.lib.getLib gnome3.dconf) makeWrapper ];
+
+  preFixup = ''
+    wrapProgram "$out/libexec/telepathy-idle" \
+      --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib gnome3.dconf}/lib/gio/modules"
+  '';
 
   meta = {
     description = "IRC connection manager for the Telepathy framework";

--- a/pkgs/applications/networking/instant-messengers/telepathy/logger/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/logger/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, dbus_glib, libxml2, sqlite, telepathy_glib, pkgconfig
-, intltool, libxslt, gobjectIntrospection, dbus_libs }:
+, gnome3, makeWrapper, intltool, libxslt, gobjectIntrospection, dbus_libs }:
 
 stdenv.mkDerivation rec {
   project = "telepathy-logger";
@@ -12,12 +12,18 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${dbus_glib.dev}/include/dbus-1.0 -I${dbus_libs.dev}/include/dbus-1.0";
 
-  buildInputs = [ dbus_glib libxml2 sqlite telepathy_glib pkgconfig intltool
-                  gobjectIntrospection dbus_libs telepathy_glib.python ];
+  buildInputs = [ dbus_glib libxml2 sqlite telepathy_glib pkgconfig intltool makeWrapper
+                  gobjectIntrospection dbus_libs telepathy_glib.python (stdenv.lib.getLib gnome3.dconf) ];
 
   nativeBuildInputs = [ libxslt ];
 
   configureFlags = "--enable-call";
+
+  preFixup = ''
+    wrapProgram "$out/libexec/telepathy-logger" \
+      --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib gnome3.dconf}/lib/gio/modules" \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+  '';
 
   meta = {
     description = "Logger service for Telepathy framework";

--- a/pkgs/applications/networking/instant-messengers/telepathy/mission-control/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/mission-control/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, telepathy_glib, libxslt, makeWrapper, upower }:
+{ stdenv, fetchurl, pkgconfig, gnome3, telepathy_glib, libxslt, makeWrapper, upower }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-5.16.3";
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     wrapProgram "$out/libexec/mission-control-5" \
+      --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib gnome3.dconf}/lib/gio/modules" \
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
   '';
 

--- a/pkgs/applications/office/gnucash/2.6.nix
+++ b/pkgs/applications/office/gnucash/2.6.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
         --prefix PERL5LIB ":" "$PERL5LIB"                               \
         --set GCONF_CONFIG_SOURCE 'xml::~/.gconf'                       \
         --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share/gsettings-schemas/${name}" \
-        --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules"  \
+        --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib dconf}/lib/gio/modules"  \
         --prefix PATH ":" "$out/bin:${stdenv.lib.makeBinPath [ perl gconf ]}"
     done
 

--- a/pkgs/desktops/gnome-3/3.22/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/apps/evolution/default.nix
@@ -32,6 +32,10 @@ in stdenv.mkDerivation rec {
   configureFlags = [ "--disable-pst-import" "--disable-autoar"
                      "--disable-libcryptui" "--with-openldap"];
 
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix GIO_EXTRA_MODULES "${dconf}/lib/gio/modules")
+  '';
+
   NIX_CFLAGS_COMPILE = "-I${nss.dev}/include/nss -I${glib.dev}/include/gio-unix-2.0";
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/gnome-3/3.22/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/apps/evolution/default.nix
@@ -2,7 +2,7 @@
 , pkgconfig, gtk3, glib, libnotify, gtkspell3
 , wrapGAppsHook, itstool, shared_mime_info, libical, db, gcr, sqlite
 , gnome3, librsvg, gdk_pixbuf, libsecret, nss, nspr, icu, libtool
-, libcanberra_gtk3, bogofilter, gst_all_1, procps, p11_kit, dconf, openldap}:
+, libcanberra_gtk3, bogofilter, gst_all_1, procps, p11_kit, openldap}:
 
 let
   majVer = gnome3.version;
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
                   libcanberra_gtk3 bogofilter gnome3.libgdata sqlite
                   gst_all_1.gstreamer gst_all_1.gst-plugins-base p11_kit
                   nss nspr libnotify procps highlight gnome3.libgweather
-                  gnome3.gsettings_desktop_schemas dconf
+                  gnome3.gsettings_desktop_schemas
                   gnome3.libgnome_keyring gnome3.glib_networking openldap ];
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
@@ -31,10 +31,6 @@ in stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-pst-import" "--disable-autoar"
                      "--disable-libcryptui" "--with-openldap"];
-
-  preFixup = ''
-    gappsWrapperArgs+=(--prefix GIO_EXTRA_MODULES "${dconf}/lib/gio/modules")
-  '';
 
   NIX_CFLAGS_COMPILE = "-I${nss.dev}/include/nss -I${glib.dev}/include/gio-unix-2.0";
 

--- a/pkgs/desktops/gnome-3/3.22/apps/seahorse/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/apps/seahorse/default.nix
@@ -1,6 +1,6 @@
 { stdenv, intltool, fetchurl, vala_0_32
 , pkgconfig, gtk3, glib
-, makeWrapper, itstool, gnupg, libsoup
+, wrapGAppsHook, itstool, gnupg, libsoup
 , gnome3, librsvg, gdk_pixbuf, gpgme
 , libsecret, avahi, p11_kit, openssh }:
 
@@ -14,15 +14,16 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-I${gnome3.glib.dev}/include/gio-unix-2.0";
 
   buildInputs = [ pkgconfig gtk3 glib intltool itstool gnome3.gcr
-                  gnome3.gsettings_desktop_schemas makeWrapper gnupg
+                  gnome3.gsettings_desktop_schemas wrapGAppsHook gnupg
                   gdk_pixbuf gnome3.defaultIconTheme librsvg gpgme
-                  libsecret avahi libsoup p11_kit vala_0_32 gnome3.gcr
+                  libsecret avahi libsoup p11_kit vala_0_32 gnome3.dconf
                   openssh ];
 
   preFixup = ''
-    wrapProgram "$out/bin/seahorse" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+    gappsWrapperArgs+=(
+      --prefix GIO_EXTRA_MODULES "${gnome3.dconf}/lib/gio/modules"
+      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share"
+    )
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/3.22/apps/seahorse/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/apps/seahorse/default.nix
@@ -16,12 +16,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig gtk3 glib intltool itstool gnome3.gcr
                   gnome3.gsettings_desktop_schemas wrapGAppsHook gnupg
                   gdk_pixbuf gnome3.defaultIconTheme librsvg gpgme
-                  libsecret avahi libsoup p11_kit vala_0_32 gnome3.dconf
+                  libsecret avahi libsoup p11_kit vala_0_32
                   openssh ];
 
   preFixup = ''
     gappsWrapperArgs+=(
-      --prefix GIO_EXTRA_MODULES "${gnome3.dconf}/lib/gio/modules"
       --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share"
     )
   '';

--- a/pkgs/desktops/gnome-3/3.22/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/evolution-data-server/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, gnome3, python
+{ fetchurl, stdenv, pkgconfig, gnome3, python, dconf
 , intltool, libsoup, libxml2, libsecret, icu, sqlite
 , p11_kit, db, nspr, nss, libical, gperf, makeWrapper, valaSupport ? true, vala_0_32 }:
 
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
   buildInputs = with gnome3;
-    [ pkgconfig glib python intltool libsoup libxml2 gtk gnome_online_accounts
+    [ pkgconfig glib python intltool libsoup libxml2 gtk gnome_online_accounts (stdenv.lib.getLib dconf)
       gcr p11_kit libgweather libgdata gperf makeWrapper icu sqlite gsettings_desktop_schemas ]
     ++ stdenv.lib.optional valaSupport vala_0_32;
 
@@ -20,7 +20,9 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     for f in "$out/libexec/"*; do
-      wrapProgram "$f" --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+      wrapProgram "$f" \
+        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
+        --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib dconf}/lib/gio/modules"
     done
   '';
 

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-contacts/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-contacts/default.nix
@@ -21,13 +21,12 @@ stdenv.mkDerivation rec {
                   gnome3.gsettings_desktop_schemas wrapGAppsHook file libnotify
                   folks gnome3.gnome_desktop telepathy_glib libsecret dbus_glib
                   libxml2 libsoup gnome3.gnome_online_accounts nspr nss
-                  gdk_pixbuf gnome3.defaultIconTheme librsvg gnome3.dconf
+                  gdk_pixbuf gnome3.defaultIconTheme librsvg
                   libchamplain clutter_gtk geocode_glib
                   vala_0_32 automake115x autoconf db ];
 
   preFixup = ''
     gappsWrapperArgs+=(
-      --prefix GIO_EXTRA_MODULES "${gnome3.dconf}/lib/gio/modules"
       --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share"
     )
   '';

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-contacts/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-contacts/default.nix
@@ -1,7 +1,7 @@
 { stdenv, intltool, fetchurl, evolution_data_server, db
 , pkgconfig, gtk3, glib, libsecret
 , libchamplain, clutter_gtk, geocode_glib
-, bash, makeWrapper, itstool, folks, libnotify, libxml2
+, bash, wrapGAppsHook, itstool, folks, libnotify, libxml2
 , gnome3, librsvg, gdk_pixbuf, file, telepathy_glib, nspr, nss
 , libsoup, vala_0_32, dbus_glib, automake115x, autoconf }:
 
@@ -18,19 +18,18 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ pkgconfig gtk3 glib intltool itstool evolution_data_server
-                  gnome3.gsettings_desktop_schemas makeWrapper file libnotify
+                  gnome3.gsettings_desktop_schemas wrapGAppsHook file libnotify
                   folks gnome3.gnome_desktop telepathy_glib libsecret dbus_glib
                   libxml2 libsoup gnome3.gnome_online_accounts nspr nss
-                  gdk_pixbuf gnome3.defaultIconTheme librsvg
+                  gdk_pixbuf gnome3.defaultIconTheme librsvg gnome3.dconf
                   libchamplain clutter_gtk geocode_glib
                   vala_0_32 automake115x autoconf db ];
 
   preFixup = ''
-    for f in "$out/bin/gnome-contacts" "$out/libexec/gnome-contacts-search-provider"; do
-      wrapProgram $f \
-        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-        --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
-    done
+    gappsWrapperArgs+=(
+      --prefix GIO_EXTRA_MODULES "${gnome3.dconf}/lib/gio/modules"
+      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share"
+    )
   '';
 
   patches = [ ./gio_unix.patch ];

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-control-center/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       accountsservice libkrb5 networkmanagerapplet libwacom samba libnotify libxkbfile
       shared_mime_info icu libtool docbook_xsl docbook_xsl_ns gnome3.grilo
       gdk_pixbuf gnome3.defaultIconTheme librsvg clutter clutter_gtk
-      gnome3.vino udev libcanberra_gtk3 libgudev wrapGAppsHook
+      gnome3.dconf gnome3.vino udev libcanberra_gtk3 libgudev wrapGAppsHook
       networkmanager modemmanager gnome3.gnome-bluetooth grilo tracker
       cracklib ];
 
@@ -39,6 +39,10 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = with gnome3; ''
+    gappsWrapperArgs+=(
+      --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
+      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:${sound-theme-freedesktop}/share:$out/share/gnome-control-center"
+    )
     for i in $out/share/applications/*; do
       substituteInPlace $i --replace "gnome-control-center" "$out/bin/gnome-control-center"
     done

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-control-center/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       accountsservice libkrb5 networkmanagerapplet libwacom samba libnotify libxkbfile
       shared_mime_info icu libtool docbook_xsl docbook_xsl_ns gnome3.grilo
       gdk_pixbuf gnome3.defaultIconTheme librsvg clutter clutter_gtk
-      gnome3.dconf gnome3.vino udev libcanberra_gtk3 libgudev wrapGAppsHook
+      gnome3.vino udev libcanberra_gtk3 libgudev wrapGAppsHook
       networkmanager modemmanager gnome3.gnome-bluetooth grilo tracker
       cracklib ];
 
@@ -40,8 +40,7 @@ stdenv.mkDerivation rec {
 
   preFixup = with gnome3; ''
     gappsWrapperArgs+=(
-      --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
-      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:${sound-theme-freedesktop}/share:$out/share/gnome-control-center"
+      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:${sound-theme-freedesktop}/share"
     )
     for i in $out/share/applications/*; do
       substituteInPlace $i --replace "gnome-control-center" "$out/bin/gnome-control-center"

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-font-viewer/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-font-viewer/default.nix
@@ -1,6 +1,6 @@
 { stdenv, intltool, fetchurl
 , pkgconfig, gtk3, glib
-, bash, makeWrapper, itstool
+, bash, wrapGAppsHook, itstool
 , gnome3, librsvg, gdk_pixbuf }:
 
 stdenv.mkDerivation rec {
@@ -14,12 +14,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig gtk3 glib intltool itstool gnome3.gnome_desktop
                   gdk_pixbuf gnome3.defaultIconTheme librsvg
-                  gnome3.gsettings_desktop_schemas makeWrapper ];
+                  gnome3.gsettings_desktop_schemas wrapGAppsHook ];
 
   preFixup = ''
-    wrapProgram "$out/bin/gnome-font-viewer" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share"
+    )
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-screenshot/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-screenshot/default.nix
@@ -1,5 +1,5 @@
 { stdenv, intltool, fetchurl, pkgconfig, libcanberra_gtk3
-, bash, gtk3, glib, makeWrapper
+, bash, gtk3, glib, wrapGAppsHook
 , itstool, gnome3, librsvg, gdk_pixbuf }:
 
 stdenv.mkDerivation rec {
@@ -13,12 +13,12 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ gdk_pixbuf gnome3.defaultIconTheme librsvg ];
 
   buildInputs = [ bash pkgconfig gtk3 glib intltool itstool libcanberra_gtk3
-                  gnome3.gsettings_desktop_schemas makeWrapper ];
+                  gnome3.gsettings_desktop_schemas wrapGAppsHook ];
 
   preFixup = ''
-    wrapProgram "$out/bin/gnome-screenshot" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "${gtk3.out}/share:${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${gtk3.out}/share:${gnome3.gnome_themes_standard}/share"
+    )
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-settings-daemon/default.nix
@@ -11,14 +11,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = with gnome3;
     [ intltool pkgconfig ibus gtk glib gsettings_desktop_schemas networkmanager
-      dconf libnotify gnome_desktop lcms2 libXtst libxkbfile libpulseaudio
+      libnotify gnome_desktop lcms2 libXtst libxkbfile libpulseaudio
       libcanberra_gtk3 upower colord libgweather xkeyboard_config
       polkit geocode_glib geoclue2 librsvg xf86_input_wacom udev libgudev libwacom libxslt
       libtool docbook_xsl docbook_xsl_ns wrapGAppsHook gnome_themes_standard ];
-
-  preFixup = with gnome3; ''
-    gappsWrapperArgs+=(--prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules")
-  '';
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-settings-daemon/default.nix
@@ -11,10 +11,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = with gnome3;
     [ intltool pkgconfig ibus gtk glib gsettings_desktop_schemas networkmanager
-      libnotify gnome_desktop lcms2 libXtst libxkbfile libpulseaudio
+      dconf libnotify gnome_desktop lcms2 libXtst libxkbfile libpulseaudio
       libcanberra_gtk3 upower colord libgweather xkeyboard_config
       polkit geocode_glib geoclue2 librsvg xf86_input_wacom udev libgudev libwacom libxslt
       libtool docbook_xsl docbook_xsl_ns wrapGAppsHook gnome_themes_standard ];
+
+  preFixup = with gnome3; ''
+    gappsWrapperArgs+=(--prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules")
+  '';
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-shell/default.nix
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
       libgweather # not declared at build time, but typelib is needed at runtime
       gnome3.gnome-clocks # schemas needed
       at_spi2_core upower ibus gnome_desktop telepathy_logger gnome3.gnome_settings_daemon
-      pythonEnv gobjectIntrospection dconf ];
+      pythonEnv gobjectIntrospection (stdenv.lib.getLib dconf) ];
 
   installFlags = [ "keysdir=$(out)/share/gnome-control-center/keybindings" ];
 
@@ -39,13 +39,13 @@ in stdenv.mkDerivation rec {
     wrapProgram "$out/bin/gnome-shell" \
       --prefix PATH : "${unzip}/bin" \
       --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules" \
+      --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib dconf}/lib/gio/modules" \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
       --prefix XDG_DATA_DIRS : "${gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS" \
       --suffix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
 
     wrapProgram "$out/libexec/gnome-shell-calendar-server" \
-      --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules" \
+      --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib dconf}/lib/gio/modules" \
       --prefix XDG_DATA_DIRS : "${evolution_data_server}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
 
     echo "${unzip}/bin" > $out/${passthru.mozillaPlugin}/extra-bin-path

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-shell/default.nix
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
       libgweather # not declared at build time, but typelib is needed at runtime
       gnome3.gnome-clocks # schemas needed
       at_spi2_core upower ibus gnome_desktop telepathy_logger gnome3.gnome_settings_daemon
-      pythonEnv gobjectIntrospection ];
+      pythonEnv gobjectIntrospection dconf ];
 
   installFlags = [ "keysdir=$(out)/share/gnome-control-center/keybindings" ];
 
@@ -39,11 +39,13 @@ in stdenv.mkDerivation rec {
     wrapProgram "$out/bin/gnome-shell" \
       --prefix PATH : "${unzip}/bin" \
       --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
+      --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules" \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
       --prefix XDG_DATA_DIRS : "${gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS" \
       --suffix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
 
     wrapProgram "$out/libexec/gnome-shell-calendar-server" \
+      --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules" \
       --prefix XDG_DATA_DIRS : "${evolution_data_server}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
 
     echo "${unzip}/bin" > $out/${passthru.mozillaPlugin}/extra-bin-path

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-system-log/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-system-log/default.nix
@@ -1,5 +1,5 @@
 { stdenv, intltool, fetchurl, pkgconfig
-, bash, gtk3, glib, makeWrapper
+, bash, gtk3, glib, wrapGAppsHook
 , itstool, gnome3, librsvg, gdk_pixbuf, libxml2 }:
 
 stdenv.mkDerivation rec {
@@ -18,12 +18,12 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ gdk_pixbuf gnome3.defaultIconTheme librsvg ];
 
   buildInputs = [ bash pkgconfig gtk3 glib intltool itstool
-                  gnome3.gsettings_desktop_schemas makeWrapper libxml2 ];
+                  gnome3.gsettings_desktop_schemas wrapGAppsHook libxml2 ];
 
   preFixup = ''
-    wrapProgram "$out/bin/gnome-system-log" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "${gtk3.out}/share:${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${gtk3.out}/share:${gnome3.gnome_themes_standard}/share"
+    )
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-system-monitor/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-system-monitor/default.nix
@@ -1,5 +1,5 @@
 { stdenv, intltool, fetchurl, pkgconfig, gtkmm3, libxml2
-, bash, gtk3, glib, makeWrapper
+, bash, gtk3, glib, wrapGAppsHook
 , itstool, gnome3, librsvg, gdk_pixbuf, libgtop }:
 
 stdenv.mkDerivation rec {
@@ -10,14 +10,14 @@ stdenv.mkDerivation rec {
   propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
 
   buildInputs = [ bash pkgconfig gtk3 glib intltool itstool libxml2
-                  gtkmm3 libgtop makeWrapper
+                  gtkmm3 libgtop wrapGAppsHook
                   gdk_pixbuf gnome3.defaultIconTheme librsvg
                   gnome3.gsettings_desktop_schemas ];
 
   preFixup = ''
-    wrapProgram "$out/bin/gnome-system-monitor" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${gtk3.out}/share:${gnome3.gnome_themes_standard}/share"
+    )
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/gnome-3/3.22/core/tracker/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/tracker/default.nix
@@ -1,6 +1,6 @@
 { stdenv, intltool, fetchurl, libxml2, upower
 , pkgconfig, gtk3, glib
-, bash, makeWrapper, itstool, vala_0_32, sqlite, libxslt
+, bash, wrapGAppsHook, itstool, vala_0_32, sqlite, libxslt
 , gnome3, librsvg, gdk_pixbuf, file, libnotify
 , evolution_data_server, gst_all_1, poppler
 , icu, taglib, libjpeg, libtiff, giflib, libcue
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ vala_0_32 pkgconfig gtk3 glib intltool itstool libxml2
                   bzip2 gnome3.totem-pl-parser libxslt
-                  gnome3.gsettings_desktop_schemas makeWrapper file
-                  gdk_pixbuf gnome3.defaultIconTheme librsvg sqlite
+                  gnome3.gsettings_desktop_schemas gnome3.dconf wrapGAppsHook
+                  file gdk_pixbuf gnome3.defaultIconTheme librsvg sqlite
                   upower libnotify evolution_data_server gnome3.libgee
                   gst_all_1.gstreamer gst_all_1.gst-plugins-base flac
                   poppler icu taglib libjpeg libtiff giflib libvorbis
@@ -31,11 +31,10 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    for f in $out/bin/* $out/libexec/*; do
-      wrapProgram $f \
-        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-        --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
-    done
+    gappsWrapperArgs+=(
+      --prefix GIO_EXTRA_MODULES "${gnome3.dconf}/lib/gio/modules"
+      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share"
+    )
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/3.22/core/tracker/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/tracker/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ vala_0_32 pkgconfig gtk3 glib intltool itstool libxml2
                   bzip2 gnome3.totem-pl-parser libxslt
-                  gnome3.gsettings_desktop_schemas gnome3.dconf wrapGAppsHook
+                  gnome3.gsettings_desktop_schemas wrapGAppsHook
                   file gdk_pixbuf gnome3.defaultIconTheme librsvg sqlite
                   upower libnotify evolution_data_server gnome3.libgee
                   gst_all_1.gstreamer gst_all_1.gst-plugins-base flac
@@ -32,7 +32,6 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     gappsWrapperArgs+=(
-      --prefix GIO_EXTRA_MODULES "${gnome3.dconf}/lib/gio/modules"
       --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share"
     )
   '';

--- a/pkgs/desktops/xfce/applications/mousepad.nix
+++ b/pkgs/desktops/xfce/applications/mousepad.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   preFixup = ''
     wrapProgram "$out/bin/mousepad" \
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:${gtksourceview}/share" \
-      --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules"
+      --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib dconf}/lib/gio/modules"
   '';
 
   meta = {

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -32,9 +32,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # ToDo: one probably should specify schemas for samba and others here
   preFixup = ''
-    wrapProgram $out/libexec/gvfsd --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+    for f in $out/libexec/*; do
+      wrapProgram $f \
+        ${stdenv.lib.optionalString gnomeSupport "--prefix GIO_EXTRA_MODULES : \"${stdenv.lib.getLib gnome.dconf}/lib/gio/modules\""} \
+        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+    done
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/inputmethods/ibus/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus/wrapper.nix
@@ -25,7 +25,7 @@ let
         wrapProgram "$out/bin/$prog" \
           --set GDK_PIXBUF_MODULE_FILE ${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache \
           --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH:$out/lib/girepository-1.0" \
-          --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules" \
+          --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib dconf}/lib/gio/modules" \
           --set IBUS_COMPONENT_PATH "$out/share/ibus/component/" \
           --set IBUS_DATAROOTDIR "$out/share" \
           --set IBUS_LIBEXECDIR "$out/libexec" \
@@ -44,7 +44,7 @@ let
         wrapProgram "$out/bin/$prog" \
           --set GDK_PIXBUF_MODULE_FILE ${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache \
           --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH:$out/lib/girepository-1.0" \
-          --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules" \
+          --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib dconf}/lib/gio/modules" \
           --set IBUS_COMPONENT_PATH "$out/share/ibus/component/" \
           --set IBUS_DATAROOTDIR "$out/share" \
           --set IBUS_LIBEXECDIR "$out/libexec" \

--- a/pkgs/tools/networking/uget/default.nix
+++ b/pkgs/tools/networking/uget/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   
   buildInputs = [
     openssl curl libnotify gstreamer gst-plugins-base gst-plugins-good
-    gnome3.gtk gnome3.dconf
+    gnome3.gtk (stdenv.lib.getLib gnome3.dconf)
   ]
   ++ (stdenv.lib.optional (aria2 != null) aria2);
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       ${stdenv.lib.optionalString (aria2 != null) ''--suffix PATH : "${aria2}/bin"''} \
       --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH" \
       --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH" \
-      --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
+      --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib gnome3.dconf}/lib/gio/modules"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Fixes #25906

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

