### PR TITLE
cntlm service: cleanup non working config options

### DIFF
--- a/nixos/modules/services/networking/cntlm.nix
+++ b/nixos/modules/services/networking/cntlm.nix
@@ -5,110 +5,122 @@ with lib;
 let
 
   cfg = config.services.cntlm;
-  uid = config.ids.uids.cntlm;
+
+  configFile = if cfg.configText != "" then
+    pkgs.writeText "cntlm.conf" ''
+      ${cfg.configText}
+    ''
+    else
+    pkgs.writeText "lighttpd.conf" ''
+      # Cntlm Authentication Proxy Configuration
+      Username ${cfg.username}
+      Domain ${cfg.domain}
+      Password ${cfg.password}
+      ${optionalString (cfg.netbios_hostname != "") "Workstation ${cfg.netbios_hostname}"}
+      ${concatMapStrings (entry: "Proxy ${entry}\n") cfg.proxy}
+      ${optionalString (cfg.noproxy != []) "NoProxy ${concatStringsSep ", " cfg.noproxy}"}
+
+      ${concatMapStrings (port: ''
+        Listen ${toString port}
+      '') cfg.port}
+
+      ${cfg.extraConfig}
+    '';
 
 in
 
 {
 
-  options = {
+  options.services.cntlm = {
 
-    services.cntlm = {
+    enable = mkOption {
+      default = false;
+      description = ''
+        Whether to enable the cntlm, which start a local proxy.
+      '';
+    };
 
-      enable = mkOption {
-        default = false;
-        description = ''
-          Whether to enable the cntlm, which start a local proxy.
-        '';
-      };
+    username = mkOption {
+      description = ''
+        Proxy account name, without the possibility to include domain name ('at' sign is interpreted literally).
+      '';
+    };
 
-      username = mkOption {
-        description = ''
-          Proxy account name, without the possibility to include domain name ('at' sign is interpreted literally).
-        '';
-      };
+    domain = mkOption {
+      description = ''Proxy account domain/workgroup name.'';
+    };
 
-      domain = mkOption {
-        description = ''Proxy account domain/workgroup name.'';
-      };
+    password = mkOption {
+      default = "/etc/cntlm.password";
+      type = types.str;
+      description = ''Proxy account password. Note: use chmod 0600 on /etc/cntlm.password for security.'';
+    };
 
-      password = mkOption {
-        default = "/etc/cntlm.password";
-        type = types.str;
-        description = ''Proxy account password. Note: use chmod 0600 on /etc/cntlm.password for security.'';
-      };
+    netbios_hostname = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        The hostname of your machine.
+      '';
+    };
 
-      netbios_hostname = mkOption {
-        type = types.str;
-        description = ''
-          The hostname of your machine.
-        '';
-      };
+    proxy = mkOption {
+      description = ''
+        A list of NTLM/NTLMv2 authenticating HTTP proxies.
 
-      proxy = mkOption {
-        description = ''
-          A list of NTLM/NTLMv2 authenticating HTTP proxies.
+        Parent proxy, which requires authentication. The same as proxy on the command-line, can be used more than  once  to  specify  unlimited
+        number  of  proxies.  Should  one proxy fail, cntlm automatically moves on to the next one. The connect request fails only if the whole
+        list of proxies is scanned and (for each request) and found to be invalid. Command-line takes precedence over the configuration file.
+      '';
+      example = [ "proxy.example.com:81" ];
+    };
 
-          Parent proxy, which requires authentication. The same as proxy on the command-line, can be used more than  once  to  specify  unlimited
-          number  of  proxies.  Should  one proxy fail, cntlm automatically moves on to the next one. The connect request fails only if the whole
-          list of proxies is scanned and (for each request) and found to be invalid. Command-line takes precedence over the configuration file.
-        '';
-      };
+    noproxy = mkOption {
+      description = ''
+        A list of domains where the proxy is skipped.
+      '';
+      default = [];
+      example = [ "*.example.com" "example.com" ];
+    };
 
-      port = mkOption {
-        default = [3128];
-        description = "Specifies on which ports the cntlm daemon listens.";
-      };
+    port = mkOption {
+      default = [3128];
+      description = "Specifies on which ports the cntlm daemon listens.";
+    };
 
-     extraConfig = mkOption {
-        type = types.lines;
-        default = "";
-        description = "Verbatim contents of <filename>cntlm.conf</filename>.";
-     };
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Additional config appended to the end of the generated <filename>cntlm.conf</filename>.";
+    };
 
+    configText = mkOption {
+       type = types.lines;
+       default = "";
+       description = "Verbatim contents of <filename>cntlm.conf</filename>.";
     };
 
   };
 
-
   ###### implementation
 
-  config = mkIf config.services.cntlm.enable {
+  config = mkIf cfg.enable {
     systemd.services.cntlm = {
       description = "CNTLM is an NTLM / NTLM Session Response / NTLMv2 authenticating HTTP proxy";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        Type = "forking";
         User = "cntlm";
         ExecStart = ''
-          ${pkgs.cntlm}/bin/cntlm -U cntlm \
-            -c ${pkgs.writeText "cntlm_config" cfg.extraConfig}
+          ${pkgs.cntlm}/bin/cntlm -U cntlm -c ${configFile} -v -f
         '';
-      };  
-    };
-   
-    services.cntlm.netbios_hostname = mkDefault config.networking.hostName;
-  
-    users.extraUsers.cntlm =  { 
-      name = "cntlm";
-      description = "cntlm system-wide daemon";
-      home = "/var/empty";
+      };
     };
 
-    services.cntlm.extraConfig =
-      ''
-        # Cntlm Authentication Proxy Configuration
-        Username        ${cfg.username}
-        Domain          ${cfg.domain}
-        Password        ${cfg.password}
-        Workstation     ${cfg.netbios_hostname}
-        ${concatMapStrings (entry: "Proxy ${entry}\n") cfg.proxy}
-    
-        ${concatMapStrings (port: ''
-          Listen ${toString port}
-        '') cfg.port}
-      '';      
+    users.extraUsers.cntlm = {
+      name = "cntlm";
+      description = "cntlm system-wide daemon";
+      isSystemUser = true;
+    };
   };
-  
 }


### PR DESCRIPTION
###### Motivation for this change

The current module configs were not working correctly.

- extraConfig was not working
- add possibility to add cntlm.conf in verbatime form
- correctly create the cntlm user with it's uid
- add no proxy option

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

