### PR TITLE
vagrant: 1.9.1 -> 1.9.5

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -2,7 +2,7 @@
 , libxml2, libxslt, makeWrapper, p7zip, xar, gzip, cpio }:
 
 let
-  version = "1.9.1";
+  version = "1.9.5";
   rake = buildRubyGem {
     inherit ruby;
     gemName = "rake";
@@ -13,16 +13,16 @@ let
   url = if stdenv.isLinux
     then "https://releases.hashicorp.com/vagrant/${version}/vagrant_${version}_${arch}.deb"
     else if stdenv.isDarwin
-      then "https://releases.hashicorp.com/vagrant/${version}/vagrant_${version}.dmg"
+      then "https://releases.hashicorp.com/vagrant/${version}/vagrant_${version}_${arch}.dmg"
       else "system ${stdenv.system} not supported";
 
   sha256 = {
-    "x86_64-linux"  = "0l1if9c4s4wkbi8k00pl7x00lil21izrd8wb9nv2b5q4gqidc1nh";
-    "i686-linux"    = "1789wjwcpgw3mljl49c8v5kycisay684gyalkkvd06928423y9zb";
-    "x86_64-darwin" = "1xrfq1a0xyifkhhjnpm6wsnms9w8c9q5rd2qqn4sm5npl7viy68p";
+    "x86_64-linux"  = "16ijzaacfbqrgh561bf51747d2rv8kydgs14dfdr572qi0f88baw";
+    "i686-linux"    = "0lvkb4k0a34a8hzlsi0apf056rhyprh5w0gn16d0n2ijnaf9j2yk";
+    "x86_64-darwin" = "070mrczsx1j0jl9sx6963l3hrk9anqa13r008wk1d22d25xj25mc";
   }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
-  arch = builtins.replaceStrings ["-linux"] [""] stdenv.system;
+  arch = builtins.replaceStrings ["-linux" "-darwin"] ["" ""] stdenv.system;
 
 in stdenv.mkDerivation rec {
   name = "vagrant-${version}";


### PR DESCRIPTION
###### Motivation for this change

Bump to the latest upstream release version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The upstream URL structure changed slightly for the macOS dmg files, so that has been adjusted along with the version bump and sha256 updates.