### PR TITLE
pythonPackages.future: 0.15.2 -> 0.16.0

### DIFF
--- a/pkgs/development/python-modules/future/default.nix
+++ b/pkgs/development/python-modules/future/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy26
+, importlib
+, argparse
+}:
+
+buildPythonPackage rec {
+  pname = "future";
+  version = "0.16.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1nzy1k4m9966sikp0qka7lirh8sqrsyainyf8rk97db7nwdfv773";
+  };
+
+  propagatedBuildInputs = lib.optionals isPy26 [ importlib argparse ];
+  doCheck = false;
+
+  meta = {
+    description = "Clean single-source support for Python 3 and 2";
+    longDescription = ''
+      python-future is the missing compatibility layer between Python 2 and
+      Python 3. It allows you to use a single, clean Python 3.x-compatible
+      codebase to support both Python 2 and Python 3 with minimal overhead.
+
+      It provides future and past packages with backports and forward ports
+      of features from Python 3 and 2. It also comes with futurize and
+      pasteurize, customized 2to3-based scripts that helps you to convert
+      either Py2 or Py3 code easily to support both Python 2 and 3 in a
+      single clean Py3-style codebase, module by module.
+    '';
+    homepage = https://python-future.org;
+    downloadPage = https://github.com/PythonCharmers/python-future/releases;
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ prikhi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11556,37 +11556,7 @@ in {
     };
   };
 
-  future = buildPythonPackage rec {
-    version = "0.15.2";
-    name = "future-${version}";
-
-    src = pkgs.fetchurl {
-      url = "http://github.com/PythonCharmers/python-future/archive/v${version}.tar.gz";
-      sha256 = "0vm61j5br6jiry6pgcxnwvxhki8ksnirp7k9mcbmxmgib3r60xd3";
-    };
-
-    propagatedBuildInputs = with self; optionals isPy26 [ importlib argparse ];
-    doCheck = false;
-
-    meta = {
-      description = "Clean single-source support for Python 3 and 2";
-      longDescription = ''
-        python-future is the missing compatibility layer between Python 2 and
-        Python 3. It allows you to use a single, clean Python 3.x-compatible
-        codebase to support both Python 2 and Python 3 with minimal overhead.
-
-        It provides future and past packages with backports and forward ports
-        of features from Python 3 and 2. It also comes with futurize and
-        pasteurize, customized 2to3-based scripts that helps you to convert
-        either Py2 or Py3 code easily to support both Python 2 and 3 in a
-        single clean Py3-style codebase, module by module.
-      '';
-      homepage = https://python-future.org;
-      downloadPage = https://github.com/PythonCharmers/python-future/releases;
-      license = licenses.mit;
-      maintainers = with maintainers; [ prikhi ];
-    };
-  };
+  future = callPackage ../development/python-modules/future { };
 
   futures = buildPythonPackage rec {
     name = "futures-${version}";


### PR DESCRIPTION
###### Motivation for this change
Needed a newer version for another package.

###### Things done
Bumped version and used fetchFromGitHub insted of fetchurl.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

