### PR TITLE
python.pkgs: hypothesis, pylibmc, ldap, pylint: minor build fixes

### DIFF
--- a/pkgs/development/python-modules/hypothesis.nix
+++ b/pkgs/development/python-modules/hypothesis.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPythonPackage, fetchFromGitHub, python
 , pythonOlder, pythonAtLeast, enum34
-, doCheck ? true, pytest, flake8, flaky
+, doCheck ? true, pytest, pytest_xdist, flake8, flaky
 }:
 buildPythonPackage rec {
   # http://hypothesis.readthedocs.org/en/latest/packaging.html
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     sha256 = "1s911pd3y9hvk0hq2fr6i68dqv1ciagryhgp13wgyfqh8hz8j6zv";
   };
 
-  checkInputs = stdenv.lib.optionals doCheck [ pytest flake8 flaky ];
+  checkInputs = stdenv.lib.optionals doCheck [ pytest pytest_xdist flake8 flaky ];
   propagatedBuildInputs = stdenv.lib.optionals (pythonOlder "3.4") [ enum34 ];
 
   inherit doCheck;

--- a/pkgs/development/python-modules/ldap.nix
+++ b/pkgs/development/python-modules/ldap.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, isPy3k, fetchurl
+{ buildPythonPackage, isPy3k, fetchPypi
 , openldap, cyrus_sasl, openssl }:
 
 buildPythonPackage rec {
@@ -7,8 +7,8 @@ buildPythonPackage rec {
   name = "${pname}-${version}";
   disabled = isPy3k;
 
-  src = fetchurl {
-    url = "mirror://pypi/p/python-ldap/python-${name}.tar.gz";
+  src = fetchPypi {
+    inherit pname version;
     sha256 = "88bab69e519dd8bd83becbe36bd141c174b0fe309e84936cf1bae685b31be779";
   };
 

--- a/pkgs/development/python-modules/pylibmc/default.nix
+++ b/pkgs/development/python-modules/pylibmc/default.nix
@@ -1,11 +1,11 @@
-{ buildPythonPackage, fetchurl, stdenv, libmemcached, zlib }:
+{ buildPythonPackage, fetchPypi, stdenv, libmemcached, zlib }:
 buildPythonPackage rec {
   version = "1.5.2";
   pname = "pylibmc";
   name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://pypi.python.org/packages/source/p/pylibmc/${name}.tar.gz";
+  src = fetchPypi {
+    inherit pname version;
     sha256 = "fc54e28a9f1b5b2ec0c030da29c7ad8a15c2755bd98aaa4142eaf419d5fabb33";
   };
 

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, buildPythonPackage, python, astroid, isort,
-  pytest,  mccabe, configparser, backports_functools_lru_cache }:
+  pytest, pytestrunner,  mccabe, configparser, backports_functools_lru_cache }:
 
   buildPythonPackage rec {
     name = "${pname}-${version}";
@@ -11,7 +11,7 @@
       sha256 = "8b4a7ab6cf5062e40e2763c0b4a596020abada1d7304e369578b522e46a6264a";
     };
 
-    buildInputs = [ pytest mccabe configparser backports_functools_lru_cache ];
+    buildInputs = [ pytest pytestrunner mccabe configparser backports_functools_lru_cache ];
 
     propagatedBuildInputs = [ astroid isort ];
 


### PR DESCRIPTION
###### Motivation for this change
Quite a bit of breakage in python packages at the moment. This fixes some of the smaller things but I don't expect a `nox-review` to be successful for this due to all the other breakage.

Among things getting changed here is conversion of a couple of packages to `fetchPypi` - have pypi dropped an old url scheme lately? Getting a lot of 404s all of a sudden from non-`fetchPypi` packages.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

