### PR TITLE
services.graphite: chmod -R entire dataDir

### DIFF
--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -488,9 +488,7 @@ in {
             # create index
             ${pkgs.python27Packages.graphite_web}/bin/build-index.sh
 
-            chown graphite:graphite ${cfg.dataDir}
-            chown graphite:graphite ${cfg.dataDir}/whisper
-            chown -R graphite:graphite ${cfg.dataDir}/log
+            chown -R graphite:graphite ${cfg.dataDir}
 
             touch ${dataDir}/db-created
           fi


### PR DESCRIPTION
###### Motivation for this change

The Graphite web interface fails with `attempt to write a readonly database` because its SQLite3 is initialised as root and never chowned.

That's done now, so it all works.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

