### PR TITLE
python.pkgs.txaio: fix tests under python 3.6

### DIFF
--- a/pkgs/development/python-modules/txaio/default.nix
+++ b/pkgs/development/python-modules/txaio/default.nix
@@ -18,8 +18,10 @@ buildPythonPackage rec {
     sed -i '152d' test/test_logging.py
   '';
 
+  # test_chained_callback has been removed just post-2.7.1 because the functionality was decided against and the test
+  # breaks on python 3.6 https://github.com/crossbario/txaio/pull/104
   checkPhase = ''
-    py.test -k "not test_sdist"
+    py.test -k "not (test_sdist or test_chained_callback)"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Consists of disabling the failing test because it is removed upstream.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

