### PR TITLE
gnuradio: [3.7.10.1->3.7.11] [Enable Darwin support]

### DIFF
--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -1,39 +1,50 @@
 { stdenv, fetchurl
-# core dependencies
+# Dependencies documented @ https://gnuradio.org/doc/doxygen/build_guide.html
+# => core dependencies
 , cmake, pkgconfig, git, boost, cppunit, fftw
-# python wrappers
+# => python wrappers
+# May be able to upgrade to swig3
 , python, swig2, numpy, scipy, matplotlib
-# grc - the gnu radio companion
+# => grc - the gnu radio companion
 , cheetah, pygtk
-# gr-wavelet: collection of wavelet blocks
+# => gr-wavelet: collection of wavelet blocks
 , gsl
-# gr-qtgui: the Qt-based GUI
+# => gr-qtgui: the Qt-based GUI
 , qt4, qwt, pyqt4 #, pyqwt
-# gr-wxgui: the Wx-based GUI
+# => gr-wxgui: the Wx-based GUI
 , wxPython, lxml
-# gr-audio: audio subsystems (system/OS dependent)
-, alsaLib
-# uhd: the Ettus USRP Hardware Driver Interface
+# => gr-audio: audio subsystems (system/OS dependent)
+, alsaLib   # linux   'audio-alsa'
+, CoreAudio # darwin  'audio-osx'
+# => uhd: the Ettus USRP Hardware Driver Interface
 , uhd
-# gr-video-sdl: PAL and NTSC display
+# => gr-video-sdl: PAL and NTSC display
 , SDL
 , libusb1, orc, pyopengl
 , makeWrapper
+# Hooks needed for dylib repair
+, fixDarwinDylibNames
+, fixDarwinFrameworks
 }:
 
 stdenv.mkDerivation rec {
   name = "gnuradio-${version}";
-  version = "3.7.10.1";
+  version = "3.7.11";
 
   src = fetchurl {
     url = "http://gnuradio.org/releases/gnuradio/${name}.tar.gz";
-    sha256 = "0ds9mcw8hgm03f82jvp3j4mm02ha6zvsl77lp13jzqmbqifbdmv3";
+    sha256 = "1m2jf8lafr6pr2dlm40nbvr6az8gwjfkzpbs4fxzv3l5hcqvmnc7";
   };
 
-  buildInputs = [
-    cmake pkgconfig git boost cppunit fftw python swig2 orc lxml qt4
-    qwt alsaLib SDL libusb1 uhd gsl makeWrapper
+  nativeBuildInputs = [
+    cmake pkgconfig git makeWrapper cppunit orc
   ];
+
+  buildInputs = [
+    boost fftw python swig2 lxml qt4
+    qwt SDL libusb1 uhd gsl 
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ CoreAudio ]
+    ++ stdenv.lib.optionals stdenv.isLinux  [ alsaLib   ];
 
   propagatedBuildInputs = [
     cheetah numpy scipy matplotlib pyqt4 pygtk wxPython pyopengl
@@ -45,19 +56,47 @@ stdenv.mkDerivation rec {
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-unused-variable"
   '';
 
+  # Framework path needed for qwt6_qt4 but not qwt5
+  cmakeFlags =                             
+    stdenv.lib.optionals stdenv.isDarwin [ "-DCMAKE_FRAMEWORK_PATH=${qwt}/lib" ];
+
+  postBuild = 
+    stdenv.lib.optionalString stdenv.isDarwin ''
+      echo "Attempting to patch qwt-dependent libs"
+      find . "(" -name "_qtgui_swig.so" -o -name "libgnuradio-qtgui*.dylib" ")" -print -exec install_name_tool -change qwt.framework/Versions/6/qwt ${qwt}/lib/qwt.framework/Versions/6/qwt "{}" ";"
+    '';
+
   # - Ensure we get an interactive backend for matplotlib. If not the gr_plot_*
   #   programs will not display anything. Yes, $MATPLOTLIBRC must point to the
   #   *dirname* where matplotlibrc is located, not the file itself.
   # - GNU Radio core is C++ but the user interface (GUI and API) is Python, so
   #   we must wrap the stuff in bin/.
+  # Notes:
+  # - May want to use makeWrapper instead of wrapProgram
+  # - see https://github.com/NixOS/nixpkgs/issues/22688 regarding use of --prefix / python.withPackages
+  # - see https://github.com/NixOS/nixpkgs/issues/24693 regarding use of DYLD_FRAMEWORK_PATH on Darwin
   postInstall = ''
     printf "backend : Qt4Agg\n" > "$out/share/gnuradio/matplotlibrc"
 
     for file in "$out"/bin/* "$out"/share/gnuradio/examples/*/*.py; do
         wrapProgram "$file" \
             --prefix PYTHONPATH : $PYTHONPATH:$(toPythonPath "$out") \
-            --set MATPLOTLIBRC "$out/share/gnuradio"
+            --set MATPLOTLIBRC "$out/share/gnuradio" ${stdenv.lib.optionalString stdenv.isDarwin " --set DYLD_FRAMEWORK_PATH /System/Library/Frameworks"}
     done
+  '';
+
+  doInstallCheck = true; # Check needs to run after install due to dependencies on nix store paths
+  installCheckTarget = "test"; # GNUr uses `make test` instead of `make check`
+  installCheckFlags  = ''
+    ARGS="-V" VERBOSE=1 
+  '';
+
+  # Needed b.c many tests depend on a home folder 
+  # - see https://github.com/NixOS/nixpkgs/issues/24693 regarding use of DYLD_FRAMEWORK_PATH on Darwin
+  preInstallCheck = ''
+    mkdir -p $NIX_BUILD_TOP/check-phase
+    export HOME=$NIX_BUILD_TOP/check-phase
+    ${stdenv.lib.optionalString stdenv.isDarwin "export DYLD_FRAMEWORK_PATH=/System/Library/Frameworks"}
   '';
 
   meta = with stdenv.lib; {
@@ -73,7 +112,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.gnuradio.org;
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ bjornfor fpletz ];
   };
 }

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -60,12 +60,6 @@ stdenv.mkDerivation rec {
   cmakeFlags =                             
     stdenv.lib.optionals stdenv.isDarwin [ "-DCMAKE_FRAMEWORK_PATH=${qwt}/lib" ];
 
-  postBuild = 
-    stdenv.lib.optionalString stdenv.isDarwin ''
-      echo "Attempting to patch qwt-dependent libs"
-      find . "(" -name "_qtgui_swig.so" -o -name "libgnuradio-qtgui*.dylib" ")" -print -exec install_name_tool -change qwt.framework/Versions/6/qwt ${qwt}/lib/qwt.framework/Versions/6/qwt "{}" ";"
-    '';
-
   # - Ensure we get an interactive backend for matplotlib. If not the gr_plot_*
   #   programs will not display anything. Yes, $MATPLOTLIBRC must point to the
   #   *dirname* where matplotlibrc is located, not the file itself.

--- a/pkgs/development/libraries/qwt/6_qt4.nix
+++ b/pkgs/development/libraries/qwt/6_qt4.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
     sed -e "s|QWT_INSTALL_PREFIX.*=.*|QWT_INSTALL_PREFIX = $out|g" -i qwtconfig.pri
   '';
 
+  fixupPhase =
+    stdenv.lib.optionalString stdenv.isDarwin ''
+      echo "Attempting to repair qwt"
+      install_name_tool -id "$out/lib/qwt.framework/Versions/6/qwt" "$out/lib/qwt.framework/Versions/6/qwt"
+    '';
+
   qmakeFlags = [ "-after doc.path=$out/share/doc/${name}" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/qwt/6_qt4.nix
+++ b/pkgs/development/libraries/qwt/6_qt4.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, qt4, qmake4Hook }:
+{ stdenv, fetchurl, qt4, qmake4Hook, AGL }:
 
 stdenv.mkDerivation rec {
   name = "qwt-6.1.2";
@@ -8,8 +8,13 @@ stdenv.mkDerivation rec {
     sha256 = "031x4hz1jpbirv9k35rqb52bb9mf2w7qav89qv1yfw1r3n6z221b";
   };
 
-  buildInputs = [ qt4 ];
+  buildInputs = [ 
+    qt4 
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ AGL ];
+
   nativeBuildInputs = [ qmake4Hook ];
+
+  enableParallelBuilding = true;
 
   postPatch = ''
     sed -e "s|QWT_INSTALL_PREFIX.*=.*|QWT_INSTALL_PREFIX = $out|g" -i qwtconfig.pri

--- a/pkgs/development/tools/misc/uhd/default.nix
+++ b/pkgs/development/tools/misc/uhd/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://ettus-apps.sourcerepo.com/redmine/ettus/projects/uhd/wiki;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ bjornfor fpletz ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13906,7 +13906,9 @@ with pkgs;
 
   gnuradio = callPackage ../applications/misc/gnuradio {
     inherit (python2Packages) cheetah lxml matplotlib numpy python pyopengl pyqt4 scipy wxPython pygtk;
+    inherit (darwin.apple_sdk.frameworks) CoreAudio;
     fftw = fftwFloat;
+    qwt = qwt6_qt4;
   };
 
   gnuradio-with-packages = callPackage ../applications/misc/gnuradio/wrapper.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9866,7 +9866,9 @@ with pkgs;
 
   qwt = callPackage ../development/libraries/qwt {};
 
-  qwt6_qt4 = callPackage ../development/libraries/qwt/6_qt4.nix { };
+  qwt6_qt4 = callPackage ../development/libraries/qwt/6_qt4.nix {
+    inherit (darwin.apple_sdk.frameworks) AGL;
+  };
 
   qxt = callPackage ../development/libraries/qxt {};
 


### PR DESCRIPTION
###### Motivation for this change
GNU Radio only required a few small tweaks to enable compilation on Darwin. Updated to 3.7.11 [which is compatible with 3.10.1 and includes bugfixes.](https://github.com/gnuradio/gnuradio/blob/v3.7.11/RELEASE-NOTES.md)
- UHD builds on Darwin with no changes, links and works
- qwt6_qt4 was already Darwin enabled, but was missing AGL

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (using nix-shell --pure)
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- This is my first pull request so I apologize if it is preferred to submit a separate pull per package. 
- There are child gnuradio packages which are still linux-only (small changes for darwin support), but I wanted to improve the PYTHONPATH situation before submitting them. 
- This package produces python outputs, so I propose changing this to a wrapper package which would depend on gnuradio-core and gnuradio-python. gnuradio-python would create a python package using `buildPythonPackage`.
- I had to use DYLD_FRAMEWORK_PATH due to Python27 linking to a pure CoreFoundation, causing QWT/QT to segfault.

Attached is the output log of nox-review:
[gnuradio_qwt6-qt4_uhd_darwin_buildoutput.txt](https://github.com/NixOS/nixpkgs/files/1033249/gnuradio_qwt6-qt4_uhd_darwin_buildoutput.txt)
