### PR TITLE
tint2: 0.14.5 -> 0.14.6

### DIFF
--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   name = "tint2-${version}";
-  version = "0.14.5";
+  version = "0.14.6";
 
   src = fetchFromGitLab {
     owner = "o9000";
     repo = "tint2";
     rev = version;
-    sha256 = "1nfvcw95wggih7pxh53cx4nlamny73nh88ggfh6a0ajjhafrd2j2";
+    sha256 = "0v7i8araj85cbl45icinvmsz5741cx2ybjgkx72m3xfcb9fqg69l";
   };
 
   enableParallelBuilding = true;
@@ -28,8 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   prePatch = ''
-    for f in ./src/tint2conf/properties.c \
-             ./src/launcher/apps-common.c \
+    for f in ./src/launcher/apps-common.c \
              ./src/launcher/icon-theme-common.c \
              ./themes/*tint2rc
     do


### PR DESCRIPTION
###### Motivation for this change

Update to new version.

**[ChangeLog](https://gitlab.com/o9000/tint2/blob/0.14.6/ChangeLog):**

2017-06-11 0.14.6
- Fixes:
  - Take into account border width when computing text height
  - Taskbar: Fix task icon size limits
  - Executor: Do not output last line if it is not terminated by newline
- Enhancements:
  - Re-execute tint2 on SIGUSR2.
    This is useful for preserving config options and environment when updating tint2.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).