### PR TITLE
`zoom-us` fixes

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, system, makeWrapper,
   alsaLib, dbus, glib, gstreamer, fontconfig, freetype, libpulseaudio, libxml2,
-  libxslt, mesa, nspr, nss, sqlite, utillinux, zlib, xorg }:
+  libxslt, mesa, nspr, nss, sqlite, utillinux, zlib, xorg, udev, expat }:
 
 let
 
@@ -35,6 +35,8 @@ in stdenv.mkDerivation {
     sqlite
     utillinux
     zlib
+    udev
+    expat
 
     xorg.libX11
     xorg.libSM
@@ -51,6 +53,7 @@ in stdenv.mkDerivation {
     xorg.libXi
     xorg.libXrender
     xorg.libXcomposite
+    xorg.libXScrnSaver
 
     stdenv.cc.cc
   ];
@@ -63,8 +66,10 @@ in stdenv.mkDerivation {
     mkdir -p $out/bin
     cp -ar * $packagePath
 
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      $packagePath/zoom
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)"  $packagePath/zoom
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)"  $packagePath/QtWebEngineProcess
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)"  $packagePath/qtdiag
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)"  $packagePath/zopen
     # included from https://github.com/NixOS/nixpkgs/commit/fc218766333a05c9352b386e0cbb16e1ae84bf53
     # it works for me without it, but, well...
     paxmark m $packagePath/zoom
@@ -77,6 +82,11 @@ in stdenv.mkDerivation {
         --set QT_XKB_CONFIG_ROOT "${xorg.xkeyboardconfig}/share/X11/xkb" \
         --set QTCOMPOSE "${xorg.libX11.out}/share/X11/locale"
     ln -s "$packagePath/zoom" "$out/bin/zoom-us"
+
+    cat > $packagePath/qt.conf <<EOF
+    [Paths]
+    Prefix = $packagePath
+    EOF
 
     $postInstallHooks
   '';

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, system, makeWrapper,
   alsaLib, dbus, glib, gstreamer, fontconfig, freetype, libpulseaudio, libxml2,
-  libxslt, mesa, nspr, nss, sqlite, utillinux, zlib, xorg, udev, expat }:
+  libxslt, mesa, nspr, nss, sqlite, utillinux, zlib, xorg, udev, expat, libv4l }:
 
 let
 
@@ -78,6 +78,7 @@ in stdenv.mkDerivation {
     # RUNPATH set via patchelf is used only for half of libraries (why?), so wrap it
     wrapProgram $packagePath/zoom \
         --prefix LD_LIBRARY_PATH : "$packagePath:$libPath" \
+        --prefix LD_PRELOAD : "${libv4l}/lib/v4l1compat.so" \
         --set QT_PLUGIN_PATH "$packagePath/platforms" \
         --set QT_XKB_CONFIG_ROOT "${xorg.xkeyboardconfig}/share/X11/xkb" \
         --set QTCOMPOSE "${xorg.libX11.out}/share/X11/locale"


### PR DESCRIPTION
###### Motivation for this change
Fix some issues for `zoom-us`. In particular,
- https://github.com/NixOS/nixpkgs/pull/26446#issuecomment-306904224 for not working SSO (cc @kamilchm )
- crash with Facebook
- warnings about `/home/levi/...` (by fixing `qt.conf`)
- black screen from webcam (my Logitech C270). This change, however, isn't as straightforward as others, so I extracted it to separate commit. If you guys ( @shlevy @k0001 @kamilchm ) have webcam working currently, and that commit breaks it for you, i'll revert it.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

