### PR TITLE
dex: init at 2.4.1

### DIFF
--- a/pkgs/servers/dex/default.nix
+++ b/pkgs/servers/dex/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+let version = "2.4.1"; in
+
+buildGoPackage rec {
+  name = "dex-${version}";
+
+  goPackagePath = "github.com/coreos/dex";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "coreos";
+    repo = "dex";
+    sha256 = "11qpn3wh74mq16xgl9l50n2v02ffqcd14xccf77j5il04xr764nx";
+  };
+
+  subPackages = [
+    "cmd/dex"
+  ];
+
+  buildFlagsArray = [
+    "-ldflags=-w -X ${goPackagePath}/version.Version=${src.rev}"
+  ];
+
+  meta = {
+    description = "OpenID Connect and OAuth2 identity provider with pluggable connectors";
+    license = lib.licenses.asl20;
+    homepage = https://github.com/coreos/dex;
+    maintainers = with lib.maintainers; [benley];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10871,6 +10871,8 @@ with pkgs;
 
   couchpotato = callPackage ../servers/couchpotato {};
 
+  dex-oidc = callPackage ../servers/dex { };
+
   dico = callPackage ../servers/dico { };
 
   dict = callPackage ../servers/dict {


### PR DESCRIPTION
There is already another thing called "dex" that manipulates .desktop
files, so I called this one "dex-oidc" in all-packages.nix.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).