### PR TITLE
vdrift: fix build

### DIFF
--- a/pkgs/games/vdrift/default.nix
+++ b/pkgs/games/vdrift/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     cp -r --reflink=auto $data data
     chmod -R +w data
     sed -i -e s,/usr/local,$out, SConstruct
+    export CXXFLAGS="$(pkg-config --cflags SDL2_image)"
     scons
   '';
   installPhase = "scons install";


### PR DESCRIPTION
###### Motivation for this change
Had been broken since 7bf7f1976545666ba958034f7e61062595338f84

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).