### PR TITLE
Overlays

### DIFF
--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -30,10 +30,17 @@
     <para>
       Example usages:
 
+      The listing below can be used to change existing attributes like `src` or `buildInputs`:
       <programlisting>pkgs.foo.override { arg1 = val1; arg2 = val2; ... }</programlisting>
+      
+      The listing below is similar to the one above but applies to all pkgs in nixpkgs. It can be used to extend pkgs with new ones or alter exiting ones. Since there is `self` and `super` one can update a library package and add a program which uses it at the same time.
+      
       <programlisting>import pkgs.path { overlays = [ (self: super: {
     foo = super.foo.override { barSupport = true ; };
   })]};</programlisting>
+
+
+      This third example shows how to modify an input dependency.
       <programlisting>mypkg = pkgs.callPackage ./mypkg.nix {
     mydep = pkgs.mydep.override { ... };
   }</programlisting>

--- a/doc/overlays.xml
+++ b/doc/overlays.xml
@@ -63,36 +63,100 @@ a symbolic link to it in <filename>~/.config/nixpkgs/overlays/</filename> direct
 packages.</para>
 
 <programlisting>
-self: super:
+pkgsself: pkgssuper:
 
 {
-  boost = super.boost.override {
-    python = self.python3;
+  boost = pkgssuper.boost.override {
+    python = pkgsself.python3;
   };
-  rr = super.callPackage ./pkgs/rr {
-    stdenv = self.stdenv_32bit;
+  rr = pkgssuper.callPackage ./pkgs/rr {
+    stdenv = pkgsself.stdenv_32bit;
   };
 }
 </programlisting>
 
-<para>The first argument, usually named <varname>self</varname>, corresponds to the final package
+<para>The first argument, usually named <varname>pkgsself</varname>, corresponds to the final package
 set. You should use this set for the dependencies of all packages specified in your
 overlay. For example, all the dependencies of <varname>rr</varname> in the example above come
-from <varname>self</varname>, as well as the overriden dependencies used in the
+from <varname>pkgsself</varname>, as well as the overriden dependencies used in the
 <varname>boost</varname> override.</para>
 
-<para>The second argument, usually named <varname>super</varname>,
+<para>The second argument, usually named <varname>pkgssuper</varname>,
 corresponds to the result of the evaluation of the previous stages of
 Nixpkgs. It does not contain any of the packages added by the current
 overlay nor any of the following overlays. This set should be used either
 to refer to packages you wish to override, or to access functions defined
 in Nixpkgs. For example, the original recipe of <varname>boost</varname>
-in the above example, comes from <varname>super</varname>, as well as the
+in the above example, comes from <varname>pkgssuper</varname>, as well as the
 <varname>callPackage</varname> function.</para>
 
 <para>The value returned by this function should be a set similar to
 <filename>pkgs/top-level/all-packages.nix</filename>, which contains
 overridden and/or new packages.</para>
+
+</section>
+
+<section xml:id="sec-overlays-extend-modify">
+<title>Overlays used to extend or modify pkgs</title>
+
+<para>
+If you want to extend nixpkgs with your own packages: add new packages, alter existing ones then you can use this code <filename>nixcloud-pkgs.nix</filename>:
+</para>
+
+<programlisting>
+{  pkgs ? import &lt;nixpkgs> {}
+,  nixcloud-backend   ? pkgs.stdenv.lib.cleanSource ../nixcloud-backend
+,  nixcloud-frontend  ? pkgs.stdenv.lib.cleanSource ../nixcloud-frontend
+,  nixcloud-editor    ? pkgs.stdenv.lib.cleanSource ../nixcloud-editor
+, ...
+}:
+let
+  nc-backend = nixcloud-backend;
+  nc-frontend = nixcloud-frontend;
+  
+  newpkgs = import pkgs.path { overlays = [ (pkgsself: pkgssuper: {
+    nixcloud-backend  = pkgs.callPackage nc-backend { inherit newpkgs; };
+    nixcloud-frontend = pkgs.callPackage "${nc-frontend}/release.nix" {
+      inherit nixcloud-editor;
+    };
+  } ) ]; };
+in newpkgs
+</programlisting>
+
+<para>
+If you want to install a package from this new set, do this:
+
+<programlisting>
+nix-build nixcloud-pkgs.nix -A nixcloud-backend
+</programlisting>
+
+If you create additional services, with the nixos module system, then you can reference your new set of modules like this:
+
+<programlisting>
+{...}:
+let
+  ncpkgs = import ./nixcloud-pkgs.nix {};
+in
+  backend = ncpkgs.nixcloud-backend;
+</programlisting>
+
+Yet more interesting, you can use <varname>override</varname> to alter the attribute like this:
+
+<programlisting>
+{...}:
+let
+  ncpkgs = import ./nixcloud-pkgs.nix {};
+in
+  backend = ncpkgs.nixcloud-frontend.override (oldAttrs: rec {
+    API_HOST="wss://....";
+  })
+</programlisting>
+
+
+Note: There used to be a <varname>pkgs.overridePackages</varname> function in <varname>nixpkgs</varname> but it was removed and replaced by the overlays concept described above.
+
+</para>
+
 
 </section>
 


### PR DESCRIPTION
###### Motivation for this change
extended the overlays section of nixpkgs doc. took me quite a few hours until i figued how to use it, see https://stackoverflow.com/questions/44316127/implementing-override-in-my-repository/44318322#44318322

@nbp this is very good work, thanks for creating this overlays stuff!

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] OS X
   - [ x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

