### PR TITLE
ImageMagick: 6.9.8-6 -> 6.9.8-9

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -12,8 +12,8 @@ let
     else throw "ImageMagick is not supported on this platform.";
 
   cfg = {
-    version = "6.9.8-6";
-    sha256 = "1sxg2wx3nrzbymh5wcqiv1x401nrz95xkrqgk3x446vx8lq7ln6w";
+    version = "6.9.8-9";
+    sha256 = "0wr6wcmvaw62f6pkgnpqnjmp331wfwmds9wmqzr4zv53s9k1lkzn";
     patches = [];
   }
     # Freeze version on mingw so we don't need to port the patch too often.

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -141,9 +141,11 @@ rec {
     http://bitlbee.intergenia.de/
   ];
 
-  # ImageMagick mirrors, see http://www.imagemagick.org/script/download.php.
+  # ImageMagick mirrors, see https://www.imagemagick.org/script/mirror.php
   imagemagick = [
-    http://www.imagemagick.org/download/
+    https://www.imagemagick.org/download/
+    https://mirror.checkdomain.de/imagemagick/
+    https://ftp.nluug.nl/ImageMagick/
     ftp://ftp.sunet.se/pub/multimedia/graphics/ImageMagick/ # also contains older versions removed from most mirrors
     http://ftp.sunet.se/pub/multimedia/graphics/ImageMagick/
     ftp://ftp.imagemagick.org/pub/ImageMagick/


### PR DESCRIPTION
###### Motivation for this change
6.9.8-6 no longer exists on any mirrors. Possibly because of CVEs.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

