### PR TITLE
google-app-engine-go-sdk: fix error on macOS

### DIFF
--- a/pkgs/development/tools/google-app-engine-go-sdk/default.nix
+++ b/pkgs/development/tools/google-app-engine-go-sdk/default.nix
@@ -1,6 +1,8 @@
-{ stdenv, fetchzip, python27, python27Packages }:
+{ stdenv, fetchzip, python27, python27Packages, makeWrapper }:
 
 assert stdenv.system == "x86_64-linux" || stdenv.system == "x86_64-darwin";
+
+with python27Packages;
 
 stdenv.mkDerivation rec {
   name = "google-app-engine-go-sdk-${version}";
@@ -17,9 +19,7 @@ stdenv.mkDerivation rec {
         sha256 = "18hgl4wz3rhaklkwaxl8gm70h7l8k225f86da682kafawrr8zhv4";
       };
 
-  buildInputs = with python27Packages; [
-    (python27.withPackages(ps: [ cffi cryptography pyopenssl ]))
-  ];
+  buildInputs = [python27 makeWrapper];
 
   installPhase = ''
     mkdir -p $out/bin $out/share/
@@ -27,7 +27,9 @@ stdenv.mkDerivation rec {
 
     # create wrappers with correct env
     for i in goapp appcfg.py; do
-      ln -s "$out/share/go_appengine/$i" "$out/bin/$i"
+      makeWrapper "$out/share/go_appengine/$i" "$out/bin/$i" \
+        --prefix PATH : "${python27}/bin" \
+        --prefix PYTHONPATH : "$(toPythonPath ${cffi}):$(toPythonPath ${cryptography}):$(toPythonPath ${pyopenssl})"
     done
   '';
 

--- a/pkgs/development/tools/google-app-engine-go-sdk/default.nix
+++ b/pkgs/development/tools/google-app-engine-go-sdk/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchzip, python27, python27Packages, makeWrapper }:
 
-assert stdenv.system == "x86_64-linux" || stdenv.system == "x86_64-darwin";
-
 with python27Packages;
 
 stdenv.mkDerivation rec {
@@ -38,7 +36,7 @@ stdenv.mkDerivation rec {
     version = version;
     homepage = "https://cloud.google.com/appengine/docs/go/";
     license = licenses.asl20;
-    platforms = with platforms; linux ++ darwin;
+    platforms = ["x86_64-linux" "x86_64-darwin"];
     maintainers = with maintainers; [ lufia ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

on macOS, execve(2) can't use executable text at shebang.
Python wrapper (perhaps rewritten with python27.withPackages) is referenced to a bash script.
Therefore all python code of `goapp` are evaluated as bash script.

see also https://github.com/NixOS/nixpkgs/pull/25856#issuecomment-303753496

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
