### PR TITLE
blackmagic init at 1.6.1

### DIFF
--- a/pkgs/development/tools/misc/blackmagic/default.nix
+++ b/pkgs/development/tools/misc/blackmagic/default.nix
@@ -1,0 +1,59 @@
+{ stdenv, lib, fetchFromGitHub
+, gcc-arm-embedded, bash, libftdi
+, python, pythonPackages
+}:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "blackmagic-${version}";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "blacksphere";
+    repo = "blackmagic";
+    rev = "d3a8f27fdbf952194e8fc5ce9b2fc9bcef7c545c";
+    sha256 = "0c3l7cfqag3g7zrfn4mmikkx7076hb1r856ybhhdh0f6zji2j6jx";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    gcc-arm-embedded
+    libftdi
+    python
+    pythonPackages.intelhex
+  ];
+
+  postPatch = ''
+    # Prevent calling out to `git' to generate a version number:
+    substituteInPlace src/Makefile \
+      --replace '`git describe --always --dirty`' '${version}'
+
+    # Fix scripts that generate headers:
+    for f in $(find scripts libopencm3/scripts -type f); do
+      patchShebangs "$f"
+    done
+  '';
+
+  buildPhase = "${stdenv.shell} ${./helper.sh}";
+  installPhase = ":"; # buildPhase does this.
+
+  meta = {
+    description = "In-application debugger for ARM Cortex microcontrollers";
+    longDescription = ''
+      The Black Magic Probe is a modern, in-application debugging tool
+      for embedded microprocessors. It allows you to see what is going
+      on "inside" an application running on an embedded microprocessor
+      while it executes.
+
+      This package builds the firmware for all supported platforms,
+      placing them in separate directories under the firmware
+      directory.  It also places the FTDI version of the blackmagic
+      executable in the bin directory.
+    '';
+    homepage = https://github.com/blacksphere/blackmagic;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pjones ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/misc/blackmagic/helper.sh
+++ b/pkgs/development/tools/misc/blackmagic/helper.sh
@@ -1,0 +1,49 @@
+################################################################################
+# Build all of the platforms manually since the `all_platforms' target
+# doesn't preserve all of the build outputs and overrides CFLAGS.
+set -e
+set -u
+
+################################################################################
+# Prevent a warning from shellcheck:
+out=${out:-/tmp}
+
+################################################################################
+export CFLAGS=$NIX_CFLAGS_COMPILE
+
+################################################################################
+PRODUCTS="blackmagic.bin blackmagic.hex blackmagic_dfu.bin blackmagic_dfu.hex"
+
+################################################################################
+make_platform() {
+  echo "Building for hardware platform $1"
+
+  make clean
+  make PROBE_HOST="$1"
+
+  if [ "$1" = libftdi ]; then
+    mkdir -p "$out/bin"
+    install -m 0555 blackmagic "$out/bin"
+  fi
+
+  for f in $PRODUCTS; do
+    if [ -r "$f" ]; then
+      mkdir -p "$out/firmware/$1"
+      install -m 0444 "$f" "$out/firmware/$1"
+    fi
+  done
+
+}
+
+################################################################################
+# Start by building libopencm3:
+make -C libopencm3
+
+################################################################################
+# And now all of the platforms:
+cd src
+
+for platform in platforms/*/Makefile.inc; do
+  probe=$(basename "$(dirname "$platform")")
+  make_platform "$probe"
+done

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6500,6 +6500,8 @@ with pkgs;
   bison3 = callPackage ../development/tools/parsing/bison/3.x.nix { };
   bison = bison3;
 
+  blackmagic = callPackage ../development/tools/misc/blackmagic { };
+
   bloaty = callPackage ../development/tools/bloaty { };
 
   bossa = callPackage ../development/tools/misc/bossa {


### PR DESCRIPTION
###### Motivation for this change 

Add package for flashing and debugging ARM Cortex controllers.



###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

