### PR TITLE
xfce4_namebar_plugin: init at 0.3.1

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -89,6 +89,7 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   xfce4_fsguard_plugin          = callPackage ./panel-plugins/xfce4-fsguard-plugin.nix          { };
   xfce4_genmon_plugin           = callPackage ./panel-plugins/xfce4-genmon-plugin.nix           { };
   xfce4-hardware-monitor-plugin = callPackage ./panel-plugins/xfce4-hardware-monitor-plugin.nix { };
+  xfce4_namebar_plugin          = callPackage ./panel-plugins/xfce4-namebar-plugin.nix          { };
   xfce4_netload_plugin          = callPackage ./panel-plugins/xfce4-netload-plugin.nix          { };
   xfce4_notes_plugin            = callPackage ./panel-plugins/xfce4-notes-plugin.nix            { };
   xfce4_mailwatch_plugin        = callPackage ./panel-plugins/xfce4-mailwatch-plugin.nix        { };

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-namebar-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-namebar-plugin.nix
@@ -1,0 +1,35 @@
+{ stdenv, pkgconfig, fetchFromGitHub, python2, vala, gtk2, libwnck, libxfce4util, xfce4panel }:
+
+stdenv.mkDerivation rec {
+  ver = "0.3.1";
+  rev = "07a23b3";
+  name = "xfce4-namebar-plugin-${ver}";
+
+  src = fetchFromGitHub {
+    owner = "TiZ-EX1";
+    repo = "xfce4-namebar-plugin";
+    rev = rev;
+    sha256 = "1sl4qmjywfvv53ch7hyfysjfd91zl38y7gdw2y3k69vkzd3h18ad";
+  };
+
+  buildInputs = [ pkgconfig python2 vala gtk2 libwnck libxfce4util xfce4panel ];
+
+  postPatch = ''
+    substituteInPlace src/preferences.vala --replace 'Environment.get_system_data_dirs()' "{ \"$out/share\" }"
+    substituteInPlace src/namebar.vala     --replace 'Environment.get_system_data_dirs()' "{ \"$out/share\" }"
+  '';
+
+  configurePhase = "python waf configure --prefix=$out";
+
+  buildPhase = "python waf build";
+
+  installPhase = "python waf install";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/TiZ-EX1/xfce4-namebar-plugin;
+    description = "A plugins which integrates titlebar and window controls into the xfce4-panel";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.volth ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

A less buggy alternative to ```xfce4_windowck_plugin```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

