### PR TITLE
emacsWithPackages: support installing larger packages

### DIFF
--- a/pkgs/build-support/emacs/elpa2nix.el
+++ b/pkgs/build-support/emacs/elpa2nix.el
@@ -28,3 +28,6 @@ The file can either be a tar file or an Emacs Lisp file."
         (insert-file-contents file))
       (when is-tar (tar-mode))
       (elpa2nix-install-from-buffer))))
+
+;; Allow installing package tarfiles larger than 10MB
+(setq large-file-warning-threshold nil)


### PR DESCRIPTION
###### Motivation for this change

I was getting the following error building tide from Melpa:

```
nix-build  -E '(import <nixpkgs> {}).emacs25WithPackages (p: [p.melpaPackages.tide])'

File tide-20170509.1134.tar is large (10.2M), really open? (y or n) Error reading from stdin
builder for ‘/nix/store/gs9ik7yf8iilsikkfing74i70m0diax3-emacs-tide-20170509.1134.drv’ failed with exit code 255
cannot build derivation ‘/nix/store/m3p080aani4rw82llp8nqk93cw2nvirk-emacs-with-packages-25.2.drv’: 1 dependencies couldn't be built
```

Solution was to disable the large file warning threshold when installing packages.


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
