### PR TITLE
musescore: 2.0.3 -> 2.1.0

### DIFF
--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchzip, cmake, pkgconfig
 , alsaLib, freetype, libjack2, lame, libogg, libpulseaudio, libsndfile, libvorbis
-, portaudio, qtbase, qtdeclarative, qtenginio, qtscript, qtsvg, qttools
+, portaudio, qtbase, qtdeclarative, qtscript, qtsvg, qttools
 , qtwebkit, qtxmlpatterns
 }:
 
 stdenv.mkDerivation rec {
   name = "musescore-${version}";
-  version = "2.0.3";
+  version = "2.1.0";
 
   src = fetchzip {
     url = "https://github.com/musescore/MuseScore/archive/v${version}.tar.gz";
-    sha256 = "067f4li48qfhz2barj70zpf2d2mlii12npx07jx9xjkkgz84z4c9";
+    sha256 = "1rlxz2nzilz7n6c0affnjk2wcxl4b8949qxs0xi555gxg01kybls";
   };
 
   hardeningDisable = [ "relro" "bindnow" ];
@@ -31,7 +31,6 @@ stdenv.mkDerivation rec {
   ];
 
   preBuild = ''
-    make lupdate
     make lrelease
   '';
 
@@ -45,7 +44,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     alsaLib libjack2 freetype lame libogg libpulseaudio libsndfile libvorbis
-    portaudio qtbase qtdeclarative qtenginio qtscript qtsvg qttools
+    portaudio qtbase qtdeclarative qtscript qtsvg qttools
     qtwebkit qtxmlpatterns #tesseract
   ];
 
@@ -56,6 +55,5 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = [ maintainers.vandenoever ];
     repositories.git = https://github.com/musescore/MuseScore;
-    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15086,7 +15086,7 @@ with pkgs;
     if stdenv.isDarwin then
       callPackage ../applications/audio/musescore/darwin.nix { }
     else
-      libsForQt56.callPackage ../applications/audio/musescore { };
+      libsForQt5.callPackage ../applications/audio/musescore { };
 
   mutt = callPackage ../applications/networking/mailreaders/mutt { };
   mutt-with-sidebar = callPackage ../applications/networking/mailreaders/mutt {


### PR DESCRIPTION
###### Motivation for this change

Newer version that is not broken.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

