### PR TITLE
Galaxis: init at 1.9

### DIFF
--- a/pkgs/games/galaxis/default.nix
+++ b/pkgs/games/galaxis/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, ncurses, xmlto }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec{
+
+  name = "galaxis-${version}";
+  version = "1.9";
+
+  src = fetchurl{
+    url = "http://www.catb.org/~esr/galaxis/${name}.tar.gz";
+    sha256 = "1dsypk5brfbc399pg4fk9myyh5yyln0ljl1aiqkypws8h4nsdphl";
+  };
+
+  buildInputs =
+  [ ncurses xmlto ];
+
+  patchPhase = ''
+    sed -i\
+     -e 's|^install: galaxis\.6 uninstall|install: galaxis.6|'\
+     -e 's|usr/||g' -e 's|ROOT|DESTDIR|g'\
+     -e 's|install -m 755 -o 0 -g 0|install -m 755|' Makefile
+  '';
+
+  dontConfigure = true;
+
+  makeFlags = [ "CC=cc" "DESTDIR=$(out)" ];
+
+  meta = {
+    description = "Rescue lifeboats lost in interstellar space";
+    longDescription = ''
+      Lifeboats from a crippled interstellar liner are adrift in a starfield. To
+      find them, you can place probes that look in all eight compass directions
+      and tell you how many lifeboats they see. If you drop a probe directly on
+      a lifeboat it will be revealed immediately. Your objective: find the
+      lifeboats as quickly as possible, before the stranded passengers run out
+      of oxygen!
+
+      This is a UNIX-hosted, curses-based clone of the nifty little Macintosh
+      freeware game Galaxis. It doesn't have the super-simple, point-and-click
+      interface of the original, but compensates by automating away some of the
+      game's simpler deductions.
+    '';
+    homepage = http://catb.org/~esr/galaxis/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.AndersonTorres ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/galaxis/default.nix
+++ b/pkgs/games/galaxis/default.nix
@@ -11,8 +11,7 @@ stdenv.mkDerivation rec{
     sha256 = "1dsypk5brfbc399pg4fk9myyh5yyln0ljl1aiqkypws8h4nsdphl";
   };
 
-  buildInputs =
-  [ ncurses xmlto ];
+  buildInputs = [ ncurses xmlto ];
 
   patchPhase = ''
     sed -i\
@@ -23,7 +22,7 @@ stdenv.mkDerivation rec{
 
   dontConfigure = true;
 
-  makeFlags = [ "CC=cc" "DESTDIR=$(out)" ];
+  makeFlags = [ "DESTDIR=$(out)" ];
 
   meta = {
     description = "Rescue lifeboats lost in interstellar space";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16934,6 +16934,8 @@ with pkgs;
     wxGTK = wxGTK28.override { unicode = false; };
   };
 
+  galaxis = callPackage ../games/galaxis { };
+
   gambatte = callPackage ../games/gambatte { };
 
   garden-of-coloured-lights = callPackage ../games/garden-of-coloured-lights { allegro = allegro4; };


### PR DESCRIPTION
###### Motivation for this change

New package

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

