### PR TITLE
qtcreator: 4.2.1 -> 4.3.0

### DIFF
--- a/pkgs/development/qtcreator/default.nix
+++ b/pkgs/development/qtcreator/default.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
+    substituteInPlace $out/share/applications/org.qt-project.qtcreator.desktop \
+      --replace "Exec=qtcreator" "Exec=$out/bin/qtcreator"
     wrapQtProgram $out/bin/qtcreator
   '';
 

--- a/pkgs/development/qtcreator/default.nix
+++ b/pkgs/development/qtcreator/default.nix
@@ -6,8 +6,8 @@
 with stdenv.lib;
 
 let
-  baseVersion = "4.2";
-  revision = "1";
+  baseVersion = "4.3";
+  revision = "0";
 in
 
 stdenv.mkDerivation rec {
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
   version = "${baseVersion}.${revision}";
 
   src = fetchurl {
-    url = "http://download.qt-project.org/official_releases/qtcreator/${baseVersion}/${version}/qt-creator-opensource-src-${version}.tar.gz";
-    sha256 = "0f2slaf579q2anflf524lbhmpwrwy3hzjfxzs10n44r7s7yc4dr5";
+    url = "http://download.qt-project.org/official_releases/qtcreator/${baseVersion}/${version}/qt-creator-opensource-src-${version}.tar.xz";
+    sha256 = "1n3ihky72p6q69n6c8s5hacq8rxdqmmr6msg89w5amwd17sam7p9";
   };
 
   buildInputs = [ qtbase qtscript qtquickcontrols qtdeclarative ];
@@ -36,18 +36,6 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    # Install desktop file
-    mkdir -p "$out/share/applications"
-    cat > "$out/share/applications/qtcreator.desktop" << __EOF__
-    [Desktop Entry]
-    Exec=$out/bin/qtcreator
-    Name=Qt Creator
-    GenericName=Cross-platform IDE for Qt
-    Icon=QtProject-qtcreator.png
-    Terminal=false
-    Type=Application
-    Categories=Qt;Development;IDE;
-    __EOF__
     wrapQtProgram $out/bin/qtcreator
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Update `qtcreator` to version 4.3.0.

Remove explicit creation and installation of a desktop file, since one is already provided in the distribution package.

[Announcement](http://blog.qt.io/blog/2017/05/24/qt-creator-4-3-0-released/)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).