### PR TITLE
xdg_utils: fix #25511 (broken sed magic)

### DIFF
--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -29,15 +29,16 @@ stdenv.mkDerivation rec {
 
   postInstall = stdenv.lib.optionalString mimiSupport ''
     cp ${mimisrc}/xdg-open $out/bin/xdg-open
-  ''
-  + ''
-    for tool in "${coreutils}/bin/cut" "${gnused}/bin/sed" \
-      "${gnugrep}"/bin/{e,}grep "${file}/bin/file" \
-      ${stdenv.lib.optionalString mimiSupport
-        '' "${gawk}/bin/awk" "${coreutils}/bin/sort" ''} ;
-    do
-      sed "s# $(basename "$tool") # $tool #g" -i "$out"/bin/*
-    done
+  '' + ''
+    sed  '2s#.#\
+    cut()   { ${coreutils}/bin/cut  "$@"; }\
+    sed()   { ${gnused}/bin/sed     "$@"; }\
+    grep()  { ${gnugrep}/bin/grep   "$@"; }\
+    egrep() { ${gnugrep}/bin/egrep  "$@"; }\
+    file()  { ${file}/bin/file      "$@"; }\
+    awk()   { ${gawk}/bin/awk       "$@"; }\
+    sort()  { ${coreutils}/bin/sort "$@"; }\
+    &#' -i "$out"/bin/*
 
     substituteInPlace $out/bin/xdg-open \
       --replace "/usr/bin/printf" "${coreutils}/bin/printf"


### PR DESCRIPTION
###### Motivation for this change

xdg_utils: fix #25511 (broken sed magic)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

