### PR TITLE
i3blocks: add optional dependencies for scripts

### DIFF
--- a/pkgs/applications/window-managers/i3/blocks.nix
+++ b/pkgs/applications/window-managers/i3/blocks.nix
@@ -1,5 +1,19 @@
-{ fetchurl, stdenv }:
+{ fetchurl, stdenv, perl, makeWrapper
+, iproute, acpi, sysstat, xset, playerctl
+, cmus, openvpn, lm_sensors, alsaUtils
+, scripts ? [ "bandwidth" "battery" "cpu_usage" "disk" "iface"
+              "keyindicator" "load_average" "mediaplayer" "memory"
+	            "openvpn" "temperature" "volume" "wifi" ]
+}:
 
+with stdenv.lib;
+
+let
+  perlscripts = [ "battery" "cpu_usage" "keyindicator"
+                  "mediaplayer" "openvpn" "temperature" ];
+  contains_any = l1: l2: 0 < length( intersectLists l1 l2 );
+
+in
 stdenv.mkDerivation rec {
   name = "i3blocks-${version}";
   version = "1.4";
@@ -12,7 +26,31 @@ stdenv.mkDerivation rec {
   buildFlags = "SYSCONFDIR=/etc all";
   installFlags = "PREFIX=\${out} VERSION=${version}";
 
-  meta = with stdenv.lib; {
+  buildInputs = optional (contains_any scripts perlscripts) perl;
+  nativeBuildInputs = [ makeWrapper ];
+
+  postFixup = ''
+    wrapProgram $out/libexec/i3blocks/bandwidth \
+      --prefix PATH : ${makeBinPath (optional (elem "bandwidth" scripts) iproute)}
+    wrapProgram $out/libexec/i3blocks/battery \
+      --prefix PATH : ${makeBinPath (optional (elem "battery" scripts) acpi)}
+    wrapProgram $out/libexec/i3blocks/cpu_usage \
+      --prefix PATH : ${makeBinPath (optional (elem "cpu_usage" scripts) sysstat)}
+    wrapProgram $out/libexec/i3blocks/iface \
+      --prefix PATH : ${makeBinPath (optional (elem "iface" scripts) iproute)}
+    wrapProgram $out/libexec/i3blocks/keyindicator \
+      --prefix PATH : ${makeBinPath (optional (elem "keyindicator" scripts) xset)}
+    wrapProgram $out/libexec/i3blocks/mediaplayer \
+      --prefix PATH : ${makeBinPath (optionals (elem "mediaplayer" scripts) [playerctl cmus])}
+    wrapProgram $out/libexec/i3blocks/openvpn \
+      --prefix PATH : ${makeBinPath (optional (elem "openvpn" scripts) openvpn)}
+    wrapProgram $out/libexec/i3blocks/temperature \
+      --prefix PATH : ${makeBinPath (optional (elem "temperature" scripts) lm_sensors)}
+    wrapProgram $out/libexec/i3blocks/volume \
+      --prefix PATH : ${makeBinPath (optional (elem "volume" scripts) alsaUtils)}
+  '';
+
+  meta = {
     description = "A flexible scheduler for your i3bar blocks";
     homepage = https://github.com/vivien/i3blocks;
     license = licenses.gpl3;


### PR DESCRIPTION
###### Motivation for this change

Many of the builtin scripts provided with i3blocks depend on packages not available by default.
This change makes sure that the various scripts can access their own dependencies.

Additionally, an parameter `scripts` has been added to select which scripts to provide the
dependencies of. By default, the dependencies of all defaults will be installed.
To change this behavior override `scripts` with a list of string corresponding to the desired packages.

TODO:

* Provide better interface for selecting scripts.
* Provide better default. (currently: all)
* Don't install undesired scripts.
* Select FreeBSD tools when on FreeBSD

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

