### PR TITLE
google-play-music-desktop-player: 4.2.0 -> 4.3.0

### DIFF
--- a/pkgs/applications/audio/google-play-music-desktop-player/default.nix
+++ b/pkgs/applications/audio/google-play-music-desktop-player/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  version = "4.2.0";
+  version = "4.3.0";
 
   deps = [
     alsaLib
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v${version}/google-play-music-desktop-player_${version}_amd64.deb";
-    sha256 = "0n59b73jc6b86p5063xz7n0z48wy9mzqcx0l34av2hqkx6wcb2h8";
+    sha256 = "0mbrfnsnajmpwyqyrjmcv84ywzimjmm2b8faxqiwfcikdgpm9amb";
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Motivation for this change
Minor update [4.3.0](https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases) was issued on 25th of April

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Built with `nix-build -A google-play-music-desktop-player` and installed with `nix-env -f . -iA google-play-music-desktop-player`, used for a couple of tracks, seems to work as expected.
