### PR TITLE
pythonPackages.scrapy: fix 1.4.0 update

### DIFF
--- a/pkgs/development/python-modules/scrapy/permissions-fix.patch
+++ b/pkgs/development/python-modules/scrapy/permissions-fix.patch
@@ -21,8 +21,3 @@ index 5941066..89f8edb 100644
  
      def run(self, args, opts):
          if len(args) not in (1, 2):
-@@ -118,4 +117,3 @@ class Command(ScrapyCommand):
-         _templates_base_dir = self.settings['TEMPLATES_DIR'] or \
-             join(scrapy.__path__[0], 'templates')
-         return join(_templates_base_dir, 'project')
--    


### PR DESCRIPTION
###### Motivation for this change

The untested update to Scrapy 1.4.0 (6b999f3c42607342231b6fe119fcf0f934f40fd8) broke this package. It's fixed by removing some useless lines from a patch.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

