### PR TITLE
generators.toPretty and traceValSeqN

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -91,7 +91,6 @@ rec {
     */
   toYAML = {}@args: toJSON args;
 
-  # TODO we need some kind of pattern matching sometimes
   /* Pretty print a value, akin to `builtins.trace`.
     * Should probably be a builtin as well.
     */
@@ -105,7 +104,13 @@ rec {
     else if isBool     v then (if v == true then "true" else "false")
     else if isString   v then "\"" + v + "\""
     else if null ==    v then "null"
-    else if isFunction v then "<λ>"
+    else if isFunction v then
+      let fna = functionArgs v;
+          showFnas = concatStringsSep "," (libAttr.mapAttrsToList
+                       (name: hasDefVal: if hasDefVal then "(${name})" else name)
+                       fna);
+      in if fna == {}    then "<λ>"
+                         else "<λ:{${showFnas}}>"
     else if isList     v then "[ "
         + libStr.concatMapStringsSep " " (toPretty args) v
       + " ]"

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -285,6 +285,36 @@ runTests {
       expected = builtins.toJSON val;
   };
 
+  testToPretty = {
+    expr = mapAttrs (const (generators.toPretty {})) rec {
+      int = 42;
+      bool = true;
+      string = "fnord";
+      null_ = null;
+      function = x: x;
+      list = [ 3 4 function [ false ] ];
+      attrs = { foo = null; "foo bar" = "baz"; };
+      drv = derivation { name = "test"; system = builtins.currentSystem; };
+    };
+    expected = rec {
+      int = "42";
+      bool = "true";
+      string = "\"fnord\"";
+      null_ = "null";
+      function = "<λ>";
+      list = "[ 3 4 ${function} [ false ] ]";
+      attrs = "{ \"foo\" = null; \"foo bar\" = \"baz\"; }";
+      drv = "<δ>";
+    };
+  };
+
+  testToPrettyAllowPrettyValues = {
+    expr = generators.toPretty { allowPrettyValues = true; }
+             { __pretty = v: "«" + v + "»"; val = "foo"; };
+    expected  = "«foo»";
+  };
+
+
 # MISC
 
   testOverridableDelayableArgsTest = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -292,6 +292,7 @@ runTests {
       string = "fnord";
       null_ = null;
       function = x: x;
+      functionArgs = { arg ? 4, foo }: arg;
       list = [ 3 4 function [ false ] ];
       attrs = { foo = null; "foo bar" = "baz"; };
       drv = derivation { name = "test"; system = builtins.currentSystem; };
@@ -302,6 +303,7 @@ runTests {
       string = "\"fnord\"";
       null_ = "null";
       function = "<λ>";
+      functionArgs = "<λ:{(arg),foo}>";
       list = "[ 3 4 ${function} [ false ] ]";
       attrs = "{ \"foo\" = null; \"foo bar\" = \"baz\"; }";
       drv = "<δ>";


### PR DESCRIPTION
First introduces a pretty printing generator, then uses that to create a debugging function that only goes `n` levels deep. See commit messages.
