### PR TITLE
coturn: allow use of ports < 1024

### DIFF
--- a/nixos/modules/services/networking/coturn.nix
+++ b/nixos/modules/services/networking/coturn.nix
@@ -320,6 +320,14 @@ in {
         RuntimeDirectory = "turnserver";
         User = "turnserver";
         Group = "turnserver";
+        AmbientCapabilities =
+          mkIf (
+            cfg.listening-port < 1024 ||
+            cfg.alt-listening-port < 1024 ||
+            cfg.tls-listening-port < 1024 ||
+            cfg.alt-tls-listening-port < 1024 ||
+            cfg.min-port < 1024
+          ) "cap_net_bind_service";
         Restart = "on-abort";
       };
     };


### PR DESCRIPTION
###### Motivation for this change
Using ports 80 and 443 for STUN/TURN has the best chance of passing through strict firewalls.  CoTURN needs to start as root in order to bind to these roots

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

