### PR TITLE
sbt: support scala-native

### DIFF
--- a/pkgs/development/tools/build-managers/sbt/scala-native.nix
+++ b/pkgs/development/tools/build-managers/sbt/scala-native.nix
@@ -1,0 +1,14 @@
+{ lib, sbt, makeWrapper, boehmgc, libunwind, re2, llvmPackages, zlib }:
+
+sbt.overrideDerivation(old: {
+  nativeBuildInputs = [ makeWrapper ];
+
+  postFixup = ''
+    wrapProgram $out/bin/sbt \
+      --set CLANG_PATH      "${llvmPackages.clang}/bin/clang" \
+      --set CLANGPP_PATH    "${llvmPackages.clang}/bin/clang" \
+      --set CPATH           "${lib.makeSearchPathOutput "dev" "include" [ re2 zlib boehmgc libunwind llvmPackages.libcxxabi llvmPackages.libcxx ]}/c++/v1" \
+      --set LIBRARY_PATH    "${lib.makeLibraryPath [ re2 zlib boehmgc libunwind llvmPackages.libcxxabi llvmPackages.libcxx ]}" \
+      --set NIX_CFLAGS_LINK "-lc++abi -lc++"
+  '';
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7062,6 +7062,7 @@ with pkgs;
   scons = callPackage ../development/tools/build-managers/scons { };
 
   sbt = callPackage ../development/tools/build-managers/sbt { };
+  sbt-with-scala-native = callPackage ../development/tools/build-managers/sbt/scala-native.nix { };
   simpleBuildTool = sbt;
 
   shards = callPackage ../development/tools/build-managers/shards { };


### PR DESCRIPTION
###### Motivation for this change

That rare case of upstream [supporting nix](https://github.com/scala-native/scala-native/blob/master/bin/scala-native.nix):  :)

But their solution is to [run ```sbt``` in ```nix-shell```](https://github.com/scala-native/scala-native/blob/master/docs/user/setup.rst) with prepared ```buildInputs``` list

As ```sbt``` is the only program to run in this environment (all the rest is launched by ```sbt```), I think it would be nicer just to wrap ```sbt``` enriching it with optional posibility to build ```scala-native``` targets even without ```nix-shell```

Just replace ```sbt``` package with ```sbt-with-scala-native``` and it will be able to find all libraries required for native builds.

cc: @MasseGuillaume 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

