### PR TITLE
nixos/tests: add tests for the LDAP stack

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -262,6 +262,7 @@ in rec {
   tests.keystone = callTest tests/keystone.nix {};
   tests.kubernetes = hydraJob (import tests/kubernetes.nix { system = "x86_64-linux"; });
   tests.latestKernel.login = callTest tests/login.nix { latestKernel = true; };
+  tests.ldap = callTest tests/ldap.nix {};
   #tests.lightdm = callTest tests/lightdm.nix {};
   tests.login = callTest tests/login.nix {};
   #tests.logstash = callTest tests/logstash.nix {};

--- a/nixos/tests/ldap.nix
+++ b/nixos/tests/ldap.nix
@@ -1,0 +1,119 @@
+import ./make-test.nix ({ pkgs, lib, ...} :
+
+let
+
+  dbSuffix = "dc=example,dc=com";
+  dbPath = "/var/db/openldap";
+  dbAdminDn = "cn=admin,${dbSuffix}";
+  dbAdminPwd = "test";
+  serverUri = "ldap:///";
+  ldapUser = "test-ldap-user";
+  ldapUserId = 10000;
+  ldapUserPwd = "test";
+  ldapGroup = "test-ldap-group";
+  ldapGroupId = 10000;
+  setupLdif = pkgs.writeText "test-ldap.ldif" ''
+    dn: ${dbSuffix}
+    dc: ${with lib; let dc = head (splitString "," dbSuffix); dcName = head (tail (splitString "=" dc)); in dcName}
+    o: ${dbSuffix}
+    objectclass: top
+    objectclass: dcObject
+    objectclass: organization
+
+    dn: cn=${ldapUser},${dbSuffix}
+    sn: ${ldapUser}
+    objectClass: person
+    objectClass: posixAccount
+    uid: ${ldapUser}
+    uidNumber: ${toString ldapUserId}
+    gidNumber: ${toString ldapGroupId}
+    homeDirectory: /home/${ldapUser}
+    loginShell: /bin/sh
+    userPassword: ${ldapUserPwd}
+
+    dn: cn=${ldapGroup},${dbSuffix}
+    objectClass: posixGroup
+    gidNumber: ${toString ldapGroupId}
+    memberUid: ${ldapUser}
+  '';
+  mkClient = useDaemon:
+    { config, pkgs, lib, ... }:
+    {
+      virtualisation.memorySize = 256;
+      virtualisation.vlans = [ 1 ];
+      security.pam.services.su.rootOK = lib.mkForce false;
+      users.ldap.enable = true;
+      users.ldap.daemon.enable = useDaemon;
+      users.ldap.loginPam = true;
+      users.ldap.nsswitch = true;
+      users.ldap.server = "ldap://server";
+      users.ldap.base = "${dbSuffix}";
+    };
+
+in
+
+{
+  name = "ldap";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ montag451 ];
+  };
+
+  nodes = {
+
+    server =
+      { config, pkgs, lib, ... }:
+      {
+        virtualisation.memorySize = 256;
+        virtualisation.vlans = [ 1 ];
+        networking.firewall.allowedTCPPorts = [ 389 ];
+        services.openldap.enable = true;
+        services.openldap.dataDir = dbPath;
+        services.openldap.urlList = [
+          serverUri
+        ];
+        services.openldap.extraConfig = ''
+          include ${pkgs.openldap.out}/etc/schema/core.schema
+          include ${pkgs.openldap.out}/etc/schema/cosine.schema
+          include ${pkgs.openldap.out}/etc/schema/inetorgperson.schema
+          include ${pkgs.openldap.out}/etc/schema/nis.schema
+
+          database mdb
+          suffix ${dbSuffix}
+          rootdn ${dbAdminDn}
+          rootpw ${dbAdminPwd}
+          directory ${dbPath}
+        '';
+      };
+
+    client1 = mkClient true; # use nss_pam_ldapd
+    client2 = mkClient false; # use nss_ldap and pam_ldap
+
+  };
+
+  testScript = ''
+    startAll;
+    $server->waitForUnit("default.target");
+    $client1->waitForUnit("default.target");
+    $client2->waitForUnit("default.target");
+
+    $server->succeed("ldapadd -D '${dbAdminDn}' -w ${dbAdminPwd} -H ${serverUri} -f '${setupLdif}'");
+
+    # NSS tests
+    subtest "nss", sub {
+        $client1->succeed("test \"\$(id -u '${ldapUser}')\" -eq ${toString ldapUserId}");
+        $client1->succeed("test \"\$(id -u -n '${ldapUser}')\" = '${ldapUser}'");
+        $client1->succeed("test \"\$(id -g '${ldapUser}')\" -eq ${toString ldapGroupId}");
+        $client1->succeed("test \"\$(id -g -n '${ldapUser}')\" = '${ldapGroup}'");
+        $client2->succeed("test \"\$(id -u '${ldapUser}')\" -eq ${toString ldapUserId}");
+        $client2->succeed("test \"\$(id -u -n '${ldapUser}')\" = '${ldapUser}'");
+        $client2->succeed("test \"\$(id -g '${ldapUser}')\" -eq ${toString ldapGroupId}");
+        $client2->succeed("test \"\$(id -g -n '${ldapUser}')\" = '${ldapGroup}'");
+    };
+
+    # PAM tests
+    subtest "pam", sub {
+        $client1->succeed("echo ${ldapUserPwd} | su -l '${ldapUser}' -c true");
+        $client2->succeed("echo ${ldapUserPwd} | su -l '${ldapUser}' -c true");
+    };
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

Following a very good remark by @fpletz regarding my pull request #26070, I decided to write some tests to check that upgrading some components of the LDAP stack of NixOS doesn't break anything.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

