### PR TITLE
Fix hooks not being called when overriding phases in various packages

### DIFF
--- a/pkgs/applications/graphics/unigine-valley/default.nix
+++ b/pkgs/applications/graphics/unigine-valley/default.nix
@@ -51,20 +51,30 @@ in
     ];
 
     unpackPhase = ''
+      runHook preUnpack
+
       cp $src extractor.run
       chmod +x extractor.run
       ./extractor.run --target $sourceRoot
+
+      runHook postUnpack
     '';
 
     patchPhase = ''
+      runHook prePatch
+
       # Patch ELF files.
       elfs=$(find bin -type f | xargs file | grep ELF | cut -d ':' -f 1)
       for elf in $elfs; do
         patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 $elf || true
       done
+
+      runHook postPatch
     '';
 
     installPhase = ''
+      runHook preInstall
+
       instdir=$out/${instPath}
 
       # Install executables and libraries
@@ -86,6 +96,8 @@ in
       wrapProgram $out/bin/valley \
         --run "cd $instdir" \
         --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:$instdir/bin:$libPath
+
+      runHook postInstall
     '';
 
     stripDebugList = ["${instPath}/bin"];

--- a/pkgs/os-specific/linux/intel-ocl/default.nix
+++ b/pkgs/os-specific/linux/intel-ocl/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
   '';
 
   patchPhase = ''
+    runHook prePatch
+
     # Remove libOpenCL.so, since we use ocl-icd's libOpenCL.so instead and this would cause a clash.
     rm opt/intel/opencl/libOpenCL.so*
 
@@ -35,18 +37,28 @@ stdenv.mkDerivation rec {
     for lib in opt/intel/opencl/*.so; do
       patchelf --set-rpath "${libPath}:$out/lib/intel-ocl" $lib || true
     done
+
+    runHook postPatch
   '';
 
   buildPhase = ''
+    runHook preBuild
+
     # Create ICD file, which just contains the path of the corresponding shared library.
     echo "$out/lib/intel-ocl/libintelocl.so" > intel.icd
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     install -D -m 0755 opt/intel/opencl/*.so* -t $out/lib/intel-ocl
     install -D -m 0644 opt/intel/opencl/*.{o,rtl,bin} -t $out/lib/intel-ocl
     install -D -m 0644 opt/intel/opencl/{LICENSE,NOTICES} -t $out/share/doc/intel-ocl
     install -D -m 0644 intel.icd -t $out/etc/OpenCL/vendors
+
+    runHook postInstall
   '';
 
   dontStrip = true;

--- a/pkgs/tools/misc/ckb/default.nix
+++ b/pkgs/tools/misc/ckb/default.nix
@@ -29,8 +29,12 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   installPhase = ''
+    runHook preInstall
+
     install -D --mode 0755 --target-directory $out/bin bin/ckb-daemon bin/ckb
     install -D --mode 0755 --target-directory $out/libexec/ckb-animations bin/ckb-animations/*
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/security/hashcat/hashcat3/default.nix
+++ b/pkgs/tools/security/hashcat/hashcat3/default.nix
@@ -18,7 +18,9 @@ stdenv.mkDerivation rec {
 
   # $out is not known until the build has started.
   configurePhase = ''
+    runHook preConfigure
     makeFlags="$makeFlags PREFIX=$out"
+    runHook postConfigure
   '';
 
   postFixup = ''


### PR DESCRIPTION
###### Motivation for this change

It's necessary to do this in order to fix ckb's compilation, now that
fixupPhase rejects derivation results containing references to the temporary
build directory. It seems like good practice so I've added it to the
other packages that I maintain.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

