### PR TITLE
steam: Added extraEmulators option to chroot env.

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -2,6 +2,7 @@
 , steam-runtime, steam-runtime-i686 ? null
 , withJava ? false
 , withPrimus ? false
+, extraPkgs ? pkgs: [ ] # extra packages to add to targetPkgs
 , nativeOnly ? false
 , runtimeOnly ? false
 , newStdcpp ? false
@@ -37,7 +38,8 @@ let
       # Zoneinfo
       etc-zoneinfo
     ] ++ lib.optional withJava jdk
-      ++ lib.optional withPrimus primus2;
+      ++ lib.optional withPrimus primus2
+      ++ extraPkgs pkgs;
 
 in buildFHSUserEnv rec {
   name = "steam";


### PR DESCRIPTION
###### Motivation for this change

I like to use steam to run all my games, including ones that work through dosbox.  This lets me include dosbox in the chroot environment, by doing this in config.nix:

`steam = pkgs.steam.override {  extraEmulators = [ pkgs.dosbox ]; };`

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

