### PR TITLE
lbreakout2: init at 2.6.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -99,6 +99,7 @@
   chris-martin = "Chris Martin <ch.martin@gmail.com>";
   chrisjefferson = "Christopher Jefferson <chris@bubblescope.net>";
   christopherpoole = "Christopher Mark Poole <mail@christopherpoole.net>";
+  ciil = "Simon Lackerbauer <simon@lackerbauer.com>";
   ckampka = "Christian Kampka <christian@kampka.net>";
   cko = "Christine Koppelt <christine.koppelt@gmail.com>";
   cleverca22 = "Michael Bishop <cleverca22@gmail.com>";

--- a/pkgs/games/lbreakout2/default.nix
+++ b/pkgs/games/lbreakout2/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, SDL, SDL_mixer, zlib, libpng, gcc }:
+
+stdenv.mkDerivation rec {
+  name = "lbreakout2-${version}";
+  version = "2.6.5";
+  buildInputs = [ SDL SDL_mixer zlib libpng gcc ];
+
+  src = fetchurl {
+    url = "http://downloads.sourceforge.net/lgames/${name}.tar.gz";
+    sha256 = "0vwdlyvh7c4y80q5vp7fyfpzbqk9lq3w8pvavi139njkalbxc14i";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Breakout clone from the LGames series";
+    homepage = http://lgames.sourceforge.net/LBreakout2/;
+    license = licenses.gpl;
+    maintainers = [ maintainers.ciil ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/games/lbreakout2/default.nix
+++ b/pkgs/games/lbreakout2/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, SDL, SDL_mixer, zlib, libpng, gcc }:
+{ stdenv, fetchurl, SDL, SDL_mixer, zlib, libpng }:
 
 stdenv.mkDerivation rec {
   name = "lbreakout2-${version}";
   version = "2.6.5";
-  buildInputs = [ SDL SDL_mixer zlib libpng gcc ];
+  buildInputs = [ SDL SDL_mixer zlib libpng ];
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/lgames/${name}.tar.gz";
+    url = "mirror://sourceforge/lgames/${name}.tar.gz";
     sha256 = "0vwdlyvh7c4y80q5vp7fyfpzbqk9lq3w8pvavi139njkalbxc14i";
   };
 

--- a/pkgs/games/lbreakout2/default.nix
+++ b/pkgs/games/lbreakout2/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Breakout clone from the LGames series";
     homepage = http://lgames.sourceforge.net/LBreakout2/;
-    license = licenses.gpl;
+    license = licenses.gpl2;
     maintainers = [ maintainers.ciil ];
     platforms = platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2644,6 +2644,8 @@ with pkgs;
 
   kytea = callPackage ../tools/text/kytea { };
 
+  lbreakout2 = callPackage ../games/lbreakout2 { };
+
   leocad = callPackage ../applications/graphics/leocad { };
 
   less = callPackage ../tools/misc/less { };


### PR DESCRIPTION
###### Things done
Just added a run of the mill default expression, and also myself to maintainers, as this is my first PR to nixpkgs.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

