### PR TITLE
Mopidy-iris: init at 3.0.0

### DIFF
--- a/pkgs/applications/audio/mopidy-iris/default.nix
+++ b/pkgs/applications/audio/mopidy-iris/default.nix
@@ -2,12 +2,12 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "mopidy-iris-${version}";
-  version = "3.0.0";
+  version = "3.0.3";
 
   src = pythonPackages.fetchPypi {
     inherit version;
     pname = "Mopidy-Iris";
-    sha256 = "0k5854f7r5mmbaw0q5b99jkgnpvmlwi2srdzdvydlysih5zwywrk";
+    sha256 = "1j8zrkvgs2f6jcqf1sn79afiirk5plfrkychlzcwqrxix293ngjr";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/applications/audio/mopidy-iris/default.nix
+++ b/pkgs/applications/audio/mopidy-iris/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, pythonPackages, mopidy, mopidy-local-images }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "mopidy-iris-${version}";
+  version = "2.14.3";
+
+  src = pythonPackages.fetchPypi {
+    inherit version;
+    pname = "Mopidy-Iris";
+    sha256 = "04vxjn0jx6im3cay54dj1bhfiac2mxn2f96lj5450h8s30ah5xz3";
+  };
+
+  propagatedBuildInputs = [
+    mopidy
+    mopidy-local-images
+    pythonPackages.configobj
+    pythonPackages.pylast
+    pythonPackages.spotipy
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/jaedb/Iris";
+    description = "A fully-functional Mopidy web client encompassing Spotify and many other backends";
+    license = licenses.asl20;
+    maintainers = [ maintainers.rvolosatovs ];
+  };
+}

--- a/pkgs/applications/audio/mopidy-iris/default.nix
+++ b/pkgs/applications/audio/mopidy-iris/default.nix
@@ -2,12 +2,12 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "mopidy-iris-${version}";
-  version = "2.14.3";
+  version = "3.0.0";
 
   src = pythonPackages.fetchPypi {
     inherit version;
     pname = "Mopidy-Iris";
-    sha256 = "04vxjn0jx6im3cay54dj1bhfiac2mxn2f96lj5450h8s30ah5xz3";
+    sha256 = "0k5854f7r5mmbaw0q5b99jkgnpvmlwi2srdzdvydlysih5zwywrk";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15005,6 +15005,8 @@ with pkgs;
 
   mopidy-musicbox-webclient = callPackage ../applications/audio/mopidy-musicbox-webclient { };
 
+  mopidy-iris = callPackage ../applications/audio/mopidy-iris { };
+
   motif = callPackage ../development/libraries/motif { };
 
   mozplugger = callPackage ../applications/networking/browsers/mozilla-plugins/mozplugger {};


### PR DESCRIPTION
_first PR to this repo_
###### Motivation for this change
Adds [Mopidy-Iris](https://github.com/jaedb/Iris), a frontend extension for Mopidy. Some packages had to be added/bumped along the way.

I was not sure where to put `mopidy-local-images` - but decided to place it in the same location as all other `mopidy-*` packages reside. `fetchPypi`(not sure which of `fetchFromGitHub` and `fetchPypi` is the preferred solution) in the `mopidy-iris` is used due to the release being un-compiled source(also see jaedb/Iris#39), this eases the process a little bit.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

