### PR TITLE
hplip: introduce nettools dependency

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, substituteAll
 , pkgconfig
+, makeWrapper
 , cups, zlib, libjpeg, libusb1, pythonPackages, sane-backends, dbus, usbutils
 , net_snmp, openssl, polkit, nettools
 , bash, coreutils, utillinux
@@ -22,20 +23,17 @@ let
     sha256 = "1y3wdax2wb6kdd8bi40wl7v9s8ffyjz95bz42sjcpzzddmlhcaxg";
   };
 
-  hplipState =
-    substituteAll
-      {
-        inherit version;
-        src = ./hplip.state;
-      };
+  hplipState = substituteAll {
+    inherit version;
+    src = ./hplip.state;
+  };
 
-  hplipPlatforms =
-    {
-      "i686-linux"   = "x86_32";
-      "x86_64-linux" = "x86_64";
-      "armv6l-linux" = "arm32";
-      "armv7l-linux" = "arm32";
-    };
+  hplipPlatforms = {
+    "i686-linux"   = "x86_32";
+    "x86_64-linux" = "x86_64";
+    "armv6l-linux" = "arm32";
+    "armv7l-linux" = "arm32";
+  };
 
   hplipArch = hplipPlatforms."${stdenv.system}"
     or (throw "HPLIP not supported on ${stdenv.system}");
@@ -58,12 +56,12 @@ pythonPackages.buildPythonApplication {
     sane-backends
     dbus
     net_snmp
-    nettools
     openssl
   ];
 
   nativeBuildInputs = [
     pkgconfig
+    makeWrapper
   ];
 
   propagatedBuildInputs = with pythonPackages; [
@@ -74,8 +72,7 @@ pythonPackages.buildPythonApplication {
     usbutils
   ] ++ stdenv.lib.optionals qtSupport [
     pyqt4
-  ]
-  ++ [ nettools ];
+  ];
 
   prePatch = ''
     # HPLIP hardcodes absolute paths everywhere. Nuke from orbit.
@@ -148,6 +145,9 @@ pythonPackages.buildPythonApplication {
   '';
 
   postFixup = ''
+    wrapProgram $out/lib/cups/filter/hpps \
+      --prefix PATH : "${nettools}/bin"
+
     substituteInPlace $out/etc/hp/hplip.conf --replace /usr $out
   '' + stdenv.lib.optionalString (!withPlugin) ''
     # A udev rule to notify users that they need the binary plugin.

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, substituteAll
 , pkgconfig
 , cups, zlib, libjpeg, libusb1, pythonPackages, sane-backends, dbus, usbutils
-, net_snmp, openssl, polkit
+, net_snmp, openssl, polkit, nettools
 , bash, coreutils, utillinux
 , qtSupport ? true
 , withPlugin ? false
@@ -58,6 +58,7 @@ pythonPackages.buildPythonApplication {
     sane-backends
     dbus
     net_snmp
+    nettools
     openssl
   ];
 
@@ -73,7 +74,8 @@ pythonPackages.buildPythonApplication {
     usbutils
   ] ++ stdenv.lib.optionals qtSupport [
     pyqt4
-  ];
+  ]
+  ++ [ nettools ];
 
   prePatch = ''
     # HPLIP hardcodes absolute paths everywhere. Nuke from orbit.


### PR DESCRIPTION
###### Motivation for this change

I wanted to print something on a HP MFP  M477fnw and cups was producing an error. Digging through the logs revealed a failing call to hostname, which is part of nettools.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

