### PR TITLE
wakatime: 7.0.4 -> 8.0.2

### DIFF
--- a/pkgs/tools/misc/wakatime/default.nix
+++ b/pkgs/tools/misc/wakatime/default.nix
@@ -2,13 +2,12 @@
 
 with pythonPackages;
 
-buildPythonPackage rec {
-  namePrefix = "";
+buildPythonApplication rec {
   name = "wakatime-${version}";
-  version = "7.0.4";
+  version = "8.0.2";
 
   src = fetchFromGitHub {
-    sha256 = "1cddabx9x11d2nxxcqlf4piysjnpfici0n5qy3n9gw81asz1djhf";
+    sha256 = "0rbjnkzjvz8mgmy44064cz8sib3x5bdjh3ffjhg9r87blnlbmcv1";
     rev = version;
     repo = "wakatime";
     owner = "wakatime";

--- a/pkgs/tools/misc/wakatime/default.nix
+++ b/pkgs/tools/misc/wakatime/default.nix
@@ -7,7 +7,7 @@ buildPythonApplication rec {
   version = "8.0.2";
 
   src = fetchFromGitHub {
-    sha256 = "0rbjnkzjvz8mgmy44064cz8sib3x5bdjh3ffjhg9r87blnlbmcv1";
+    sha256 = "005irdzdii5cpd0nj1pindfg2mi93qpsfp91yh9qyljsz676fv8c";
     rev = version;
     repo = "wakatime";
     owner = "wakatime";


### PR DESCRIPTION
###### Motivation for this change

Upgrade to latest version and switch from `buildPythonPackage` to `buildPythonApplication`.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
