### PR TITLE
guetzli: init at  1.0.1

### DIFF
--- a/pkgs/applications/graphics/guetzli/default.nix
+++ b/pkgs/applications/graphics/guetzli/default.nix
@@ -1,11 +1,14 @@
-{ stdenv, libpng, fetchgit, pkgconfig }:
+{ stdenv, libpng, fetchFromGitHub, pkgconfig }:
+let
+  version = "1.0.1";
+in
 stdenv.mkDerivation {
-  name = "guetzli-1.0.1";
-  src = fetchgit {
-    url = "https://github.com/google/guetzli.git";
-    rev = "a0f47a297f802630f937a3091964838eaf3b87d8";
+  name = "guetzli-${version}";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "guetzli";
+    rev = "v${version}";
     sha256 = "1wy9wfvyradp0aigfv8yijvj0dgb5kpq2yf2xki15f605jc1r5dm";
-    fetchSubmodules = true;
   };
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libpng ];

--- a/pkgs/applications/graphics/guetzli/default.nix
+++ b/pkgs/applications/graphics/guetzli/default.nix
@@ -7,7 +7,8 @@ stdenv.mkDerivation {
     sha256 = "1wy9wfvyradp0aigfv8yijvj0dgb5kpq2yf2xki15f605jc1r5dm";
     fetchSubmodules = true;
   };
-  buildInputs = [ libpng pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libpng ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/applications/graphics/guetzli/default.nix
+++ b/pkgs/applications/graphics/guetzli/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, libpng, fetchgit, pkgconfig }:
+stdenv.mkDerivation {
+  name = "guetzli-1.0.1";
+  src = fetchgit {
+    url = "https://github.com/google/guetzli.git";
+    rev = "a0f47a297f802630f937a3091964838eaf3b87d8";
+    sha256 = "1wy9wfvyradp0aigfv8yijvj0dgb5kpq2yf2xki15f605jc1r5dm";
+    fetchSubmodules = true;
+  };
+  buildInputs = [ libpng pkgconfig ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install bin/Release/guetzli $out/bin/
+  '';
+
+  meta = {
+    description = "Perceptual JPEG encoder";
+    longDescription = "Guetzli is a JPEG encoder that aims for excellent compression density at high visual quality.";
+    homepage = "https://github.com/google/guetzli";
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.x86_64;
+    maintainers = [ stdenv.lib.maintainers.seppeljordan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18360,6 +18360,8 @@ with pkgs;
 
   greybird = callPackage ../misc/themes/greybird { };
 
+  guetzli = callPackage ../applications/graphics/guetzli { };
+
   gxemul = callPackage ../misc/emulators/gxemul { };
 
   hatari = callPackage ../misc/emulators/hatari { };


### PR DESCRIPTION
###### Motivation for this change
It would be nice to have guetzli inside nixpkgs

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` *does not apply*
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

