### PR TITLE
TheanoWithCuda: depend on future for older pythons #26103

### DIFF
--- a/pkgs/development/python-modules/Theano/theano-with-cuda/default.nix
+++ b/pkgs/development/python-modules/Theano/theano-with-cuda/default.nix
@@ -1,5 +1,7 @@
 { buildPythonPackage
 , fetchFromGitHub
+, pythonOlder
+, future
 , numpy
 , six
 , scipy
@@ -57,7 +59,7 @@ buildPythonPackage rec {
     cudatoolkit
     libgpuarray
     cudnn
-  ];
+  ] ++ (stdenv.lib.optional (pythonOlder "3.0") future);
 
   passthru.cudaSupport = true;
 }

--- a/pkgs/development/python-modules/Theano/theano-with-cuda/default.nix
+++ b/pkgs/development/python-modules/Theano/theano-with-cuda/default.nix
@@ -56,7 +56,8 @@ buildPythonPackage rec {
     pycuda
     cudatoolkit
     libgpuarray
-  ] ++ (stdenv.lib.optional (cudnn != null) [ cudnn ]);
+    cudnn
+  ];
 
   passthru.cudaSupport = true;
 }


### PR DESCRIPTION
###### Motivation for this change

Closes #26103.  Needs to be merged after #26263.

###### Things done

I tested the commits against the 17.03 release.  I couldn't get `master` to build due to unrelated issues in building the dependencies.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

