### PR TITLE
grin: Fix build dependencies

### DIFF
--- a/pkgs/tools/text/grin/default.nix
+++ b/pkgs/tools/text/grin/default.nix
@@ -1,11 +1,14 @@
-{ stdenv, fetchgit, python2Packages }:
+{ stdenv, fetchFromGitHub, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  name = "grin-1.2.1";
+  program = "grin";
+  version = "1.2.1";
+  name = "${program}-${version}";
   namePrefix = "";
 
-  src = fetchgit {
-    url = "git://github.com/rkern/grin";
+  src = fetchFromGitHub {
+    owner = "rkern";
+    repo = program;
     rev = "8dd4b5309b3bc04fe9d3e71836420f7d8d4a293f";
     sha256 = "0vz2aahwdcy1296g4w3i79dkvmzk9jc2n2zmlcvlg5m3s6h7b6jd";
   };
@@ -13,7 +16,7 @@ python2Packages.buildPythonApplication rec {
   buildInputs = with python2Packages; [ nose ];
 
   meta = {
-    homepage = https://pypi.python.org/pypi/grin;
+    homepage = https://github.com/rkern/grin;
     description = "A grep program configured the way I like it";
     platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.sjagoe ];

--- a/pkgs/tools/text/grin/default.nix
+++ b/pkgs/tools/text/grin/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchurl, python2Packages }:
+{ stdenv, fetchgit, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
   name = "grin-1.2.1";
   namePrefix = "";
 
-  src = fetchurl {
-    url = "mirror://pypi/g/grin/${name}.tar.gz";
-    sha256 = "1swzwb17wibam8jszdv98h557hlx44pg6psv6rjz7i33qlxk0fdz";
+  src = fetchgit {
+    url = "git://github.com/rkern/grin";
+    rev = "8dd4b5309b3bc04fe9d3e71836420f7d8d4a293f";
+    sha256 = "0vz2aahwdcy1296g4w3i79dkvmzk9jc2n2zmlcvlg5m3s6h7b6jd";
   };
 
   buildInputs = with python2Packages; [ nose ];
-  propagatedBuildInputs = with python2Packages; [ argparse ];
 
   meta = {
     homepage = https://pypi.python.org/pypi/grin;


### PR DESCRIPTION
###### Motivation for this change

Maintenance of `grin` package to fix build errors due to dependency changes.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

