### PR TITLE
sqlite3_analyzer: 3.17.0 -> 3.19.2

### DIFF
--- a/pkgs/development/libraries/sqlite/sqlite3_analyzer.nix
+++ b/pkgs/development/libraries/sqlite/sqlite3_analyzer.nix
@@ -1,11 +1,11 @@
 { lib, stdenv, fetchurl, unzip, tcl }:
 
 stdenv.mkDerivation {
-  name = "sqlite3_analyzer-3.17.0";
+  name = "sqlite3_analyzer-3.19.2";
 
   src = fetchurl {
-    url = "https://www.sqlite.org/2017/sqlite-src-3170000.zip";
-    sha256 = "1hs8nzk2pjr4fhhrwcyqwpa24gd4ndp6f0japykg5wfadgp4nxc6";
+    url = "https://www.sqlite.org/2017/sqlite-src-3190200.zip";
+    sha256 = "1hdbs41mdyyy641gix87pllsd29p8dim7gj4qvmiyfra2q5kg749";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

Update sqlite3_analyzer to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

