### PR TITLE
python.pkgs.magic-wormhole: fix build mostly through adding new dependencies

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonAtLeast
 , nettools
 , glibcLocales
 , autobahn
@@ -12,6 +13,10 @@
 , tqdm
 , python
 , mock
+, ipaddress
+, humanize
+, pyopenssl
+, service-identity
 }:
 
 buildPythonPackage rec {
@@ -26,7 +31,7 @@ buildPythonPackage rec {
 
   checkInputs = [ mock ];
   buildInputs = [ nettools glibcLocales ];
-  propagatedBuildInputs = [ autobahn cffi click hkdf pynacl spake2 tqdm ];
+  propagatedBuildInputs = [ autobahn cffi click hkdf pynacl spake2 tqdm ipaddress humanize pyopenssl service-identity ];
 
   postPatch = ''
     sed -i -e "s|'ifconfig'|'${nettools}/bin/ifconfig'|" src/wormhole/ipaddrs.py
@@ -34,6 +39,8 @@ buildPythonPackage rec {
     # XXX: disable one test due to warning:
     # setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
     sed -i -e "s|def test_text_subprocess|def skip_test_text_subprocess|" src/wormhole/test/test_scripts.py
+  '' + lib.optionalString (pythonAtLeast "3.3") ''
+    sed -i -e 's|"ipaddress",||' setup.py
   '';
 
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Things that build are good.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

