### PR TITLE
nodejs: init at 8.0.0

### DIFF
--- a/pkgs/development/web/nodejs/v8.nix
+++ b/pkgs/development/web/nodejs/v8.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
+, pkgconfig, runCommand, which, libtool, fetchpatch
+, callPackage
+, darwin ? null
+, enableNpm ? true
+}@args:
+
+let
+  nodejs = import ./nodejs.nix args;
+  baseName = if enableNpm then "nodejs" else "nodejs-slim";
+in
+  stdenv.mkDerivation (nodejs // rec {
+    version = "8.0.0";
+    name = "${baseName}-${version}";
+    src = fetchurl {
+      url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
+      sha256 = "072g2zv58aa5zxs8fs9bdsi3mqklf2yj9mf58yjg5frbcfikm395";
+    };
+
+    patches = stdenv.lib.optionals stdenv.isDarwin [ ./no-xcode-v7.patch ];
+  })
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2794,6 +2794,15 @@ with pkgs;
     enableNpm = false;
   };
 
+  nodejs-8_x = callPackage ../development/web/nodejs/v8.nix {
+    libtool = darwin.cctools;
+  };
+
+  nodejs-slim-8_x = callPackage ../development/web/nodejs/v8.nix {
+    libtool = darwin.cctools;
+    enableNpm = false;
+  };
+
   nodePackages_6_x = callPackage ../development/node-packages/default-v6.nix {
     nodejs = pkgs.nodejs-6_x;
   };


### PR DESCRIPTION
###### Motivation for this change

Nodejs has just been released with a new major version which will become the next LTS version later this year.
Also the bundled `npm` version was updated to v5.0.0 which comes with new lockfile format.

[Release Notes nodejs](https://nodejs.org/en/blog/release/v8.0.0/)
[Release Notes npm](http://blog.npmjs.org/post/161081169345/v500)

###### Things done

- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
