### PR TITLE
boost: enable static libraries on Darwin

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -5,7 +5,7 @@
 , enableSingleThreaded ? false
 , enableMultiThreaded ? true
 , enableShared ? !(stdenv.cross.libc or null == "msvcrt") # problems for now
-, enableStatic ? !enableShared
+, enableStatic ? !enableShared || stdenv.isDarwin
 , enablePIC ? false
 , enableExceptions ? false
 , taggedLayout ? ((enableRelease && enableDebug) || (enableSingleThreaded && enableMultiThreaded) || (enableShared && enableStatic))


### PR DESCRIPTION
###### Motivation for this change

This seems to be necessary for CMake/Boost projects to build on Darwin.

My test case was `solc`, which currently does not build on Darwin.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

