### PR TITLE
tinc: Mention in docs that the host name may not be used verbatim.

### DIFF
--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -35,7 +35,8 @@ in
               description = ''
                 The name of the node which is used as an identifier when communicating
                 with the remote nodes in the mesh. If null then the hostname of the system
-                is used.
+                is used to derive a name (note that tinc may replace hyphens in the
+                hostname by underscores).
               '';
             };
 

--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -35,8 +35,8 @@ in
               description = ''
                 The name of the node which is used as an identifier when communicating
                 with the remote nodes in the mesh. If null then the hostname of the system
-                is used to derive a name (note that tinc may replace hyphens in the
-                hostname by underscores).
+                is used to derive a name (note that tinc may replace non-alphanumeric characters in
+                hostnames by underscores).
               '';
             };
 


### PR DESCRIPTION
Source:

  https://github.com/gsliepen/tinc/blob/5c344f297682cf11793407fca4547968aee22d95/src/net_setup.c#L341

###### Motivation for this change

This can lead to confusion / misconfiguration if not mentioned.
