### PR TITLE
qt5ct: 0.32 -> 0.33

### DIFF
--- a/pkgs/tools/misc/qt5ct/default.nix
+++ b/pkgs/tools/misc/qt5ct/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "qt5ct-${version}";
-  version = "0.32";
+  version = "0.33";
 
   src = fetchurl {
     url = "mirror://sourceforge/qt5ct/qt5ct-${version}.tar.bz2";
-    sha256 = "0gzmqx6j8g8vgdg5sazfw31h825jdsjbkj8lk167msvahxgrf0fm";
+    sha256 = "0by0wz40rl9gxvwbd85j0y5xy9mjab1cya96rv48x677v95lhm9f";
   };
 
   nativeBuildInputs = [ makeQtWrapper qmakeHook qttools ];


### PR DESCRIPTION
###### Motivation for this change

Update to new version.

[Changelog](https://www.opendesktop.org/content/show.php?content=168066):

- fixed build without dbus support
- fixed Qt 5.6 support
- updated Hebrew translation

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).