### PR TITLE
mupdf: 1.10a -> 1.11

### DIFF
--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -3,26 +3,26 @@
 , libX11, libXcursor, libXrandr, libXinerama, libXext, harfbuzz, mesa }:
 
 stdenv.mkDerivation rec {
-  version = "1.10a";
+  version = "1.11";
   name = "mupdf-${version}";
 
   src = fetchurl {
     url = "http://mupdf.com/downloads/archive/${name}-source.tar.gz";
-    sha256 = "0dm8wcs8i29aibzkqkrn8kcnk4q0kd1v66pg48h5c3qqp4v1zk5a";
+    sha256 = "02phamcchgsmvjnb3ir7r5sssvx9fcrscn297z73b82n1jl79510";
   };
 
   patches = [
     # Compatibility with new openjpeg
     (fetchpatch {
-      name = "mupdf-1.9a-openjpeg-2.1.1.patch";
-      url = "https://git.archlinux.org/svntogit/community.git/plain/mupdf/trunk/0001-mupdf-openjpeg.patch?id=5a28ad0a8999a9234aa7848096041992cc988099";
-      sha256 = "1i24qr4xagyapx4bijjfksj4g3bxz8vs5c2mn61nkm29c63knp75";
+      name = "mupdf-1.11-openjpeg-2.1.1.patch";
+      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/0001-mupdf-openjpeg.patch?h=packages/mupdf&id=3d997e7ff2ac20c44856ede22760ba6fbca81a5c";
+      sha256 = "1vr12kpzmmfr8pp3scwfhrm5laqwd58xm6vx971c4y8bxy60b2ig";
     })
 
     (fetchurl {
-      name = "CVE-2017-5896.patch";
-      url = "http://git.ghostscript.com/?p=mupdf.git;a=patch;h=2c4e5867ee699b1081527bc6c6ea0e99a35a5c27";
-      sha256 = "14k7x47ifx82sds1c06ibzbmcparfg80719jhgwjk6w1vkh4r693";
+      name = "mupdf-1.11-CVE-2017-6060.patch";
+      url = "http://git.ghostscript.com/?p=mupdf.git;a=blobdiff_plain;f=platform/x11/jstest_main.c;h=f158d9628ed0c0a84e37fe128277679e8334422a;hp=13c3a0a3ba3ff4aae29f6882d23740833c1d842f;hb=06a012a42c9884e3cd653e7826cff1ddec04eb6e;hpb=34e18d127a02146e3415b33c4b67389ce1ddb614";
+      sha256 = "163bllvjrbm0gvjb25lv7b6sih4zr4g4lap3h0cbq8dvpjxx0jfc";
     })
   ];
 
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = http://mupdf.com;
     repositories.git = git://git.ghostscript.com/mupdf.git;
-    description = "Lightweight PDF viewer and toolkit written in portable C";
+    description = "Lightweight PDF, XPS, and E-book viewer and toolkit written in portable C";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ viric vrthra fpletz ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

Update to new version.

[News](https://mupdf.com/news.html)

Notes:
- CVE-2017-5896: not needed anymore, as it has been integrated to upstream
- CVE-2017-6060: see [agostino's blog](https://blogs.gentoo.org/ago/2017/02/17/mupdf-mujstest-stack-based-buffer-overflow-in-main-jstest_main-c/)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).