### PR TITLE
Keep older versions of cmdliner and ocp-indent

### DIFF
--- a/pkgs/development/ocaml-modules/cmdliner/1.0.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/1.0.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam, topkg, result }:
+
+let
+  pname = "cmdliner";
+in
+
+assert stdenv.lib.versionAtLeast ocaml.version "4.01.0";
+
+stdenv.mkDerivation rec {
+  name = "ocaml-${pname}-${version}";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "http://erratique.ch/software/${pname}/releases/${pname}-${version}.tbz";
+    sha256 = "1ryn7qis0izg0wcal8zdlikzzl689l75y6f4zc6blrm93y5agy9x";
+  };
+
+  unpackCmd = "tar xjf $src";
+
+  nativeBuildInputs = [ ocamlbuild opam topkg ];
+  buildInputs = [ ocaml findlib ];
+  propagatedBuildInputs = [ result ];
+
+  createFindlibDestdir = true;
+
+  buildPhase = ''
+    ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib pkg/pkg.ml build
+  '';
+
+  installPhase = ''
+    opam-installer --script --prefix=$out | sh
+    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://erratique.ch/software/cmdliner;
+    description = "An OCaml module for the declarative definition of command line interfaces";
+    license = licenses.bsd3;
+    platforms = ocaml.meta.platforms or [];
+    maintainers = [ maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/default.nix
@@ -1,33 +1,30 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam, topkg, result }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam }:
 
 let
   pname = "cmdliner";
 in
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.01.0";
+assert stdenv.lib.versionAtLeast ocaml.version "3.12";
 
 stdenv.mkDerivation rec {
+
   name = "ocaml-${pname}-${version}";
-  version = "1.0.0";
+  version = "0.9.8";
 
   src = fetchurl {
     url = "http://erratique.ch/software/${pname}/releases/${pname}-${version}.tbz";
-    sha256 = "1ryn7qis0izg0wcal8zdlikzzl689l75y6f4zc6blrm93y5agy9x";
+    sha256 = "0hdxlkgiwjml9dpaa80282a8350if7mc1m6yz2mrd7gci3fszykx";
   };
 
   unpackCmd = "tar xjf $src";
-
-  nativeBuildInputs = [ ocamlbuild opam topkg ];
+  nativeBuildInputs = [ ocamlbuild opam ];
   buildInputs = [ ocaml findlib ];
-  propagatedBuildInputs = [ result ];
 
   createFindlibDestdir = true;
 
-  buildPhase = ''
-    ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib pkg/pkg.ml build
-  '';
-
-  installPhase = ''
+  configurePhase = "ocaml pkg/git.ml";
+  buildPhase     = "ocaml pkg/build.ml native=true native-dynlink=true";
+  installPhase   = ''
     opam-installer --script --prefix=$out | sh
     ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/
   '';

--- a/pkgs/development/tools/ocaml/ocp-indent/1.5.2.nix
+++ b/pkgs/development/tools/ocaml/ocp-indent/1.5.2.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchzip, ocaml, findlib, ocpBuild, opam, cmdliner }:
+
+let inherit (stdenv.lib) getVersion versionAtLeast; in
+
+assert versionAtLeast (getVersion ocaml) "3.12.1";
+assert versionAtLeast (getVersion ocpBuild) "1.99.6-beta";
+assert versionAtLeast "0.9.8" (getVersion cmdliner);
+
+stdenv.mkDerivation {
+
+  name = "ocp-indent-1.5.2";
+
+  src = fetchzip {
+    url = "https://github.com/OCamlPro/ocp-indent/archive/1.5.2.tar.gz";
+    sha256 = "0ynv2yhm7akpvqp72pdabhddwr352s1k85q8m1khsvspgg1mkiqz";
+  };
+
+  nativeBuildInputs = [ ocpBuild opam ];
+
+  buildInputs = [ ocaml findlib cmdliner ];
+
+  createFindlibDestdir = true;
+
+  preConfigure = "patchShebangs ./install.sh";
+
+  postInstall = ''
+    mv $out/lib/{ocp-indent,ocaml/${getVersion ocaml}/site-lib/}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://typerex.ocamlpro.com/ocp-indent.html";
+    description = "A customizable tool to indent OCaml code";
+    license = licenses.gpl3;
+    platforms = ocaml.meta.platforms or [];
+    maintainers = [ maintainers.jirkamarsik ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -389,6 +389,7 @@ let
     ocpBuild = callPackage ../development/tools/ocaml/ocp-build { };
 
     ocpIndent = callPackage ../development/tools/ocaml/ocp-indent { cmdliner = cmdliner_1_0; };
+    ocpIndent_1_5_2 = callPackage ../development/tools/ocaml/ocp-indent/1.5.2.nix { };
 
     ocp-index = callPackage ../development/tools/ocaml/ocp-index { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -391,7 +391,7 @@ let
     ocpIndent = callPackage ../development/tools/ocaml/ocp-indent { cmdliner = cmdliner_1_0; };
     ocpIndent_1_5_2 = callPackage ../development/tools/ocaml/ocp-indent/1.5.2.nix { };
 
-    ocp-index = callPackage ../development/tools/ocaml/ocp-index { };
+    ocp-index = callPackage ../development/tools/ocaml/ocp-index { ocpIndent = ocpIndent_1_5_2; };
 
     ocplib-endian = callPackage ../development/ocaml-modules/ocplib-endian { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -130,6 +130,8 @@ let
 
     cmdliner = callPackage ../development/ocaml-modules/cmdliner { };
 
+    cmdliner_1_0 = callPackage ../development/ocaml-modules/cmdliner/1.0.nix { };
+
     cohttp = callPackage ../development/ocaml-modules/cohttp {
       lwt = ocaml_lwt;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -388,7 +388,7 @@ let
 
     ocpBuild = callPackage ../development/tools/ocaml/ocp-build { };
 
-    ocpIndent = callPackage ../development/tools/ocaml/ocp-indent { };
+    ocpIndent = callPackage ../development/tools/ocaml/ocp-indent { cmdliner = cmdliner_1_0; };
 
     ocp-index = callPackage ../development/tools/ocaml/ocp-index { };
 


### PR DESCRIPTION
###### Motivation for this change

PR https://github.com/NixOS/nixpkgs/pull/26195 (which upgraded `cmdliner` to version 1.0.0) introduced an issue because some ocaml packages are not yet compatible with it.

This PR keeps both versions of `cmdliner` (the old 0.9.8 and the new 1.0.0) and makes the old one the default.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @vbgl 