### PR TITLE
grammalecte: init at v0.5.17

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7126,6 +7126,30 @@ in {
     };
   };
 
+  grammalecte = buildPythonPackage rec {
+    name = "grammalecte";
+    version = "v0.5.17";
+
+    src = pkgs.fetchurl {
+      url = "http://www.dicollecte.org/grammalecte/oxt/Grammalecte-fr-${version}.zip";
+      sha256 = "0ccvj8p8bwvrj8bp370dzjs16pwm755a7364lvk8bp4505n7g0b6";
+    };
+
+    preBuild = "cd ..";
+    postInstall = ''
+    mkdir $out/bin
+    cp $out/cli.py $out/bin/gramalecte
+    chmod a+rx $out/bin/gramalecte
+    '';
+
+   meta = {
+      description = "Grammalecte est un correcteur grammatical open source dédié à la langue française.";
+      homepage = "https://dicollecte.org/grammalecte/";
+      license = licenses.gpl3;
+      maintainers = with maintainers; [ apeyroux ];
+    };
+  };
+  
   grip = buildPythonPackage rec {
     version = "4.3.2";
     name = "grip-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11811,7 +11811,7 @@ in {
     name = "grammalecte";
     version = "v0.5.17";
 
-    doCheck = false;
+    doCheck = true;
     
     src = pkgs.fetchurl {
       url = "http://www.dicollecte.org/grammalecte/oxt/Grammalecte-fr-${version}.zip";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11819,9 +11819,7 @@ in {
     postInstall = ''
       mkdir $out/bin
       cp $out/cli.py $out/bin/gramalecte
-      cp $out/server.py $out/bin/gramalected
       chmod a+rx $out/bin/gramalecte
-      chmod a+rx $out/bin/gramalected
     '';
 
    meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7126,30 +7126,6 @@ in {
     };
   };
 
-  grammalecte = buildPythonPackage rec {
-    name = "grammalecte";
-    version = "v0.5.17";
-
-    src = pkgs.fetchurl {
-      url = "http://www.dicollecte.org/grammalecte/oxt/Grammalecte-fr-${version}.zip";
-      sha256 = "0ccvj8p8bwvrj8bp370dzjs16pwm755a7364lvk8bp4505n7g0b6";
-    };
-
-    preBuild = "cd ..";
-    postInstall = ''
-    mkdir $out/bin
-    cp $out/cli.py $out/bin/gramalecte
-    chmod a+rx $out/bin/gramalecte
-    '';
-
-   meta = {
-      description = "Grammalecte est un correcteur grammatical open source dédié à la langue française.";
-      homepage = "https://dicollecte.org/grammalecte/";
-      license = licenses.gpl3;
-      maintainers = with maintainers; [ apeyroux ];
-    };
-  };
-  
   grip = buildPythonPackage rec {
     version = "4.3.2";
     name = "grip-${version}";
@@ -11830,6 +11806,31 @@ in {
     };
   };
 
+  grammalecte = buildPythonPackage rec {
+    name = "grammalecte";
+    version = "v0.5.17";
+
+    src = pkgs.fetchurl {
+      url = "http://www.dicollecte.org/grammalecte/oxt/Grammalecte-fr-${version}.zip";
+      sha256 = "0ccvj8p8bwvrj8bp370dzjs16pwm755a7364lvk8bp4505n7g0b6";
+    };
+
+    preBuild = "cd ..";
+    postInstall = ''
+      mkdir $out/bin
+      cp $out/cli.py $out/bin/gramalecte
+      cp $out/server.py $out/bin/gramalected
+      chmod a+rx $out/bin/gramalecte
+      chmod a+rx $out/bin/gramalected
+    '';
+
+   meta = {
+      description = "Grammalecte est un correcteur grammatical open source dédié à la langue française.";
+      homepage = "https://dicollecte.org/grammalecte/";
+      license = licenses.gpl3;
+      maintainers = with maintainers; [ apeyroux ];
+    };
+  };
 
   greenlet = buildPythonPackage rec {
     name = "greenlet-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11807,19 +11807,26 @@ in {
   };
 
   grammalecte = buildPythonPackage rec {
+    disabled = ! isPy3k;
     name = "grammalecte";
     version = "v0.5.17";
 
+    doCheck = false;
+    
     src = pkgs.fetchurl {
       url = "http://www.dicollecte.org/grammalecte/oxt/Grammalecte-fr-${version}.zip";
       sha256 = "0ccvj8p8bwvrj8bp370dzjs16pwm755a7364lvk8bp4505n7g0b6";
     };
 
+    propagatedBuildInputs = with self; [ bottle ];
+
     preBuild = "cd ..";
     postInstall = ''
       mkdir $out/bin
       cp $out/cli.py $out/bin/gramalecte
+      cp $out/server.py $out/bin/gramalected
       chmod a+rx $out/bin/gramalecte
+      chmod a+rx $out/bin/gramalected
     '';
 
    meta = {


### PR DESCRIPTION
###### Motivation for this change

Grammalecte is an open source grammar checker dedicated to the French language. Grammalecte est un correcteur grammatical open source dédié à la langue française

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

