### PR TITLE
Yade: init at 2017.01a

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -415,6 +415,7 @@
   refnil = "Martin Lavoie <broemartino@gmail.com>";
   regnat = "Théophane Hufschmitt <regnat@regnat.ovh>";
   relrod = "Ricky Elrod <ricky@elrod.me>";
+  remche = "Rémi Cailletaud <remche@remche.org>";
   renzo = "Renzo Carbonara <renzocarbonara@gmail.com>";
   retrry = "Tadas Barzdžius <retrry@gmail.com>";
   rick68 = "Wei-Ming Yang <rick68@gmail.com>";

--- a/pkgs/applications/science/physics/yade/cmake.patch
+++ b/pkgs/applications/science/physics/yade/cmake.patch
@@ -1,0 +1,20 @@
+--- a/cMake/FindCGAL.cmake
++++ b/cMake/FindCGAL.cmake
+@@ -13,11 +13,11 @@
+ IF(CGAL_INCLUDE_DIR AND CGAL_LIBRARIES)
+     SET(CGAL_FOUND TRUE)
+ ELSE(CGAL_INCLUDE_DIR AND CGAL_LIBRARIES)
+-    FIND_PATH(CGAL_INCLUDE_DIR basic.h
+-        /usr/include/CGAL
+-        /usr/local/include/CGAL
+-        $ENV{ProgramFiles}/CGAL/*/include/CGAL
+-        $ENV{SystemDrive}/CGAL/*/include/CGAL
++       FIND_PATH(CGAL_INCLUDE_DIR CGAL/basic.h
++        /usr/include/
++        /usr/local/include/
++        $ENV{ProgramFiles}/CGAL/*/include/
++        $ENV{SystemDrive}/CGAL/*/include/
+     )
+     FIND_LIBRARY(CGAL_LIBRARIES NAMES CGAL libCGAL
+         PATHS
+

--- a/pkgs/applications/science/physics/yade/default.nix
+++ b/pkgs/applications/science/physics/yade/default.nix
@@ -118,7 +118,7 @@ in
       cmakeFlags="-DCMAKE_INSTALL_PREFIX=$out -DENABLE_GUI=OFF -DSUFFIX=-${version}"
     '';
 
-  };
+  }
 
 
 

--- a/pkgs/applications/science/physics/yade/default.nix
+++ b/pkgs/applications/science/physics/yade/default.nix
@@ -1,4 +1,6 @@
-with (import <nixpkgs> {});
+{ stdenv, fetchurl, fetchFromGitHub, pkgconfig, cmake, makeWrapper, python27Packages,
+boost, cgal, loki, pythonFull, eigen3_3, bzip2, zlib, openblas, vtk, gmp, gts, metis,
+mpfr, suitesparse, glib, pcre } :
 
 let 
 
@@ -7,10 +9,12 @@ let
     minieigen = pythonPackages.buildPythonPackage rec {
       name = "minieigen";
 
-      src = pkgs.fetchurl {
-        url = "https://github.com/eudoxos/minieigen/archive/master.zip";
-        sha256 = "71d91f716aeb85e6433696fc0754c32d8f4956f3685d12df925c2c9183a2a108";
-      };
+      src = pkgs.fetchFromGitHub {
+        owner = "eudoxos";
+        repo = "minieigen";
+        rev = "7bd0a2e823333477a2172b428a3801d9cae0800f";
+        sha256 = "1jksrbbcxshxx8iqpxkc1y0v091hwji9xvz9w963gjpan4jf61wj";
+        };
 
       buildInputs = [ unzip pythonPackages.boost boost.dev eigen3_3 ];
 
@@ -27,95 +31,94 @@ let
 
 in 
 
- {
 
-    minieigen = minieigen;
+  minieigen = minieigen;
 
-    yade = stdenv.mkDerivation rec {
+  stdenv.mkDerivation rec {
 
-      name = "yade-${version}";
-      version = "2017.01a";
+    name = "yade-${version}";
+    version = "2017.01a";
 
-      meta = {
-        description = "An extensible open-source framework for discrete numerical models, focused on Discrete Element Method";
-        license     = stdenv.lib.licenses.gpl2;
-        homepage    = https://www.yade-dem.org/;
-        platforms   = stdenv.lib.platforms.unix;
-        maintainers = with stdenv.lib.maintainers; [ remche ];
-      };
-
-      nativeBuildInputs = [
-        pkgconfig
-        cmake
-        makeWrapper
-        python2Packages.wrapPython
-        gmp.dev
-        mpfr.dev
-        bzip2.dev
-        zlib.dev 
-        glib.dev
-        pcre.dev
-        boost.dev
-      ];
-
-      buildInputs = [ 
-        boost
-        cgal
-        loki
-        python27Full
-        python27Packages.numpy
-        eigen3_3
-        bzip2
-        zlib
-        openblas
-        vtk
-        gmp
-        gts
-        metis
-        mpfr
-        suitesparse
-        glib
-        pcre
-        minieigen
-      ];
-
-      pythonPath = with pythonPackages; [
-        pygments
-        pexpect
-        decorator
-        numpy
-        ipython
-        ipython_genutils
-        traitlets
-        enum
-        six
-        boost
-        minieigen
-        pillow
-        matplotlib
-      ];
-
-      src = fetchurl
-      {
-        url = "https://launchpad.net/yade/trunk/yade-1.00.0/+download/yade-2017.01a.tar.gz";
-        md5 = "29f83f12f6cdacfd24f1928d90f72906";
-      };
-
-      patches = [ ./cmake.patch ];
-
-      postInstall = ''
-        wrapPythonPrograms
-      '';
-
-      enableParallelBuilding = true;
-
-      system = builtins.currentSystem;
-
-      preConfigure = ''
-        cmakeFlags="-DCMAKE_INSTALL_PREFIX=$out -DENABLE_GUI=OFF -DSUFFIX=-${version}"
-      '';
-
+    meta = {
+      description = "An extensible open-source framework for discrete numerical models, focused on Discrete Element Method";
+      license     = stdenv.lib.licenses.gpl2;
+      homepage    = https://www.yade-dem.org/;
+      platforms   = stdenv.lib.platforms.unix;
+      maintainers = with stdenv.lib.maintainers; [ remche ];
     };
 
- }
+    nativeBuildInputs = [
+      pkgconfig
+      cmake
+      makeWrapper
+      python2Packages.wrapPython
+      gmp.dev
+      mpfr.dev
+      bzip2.dev
+      zlib.dev 
+      glib.dev
+      pcre.dev
+      boost.dev
+    ];
+
+    buildInputs = [ 
+      boost
+      cgal
+      loki
+      python27Full
+      python27Packages.numpy
+      eigen3_3
+      bzip2
+      zlib
+      openblas
+      vtk
+      gmp
+      gts
+      metis
+      mpfr
+      suitesparse
+      glib
+      pcre
+      minieigen
+    ];
+
+    pythonPath = with pythonPackages; [
+      pygments
+      pexpect
+      decorator
+      numpy
+      ipython
+      ipython_genutils
+      traitlets
+      enum
+      six
+      boost
+      minieigen
+      pillow
+      matplotlib
+    ];
+
+    src = fetchurl
+    {
+      url = "https://launchpad.net/yade/trunk/yade-1.00.0/+download/yade-2017.01a.tar.gz";
+      md5 = "29f83f12f6cdacfd24f1928d90f72906";
+    };
+
+    patches = [ ./cmake.patch ];
+
+    postInstall = ''
+      wrapPythonPrograms
+    '';
+
+    enableParallelBuilding = true;
+
+    system = builtins.currentSystem;
+
+    preConfigure = ''
+      cmakeFlags="-DCMAKE_INSTALL_PREFIX=$out -DENABLE_GUI=OFF -DSUFFIX=-${version}"
+    '';
+
+  };
+
+
 

--- a/pkgs/applications/science/physics/yade/default.nix
+++ b/pkgs/applications/science/physics/yade/default.nix
@@ -1,0 +1,121 @@
+with (import <nixpkgs> {});
+
+let 
+
+  pythonPackages = python27Packages;
+
+    minieigen = pythonPackages.buildPythonPackage rec {
+      name = "minieigen";
+
+      src = pkgs.fetchurl {
+        url = "https://github.com/eudoxos/minieigen/archive/master.zip";
+        sha256 = "71d91f716aeb85e6433696fc0754c32d8f4956f3685d12df925c2c9183a2a108";
+      };
+
+      buildInputs = [ unzip pythonPackages.boost boost.dev eigen3_3 ];
+
+      patchPhase = ''
+        sed -i "s/^.*libraries=libraries.//g" setup.py 
+      '';
+
+      preConfigure = ''
+        export LDFLAGS="-L${eigen3_3.out}/lib -l boost_python"
+        export CFLAGS="-I${eigen3_3.out}/include/eigen3"
+      '';
+
+    };
+
+in 
+
+ {
+
+    minieigen = minieigen;
+
+    yade = stdenv.mkDerivation rec {
+
+      name = "yade-${version}";
+      version = "2017.01a";
+
+      meta = {
+        description = "An extensible open-source framework for discrete numerical models, focused on Discrete Element Method";
+        license     = stdenv.lib.licenses.gpl2;
+        homepage    = https://www.yade-dem.org/;
+        platforms   = stdenv.lib.platforms.unix;
+        maintainers = with stdenv.lib.maintainers; [ remche ];
+      };
+
+      nativeBuildInputs = [
+        pkgconfig
+        cmake
+        makeWrapper
+        python2Packages.wrapPython
+        gmp.dev
+        mpfr.dev
+        bzip2.dev
+        zlib.dev 
+        glib.dev
+        pcre.dev
+        boost.dev
+      ];
+
+      buildInputs = [ 
+        boost
+        cgal
+        loki
+        python27Full
+        python27Packages.numpy
+        eigen3_3
+        bzip2
+        zlib
+        openblas
+        vtk
+        gmp
+        gts
+        metis
+        mpfr
+        suitesparse
+        glib
+        pcre
+        minieigen
+      ];
+
+      pythonPath = with pythonPackages; [
+        pygments
+        pexpect
+        decorator
+        numpy
+        ipython
+        ipython_genutils
+        traitlets
+        enum
+        six
+        boost
+        minieigen
+        pillow
+        matplotlib
+      ];
+
+      src = fetchurl
+      {
+        url = "https://launchpad.net/yade/trunk/yade-1.00.0/+download/yade-2017.01a.tar.gz";
+        md5 = "29f83f12f6cdacfd24f1928d90f72906";
+      };
+
+      patches = [ ./cmake.patch ];
+
+      postInstall = ''
+        wrapPythonPrograms
+      '';
+
+      enableParallelBuilding = true;
+
+      system = builtins.currentSystem;
+
+      preConfigure = ''
+        cmakeFlags="-DCMAKE_INSTALL_PREFIX=$out -DENABLE_GUI=OFF -DSUFFIX=-${version}"
+      '';
+
+    };
+
+ }
+

--- a/pkgs/applications/science/physics/yade/default.nix
+++ b/pkgs/applications/science/physics/yade/default.nix
@@ -32,7 +32,7 @@ let
 in 
 
 
-  minieigen = minieigen;
+  inherit minieigen;
 
   stdenv.mkDerivation rec {
 

--- a/pkgs/applications/science/physics/yade/default.nix
+++ b/pkgs/applications/science/physics/yade/default.nix
@@ -112,8 +112,6 @@ in
 
     enableParallelBuilding = true;
 
-    system = builtins.currentSystem;
-
     preConfigure = ''
       cmakeFlags="-DCMAKE_INSTALL_PREFIX=$out -DENABLE_GUI=OFF -DSUFFIX=-${version}"
     '';


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

