### PR TITLE
docker tools: fix pull image function

### DIFF
--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -83,16 +83,12 @@ rec {
   };
 
   # 4. example of pulling an image. could be used as a base for other images
-  #
-  # ***** Currently broken, getting 404s. Perhaps the docker API has changed?
-  #
-  #
-  # debian = pullImage {
-  #   imageName = "debian";
-  #   imageTag = "jessie";
-  #   # this hash will need change if the tag is updated at docker hub
-  #   sha256 = "18kd495lc2k35h03bpcbdjnix17nlqbwf6nmq3sb161blf0dk14q";
-  # };
+  nix = pullImage {
+    imageName = "nixos/nix";
+    imageTag = "1.11";
+    # this hash will need change if the tag is updated at docker hub
+    sha256 = "1gk4bq05vl3rj3mh4mlbl4iicgndmimlv8jvkhdk4hrv0r44bwr3";
+  };
 
   # 5. example of multiple contents, emacs and vi happily coexisting
   editors = buildImage {

--- a/pkgs/build-support/docker/pull.sh
+++ b/pkgs/build-support/docker/pull.sh
@@ -1,86 +1,36 @@
-# Reference: docker src contrib/download-frozen-image.sh
-
 source $stdenv/setup
 
-# Curl flags to handle redirects, not use EPSV, handle cookies for
-# servers to need them during redirects, and work on SSL without a
-# certificate (this isn't a security problem because we check the
-# cryptographic hash of the output anyway).
-curl=$(command -v curl)
-curl() {
-  [[ -n ${token:-} ]] && set -- -H "Authorization: Token $token" "$@"
-  $curl \
-    --location --max-redirs 20 \
-    --retry 3 \
-    --fail \
-    --disable-epsv \
-    --cookie-jar cookies \
-    --insecure \
-    $curlOpts \
-    $NIX_CURL_FLAGS \
-    "$@"
-}
+mkdir -p /var/lib/docker
+mkfs.ext4 /dev/vda
+mount -t ext4 /dev/vda /var/lib/docker
 
-fetchLayer() {
-    local url="$1"
-    local dest="$2"
-    local curlexit=18;
+modprobe virtio_net
+dhclient eth0
 
-    # if we get error code 18, resume partial download
-    while [ $curlexit -eq 18 ]; do
-        # keep this inside an if statement, since on failure it doesn't abort the script
-        if curl -C - "$url" --output "$dest"; then
-            return 0
-        else
-            curlexit=$?;
-        fi
-    done
+mkdir -p /etc/ssl/certs/
+cp "$certs" "/etc/ssl/certs/"
 
-    return $curlexit
-}
-
-headers=$(curl -o /dev/null -D- -H 'X-Docker-Token: true' \
-          "$indexUrl/$registryVersion/repositories/$imageName/images")
-
-header() {
-  grep $1 <<< "$headers" | tr -d '\r' | cut -d ' ' -f 2
-}
-
-# this only takes the first endpoint, more may be provided
-# https://docs.docker.com/v1.6/reference/api/docker-io_api/
-if ! registryUrl=$(header X-Docker-Endpoints); then
-  echo "error: index returned no endpoint"
-  exit 1
-fi
-baseUrl="https://$registryUrl/$registryVersion"
-
-token="$(header X-Docker-Token || true)";
-
-if [ -z "$imageId" ]; then
-    imageId="$(curl "$baseUrl/repositories/$imageName/tags/$imageTag")"
-    imageId="${imageId//\"/}"
-    if [ -z "$imageId" ]; then
-        echo "error: no image ID found for ${imageName}:${imageTag}"
-        exit 1
+# from https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
+mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+cd /sys/fs/cgroup
+for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
+  mkdir -p $sys
+  if ! mountpoint -q $sys; then
+    if ! mount -n -t cgroup -o $sys cgroup $sys; then
+      rmdir $sys || true
     fi
-
-    echo "found image ${imageName}:${imageTag}@$imageId"
-fi
-
-mkdir -p $out
-
-jshon -n object \
-  -n object -s "$imageId" -i "$imageTag" \
-  -i "$imageName" > $out/repositories
-
-curl "$baseUrl/images/$imageId/ancestry" -o ancestry.json
-
-layerIds=$(jshon -a -u < ancestry.json)
-for layerId in $layerIds; do
-    echo "fetching layer $layerId"
-    
-    mkdir "$out/$layerId"
-    echo '1.0' > "$out/$layerId/VERSION"
-    curl "$baseUrl/images/$layerId/json" | python $detjson > "$out/$layerId/json"
-    fetchLayer "$baseUrl/images/$layerId/layer" "$out/$layerId/layer.tar"
+  fi
 done
+
+# run docker daemon
+dockerd -H tcp://127.0.0.1:5555 -H unix:///var/run/docker.sock &
+
+until $(curl --output /dev/null --silent --connect-timeout 2 http://127.0.0.1:5555); do
+  printf '.'
+  sleep 1
+done
+
+rm -r $out
+
+docker pull ${imageId}
+docker save ${imageId} > $out


### PR DESCRIPTION
###### Motivation for this change
- current dockerTools.pullImage outputs 404 no matter what image you gave it even before it starts to download layers (as far as I can see v1 docker registry api is deprecated)
- current dockerTools.pullImage does not support "/" in the imageName

###### Things done

Mentioned issues are resolved.

And yes, I do use qemu for starting docker daemon and downloading the image with it, it is the most reliable option (and it works without kvm enabled system, altho a bit slow) and I know that it is not ideal, but if someone wants to make it better, use something like https://pypi.python.org/pypi/python-dxf and reverse engineer the json file(s) needed

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

