### PR TITLE
tilix: init at 1.5.8

### DIFF
--- a/pkgs/applications/misc/tilix/default.nix
+++ b/pkgs/applications/misc/tilix/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, dmd, gnome3, dbus
+, gsettings_desktop_schemas, libsecret, desktop_file_utils, gettext, gtkd
+, perlPackages, wrapGAppsHook, xdg_utils }:
+
+stdenv.mkDerivation rec {
+  name = "tilix-${version}";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "gnunn1";
+    repo = "tilix";
+    rev = "${version}";
+    sha256 = "10nw3q6s941dm44bkfryl1xclr1xy1vjr2n8w7g6kfahpcazf8f8";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook dmd desktop_file_utils perlPackages.Po4a pkgconfig xdg_utils
+    wrapGAppsHook
+  ];
+  buildInputs = [ gnome3.dconf gettext gsettings_desktop_schemas gtkd dbus ];
+
+  preBuild = ''
+    makeFlagsArray=(PERL5LIB="${perlPackages.Po4a}/lib/perl5")
+  '';
+
+  postInstall = with gnome3; ''
+    ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
+
+
+  preFixup = ''
+    substituteInPlace $out/share/applications/com.gexperts.Tilix.desktop \
+      --replace "Exec=tilix" "Exec=$out/bin/tilix"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tiling terminal emulator following the Gnome Human Interface Guidelines.";
+    homepage = "https://gnunn1.github.io/tilix-web";
+    licence = licenses.mpl20;
+    maintainer = with maintainers; [ midchildan ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -1,0 +1,98 @@
+{ stdenv, fetchzip, atk, cairo, dmd, gdk_pixbuf, gnome3, gst_all_1, librsvg
+, pango, pkgconfig, substituteAll, which }:
+
+stdenv.mkDerivation rec {
+  name = "gtkd-${version}";
+  version = "3.6.5";
+
+  src = fetchzip {
+    url = "https://gtkd.org/Downloads/sources/GtkD-${version}.zip";
+    sha256 = "1ypxxqklad5wwyvc39wnphnqp5y4q5zbf9j5mxb3bg9vnls48vx1";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ dmd pkgconfig which ];
+  propagatedBuildInputs = [
+    atk cairo gdk_pixbuf glib gstreamer gst_plugins_base gtk3 gtksourceview
+    libgda libpeas librsvg pango vte
+  ];
+
+  prePatch = ''
+    substituteAll ${./paths.d} generated/gtkd/gtkd/paths.d
+    substituteInPlace src/cairo/gtkc/cairo-compiletime.d \
+      --replace libcairo.so.2 ${cairo}/lib/libcairo.so.2 \
+      --replace libcairo.dylib ${cairo}/lib/libcairo.dylib
+    substituteInPlace src/cairo/gtkc/cairo-runtime.d \
+      --replace libcairo.so.2 ${cairo}/lib/libcairo.so.2 \
+      --replace libcairo.dylib ${cairo}/lib/libcairo.dylib
+    substituteInPlace generated/gtkd/gtkc/gdkpixbuf.d \
+      --replace libgdk_pixbuf-2.0.so.0 ${gdk_pixbuf}/lib/libgdk_pixbuf-2.0.so.0 \
+      --replace libgdk_pixbuf-2.0.0.dylib ${gdk_pixbuf}/lib/libgdk_pixbuf-2.0.0.dylib
+    substituteInPlace generated/gtkd/gtkc/atk.d \
+      --replace libatk-1.0.so.0 ${atk}/lib/libatk-1.0.so.0 \
+      --replace libatk-1.0.0.dylib ${atk}/lib/libatk-1.0.0.dylib
+    substituteInPlace generated/gtkd/gtkc/pango.d \
+      --replace libpango-1.0.so.0 ${pango.out}/lib/libpango-1.0.so.0 \
+      --replace libpangocairo-1.0.so.0 ${pango.out}/lib/libpangocairo-1.0.so.0 \
+      --replace libpango-1.0.0.dylib ${pango.out}/lib/libpango-1.0.0.dylib \
+      --replace libpangocairo-1.0.0.dylib ${pango.out}/lib/libpangocairo-1.0.0.dylib
+    substituteInPlace generated/gtkd/gtkc/gobject.d \
+      --replace libgobject-2.0.so.0 ${glib}/lib/libgobject-2.0.so.0 \
+      --replace libgobject-2.0.0.dylib ${glib}/lib/libgobject-2.0.0.dylib
+    substituteInPlace generated/gtkd/gtkc/rsvg.d \
+      --replace librsvg-2.so.2 ${librsvg}/lib/librsvg-2.so.2 \
+      --replace librsvg-2.2.dylib ${librsvg}/lib/librsvg-2.2.dylib
+    substituteInPlace generated/gtkd/gtkc/cairo.d \
+      --replace libcairo.so.2 ${cairo}/lib/libcairo.so.2 \
+      --replace libcairo.dylib ${cairo}/lib/libcairo.dylib
+    substituteInPlace generated/gtkd/gtkc/gdk.d \
+      --replace libgdk-3.so.0 ${gtk3}/lib/libgdk-3.so.0 \
+      --replace libgdk-3.0.dylib ${gtk3}/lib/libgdk-3.0.dylib
+    substituteInPlace generated/peas/peasc/peas.d \
+      --replace libpeas-1.0.so.0 ${libpeas}/lib/libpeas-1.0.so.0 \
+      --replace libpeas-gtk-1.0.so.0 ${libpeas}/lib/libpeas-gtk-1.0.so.0 \
+      --replace libpeas-1.0.0.dylib ${libpeas}/lib/libpeas-1.0.0.dylib \
+      --replace gtk-1.0.0.dylib ${libpeas}/lib/gtk-1.0.0.dylib
+    substituteInPlace generated/vte/vtec/vte.d \
+      --replace libvte-2.91.so.0 ${vte}/lib/libvte-2.91.so.0 \
+      --replace libvte-2.91.0.dylib ${vte}/lib/libvte-2.91.0.dylib
+    substituteInPlace generated/gstreamer/gstreamerc/gstinterfaces.d \
+      --replace libgstvideo-1.0.so.0 ${gst_plugins_base}/lib/libgstvideo-1.0.so.0 \
+      --replace libgstvideo-1.0.0.dylib ${gst_plugins_base}/lib/libgstvideo-1.0.0.dylib
+    substituteInPlace generated/sourceview/gsvc/gsv.d \
+      --replace libgtksourceview-3.0.so.1 ${gtksourceview}/lib/libgtksourceview-3.0.so.1 \
+      --replace libgtksourceview-3.0.1.dylib ${gtksourceview}/lib/libgtksourceview-3.0.1.dylib
+    substituteInPlace generated/gtkd/gtkc/glib.d \
+      --replace libglib-2.0.so.0 ${glib}/lib/libglib-2.0.so.0 \
+      --replace libgmodule-2.0.so.0 ${glib}/lib/libgmodule-2.0.so.0 \
+      --replace libgobject-2.0.so.0 ${glib}/lib/libgobject-2.0.so.0 \
+      --replace libglib-2.0.0.dylib ${glib}/lib/libglib-2.0.0.dylib \
+      --replace libgmodule-2.0.0.dylib ${glib}/lib/libgmodule-2.0.0.dylib \
+      --replace libgobject-2.0.0.dylib ${glib}/lib/libgobject-2.0.0.dylib
+    substituteInPlace generated/gtkd/gtkc/gio.d \
+      --replace libgio-2.0.so.0 ${glib}/lib/libgio-2.0.so.0 \
+      --replace libgio-2.0.0.dylib ${glib}/lib/libgio-2.0.0.dylib
+    substituteInPlace generated/gstreamer/gstreamerc/gstreamer.d \
+      --replace libgstreamer-1.0.so.0 ${gstreamer}/lib/libgstreamer-1.0.so.0 \
+      --replace libgstreamer-1.0.0.dylib ${gstreamer}/lib/libgstreamer-1.0.0.dylib
+    substituteInPlace generated/gtkd/gtkc/gtk.d \
+      --replace libgdk-3.so.0 ${gtk3}/lib/libgdk-3.so.0 \
+      --replace libgtk-3.so.0 ${gtk3}/lib/libgtk-3.so.0 \
+      --replace libgdk-3.0.dylib ${gtk3}/lib/libgdk-3.0.dylib \
+      --replace libgtk-3.0.dylib ${gtk3}/lib/libgtk-3.0.dylib
+  '';
+
+  installFlags = "prefix=$(out)";
+
+  inherit atk cairo gdk_pixbuf librsvg pango;
+  inherit (gnome3) glib gtk3 gtksourceview libgda libpeas vte;
+  inherit (gst_all_1) gstreamer;
+  gst_plugins_base = gst_all_1.gst-plugins-base;
+
+  meta = with stdenv.lib; {
+    description = "D binding and OO wrapper for GTK+";
+    homepage = "https://gtkd.org";
+    licence = licenses.lgpl3Plus;
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/libraries/gtkd/paths.d
+++ b/pkgs/development/libraries/gtkd/paths.d
@@ -1,0 +1,142 @@
+/*
+ * gtkD is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version, with
+ * some exceptions, please read the COPYING file.
+ *
+ * gtkD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with gtkD; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110, USA
+ *
+ * paths.d  -- list of libraries that will be dynamically linked with gtkD
+ *
+ * Added:	John Reimer	-- 2004-12-20
+ * Updated: 2005-02-21 changed names; added version(linux)
+ * Updated: 2005-05-05 updated Linux support
+ * Updated: 2008-02-16 Tango support
+ */
+
+module gtkd.paths;
+
+/*
+ * Define the Libraries that gtkD will be using.
+ *   This is a growable list, as long as the programmer
+ *   also adds to the importLibs list.
+ */
+
+enum LIBRARY
+{
+	ATK,
+	CAIRO,
+	GDK,
+	GDKPIXBUF,
+	GLIB,
+	GMODULE,
+	GOBJECT,
+	GIO,
+	GTHREAD,
+	GTK,
+	PANGO,
+	PANGOCAIRO,
+	GLGDK,
+	GLGTK,
+	GDA,
+	GSV,
+	GSV1,
+	GSTREAMER,
+	GSTINTERFACES,
+	VTE,
+	PEAS,
+	RSVG,
+}
+
+version (Windows)
+{
+	const string[LIBRARY.max+1] importLibs =
+	[
+		LIBRARY.ATK:           "libatk-1.0-0.dll",
+		LIBRARY.CAIRO:         "libcairo-2.dll",
+		LIBRARY.GDK:           "libgdk-3-0.dll",
+		LIBRARY.GDKPIXBUF:     "libgdk_pixbuf-2.0-0.dll",
+		LIBRARY.GLIB:          "libglib-2.0-0.dll",
+		LIBRARY.GMODULE:       "libgmodule-2.0-0.dll",
+		LIBRARY.GOBJECT:       "libgobject-2.0-0.dll",
+		LIBRARY.GIO:           "libgio-2.0-0.dll",
+		LIBRARY.GTHREAD:       "libgthread-2.0-0.dll",
+		LIBRARY.GTK:           "libgtk-3-0.dll",
+		LIBRARY.PANGO:         "libpango-1.0-0.dll",
+		LIBRARY.PANGOCAIRO:    "libpangocairo-1.0-0.dll",
+		LIBRARY.GLGDK:         "libgdkglext-3.0-0.dll",
+		LIBRARY.GLGTK:         "libgtkglext-3.0-0.dll",
+		LIBRARY.GDA:           "libgda-4.0-4.dll",
+		LIBRARY.GSV:           "libgtksourceview-3.0-0.dll",
+		LIBRARY.GSV1:          "libgtksourceview-3.0-1.dll",
+		LIBRARY.GSTREAMER:     "libgstreamer-1.0.dll",
+		LIBRARY.GSTINTERFACES: "libgstvideo-1.0.dll",
+		LIBRARY.VTE:           "libvte-2.91.dll",
+		LIBRARY.PEAS:          "libpeas-1.0.dll",
+		LIBRARY.RSVG:          "librsvg-2-2.dll",
+	];
+}
+else version(darwin)
+{
+	const string[LIBRARY.max+1] importLibs =
+	[
+		LIBRARY.ATK:           "@atk@/lib/libatk-1.0.dylib",
+		LIBRARY.CAIRO:         "@cairo@/lib/libcairo.dylib",
+		LIBRARY.GDK:           "@gtk3@/lib/libgdk-3.0.dylib",
+		LIBRARY.GDKPIXBUF:     "@gdk_pixbuf@/lib/libgdk_pixbuf-2.0.dylib",
+		LIBRARY.GLIB:          "@glib@/lib/libglib-2.0.dylib",
+		LIBRARY.GMODULE:       "@glib@/lib/libgmodule-2.0.dylib",
+		LIBRARY.GOBJECT:       "@glib@/lib/libgobject-2.0.dylib",
+		LIBRARY.GIO:           "@glib@/lib/libgio-2.0.dylib",
+		LIBRARY.GTHREAD:       "@glib@/lib/libgthread-2.0.dylib",
+		LIBRARY.GTK:           "@gtk3@/lib/libgtk-3.0.dylib",
+		LIBRARY.PANGO:         "@pango@/lib/libpango-1.0.dylib",
+		LIBRARY.PANGOCAIRO:    "@pango@/lib/libpangocairo-1.0.dylib",
+		LIBRARY.GLGDK:         "libgdkglext-3.0.dylib",
+		LIBRARY.GLGTK:         "libgtkglext-3.0.dylib",
+		LIBRARY.GDA:           "@libgda@/lib/libgda-2.dylib",
+		LIBRARY.GSV:           "@gtksourceview@/lib/libgtksourceview-3.0.dylib",
+		LIBRARY.GSV1:          "@gtksourceview@/lib/libgtksourceview-3.0.dylib",
+		LIBRARY.GSTREAMER:     "@gstreamer@/lib/libgstreamer-1.0.dylib",
+		LIBRARY.GSTINTERFACES: "@gst_plugins_base@/lib/libgstvideo-1.0.dylib",
+		LIBRARY.VTE:           "@vte@/lib/libvte-2.91.dylib",
+		LIBRARY.PEAS:          "@libpeas@/lib/libpeas-1.0.dylib",
+		LIBRARY.RSVG:          "@librsvg@/lib/librsvg-2.dylib",
+	];
+}
+else
+{
+	const string[LIBRARY.max+1] importLibs =
+	[
+		LIBRARY.ATK:           "@atk@/lib/libatk-1.0.so.0",
+		LIBRARY.CAIRO:         "@cairo@/lib/libcairo.so.2",
+		LIBRARY.GDK:           "@gtk3@/lib/libgdk-3.so.0",
+		LIBRARY.GDKPIXBUF:     "@gdk_pixbuf@/lib/libgdk_pixbuf-2.0.so.0",
+		LIBRARY.GLIB:          "@glib@/lib/libglib-2.0.so.0",
+		LIBRARY.GMODULE:       "@glib@/lib/libgmodule-2.0.so.0",
+		LIBRARY.GOBJECT:       "@glib@/lib/libgobject-2.0.so.0",
+		LIBRARY.GIO:           "@glib@/lib/libgio-2.0.so.0",
+		LIBRARY.GTHREAD:       "@glib@/lib/libgthread-2.0.so.0",
+		LIBRARY.GTK:           "@gtk3@/lib/libgtk-3.so.0",
+		LIBRARY.PANGO:         "@pango@/lib/libpango-1.0.so.0",
+		LIBRARY.PANGOCAIRO:    "@pango@/lib/libpangocairo-1.0.so.0",
+		LIBRARY.GLGDK:         "libgdkglext-3.0.so.0",
+		LIBRARY.GLGTK:         "libgtkglext-3.0.so.0",
+		LIBRARY.GDA:           "@libgda@/lib/libgda-4.0.so.4",
+		LIBRARY.GSV:           "@gtksourceview@/lib/libgtksourceview-3.0.so.0",
+		LIBRARY.GSV1:          "@gtksourceview@/lib/libgtksourceview-3.0.so.1",
+		LIBRARY.GSTREAMER:     "@gstreamer@/lib/libgstreamer-1.0.so.0",
+		LIBRARY.GSTINTERFACES: "@gst_plugins_base@/lib/libgstvideo-1.0.so.0",
+		LIBRARY.VTE:           "@vte@/lib/libvte-2.91.so.0",
+		LIBRARY.PEAS:          "@libpeas@/lib/libpeas-1.0.so.0",
+		LIBRARY.RSVG:          "@librsvg@/lib/librsvg-2.so.2",
+	];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2263,6 +2263,8 @@ with pkgs;
 
   gtdialog = callPackage ../development/libraries/gtdialog {};
 
+  gtkd = callPackage ../development/libraries/gtkd { };
+
   gtkgnutella = callPackage ../tools/networking/p2p/gtk-gnutella { };
 
   gtkvnc = callPackage ../tools/admin/gtk-vnc {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4340,6 +4340,8 @@ with pkgs;
 
   tie = callPackage ../development/tools/misc/tie { };
 
+  tilix = callPackage ../applications/misc/tilix { };
+
   tinc_pre = callPackage ../tools/networking/tinc/pre.nix { };
 
   tiny8086 = callPackage ../applications/virtualization/8086tiny { };


### PR DESCRIPTION
###### Motivation for this change
Tilix is a tiling terminal emulator following the Gnome human interface guidelines.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---