### PR TITLE
Silence lndir output in symlinkJoin

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -71,7 +71,7 @@ rec {
       ''
         mkdir -p $out
         for i in $paths; do
-          ${lndir}/bin/lndir $i $out
+          ${lndir}/bin/lndir -silent $i $out
         done
         ${postBuild}
       '';


### PR DESCRIPTION
###### Motivation for this change

Recently, haskell-packages started using symlinkJoin for ghcWithPackages, and lndir's verbose output makes build output far less readable.  This PR silences that output.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

