### PR TITLE
python-ldap: fixup tests for 2.4.38 update

### DIFF
--- a/pkgs/development/python-modules/ldap.nix
+++ b/pkgs/development/python-modules/ldap.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, isPy3k, fetchPypi
+{ lib, writeText, buildPythonPackage, isPy3k, fetchPypi
 , openldap, cyrus_sasl, openssl }:
 
 buildPythonPackage rec {
@@ -11,6 +11,28 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "88bab69e519dd8bd83becbe36bd141c174b0fe309e84936cf1bae685b31be779";
   };
+
+  # Needed by tests to setup a mockup ldap server.
+  BIN = "${openldap}/bin";
+  SBIN = "${openldap}/bin";
+  SLAPD = "${openldap}/libexec/slapd";
+  SCHEMA = "${openldap}/etc/schema";
+
+  patches = lib.singleton (writeText "avoid-syslog.diff" ''
+    diff a/Lib/slapdtest.py b/Lib/slapdtest.py
+    --- a/Lib/slapdtest.py
+    +++ b/Lib/slapdtest.py
+    @@ -60,7 +60,8 @@ def combined_logger(
+                 pass
+         # for writing to syslog
+         new_logger = logging.getLogger(log_name)
+    -    if sys_log_format:
+    +    # /dev/log does not exist in nix build environment.
+    +    if False:
+             my_syslog_formatter = logging.Formatter(
+                 fmt=' '.join((log_name, sys_log_format)))
+             my_syslog_handler = logging.handlers.SysLogHandler(
+  '');
 
   NIX_CFLAGS_COMPILE = "-I${cyrus_sasl.dev}/include/sasl";
   propagatedBuildInputs = [openldap cyrus_sasl openssl];


### PR DESCRIPTION
This fixes python-ldap and dependant packages like radicale & inginious.
I am not too happy with the hacky patch included, but it seems the only option.

- [X] I built radicale & inginious on NixOS, seems ok.

/cc @Fridh