### PR TITLE
half: init at 1.12.0

### DIFF
--- a/pkgs/development/libraries/half/default.nix
+++ b/pkgs/development/libraries/half/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  version = "1.12.0";
+  name = "half-${version}";
+
+  src = fetchzip {
+    url = "mirror://sourceforge/half/${version}/half-${version}.zip";
+    sha256 = "0096xiw8nj86vxnn3lfcl94vk9qbi5i8lnydri9ws358ly6002vc";
+    stripRoot = false;
+  };
+
+  buildCommand = ''
+    mkdir -p $out/include $out/share/doc
+    cp $src/include/half.hpp               $out/include/
+    cp $src/{ChangeLog,LICENSE,README}.txt $out/share/doc/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "C++ library for half precision floating point arithmetics";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = [ maintainers.volth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2327,6 +2327,8 @@ with pkgs;
 
   hal-flash = callPackage ../os-specific/linux/hal-flash { };
 
+  half = callPackage ../development/libraries/half { };
+
   halibut = callPackage ../tools/typesetting/halibut { };
 
   hardinfo = callPackage ../tools/system/hardinfo { };


### PR DESCRIPTION
###### Motivation for this change

Header-only C++ library (one .hpp file).
Having it in nixpkgs made it discoverable by cmake, etc

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

