### PR TITLE
pythonPackages.rarfile: use free libarchive by default.

### DIFF
--- a/pkgs/development/python-modules/rarfile/default.nix
+++ b/pkgs/development/python-modules/rarfile/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, pytest, nose, unrar, glibcLocales }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, pytest, nose, libarchive, glibcLocales
+# unrar is non-free software
+, useUnrar ? false, unrar
+}:
+
+assert useUnrar -> unrar != null;
+assert !useUnrar -> libarchive != null;
 
 buildPythonPackage rec {
   pname = "rarfile";
@@ -15,8 +21,16 @@ buildPythonPackage rec {
 
   prePatch = ''
     substituteInPlace rarfile.py \
-      --replace 'UNRAR_TOOL = "unrar"' "UNRAR_TOOL = \"${unrar}/bin/unrar\""
-  '';
+  '' + (if useUnrar then
+        ''--replace 'UNRAR_TOOL = "unrar"' "UNRAR_TOOL = \"${unrar}/bin/unrar\""
+        ''
+       else
+        ''--replace 'ALT_TOOL = "bsdtar"' "ALT_TOOL = \"${libarchive}/bin/bsdtar\""
+        '')
+     + ''
+   '';
+  # the tests only work with the standard unrar package
+  doCheck = useUnrar;
   LC_ALL = "en_US.UTF-8";
   checkPhase = ''
     py.test test -k "not test_printdir"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2603,7 +2603,7 @@ in {
 
   };
 
-  rarfile = callPackage ../development/python-modules/rarfile {};
+  rarfile = callPackage ../development/python-modules/rarfile { inherit (pkgs) libarchive; };
 
   proboscis = buildPythonPackage rec {
     name = "proboscis-1.2.6.0";


### PR DESCRIPTION
`unrar` is a non-free package, so it should only be used on request.
rarfile can use the rar-mode of `libarchive` instead, which should work well
enough for most cases.

###### Motivation for this change

Packages like `beets` were broken, because they suddenly depended on unfree `unrar`.