### PR TITLE
factorio: 0.15.1 -> 0.15.16

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -10,7 +10,7 @@ assert releaseType == "alpha" || releaseType == "headless" || releaseType == "de
 
 with stdenv.lib;
 let
-  version = if releaseType != "demo" then "0.15.1" else "0.14.23";
+  version = if releaseType != "demo" then "0.15.16" else "0.14.23";
 
   arch = if stdenv.system == "x86_64-linux" then {
     inUrl = "linux64";
@@ -27,8 +27,8 @@ let
     url = "https://www.factorio.com/get-download/${version}/${releaseType}/${arch.inUrl}";
     name = "factorio_${releaseType}_${arch.inTar}-${version}.${extension}";
     x64 = {
-      headless =           fetchurl { inherit name url; sha256 = "1z84a9yzlld6fv53viwvswp52hlc9fkxzhb2pil7sidzkws3g49l"; };
-      alpha    = authenticatedFetch { inherit name url; sha256 = "11bxasghrhqb2yg1842v1608x3mjdjv3015jgifpv1xmcqak44jp"; };
+      headless =           fetchurl { inherit name url; sha256 = "0ig0nrvqllb9294qn2ci5j5s31ycsjn23bp6hc633xqkgfmklmic"; };
+      alpha    = authenticatedFetch { inherit name url; sha256 = "0bf0z6fi0cpbq487hz4sz8ljapchzhld01sj767wsldakjfkm9g9"; };
       demo     =           fetchurl { inherit name url; sha256 = "10a2lwmspqviwgymn3zhjgpiynsa6dplgnikdirma5sl2hhcfb6s"; };
     };
     i386 = {


### PR DESCRIPTION
###### Motivation for this change
version update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- [x] Tested without sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

How do I get the short sha256 for the authenticatedFetch? What encoding is it, anyway?

@Baughn @elitak