### PR TITLE
simpleproxy: init at 3.5

### DIFF
--- a/pkgs/tools/networking/simpleproxy/default.nix
+++ b/pkgs/tools/networking/simpleproxy/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "simpleproxy-${version}";
+  version = "3.5";
+  rev = "v.${version}";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "vzaliva";
+    repo = "simpleproxy";
+    sha256 = "1my9g4vp19dikx3fsbii4ichid1bs9b9in46bkg05gbljhj340f6";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/vzaliva/simpleproxy;
+    description = "A simple TCP proxy";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.montag451 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4056,6 +4056,8 @@ with pkgs;
   silver-searcher = callPackage ../tools/text/silver-searcher { };
   ag = self.silver-searcher;
 
+  simpleproxy = callPackage ../tools/networking/simpleproxy { };
+
   simplescreenrecorder = callPackage ../applications/video/simplescreenrecorder { };
 
   sipsak = callPackage ../tools/networking/sipsak { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

