### PR TITLE
scudcloud: 1.54 -> 1.58

### DIFF
--- a/pkgs/applications/networking/instant-messengers/scudcloud/default.nix
+++ b/pkgs/applications/networking/instant-messengers/scudcloud/default.nix
@@ -1,14 +1,12 @@
-{ stdenv, fetchgit, python3Packages }:
+{ stdenv, fetchurl, python3Packages }:
 
-python3Packages.buildPythonPackage {
-  name = "scudcloud-1.44";
+let version = "1.58";
+in python3Packages.buildPythonPackage {
+  name = "scudcloud-${version}";
 
-  # Branch 254-port-to-qt5
-  # https://github.com/raelgc/scudcloud/commit/65c304416dfdd5f456fa6f7301432a953d5e12d0
-  src = fetchgit {
-      url = https://github.com/raelgc/scudcloud/;
-      rev = "65c304416dfdd5f456fa6f7301432a953d5e12d0";
-      sha256 = "0h1055y88kldqw31ayqfx9zsksgxsyqd8h0hwnhj80yn3jcx0rp6";
+  src = fetchurl {
+    url = "https://github.com/raelgc/scudcloud/archive/v${version}.tar.gz";
+    sha256 = "1j84qdc2j3dvl1nhrjqm0blc8ww723p9a6hqprkkp8alw77myq1l";
   };
 
   propagatedBuildInputs = with python3Packages; [ pyqt5 dbus-python ];


### PR DESCRIPTION
###### Motivation for this change

Old slack application was showing annoying "this version of API is old one, update this client". Also, finally, scudcloud master switched to qt5, so no more problems with "Stuck on loading screen". see https://github.com/raelgc/scudcloud/issues/335

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @jagajaga 
