### PR TITLE
radare2: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -13,12 +13,12 @@ let
   optional = stdenv.lib.optional;
 in
 stdenv.mkDerivation rec {
-  version = "1.4.0";
+  version = "1.5.0";
   name = "radare2-${version}";
 
   src = fetchurl {
     url = "http://cloud.radare.org/get/${version}/${name}.tar.gz";
-    sha256 = "bf6e9ad94fd5828d3936563b8b13218433fbf44231cacfdf37a7312ae2b3e93e";
+    sha256 = "1al57j62di1w70lr1yyizfsygh8015sdydf2h5a87g1pd9vzlyfg";
   };
 
 


### PR DESCRIPTION
###### Motivation for this change

new version

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

