### PR TITLE
restic: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/tools/backup/restic/default.nix
+++ b/pkgs/tools/backup/restic/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "restic-${version}";
-  version = "0.5.0";
+  version = "0.6.0";
 
   goPackagePath = "github.com/restic/restic";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "restic";
     repo = "restic";
     rev = "v${version}";
-    sha256 = "0dj6zg4b00pwgs6nj7w5s0jxm6cfavd9kdcq0z4spypwdf211cgl";
+    sha256 = "0kjk8fyfmbnh2jayfjq4ggkc99rh02jkv8gvqcpyqnw3dxznwrk2";
   };
 
   buildPhase = ''
@@ -28,5 +28,6 @@ buildGoPackage rec {
     description = "A backup program that is fast, efficient and secure";
     platforms = platforms.linux;
     license = licenses.bsd2;
+    maintainers = [ maintainers.mbrgm ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upgrade to latest version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

