### PR TITLE
rssguard: init at 3.4.0

### DIFF
--- a/pkgs/applications/networking/feedreaders/rssguard/default.nix
+++ b/pkgs/applications/networking/feedreaders/rssguard/default.nix
@@ -1,26 +1,19 @@
-{ stdenv, fetchFromGitHub, qmakeHook, qtwebengine, qttools }:
+{ stdenv, fetchgit, qmakeHook, qtwebengine, qttools, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "rssguard-${version}";
   version = "3.4.0";
 
-  src = fetchFromGitHub {
-    owner = "martinrotter";
-    repo = "rssguard";
-    # fetchFromGitHub doesn't support rev being a tag when fetchSubmodules=true,
-    # so need to use the hash commit. See:
-    # https://github.com/NixOS/nixpkgs/issues/26302
-    #rev = "${version}";
-    rev = "cb15ba92c9bc1b80e2b81d7976438e562ee1ef90";
+  src = fetchgit {
+    url = https://github.com/martinrotter/rssguard;
+    rev = "refs/tags/${version}";
     sha256 = "1cdpfjj2lm1q2qh0w0mh505blcmi4n78458d3z3c1zn9ls9b9zsp";
     fetchSubmodules = true;
   };
 
-  buildInputs =  [ qmakeHook qtwebengine qttools ];
-
-  preConfigure = ''
-    qmakeFlags="$qmakeFlags CONFIG+=release"
-  '';
+  buildInputs =  [ qtwebengine qttools ];
+  nativeBuildInputs = [ qmakeHook wrapGAppsHook ];
+  qmakeFlags = [ "CONFIG+=release" ];
 
   meta = with stdenv.lib; {
     description = "Simple RSS/Atom feed reader with online synchronization";

--- a/pkgs/applications/networking/feedreaders/rssguard/default.nix
+++ b/pkgs/applications/networking/feedreaders/rssguard/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, qmakeHook, qtwebengine, qttools }:
+
+stdenv.mkDerivation rec {
+  name = "rssguard-${version}";
+  version = "3.4.0";
+
+  src = fetchFromGitHub {
+    owner = "martinrotter";
+    repo = "rssguard";
+    # fetchFromGitHub doesn't support rev being a tag when fetchSubmodules=true,
+    # so need to use the hash commit. See:
+    # https://github.com/NixOS/nixpkgs/issues/26302
+    #rev = "${version}";
+    rev = "cb15ba92c9bc1b80e2b81d7976438e562ee1ef90";
+    sha256 = "1cdpfjj2lm1q2qh0w0mh505blcmi4n78458d3z3c1zn9ls9b9zsp";
+    fetchSubmodules = true;
+  };
+
+  buildInputs =  [ qmakeHook qtwebengine qttools ];
+
+  preConfigure = ''
+    qmakeFlags="$qmakeFlags CONFIG+=release"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple RSS/Atom feed reader with online synchronization";
+    longDescription = ''
+      RSS Guard is a simple, light and easy-to-use RSS/ATOM feed aggregator
+      developed using Qt framework and with online feed synchronization support
+      for ownCloud/Nextcloud.
+    '';
+    homepage = https://github.com/martinrotter/rssguard;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15163,7 +15163,6 @@ with pkgs;
   polybar = callPackage ../applications/misc/polybar { };
 
   rssguard = libsForQt5.callPackage ../applications/networking/feedreaders/rssguard { };
-  #rssguard = libsForQt5.callPackage ../applications/networking/newsreaders/rssguard { };
 
   scudcloud = callPackage ../applications/networking/instant-messengers/scudcloud { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15162,6 +15162,9 @@ with pkgs;
 
   polybar = callPackage ../applications/misc/polybar { };
 
+  rssguard = libsForQt5.callPackage ../applications/networking/feedreaders/rssguard { };
+  #rssguard = libsForQt5.callPackage ../applications/networking/newsreaders/rssguard { };
+
   scudcloud = callPackage ../applications/networking/instant-messengers/scudcloud { };
 
   shotcut = libsForQt5.callPackage ../applications/video/shotcut { };


### PR DESCRIPTION
###### Motivation for this change

RSS Guard is a simple, light and easy-to-use RSS/ATOM feed aggregator developed using Qt framework and with online feed synchronization support for ownCloud/Nextcloud.

Please check my commit and feel free to comment. This is my first contribution of a real application so I may be doing something wrong. So thanks for any feedback!

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

