### PR TITLE
Add astropy to nixpkgs.

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -269,6 +269,7 @@
   kaiha = "Kai Harries <kai.harries@gmail.com>";
   kamilchm = "Kamil Chmielewski <kamil.chm@gmail.com>";
   kampfschlaefer = "Arnold Krille <arnold@arnoldarts.de>";
+  kentjames = "James Kent <jameschristopherkent@gmail.com";
   kevincox = "Kevin Cox <kevincox@kevincox.ca>";
   khumba = "Bryan Gardiner <bog@khumba.net>";
   KibaFox = "Kiba Fox <kiba.fox@foxypossibilities.com>";

--- a/pkgs/development/python-modules/astropy/default.nix
+++ b/pkgs/development/python-modules/astropy/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, numpy
+, cython
+, h5py
+, scipy }:
+
+buildPythonPackage rec {
+  
+  pname = "astropy";
+  version = "1.3.3";
+
+  name = "${pname}-${version}";
+  doCheck = false; #Some tests are failing. More importantly setup.py hangs on completion. Needs fixing with a proper shellhook.
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ed093e033fcbee5a3ec122420c3376f8a80f74663214560727d3defe82170a99";
+  };
+  propagatedBuildInputs = [ numpy cython h5py scipy ];
+
+
+  meta = {
+    description = "Astronomy/Astrophysics library for Python";
+    homepage = "http://www.astropy.org";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ kentjames ];
+  };
+}
+
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -141,6 +141,8 @@ in {
 
   asn1crypto = callPackage ../development/python-modules/asn1crypto { };
 
+  astropy = callPackage ../development/python-modules/astropy {  };
+
   automat = callPackage ../development/python-modules/automat { };
 
   # packages defined elsewhere


### PR DESCRIPTION
###### Motivation for this change

I'm an astrophysicist and I usually add this to my python environments manually. Astropy is THE standard in the field and it makes a lot of sense that it is added to the nixpkgs tree.



###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

