### PR TITLE
nixos-artwork: do not leak nix hashes to filenames in /share/artwork/gnome/

### DIFF
--- a/pkgs/data/misc/nixos-artwork/wallpapers.nix
+++ b/pkgs/data/misc/nixos-artwork/wallpapers.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl }:
 
 let
-  mkNixBackground = { name, src, description } @ attrs:
+  mkNixBackground = { name, filename, src, description } @ attrs:
 
     stdenv.mkDerivation {
       inherit name src;
@@ -10,7 +10,7 @@ let
 
       installPhase = ''
         mkdir -p $out/share/artwork/gnome
-        ln -s $src $out/share/artwork/gnome/
+        ln -s $src $out/share/artwork/gnome/${filename}
       '';
 
       meta = with stdenv.lib; {
@@ -28,6 +28,7 @@ in
   gnome-dark = mkNixBackground {
     name = "gnome-dark-2015-02-27";
     description = "Gnome Dark background for Nix";
+    filename = "Gnome_Dark.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/Nix/nixos-artwork/7ece5356398db14b5513392be4b31f8aedbb85a2/gnome/Gnome_Dark.png;
       sha256 = "0c7sl9k4zdjwvdz3nhlm8i4qv4cjr0qagalaa1a438jigixx27l7";
@@ -37,6 +38,7 @@ in
   mosaic-blue = mkNixBackground {
     name = "mosaic-blue-2016-02-19";
     description = "Mosaic blue background for Nix";
+    filename = "nix-wallpaper-mosaic-blue.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-mosaic-blue.png;
       sha256 = "1cbcssa8qi0giza0k240w5yy4yb2bhc1p1r7pw8qmziprcmwv5n5";
@@ -46,6 +48,7 @@ in
   simple-blue = mkNixBackground {
     name = "simple-blue-2016-02-19";
     description = "Simple blue background for Nix";
+    filename = "nix-wallpaper-simple-blue.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-blue.png;
       sha256 = "1llr175m454aqixxwbp3kb5qml2hi1kn7ia6lm7829ny6y7xrnms";
@@ -55,6 +58,7 @@ in
   simple-dark-gray = mkNixBackground {
     name = "simple-dark-gray-2016-02-19";
     description = "Simple dark gray background for Nix";
+    filename = "nix-wallpaper-simple-dark-gray.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-dark-gray.png;
       sha256 = "1282cnqc5qynp0q9gdll7bgpw23yp5bhvaqpar59ibkh3iscg8i5";
@@ -64,6 +68,7 @@ in
   simple-light-gray = mkNixBackground {
     name = "simple-light-gray-2016-02-19";
     description = "Simple light gray background for Nix";
+    filename = "nix-wallpaper-simple-light-gray.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-light-gray.png;
       sha256 = "0i6d0xv1nzrv7na9hjrgzl3jrwn81vnprnq2pxyznlxbjcgkjnk2";
@@ -73,6 +78,7 @@ in
   simple-red = mkNixBackground {
     name = "simple-red-2016-02-19";
     description = "Simple red background for Nix";
+    filename = "nix-wallpaper-simple-red.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-red.png;
       sha256 = "16drprsi3q8xbxx3bxp54yld04c4lq6jankw8ww1irg7z61a6wjs";
@@ -82,6 +88,7 @@ in
   stripes-logo = mkNixBackground {
     name = "stripes-logo-2016-02-19";
     description = "Stripes logo background for Nix";
+    filename = "nix-wallpaper-stripes-logo.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-stripes-logo.png;
       sha256 = "0cqjkgp30428c1yy8s4418k4qz0ycr6fzcg4rdi41wkh5g1hzjnl";
@@ -91,6 +98,7 @@ in
   stripes = mkNixBackground {
     name = "stripes-2016-02-19";
     description = "Stripes background for Nix";
+    filename = "nix-wallpaper-stripes.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-stripes.png;
       sha256 = "116337wv81xfg0g0bsylzzq2b7nbj6hjyh795jfc9mvzarnalwd3";

--- a/pkgs/data/misc/nixos-artwork/wallpapers.nix
+++ b/pkgs/data/misc/nixos-artwork/wallpapers.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl }:
 
 let
-  mkNixBackground = { name, filename, src, description } @ attrs:
+  mkNixBackground = { name, src, description } @ attrs:
 
     stdenv.mkDerivation {
       inherit name src;
@@ -10,7 +10,7 @@ let
 
       installPhase = ''
         mkdir -p $out/share/artwork/gnome
-        ln -s $src $out/share/artwork/gnome/${filename}
+        ln -s $src $out/share/artwork/gnome/${src.name}
       '';
 
       meta = with stdenv.lib; {
@@ -28,7 +28,6 @@ in
   gnome-dark = mkNixBackground {
     name = "gnome-dark-2015-02-27";
     description = "Gnome Dark background for Nix";
-    filename = "Gnome_Dark.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/Nix/nixos-artwork/7ece5356398db14b5513392be4b31f8aedbb85a2/gnome/Gnome_Dark.png;
       sha256 = "0c7sl9k4zdjwvdz3nhlm8i4qv4cjr0qagalaa1a438jigixx27l7";
@@ -38,7 +37,6 @@ in
   mosaic-blue = mkNixBackground {
     name = "mosaic-blue-2016-02-19";
     description = "Mosaic blue background for Nix";
-    filename = "nix-wallpaper-mosaic-blue.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-mosaic-blue.png;
       sha256 = "1cbcssa8qi0giza0k240w5yy4yb2bhc1p1r7pw8qmziprcmwv5n5";
@@ -48,7 +46,6 @@ in
   simple-blue = mkNixBackground {
     name = "simple-blue-2016-02-19";
     description = "Simple blue background for Nix";
-    filename = "nix-wallpaper-simple-blue.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-blue.png;
       sha256 = "1llr175m454aqixxwbp3kb5qml2hi1kn7ia6lm7829ny6y7xrnms";
@@ -58,7 +55,6 @@ in
   simple-dark-gray = mkNixBackground {
     name = "simple-dark-gray-2016-02-19";
     description = "Simple dark gray background for Nix";
-    filename = "nix-wallpaper-simple-dark-gray.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-dark-gray.png;
       sha256 = "1282cnqc5qynp0q9gdll7bgpw23yp5bhvaqpar59ibkh3iscg8i5";
@@ -68,7 +64,6 @@ in
   simple-light-gray = mkNixBackground {
     name = "simple-light-gray-2016-02-19";
     description = "Simple light gray background for Nix";
-    filename = "nix-wallpaper-simple-light-gray.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-light-gray.png;
       sha256 = "0i6d0xv1nzrv7na9hjrgzl3jrwn81vnprnq2pxyznlxbjcgkjnk2";
@@ -78,7 +73,6 @@ in
   simple-red = mkNixBackground {
     name = "simple-red-2016-02-19";
     description = "Simple red background for Nix";
-    filename = "nix-wallpaper-simple-red.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-red.png;
       sha256 = "16drprsi3q8xbxx3bxp54yld04c4lq6jankw8ww1irg7z61a6wjs";
@@ -88,7 +82,6 @@ in
   stripes-logo = mkNixBackground {
     name = "stripes-logo-2016-02-19";
     description = "Stripes logo background for Nix";
-    filename = "nix-wallpaper-stripes-logo.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-stripes-logo.png;
       sha256 = "0cqjkgp30428c1yy8s4418k4qz0ycr6fzcg4rdi41wkh5g1hzjnl";
@@ -98,7 +91,6 @@ in
   stripes = mkNixBackground {
     name = "stripes-2016-02-19";
     description = "Stripes background for Nix";
-    filename = "nix-wallpaper-stripes.png";
     src = fetchurl {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-stripes.png;
       sha256 = "116337wv81xfg0g0bsylzzq2b7nbj6hjyh795jfc9mvzarnalwd3";


### PR DESCRIPTION
###### Motivation for this change

Fixes #26565

After #26460 ```nixos-rebuild``` fails with error
```
cannot copy /nix/store/sj1psbij342r12xv61fx6jcxwapkkj3g-gnome-dark-2015-02-27/share/artwork/gnome/Gnome_Dark.png to /boot
```

because the filename contains nix hash:
```
/etc/nixos$ ls -l /nix/store/sj1psbij342r12xv61fx6jcxwapkkj3g-gnome-dark-2015-02-27/share/artwork/gnome                                               
total 0                                                                                                                                               
lrwxrwxrwx 3 root root 58 Jan  1  1970 1vhgkmby6lkm6qz3kv6pmzylv1599z7y-Gnome_Dark.png -> /nix/store/1vhgkmby6lkm6qz3kv6pmzylv1599z7y-Gnome_Dark.png  
```
