### PR TITLE
catch: 1.7.0 -> 1.9.5

### DIFF
--- a/pkgs/development/libraries/catch/default.nix
+++ b/pkgs/development/libraries/catch/default.nix
@@ -3,16 +3,16 @@
 stdenv.mkDerivation rec {
 
   name = "catch-${version}";
-  version = "1.7.0";
+  version = "1.9.5";
 
   src = fetchFromGitHub {
     owner = "philsquared";
     repo = "Catch";
-    rev = "v." + version;
-    sha256 = "0harki6irc4mqipjc24zyy0jimidr5ng3ss29bnpzbbwhrnkyrgm";
+    rev = "v${version}";
+    sha256 = "1in4f6w1pja8m1hvyiwx7s7gxnj6nlj1fgxw9blldffh09ikgpm2";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
   cmakeFlags = [ "-DUSE_CPP14=ON" ];
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

Update to version 1.9.5.

[Changes](https://github.com/philsquared/Catch/releases)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).