### PR TITLE
erlang: refactor to generalize Erlang/OTP derivations

### DIFF
--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -1,0 +1,21 @@
+{ pkgs }:
+
+rec {
+
+  /* Uses generic-builder to evaluate provided drv containing OTP-version specific data.
+
+  drv: package containing version-specific args;
+  builder: generic builder for all Erlang versions;
+  gargs: arguments passed to the generic-builder, used mostly to customize dependencies;
+  args: arguments merged into version-specific args, used mostly to enable/disable high-level OTP
+    features, like ODBC or WX support;
+
+  Please note that "mkDerivation" defined here is the one called from R16.nix and similar files.
+  */
+  callErlang = drv: gargs: args: pkgs.callPackage drv (
+    let builder = pkgs.callPackage ../../development/interpreters/erlang/generic-builder.nix gargs;
+    in {
+      mkDerivation = a: builder (a // args);
+    });
+
+}

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -2,20 +2,36 @@
 
 rec {
 
-  /* Uses generic-builder to evaluate provided drv containing OTP-version specific data.
+  /* Similar to callPackageWith/callPackage, but without makeOverridable
+  */
+  callPackageWith = autoArgs: fn: args:
+    let
+      f = if builtins.isFunction fn then fn else import fn;
+      auto = builtins.intersectAttrs (builtins.functionArgs f) autoArgs;
+    in f (auto // args);
+
+  callPackage = callPackageWith pkgs;
+
+  /* Uses generic-builder to evaluate provided drv containing OTP-version
+  specific data.
 
   drv: package containing version-specific args;
   builder: generic builder for all Erlang versions;
-  gargs: arguments passed to the generic-builder, used mostly to customize dependencies;
-  args: arguments merged into version-specific args, used mostly to enable/disable high-level OTP
-    features, like ODBC or WX support;
+  args: arguments merged into version-specific args, used mostly to customize
+        dependencies;
 
-  Please note that "mkDerivation" defined here is the one called from R16.nix and similar files.
+  Arguments passed to the generic-builder are overridable, used to
+  enable/disable high-level OTP features, like ODBC or WX support;
+
+  Please note that "mkDerivation" defined here is the one called from R16.nix
+  and similar files.
   */
-  callErlang = drv: gargs: args: pkgs.callPackage drv (
-    let builder = pkgs.callPackage ../../development/interpreters/erlang/generic-builder.nix gargs;
-    in {
-      mkDerivation = a: builder (a // args);
-    });
+  callErlang = drv: args:
+    let
+      builder = callPackage ../../development/interpreters/erlang/generic-builder.nix args;
+    in
+      callPackage drv {
+        mkDerivation = pkgs.makeOverridable builder;
+      };
 
 }

--- a/pkgs/development/interpreters/erlang/R16.nix
+++ b/pkgs/development/interpreters/erlang/R16.nix
@@ -25,7 +25,6 @@ mkDerivation rec {
       sha256 = "17f3k5j17rdsah18gywjngip6cbfgp6nb9di6il4pahmf9yvqc8g";
     };
   in ''
-    ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
     tar xf "${manpages}" -C "$out/lib/erlang"
     for i in "$out"/lib/erlang/man/man[0-9]/*.[0-9]; do
       prefix="''${i%/*}"

--- a/pkgs/development/interpreters/erlang/R16.nix
+++ b/pkgs/development/interpreters/erlang/R16.nix
@@ -1,17 +1,6 @@
-{ stdenv, fetchurl, perl, gnum4, ncurses, openssl
-, gnused, gawk, makeWrapper
-, odbcSupport ? false, unixODBC ? null
-, wxSupport ? false, mesa ? null, wxGTK ? null, xorg ? null
-, enableDebugInfo ? false
-, Carbon ? null, Cocoa ? null }:
+{ mkDerivation, fetchurl }:
 
-assert wxSupport -> mesa != null && wxGTK != null && xorg != null;
-assert odbcSupport -> unixODBC != null;
-
-with stdenv.lib;
-
-stdenv.mkDerivation rec {
-  name = "erlang-" + version + "${optionalString odbcSupport "-odbc"}";
+mkDerivation rec {
   version = "16B03-1";
 
   src = fetchurl {
@@ -19,28 +8,17 @@ stdenv.mkDerivation rec {
     sha256 = "1rvyfh22g1fir1i4xn7v2md868wcmhajwhfsq97v7kn5kd2m7khp";
   };
 
-  debugInfo = enableDebugInfo;
-
-  buildInputs =
-    [ perl gnum4 ncurses openssl makeWrapper
-    ] ++ optionals wxSupport [ mesa wxGTK xorg.libX11 ]
-      ++ optional odbcSupport unixODBC
-      ++ optionals stdenv.isDarwin [ Carbon Cocoa ];
-
-  # Clang 4 (rightfully) thinks signed comparisons of pointers with NULL are nonsense
   prePatch = ''
-    substituteInPlace lib/wx/c_src/wxe_impl.cpp --replace 'temp > NULL' 'temp != NULL'
+    sed -i "s@/bin/rm@rm@" lib/odbc/configure erts/configure
   '';
-
-  patchPhase = '' sed -i "s@/bin/rm@rm@" lib/odbc/configure erts/configure '';
 
   preConfigure = ''
     export HOME=$PWD/../
     sed -e s@/bin/pwd@pwd@g -i otp_build
   '';
 
-  configureFlags= "--with-ssl=${openssl.dev} ${optionalString odbcSupport "--with-odbc=${unixODBC}"} ${optionalString stdenv.isDarwin "--enable-darwin-64bit"}";
-
+  # Do not install docs, instead use prebuilt versions.
+  installTargets = "install";
   postInstall = let
     manpages = fetchurl {
       url = "http://www.erlang.org/download/otp_doc_man_R${version}.tar.gz";
@@ -55,29 +33,4 @@ stdenv.mkDerivation rec {
       ln -s "$i" "$out/share/man/''${prefix##*/}/''${i##*/}erl"
     done
   '';
-
-  # Some erlang bin/ scripts run sed and awk
-  postFixup = ''
-    wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"
-    wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnused gawk ]}"
-  '';
-
-  setupHook = ./setup-hook.sh;
-
-  meta = {
-    homepage = "http://www.erlang.org/";
-    description = "Programming language used for massively scalable soft real-time systems";
-
-    longDescription = ''
-      Erlang is a programming language used to build massively scalable
-      soft real-time systems with requirements on high availability.
-      Some of its uses are in telecoms, banking, e-commerce, computer
-      telephony and instant messaging. Erlang's runtime system has
-      built-in support for concurrency, distribution and fault
-      tolerance.
-    '';
-
-    platforms = platforms.unix;
-    maintainers = [ maintainers.the-kenny ];
-  };
 }

--- a/pkgs/development/interpreters/erlang/R16B02-8-basho.nix
+++ b/pkgs/development/interpreters/erlang/R16B02-8-basho.nix
@@ -36,6 +36,10 @@ stdenv.mkDerivation rec {
 
   patchPhase = '' sed -i "s@/bin/rm@rm@" lib/odbc/configure.in erts/configure.in '';
 
+  postPatch = ''
+    patchSheBangs make
+  '';
+
   preConfigure = ''
     export HOME=$PWD/../
     export LANG=C

--- a/pkgs/development/interpreters/erlang/R16B02-8-basho.nix
+++ b/pkgs/development/interpreters/erlang/R16B02-8-basho.nix
@@ -1,76 +1,38 @@
-{ stdenv, fetchurl, fetchFromGitHub, perl, gnum4, ncurses, openssl, autoconf264, gcc, erlang
-, gnused, gawk, makeWrapper
-, odbcSupport ? false, unixODBC ? null
-, wxSupport ? false, mesa ? null, wxGTK ? null, xorg ? null
-, enableDebugInfo ? false
-, Carbon ? null, Cocoa ? null }:
+{ pkgs, mkDerivation }:
 
-assert wxSupport -> mesa != null && wxGTK != null && xorg != null;
-assert odbcSupport -> unixODBC != null;
-
-with stdenv.lib;
-
-stdenv.mkDerivation rec {
-  name = "erlang-basho-" + version + "${optionalString odbcSupport "-odbc"}";
+mkDerivation rec {
+  baseName = "erlang";
   version = "16B02";
 
-  src = fetchFromGitHub {
+  src = pkgs.fetchFromGitHub {
     owner = "basho";
     repo = "otp";
     rev = "OTP_R16B02_basho8";
     sha256 = "1w0hbm0axxxa45v3kl6bywc9ayir5vwqxjpnjlzc616ldszb2m0x";
   };
 
-  debugInfo = enableDebugInfo;
-
-  buildInputs =
-    [ perl gnum4 ncurses openssl makeWrapper autoconf264 gcc
-    ] ++ optional wxSupport [ mesa wxGTK xorg.libX11 ]
-      ++ optional odbcSupport [ unixODBC ]
-      ++ optionals stdenv.isDarwin [ Carbon Cocoa ];
-
-  # Clang 4 (rightfully) thinks signed comparisons of pointers with NULL are nonsense
-  prePatch = ''
-    substituteInPlace lib/wx/c_src/wxe_impl.cpp --replace 'temp > NULL' 'temp != NULL'
-  '';
-
-  patchPhase = '' sed -i "s@/bin/rm@rm@" lib/odbc/configure.in erts/configure.in '';
-
-  postPatch = ''
-    patchSheBangs make
-  '';
-
   preConfigure = ''
     export HOME=$PWD/../
     export LANG=C
     export ERL_TOP=$(pwd)
     sed -e s@/bin/pwd@pwd@g -i otp_build
-    sed -e s@"/usr/bin/env escript"@${erlang}/bin/escript@g -i lib/diameter/bin/diameterc
-  '';
+    sed -e s@"/usr/bin/env escript"@$(pwd)/bootstrap/bin/escript@g -i lib/diameter/bin/diameterc
 
-  configureFlags= [
-    "--with-ssl=${openssl.dev}"
-    "--enable-smp-support"
-    "--enable-threads"
-    "--enable-kernel-poll"
-    "--disable-hipe"
-    "${optionalString odbcSupport "--with-odbc=${unixODBC}"}"
-    "${optionalString stdenv.isDarwin "--enable-darwin-64bit"}"
-    "${optionalString stdenv.isLinux "--enable-m64-build"}"
-  ];
-
-  buildPhase = ''
     ./otp_build autoconf
-    ./otp_build setup -a --prefix=$out $configureFlags
   '';
 
+  enableHipe = false;
+
+  # Do not install docs, instead use prebuilt versions.
+  installTargets = "install";
   postInstall = let
-    manpages = fetchurl {
+    manpages = pkgs.fetchurl {
       url = "http://www.erlang.org/download/otp_doc_man_R${version}.tar.gz";
       sha256 = "12apxjmmd591y9g9bhr97z5jbd1jarqg7wj0y2sqhl21hc1yp75p";
     };
   in ''
-    ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
+    sed -e s@$(pwd)/bootstrap/bin/escript@$out/bin/escript@g -i $out/lib/erlang/lib/diameter-1.4.3/bin/diameterc
+
     tar xf "${manpages}" -C "$out/lib/erlang"
     for i in "$out"/lib/erlang/man/man[0-9]/*.[0-9]; do
       prefix="''${i%/*}"
@@ -78,14 +40,6 @@ stdenv.mkDerivation rec {
       ln -s "$i" "$out/share/man/''${prefix##*/}/''${i##*/}erl"
     done
   '';
-
-  # Some erlang bin/ scripts run sed and awk
-  postFixup = ''
-    wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"
-    wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${gnused}/bin/:${gawk}/bin"
-  '';
-
-  setupHook = ./setup-hook.sh;
 
   meta = {
     homepage = "https://github.com/basho/otp/";
@@ -103,7 +57,7 @@ stdenv.mkDerivation rec {
     '';
 
     platforms = ["x86_64-linux" "x86_64-darwin"];
-    license = stdenv.lib.licenses.asl20;
-    maintainers = with maintainers; [ mdaiter ];
+    license = pkgs.stdenv.lib.licenses.asl20;
+    maintainers = with pkgs.stdenv.lib.maintainers; [ mdaiter ];
   };
 }

--- a/pkgs/development/interpreters/erlang/R17.nix
+++ b/pkgs/development/interpreters/erlang/R17.nix
@@ -1,26 +1,6 @@
-{ stdenv, fetchurl, perl, gnum4, ncurses, openssl
-, gnused, gawk, makeWrapper
-, Carbon, Cocoa
-, odbcSupport ? false, unixODBC ? null
-, wxSupport ? true, mesa ? null, wxGTK ? null, xorg ? null, wxmac ? null
-, javacSupport ? false, openjdk ? null
-, enableHipe ? true
-, enableDebugInfo ? false
-, enableDirtySchedulers ? false
-}:
+{ mkDerivation, fetchurl }:
 
-assert wxSupport -> (if stdenv.isDarwin
-  then wxmac != null
-  else mesa != null && wxGTK != null && xorg != null);
-
-assert odbcSupport -> unixODBC != null;
-assert javacSupport ->  openjdk != null;
-
-with stdenv.lib;
-
-stdenv.mkDerivation rec {
-  name = "erlang-" + version + "${optionalString odbcSupport "-odbc"}"
-  + "${optionalString javacSupport "-javac"}";
+mkDerivation rec {
   version = "17.5";
 
   src = fetchurl {
@@ -28,36 +8,17 @@ stdenv.mkDerivation rec {
     sha256 = "0x34hj1a4j3rphqdaapdld7la4sqiqillamcz06wac0vk0684a1w";
   };
 
-  buildInputs =
-    [ perl gnum4 ncurses openssl makeWrapper
-    ] ++ optionals wxSupport (if stdenv.isDarwin then [ wxmac ] else [ mesa wxGTK xorg.libX11 ])
-      ++ optional odbcSupport unixODBC
-      ++ optional javacSupport openjdk
-      ++ stdenv.lib.optionals stdenv.isDarwin [ Carbon Cocoa ];
-
-  patchPhase = ''
-    # Clang 4 (rightfully) thinks signed comparisons of pointers with NULL are nonsense
-    substituteInPlace lib/wx/c_src/wxe_impl.cpp --replace 'temp > NULL' 'temp != NULL'
-
+  prePatch = ''
     sed -i "s@/bin/rm@rm@" lib/odbc/configure erts/configure
   '';
-
-  debugInfo = enableDebugInfo;
 
   preConfigure = ''
     export HOME=$PWD/../
     sed -e s@/bin/pwd@pwd@g -i otp_build
   '';
 
-  configureFlags= [
-    "--with-ssl=${openssl.dev}"
-  ] ++ optional enableHipe "--enable-hipe"
-    ++ optional enableDirtySchedulers "--enable-dirty-schedulers"
-    ++ optional wxSupport "--enable-wx"
-    ++ optional odbcSupport "--with-odbc=${unixODBC}"
-    ++ optional javacSupport "--with-javac"
-    ++ optional stdenv.isDarwin "--enable-darwin-64bit";
-
+  # Do not install docs, instead use prebuilt versions.
+  installTargets = "install";
   postInstall = let
     manpages = fetchurl {
       url = "http://www.erlang.org/download/otp_doc_man_${version}.tar.gz";
@@ -72,29 +33,4 @@ stdenv.mkDerivation rec {
       ln -s "$i" "$out/share/man/''${prefix##*/}/''${i##*/}erl"
     done
   '';
-
-  # Some erlang bin/ scripts run sed and awk
-  postFixup = ''
-    wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"
-    wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnused gawk ]}"
-  '';
-
-  setupHook = ./setup-hook.sh;
-
-  meta = {
-    homepage = "http://www.erlang.org/";
-    description = "Programming language used for massively scalable soft real-time systems";
-
-    longDescription = ''
-      Erlang is a programming language used to build massively scalable
-      soft real-time systems with requirements on high availability.
-      Some of its uses are in telecoms, banking, e-commerce, computer
-      telephony and instant messaging. Erlang's runtime system has
-      built-in support for concurrency, distribution and fault
-      tolerance.
-    '';
-
-    platforms = platforms.unix;
-    maintainers = [ maintainers.the-kenny maintainers.sjmackenzie ];
-  };
 }

--- a/pkgs/development/interpreters/erlang/R17.nix
+++ b/pkgs/development/interpreters/erlang/R17.nix
@@ -25,7 +25,6 @@ mkDerivation rec {
       sha256 = "1hspm285bl7i9a0d4r6j6lm5yk4sb5d9xzpia3simh0z06hv5cc5";
     };
   in ''
-    ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
     tar xf "${manpages}" -C "$out/lib/erlang"
     for i in "$out"/lib/erlang/man/man[0-9]/*.[0-9]; do
       prefix="''${i%/*}"

--- a/pkgs/development/interpreters/erlang/R18.nix
+++ b/pkgs/development/interpreters/erlang/R18.nix
@@ -1,113 +1,22 @@
-{ stdenv, fetchurl, fetchpatch, fetchFromGitHub, perl, gnum4, ncurses, openssl
-, gnused, gawk, autoconf, libxslt, libxml2, makeWrapper
-, Carbon, Cocoa
-, odbcSupport ? false, unixODBC ? null
-, wxSupport ? true, mesa ? null, wxGTK ? null, xorg ? null, wxmac ? null
-, javacSupport ? false, openjdk ? null
-, enableHipe ? true
-, enableDebugInfo ? false
-, enableDirtySchedulers ? false
-}:
+{ mkDerivation, fetchurl }:
 
-assert wxSupport -> (if stdenv.isDarwin
-  then wxmac != null
-  else mesa != null && wxGTK != null && xorg != null);
-
-assert odbcSupport -> unixODBC != null;
-assert javacSupport ->  openjdk != null;
-
-with stdenv.lib;
-
-stdenv.mkDerivation rec {
-  name = "erlang-" + version + "${optionalString odbcSupport "-odbc"}"
-  + "${optionalString javacSupport "-javac"}";
-  version = "18.3.4.4";
-
-  # Minor OTP releases are not always released as tarbals at
-  # http://erlang.org/download/ So we have to download from
-  # github. And for the same reason we can't use a prebuilt manpages
-  # tarball and need to build manpages ourselves.
-  src = fetchFromGitHub {
-    owner = "erlang";
-    repo = "otp";
-    rev = "OTP-${version}";
-    sha256 = "0wilm21yi9m3v6j26vc04hsa58cxca5z4q9yxx71hm81cbm1xbwk";
-  };
-
-  buildInputs =
-    [ perl gnum4 ncurses openssl autoconf libxslt libxml2 makeWrapper
-    ] ++ optionals wxSupport (if stdenv.isDarwin then [ wxmac ] else [ mesa wxGTK xorg.libX11 ])
-      ++ optional odbcSupport unixODBC
-      ++ optional javacSupport openjdk
-      ++ stdenv.lib.optionals stdenv.isDarwin [ Carbon Cocoa ];
-
-  debugInfo = enableDebugInfo;
-
+let
   rmAndPwdPatch = fetchurl {
      url = "https://github.com/erlang/otp/commit/98b8650d22e94a5ff839170833f691294f6276d0.patch";
      sha256 = "0cd5pkqrigiqz6cyma5irqwzn0bi17k371k9vlg8ir31h3zmqfip";
   };
 
   envAndCpPatch = fetchurl {
-     url = "https://github.com/binarin/otp/commit/9f9841eb7327c9fe73e84e197fd2965a97b639cf.patch";
+     url = "https://github.com/erlang/otp/commit/9f9841eb7327c9fe73e84e197fd2965a97b639cf.patch";
      sha256 = "10h5348p6g279b4q01i5jdqlljww5chcvrx5b4b0dv79pk0p0m9f";
   };
 
-  # Clang 4 (rightfully) thinks signed comparisons of pointers with NULL are nonsense
-  prePatch = ''
-    substituteInPlace lib/wx/c_src/wxe_impl.cpp --replace 'temp > NULL' 'temp != NULL'
-  '';
+in mkDerivation rec {
+  version = "18.3.4.4";
+  sha256 = "0wilm21yi9m3v6j26vc04hsa58cxca5z4q9yxx71hm81cbm1xbwk";
 
   patches = [
     rmAndPwdPatch
     envAndCpPatch
   ];
-
-  preConfigure = ''
-    ./otp_build autoconf
-  '';
-
-  configureFlags= [
-    "--with-ssl=${openssl.dev}"
-  ] ++ optional enableHipe "--enable-hipe"
-    ++ optional enableDirtySchedulers "--enable-dirty-schedulers"
-    ++ optional wxSupport "--enable-wx"
-    ++ optional odbcSupport "--with-odbc=${unixODBC}"
-    ++ optional javacSupport "--with-javac"
-    ++ optional stdenv.isDarwin "--enable-darwin-64bit";
-
-  # install-docs will generate and install manpages and html docs
-  # (PDFs are generated only when fop is available).
-  installTargets = "install install-docs";
-
-  postInstall = ''
-    ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
-  '';
-
-  # Some erlang bin/ scripts run sed and awk
-  postFixup = ''
-    wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"
-    wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnused gawk ]}"
-  '';
-
-  setupHook = ./setup-hook.sh;
-
-  meta = {
-    homepage = "http://www.erlang.org/";
-    downloadPage = "http://www.erlang.org/download.html";
-    description = "Programming language used for massively scalable soft real-time systems";
-
-    longDescription = ''
-      Erlang is a programming language used to build massively scalable
-      soft real-time systems with requirements on high availability.
-      Some of its uses are in telecoms, banking, e-commerce, computer
-      telephony and instant messaging. Erlang's runtime system has
-      built-in support for concurrency, distribution and fault
-      tolerance.
-    '';
-
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ the-kenny sjmackenzie couchemar ];
-    license = licenses.asl20;
-  };
 }

--- a/pkgs/development/interpreters/erlang/R19.nix
+++ b/pkgs/development/interpreters/erlang/R19.nix
@@ -1,101 +1,10 @@
-{ stdenv, fetchurl, fetchFromGitHub, perl, gnum4, ncurses, openssl
-, gnused, gawk, autoconf, libxslt, libxml2, makeWrapper
-, Carbon, Cocoa
-, odbcSupport ? false, unixODBC ? null
-, wxSupport ? true, mesa ? null, wxGTK ? null, xorg ? null, wxmac ? null
-, javacSupport ? false, openjdk ? null
-, enableHipe ? true
-, enableDebugInfo ? false
-, enableDirtySchedulers ? false
-}:
+{ mkDerivation, fetchurl }:
 
-assert wxSupport -> (if stdenv.isDarwin
-  then wxmac != null
-  else mesa != null && wxGTK != null && xorg != null);
-
-assert odbcSupport -> unixODBC != null;
-assert javacSupport ->  openjdk != null;
-
-with stdenv.lib;
-
-stdenv.mkDerivation rec {
-  name = "erlang-" + version + "${optionalString odbcSupport "-odbc"}"
-  + "${optionalString javacSupport "-javac"}";
+mkDerivation rec {
   version = "19.3";
-
-  # Minor OTP releases are not always released as tarbals at
-  # http://erlang.org/download/ So we have to download from
-  # github. And for the same reason we can't use a prebuilt manpages
-  # tarball and need to build manpages ourselves.
-  src = fetchFromGitHub {
-    owner = "erlang";
-    repo = "otp";
-    rev = "OTP-${version}";
-    sha256 = "0pp2hl8jf4iafpnsmf0q7jbm313daqzif6ajqcmjyl87m5pssr86";
-  };
-
-  buildInputs =
-    [ perl gnum4 ncurses openssl autoconf libxslt libxml2 makeWrapper
-    ] ++ optionals wxSupport (if stdenv.isDarwin then [ wxmac ] else [ mesa wxGTK xorg.libX11 ])
-      ++ optional odbcSupport unixODBC
-      ++ optional javacSupport openjdk
-      ++ stdenv.lib.optionals stdenv.isDarwin [ Carbon Cocoa ];
-
-  debugInfo = enableDebugInfo;
+  sha256 = "0pp2hl8jf4iafpnsmf0q7jbm313daqzif6ajqcmjyl87m5pssr86";
 
   prePatch = ''
-    substituteInPlace configure.in \
-      --replace '`sw_vers -productVersion`' '10.10'
-
-    # Clang 4 (rightfully) thinks signed comparisons of pointers with NULL are nonsense
-    substituteInPlace lib/wx/c_src/wxe_impl.cpp --replace 'temp > NULL' 'temp != NULL'
+    substituteInPlace configure.in --replace '`sw_vers -productVersion`' '10.10'
   '';
-
-  preConfigure = ''
-    ./otp_build autoconf
-  '';
-
-  configureFlags= [
-    "--with-ssl=${openssl.dev}"
-  ] ++ optional enableHipe "--enable-hipe"
-    ++ optional enableDirtySchedulers "--enable-dirty-schedulers"
-    ++ optional wxSupport "--enable-wx"
-    ++ optional odbcSupport "--with-odbc=${unixODBC}"
-    ++ optional javacSupport "--with-javac"
-    ++ optional stdenv.isDarwin "--enable-darwin-64bit";
-
-  # install-docs will generate and install manpages and html docs
-  # (PDFs are generated only when fop is available).
-  installTargets = "install install-docs";
-
-  postInstall = ''
-    ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
-  '';
-
-  # Some erlang bin/ scripts run sed and awk
-  postFixup = ''
-    wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"
-    wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnused gawk ]}"
-  '';
-
-  setupHook = ./setup-hook.sh;
-
-  meta = {
-    homepage = "http://www.erlang.org/";
-    downloadPage = "http://www.erlang.org/download.html";
-    description = "Programming language used for massively scalable soft real-time systems";
-
-    longDescription = ''
-      Erlang is a programming language used to build massively scalable
-      soft real-time systems with requirements on high availability.
-      Some of its uses are in telecoms, banking, e-commerce, computer
-      telephony and instant messaging. Erlang's runtime system has
-      built-in support for concurrency, distribution and fault
-      tolerance.
-    '';
-
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ yurrriq couchemar DerTim1 mdaiter ];
-    license = licenses.asl20;
-  };
 }

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -1,0 +1,132 @@
+{ pkgs, stdenv, fetchurl, fetchFromGitHub, makeWrapper, autoconf, gawk, gnum4, gnused
+, libxml2, libxslt, ncurses, openssl, perl
+, openjdk ? null # javacSupport
+, unixODBC ? null # odbcSupport
+, mesa ? null, wxGTK ? null, wxmac ? null, xorg ? null # wxSupport
+}:
+
+{ version
+, sha256 ? null
+, rev ? "OTP-${version}"
+, src ? fetchFromGitHub { inherit rev sha256; owner = "erlang"; repo = "otp"; }
+, enableHipe ? true
+, enableDebugInfo ? false
+, javacSupport ? false, javacPackages ? [ openjdk ]
+, odbcSupport ? false, odbcPackages ? [ unixODBC ]
+, wxSupport ? true, wxPackages ? [ mesa wxGTK xorg.libX11 ]
+, preUnpack ? "", postUnpack ? ""
+, patches ? [], patchPhase ? "", prePatch ? "", postPatch ? ""
+, configureFlags ? [], configurePhase ? "", preConfigure ? "", postConfigure ? ""
+, buildPhase ? "", preBuild ? "", postBuild ? ""
+, installPhase ? "", preInstall ? "", postInstall ? ""
+, installTargets ? "install install-docs"
+, checkPhase ? "", preCheck ? "", postCheck ? ""
+, fixupPhase ? "", preFixup ? "", postFixup ? ""
+}:
+
+assert wxSupport -> (if stdenv.isDarwin
+  then wxmac != null
+  else mesa != null && wxGTK != null && xorg != null);
+
+assert odbcSupport -> unixODBC != null;
+assert javacSupport -> openjdk != null;
+
+let
+  inherit (stdenv.lib) optional optionals optionalAttrs optionalString;
+  wxPackages2 = if stdenv.isDarwin then [ wxmac ] else wxPackages;
+
+in stdenv.mkDerivation ({
+  name = "erlang-${version}"
+    + optionalString javacSupport "-javac"
+    + optionalString odbcSupport "-odbc";
+
+  inherit src version;
+
+  buildInputs = [ perl gnum4 ncurses openssl autoconf libxslt libxml2 makeWrapper ]
+    ++ optionals wxSupport wxPackages2
+    ++ optionals odbcSupport odbcPackages
+    ++ optionals javacSupport javacPackages
+    ++ optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [ Carbon Cocoa ]);
+
+  debugInfo = enableDebugInfo;
+
+  # Clang 4 (rightfully) thinks signed comparisons of pointers with NULL are nonsense
+  prePatch = ''
+    substituteInPlace lib/wx/c_src/wxe_impl.cpp --replace 'temp > NULL' 'temp != NULL'
+
+    ${prePatch}
+  '';
+
+  postPatch = ''
+    patchShebangs make
+
+    ${postPatch}
+  '';
+
+  preConfigure = ''
+    ./otp_build autoconf
+  '';
+
+  configureFlags = [ "--with-ssl=${openssl.dev}" ]
+    ++ optional enableHipe "--enable-hipe"
+    ++ optional javacSupport "--with-javac"
+    ++ optional odbcSupport "--with-odbc=${unixODBC}"
+    ++ optional wxSupport "--enable-wx"
+    ++ optional stdenv.isDarwin "--enable-darwin-64bit";
+
+  # install-docs will generate and install manpages and html docs
+  # (PDFs are generated only when fop is available).
+
+  postInstall = ''
+    ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
+  '';
+
+  # Some erlang bin/ scripts run sed and awk
+  postFixup = ''
+    wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"
+    wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnused gawk ]}"
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.erlang.org/";
+    downloadPage = "http://www.erlang.org/download.html";
+    description = "Programming language used for massively scalable soft real-time systems";
+
+    longDescription = ''
+      Erlang is a programming language used to build massively scalable
+      soft real-time systems with requirements on high availability.
+      Some of its uses are in telecoms, banking, e-commerce, computer
+      telephony and instant messaging. Erlang's runtime system has
+      built-in support for concurrency, distribution and fault
+      tolerance.
+    '';
+
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ the-kenny sjmackenzie couchemar gleber ];
+    license = licenses.asl20;
+  };
+}
+// optionalAttrs (preUnpack != "")      { inherit preUnpack; }
+// optionalAttrs (postUnpack != "")     { inherit postUnpack; }
+// optionalAttrs (patches != [])        { inherit patches; }
+// optionalAttrs (patchPhase != "")     { inherit patchPhase; }
+// optionalAttrs (configureFlags != []) { inherit configureFlags; }
+// optionalAttrs (configurePhase != "") { inherit configurePhase; }
+// optionalAttrs (preConfigure != "")   { inherit preConfigure; }
+// optionalAttrs (postConfigure != "")  { inherit postConfigure; }
+// optionalAttrs (buildPhase != "")     { inherit buildPhase; }
+// optionalAttrs (preBuild != "")       { inherit preBuild; }
+// optionalAttrs (postBuild != "")      { inherit postBuild; }
+// optionalAttrs (checkPhase != "")     { inherit checkPhase; }
+// optionalAttrs (preCheck != "")       { inherit preCheck; }
+// optionalAttrs (postCheck != "")      { inherit postCheck; }
+// optionalAttrs (installPhase != "")   { inherit installPhase; }
+// optionalAttrs (installTargets != "") { inherit installTargets; }
+// optionalAttrs (preInstall != "")     { inherit preInstall; }
+// optionalAttrs (postInstall != "")    { inherit postInstall; }
+// optionalAttrs (fixupPhase != "")     { inherit fixupPhase; }
+// optionalAttrs (preFixup != "")       { inherit preFixup; }
+// optionalAttrs (postFixup != "")      { inherit postFixup; }
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5949,93 +5949,22 @@ with pkgs;
 
   clooj = callPackage ../development/interpreters/clojure/clooj.nix { };
 
-  erlangR16 = callPackage ../development/interpreters/erlang/R16.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-  };
-  erlangR16_odbc = callPackage ../development/interpreters/erlang/R16.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    odbcSupport = true;
-  };
-  erlang_basho_R16B02 = callPackage ../development/interpreters/erlang/R16B02-8-basho.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-  };
-  erlang_basho_R16B02_odbc = callPackage ../development/interpreters/erlang/R16B02-8-basho.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    odbcSupport = true;
-  };
-  erlangR17 = callPackage ../development/interpreters/erlang/R17.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-  };
-  erlangR17_odbc = callPackage ../development/interpreters/erlang/R17.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    odbcSupport = true;
-  };
-  erlangR17_javac = callPackage ../development/interpreters/erlang/R17.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    javacSupport = true;
-  };
-  erlangR17_odbc_javac = callPackage ../development/interpreters/erlang/R17.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    javacSupport = true; odbcSupport = true;
-  };
-  erlangR18 = callPackage ../development/interpreters/erlang/R18.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    wxGTK = wxGTK30;
-  };
-  erlangR18_odbc = callPackage ../development/interpreters/erlang/R18.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    wxGTK = wxGTK30;
-    odbcSupport = true;
-  };
-  erlangR18_javac = callPackage ../development/interpreters/erlang/R18.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    wxGTK = wxGTK30;
-    javacSupport = true;
-  };
-  erlangR18_odbc_javac = callPackage ../development/interpreters/erlang/R18.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    wxGTK = wxGTK30;
-    javacSupport = true; odbcSupport = true;
-  };
-  erlangR19 = callPackage ../development/interpreters/erlang/R19.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    wxGTK = wxGTK30;
-  };
-  erlangR19_odbc = callPackage ../development/interpreters/erlang/R19.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    wxGTK = wxGTK30;
-    odbcSupport = true;
-  };
-  erlangR19_javac = callPackage ../development/interpreters/erlang/R19.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    wxGTK = wxGTK30;
-    javacSupport = true;
-  };
-  erlangR19_odbc_javac = callPackage ../development/interpreters/erlang/R19.nix {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    wxGTK = wxGTK30;
-    javacSupport = true; odbcSupport = true;
-  };
-  erlang = erlangR18;
-  erlang_odbc = erlangR18_odbc;
-  erlang_javac = erlangR18_javac;
-  erlang_odbc_javac = erlangR18_odbc_javac;
+  beam = callPackage ./beam-packages.nix { };
 
-  rebar = callPackage ../development/tools/build-managers/rebar { };
-  rebar3-open = callPackage ../development/tools/build-managers/rebar3 { hermeticRebar3 = false; };
-  rebar3 = callPackage ../development/tools/build-managers/rebar3 { hermeticRebar3 = true; };
-  hexRegistrySnapshot = callPackage ../development/beam-modules/hex-registry-snapshot.nix { };
-  fetchHex = callPackage ../development/beam-modules/fetch-hex.nix { };
+  inherit (beam.interpreters)
+    erlang erlang_odbc erlang_javac erlang_odbc_javac
+    elixir
+    lfe
+    erlangR16 erlangR16_odbc
+    erlang_basho_R16B02 erlang_basho_R16B02_odbc
+    erlangR17 erlangR17_odbc erlangR17_javac erlangR17_odbc_javac
+    erlangR18 erlangR18_odbc erlangR18_javac erlangR18_odbc_javac
+    erlangR19 erlangR19_odbc erlangR19_javac erlangR19_odbc_javac;
 
-  beamPackages = callPackage ../development/beam-modules { };
-  hex2nix = beamPackages.callPackage ../development/tools/erlang/hex2nix { };
-  cuter = callPackage ../development/tools/erlang/cuter { };
-
-  relxExe = callPackage ../development/tools/erlang/relx-exe {};
-
-  elixir = callPackage ../development/interpreters/elixir { debugInfo = true; };
-
-  lfe = callPackage ../development/interpreters/lfe { };
+  inherit (beam.packages)
+    rebar rebar3-open rebar3
+    hexRegistrySnapshot fetchHex beamPackages
+    hex2nix cuter relxExe;
 
   groovy = callPackage ../development/interpreters/groovy { };
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -12,54 +12,28 @@ rec {
     erlang_odbc_javac = erlangR18_odbc_javac;
 
     # These are standard Erlang versions, using the generic builder.
-    erlangR16 = lib.callErlang ../development/interpreters/erlang/R16.nix {} {};
-    erlangR16_odbc = lib.callErlang ../development/interpreters/erlang/R16.nix {} {
-      odbcSupport = true;
-    };
-    erlangR17 = lib.callErlang ../development/interpreters/erlang/R17.nix {} {};
-    erlangR17_odbc = lib.callErlang ../development/interpreters/erlang/R17.nix {} {
-      odbcSupport = true;
-    };
-    erlangR17_javac = lib.callErlang ../development/interpreters/erlang/R17.nix {} {
-      javacSupport = true;
-    };
-    erlangR17_odbc_javac = lib.callErlang ../development/interpreters/erlang/R17.nix {} {
+    erlangR16 = lib.callErlang ../development/interpreters/erlang/R16.nix {};
+    erlangR16_odbc = erlangR16.override { odbcSupport = true; };
+    erlangR17 = lib.callErlang ../development/interpreters/erlang/R17.nix {};
+    erlangR17_odbc = erlangR17.override { odbcSupport = true; };
+    erlangR17_javac = erlangR17.override { javacSupport = true; };
+    erlangR17_odbc_javac = erlangR17.override {
       javacSupport = true; odbcSupport = true;
     };
     erlangR18 = lib.callErlang ../development/interpreters/erlang/R18.nix {
       wxGTK = wxGTK30;
-    } {};
-    erlangR18_odbc = lib.callErlang ../development/interpreters/erlang/R18.nix {
-      wxGTK = wxGTK30;
-    } {
-      odbcSupport = true;
     };
-    erlangR18_javac = lib.callErlang ../development/interpreters/erlang/R18.nix {
-      wxGTK = wxGTK30;
-    } {
-      javacSupport = true;
-    };
-    erlangR18_odbc_javac = lib.callErlang ../development/interpreters/erlang/R18.nix {
-      wxGTK = wxGTK30;
-    } {
+    erlangR18_odbc = erlangR18.override { odbcSupport = true; };
+    erlangR18_javac = erlangR18.override { javacSupport = true; };
+    erlangR18_odbc_javac = erlangR18.override {
       javacSupport = true; odbcSupport = true;
     };
     erlangR19 = lib.callErlang ../development/interpreters/erlang/R19.nix {
       wxGTK = wxGTK30;
-    } {};
-    erlangR19_odbc = lib.callErlang ../development/interpreters/erlang/R19.nix {
-      wxGTK = wxGTK30;
-    } {
-      odbcSupport = true;
     };
-    erlangR19_javac = lib.callErlang ../development/interpreters/erlang/R19.nix {
-      wxGTK = wxGTK30;
-    } {
-      javacSupport = true;
-    };
-    erlangR19_odbc_javac = lib.callErlang ../development/interpreters/erlang/R19.nix {
-      wxGTK = wxGTK30;
-    } {
+    erlangR19_odbc = erlangR19.override { odbcSupport = true; };
+    erlangR19_javac = erlangR19.override { javacSupport = true; };
+    erlangR19_odbc_javac = erlangR19.override {
       javacSupport = true; odbcSupport = true;
     };
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -38,11 +38,9 @@ rec {
     };
 
     # Bash fork, using custom builder.
-    erlang_basho_R16B02 = callPackage ../development/interpreters/erlang/R16B02-8-basho.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    erlang_basho_R16B02 = lib.callErlang ../development/interpreters/erlang/R16B02-8-basho.nix {
     };
-    erlang_basho_R16B02_odbc = callPackage ../development/interpreters/erlang/R16B02-8-basho.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    erlang_basho_R16B02_odbc = erlang_basho_R16B02.override {
       odbcSupport = true;
     };
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -1,22 +1,69 @@
 { pkgs, stdenv, callPackage, wxGTK30, darwin }:
 
 rec {
+  lib = import ../development/beam-modules/lib.nix { inherit pkgs; };
 
   interpreters = rec {
 
+    # R18 is the Default version.
     erlang = erlangR18;
     erlang_odbc = erlangR18_odbc;
     erlang_javac = erlangR18_javac;
     erlang_odbc_javac = erlangR18_odbc_javac;
 
-    erlangR16 = callPackage ../development/interpreters/erlang/R16.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    };
-
-    erlangR16_odbc = callPackage ../development/interpreters/erlang/R16.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    # These are standard Erlang versions, using the generic builder.
+    erlangR16 = lib.callErlang ../development/interpreters/erlang/R16.nix {} {};
+    erlangR16_odbc = lib.callErlang ../development/interpreters/erlang/R16.nix {} {
       odbcSupport = true;
     };
+    erlangR17 = lib.callErlang ../development/interpreters/erlang/R17.nix {} {};
+    erlangR17_odbc = lib.callErlang ../development/interpreters/erlang/R17.nix {} {
+      odbcSupport = true;
+    };
+    erlangR17_javac = lib.callErlang ../development/interpreters/erlang/R17.nix {} {
+      javacSupport = true;
+    };
+    erlangR17_odbc_javac = lib.callErlang ../development/interpreters/erlang/R17.nix {} {
+      javacSupport = true; odbcSupport = true;
+    };
+    erlangR18 = lib.callErlang ../development/interpreters/erlang/R18.nix {
+      wxGTK = wxGTK30;
+    } {};
+    erlangR18_odbc = lib.callErlang ../development/interpreters/erlang/R18.nix {
+      wxGTK = wxGTK30;
+    } {
+      odbcSupport = true;
+    };
+    erlangR18_javac = lib.callErlang ../development/interpreters/erlang/R18.nix {
+      wxGTK = wxGTK30;
+    } {
+      javacSupport = true;
+    };
+    erlangR18_odbc_javac = lib.callErlang ../development/interpreters/erlang/R18.nix {
+      wxGTK = wxGTK30;
+    } {
+      javacSupport = true; odbcSupport = true;
+    };
+    erlangR19 = lib.callErlang ../development/interpreters/erlang/R19.nix {
+      wxGTK = wxGTK30;
+    } {};
+    erlangR19_odbc = lib.callErlang ../development/interpreters/erlang/R19.nix {
+      wxGTK = wxGTK30;
+    } {
+      odbcSupport = true;
+    };
+    erlangR19_javac = lib.callErlang ../development/interpreters/erlang/R19.nix {
+      wxGTK = wxGTK30;
+    } {
+      javacSupport = true;
+    };
+    erlangR19_odbc_javac = lib.callErlang ../development/interpreters/erlang/R19.nix {
+      wxGTK = wxGTK30;
+    } {
+      javacSupport = true; odbcSupport = true;
+    };
+
+    # Bash fork, using custom builder.
     erlang_basho_R16B02 = callPackage ../development/interpreters/erlang/R16B02-8-basho.nix {
       inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
     };
@@ -24,62 +71,9 @@ rec {
       inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
       odbcSupport = true;
     };
-    erlangR17 = callPackage ../development/interpreters/erlang/R17.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    };
-    erlangR17_odbc = callPackage ../development/interpreters/erlang/R17.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-      odbcSupport = true;
-    };
-    erlangR17_javac = callPackage ../development/interpreters/erlang/R17.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-      javacSupport = true;
-    };
-    erlangR17_odbc_javac = callPackage ../development/interpreters/erlang/R17.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-      javacSupport = true; odbcSupport = true;
-    };
-    erlangR18 = callPackage ../development/interpreters/erlang/R18.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-      wxGTK = wxGTK30;
-    };
-    erlangR18_odbc = callPackage ../development/interpreters/erlang/R18.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-      wxGTK = wxGTK30;
-      odbcSupport = true;
-    };
-    erlangR18_javac = callPackage ../development/interpreters/erlang/R18.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-      wxGTK = wxGTK30;
-      javacSupport = true;
-    };
-    erlangR18_odbc_javac = callPackage ../development/interpreters/erlang/R18.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-      wxGTK = wxGTK30;
-      javacSupport = true; odbcSupport = true;
-    };
-    erlangR19 = callPackage ../development/interpreters/erlang/R19.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-      wxGTK = wxGTK30;
-    };
-    erlangR19_odbc = callPackage ../development/interpreters/erlang/R19.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-      wxGTK = wxGTK30;
-      odbcSupport = true;
-    };
-    erlangR19_javac = callPackage ../development/interpreters/erlang/R19.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-      wxGTK = wxGTK30;
-      javacSupport = true;
-    };
-    erlangR19_odbc_javac = callPackage ../development/interpreters/erlang/R19.nix {
-      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-      wxGTK = wxGTK30;
-      javacSupport = true; odbcSupport = true;
-    };
 
+    # Other Beam languages.
     elixir = callPackage ../development/interpreters/elixir { debugInfo = true; };
-
     lfe = callPackage ../development/interpreters/lfe { };
   };
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -1,0 +1,99 @@
+{ pkgs, stdenv, callPackage, wxGTK30, darwin }:
+
+rec {
+
+  interpreters = rec {
+
+    erlang = erlangR18;
+    erlang_odbc = erlangR18_odbc;
+    erlang_javac = erlangR18_javac;
+    erlang_odbc_javac = erlangR18_odbc_javac;
+
+    erlangR16 = callPackage ../development/interpreters/erlang/R16.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    };
+
+    erlangR16_odbc = callPackage ../development/interpreters/erlang/R16.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      odbcSupport = true;
+    };
+    erlang_basho_R16B02 = callPackage ../development/interpreters/erlang/R16B02-8-basho.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    };
+    erlang_basho_R16B02_odbc = callPackage ../development/interpreters/erlang/R16B02-8-basho.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      odbcSupport = true;
+    };
+    erlangR17 = callPackage ../development/interpreters/erlang/R17.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    };
+    erlangR17_odbc = callPackage ../development/interpreters/erlang/R17.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      odbcSupport = true;
+    };
+    erlangR17_javac = callPackage ../development/interpreters/erlang/R17.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      javacSupport = true;
+    };
+    erlangR17_odbc_javac = callPackage ../development/interpreters/erlang/R17.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      javacSupport = true; odbcSupport = true;
+    };
+    erlangR18 = callPackage ../development/interpreters/erlang/R18.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      wxGTK = wxGTK30;
+    };
+    erlangR18_odbc = callPackage ../development/interpreters/erlang/R18.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      wxGTK = wxGTK30;
+      odbcSupport = true;
+    };
+    erlangR18_javac = callPackage ../development/interpreters/erlang/R18.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      wxGTK = wxGTK30;
+      javacSupport = true;
+    };
+    erlangR18_odbc_javac = callPackage ../development/interpreters/erlang/R18.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      wxGTK = wxGTK30;
+      javacSupport = true; odbcSupport = true;
+    };
+    erlangR19 = callPackage ../development/interpreters/erlang/R19.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      wxGTK = wxGTK30;
+    };
+    erlangR19_odbc = callPackage ../development/interpreters/erlang/R19.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      wxGTK = wxGTK30;
+      odbcSupport = true;
+    };
+    erlangR19_javac = callPackage ../development/interpreters/erlang/R19.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      wxGTK = wxGTK30;
+      javacSupport = true;
+    };
+    erlangR19_odbc_javac = callPackage ../development/interpreters/erlang/R19.nix {
+      inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      wxGTK = wxGTK30;
+      javacSupport = true; odbcSupport = true;
+    };
+
+    elixir = callPackage ../development/interpreters/elixir { debugInfo = true; };
+
+    lfe = callPackage ../development/interpreters/lfe { };
+  };
+
+  packages = rec {
+    rebar = callPackage ../development/tools/build-managers/rebar { };
+    rebar3-open = callPackage ../development/tools/build-managers/rebar3 { hermeticRebar3 = false; };
+    rebar3 = callPackage ../development/tools/build-managers/rebar3 { hermeticRebar3 = true; };
+    hexRegistrySnapshot = callPackage ../development/beam-modules/hex-registry-snapshot.nix { };
+    fetchHex = callPackage ../development/beam-modules/fetch-hex.nix { };
+
+    beamPackages = callPackage ../development/beam-modules { };
+    hex2nix = beamPackages.callPackage ../development/tools/erlang/hex2nix { };
+    cuter = callPackage ../development/tools/erlang/cuter { };
+
+    relxExe = callPackage ../development/tools/erlang/relx-exe {};
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

This PR does not change anything feature-wise, and instead aims at unify how different Erlang versions are built.

This is a subset of https://github.com/NixOS/nixpkgs/pull/17240 (and is a heavily-inspired re-implementation of it). It contains:
- move all Beam packages into beam-packages.nix file which lives by the side of all-packages.nix;
- deduplicates contents of pkgs/development/interpreters/erlang/R{16-19}.nix into a generic builder;
- supports OTP build features like odbc- and javasupport

It does not contain:
- a fixpoint to build Erlang packages using different OTP versions;
- Elixir generalization;
- LFE generalization.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @LnL7 @ankhers @ericbmerritt @yurrriq 