### PR TITLE
programs.zsh.syntaxHighlighting: refactor to use attr sets rather than recursive lists for patterns

### DIFF
--- a/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
+++ b/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
@@ -39,12 +39,12 @@ in
 
         patterns = mkOption {
           default = [];
-          type = types.listOf(types.listOf(types.string));
+          type = types.attrsOf types.string;
 
           example = literalExample ''
-            [
-              ["rm -rf *" "fg=white,bold,bg=red"]
-            ]
+            {
+              "rm -rf *" = "fg=white,bold,bg=red";
+            }
           '';
 
           description = ''
@@ -67,14 +67,17 @@ in
           "ZSH_HIGHLIGHT_HIGHLIGHTERS=(${concatStringsSep " " cfg.highlighters})"
         }
 
-        ${optionalString (length(cfg.patterns) > 0)
-          (assert(elem "pattern" cfg.highlighters); (foldl (
-            a: b:
-              assert(length(b) == 2); ''
-                ${a}
-                ZSH_HIGHLIGHT_PATTERNS+=('${elemAt b 0}' '${elemAt b 1}')
-              ''
-          ) "") cfg.patterns)
+        ${let
+            n = attrNames cfg.patterns;
+          in
+            optionalString (length(n) > 0)
+              (assert(elem "pattern" cfg.highlighters); (foldl (
+                a: b:
+                  ''
+                    ${a}
+                    ZSH_HIGHLIGHT_PATTERNS+=('${b}' '${attrByPath [b] "" cfg.patterns}')
+                  ''
+              ) "") n)
         }
       '';
     };

--- a/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
+++ b/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
@@ -8,13 +8,7 @@ in
   {
     options = {
       programs.zsh.syntaxHighlighting = {
-        enable = mkOption {
-          default = false;
-          type = types.bool;
-          description = ''
-            Enable zsh-syntax-highlighting.
-          '';
-        };
+        enable = mkEnableOption "zsh-syntax-highlighting";
 
         highlighters = mkOption {
           default = [ "main" ];


### PR DESCRIPTION
###### Motivation for this change

:warning: **BC break**: this changes the type of an option which might the setup of several people.
However I'm not sure how to document this BC break properly (I'd love to get some input from a maintainer here)

The idea has been described here: https://github.com/NixOS/nixpkgs/pull/25323#issuecomment-298677369

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

