### PR TITLE
antlr4_7: init at 4.7

### DIFF
--- a/pkgs/development/tools/parsing/antlr/4.7.nix
+++ b/pkgs/development/tools/parsing/antlr/4.7.nix
@@ -1,0 +1,41 @@
+{stdenv, fetchurl, jre}:
+
+stdenv.mkDerivation rec {
+  name = "antlr-${version}";
+  version = "4.7";
+  src = fetchurl {
+    url ="http://www.antlr.org/download/antlr-${version}-complete.jar";
+    sha256 = "0r08ay63s5aajix5j8j7lf7j7l7wiwdkr112b66nyhkj5f6c72yd";
+  };
+
+  unpackPhase = "true";
+ 
+  installPhase = ''
+    mkdir -p "$out"/{share/java,bin}
+    cp "$src" "$out/share/java/antlr-${version}-complete.jar"
+
+    echo "#! ${stdenv.shell}" >> "$out/bin/antlr"
+    echo "'${jre}/bin/java' -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' -Xmx500M org.antlr.v4.Tool \"\$@\"" >> "$out/bin/antlr"
+    
+    echo "#! ${stdenv.shell}" >> "$out/bin/grun"
+    echo "'${jre}/bin/java' -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' org.antlr.v4.gui.TestRig \"\$@\"" >> "$out/bin/grun"
+
+    chmod a+x "$out/bin/antlr" "$out/bin/grun"
+    ln -s "$out/bin/antlr"{,4}
+  '';
+
+  inherit jre;
+
+  meta = with stdenv.lib; {
+    description = "Powerful parser generator";
+    longDescription = ''
+      ANTLR (ANother Tool for Language Recognition) is a powerful parser
+      generator for reading, processing, executing, or translating structured
+      text or binary files. It's widely used to build languages, tools, and
+      frameworks. From a grammar, ANTLR generates a parser that can build and
+      walk parse trees.
+    '';
+    homepage = http://www.antlr.org/;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6413,6 +6413,9 @@ with pkgs;
   antlr3_5 = callPackage ../development/tools/parsing/antlr/3.5.nix { };
   antlr3 = antlr3_5;
 
+  antlr4_7 = callPackage ../development/tools/parsing/antlr/4.7.nix { };
+  antlr4 = antlr4_7;
+
   ant = apacheAnt;
 
   apacheAnt = callPackage ../development/tools/build-managers/apache-ant { };


### PR DESCRIPTION
###### Motivation for this change

Antlr is a really useful tool for polyglot parser generation and this expression contains the tool and java run-time. Also included is the  `grun` testing rig.

I have tested that it is possible to perform the steps described in the [getting started guide](https://github.com/antlr/antlr4/blob/master/doc/getting-started.md) on my local machine as well as used it to generate parsers in java, javascript and golang.

Other run-times are not included in this expression, but they are typically installed by language specific package managers, with the exception of C++. I expect this dependency would be managed by the project using the tool however. 

`grun` gui mode is gtk dependent which may vary based on environment, but I didn't want to include them as explicit dependencies as they are not needed to use `grun` in other modes.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

