### PR TITLE
mcrcon: init at 0.0.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -132,6 +132,7 @@
   deepfire = "Kosyrev Serge <_deepfire@feelingofgreen.ru>";
   demin-dmitriy = "Dmitriy Demin <demindf@gmail.com>";
   DerGuteMoritz = "Moritz Heidkamp <moritz@twoticketsplease.de>";
+  dermetfan = "Robin Stumm <serverkorken@gmail.com>";
   DerTim1 = "Tim Digel <tim.digel@active-group.de>";
   desiderius = "Didier J. Devroye <didier@devroye.name>";
   devhell = "devhell <\"^\"@regexmail.net>";

--- a/pkgs/tools/networking/mcrcon/default.nix
+++ b/pkgs/tools/networking/mcrcon/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "mcrcon-${version}";
+  version = "0.0.5";
+
+  src = fetchFromGitHub {
+    owner = "Tiiffi";
+    repo = "mcrcon";
+    rev = "v${version}";
+    sha256 = "1pwr1cjldjy8bxqpp7w03nvdpw8l4vqfnk6w6b3mf0qpap1k700z";
+  };
+
+  buildPhase = ''
+    $CC mcrcon.c -o mcrcon
+  '';
+
+  installPhase = ''
+    install -Dm 755 mcrcon $out/bin/mcrcon
+  '';
+
+  meta = {
+    homepage = https://bukkit.org/threads/admin-rcon-mcrcon-remote-connection-client-for-minecraft-servers.70910/;
+    description = "Minecraft console client with Bukkit coloring support.";
+    longDescription = ''
+      Mcrcon is a powerful Minecraft RCON terminal client with Bukkit coloring support.
+      It is well suited for remote administration and to be used as part of automated server maintenance scripts.
+      It does not trigger "IO: Broken pipe" or "IO: Connection reset" spam bugs on the server side.
+    '';
+    maintainers = with stdenv.lib.maintainers; [ dermetfan ];
+    license = with stdenv.lib.licenses; [ zlib libpng ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1689,6 +1689,8 @@ with pkgs;
 
   eid-viewer = callPackage ../tools/security/eid-viewer { };
 
+  mcrcon = callPackage ../tools/networking/mcrcon {};
+
   ### DEVELOPMENT / EMSCRIPTEN
 
   buildEmscriptenPackage = callPackage ../development/em-modules/generic { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

