### PR TITLE
Wrap gnome control center and online accounts

### DIFF
--- a/pkgs/desktops/gnome-3/3.22/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-control-center/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, gnome3, ibus, intltool, upower, makeWrapper
+{ fetchurl, stdenv, pkgconfig, gnome3, ibus, intltool, upower, wrapGAppsHook
 , libcanberra_gtk2, libcanberra_gtk3, accountsservice, libpwquality, libpulseaudio
 , gdk_pixbuf, librsvg, libxkbfile, libnotify, libgudev
 , libxml2, polkit, libxslt, libgtop, libsoup, colord, colord-gtk
@@ -20,13 +20,13 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = false;
 
   buildInputs = with gnome3;
-    [ pkgconfig intltool ibus gtk glib upower libcanberra_gtk2 gsettings_desktop_schemas
+    [ pkgconfig intltool ibus gtk glib glib_networking upower libcanberra_gtk2 gsettings_desktop_schemas
       libxml2 gnome_desktop gnome_settings_daemon polkit libxslt libgtop gnome-menus
       gnome_online_accounts libsoup colord libpulseaudio fontconfig colord-gtk libpwquality
       accountsservice libkrb5 networkmanagerapplet libwacom samba libnotify libxkbfile
       shared_mime_info icu libtool docbook_xsl docbook_xsl_ns gnome3.grilo
       gdk_pixbuf gnome3.defaultIconTheme librsvg clutter clutter_gtk
-      gnome3.vino udev libcanberra_gtk3 libgudev
+      gnome3.vino udev libcanberra_gtk3 libgudev wrapGAppsHook
       networkmanager modemmanager makeWrapper gnome3.gnome-bluetooth grilo tracker
       cracklib ];
 
@@ -39,9 +39,6 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = with gnome3; ''
-    wrapProgram $out/bin/gnome-control-center \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:${sound-theme-freedesktop}/share:$out/share:$out/share/gnome-control-center:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
     for i in $out/share/applications/*; do
       substituteInPlace $i --replace "gnome-control-center" "$out/bin/gnome-control-center"
     done

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-online-accounts/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-online-accounts/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, glib, libxslt, gtk, makeWrapper
+{ stdenv, fetchurl, pkgconfig, glib, libxslt, gtk, wrapGAppsHook
 , webkitgtk, json_glib, rest, libsecret, dbus_glib, gnome_common
-, telepathy_glib, intltool, dbus_libs, icu
+, telepathy_glib, intltool, dbus_libs, icu, glib_networking
 , libsoup, docbook_xsl_ns, docbook_xsl, gnome3
 }:
 
@@ -11,15 +11,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ pkgconfig glib libxslt gtk webkitgtk json_glib rest gnome_common makeWrapper
-                  libsecret dbus_glib telepathy_glib intltool icu libsoup
+  buildInputs = [ pkgconfig glib libxslt gtk webkitgtk json_glib rest gnome_common wrapGAppsHook
+                  libsecret dbus_glib telepathy_glib glib_networking intltool icu libsoup
                   docbook_xsl_ns docbook_xsl gnome3.defaultIconTheme ];
-
-  preFixup = ''
-    for f in "$out/libexec/"*; do
-      wrapProgram "$f" --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-    done
-  '';
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

I could not add an exchange account using `gnome-online-accounts` because it could not find `glib_networking`

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

