### PR TITLE
skypeforlinux: 5.2.0.1 -> 5.3.0.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -4,7 +4,7 @@
 
 let
 
-  version = "5.2.0.1";
+  version = "5.3.0.1";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -24,7 +24,7 @@ let
     gnome2.pango
 
     gnome2.gnome_keyring
-    
+
     libnotify
     nspr
     nss
@@ -49,8 +49,8 @@ let
   src =
     if stdenv.system == "x86_64-linux" then
       fetchurl {
-        url = "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_5.2.0.1_amd64.deb";
-        sha256 = "1dwyj5wm2amkysbnzxsskq6sl7rbqggm6n4sabnq7wd5xnbq4i06";
+        url = "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb";
+        sha256 = "08sf9nqnznsydw4965w7ixwwba54hjc02ga7vcnz9vpx5hln3nrz";
       }
     else
       throw "Skype for linux is not supported on ${stdenv.system}";


### PR DESCRIPTION
###### Motivation for this change

Update skypeforlinux to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

