### PR TITLE
csound: add jack and other dependencies, update version

### DIFF
--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchFromGitHub, cmake, libsndfile, flex, bison, boost
+{ stdenv, fetchFromGitHub, cmake, libsndfile, libsamplerate, flex, bison, boost, gettext
 , alsaLib ? null
 , libpulseaudio ? null
-, tcltk ? null
+, libjack2 ? null
 , liblo ? null
-
-# maybe csound can be compiled with support for those, see configure output
-# , ladspa ? null
-# , fluidsynth ? null
-# , jack ? null
-# , gmm ? null
-# , wiiuse ? null
+, ladspa-sdk ? null
+, fluidsynth ? null
+# , gmm ? null  # opcodes don't build with gmm 5.1
+, eigen ? null
+, curl ? null
+, tcltk ? null
+, fltk ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -27,8 +27,15 @@ stdenv.mkDerivation rec {
     sha256 = "03xnva17sw35ga3n96x1zdfgw913dga1hccly85wzfn0kxz4rld9";
   };
 
-  nativeBuildInputs = [ cmake flex bison ];
-  buildInputs = [ libsndfile alsaLib libpulseaudio tcltk boost liblo ];
+  cmakeFlags = [ "-DBUILD_CSOUND_AC=0" ] # fails to find Score.hpp
+    ++ stdenv.lib.optional (libjack2 != null) "-DJACK_HEADER=${libjack2}/include/jack/jack.h";
+
+  nativeBuildInputs = [ cmake flex bison gettext ];
+  buildInputs = [ libsndfile libsamplerate boost ]
+    ++ builtins.filter (optional: optional != null) [
+      alsaLib libpulseaudio libjack2
+      liblo ladspa-sdk fluidsynth eigen
+      curl tcltk fltk ];
 
   meta = with stdenv.lib; {
     description = "Sound design, audio synthesis, and signal processing system, providing facilities for music composition and performance on all major operating systems and platforms";

--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -13,8 +13,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "csound-6.08.1";
-  version = "6.08.1";
+  name = "csound-${version}";
+  version = "6.09.0";
 
   enableParallelBuilding = true;
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     owner = "csound";
     repo = "csound";
     rev = version;
-    sha256 = "03xnva17sw35ga3n96x1zdfgw913dga1hccly85wzfn0kxz4rld9";
+    sha256 = "1vfb0mab89psfwidadjrn5mbzq3bhjbyrrmyp98yp0xm6a8cssih";
   };
 
   cmakeFlags = [ "-DBUILD_CSOUND_AC=0" ] # fails to find Score.hpp


### PR DESCRIPTION
###### Motivation for this change

Needed to have jack output in csound, and while I was in there I saw some other dependencies which could and should be enabled.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) -- only `csound`
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
