### PR TITLE
mod_auth_mellon: 0.12.0 -> 0.13.1

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_auth_mellon/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_auth_mellon/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
 
   name = "mod_auth_mellon-${version}";
-  version = "0.12.0";
+  version = "0.13.1";
 
   src = fetchFromGitHub {
     owner = "UNINETT";
     repo = "mod_auth_mellon";
     rev = "v${version}";
-    sha256 = "1p6v6vgrfvgvc5y2ygqyyxi0klpm3nxaw3fg35zmpmw663w8skqn";
+    sha256 = "16b43y5a5p8g1287x04rv923230cy8dfs2j18cx6208n4bv4dvnk";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

latest upstream version

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).