### PR TITLE
fetchsvn: set LC_ALL in builder to allow svn to handle unicode filenames

### DIFF
--- a/pkgs/build-support/fetchsvn/builder.sh
+++ b/pkgs/build-support/fetchsvn/builder.sh
@@ -18,6 +18,10 @@ if test -n "$http_proxy"; then
     export HOME="$PWD"
 fi;
 
+if test -z "$LC_ALL"; then
+    export LC_ALL="en_US.UTF-8"
+fi;
+
 # Pipe the "p" character into Subversion to force it to accept the
 # server's certificate.  This is perfectly safe: we don't care
 # whether the server is being spoofed --- only the cryptographic

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -1,4 +1,4 @@
-{stdenv, subversion, sshSupport ? false, openssh ? null}:
+{stdenv, subversion, glibcLocales, sshSupport ? false, openssh ? null}:
 {url, rev ? "HEAD", md5 ? "", sha256 ? "",
  ignoreExternals ? false, ignoreKeywords ? false, name ? null}:
 
@@ -31,7 +31,7 @@ else
 stdenv.mkDerivation {
   name = name_;
   builder = ./builder.sh;
-  buildInputs = [subversion];
+  buildInputs = [ subversion glibcLocales ];
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";


### PR DESCRIPTION
###### Motivation for this change
Without this, svn will fail when it reaches a unicode filename.

If you need a repo with unicode files to test this, try https://svn.openstreetmap.org/applications/editors/josm revision 32680 (it's in the main repo so `ignoreExternals=true` will save you a lot of time).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (fixed output derivation, there were none)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

