### PR TITLE
pythonPackages.pytest-localserver: 0.3.5 -> 0.3.7

### DIFF
--- a/pkgs/development/python-modules/pytest-localserver/default.nix
+++ b/pkgs/development/python-modules/pytest-localserver/default.nix
@@ -1,0 +1,33 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, requests
+, pytest
+, six
+, werkzeug
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-localserver";
+  name = "${pname}-${version}";
+  version = "0.3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1c11hn61n06ms0wmw6536vs5k4k9hlndxsb3p170nva56a9dfa6q";
+  };
+
+  propagatedBuildInputs = [ werkzeug ];
+  buildInputs = [ pytest six requests ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = {
+    description = "Plugin for the pytest testing framework to test server connections locally";
+    homepage = https://pypi.python.org/pypi/pytest-localserver;
+    license = lib.licenses.mit;
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5279,29 +5279,7 @@ in {
 
   pytest_xdist = callPackage ../development/python-modules/pytest-xdist { };
 
-  pytest-localserver = buildPythonPackage rec {
-    pname = "pytest-localserver";
-    name = "${pname}-${version}";
-    version = "0.3.7";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "1c11hn61n06ms0wmw6536vs5k4k9hlndxsb3p170nva56a9dfa6q";
-    };
-
-    propagatedBuildInputs = with self; [ werkzeug ];
-    buildInputs = with self; [ pytest six requests ];
-
-    checkPhase = ''
-      py.test
-    '';
-
-    meta = {
-      description = "Plugin for the pytest testing framework to test server connections locally";
-      homepage = https://pypi.python.org/pypi/pytest-localserver;
-      license = licenses.mit;
-    };
-  };
+  pytest-localserver = callPackage ../development/python-modules/pytest-localserver { };
 
   pytest-subtesthack = buildPythonPackage rec {
     name = "pytest-subtesthack-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5281,11 +5281,11 @@ in {
 
   pytest-localserver = buildPythonPackage rec {
     name = "pytest-localserver-${version}";
-    version = "0.3.5";
+    version = "0.3.7";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/p/pytest-localserver/${name}.tar.gz";
-      sha256 = "0dvqspjr6va55zwmnnc2mmpqc7mm65kxig9ya44x1z8aadzxpa4p";
+      sha256 = "1c11hn61n06ms0wmw6536vs5k4k9hlndxsb3p170nva56a9dfa6q";
     };
 
     propagatedBuildInputs = with self; [ werkzeug ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5280,11 +5280,12 @@ in {
   pytest_xdist = callPackage ../development/python-modules/pytest-xdist { };
 
   pytest-localserver = buildPythonPackage rec {
-    name = "pytest-localserver-${version}";
+    pname = "pytest-localserver";
+    name = "${pname}-${version}";
     version = "0.3.7";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest-localserver/${name}.tar.gz";
+    src = fetchPypi {
+      inherit pname version;
       sha256 = "1c11hn61n06ms0wmw6536vs5k4k9hlndxsb3p170nva56a9dfa6q";
     };
 


### PR DESCRIPTION
## Warning

This patch is based on the `nixos-unstable` branch.

###### Motivation for this change

Closes #26237 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Artificially tested (by building). Going to rebuild my system with this patch now and reporting back then.