### PR TITLE
ocamlPackages.ppx_tools_versioned: 5.0alpha -> 5.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
@@ -2,7 +2,7 @@
 
 buildOcaml rec {
   name = "ppx_tools_versioned";
-  version = "5.0alpha";
+  version = "5.0.1";
 
   minimumSupportedOcamlVersion = "4.02";
 
@@ -10,7 +10,7 @@ buildOcaml rec {
     owner = "let-def";
     repo = "ppx_tools_versioned";
     rev = version;
-    sha256 = "0sa3w0plpa0s202s9yjgz7dbk32xd2s6fymkjijrhj4lkvh08mba";
+    sha256 = "1rpbxbhk3k7f61h7lr4qkllkc12gjpq0rg52q7i6hcrg2dxkhwh6";
   };
 
   propagatedBuildInputs = [ ocaml-migrate-parsetree ];


### PR DESCRIPTION
###### Motivation for this change

Update to the most recent released version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] (N/A) Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

`nox-review wip` fails on the build of Reason, but Reason did not build before this commit either. The error is the same one as reported here: https://github.com/facebook/reason/issues/1224

