### PR TITLE
cmdliner: 0.9.8 -> 1.0.0, ocp-indent: 1.5.2 -> 1.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/default.nix
@@ -1,31 +1,34 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam, topkg, result }:
 
 let
   pname = "cmdliner";
 in
 
-assert stdenv.lib.versionAtLeast ocaml.version "3.12";
+assert stdenv.lib.versionAtLeast ocaml.version "4.01.0";
 
 stdenv.mkDerivation rec {
-
   name = "ocaml-${pname}-${version}";
-  version = "0.9.8";
+  version = "1.0.0";
 
   src = fetchurl {
     url = "http://erratique.ch/software/${pname}/releases/${pname}-${version}.tbz";
-    sha256 = "0hdxlkgiwjml9dpaa80282a8350if7mc1m6yz2mrd7gci3fszykx";
+    sha256 = "1ryn7qis0izg0wcal8zdlikzzl689l75y6f4zc6blrm93y5agy9x";
   };
 
   unpackCmd = "tar xjf $src";
-  buildInputs = [ ocaml findlib ocamlbuild opam ];
+
+  nativeBuildInputs = [ ocamlbuild opam topkg ];
+  buildInputs = [ ocaml findlib ];
+  propagatedBuildInputs = [ result ];
 
   createFindlibDestdir = true;
 
-  configurePhase = "ocaml pkg/git.ml";
-  buildPhase     = "ocaml pkg/build.ml native=true native-dynlink=true";
-  installPhase   = ''
-    opam-installer --script --prefix=$out ${pname}.install > install.sh
-    sh install.sh
+  buildPhase = ''
+    ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib pkg/pkg.ml build
+  '';
+
+  installPhase = ''
+    opam-installer --script --prefix=$out | sh
     ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/
   '';
 
@@ -33,7 +36,7 @@ stdenv.mkDerivation rec {
     homepage = http://erratique.ch/software/cmdliner;
     description = "An OCaml module for the declarative definition of command line interfaces";
     license = licenses.bsd3;
-    maintainers = [ maintainers.vbgl ];
     platforms = ocaml.meta.platforms or [];
+    maintainers = [ maintainers.vbgl ];
   };
 }

--- a/pkgs/development/tools/ocaml/ocp-indent/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-indent/default.nix
@@ -3,18 +3,21 @@
 let inherit (stdenv.lib) getVersion versionAtLeast; in
 
 assert versionAtLeast (getVersion ocaml) "3.12.1";
+assert versionAtLeast (getVersion cmdliner) "1.0.0";
 assert versionAtLeast (getVersion ocpBuild) "1.99.6-beta";
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
 
-  name = "ocp-indent-1.5.2";
+  name = "ocp-indent-${version}";
+  version = "1.6.0";
 
   src = fetchzip {
-    url = "https://github.com/OCamlPro/ocp-indent/archive/1.5.2.tar.gz";
-    sha256 = "0ynv2yhm7akpvqp72pdabhddwr352s1k85q8m1khsvspgg1mkiqz";
+    url = "https://github.com/OCamlPro/ocp-indent/archive/${version}.tar.gz";
+    sha256 = "1h9y597s3ag8w1z32zzv4dfk3ppq557s55bnlfw5a5wqwvia911f";
   };
 
-  buildInputs = [ ocaml findlib ocpBuild opam cmdliner ];
+  nativeBuildInputs = [ ocpBuild opam ];
+  buildInputs = [ ocaml findlib cmdliner ];
 
   createFindlibDestdir = true;
 


### PR DESCRIPTION
###### Motivation for this change

Update to new versions.

[cmdliner changes](https://github.com/dbuenzli/cmdliner/blob/master/CHANGES.md)

[ocp-indent changes](https://github.com/OCamlPro/ocp-indent/blob/rewind/CHANGELOG)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).