### PR TITLE
reno: 1.8.0 -> 2.3.2

### DIFF
--- a/pkgs/development/tools/reno/default.nix
+++ b/pkgs/development/tools/reno/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pythonPackages }:
 
-pythonPackages.buildPythonApplication rec {
+with pythonPackages; buildPythonApplication rec {
   name = "reno-${version}";
-  version = "1.8.0";
+  version = "2.3.2";
 
   src = fetchurl {
     url = "mirror://pypi/r/reno/${name}.tar.gz";
-    sha256 = "1pqg0xzcilmyrrnpa87m11xwlvfc94a98s28z9cgddkhw27lg3ps";
+    sha256 = "018vl9fj706jjf07xdx8q6761s53mrihjn69yjq09gp0vmp1g7i4";
   };
 
   # Don't know how to make tests pass
@@ -15,8 +15,8 @@ pythonPackages.buildPythonApplication rec {
   # Nothing to strip (python files)
   dontStrip = true;
 
-  propagatedBuildInputs = with pythonPackages; [ pbr six pyyaml ];
-  buildInputs = with pythonPackages; [ Babel ];
+  propagatedBuildInputs = [ pbr six pyyaml dulwich ];
+  buildInputs = [ Babel ];
 
   meta = with stdenv.lib; {
     description = "Release Notes Manager";


### PR DESCRIPTION
###### Motivation for this change
Update to newer version. As a side effect it also fixes the dependency on old pbr.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

