### PR TITLE
seth: 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/applications/altcoins/seth.nix
+++ b/pkgs/applications/altcoins/seth.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "seth-${version}";
-  version = "0.5.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "dapphub";
     repo = "seth";
     rev = "v${version}";
-    sha256 = "0bgygvilhbabb0y9pv9cn8cx7cj513w9is4vh6v69h2czknrjmgz";
+    sha256 = "1qph1gldj24r8l6aswb1w133lrm8zsxmmxl4krjik0a73bm4ghdm";
   };
 
   nativeBuildInputs = [makeWrapper];


### PR DESCRIPTION
###### Motivation for this change

This release of Seth restores a couple of yanked subcommands which turned out to be needed for compatibility with https://github.com/dapphub/dapp.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
