### PR TITLE
rigsofrods: 20160412 -> 0.4.7.0

### DIFF
--- a/pkgs/games/rigsofrods/default.nix
+++ b/pkgs/games/rigsofrods/default.nix
@@ -4,14 +4,14 @@
   }:
 
 stdenv.mkDerivation rec {
-  version = "git-20160412";
+  version = "0.4.7.0";
   name = "rigsofrods-${version}";
 
   src = fetchFromGitHub {
     owner = "RigsOfRods";
     repo = "rigs-of-rods";
-    rev = "1ebd359dbd467b4c3171dd6d054e7d8ec39f78ba";
-    sha256 = "0h71nrgq5r5cnh20c7wl8jzyaf50dj1b5jdrwihnklpsfyfvjlw4";
+    rev = version;
+    sha256 = "0cb1il7qm45kfhh6h6jwfpxvjlh2dmg8z1yz9kj4d6098myf2lg4";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
Upstream release

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

