### PR TITLE
WIP: allow bgSupport for windowManagers as well

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -7,10 +7,6 @@ let
   xcfg = config.services.xserver;
   cfg = xcfg.desktopManager;
 
-  # If desktop manager `d' isn't capable of setting a background and
-  # the xserver is enabled, `feh' or `xsetroot' are used as a fallback.
-  needBGCond = d: ! (d ? bgSupport && d.bgSupport) && xcfg.enable;
-
 in
 
 {
@@ -42,17 +38,7 @@ in
         apply = list: {
           list = map (d: d // {
             manage = "desktop";
-            start = d.start
-            + optionalString (needBGCond d) ''
-              if [ -e $HOME/.background-image ]; then
-                ${pkgs.feh}/bin/feh --bg-scale $HOME/.background-image
-              else
-                # Use a solid black background as fallback
-                ${pkgs.xorg.xsetroot}/bin/xsetroot -solid black
-              fi
-            '';
           }) list;
-          needBGPackages = [] != filter needBGCond list;
         };
       };
 
@@ -82,7 +68,5 @@ in
 
   config = {
     services.xserver.displayManager.session = cfg.session.list;
-    environment.systemPackages =
-      mkIf cfg.session.needBGPackages [ pkgs.feh ]; # xsetroot via xserver.enable
   };
 }

--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -45,6 +45,7 @@ in
         example = [{
           name = "wmii";
           start = "...";
+          bgSupport = true;
         }];
         description = ''
           Internal option used to add some common line to window manager
@@ -53,6 +54,15 @@ in
         '';
         apply = map (d: d // {
           manage = "window";
+          start = d.start
+            + optionalString (d ? bgSupport && d.bgSupport)
+              ''
+                if [ -e $HOME/.background-image ]; then
+                  ${pkgs.feh}/bin/feh --bg-scale $HOME/.background-image
+                else
+                  ${pkgs.xorg.xsetroot}/bin/xsetroot -solid black
+                fi
+              '';
         });
       };
 

--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -54,15 +54,6 @@ in
         '';
         apply = map (d: d // {
           manage = "window";
-          start = d.start
-            + optionalString (d ? bgSupport && d.bgSupport)
-              ''
-                if [ -e $HOME/.background-image ]; then
-                  ${pkgs.feh}/bin/feh --bg-scale $HOME/.background-image
-                else
-                  ${pkgs.xorg.xsetroot}/bin/xsetroot -solid black
-                fi
-              '';
         });
       };
 

--- a/nixos/modules/services/x11/window-managers/i3.nix
+++ b/nixos/modules/services/x11/window-managers/i3.nix
@@ -56,6 +56,7 @@ in
   config = mkIf cfg.enable {
     services.xserver.windowManager.session = [{
       name  = "i3";
+      bgSupport = true;
       start = ''
         ${cfg.extraSessionCommands}
 


### PR DESCRIPTION
###### Motivation for this change

see #25978 

I'd like to have some configurable background for windowManagers as well.

This isn't mergable right now, here's a TODO list:

- [x] basic implementation for background-image support
- [ ] test windowManagers
  - [x] i3
  - [ ] XMonad
  - [x] ~Awesome~ :warning: No support for backgrounds with `feh`
  - ...
- [ ] allow directory as well (using `feh --randomize` for multiple backgrounds)
- [x] avoid code duplication (this is stolen from `display-managers/default.nix`, could be moved into a general function to avoid duplicated code)
- [ ] beautify commit history
- [ ] fix merge conflict
- [ ] confirm that desktopManagers still work

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

