### PR TITLE
libvmi: init at 3e4114

### DIFF
--- a/pkgs/development/libraries/libvmi/default.nix
+++ b/pkgs/development/libraries/libvmi/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, xen, which, autoreconfHook, fetchFromGitHub, yacc, bison, flex, glib, libtool, autoconf, automake, pkgconfig, libvirt }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "libvmi-${version}";
+  version = "${stdenv.lib.strings.substring 0 7 rev}-2017-05-27";
+  rev = "3e4114a64f012f1d3e2eb660bc65dcd130295d49";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "libvmi";
+    repo = "libvmi";
+    sha256 = "0vbmrj0ij19i55afkqj64q7sgh0scpwk3c99qx6p6gn1qcy2wdss";
+  };
+
+  buildInputs = [ glib xen which libvirt ];
+  nativeBuildInputs = [ autoreconfHook yacc bison flex libtool autoconf automake pkgconfig ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://libvmi.com/";
+    description = "A C library for virtual machine introspection";
+    longDescription = ''
+      LibVMI is a C library with Python bindings that makes it easy to monitor the low-level
+      details of a running virtual machine by viewing its memory, trapping on hardware events,
+      and accessing the vCPU registers.
+    '';
+    license = [ licenses.gpl3 licenses.lgpg ];
+    maintainers = with maintainers; [ eleanor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9103,6 +9103,8 @@ with pkgs;
 
   libvisual = callPackage ../development/libraries/libvisual { };
 
+  libvmi = callPackage ../development/libraries/libvmi { };
+
   libvncserver = callPackage ../development/libraries/libvncserver {};
 
   libviper = callPackage ../development/libraries/libviper { };
@@ -13355,7 +13357,7 @@ with pkgs;
   clipit = callPackage ../applications/misc/clipit { };
 
   cloud-print-connector = callPackage ../servers/cloud-print-connector { };
-  
+
   cmatrix = callPackage ../applications/misc/cmatrix { };
 
   cmus = callPackage ../applications/audio/cmus {
@@ -17791,7 +17793,7 @@ with pkgs;
   coqPackages_8_5 = mkCoqPackages_8_5 coqPackages_8_5;
   coqPackages_8_6 = mkCoqPackages_8_6 coqPackages_8_6;
   coqPackages = coqPackages_8_6;
-  
+
   coq_8_4 = coqPackages_8_4.coq;
   coq_8_5 = coqPackages_8_5.coq;
   coq_8_6 = coqPackages_8_6.coq;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

