### PR TITLE
ibus-m17n: fix homepage URL.

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-m17n/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-m17n/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     isIbusEngine = true;
     description  = "m17n engine for ibus";
-    homepage     = https://github.com.com/ibus/ibus-m17n;
+    homepage     = https://github.com/ibus/ibus-m17n;
     license      = licenses.gpl2;
     platforms    = platforms.linux;
     maintainers  = with maintainers; [ ericsagnes ];


### PR DESCRIPTION
###### Motivation for this change

Not much, saw an erroneous URL while searching for ibus input methods.

###### Things done

Hmmm. I actually have not built the package. If you want me to test it anyway, please ask, and I will and report back. I do not know the package, though.

I'm under the impression that changes to that kind of metadata shouldn't affect the operation of the package. Don't hesitate to tell me if I'm wrong.

(Hey, at least I'm honest here!)

---

- ~~[ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)~~
- ~~Built on platform(s)~~
   - ~~[ ] NixOS~~
   - ~~[ ] macOS~~
   - ~~[ ] Linux~~
- ~~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~
- ~~[ ] Tested execution of all binary files (usually in `./result/bin/`)~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

