### PR TITLE
xen: fix pygrub by making sure it is wrapped

### DIFF
--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -204,6 +204,8 @@ stdenv.mkDerivation (rec {
       --replace SBINDIR=\"$out/sbin\" SBINDIR=\"$out/bin\"
 
     wrapPythonPrograms
+    # We also need to wrap pygrub, which lies in lib
+    wrapPythonProgramsIn "$out/lib" "$out $pythonPath"
 
     shopt -s extglob
     for i in $out/etc/xen/scripts/!(*.sh); do


### PR DESCRIPTION
Recent commit c10af9e744c91dff1ccc07a52a0b57d1e4d339f3 changed the
behaviour of wrapPythonPrograms, which caused pygrub to no longer
being wrapped. This commit fixes this.

###### Motivation for this change

Due to the failure to wrap `pygrub`, it now fails with the following error message:
```
Traceback (most recent call last):
  File "/run/current-system/sw/lib/xen/bin/pygrub", line 20, in <module>
    import xen.lowlevel.xc
ImportError: No module named xen.lowlevel.xc
```

To fix that, we explicitly wrap all python scripts in `$out/lib`.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
