### PR TITLE
snpeff: 4.3i -> 4.3p

### DIFF
--- a/pkgs/applications/science/biology/snpeff/default.nix
+++ b/pkgs/applications/science/biology/snpeff/default.nix
@@ -2,14 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "snpeff-${version}";
-  version = "4.3i";
+  version = "4.3p";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/snpeff/snpEff_latest_core.zip";
-    sha256 = "0i1slg201c8yjfr4wrg4xcgzwi0c8b9l3fb1i73fphq6q6zdblzb";
+    url = "mirror://sourceforge/project/snpeff/snpEff_v4_3p_core.zip";
+    sha256 = "1xb3k0yxd634znw2q083ligm2ww4p6v64041r9sdy3930lhjvxb1";
   };
 
   buildInputs = [ unzip jre makeWrapper ];
+
+  sourceRoot = "snpEff";
 
   installPhase = ''
     mkdir -p $out/libexec/snpeff


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

