### PR TITLE
pick: 1.4.0 -> 1.6.1

### DIFF
--- a/pkgs/tools/misc/pick/default.nix
+++ b/pkgs/tools/misc/pick/default.nix
@@ -2,18 +2,22 @@
 
 stdenv.mkDerivation rec {
   name = "pick-${version}";
-  version = "1.4.0";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "thoughtbot";
     repo = "pick";
     rev = "v${version}";
-    sha256 = "113if0jh7svwrwrxhrsbi7h1whfr5707v2ny4dc9kk2sjbv6b9pg";
+    sha256 = "0iw3yqwg8j0pg56xx52xwn7n95vxlqbqh71zrc934v4mq971qlhd";
   };
 
   buildInputs = [ ncurses ];
 
   nativeBuildInputs = [ autoreconfHook ];
+
+  postPatch = ''
+    sed -i -e 's/\[curses]/\[ncurses]/g' configure.ac
+  '';
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;


### PR DESCRIPTION
###### Motivation for this change

bump to latest upstream

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

