### PR TITLE
pythonPackages.thefuck: init at 3.18

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -99,6 +99,7 @@
   ./programs/spacefm.nix
   ./programs/ssh.nix
   ./programs/ssmtp.nix
+  ./programs/thefuck.nix
   ./programs/tmux.nix
   ./programs/venus.nix
   ./programs/vim.nix

--- a/nixos/modules/programs/thefuck.nix
+++ b/nixos/modules/programs/thefuck.nix
@@ -1,0 +1,31 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.thefuck;
+in
+  {
+    options = {
+      programs.thefuck = {
+        enable = mkEnableOption "thefuck";
+
+        alias = mkOption {
+          default = "fuck";
+          type = types.string;
+
+          description = ''
+            `thefuck` needs an alias to be configured.
+            The default value is `fuck`, but you can use anything else as well.
+          '';
+        };
+      };
+    };
+
+    config = mkIf cfg.enable {
+      environment.systemPackages = with pkgs; [ thefuck ];
+      environment.shellInit = ''
+        eval $(${pkgs.thefuck}/bin/thefuck --alias ${cfg.alias})
+      '';
+    };
+  }

--- a/pkgs/tools/misc/thefuck/default.nix
+++ b/pkgs/tools/misc/thefuck/default.nix
@@ -1,0 +1,27 @@
+{ fetchurl, stdenv, pkgs, ... }:
+
+pkgs.pythonPackages.buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "thefuck";
+  version = "3.18";
+
+  src = fetchurl {
+    url = "https://github.com/nvbn/${pname}/archive/${version}.tar.gz";
+    sha256 = "1xsvkqh89rgxq5w03mnlcfkn9y39nfwhb2pjabjspcc2mi2mq5y6";
+  };
+
+  propagatedBuildInputs = with pkgs.pythonPackages; [
+    psutil
+    colorama
+    six
+    decorator
+    pathlib2
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/nvbn/thefuck";
+    description = "Magnificent app which corrects your previous console command.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4333,6 +4333,8 @@ with pkgs;
 
   thc-hydra = callPackage ../tools/security/thc-hydra { };
 
+  thefuck = callPackage ../tools/misc/thefuck { };
+
   thin-provisioning-tools = callPackage ../tools/misc/thin-provisioning-tools {  };
 
   tiled = libsForQt5.callPackage ../applications/editors/tiled { };


### PR DESCRIPTION
###### Motivation for this change

This tool (https://github.com/nvbn/thefuck) is highly needed to increase my productivity on mondays like this.

I created a module which automatically builds the alias `thefuck --alias` needed for the actual setup and a python package to build `thefuck`.

I tested the change using the following configuration:

``` nix
{
  fuck = { pkgs, lib, ... }: with lib; {
    programs.thefuck.enable = true;

    users.extraUsers.test = {
      password = "123456";
      extraGroups = [ "wheel" ];
      isNormalUser = true;
      shell = "/run/current-system/sw/bin/zsh";
    };

    # used to confirm that it works with `zsh` as well
    programs.zsh.enable = true;
  };
}
```

Command to bootstrap the VM:

```
NIX_PATH=nixpkgs=$HOME/Projects/nixpkgs/ nixos-build-vms vmtest.nix
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

