### PR TITLE
doc: clarify building-nixos CD/DVD instructions

### DIFF
--- a/nixos/doc/manual/development/building-nixos.xml
+++ b/nixos/doc/manual/development/building-nixos.xml
@@ -12,12 +12,12 @@ your <filename>configuration.nix</filename> to configure the system that
 would be installed on the CD.</para>
 
 <para>Default CD/DVD configurations are available
-inside <filename>nixos/modules/installer/cd-dvd</filename>.  To build them
-you have to set <envar>NIXOS_CONFIG</envar> before
-running <command>nix-build</command> to build the ISO.
+inside <filename>nixos/modules/installer/cd-dvd</filename>.
 
 <screen>
-$ nix-build -A config.system.build.isoImage -I nixos-config=modules/installer/cd-dvd/installation-cd-minimal.nix</screen>
+$ git clone https://github.com/NixOS/nixpkgs.git
+$ cd nixpkgs/nixos
+$ nix-build -A config.system.build.isoImage -I nixos-config=modules/installer/cd-dvd/installation-cd-minimal.nix default.nix</screen>
 
 </para>
 


### PR DESCRIPTION
This change updates the instructions for building a NixOS ISO so that it's clear how to do it.

Previously, the instructions stated to set NIXOS_CONFIG prior to running `nix-build`, yet the example provided by-passed NIXOS_CONFIG anyway. But the *really* important missing piece is the need for nixos/default.nix. See #21840.

This change removes the NIXOS_CONFIG verbiage, and adds steps to clone nixpkgs and (most importantly) cd'ing into nixpkgs/nixos. That way, the reader may think: *Oh, so I need a default.nix and a configuration.nix. Ahhh, OK.*

I purposely added the redundant default.nix argument.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

