### PR TITLE
Ipmiview: 2.11.0 -> 2.12.0

### DIFF
--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
    version = "2.12.0";
    buildVersion = "160804";
 
-   src = pkgs.fetchurl {
+   src = fetchurl {
     url = "ftp://ftp.supermicro.com/utility/IPMIView/Linux/IPMIView_${version}_build.${buildVersion}_bundleJRE_Linux_x64.tar.gz";
     sha256 = "787a060413451a4a5993c31805f55a221087b7199bbaf20e9fe1254e2a76db42";
   };
@@ -24,8 +24,9 @@ stdenv.mkDerivation rec {
    installPhase = ''
      mkdir -p $out/bin
      cp -R . $out/
-     echo "$out/jre/bin/java -jar $out/IPMIView20.jar" > $out/bin/IPMIView
-     chmod +x $out/bin/IPMIView
+     makeWrapper $out/jre/bin/java $out/bin/IPMIView \
+       --prefix PATH : "$out/jre/bin" \
+       --add-flags "-jar $out/IPMIView20.jar"
    '';
 
    meta = with stdenv.lib; {

--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -4,10 +4,11 @@ assert stdenv.isLinux;
 
 stdenv.mkDerivation rec {
    name = "IPMIView-${version}";
-   version = "160804";
+   version = "2.12.0";
+   buildVersion = "160804";
 
    src = pkgs.fetchurl {
-    url = "ftp://ftp.supermicro.com/utility/IPMIView/Linux/IPMIView_2.12.0_build.${version}_bundleJRE_Linux_x64.tar.gz";
+    url = "ftp://ftp.supermicro.com/utility/IPMIView/Linux/IPMIView_${version}_build.${buildVersion}_bundleJRE_Linux_x64.tar.gz";
     sha256 = "787a060413451a4a5993c31805f55a221087b7199bbaf20e9fe1254e2a76db42";
   };
 

--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -4,12 +4,12 @@ assert stdenv.isLinux;
 
 stdenv.mkDerivation rec {
    name = "IPMIView-${version}";
-   version = "20151223";
+   version = "160804";
 
-   src = fetchurl {
-     url = "ftp://ftp.supermicro.com/utility/IPMIView/Linux/IPMIView_V2.11.0_bundleJRE_Linux_x64_${version}.tar.gz";
-     sha256 = "1rv9j0id7i2ipm25n60bpfdm1gj44xg2aj8rnx4s6id3ln90q121";
-   };
+   src = pkgs.fetchurl {
+    url = "ftp://ftp.supermicro.com/utility/IPMIView/Linux/IPMIView_2.12.0_build.${version}_bundleJRE_Linux_x64.tar.gz";
+    sha256 = "787a060413451a4a5993c31805f55a221087b7199bbaf20e9fe1254e2a76db42";
+  };
 
    buildInputs = [ patchelf makeWrapper ];
 
@@ -31,4 +31,3 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
    };
   }
-


### PR DESCRIPTION
###### Motivation for this change

Update version to latest. Old version no longer exists.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The package does build now after bumping the version, however when using the program and attempting to launch a console with ipmi I get the error 

> Cannot run program “java” error=2, No such file or directory 

I attempted to fix it and looked around but was unable to find the cause of the error. It seems that it's trying to launch the wrong "java". I don't know if this error existed before because I was never able to use the previous version.