### PR TITLE
pijul: 0.4.4 -> 0.6.0

### DIFF
--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -4,21 +4,21 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "pijul-${version}";
-  version = "0.4.4";
+  version = "0.6.0";
 
   src = fetchurl {
     url = "https://pijul.org/releases/${name}.tar.gz";
-    sha256 = "8f133b7e14bfa84156c103126d53b12c6dfb996dcdebcf1091199ff9c77f3713";
+    sha256 = "a6b066b49b25d1083320c5ab23941deee795e1fcbe1faa951e95189fd594cdb3";
   };
 
-  sourceRoot = "${name}/pijul";
+  sourceRoot = "pijul";
 
-  buildInputs = [ perl ]++ stdenv.lib.optionals stdenv.isDarwin
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin
     (with darwin.apple_sdk.frameworks; [ Security ]);
 
   doCheck = false;
-  
-  depsSha256 = "1zdvnarg182spgydmqwxxr929j44d771zkq7gyh152173i0xqb20";
+
+  depsSha256 = "0raim0ahqg6fkidb6picfzircdzwdbsdmmv8in70r5hw770bv67r";
 
   meta = with stdenv.lib; {
     description = "A distributed version control system";


### PR DESCRIPTION
###### Motivation for this change

Update pijul to the latest version
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

