### PR TITLE
libnetfilter_log: init at 1.0.1

### DIFF
--- a/pkgs/development/libraries/libmnl/default.nix
+++ b/pkgs/development/libraries/libmnl/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       re-inventing the wheel.
     '';
     homepage = http://netfilter.org/projects/libmnl/index.html;
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = stdenv.lib.licenses.lgpl21Plus;
 
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/development/libraries/libnetfilter_log/default.nix
+++ b/pkgs/development/libraries/libnetfilter_log/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, pkgconfig, libnfnetlink, libmnl }:
+
+stdenv.mkDerivation rec {
+  name = "libnetfilter_log-${version}";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "http://netfilter.org/projects/libnetfilter_log/files/${name}.tar.bz2";
+    sha256 = "089vjcfxl5qjqpswrbgklf4wflh44irmw6sk2k0kmfixfmszxq3l";
+  };
+
+  buildInputs = [ libmnl ];
+  propagatedBuildInputs = [ libnfnetlink ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  meta = with stdenv.lib; {
+    description = "Userspace library providing interface to packets that have been logged by the kernel packet filter";
+    longDescription = ''
+      libnetfilter_log is a userspace library providing interface to packets
+      that have been logged by the kernel packet filter. It is is part of a
+      system that deprecates the old syslog/dmesg based packet logging. This
+      library has been previously known as libnfnetlink_log.
+    '';
+    homepage = http://netfilter.org/projects/libnetfilter_log/;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ orivej nckx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8912,6 +8912,8 @@ with pkgs;
 
   libnetfilter_cttimeout = callPackage ../development/libraries/libnetfilter_cttimeout { };
 
+  libnetfilter_log = callPackage ../development/libraries/libnetfilter_log { };
+
   libnetfilter_queue = callPackage ../development/libraries/libnetfilter_queue { };
 
   libnfnetlink = callPackage ../development/libraries/libnfnetlink { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] ~~macOS~~ (Linux only)
   - [x] Linux
- [ ] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~ (new package)
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~ (no binaries)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).