### PR TITLE
cloud-init: remove argparse from requirements.txt

### DIFF
--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -23,10 +23,13 @@ in pythonPackages.buildPythonApplication rec {
 
     substituteInPlace cloudinit/config/cc_growpart.py \
       --replace 'util.subp(["growpart"' 'util.subp(["${cloud-utils}/bin/growpart"'
+
+    # Argparse is part of python stdlib
+    sed -i s/argparse// requirements.txt
     '';
 
   propagatedBuildInputs = with pythonPackages; [ cheetah jinja2 prettytable
-    oauthlib pyserial configobj pyyaml argparse requests jsonpatch ];
+    oauthlib pyserial configobj pyyaml requests jsonpatch ];
 
   meta = {
     homepage = http://cloudinit.readthedocs.org;


### PR DESCRIPTION
Argparse is part of python stdlib.

###### Motivation for this change
`cloud-init` package doesn't build since `argparse` module has been removed from `pythonPackages`.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

