### PR TITLE
zynaddsubfx: 2.5.4 -> 3.0.1

### DIFF
--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, alsaLib, cmake, libjack2, fftw, fltk13, libjpeg
-, minixml, pkgconfig, zlib, liblo
+{ stdenv, fetchurl, alsaLib, cairo, cmake, libjack2, fftw, fltk13, lash,  libjpeg
+, libXpm, minixml, ntk, pkgconfig, zlib, liblo
 }:
 
 stdenv.mkDerivation  rec {
   name = "zynaddsubfx-${version}";
-  version = "2.5.4";
+  version = "3.0.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/zynaddsubfx/zynaddsubfx-${version}.tar.bz2";
-    sha256 = "16llaa2wg2gbgjhwp3632b2vx9jvanj4csv7d41k233ms6d1sjq1";
+    sha256 = "1qijvlbv41lnqaqbp6gh1i42xzf1syviyxz8wr39xbz55cw7y0d8";
   };
 
-  buildInputs = [ alsaLib libjack2 fftw fltk13 libjpeg minixml zlib liblo ];
+  buildInputs = [ alsaLib cairo libjack2 fftw fltk13 lash libjpeg libXpm minixml ntk zlib liblo ];
   nativeBuildInputs = [ cmake pkgconfig ];
 
   hardeningDisable = [ "format" ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

