### PR TITLE
Add astropy to nixpkgs.

### DIFF
--- a/pkgs/development/python-modules/astropy/default.nix
+++ b/pkgs/development/python-modules/astropy/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchurl
+, stdenv 
+, python3Packages
+, buildPythonPackage }:
+
+buildPythonPackage rec {
+    name = "astropy";
+    version = "1.3.3";
+    src = fetchurl {
+      url = "https://pypi.python.org/packages/f2/ad/110f13061ca68f3397216c2716b6687efab4d85e59366d94414c92274554/astropy-1.3.3.tar.gz";
+      sha256 = "ed093e033fcbee5a3ec122420c3376f8a80f74663214560727d3defe82170a99";      
+  };
+  doCheck = false;
+  buildInputs = with python3Packages; [ numpy ];
+
+
+  meta = {
+    description = "Astronomy/Astrophysics library for Python";
+    homepage = "http://www.astropy.org";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ KentJames ];
+  };
+  }
+
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -141,6 +141,8 @@ in {
 
   asn1crypto = callPackage ../development/python-modules/asn1crypto { };
 
+  astropy = callPackage ../development/python-modules/astropy {  };
+
   automat = callPackage ../development/python-modules/automat { };
 
   # packages defined elsewhere


### PR DESCRIPTION
###### Motivation for this change

I'm an astrophysicist and I usually add this to my python environments manually. Astropy is THE standard in the field and it makes a lot of sense that it is added to the nixpkgs tree.  

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

