### PR TITLE
python.pkgs.ldap: only set environment variables for tests during check phase

### DIFF
--- a/pkgs/development/python-modules/ldap.nix
+++ b/pkgs/development/python-modules/ldap.nix
@@ -13,10 +13,12 @@ buildPythonPackage rec {
   };
 
   # Needed by tests to setup a mockup ldap server.
-  BIN = "${openldap}/bin";
-  SBIN = "${openldap}/bin";
-  SLAPD = "${openldap}/libexec/slapd";
-  SCHEMA = "${openldap}/etc/schema";
+  preCheck = ''
+    export BIN="${openldap}/bin"
+    export SBIN="${openldap}/bin"
+    export SLAPD="${openldap}/libexec/slapd"
+    export SCHEMA="${openldap}/etc/schema"
+  '';
 
   patches = lib.singleton (writeText "avoid-syslog.diff" ''
     diff a/Lib/slapdtest.py b/Lib/slapdtest.py


### PR DESCRIPTION
###### Motivation for this change
Just a slight tidyup of a previous merge.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

