### PR TITLE
xonotic: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -4,15 +4,15 @@
 , # glx
   libX11, mesa, libXpm, libXext, libXxf86vm, alsaLib
 , # sdl
-  SDL
+  SDL2
 }:
 
 stdenv.mkDerivation rec {
-  name = "xonotic-0.8.1";
+  name = "xonotic-0.8.2";
 
   src = fetchurl {
     url = "http://dl.xonotic.org/${name}.zip";
-    sha256 = "0vy4hkrbpz9g91gb84cbv4xl845qxaknak6hshk2yflrw90wr2xy";
+    sha256 = "1mcs6l4clvn7ibfq3q69k2p0z6ww75rxvnngamdq5ic6yhq74bx2";
   };
 
   buildInputs = [
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     # glx
     libX11 mesa libXpm libXext libXxf86vm alsaLib
     # sdl
-    SDL
+    SDL2
     zlib libvorbis curl
   ];
 
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.xonotic.org;
     license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [ astsmtl ];
+    maintainers = with stdenv.lib.maintainers; [ astsmtl zalakain ];
     platforms = stdenv.lib.platforms.linux;
     hydraPlatforms = [];
   };


### PR DESCRIPTION
As with 0.8.1, music is still not working, see  #26117.
For map downloads #26089 must be accepted.

###### Motivation for this change

Update to the latest stable version.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

