### PR TITLE
Fixed meteor Future is not defined error

### DIFF
--- a/pkgs/servers/meteor/main.patch
+++ b/pkgs/servers/meteor/main.patch
@@ -2,7 +2,7 @@ diff --git a/tools/cli/main.js b/tools/cli/main.js
 index 84f94bc..4fbda17 100644
 --- a/tools/cli/main.js
 +++ b/tools/cli/main.js
-@@ -484,6 +484,44 @@ var springboard = function (rel, options) {
+@@ -484,6 +484,45 @@ var springboard = function (rel, options) {
      process.exit(ret.wait());
    }
  
@@ -10,6 +10,7 @@ index 84f94bc..4fbda17 100644
 +  // patch shebang:
 +  var fs = require('fs');
 +  var path = require("path")
++  var Future = require("fibers/future")
 +  var srcOld = fs.readFileSync(executable, 'utf8');
 +  srcNew = srcOld.replace(/^#!\/bin\/bash/, '#!/bin/sh');
 +  if (srcOld !== srcNew) {


### PR DESCRIPTION
###### Motivation for this change
When starting meteor 1.4.2.3 or latest after installing the meteor package the error below occurs. This PR fixes this error.

/nix/store/lczw40pq0qgqz4knh1z6xs1qfa7gi7cr-meteor-1.4.2.3/packages/meteor-tool/.1.4.2_3.17tso1e++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/meteor-promise/promise_server.js:190
      throw error;
      ^

ReferenceError: Future is not defined
    at spawnSync (/tools/cli/main.js:540:1)
    at patchelf (/tools/cli/main.js:561:1)
    at springboard (/tools/cli/main.js:569:3)
    at /tools/cli/main.js:1166:3

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

