### PR TITLE
qt5ct: 0.30 -> 0.32

### DIFF
--- a/pkgs/tools/misc/qt5ct/default.nix
+++ b/pkgs/tools/misc/qt5ct/default.nix
@@ -1,16 +1,17 @@
-{stdenv, fetchurl, qtbase, qtsvg, qttools, qmakeHook, makeQtWrapper}:
+{ stdenv, fetchurl, qtbase, qtsvg, qttools, qmakeHook, makeQtWrapper }:
 
 stdenv.mkDerivation rec {
   name = "qt5ct-${version}";
-  version = "0.30";
+  version = "0.32";
 
   src = fetchurl {
     url = "mirror://sourceforge/qt5ct/qt5ct-${version}.tar.bz2";
-    sha256 = "1k0ywd440qvf84chadjb4fnkn8dkfl56cc3a6wqg6a59drslvng6";
+    sha256 = "0gzmqx6j8g8vgdg5sazfw31h825jdsjbkj8lk167msvahxgrf0fm";
   };
 
-  buildInputs = [ qtbase qtsvg ];
   nativeBuildInputs = [ makeQtWrapper qmakeHook qttools ];
+
+  buildInputs = [ qtbase qtsvg ];
 
   preConfigure = ''
     qmakeFlags="$qmakeFlags PLUGINDIR=$out/lib/qt5/plugins"


### PR DESCRIPTION
###### Motivation for this change

[Changelogs](https://www.opendesktop.org/content/show.php?content=168066#updates-panel)

**0.32** 12 days ago

- added global menu support
- updated Czech translation
- updated Greek translation
- updated Russian translation

**0.31** 1 month ago

- added option "Toolbar button style"
- added option "Mouse wheel scroll lines"
- added test for minimal Qt version
- added Arabic translation
- using c++11 for source code
- fixed Qt 5.4 support
- updated Russian translation
- updated Bulgarian translation
- updated Dutch (Netherlands) translation
- updated Chinese (Taiwan) translation
- updated German translation
- updated Serbian translation
- updated Czech translation

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).