### PR TITLE
ntk: 2014-10-18 -> 2017-04-22

### DIFF
--- a/pkgs/development/libraries/audio/ntk/default.nix
+++ b/pkgs/development/libraries/audio/ntk/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ntk-${version}";
-  version = "2014-10-18";
+  version = "2017-04-22";
   src = fetchgit {
     url = "git://git.tuxfamily.org/gitroot/non/fltk.git";
-    rev = "5719b0044d9f267de5391fab006370cc7f4e70bd";
-    sha256 = "1wpqy5kk6sk31qyx1c6gdslcqcbczgji6lk8w1l8kri0s908ywyj";
+    rev = "92365eca0f9a6f054abc70489c009aba0fcde0ff";
+    sha256 = "0pph7hf07xaa011zr40cs62f3f7hclfbv5kcrl757gcp2s5pi2iq";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

