### PR TITLE
ply: init at v1-beta1(9e810b1)

### DIFF
--- a/pkgs/os-specific/linux/ply/default.nix
+++ b/pkgs/os-specific/linux/ply/default.nix
@@ -1,0 +1,30 @@
+{ autoconf, automake, flex, yacc, stdenv, kernel, fetchFromGitHub }:
+let
+  version = "1.0.beta1-9e810b1";
+in stdenv.mkDerivation {
+  name = "ply-${version}";
+  nativeBuildInputs = [
+    autoconf
+    automake
+  ];
+
+  buildInputs = [
+    flex
+    yacc
+    kernel
+    stdenv.cc
+  ];
+
+  src = fetchFromGitHub {
+    owner = "iovisor";
+    repo = "ply";
+    rev = "9e810b157ba079c32c430a7d4c6034826982056e";
+    sha256 = "15cp6iczawaqlhsa0af6i37zn5iq53kh6ya8s2hzd018yd7mhg50";
+  };
+
+  preConfigure = "sh autogen.sh --prefix=$out";
+
+  configureFlags = [
+    "--with-kerneldir=${kernel.dev}"
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12008,6 +12008,8 @@ with pkgs;
     nvidia_x11_beta      = nvidiaPackages.beta;
     nvidia_x11           = nvidiaPackages.stable;
 
+    ply = callPackage ../os-specific/linux/ply { };
+
     rtl8723bs = callPackage ../os-specific/linux/rtl8723bs { };
 
     rtl8812au = callPackage ../os-specific/linux/rtl8812au { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

