### PR TITLE
lynx: Fix SSL, widec support

### DIFF
--- a/pkgs/applications/networking/browsers/lynx/default.nix
+++ b/pkgs/applications/networking/browsers/lynx/default.nix
@@ -13,14 +13,10 @@ stdenv.mkDerivation rec {
     sha256 = "1cqm1i7d209brkrpzaqqf2x951ra3l67dw8x9yg10vz7rpr9441a";
   };
 
-  configureFlags = stdenv.lib.optional sslSupport "--with-ssl";
+  configureFlags = [ "--enable-widec" ] ++ stdenv.lib.optional sslSupport "--with-ssl";
 
   nativeBuildInputs = stdenv.lib.optional sslSupport pkgconfig;
   buildInputs = [ ncurses gzip ] ++ stdenv.lib.optional sslSupport openssl.dev;
-
-  crossAttrs = {
-    configureFlags = configureFlags ++ [ "--enable-widec" ];
-  };
 
   meta = with stdenv.lib; {
     homepage = http://lynx.isc.org/;

--- a/pkgs/applications/networking/browsers/lynx/default.nix
+++ b/pkgs/applications/networking/browsers/lynx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses, gzip
+{ stdenv, fetchurl, ncurses, gzip, pkgconfig
 , sslSupport ? true, openssl ? null
 }:
 
@@ -13,10 +13,10 @@ stdenv.mkDerivation rec {
     sha256 = "1cqm1i7d209brkrpzaqqf2x951ra3l67dw8x9yg10vz7rpr9441a";
   };
 
-  configureFlags = []
-    ++ stdenv.lib.optionals sslSupport [ "--with-ssl=${openssl.dev}" ];
+  configureFlags = stdenv.lib.optional sslSupport "--with-ssl";
 
-  buildInputs = [ ncurses gzip ];
+  nativeBuildInputs = stdenv.lib.optional sslSupport pkgconfig;
+  buildInputs = [ ncurses gzip ] ++ stdenv.lib.optional sslSupport openssl.dev;
 
   crossAttrs = {
     configureFlags = configureFlags ++ [ "--enable-widec" ];


### PR DESCRIPTION
lynx wants both the "include" and "lib/lib*.so" paths
to be children of the path given to "--with-ssl",
which is not provided by any of the current openssl outputs.

To fix lynx so it supports SSL (and https URLs),
let it use pkgconfig to figure out where openssl's bits are.

###### Motivation for this change

nix-built "lynx" doesn't support HTTPS (even when configured to use openSSL, which is the default).

nix-built "lynx" also doesn't handle wide characters currently (unless performing a cross build), so I've changed this to be always enabled instead.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

