### PR TITLE
pass: add plugins to support importing and updating

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl
+{ stdenv, lib, fetchurl, fetchFromGitHub
 , coreutils, gnused, getopt, git, tree, gnupg, which, procps, qrencode
 , makeWrapper
 
@@ -12,7 +12,17 @@ assert x11Support -> xclip != null
                   && xdotool != null
                   && dmenu != null;
 
-stdenv.mkDerivation rec {
+let
+  plugins = map (p: (fetchFromGitHub {
+    owner  = "roddhjav";
+    repo   = "pass-${p.name}";
+    inherit (p) rev sha256;
+  })) [
+    { name = "import"; rev = "491935bd275f29ceac2b876b3a288011d1ce31e7"; sha256 = "02mbh05ab8h7kc30hz718d1d1vkjz43b96c7p0xnd92610d2q66q"; }
+    { name = "update"; rev = "cf576c9036fd18efb9ed29e0e9f811207b556fde"; sha256 = "1hhbrg6a2walrvla6q4cd3pgrqbcrf9brzjkb748735shxfn52hd"; }
+  ];
+
+in stdenv.mkDerivation rec {
   version = "1.7.1";
   name    = "password-store-${version}";
 
@@ -29,6 +39,13 @@ stdenv.mkDerivation rec {
   installFlags = [ "PREFIX=$(out)" "WITH_ALLCOMP=yes" ];
 
   postInstall = ''
+    # plugins
+    ${stdenv.lib.concatStringsSep "\n" (map (plugin: ''
+      pushd ${plugin}
+      PREFIX=$out make install
+      popd
+    '') plugins)}
+
     # Install Emacs Mode. NOTE: We can't install the necessary
     # dependencies (s.el and f.el) here. The user has to do this
     # himself.


### PR DESCRIPTION
###### Motivation for this change

There are some neat plugins for pass and while the importer requires ruby and python to run, I don't think we should force them in order to not inflate the size of the closure.

This way they are available (and working if ruby/python is in the path).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

