### PR TITLE
mplayer: Use system ffmpeg instead of vendored version.

### DIFF
--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -93,6 +93,8 @@ stdenv.mkDerivation rec {
 
   prePatch = ''
     sed -i /^_install_strip/d configure
+
+    rm -rf ffmpeg
   '';
 
   buildInputs = with stdenv.lib;
@@ -159,6 +161,7 @@ stdenv.mkDerivation rec {
       ${optionalString stdenv.isLinux "--enable-vidix"}
       ${optionalString stdenv.isLinux "--enable-fbdev"}
       --disable-ossaudio
+      --disable-ffmpeg_a
     '';
 
   NIX_LDFLAGS = with stdenv.lib;


### PR DESCRIPTION

###### Motivation for this change

Looks like using system ffmpeg was intended behavior (ffmpeg is build dependency),
but mplayer was using its provided version instead.

Fixes use of mplayer with https:// URL's.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

