### PR TITLE
slack: 2.5.2 -> 2.6.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, dpkg
-, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib, gnome2
-, libnotify, nspr, nss, systemd, xorg }:
+, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib
+, gnome2, libnotify, libxcb, nspr, nss, systemd, xorg }:
 
 let
 
-  version = "2.5.2";
+  version = "2.6.2";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -22,6 +22,7 @@ let
     gnome2.gtk
     gnome2.pango
     libnotify
+    libxcb
     nspr
     nss
     stdenv.cc.cc
@@ -45,7 +46,7 @@ let
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "https://downloads.slack-edge.com/linux_releases/slack-desktop-${version}-amd64.deb";
-        sha256 = "0mg8js18lnnwyvqksrhpym7d04bin16bh7sdmxbm36iijb9ajxmi";
+        sha256 = "01zdzzpnv8qpmcpy6h9x7izrnwm0y015j5p5rnjwx8ki712wnmm8";
       }
     else
       throw "Slack is not supported on ${stdenv.system}";


### PR DESCRIPTION
I added libxcb as a dependency. Without it, 2.6.2 crashes on launch:

    $ slack
    slack: error while loading shared libraries: libxcb.so.1: cannot open
    shared object file: No such file or directory

###### Motivation for this change

[Various fixes.](https://slack-files.com/T12KS1G65-F3QT9B7DJ-c285b109a3)

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).