### PR TITLE
pythonPackages.gensim: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/bz2file/default.nix
+++ b/pkgs/development/python-modules/bz2file/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, isPy3k
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "bz2file";
+  version = "0.98";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "126s53fkpx04f33a829yqqk8fj4png3qwg4m66cvlmhmwc8zihb4";
+  };
+
+  doCheck = false;
+  # The test module (test_bz2file) is not available
+
+  meta = {
+    description = "Bz2file is a Python library for reading and writing bzip2-compressed files";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jpbernardy ];
+  };
+}

--- a/pkgs/development/python-modules/gensim/default.nix
+++ b/pkgs/development/python-modules/gensim/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, six
+, scipy
+, smart_open
+, scikitlearn
+, testfixtures
+, unittest2
+}:
+
+buildPythonPackage rec {
+  pname = "gensim";
+  name = "${pname}-${version}";
+  version = "2.1.0";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wn7bji9b80wn1yggmh7a0dlwzdjr6cp24x4p33j2rf29lxnm2kc";
+  };
+
+  propagatedBuildInputs = [ smart_open numpy six scipy
+                            # scikitlearn testfixtures unittest2 # for tests
+                          ];
+  doCheck = false;
+
+  # Two tests fail.
+
+  # ERROR: testAddMorphemesToEmbeddings (gensim.test.test_varembed_wrapper.TestVarembed)
+  # ImportError: Could not import morfessor.
+  # This package is not in nix
+
+  # ERROR: testWmdistance (gensim.test.test_fasttext_wrapper.TestFastText)
+  # ImportError: Please install pyemd Python package to compute WMD.
+  # This package is not in nix
+
+  meta = {
+    description = "Topic-modelling library";
+    homepage = "https://radimrehurek.com/gensim/";
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ jpbernardy ];
+  };
+}

--- a/pkgs/development/python-modules/smart_open/default.nix
+++ b/pkgs/development/python-modules/smart_open/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, isPy3k
+, fetchPypi
+, boto
+, bz2file
+, moto
+, requests
+, responses
+}:
+
+buildPythonPackage rec {
+  pname = "smart_open";
+  name = "${pname}-${version}";
+  version = "1.5.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0m5j71f7f36s17v4mwv0bxg4azknvcy82rbjp28b4vifrjd6dm7s";
+  };
+
+  propagatedBuildInputs = [ boto bz2file requests responses moto ];
+  meta = {
+    license = lib.licenses.mit;
+    description = "smart_open is a Python 2 & Python 3 library for efficient streaming of very large file";
+    maintainers = with lib.maintainers; [ jpbernardy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -30483,6 +30483,8 @@ EOF
 
   distro = callPackage ../development/python-modules/distro { };
 
+  bz2file =  callPackage ../development/python-modules/bz2file { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2969,11 +2969,11 @@ in {
 
   boto = buildPythonPackage rec {
     name = "boto-${version}";
-    version = "2.45.0";
+    version = "2.47.0";
 
     src = pkgs.fetchurl {
       url = "https://github.com/boto/boto/archive/${version}.tar.gz";
-      sha256 = "18z5nacnbdpw3pmzc56didhy4sfik8riap204px24350g9xlgz7i";
+      sha256 = "051gq8z9m2cir03jhc00qs36bnpla7zkqm9xqiqcqvdknmi2ndbq";
     };
 
     checkPhase = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -30487,6 +30487,8 @@ EOF
 
   smart_open =  callPackage ../development/python-modules/smart_open { };
 
+  gensim = callPackage  ../development/python-modules/gensim { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -30485,6 +30485,8 @@ EOF
 
   bz2file =  callPackage ../development/python-modules/bz2file { };
 
+  smart_open =  callPackage ../development/python-modules/smart_open { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

Adding the gensim library to python packages

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

