### PR TITLE
ranger: add imagePreviewSupport option and make previews work out of the box

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchurl, pythonPackages, w3m, file, less }:
+{ stdenv, fetchurl, pythonPackages, file, less
+, imagePreviewSupport ? true, w3m ? null}:
+
+with stdenv.lib;
+
+assert imagePreviewSupport -> w3m != null;
 
 pythonPackages.buildPythonApplication rec {
   name = "ranger-1.8.1";
@@ -23,14 +28,23 @@ pythonPackages.buildPythonApplication rec {
   '';
 
   preConfigure = ''
-    substituteInPlace ranger/ext/img_display.py \
-      --replace /usr/lib/w3m ${w3m}/libexec/w3m
     substituteInPlace ranger/__init__.py \
       --replace "DEFAULT_PAGER = 'less'" "DEFAULT_PAGER = '${stdenv.lib.getBin less}/bin/less'"
 
     for i in ranger/config/rc.conf doc/config/rc.conf ; do
       substituteInPlace $i --replace /usr/share $out/share
     done
+
+    # give file previews out of the box
+    substituteInPlace ranger/config/rc.conf \
+      --replace "set preview_script ~/.config/ranger/scope.sh" "set preview_script $out/share/doc/ranger/config/scope.sh"
+  '' + optionalString imagePreviewSupport ''
+    substituteInPlace ranger/ext/img_display.py \
+      --replace /usr/lib/w3m ${w3m}/libexec/w3m
+
+    # give image previews out of the box when building with w3m
+    substituteInPlace ranger/config/rc.conf \
+      --replace "set preview_images false" "set preview_images true" \
   '';
 
 }


### PR DESCRIPTION
Merge #26452 first or this won't build.

###### Motivation for this change
See commit message.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

