### PR TITLE
i2p: 0.9.28 -> 0.9.30 (and build wrapper from source) (and for 32bit)

### DIFF
--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -1,10 +1,10 @@
 { stdenv, procps, coreutils, fetchurl, jdk, jre, ant, gettext, which }:
 
 stdenv.mkDerivation rec {
-  name = "i2p-0.9.28";
+  name = "i2p-0.9.30";
   src = fetchurl {
     url = "https://github.com/i2p/i2p.i2p/archive/${name}.tar.gz";
-    sha256 = "1xagyywnck2c5xalr7bc7cv5ikk4igf7avmc0n28nz9pkais1y1y";
+    sha256 = "03hrirmah3ba9ygql487jy233nsxkfjyz82mmyppazi0mcgiass1";
   };
   buildInputs = [ jdk ant gettext which ];
   patches = [ ./i2p.patch ];

--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -13,7 +13,8 @@ let wrapper = stdenv.mkDerivation rec {
     export JAVA_HOME=${jdk}/lib/openjdk/jre/
     export JAVA_TOOL_OPTIONS=-Djava.home=$JAVA_HOME
     export CLASSPATH=${jdk}/lib/openjdk/lib/tools.jar
-    ./build32.sh
+    sed 's/ testsuite$//' -i src/c/Makefile-linux-x86-64.make
+    ${if stdenv.isi686 then "./build32.sh" else "./build64.sh"}
   '';
   installPhase = ''
     mkdir -p $out/{bin,lib}
@@ -67,7 +68,6 @@ stdenv.mkDerivation rec {
     description = "Applications and router for I2P, anonymity over the Internet";
     maintainers = [ maintainers.joelmo ];
     license = licenses.gpl2;
-    # TODO: support other systems, just copy appropriate lib/wrapper.. to $out
     platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }

--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -16,7 +16,19 @@ stdenv.mkDerivation rec {
     set -B
     mkdir -p $out/{bin,share}
     cp -r pkg-temp/* $out
-    cp installer/lib/wrapper/linux64/* $out
+    '' +
+
+    # TODO: Compile wrapper ourselves, see https://geti2p.net/en/misc/manual-wrapper
+    (if stdenv.system == "i686-linux"
+    then ''
+      cp installer/lib/wrapper/linux/* $out
+    '' else ''
+      cp installer/lib/wrapper/linux64/* $out
+    '')
+
+     # */ # comment end for vim
+
+    + ''
     sed -i $out/i2prouter -i $out/runplain.sh \
       -e "s#uname#${coreutils}/bin/uname#" \
       -e "s#which#${which}/bin/which#" \
@@ -39,6 +51,6 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.joelmo ];
     license = licenses.gpl2;
     # TODO: support other systems, just copy appropriate lib/wrapper.. to $out
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS (only built on 32bit)
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---