### PR TITLE
pythonPackages.intelhex init at 2.1

### DIFF
--- a/pkgs/development/python-modules/intelhex/default.nix
+++ b/pkgs/development/python-modules/intelhex/default.nix
@@ -13,13 +13,6 @@ buildPythonPackage rec {
     sha256 = "0k5l1mn3gv1vb0jd24ygxksx8xqr57y1ivgyj37jsrwpzrp167kw";
   };
 
-  # FAIL: test_xrange_longint (intelhex.test.TestXrangeLongInt)
-  # AssertionError: OverflowError not raised
-  #
-  # Harmless test failure:
-  #  https://github.com/bialix/intelhex/issues/14
-  doCheck = false;
-
   meta = {
     homepage = https://github.com/bialix/intelhex;
     description = "Python library for Intel HEX files manipulations";

--- a/pkgs/development/python-modules/intelhex/default.nix
+++ b/pkgs/development/python-modules/intelhex/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "intelhex";
+  version = "2.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0k5l1mn3gv1vb0jd24ygxksx8xqr57y1ivgyj37jsrwpzrp167kw";
+  };
+
+  # FAIL: test_xrange_longint (intelhex.test.TestXrangeLongInt)
+  # AssertionError: OverflowError not raised
+  #
+  # Harmless test failure:
+  #  https://github.com/bialix/intelhex/issues/14
+  doCheck = false;
+
+  meta = {
+    homepage = https://github.com/bialix/intelhex;
+    description = "Python library for Intel HEX files manipulations";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ pjones ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -216,6 +216,8 @@ in {
     hdf5 = pkgs.hdf5-mpi;
   };
 
+  intelhex = callPackage ../development/python-modules/intelhex { };
+
   mpi4py = callPackage ../development/python-modules/mpi4py {
     mpi = pkgs.openmpi;
   };


### PR DESCRIPTION
###### Motivation for this change

This package is a dependency of another package that I'll be submitting shortly.  In other words, I need this PR approved so I can submit another one :)

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

