### PR TITLE
git-annex-remote-rclone: 0.4 -> 0.5

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-annex-remote-rclone/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-annex-remote-rclone/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "git-annex-remote-rclone-${version}";
-  version = "0.4";
+  version = "0.5";
   rev = "v${version}";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "DanielDent";
     repo = "git-annex-remote-rclone";
-    sha256 = "1myk307hqm8dlxhkmwr347rdd28niv5h0gyrxm30y77zlly30ddk";
+    sha256 = "1353b6q3lnxhpdfy9yd2af65v7aypdhyvgn7ziksmsrbi12lb74i";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

