### PR TITLE
calibre: fix RPATH

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -92,6 +92,14 @@ stdenv.mkDerivation rec {
     for entry in $out/share/applications/*.desktop; do
       substituteAllInPlace $entry
     done
+
+    # RPATHs in /tmp aren't removed by --shrink-rpath as a library still exists
+    # there when run. This rewrites the RPATHs to only point to paths in
+    # /nix/store. patchelf > 0.9 will fix this properly.
+    # Hack resolves #26140.
+    for entry in $out/lib/calibre/calibre/plugins/*.so; do
+      patchelf --set-rpath "${stdenv.lib.makeLibraryPath buildInputs}" $entry
+    done
   '';
 
   calibreDesktopItem = makeDesktopItem {


### PR DESCRIPTION
###### Motivation for this change

Resolve build failure reported in #26140 .

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

