### PR TITLE
python-ldap: Fix src url broken by pname refactor

### DIFF
--- a/pkgs/development/python-modules/ldap.nix
+++ b/pkgs/development/python-modules/ldap.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   disabled = isPy3k;
 
   src = fetchurl {
-    url = "mirror://pypi/p/python-ldap/python-${name}.tar.gz";
+    url = "mirror://pypi/p/python-ldap/${name}.tar.gz";
     sha256 = "88bab69e519dd8bd83becbe36bd141c174b0fe309e84936cf1bae685b31be779";
   };
 


### PR DESCRIPTION
Related refactor in 959842a9c72ed6cc8566e23c1ce17e9ef0d8ec0c:

> Python: add pname attributes to libraries so that we can use the update script.

/cc @FRidh