### PR TITLE
python-modules/protobuf: fix darwin build by using $CXX instead of $CC

### DIFF
--- a/pkgs/development/python-modules/protobuf.nix
+++ b/pkgs/development/python-modules/protobuf.nix
@@ -23,7 +23,9 @@ buildPythonPackage rec {
     export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2
   '';
 
+  # force use of $CXX to ensure C++ system headers are available
   preBuild = optionalString (versionAtLeast protobuf.version "2.6.0") ''
+    export CC=$CXX
     ${python}/bin/${python.executable} setup.py build_ext --cpp_implementation
   '';
 


### PR DESCRIPTION
fixes #26531 (or works around?)

###### Motivation for this change

This is about issue #26531. The minimal change I could make to get the package to build for me locally. I doubt it's the best way to go about it.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

