### PR TITLE
virtmanager: Fix python import error

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -44,6 +44,10 @@ python2Packages.buildPythonApplication rec {
     ${glib.dev}/bin/glib-compile-schemas "$out"/share/glib-2.0/schemas
   '';
 
+  preFixup = ''
+    gappsWrapperArgs+=(--set PYTHONPATH "$PYTHONPATH")
+  '';
+
   # Failed tests
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change
`PYTHONPATH` was not set when running virt-manager, resulting in the following error:

```console
$ virt-manager
Traceback (most recent call last):
  File "/nix/store/2iiz3nfs5x9wbprf0mfiahir0hzibbgf-virt-manager-1.4.1/share/virt-manager/virt-manager", line 29, in <module>
    import gi
ImportError: No module named gi
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

