### PR TITLE
nixos/bcache: install udev rules outside initrd too

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -61,6 +61,7 @@ let
           --replace \"/sbin/mdadm \"${pkgs.mdadm}/sbin/mdadm \
           --replace \"/sbin/blkid \"${pkgs.utillinux}/sbin/blkid \
           --replace \"/bin/mount \"${pkgs.utillinux}/bin/mount \
+          --replace \"/bin/sh \"${pkgs.bash}/bin/sh \
           --replace /usr/bin/readlink ${pkgs.coreutils}/bin/readlink \
           --replace /usr/bin/basename ${pkgs.coreutils}/bin/basename
       done

--- a/nixos/modules/tasks/bcache.nix
+++ b/nixos/modules/tasks/bcache.nix
@@ -4,6 +4,8 @@
 
   environment.systemPackages = [ pkgs.bcache-tools ];
 
+  services.udev.packages = [ pkgs.bcache-tools ];
+
   boot.initrd.extraUdevRulesCommands = ''
     cp -v ${pkgs.bcache-tools}/lib/udev/rules.d/*.rules $out/
   ''; 

--- a/pkgs/tools/filesystems/bcache-tools/default.nix
+++ b/pkgs/tools/filesystems/bcache-tools/default.nix
@@ -5,6 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.0.7";
 
   src = fetchurl {
+    name = "${name}.tar.gz";
     url = "https://github.com/g2p/bcache-tools/archive/v${version}.tar.gz";
     sha256 = "1gbsh2qw0a7kgck6w0apydiy37nnz5xvdgipa0yqrfmghl86vmv4";
   };


### PR DESCRIPTION
###### Motivation for this change
Should fix https://github.com/NixOS/nixpkgs/issues/26281 ("Bcache udev rules not installed outside initrd").

(Apparently I cannot verify that these rules are working by generating symlinks to bcache devices in /dev/disk/by-*, because on my system I run LVM on top of bcache.)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

