### PR TITLE
ghc821: init at 8.2.1-rc2 (a.k.a., 8.2.0.20170507)

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.1.nix
+++ b/pkgs/development/compilers/ghc/8.2.1.nix
@@ -1,0 +1,117 @@
+{ stdenv, lib, fetchurl, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
+, autoconf, automake, happy, alex, python3, sphinx, hscolour
+, buildPlatform, targetPlatform , selfPkgs, cross ? null
+
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # library instead of the faster but GPLed integer-gmp library.
+, enableIntegerSimple ? false, gmp
+}:
+
+let
+  inherit (bootPkgs) ghc;
+  version = "8.2.1-rc2";
+  preReleaseName = "ghc-8.2.0.20170507";
+  commonBuildInputs = [ alex autoconf automake ghc happy hscolour perl python3 sphinx ];
+  commonPreConfigure =  ''
+    sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
+  '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/${preReleaseName}"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    export NIX_LDFLAGS+=" -no_dtrace_dof"
+  '' + stdenv.lib.optionalString enableIntegerSimple ''
+    echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
+  '';
+in stdenv.mkDerivation (rec {
+  inherit version;
+  name = "ghc-${version}";
+
+  src = fetchurl {
+    url = "https://downloads.haskell.org/~ghc/${version}/${preReleaseName}-src.tar.xz";
+    sha256 = "1hy3l6nzkyhzwy9mii4zs51jv048zwvdqk1q3188jznz35392zrn";
+  };
+
+  postPatch = "patchShebangs .";
+
+  preConfigure = commonPreConfigure;
+
+  buildInputs = commonBuildInputs;
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "CC=${stdenv.cc}/bin/cc"
+    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
+    "--datadir=$doc/share/doc/ghc"
+  ] ++ stdenv.lib.optional (! enableIntegerSimple) [
+    "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
+  ] ++ stdenv.lib.optional stdenv.isDarwin [
+    "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
+  ];
+
+  # required, because otherwise all symbols from HSffi.o are stripped, and
+  # that in turn causes GHCi to abort
+  stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
+
+  checkTarget = "test";
+
+  postInstall = ''
+    paxmark m $out/lib/${preReleaseName}/bin/{ghc,haddock}
+
+    # Install the bash completion file.
+    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/ghc
+
+    # Patch scripts to include "readelf" and "cat" in $PATH.
+    for i in "$out/bin/"*; do
+      test ! -h $i || continue
+      egrep --quiet '^#!' <(head -n 1 $i) || continue
+      sed -i -e '2i export PATH="$PATH:${stdenv.lib.makeBinPath [ binutils coreutils ]}"' $i
+    done
+  '';
+
+  outputs = [ "out" "doc" ];
+
+  passthru = {
+    inherit bootPkgs;
+  } // stdenv.lib.optionalAttrs (targetPlatform != buildPlatform) {
+    crossCompiler = selfPkgs.ghc.override {
+      cross = targetPlatform;
+      bootPkgs = selfPkgs;
+    };
+  };
+
+  meta = {
+    homepage = "http://haskell.org/ghc";
+    description = "The Glasgow Haskell Compiler";
+    maintainers = with stdenv.lib.maintainers; [ marcweber andres peti ];
+    inherit (ghc.meta) license platforms;
+  };
+
+} // stdenv.lib.optionalAttrs (cross != null) {
+  name = "${cross.config}-ghc-${version}";
+
+  preConfigure = commonPreConfigure + ''
+    sed 's|#BuildFlavour  = quick-cross|BuildFlavour  = perf-cross|' mk/build.mk.sample > mk/build.mk
+  '';
+
+  configureFlags = [
+    "CC=${stdenv.ccCross}/bin/${cross.config}-cc"
+    "LD=${stdenv.binutils}/bin/${cross.config}-ld"
+    "AR=${stdenv.binutils}/bin/${cross.config}-ar"
+    "NM=${stdenv.binutils}/bin/${cross.config}-nm"
+    "RANLIB=${stdenv.binutils}/bin/${cross.config}-ranlib"
+    "--target=${cross.config}"
+    "--enable-bootstrap-with-devel-snapshot"
+  ] ++
+    # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
+    lib.optional (cross.config or null == "aarch64-apple-darwin14") "--disable-large-address-space";
+
+  buildInputs = commonBuildInputs ++ [ stdenv.ccCross stdenv.binutils ];
+
+  dontSetConfigureCross = true;
+
+  passthru = {
+    inherit bootPkgs cross;
+    cc = "${stdenv.ccCross}/bin/${cross.config}-cc";
+    ld = "${stdenv.binutils}/bin/${cross.config}-ld";
+  };
+})

--- a/pkgs/development/haskell-modules/configuration-ghc-8.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.2.x.nix
@@ -1,0 +1,60 @@
+{ pkgs }:
+
+with import ./lib.nix { inherit pkgs; };
+
+self: super: {
+
+  # Suitable LLVM version.
+  llvmPackages = pkgs.llvmPackages_39;
+
+  # Disable GHC 8.2.x core libraries.
+  array = null;
+  base = null;
+  binary = null;
+  bytestring = null;
+  Cabal = null;
+  containers = null;
+  deepseq = null;
+  directory = null;
+  filepath = null;
+  ghc-boot = null;
+  ghc-boot-th = null;
+  ghc-compact = null;
+  ghc-prim = null;
+  ghci = null;
+  haskeline = null;
+  hoopl = null;
+  hpc = null;
+  integer-gmp = null;
+  pretty = null;
+  process = null;
+  rts = null;
+  template-haskell = null;
+  terminfo = null;
+  time = null;
+  transformers = null;
+  unix = null;
+  xhtml = null;
+
+  # cabal-install can use the native Cabal library.
+  cabal-install = super.cabal-install.override { Cabal = null; };
+
+  # jailbreak-cabal can use the native Cabal library.
+  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = null; };
+
+  # https://github.com/bmillwood/applicative-quoters/issues/6
+  applicative-quoters = appendPatch super.applicative-quoters (pkgs.fetchpatch {
+    url = "https://patch-diff.githubusercontent.com/raw/bmillwood/applicative-quoters/pull/7.patch";
+    sha256 = "026vv2k3ks73jngwifszv8l59clg88pcdr4mz0wr0gamivkfa1zy";
+  });
+
+  ## GHC > 8.0.2
+
+  # http://hub.darcs.net/dolio/vector-algorithms/issue/9#comment-20170112T145715
+  vector-algorithms = dontCheck super.vector-algorithms;
+
+  # https://github.com/thoughtbot/yesod-auth-oauth2/pull/77
+  yesod-auth-oauth2 = doJailbreak super.yesod-auth-oauth2;
+
+
+}

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -68,6 +68,13 @@ in rec {
       inherit (bootPkgs) hscolour;
       sphinx = pkgs.python27Packages.sphinx;
     };
+    ghc821 = callPackage ../development/compilers/ghc/8.2.1.nix rec {
+      bootPkgs = packages.ghc802;
+      inherit (bootPkgs) hscolour alex happy;
+      inherit buildPlatform targetPlatform;
+      sphinx = pkgs.python3Packages.sphinx;
+      selfPkgs = packages.ghc821;
+    };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix rec {
       bootPkgs = packages.ghc7103;
       inherit (bootPkgs) alex happy;
@@ -156,6 +163,10 @@ in rec {
       ghc = compiler.ghc802;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.0.x.nix { };
     };
+    ghc821 = callPackage ../development/haskell-modules {
+      ghc = compiler.ghc821;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
+    };
     ghcHEAD = callPackage ../development/haskell-modules {
       ghc = compiler.ghcHEAD;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-head.nix { };
@@ -164,6 +175,10 @@ in rec {
     ghcCross = callPackage ../development/haskell-modules {
       ghc = compiler.ghcHEAD.crossCompiler;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-head.nix { };
+    };
+    ghcCross821 = callPackage ../development/haskell-modules {
+      ghc = compiler.ghc821.crossCompiler;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
     };
     ghcjs = callPackage ../development/haskell-modules {
       ghc = compiler.ghcjs;


### PR DESCRIPTION
The approach taken to add this package was to port over the definitions
currently existing for 8.2.0, and making the necessesary changes to get
this building.

The Haskell package set associated with this compiler doesn't yet
guarantee that all or most of the packages successfully build with this
new compiler, but that will improve over time after this GHC 8.2.1
is officially released and the ecosystem catches up.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

