### PR TITLE
Upgrades Inspectrum to new version to work with QT5.8

### DIFF
--- a/pkgs/applications/graphics/awesomebump/default.nix
+++ b/pkgs/applications/graphics/awesomebump/default.nix
@@ -14,6 +14,13 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  # Before we do various fixups, remove qt tree---this means the
+  # standard RPATH shrinking code will remove the references.  Should
+  # be obsoleted when NixOS/patchelf#98 is released.
+  preFixup = ''
+    rm -rf $(pwd)/../../__nix_qt5__
+  '';
+
   installPhase =
     ''
       d=$out/libexec/AwesomeBump

--- a/pkgs/applications/misc/inspectrum/default.nix
+++ b/pkgs/applications/misc/inspectrum/default.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "miek";
     repo = "inspectrum";
-    rev = "d8d1969a4cceeee0ebfd2f39e791fddd5155d4de";
-    sha256 = "05sarfin9wqkvgwn3fil1r4bay03cwzzhjwbdjslibc5chdrr2cn";
+    rev = "a89d1337efb31673ccb6a6681bb89c21894c76f7";
+    sha256 = "1fvnr8gca25i6s9mg9b2hyqs0zzr4jicw13mimc9dhrgxklrr1yv";
   };
 
   buildInputs = [

--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/plasma/5.9.5/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/plasma/5.10.0/ -A '*.tar.xz' )

--- a/pkgs/desktops/plasma-5/srcs.nix
+++ b/pkgs/desktops/plasma-5/srcs.nix
@@ -3,323 +3,339 @@
 
 {
   bluedevil = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/bluedevil-5.9.5.tar.xz";
-      sha256 = "0szdfim94c9zjq6jl7n6xpnxf7c4b62wk5b6vv1yfday51gi643r";
-      name = "bluedevil-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/bluedevil-5.10.0.tar.xz";
+      sha256 = "0cw0qac672pvgq3cqkgmmk0yv9q42sfw0y1bvw5x51a7dqhqc7vl";
+      name = "bluedevil-5.10.0.tar.xz";
     };
   };
   breeze = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/breeze-5.9.5.tar.xz";
-      sha256 = "0g9y0lsx5c3r7qzrdxbanya86lqkbaf5f7has736nqw28a2jncc3";
-      name = "breeze-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/breeze-5.10.0.tar.xz";
+      sha256 = "1s3lsn3ykrr2190x5l1hxjwzcxwplimjbh3pc1hi827h6fq1x6mn";
+      name = "breeze-5.10.0.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/breeze-grub-5.9.5.tar.xz";
-      sha256 = "02ml0v3srim4vdw1bwycb3wi6ijdvmf1ph0my3w5ci1k5fj402s4";
-      name = "breeze-grub-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/breeze-grub-5.10.0.tar.xz";
+      sha256 = "1nzi29ff1b2ph2a1gngdjlia3k95qd3sf0ws7kbmb5l198chx0k1";
+      name = "breeze-grub-5.10.0.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/breeze-gtk-5.9.5.tar.xz";
-      sha256 = "0na40qrgyml0fc3p8lgxls4zy7ifigns0594q9i3jwfz1izsiprj";
-      name = "breeze-gtk-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/breeze-gtk-5.10.0.tar.xz";
+      sha256 = "1fdsf1bxxhpd6a3xk9021qr5g1305ghp4bk6lrdl8cxsfqrlqg2n";
+      name = "breeze-gtk-5.10.0.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/breeze-plymouth-5.9.5.tar.xz";
-      sha256 = "1fnqq4f7pr7bwfgrgk1d2qjai178lxsfsxr1jjdx61wrn1fnc3yk";
-      name = "breeze-plymouth-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/breeze-plymouth-5.10.0.tar.xz";
+      sha256 = "0nkb2cwld10335ylclnv796fc3fhxq6bjl7ppys43cj151crxwyg";
+      name = "breeze-plymouth-5.10.0.tar.xz";
     };
   };
   discover = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/discover-5.9.5.tar.xz";
-      sha256 = "0846xskdy0sv9p76i78cbj7qy2xcq90lir78haiy6s8pfnxc27i3";
-      name = "discover-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/discover-5.10.0.tar.xz";
+      sha256 = "1dqnmxn54sdrwm3l8mv5nywjlw97vgp9dw22m41fcw8xr1gxgkd0";
+      name = "discover-5.10.0.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kactivitymanagerd-5.9.5.tar.xz";
-      sha256 = "0jf0kxwgyc0b3fkr05mz678p99fkr42rljqw57sjq7qhypknzd07";
-      name = "kactivitymanagerd-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kactivitymanagerd-5.10.0.tar.xz";
+      sha256 = "0dzgxq45dcbaiih5kfwhqwzghbg1m9vpzlkwhlpf76lvscfy9qj5";
+      name = "kactivitymanagerd-5.10.0.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kde-cli-tools-5.9.5.tar.xz";
-      sha256 = "196h4gsfqx1338jps1rkvaabi6zmsncv7ywylqvirn6mxrfq7r2n";
-      name = "kde-cli-tools-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kde-cli-tools-5.10.0.tar.xz";
+      sha256 = "044nak5cvs1d9y03kvay72g40bigxjbadpj60n7wwmwnpg4vxrsi";
+      name = "kde-cli-tools-5.10.0.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kdecoration-5.9.5.tar.xz";
-      sha256 = "1vjj8gjh8ig0bxbfjjmyga7rl497yzqdprgpqfkg92g9pxhr2lnl";
-      name = "kdecoration-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kdecoration-5.10.0.tar.xz";
+      sha256 = "19znx1a21dlybrq5wgakqyki2f84v8f2galnw0xjpcy5jh6gwc3d";
+      name = "kdecoration-5.10.0.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kde-gtk-config-5.9.5.tar.xz";
-      sha256 = "1aafc9zrraqz9x830v9fgyygsqy17iwr2hf2vrcn2ffhw6ix47cy";
-      name = "kde-gtk-config-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kde-gtk-config-5.10.0.tar.xz";
+      sha256 = "0q85zxv7vbfyd6p91yfsqza95a7yq408akg9a08nv8i7f0w5kv8i";
+      name = "kde-gtk-config-5.10.0.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kdeplasma-addons-5.9.5.tar.xz";
-      sha256 = "107j3szxslc4cqin2f32y25lbwyi0a6lqsp9739113zr0jjrwlll";
-      name = "kdeplasma-addons-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kdeplasma-addons-5.10.0.tar.xz";
+      sha256 = "16mrzrzb34l5scykkrs0f4zsrb5c18n213llk84ijphfkzb4dbhz";
+      name = "kdeplasma-addons-5.10.0.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kgamma5-5.9.5.tar.xz";
-      sha256 = "1kzqix97qh17lfz9ksqywmas630aw0z4y44mcwp34w9gp79i5dj5";
-      name = "kgamma5-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kgamma5-5.10.0.tar.xz";
+      sha256 = "0gxmc1zkxm4xz7z6a08j8p50cqlf42ikxhlzxzpgqc28g841dn09";
+      name = "kgamma5-5.10.0.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/khotkeys-5.9.5.tar.xz";
-      sha256 = "05y6kbcbalvlrldm9kfkj9aj0r6nbyj1gbj28g37jv58l6qc75d9";
-      name = "khotkeys-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/khotkeys-5.10.0.tar.xz";
+      sha256 = "0w5m2zigdj5z96dn44cp2857rp3d9l9f7ps0gnwradnq8ildlzfp";
+      name = "khotkeys-5.10.0.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kinfocenter-5.9.5.tar.xz";
-      sha256 = "0jbi3qavqwvx691biy8gbq4m2c3ksy6p1hpyi41qaaczksr3fvsg";
-      name = "kinfocenter-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kinfocenter-5.10.0.tar.xz";
+      sha256 = "12ji32n0f8ns200za99g23kq3mbs7m6ibyf60v7rab4q14hfvnbk";
+      name = "kinfocenter-5.10.0.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kmenuedit-5.9.5.tar.xz";
-      sha256 = "1mfy1z70zfw3x40h8qjp49i7pp5c5fprh7znwwj4hk2qkn1zrn0j";
-      name = "kmenuedit-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kmenuedit-5.10.0.tar.xz";
+      sha256 = "03c9xw13rb5g3ly216bwgqwna7l7mh98hrirs3lgk01ml1aa71an";
+      name = "kmenuedit-5.10.0.tar.xz";
     };
   };
   kscreen = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kscreen-5.9.5.tar.xz";
-      sha256 = "1df0h1js6b6060cxm27sp70lvk8fak14ibzzrm6f3yv32wlzxwfi";
-      name = "kscreen-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kscreen-5.10.0.tar.xz";
+      sha256 = "0jx12yh1gng0rb8wyv1sks2cp6ra1bbj4acqayc61h7p9pq3c83h";
+      name = "kscreen-5.10.0.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kscreenlocker-5.9.5.tar.xz";
-      sha256 = "1hf0zgfdgd7vinmbk2k73w6mpfbfv830kqfvw23qk4nrrap131bi";
-      name = "kscreenlocker-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kscreenlocker-5.10.0.tar.xz";
+      sha256 = "1m1fsskivb10vvbwgam3xhisslaz885v302b2yfgncx9ra458qpf";
+      name = "kscreenlocker-5.10.0.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/ksshaskpass-5.9.5.tar.xz";
-      sha256 = "1ilydfc64s2yc5xrqcc0k2s9ijnppql32dkb9cpmwfqi608digi1";
-      name = "ksshaskpass-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/ksshaskpass-5.10.0.tar.xz";
+      sha256 = "1yhwwjm8indr0h80nvr634fdzmjzy1wq5ap9ny8fppjs9mc6w546";
+      name = "ksshaskpass-5.10.0.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/ksysguard-5.9.5.tar.xz";
-      sha256 = "1dhzkm3rc8rl92ym0mampf49p8ippbpfbwcvwzg6rakhxxifd4q6";
-      name = "ksysguard-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/ksysguard-5.10.0.tar.xz";
+      sha256 = "0ji4y12i94r6h1qf7ya3m25fw900jzwsbm2vgrq2sc5z9p6iy4zs";
+      name = "ksysguard-5.10.0.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kwallet-pam-5.9.5.tar.xz";
-      sha256 = "0nchpbw5yxy7vsz3mx1mx5hk36yvwqarnzzigssh1kz1r19jn6rn";
-      name = "kwallet-pam-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kwallet-pam-5.10.0.tar.xz";
+      sha256 = "16d9l03jrs3y2zbnam6ldyd55n9zb33z9bc1hzwc0i7mh2hd81l6";
+      name = "kwallet-pam-5.10.0.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kwayland-integration-5.9.5.tar.xz";
-      sha256 = "07la7q6dvmysdv6clk2siq1c3b9jbx5kblgc5qf3233bg57hqw7r";
-      name = "kwayland-integration-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kwayland-integration-5.10.0.tar.xz";
+      sha256 = "167bnllcyqhwmm7dx48n95dwa4fkw3fxkajh37gyvivb32rj88is";
+      name = "kwayland-integration-5.10.0.tar.xz";
     };
   };
   kwin = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kwin-5.9.5.tar.xz";
-      sha256 = "13f9drny8lxpxmgqmirk7k0zapx6bp74jyxxzh7ii36davlhckjd";
-      name = "kwin-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kwin-5.10.0.tar.xz";
+      sha256 = "1rg1g4lzwi4ilmapzjjg254i2qgp715d6zz397gicldz5rs2ma05";
+      name = "kwin-5.10.0.tar.xz";
     };
   };
   kwrited = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kwrited-5.9.5.tar.xz";
-      sha256 = "1spcsixpcn4g4dm5c1hfqfpkkmma3fgdx0bkm2zzh5q72jzl3bda";
-      name = "kwrited-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/kwrited-5.10.0.tar.xz";
+      sha256 = "11ldawwp41rkqi73vag7j0vbf1swjnww5dr8j2bknw44228wzkd1";
+      name = "kwrited-5.10.0.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/libkscreen-5.9.5.tar.xz";
-      sha256 = "1sq078ri8vz3s4r606n3i9j9cb4drga2mwwa5glkirnazps32004";
-      name = "libkscreen-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/libkscreen-5.10.0.tar.xz";
+      sha256 = "1ijx0dzqr12p5gzq46hbln3iqp250ngpmwmxcacpg9b2wxyb3hwh";
+      name = "libkscreen-5.10.0.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/libksysguard-5.9.5.tar.xz";
-      sha256 = "0b0lvpss5sdjnxbrwaa5w7x87mzpbk23n2ly5vyg6imcycnxh7kw";
-      name = "libksysguard-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/libksysguard-5.10.0.tar.xz";
+      sha256 = "1hvwp6zvlmwhc980hl4bm13dj1w8bl0wkwh8a52lqjlksx4l7vi0";
+      name = "libksysguard-5.10.0.tar.xz";
     };
   };
   milou = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/milou-5.9.5.tar.xz";
-      sha256 = "1qzqa26sxggpqw4jkrjasf20xfijpjyjg7x96bvbjs1gcp1fi9gw";
-      name = "milou-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/milou-5.10.0.tar.xz";
+      sha256 = "0ypw8acq28i3palvmb0a3l0c6kdvjnqh9l59xwwj3501m74xh72l";
+      name = "milou-5.10.0.tar.xz";
     };
   };
   oxygen = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/oxygen-5.9.5.tar.xz";
-      sha256 = "0p73dyyg887by1yi8gjaj366l7vm0p19z10m5fkmhylhmzihv4z3";
-      name = "oxygen-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/oxygen-5.10.0.tar.xz";
+      sha256 = "0m6c4jf73zdifmam6miwgd9maf1by6lqxmw0higzvpw3dg6v271p";
+      name = "oxygen-5.10.0.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-desktop-5.9.5.tar.xz";
-      sha256 = "1f9mq7q05abj6xgpchzkhghs0mwf7qycjvg3l4c7y7p9hsn3gx71";
-      name = "plasma-desktop-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/plasma-desktop-5.10.0.tar.xz";
+      sha256 = "02596cfh8qs4z5ifwh3kladn7cfgblffzja33mc5h71z83p922rm";
+      name = "plasma-desktop-5.10.0.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-integration-5.9.5.tar.xz";
-      sha256 = "05qxrrrfhq0m2xq9ig0cgxrl692hmv9lhckhs22m8a1dppsgv10w";
-      name = "plasma-integration-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/plasma-integration-5.10.0.tar.xz";
+      sha256 = "0ddliqzgs5sc8d062gp2sb3x78np53mf7rmcwb82smanfw77r14n";
+      name = "plasma-integration-5.10.0.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-nm-5.9.5.tar.xz";
-      sha256 = "1bdg7mnfxffzwp7s4hbmk8zj17408fnwj5z4j68l64lbn1lmwq0w";
-      name = "plasma-nm-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/plasma-nm-5.10.0.tar.xz";
+      sha256 = "0jg6zwc80v4gxqc9kb3j61knizcb84b1hq7xc1xmspn3d835b70w";
+      name = "plasma-nm-5.10.0.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-pa-5.9.5.tar.xz";
-      sha256 = "0xam3rnd36mvn7021zzs9y5i02ac8c15alnpag8shrsbdv2cbyry";
-      name = "plasma-pa-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/plasma-pa-5.10.0.tar.xz";
+      sha256 = "1k11p3h5v2mqb5n8rbv6cr0nki12bl8jy76phqcpcsdwp5v4ja3r";
+      name = "plasma-pa-5.10.0.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-sdk-5.9.5.tar.xz";
-      sha256 = "0dvxw7b65pn86qzf9j30c4pw0vi12kasgf7idbgmhzwl17k4i1mx";
-      name = "plasma-sdk-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/plasma-sdk-5.10.0.tar.xz";
+      sha256 = "13y19hw4gga7g7dsbfxrib597svsy8s4qww7s2hc1adg2nv0qpgc";
+      name = "plasma-sdk-5.10.0.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-tests-5.9.5.tar.xz";
-      sha256 = "06sn7gz5psmnsilhaprqag2ma03kzj24m7r0gf8wdaqgsla05vwg";
-      name = "plasma-tests-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/plasma-tests-5.10.0.tar.xz";
+      sha256 = "0z0krr454lazshfqc7ybixj5cq0hfylmd4dx9kkb3jjpb44xq7if";
+      name = "plasma-tests-5.10.0.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.9.5.1";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-workspace-5.9.5.1.tar.xz";
-      sha256 = "07lbq3b3h0ibf4xbk4mxyi3kx17wrqv0s1bqf01azm1wgni70xw5";
-      name = "plasma-workspace-5.9.5.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/plasma-workspace-5.10.0.tar.xz";
+      sha256 = "0savp6yyg430w4pr36ycnnjrg1f7sfpib7ys2gcvna100449xg59";
+      name = "plasma-workspace-5.10.0.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-workspace-wallpapers-5.9.5.tar.xz";
-      sha256 = "05k56vsmhxh0wdz9msk1x3lq2dblladl4002111fi9s92hg4dmsn";
-      name = "plasma-workspace-wallpapers-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/plasma-workspace-wallpapers-5.10.0.tar.xz";
+      sha256 = "0mq6b8ndx9h9hmrnjpgr7byc3llqn1k64n1kz02x24qjgm5h42gr";
+      name = "plasma-workspace-wallpapers-5.10.0.tar.xz";
+    };
+  };
+  plymouth-kcm = {
+    version = "5.10.0";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma/5.10.0/plymouth-kcm-5.10.0.tar.xz";
+      sha256 = "0bhmz2r2gn6p7m7641yhw4qr10agcxszqg7g27vw05kqym755g38";
+      name = "plymouth-kcm-5.10.0.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.9.5";
+    version = "1-5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/polkit-kde-agent-1-5.9.5.tar.xz";
-      sha256 = "05qzq07g7wb6942p6yyrah37vyadbfyz7akk87zrxwiahiighy42";
-      name = "polkit-kde-agent-1-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/polkit-kde-agent-1-5.10.0.tar.xz";
+      sha256 = "0720aabwzqgqwqxmakw4w5is0qr6pl1ws3fdq8qzckdbyqyxrk3k";
+      name = "polkit-kde-agent-1-5.10.0.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/powerdevil-5.9.5.tar.xz";
-      sha256 = "0i8rri9ndm9ins4ii4qmdsmjkxqf69xpz85lwcdsv0sci6imxhcz";
-      name = "powerdevil-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/powerdevil-5.10.0.tar.xz";
+      sha256 = "1903xry7k9dc62m9xykc0wlskz24760nsrf3qzbipcagmaawg3c4";
+      name = "powerdevil-5.10.0.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/sddm-kcm-5.9.5.tar.xz";
-      sha256 = "0q0q3c439dbrvb4snfjfymgf8pld26gdqbak4gyp3j7nc2gjisk6";
-      name = "sddm-kcm-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/sddm-kcm-5.10.0.tar.xz";
+      sha256 = "000cr78hfkdijbwdpjamxxvh1m2kpiylhnpzxxl4g2ckppkmd0cz";
+      name = "sddm-kcm-5.10.0.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/systemsettings-5.9.5.tar.xz";
-      sha256 = "0xg8y8hpm0v2bflsh6l85yx969jn1nqlszwydp3ryvdwliv5hgg9";
-      name = "systemsettings-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/systemsettings-5.10.0.tar.xz";
+      sha256 = "19179qdyilzznrg3qc8njs9d2psxyvpy5mfn54yi61r809bfr3z4";
+      name = "systemsettings-5.10.0.tar.xz";
     };
   };
   user-manager = {
-    version = "5.9.5";
+    version = "5.10.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/user-manager-5.9.5.tar.xz";
-      sha256 = "056rnca3v6vs7sjqz9drndir3csz457qkzf30rp0dh5dl9k9cxxn";
-      name = "user-manager-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.0/user-manager-5.10.0.tar.xz";
+      sha256 = "1521b3wx9jhn6qssr67gz3hnh1vwz4gimadnxbh71bpb74yd5sn9";
+      name = "user-manager-5.10.0.tar.xz";
+    };
+  };
+  xdg-desktop-portal-kde = {
+    version = "5.10.0";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma/5.10.0/xdg-desktop-portal-kde-5.10.0.tar.xz";
+      sha256 = "1a52v3acl4gkwclggl1jsabjc2s6nb8ag2mp0p90z7z4h55lkb95";
+      name = "xdg-desktop-portal-kde-5.10.0.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/frameworks/5.33/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/frameworks/5.34/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,595 +3,595 @@
 
 {
   attica = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/attica-5.33.0.tar.xz";
-      sha256 = "1dr5yhg0cy4b6k91mk6w090zjizgxaa808h799m14jqzgj63z5d6";
-      name = "attica-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/attica-5.34.0.tar.xz";
+      sha256 = "0l8gmsmpwzg6nzwwlnsdl6r6qkhnhirpmrkag9xpd2sbmy734x53";
+      name = "attica-5.34.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/baloo-5.33.0.tar.xz";
-      sha256 = "174my99i5mggab98l38y2bk27xp25mpz58rl8rhnb3wsbgxcx7iz";
-      name = "baloo-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/baloo-5.34.0.tar.xz";
+      sha256 = "0z53lnniq9xdk09d73z0p1xs1qmaf71m4znm4hmq956yg4yqa1ya";
+      name = "baloo-5.34.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/bluez-qt-5.33.0.tar.xz";
-      sha256 = "0cpkdv4k68f0rcg3j91418i59dmc94qlnv3xk1chq0fdi0cssrri";
-      name = "bluez-qt-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/bluez-qt-5.34.0.tar.xz";
+      sha256 = "040gs2a1fx996gqdx2pwxh00szb1vb85055z946nqvqfn01921df";
+      name = "bluez-qt-5.34.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/breeze-icons-5.33.0.tar.xz";
-      sha256 = "07nb4xq00fw50r4vf10npa2z690rwkmlxdy42lxx3ixci4qw4204";
-      name = "breeze-icons-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/breeze-icons-5.34.0.tar.xz";
+      sha256 = "1znzlggb6yrkw5rr2n75g7cfv9x5p9d55hss09c4i79lxrh1bk4a";
+      name = "breeze-icons-5.34.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/extra-cmake-modules-5.33.0.tar.xz";
-      sha256 = "013adgrz8s0w7a7z2ahkv28cq4c2cy00cw6y8akpkxazqhv5xzzk";
-      name = "extra-cmake-modules-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/extra-cmake-modules-5.34.0.tar.xz";
+      sha256 = "1r3dyvrv77xrpjlzpa6yazwkknirvx1ccvdyj9x0mlk4vfi05nh5";
+      name = "extra-cmake-modules-5.34.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/frameworkintegration-5.33.0.tar.xz";
-      sha256 = "01c1jq77hm3v5xi84gn5hymlnnn1igcpz9v49yxgyvnihlblb1ll";
-      name = "frameworkintegration-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/frameworkintegration-5.34.0.tar.xz";
+      sha256 = "0hq1r2znjzy0wzm3nsclqmih1aia5300bsf87a2l4919q0ildb20";
+      name = "frameworkintegration-5.34.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kactivities-5.33.0.tar.xz";
-      sha256 = "092gk0zn15qm4pihxf1h4qn2n618wp43k67ffy3saw4fadqmxpsz";
-      name = "kactivities-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kactivities-5.34.0.tar.xz";
+      sha256 = "0dg6bkdxf4sicij4szmi55npn6chp0sfmw27qi1s582ymqzjgf5m";
+      name = "kactivities-5.34.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kactivities-stats-5.33.0.tar.xz";
-      sha256 = "1269nh4l94b3yxyvzdjw6vb8pxjylrvnrv28vnar8dmx0sbh5jpf";
-      name = "kactivities-stats-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kactivities-stats-5.34.0.tar.xz";
+      sha256 = "1dfaq4hsd9wm1ka45dkxbl9wwr7s5ixbnnghqwxhl7a60imc680r";
+      name = "kactivities-stats-5.34.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kapidox-5.33.0.tar.xz";
-      sha256 = "162x868dwl92361ss1dxv0gqh8g4apshcgb1ww4nizy239mfj8h0";
-      name = "kapidox-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kapidox-5.34.0.tar.xz";
+      sha256 = "190d5z6i71jrvfna6vnlim2p9rgc33s1fxl0zarn276683i1rwvg";
+      name = "kapidox-5.34.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/karchive-5.33.0.tar.xz";
-      sha256 = "0i5grm0dhm9z6fd63ppykd6vl45k5nam4q8w1psrz7vjmr6sd924";
-      name = "karchive-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/karchive-5.34.0.tar.xz";
+      sha256 = "0g8jskdar2znviwh9bs3kia093wgfnhl04x4jcg2rvh78ylkpvxw";
+      name = "karchive-5.34.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kauth-5.33.0.tar.xz";
-      sha256 = "1lfi4w4jgc9m83q6v3jf8p91x12vvcc3g59dlg7dh2agrh07r9y7";
-      name = "kauth-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kauth-5.34.0.tar.xz";
+      sha256 = "06cw1bsp7inh5wglajm8aahy17p35ixgnijb7d74gjqzbj4cv93d";
+      name = "kauth-5.34.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kbookmarks-5.33.0.tar.xz";
-      sha256 = "186difbzrpqlbi140ylkzb50d3fmn2pdz8i0r3gbc71726fqld82";
-      name = "kbookmarks-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kbookmarks-5.34.0.tar.xz";
+      sha256 = "0ggn4rz8ch82ph64q6yik9fb1mp6kmsd7n33p769zl1lw7fldn0v";
+      name = "kbookmarks-5.34.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kcmutils-5.33.0.tar.xz";
-      sha256 = "0n0cmjxlp0kkgrxng2ympnl1v5a1bjr2d9c20hf31xhvmya3y9nd";
-      name = "kcmutils-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kcmutils-5.34.0.tar.xz";
+      sha256 = "1b52lwn7qjqrn06va7j1jswlzs6bx0drs90myf3607k52ffbf4hy";
+      name = "kcmutils-5.34.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kcodecs-5.33.0.tar.xz";
-      sha256 = "1pdijdlrl9p5w6dixqx0lmkzwsk5xarzjhpwh616j2sinfra0w31";
-      name = "kcodecs-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kcodecs-5.34.0.tar.xz";
+      sha256 = "0k51s4qlf0kq6i8f3wrsz5lrkzjqb1j26hrmlmg57vn91r58iash";
+      name = "kcodecs-5.34.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kcompletion-5.33.0.tar.xz";
-      sha256 = "13mv5mm90jv4k56h4n6d7r2a0pax2mhdrm51xd99fjynad129lhi";
-      name = "kcompletion-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kcompletion-5.34.0.tar.xz";
+      sha256 = "18hvdk5b1nkh6b3vx0jajri57rl266b0qjsiwirh5wmjc81xbpcw";
+      name = "kcompletion-5.34.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kconfig-5.33.0.tar.xz";
-      sha256 = "1inhpil19pv3jjf7mz4f5g367n1ciiixndij10p1zxk5zy46zzmf";
-      name = "kconfig-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kconfig-5.34.0.tar.xz";
+      sha256 = "0blbx6b3fk6p8cv2iywk2avn9w1411bb0g5wwv456a9ggi01988x";
+      name = "kconfig-5.34.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kconfigwidgets-5.33.0.tar.xz";
-      sha256 = "0sd974r7xrpnhyqabgix0zb1rlis32ijj0wiabbqi4ns0nhhi3qf";
-      name = "kconfigwidgets-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kconfigwidgets-5.34.0.tar.xz";
+      sha256 = "0h4kappsffrp2qgg8wza1ybgah2dlcgpz591llfvaz31ldsml9hk";
+      name = "kconfigwidgets-5.34.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kcoreaddons-5.33.0.tar.xz";
-      sha256 = "1906jscfc2kpd22d7yk88ziy3ky3hcfxy5y593pfzjl41gyhsiyl";
-      name = "kcoreaddons-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kcoreaddons-5.34.0.tar.xz";
+      sha256 = "1ybr4bv8rhp4cxpf8mfsc4dk0klzrfh1z8g2cw6zasmksxmmwi90";
+      name = "kcoreaddons-5.34.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kcrash-5.33.0.tar.xz";
-      sha256 = "136wlvaf4r54k8x0z0jvs7l35m0v22y6zqkhc8f91dr1y2ym2jnk";
-      name = "kcrash-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kcrash-5.34.0.tar.xz";
+      sha256 = "1cshay7dhbqgh62nq85vd9sm20gq9s9f70mdnzjjh1q7cajybkp3";
+      name = "kcrash-5.34.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdbusaddons-5.33.0.tar.xz";
-      sha256 = "1xxbmr88w7hqxsrhjbgic0pn4adkydhv9xd77vwbzjj47123mph2";
-      name = "kdbusaddons-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdbusaddons-5.34.0.tar.xz";
+      sha256 = "1skblxfnjhbyiwavsfhksc2ybc2sikw3xr0js6mlfbpmvqzghn6h";
+      name = "kdbusaddons-5.34.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdeclarative-5.33.0.tar.xz";
-      sha256 = "1333vv6kbdk4sdkkc8lnncgmm3203ca8ybn9nj6ch3zqwyxcaagk";
-      name = "kdeclarative-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdeclarative-5.34.0.tar.xz";
+      sha256 = "1mfj32p631zvwz9ldk8536ifb4n825zxbhx69bfllhw2vn1am7z2";
+      name = "kdeclarative-5.34.0.tar.xz";
     };
   };
   kded = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kded-5.33.0.tar.xz";
-      sha256 = "02g66ip0d0cwb8grb6f3z1j7178w76pfs2f8d2dl1rax4hnjppd0";
-      name = "kded-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kded-5.34.0.tar.xz";
+      sha256 = "0qy4w7bcg60gyf6y6c11kqcshnld55a8w4fzglpwgqfbliyi5yzq";
+      name = "kded-5.34.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/portingAids/kdelibs4support-5.33.0.tar.xz";
-      sha256 = "1gyyvp4kqnjaf764y2z24jk68h5h0ax1z9h25msczy6bd4ify5v9";
-      name = "kdelibs4support-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/portingAids/kdelibs4support-5.34.0.tar.xz";
+      sha256 = "0q9jjsjcvc43va4yvfay2xi40vb95lnqhgzavpqcndzjihixwmi0";
+      name = "kdelibs4support-5.34.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdesignerplugin-5.33.0.tar.xz";
-      sha256 = "1f4f53xag6xbvacpn5j0zrsdwimksnckdza6kswcri5q258yb6ks";
-      name = "kdesignerplugin-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdesignerplugin-5.34.0.tar.xz";
+      sha256 = "1jnarg7wrhdjfq73q4wplazxsz927mpf0l6m0i4akq4dlp1b7aah";
+      name = "kdesignerplugin-5.34.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdesu-5.33.0.tar.xz";
-      sha256 = "06scns6jgs372xx7fssdj63110nrnvy9dmm1k7gc0pyhn0a5yk8a";
-      name = "kdesu-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdesu-5.34.0.tar.xz";
+      sha256 = "04mx0d6kf8slgkkgbna3cyv4c491jvlwcwqxc7zikz0i03l341id";
+      name = "kdesu-5.34.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdewebkit-5.33.0.tar.xz";
-      sha256 = "0lxca56ib5pldc6f3z2gw05jbi2kyd9rqp52pgzfs4kgvvs6gblh";
-      name = "kdewebkit-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdewebkit-5.34.0.tar.xz";
+      sha256 = "155rn5bib4jq1ml35l4hll9cv30bp83wva4kgrhfc4y8cp46p9wk";
+      name = "kdewebkit-5.34.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdnssd-5.33.0.tar.xz";
-      sha256 = "11pnh18z030zzkiibvd9lfp5i194qwk3pccncc9968nnc0bgghxa";
-      name = "kdnssd-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdnssd-5.34.0.tar.xz";
+      sha256 = "082mdim9wykdap4fmjfayk443rbarsk1p8cn3mspx2nw047yja80";
+      name = "kdnssd-5.34.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdoctools-5.33.0.tar.xz";
-      sha256 = "04d48gi5d273x3p7572szlpyiz8iyw1ic53b9jblhyfyp93gvpb9";
-      name = "kdoctools-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdoctools-5.34.0.tar.xz";
+      sha256 = "145jjhsd0whmcj91zbjz2b1jyj4wasw60hbwyd4xvqds8cp0l02h";
+      name = "kdoctools-5.34.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kemoticons-5.33.0.tar.xz";
-      sha256 = "0p9320zln553wi055ql04j8kk329l3wiksprg9rkgzya2gynflyl";
-      name = "kemoticons-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kemoticons-5.34.0.tar.xz";
+      sha256 = "02h12qy0w6mcgkczi3md1znnvp7r47l8h416nd080ljpsydalgx8";
+      name = "kemoticons-5.34.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kfilemetadata-5.33.0.tar.xz";
-      sha256 = "1bbw1h8kml8glnck8hh4s13abbksw2fa7g93p25vbhdcyr7zgkr0";
-      name = "kfilemetadata-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kfilemetadata-5.34.0.tar.xz";
+      sha256 = "1rvlg6by8daiq5ff3qlxcw9k2iq4qicsj0c8a00xfy3w4h9ip9h5";
+      name = "kfilemetadata-5.34.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kglobalaccel-5.33.0.tar.xz";
-      sha256 = "0hc46vwiz81iqzkrc0qahd7gn71kh5wc32kjvh6h4ijlnfmdih07";
-      name = "kglobalaccel-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kglobalaccel-5.34.0.tar.xz";
+      sha256 = "1i32dq70qxjbfvlw0wqxvqvl6ysydmpg3zbiflff4z1qrmvmpw6a";
+      name = "kglobalaccel-5.34.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kguiaddons-5.33.0.tar.xz";
-      sha256 = "171lvykvznrrqdi1frm9akzx5rsrj04vvav3sv64x7hfsas0a7p1";
-      name = "kguiaddons-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kguiaddons-5.34.0.tar.xz";
+      sha256 = "1nmlwvy2jdmh0m6bmahvk68vl2rs9s28c10dkncpi6gvhsdkigqx";
+      name = "kguiaddons-5.34.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/portingAids/khtml-5.33.0.tar.xz";
-      sha256 = "0j9viw8fydh1x548wx39bphk5bf11fyrghshxz14a79rll8w7qmc";
-      name = "khtml-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/portingAids/khtml-5.34.0.tar.xz";
+      sha256 = "0j490jfnz8pbfl1i11wj514nw0skpnxr2fvi9pqpfql9lfhsanxv";
+      name = "khtml-5.34.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/ki18n-5.33.0.tar.xz";
-      sha256 = "02xf9q3vnw8nn2if6a3pfj8v96414j7gnc6097k0wxfyis9i46k1";
-      name = "ki18n-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/ki18n-5.34.0.tar.xz";
+      sha256 = "0glvmmy01mp6hnix79aichgwjq842kgf5q5zynkg6mch85y4ary7";
+      name = "ki18n-5.34.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kiconthemes-5.33.0.tar.xz";
-      sha256 = "1zys55d7jjjjllyi9p4difnr6xg9580bgcg5pnm966ak6zhj6682";
-      name = "kiconthemes-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kiconthemes-5.34.0.tar.xz";
+      sha256 = "0hbl82r6qc8dh9v9n9xjkx966czkq5yjxx2rx7sbilj2p9v3saii";
+      name = "kiconthemes-5.34.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kidletime-5.33.0.tar.xz";
-      sha256 = "0z6i224kmj9l15x923pa30mlhjw66chm9v8qvzg1vhmk36jyw789";
-      name = "kidletime-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kidletime-5.34.0.tar.xz";
+      sha256 = "0z8x6iz52y2m8llsp2q4qayxswkzay7ksimzy47crfag442bw24g";
+      name = "kidletime-5.34.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kimageformats-5.33.0.tar.xz";
-      sha256 = "1m9d51pvrc7fa38mp4jn4cdn558nd6kvik3ry6gvv8im67qyq4ga";
-      name = "kimageformats-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kimageformats-5.34.0.tar.xz";
+      sha256 = "0q9ng4clqk2dqw43nk1pmq1d61rahc3qr4dmg4y3kjvz3ahnnijw";
+      name = "kimageformats-5.34.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kinit-5.33.0.tar.xz";
-      sha256 = "0v3dcgbi5qwg9nmn668r2v1b257qhmkdb2l3p7hhx06ygypk4yjp";
-      name = "kinit-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kinit-5.34.0.tar.xz";
+      sha256 = "08429kjihpaip73wszr3rsii8sdlwgm3kxx7g0hpjhkj9d2jq3m1";
+      name = "kinit-5.34.0.tar.xz";
     };
   };
   kio = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kio-5.33.0.tar.xz";
-      sha256 = "1pls5yjkhz7fkawks4c0lmsix0nafv7hyp33yh7dm4hijd8zy5cf";
-      name = "kio-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kio-5.34.0.tar.xz";
+      sha256 = "1i23ld5b9gafh2x3lv79jbggbd92xyhk7rg3n765w3bsfpg2ijva";
+      name = "kio-5.34.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kitemmodels-5.33.0.tar.xz";
-      sha256 = "1ma21qydbmj2qr4ib4qv13wip99lq3lm8d6p137bg9x6nqfa4qzn";
-      name = "kitemmodels-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kitemmodels-5.34.0.tar.xz";
+      sha256 = "1liq1ppa7xb1dcncv25c2a0xy3l9bvb2a56cff90c0b0vwr239q5";
+      name = "kitemmodels-5.34.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kitemviews-5.33.0.tar.xz";
-      sha256 = "1nc07lxh37l1fwz6xmsrcplimgmrna9ij2dq3pnfrxr319c29890";
-      name = "kitemviews-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kitemviews-5.34.0.tar.xz";
+      sha256 = "054accbis471zj1gbfxbc99062r2hvpb04i6w3r8fa4ml8s6brqk";
+      name = "kitemviews-5.34.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kjobwidgets-5.33.0.tar.xz";
-      sha256 = "01adg7axi1bp59z1c7xnxg2p1ahhrzxwxrjn3ci805m8ns6d40cz";
-      name = "kjobwidgets-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kjobwidgets-5.34.0.tar.xz";
+      sha256 = "0lrx761vf947mb2q1l2jgi0wgwj8cz2nn1xg0j38bh99sgddmzpf";
+      name = "kjobwidgets-5.34.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/portingAids/kjs-5.33.0.tar.xz";
-      sha256 = "1w0kdxnzcwmgskl4qsw6aq5189yxqyhq9qajihr2yga0hyglf3iv";
-      name = "kjs-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/portingAids/kjs-5.34.0.tar.xz";
+      sha256 = "18b7k1hi73iqn06c1ryy9lcmvscr9d08q7n1wwkrn0l2xmy05xsq";
+      name = "kjs-5.34.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/portingAids/kjsembed-5.33.0.tar.xz";
-      sha256 = "1vk2m8i315nrys9c4kk3hdlp8hdn2ils0lb8v4nnkvbj3s1f4a8p";
-      name = "kjsembed-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/portingAids/kjsembed-5.34.0.tar.xz";
+      sha256 = "17w8i370pqks1fj3pcziz7j014chnc6yi7md7w2p4xprw54pbmbk";
+      name = "kjsembed-5.34.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/portingAids/kmediaplayer-5.33.0.tar.xz";
-      sha256 = "13xpvi0vxd3vva2d64x8l1knj270al4329kwf9xaays66g6gshgs";
-      name = "kmediaplayer-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/portingAids/kmediaplayer-5.34.0.tar.xz";
+      sha256 = "1mq87qf86sdvwhas4w7rspd221qp4x9kds4nd0lpldiay4483k86";
+      name = "kmediaplayer-5.34.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/knewstuff-5.33.0.tar.xz";
-      sha256 = "1j4jj2k6jngcp98mfxq1cdp7x0j43rgr5gxn9viqp92liak68lsh";
-      name = "knewstuff-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/knewstuff-5.34.0.tar.xz";
+      sha256 = "19d53ylwr92dzl9agk4j765zvb897rcm55z7pr6841aj58jk9b82";
+      name = "knewstuff-5.34.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/knotifications-5.33.0.tar.xz";
-      sha256 = "17ppfwhl3mqd3l4r56whqcxagx6br02hdwlqy7npn32g797hkayd";
-      name = "knotifications-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/knotifications-5.34.0.tar.xz";
+      sha256 = "12z5hza0n5zr6mv3gkwhzb8zkrmk6dvgq8hrzwm8rzkgphjr6pi9";
+      name = "knotifications-5.34.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/knotifyconfig-5.33.0.tar.xz";
-      sha256 = "0m9fdvbakv0plq3m7sj6wj980wfd3m37cabximz9gmi0zkcadzmw";
-      name = "knotifyconfig-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/knotifyconfig-5.34.0.tar.xz";
+      sha256 = "0lwl22vq770jyp45j32s0ss8yiqdwbink6cdhkbapg3pzbiwklyk";
+      name = "knotifyconfig-5.34.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kpackage-5.33.0.tar.xz";
-      sha256 = "03ls567fj54fzibc8fafffas97abyanl0sn041z51sr7mjp425cs";
-      name = "kpackage-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kpackage-5.34.0.tar.xz";
+      sha256 = "0wdymhcrjggxb7andz36cfk9f240vvbq5yahlxyhfp9z69lriw5q";
+      name = "kpackage-5.34.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kparts-5.33.0.tar.xz";
-      sha256 = "0fd0dqmaf8ksx3czzihjd4z0yg682a9bcy09vdhj2grki7w9fxha";
-      name = "kparts-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kparts-5.34.0.tar.xz";
+      sha256 = "1a5n0f7ljdc2bm6vggzwbvpblyxjqn9m9pam70iab964pqqalgp7";
+      name = "kparts-5.34.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kpeople-5.33.0.tar.xz";
-      sha256 = "19vag6ci82jh5lw5c7734rlp89wr7xb0d8as98ykz2wmkk0mqql7";
-      name = "kpeople-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kpeople-5.34.0.tar.xz";
+      sha256 = "0krm74dl80s48nhiygga4dvkvqqimxdx4nczbk4qvj7j1g9p2rsh";
+      name = "kpeople-5.34.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kplotting-5.33.0.tar.xz";
-      sha256 = "0niqhj270l36il3ql6xljg9gbb0yw25ky8wsc7l0021mxvhficri";
-      name = "kplotting-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kplotting-5.34.0.tar.xz";
+      sha256 = "1ffy9b08128ym024wlfgnzk52vpy0mbaa91dhndpr40qcz0i67sh";
+      name = "kplotting-5.34.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kpty-5.33.0.tar.xz";
-      sha256 = "0xcmqdphqy2a44bksqiv8cjlzfkjpbpazfk5f8ml97vdqvwa6qp5";
-      name = "kpty-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kpty-5.34.0.tar.xz";
+      sha256 = "00k5hhz7nf3nf47xb003ni1chi03imyrfajap6ay4zp90l8fr950";
+      name = "kpty-5.34.0.tar.xz";
     };
   };
   kross = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/portingAids/kross-5.33.0.tar.xz";
-      sha256 = "13dldb4df4spsqr3878bimv009fzq4pdvmwlaw753c0lrp97pd9l";
-      name = "kross-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/portingAids/kross-5.34.0.tar.xz";
+      sha256 = "092qz8vyiialv9fvk4wvn8mrfhz5i5hnbq0xnz6nvi1pk3db6bxq";
+      name = "kross-5.34.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/krunner-5.33.0.tar.xz";
-      sha256 = "0za052rsqf5kaz1c48k63a905b3x953wi6f07m44m6dm38p5ixq8";
-      name = "krunner-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/krunner-5.34.0.tar.xz";
+      sha256 = "0n527p708k719zgmvvbmp20xmg72f85cll05q05p4h317g7wz6i5";
+      name = "krunner-5.34.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kservice-5.33.0.tar.xz";
-      sha256 = "0jqq4ahscnqvzv8inhfzb9s6x97s60c4w8chpg16qwc7dqag887h";
-      name = "kservice-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kservice-5.34.0.tar.xz";
+      sha256 = "0sikwn49s2iq1nj518q55m2p0hvdvwm98cpf0dkjb1z1v6fgjc37";
+      name = "kservice-5.34.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/ktexteditor-5.33.0.tar.xz";
-      sha256 = "12fcqcxamkxv38w4j9waqmim7k801v6r6izlyg59iiy56yks4ms5";
-      name = "ktexteditor-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/ktexteditor-5.34.0.tar.xz";
+      sha256 = "182a0swfgdqr0faq3ksk6hlfvdi1afd0hpys5vayjjf263m19xxw";
+      name = "ktexteditor-5.34.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/ktextwidgets-5.33.0.tar.xz";
-      sha256 = "09rjr3655pbzwgjsmwbjsm7jwrxydl2jwhgbk8ziv1bgcg6cjrjy";
-      name = "ktextwidgets-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/ktextwidgets-5.34.0.tar.xz";
+      sha256 = "1hri34b373bww5gv14qli2nm77k05pk170nbb2vv2zvzv93g25gw";
+      name = "ktextwidgets-5.34.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kunitconversion-5.33.0.tar.xz";
-      sha256 = "0bflic2va9bc17q0smc4dzmgh72cjfjjaahhsvvnj54g2qggznkq";
-      name = "kunitconversion-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kunitconversion-5.34.0.tar.xz";
+      sha256 = "0v4x0flbfavrzfiqh71mdkqgp1fzk4f52msvq6w60i2s3sz7hcsm";
+      name = "kunitconversion-5.34.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kwallet-5.33.0.tar.xz";
-      sha256 = "1jpybsksai9gm2bihcgl5m56rjfd0crj9i8j0l2s4vmmzxyflczj";
-      name = "kwallet-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kwallet-5.34.0.tar.xz";
+      sha256 = "08z3ddsam5n5qn2svscp4hgksf6qd1h8lqw1v382p01nnmhxadz5";
+      name = "kwallet-5.34.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kwayland-5.33.0.tar.xz";
-      sha256 = "18nvdhfijnvzjiy0vjmqvf2nwz64ymxpnhlhs75y1d2ib8rm8qfq";
-      name = "kwayland-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kwayland-5.34.0.tar.xz";
+      sha256 = "1zxb9ram47vbiik8h0czyvacrdiijhnslkpcm61l4r1rb0ybb0ib";
+      name = "kwayland-5.34.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kwidgetsaddons-5.33.0.tar.xz";
-      sha256 = "1dnspi7zf57lsihdynbik2iwvnhv8098vqyz0rps8s8pnjl7x8k4";
-      name = "kwidgetsaddons-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kwidgetsaddons-5.34.0.tar.xz";
+      sha256 = "0hw87iig75mfgl5p3ph6zkwap31h357bm7rlyv5d9nnp10bq0hfg";
+      name = "kwidgetsaddons-5.34.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kwindowsystem-5.33.0.tar.xz";
-      sha256 = "1dj18774rlpxh9p8a07shhb4dzc0zpv4qvmh4j2y4c1g6v7n6b3p";
-      name = "kwindowsystem-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kwindowsystem-5.34.0.tar.xz";
+      sha256 = "1sp2x7afhw19vmhdp2qyrmljz8h0875xjk95n8c5gzypk7sr0l83";
+      name = "kwindowsystem-5.34.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kxmlgui-5.33.0.tar.xz";
-      sha256 = "1q89xsrdhrsz7jb68hq8r3xdmhz0s19zwvd06skn6cfqx7r32ng0";
-      name = "kxmlgui-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kxmlgui-5.34.0.tar.xz";
+      sha256 = "1v8m6qzjqg3ic14a5ki37bf13kifzcbhly68zcxgs5b92hr953iy";
+      name = "kxmlgui-5.34.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kxmlrpcclient-5.33.0.tar.xz";
-      sha256 = "1zc6pn412day923k22br82xypvk24znb0ns1qsdlmrd2cnmv8l28";
-      name = "kxmlrpcclient-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kxmlrpcclient-5.34.0.tar.xz";
+      sha256 = "0kp3ab50m5jl2jgw883ip67s6gs0l3saprzrqa9r3hydn2c4s3md";
+      name = "kxmlrpcclient-5.34.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/modemmanager-qt-5.33.0.tar.xz";
-      sha256 = "098l3plck45bn7lph7mfkm03q18zxl1s8aa3pyh6b69wk45r7j54";
-      name = "modemmanager-qt-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/modemmanager-qt-5.34.0.tar.xz";
+      sha256 = "1cf5nsc8h7djvr19fm5dphzplh1wm3asvn0a7r71spg0i7lzi89h";
+      name = "modemmanager-qt-5.34.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/networkmanager-qt-5.33.0.tar.xz";
-      sha256 = "0pc4n4m93ypx1ryasw8n3bqll7v4yqa3749ir0qi096y5vysdd2m";
-      name = "networkmanager-qt-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/networkmanager-qt-5.34.0.tar.xz";
+      sha256 = "05s0irvkg0g57acriablyha2wb9c7w3xhq223vdddjqpcdx0pnkl";
+      name = "networkmanager-qt-5.34.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/oxygen-icons5-5.33.0.tar.xz";
-      sha256 = "17kp66hra0vfkcvd7fh5q23wr040h0z6di4gdrm2zi1w5jbhw9kn";
-      name = "oxygen-icons5-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/oxygen-icons5-5.34.0.tar.xz";
+      sha256 = "0cmxxssir5zbp5nlxq81h2xfd6wrxbbkydyw93dby7r56isl7ga5";
+      name = "oxygen-icons5-5.34.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/plasma-framework-5.33.0.tar.xz";
-      sha256 = "0rqm773n2r6vwmv41x27lr2zmx26s5s27ym3a6qy0w18fr86fxsd";
-      name = "plasma-framework-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/plasma-framework-5.34.0.tar.xz";
+      sha256 = "0waicqskfwc8xpmrym165hwlfv6nzbwc783sac5vrhbyk4bwk8x9";
+      name = "plasma-framework-5.34.0.tar.xz";
     };
   };
   prison = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/prison-5.33.0.tar.xz";
-      sha256 = "0hh065294s7sjj34vfwwb8zgagf1sa09l9filadl1ly0ig9f6h1r";
-      name = "prison-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/prison-5.34.0.tar.xz";
+      sha256 = "00wj4yyfhhcq9b54civ5hy1grz70mmi676x50y12crcbbgkxm1lx";
+      name = "prison-5.34.0.tar.xz";
     };
   };
   solid = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/solid-5.33.0.tar.xz";
-      sha256 = "0jb8jjv6mhwriqxfkd9fj0b7y1ab6vnwqi53sk4w4vw53d0wkqxm";
-      name = "solid-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/solid-5.34.0.tar.xz";
+      sha256 = "02kz21p3p1s1rg7gf34fr6ynhji6x97yvsfdpvbfxbhijabbh4ib";
+      name = "solid-5.34.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/sonnet-5.33.0.tar.xz";
-      sha256 = "096ybf95rx5ybvl74nlnn9x2yb2j1akn8g8ywv1vwi2ckfpnp3sd";
-      name = "sonnet-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/sonnet-5.34.0.tar.xz";
+      sha256 = "06gxrh8rb75ydkqxk5dhlmwndnczp264jx588ryfwlf3vlnk99vs";
+      name = "sonnet-5.34.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/syntax-highlighting-5.33.0.tar.xz";
-      sha256 = "0nn078sw0bkw1m5vsv02n46sc05blg3qnhxpmph2cikz5y86x9jq";
-      name = "syntax-highlighting-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/syntax-highlighting-5.34.0.tar.xz";
+      sha256 = "0ryfwblvzj9rd5jj7l8scmbb49ygzk77ng05hrznsipczin2cjw8";
+      name = "syntax-highlighting-5.34.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/threadweaver-5.33.0.tar.xz";
-      sha256 = "16y7irjyyp4smy7nm7j4zc3gk9a046bwxvv51l7rfs7n4z0550ki";
-      name = "threadweaver-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/threadweaver-5.34.0.tar.xz";
+      sha256 = "1gylpl283qf1jcfyib4q5xwnpdq13hnd2cp2i7xjazdw2jp40zhr";
+      name = "threadweaver-5.34.0.tar.xz";
     };
   };
 }

--- a/pkgs/tools/misc/ckb/default.nix
+++ b/pkgs/tools/misc/ckb/default.nix
@@ -28,6 +28,13 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
+  # Before we do various fixups, remove qt tree---this means the
+  # standard RPATH shrinking code will remove the references.  Should
+  # be obsoleted when NixOS/patchelf#98 is released.
+  preFixup = ''
+    rm -rf $(pwd)/../__nix_qt5__
+  '';
+
   installPhase = ''
     install -D --mode 0755 --target-directory $out/bin bin/ckb-daemon bin/ckb
     install -D --mode 0755 --target-directory $out/libexec/ckb-animations bin/ckb-animations/*

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9743,8 +9743,23 @@ with pkgs;
 
   libsForQt58 = recurseIntoAttrs (lib.makeScope qt58.newScope mkLibsForQt5);
 
-  qt5 = qt58;
-  libsForQt5 = libsForQt58;
+  qt59 = recurseIntoAttrs (makeOverridable
+    (import ../development/libraries/qt-5/5.9) {
+      inherit newScope;
+      inherit stdenv fetchurl makeSetupHook makeWrapper;
+      bison = bison2; # error: too few arguments to function 'int yylex(...
+      inherit cups;
+      harfbuzz = harfbuzz-icu;
+      mesa = mesa_noglu;
+      inherit perl;
+      inherit (gst_all_1) gstreamer gst-plugins-base;
+      inherit (gnome3) gtk3 dconf;
+    });
+
+  libsForQt59 = recurseIntoAttrs (lib.makeScope qt59.newScope mkLibsForQt5);
+
+  qt5 = qt59;
+  libsForQt5 = libsForQt59;
 
   qt5ct = libsForQt5.callPackage ../tools/misc/qt5ct { };
 
@@ -14510,7 +14525,7 @@ with pkgs;
     lcms = lcms2;
   };
 
-  inspectrum = callPackage ../applications/misc/inspectrum { };
+  inspectrum = libsForQt5.callPackage ../applications/misc/inspectrum { };
 
   ion3 = callPackage ../applications/window-managers/ion-3 {
     lua = lua5_1;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

