### PR TITLE
Update runc to 1.0.0-rc3

### DIFF
--- a/pkgs/applications/virtualization/runc/default.nix
+++ b/pkgs/applications/virtualization/runc/default.nix
@@ -5,29 +5,14 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "runc-${version}";
-  version = "1.0.0-rc2";
+  version = "1.0.0-rc3";
 
   src = fetchFromGitHub {
     owner = "opencontainers";
     repo = "runc";
     rev = "v${version}";
-    sha256 = "06bxc4g3frh4i1lkzvwdcwmzmr0i52rz4a4pij39s15zaigm79wk";
+    sha256 = "14hdhnni0rz3g0bhcaq95zn2zrhyds0mq2pm2padbamg4bgq4r1c";
   };
-
-  patches = [
-    # Two patches to fix CVE-2016-9962
-    # From https://bugzilla.suse.com/show_bug.cgi?id=1012568
-    (fetchpatch {
-      name = "0001-libcontainer-nsenter-set-init-processes-as-non-dumpa.patch";
-      url = "https://bugzilla.suse.com/attachment.cgi?id=709048&action=diff&context=patch&collapsed=&headers=1&format=raw";
-      sha256 = "1cfsmsyhc45a2929825mdaql0mrhhbrgdm54ly0957j2f46072ck";
-    })
-    (fetchpatch {
-      name = "0002-libcontainer-init-only-pass-stateDirFd-when-creating.patch";
-      url = "https://bugzilla.suse.com/attachment.cgi?id=709049&action=diff&context=patch&collapsed=&headers=1&format=raw";
-      sha256 = "1ykwg1mbvsxsnsrk9a8i4iadma1g0rgdmaj19dvif457hsnn31wl";
-    })
-  ];
 
   outputs = [ "out" "man" ];
 
@@ -37,7 +22,16 @@ stdenv.mkDerivation rec {
 
   makeFlags = ''BUILDTAGS+=seccomp BUILDTAGS+=apparmor'';
 
+  preConfigure = ''
+    # Extract the source
+    cd "$NIX_BUILD_TOP"
+    mkdir -p "go/src/github.com/opencontainers"
+    mv "$sourceRoot" "go/src/github.com/opencontainers/runc"
+    export GOPATH=$NIX_BUILD_TOP/go:$GOPATH
+  '';
+
   preBuild = ''
+    cd go/src/github.com/opencontainers/runc
     patchShebangs .
     substituteInPlace libcontainer/apparmor/apparmor.go \
       --replace /sbin/apparmor_parser ${apparmor-parser}/bin/apparmor_parser


### PR DESCRIPTION
###### Motivation for this change

- Fix compilation problems
- Remove patches as those are included in the sources now

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

