### PR TITLE
Link vagrant against libffi

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -97,8 +97,8 @@ in stdenv.mkDerivation rec {
 
     # ruby libs
     rm -rf opt/vagrant/embedded/lib/*
-    for lib in $(ls ${ruby}/lib); do
-      ln -s ${ruby}/lib/$lib opt/vagrant/embedded/lib/$lib
+    for lib in ${ruby}/lib/*; do
+      ln -s $lib opt/vagrant/embedded/lib/''${lib##*/}
     done
 
     # libiconv: iconv

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, dpkg, curl, libarchive, openssl, ruby, buildRubyGem, libiconv
-, libxml2, libxslt, makeWrapper, p7zip, xar, gzip, cpio }:
+, libxml2, libxslt, libffi, makeWrapper, p7zip, xar, gzip, cpio }:
 
 let
   version = "1.9.5";
@@ -96,8 +96,10 @@ in stdenv.mkDerivation rec {
     ln -s ${ruby}/bin/ruby opt/vagrant/embedded/bin
 
     # ruby libs
-    rm -rf opt/vagrant/embedded/lib
-    ln -s ${ruby}/lib opt/vagrant/embedded/lib
+    rm -rf opt/vagrant/embedded/lib/*
+    for lib in $(ls ${ruby}/lib); do
+      ln -s ${ruby}/lib/$lib opt/vagrant/embedded/lib/$lib
+    done
 
     # libiconv: iconv
     rm opt/vagrant/embedded/bin/iconv
@@ -113,6 +115,9 @@ in stdenv.mkDerivation rec {
     rm opt/vagrant/embedded/bin/{xslt-config,xsltproc}
     ln -s ${libxslt.dev}/bin/xslt-config opt/vagrant/embedded/bin
     ln -s ${libxslt.bin}/bin/xsltproc opt/vagrant/embedded/bin
+
+    # libffi
+    ln -s ${libffi}/lib/libffi.so.6 opt/vagrant/embedded/lib/libffi.so.6
 
     mkdir -p "$out"
     cp -r opt "$out"


### PR DESCRIPTION
###### Motivation for this change

Vagrant requires libffi to run
with (vagrant-fsnotify)[https://github.com/adrienkohlbecker/vagrant-fsnotify].

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

