### PR TITLE
sorcer: 1.1.1 -> 1.1.3

### DIFF
--- a/pkgs/applications/audio/sorcer/default.nix
+++ b/pkgs/applications/audio/sorcer/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, boost, cairomm, cmake, libsndfile, lv2, ntk, pkgconfig, python }:
+{ stdenv, fetchFromGitHub , boost, cairomm, cmake, libsndfile, lv2, ntk, pkgconfig, python }:
 
 stdenv.mkDerivation rec {
   name = "sorcer-${version}";
-  version = "1.1.1";
+  version = "1.1.3";
 
-  src = fetchurl {
-    url = "https://github.com/harryhaaren/openAV-Sorcer/archive/release-${version}.tar.gz";
-    sha256 = "1jkhs2rhn4givac7rlbj8067r7qq6jnj3ixabb346nw7pd6gn1wn";
+  src = fetchFromGitHub {
+    owner = "openAVproductions";
+    repo = "openAV-Sorcer";
+    rev = "release-${version}";
+    sha256 = "1x7pi77nal10717l02qpnhrx6d7w5nqrljkn9zx5w7gpb8fpb3vp";
   };
 
   buildInputs = [ boost cairomm cmake libsndfile lv2 ntk pkgconfig python ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

