### PR TITLE
colordiff: 1.0.16 -> 1.0.18

### DIFF
--- a/pkgs/tools/text/colordiff/default.nix
+++ b/pkgs/tools/text/colordiff/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, perl /*, xmlto */}:
 
 stdenv.mkDerivation rec {
-  name = "colordiff-1.0.16";
+  name = "colordiff-1.0.18";
 
   src = fetchurl {
     urls = [
       "http://www.colordiff.org/${name}.tar.gz"
       "http://www.colordiff.org/archive/${name}.tar.gz"
     ];
-    sha256 = "12qkkw13261dra8pg7mzx4r8p9pb0ajb090bib9j1s6hgphwzwga";
+    sha256 = "1q6n60n4b9fnzccxyxv04mxjsql4ddq17vl2c74ijvjdhpcfrkr9";
   };
 
   buildInputs = [ perl /* xmlto */ ];


### PR DESCRIPTION
###### Motivation for this change

Update to new version.

[Changes](https://www.colordiff.org/changes.html)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).