### PR TITLE
broadcom-sta: add patch for kernel 4.11+

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation {
     ./linux-4.7.patch
     # source: https://git.archlinux.org/svntogit/community.git/tree/trunk/004-linux48.patch?h=packages/broadcom-wl-dkms
     ./linux-4.8.patch
+    # source: https://aur.archlinux.org/cgit/aur.git/tree/linux411.patch?h=broadcom-wl
+    ./linux-4.11.patch
     ./null-pointer-fix.patch
     ./gcc.patch
   ];

--- a/pkgs/os-specific/linux/broadcom-sta/linux-4.11.patch
+++ b/pkgs/os-specific/linux/broadcom-sta/linux-4.11.patch
@@ -1,0 +1,52 @@
+diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+index a9671e2..da36405 100644
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
+@@ -30,6 +30,9 @@
+ #include <linux/kthread.h>
+ #include <linux/netdevice.h>
+ #include <linux/ieee80211.h>
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++#include <linux/sched/signal.h>
++#endif
+ #include <net/cfg80211.h>
+ #include <linux/nl80211.h>
+ #include <net/rtnetlink.h>
+diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+index 489c9f5..f8278ad 100644
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -117,6 +117,9 @@ int wl_found = 0;
+ 
+ typedef struct priv_link {
+ 	wl_if_t *wlif;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++	unsigned long last_rx;
++#endif
+ } priv_link_t;
+ 
+ #define WL_DEV_IF(dev)          ((wl_if_t*)((priv_link_t*)DEV_PRIV(dev))->wlif)
+@@ -2450,6 +2453,9 @@ wl_monitor(wl_info_t *wl, wl_rxsts_t *rxsts, void *p)
+ {
+ 	struct sk_buff *oskb = (struct sk_buff *)p;
+ 	struct sk_buff *skb;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++	priv_link_t *priv_link;
++#endif
+ 	uchar *pdata;
+ 	uint len;
+ 
+@@ -2916,7 +2922,13 @@ wl_monitor(wl_info_t *wl, wl_rxsts_t *rxsts, void *p)
+ 	if (skb == NULL) return;
+ 
+ 	skb->dev = wl->monitor_dev;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++	priv_link = MALLOC(wl->osh, sizeof(priv_link_t));
++	priv_link = netdev_priv(skb->dev);
++	priv_link->last_rx = jiffies;
++#else
+ 	skb->dev->last_rx = jiffies;
++#endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 22)
+ 	skb_reset_mac_header(skb);
+ #else


### PR DESCRIPTION
###### Motivation for this change

broadcom-sta doesn't build against 4.11+ kernel. 

###### Things done

copied patch from arch

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

