### PR TITLE
gh-ost: init at 1.0.36

### DIFF
--- a/pkgs/tools/misc/gh-ost/default.nix
+++ b/pkgs/tools/misc/gh-ost/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+let
+  goPackagePath = "github.com/github/gh-ost";
+  version = "1.0.36";
+  sha256 = "0qa7k50bf87bx7sr6iwqri8l49f811gs0bj3ivslxfibcs1z5d4h";
+
+in {
+  gh-ost = buildGoPackage ({
+    name = "gh-ost-${version}";
+    inherit goPackagePath;
+
+    src = fetchFromGitHub {
+      owner = "github";
+      repo  = "gh-ost";
+      rev   = "v${version}";
+      inherit sha256;
+    };
+
+    meta = with stdenv.lib; {
+      description = "Triggerless online schema migration solution for MySQL";
+      homepage = https://github.com/github/gh-ost;
+      license = licenses.mit;
+      platforms = platforms.linux;
+    };
+  });
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -999,6 +999,8 @@ with pkgs;
 
   genromfs = callPackage ../tools/filesystems/genromfs { };
 
+  gh-ost = callPackage ../tools/misc/gh-ost { };
+
   gist = callPackage ../tools/text/gist { };
 
   glide = callPackage ../development/tools/glide { };


### PR DESCRIPTION
###### Motivation for this change

The gh-ost utility can be used to manipulate MySQL databases and we would like to use it on our NixOS machines.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

