### PR TITLE
Speed up parsing @args.rsp compiler arguments

### DIFF
--- a/pkgs/build-support/cc-wrapper/utils.sh
+++ b/pkgs/build-support/cc-wrapper/utils.sh
@@ -28,17 +28,16 @@ badPath() {
 # States: 0 - outside, 1/2 - unquoted arg/slash, 3/4 - 'arg'/slash, 5/6 - "arg"/slash.
 # State transitions:
 rspT=(01235 01235 11111 33413 33333 55651 55555)
-# Push char on transition:
-rspC[01]=1 rspC[11]=1 rspC[21]=1 rspC[33]=1 rspC[43]=1 rspC[55]=1 rspC[65]=1
+# Push (a) arg or (c) char on transition:
+rspP[10]=a rspP[01]=c rspP[11]=c rspP[21]=c rspP[33]=c rspP[43]=c rspP[55]=c rspP[65]=c
 
 rspParse() {
     rsp=()
-    local s="$1"
     local state=0
     local arg=''
+    local c
 
-    for (( i=0; i<${#s}; i++ )); do
-        local c="${s:$i:1}"
+    while read -r -N1 c; do
         local cls=1
         case "$c" in
             ' ' | $'\t' | $'\r' | $'\n') cls=0 ;;
@@ -48,12 +47,10 @@ rspParse() {
         esac
         local nextstates="${rspT[$state]}"
         local nextstate="${nextstates:$cls:1}"
-        if [ "${rspC[$state$nextstate]}" ]; then
-            arg+="$c"
-        elif [ "$state$nextstate" = "10" ]; then
-            rsp+=("$arg")
-            arg=''
-        fi
+        case "${rspP[$state$nextstate]}" in
+            'c') arg+="$c" ;;
+            'a') rsp+=("$arg"); arg='' ;;
+        esac
         state="$nextstate"
     done
 
@@ -68,7 +65,7 @@ expandResponseParams() {
         local p="$1"
         shift
         if [ "${p:0:1}" = '@' -a -e "${p:1}" ]; then
-            rspParse "$(<"${p:1}")"
+            rspParse <"${p:1}"
             set -- "${rsp[@]}" "$@"
         else
             params+=("$p")


### PR DESCRIPTION
Improves upon #25205.

https://gist.github.com/pbogdan/9d6986bf931b58a70d75e14eb40ee8a1 parsing time is
reduced from one minute to one second.
