### PR TITLE
rename webkitgtk24x⇒webkitgtk24x-gtk3; webkitgtk2⇒webkitgtk24x-gtk2

### DIFF
--- a/pkgs/applications/editors/eclipse/build-eclipse.nix
+++ b/pkgs/applications/editors/eclipse/build-eclipse.nix
@@ -1,5 +1,5 @@
 { stdenv, makeDesktopItem, freetype, fontconfig, libX11, libXrender
-, zlib, jdk, glib, gtk2, libXtst, gsettings_desktop_schemas, webkitgtk2
+, zlib, jdk, glib, gtk2, libXtst, gsettings_desktop_schemas, webkitgtk24x-gtk2
 , makeWrapper, ... }:
 
 { name, src ? builtins.getAttr stdenv.system sources, sources ? null, description }:
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     fontconfig freetype glib gsettings_desktop_schemas gtk2 jdk libX11
     libXrender libXtst makeWrapper zlib
-  ] ++ stdenv.lib.optional (webkitgtk2 != null) webkitgtk2;
+  ] ++ stdenv.lib.optional (webkitgtk24x-gtk2 != null) webkitgtk24x-gtk2;
 
   buildCommand = ''
     # Unpack tarball.
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper $out/eclipse/eclipse $out/bin/eclipse \
       --prefix PATH : ${jdk}/bin \
-      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath ([ glib gtk2 libXtst ] ++ stdenv.lib.optional (webkitgtk2 != null) webkitgtk2)} \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath ([ glib gtk2 libXtst ] ++ stdenv.lib.optional (webkitgtk24x-gtk2 != null) webkitgtk24x-gtk2)} \
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
       --add-flags "-configuration \$HOME/.eclipse/''${productId}_$productVersion/configuration"
 

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, makeDesktopItem, makeWrapper
 , freetype, fontconfig, libX11, libXext, libXrender, zlib
 , glib, gtk2, libXtst, jdk, gsettings_desktop_schemas
-, webkitgtk2 ? null  # for internal web browser
+, webkitgtk24x-gtk2 ? null  # for internal web browser
 , buildEnv, writeText, runCommand
 , callPackage
 }:
@@ -12,7 +12,7 @@ rec {
 
   buildEclipse = import ./build-eclipse.nix {
     inherit stdenv makeDesktopItem freetype fontconfig libX11 libXrender zlib
-            jdk glib gtk2 libXtst gsettings_desktop_schemas webkitgtk2
+            jdk glib gtk2 libXtst gsettings_desktop_schemas webkitgtk24x-gtk2
             makeWrapper;
   };
 

--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -5,7 +5,7 @@
 , withX ? !stdenv.isDarwin
 , withGTK2 ? false, gtk2 ? null
 , withGTK3 ? true, gtk3 ? null, gsettings_desktop_schemas ? null
-, withXwidgets ? false, webkitgtk24x ? null, wrapGAppsHook ? null, glib_networking ? null
+, withXwidgets ? false, webkitgtk24x-gtk3 ? null, wrapGAppsHook ? null, glib_networking ? null
 , withCsrc ? true
 , srcRepo ? false, autoconf ? null, automake ? null, texinfo ? null
 }:
@@ -16,7 +16,7 @@ assert withGTK2 -> withX || stdenv.isDarwin;
 assert withGTK3 -> withX || stdenv.isDarwin;
 assert withGTK2 -> !withGTK3 && gtk2 != null;
 assert withGTK3 -> !withGTK2 && gtk3 != null;
-assert withXwidgets -> withGTK3 && webkitgtk24x != null;
+assert withXwidgets -> withGTK3 && webkitgtk24x-gtk3 != null;
 
 let
   toolkit =
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional (withX && withGTK2) gtk2
     ++ lib.optionals (withX && withGTK3) [ gtk3 gsettings_desktop_schemas ]
     ++ lib.optional (stdenv.isDarwin && withX) cairo
-    ++ lib.optionals (withX && withXwidgets) [ webkitgtk24x glib_networking ];
+    ++ lib.optionals (withX && withXwidgets) [ webkitgtk24x-gtk3 glib_networking ];
 
   propagatedBuildInputs = lib.optionals stdenv.isDarwin [ AppKit GSS ImageIO ];
 

--- a/pkgs/applications/networking/browsers/dwb/default.nix
+++ b/pkgs/applications/networking/browsers/dwb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pkgconfig, makeWrapper, libsoup, webkitgtk2, gtk2, gnutls
+{ stdenv, fetchgit, pkgconfig, makeWrapper, libsoup, webkitgtk24x-gtk2, gtk2, gnutls
 , json_c, m4, glib_networking, gsettings_desktop_schemas, dconf }:
 
 stdenv.mkDerivation {
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ pkgconfig makeWrapper gsettings_desktop_schemas libsoup
-    webkitgtk2 gtk2 gnutls json_c m4 ];
+    webkitgtk24x-gtk2 gtk2 gnutls json_c m4 ];
 
   # There are Xlib and gtk warnings therefore I have set Wno-error
   makeFlags = ''PREFIX=$(out) GTK=2 CPPFLAGS="-Wno-error"'';

--- a/pkgs/applications/networking/mailreaders/astroid/default.nix
+++ b/pkgs/applications/networking/mailreaders/astroid/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, scons, pkgconfig, gnome3, gmime, webkitgtk24x
+{ stdenv, fetchFromGitHub, scons, pkgconfig, gnome3, gmime, webkitgtk24x-gtk3
 , libsass, notmuch, boost, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ scons pkgconfig wrapGAppsHook ];
 
-  buildInputs = [ gnome3.gtkmm gmime webkitgtk24x libsass gnome3.libpeas
+  buildInputs = [ gnome3.gtkmm gmime webkitgtk24x-gtk3 libsass gnome3.libpeas
                   notmuch boost gnome3.gsettings_desktop_schemas
                   gnome3.adwaita-icon-theme ];
 

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, wrapGAppsHook
 , curl, dbus, dbus_glib, enchant, gtk2, gnutls, gnupg, gpgme, hicolor_icon_theme
 , libarchive, libcanberra_gtk2, libetpan, libnotify, libsoup, libxml2, networkmanager
-, openldap , perl, pkgconfig, poppler, python, shared_mime_info, webkitgtk2
+, openldap , perl, pkgconfig, poppler, python, shared_mime_info, webkitgtk24x-gtk2
 , glib_networking, gsettings_desktop_schemas, libSM, libytnef
 
 # Build options
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
     ++ optional enableNetworkManager networkmanager
     ++ optional enableLdap openldap
     ++ optional enablePluginPdf poppler
-    ++ optional enablePluginFancy webkitgtk2;
+    ++ optional enablePluginFancy webkitgtk24x-gtk2;
 
   configureFlags =
     optional (!enableLdap) "--disable-ldap"

--- a/pkgs/applications/video/miro/default.nix
+++ b/pkgs/applications/video/miro/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig
-, pythonPackages, pyrex096, ffmpeg, boost, glib, gtk2, webkitgtk2, libsoup
+, pythonPackages, pyrex096, ffmpeg, boost, glib, gtk2, webkitgtk24x-gtk2, libsoup
 , taglib, sqlite
 , libtorrentRasterbar, glib_networking, gsettings_desktop_schemas
 , gst-python, gst-plugins-base, gst-plugins-good, gst-ffmpeg
@@ -70,7 +70,7 @@ in buildPythonApplication rec {
   '';
 
   buildInputs = with pythonPackages; [ pygtk pygobject2 ] ++ [
-    pkgconfig pyrex096 ffmpeg boost glib gtk2 webkitgtk2 libsoup
+    pkgconfig pyrex096 ffmpeg boost glib gtk2 webkitgtk24x-gtk2 libsoup
     taglib gsettings_desktop_schemas sqlite
   ];
 

--- a/pkgs/desktops/gnome-3/3.22/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/default.nix
@@ -76,7 +76,7 @@ let
   dconf-editor = callPackage ./core/dconf-editor { };
 
   # empathy = callPackage ./core/empathy {
-  #   webkitgtk = webkitgtk24x;
+  #   webkitgtk = webkitgtk24x-gtk3;
   #   clutter-gst = pkgs.clutter-gst;
   # };
 
@@ -257,7 +257,7 @@ let
 
   bijiben = callPackage ./apps/bijiben {
     # https://bugzilla.gnome.org/show_bug.cgi?id=728293
-    webkitgtk = pkgs.webkitgtk24x;
+    webkitgtk = pkgs.webkitgtk24x-gtk3;
   };
 
   cheese = callPackage ./apps/cheese { };
@@ -363,7 +363,7 @@ let
 
   geary = callPackage ./misc/geary {
     # https://bugzilla.gnome.org/show_bug.cgi?id=728002
-    webkitgtk = pkgs.webkitgtk24x;
+    webkitgtk = pkgs.webkitgtk24x-gtk3;
   };
 
   gfbgraph = callPackage ./misc/gfbgraph { };

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -129,8 +129,8 @@ self: super: builtins.intersectAttrs super {
   gtksourceview2 = addPkgconfigDepend super.gtksourceview2 pkgs.gtk2;
 
   # Need WebkitGTK, not just webkit.
-  webkit = super.webkit.override { webkit = pkgs.webkitgtk2; };
-  websnap = super.websnap.override { webkit = pkgs.webkitgtk24x; };
+  webkit = super.webkit.override { webkit = pkgs.webkitgtk24x-gtk2; };
+  websnap = super.websnap.override { webkit = pkgs.webkitgtk24x-gtk3; };
 
   hs-mesos = overrideCabal super.hs-mesos (drv: {
     # Pass _only_ mesos; the correct protobuf is propagated.

--- a/pkgs/development/libraries/wxwidgets/3.0/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/default.nix
@@ -2,13 +2,13 @@
 , xf86vidmodeproto , gstreamer, gst-plugins-base, GConf, setfile
 , withMesa ? true, mesa_glu ? null, mesa_noglu ? null
 , compat24 ? false, compat26 ? true, unicode ? true
-, withWebKit ? false, webkitgtk2 ? null
+, withWebKit ? false, webkitgtk24x-gtk2 ? null
 , AGL ? null, Carbon ? null, Cocoa ? null, Kernel ? null, QTKit ? null
 }:
 
 
 assert withMesa -> mesa_glu != null && mesa_noglu != null;
-assert withWebKit -> webkitgtk2 != null;
+assert withWebKit -> webkitgtk24x-gtk2 != null;
 
 with stdenv.lib;
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
     [ gtk2 libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer
       gst-plugins-base GConf ]
     ++ optional withMesa mesa_glu
-    ++ optional withWebKit webkitgtk2
+    ++ optional withWebKit webkitgtk24x-gtk2
     ++ optionals stdenv.isDarwin [ setfile Carbon Cocoa Kernel QTKit ];
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/tools/networking/mu/default.nix
+++ b/pkgs/tools/networking/mu/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, sqlite, pkgconfig, autoreconfHook, pmccabe
 , xapian, glib, gmime, texinfo , emacs, guile
-, gtk3, webkitgtk24x, libsoup, icu
+, gtk3, webkitgtk24x-gtk3, libsoup, icu
 , withMug ? false }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   # pmccabe should be a checkInput instead, but configure looks for it
   buildInputs = [
     sqlite xapian glib gmime texinfo emacs guile libsoup icu
-  ] ++ stdenv.lib.optionals withMug [ gtk3 webkitgtk24x ];
+  ] ++ stdenv.lib.optionals withMug [ gtk3 webkitgtk24x-gtk3 ];
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   checkInputs = [ pmccabe ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10342,7 +10342,7 @@ with pkgs;
 
   webkitgtk = webkitgtk214x;
 
-  webkitgtk24x = callPackage ../development/libraries/webkitgtk/2.4.nix {
+  webkitgtk24x-gtk3 = callPackage ../development/libraries/webkitgtk/2.4.nix {
     harfbuzz = harfbuzz-icu;
     gst-plugins-base = gst_all_1.gst-plugins-base;
     inherit (darwin) libobjc;
@@ -10353,7 +10353,7 @@ with pkgs;
     gst-plugins-base = gst_all_1.gst-plugins-base;
   };
 
-  webkitgtk2 = webkitgtk24x.override {
+  webkitgtk24x-gtk2 = webkitgtk24x-gtk3.override {
     withGtk2 = true;
     enableIntrospection = false;
   };
@@ -13550,7 +13550,7 @@ with pkgs;
 
   eaglemode = callPackage ../applications/misc/eaglemode { };
 
-  eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse { webkitgtk2 = null; });
+  eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse { webkitgtk24x-gtk2 = null; });
 
   ecs-agent = callPackage ../applications/virtualization/ecs-agent { };
 
@@ -14151,7 +14151,7 @@ with pkgs;
     inherit (gnome3) dconf;
     gconf = gnome2.GConf;
     goffice = goffice_0_8;
-    webkit = webkitgtk2;
+    webkit = webkitgtk24x-gtk2;
     guile = guile_1_8;
     slibGuile = slibGuile.override { scheme = guile_1_8; };
     glib = glib;
@@ -14534,7 +14534,7 @@ with pkgs;
   jbrout = callPackage ../applications/graphics/jbrout { };
 
   jumanji = callPackage ../applications/networking/browsers/jumanji {
-    webkitgtk = webkitgtk24x;
+    webkitgtk = webkitgtk24x-gtk3;
     gtk = gtk3;
   };
 
@@ -16126,7 +16126,7 @@ with pkgs;
   uwimap = callPackage ../tools/networking/uwimap { };
 
   uzbl = callPackage ../applications/networking/browsers/uzbl {
-    webkit = webkitgtk2;
+    webkit = webkitgtk24x-gtk2;
   };
 
   utox = callPackage ../applications/networking/instant-messengers/utox { };
@@ -16584,7 +16584,7 @@ with pkgs;
     gconf = gnome2.GConf;
     inherit (gnome2) gtkhtml libgtkhtml libglade scrollkeeper;
     python = python27;
-    webkitgtk = webkitgtk2;
+    webkitgtk = webkitgtk24x-gtk2;
   };
 
   xournal = callPackage ../applications/graphics/xournal {
@@ -18612,12 +18612,12 @@ with pkgs;
   });
 
   vimprobable2-unwrapped = callPackage ../applications/networking/browsers/vimprobable2 {
-    webkit = webkitgtk2;
+    webkit = webkitgtk24x-gtk2;
   };
   vimprobable2 = wrapFirefox vimprobable2-unwrapped { };
 
   vimb-unwrapped = callPackage ../applications/networking/browsers/vimb {
-    webkit = webkitgtk2;
+    webkit = webkitgtk24x-gtk2;
   };
   vimb = wrapFirefox vimb-unwrapped { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21080,7 +21080,7 @@ in {
 
     buildInputs = [
       pkgs.pkgconfig pkgs.gtk2 self.pygtk pkgs.libxml2
-      pkgs.libxslt pkgs.libsoup pkgs.webkitgtk2 pkgs.icu
+      pkgs.libxslt pkgs.libsoup pkgs.webkitgtk24x-gtk2 pkgs.icu
     ];
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

It was confusing whether ```2``` in ```webkitgtk2``` means version of ```webkitgtk``` or version of ```gtk```

It also made clear that [wxwidgets depends on outdated and insecure webkitgtk 2.4](https://github.com/NixOS/nixpkgs/compare/master...volth:webkitgtk-naming?expand=1#diff-8be06145e2ed680686ba6be2c686062b) which might have to be fixed.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

