### PR TITLE
Fix various setuid/setgid permissions fallout

### DIFF
--- a/pkgs/applications/misc/udevil/default.nix
+++ b/pkgs/applications/misc/udevil/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation {
   };
   buildInputs = [ intltool glib pkgconfig udev ];
   configurePhase = ''
-    substituteInPlace src/Makefile.am --replace "-o root -g root" ""
     substituteInPlace src/Makefile.in --replace "-o root -g root" ""
+    substituteInPlace src/Makefile.in --replace 4755 0755
     ./configure \
       --prefix=$out \
       --with-mount-prog=${utillinux}/bin/mount \
@@ -16,10 +16,6 @@ stdenv.mkDerivation {
       --with-losetup-prog=${utillinux}/bin/losetup \
       --with-setfacl-prog=${acl.bin}/bin/setfacl \
       --sysconfdir=$prefix/etc
-  '';
-  preConfigure = ''
-    cat src/Makefile.am
-    exit 2
   '';
   patches = [ ./device-info-sys-stat.patch ];
   meta = {

--- a/pkgs/applications/misc/udevil/default.nix
+++ b/pkgs/applications/misc/udevil/default.nix
@@ -8,6 +8,7 @@ stdenv.mkDerivation {
   buildInputs = [ intltool glib pkgconfig udev ];
   configurePhase = ''
     substituteInPlace src/Makefile.in --replace "-o root -g root" ""
+    # do not set setuid bit in nix store
     substituteInPlace src/Makefile.in --replace 4755 0755
     ./configure \
       --prefix=$out \

--- a/pkgs/games/unnethack/default.nix
+++ b/pkgs/games/unnethack/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
                      "--with-gamesdir=/tmp/unnethack"
                    ];
 
+  makeFlags = [ "GAMEPERM=744" ];
+
   postInstall = ''
     cp -r /tmp/unnethack $out/share/unnethack/profile
     mv $out/bin/unnethack $out/bin/.wrapped_unnethack

--- a/pkgs/games/xconq/default.nix
+++ b/pkgs/games/xconq/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     # Fix Makefiles
     find . -name 'Makefile.in' -exec sed -re 's@^        ( *)(cd|[&][&])@	\1\2@' -i '{}' ';'
     find . -name 'Makefile.in' -exec sed -e '/chown/d; /chgrp/d' -i '{}' ';'
+    find . -name 'Makefile.in' -exec sed -e 's/04755/755/g' -i '{}' ';'
     sed -e '/^			* *[$][(]tcltkdir[)]\/[*][.][*]/d' -i tcltk/Makefile.in
 
     # Fix C files

--- a/pkgs/games/xconq/default.nix
+++ b/pkgs/games/xconq/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     # Fix Makefiles
     find . -name 'Makefile.in' -exec sed -re 's@^        ( *)(cd|[&][&])@	\1\2@' -i '{}' ';'
     find . -name 'Makefile.in' -exec sed -e '/chown/d; /chgrp/d' -i '{}' ';'
+    # do not set sticky bit in nix store
     find . -name 'Makefile.in' -exec sed -e 's/04755/755/g' -i '{}' ';'
     sed -e '/^			* *[$][(]tcltkdir[)]\/[*][.][*]/d' -i tcltk/Makefile.in
 

--- a/pkgs/games/xsokoban/default.nix
+++ b/pkgs/games/xsokoban/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     cat >>config.h <<EOF
     #define HERE "@nixos-packaged"
     #define WWW 0
-    #define OWNER "'$(whoami)'"
+    #define OWNER "$(whoami)"
     #define ROOTDIR "$out/lib/xsokoban"
     #define ANYLEVEL 1
     #define SCOREFILE ".xsokoban-score"

--- a/pkgs/games/xsokoban/default.nix
+++ b/pkgs/games/xsokoban/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
+  prePatch = ''
+    substituteInPlace Makefile.in --replace 4755 0755
+  '';
+
   preConfigure = ''
     sed -e 's/getline/my_getline/' -i score.c
 

--- a/pkgs/os-specific/linux/rewritefs/default.nix
+++ b/pkgs/os-specific/linux/rewritefs/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig fuse pcre ];
 
   prePatch = ''
+    # do not set sticky bit in nix store
     substituteInPlace Makefile --replace 6755 0755
   '';
 

--- a/pkgs/os-specific/linux/rewritefs/default.nix
+++ b/pkgs/os-specific/linux/rewritefs/default.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
  
   buildInputs = [ pkgconfig fuse pcre ];
 
+  prePatch = ''
+    substituteInPlace Makefile --replace 6755 0755
+  '';
+
   preConfigure = "substituteInPlace Makefile --replace /usr/local $out";
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/computing/torque/default.nix
+++ b/pkgs/servers/computing/torque/default.nix
@@ -29,8 +29,9 @@ stdenv.mkDerivation rec {
 
    for f in $(find ./ -name Makefile.in); do
      echo patching $f...
-     sed -i $f -e '/PBS_MKDIRS/d'
+     sed -i $f -e '/PBS_MKDIRS/d' -e '/chmod u+s/d'
    done
+
   '';
 
   postInstall = ''

--- a/pkgs/servers/http/hiawatha/default.nix
+++ b/pkgs/servers/http/hiawatha/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
 
   buildInputs =  [ cmake libxslt zlib libxml2 ] ++ stdenv.lib.optional enableSSL openssl ;
 
+  prePatch = ''
+    substituteInPlace CMakeLists.txt --replace SETUID ""
+  '';
+
   cmakeFlags = [
     ( if enableSSL then "-DENABLE_TLS=on" else "-DENABLE_TLS=off" )
     ( if enableMonitor then "-DENABLE_MONITOR=on" else "-DENABLE_MONITOR=off" )

--- a/pkgs/shells/rssh/default.nix
+++ b/pkgs/shells/rssh/default.nix
@@ -59,6 +59,12 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # Run this after to avoid conflict with patches above
+  postPatch = ''
+    sed -i '/chmod u+s/d' Makefile.in
+  '';
+
+
   buildInputs = [ openssh rsync cvs ];
 
   configureFlags = [

--- a/pkgs/tools/misc/uucp/default.nix
+++ b/pkgs/tools/misc/uucp/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   prePatch = ''
+    # do not set sticky bit in nix store
     substituteInPlace Makefile.in \
       --replace 4555 0555
     sed -i '/chown $(OWNER)/d' Makefile.in

--- a/pkgs/tools/misc/uucp/default.nix
+++ b/pkgs/tools/misc/uucp/default.nix
@@ -10,6 +10,12 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
+  prePatch = ''
+    substituteInPlace Makefile.in \
+      --replace 4555 0555
+    sed -i '/chown $(OWNER)/d' Makefile.in
+  '';
+
   meta = {
     description = "Unix-unix cp over serial line, also includes cu program";
 

--- a/pkgs/tools/security/logkeys/default.nix
+++ b/pkgs/tools/security/logkeys/default.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace src/Makefile.in --replace 'root' '$(id -u)'
     substituteInPlace configure --replace '/dev/input' '/tmp'
+    sed -i '/chmod u+s/d' src/Makefile.in
  '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   prePatch = ''
+    # do not set sticky bit in nix store
     substituteInPlace src/Makefile.in --replace 04755 0755
   '';
 

--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
     sha256 = "07fvh8qy0l1h93lccc625f48d8yp0pkp5rjjykq13pb07ar0x64y";
   };
 
+  prePatch = ''
+    substituteInPlace src/Makefile.in --replace 04755 0755
+  '';
+
   configureFlags = [
     "--with-env-editor"
     "--with-editor=/run/current-system/sw/bin/nano"

--- a/pkgs/tools/security/super/default.nix
+++ b/pkgs/tools/security/super/default.nix
@@ -9,6 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "0k476f83w7f45y9jpyxwr00ikv1vhjiq0c26fgjch9hnv18icvwy";
   };
 
+  prePatch = ''
+    substituteInPlace Makefile.in \
+      --replace "-o root" "" \
+      --replace 04755 755
+  '';
+
   patches = [
    (fetchpatch { url = http://anonscm.debian.org/cgit/users/robert/super.git/plain/debian/patches/14-Fix-unchecked-setuid-call.patch;
                  sha256 = "08m9hw4kyfjv0kqns1cqha4v5hkgp4s4z0q1rgif1fnk14xh7wqh";

--- a/pkgs/tools/security/super/default.nix
+++ b/pkgs/tools/security/super/default.nix
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   prePatch = ''
+    # do not set sticky bit in nix store
     substituteInPlace Makefile.in \
       --replace "-o root" "" \
       --replace 04755 755

--- a/pkgs/tools/system/at/install.patch
+++ b/pkgs/tools/system/at/install.patch
@@ -20,7 +20,7 @@
 +	$(INSTALL) -m 755 -d $(IROOT)$(sbindir)
 +	$(INSTALL) -m 755 -d $(IROOT)$(docdir)
 +	$(INSTALL) -m 755 -d $(IROOT)$(atdocdir)
-+	$(INSTALL) -m 6755 -s at $(IROOT)$(bindir)
++	$(INSTALL) -m 0755 -s at $(IROOT)$(bindir)
  	$(LN_S) -f at $(IROOT)$(bindir)/atq
  	$(LN_S) -f at $(IROOT)$(bindir)/atrm
 -	$(INSTALL) -g root -o root -m 755 batch $(IROOT)$(bindir)

--- a/pkgs/tools/system/cron/default.nix
+++ b/pkgs/tools/system/cron/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation {
   hardeningEnable = [ "pie" ];
 
   preBuild = ''
+    # do not set sticky bit in /nix/store 
     substituteInPlace Makefile --replace ' -o root' ' ' --replace 111 755 --replace 4755 0755
     makeFlags="DESTROOT=$out CC=cc"
 

--- a/pkgs/tools/system/cron/default.nix
+++ b/pkgs/tools/system/cron/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   hardeningEnable = [ "pie" ];
 
   preBuild = ''
-    substituteInPlace Makefile --replace ' -o root' ' ' --replace 111 755
+    substituteInPlace Makefile --replace ' -o root' ' ' --replace 111 755 --replace 4755 0755
     makeFlags="DESTROOT=$out CC=cc"
 
     # We want to ignore the $glibc/include/paths.h definition of

--- a/pkgs/tools/system/logcheck/default.nix
+++ b/pkgs/tools/system/logcheck/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   prePatch = ''
+    # do not set sticky bit in nix store.
     substituteInPlace Makefile --replace 2750 0750
   '';
 

--- a/pkgs/tools/system/logcheck/default.nix
+++ b/pkgs/tools/system/logcheck/default.nix
@@ -10,6 +10,10 @@ stdenv.mkDerivation rec {
     sha256 = "1x4skb5nmv2xj8cygj8pq1rd1ws4m2fsibw54yslgdyjri4r2yq7";
   };
 
+  prePatch = ''
+    substituteInPlace Makefile --replace 2750 0750
+  '';
+
   preConfigure = ''
     substituteInPlace src/logtail --replace "/usr/bin/perl" "${perl}/bin/perl"
     substituteInPlace src/logtail2 --replace "/usr/bin/perl" "${perl}/bin/perl"


### PR DESCRIPTION
###### Motivation for this change

Fixes all packages explicitly listed as failing in #26600.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

