### PR TITLE
bind: add cfg options for listen-on and listen-on-v6.

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -14,8 +14,8 @@ let
       acl badnetworks { ${concatMapStrings (entry: " ${entry}; ") cfg.blockedNetworks} };
 
       options {
-        listen-on {any;};
-        listen-on-v6 {any;};
+        listen-on { ${concatMapStrings (entry: " ${entry}; ") cfg.listenOn} };
+        listen-on-v6 { ${concatMapStrings (entry: " ${entry}; ") cfg.listenOnIpv6} };
         allow-query { cachenetworks; };
         blackhole { badnetworks; };
         forward first;
@@ -93,6 +93,20 @@ in
         default = config.networking.nameservers;
         description = "
           List of servers we should forward requests to.
+        ";
+      };
+
+      listenOn = mkOption {
+        default = ["any"];
+        description = "
+          Interfaces to listen on.
+        ";
+      };
+
+      listenOnIpv6 = mkOption {
+        default = ["any"];
+        description = "
+          Ipv6 interfaces to listen on.
         ";
       };
 

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -98,6 +98,7 @@ in
 
       listenOn = mkOption {
         default = ["any"];
+        type = types.listOf types.str;
         description = "
           Interfaces to listen on.
         ";
@@ -105,6 +106,7 @@ in
 
       listenOnIpv6 = mkOption {
         default = ["any"];
+        type = types.listOf types.str;
         description = "
           Ipv6 interfaces to listen on.
         ";


### PR DESCRIPTION
This adds configuration options for the bind package so that the interfaces that bind listens on can be configured rather than just hardcoded as any. The default values preserve the old behavior to be backwards compatible.

###### Motivation for this change

The bind configuration is always listening on "any" interface. This change allows configuration of which interfaces to listen on. This is useful to listen on only certain networks.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

