### PR TITLE
aspellWithDicts: create derivation with aspell and selected dictionaries

### DIFF
--- a/pkgs/development/libraries/aspell/aspell-with-dicts.nix
+++ b/pkgs/development/libraries/aspell/aspell-with-dicts.nix
@@ -1,0 +1,30 @@
+# Create a derivation that contains aspell and selected dictionaries.
+# Composition is done using `pkgs.buildEnv`.
+
+{ aspell
+, buildEnv
+, makeWrapper
+, aspellDicts
+}:
+
+f:
+
+let
+  dicts = f aspellDicts;
+in buildEnv {
+  name = "aspell-env";
+  paths = [ aspell ] ++ dicts;
+  buildInputs = [ makeWrapper ];
+  postBuild = ''
+    # Remove the symbolic link to /bin and construct wrappers
+    rm $out/bin
+    mkdir -p $out/bin
+    pushd "${aspell}/bin"
+    for prg in *; do
+      if [ -f "$prg" ]; then
+        makeWrapper "${aspell}/bin/$prg" "$out/bin/$prg" --set ASPELL_CONF "data-dir $out/lib/aspell"
+      fi
+    done
+    popd
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7280,6 +7280,8 @@ with pkgs;
 
   aspellDicts = recurseIntoAttrs (callPackages ../development/libraries/aspell/dictionaries.nix {});
 
+  aspellWithDicts = callPackage ../development/libraries/aspell/aspell-with-dicts.nix { };
+
   attica = callPackage ../development/libraries/attica { };
 
   attr = callPackage ../development/libraries/attr { };


### PR DESCRIPTION
Currently, `aspell` checks the active profiles for dictionaries. While
this may be convenient, it does not work with `nix-shell` and it doesn't
allow any isolation.

This commit adds the possibility to use composition by creating a
derivation with `buildEnv` that contains `aspell` and selected
dictionaries.

Nix example:
```
my_aspell = aspellWithDicts(ps: with ps; [ en nl ])
```
`nix-shell` example:
```
nix-shell -p 'aspellWithDicts(ps: with ps; [ en nl ])'
```