### PR TITLE
irrlicht: link to X11 libs explicitly

### DIFF
--- a/pkgs/development/libraries/irrlicht/default.nix
+++ b/pkgs/development/libraries/irrlicht/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildPhase = ''
-    make sharedlib NDEBUG=1
+    make sharedlib NDEBUG=1 "LDFLAGS=-lX11 -lGL -lXxf86vm"
   '';
 
   preInstall = ''


### PR DESCRIPTION
###### Motivation for this change
This allows applications that require irrlicht to depend on the X
libraries implicitly rather than explicitly. #25172

Not sure if this is the best way to solve the problem. Feedback welcome!


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

