### PR TITLE
Fixup calibre RPATH stuff

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -61,6 +61,13 @@ stdenv.mkDerivation rec {
     chardet cherrypy html5lib_0_9999999 odfpy routes
   ]);
 
+  # Before we do various fixups, remove qt tree---this means the
+  # standard RPATH shrinking code will remove the references.  Should
+  # be obsoleted when NixOS/patchelf#98 is released.
+  preFixup = ''
+    rm -rf $(pwd)/../__nix_qt5__
+  '';
+
   installPhase = ''
     export HOME=$TMPDIR/fakehome
     export POPPLER_INC_DIR=${poppler_utils.dev}/include/poppler


### PR DESCRIPTION
###### Motivation for this change
Get the expression building again.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
---
I think this is a _slightly_ cleaner option than #26201
