### PR TITLE
cfssl: init at 20170527

### DIFF
--- a/pkgs/tools/security/cfssl/default.nix
+++ b/pkgs/tools/security/cfssl/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, pkgs }:
+
+buildGoPackage rec {
+  name = "cfssl-${version}";
+  version = "20170527";
+
+  goPackagePath = "github.com/cloudflare/cfssl";
+
+  src = fetchFromGitHub {
+    owner = "cloudflare";
+    repo = "cfssl";
+    rev = "114dc9691ec7bf3dac49d5953eccf7d91a0e0904";
+    sha256 = "1ijq43mrzrf1gkgj5ssxq7sgy6sd4rl706dzqkq9krqv5f6kwhj1";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://cfssl.org/;
+    description = "Cloudflare's PKI and TLS toolkit";
+    platforms = platforms.linux;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ mbrgm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1386,6 +1386,8 @@ with pkgs;
 
   c14 = callPackage ../applications/networking/c14 { };
 
+  cfssl = callPackage ../tools/security/cfssl { };
+
   checkbashisms = callPackage ../development/tools/misc/checkbashisms { };
 
   clamav = callPackage ../tools/security/clamav { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

