### PR TITLE
TheanoWithCuda: cudnn shouldn't be optional

### DIFF
--- a/pkgs/development/python-modules/Theano/theano-with-cuda/default.nix
+++ b/pkgs/development/python-modules/Theano/theano-with-cuda/default.nix
@@ -56,7 +56,8 @@ buildPythonPackage rec {
     pycuda
     cudatoolkit
     libgpuarray
-  ] ++ (stdenv.lib.optional (cudnn != null) [ cudnn ]);
+    cudnn
+  ];
 
   passthru.cudaSupport = true;
 }


### PR DESCRIPTION
###### Motivation for this change

The `propagatedBuildInputs` contained `optional (cudnn != null) [ cudnn ]`.  As `optional` wraps its arguement in a list (`optionals` is intended for lists not `optional`) this changes `propagatedBuildInputs` into a nested list.

For the package itself, this appears to have no effect.  The nested list is flattened and it produces the exact same derivation.  When used with `withPackages`, however, nested values do not get flattened.  Instead they are just silently dropped.

Before this change

```bash
fgrep -q cudnn  $(nix-instantiate -E '(import ./. {}).python27Packages.TheanoWithCuda' && echo present || echo not present
```
```
present
```
```bash
fgrep -q cudnn  $(nix-instantiate -E '(import ./. {}).python27.withPackages (ppkgs: [ppkgs.TheanoWithCuda])') && echo present || echo not present
```
```
not present
```

After this change

```bash
fgrep -q cudnn  $(nix-instantiate -E '(import ./. {}).python27Packages.TheanoWithCuda' && echo present || echo not present
```
```
present
```
```bash
fgrep -q cudnn  $(nix-instantiate -E '(import ./. {}).python27.withPackages (ppkgs: [ppkgs.TheanoWithCuda])') && echo present || echo not present
```
```
present
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

