### PR TITLE
idea.idea-ultimate: 2017.1.2 -> 2017.1.3

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -269,12 +269,12 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2017.1.2";
+    version = "2017.1.3";
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}-no-jdk.tar.gz";
-      sha256 = "03p5946j8m1v2ca21fz4cy4d90y6ksb8xcgd6ff7g15lg46hpjsm";
+      sha256 = "1gl62zrs3yxakgwbm29bv9z68jgy5ixc28zcagydx2h4j2b1fb19";
     };
     wmClass = "jetbrains-idea";
   };


### PR DESCRIPTION
###### Motivation for this change

Jetbrains released a new minor version.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: First pull request on NixOS/nixpkgs, if I missed something please let me know. I tested the package by `nix-build -A idea.idea-ultimate`, tested `./result/bin/idea-ultimate` and later installed it into my profile with `nix-env -f . -iA idea.idea-ultimate`.