### PR TITLE
gerbil: 0.10 -> 0.11

### DIFF
--- a/pkgs/development/compilers/gerbil/default.nix
+++ b/pkgs/development/compilers/gerbil/default.nix
@@ -3,10 +3,10 @@
 stdenv.mkDerivation rec {
   name    = "gerbil-${version}";
 
-  version = "0.10";
+  version = "0.11";
   src = fetchurl {
     url    = "https://github.com/vyzo/gerbil/archive/v${version}.tar.gz";
-    sha256 = "14wzdnifr99g1mvm2xwks97nhaq62hfx43pxcw9gs647i7cymbly";
+    sha256 = "0mqg6cqdcf5qr7vk79x5zkls7z2wm8i3lhwn0b7i0g1m6yyyyff7";
   };
 
   buildInputs = [ gambit openssl zlib coreutils rsync bash ];
@@ -46,7 +46,7 @@ EOF
   dontStrip = true;
 
   meta = {
-    description = "Gerbil";
+    description = "Gerbil Scheme";
     homepage    = "https://github.com/vyzo/gerbil";
     license     = stdenv.lib.licenses.lgpl2;
     platforms   = stdenv.lib.platforms.linux;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

