### PR TITLE
lilypond-with-fonts: fix quoting

### DIFF
--- a/pkgs/misc/lilypond/with-fonts.nix
+++ b/pkgs/misc/lilypond/with-fonts.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
       install -m755 -Dt $out/bin ${lilypond}/bin/*
 
       for p in $out/bin/*; do
-        substituteInPlace $p --replace "exec -a ${lilypond}" "exec -a $out"
+        substituteInPlace $p --replace "exec -a \"${lilypond}" "exec -a \"$out"
       done
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

It looks like the wrapper script changed its quoting at some point, which broke `lilypond-with-fonts`. This commit fixes it. I'd love to have tests for this going forward, but I'm not sure how best to approach writing them. Manually, I can check as follows.

Assuming:
```nix
{
  my-lilypond = lilypond-with-fonts.override {
    fonts = with openlilylib-fonts; [ improviso ];
  };
}
```

The output of:
```fish
 lilypond -dshow-available-fonts
```
... should include several lines that start with:
> family improviso


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
