### PR TITLE
git-series: install man page

### DIFF
--- a/pkgs/development/tools/git-series/default.nix
+++ b/pkgs/development/tools/git-series/default.nix
@@ -18,6 +18,11 @@ buildRustPackage rec {
   nativeBuildInputs = [ cmake pkgconfig perl ];
   buildInputs = [ openssl zlib ];
 
+  postBuild = ''
+    mkdir -p "$out/man/man1"
+    cp "$src/git-series.1" "$out/man/man1"
+  '';
+
   meta = with stdenv.lib; {
     description = "A tool to help with formatting git patches for review on mailing lists";
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes #26373 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

