### PR TITLE
programs.zsh.syntaxHighlighting: Fix default value for patterns

### DIFF
--- a/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
+++ b/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
@@ -32,7 +32,7 @@ in
         };
 
         patterns = mkOption {
-          default = [];
+          default = {};
           type = types.attrsOf types.string;
 
           example = literalExample ''


### PR DESCRIPTION
###### Motivation for this change

Commit 0925f79d561b077c40c53e3fb213df461bdf2b06 changes `programs.zsh.syntaxHighlighting.patterns` to use attrsets instead of lists of lists. However, the default value was not changed to match the new schema.  Building a configuration which uses the default value currently results in an error.

@Ma27 @Mic92

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

