### PR TITLE
pythonPackages.uncertainties: move to development/python-modules

### DIFF
--- a/pkgs/development/python-modules/uncertainties/default.nix
+++ b/pkgs/development/python-modules/uncertainties/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchPypi, buildPythonPackage, nose, numpy }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "uncertainties";
+  version = "3.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "de0765cac6911e5afa93ee941063a07b4a98dbd9c314c5eea4ab14bfff0054a4";
+  };
+
+  buildInputs = [ nose numpy ];
+
+  # No tests included
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "http://pythonhosted.org/uncertainties/";
+    description = "Transparent calculations with uncertainties on the quantities involved (aka error propagation)";
+    maintainer = with maintainers; [ rnhmjoj ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -28148,27 +28148,7 @@ EOF
   };
 
 
-  uncertainties = buildPythonPackage rec {
-    name = "uncertainties-${version}";
-    version = "3.0.1";
-
-    src = pkgs.fetchurl {
-       url = "mirror://pypi/u/uncertainties/${name}.tar.gz";
-       sha256 = "de0765cac6911e5afa93ee941063a07b4a98dbd9c314c5eea4ab14bfff0054a4";
-    };
-
-    buildInputs = with self; [ nose numpy ];
-
-    meta = {
-      homepage = "http://pythonhosted.org/uncertainties/";
-      description = "Transparent calculations with uncertainties on the quantities involved (aka error propagation)";
-      license = licenses.bsd3;
-    };
-
-    # No tests included
-    doCheck = false;
-  };
-
+  uncertainties = callPackage ../development/python-modules/uncertainties { };
 
   funcy = buildPythonPackage rec {
     name = "funcy-1.6";


### PR DESCRIPTION
###### Motivation for this change
Moving libraries outside python-packages.nix


###### Things done

- [x] Tested using sandboxing
  - Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (none)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

