### PR TITLE
hyper: 1.3.1 -> 1.3.3

### DIFF
--- a/pkgs/applications/misc/hyper/default.nix
+++ b/pkgs/applications/misc/hyper/default.nix
@@ -11,11 +11,11 @@ let
   ];
 in
 stdenv.mkDerivation rec {
-  version = "1.3.1";
+  version = "1.3.3";
   name = "hyper-${version}";
   src = fetchurl {
     url = "https://github.com/zeit/hyper/releases/download/${version}/hyper_${version}.deb";
-    sha256 = "1i1rnq10a9kid8lggrd1gp9g08v98la8idnyk4kx4vn0svqy7nvl";
+    sha256 = "1i68n77yv1g4dfx4xfmcb06mfpwhf0gnb3wmldg2gxkhs0fn19zg";
   };
   buildInputs = [ dpkg ];
   unpackPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Update to 1.3.3

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

