### PR TITLE
cyrus-sasl: Add saslauthd service and LDAP support

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -534,6 +534,7 @@
   ./services/system/earlyoom.nix
   ./services/system/kerberos.nix
   ./services/system/nscd.nix
+  ./services/system/saslauthd.nix
   ./services/system/uptimed.nix
   ./services/torrent/deluge.nix
   ./services/torrent/flexget.nix

--- a/nixos/modules/services/system/saslauthd.nix
+++ b/nixos/modules/services/system/saslauthd.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  nssModulesPath = config.system.nssModules.path;
+  cfg = config.services.saslauthd;
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.saslauthd = {
+
+      enable = mkEnableOption "Whether to enable the Cyrus SASL authentication daemon.";
+
+      package = mkOption {
+        default = pkgs.cyrus_sasl.bin;
+        defaultText = "pkgs.cyrus_sasl.bin";
+        type = types.package;
+        description = "Cyrus SASL package to use.";
+      };
+
+      mechanism = mkOption {
+        type = types.str;
+        default = "pam";
+        description = "Auth mechanism to use";
+      };
+
+      config = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Configuration to use for Cyrus SASL authentication daemon.";
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    systemd.services.saslauthd = {
+      description = "Cyrus SASL authentication daemon";
+
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = "@${cfg.package}/sbin/saslauthd saslauthd -a ${cfg.mechanism} -O ${pkgs.writeText "saslauthd.conf" cfg.config}";
+        Type = "forking";
+        PIDFile = "/run/saslauthd/saslauthd.pid";
+        Restart = "always";
+      };
+    };
+  };
+}

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation rec {
   # Set this variable at build-time to make sure $out can be evaluated.
   preConfigure = ''
     configureFlagsArray=( --with-plugindir=$out/lib/sasl2
-                          --with-configdir=$out/lib/sasl2
                           --with-saslauthd=/run/saslauthd
                           --enable-login
                         )

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, openssl, kerberos, db, gettext, pam, fixDarwinDylibNames, autoreconfHook }:
+{ lib, stdenv, fetchurl, openssl, openldap, kerberos, db, gettext, pam, fixDarwinDylibNames, autoreconfHook, enableLdap ? false }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ openssl db gettext kerberos ]
+    ++ lib.optional enableLdap openldap
     ++ lib.optional stdenv.isFreeBSD autoreconfHook
     ++ lib.optional stdenv.isLinux pam
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
@@ -29,7 +30,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-openssl=${openssl.dev}"
-  ];
+  ] ++ lib.optional enableLdap "--with-ldap=${openldap.dev}";
 
   # Set this variable at build-time to make sure $out can be evaluated.
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

I'm currently trying to set up a mail server (well, just a forwarder) with LDAP and Postfix. To this end, I've had to add support to the saslauthd service to NixOS, along with (optional, off-by-default) LDAP support.

I removed the --with-configdir to allow configs to be tucked in `/etc/sasl2` along with the default location (`$plugindir`). This is necessary to allow configuring cyrus-sasl's behavior for some apps. For instance, I configure postfix's sasl2 with : 

```
environment.etc."sasl2/smtpd.conf".text = ''
pwcheck_method: saslauthd
mech_list: PLAIN LOGIN
'';
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

