### PR TITLE
metasploit: 4.14.17 -> 4.14.25

### DIFF
--- a/pkgs/development/ruby-modules/bundix/default.nix
+++ b/pkgs/development/ruby-modules/bundix/default.nix
@@ -1,13 +1,18 @@
-{ buildRubyGem, lib, bundler, ruby, nix, nix-prefetch-git }:
+{ buildRubyGem, fetchFromGitHub, lib, bundler, ruby, nix, nix-prefetch-git }:
 
 buildRubyGem rec {
   inherit ruby;
 
   name = "${gemName}-${version}";
   gemName = "bundix";
-  version = "2.1.0";
+  version = "2.2.0";
 
-  sha256 = "5a073c59dfc7e2367c47e6513fc8914d27e11c08f82bc1103c4793dfb2837bef";
+  src = fetchFromGitHub {
+    owner = "manveru";
+    repo = "bundix";
+    rev = version;
+    sha256 = "0lnzkwxprdz73axk54y5p5xkw56n3lra9v2dsvqjfw0ab66ld0iy";
+  };
 
   buildInputs = [bundler];
 

--- a/pkgs/tools/security/metasploit/Gemfile
+++ b/pkgs/tools/security/metasploit/Gemfile
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem "metasploit-framework", git: "https://github.com/rapid7/metasploit-framework", ref: "refs/tags/4.14.17"
+gem "metasploit-framework", git: "https://github.com/rapid7/metasploit-framework", ref: "refs/tags/4.14.25"

--- a/pkgs/tools/security/metasploit/Gemfile.lock
+++ b/pkgs/tools/security/metasploit/Gemfile.lock
@@ -1,12 +1,13 @@
 GIT
   remote: https://github.com/rapid7/metasploit-framework
-  revision: fd3da8f3350d6cf7f0449bf0ead4d51747525c0a
-  ref: refs/tags/4.14.17
+  revision: 8a194207f07c2b8c91c1a72e57c25683d4e9f744
+  ref: refs/tags/4.14.25
   specs:
-    metasploit-framework (4.14.17)
+    metasploit-framework (4.14.25)
       actionpack (~> 4.2.6)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
+      backports
       bcrypt
       bit-struct
       filesize
@@ -16,7 +17,7 @@ GIT
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.2.29)
+      metasploit-payloads (= 1.2.32)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.1.9)
       msgpack
@@ -36,7 +37,7 @@ GIT
       rb-readline
       recog
       redcarpet
-      rex-arch (= 0.1.4)
+      rex-arch
       rex-bin_tools
       rex-core
       rex-encoder
@@ -96,8 +97,9 @@ GEM
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (6.0.4)
-    arel-helpers (2.3.0)
+    arel-helpers (2.4.0)
       activerecord (>= 3.1.0, < 6)
+    backports (3.8.0)
     bcrypt (3.1.11)
     bindata (2.4.0)
     bit-struct (0.16)
@@ -106,7 +108,7 @@ GEM
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     filesize (0.1.1)
-    i18n (0.8.1)
+    i18n (0.8.4)
     jsobfu (0.4.2)
       rkelly-remix
     json (2.1.0)
@@ -117,19 +119,20 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-credential (2.0.9)
+    metasploit-credential (2.0.10)
       metasploit-concern
       metasploit-model
       metasploit_data_models
       pg
       railties
+      rex-socket
       rubyntlm
       rubyzip
     metasploit-model (2.0.4)
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.2.29)
+    metasploit-payloads (1.2.32)
     metasploit_data_models (2.0.14)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
@@ -141,7 +144,7 @@ GEM
       railties (~> 4.2.6)
       recog (~> 2.0)
     metasploit_payloads-mettle (0.1.9)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.2.0)
     minitest (5.10.2)
     msgpack (1.1.0)
     multipart-post (2.0.0)
@@ -149,8 +152,8 @@ GEM
     net-ssh (4.1.0)
     network_interface (0.0.1)
     nexpose (6.0.0)
-    nokogiri (1.7.2)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     openssl-ccm (1.2.1)
@@ -166,7 +169,7 @@ GEM
       arel (>= 4.0.1)
       pg_array_parser (~> 0.0.9)
     public_suffix (2.0.5)
-    rack (1.6.6)
+    rack (1.6.8)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails-deprecated_sanitizer (1.0.3)
@@ -184,10 +187,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
     rb-readline (0.5.4)
-    recog (2.1.6)
+    recog (2.1.8)
       nokogiri
     redcarpet (3.4.0)
-    rex-arch (0.1.4)
+    rex-arch (0.1.8)
       rex-text
     rex-bin_tools (0.1.3)
       metasm
@@ -234,7 +237,7 @@ GEM
       rex-text
     rkelly-remix (0.0.7)
     robots (0.10.1)
-    ruby_smb (0.0.12)
+    ruby_smb (0.0.18)
       bindata
       rubyntlm
       windows_error

--- a/pkgs/tools/security/metasploit/default.nix
+++ b/pkgs/tools/security/metasploit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, ruby, bundlerEnv, ncurses }:
+{ stdenv, fetchFromGitHub, makeWrapper, ruby, bundlerEnv }:
 
 # Maintainer notes for updating:
 # 1. increment version number in expression and in Gemfile
@@ -13,13 +13,13 @@ let
   };
 in stdenv.mkDerivation rec {
   name = "metasploit-framework-${version}";
-  version = "4.14.17";
+  version = "4.14.25";
 
   src = fetchFromGitHub {
     owner = "rapid7";
     repo = "metasploit-framework";
     rev = version;
-    sha256 = "0g666lxin9f0v9vhfh3s913ym8fnh32rpfl1rpj8d8n1azch5fn0";
+    sha256 = "0cp1ybq29a0r7kabg4p2yj0qm90hjvr4xxp0pynb2g406sbyycjm";
   };
 
   buildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/metasploit/gemset.nix
+++ b/pkgs/tools/security/metasploit/gemset.nix
@@ -58,10 +58,18 @@
   arel-helpers = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0k8hqa2505b2s3w6gajh2lvi2mn832yqldiy2z4c55phzkmr08sr";
+      sha256 = "1sx4qbzhld3a99175p2krz3hv1npc42rv3sd8x4awzkgplg3zy9c";
       type = "gem";
     };
-    version = "2.3.0";
+    version = "2.4.0";
+  };
+  backports = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17pcz0z6jms5jydr1r95kf1bpk3ms618hgr26c62h34icy9i1dpm";
+      type = "gem";
+    };
+    version = "3.8.0";
   };
   bcrypt = {
     source = {
@@ -122,10 +130,10 @@
   i18n = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1s6971zmjxszdrp59vybns9gzxpdxzdklakc5lp8nl4fx5kpxkbp";
+      sha256 = "1j491wrfzham4nk8q4bifah3lx7nr8wp9ahfb7vd3hxn71v7kic7";
       type = "gem";
     };
-    version = "0.8.1";
+    version = "0.8.4";
   };
   jsobfu = {
     source = {
@@ -170,20 +178,20 @@
   metasploit-credential = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1y36f1f4nw0imhfbckl213ah7qgfldrkv2fpv2acslb6iqiaa3gk";
+      sha256 = "1zblyy2yv31zap6dzf3lpkhvnafkwbzdvr6nsqmyh95ci8yy1q6r";
       type = "gem";
     };
-    version = "2.0.9";
+    version = "2.0.10";
   };
   metasploit-framework = {
     source = {
       fetchSubmodules = false;
-      rev = "fd3da8f3350d6cf7f0449bf0ead4d51747525c0a";
-      sha256 = "1r04drq34qfbhmhp0mqnm13vrycr7dcq670zk8xqiif5rhbij6qv";
+      rev = "8a194207f07c2b8c91c1a72e57c25683d4e9f744";
+      sha256 = "0q7iv9wd65ji1cay6am4dskrlibvp3wyn66gvld8p1nfnnvn5vmq";
       type = "git";
       url = "https://github.com/rapid7/metasploit-framework";
     };
-    version = "4.14.17";
+    version = "4.14.25";
   };
   metasploit-model = {
     source = {
@@ -196,10 +204,10 @@
   metasploit-payloads = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0c6wvnxgwdiryz5skzrp2wcfbxp57icaclckjcaxlw63v09wgjii";
+      sha256 = "1dqnyzp60da6f8kgnbpjmv5xsg1hvyyd2jkkzbh69sgwp4nw3i9g";
       type = "gem";
     };
-    version = "1.2.29";
+    version = "1.2.32";
   };
   metasploit_data_models = {
     source = {
@@ -220,10 +228,10 @@
   mini_portile2 = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1y25adxb1hgg1wb2rn20g3vl07qziq6fz364jc5694611zz863hb";
+      sha256 = "0g5bpgy08q0nc0anisg3yvwc1gc3inl854fcrg48wvg7glqd6dpm";
       type = "gem";
     };
-    version = "2.1.0";
+    version = "2.2.0";
   };
   minitest = {
     source = {
@@ -284,10 +292,10 @@
   nokogiri = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0jd8q3pr5rkrxx1vklvhcqcgl8kmfv5c8ny36ni3z5mirw6cm70c";
+      sha256 = "1nffsyx1xjg6v5n9rrbi8y1arrcx2i5f21cp6clgh9iwiqkr7rnn";
       type = "gem";
     };
-    version = "1.7.2";
+    version = "1.8.0";
   };
   octokit = {
     source = {
@@ -372,10 +380,10 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "073d6rjgqfb4xjhbshyrflqgbdvxqvx4b907j2d4mi5qgbv8y2ax";
+      sha256 = "19m7aixb2ri7p1n0iqaqx8ldi97xdhvbxijbyrrcdcl6fv5prqza";
       type = "gem";
     };
-    version = "1.6.6";
+    version = "1.6.8";
   };
   rack-test = {
     source = {
@@ -436,10 +444,10 @@
   recog = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "08ypzrn40jbjbzwdbbjkcqdm74zlsc0yr2iqs0yn479fa5k8ajw4";
+      sha256 = "0d12889rx9ylm0jybg9n5sqx0v413hy9zjqs9rd9qjd1kjva7y87";
       type = "gem";
     };
-    version = "2.1.6";
+    version = "2.1.8";
   };
   redcarpet = {
     source = {
@@ -452,10 +460,10 @@
   rex-arch = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1y2mzv6wkqgclxl1x65mdq4d0lcgbbny4r1v24c16gi4jg9nsnc1";
+      sha256 = "13dyic499iblhddmy7w01ajr5l5rm6szagy6vz7sx138y21d1y6f";
       type = "gem";
     };
-    version = "0.1.4";
+    version = "0.1.8";
   };
   rex-bin_tools = {
     source = {
@@ -612,10 +620,10 @@
   ruby_smb = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1v2acyx6csndb08sidb1pbixn2dlx9s75cpnjv4riwj0qlp8blli";
+      sha256 = "1jby5wlppxhc2jlqldic05aqd5l57171lsxqv86702grk665n612";
       type = "gem";
     };
-    version = "0.0.12";
+    version = "0.0.18";
   };
   rubyntlm = {
     source = {

--- a/pkgs/tools/security/metasploit/shell.nix
+++ b/pkgs/tools/security/metasploit/shell.nix
@@ -3,6 +3,8 @@ with import <nixpkgs> {};
 stdenv.mkDerivation {
   name = "env";
   buildInputs = [
+    ruby.devEnv
+    git
     sqlite
     libpcap
     postgresql


### PR DESCRIPTION
###### Motivation for this change

Bump metasploit version

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
