### PR TITLE
pythonPackages.pywinrm: 0.1.1 -> 0.2.2

### DIFF
--- a/pkgs/development/python-modules/ntlm-auth/default.nix
+++ b/pkgs/development/python-modules/ntlm-auth/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, pytest
+, unittest2
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "ntlm-auth";
+  version = "1.0.3";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "jborean93";
+    repo = "ntlm-auth";
+    rev = "v${version}";
+    sha256 = "09f2g4ivfi9lh1kr30hlg0q4n2imnvmd79w83gza11q9nmhhiwpz";
+  };
+
+  checkInputs = [ mock pytest unittest2 ];
+  propagatedBuildInputs = [ six ];
+
+  # Functional tests require networking
+  checkPhase = ''
+    py.test --ignore=tests/functional/test_iis.py
+  '';
+
+  meta = with lib; {
+    description = "Calculates NTLM Authentication codes";
+    homepage = https://github.com/jborean93/ntlm-auth;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ elasticdog ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/pywinrm/default.nix
+++ b/pkgs/development/python-modules/pywinrm/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, mock
+, pytest
+, requests
+, requests_ntlm
+, six
+, xmltodict
+}:
+
+buildPythonPackage rec {
+  pname = "pywinrm";
+  version = "0.2.2";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06xc0mbqf718vmsp0fq0rb64nql66l5w2x23bmqnzl6nzc0gfc1h";
+  };
+
+  checkInputs = [ mock pytest ];
+  propagatedBuildInputs = [ requests requests_ntlm six xmltodict ];
+
+  meta = with lib; {
+    description = "Python library for Windows Remote Management";
+    homepage = "http://github.com/diyan/pywinrm/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ elasticdog ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/requests_ntlm/default.nix
+++ b/pkgs/development/python-modules/requests_ntlm/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ntlm-auth
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "requests_ntlm";
+  version = "1.0.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hb689p2jyb867c2wlq5mjkqxgc0jq6lxv3rmhw8rq9qangk3jjk";
+  };
+
+  propagatedBuildInputs = [ ntlm-auth requests ];
+
+  # Tests require networking
+  doCheck = false;
+
+  meta = with lib; {
+    description = "HTTP NTLM authentication support for python-requests";
+    homepage = https://github.com/requests/requests-ntlm;
+    license = licenses.isc;
+    maintainers = with maintainers; [ elasticdog ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21092,25 +21092,7 @@ in {
     };
   };
 
-  pywinrm = buildPythonPackage rec {
-    version = "0.1.1";
-    name = "pywinrm-${version}";
-
-    src = pkgs.fetchurl {
-      url = "https://github.com/diyan/pywinrm/archive/v${version}.tar.gz";
-      sha256 = "1pc0987f6q5sxcgm50a1k1xz2pk45ny9xxnyapaf60662rcavvfb";
-    };
-
-    propagatedBuildInputs = with self; [ isodate kerberos xmltodict ];
-
-    meta = {
-      homepage = "http://github.com/diyan/pywinrm/";
-      description = "Python library for Windows Remote Management";
-      license = licenses.mit;
-      # error: libgssapi_krb5.so: cannot open shared object file: No such file or directory
-      broken = true; #
-    };
-  };
+  pywinrm = callPackage ../development/python-modules/pywinrm { };
 
   PyXAPI = stdenv.mkDerivation rec {
     name = "PyXAPI-0.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21373,6 +21373,8 @@ in {
     };
   };
 
+  requests_ntlm = callPackage ../development/python-modules/requests_ntlm { };
+
   requests_oauthlib = callPackage ../development/python-modules/requests-oauthlib.nix { };
 
   requests_toolbelt = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -234,6 +234,8 @@ in {
 
   nltk = callPackage ../development/python-modules/nltk.nix { };
 
+  ntlm-auth = callPackage ../development/python-modules/ntlm-auth { };
+
   pitz = callPackage ../applications/misc/pitz { };
 
   plantuml = callPackage ../tools/misc/plantuml { };


### PR DESCRIPTION
###### Motivation for this change

Bump version to latest upstream release and remove the already broken/optional Kerberos support.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The latest version of *pywinrm* has a new dependency on *requests_ntlm* which requires the lower-level *ntlm-auth*. I've removed the optional *kerberos* dependency, as it was already broken, now requires additional dependencies to function, and I couldn't figure out a clean way of manipulating the `LD_LIBRARY_PATH` (or patch things with the absolute path) to fix the original error:

> error: libgssapi_krb5.so: cannot open shared object file: No such file or directory

The other changed dependencies were just making things accurate with the upstream requirements. Here's the `pipdeptree` output, if you're curious:

```
pywinrm==0.2.2
  - requests [required: >=2.9.1, installed: 2.14.2]
  - requests-ntlm [required: >=0.3.0, installed: 1.0.0]
    - ntlm-auth [required: >=1.0.2, installed: 1.0.3]
      - six [required: Any, installed: 1.10.0]
    - requests [required: >=2.0.0, installed: 2.14.2]
  - six [required: Any, installed: 1.10.0]
  - xmltodict [required: Any, installed: 0.11.0]
```

The tests I disabled require a local IIS server and network access. 