### PR TITLE
pandas: add 'which' dependency

### DIFF
--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -19,6 +19,7 @@
 , openpyxl
 , tables
 , xlwt
+, which
 , libcxx ? null
 }:
 
@@ -52,6 +53,7 @@ in buildPythonPackage rec {
     openpyxl
     tables
     xlwt
+    which # Used to test presence of executables
   ];
 
   # For OSX, we need to add a dependency on libcxx, which provides


### PR DESCRIPTION
`pandas` has an undeclared dependency on `which` (it uses it to test for the presence of executables). You wouldn't notice it unless you were running in `nix-shell --pure`, which I was to troubleshoot other things.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

