### PR TITLE
flashplayer: 26.0.0.126 -> 26.0.0.131

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -94,12 +94,12 @@ let
 
   flash = stdenv.mkDerivation rec {
     name = "flashplayer-ppapi-${version}";
-    version = "26.0.0.126";
+    version = "26.0.0.131";
 
     src = fetchzip {
       url = "https://fpdownload.adobe.com/pub/flashplayer/pdc/"
           + "${version}/flash_player_ppapi_linux.x86_64.tar.gz";
-      sha256 =  "17ivhkdkbnzxr10ln1ix30k1hmaak5p9zzcchdyrjxdpzfk5qq7s";
+      sha256 = "1cw5pmzfyaaxxd3kf90nz8zn5r06qmkh8l793j3db4n0ffxg5c1s";
       stripRoot = false;
     };
 

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
@@ -73,7 +73,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-${version}";
-  version = "26.0.0.126";
+  version = "26.0.0.131";
 
   src = fetchurl {
     url =
@@ -84,14 +84,14 @@ stdenv.mkDerivation rec {
     sha256 =
       if debug then
         if arch == "x86_64" then
-          "0i5rr8bymbdzwqpns854i2r9390av89v1ikh8msincczq5vpj012"
+          "0yqrw2gl9i0z33kcv5dpp3x3jyq9ksqfaqjgkk7xcy127ahric8s"
         else
-          "1mzq3wvq6rxqfdlapd0b1ymw7389414jxwhkd6wk3677qdhr1y42"
+          "0cmjqm5asqqcqavpkldm6wgjb49m9n018rixi7cj9zcwhfakm7zr"
       else
         if arch == "x86_64" then
-          "0684kizzfwfzaj0i54cdlkx3fqb3kyhb9jw88n031bjrzv7ddiz7"
+          "0agz4k5319m5bd0nqzkzvy8r28nr6c5j9b0jr6a8yh9s844aga8w"
         else
-          "1pn15wnldabacmahlqdsl8nd60982j77bghjlf2cdc7drysby3ns";
+          "0jzvhyi1qgfjp9l85ffgcxqa87ymi899q2j68b9hfsn9hlw1sc5f";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
@@ -55,7 +55,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-standalone-${version}";
-  version = "26.0.0.126";
+  version = "26.0.0.131";
 
   src = fetchurl {
     url =
@@ -65,9 +65,9 @@ stdenv.mkDerivation rec {
         "https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flash_player_sa_linux.x86_64.tar.gz";
     sha256 =
       if debug then
-        "17s55b1ncjj0hnldjmxm133z0i4jf49wbh4sn1cfwrw6xrhgbkiw"
+        "000a019x15yk6qkx8yg7l496lc5knvw0kqgzial491d73zw8qjhn"
       else
-        "02j98ji2jw2sxrs9hhlkkdrhpf2c4hc336cfvqzdf1iajza5was8";
+        "0rmsfi70hvp5vvdvcr8w7knz8bzf70r3ysnsgz3yv3b9p5dvsbjk";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change
- Buttons can't be clicked in some AS2 content (FP-4198473)

https://helpx.adobe.com/flash-player/release-note/fp_26_air_26_release_notes.html

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

