### PR TITLE
insync: check if architecture is x86_64 before downloading the binary.

### DIFF
--- a/pkgs/applications/networking/insync/default.nix
+++ b/pkgs/applications/networking/insync/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     	sha256 = "1gf1qg7mkbcgqhwxkiljmd1w2zvarq6vhxhips3w06bqdyg12210";
       }
     else
-      throw "insync is not supported on ${stdenv.system}";
+      throw "${name} is not supported on ${stdenv.system}";
 
   buildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/networking/insync/default.nix
+++ b/pkgs/applications/networking/insync/default.nix
@@ -3,10 +3,14 @@
 stdenv.mkDerivation rec {
   name = "insync-${version}";
   version = "1.3.16.36155";
-  src = fetchurl {
-    url = "http://s.insynchq.com/builds/insync-portable_${version}_amd64.tar.bz2";
-    sha256 = "1gf1qg7mkbcgqhwxkiljmd1w2zvarq6vhxhips3w06bqdyg12210";
-  };
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "http://s.insynchq.com/builds/insync-portable_${version}_amd64.tar.bz2";
+    	sha256 = "1gf1qg7mkbcgqhwxkiljmd1w2zvarq6vhxhips3w06bqdyg12210";
+      }
+    else
+      throw "insync is not supported on ${stdenv.system}";
 
   buildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
###### Motivation for this change

Check if architecture is x86_64 before downloading the binary.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

