### PR TITLE
Do not verify SSL peer when fetching sources

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -1,4 +1,4 @@
-{stdenv, git, cacert}: let
+{stdenv, git}: let
   urlToName = url: rev: let
     base = baseNameOf (stdenv.lib.removeSuffix "/" url);
 
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
 
   inherit url rev leaveDotGit fetchSubmodules deepClone branchName;
 
-  GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  GIT_SSL_NO_VERIFY = 1;
 
   impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars ++ [
     "GIT_PROXY_COMMAND" "SOCKS_SERVER"

--- a/pkgs/build-support/fetchrepoproject/default.nix
+++ b/pkgs/build-support/fetchrepoproject/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
     ${optionalString (!createMirror) "rm -rf $out/.repo"}
   '';
 
-  GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  GIT_SSL_NO_VERIFY = 1;
 
   impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars ++ [
     "GIT_PROXY_COMMAND" "SOCKS_SERVER"


### PR DESCRIPTION
I would be greatful if as many people as possible could review this pull request as it potentially has security implications.

The idea is that we check the hashes of sources after fetching them, so there is no need to verify the SSL peer when making the connection. For example, `fetchurl` uses the `--insecure` option in order to make `curl` skip verification. Additionally, this way we get rid of the `pkgs.cacert` dependency in some places.

Fetchers that use `pkgs.cacert`:

* [x] `fetchgit` (tested)
* [ ] `fetchrepoproject` (can someone test the change please?)
* [ ] `docker/pull.{nix,sh}` (something crazy is going on there)
* [ ] `fetchbower` (haven’t looked yet)
* [ ] `fetchdarcs` (looks like there is no way to disable)
* [ ] `fetchgx` (haven’t looked yet)
* [ ] `fetchcargo` (haven’t looked yet)

Various other places, which I haven’t looked at yet:

~~~~
pkgs/applications/networking/browsers/chromium/update.nix:          if SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt" \
pkgs/applications/networking/remote/citrix-receiver/default.nix:    awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "cert." c ".pem"}' < ${cacert}/etc/ssl/certs/ca-bundle.crt
pkgs/build-support/rust/default.nix:    export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
pkgs/development/compilers/go/1.7.nix:  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
pkgs/development/compilers/go/1.8.nix:  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
pkgs/development/compilers/mono/generic.nix:    $out/bin/cert-sync ${cacert}/etc/ssl/certs/ca-bundle.crt
pkgs/development/compilers/openjdk/7.nix:      perl ${./generate-cacerts.pl} $jre/lib/openjdk/jre/bin/keytool ${cacert}/etc/ssl/certs/ca-bundle.crt
pkgs/development/compilers/openjdk/8.nix:      perl ${./generate-cacerts.pl} $jre/lib/openjdk/jre/bin/keytool ${cacert}/etc/ssl/certs/ca-bundle.crt
pkgs/development/compilers/rust/beta.nix:      export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
pkgs/development/compilers/rust/cargo.nix:      --set CARGO_HTTP_CAINFO "${cacert}/etc/ssl/certs/ca-bundle.crt" \
pkgs/development/compilers/rust/cargo.nix:      --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt" \
pkgs/development/compilers/rust/cargo.nix:    export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
pkgs/development/compilers/rust/nightly.nix:      export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
pkgs/development/haskell-modules/generic-stack-builder.nix:  GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
pkgs/development/libraries/openssl/use-etc-ssl-certs-darwin.patch:+#  define X509_CERT_FILE          "/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
pkgs/development/libraries/qt-5/5.6/qtwebengine/default.nix:    sed -i -e 's,/cert.pem,/certs/ca-bundle.crt,' src/3rdparty/chromium/third_party/boringssl/src/crypto/x509/x509_def.c
pkgs/games/factorio/fetch.sh: --cacert $cacert/etc/ssl/certs/ca-bundle.crt \
pkgs/servers/xmpp/ejabberd/default.nix:    GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
~~~~

I strongly suspect that some of those usages are either not needed or are plain wrong, given all that movement with `NIX_SSL_CERT_FILE` and attempts to make packages behave use trusted roots from the system as opposed to pulling `pkgs.cacert`.