### PR TITLE
Add FeedReader

### DIFF
--- a/pkgs/applications/networking/newsreaders/feedreader/default.nix
+++ b/pkgs/applications/networking/newsreaders/feedreader/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, vala
+, pkgconfig
+, libjson
+, sqlite
+, libsecret
+, libnotify
+, libxml2
+, gettext
+, glib
+, json_glib
+, curl
+, gst_all_1
+, gnome3
+}:
+
+stdenv.mkDerivation rec {
+  name = "feedreader-${version}";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "jangernert";
+    repo = "FeedReader";
+    # When fetchSubmodules=true, rev can't be a tag but must be a commit hash.
+    # See this issue: https://github.com/NixOS/nixpkgs/issues/26302
+    #rev = "v${version}";
+    rev = "c65573befe9faed5bed92359ceaa2cdf033e4e13";
+    sha256 = "1jhhbkgknnv4smj5imvflsk9fmr2kgqgcxr967ih1gq1dyh4pii8";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    cmake
+    vala
+    pkgconfig
+    libjson
+    sqlite
+    libsecret
+    libnotify
+    libxml2
+    gettext
+    curl
+    glib
+    json_glib
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gnome3.libsoup
+    gnome3.webkitgtk
+    gnome3.rest
+    gnome3.libgee
+    gnome3.gnome_online_accounts
+    gnome3.libpeas
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/gsettings-schemas/$name
+    mv $out/share/glib-2.0 $out/share/gsettings-schemas/$name
+    ${glib.dev}/bin/glib-compile-schemas $out/share/gsettings-schemas/$name/glib-2.0/schemas
+  '';
+
+  meta = with stdenv.lib; {
+    description = "RSS/Atom news feed reader with synchronization";
+    longDescription = ''
+      A modern desktop feed reader combining all the advantages of web based
+      services like synchronisation across all your devices.
+    '';
+    homepage = https://jangernert.github.io/FeedReader/;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-online-accounts/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-online-accounts/default.nix
@@ -2,6 +2,7 @@
 , webkitgtk, json_glib, rest, libsecret, dbus_glib, gnome_common
 , telepathy_glib, intltool, dbus_libs, icu
 , libsoup, docbook_xsl_ns, docbook_xsl, gnome3
+, vala
 }:
 
 stdenv.mkDerivation rec {
@@ -13,13 +14,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig glib libxslt gtk webkitgtk json_glib rest gnome_common makeWrapper
                   libsecret dbus_glib telepathy_glib intltool icu libsoup
-                  docbook_xsl_ns docbook_xsl gnome3.defaultIconTheme ];
+                  docbook_xsl_ns docbook_xsl gnome3.defaultIconTheme vala ];
 
   preFixup = ''
     for f in "$out/libexec/"*; do
       wrapProgram "$f" --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
     done
   '';
+
+  configureFlags = [ "--enable-vala" ];
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13353,7 +13353,7 @@ with pkgs;
   clipit = callPackage ../applications/misc/clipit { };
 
   cloud-print-connector = callPackage ../servers/cloud-print-connector { };
-  
+
   cmatrix = callPackage ../applications/misc/cmatrix { };
 
   cmus = callPackage ../applications/audio/cmus {
@@ -13837,6 +13837,8 @@ with pkgs;
   fbreader = callPackage ../applications/misc/fbreader { };
 
   fdr = libsForQt5.callPackage ../applications/science/programming/fdr { };
+
+  feedreader = callPackage ../applications/networking/newsreaders/feedreader {};
 
   fehlstart = callPackage ../applications/misc/fehlstart { };
 
@@ -17789,7 +17791,7 @@ with pkgs;
   coqPackages_8_5 = mkCoqPackages_8_5 coqPackages_8_5;
   coqPackages_8_6 = mkCoqPackages_8_6 coqPackages_8_6;
   coqPackages = coqPackages_8_6;
-  
+
   coq_8_4 = coqPackages_8_4.coq;
   coq_8_5 = coqPackages_8_5.coq;
   coq_8_6 = coqPackages_8_6.coq;


### PR DESCRIPTION
###### Motivation for this change

**NOTE: This is work in progress, not ready yet. I just need some help to finish this.**

FeedReader is a very nice RSS/Atom reader with online synchronization support with ownCloud.

Question: I added Vala support to Gnome Online Accounts. Is this ok? FeedReader requires that.

The `feedreader` package compiles but I get errors when trying to run it:

```
$ nix-shell -p feedreader
$ feedreader
(feedreader:9953): GLib-GIO-ERROR **: Settings schema 'org.gnome.feedreader' is not installed
Trace/breakpoint trap
```

Any ideas how to fix this? I tried adding schema installation to `postInstall` but apparently it doesn't work. I'm using KDE if that matters.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

