### PR TITLE
arphic: init at 0.2.20080216.2

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -45,6 +45,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "Apple Public Source License 2.0";
   };
 
+  arphicpl = {
+    fullName = "Arphic Public License";
+    url = https://www.freedesktop.org/wiki/Arphic_Public_License/;
+  };
+
   artistic1 = spdx {
     spdxId = "Artistic-1.0";
     fullName = "Artistic License 1.0";

--- a/pkgs/data/fonts/arphic/default.nix
+++ b/pkgs/data/fonts/arphic/default.nix
@@ -15,14 +15,12 @@
 
     phases = [ "unpackPhase" "installPhase" ];
 
-    installPhase =
-      ''
-      mkdir -p $out/share/fonts $out/share/fonts/truetype
-      cp -v ukai.ttc $out/share/fonts/truetype/arphic-ukai.ttc
+    installPhase = ''
+      install -D -v ukai.ttc $out/share/fonts/truetype/arphic-ukai.ttc
       cd $out/share/fonts
       mkfontdir
       mkfontscale
-      '';
+    '';
 
     meta = with stdenv.lib; {
       description = "CJK Unicode font Kai style";
@@ -48,14 +46,12 @@
 
     phases = [ "unpackPhase" "installPhase" ];
 
-    installPhase =
-      ''
-      mkdir -p $out/share/fonts $out/share/fonts/truetype
-      cp -v uming.ttc $out/share/fonts/truetype/arphic-uming.ttc
+    installPhase = ''
+      install -D -v uming.ttc $out/share/fonts/truetype/arphic-uming.ttc
       cd $out/share/fonts
       mkfontdir
       mkfontscale
-      '';
+    '';
 
     meta = with stdenv.lib; {
       description = "CJK Unicode font Ming style";

--- a/pkgs/data/fonts/arphic/default.nix
+++ b/pkgs/data/fonts/arphic/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, fetchurl, mkfontscale, mkfontdir }:
+
+{
+  arphic-ukai = stdenv.mkDerivation rec {
+    name = "arphic-ukai-${version}";
+
+    version = "0.2.20080216.2";
+
+    src = fetchurl {
+      url = "http://archive.ubuntu.com/ubuntu/pool/main/f/fonts-arphic-ukai/fonts-arphic-ukai_${version}.orig.tar.bz2";
+      sha256 = "1lp3i9m6x5wrqjkh1a8vpyhmsrhvsa2znj2mx13qfkwza5rqv5ml";
+    };
+
+    buildInputs = [ mkfontscale mkfontdir ];
+
+    phases = [ "unpackPhase" "installPhase" ];
+
+    installPhase =
+      ''
+      mkdir -p $out/share/fonts $out/share/fonts/truetype
+      cp -v ukai.ttc $out/share/fonts/truetype/arphic-ukai.ttc
+      cd $out/share/fonts
+      mkfontdir
+      mkfontscale
+      '';
+
+    meta = with stdenv.lib; {
+      description = "CJK Unicode font Kai style";
+      homepage = https://www.freedesktop.org/wiki/Software/CJKUnifonts/;
+
+      license = licenses.arphicpl;
+      maintainers = [ maintainers.changlinli ];
+      platforms = platforms.all;
+    };
+  };
+
+  arphic-uming = stdenv.mkDerivation rec {
+    name = "arphic-uming-${version}";
+
+    version = "0.2.20080216.2";
+
+    src = fetchurl {
+      url = "http://archive.ubuntu.com/ubuntu/pool/main/f/fonts-arphic-uming/fonts-arphic-uming_${version}.orig.tar.bz2";
+      sha256 = "1ny11n380vn7sryvy1g3a83y3ll4h0jf9wgnrx55nmksx829xhg3";
+    };
+
+    buildInputs = [ mkfontscale mkfontdir ];
+
+    phases = [ "unpackPhase" "installPhase" ];
+
+    installPhase =
+      ''
+      mkdir -p $out/share/fonts $out/share/fonts/truetype
+      cp -v uming.ttc $out/share/fonts/truetype/arphic-uming.ttc
+      cd $out/share/fonts
+      mkfontdir
+      mkfontscale
+      '';
+
+    meta = with stdenv.lib; {
+      description = "CJK Unicode font Ming style";
+      homepage = https://www.freedesktop.org/wiki/Software/CJKUnifonts/;
+
+      license = licenses.arphicpl;
+      maintainers = [ maintainers.changlinli ];
+      platforms = platforms.all;
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -474,6 +474,9 @@ with pkgs;
 
   arp-scan = callPackage ../tools/misc/arp-scan { };
 
+  inherit (callPackages ../data/fonts/arphic {})
+    arphic-ukai arphic-uming;
+
   artyFX = callPackage ../applications/audio/artyFX {};
 
   as31 = callPackage ../development/compilers/as31 {};


### PR DESCRIPTION
Adding some CJK fonts generated by the Arphic foundry.

###### Motivation for this change

Adding some Unicode Arphic CJK fonts. These are a couple of CJK fonts that are on most other Linux distributions that aren't on NixOS

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

