### PR TITLE
pgcli: 1.5.1 -> 1.6.0

### DIFF
--- a/pkgs/development/tools/database/pgcli/default.nix
+++ b/pkgs/development/tools/database/pgcli/default.nix
@@ -2,10 +2,10 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "pgcli-${version}";
-  version = "1.5.1";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
-    sha256 = "1wp8pzi9hwz16fpcr0mq3ffydwdscfg5whhzc91757dw995sgl0s";
+    sha256 = "0f1zv4kwi2991pclf8chrhgjwf8jkqxdh5ndc9qx6igh56iyyncz";
     rev = "v${version}";
     repo = "pgcli";
     owner = "dbcli";
@@ -13,7 +13,8 @@ pythonPackages.buildPythonApplication rec {
 
   buildInputs = with pythonPackages; [ pytest mock ];
   checkPhase = ''
-    py.test tests -k 'not test_missing_rc_dir and not test_quoted_db_uri and not test_port_db_uri'
+    mkdir /tmp/homeless-shelter
+    HOME=/tmp/homeless-shelter py.test tests -k 'not test_missing_rc_dir and not test_quoted_db_uri and not test_port_db_uri'
   '';
 
   propagatedBuildInputs = with pythonPackages; [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17679,17 +17679,18 @@ in {
 
   pgspecial = buildPythonPackage rec {
     pname = "pgspecial";
-    version = "1.7.0";
+    version = "1.8.0";
     name = "${pname}-${version}";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "0jnv8mr75pjhj2azb2ljhhkd7s1b0b59f7xps322kqbpmwf26zi9";
+      sha256 = "1dwlv3m4jl34zsakmvxg6hgbfv786jl8dcffxsrlnmcpks829xc9";
     };
 
     buildInputs = with self; [ pytest psycopg2 ];
 
     checkPhase = ''
+      find tests -name \*.pyc -delete
       py.test tests
     '';
 


### PR DESCRIPTION
###### Motivation for this change
Update pgcli to 1.6.0. Also updates pgspecial to 1.8.0, since is the minimum required version for pgcli 1.6.0

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

