### PR TITLE
profanity: enable tray icon support

### DIFF
--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -3,10 +3,12 @@
 
 , autoAwaySupport ? false, libXScrnSaver ? null, libX11 ? null
 , notifySupport ? false,   libnotify ? null, gdk_pixbuf ? null
+, traySupport ? false,     gnome2 ? null
 }:
 
 assert autoAwaySupport -> libXScrnSaver != null && libX11 != null;
 assert notifySupport   -> libnotify != null && gdk_pixbuf != null;
+assert traySupport     -> gnome2 != null;
 
 with stdenv.lib;
 
@@ -23,7 +25,8 @@ stdenv.mkDerivation rec {
     pkgconfig readline libuuid libmesode
     glib openssl expat ncurses libotr curl
   ] ++ optionals autoAwaySupport [ libXScrnSaver libX11 ]
-    ++ optionals notifySupport   [ libnotify gdk_pixbuf ];
+    ++ optionals notifySupport   [ libnotify gdk_pixbuf ]
+    ++ optionals traySupport     [ gnome2.gtk ];
 
   meta = {
     description = "A console based XMPP client";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15482,6 +15482,7 @@ with pkgs;
 
   profanity = callPackage ../applications/networking/instant-messengers/profanity {
     notifySupport   = config.profanity.notifySupport   or true;
+    traySupport     = config.profanity.traySupport     or true;
     autoAwaySupport = config.profanity.autoAwaySupport or true;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Profanity can show a tray icon, e.g. showing that messages were received. This enables support for the feature.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

