### PR TITLE
amarok-kf5: init at 2.8.91-20170228

### DIFF
--- a/pkgs/applications/audio/amarok/kf5.nix
+++ b/pkgs/applications/audio/amarok/kf5.nix
@@ -1,0 +1,37 @@
+{ mkDerivation, fetchgit, lib
+, extra-cmake-modules, kdoctools
+, qca-qt5, qjson, qtscript, qtwebkit
+, kcmutils, kconfig, kdelibs4support, kdnssd, kinit, knewstuff, knotifyconfig, ktexteditor
+, phonon, plasma-framework, threadweaver
+, curl, ffmpeg, gdk_pixbuf, libaio, libmtp, loudmouth, lzo, lz4, mariadb, pcre, snappy, taglib, taglib_extras
+}:
+
+let
+  pname = "amarok";
+  version = "2.8.91-20170228";
+
+in mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchgit {
+    url    = git://anongit.kde.org/amarok.git;
+    # go back to the KDE mirror when kf5 is merged into master
+    # url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
+    rev    = "323e2d5b43245c4c06e0b83385d37ef0d32920cb";
+    sha256 = "05w7kl6qfmkjz0y1bhgkkbmsqdll30bkjd6npkzvivrvp7dplmbh";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  propagatedBuildInputs = [
+    qca-qt5 qjson qtscript qtwebkit
+    kcmutils kconfig kdelibs4support kdnssd kinit knewstuff knotifyconfig ktexteditor
+    phonon plasma-framework threadweaver
+    curl ffmpeg gdk_pixbuf libaio libmtp loudmouth lz4 lzo mariadb pcre snappy taglib taglib_extras
+  ];
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13135,6 +13135,8 @@ with pkgs;
     ffmpeg = ffmpeg_2;
   };
 
+  amarok-kf5 = libsForQt5.callPackage ../applications/audio/amarok/kf5.nix { };
+
   AMB-plugins = callPackage ../applications/audio/AMB-plugins { };
 
   ams-lv2 = callPackage ../applications/audio/ams-lv2 { };


### PR DESCRIPTION
###### Motivation for this change

Amarok is in the process of being ported to KF5 as the current version in nixpkgs depends on KDE4.

As the port isn't quite complete, this version hasn't reached feature parity so it's a bit early to simply drop the old version.

@ttuegel , any thoughts on the ```-kf5``` suffix?

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
