### PR TITLE
nixos/bcache: install udev rules outside initrd too [version 3]

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -167,7 +167,7 @@ let
             --replace /sbin/blkid ${extraUtils}/bin/blkid \
             --replace ${pkgs.lvm2}/sbin ${extraUtils}/bin \
             --replace /sbin/mdadm ${extraUtils}/bin/mdadm \
-            --replace /bin/sh ${extraUtils}/bin/sh \
+            --replace ${pkgs.bash}/bin/sh ${extraUtils}/bin/sh \
             --replace /usr/bin/readlink ${extraUtils}/bin/readlink \
             --replace /usr/bin/basename ${extraUtils}/bin/basename \
             --replace ${udev}/bin/udevadm ${extraUtils}/bin/udevadm

--- a/nixos/modules/tasks/bcache.nix
+++ b/nixos/modules/tasks/bcache.nix
@@ -4,6 +4,8 @@
 
   environment.systemPackages = [ pkgs.bcache-tools ];
 
+  services.udev.packages = [ pkgs.bcache-tools ];
+
   boot.initrd.extraUdevRulesCommands = ''
     cp -v ${pkgs.bcache-tools}/lib/udev/rules.d/*.rules $out/
   ''; 

--- a/pkgs/tools/filesystems/bcache-tools/default.nix
+++ b/pkgs/tools/filesystems/bcache-tools/default.nix
@@ -5,6 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.0.7";
 
   src = fetchurl {
+    name = "${name}.tar.gz";
     url = "https://github.com/g2p/bcache-tools/archive/v${version}.tar.gz";
     sha256 = "1gbsh2qw0a7kgck6w0apydiy37nnz5xvdgipa0yqrfmghl86vmv4";
   };

--- a/pkgs/tools/filesystems/bcache-tools/default.nix
+++ b/pkgs/tools/filesystems/bcache-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, utillinux }:
+{ stdenv, fetchurl, pkgconfig, utillinux, bash }:
 
 stdenv.mkDerivation rec {
   name = "bcache-tools-${version}";
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
 
   preBuild = ''
     export makeFlags="$makeFlags PREFIX=\"$out\" UDEVLIBDIR=\"$out/lib/udev/\"";
+    sed -e "s|/bin/sh|${bash}/bin/sh|" -i *.rules
   '';
 
   preInstall = ''


### PR DESCRIPTION
###### Motivation for this change
This is an alternative version of https://github.com/NixOS/nixpkgs/pull/26344, with what I consider better stage-1.nix changes.

Should fix https://github.com/NixOS/nixpkgs/issues/26281 ("Bcache udev rules not installed outside initrd").

(Apparently I cannot verify that these rules are working by generating symlinks to bcache devices in /dev/disk/by-*, because on my system I run LVM on top of bcache.)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

