### PR TITLE
Fixing attribute name mistake: setguid => setgid

### DIFF
--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -80,8 +80,8 @@ let
                     group = "root";
                   } // s)
           else if 
-             (s ? "setuid"  && s.setuid  == true) ||
-             (s ? "setguid" && s.setguid == true) ||
+             (s ? "setuid" && s.setuid) ||
+             (s ? "setgid" && s.setgid) ||
              (s ? "permissions")
           then mkSetuidProgram s
           else mkSetuidProgram


### PR DESCRIPTION
###### Motivation for this change
Fixing a coding mistake in the changes made to `nixos/modules/security/wrappers/default.nix` for the setcap wrapper support.

The mistake was related to conditional logic checking if a `setuid` or `setgid` attribute was set on an argument set and if so if either were `true`. The mistake was that `setgid` was misspelled as `setugid` which means that if a wrapper program had `setuid = false` but `setgid = true` and no `permissions` attribute in the argset it would use the default `mkSetuidProgram` configuration.

This is not correct behavior because it means a program's user or group if neither of those attributes were not set in the argset would be defaulted to `root` and this is dangerous.

The fix is to correct the spelling mistake.

This was caught while investigating #26611. 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I have yet to build and test this, I will probably get to that tonight, so don't merge until that has happened.