### PR TITLE
pnmixer: 0.7.1-rc1 -> 0.7.1

### DIFF
--- a/pkgs/tools/audio/pnmixer/default.nix
+++ b/pkgs/tools/audio/pnmixer/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pnmixer-${version}";
-  version = "0.7.1-rc1";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "nicklan";
     repo = "pnmixer";
     rev = "v${version}";
-    sha256 = "0ns7s1jsc7fc3fvs9m3xwbv1fk1410cqc5w1cmia1mlzy94r3r6p";
+    sha256 = "0mmrq4m2rk0wmkfmqs3fk2rnw5g5lvd7ill2s3d7ggf9vba1pcn2";
   };
 
   nativeBuildInputs = [ cmake pkgconfig gettext ];
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = https://github.com/nicklan/pnmixer;
-    description = "ALSA mixer for the system tray";
+    description = "ALSA volume mixer for the system tray";
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ campadrenalin romildo ];


### PR DESCRIPTION
###### Motivation for this change

[Changes](https://github.com/nicklan/pnmixer/releases)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).