### PR TITLE
nix-daemon: Add CPU and IO weight options

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -174,6 +174,25 @@ in
         '';
       };
 
+      daemonCPUWeight = mkOption {
+        type = types.int;
+        default = 20;
+        description = ''
+          Nix daemon service CPU weight. This sets the overall priority of its
+          CPU use, but does not limit maximum use. The system-wide default is 100.
+        '';
+      };
+
+      daemonIOWeight = mkOption {
+        type = types.int;
+        default = 20;
+        description = ''
+          Nix daemon service I/O weight. This sets the overall priority of its
+          disk I/O use, but does not limit maximum use. The system-wide default
+          is 100.
+        '';
+      };
+
       buildMachines = mkOption {
         type = types.listOf types.attrs;
         default = [];
@@ -346,7 +365,7 @@ in
 
 
   ###### implementation
-
+  
   config = {
 
     nix.binaryCachePublicKeys = [ "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" ];
@@ -387,6 +406,8 @@ in
 
         serviceConfig =
           { Nice = cfg.daemonNiceLevel;
+            CPUWeight = assert (cfg.daemonCPUWeight >= 1 && cfg.daemonCPUWeight <= 10000); cfg.daemonCPUWeight;
+            IOWeight = assert (cfg.daemonIOWeight >= 1 && cfg.daemonIOWeight <= 10000); cfg.daemonIOWeight;
             IOSchedulingPriority = cfg.daemonIONiceLevel;
             LimitNOFILE = 4096;
           };

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -624,7 +624,7 @@ in
     systemd.user.extraConfig = mkOption {
       default = "";
       type = types.lines;
-      example = "DefaultCPUAccounting=yes";
+      example = "DefaultCPUAccounting=no";
       description = ''
         Extra config options for systemd user instances. See man systemd-user.conf for
         available options.
@@ -725,6 +725,8 @@ in
 
       "systemd/system.conf".text = ''
         [Manager]
+        DefaultCPUAccounting=yes
+        DefaultIOAccounting=yes
         ${config.systemd.extraConfig}
       '';
 


### PR DESCRIPTION
###### Motivation for this change

Making Chrome (or other UI elements) less laggy.

CPU prioritization by way of 'nice' doesn't work very well. Modern systems have a better option, in that systemd can be used to set CPU timeslice weighting explicitly. This requires turning on accounting for the same, globally across the system, which I do with the systemd config patch.

The second patch makes the CPU weighting configurable for the nix-daemon service, and defaults it to the minimum possible. I believe this is a good default for desktop systems, as well as most servers; the builds are generally batch processes, and this setting does not prevent it from using all *idle* time.

All of the above is duplicated for I/O accounting, although I cannot test the impact from this due to running on NVMe.

There is a very slight performance impact from the accounting, but not so you'd notice. My experience is that it (if it exists at all) is vastly outweighed by usability improvements through making interactive sessions higher priority.

(I've been told that CPU and I/O accounting has low impact, while memory accounting has medium. This patch does not enable memory accounting.)

Other batch services should probably get the same treatment.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

