### PR TITLE
php: set extension dir to correct location

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -274,9 +274,10 @@ let
 
         #[[ -z "$libxml2" ]] || addToSearchPath PATH $libxml2/bin
 
+        export EXTENSION_DIR=$out/lib/php/extensions
+
         configureFlags+=(--with-config-file-path=$out/etc \
-          --includedir=$dev/include \
-          EXTENSION_DIR=$out/lib/php/extensions)
+          --includedir=$dev/include)
       '';
 
       configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

The extension dir was no longer correctly set to $out/lib/php/extensions
as PHP expects the EXTENSION_DIR as environment variable not config flag.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

