### PR TITLE
zoom-us: init at 2.0.91373.0502

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -1,0 +1,91 @@
+{ stdenv, fetchurl, system, rsync, makeWrapper,
+  alsaLib, dbus, glib, gstreamer, fontconfig, freetype, libpulseaudio, libxml2,
+  libxslt, mesa, nspr, nss, sqlite, utillinux, zlib, xorg }:
+
+let
+
+  version = "2.0.91373.0502";
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://zoom.us/client/${version}/zoom_x86_64.tar.xz";
+      sha256 = "0gcbfsvybkvnyklm82irgz19x3jl0hz9bwf2l9jga188057pfj7a";
+    };
+  };
+
+in stdenv.mkDerivation {
+  name = "zoom-us-${version}";
+
+  src = srcs.${system};
+
+  buildInputs = [ rsync makeWrapper ];
+
+  libPath = stdenv.lib.makeLibraryPath [
+    alsaLib
+    dbus
+    glib
+    gstreamer
+    fontconfig
+    freetype
+    libpulseaudio
+    libxml2
+    libxslt
+    mesa
+    nspr
+    nss
+    sqlite
+    utillinux
+    zlib
+
+    xorg.libX11
+    xorg.libSM
+    xorg.libICE
+    xorg.libxcb
+    xorg.xcbutilimage
+    xorg.xcbutilkeysyms
+    xorg.libXcursor
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXdamage
+    xorg.libXtst
+    xorg.libxshmfence
+    xorg.libXi
+    xorg.libXrender
+    xorg.libXcomposite
+
+    stdenv.cc.cc
+  ];
+
+  installPhase = ''
+    $preInstallHooks
+
+    mkdir -p $out/share
+    mkdir -p $out/bin
+    rsync -av . $out/share/
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      $out/share/zoom
+    # included from https://github.com/NixOS/nixpkgs/commit/fc218766333a05c9352b386e0cbb16e1ae84bf53
+    # it works for me without it, but, well...
+    paxmark m $out/share/zoom
+    #paxmark m $out/share/QtWebEngineProcess # is this what dtzWill talked about?
+
+    # RUNPATH set via patchelf is used only for half of libraries (why?), so wrap it
+    wrapProgram $out/share/zoom \
+        --prefix LD_LIBRARY_PATH : "$out/share:$libPath" \
+        --set QT_PLUGIN_PATH "$out/share/platforms" \
+        --set QT_XKB_CONFIG_ROOT "${xorg.xkeyboardconfig}/share/X11/xkb" \
+        --set QTCOMPOSE "${xorg.libX11.out}/share/X11/locale"
+    ln -s "$out/share/zoom" "$out/bin/zoom"
+
+    $postInstallHooks
+  '';
+
+  meta = {
+    homepage = http://zoom.us;
+    description = "zoom.us video conferencing application";
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ danbst ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16788,6 +16788,8 @@ with pkgs;
 
   zim = callPackage ../applications/office/zim { };
 
+  zoom-us = callPackage ../applications/networking/instant-messengers/zoom-us { };
+
   zotero = callPackage ../applications/office/zotero {
     firefox = firefox-esr-unwrapped;
   };


### PR DESCRIPTION
Actually, reintroduce after removal (https://github.com/NixOS/nixpkgs/commit/bb99babc5a1c62edd012da5a1ad14cd3fe1abf0a)
and use bundled Qt.

Stepping up as a maintainer

Still, some bugs present (like crash when log-in using Facebook, clear ~/.zoom to recover, bug reported upstream) and I didn't test video (no cam).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

