### PR TITLE
python.pkgs.flask_migrate: 1.7.0 -> 2.0.3

### DIFF
--- a/pkgs/development/python-modules/flask-migrate/default.nix
+++ b/pkgs/development/python-modules/flask-migrate/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, python, glibcLocales, flask, flask_sqlalchemy, flask_script, alembic
+}:
+
+with stdenv.lib;
+
+buildPythonPackage rec {
+  pname = "Flask-Migrate";
+  version = "2.0.3";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "107x78lkqsnbg92dld3dkagg07jvchp3ib3y0sivc4ipz6n1y7rk";
+  };
+
+  checkInputs = optional isPy3k glibcLocales;
+  propagatedBuildInputs = [ flask flask_sqlalchemy flask_script alembic ];
+
+  # tests invoke the flask cli which uses click and therefore has py3k encoding troubles
+  preCheck = optionalString isPy3k ''
+    export LANG="en_US.UTF-8"
+  '';
+
+  meta = {
+    description = "SQLAlchemy database migrations for Flask applications using Alembic";
+    license = licenses.mit;
+    homepage = https://github.com/miguelgrinberg/Flask-Migrate;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11020,30 +11020,7 @@ in {
 
   flask_ldap_login = callPackage ../development/python-modules/flask-ldap-login.nix { };
 
-  flask_migrate = buildPythonPackage rec {
-    name = "Flask-Migrate-${version}";
-    version = "1.7.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/F/Flask-Migrate/Flask-Migrate-1.7.0.tar.gz";
-      sha256 = "16d7vnaj9xmxvb3qbcmhahm3ldfdhzzi6y221h62x4v1v1jayx7v";
-    };
-
-    # When tests run with python3*, tests should run commands as "python3 <args>",
-    # not "python <args>"
-    patchPhase = ''
-      substituteInPlace tests/test_migrate.py --replace "python" "${python.executable}"
-      substituteInPlace tests/test_multidb_migrate.py --replace "python" "${python.executable}"
-    '';
-
-    propagatedBuildInputs = with self ; [ flask flask_sqlalchemy flask_script alembic ];
-
-    meta = {
-      description = "SQLAlchemy database migrations for Flask applications using Alembic";
-      license = licenses.mit;
-      homepage = https://github.com/miguelgrinberg/Flask-Migrate;
-    };
-  };
+  flask_migrate = callPackage ../development/python-modules/flask-migrate { };
 
   flask_oauthlib = callPackage ../development/python-modules/flask-oauthlib.nix { };
 


### PR DESCRIPTION
Fixes build against new dependencies after some test tinkering

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

