### PR TITLE
rebulk: 0.8.2 -> 0.9.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11914,12 +11914,12 @@ in {
   guessit = callPackage ../development/python-modules/guessit { };
 
   rebulk = buildPythonPackage rec {
-    version = "0.8.2";
+    version = "0.9.0";
     name = "rebulk-${version}";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/r/rebulk/${name}.tar.gz";
-      sha256 = "8c09901bda7b79a21d46faf489d67d017aa54d38bdabdb53f824068a6640401a";
+      sha256 = "1sw516ihfrb7i9bfl1n3049akvb23mpsk3llh7w3xfnbvkfrpip0";
     };
 
     # Some kind of trickery with imports that doesn't work.


### PR DESCRIPTION
This allows to build guessit-2.1.4:
[...]
creating build/bdist.linux-x86_64/wheel/guessit-2.1.4.dist-info/WHEEL
installing
/tmp/nix-build-python2.7-guessit-2.1.4.drv-0/guessit-2.1.4/dist /tmp/nix-build-python2.7-guessit-2.1.4.drv-0/guessit-2.1.4
Processing ./guessit-2.1.4-py2-none-any.whl
Collecting rebulk>=0.9.0 (from guessit==2.1.4)
  Could not find a version that satisfies the requirement rebulk>=0.9.0 (from guessit==2.1.4) (from versions: )
No matching distribution found for rebulk>=0.9.0 (from guessit==2.1.4)
builder for ‘/nix/store/cnaxh7bmxwmks2vnfqis2xb23gvjsh92-python2.7-guessit-2.1.4.drv’ failed with exit code 1

###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

