### PR TITLE
git: 2.13.0 -> 2.13.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  version = "2.13.0";
+  version = "2.13.1";
   svn = subversionClient.override { perlBindings = true; };
 in
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "0n0j36rapw31zb0sabap88ffncv8jg3nwc4miyim64ilyav2mgsb";
+    sha256 = "1zl88rlga9nhgaqc9d04vp1l1g4x6qj1d02698asnxrzk36vxh9v";
   };
 
   hardeningDisable = [ "format" ];


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

