### PR TITLE
virtualboxGuestAdditions: install mount helper as regular executable

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation {
     sed -i -e "s|/usr/bin|$out/bin|" bin/VBoxClient-all
 
     # Install binaries
-    install -D -m 4755 lib/VBoxGuestAdditions/mount.vboxsf $out/bin/mount.vboxsf
+    install -D -m 755 lib/VBoxGuestAdditions/mount.vboxsf $out/bin/mount.vboxsf
     install -D -m 755 sbin/VBoxService $out/bin/VBoxService
 
     mkdir -p $out/bin


### PR DESCRIPTION
Installing the vboxsf mount helper with the set-user-id bit set results in "operation not permitted", as creating s*id files is now disallowed.  See e.g., https://hydra.nixos.org/build/54069060

If this is okay, I'll pick to release as well, seems like this issue is blocking the tested job.

cc @vcunat 