### PR TITLE
lifelines: init at unstable-2019-05-07

### DIFF
--- a/pkgs/applications/misc/lifelines/default.nix
+++ b/pkgs/applications/misc/lifelines/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, gettext, libiconv, bison, ncurses, perl, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "lifelines";
+  version = "unstable-2019-05-07";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "43f29285ed46fba322b6a14322771626e6b02c59";
+    sha256 = "1agszzlmkxmznpc1xj0vzxkskrcfagfjvqsdyw1yp5yg6bsq272y";
+  };
+
+  buildInputs = [
+    gettext
+    libiconv
+    ncurses
+    perl
+  ];
+  nativeBuildInputs = [ autoreconfHook bison ];
+
+  meta = with stdenv.lib; {
+    description = "Genealogy tool with ncurses interface";
+    homepage = "https://lifelines.github.io/lifelines/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ disassembler ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18680,6 +18680,8 @@ in
 
   libvmi = callPackage ../development/libraries/libvmi { };
 
+  lifelines = callPackage ../applications/misc/lifelines { };
+
   liferea = callPackage ../applications/networking/newsreaders/liferea {
     inherit (gnome3) dconf;
   };


### PR DESCRIPTION
###### Motivation for this change
Adds lifelines command line genealogy tool. Using unstable because tag 3.1.1 will not build. Currently points at my repo, but will switch to upstream as soon as https://github.com/MarcNo/lifelines/pull/311 is merged.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

