### PR TITLE
elfkickers: fix typo in enableParallelBuilding.

### DIFF
--- a/pkgs/development/tools/misc/elfkickers/default.nix
+++ b/pkgs/development/tools/misc/elfkickers/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "CC=cc prefix=$(out)" ];
 
-  enableParallelBuildingg = true;
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = "http://www.muppetlabs.com/~breadbox/software/elfkickers.html";


### PR DESCRIPTION
Thanks @bjornfor for spotting this!

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

