### PR TITLE
hugo: 0.22.1 -> 0.23

### DIFF
--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -2,15 +2,15 @@
 
 buildGoPackage rec {
   name = "hugo-${version}";
-  version = "0.22.1";
+  version = "0.23";
 
-  goPackagePath = "github.com/spf13/hugo";
+  goPackagePath = "github.com/gohugoio/hugo";
 
   src = fetchFromGitHub {
     owner = "spf13";
     repo = "hugo";
     rev = "v${version}";
-    sha256 = "0m459np11izsflwdja6k0znaxvd8zpgivvswnq9501m49h8m4x7q";
+    sha256 = "0phw5pcmrmryxb83jzifhqh3vx20qiwh4dkk802v38fw07z1hvki";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/applications/misc/hugo/deps.nix
+++ b/pkgs/applications/misc/hugo/deps.nix
@@ -31,8 +31,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/bep/gitmap";
-      rev = "dcb907b39a0690430d435eb8f63cd8811961231f";
-      sha256 = "0bw4spyiidrvd8rls9g57mwxykfmv57qi9mcnjadbqrpv92br856";
+      rev = "de8030ebafb76c6e84d50ee6d143382637c00598";
+      sha256 = "0adkv2ghi0zd104akksa9wjzj7s849wpa1rij03mycgxp4si9ami";
     };
   }
   {
@@ -247,8 +247,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/russross/blackfriday";
-      rev = "0ba0f2b6ed7c475a92e4df8641825cb7a11d1fa3";
-      sha256 = "0jj9zkk64sxs8vpfhz95y9li30q6qnxm7sncsfjn2ykcdgs252f7";
+      rev = "067529f716f4c3f5e37c8c95ddd59df1007290ae";
+      sha256 = "1l61ib6r6mg587p58li5zhafjkkmrzacachcjg1cvw0k4zza9137";
     };
   }
   {


### PR DESCRIPTION
###### Motivation for this change
This release includes a move to a new github organization.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

