### PR TITLE
rictydiminished-with-firacode: init at 0.0.1

### DIFF
--- a/pkgs/data/fonts/rictydiminished-with-firacode/default.nix
+++ b/pkgs/data/fonts/rictydiminished-with-firacode/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchgit, fontforge, pythonFull }:
+
+stdenv.mkDerivation rec {
+  name = "rictydiminished-with-firacode-${version}";
+  version = "0.0.1";
+  src = fetchgit {
+    url = "https://github.com/hakatashi/RictyDiminished-with-FiraCode.git";
+    rev = "refs/tags/${version}";
+#    sha256 = "1s3rgia6x9fxc2pvlwm203grqkb49px6q0xnh8kbqxqsgna615p2";
+    sha256 = "12lhb0k4d8p4lzw9k6hlsxpfpc15zfshz1h5cbaa88sb8n5jh360";
+    fetchSubmodules = true;
+  };
+
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/rictydiminished-with-firacode
+    cp *.ttf $out/share/fonts/rictydiminished-with-firacode
+  '';
+
+  nativeBuildInputs = [
+    fontforge
+    (pythonFull.withPackages (ps: [
+      ps.jinja2
+      ps."3to2"
+      ps.fonttools
+    ]))
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/hakatashi/RictyDiminished-with-FiraCode;
+    description = "The best Japanese programming font meets the awesone ligatures of Firacode";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ mt-caret ];
+  };
+}
+

--- a/pkgs/data/fonts/rictydiminished-with-firacode/default.nix
+++ b/pkgs/data/fonts/rictydiminished-with-firacode/default.nix
@@ -6,7 +6,6 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "https://github.com/hakatashi/RictyDiminished-with-FiraCode.git";
     rev = "refs/tags/${version}";
-#    sha256 = "1s3rgia6x9fxc2pvlwm203grqkb49px6q0xnh8kbqxqsgna615p2";
     sha256 = "12lhb0k4d8p4lzw9k6hlsxpfpc15zfshz1h5cbaa88sb8n5jh360";
     fetchSubmodules = true;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12945,6 +12945,8 @@ with pkgs;
 
   raleway = callPackage ../data/fonts/raleway { };
 
+  rictydiminished-with-firacode = callPackage ../data/fonts/rictydiminished-with-firacode { };
+
   roboto = callPackage ../data/fonts/roboto { };
 
   roboto-mono = callPackage ../data/fonts/roboto-mono { };


### PR DESCRIPTION
###### Motivation for this change

Add RictyDiminished-with-FiraCode.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

