### PR TITLE
nbstripout: wrap the executable

### DIFF
--- a/pkgs/applications/version-management/nbstripout/default.nix
+++ b/pkgs/applications/version-management/nbstripout/default.nix
@@ -1,38 +1,50 @@
-{lib, python2Packages, git, mercurial, coreutils}:
+{lib, python2Packages, git, mercurial, coreutils, runCommand, makeWrapper}:
 
 with python2Packages;
-buildPythonApplication rec {
-  name = "${pname}-${version}";
-  version = "0.3.0";
-  pname = "nbstripout";
+let
+  nbstripout = buildPythonApplication rec {
+    name = "${pname}-${version}";
+    version = "0.3.0";
+    pname = "nbstripout";
 
-  # Mercurial should be added as a build input but because it's a Python
-  # application, it would mess up the Python environment. Thus, don't add it
-  # here, instead add it to PATH when running unit tests
-  buildInputs = [ pytest pytest-flake8 pytest-cram git pytestrunner ];
-  propagatedBuildInputs = [ ipython nbformat ];
+    # Mercurial should be added as a build input but because it's a Python
+    # application, it would mess up the Python environment. Thus, don't add it
+    # here, instead add it to PATH when running unit tests
+    buildInputs = [ pytest pytest-flake8 pytest-cram git pytestrunner ];
+    propagatedBuildInputs = [ nbformat ];
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "126xhjma4a0k7gq58hbqglhb3rai0a576azz7g8gmqjr3kl0264v";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "126xhjma4a0k7gq58hbqglhb3rai0a576azz7g8gmqjr3kl0264v";
+    };
+
+    # for some reason, darwin uses /bin/sh echo native instead of echo binary, so
+    # force using the echo binary
+    postPatch = ''
+      substituteInPlace tests/test-git.t --replace "echo" "${coreutils}/bin/echo"
+    '';
+
+    # ignore flake8 tests for the nix wrapped setup.py
+    checkPhase = ''
+      PATH=$PATH:$out/bin:${mercurial}/bin pytest --ignore=nix_run_setup.py .
+    '';
+
+    meta = {
+      inherit version;
+      description = "Strip output from Jupyter and IPython notebooks";
+      homepage = https://github.com/kynan/nbstripout;
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ jluttine ];
+    };
   };
-
-  # for some reason, darwin uses /bin/sh echo native instead of echo binary, so
-  # force using the echo binary
-  postPatch = ''
-    substituteInPlace tests/test-git.t --replace "echo" "${coreutils}/bin/echo"
-  '';
-
-  # ignore flake8 tests for the nix wrapped setup.py
-  checkPhase = ''
-    PATH=$PATH:$out/bin:${mercurial}/bin pytest --ignore=nix_run_setup.py .
-  '';
-
-  meta = {
-    inherit version;
-    description = "Strip output from Jupyter and IPython notebooks";
-    homepage = https://github.com/kynan/nbstripout;
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ jluttine ];
-  };
-}
+in
+# Wrap the executable so that only it is added to the path but not the
+# dependencies (python, jupyter, etc).
+runCommand "nbstripout"
+  { buildInputs = [ nbstripout makeWrapper ]; }
+  ''
+    mkdir -p $out/bin
+    makeWrapper \
+      ${nbstripout}/bin/nbstripout \
+      $out/bin/nbstripout
+  ''


### PR DESCRIPTION
###### Motivation for this change

Without wrapping, installing nbstripout adds Python, Jupyter and some other
run-time dependencies to PATH. With wrapping, they are only visible to
nbstripout.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

