### PR TITLE
ddcutil: init at 0.8.2

### DIFF
--- a/pkgs/tools/misc/ddcutil/default.nix
+++ b/pkgs/tools/misc/ddcutil/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, glib, i2c-tools, udev, libgudev, libusb, libdrm, xorg }:
+
+stdenv.mkDerivation rec {
+  name = "ddcutil-${version}";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner  = "rockowitz";
+    repo   = "ddcutil";
+    rev    = "v${version}";
+    sha256 = "1hcdg54xyb1pfl03iqll14y9yglwmyvxyvhbql87hd9q0dywah6m";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [
+    i2c-tools udev libgudev
+    glib libusb libdrm xorg.libXrandr
+  ];
+
+  meta = with stdenv.lib; {
+    homepage    = http://www.ddcutil.com/;
+    description = "Query and change Linux monitor settings using DDC/CI and USB";
+    license     = licenses.gpl2;
+    maintainer  = with maintainers; [ rnhmjoj ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1544,6 +1544,8 @@ with pkgs;
 
   ddccontrol-db = callPackage ../data/misc/ddccontrol-db { };
 
+  ddcutil = callPackage ../tools/misc/ddcutil { };
+
   ddclient = callPackage ../tools/networking/ddclient { };
 
   dd_rescue = callPackage ../tools/system/dd_rescue { };


### PR DESCRIPTION
###### Motivation for this change
ddccontrol doesn't seem to work with my GPU.

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---