### PR TITLE
mkPythonDerivation: obey a dontWrapPythonPrograms attribute

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -37,6 +37,9 @@
 # generated binaries.
 , makeWrapperArgs ? []
 
+# Skip wrapping of python programs altogether
+, dontWrapPythonPrograms ? false
+
 , meta ? {}
 
 , passthru ? {}
@@ -76,7 +79,7 @@ python.stdenv.mkDerivation (builtins.removeAttrs attrs ["disabled"] // {
   doCheck = false;
   doInstallCheck = doCheck;
 
-  postFixup = ''
+  postFixup = lib.optionalString (!dontWrapPythonPrograms) ''
     wrapPythonPrograms
   '' + lib.optionalString catchConflicts ''
     # Check if we have two packages with the same name in the closure and fail.

--- a/pkgs/development/python-modules/django/1_10.nix
+++ b/pkgs/development/python-modules/django/1_10.nix
@@ -21,6 +21,7 @@ buildPythonPackage rec {
   ];
 
   # patch only $out/bin to avoid problems with starter templates (see #3134)
+  dontWrapPythonPrograms = true;
   postFixup = ''
     wrapPythonProgramsIn $out/bin "$out $pythonPath"
   '';

--- a/pkgs/development/python-modules/django/1_11.nix
+++ b/pkgs/development/python-modules/django/1_11.nix
@@ -21,6 +21,7 @@ buildPythonPackage rec {
   ];
 
   # patch only $out/bin to avoid problems with starter templates (see #3134)
+  dontWrapPythonPrograms = true;
   postFixup = ''
     wrapPythonProgramsIn $out/bin "$out $pythonPath"
   '';

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9971,6 +9971,7 @@ in {
     };
 
     # patch only $out/bin to avoid problems with starter templates (see #3134)
+    dontWrapPythonPrograms = true;
     postFixup = ''
       wrapPythonProgramsIn $out/bin "$out $pythonPath"
     '';
@@ -9998,6 +9999,7 @@ in {
     doCheck = false;
 
     # patch only $out/bin to avoid problems with starter templates (see #3134)
+    dontWrapPythonPrograms = true;
     postFixup = ''
       wrapPythonProgramsIn $out/bin "$out $pythonPath"
     '';
@@ -10024,6 +10026,7 @@ in {
     doCheck = false;
 
     # patch only $out/bin to avoid problems with starter templates (see #3134)
+    dontWrapPythonPrograms = true;
     postFixup = ''
       wrapPythonProgramsIn $out/bin "$out $pythonPath"
     '';


### PR DESCRIPTION
###### Motivation for this change
85a87f5155f66dbdfcdb9869f4bd4f2a10fe8e2c broke python packages not wanting *all* potential "programs" wrapped with `wrapPythonPrograms` but also not wanting to have to replace/disable the whole `fixupPhase`. Notably django.

I propose borrowing a leaf out of `mkDerivation`'s book and making `mkPythonDerivation` obey a `dontWrapPythonPrograms` flag.

This includes a followup commit adding the flag to django packages to fix them.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

