### PR TITLE
dkimproxy: init at 1.4.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -160,6 +160,7 @@
   ehegnes = "Eric Hegnes <eric.hegnes@gmail.com>";
   ehmry = "Emery Hemingway <emery@vfemail.net>";
   eikek = "Eike Kettner <eike.kettner@posteo.de>";
+  ekleog = "Leo Gaspard <leo@gaspard.io>";
   elasticdog = "Aaron Bull Schaefer <aaron@elasticdog.com>";
   eleanor = "Dejan Lukan <dejan@proteansec.com>";
   elitak = "Eric Litak <elitak@gmail.com>";

--- a/pkgs/servers/mail/dkimproxy/default.nix
+++ b/pkgs/servers/mail/dkimproxy/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     description = "SMTP-proxy that signs and/or verifies emails";
     homepage = http://dkimproxy.sourceforge.net/;
     license = licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = [ maintainers.ekleog ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/servers/mail/dkimproxy/default.nix
+++ b/pkgs/servers/mail/dkimproxy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, perl, fetchurl, Error, MailDKIM, MIMEtools, NetServer}:
+{ stdenv, perl, fetchurl, Error, MailDKIM, MIMEtools, NetServer }:
 
 let
   pkg = "dkimproxy";

--- a/pkgs/servers/mail/dkimproxy/default.nix
+++ b/pkgs/servers/mail/dkimproxy/default.nix
@@ -12,6 +12,17 @@ stdenv.mkDerivation rec {
     sha256 = "1gc5c7lg2qrlck7b0lvjfqr824ch6jkrzkpsn0gjvlzg7hfmld75";
   };
 
+  # Idea taken from pkgs/development/perl-modules/generic/builder.sh
+  preFixup = ''
+    perlFlags=
+    for i in $(IFS=:; echo $PERL5LIB); do
+      perlFlags="$perlFlags -I$i"
+    done
+    for f in $(ls $out/bin); do
+      sed -i $out/bin/$f -e "s|#\!\(.*/perl.*\)$|#\! \1 $perlFlags|"
+    done
+  '';
+
   buildInputs = [ perl ];
   propagatedBuildInputs = [ Error MailDKIM MIMEtools NetServer ];
 

--- a/pkgs/servers/mail/dkimproxy/default.nix
+++ b/pkgs/servers/mail/dkimproxy/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, buildPerlPackage, fetchurl, Error, MailDKIM, MIMEtools, NetServer}:
+{ stdenv, perl, fetchurl, Error, MailDKIM, MIMEtools, NetServer}:
 
 let
   pkg = "dkimproxy";
   version = "1.4.1";
 in
-buildPerlPackage rec {
+stdenv.mkDerivation rec {
   name = "${pkg}-${version}";
 
   src = fetchurl {
@@ -12,25 +12,14 @@ buildPerlPackage rec {
     sha256 = "1gc5c7lg2qrlck7b0lvjfqr824ch6jkrzkpsn0gjvlzg7hfmld75";
   };
 
+  buildInputs = [ perl ];
   propagatedBuildInputs = [ Error MailDKIM MIMEtools NetServer ];
 
-  # Disable all things adapted to library perl packages
-  doCheck = false;
-  outputs = [ "out" ];
-
-  # Use "normal" build setup
-  configurePhase = ''
-    ./configure --prefix=$out
-  '';
-  installPhase = ''
-    make install
-  '';
-
-  meta = {
+  meta = with stdenv.lib; {
     description = "SMTP-proxy that signs and/or verifies emails";
     homepage = http://dkimproxy.sourceforge.net/;
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.all;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/mail/dkimproxy/default.nix
+++ b/pkgs/servers/mail/dkimproxy/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, buildPerlPackage, fetchurl, Error, MailDKIM, MIMEtools, NetServer}:
+
+let
+  pkg = "dkimproxy";
+  version = "1.4.1";
+in
+buildPerlPackage rec {
+  name = "${pkg}-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/dkimproxy/${name}.tar.gz";
+    sha256 = "1gc5c7lg2qrlck7b0lvjfqr824ch6jkrzkpsn0gjvlzg7hfmld75";
+  };
+
+  propagatedBuildInputs = [ Error MailDKIM MIMEtools NetServer ];
+
+  # Disable all things adapted to library perl packages
+  doCheck = false;
+  outputs = [ "out" ];
+
+  # Use "normal" build setup
+  configurePhase = ''
+    ./configure --prefix=$out
+  '';
+  installPhase = ''
+    make install
+  '';
+
+  meta = {
+    description = "SMTP-proxy that signs and/or verifies emails";
+    homepage = http://dkimproxy.sourceforge.net/;
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = [ ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10775,6 +10775,10 @@ with pkgs;
 
   diod = callPackage ../servers/diod { lua = lua5_1; };
 
+  dkimproxy = callPackage ../servers/mail/dkimproxy {
+    inherit (perlPackages) Error MailDKIM MIMEtools NetServer;
+  };
+
   dnschain = callPackage ../servers/dnschain { };
 
   dovecot = callPackage ../servers/mail/dovecot { };


### PR DESCRIPTION
###### Motivation for this change

OpenSMTPD not supporting OpenDKIM but only dkimproxy (for the time being), dkimproxy may prove useful.

Note: I have just tested the executable appears to build at the moment, not yet that it works, not having yet a fully functional OpenSMTPD setup. The package builds on NixOS with sandboxing, and all executables appear to run without obvious errors. I'll come back after having finished setting up an OpenSMTPD using it if that's required for merging.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

