### PR TITLE
python: django-compat & django-hijack tests (also bump django-hijack)

### DIFF
--- a/pkgs/development/python-modules/django-compat/default.nix
+++ b/pkgs/development/python-modules/django-compat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchurl,
+{ stdenv, buildPythonPackage, fetchFromGitHub, python,
   django, django_nose, six
 }:
 buildPythonPackage rec {
@@ -6,19 +6,38 @@ buildPythonPackage rec {
   name = "${pname}-${version}";
   version = "1.0.14";
 
-  src = fetchurl {
-    url = "mirror://pypi/d/django-compat/${name}.tar.gz";
-    sha256 = "18y5bxxmafcd4np42mzbalva5lpssq0b8ki7zckbzvdv2mnv43xj";
+  # the pypi packages don't include everything required for the tests
+  src = fetchFromGitHub {
+    owner = "arteria";
+    repo = "django-compat";
+    rev = "v${version}";
+    sha256 = "11g6ra6djkchqk44v8k7biaxd1v69qyyyask5l92vmrvb0qiwvm8";
   };
 
-  doCheck = false;
+  checkPhase = ''
+    runHook preCheck
 
-  buildInputs = [ django_nose ];
+    # we have to do a little bit of tinkering to convince the tests to run against the installed package, not the
+    # source directory
+    mkdir -p testbase/compat
+    pushd testbase
+    # note we're not copying the direct contents of compat/ (notably __init__.py) so python won't recognize this as a
+    # package, but the tests need to be in a specific path for the test templates to get picked up.
+    cp -r ../compat/tests compat/
+    cp ../runtests.py .
+    ${python.interpreter} runtests.py compat/tests
+    popd
+
+    runHook postCheck
+  '';
+
+  checkInputs = [ django_nose ];
   propagatedBuildInputs = [ django six ];
 
   meta = with stdenv.lib; {
     description = "Forward and backwards compatibility layer for Django 1.4, 1.7, 1.8, 1.9, 1.10 and 1.11";
     homepage = https://github.com/arteria/django-compat;
     license = licenses.mit;
+    maintainers = with maintainers; [ ris ];
   };
 }

--- a/pkgs/development/python-modules/django-hijack/default.nix
+++ b/pkgs/development/python-modules/django-hijack/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, python,
+  django, django_compat, django_nose
+}:
+buildPythonPackage rec {
+  name = "django-hijack-${version}";
+  version = "2.1.4";
+
+  # the pypi packages don't include everything required for the tests
+  src = fetchFromGitHub {
+    owner = "arteria";
+    repo = "django-hijack";
+    rev = "v${version}";
+    sha256 = "1wbm6l8mzpkj4wsj4fyfamzpzi3day2v1cva5j89v4dn4403jq21";
+  };
+
+  checkInputs = [ django_nose ];
+  propagatedBuildInputs = [ django django_compat ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    # we have to do a little bit of tinkering to convince the tests to run against the installed package, not the
+    # source directory
+    mkdir testbase
+    pushd testbase
+    cp ../runtests.py .
+    ${python.interpreter} runtests.py hijack
+    popd
+
+    runHook postCheck
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Allows superusers to hijack (=login as) and work on behalf of another user";
+    homepage = https://github.com/arteria/django-hijack;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10195,26 +10195,10 @@ in {
     };
   };
 
-  # This package likely needs an older version of Django.
+  # This package may need an older version of Django.
   # Override the package set and set e.g. `django = super.django_1_9`.
   # See the Nixpkgs manual for examples on how to override the package set.
-  django_hijack = buildPythonPackage rec {
-    name = "django-hijack-${version}";
-    version = "2.0.7";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/django-hijack/${name}.tar.gz";
-      sha256 = "0rpi1bkfx74xfbb2nk874kfdra1jcqp2vzky1r3z7zidlc9kah04";
-    };
-
-    propagatedBuildInputs = with self; [ django django_compat ];
-
-    meta = {
-      description = "Allows superusers to hijack (=login as) and work on behalf of another user";
-      homepage = https://github.com/arteria/django-hijack;
-      license = licenses.mit;
-    };
-  };
+  django_hijack = callPackage ../development/python-modules/django-hijack { };
 
   django_nose = buildPythonPackage rec {
     name = "django-nose-${version}";


### PR DESCRIPTION
###### Motivation for this change
Ah - seems we were both tinkering with this one at the same time.

Both `django-compat` and `django-hijack`'s (same author) tests are run using a custom `runtests.py` script, which isn't included in the sdist packages on pypi. So I fixed the two packages by pulling the source from github tags instead and included a custom `checkPhase`.

While I was at it I also bumped `django-hijack` to the latest version and split it into a separate file.

I'm not totally sure as to the origin of `django-hijack`'s django 1.9 requirement, but, well, the tests sure as hell pass with django 1.11.1. So I'm assuming it's safe to disregard that problem as ancient history...? 

Added self as maintainer as I think I (or one of my old colleagues) added these packages in the first place.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

