### PR TITLE
llvm_4: Fix debugVersion

### DIFF
--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -115,11 +115,11 @@ in stdenv.mkDerivation rec {
   + stdenv.lib.optionalString (enableSharedLibraries) ''
     moveToOutput "lib/libLLVM-*" "$lib"
     moveToOutput "lib/libLLVM.${shlib}" "$lib"
-    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-release.cmake" \
+    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
       --replace "\''${_IMPORT_PREFIX}/lib/libLLVM-" "$lib/lib/libLLVM-"
   ''
   + stdenv.lib.optionalString (stdenv.isDarwin && enableSharedLibraries) ''
-    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-release.cmake" \
+    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
       --replace "\''${_IMPORT_PREFIX}/lib/libLLVM.dylib" "$lib/lib/libLLVM.dylib"
     install_name_tool -id $lib/lib/libLLVM.dylib $lib/lib/libLLVM.dylib
     install_name_tool -change @rpath/libLLVM.dylib $lib/lib/libLLVM.dylib $out/bin/llvm-config


### PR DESCRIPTION
###### Motivation for this change

LLVM 4.0 in debug mode previously failed on installation phase
when `substituteInPlace` could not find the cmake exports file.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC maintainers: @lovek323 @viric @dtzWill