### PR TITLE
pythonPackages.tensorflow: Don't change the rpath to point to gcc4.9

### DIFF
--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -5,7 +5,6 @@
 , cudaSupport ? false
 , cudatoolkit ? null
 , cudnn ? null
-, gcc49 ? null
 , linuxPackages ? null
 , numpy
 , six
@@ -13,13 +12,11 @@
 , swig
 , werkzeug
 , mock
-, gcc
 , zlib
 }:
 
 assert cudaSupport -> cudatoolkit != null
                    && cudnn != null
-                   && gcc49 != null
                    && linuxPackages != null;
 
 # unsupported combination
@@ -98,7 +95,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = with stdenv.lib;
     [ numpy six protobuf3_2 swig werkzeug mock ]
-    ++ optionals cudaSupport [ cudatoolkit cudnn gcc49 ];
+    ++ optionals cudaSupport [ cudatoolkit cudnn stdenv.cc ];
 
   # Note that we need to run *after* the fixup phase because the
   # libraries are loaded at runtime. If we run in preFixup then
@@ -106,10 +103,10 @@ buildPythonPackage rec {
   postFixup = let
     rpath = stdenv.lib.makeLibraryPath
       (if cudaSupport then
-        [ gcc49.cc.lib zlib cudatoolkit cudnn
+        [ stdenv.cc.cc.lib zlib cudatoolkit cudnn
           linuxPackages.nvidia_x11 ]
       else
-        [ gcc.cc.lib zlib ]
+        [ stdenv.cc.cc.lib zlib ]
       );
   in
   ''


### PR DESCRIPTION
When using cuda, the rpath was set to include GCC lib version 4.9.
I am not sure what this was attempting to do, but an effect was to
prevent certain python libraries to find the correct (newer) version
of the std lib.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

