### PR TITLE
zabbix-cli: init at 1.6.1

### DIFF
--- a/pkgs/tools/misc/zabbix-cli/default.nix
+++ b/pkgs/tools/misc/zabbix-cli/default.nix
@@ -1,0 +1,24 @@
+{ fetchFromGitHub, lib, python2Packages }:
+let
+  pythonPackages = python2Packages;
+
+in pythonPackages.buildPythonApplication rec {
+  name = "zabbix-cli-${version}";
+  version = "1.6.1";
+
+  propagatedBuildInputs = with pythonPackages; [ argparse requests ];
+
+  src = fetchFromGitHub {
+    owner = "usit-gd";
+    repo = "zabbix-cli";
+    rev = version;
+    sha256 = "17ip3s8ifgj264zwxrr857wk02xmzmlsjrr613mdhkgdwizqbcs3";
+  };
+
+  meta = with lib; {
+    description = "Command-line interface for Zabbix";
+    homepage = src.meta.homepage;
+    license = [ licenses.gpl3 ];
+    maintainers = [ maintainers.womfoo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1695,6 +1695,8 @@ with pkgs;
 
   mcrcon = callPackage ../tools/networking/mcrcon {};
 
+  zabbix-cli = callPackage ../tools/misc/zabbix-cli { };
+
   ### DEVELOPMENT / EMSCRIPTEN
 
   buildEmscriptenPackage = callPackage ../development/em-modules/generic { };


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).