### PR TITLE
nixos-artwork: add more wallpapers

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -35,10 +35,10 @@ let
      chmod -R a+w $out/share/gsettings-schemas/nixos-gsettings-overrides
      cat - > $out/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas/nixos-defaults.gschema.override <<- EOF
        [org.gnome.desktop.background]
-       picture-uri='${pkgs.nixos-artwork}/share/artwork/gnome/Gnome_Dark.png'
+       picture-uri='${pkgs.nixos-artwork.wallpapers.gnome-dark}/share/artwork/gnome/Gnome_Dark.png'
 
        [org.gnome.desktop.screensaver]
-       picture-uri='${pkgs.nixos-artwork}/share/artwork/gnome/Gnome_Dark.png'
+       picture-uri='${pkgs.nixos-artwork.wallpapers.gnome-dark}/share/artwork/gnome/Gnome_Dark.png'
 
        ${cfg.extraGSettingsOverrides}
      EOF

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -111,7 +111,7 @@ in
 
       background = mkOption {
         type = types.str;
-        default = "${pkgs.nixos-artwork}/share/artwork/gnome/Gnome_Dark.png";
+        default = "${pkgs.nixos-artwork.wallpapers.gnome-dark}/share/artwork/gnome/Gnome_Dark.png";
         description = ''
           The background image or color to use.
         '';

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -489,7 +489,7 @@ in
           sha256 = "14kqdx2lfqvh40h6fjjzqgff1mwk74dmbjvmqphi6azzra7z8d59";
         }
         # GRUB 1.97 doesn't support gzipped XPMs.
-        else "${pkgs.nixos-artwork}/share/artwork/gnome/Gnome_Dark.png");
+        else "${pkgs.nixos-artwork.wallpapers.gnome-dark}/share/artwork/gnome/Gnome_Dark.png");
     }
 
     (mkIf cfg.enable {

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -221,7 +221,7 @@ let
                 docbook5_xsl
                 unionfs-fuse
                 ntp
-                nixos-artwork
+                nixos-artwork.wallpapers.gnome-dark
                 perlPackages.XMLLibXML
                 perlPackages.ListCompare
 

--- a/pkgs/data/misc/nixos-artwork/default.nix
+++ b/pkgs/data/misc/nixos-artwork/default.nix
@@ -1,23 +1,5 @@
-{ stdenv, fetchurl }:
+{ callPackage }:
 
-stdenv.mkDerivation {
-  name = "nixos-artwork-2015-02-27";
-  # Remember to check the default lightdm wallpaper when updating
-
-  GnomeDark = fetchurl {
-    url = https://raw.githubusercontent.com/NixOS/nixos-artwork/7ece5356398db14b5513392be4b31f8aedbb85a2/gnome/Gnome_Dark.png;
-    sha256 = "0c7sl9k4zdjwvdz3nhlm8i4qv4cjr0qagalaa1a438jigixx27l7";
-  };
-
-  unpackPhase = "true";
-
-  installPhase = ''
-    mkdir -p $out/share/artwork/gnome
-    ln -s $GnomeDark $out/share/artwork/gnome/Gnome_Dark.png
-  '';
-  
-  meta = with stdenv.lib; {
-    homepage = https://github.com/NixOS/nixos-artwork;
-    platforms = platforms.all;
-  };
+rec {
+  wallpapers = callPackage ./wallpapers.nix { };
 }

--- a/pkgs/data/misc/nixos-artwork/wallpapers.nix
+++ b/pkgs/data/misc/nixos-artwork/wallpapers.nix
@@ -1,0 +1,100 @@
+{ stdenv, fetchurl }:
+
+let
+  mkNixBackground = { name, src, description } @ attrs:
+
+    stdenv.mkDerivation {
+      inherit name src;
+
+      unpackPhase = "true";
+
+      installPhase = ''
+        mkdir -p $out/share/artwork/gnome
+        ln -s $src $out/share/artwork/gnome/
+      '';
+
+      meta = with stdenv.lib; {
+        inherit description;
+        homepage = https://github.com/NixOS/nixos-artwork;
+        license = licenses.free;
+        platforms = platforms.all;
+      };
+    };
+
+in
+
+{
+
+  gnome-dark = mkNixBackground {
+    name = "gnome-dark-2015-02-27";
+    description = "Gnome Dark background for Nix";
+    src = fetchurl {
+      url = https://raw.githubusercontent.com/Nix/nixos-artwork/7ece5356398db14b5513392be4b31f8aedbb85a2/gnome/Gnome_Dark.png;
+      sha256 = "0c7sl9k4zdjwvdz3nhlm8i4qv4cjr0qagalaa1a438jigixx27l7";
+    };
+  };
+
+  mosaic-blue = mkNixBackground {
+    name = "mosaic-blue-2016-02-19";
+    description = "Mosaic blue background for Nix";
+    src = fetchurl {
+      url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-mosaic-blue.png;
+      sha256 = "1cbcssa8qi0giza0k240w5yy4yb2bhc1p1r7pw8qmziprcmwv5n5";
+    };
+  };
+
+  simple-blue = mkNixBackground {
+    name = "simple-blue-2016-02-19";
+    description = "Simple blue background for Nix";
+    src = fetchurl {
+      url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-blue.png;
+      sha256 = "1llr175m454aqixxwbp3kb5qml2hi1kn7ia6lm7829ny6y7xrnms";
+    };
+  };
+
+  simple-dark-gray = mkNixBackground {
+    name = "simple-dark-gray-2016-02-19";
+    description = "Simple dark gray background for Nix";
+    src = fetchurl {
+      url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-dark-gray.png;
+      sha256 = "1282cnqc5qynp0q9gdll7bgpw23yp5bhvaqpar59ibkh3iscg8i5";
+    };
+  };
+
+  simple-light-gray = mkNixBackground {
+    name = "simple-light-gray-2016-02-19";
+    description = "Simple light gray background for Nix";
+    src = fetchurl {
+      url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-light-gray.png;
+      sha256 = "0i6d0xv1nzrv7na9hjrgzl3jrwn81vnprnq2pxyznlxbjcgkjnk2";
+    };
+  };
+
+  simple-red = mkNixBackground {
+    name = "simple-red-2016-02-19";
+    description = "Simple red background for Nix";
+    src = fetchurl {
+      url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-red.png;
+      sha256 = "16drprsi3q8xbxx3bxp54yld04c4lq6jankw8ww1irg7z61a6wjs";
+    };
+  };
+
+  stripes-logo = mkNixBackground {
+    name = "stripes-logo-2016-02-19";
+    description = "Stripes logo background for Nix";
+    src = fetchurl {
+      url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-stripes-logo.png;
+      sha256 = "0cqjkgp30428c1yy8s4418k4qz0ycr6fzcg4rdi41wkh5g1hzjnl";
+    };
+  };
+
+  stripes = mkNixBackground {
+    name = "stripes-2016-02-19";
+    description = "Stripes background for Nix";
+    src = fetchurl {
+      url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-stripes.png;
+      sha256 = "116337wv81xfg0g0bsylzzq2b7nbj6hjyh795jfc9mvzarnalwd3";
+    };
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change

[nixos-artwork](https://github.com/NixOS/nixos-artwork) has some NixOS artwork. The package `nixos-artwork` includes only the `Gnome_Dark` wallpaper.

This PR restructures the `nixos-artwork` package to make it easy to selectively incorporate other components from upstream without needing to download the full package.

Until now only the Gnome_Dark wallpaper was included. Add other wallpapers available in the package repository.

This has been previously discussed in https://github.com/NixOS/nixpkgs/commit/48381b7621a51512fa0a87f019d5d5915d9f3d20 and https://github.com/NixOS/nixpkgs/commit/248a1b4d51555ce1ca5c3d8d496ec4ee9ef07f54.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).