### PR TITLE
musescore (darwin): 2.0.3 -> 2.1

### DIFF
--- a/pkgs/applications/audio/musescore/darwin.nix
+++ b/pkgs/applications/audio/musescore/darwin.nix
@@ -1,20 +1,18 @@
 { stdenv, lib, fetchurl, undmg }:
 
 let
-  major = "2";
-  minor = "1";
-  patch = null;
-  appName = "MuseScore ${major}";
+  versionComponents = [ "2" "1" ];
+  appName = "MuseScore ${builtins.head versionComponents}";
 in
 
 with lib;
 
 stdenv.mkDerivation rec {
   name = "musescore-darwin-${version}";
-  version = "${major}.${minor}" + optionalString (!isNull patch) ".${patch}";
+  version = "${concatStringsSep "." versionComponents}";
 
   src = fetchurl {
-    url =  "ftp://ftp.osuosl.org/pub/musescore/releases/MuseScore-${major}.${minor}/MuseScore-${version}.dmg";
+    url =  "ftp://ftp.osuosl.org/pub/musescore/releases/MuseScore-${concatStringsSep "." (take 3 versionComponents)}/MuseScore-${version}.dmg";
     sha256 = "19xkaxlkbrhvfip6n3iw6q7463ngr6y5gfisrpjqg2xl2igyl795";
   };
 

--- a/pkgs/applications/audio/musescore/darwin.nix
+++ b/pkgs/applications/audio/musescore/darwin.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchurl, undmg }:
+{ stdenv, lib, fetchurl, undmg }:
 
 let
   major = "2";
-  minor = "0.3";
-  patch = "1";
+  minor = "1";
+  patch = null;
   appName = "MuseScore ${major}";
 in
 
+with lib;
+
 stdenv.mkDerivation rec {
   name = "musescore-darwin-${version}";
-  version = "${major}.${minor}.${patch}";
+  version = "${major}.${minor}" + optionalString (!isNull patch) ".${patch}";
 
   src = fetchurl {
     url =  "ftp://ftp.osuosl.org/pub/musescore/releases/MuseScore-${major}.${minor}/MuseScore-${version}.dmg";
-    sha256 = "0a9v2nc7sx2az7xpd9i7b84m7xk9zcydfpis5fj334r5yqds4rm1";
+    sha256 = "19xkaxlkbrhvfip6n3iw6q7463ngr6y5gfisrpjqg2xl2igyl795";
   };
 
   buildInputs = [ undmg ];


### PR DESCRIPTION
N.B. I've very amenable to alternative solutions to [the "no patch in this version" problem](https://github.com/NixOS/nixpkgs/pull/26297/files#diff-32b14c367f3e6d63dcf972d8e619bc5eR14).

###### Motivation for this change

Update to latest version.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
