### PR TITLE
arduino: 1.6.12 -> 1.8.2

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -54,25 +54,25 @@ let
              + stdenv.lib.optionalString (!withGui) "-core";
 in
 stdenv.mkDerivation rec {
-  version = "1.6.12";
+  version = "1.8.2";
   name = "${flavor}-${version}";
 
   src = fetchFromGitHub {
     owner = "arduino";
     repo = "Arduino";
     rev = "${version}";
-    sha256 = "0rz8dv1mncwx2wkafakxqdi2y0rq3f72fr57cg0z5hgdgdm89lkh";
+    sha256 = "1ssznjmzmahayslj2xnci9b5wpsl53nyg85say54akng93qipmfb";
   };
 
   teensyduino_src = fetchurl {
-    url = "http://www.pjrc.com/teensy/td_131/TeensyduinoInstall.${teensy_architecture}";
+    url = "https://www.pjrc.com/teensy/td_136/TeensyduinoInstall.${teensy_architecture}";
     sha256 =
       lib.optionalString ("${teensy_architecture}" == "linux64")
-        "1q4wv6s0900hyv9z1mjq33fr2isscps4q3bsy0h12wi3l7ir94g9"
+        "0qvb5z9y6nsqy0kzib9fvvbn8dakl50vib6r3nm6bnpvyxzwjl2r"
       + lib.optionalString ("${teensy_architecture}" == "linux32")
-        "06fl951f44avqyqim5qmy73siylbqcnsmz55zmj2dzhgf4sflkvc"
+        "14ca62vq7cpx269vfd92shi80qj8spf0dzli8gfcb39ss2zc4jf1"
       + lib.optionalString ("${teensy_architecture}" == "linuxarm")
-        "0ldf33w8wkqwklcj8fn4p22f23ibpwpf7873dc6i2jfmmbx0yvxn";
+        "122z1gxcgkmwjb8wdklb2w8c3qkj5rc1ap5n4a8fi3kjz29va9rx";
   };
 
   buildInputs = [ jdk ant libusb libusb1 unzip zlib ncurses5 readline
@@ -92,6 +92,10 @@ stdenv.mkDerivation rec {
       download_dst=(''${download_dst[@]:1})
       cp -v $file_src $file_dst
     done
+
+    # Deliberately break build.xml's download statement in order to cause
+    # an error if anything needed is missing from download.nix.
+    substituteInPlace build/build.xml --replace "get src" "get error"
 
     cd ./arduino-core && ant
     cd ../build && ant 
@@ -208,7 +212,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Open-source electronics prototyping platform";
     homepage = http://arduino.cc/;
-    license = stdenv.lib.licenses.gpl2;
+    license = if withTeensyduino then licenses.unfreeRedistributable else licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ antono auntie robberer bjornfor ];
   };

--- a/pkgs/development/arduino/arduino-core/downloads.nix
+++ b/pkgs/development/arduino/arduino-core/downloads.nix
@@ -2,28 +2,28 @@
 
 {
   "build/shared/reference-1.6.6-3.zip" = fetchurl {
-    url = "http://downloads.arduino.cc/reference-1.6.6-3.zip";
+    url = "https://downloads.arduino.cc/reference-1.6.6-3.zip";
     sha256 = "119nj1idz85l71fy6a6wwsx0mcd8y0ib1wy0l6j9kz88nkwvggy3";
   };
   "build/shared/Galileo_help_files-1.6.2.zip" = fetchurl {
-    url = "http://downloads.arduino.cc/Galileo_help_files-1.6.2.zip";
+    url = "https://downloads.arduino.cc/Galileo_help_files-1.6.2.zip";
     sha256 = "0qda0xml353sfhjmx9my4mlcyzbf531k40dcr1cnsa438xp2fw0w";
   };
   "build/shared/Edison_help_files-1.6.2.zip" = fetchurl {
-    url = "http://downloads.arduino.cc/Edison_help_files-1.6.2.zip";
+    url = "https://downloads.arduino.cc/Edison_help_files-1.6.2.zip";
     sha256 = "1x25rivmh0zpa6lr8dafyxvim34wl3wnz3r9msfxg45hnbjqqwan";
   };
-  "build/Firmata-2.5.3.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/Firmata/archive/2.5.3.zip";
-    sha256 = "1ims6bdmwv8lgcvd4ri4i39vqm1q5jbwirmki35bybqqb1sl171v";
+  "build/Firmata-2.5.6.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Firmata/archive/2.5.6.zip";
+    sha256 = "117dd4pdlgv60gdlgm2ckjfq89i0dg1q8vszg6hxywdf701c1fk4";
   };
   "build/Bridge-1.6.3.zip" = fetchurl {
     url = "https://github.com/arduino-libraries/Bridge/archive/1.6.3.zip";
     sha256 = "1lha5wkzz63bgcn7bhx4rmgsh9ywa47lffycpyz6qjnl1pvm5mmj";
   };
-  "build/Robot_Control-1.0.2.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/Robot_Control/archive/1.0.2.zip";
-    sha256 = "1wdpz3ilnza3lfd5a628dryic46j72h4a89y8vp0qkbscvifcvdk";
+  "build/Robot_Control-1.0.3.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Robot_Control/archive/1.0.3.zip";
+    sha256 = "1pc3b8skbpx7j32jnxa67mfqhnsmfz3876pc9mdyzpsad4mmcn62";
   };
   "build/Robot_Motor-1.0.2.zip" = fetchurl {
     url = "https://github.com/arduino-libraries/Robot_Motor/archive/1.0.2.zip";
@@ -37,9 +37,9 @@
     url = "https://github.com/arduino-libraries/SpacebrewYun/archive/1.0.1.zip";
     sha256 = "1zs6ymlzw66bglrm0x6d3cvr52q85c8rlm525x0wags111xx3s90";
   };
-  "build/Temboo-1.1.7.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/Temboo/archive/1.1.7.zip";
-    sha256 = "0fq2q6qs0qp15njsl9dif8dkpxgb4cgg8jk3s5y0fcz9lb8m2j50";
+  "build/Temboo-1.2.1.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Temboo/archive/1.2.1.zip";
+    sha256 = "1fyzfihsbcjpjasqbmbbfcall2zl48nzrp4xk9pslppal31mvl8x";
   };
   "build/Esplora-1.0.4.zip" = fetchurl {
     url = "https://github.com/arduino-libraries/Esplora/archive/1.0.4.zip";
@@ -53,72 +53,100 @@
     url = "https://github.com/arduino-libraries/Keyboard/archive/1.0.1.zip";
     sha256 = "1spv73zhjbrb0vgpzjnh6wr3bddlbyzv78d21dbn8z2l0aqv2sac";
   };
+  "build/SD-1.1.1.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/SD/archive/1.1.1.zip";
+    sha256 = "0nackcf7yx5np1s24wnsrcjl8j0nlmqqir6316vqqkfayvb1247n";
+  };
+  "build/Servo-1.1.2.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Servo/archive/1.1.2.zip";
+    sha256 = "14k1883qrx425wnm0r8kszzq32yvvs3jwxf3g7ybp7v0ga0q47l7";
+  };
+  "build/Adafruit_CircuitPlayground-1.6.4.zip" = fetchurl {
+    url = "https://github.com/Adafruit/Adafruit_CircuitPlayground/archive/1.6.4.zip";
+    sha256 = "1ph7m0l1sfx9db56n2h6vi78pn3zyah813lfhqiqghncx34amrhj";
+  };
   "build/libastylej-2.05.1-3.zip" = fetchurl {
-    url = "http://downloads.arduino.cc/libastylej-2.05.1-3.zip";
+    url = "https://downloads.arduino.cc/libastylej-2.05.1-3.zip";
     sha256 = "0a1xy2cdl0xls5r21vy5d2j1dapn1jsdw0vbimlwnzfx7r84mxa6";
   };
-  "build/liblistSerials-1.1.4.zip" = fetchurl {
-    url = "http://downloads.arduino.cc/liblistSerials/liblistSerials-1.1.4.zip";
-    sha256 = "1w0zs155hs5b87i5wj049hfj2jsnf9jk30qq93wz1mxab01261v0";
+  "build/liblistSerials-1.4.0.zip" = fetchurl {
+    url = "https://downloads.arduino.cc/liblistSerials/liblistSerials-1.4.0.zip";
+    sha256 = "129mfbyx7snq3znzhkfbdjiifdr85cwk6wjn8l9ia0wynszs5zyv";
   };
-  "build/shared/WiFi101-Updater-ArduinoIDE-Plugin-0.8.0.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/releases/download/v0.8.0/WiFi101-Updater-ArduinoIDE-Plugin-0.8.0.zip";
-    sha256 = "0fp4mb1qa3w02hrwd51wf261l8ywcl36mi9wipsrgx2y29pk759z";
+  "build/shared/WiFi101-Updater-ArduinoIDE-Plugin-0.9.0.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/releases/download/v0.9.0/WiFi101-Updater-ArduinoIDE-Plugin-0.9.0.zip";
+    sha256 = "1nkk87q2l3bs9y387hdxzgqllm0lqpmc5kdmr6my4hjz5lcpgbza";
   };
 }
 // optionalAttrs (system == "x86_64-linux") {
-  "build/arduino-builder-linux64-1.3.21_r1.tar.bz2" = fetchurl {
-    url = "http://downloads.arduino.cc/tools/arduino-builder-linux64-1.3.21_r1.tar.bz2";
-    sha256 = "1cqx5smzm4dhbj2ah191vbbxi0l7xj95c5gcdbgqm9283hrpfrn7";
+  "build/arduino-builder-linux64-1.3.25.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-linux64-1.3.25.tar.bz2";
+    sha256 = "15y80p255w2rg028vc8dq4hpqsmf770qigv3hgf78npb4qrjnqqf";
   };
-  "build/linux/avr-gcc-4.9.2-atmel3.5.3-arduino2-x86_64-pc-linux-gnu.tar.bz2" = fetchurl {
-    url = "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-x86_64-pc-linux-gnu.tar.bz2";
-    sha256 = "124icbjh28cax6pgg6bzrfdi27shsn9mjjshgrr93pczpg8sc0rr";
+  "build/linux/avr-gcc-4.9.2-atmel3.5.4-arduino2-x86_64-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-x86_64-pc-linux-gnu.tar.bz2";
+    sha256 = "132qm8l6h50z4s9h0i5mfv6bp0iia0pp9kc3gd37hkajy4bh4j0r";
   };
-  "build/linux/avrdude-6.3.0-arduino6-x86_64-pc-linux-gnu.tar.bz2" = fetchurl {
-    url = "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-x86_64-pc-linux-gnu.tar.bz2";
-    sha256 = "08b6dbllnvzv1aqx0v037zks4r3vqcx6yxxv040wf431mmf8gd4p";
+  "build/linux/avrdude-6.3.0-arduino9-x86_64-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-x86_64-pc-linux-gnu.tar.bz2";
+    sha256 = "0shz5ymnlsrbnaqcb13fwbd73hz9k45adw14gf1ywjgywa2cpk68";
+  };
+  "build/linux/arduinoOTA-1.1.1-linux_amd64.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduinoOTA-1.1.1-linux_amd64.tar.bz2";
+    sha256 = "0xy25srvpz6d0yfnz8b17mkmary3k51lb1cvgw7n2zyxayjd0npb";
   };
 }
 // optionalAttrs (system == "i686-linux") {
-  "build/arduino-builder-linux32-1.3.21_r1.tar.bz2" = fetchurl {
-    url = "http://downloads.arduino.cc/tools/arduino-builder-linux32-1.3.21_r1.tar.bz2";
-    sha256 = "1prfwb5scprvd74gihd78ibsdy3806b0fsjhgyj9in4w1q8s3dxj";
+  "build/arduino-builder-linux32-1.3.25.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-linux32-1.3.25.tar.bz2";
+    sha256 = "0hjiqbf7xspdcr7lganqnl68qcmndc9pz06dghkrwzbzc5ki72qr";
   };
-  "build/linux/avr-gcc-4.9.2-atmel3.5.3-arduino2-i686-pc-linux-gnu.tar.bz2" = fetchurl {
-    url = "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-i686-pc-linux-gnu.tar.bz2";
-    sha256 = "0s7chsp1jyk477zvfaraf0yacvlzahkwqxpws4k0kjadghg9a27i";
+  "build/linux/avr-gcc-4.9.2-atmel3.5.4-arduino2-i686-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-i686-pc-linux-gnu.tar.bz2";
+    sha256 = "1d81z5m4cklv29hgb5ywrmyq64ymlwmjx2plm1gzs1mcpg7d9ab3";
   };
-  "build/linux/avrdude-6.3.0-arduino6-i686-pc-linux-gnu.tar.bz2" = fetchurl {
-    url = "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-i686-pc-linux-gnu.tar.bz2";
-    sha256 = "1yyn016b5162j94nmqcznfabi5y2ly27z2whr77387bvjnqc8jsz";
+  "build/linux/avrdude-6.3.0-arduino9-i686-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-i686-pc-linux-gnu.tar.bz2";
+    sha256 = "12r1drjafxwzrvf1y1glxd46rv870mhz1ifn0g328ciwivas4da2";
+  };
+  "build/linux/arduinoOTA-1.1.1-linux_386.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduinoOTA-1.1.1-linux_386.tar.bz2";
+    sha256 = "1vvilbbbvv68svxzyhjspacbavcqakph5glhnz7c0mxkspqixjbs";
   };
 }
 // optionalAttrs (system == "x86_64-darwin") {
-  "build/arduino-builder-macosx-1.3.21_r1.tar.bz2" = fetchurl {
-    url = "http://downloads.arduino.cc/tools/arduino-builder-macosx-1.3.21_r1.tar.bz2";
-    sha256 = "06y5j1z9jjnqa7v6nl9dflm1qqpf3ar1jc53zxgdgsrb9c473d8l";
+  "build/arduino-builder-macosx-1.3.25.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-macosx-1.3.25.tar.bz2";
+    sha256 = "0inkxjzdplb8b17j7lyam6v9gca25rxmsinrkgqnx3xxgkaxz2k0";
   };
-  "build/linux/avr-gcc-4.9.2-arduino5-i386-apple-darwin11.tar.bz2" = fetchurl {
-    url = "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-i386-apple-darwin11.tar.bz2";
-    sha256 = "12r4a1q7mh1gbasy7lqn0p4acg699lglw7il9d5f5vwd32pmh4ii";
+  "build/macosx/avr-gcc-4.9.2-atmel3.5.4-arduino2-i386-apple-darwin11.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-i386-apple-darwin11.tar.bz2";
+    sha256 = "0c27i3y4f5biinxjdpp43wbj00lz7dvl08pnqr7hpkzaalsyvcv7";
   };
-  "build/linux/avrdude-6.3.0-arduino6-i386-apple-darwin11.tar.bz2" = fetchurl {
-    url = "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-i386-apple-darwin11.tar.bz2";
-    sha256 = "11703f0r82aq3mmkiy7vwa4jfjhs9826qpp724hbng9dx74kk86r";
+  "build/macosx/avrdude-6.3.0-arduino9-i386-apple-darwin11.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-i386-apple-darwin11.tar.bz2";
+    sha256 = "0rc4x8mcsva4v6j7ssfj8rdyg14l2pd9ivgdm39m5wnz8b06p85z11703f0r82aq3mmkiy7vwa4jfjhs9826qpp724hbng9dx74kk86r";
+  };
+  "build/macosx/appbundler/appbundler-1.0ea-arduino4.jar.zip" = fetchurl {
+    url = "https://downloads.arduino.cc/appbundler-1.0ea-arduino4.jar.zip";
+    sha256 = "1vz0g98ancfqdf7yx5m3zrxmzb3fwp18zh5lkh2nyl5xlr9m368z";
   };
 }
 // optionalAttrs (system == "armv6l-linux") {
-  "build/arduino-builder-arm-1.3.21_r1.tar.bz2" = fetchurl {
-    url = "http://downloads.arduino.cc/tools/arduino-builder-arm-1.3.21_r1.tar.bz2";
-    sha256 = "1ik6r5n6g20x4pb0vbxbkqxgzj39f13n995ki9xgpsrq22x6g1n4";
+  "build/arduino-builder-linuxarm-1.3.25.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-linuxarm-1.3.25.tar.bz2";
+    sha256 = "1jvlihpcbdv1sgq1wjdwp7dhznk7nd88zin6yj40kr80gcd2ykry";
   };
-  "build/linux/avr-gcc-4.9.2-arduino5-armhf-pc-linux-gnu.tar.bz2" = fetchurl {
-    url = "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-armhf-pc-linux-gnu.tar.bz2";
-    sha256 = "08b8z7ca0wcgzxmjz6q5ihjrm3i10frnrcqpvwjrlsxw37ah1wvp";
+  "build/linux/avr-gcc-4.9.2-atmel3.5.4-arduino2-armhf-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-armhf-pc-linux-gnu.tar.bz2";
+    sha256 = "033jb1vmspcxsv0w9pk73xv195xnbnmckjsiccgqs8xx36g00dpf";
   };
-  "build/linux/avrdude-6.3.0-arduino6-armhf-pc-linux-gnu.tar.bz2" = fetchurl {
-    url = "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-armhf-pc-linux-gnu.tar.bz2";
-    sha256 = "1rybp4hgk0mm7dydr3rj7yx59jzi30s4kyadzkjv13nm4ds209i4";
+  "build/linux/avrdude-6.3.0-arduino9-armhf-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-armhf-pc-linux-gnu.tar.bz2";
+    sha256 = "1kp1xry97385zbrs94j285h1gqlzyyhkchh26z7zq6c0wi5879i5";
+  };
+  "build/linux/arduinoOTA-1.1.1-linux_arm.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduinoOTA-1.1.1-linux_arm.tar.bz2";
+    sha256 = "0k1pib8lmvk6c0y3m038fj3mc18ax1hy3kbvgd5nygrxvy1hv274";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
1.6.12 is no longer supported by the Arduino developers.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Noteworthy changes

While making this update, I made a typo in a filename in downloads.nix, and Arduino's `build.xml` downloaded the correct file itself. In order to make sure all sources are downloaded through Nix, I added a simple patch that breaks `build.xml`'s download functionality.

I also did some investigating to try to find a way to install the Teensyduino version by some method other than running a graphical installer with `xdotool`. But what I discovered is that the graphical installer is a closed-source binary which adds more closed-source binary executables to Arduino (not just firmware). So I changed its license to unfree, and the download method (of everything) from http to https.

