### PR TITLE
pythonPackages.netcdf4: add missing cython dependency

### DIFF
--- a/pkgs/development/python-modules/netcdf4/default.nix
+++ b/pkgs/development/python-modules/netcdf4/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchurl, isPyPy
-, numpy, zlib, netcdf, hdf5, curl, libjpeg
+, numpy, zlib, netcdf, hdf5, curl, libjpeg, cython
 }:
 buildPythonPackage rec {
   pname = "netCDF4";
@@ -12,6 +12,10 @@ buildPythonPackage rec {
     url = "mirror://pypi/n/netCDF4/${name}.tar.gz";
     sha256 = "31eb4eae5fd3b2bd8f828721142ddcefdbf10287281bf6f636764dd7957f8450";
   };
+
+  buildInputs = [
+    cython
+  ];
 
   propagatedBuildInputs = [
     numpy

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8066,7 +8066,7 @@ in {
     };
   };
 
-  netcdf4 = callPackage ../development/python-modules/netcdf4.nix { };
+  netcdf4 = callPackage ../development/python-modules/netcdf4 { };
 
   Nikola = callPackage ../development/python-modules/Nikola { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

