### PR TITLE
lib and doc: Use "libSystem" as identifier for that libc in platforms

### DIFF
--- a/doc/cross-compilation.xml
+++ b/doc/cross-compilation.xml
@@ -128,7 +128,7 @@
         <listitem>
           <para>
             This is a string identifying the standard C library used.
-            Valid identifiers include "glibc" for GNU libc, "libsystem" for Darwin's Libsystem, and "uclibc" for µClibc.
+            Valid identifiers include "glibc" for GNU libc, "libSystem" for Darwin's Libsystem, and "uclibc" for µClibc.
             It should probably be refactored to use the module system, like <varname>parse</varname>.
           </para>
         </listitem>

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -96,14 +96,14 @@ rec {
   iphone64 = {
     config = "aarch64-apple-darwin14";
     arch = "arm64";
-    libc = "libsystem";
+    libc = "libSystem";
     platform = {};
   };
 
   iphone32 = {
     config = "arm-apple-darwin10";
     arch = "armv7-a";
-    libc = "libsystem";
+    libc = "libSystem";
     platform = {};
   };
 


### PR DESCRIPTION
###### Motivation for this change

Oops not sure how I was so inconsistent.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

