### PR TITLE
systemd: allow setting timezone via timedatectl

### DIFF
--- a/nixos/modules/config/timezone.nix
+++ b/nixos/modules/config/timezone.nix
@@ -14,13 +14,16 @@ in
     time = {
 
       timeZone = mkOption {
-        default = "UTC";
-        type = types.str;
+        default = null;
+        type = types.nullOr types.str;
         example = "America/New_York";
         description = ''
           The time zone used when displaying times and dates. See <link
           xlink:href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"/>
           for a comprehensive list of possible values for this setting.
+
+          If null, the timezone will default to UTC and can be set imperatively
+          using timedatectl.
         '';
       };
 
@@ -40,13 +43,14 @@ in
     # This way services are restarted when tzdata changes.
     systemd.globalEnvironment.TZDIR = tzdir;
 
-    environment.etc.localtime =
-      { source = "/etc/zoneinfo/${config.time.timeZone}";
-        mode = "direct-symlink";
+    systemd.services.systemd-timedated.environment = lib.optionalAttrs (config.time.timeZone != null) { NIXOS_STATIC_TIMEZONE = "1"; };
+
+    environment.etc = {
+      zoneinfo.source = tzdir;
+    } // lib.optionalAttrs (config.time.timeZone == null) {
+        localtime.source = "/etc/zoneinfo/${config.time.timeZone}";
+        localtime.mode = "direct-symlink";
       };
-
-    environment.etc.zoneinfo.source = tzdir;
-
   };
 
 }

--- a/nixos/tests/timezone.nix
+++ b/nixos/tests/timezone.nix
@@ -1,0 +1,45 @@
+{
+  timezone-static = import ./make-test.nix ({ pkgs, ... }: {
+    name = "timezone-static";
+    meta.maintainers = with pkgs.lib.maintainers; [ lheckemann ];
+
+    machine.time.timeZone = "Europe/Amsterdam";
+
+    testScript = ''
+      $machine->waitForUnit("dbus.socket");
+      $machine->fail("timedatectl set-timezone Asia/Tokyo");
+      my @dateResult = $machine->execute('date -d @0 "+%Y-%m-%d %H:%M:%S"');
+      $dateResult[1] eq "1970-01-01 01:00:00\n" or die "Timezone seems to be wrong";
+    '';
+  });
+
+  timezone-imperative = import ./make-test.nix ({ pkgs, ... }: {
+    name = "timezone-imperative";
+    meta.maintainers = with pkgs.lib.maintainers; [ lheckemann ];
+
+    machine.time.timeZone = null;
+
+    testScript = ''
+      $machine->waitForUnit("dbus.socket");
+
+      # Should default to UTC
+      my @dateResult = $machine->execute('date -d @0 "+%Y-%m-%d %H:%M:%S"');
+      print $dateResult[1];
+      $dateResult[1] eq "1970-01-01 00:00:00\n" or die "Timezone seems to be wrong";
+
+      $machine->succeed("timedatectl set-timezone Asia/Tokyo");
+
+      # Adjustment should be taken into account
+      my @dateResult = $machine->execute('date -d @0 "+%Y-%m-%d %H:%M:%S"');
+      print $dateResult[1];
+      $dateResult[1] eq "1970-01-01 09:00:00\n" or die "Timezone was not adjusted";
+
+      # Adjustment should persist across a reboot
+      $machine->shutdown;
+      $machine->waitForUnit("dbus.socket");
+      my @dateResult = $machine->execute('date -d @0 "+%Y-%m-%d %H:%M:%S"');
+      print $dateResult[1];
+      $dateResult[1] eq "1970-01-01 09:00:00\n" or die "Timezone adjustment was not persisted";
+    '';
+  });
+}


### PR DESCRIPTION
###### Motivation for this change
#26469

I'm not sure about the exact process of getting this into nixpkgs proper. There's the matter of getting lheckemann/systemd@5352df7b281f2627e712dfde46ec67736b12e00e into nixos's systemd (thankfully github allows referring to commits from forks in the source repo so this works even though it hasn't been merged anywhere) in addition to this. I've PRed this to staging because of the mass rebuild it causes.

Any feedback on the material contents of the PR in addition to process information is of course also very welcome!

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).