### PR TITLE
kodiPlugins: fix path for shared object links

### DIFF
--- a/pkgs/applications/video/kodi/commons.nix
+++ b/pkgs/applications/video/kodi/commons.nix
@@ -77,7 +77,7 @@ rec {
     # them. Symlinking .so, as setting LD_LIBRARY_PATH is of no use
     installPhase = let n = namespace; in ''
       make install
-      ln -s $out/lib/addons/${n}/${n}.so.${version} $out/${pluginDir}/${n}.so
+      ln -s $out/lib/addons/${n}/${n}.so.${version} $out/${pluginDir}/${n}/${n}.so.${version}
     '';
 
   };


### PR DESCRIPTION
###### Motivation for this change

513e66e310f324f42565faea0d87128787d875a9 broke plugins with shared objects because the path was wrong, this fixes it.

/cc @edwtjo

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

