### PR TITLE
lxappearance: add variant for Gtk+-3

### DIFF
--- a/pkgs/desktops/lxde/core/lxappearance/default.nix
+++ b/pkgs/desktops/lxde/core/lxappearance/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, libX11, gtk2 }:
+{ stdenv, fetchurl, intltool, pkgconfig, libX11, gtk2, withGtk3 ? false, gtk3 }:
 
 stdenv.mkDerivation rec {
   name = "lxappearance-0.6.3";
@@ -10,7 +10,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool ];
 
-  buildInputs = [ libX11 gtk2 ];
+  buildInputs = [ libX11 (if withGtk3 then gtk3 else gtk2) ];
+
+  patches = [ ./lxappearance-0.6.3-xdg.system.data.dirs.patch ];
+
+  configureFlags = stdenv.lib.optional withGtk3 "--enable-gtk3";
 
   meta = {
     description = "A lightweight program for configuring the theme and fonts of gtk applications";

--- a/pkgs/desktops/lxde/core/lxappearance/lxappearance-0.6.3-xdg.system.data.dirs.patch
+++ b/pkgs/desktops/lxde/core/lxappearance/lxappearance-0.6.3-xdg.system.data.dirs.patch
@@ -1,0 +1,27 @@
+--- lxappearance-0.6.3/src/widget-theme.c.orig	2016-02-20 20:48:38.000000000 -0200
++++ lxappearance-0.6.3/src/widget-theme.c	2017-06-09 17:37:53.369555085 -0300
+@@ -66,6 +66,7 @@
+ static void load_themes()
+ {
+     char* dir;
++    const gchar * const * dirs;
+     GSList* themes = NULL, *l;
+     GtkTreeIter sel_it = {0};
+     GtkTreeSelection* tree_sel;
+@@ -85,6 +86,16 @@
+     themes = load_themes_in_dir(dir, themes);
+     g_free(dir);
+ 
++    /* load from sharedata theme dirs */
++    dirs = g_get_system_data_dirs();
++    while (*dirs != NULL)
++    {
++        dir = g_build_filename(*dirs, "themes", NULL);
++        themes = load_themes_in_dir(dir, themes);
++        g_free(dir);
++        dirs++;
++    }
++
+     themes = g_slist_sort(themes, (GCompareFunc)strcmp);
+     for(l = themes; l; l=l->next)
+     {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6053,6 +6053,10 @@ with pkgs;
     gtk2 = gtk2-x11;
   };
 
+  lxappearance-gtk3 = callPackage ../desktops/lxde/core/lxappearance {
+    withGtk3 = true;
+  };
+
   lxmenu-data = callPackage ../desktops/lxde/core/lxmenu-data.nix { };
 
   lxpanel = callPackage ../desktops/lxde/core/lxpanel {


### PR DESCRIPTION
###### Motivation for this change

`lxappearance` supports both Gtk+-2 and Gtk+-3. The current `lxappearance` package continues to be for Gtk+-2. This PR adds `lxappearance-gtk3` for Gtk+-3.

Also related: https://github.com/NixOS/nixpkgs/issues/18559

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).