### PR TITLE
Theano cleanup

### DIFF
--- a/pkgs/development/python-modules/Theano/default.nix
+++ b/pkgs/development/python-modules/Theano/default.nix
@@ -50,12 +50,15 @@ in buildPythonPackage rec {
   };
 
   postPatch = ''
-    sed -i 's,g++,${gcc_}/bin/g++,g' theano/configdefaults.py
-  '' + lib.optionalString cudnnSupport ''
-    sed -i \
-      -e "s,ctypes.util.find_library('cudnn'),'${cudnn}/lib/libcudnn.so',g" \
-      -e "s/= _dnn_check_compile()/= (True, None)/g" \
-      theano/gpuarray/dnn.py
+    substituteInPlace theano/configdefaults.py \
+      --replace 'StrParam(param, is_valid=warn_cxx)' 'StrParam('\'''${gcc_}/bin/g++'\''', is_valid=warn_cxx)' \
+      --replace 'rc == 0 and config.cxx != ""' 'config.cxx != ""'
+  '' + stdenv.lib.optionalString cudaSupport ''
+    substituteInPlace theano/configdefaults.py \
+      --replace 'StrParam(get_cuda_root)' 'StrParam('\'''${cudatoolkit}'\''')'
+  '' + stdenv.lib.optionalString cudnnSupport ''
+    substituteInPlace theano/configdefaults.py \
+      --replace 'StrParam(default_dnn_base_path)' 'StrParam('\'''${cudnn}'\''')'
   '';
 
   preCheck = ''

--- a/pkgs/development/python-modules/Theano/default.nix
+++ b/pkgs/development/python-modules/Theano/default.nix
@@ -1,8 +1,8 @@
 { stdenv
+, runCommandCC
 , lib
 , fetchPypi
 , gcc
-, writeScriptBin
 , buildPythonPackage
 , isPyPy
 , pythonOlder
@@ -24,17 +24,22 @@ assert cudaSupport -> nvidia_x11 != null
                    && cudnn != null;
 
 let
-  extraFlags =
-    lib.optionals cudaSupport [ "-I ${cudatoolkit}/include" "-L ${cudatoolkit}/lib" ]
-    ++ lib.optionals cudnnSupport [ "-I ${cudnn}/include" "-L ${cudnn}/lib" ]
-    ++ lib.optionals cudaSupport [ "-I ${libgpuarray}/include" "-L ${libgpuarray}/lib" ];
+  wrapped = command: buildTop: buildInputs:
+    runCommandCC "${command}-wrapped" { inherit buildInputs; } ''
+      type -P '${command}' || { echo '${command}: not found'; exit 1; }
+      cat > "$out" <<EOF
+      #!$(type -P bash)
+      $(declare -xp | sed -e '/^[^=]\+="\('"''${NIX_STORE//\//\\/}"'\|[^\/]\)/!d')
+      declare -x NIX_BUILD_TOP="${buildTop}"
+      $(type -P '${command}') "\$@"
+      EOF
+      chmod +x "$out"
+    '';
 
-  gcc_ = writeScriptBin "g++" ''
-    #!${stdenv.shell}
-    export NIX_CC_WRAPPER_${stdenv.cc.infixSalt}_TARGET_HOST=1
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE ${toString extraFlags}"
-    exec ${gcc}/bin/g++ "$@"
-  '';
+  # Theano spews warnings and disabled flags if the compiler isn't named g++
+  cxx_compiler = wrapped "g++" "\\$HOME/.theano"
+    (    stdenv.lib.optional cudaSupport libgpuarray_
+      ++ stdenv.lib.optional cudnnSupport cudnn );
 
   libgpuarray_ = libgpuarray.override { inherit cudaSupport cudatoolkit; };
 
@@ -51,7 +56,7 @@ in buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace theano/configdefaults.py \
-      --replace 'StrParam(param, is_valid=warn_cxx)' 'StrParam('\'''${gcc_}/bin/g++'\''', is_valid=warn_cxx)' \
+      --replace 'StrParam(param, is_valid=warn_cxx)' 'StrParam('\'''${cxx_compiler}'\''', is_valid=warn_cxx)' \
       --replace 'rc == 0 and config.cxx != ""' 'config.cxx != ""'
   '' + stdenv.lib.optionalString cudaSupport ''
     substituteInPlace theano/configdefaults.py \

--- a/pkgs/development/python-modules/Theano/default.nix
+++ b/pkgs/development/python-modules/Theano/default.nix
@@ -36,7 +36,7 @@ let
     exec ${gcc}/bin/g++ "$@"
   '';
 
-  libgpuarray_ = libgpuarray.override { inherit cudaSupport; };
+  libgpuarray_ = libgpuarray.override { inherit cudaSupport cudatoolkit; };
 
 in buildPythonPackage rec {
   pname = "Theano";


### PR DESCRIPTION
###### Motivation for this change

The first patch merges the cuda and non-cuda derivations.  This removes a lot of duplication and was mentioned in the original commit 07dcc4f43aeb3703cf55002dc00af89cc3585a69 as something that should be done.

The second patch bakes the build-time compiler into Theano for it to use when it compiles up and loads it EDSL.  Without this, it uses whatever compiler is current in the environment.  This can cause issues, especially in the non-NixOS case where the system compiler is often not a good choice.

I've built and tested this against the 17.03 release.  It wouldn't build against master for me due to issues with the dependencies unreleated to these patches.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

