### PR TITLE
flashplayer: 25.0.0.171 -> 26.0.0.126 [Critical security fixes]

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -94,12 +94,12 @@ let
 
   flash = stdenv.mkDerivation rec {
     name = "flashplayer-ppapi-${version}";
-    version = "25.0.0.171";
+    version = "26.0.0.126";
 
     src = fetchzip {
       url = "https://fpdownload.adobe.com/pub/flashplayer/pdc/"
           + "${version}/flash_player_ppapi_linux.x86_64.tar.gz";
-      sha256 = "0g2955wybwqlcgslm0mfi0jdnpih1w10lkzm5g5am4smgpch8prs";
+      sha256 =  "17ivhkdkbnzxr10ln1ix30k1hmaak5p9zzcchdyrjxdpzfk5qq7s";
       stripRoot = false;
     };
 

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
@@ -73,25 +73,25 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-${version}";
-  version = "25.0.0.171";
+  version = "26.0.0.126";
 
   src = fetchurl {
     url =
       if debug then
-        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/25/flash_player_npapi_linux_debug.${arch}.tar.gz"
+        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flash_player_npapi_linux_debug.${arch}.tar.gz"
       else
         "https://fpdownload.adobe.com/get/flashplayer/pdc/${version}/flash_player_npapi_linux.${arch}.tar.gz";
     sha256 =
       if debug then
         if arch == "x86_64" then
-          "0rm7kdb8h1pf9z2sl3lv8siyizz3dw4fyfmizn48622nsfh13dzd"
+          "0i5rr8bymbdzwqpns854i2r9390av89v1ikh8msincczq5vpj012"
         else
-          "1akvvya0jn708ifmrf4pbpp3dpi10i3mgyld46275lcwpz8xhyw5"
+          "1mzq3wvq6rxqfdlapd0b1ymw7389414jxwhkd6wk3677qdhr1y42"
       else
         if arch == "x86_64" then
-          "1r6cr00ax590jgjfp20wya67gkpw6cw0dgb9ixvlxnld4wi4mzk0"
+          "0684kizzfwfzaj0i54cdlkx3fqb3kyhb9jw88n031bjrzv7ddiz7"
         else
-          "1x326qihprq59s70szf0yh96p78mbnkw41lhar71128nv91mnfc3";
+          "1pn15wnldabacmahlqdsl8nd60982j77bghjlf2cdc7drysby3ns";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
@@ -55,19 +55,19 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-standalone-${version}";
-  version = "25.0.0.171";
+  version = "26.0.0.126";
 
   src = fetchurl {
     url =
       if debug then
-        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/25/flash_player_sa_linux_debug.x86_64.tar.gz"
+        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flash_player_sa_linux_debug.x86_64.tar.gz"
       else
-        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/25/flash_player_sa_linux.x86_64.tar.gz";
+        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flash_player_sa_linux.x86_64.tar.gz";
     sha256 =
       if debug then
-        "1llvglydsqp5r9f903bzn8i09zg6rcka7lzxlhb8xi0gbw4imsv2"
+        "17s55b1ncjj0hnldjmxm133z0i4jf49wbh4sn1cfwrw6xrhgbkiw"
       else
-        "1sx20mgja17hi6zp5ygqg4sklp5h0h55j3jw5b759j9c2x1frq5g";
+        "02j98ji2jw2sxrs9hhlkkdrhpf2c4hc336cfvqzdf1iajza5was8";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

- Critical security fixes
- Other bug fixes
- Other enhancements

https://helpx.adobe.com/flash-player/release-note/fp_26_air_26_release_notes.html
https://helpx.adobe.com/security/products/flash-player/apsb17-17.html


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

- Built packages
  - `nix-env -i -f . -A pkgs.flashplayer`
  - `nix-build -I nixpkgs=. -A pkgsi686Linux.flashplayer`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).flashplayer.override { debug = true; }"`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).pkgsi686Linux.flashplayer.override { debug = true; }"`
  - `nix-build -I nixpkgs=. -A pkgs.flashplayer-standalone`
  - `nix-build -I nixpkgs=. -A pkgs.flashplayer-standalone-debugger`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).chromium.override { enablePepperFlash = true; }"`
- Played a video with Firefox (x86_64)
- Played a video with Chromium (x86_64)
- Checked the version with Firefox (x86_64) http://www.adobe.com/software/flash/about/
- Checked the version with Chromium (x86_64) http://www.adobe.com/software/flash/about/
- Played a video with `flashplayer-standalone` and `flashplayer-standalone-debugger` (x86_64)

---

