### PR TITLE
strongswan: 5.5.2 -> 5.5.3

### DIFF
--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "strongswan-${version}";
-  version = "5.5.2";
+  version = "5.5.3";
 
   src = fetchurl {
     url = "http://download.strongswan.org/${name}.tar.bz2";
-    sha256 = "0slzrr5amn1rs9lrjca0fv5n1ya5jwlspfiqg9xzq1bghg56z5ys";
+    sha256 = "1m7qq0l5pwj1wy0f7h2b7msb1d98rx78z6xg27g0hiqpk6qm9sn5";
   };
 
   dontPatchELF = true;


### PR DESCRIPTION
Strongswan-5.5.3 changelog: https://wiki.strongswan.org/versions/65

I tested it on my own VPN.

Since this fixes a DoS vulnerability it would be great if this can be cherry-picked on `release-17.03` as well.