### PR TITLE
pybitmessage: 0.4.4 -> 0.6.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pybitmessage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pybitmessage/default.nix
@@ -1,33 +1,29 @@
 { stdenv, fetchFromGitHub, pythonPackages, openssl }:
 
-stdenv.mkDerivation rec {
+pythonPackages.buildPythonApplication rec {
   name = "pybitmessage-${version}";
 
-  version = "0.4.4";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "bitmessage";
     repo = "PyBitmessage";
     rev = "v${version}";
-    sha256 = "1f4h0yc1mfjnxzvxiv9hxgak59mgr3a5ykv50vlyiay82za20jax";
+    sha256 = "04sgns9qczzw2152gqdr6bjyy4fmgs26cz8n3qck94l0j51rxhz8";
   };
 
-  buildInputs = with pythonPackages; [ python pyqt4 wrapPython ] ++ [ openssl ];
+  propagatedBuildInputs = with pythonPackages; [ msgpack pyqt4 ] ++ [ openssl ];
 
   preConfigure = ''
-    substituteInPlace Makefile \
-      --replace "PREFIX?=/usr/local" "" \
-      --replace "/usr" ""
+    substituteInPlace setup.py \
+      --replace "nothing = raw_input()" pass \
+      --replace 'print "It looks like building the package failed.\n" \' pass \
+      --replace '    "You may be missing a C++ compiler and the OpenSSL headers."' pass
+
   '';
 
-  makeFlags = [ "DESTDIR=$(out)" ];
-
-  postInstall = ''
-    substituteInPlace $out/bin/pybitmessage \
-      --replace "exec python2" "exec ${pythonPackages.python}/bin/python" \
-      --replace "/opt/openssl-compat-bitcoin/lib/" "${openssl.out}/lib/"
-    wrapProgram $out/bin/pybitmessage \
-      --prefix PYTHONPATH : "$(toPythonPath $out):$PYTHONPATH"
+  makeWrapperArgs = ''
+    --prefix LD_LIBRARY_PATH : "${openssl.out}/lib/"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/instant-messengers/pybitmessage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pybitmessage/default.nix
@@ -15,6 +15,7 @@ pythonPackages.buildPythonApplication rec {
   propagatedBuildInputs = with pythonPackages; [ msgpack pyqt4 ] ++ [ openssl ];
 
   preConfigure = ''
+    # Remove interaction and misleading output
     substituteInPlace setup.py \
       --replace "nothing = raw_input()" pass \
       --replace 'print "It looks like building the package failed.\n" \' pass \

--- a/pkgs/development/interpreters/python/wrap.sh
+++ b/pkgs/development/interpreters/python/wrap.sh
@@ -30,7 +30,7 @@ patchPythonScript() {
 
     # The magicalSedExpression will invoke a "$(basename "$f")", so
     # if you change $f to something else, be sure to also change it
-    # in pkgs/top-level/python-packages.nix!
+    # in wrap-python.nix!
     # It also uses $program_PYTHONPATH.
     sed -i "$f" -re '@magicalSedExpression@'
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

It seems kinda strange to me to have pybitmessage in `instant-messengers` (since it is not meant to be used that way, but rather asynchronously), I think it would fit better in `p2p`.  Should I change that too?