### PR TITLE
pythonPackages.Pmw: init at 2.0.1

### DIFF
--- a/pkgs/development/python-modules/Pmw/default.nix
+++ b/pkgs/development/python-modules/Pmw/default.nix
@@ -1,0 +1,15 @@
+{ lib , buildPythonPackage , fetchPypi, tkinter }:
+
+buildPythonPackage rec {
+  pname = "Pmw";
+  version = "2.0.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "080iml3868nxniyn56kcwnbghm10j7fw74a5nj0s19sm4zsji78b";
+  };
+
+  propagatedBuildInputs = [ tkinter ];
+  doCheck = false;
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -240,6 +240,8 @@ in {
 
   plantuml = callPackage ../tools/misc/plantuml { };
 
+  Pmw = callPackage ../development/python-modules/Pmw { };
+
   pyaes = callPackage ../development/python-modules/pyaes.nix { };
 
   pyatspi = if isPy3k then callPackage ../development/python-modules/pyatspi { } else throw "pyatspi not supported for interpreter ${python.executable}";


### PR DESCRIPTION
###### Motivation for this change

Pymol's optional dependency for displaying a menu

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

