### PR TITLE
buildRustPackage: inherit preUnpack

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -8,6 +8,7 @@
 , cargoUpdateHook ? ""
 , cargoDepsHook ? ""
 , cargoBuildFlags ? []
+, preUnpack ? ""
 , ... } @ args:
 
 let
@@ -16,7 +17,7 @@ let
   };
 
   cargoDeps = fetchDeps {
-    inherit name src srcs sourceRoot cargoUpdateHook;
+    inherit name src srcs preUnpack sourceRoot cargoUpdateHook;
     sha256 = depsSha256;
   };
 

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -1,10 +1,11 @@
 { stdenv, cacert, git, rust, rustRegistry }:
-{ name ? "cargo-deps", src, srcs, sourceRoot, sha256, cargoUpdateHook ? "" }:
+{ name ? "cargo-deps", src, srcs, sourceRoot, sha256,
+  cargoUpdateHook ? "", preUnpack }:
 
 stdenv.mkDerivation {
   name = "${name}-fetch";
   buildInputs = [ rust.cargo rust.rustc git ];
-  inherit src srcs sourceRoot rustRegistry cargoUpdateHook;
+  inherit src srcs sourceRoot preUnpack rustRegistry cargoUpdateHook;
 
   phases = "unpackPhase installPhase";
 


### PR DESCRIPTION
###### Motivation for this change

When a preUnpack phase is provided for a rust package, it's generally needed by fetch-cargo-deps too in order to reach the Cargo.toml file in the unpacked archive. This changes makes fetchcargo inherit the preUnpack from the package it's being called for. I'm not sure if postUnpack is needed or useful. Opinions?
