### PR TITLE
Removes .desktop file from targets

### DIFF
--- a/pkgs/applications/misc/yakuake/default.nix
+++ b/pkgs/applications/misc/yakuake/default.nix
@@ -58,6 +58,6 @@ in
 kdeWrapper
 {
   inherit unwrapped;
-  targets = [ "bin/yakuake" "share/applications/org.kde.yakuake.desktop" ];
+  targets = [ "bin/yakuake" ];
   paths = [ konsole.unwrapped ];
 }


### PR DESCRIPTION
Exposing the .desktop file via the targets is the wrong way, because
the kdeWrapper wraps all the files in the targets.

###### Motivation for this change
Reverts the .desktop file changes from pull request #26063

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

