### PR TITLE
xcursor themes: added the comix, flatbed, gruppled, polar and premium xcursor themes

### DIFF
--- a/pkgs/data/icons/comix-xcursor-theme/default.nix
+++ b/pkgs/data/icons/comix-xcursor-theme/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchurl, libX11, libXcursor, variants ?
+  [      "Black"      "Blue"      "Green"      "Orange"      "Red"      "White"
+    "Slim-Black" "Slim-Blue" "Slim-Green" "Slim-Orange" "Slim-Red" "Slim-White" ] }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "${package-name}-${version}";
+  package-name = "comix-xcursor-theme";
+  version = "0.9.0";
+
+  src = fetchurl {
+    url = "http://www.limitland.de/downloads/comixcursors/ComixCursors-${version}.tar.bz2";
+    sha256 = "0j16pihx39kqzw4zyzdlc6qhd1sb8q0kpprz2zz0wia36wvdgsci";
+  };
+  sourceRoot = ".";
+
+  buildInputs = [ libX11 libXcursor ];
+
+  installPhase = ''
+    mkdir -p $out/share/icons
+    for theme in ${concatStringsSep " " variants}; do
+      cp -R ComixCursors-$theme $out/share/icons/
+    done
+  '';
+
+  meta = {
+    description = "Comix X cursor theme";
+    homepage = http://www.limitland.de/comixcursors;
+    platforms = platforms.all;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ msteen ];
+  };
+}

--- a/pkgs/data/icons/flatbed-xcursor-theme/default.nix
+++ b/pkgs/data/icons/flatbed-xcursor-theme/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchurl, libX11, libXcursor, variants ?
+  [    "Black"    "Blue"    "Green"    "Orange"    "White"
+    "LH-Black" "LH-Blue" "LH-Green" "LH-Orange" "LH-White" ] }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "${package-name}-${version}";
+  package-name = "flatbed-xcursor-theme";
+  version = "0.4";
+
+  src = fetchurl {
+    url = "http://www.limitland.de/downloads/flatbedcursors/FlatbedCursors-${version}.tar.bz2";
+    sha256 = "0rwwdyfqikz42fl7srskr91gx8dz0iwswb4zp4lhllcyxv57g9cn";
+  };
+  sourceRoot = ".";
+
+  buildInputs = [ libX11 libXcursor ];
+
+  installPhase = ''
+    mkdir -p $out/share/icons
+    for theme in ${concatStringsSep " " variants}; do
+      cp -R FlatbedCursors-$theme $out/share/icons/
+    done
+  '';
+
+  meta = {
+    description = "Flatbed X cursor theme";
+    homepage = http://www.limitland.de/flatbedcursors;
+    platforms = platforms.all;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ msteen ];
+  };
+}

--- a/pkgs/data/icons/polar-xcursor-theme/default.nix
+++ b/pkgs/data/icons/polar-xcursor-theme/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchurl, variants ? [ "Blue" "Green" ] }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "${package-name}-${version}";
+  package-name = "polar-xcursor-theme";
+  version = "1.4";
+
+  src = fetchurl {
+    url = "https://dl.opendesktop.org/api/files/download/id/1460735356/27913-PolarCursorThemes.tar.bz2";
+    sha256 = "15lmfgpzq9zfsd6q80zp3ylqdxsqmdrl5ykvwlw11qhxzl34viz4";
+  };
+
+  installPhase = ''
+    for theme in ${concatStringsSep " " variants}; do
+      mkdir -p $out/share/icons/$theme
+      cp -R PolarCursorTheme-$theme/{cursors,index.theme} $out/share/icons/PolarCursorTheme-$theme/
+      pushd $out/share/icons/PolarCursorTheme-$theme/cursors
+      # Extracted from one of the comments on this theme.
+      ln -s xterm ibeam
+      ln -s question_arrow whats_this
+      ln -s watch wait
+      ln -s fleur size_all
+      ln -s bottom_right_corner size_fdiag
+      ln -s bottom_left_corner size_bdiag
+      ln -s right_side size_hor
+      ln -s top_side size_ver
+      ln -s hand pointer
+      ln -s hand pointing_hand
+      ln -s dnd-none forbidden
+      ln -s HandGrab openhand
+      ln -s HandSqueezed closedhand
+      popd
+    done
+  '';
+
+  meta = {
+    description = "Polar X cursor theme";
+    homepage = http://www.kde-look.org/content/show.php?content=27913;
+    platforms = platforms.all;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ msteen ];
+  };
+}

--- a/pkgs/data/icons/premium-xcursor-theme/default.nix
+++ b/pkgs/data/icons/premium-xcursor-theme/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchurl, variants ? [ "Premium" "Premium-left" ] }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "${package-name}-${version}";
+  package-name = "premium-xcursor-theme";
+  version = "0.3";
+
+  src = fetchurl {
+    url = "https://dl.opendesktop.org/api/files/download/id/1460735120/14485-Premium-${version}.tar.bz2";
+    sha256 = "15lmfgpzq8zfsd6q80zp3ylqdxsqmdrl5ykvwlw11qhxzl34viz4";
+  };
+
+  installPhase = ''
+    for theme in ${concatStringsSep " " variants}; do
+      mkdir -p $out/share/icons/$theme
+      cp -R $theme/{cursors,index.theme} $out/share/icons/$theme/
+    done
+  '';
+
+  meta = {
+    description = "Premium X cursor theme";
+    homepage = http://www.kde-look.org/content/show.php?content=14485;
+    platforms = platforms.all;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ msteen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12682,6 +12682,8 @@ with pkgs;
 
   comic-relief = callPackage ../data/fonts/comic-relief {};
 
+  comix-xcursor-theme = callPackage ../data/icons/comix-xcursor-theme { };
+
   coreclr = callPackage ../development/compilers/coreclr { };
 
   corefonts = callPackage ../data/fonts/corefonts { };
@@ -12767,6 +12769,8 @@ with pkgs;
   fira-code-symbols = callPackage ../data/fonts/fira-code/symbols.nix { };
 
   fira-mono = callPackage ../data/fonts/fira-mono { };
+
+  flatbed-xcursor-theme = callPackage ../data/icons/flatbed-xcursor-theme { };
 
   font-awesome-ttf = callPackage ../data/fonts/font-awesome-ttf { };
 
@@ -12921,11 +12925,15 @@ with pkgs;
   paratype-pt-sans = callPackage ../data/fonts/paratype-pt/sans.nix {};
   paratype-pt-serif = callPackage ../data/fonts/paratype-pt/serif.nix {};
 
+  polar-xcursor-theme = callPackage ../data/icons/polar-xcursor-theme { };
+
   poly = callPackage ../data/fonts/poly { };
 
   posix_man_pages = callPackage ../data/documentation/man-pages-posix { };
 
   powerline-fonts = callPackage ../data/fonts/powerline-fonts { };
+
+  premium-xcursor-theme = callPackage ../data/icons/premium-xcursor-theme { };
 
   profont = callPackage ../data/fonts/profont { };
 


### PR DESCRIPTION
###### Motivation for this change
I wanted a different xcursor theme, but could not find any that I liked available.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

