### PR TITLE
buck: init at v2017.05.31.01

### DIFF
--- a/pkgs/development/tools/build-managers/buck/default.nix
+++ b/pkgs/development/tools/build-managers/buck/default.nix
@@ -1,8 +1,6 @@
-{ stdenv, fetchFromGitHub, jdk, ant, python2, python2Packages, watchman, unzip, bash, jre, makeWrapper }:
+{ stdenv, fetchFromGitHub, jdk, ant, python2, python2Packages, watchman, unzip, bash, makeWrapper }:
 
-
-let
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "buck-${version}";
   version = "v2017.05.31.01";
 
@@ -31,7 +29,7 @@ in stdenv.mkDerivation rec {
     install -D -m755 buck-out/gen/programs/buck.pex $out/bin/buck
     wrapProgram $out/bin/buck \
       --prefix PYTHONPATH : $PYTHONPATH \
-      --prefix PATH : "${stdenv.lib.makeBinPath [jre watchman]}"
+      --prefix PATH : "${stdenv.lib.makeBinPath [jdk watchman]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/build-managers/buck/default.nix
+++ b/pkgs/development/tools/build-managers/buck/default.nix
@@ -1,0 +1,46 @@
+  { stdenv, pkgs, fetchFromGitHub, fetchgit, jdk, ant, python2, watchman, unzip, bash }:
+
+stdenv.mkDerivation rec {
+  name = "buck-${version}";
+  version = "v2017.05.31.01";
+
+  src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "buck";
+    rev = "0b8b3828a11afa79dc128832cb55b106f07e48aa";
+    sha256 = "1g3yg8qq91cdhsq7zmir7wxw3767l120f5zhq969gppdw9apqy0s";
+  };
+
+  patches = [ ./pex-mtime.patch ];
+
+  postPatch = ''
+    for f in $(grep -l -r '/bin/bash'); do
+      substituteInPlace "$f" --replace '/bin/bash' '${bash}/bin/bash'
+    done
+  '';
+
+  buildInputs = [ jdk ant ];
+
+  propagatedBuildInputs = [ python2 watchman pkgs.python27Packages.pywatchman ];
+
+  buildPhase =
+    ''
+      ant
+      ./bin/buck --version
+      ./bin/buck build buck
+    '';
+
+  installPhase =
+    ''
+      mkdir -p $out/bin
+      cp  buck-out/gen/programs/buck.pex $out/bin/buck
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = https://buckbuild.com/;
+    description = "A high-performance build tool";
+    maintainers = [ maintainers.jgertm ];
+    license = licenses.asl20;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/build-managers/buck/pex-mtime.patch
+++ b/pkgs/development/tools/build-managers/buck/pex-mtime.patch
@@ -1,0 +1,21 @@
+diff --git a/third-party/py/pex/pex/common.py b/third-party/py/pex/pex/common.py
+index 76459ce23..491dcfc0b 100644
+--- a/third-party/py/pex/pex/common.py
++++ b/third-party/py/pex/pex/common.py
+@@ -12,6 +12,7 @@ import stat
+ import sys
+ import tempfile
+ import threading
++import time
+ import zipfile
+ from collections import defaultdict
+ from uuid import uuid4
+@@ -328,4 +329,7 @@ class Chroot(object):
+   def zip(self, filename, mode='wb'):
+     with contextlib.closing(zipfile.ZipFile(filename, mode)) as zf:
+       for f in sorted(self.files()):
+-        zf.write(os.path.join(self.chroot, f), arcname=f, compress_type=zipfile.ZIP_DEFLATED)
++        file = os.path.join(self.chroot, f)
++        instant = 315532800
++        os.utime(file, (instant, instant))
++        zf.write(file, arcname=f, compress_type=zipfile.ZIP_DEFLATED)

--- a/pkgs/development/tools/build-managers/buck/pex-mtime.patch
+++ b/pkgs/development/tools/build-managers/buck/pex-mtime.patch
@@ -1,21 +1,13 @@
 diff --git a/third-party/py/pex/pex/common.py b/third-party/py/pex/pex/common.py
-index 76459ce23..491dcfc0b 100644
+index 76459ce23..eff411b20 100644
 --- a/third-party/py/pex/pex/common.py
 +++ b/third-party/py/pex/pex/common.py
-@@ -12,6 +12,7 @@ import stat
- import sys
- import tempfile
- import threading
-+import time
- import zipfile
- from collections import defaultdict
- from uuid import uuid4
-@@ -328,4 +329,7 @@ class Chroot(object):
+@@ -328,4 +328,7 @@ class Chroot(object):
    def zip(self, filename, mode='wb'):
      with contextlib.closing(zipfile.ZipFile(filename, mode)) as zf:
        for f in sorted(self.files()):
 -        zf.write(os.path.join(self.chroot, f), arcname=f, compress_type=zipfile.ZIP_DEFLATED)
-+        file = os.path.join(self.chroot, f)
-+        instant = 315532800
-+        os.utime(file, (instant, instant))
-+        zf.write(file, arcname=f, compress_type=zipfile.ZIP_DEFLATED)
++        path = os.path.join(self.chroot, f)
++        instant = 615532801
++        os.utime(path, (instant, instant))
++        zf.write(path, arcname=f, compress_type=zipfile.ZIP_DEFLATED)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6552,6 +6552,8 @@ with pkgs;
     wxGTK = wxGTK30;
   };
 
+  buck = callPackage ../development/tools/build-managers/buck { };
+
   buildbot = callPackage ../development/tools/build-managers/buildbot {
     pythonPackages = python2Packages;
   };


### PR DESCRIPTION
###### Motivation for this change

This PR introduces the `buck` build tool, developed at Facebook. It contains merely the static .pex file generated by `buck build buck`, not the recommended mutable directory that buck uses to satisfy the version specified by a project's `.buckversion` file. 

Such is life in Nixistan.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

