### PR TITLE
Datadog: package update + module refactoring

### DIFF
--- a/nixos/modules/services/monitoring/dd-agent/dd-agent-defaults.nix
+++ b/nixos/modules/services/monitoring/dd-agent/dd-agent-defaults.nix
@@ -1,8 +1,0 @@
-# Generated using update-dd-agent-default, please re-run after updating dd-agent. DO NOT EDIT MANUALLY.
-[
-  "auto_conf"
-  "agent_metrics.yaml.default"
-  "disk.yaml.default"
-  "network.yaml.default"
-  "ntp.yaml.default"
-]

--- a/nixos/modules/services/monitoring/dd-agent/dd-agent.nix
+++ b/nixos/modules/services/monitoring/dd-agent/dd-agent.nix
@@ -16,100 +16,24 @@ let
     forwarder_log_file: /var/log/datadog/forwarder.log
     dogstatsd_log_file: /var/log/datadog/dogstatsd.log
     pup_log_file:       /var/log/datadog/pup.log
-
-    # proxy_host: my-proxy.com
-    # proxy_port: 3128
-    # proxy_user: user
-    # proxy_password: password
-
-    # tags: mytag0, mytag1
     ${optionalString (cfg.tags != null ) "tags: ${concatStringsSep "," cfg.tags }"}
-
-    # collect_ec2_tags: no
-    # recent_point_threshold: 30
-    # use_mount: no
-    # listen_port: 17123
-    # graphite_listen_port: 17124
-    # non_local_traffic: no
-    # use_curl_http_client: False
-    # bind_host: localhost
-
-    # use_pup: no
-    # pup_port: 17125
-    # pup_interface: localhost
-    # pup_url: http://localhost:17125
-
-    # dogstatsd_port : 8125
-    # dogstatsd_interval : 10
-    # dogstatsd_normalize : yes
-    # statsd_forward_host: address_of_own_statsd_server
-    # statsd_forward_port: 8125
-
-    # device_blacklist_re: .*\/dev\/mapper\/lxc-box.*
-
-    # ganglia_host: localhost
-    # ganglia_port: 8651
+    ${cfg.extraDdConfig}
   '';
 
-  diskConfig = pkgs.writeText "disk.yaml" ''
-    init_config:
-
-    instances:
-      - use_mount: no
-  '';
-  
-  networkConfig = pkgs.writeText "network.yaml" ''
-    init_config:
-
-    instances:
-      # Network check only supports one configured instance
-      - collect_connection_state: false
-        excluded_interfaces:
-          - lo
-          - lo0
-  '';
-  
-  postgresqlConfig = pkgs.writeText "postgres.yaml" cfg.postgresqlConfig;
-  nginxConfig = pkgs.writeText "nginx.yaml" cfg.nginxConfig;
-  mongoConfig = pkgs.writeText "mongo.yaml" cfg.mongoConfig;
-  jmxConfig = pkgs.writeText "jmx.yaml" cfg.jmxConfig;
-  processConfig = pkgs.writeText "process.yaml" cfg.processConfig;
-  
   etcfiles =
-    let
-      defaultConfd = import ./dd-agent-defaults.nix;
-    in (map (f: { source = "${pkgs.dd-agent}/agent/conf.d-system/${f}";
-                  target = "dd-agent/conf.d/${f}";
-                }) defaultConfd) ++ [
-      { source = ddConf;
-        target = "dd-agent/datadog.conf";
-      }
-      { source = diskConfig;
-        target = "dd-agent/conf.d/disk.yaml";
-      }
-      { source = networkConfig;
-        target = "dd-agent/conf.d/network.yaml";
-      } ] ++
-    (optional (cfg.postgresqlConfig != null)
-      { source = postgresqlConfig;
-        target = "dd-agent/conf.d/postgres.yaml";
-      }) ++
-    (optional (cfg.nginxConfig != null)
-      { source = nginxConfig;
-        target = "dd-agent/conf.d/nginx.yaml";
-      }) ++
-    (optional (cfg.mongoConfig != null)
-      { source = mongoConfig;
-        target = "dd-agent/conf.d/mongo.yaml";
-      }) ++
-    (optional (cfg.processConfig != null)
-      { source = processConfig;
-        target = "dd-agent/conf.d/process.yaml";
-      }) ++
-    (optional (cfg.jmxConfig != null)
-      { source = jmxConfig;
-        target = "dd-agent/conf.d/jmx.yaml";
-      });
+    map (i: { source = if builtins.hasAttr "config" i
+                       then pkgs.writeText "${i.name}.yaml" i.config
+                       else "${cfg.agent}/agent/conf.d-system/${i.name}.yaml";
+              target = "dd-agent/conf.d/${i.name}.yaml";
+            }
+        ) cfg.integrations ++
+        [ { source = ddConf;
+            target = "dd-agent/datadog.conf";
+          }
+        ];
+
+  # restart triggers
+  etcSources = map (i: i.source) etcfiles;
 
 in {
   options.services.dd-agent = {
@@ -139,44 +63,46 @@ in {
       type = types.uniq (types.nullOr types.string);
     };
 
-    postgresqlConfig = mkOption {
-      description = "Datadog PostgreSQL integration configuration";
-      default = null;
-      type = types.uniq (types.nullOr types.string);
+    agent = mkOption {
+      description = "The dd-agent package to use. Useful when overriding the package.";
+      default = pkgs.dd-agent;
+      type = types.package;
     };
 
-    nginxConfig = mkOption {
-      description = "Datadog nginx integration configuration";
-      default = null;
-      type = types.uniq (types.nullOr types.string);
-    };
-    
-    mongoConfig = mkOption {
-      description = "MongoDB integration configuration";
-      default = null;
-      type = types.uniq (types.nullOr types.string);
-    };
-
-    jmxConfig = mkOption {
-      description = "JMX integration configuration";
-      default = null;
-      type = types.uniq (types.nullOr types.string);
-    };
-
-    processConfig = mkOption {
+    integrations = mkOption {
       description = ''
-        Process integration configuration
- 
-        See http://docs.datadoghq.com/integrations/process/
+        Any integrations to use. Default config used if none
+        specified. It is currently up to the user to make sure that
+        the dd-agent package used has all the dependencies chosen
+        integrations require in scope.
       '';
-      default = null;
-      type = types.uniq (types.nullOr types.string);
+      type = types.listOf (types.attrsOf types.string);
+      default = [];
+      example = ''
+        [ { name = "elastic";
+            config = '''
+              init_config:
+
+              instances:
+                - url: http://localhost:9200
+            ''';
+          }
+          { name = "nginx"; }
+          { name = "ntp"; }
+          { name = "network"; }
+        ]
+      '';
     };
 
+    extraDdConfig = mkOption {
+      description = "Extra settings to append to datadog agent config.";
+      default = "";
+      type = types.string;
+    };
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ pkgs."dd-agent" pkgs.sysstat pkgs.procps ];
+    environment.systemPackages = [ cfg.agent pkgs.sysstat pkgs.procps ];
 
     users.extraUsers.datadog = {
       description = "Datadog Agent User";
@@ -190,46 +116,30 @@ in {
 
     systemd.services.dd-agent = {
       description = "Datadog agent monitor";
-      path = [ pkgs."dd-agent" pkgs.python pkgs.sysstat pkgs.procps ];
+      path = [ cfg.agent pkgs.python pkgs.sysstat pkgs.procps ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        ExecStart = "${pkgs.dd-agent}/bin/dd-agent foreground";
+        ExecStart = "${cfg.agent}/bin/dd-agent foreground";
         User = "datadog";
         Group = "datadog";
         Restart = "always";
         RestartSec = 2;
       };
-      restartTriggers = [ pkgs.dd-agent ddConf diskConfig networkConfig postgresqlConfig nginxConfig mongoConfig jmxConfig processConfig ];
+      restartTriggers = [ cfg.agent ddConf ] ++ etcSources;
     };
 
-    systemd.services.dogstatsd = {
-      description = "Datadog statsd";
-      path = [ pkgs."dd-agent" pkgs.python pkgs.procps ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        ExecStart = "${pkgs.dd-agent}/bin/dogstatsd start";
-        User = "datadog";
-        Group = "datadog";
-        Type = "forking";
-        PIDFile = "/tmp/dogstatsd.pid";
-        Restart = "always";
-        RestartSec = 2;
-      };
-      restartTriggers = [ pkgs.dd-agent ddConf diskConfig networkConfig postgresqlConfig nginxConfig mongoConfig jmxConfig processConfig ];
-    };
-
-    systemd.services.dd-jmxfetch = lib.mkIf (cfg.jmxConfig != null) {
+    systemd.services.dd-jmxfetch = lib.mkIf (builtins.any (i: i.name == "jmx") cfg.integrations) {
       description = "Datadog JMX Fetcher";
-      path = [ pkgs."dd-agent" pkgs.python pkgs.sysstat pkgs.procps pkgs.jdk ];
+      path = [ cfg.agent pkgs.python pkgs.sysstat pkgs.procps pkgs.jdk ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        ExecStart = "${pkgs.dd-agent}/bin/dd-jmxfetch";
+        ExecStart = "${cfg.agent}/bin/dd-jmxfetch";
         User = "datadog";
         Group = "datadog";
         Restart = "always";
         RestartSec = 2;
       };
-      restartTriggers = [ pkgs.dd-agent ddConf diskConfig networkConfig postgresqlConfig nginxConfig mongoConfig jmxConfig ];
+      restartTriggers = [ cfg.agent ddConf ] ++ etcSources;
     };
 
     environment.etc = etcfiles;

--- a/nixos/modules/services/monitoring/dd-agent/update-dd-agent-defaults
+++ b/nixos/modules/services/monitoring/dd-agent/update-dd-agent-defaults
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-dd=$(nix-build --no-out-link -A dd-agent ../../../..)
-echo '# Generated using update-dd-agent-default, please re-run after updating dd-agent. DO NOT EDIT MANUALLY.' > dd-agent-defaults.nix
-echo '[' >> dd-agent-defaults.nix
-echo '  "auto_conf"' >> dd-agent-defaults.nix
-for f in $(find $dd/agent/conf.d-system -maxdepth 1 -type f | grep -v '\.example' | sort); do
-  echo "  \"$(basename $f)\"" >> dd-agent-defaults.nix
-done
-echo ']' >> dd-agent-defaults.nix

--- a/pkgs/tools/networking/dd-agent/datadog-trace-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-trace-agent.nix
@@ -1,0 +1,15 @@
+{ buildGoPackage, fetchFromGitHub, go, rake, git, writeText }:
+
+let version = "5.12.3";
+in
+buildGoPackage {
+  name = "datadog-trace-agent";
+  src = fetchFromGitHub {
+    owner = "datadog";
+    repo = "datadog-trace-agent";
+    rev = version;
+    sha256 = "14qjkzmcvismzm9xkc8wns05c6986agxyiddvpn2dh0af60llx1z";
+  };
+  goPackagePath = "github.com/DataDog/datadog-trace-agent";
+  goDeps = ./trace-deps.nix;
+}

--- a/pkgs/tools/networking/dd-agent/default.nix
+++ b/pkgs/tools/networking/dd-agent/default.nix
@@ -1,5 +1,11 @@
 { stdenv, fetchFromGitHub, pythonPackages
-, sysstat, unzip, makeWrapper }:
+, sysstat, unzip, makeWrapper
+# We need extraBuildInputs as we want to be able to override this
+# package with python packages _and_ have the produced binaries
+# wrapper with their PYTHONPATH. This means overrideAttrs is not
+# strong enough (it overrides too late), we need to call it
+# beforehand.
+, extraBuildInputs ? [ ] }:
 let
   inherit (pythonPackages) python;
   docker_1_10 = pythonPackages.buildPythonPackage rec {
@@ -26,33 +32,42 @@ let
     # due to flake8
     doCheck = false;
   };
+  version = "5.13.2";
+
+  integrations = fetchFromGitHub {
+    owner = "datadog";
+    repo = "integrations-core";
+    rev = version;
+    sha256 = "1nbjmkq0wdfndmx0qap69h2rkwkkb0632j87h9d3j99bykyav3y3";
+  };
 
 in stdenv.mkDerivation rec {
-  version = "5.11.2";
   name = "dd-agent-${version}";
 
   src = fetchFromGitHub {
     owner  = "datadog";
     repo   = "dd-agent";
     rev    = version;
-    sha256 = "1iqxvgpsqibqw3vk79158l2pnb6y4pjhjp2d6724lm5rpz4825lx";
+    sha256 = "0x2bxi70l2yf0wi232qksvcscjdpjg8l7dmgg1286vqryyfazfjb";
   };
 
   buildInputs = [
     python
     unzip
     makeWrapper
-    pythonPackages.requests
-    pythonPackages.psycopg2
-    pythonPackages.psutil
-    pythonPackages.ntplib
-    pythonPackages.simplejson
-    pythonPackages.pyyaml
-    pythonPackages.pymongo_2_9_1
-    pythonPackages.python-etcd
-    pythonPackages.consul
+    pythonPackages.boto
     docker_1_10
-  ];
+    pythonPackages.kazoo
+    pythonPackages.ntplib
+    pythonPackages.consul
+    pythonPackages.python-etcd
+    pythonPackages.pyyaml
+    pythonPackages.requests
+    pythonPackages.simplejson
+    pythonPackages.supervisor
+    pythonPackages.tornado
+    pythonPackages.uptime
+  ] ++ extraBuildInputs;
   propagatedBuildInputs = with pythonPackages; [ python tornado ];
 
   buildCommand = ''
@@ -66,6 +81,24 @@ in stdenv.mkDerivation rec {
 
     # Move out default conf.d so that /etc/dd-agent/conf.d is used
     mv $out/agent/conf.d $out/agent/conf.d-system
+
+    # Sometime between 5.11.2 and 5.13.2 datadog moved out all its
+    # checks into separate repository. Copy them back in so dd-agent
+    # service can easily pick and choose by copying out configs into
+    # its etc files.
+    mkdir -p $out/agent/checks.d
+    for i in ${toString integrations}/* # */
+    do
+      if [ -f "$i/check.py" ]; then
+        if [ -f "$i/conf.yaml.default" -o -f "$i/conf.yaml.example" ]; then
+          local name=$(basename $i)
+          cp $i/check.py $out/agent/checks.d/$name.py
+          # Copy .default file first unless it doesn't exist then copy .default
+          cp $i/conf.yaml.default $out/agent/conf.d-system/$name.yaml &> /dev/null || \
+            cp $i/conf.yaml.example $out/agent/conf.d-system/$name.yaml
+        fi
+      fi
+    done
 
     cat > $out/bin/dd-jmxfetch <<EOF
     #!/usr/bin/env bash

--- a/pkgs/tools/networking/dd-agent/default.nix
+++ b/pkgs/tools/networking/dd-agent/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pythonPackages
-, sysstat, unzip, makeWrapper
+, sysstat, unzip, makeWrapper, datadog-trace-agent
 # We need extraBuildInputs as we want to be able to override this
 # package with python packages _and_ have the produced binaries
 # wrapper with their PYTHONPATH. This means overrideAttrs is not
@@ -114,6 +114,9 @@ in stdenv.mkDerivation rec {
       --prefix PYTHONPATH : $PYTHONPATH
     wrapProgram $out/bin/dd-jmxfetch \
       --prefix PYTHONPATH : $PYTHONPATH
+
+    # Make sure to include trace-agent binary so APM can work.
+    ln -s ${datadog-trace-agent}/bin/agent $out/bin/trace-agent
 
     patchShebangs $out
   '';

--- a/pkgs/tools/networking/dd-agent/trace-deps.nix
+++ b/pkgs/tools/networking/dd-agent/trace-deps.nix
@@ -1,0 +1,73 @@
+[ { goPackagePath = "github.com/cihub/seelog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cihub/seelog";
+      rev = "d2c6e5aa9fbfdd1c624e140287063c7730654115";
+      sha256 = "0ab9kyrh51x1x71z37pwjsla0qv11a1qv697xafyc4r5nq5hds6p";
+    };
+  }
+  { goPackagePath = "github.com/DataDog/datadog-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DataDog/datadog-go";
+      rev = "a9c7a9896c1847c9cc2b068a2ae68e9d74540a5d";
+      sha256 = "1m1vpi2s22dqcq0fqhfp3skzkmsbmhzyiw2kh2dw6ii7qimy8zki";
+    };
+  }
+  { goPackagePath = "github.com/go-ini/ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev = "74bdc99692c3408cb103221e38675ce8fda0a718";
+      sha256 = "0ad93rznilmd1hw20nlkr7ywi3sbd299mynf4db20k5yl34r3498";
+    };
+  }
+  { goPackagePath = "github.com/golang/tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/tools";
+      rev = "219e654bb7266d3b73c4610ed24c33d12560826a";
+      sha256 = "05gj9l8i30iw3yrxsxl6b3bxcxmczw2ghk8i5v96d2ngkzgn5qsz";
+    };
+  }
+  { goPackagePath = "github.com/philhofer/fwd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/philhofer/fwd";
+      rev = "98c11a7a6ec829d672b03833c3d69a7fae1ca972";
+      sha256 = "1vp52nxmnh3acmxa2izlwcly65apm7fmiil76vzijakni36nxi8h";
+    };
+  }
+  { goPackagePath = "github.com/shirou/gopsutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shirou/gopsutil";
+      rev = "70a1b78fe69202d93d6718fc9e3a4d6f81edfd58";
+      sha256 = "04qbzj7r7ahq6s407lh9rb3xagbnaj5wp79siq49qkiz3101kfdb";
+    };
+  }
+  { goPackagePath = "github.com/shirou/w32";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shirou/w32";
+      rev = "bb4de0191aa41b5507caa14b0650cdbddcd9280b";
+      sha256 = "0xh5vqblhr2c3mlaswawx6nipi4rc2x73rbdvlkakmgi0nnl50m4";
+    };
+  }
+  { goPackagePath = "github.com/StackExchange/wmi";
+    fetch = {
+      type = "git";
+      url = "https://github.com/StackExchange/wmi";
+      rev = "e542ed97d15e640bdc14b5c12162d59e8fc67324";
+      sha256 = "0x8l0v8x6n3y97lx7m50j3bnvf3pnpr02bbxig5lyw99ygrkr0yb";
+    };
+  }
+  { goPackagePath = "github.com/tinylib/msgp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tinylib/msgp";
+      rev = "362bfb3384d53ae4d5dd745983a4d70b6d23628c";
+      sha256 = "0b39cp417ndznkfwdqcbh89f9x3ml4rn7kf4l4als7vqrrwk7vrz";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13701,6 +13701,8 @@ with pkgs;
 
   das_watchdog = callPackage ../tools/system/das_watchdog { };
 
+  datadog-trace-agent = callPackage ../tools/networking/dd-agent/datadog-trace-agent.nix {};
+
   dbvisualizer = callPackage ../applications/misc/dbvisualizer {};
 
   dd-agent = callPackage ../tools/networking/dd-agent { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25825,6 +25825,24 @@ EOF
     };
   };
 
+  tornado_3_2_2 = buildPythonPackage rec {
+    name = "tornado-${version}";
+    version = "3.2.2";
+
+    propagatedBuildInputs = with self; [ backports_abc backports_ssl_match_hostname certifi singledispatch ];
+
+    # We specify the name of the test files to prevent
+    # https://github.com/NixOS/nixpkgs/issues/14634
+    checkPhase = ''
+      ${python.interpreter} -m unittest discover *_test.py
+    '';
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/t/tornado/${name}.tar.gz";
+      sha256 = "13mq6nx98999zql8p2zlg4sj2hr2sxq9w11mqzi7rjfjs0z2sn8i";
+    };
+  };
+
   tokenlib = buildPythonPackage rec {
     name = "tokenlib-${version}";
     version = "0.3.1";


### PR DESCRIPTION
###### Motivation for this change
I have previously updated and changed the API of the datadog service. As per request, I have reverted that and I'm submitting it as a pull request instead. Additionally to previous work, I'm also providing an additional patch that brings back the old API without sacrificing any of the new one. Personally I think users should simply upgrade to (what I think is) a much more flexible API.

###### Things done
The upgrade itself is deployed on actual machines running now and works great. The backwards compatibility patch was only tested for evaluation with `nixos-rebuild dry-run`.

