### PR TITLE
haskell-modules: refactor package set

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -2,6 +2,7 @@
 , compilerConfig ? (self: super: {})
 , packageSetConfig ? (self: super: {})
 , overrides ? (self: super: {})
+, initialPackages ? import ./hackage-packages.nix
 }:
 
 let
@@ -10,7 +11,7 @@ let
   inherit (import ./lib.nix { inherit pkgs; }) overrideCabal makePackageSet;
 
   haskellPackages = makePackageSet {
-    package-set = import ./hackage-packages.nix;
+    package-set = initialPackages;
     inherit ghc;
   };
 


### PR DESCRIPTION
This change is effectively a no-op to nixpkgs. However, it gives users
the flexibility to create and maintain their own package sets per
project, while benefiting from nix's Haskell configurations.

I would make immediate use of this change in stack2nix, a project that
generates nix expressions for all the dependencies of a given Haskell
project. @domenkozar is familiar with the motivations and helped
refine this change

(cherry picked from commit ed6ecacf6430e4331b2b56a4324c2e6d349bd30b)
Reason: enable faster builds for current users of the stack2nix
project.

###### Motivation for this change

The change has already been merged into `master` (see PR #26253), but having it in `release-17.03` would make the independent stack2nix project more immediately useful. Currently stack2nix is at https://github.com/jmitchell/stack2nix, but after some cleanup it will soon be moved to an organization.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip --against release-17.03"`
    - reports "Nothing changed"
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

