### PR TITLE
faustCompressors: 1.1.1 -> 1.2

### DIFF
--- a/pkgs/applications/audio/magnetophonDSP/faustCompressors/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/faustCompressors/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
   name = "faustCompressors-v${version}";
-  version = "1.1.1";
+  version = "1.2";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
     repo = "faustCompressors";
     rev = "v${version}";
-    sha256 = "0mkram2hm7i5za7pfn5crh2arbajk8praksxzgjx90rrxwl1y3d1";
+    sha256 = "144f6g17q4m50kxzdncsfzdyycdfprnpwdaxcwgxj4jky1xsha1d";
   };
 
   buildInputs = [ faust2jaqt faust2lv2 ];
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     for f in *.dsp;
     do
+      echo "compiling standalone from" $f
       faust2jaqt -time -double -t 99999 $f
     done
 
@@ -22,6 +23,7 @@ stdenv.mkDerivation rec {
 
     for f in *.dsp;
     do
+      echo "compiling plugin from" $f
       faust2lv2  -time -double -gui -t 99999 $f
     done
   '';
@@ -30,6 +32,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib/lv2
     mv *.lv2/ $out/lib/lv2
     mkdir -p $out/bin
+    rm newlib.sh
     for f in $(find . -executable -type f);
     do
       cp $f $out/bin/


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

