### PR TITLE
ltris: init at 1.0.19

### DIFF
--- a/pkgs/games/ltris/default.nix
+++ b/pkgs/games/ltris/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, SDL, SDL_mixer }:
+
+stdenv.mkDerivation rec {
+  name = "ltris-${version}";
+  version = "1.0.19";
+  buildInputs = [ SDL SDL_mixer ];
+
+  src = fetchurl {
+    url = "mirror://sourceforge/lgames/${name}.tar.gz";
+    sha256 = "1895wv1fqklrj4apkz47rnkcfhfav7zjknskw6p0886j35vrwslg";
+  };
+
+  patchPhase = "patch -p0 < ${./gcc5_compliance.diff}";
+
+  meta = with stdenv.lib; {
+    description = "Tetris clone from the LGames series";
+    homepage = http://lgames.sourceforge.net/LBreakout2/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.ciil ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/ltris/gcc5_compliance.diff
+++ b/pkgs/games/ltris/gcc5_compliance.diff
@@ -1,0 +1,299 @@
+Index: ChangeLog
+===================================================================
+--- ChangeLog	(revision 163)
++++ ChangeLog	(revision 164)
+@@ -1,3 +1,5 @@
++- removed all inline keywords to work with GCC 5 (2015/05/16 MS)
++
+ 1.0.19:
+ - removed link to lib math as not needed (2013/10/29 MS)
+ - reset key states when unpausing to prevent unwanted movement (2013/10/29 MS)
+Index: src/bowl.c
+===================================================================
+--- src/bowl.c	(revision 163)
++++ src/bowl.c	(revision 164)
+@@ -333,7 +333,7 @@
+ Set a tile contents and pixel contents.
+ ====================================================================
+ */
+-inline void bowl_set_tile( Bowl *bowl, int x, int y, int tile_id )
++void bowl_set_tile( Bowl *bowl, int x, int y, int tile_id )
+ {
+     int i, j = y * bowl->block_size;
+     bowl->contents[x][y] = tile_id;
+Index: src/sdl.c
+===================================================================
+--- src/sdl.c	(revision 163)
++++ src/sdl.c	(revision 164)
+@@ -244,7 +244,7 @@
+ #endif
+ 
+ /* return full path of bitmap */
+-inline void get_full_bmp_path( char *full_path, char *file_name )
++void get_full_bmp_path( char *full_path, char *file_name )
+ {
+     sprintf(full_path,  "%s/gfx/%s", SRC_DIR, file_name );
+ }
+@@ -330,7 +330,7 @@
+ /*
+     lock surface
+ */
+-inline void lock_surf(SDL_Surface *sur)
++void lock_surf(SDL_Surface *sur)
+ {
+     if (SDL_MUSTLOCK(sur))
+         SDL_LockSurface(sur);
+@@ -339,7 +339,7 @@
+ /*
+     unlock surface
+ */
+-inline void unlock_surf(SDL_Surface *sur)
++void unlock_surf(SDL_Surface *sur)
+ {
+     if (SDL_MUSTLOCK(sur))
+         SDL_UnlockSurface(sur);
+@@ -666,7 +666,7 @@
+ /*
+     lock font surface
+ */
+-inline void lock_font(Font *fnt)
++void lock_font(Font *fnt)
+ {
+     if (SDL_MUSTLOCK(fnt->pic))
+         SDL_LockSurface(fnt->pic);
+@@ -675,7 +675,7 @@
+ /*
+     unlock font surface
+ */
+-inline void unlock_font(Font *fnt)
++void unlock_font(Font *fnt)
+ {
+     if (SDL_MUSTLOCK(fnt->pic))
+         SDL_UnlockSurface(fnt->pic);
+@@ -905,7 +905,7 @@
+ /*
+     update rectangle (0,0,0,0)->fullscreen
+ */
+-inline void refresh_screen(int x, int y, int w, int h)
++void refresh_screen(int x, int y, int w, int h)
+ {
+     SDL_UpdateRect(sdl.screen, x, y, w, h);
+ }
+@@ -1055,7 +1055,7 @@
+ /*
+     lock surface
+ */
+-inline void lock_screen()
++void lock_screen()
+ {
+     if (SDL_MUSTLOCK(sdl.screen))
+         SDL_LockSurface(sdl.screen);
+@@ -1064,7 +1064,7 @@
+ /*
+     unlock surface
+ */
+-inline void unlock_screen()
++void unlock_screen()
+ {
+     if (SDL_MUSTLOCK(sdl.screen))
+         SDL_UnlockSurface(sdl.screen);
+@@ -1073,7 +1073,7 @@
+ /*
+     flip hardware screens (double buffer)
+ */
+-inline void flip_screen()
++void flip_screen()
+ {
+     SDL_Flip(sdl.screen);
+ }
+@@ -1132,7 +1132,7 @@
+ /*
+     get milliseconds since last call
+ */
+-inline int get_time()
++int get_time()
+ {
+     int ms;
+     cur_time = SDL_GetTicks();
+@@ -1148,7 +1148,7 @@
+ /*
+     reset timer
+ */
+-inline void reset_timer()
++void reset_timer()
+ {
+     last_time = SDL_GetTicks();
+ }
+Index: src/sdl.h
+===================================================================
+--- src/sdl.h	(revision 163)
++++ src/sdl.h	(revision 164)
+@@ -41,8 +41,8 @@
+ SDL_Surface* load_surf(char *fname, int f);
+ SDL_Surface* create_surf(int w, int h, int f);
+ void free_surf( SDL_Surface **surf );
+-inline void lock_surf(SDL_Surface *sur);
+-inline void unlock_surf(SDL_Surface *sur);
++void lock_surf(SDL_Surface *sur);
++void unlock_surf(SDL_Surface *sur);
+ void blit_surf(void);
+ void alpha_blit_surf(int alpha);
+ void fill_surf(int c);
+@@ -86,8 +86,8 @@
+ Font* load_fixed_font(char *fname, int off, int len, int w);
+ void free_font(Font **sfnt);
+ int  write_text(Font *sfnt, SDL_Surface *dest, int x, int y, char *str, int alpha);
+-inline void lock_font(Font *sfnt);
+-inline void unlock_font(Font *sfnt);
++void lock_font(Font *sfnt);
++void unlock_font(Font *sfnt);
+ SDL_Rect last_write_rect(Font *fnt);
+ int  text_width(Font *fnt, char *str);
+ 
+@@ -132,14 +132,14 @@
+ char** get_mode_names( int *count );
+ int  set_video_mode( Video_Mode mode );
+ void hardware_cap();
+-inline void refresh_screen( int x, int y, int w, int h );
++void refresh_screen( int x, int y, int w, int h );
+ void refresh_rects();
+ void add_refresh_rect(int x, int y, int w, int h);
+ int  wait_for_key();
+ void wait_for_click();
+-inline void lock_screen();
+-inline void unlock_screen();
+-inline void flip_screen();
++void lock_screen();
++void unlock_screen();
++void flip_screen();
+ void fade_screen( int type, int ms );
+ void take_screenshot( int i );
+ 
+@@ -148,8 +148,8 @@
+ SDL_Cursor* create_cursor( int width, int height, int hot_x, int hot_y, char *source );
+ 
+ /* timer */
+-inline int get_time();
+-inline void reset_timer();
++int get_time();
++void reset_timer();
+ 
+ #ifdef __cplusplus
+ };
+Index: src/tools.c
+===================================================================
+--- src/tools.c	(revision 163)
++++ src/tools.c	(revision 164)
+@@ -23,7 +23,7 @@
+ #include "ltris.h"
+ 
+ /* compares to strings and returns true if their first strlen(str1) chars are equal */
+-inline int strequal( char *str1, char *str2 )
++int strequal( char *str1, char *str2 )
+ {
+     if ( strlen( str1 ) != strlen( str2 ) ) return 0;
+     return ( !strncmp( str1, str2, strlen( str1 ) ) );
+@@ -30,7 +30,7 @@
+ }
+ 
+ /* set delay to ms milliseconds */
+-inline void delay_set( Delay *delay, int ms )
++void delay_set( Delay *delay, int ms )
+ {
+     delay->limit = ms;
+     delay->cur = 0;
+@@ -37,13 +37,13 @@
+ }
+ 
+ /* reset delay ( cur = 0 )*/
+-inline void delay_reset( Delay *delay )
++void delay_reset( Delay *delay )
+ {
+     delay->cur = 0;
+ }
+ 
+ /* check if times out and reset */
+-inline int delay_timed_out( Delay *delay, int ms )
++int delay_timed_out( Delay *delay, int ms )
+ {
+     delay->cur += ms;
+     if ( delay->cur >= delay->limit ) {
+@@ -56,12 +56,12 @@
+ }
+ 
+ /* set timer so that we have a time out next call of delay_timed_out() */
+-inline void delay_force_time_out( Delay *delay )
++void delay_force_time_out( Delay *delay )
+ {
+     delay->cur = delay->limit;
+ }
+ 
+-inline void goto_tile( int *x, int *y, int d )
++void goto_tile( int *x, int *y, int d )
+ {
+     /*  0 -up, clockwise, 5 - left up */
+     switch ( d ) {
+@@ -326,24 +326,24 @@
+ the target value until reached when counter_update() is called.
+ ====================================================================
+ */
+-inline void counter_set( Counter *counter, double value )
++void counter_set( Counter *counter, double value )
+ {
+     counter->value = value;
+     counter->approach = value;
+ }
+-inline void counter_add( Counter *counter, double add )
++void counter_add( Counter *counter, double add )
+ {
+     counter->value += add;
+ }
+-inline double counter_get_approach( Counter counter )
++double counter_get_approach( Counter counter )
+ {
+     return counter.approach;
+ }
+-inline double counter_get( Counter counter )
++double counter_get( Counter counter )
+ {
+     return counter.value;
+ }
+-inline void counter_update( Counter *counter, int ms )
++void counter_update( Counter *counter, int ms )
+ {
+     double change;
+     if ( counter->approach == counter->value ) return;
+Index: src/tools.h
+===================================================================
+--- src/tools.h	(revision 163)
++++ src/tools.h	(revision 164)
+@@ -33,7 +33,7 @@
+ #define VEC_DIST( vec1, vec2 ) ( sqrt( ( vec1.x - vec2.x ) * ( vec1.x - vec2.x ) + ( vec1.y - vec2.y ) * ( vec1.y - vec2.y ) ) )
+ 
+ /* compares to strings and returns true if their first strlen(str1) chars are equal */
+-inline int strequal( char *str1, char *str2 );
++int strequal( char *str1, char *str2 );
+ 
+ /* delete lines */
+ void delete_lines( char **lines, int line_number );
+@@ -45,16 +45,16 @@
+ } Delay;
+ 
+ /* set delay to ms milliseconds */
+-inline void delay_set( Delay *delay, int ms );
++void delay_set( Delay *delay, int ms );
+ 
+ /* reset delay ( cur = 0 )*/
+-inline void delay_reset( Delay *delay );
++void delay_reset( Delay *delay );
+ 
+ /* check if time's out ( add ms milliseconds )and reset */
+-inline int delay_timed_out( Delay *delay, int ms );
++int delay_timed_out( Delay *delay, int ms );
+ 
+ /* set timer so that we have a time out next call of delay_timed_out() */
+-inline void delay_force_time_out( Delay *delay );
++void delay_force_time_out( Delay *delay );
+ 
+ /* return distance betwteen to map positions */
+ int get_dist( int x1, int y1, int x2, int y2 );

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2967,6 +2967,8 @@ with pkgs;
 
   lshw = callPackage ../tools/system/lshw { };
 
+  ltris = callPackage ../games/ltris { };
+
   lxc = callPackage ../os-specific/linux/lxc { };
   lxcfs = callPackage ../os-specific/linux/lxcfs { };
   lxd = callPackage ../tools/admin/lxd { };


### PR DESCRIPTION
###### Motivation for this change
Added another lgames package. Needs gcc 4.9 because of known compilation issues since 2015 (cf. http://git.net/ml/general/2015-05/msg25721.html).

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

