### PR TITLE
cloudmonkey: init at 5.3.3 with related dependency argcomplete: init at 1.8.2

### DIFF
--- a/pkgs/development/python-modules/argcomplete/default.nix
+++ b/pkgs/development/python-modules/argcomplete/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage, fetchPypi, lib,
+  coverage, dicttoxml, flake8, pexpect, prettytable, requests_toolbelt
+}:
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "argcomplete";
+  version = "1.8.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0sslhl1klvh92c8hjsz3y3mmnpcqspcgi49g5cik2rpbfkhcsb3s";
+  };
+
+  doCheck = false; # bash-completion test fails with "compgen: command not found".
+
+  # re-enable if we are able to make testing work
+  # buildInputs = [ coverage flake8 ];
+
+  propagatedBuildInputs = [ dicttoxml pexpect prettytable requests_toolbelt ];
+
+  meta = with lib; {
+    description = "Bash tab completion for argparse";
+    homepage = "https://argcomplete.readthedocs.io";
+    maintainers = [ maintainers.womfoo ];
+    license = [ licenses.asl20 ];
+  };
+}

--- a/pkgs/tools/virtualization/cloudmonkey/default.nix
+++ b/pkgs/tools/virtualization/cloudmonkey/default.nix
@@ -1,0 +1,27 @@
+{ python2Packages, lib }:
+
+with python2Packages;
+
+buildPythonApplication rec {
+
+  name = "${pname}-${version}";
+  pname = "cloudmonkey";
+  version = "5.3.3";
+
+  propagatedBuildInputs = [ argcomplete pygments ];
+
+  doCheck = false; # upstream has no tests defined
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "064yk3lwl272nyn20xxrh0qxzh3r1rl9015qqf2i4snqdzwd5cf7";
+  };
+
+  meta = with lib; {
+    description = "CLI for Apache CloudStack.";
+    homepage = "https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+cloudmonkey+CLI";
+    license = [ licenses.asl20 ];
+    maintainers = [ maintainers.womfoo ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -814,6 +814,8 @@ with pkgs;
 
   cloud-init = callPackage ../tools/virtualization/cloud-init { };
 
+  cloudmonkey = callPackage ../tools/virtualization/cloudmonkey { };
+
   clib = callPackage ../tools/package-management/clib { };
 
   colord-kde = libsForQt5.callPackage ../tools/misc/colord-kde {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1159,6 +1159,8 @@ in {
     };
   };
 
+  argcomplete = callPackage ../development/python-modules/argcomplete { };
+
   area53 = buildPythonPackage (rec {
     name = "Area53-0.94";
 


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).