### PR TITLE
musl: 1.1.15 -> 1.1.16

### DIFF
--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name    = "musl-${version}";
-  version = "1.1.15";
+  version = "1.1.16";
 
   src = fetchurl {
     url    = "http://www.musl-libc.org/releases/${name}.tar.gz";
-    sha256 = "1ymhxkskivzph0q34zadwfglc5gyahqajm7chqqn2zraxv3lgr4p";
+    sha256 = "048h0w4yjyza4h05bkc6dpwg3hq6l03na46g0q1ha8fpwnjqawck";
   };
 
   enableParallelBuilding = true;
@@ -24,13 +24,7 @@ stdenv.mkDerivation rec {
     "--enable-static"
   ];
 
-  patches = [
-    # CVE-2016-8859: http://www.openwall.com/lists/oss-security/2016/10/19/1
-    (fetchpatch {
-      url = "https://git.musl-libc.org/cgit/musl/patch/?id=c3edc06d1e1360f3570db9155d6b318ae0d0f0f7";
-      sha256 = "15ih0aj27lz4sgq8r5jndc3qy5gz3ciraavrqpp0vw8h5wjcsb9v";
-    })
-  ];
+  patches = [];
 
   dontDisableStatic = true;
 


### PR DESCRIPTION
Features some bugfixes and allows us to drop the patch

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

