### PR TITLE
Firefox

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "53.0.3";
+    version = "54.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "cef5de1e9d6ddf6509a80cd30169fdce701b2fed022979ba5931ccea7b8f77cb644b01984dae028d350e32321cfe2eefc0236c0731bf5a2be12a994fc3fc1118";
+      sha512 = "3cqwn8izdi8l706h0xr09r6vbrhsvzqr3f8g70hygcad3iydihkfddb3qdimynaqmn2lrdl66paqigfgwilpcdfbzhx7xp70h49dxhg";
     };
 
     meta = {

--- a/pkgs/development/libraries/nspr/default.nix
+++ b/pkgs/development/libraries/nspr/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl
 , CoreServices ? null }:
 
-let version = "4.13.1"; in
+let version = "4.15"; in
 
 stdenv.mkDerivation {
   name = "nspr-${version}";
 
   src = fetchurl {
     url = "mirror://mozilla/nspr/releases/v${version}/src/nspr-${version}.tar.gz";
-    sha256 = "5e4c1751339a76e7c772c0c04747488d7f8c98980b434dc846977e43117833ab";
+    sha256 = "101dksqm1z0hzd7ap82ccbxjr48s6q3xhshdl81qkj6hqdmy1p97";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -9,11 +9,12 @@ let
 
 in stdenv.mkDerivation rec {
   name = "nss-${version}";
-  version = "3.30";
+  version = "3.31";
+  url_version = builtins.replaceStrings [ "." ] [ "_" ] version;
 
   src = fetchurl {
-    url = "mirror://mozilla/security/nss/releases/NSS_3_30_RTM/src/${name}.tar.gz";
-    sha256 = "a8c0000dae5e992f6563972e26dbfefc50d006dd845c43b8ca24ea50169ff3a9";
+    url = "mirror://mozilla/security/nss/releases/NSS_${url_version}_RTM/src/${name}.tar.gz";
+    sha256 = "0pd643a8ns7q5az5ai3ascrw666i2kbfiyy1c9hlhw9jd8jn21g9";
   };
 
   buildInputs = [ perl zlib sqlite ];


### PR DESCRIPTION
###### Motivation for this change

Update firefox to 54.0. This requires updating nspr and nss too.

I didn't test with nox, given `nix-shell -p nox` seems to fail building with `AttributeError: '_NamespacePath' object has no attribute 'sort'`, on my current 0011f9065a nixpkgs checkout.

`firefox` builds and runs successfully on my computer after these changes.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

