### PR TITLE
lib-tests: fix test for isStorePath

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -90,7 +90,7 @@ runTests {
   testIsStorePath =  {
     expr =
       let goodPath =
-            "/nix/store/d945ibfx9x185xf04b890y4f9g3cbb63-python-2.7.11";
+            "${builtins.storeDir}/d945ibfx9x185xf04b890y4f9g3cbb63-python-2.7.11";
       in {
         storePath = isStorePath goodPath;
         storePathAppendix = isStorePath


### PR DESCRIPTION
###### Motivation for this change

Fixes the isStorePath tests introduced in https://github.com/NixOS/nixpkgs/commit/3fa1be6f49

http://hydra.nixos.org/build/54143467

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
