### PR TITLE
peercoin: init 0.6.2

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -74,4 +74,6 @@ rec {
 
   parity = callPackage ./parity { };
   parity-beta = callPackage ./parity/beta.nix { };
+
+  peercoin  = callPackage ./peercoin.nix { withGui = true; };
 }

--- a/pkgs/applications/altcoins/peercoin.nix
+++ b/pkgs/applications/altcoins/peercoin.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchFromGitHub
+, pkgconfig, autoreconfHook
+, openssl, db48, boost, zlib, miniupnpc
+, protobuf, utillinux, qt4, qrencode
+, withGui, libevent }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+
+  name = "peercoin" + (toString (optional (!withGui) "d")) + "-" + version;
+  version = "0.6.2ppc";
+
+  src = fetchFromGitHub {
+    owner = "peercoin";
+    repo = "peercoin";
+    rev = "v${version}";
+    sha256 = "16wxwwrv83x0qjj4dndlkrpw9ril9j0rh6skp1q1xm5zyc0fx0xl";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ openssl db48 boost zlib
+                  miniupnpc utillinux protobuf libevent qt4 ]
+                  ++ optionals withGui [ qrencode ];
+
+  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
+                     ++ optionals withGui [ "--with-gui=qt4" ];
+
+  buildPhase = ''
+    qmake
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp peercoin-qt $out/bin/
+  '';
+
+  meta = {
+    description = "A lite version of Bitcoin using scrypt as a proof-of-work algorithm";
+    longDescription= ''
+      Peercoin is a peer-to-peer Internet currency that enables instant payments
+      to anyone in the world. It is based on the Bitcoin protocol but differs
+      from Bitcoin in that it can be efficiently mined with consumer-grade hardware.
+      Litecoin provides faster transaction confirmations (2.5 minutes on average)
+      and uses a memory-hard, scrypt-based mining proof-of-work algorithm to target
+      the regular computers and GPUs most people already have.
+      The Litecoin network is scheduled to produce 84 million currency units.
+    '';
+    homepage = https://peercoin.org/;
+    platforms = platforms.unix;
+    license = licenses.mit;
+    maintainers = with maintainers; [ offline AndersonTorres ];  
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

