### PR TITLE
polkit: add patch for Bug 96977

### DIFF
--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, glib, expat, pam, intltool, spidermonkey_17
 , gobjectIntrospection, libxslt, docbook_xsl, docbook_xml_dtd_412
-, useSystemd ? stdenv.isLinux, systemd }:
+, useSystemd ? stdenv.isLinux, systemd, fetchpatch }:
 
 let
 
@@ -28,6 +28,15 @@ stdenv.mkDerivation rec {
     [ pkgconfig glib expat pam intltool spidermonkey_17 gobjectIntrospection ]
     ++ [ libxslt docbook_xsl docbook_xml_dtd_412 ] # man pages
     ++ stdenv.lib.optional useSystemd systemd;
+
+  patches = [
+    # https://bugs.freedesktop.org/show_bug.cgi?id=96977
+    (fetchpatch {
+      url = "https://bugs.freedesktop.org/attachment.cgi?id=125189";
+      sha256 = "1y2cakbrcxrhzj5dyj5acj7kl8phc54pr7xzv1jh73744j2hdi5b";
+      name = "systemd-session.patch";
+    })
+  ];
 
   # Ugly hack to overwrite hardcoded directories
   # TODO: investigate a proper patch which will be accepted upstream


### PR DESCRIPTION
###### Motivation for this change

I am affected by this bug : https://bugs.freedesktop.org/show_bug.cgi?id=96977
A patch is available but upstream has not been showing interest in it for a year, so...

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` : I rebuilt my system with it except libreoffice and reverse dependencies of webkit-gtk for compilation time reasons
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

