### PR TITLE
instead: 2.4.1 -> 3.0.0; instead-launcher: 0.6.3 -> 0.7.0

### DIFF
--- a/pkgs/games/instead-launcher/default.nix
+++ b/pkgs/games/instead-launcher/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "instead-launcher-${version}";
 
-  version = "0.6.3";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "instead-hub";
     repo = "instead-launcher";
     rev = version;
-    sha256 = "1q0hdgfy9pr48zvxr9x614ka6bd0g8sicdk2a673nwfdyd41p9cw";
+    sha256 = "1svy8i8anspway01pnz2cy69aad03anvkq04wrdfv1h9c34gbvb9";
   };
 
   patches = [ ./path.patch ];

--- a/pkgs/games/instead/default.nix
+++ b/pkgs/games/instead/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, SDL, SDL_ttf, SDL_image, SDL_mixer, pkgconfig, lua, zlib, unzip }:
 
 let
-  version = "2.4.1";
+  version = "3.0.0";
 
   # I took several games at random from http://instead.syscall.ru/games/
   games = [
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/project/instead/instead/${version}/instead_${version}.tar.gz";
-    sha256 = "1i69b10jfb980d5zhmvh1i789hh982vxiwgqna82b84pdf3y7kgw";
+    sha256 = "14scbb5x36dywak930ry7hwv502jnzc4m5cjkymqn1vz1xkq2m5w";
   };
 
   NIX_LDFLAGS = "-llua -lgcc_s";


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
