### PR TITLE
gcc 7: Remove `cross` arguments and don't use stdenv.is*

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5245,10 +5245,6 @@ with pkgs;
     # PGO seems to speed up compilation by gcc by ~10%, see #445 discussion
     profiledCompiler = with stdenv; (!isDarwin && (isi686 || isx86_64));
 
-    # When building `gcc.crossDrv' (a "Canadian cross", with host == target
-    # and host != build), `cross' must be null but the cross-libc must still
-    # be passed.
-    cross = null;
     libcCross = if targetPlatform != buildPlatform then libcCross else null;
 
     isl = if !stdenv.isDarwin then isl_0_17 else null;


### PR DESCRIPTION
###### Motivation for this change

These changes were already done for the older GCCs, but 7 slipped through the cracks.

[@abbradar this is my fault when rebasing and old PR and not seeing yours :).]

###### Things done

No hashes should be changed whatsoever.