### PR TITLE
ocamlPackages.core_bench: init at 113.33.03

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/core_bench.nix
+++ b/pkgs/development/ocaml-modules/janestreet/core_bench.nix
@@ -1,0 +1,20 @@
+{ stdenv
+, buildOcamlJane
+, core
+, core_extended
+, textutils
+}:
+
+buildOcamlJane rec {
+  name = "core_bench";
+  hash = "1d1ainpakgsf5rg8dvar12ksgilqcc4465jr8gf7fz5mmn0mlifj";
+  propagatedBuildInputs =
+    [ core core_extended textutils ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/core_bench;
+    description = "Micro-benchmarking library for OCaml";
+    license = licenses.asl20;
+    maintainers = [ maintainers.pmahoney ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -728,6 +728,9 @@ let
       then callPackage ../development/ocaml-modules/janestreet/bin_prot.nix {}
       else bin_prot_p4;
 
+    core_bench =
+      callPackage ../development/ocaml-modules/janestreet/core_bench.nix {};
+
     core_kernel =
       if lib.versionOlder "4.03" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/core_kernel-113_33_01.nix {}


### PR DESCRIPTION
###### Motivation for this change

Adding core_bench library (used in [Real World OCaml](https://realworldocaml.org/v1/en/html/lists-and-patterns.html))

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

