### PR TITLE
apvlv: copy main_menubar.glade to out dir

### DIFF
--- a/pkgs/applications/misc/apvlv/default.nix
+++ b/pkgs/applications/misc/apvlv/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
     # displays pdfStartup.pdf as default pdf entry
     mkdir -p $out/share/doc/apvlv/
     cp ../Startup.pdf $out/share/doc/apvlv/Startup.pdf
+    cp ../main_menubar.glade $out/share/doc/apvlv/main_menubar.glade
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

The application relies on [main_menubar.glade to generate part of the GTK-based UI](https://github.com/naihe2010/apvlv/blob/v0.1.5/src/ApvlvMenu.cc#L51).

Currently `apvlv` fails with the `(apvlv:16999): Gtk-ERROR **: failed to add UI: Failed to open file '${NIX_PREFIX}-apvlv-0.1.5/share/doc/apvlv/main_menubar.glade': No such file or directory
zsh: trace trap  apvlv` error because this file is copied into the output directory for the package.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

###### TL;DR

Added the apvlv package to my nixos-configuration and ended up with an error message that indicated a missing main_menubar.glade file. After initially writing an [override for my own setup](https://github.com/vidbina/nixos-configuration/commit/716303c60c7a13bb787b97a231c280a48728561a), I decide to add the cp command for the required file to the installPhase in the nixpkgs description. Built this against my `nixos-version` to confirm it works, subsequently against release-17.03 9e0a260195 (which took forever to `nixos-rebuild test`) then failed because `git.efa3635.drv` couldn't be built and finally cherry-picked the commit of interest into master.

> Tried to rebase, but there were so many conflicts that pursuing of this approach seemed disproportionate to the minor (single line append) change. If I must rebase, I am glad to receive some pointers on how to perform this without introducing a significant risk of breaking changes elsewhere in nixpkgs.
