### PR TITLE
kdevelop: 5.0.4 -> 5.1.1

### DIFF
--- a/pkgs/applications/editors/kdevelop5/kdevelop.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop.nix
@@ -9,16 +9,15 @@
 
 let
   pname = "kdevelop";
-  version = "5.0.4";
-  dirVersion = "5.0.4";
+  version = "5.1.1";
 
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${dirVersion}/src/${name}.tar.xz";
-    sha256 = "191142b2bdb14837c82721fdfeb15e852329f2c4c0d48fd479c57514c3235d55";
+    url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
+    sha256 = "0a01a4ffb2f01802cf4945521a3149a8f82c21fa8a97935991f1854b7db5d754";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/editors/kdevelop5/kdevplatform.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevplatform.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, gettext, pkgconfig, extra-cmake-modules, makeQtWrapper
+{ stdenv, fetchurl, fetchpatch, cmake, gettext, pkgconfig, extra-cmake-modules, makeQtWrapper
 , boost, subversion, apr, aprutil
 , qtscript, qtwebkit, grantlee, karchive, kconfig, kcoreaddons, kguiaddons, kiconthemes, ki18n
 , kitemmodels, kitemviews, kio, kparts, sonnet, kcmutils, knewstuff, knotifications
@@ -6,17 +6,24 @@
 
 let
   pname = "kdevplatform";
-  version = "5.0.4";
-  dirVersion = "5.0.4";
+  version = "5.1.1";
 
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   
   src = fetchurl {
-    url = "mirror://kde/stable/kdevelop/${dirVersion}/src/${name}.tar.xz";
-    sha256 = "01abfcd71383048d017fe989ccce0e7590010a3975bbe6e161f55ababe2ad471";
+    url = "mirror://kde/stable/kdevelop/${version}/src/${name}.tar.xz";
+    sha256 = "3159440512b1373c1a4b35f401ba1f81217de9578372b45137af141eeda6e726";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "kdevplatform-project-selection.patch";
+      url = "https://cgit.kde.org/kdevplatform.git/patch/?id=da4c0fdfcf21dc2a8f48a2b1402213a32effd47a";
+      sha256 = "16ws8l6dciy2civjnsaj03ml2bzvg4a9g7gd4iyx4hprw65zrcxm";
+    })
+  ];
 
   nativeBuildInputs = [ cmake gettext pkgconfig extra-cmake-modules makeQtWrapper ];
 


### PR DESCRIPTION
Including also a patch for bug https://bugs.kde.org/show_bug.cgi?id=379433
which is a quite annoying regression from 5.0.4. The patch is the same as
the change committed upstream.

Please merge back to release-17.03 as well.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

