### PR TITLE
artyFX: 2015-05-07 -> 1.3

### DIFF
--- a/pkgs/applications/audio/artyFX/default.nix
+++ b/pkgs/applications/audio/artyFX/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchgit, cairomm, cmake, libjack2, libpthreadstubs, libXdmcp, libxshmfence, libsndfile, lv2, ntk, pkgconfig }:
+{ stdenv, fetchFromGitHub , cairomm, cmake, libjack2, libpthreadstubs, libXdmcp, libxshmfence, libsndfile, lv2, ntk, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "artyFX-git-${version}";
-  version = "2015-05-07";
+  name = "artyFX-${version}";
+  version = "1.3";
 
-  src = fetchgit {
-    url = "https://github.com/harryhaaren/openAV-ArtyFX.git";
-    rev = "3a8cb9a5e4ffaf27a497a31cc9cd6f2e79622d5b";
-    sha256 = "0nsmycm64a686ysfnmdvnaazijvfj90z5wyp96kyr81nsrbcv2ij";
+  src = fetchFromGitHub {
+    owner = "openAVproductions";
+    repo = "openAV-ArtyFX";
+    rev = "release-${version}";
+    sha256 = "012hcy1mxl7gs2lipfcqp5x0xv1azb9hjrwf0h59yyxnzx96h7c9";
   };
 
   buildInputs = [ cairomm cmake libjack2 libpthreadstubs libXdmcp libxshmfence libsndfile lv2 ntk pkgconfig   ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

