### PR TITLE
Expose custom Rust registry versions

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -1,5 +1,10 @@
-{ stdenv, callPackage, path, cacert, git, rust }:
+{ stdenv, callPackage, path, cacert, git, rust, rustRegistry }:
+
+let
+  rustRegistry' = rustRegistry;
+in
 { name, depsSha256
+, rustRegistry ? rustRegistry'
 , src ? null
 , srcs ? null
 , sourceRoot ? null
@@ -8,13 +13,10 @@
 , cargoUpdateHook ? ""
 , cargoDepsHook ? ""
 , cargoBuildFlags ? []
-, registry ? null
 , ... } @ args:
 
 let
   lib = stdenv.lib;
-  rustRegistry = callPackage (path + /pkgs/top-level/rust-packages.nix)
-    (lib.optionalAttrs (registry != null) { src = registry; });
 
   fetchDeps = import ./fetchcargo.nix {
     inherit stdenv cacert git rust rustRegistry;

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cacert, git, rust, rustRegistry }:
+{ stdenv, callPackage, path, cacert, git, rust }:
 { name, depsSha256
 , src ? null
 , srcs ? null
@@ -8,9 +8,14 @@
 , cargoUpdateHook ? ""
 , cargoDepsHook ? ""
 , cargoBuildFlags ? []
+, registry ? null
 , ... } @ args:
 
 let
+  lib = stdenv.lib;
+  rustRegistry = callPackage (path + /pkgs/top-level/rust-packages.nix)
+    (lib.optionalAttrs (registry != null) { src = registry; });
+
   fetchDeps = import ./fetchcargo.nix {
     inherit stdenv cacert git rust rustRegistry;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5770,6 +5770,8 @@ with pkgs;
     inherit (darwin) apple_sdk;
   };
 
+  rustRegistry = callPackage ./rust-packages.nix { };
+
   rust = rustStable;
   rustStable = callPackage ../development/compilers/rust {
     inherit (llvmPackages_4) llvm;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5788,7 +5788,6 @@ with pkgs;
   rustNightlyBin = lowPrio (callPackage ../development/compilers/rust/nightlyBin.nix {
      buildRustPackage = callPackage ../build-support/rust {
        rust = rustNightlyBin;
-       rustRegistry = callPackage ./rust-packages.nix { };
      };
   });
 
@@ -5804,8 +5803,6 @@ with pkgs;
       callPackage = newScope self;
     in {
       inherit rust;
-
-      rustRegistry = callPackage ./rust-packages.nix { };
 
       buildRustPackage = callPackage ../build-support/rust {
         inherit rust;

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -4,24 +4,16 @@
 # version that we define here. If you're having problems downloading / finding
 # a Rust library, try updating this to a newer commit.
 
-{ runCommand, fetchFromGitHub, git }:
+{ runCommand, fetchFromGitHub, git
+, src ? fetchFromGitHub {
+    owner = "rust-lang";
+    repo = "crates.io-index";
+    rev = "05e6194f31ccfb1dfd08f80d223c9a473b3e4d48";
+    sha256 = "02ak1jla0fwh52x77r6pzszh7pldg6s43flazk53pr0mzx7vfw72";
+  }
+}:
 
-let
-  version = "2017-05-31";
-  rev = "d85037df75a945b5a368d6ceaa7e030b67473a51";
-  sha256 = "0567lfjxvbn4pb39557yfdq1nm4ssgbvzvzkrdqnx9sx5xyx7n4s";
-
-  src = fetchFromGitHub {
-      inherit rev;
-      inherit sha256;
-
-      owner = "rust-lang";
-      repo = "crates.io-index";
-  };
-
-in
-
-runCommand "rustRegistry-${version}-${builtins.substring 0 7 rev}" { inherit src; } ''
+runCommand "rustRegistry" { inherit src; } ''
   # For some reason, cargo doesn't like fetchgit's git repositories, not even
   # if we set leaveDotGit to true, set the fetchgit branch to 'master' and clone
   # the repository (tested with registry rev


### PR DESCRIPTION
###### Motivation for this change

This allows users to specify a custom registry src,
because currently every packager would need to create
an outdated Cargo.lock just to be compatible with the
probably outdated rustRegistry in nixpkgs.

Currently there is no easy way to convince cargo to
do that, so this makes that workaround unnecessary.

Not tested, this is only a PR already for review purposes, don't merge just yet

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

