### PR TITLE
jing-trang: use jre_headless

### DIFF
--- a/pkgs/tools/text/xml/jing-trang/default.nix
+++ b/pkgs/tools/text/xml/jing-trang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jre, jdk, ant, saxon }:
+{ stdenv, fetchFromGitHub, jre_headless, jdk, ant, saxon }:
 
 stdenv.mkDerivation rec {
   name = "jing-trang-${version}";
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
     for tool in jing trang; do
     cat > "$out/bin/$tool" <<EOF
     #! $SHELL
-    export JAVA_HOME='${jre}'
-    exec '${jre}/bin/java' -jar '$out/share/java/$tool.jar' "\$@"
+    export JAVA_HOME='${jre_headless}'
+    exec '${jre_headless}/bin/java' -jar '$out/share/java/$tool.jar' "\$@"
     EOF
     done
 


### PR DESCRIPTION
###### Motivation for this change
This halves its closure size.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).