### PR TITLE
xorg-input-libinput: 0.25.0 -> 0.25.1

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -316,6 +316,11 @@ in
   };
 
   xf86inputlibinput = attrs: attrs // {
+    name = "xf86-input-libinput-0.25.1";
+    src = args.fetchurl {
+      url = mirror://xorg/individual/driver/xf86-input-libinput-0.25.1.tar.bz2;
+      sha256 = "1q67hjd67ni1nq7kgxdrrdgkyhzaqvvn2vlnsiiq9w4y3icpv7s8";
+    };
     buildInputs = attrs.buildInputs ++ [ args.libinput ];
     installFlags = "sdkdir=\${out}/include/xorg";
   };


### PR DESCRIPTION
This isn't part of a full xorg release, so I just added it to the xorg
overrides.nix.

Changelog and release announcement:
https://lists.x.org/archives/xorg-announce/2017-May/002798.html

###### Motivation for this change
Upstream release

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

