### PR TITLE
xfce4-dockbarx-plugin: fix #26379

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-dockbarx-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-dockbarx-plugin.nix
@@ -30,7 +30,9 @@ stdenv.mkDerivation rec {
 
   installPhase = "python waf install";
 
-  postFixup = "wrapPythonPrograms";
+  postFixup = ''
+    wrapPythonProgramsIn "$out/share/xfce4/panel/plugins" "$out $pythonPath"
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/TiZ-EX1/xfce4-dockbarx-plugin;


### PR DESCRIPTION
###### Motivation for this change

Fix #26379
regression after https://github.com/NixOS/nixpkgs/commit/aa86d9fa7a93023f6c54f45631505375dc628b91

@FRidh if you insist on https://github.com/NixOS/nixpkgs/commit/aa86d9fa7a93023f6c54f45631505375dc628b91 please review all 41 usages of ```wrapPythonPrograms```. Some of them might have something to wrap in other directories than ```$out/bin```. It is already the second found regression of that commit (another is https://github.com/NixOS/nixpkgs/pull/26375)