### PR TITLE
kernel: enable audio jack reconfiguration

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -213,6 +213,8 @@ with stdenv.lib;
   SND_DYNAMIC_MINORS y
   SND_AC97_POWER_SAVE y # AC97 Power-Saving Mode
   SND_HDA_INPUT_BEEP y # Support digital beep via input layer
+  SND_HDA_RECONFIG y # Support reconfiguration of jack functions
+  SND_HDA_PATCH_LOADER y # Support configuring jack functions via fw mechanism at boot
   SND_USB_CAIAQ_INPUT y
   ${optionalString (versionOlder version "4.12") ''
     PSS_MIXER y # Enable PSS mixer (Beethoven ADSP-16 and other compatible)


### PR DESCRIPTION
###### Motivation for this change
Change kernel config to allow for changing the functions of the audio
jacks at run-time as well as at boot time.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

