### PR TITLE
NetworkManager: fix openconnect for console tools

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -3,7 +3,7 @@
 , libgcrypt, dnsmasq, bluez5, readline
 , gobjectIntrospection, modemmanager, openresolv, libndp, newt, libsoup
 , ethtool, iputils, gnused, coreutils, file, inetutils, kmod, jansson, libxslt
-, python3Packages, docbook_xsl, fetchpatch }:
+, python3Packages, docbook_xsl, fetchpatch, openconnect }:
 
 stdenv.mkDerivation rec {
   name    = "network-manager-${version}";
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
       --replace /bin/sed ${gnused}/bin/sed
     substituteInPlace data/NetworkManager.service.in \
       --replace /bin/kill ${coreutils}/bin/kill
+    substituteInPlace clients/common/nm-vpn-helpers.c \
+      --subst-var-by openconnect ${openconnect}
     # to enable link-local connections
     configureFlags="$configureFlags --with-udev-dir=$out/lib/udev"
   '';
@@ -76,6 +78,7 @@ stdenv.mkDerivation rec {
       name = "null-dereference.patch";
       url = "https://github.com/NetworkManager/NetworkManager/commit/4e8eddd100bbc8429806a70620c90b72cfd29cb1.patch";
     })
+    ./openconnect_helper_path.patch
   ];
 
   buildInputs = [ systemd libgudev libnl libuuid polkit ppp libndp

--- a/pkgs/tools/networking/network-manager/openconnect_helper_path.patch
+++ b/pkgs/tools/networking/network-manager/openconnect_helper_path.patch
@@ -1,0 +1,29 @@
+diff --git a/clients/common/nm-vpn-helpers.c b/clients/common/nm-vpn-helpers.c
+index 15611c45c..4a7444d3a 100644
+--- a/clients/common/nm-vpn-helpers.c
++++ b/clients/common/nm-vpn-helpers.c
+@@ -203,23 +203,8 @@ nm_vpn_openconnect_authenticate_helper (const char *host,
+ 	gboolean ret;
+ 	char **strv = NULL, **iter;
+ 	char *argv[4];
+-	const char *path;
+-	const char *const DEFAULT_PATHS[] = {
+-		"/sbin/",
+-		"/usr/sbin/",
+-		"/usr/local/sbin/",
+-		"/bin/",
+-		"/usr/bin/",
+-		"/usr/local/bin/",
+-		NULL,
+-	};
+-
+-	path = nm_utils_file_search_in_paths ("openconnect", "/usr/sbin/openconnect", DEFAULT_PATHS,
+-	                                      G_FILE_TEST_IS_EXECUTABLE, NULL, NULL, error);
+-	if (!path)
+-		return FALSE;
+ 
+-	argv[0] = (char *) path;
++	argv[0] = "@openconnect@/bin/openconnect";
+ 	argv[1] = "--authenticate";
+ 	argv[2] = (char *) host;
+ 	argv[3] = NULL;


### PR DESCRIPTION
###### Motivation for this change

This change allows `nmcli` and `nmtui` to work correctly with
openconnect.  This is dony by hard-coding the openconnect binary location.

see #25915 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

