### PR TITLE
inkscape: patch python interpreter for extension code

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -26,17 +26,18 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs share/extensions
     patchShebangs fix-roff-punct
-  '';
 
-  # Python is used at run-time to execute scripts, e.g., those from
-  # the "Effects" menu.
-  propagatedBuildInputs = [ python2Env ];
+    # Python is used at run-time to execute scripts, e.g., those from
+    # the "Effects" menu.
+    substituteInPlace src/extension/implementation/script.cpp \
+      --replace '"python-interpreter", "python"' '"python-interpreter", "${python2Env}/bin/python"'
+  '';
 
   buildInputs = [
     pkgconfig perl perlXMLParser libXft libpng zlib popt boehmgc
     libxml2 libxslt glib gtkmm2 glibmm libsigcxx lcms boost gettext
     makeWrapper intltool gsl poppler imagemagick libwpg librevenge
-    libvisio libcdr libexif automake114x potrace cmake
+    libvisio libcdr libexif automake114x potrace cmake python2Env
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Previously python extension scripts didn’t work because the interpreter name is hardcoded in the source file.