### PR TITLE
go-modules/generic: add missing PATHs to GOPATH when using nix-shell

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -198,7 +198,7 @@ go.stdenv.mkDerivation (
      ln -s "${dep.src}" "$d/src/${dep.goPackagePath}"
   ''
   ) goPath) + ''
-    export GOPATH="$d:$GOPATH"
+    export GOPATH=${lib.concatStringsSep ":" ( ["$d"] ++ ["$GOPATH"] ++ ["$PWD"] ++ extraSrcPaths)}
   '';
 
   disallowedReferences = lib.optional (!allowGoReference) go


### PR DESCRIPTION
###### Motivation for this change
using `nix-shell` for hacking on my go project is nice but after hours of debugging i found that two GOPATHS would always be missing:

- PWD
- extraSrcPaths

this PR fixes it by adding both into GOPATH when using `nix-shell`.

i've tested it with `nixcloud-backend` and it works nicely. also, using `nix-build` instead of `nix-shell` is not affected from this change at all.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

