### PR TITLE
cifs-utils: 6.5 -> 6.6

### DIFF
--- a/pkgs/os-specific/linux/cifs-utils/default.nix
+++ b/pkgs/os-specific/linux/cifs-utils/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "cifs-utils-${version}";
-  version = "6.5";
+  version = "6.6";
 
   src = fetchurl {
     url = "mirror://samba/pub/linux-cifs/cifs-utils/${name}.tar.bz2";
-    sha256 = "1xs9rwqfpx8qj5mcmagw6y1hzwc71zhzb5r8hv06sz16p1w6axz2";
+    sha256 = "09biws1jm23l3mjb9kh99v57z8bgzybrmimwddb40s6y0yl54wfh";
   };
 
   buildInputs = [ kerberos keyutils pam talloc ];


### PR DESCRIPTION
###### Motivation for this change

new version, There actually is a 6.7, but that one doesn't build because of missing files upstream.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

