### PR TITLE
libinput: 1.5.1 -> 1.7.2

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -17,11 +17,11 @@ in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "libinput-${version}";
-  version = "1.5.1";
+  version = "1.7.2";
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/libinput/${name}.tar.xz";
-    sha256 = "d4f63933b0967bd691735af5e3919e2d29c2121d4e05867cc4e10ff3ae8e2dd8";
+    sha256 = "0b1e5a6c106ccc609ccececd9e33e6b27c8b01fc7457ddb4c1dd266e780d6bc2";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Changelogs:

1.5.2: https://lists.freedesktop.org/archives/wayland-devel/2016-November/031926.html
1.5.3: https://lists.freedesktop.org/archives/wayland-devel/2016-December/032110.html
1.5.5: https://lists.freedesktop.org/archives/wayland-devel/2017-January/032610.html
1.6.0: https://lists.freedesktop.org/archives/wayland-devel/2017-January/032746.html
1.6.1: https://lists.freedesktop.org/archives/wayland-devel/2017-February/032940.html
1.6.2: https://lists.freedesktop.org/archives/wayland-devel/2017-February/033169.html
1.6.3: https://lists.freedesktop.org/archives/wayland-devel/2017-March/033377.html
1.7.0: https://lists.freedesktop.org/archives/wayland-devel/2017-March/033531.html
1.7.1: https://lists.freedesktop.org/archives/wayland-devel/2017-April/033962.html
1.7.2: https://lists.freedesktop.org/archives/wayland-devel/2017-May/034037.html

Lots of fixes, most notably around trackpad support on high-dpi
systems.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I can't realistically test `nox-review wip` for this change because it seems to affect practically every huge graphical app.  Right now I'm waiting for the entirety of KDE to build on my laptop...