### PR TITLE
ssh module: disable agent by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -104,6 +104,15 @@ rmdir /var/lib/ipfs/.ipfs
       <literal>dataDir</literal>.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      The <literal>ssh-agent</literal> user service is not started by default
+      anymore. Use <literal>programs.ssh.startAgent</literal> to enable it if
+      needed. There is also a new <literal>programs.gnupg.agent</literal>
+      module that creates a <literal>gpg-agent</literal> user service. It can
+      also serve as a SSH agent if <literal>enableSSHSupport</literal> is set.
+    </para>
+  </listitem>
 </itemizedlist>
 
 

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -74,7 +74,7 @@ in
 
       startAgent = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = ''
           Whether to start the OpenSSH agent when you log in.  The OpenSSH agent
           remembers private keys for you so that you don't have to type in


### PR DESCRIPTION
###### Motivation for this change

This should be a rather uncontroversial change but some feedback would be appreciated

IMHO launching a ssh-agent is not needed for every user session. It might make sense on desktop systems but not on servers or in containers.