### PR TITLE
buck: build buckd as well

### DIFF
--- a/pkgs/development/tools/build-managers/buck/default.nix
+++ b/pkgs/development/tools/build-managers/buck/default.nix
@@ -20,16 +20,23 @@ stdenv.mkDerivation rec {
   buildInputs = [ jdk ant python2 watchman python2Packages.pywatchman ];
   nativeBuildInputs = [ makeWrapper ];
 
+  targets = [ "buck" "buckd" ];
+
   buildPhase = ''
     ant
-    ./bin/buck build buck
+
+    for exe in ${toString targets}; do
+      ./bin/buck build //programs:$exe
+    done
   '';
 
   installPhase = ''
-    install -D -m755 buck-out/gen/programs/buck.pex $out/bin/buck
-    wrapProgram $out/bin/buck \
-      --prefix PYTHONPATH : $PYTHONPATH \
-      --prefix PATH : "${stdenv.lib.makeBinPath [jdk watchman]}"
+    for exe in ${toString targets}; do
+      install -D -m755 buck-out/gen/programs/$exe.pex $out/bin/$exe
+      wrapProgram $out/bin/$exe \
+        --prefix PYTHONPATH : $PYTHONPATH \
+        --prefix PATH : "${stdenv.lib.makeBinPath [jdk watchman]}"
+    done
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
buck tries to launch buckd to run in the background. While not neccessary, it
does speed up builds.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

