### PR TITLE
Generalize notion of arch-dependent modules

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -25,4 +25,10 @@ rec {
       throw "${shell} is not a shell package"
     else
       shell;
+
+  # Environment attributes type and conversion function.
+  environmentAttrs = with types; attrsOf (either path (either str (listOf str)));
+  makeEnvironmentValue = v: if isList v then concatStringsSep ":" v else v;
+  mergeEnvironment = zipAttrsWith (name: values: if all isList values then concatLists values else last values);
+
 }

--- a/nixos/modules/config/debug-info.nix
+++ b/nixos/modules/config/debug-info.nix
@@ -32,9 +32,7 @@ with lib;
 
   config = {
 
-    # FIXME: currently disabled because /lib is already in
-    # environment.pathsToLink, and we can't have both.
-    #environment.pathsToLink = [ "/lib/debug/.build-id" ];
+    environment.pathsToLink = [ "/lib/debug/.build-id" ];
 
     environment.extraOutputsToInstall =
       optional config.environment.enableDebugInfo "debug";

--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -126,6 +126,9 @@ with lib;
     environment.systemPackages =
       optional (config.i18n.supportedLocales != []) config.i18n.glibcLocales;
 
+    environment.pathsToLink =
+      optional (config.i18n.supportedLocales != []) "/lib/locale";
+
     environment.sessionVariables =
       { LANG = config.i18n.defaultLocale;
         LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -16,7 +16,7 @@ let
 
       suffixedVariables =
         flip mapAttrs cfg.profileRelativeEnvVars (envVar: listSuffixes:
-          concatMap (profile: map (suffix: "${profile}${suffix}") listSuffixes) cfg.profiles
+          concatMap (profile: map (suffix: "${profile}${suffix}") (toList listSuffixes)) cfg.profiles
         );
 
       allVariables =
@@ -33,6 +33,7 @@ in
   options = {
 
     environment.variables = mkOption {
+      type = utils.environmentAttrs;
       default = {};
       description = ''
         A set of environment variables used in the global environment.
@@ -41,16 +42,14 @@ in
         strings.  The latter is concatenated, interspersed with colon
         characters.
       '';
-      type = with types; attrsOf (either str (listOf str));
-      apply = mapAttrs (n: v: if isList v then concatStringsSep ":" v else v);
     };
 
     environment.profiles = mkOption {
+      type = types.listOf types.str;
       default = [];
       description = ''
         A list of profiles used to setup the global environment.
       '';
-      type = types.listOf types.str;
     };
 
     environment.profileRelativeEnvVars = mkOption {
@@ -66,6 +65,7 @@ in
 
     # !!! isn't there a better way?
     environment.extraInit = mkOption {
+      type = types.lines;
       default = "";
       description = ''
         Shell script code called during global environment initialisation
@@ -73,40 +73,40 @@ in
         This code is asumed to be shell-independent, which means you should
         stick to pure sh without sh word split.
       '';
-      type = types.lines;
     };
 
     environment.shellInit = mkOption {
+      type = types.lines;
       default = "";
       description = ''
         Shell script code called during shell initialisation.
         This code is asumed to be shell-independent, which means you should
         stick to pure sh without sh word split.
       '';
-      type = types.lines;
     };
 
     environment.loginShellInit = mkOption {
+      type = types.lines;
       default = "";
       description = ''
         Shell script code called during login shell initialisation.
         This code is asumed to be shell-independent, which means you should
         stick to pure sh without sh word split.
       '';
-      type = types.lines;
     };
 
     environment.interactiveShellInit = mkOption {
+      type = types.lines;
       default = "";
       description = ''
         Shell script code called during interactive shell initialisation.
         This code is asumed to be shell-independent, which means you should
         stick to pure sh without sh word split.
       '';
-      type = types.lines;
     };
 
     environment.shellAliases = mkOption {
+      type = types.attrs; # types.attrsOf types.stringOrPath;
       default = {};
       example = { ll = "ls -l"; };
       description = ''
@@ -114,16 +114,15 @@ in
         this option) to command strings or directly to build outputs. The
         aliases are added to all users' shells.
       '';
-      type = types.attrs; # types.attrsOf types.stringOrPath;
     };
 
     environment.binsh = mkOption {
+      type = types.path;
       default = "${config.system.build.binsh}/bin/sh";
       defaultText = "\${config.system.build.binsh}/bin/sh";
       example = literalExample ''
         "''${pkgs.dash}/bin/dash"
       '';
-      type = types.path;
       visible = false;
       description = ''
         The shell executable that is linked system-wide to
@@ -134,6 +133,7 @@ in
     };
 
     environment.shells = mkOption {
+      type = types.listOf (types.either types.shellPackage types.path);
       default = [];
       example = literalExample "[ pkgs.bashInteractive pkgs.zsh ]";
       description = ''
@@ -141,7 +141,6 @@ in
         No need to mention <literal>/bin/sh</literal>
         here, it is placed into this list implicitly.
       '';
-      type = types.listOf (types.either types.shellPackage types.path);
     };
 
   };

--- a/nixos/modules/config/system-libs.nix
+++ b/nixos/modules/config/system-libs.nix
@@ -1,0 +1,119 @@
+# This module defines the packages that appear in
+# /run/current-system/sw.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.libraries;
+
+  system = pkgs.stdenv.system;
+  system32 = pkgs.pkgsi686Linux.stdenv.system;
+
+  pathsToLink = [ "/lib" "/share" "/etc" ];
+
+  mkLibPath = paths: pkgs.buildEnv {
+    name = "libraries";
+    inherit paths pathsToLink;
+    ignoreCollisions = true;
+  };
+
+  mkSanitized = paths: pkgs.buildEnv {
+    name = "sanitized-libraries";
+    inherit paths pathsToLink;
+    ignoreCollisions = true;
+    postBuild = ''
+      for i in $out/lib/*; do
+        if [ -f "$(readlink -f "$i")" ]; then
+          rm "$i"
+        fi
+      done
+    '';
+  };
+
+  libPkgs = zipAttrsWith (name: mkLibPath) cfg.unsafePackages;
+
+  libPath = libPkgs.${system};
+  libPath32 = libPkgs.${system32};
+
+  # We use more "stable" absolute paths in systemd environment and symlinks for users.
+  mkEnv = path: path32: mapAttrs (name: concatMap (suffix: [ "${path}/${suffix}" ] ++ optional cfg.support32Bit "${path32}/${suffix}")) cfg.environment;
+
+in
+
+{
+  options = {
+
+    libraries = {
+
+      packages = mkOption {
+        type = types.listOf (types.attrsOf types.package);
+        default = [];
+        example = literalExample "with pkgs_multiarch; [ mesa ]";
+        description = ''
+          The set of packages that appear in
+          <filename>/run/current-system/''${system}-lib</filename>
+          for each supported architecture. They are supposed
+          to be arch-dependent library plugins, like DRI drivers,
+          input methods etc.
+
+	  <note><para>Packages placed here are stripped of files in
+          <filename>/lib</filename> to avoid library path contamination.</para></note>
+        '';
+      };
+
+      unsafePackages = mkOption {
+        type = types.listOf (types.attrsOf types.package);
+        example = literalExample "with pkgs_multiarch; [ mesa ]";
+        internal = true;
+        description = ''
+          Packages which get into <literal>LD_LIBRARY_PATH</literal>.
+        '';
+      };
+
+      environment = mkOption {
+        type = types.attrsOf (types.listOf types.str);
+        default = {};
+        example = { "LD_LIBRARY_PATH" = [ "lib" ]; };
+        description = ''
+          Relative environment variables that need to be pointed to the libraries.
+	  Each entry has path to libraries prepended for each architecture and
+          concatenated with a colon.
+        '';
+      };
+
+      support32Bit = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to support 32-bit binaries on a 64-bit system.
+        '';
+      };
+
+    };
+
+  };
+
+  config = {
+
+    assertions = lib.singleton {
+      assertion = cfg.support32Bit -> pkgs.stdenv.isx86_64;
+      message = "Option support32Bit only makes sense on a 64-bit system.";
+    };
+
+    systemd.globalEnvironment = mkEnv libPath libPath32;
+    environment.sessionVariables = mkEnv "/run/current-system/${system}-lib" "/run/current-system/${system32}-lib";
+
+    libraries.environment."LD_LIBRARY_PATH" = [ "lib" ]; # FIXME: remove when libglvnd allows us to have fully dynamic OpenGL dispatch.
+    libraries.unsafePackages = [ (zipAttrsWith (name: mkSanitized) cfg.packages) ];
+
+    system.extraSystemBuilderCmds = ''
+      ln -s ${libPath} $out/${system}-lib
+      ${optionalString cfg.support32Bit ''
+        ln -s ${libPath32} $out/${system32}-lib
+      ''}
+    '';
+
+  };
+}

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -104,7 +104,6 @@ in
         "/etc/xdg"
         "/etc/gtk-2.0"
         "/etc/gtk-3.0"
-        "/lib" # FIXME: remove and update debug-info.nix
         "/sbin"
         "/share/applications"
         "/share/desktop-directories"

--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, pkgs_i686, ... }:
+{ config, lib, pkgs, pkgs_multiarch, ... }:
 
 with lib;
 
@@ -10,23 +10,9 @@ let
 
   videoDrivers = config.services.xserver.videoDrivers;
 
-  makePackage = p: pkgs.buildEnv {
-    name = "mesa-drivers+txc-${p.mesa_drivers.version}";
-    paths =
-      [ p.mesa_drivers
-        p.mesa_drivers.out # mainly for libGL
-        (if cfg.s3tcSupport then p.libtxc_dxtn else p.libtxc_dxtn_s2tc)
-      ];
-  };
-
-  package = pkgs.buildEnv {
-    name = "opengl-drivers";
-    paths = [ cfg.package ] ++ cfg.extraPackages;
-  };
-
-  package32 = pkgs.buildEnv {
-    name = "opengl-drivers-32bit";
-    paths = [ cfg.package32 ] ++ cfg.extraPackages32;
+  makePackage = paths: pkgs.buildEnv {
+    name = "mesa-drivers+txc-${pkgs.mesa_drivers.version}";
+    inherit paths;
   };
 
 in
@@ -38,27 +24,6 @@ in
       type = types.bool;
       default = false;
       internal = true;
-    };
-
-    hardware.opengl.driSupport = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable accelerated OpenGL rendering through the
-        Direct Rendering Interface (DRI).
-      '';
-    };
-
-    hardware.opengl.driSupport32Bit = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        On 64-bit systems, whether to support Direct Rendering for
-        32-bit applications (such as Wine).  This is currently only
-        supported for the <literal>nvidia</literal> and 
-        <literal>ati_unfree</literal> drivers, as well as
-        <literal>Mesa</literal>.
-      '';
     };
 
     hardware.opengl.s3tcSupport = mkOption {
@@ -73,41 +38,10 @@ in
     };
 
     hardware.opengl.package = mkOption {
-      type = types.package;
+      type = types.attrsOf types.package;
       internal = true;
       description = ''
-        The package that provides the OpenGL implementation.
-      '';
-    };
-
-    hardware.opengl.package32 = mkOption {
-      type = types.package;
-      internal = true;
-      description = ''
-        The package that provides the 32-bit OpenGL implementation on
-        64-bit systems. Used when <option>driSupport32Bit</option> is
-        set.
-      '';
-    };
-
-    hardware.opengl.extraPackages = mkOption {
-      type = types.listOf types.package;
-      default = [];
-      example = literalExample "with pkgs; [ vaapiIntel libvdpau-va-gl vaapiVdpau ]";
-      description = ''
-        Additional packages to add to OpenGL drivers. This can be used
-        to add OpenCL drivers, VA-API/VDPAU drivers etc.
-      '';
-    };
-
-    hardware.opengl.extraPackages32 = mkOption {
-      type = types.listOf types.package;
-      default = [];
-      example = literalExample "with pkgs.pkgsi686Linux; [ vaapiIntel libvdpau-va-gl vaapiVdpau ]";
-      description = ''
-        Additional packages to add to 32-bit OpenGL drivers on
-        64-bit systems. Used when <option>driSupport32Bit</option> is
-        set. This can be used to add OpenCL drivers, VA-API/VDPAU drivers etc.
+        Arch-dependent package that provides the OpenGL implementation.
       '';
     };
 
@@ -115,32 +49,26 @@ in
 
   config = mkIf cfg.enable {
 
-    assertions = lib.singleton {
-      assertion = cfg.driSupport32Bit -> pkgs.stdenv.isx86_64;
-      message = "Option driSupport32Bit only makes sense on a 64-bit system.";
-    };
-
-    system.activationScripts.setup-opengl =
-      ''
-        ln -sfn ${package} /run/opengl-driver
-        ${if pkgs.stdenv.isi686 then ''
-          ln -sfn opengl-driver /run/opengl-driver-32
-        '' else if cfg.driSupport32Bit then ''
-          ln -sfn ${package32} /run/opengl-driver-32
-        '' else ''
-          rm -f /run/opengl-driver-32
-        ''}
-      '';
-
-    environment.sessionVariables.LD_LIBRARY_PATH =
-      [ "/run/opengl-driver/lib" ] ++ optional cfg.driSupport32Bit "/run/opengl-driver-32/lib";
-
-    environment.variables.XDG_DATA_DIRS =
-      [ "/run/opengl-driver/share" ] ++ optional cfg.driSupport32Bit "/run/opengl-driver-32/share";
-
-    hardware.opengl.package = mkDefault (makePackage pkgs);
-    hardware.opengl.package32 = mkDefault (makePackage pkgs_i686);
+    hardware.opengl.package = mkDefault (zipAttrsWith (path: makePackage) (with pkgs_multiarch; [
+      mesa_drivers
+      (mapAttrs (name: pkg: pkg.out) mesa_drivers) # mainly for libGL
+      (if cfg.s3tcSupport then libtxc_dxtn else libtxc_dxtn_s2tc)
+    ]));
 
     boot.extraModulePackages = optional (elem "virtualbox" videoDrivers) kernelPackages.virtualboxGuestAdditions;
+
+    libraries.unsafePackages = [ cfg.package ];
+
+    # Backwards compatibility.
+    system.activationScripts.setup-opengl =
+      ''
+        if [ -L /run/opengl-driver ]; then
+          ln -sfn /run/current-system/${pkgs.stdenv.system}-lib /run/opengl-driver
+        fi
+        if [ -L /run/opengl-driver-32 ]; then
+          ln -sfn /run/current-system/${pkgs.pkgsi686Linux.stdenv.system}-lib /run/opengl-driver-32
+        fi
+      '';
+
   };
 }

--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -1,27 +1,27 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, pkgs_multiarch, lib, ... }:
 
 with lib;
 let
   cfg = config.i18n.inputMethod;
 
-  gtk2_cache = pkgs.runCommand "gtk2-immodule.cache"
+  gtk2_cache = system: pkgs.runCommand "gtk2-immodule.cache"
     { preferLocalBuild = true;
       allowSubstitutes = false;
-      buildInputs = [ pkgs.gtk2 cfg.package ];
+      buildInputs = map (x: x.${system}) [ pkgs_multiarch.gtk2 cfg.package ];
     }
     ''
       mkdir -p $out/etc/gtk-2.0/
-      GTK_PATH=${cfg.package}/lib/gtk-2.0/ gtk-query-immodules-2.0 > $out/etc/gtk-2.0/immodules.cache
+      GTK_PATH=${cfg.package.${system}}/lib/gtk-2.0 gtk-query-immodules-2.0 > $out/etc/gtk-2.0/immodules-${system}.cache
     '';
 
-  gtk3_cache = pkgs.runCommand "gtk3-immodule.cache"
+  gtk3_cache = system: pkgs.runCommand "gtk3-immodule.cache"
     { preferLocalBuild = true;
       allowSubstitutes = false;
-      buildInputs = [ pkgs.gtk3 cfg.package ];
+      buildInputs = map (x: x.${system}) [ pkgs_multiarch.gtk3 cfg.package ];
     }
     ''
       mkdir -p $out/etc/gtk-3.0/
-      GTK_PATH=${cfg.package}/lib/gtk-3.0/ gtk-query-immodules-3.0 > $out/etc/gtk-3.0/immodules.cache
+      GTK_PATH=${cfg.package.${system}}/lib/gtk-3.0 gtk-query-immodules-3.0 > $out/etc/gtk-3.0/immodules-${system}.cache
     '';
 
 in
@@ -50,17 +50,18 @@ in
 
       package = mkOption {
         internal = true;
-        type     = types.path;
+        type     = types.attrsOf types.package;
         default  = null;
         description = ''
-          The input method method package.
+          The input method method package function.
         '';
       };
     };
   };
 
   config = mkIf (cfg.enabled != null) {
-    environment.systemPackages = [ cfg.package gtk2_cache gtk3_cache ];
+    environment.systemPackages = [ cfg.package.${pkgs.stdenv.system} ];
+    libraries.packages = map (cache: mapAttrs (system: stdenv: cache system) pkgs_multiarch.stdenv) [ gtk2_cache gtk3_cache ];
   };
 
   meta = {

--- a/nixos/modules/i18n/input-method/fcitx.nix
+++ b/nixos/modules/i18n/input-method/fcitx.nix
@@ -1,23 +1,23 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, pkgs_multiarch, lib, ... }:
 
 with lib;
 
 let
   cfg = config.i18n.inputMethod.fcitx;
-  fcitxPackage = pkgs.fcitx.override { plugins = cfg.engines; };
-  fcitxEngine = types.package // {
-    name  = "fcitx-engine";
-    check = x: (lib.types.package.check x) && (attrByPath ["meta" "isFcitxEngine"] false x);
-  };
+  fcitxPackage = system: pkgs_multiarch.fcitx.${system}.override { plugins = map (es: es.${system}) cfg.engines; };
+  fcitxEngines = types.listOf (types.attrsOf (types.package // {
+    name  = "fcitxEngine";
+    check = x: attrByPath ["meta" "isFcitxEngine"] false x;
+  }));
 in
 {
   options = {
 
     i18n.inputMethod.fcitx = {
       engines = mkOption {
-        type    = with types; listOf fcitxEngine;
+        type    = fcitxEngines;
         default = [];
-        example = literalExample "with pkgs.fcitx-engines; [ mozc hangul ]";
+        example = literalExample "with pkgs_multiarch.fcitx-engines; [ mozc hangul ]";
         description =
           let
             enginesDrv = filterAttrs (const isDerivation) pkgs.fcitx-engines;
@@ -31,13 +31,13 @@ in
   };
 
   config = mkIf (config.i18n.inputMethod.enabled == "fcitx") {
-    i18n.inputMethod.package = fcitxPackage;
+    i18n.inputMethod.package = mapAttrs (name: stdenv: fcitxPackage stdenv.system) pkgs_multiarch.stdenv;
 
     environment.variables = {
       GTK_IM_MODULE = "fcitx";
       QT_IM_MODULE  = "fcitx";
       XMODIFIERS    = "@im=fcitx";
     };
-    services.xserver.displayManager.sessionCommands = "${fcitxPackage}/bin/fcitx";
+    services.xserver.displayManager.sessionCommands = "${fcitxPackage pkgs.stdenv.system}/bin/fcitx";
   };
 }

--- a/nixos/modules/i18n/input-method/nabi.nix
+++ b/nixos/modules/i18n/input-method/nabi.nix
@@ -1,9 +1,9 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, pkgs_multiarch, lib, ... }:
 
 with lib;
 {
   config = mkIf (config.i18n.inputMethod.enabled == "nabi") {
-    i18n.inputMethod.package = pkgs.nabi;
+    i18n.inputMethod.package = pkgs_multiarch.nabi;
 
     environment.variables = {
       GTK_IM_MODULE = "nabi";

--- a/nixos/modules/i18n/input-method/uim.nix
+++ b/nixos/modules/i18n/input-method/uim.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, pkgs_multiarch, lib, ... }:
 
 with lib;
 
@@ -22,7 +22,7 @@ in
   };
 
   config = mkIf (config.i18n.inputMethod.enabled == "uim") {
-    i18n.inputMethod.package = pkgs.uim;
+    i18n.inputMethod.package = pkgs_multiarch.uim;
 
     environment.variables = {
       GTK_IM_MODULE = "uim";

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -42,6 +42,10 @@ let
     merge = lib.mergeOneOption;
   };
 
+  prefixArch = pkgs:
+    let system = pkgs.stdenv.system;
+    in mapAttrsRecursiveCond (x: !(isDerivation x)) (path: pkg: { ${system} = pkg; }) pkgs;
+
   _pkgs = import ../../.. config.nixpkgs;
 
 in
@@ -102,6 +106,7 @@ in
     _module.args = {
       pkgs = _pkgs;
       pkgs_i686 = _pkgs.pkgsi686Linux;
+      pkgs_multiarch = recursiveUpdate (prefixArch _pkgs) (prefixArch _pkgs.pkgsi686Linux);
     };
   };
 }

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -20,6 +20,7 @@
   ./config/swap.nix
   ./config/sysctl.nix
   ./config/system-environment.nix
+  ./config/system-libs.nix
   ./config/system-path.nix
   ./config/timezone.nix
   ./config/unix-odbc-drivers.nix

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -21,6 +21,7 @@ in
         PAGER = mkDefault "less -R";
         EDITOR = mkDefault "nano";
         XCURSOR_PATH = [ "$HOME/.icons" ];
+        GTK_DATA_PREFIX = "/run/current-system/sw";
       };
 
     environment.profiles =
@@ -37,15 +38,17 @@ in
         TERMINFO_DIRS = [ "/share/terminfo" ];
         PERL5LIB = [ "/lib/perl5/site_perl" ];
         KDEDIRS = [ "" ];
-        STRIGI_PLUGIN_PATH = [ "/lib/strigi/" ];
-        QT_PLUGIN_PATH = [ "/lib/qt4/plugins" "/lib/kde4/plugins" ];
-        QTWEBKIT_PLUGIN_PATH = [ "/lib/mozilla/plugins/" ];
-        GTK_PATH = [ "/lib/gtk-2.0" "/lib/gtk-3.0" ];
         XDG_CONFIG_DIRS = [ "/etc/xdg" ];
         XDG_DATA_DIRS = [ "/share" ];
         XCURSOR_PATH = [ "/share/icons" ];
-        MOZ_PLUGIN_PATH = [ "/lib/mozilla/plugins" ];
+
         LIBEXEC_PATH = [ "/lib/libexec" ];
+        STRIGI_PLUGIN_PATH = [ "/lib/strigi" ];
+        QT_PLUGIN_PATH = [ "/lib/qt4/plugins" "/lib/kde4/plugins" "/lib/qt5/plugins" ];
+        QTWEBKIT_PLUGIN_PATH = [ "/lib/mozilla/plugins" ];
+        GTK_PATH = [ "/lib/gtk-2.0" "/lib/gtk-3.0" ];
+        MOZ_PLUGIN_PATH = [ "/lib/mozilla/plugins" ];
+        GIO_EXTRA_MODULES = [ "/lib/gio/modules" ];
       };
 
     environment.extraInit =

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -27,7 +27,9 @@ in
     environment.profiles =
       [ "$HOME/.nix-profile"
         "/nix/var/nix/profiles/default"
-        "/run/current-system/sw"
+        "/run/current-system/${pkgs.stdenv.system}-lib"
+      ] ++ optional config.libraries.support32Bit "/run/current-system/${pkgs.pkgsi686Linux.stdenv.system}-lib" ++
+      [ "/run/current-system/sw"
       ];
 
     # TODO: move most of these elsewhere

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -92,11 +92,12 @@ with lib;
     # !!! this hardcodes bash, could we detect from config which shell is actually used?
     (mkRenamedOptionModule [ "environment" "promptInit" ] [ "programs" "bash" "promptInit" ])
 
-    (mkRenamedOptionModule [ "services" "xserver" "driSupport" ] [ "hardware" "opengl" "driSupport" ])
-    (mkRenamedOptionModule [ "services" "xserver" "driSupport32Bit" ] [ "hardware" "opengl" "driSupport32Bit" ])
+    (mkRemovedOptionModule [ "services" "xserver" "driSupport" ] "No longer used")
+    (mkRemovedOptionModule [ "hardware" "opengl" "driSupport" ] "No longer used")
+    (mkRenamedOptionModule [ "services" "xserver" "driSupport32Bit" ] [ "libraries" "support32Bit" ])
     (mkRenamedOptionModule [ "services" "xserver" "s3tcSupport" ] [ "hardware" "opengl" "s3tcSupport" ])
     (mkRenamedOptionModule [ "hardware" "opengl" "videoDrivers" ] [ "services" "xserver" "videoDrivers" ])
-    (mkRenamedOptionModule [ "services" "xserver" "vaapiDrivers" ] [ "hardware" "opengl" "extraPackages" ])
+    (mkRenamedOptionModule [ "services" "xserver" "vaapiDrivers" ] [ "libraries" "packages" ])
 
     (mkRenamedOptionModule [ "services" "mysql55" ] [ "services" "mysql" ])
 
@@ -214,5 +215,9 @@ with lib;
     (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "theme" ] [ "programs" "zsh" "ohMyZsh" "theme" ])
     (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "custom" ] [ "programs" "zsh" "ohMyZsh" "custom" ])
     (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "plugins" ] [ "programs" "zsh" "ohMyZsh" "plugins" ])
+
+    # Libraries
+    (mkRenamedOptionModule [ "hardware" "opengl" "driSupport32Bit" ] [ "libraries" "support32Bit" ])
+    (mkRenamedOptionModule [ "hardware" "opengl" "extraPackages" ] [ "libraries" "packages" ])
   ];
 }

--- a/nixos/modules/services/hardware/acpid.nix
+++ b/nixos/modules/services/hardware/acpid.nix
@@ -118,9 +118,8 @@ in
       unitConfig = {
         ConditionVirtualization = "!systemd-nspawn";
         ConditionPathExists = [ "/proc/acpi" ];
+        ExecStart = "${pkgs.acpid}/bin/acpid --confdir ${acpiConfDir}";
       };
-
-      script = "acpid --confdir ${acpiConfDir}";
     };
 
   };

--- a/nixos/modules/services/misc/cgminer.nix
+++ b/nixos/modules/services/misc/cgminer.nix
@@ -125,7 +125,6 @@ in
       wantedBy = [ "multi-user.target" ];
 
       environment = {
-        LD_LIBRARY_PATH = ''/run/opengl-driver/lib:/run/opengl-driver-32/lib'';
         DISPLAY = ":${toString config.services.xserver.display}";
         GPU_MAX_ALLOC_PERCENT = "100";
         GPU_USE_SYNC_OBJECTS = "1";

--- a/nixos/modules/services/misc/dictd.nix
+++ b/nixos/modules/services/misc/dictd.nix
@@ -61,7 +61,6 @@ in
     systemd.services.dictd = {
       description = "DICT.org Dictionary Server";
       wantedBy = [ "multi-user.target" ];
-      environment = { LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive"; };
       serviceConfig.Type = "forking";
       script = "${pkgs.dict}/sbin/dictd -s -c ${dictdb}/share/dictd/dictd.conf --locale en_US.UTF-8";
     };

--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -49,8 +49,7 @@ let
       partOf = [ "samba.target" ];
 
       environment = {
-        LD_LIBRARY_PATH = nssModulesPath;
-        LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
+        LD_LIBRARY_PATH = [ nssModulesPath ];
       };
 
       serviceConfig = {

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -51,7 +51,7 @@ in
 
         wantedBy = [ "nss-lookup.target" "nss-user-lookup.target" ];
 
-        environment = { LD_LIBRARY_PATH = nssModulesPath; };
+        environment."LD_LIBRARY_PATH" = [ nssModulesPath ];
 
         preStart =
           ''

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -38,21 +38,18 @@ in
       pkgs.xorg.xcursorthemes
     ];
 
-    environment.pathsToLink = [ "/etc/enlightenment" "/etc/xdg" "/share/enlightenment" "/share/elementary" "/share/applications" "/share/locale" "/share/icons" "/share/themes" "/share/mime" "/share/desktop-directories" ];
+    environment.pathsToLink = [
+      "/etc/enlightenment" "/etc/xdg" "/share/enlightenment"
+      "/share/elementary" "/share/applications" "/share/locale" "/share/icons"
+      "/share/themes" "/share/mime" "/share/desktop-directories"
+    ];
 
     services.xserver.desktopManager.session = [
     { name = "Enlightenment";
       start = ''
-        # Set GTK_DATA_PREFIX so that GTK+ can find the themes
-        export GTK_DATA_PREFIX=${config.system.path}
-        # find theme engines
-        export GTK_PATH=${config.system.path}/lib/gtk-3.0:${config.system.path}/lib/gtk-2.0
         export XDG_MENU_PREFIX=enlightenment
 
         export GST_PLUGIN_PATH="${GST_PLUGIN_PATH}"
-
-        # make available for D-BUS user services
-        #export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}:${config.system.path}/share:${e.efl}/share
 
         # Update user dirs as described in http://freedesktop.org/wiki/Software/xdg-user-dirs/
         ${pkgs.xdg-user-dirs}/bin/xdg-user-dirs-update
@@ -92,7 +89,6 @@ in
             StandardOutput = "null";
           };
       };
-
 
   };
 

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -135,12 +135,6 @@ in {
       { name = "gnome3";
         bgSupport = true;
         start = ''
-          # Set GTK_DATA_PREFIX so that GTK+ can find the themes
-          export GTK_DATA_PREFIX=${config.system.path}
-
-          # find theme engines
-          export GTK_PATH=${config.system.path}/lib/gtk-3.0:${config.system.path}/lib/gtk-2.0
-
           export XDG_MENU_PREFIX=gnome
 
           ${concatMapStrings (p: ''
@@ -162,9 +156,6 @@ in {
 
           # Let nautilus find extensions
           export NAUTILUS_EXTENSION_DIR=${config.system.path}/lib/nautilus/extensions-3.0/
-
-          # Find the mouse
-          export XCURSOR_PATH=~/.icons:${config.system.path}/share/icons
 
           # Update user dirs as described in http://freedesktop.org/wiki/Software/xdg-user-dirs/
           ${pkgs.xdg-user-dirs}/bin/xdg-user-dirs-update

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, pkgs_multiarch, ... }:
 
 with lib;
 
@@ -167,9 +167,8 @@ in {
 
     services.xserver.updateDbusEnvironment = true;
 
-    environment.variables.GIO_EXTRA_MODULES = [ "${gnome3.dconf}/lib/gio/modules"
-                                                "${gnome3.glib_networking.out}/lib/gio/modules"
-                                                "${gnome3.gvfs}/lib/gio/modules" ];
+    libraries.packages = with pkgs_multiarch.gnome3; [ dconf glib_networking.out gvfs ];
+
     environment.systemPackages = gnome3.corePackages ++ cfg.sessionPath
       ++ (removePackagesByName gnome3.optionalPackages config.environment.gnome3.excludePackages);
 

--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, pkgs_multiarch, ... }:
 
 with lib;
 
@@ -59,7 +59,7 @@ in
       "/share/lxqt"
     ];
 
-    environment.variables.GIO_EXTRA_MODULES = [ "${pkgs.gvfs}/lib/gio/modules" ];
+    libraries.packages = [ pkgs_multiarch.gvfs ];
 
   };
 

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -183,7 +183,6 @@ in
       environment.variables = {
         # Enable GTK applications to load SVG icons
         GDK_PIXBUF_MODULE_FILE = "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache";
-        QT_PLUGIN_PATH = "/run/current-system/sw/lib/qt5/plugins";
       };
 
       fonts.fonts = with pkgs; [ noto-fonts hack-font ];

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, pkgs_multiarch, ... }:
 
 with lib;
 
@@ -78,14 +78,13 @@ in
     services.xserver.updateDbusEnvironment = true;
 
     environment.systemPackages =
-      [ pkgs.gtk2.out # To get GTK+'s themes and gtk-update-icon-cache
+      [ pkgs.gtk2 # To get GTK+'s themes and gtk-update-icon-cache
         pkgs.hicolor_icon_theme
         pkgs.tango-icon-theme
         pkgs.shared_mime_info
         pkgs.which # Needed by the xfce's xinitrc script.
         pkgs."${cfg.screenLock}"
         pkgs.xfce.exo
-        pkgs.xfce.gtk_xfce_engine
         pkgs.xfce.mousepad
         pkgs.xfce.ristretto
         pkgs.xfce.terminal
@@ -117,10 +116,13 @@ in
 	   pkgs.xfce.xfce4notifyd  # found via dbus
          ];
 
+    libraries.packages = with pkgs_multiarch.xfce; [
+      gtk_xfce_engine
+      gvfs
+    ];
+
     environment.pathsToLink =
       [ "/share/xfce4" "/share/themes" "/share/mime" "/share/desktop-directories" "/share/gtksourceview-2.0" ];
-
-    environment.variables.GIO_EXTRA_MODULES = [ "${pkgs.xfce.gvfs}/lib/gio/modules" ];
 
     # Enable helpful DBus services.
     services.udisks2.enable = true;

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -67,9 +67,6 @@ in
           ''
             ${cfg.extraSessionCommands}
 
-            # Set GTK_PATH so that GTK+ can find the theme engines.
-            export GTK_PATH="${config.system.path}/lib/gtk-2.0:${config.system.path}/lib/gtk-3.0"
-
             # Set GTK_DATA_PREFIX so that GTK+ can find the Xfce themes.
             export GTK_DATA_PREFIX=${config.system.path}
 

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -7,23 +7,21 @@ let
   xcfg = config.services.xserver;
   dmcfg = xcfg.displayManager;
   cfg = dmcfg.sddm;
-  xEnv = config.systemd.services."display-manager".environment;
 
   sddm = cfg.package;
 
   xserverWrapper = pkgs.writeScript "xserver-wrapper" ''
-    #!/bin/sh
-    ${concatMapStrings (n: "export ${n}=\"${getAttr n xEnv}\"\n") (attrNames xEnv)}
+    #!${pkgs.stdenv.shell}
     exec systemd-cat ${dmcfg.xserverBin} ${toString dmcfg.xserverArgs} "$@"
   '';
 
   Xsetup = pkgs.writeScript "Xsetup" ''
-    #!/bin/sh
+    #!${pkgs.stdenv.shell}
     ${cfg.setupScript}
   '';
 
   Xstop = pkgs.writeScript "Xstop" ''
-    #!/bin/sh
+    #!${pkgs.stdenv.shell}
     ${cfg.stopScript}
   '';
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -601,10 +601,10 @@ in
 
         environment =
           {
-            XORG_DRI_DRIVER_PATH = "/run/opengl-driver/lib/dri"; # !!! Depends on the driver selected at runtime.
-            LD_LIBRARY_PATH = concatStringsSep ":" (
-              [ "${xorg.libX11.out}/lib" "${xorg.libXext.out}/lib" "/run/opengl-driver/lib" ]
-              ++ concatLists (catAttrs "libPath" cfg.drivers));
+            XORG_DRI_DRIVER_PATH = "/run/current-system/${pkgs.stdenv.system}-lib/lib/dri"; # !!! Depends on the driver selected at runtime.
+            LD_LIBRARY_PATH =
+              [ "${xorg.libX11.out}/lib" "${xorg.libXext.out}/lib" ]
+              ++ concatLists (catAttrs "libPath" cfg.drivers);
           } // cfg.displayManager.job.environment;
 
         preStart =

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1,7 +1,7 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, utils, pkgs, ... }:
 
 with lib;
-with import ./systemd-unit-options.nix { inherit config lib; };
+with import ./systemd-unit-options.nix { inherit config lib utils; };
 with import ./systemd-lib.nix { inherit config lib pkgs; };
 
 let

--- a/nixos/modules/system/boot/systemd-nspawn.nix
+++ b/nixos/modules/system/boot/systemd-nspawn.nix
@@ -1,7 +1,7 @@
-{ config, lib , pkgs, ...}:
+{ config, lib, utils, pkgs, ...}:
 
 with lib;
-with import ./systemd-unit-options.nix { inherit config lib; };
+with import ./systemd-unit-options.nix { inherit config lib utils; };
 with import ./systemd-lib.nix { inherit config lib pkgs; };
 
 let

--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -1,4 +1,4 @@
-{ config, lib }:
+{ config, lib, utils }:
 
 with lib;
 with import ./systemd-lib.nix { inherit config lib pkgs; };
@@ -198,7 +198,7 @@ in rec {
 
     environment = mkOption {
       default = {};
-      type = types.attrs; # FIXME
+      type = utils.environmentAttrs;
       example = { PATH = "/foo/bar/bin"; LANG = "nl_NL.UTF-8"; };
       description = "Environment variables passed to the service's processes.";
     };

--- a/pkgs/applications/graphics/unigine-valley/default.nix
+++ b/pkgs/applications/graphics/unigine-valley/default.nix
@@ -95,7 +95,7 @@ in
       install -m 0755 valley $out/bin/valley
       wrapProgram $out/bin/valley \
         --run "cd $instdir" \
-        --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:$instdir/bin:$libPath
+        --prefix LD_LIBRARY_PATH : $instdir/bin:$libPath
 
       runHook postInstall
     '';

--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -50,7 +50,7 @@ let
   etcProfile = writeText "profile" ''
     export PS1='${name}-chrootenv:\u@\h:\w\$ '
     export LOCALE_ARCHIVE='/usr/lib/locale/locale-archive'
-    export LD_LIBRARY_PATH='/run/opengl-driver/lib:/run/opengl-driver-32/lib:/usr/lib:/usr/lib32'
+    export LD_LIBRARY_PATH='/run/current-system/${pkgs.stdenv.system}-lib/lib:/run/current-system/${pkgsi686Linux.stdenv.system}-lib/lib:/usr/lib:/usr/lib32'
     export PATH='/run/wrappers/bin:/usr/bin:/usr/sbin'
 
     # Force compilers and other tools to look in default search paths

--- a/pkgs/development/libraries/gtk+/2.0-immodules.cache.patch
+++ b/pkgs/development/libraries/gtk+/2.0-immodules.cache.patch
@@ -1,27 +1,52 @@
---- a/gtk/gtkrc.c	2014-09-30 05:02:17.000000000 +0900
-+++ b/gtk/gtkrc.c	2016-04-09 17:39:51.363288355 +0900
-@@ -445,5 +445,23 @@
+diff -ru3 gtk+-2.24.31-old/gtk/gtkrc.c gtk+-2.24.31/gtk/gtkrc.c
+--- gtk+-2.24.31-old/gtk/gtkrc.c	2017-05-31 17:16:50.621477657 +0300
++++ gtk+-2.24.31/gtk/gtkrc.c	2017-05-31 18:31:11.016403313 +0300
+@@ -440,11 +440,47 @@
+ gtk_rc_get_im_module_file (void)
+ {
+   const gchar *var = g_getenv ("GTK_IM_MODULE_FILE");
+-  gchar *result = NULL;
++  const gchar *nix_profiles = g_getenv ("NIX_PROFILES");
++  gchar *result = NULL, *candidate;
++  const gchar * const *nix_dirs;
++  gint i;
+ 
    if (var)
      result = g_strdup (var);
  
-+  // check NIX_PROFILES paths.
-+  const gchar *nixProfilesEnv = g_getenv ("NIX_PROFILES");
-+  gchar *cachePath;
-+  guint i;
-+
-+  if(nixProfilesEnv && !result){
-+    gchar **paths = g_strsplit(nixProfilesEnv, " ", -1);
-+    for (i = 0; paths[i] != NULL; i++){
-+      cachePath = g_build_filename(paths[i], "etc", "gtk-2.0", "immodules.cache", NULL);
-+      if( g_file_test( cachePath, G_FILE_TEST_EXISTS) ){
-+        if(result) g_free(result);
-+        result = g_strdup(cachePath);
-+      }
-+      g_free(cachePath);
++  if(!result && nix_profiles)
++    {
++      nix_dirs = g_strsplit (nix_profiles, " ", -1);
++      for (i = 0; nix_dirs[i]; i++)
++        {
++          candidate = g_build_filename (nix_dirs[i], "etc", "gtk-2.0", "immodules-@system@.cache", NULL);
++          if (g_file_test (candidate, G_FILE_TEST_EXISTS))
++            {
++              if (result)
++                g_free (result);
++              result = candidate;
++            }
++          else
++            g_free (candidate);
++        }
++      if (!result)
++        {
++          for (i = 0; nix_dirs[i]; i++)
++            {
++              candidate = g_build_filename (nix_dirs[i], "etc", "gtk-2.0", "immodules.cache", NULL);
++              if (g_file_test (candidate, G_FILE_TEST_EXISTS))
++                {
++                  if (result)
++                    g_free (result);
++                  result = candidate;
++                }
++              else
++                g_free (candidate);
++            }
++        }
++      g_strfreev (nix_dirs);
 +    }
-+    g_strfreev(paths);
-+  }
 +
    if (!result)
      {
-
+       if (im_module_file)

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gettext, glib, atk, pango, cairo, perl, xorg
+{ stdenv, substituteAll, fetchurl, pkgconfig, gettext, glib, atk, pango, cairo, perl, xorg
 , gdk_pixbuf, libintlOrEmpty, xlibsWrapper
 , xineramaSupport ? stdenv.isLinux
 , cupsSupport ? true, cups ? null
@@ -30,7 +30,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ setupHook perl pkgconfig gettext ];
 
-  patches = [ ./2.0-immodules.cache.patch ./gtk2-theme-paths.patch ];
+  patches = [
+    (substituteAll {
+      src = ./2.0-immodules.cache.patch;
+      inherit (stdenv) system;
+    })
+    ./gtk2-theme-paths.patch
+  ];
 
   propagatedBuildInputs = with xorg;
     [ glib cairo pango gdk_pixbuf atk ]

--- a/pkgs/development/libraries/gtk+/3.0-immodules.cache.patch
+++ b/pkgs/development/libraries/gtk+/3.0-immodules.cache.patch
@@ -1,27 +1,52 @@
---- a/gtk/deprecated/gtkrc.c	2016-04-02 18:43:08.401663112 +0900
-+++ b/gtk/deprecated/gtkrc.c	2016-04-02 18:29:19.927608592 +0900
-@@ -774,5 +774,23 @@
+diff -ru3 gtk+-3.22.12-old/gtk/deprecated/gtkrc.c gtk+-3.22.12/gtk/deprecated/gtkrc.c
+--- gtk+-3.22.12-old/gtk/deprecated/gtkrc.c	2017-05-31 17:45:36.491760231 +0300
++++ gtk+-3.22.12/gtk/deprecated/gtkrc.c	2017-05-31 18:32:13.992465669 +0300
+@@ -769,11 +769,47 @@
+ gtk_rc_get_im_module_file (void)
+ {
+   const gchar *var = g_getenv ("GTK_IM_MODULE_FILE");
+-  gchar *result = NULL;
++  const gchar *nix_profiles = g_getenv ("NIX_PROFILES");
++  gchar *result = NULL, *candidate;
++  const gchar * const *nix_dirs;
++  gint i;
+ 
    if (var)
      result = g_strdup (var);
  
-+  // check NIX_PROFILES paths.
-+  const gchar *nixProfilesEnv = g_getenv ("NIX_PROFILES");
-+  gchar *cachePath;
-+  guint i;
-+
-+  if(nixProfilesEnv && !result){
-+    gchar **paths = g_strsplit(nixProfilesEnv, " ", -1);
-+    for (i = 0; paths[i] != NULL; i++){
-+      cachePath = g_build_filename(paths[i], "etc", "gtk-3.0", "immodules.cache", NULL);
-+      if( g_file_test( cachePath, G_FILE_TEST_EXISTS) ){
-+        if(result) g_free(result);
-+        result = g_strdup(cachePath);
-+      }
-+      g_free(cachePath);
++  if(!result && nix_profiles)
++    {
++      nix_dirs = g_strsplit (nix_profiles, " ", -1);
++      for (i = 0; nix_dirs[i]; i++)
++        {
++          candidate = g_build_filename (nix_dirs[i], "etc", "gtk-3.0", "immodules-@system@.cache", NULL);
++          if (g_file_test (candidate, G_FILE_TEST_EXISTS))
++            {
++              if (result)
++                g_free (result);
++              result = candidate;
++            }
++          else
++            g_free (candidate);
++        }
++      if (!result)
++        {
++          for (i = 0; nix_dirs[i]; i++)
++            {
++              candidate = g_build_filename (nix_dirs[i], "etc", "gtk-3.0", "immodules.cache", NULL);
++              if (g_file_test (candidate, G_FILE_TEST_EXISTS))
++                {
++                  if (result)
++                    g_free (result);
++                  result = candidate;
++                }
++              else
++                g_free (candidate);
++            }
++        }
++      g_strfreev (nix_dirs);
 +    }
-+    g_strfreev(paths);
-+  }
 +
    if (!result)
      {
- 
+       if (im_module_file)

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gettext, perl
+{ stdenv, substituteAll, fetchurl, pkgconfig, gettext, perl
 , expat, glib, cairo, pango, gdk_pixbuf, atk, at_spi2_atk, gobjectIntrospection
 , xorg, epoxy, json_glib, libxkbcommon, gmp
 , waylandSupport ? stdenv.isLinux, wayland, wayland-protocols
@@ -29,7 +29,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig gettext gobjectIntrospection perl ];
 
-  patches = [ ./3.0-immodules.cache.patch ];
+  patches = [
+    (substituteAll {
+      src = ./3.0-immodules.cache.patch;
+      inherit (stdenv) system;
+    })
+  ];
 
   buildInputs = [ libxkbcommon epoxy json_glib ];
   propagatedBuildInputs = with xorg; with stdenv.lib;

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -19,7 +19,7 @@
     and are designed to be the buildInput of other packages.
   - DRI drivers are compiled into $drivers output, which is much bigger and
     depends on LLVM. These should be searched at runtime in
-    "/run/opengl-driver{,-32}/lib/*" and so are kind-of impure (given by NixOS).
+    "/run/current-system/${system}-lib/lib/*" and so are kind-of impure (given by NixOS).
     (I suppose on non-NixOS one would create the appropriate symlinks from there.)
   - libOSMesa is in $osmesa (~4 MB)
 */
@@ -69,7 +69,7 @@ in
 let
   version = "17.1.2";
   branch  = head (splitString "." version);
-  driverLink = "/run/opengl-driver" + optionalString stdenv.isi686 "-32";
+  driverLink = "/run/current-system/${stdenv.system}-lib";
 in
 
 stdenv.mkDerivation {

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -115,9 +115,9 @@ let
       ];
 
       installPhase = base.installPhase + ''
-        wrapProgram $out/bin/factorio                                \
-          --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:$libPath \
-          --run "$out/share/factorio/update-config.sh"               \
+        wrapProgram $out/bin/factorio                  \
+          --prefix LD_LIBRARY_PATH : $libPath          \
+          --run "$out/share/factorio/update-config.sh" \
           --argv0 "" \
           --add-flags "-c \$HOME/.factorio/config.cfg ${optionalString (mods != []) "--mod-directory=${modDir}"}"
 

--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
 
   # the install rule tries to bundle ALL deps into the output for portability
   installPhase = ''
-    RESULT=/run/opengl-driver/lib/
+    RESULT=/run/current-system/${stdenv.system}-lib/lib/
     for x in $libpath; do
       RESULT=$x/lib/:$RESULT
     done

--- a/pkgs/games/tome4/default.nix
+++ b/pkgs/games/tome4/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, openal, libpng, libvorbis, mesa_glu, premake4, SDL2, SDL2_image, SDL2_ttf }:
+{stdenv, fetchurl, openal, libpng, libvorbis, mesa_glu, mesa_noglu, premake4, SDL2, SDL2_image, SDL2_ttf }:
 
 stdenv.mkDerivation rec {
   version = "1.4.9";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     substituteInPlace premake4.lua \
       --replace "/opt/SDL-2.0/include/SDL2" "${SDL2.dev}/include/SDL2" \
-      --replace "/usr/include/GL" "/run/opengl-driver/include"
+      --replace "/usr/include/GL" "${mesa_noglu.dev}/include"
     premake4 gmake
   '';
   makeFlags = [ "config=release" ];


### PR DESCRIPTION
###### Motivation for this change

Currently we have several places in NixOS which use global architecture-dependent modules:

* OpenGL drivers;
* Input methods;
* sane drivers;
* GTK engines;

All of those share common properties:

* They are necessarily "impure";
* They are architecture-dependent -- that is, 32-bit program must use 32-bit modules;
* They are commonly found through hardcoded paths or environment variables.

This patch allows NixOS modules to specify functions that return needed packages given a package set as value for `libraries.packages`. Those functions are combined and used to build per-arch environments in /run/current-system/${system}-lib where `system` is `stdenv.system` for a given arch. Also we add a way to specify PATH-like variables that refer to those directories in `libraries.environment`.

For now those paths are added in `LD_LIBRARY_PATH` like OpenGL drivers currently. We want to move from this when `libglvnd` allows us but meanwhile I sanitize all packages in `libraries.packages`, removing all non-directories in `/lib`. This shields people from accidentially polluting their library path by e.g. adding a VDPAU driver. To avoid sanitization one needs to use `libraries.unsafePackages`, the only current user now is our OpenGL module. When `LD_LIBRARY_PATH=/lib` is dropped this won't be necessary.

The end goal of this patch is to both streamline arch-dependent modules and add multi-arch support to things that don't have it now, for example IM modules. If implemented correctly all applications, both 32-bit and 64-bit, should have same themes, input modules, drivers and all other arch-dependent modules available in the system as long as `libraries.support32Bit` is flipped. Also we get rid of `/run/opengl-driver{,-32}` which I dislike personally (why have it when we already have `/run/current-system`?) :D

This patchset also cleans up our environment variables situation, some things being prerequisites to the main idea and some (DEs envvar cleanup) because they came along and were straightforward.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Initial implementation is finished and I'm now trying to build my system with this. Before continuing though I'd like to hear feedback from others.