### PR TITLE
elfkickers: init at 3.1

### DIFF
--- a/pkgs/development/tools/misc/elfkickers/default.nix
+++ b/pkgs/development/tools/misc/elfkickers/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "elfkickers-${version}";
+  version = "3.1";
+
+  src = fetchurl {
+    url = "http://www.muppetlabs.com/~breadbox/pub/software/ELFkickers-${version}.tar.gz";
+    sha256 = "0n0sypjrdm3ramv0sby4sdh3i3j9d0ihadr951wa08ypdnq3yrkd";
+  };
+
+  makeFlags = [ "CC=cc prefix=$(out)" ];
+
+  enableParallelBuildingg = true;
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.muppetlabs.com/~breadbox/software/elfkickers.html";
+    description = "A collection of programs that access and manipulate ELF files";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6690,6 +6690,8 @@ with pkgs;
 
   elfutils = callPackage ../development/tools/misc/elfutils { };
 
+  elfkickers = callPackage ../development/tools/misc/elfkickers { };
+
   emma = callPackage ../development/tools/analysis/emma { };
 
   epm = callPackage ../development/tools/misc/epm { };


### PR DESCRIPTION
###### Motivation for this change

Misc utilities for poking at ELF files.

[repology info](https://repology.org/metapackage/elfkickers/versions)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

