### PR TITLE
merlin: 2.5.3 -> 2.5.4

### DIFF
--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, ocaml, findlib, yojson, menhir, lib
+{ stdenv, fetchzip, ocaml, findlib, yojson, lib
 , withEmacsMode ? false, emacs }:
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.00";
@@ -8,10 +8,10 @@ let
   then
     "2.3.1"
   else
-    "2.5.3";
+    "2.5.4";
   hashes = {
     "2.3.1" = "192jamcc7rmvadlqqsjkzsl6hlgwhg9my1qc89fxh1lmd4qdsrpn";
-    "2.5.3" = "0qljklgcrpqdxzvcqj7b4785zcz322pjvw9cddbmzla33hagglha";
+    "2.5.4" = "101vk16c5wayd51s8w0mvy99bk7q3gm2gz8i8616wa1lmyszjknh";
   };
 in
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     sha256 = hashes."${version}";
   };
 
-  buildInputs = [ ocaml findlib yojson menhir ]
+  buildInputs = [ ocaml findlib yojson ]
     ++ stdenv.lib.optional withEmacsMode emacs;
 
   preConfigure = "mkdir -p $out/bin";


### PR DESCRIPTION
###### Motivation for this change

- Update to version 2.5.4.
- Remove dependency on `menhir`, which seems not needed.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).