### PR TITLE
qstopmotion: init -> 2.3.2

### DIFF
--- a/pkgs/applications/video/qstopmotion/default.nix
+++ b/pkgs/applications/video/qstopmotion/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, qt5, gstreamer, gstreamermm, gst_plugins_bad
+, gst_plugins_base, gst_plugins_good, ffmpeg, guvcview, automoc4
+, cmake, libxml2, gettext, pkgconfig, libgphoto2, gphoto2, v4l_utils
+, libv4l, pcre }:
+
+stdenv.mkDerivation rec {
+  pname = "qstopmotion";
+  version = "2.3.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/${pname}/Version_2_3_2/${name}-Source.tar.gz";
+    sha256 = "1vbiznwyc05jqg0dpmgxmvf7kdzmlck0i8v2c5d69kgrdnaypcrf";
+  };
+
+  buildInputs = [ qt5.qtbase gstreamer gstreamermm gst_plugins_bad gst_plugins_good
+                  gst_plugins_base ffmpeg guvcview v4l_utils libv4l pcre
+		];
+
+  nativeBuildInputs = [ pkgconfig cmake gettext libgphoto2 gphoto2 libxml2 libv4l ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.qstopmotion.org";
+    description = "Create stopmotion animation with a (web)camera";
+    longDescription = ''
+      Qstopmotion is a tool to create stopmotion
+      animation. Its users are able to create stop-motions from pictures
+      imported from a camera or from the harddrive and export the
+      animation to different video formats such as mpeg or avi.
+    '';
+
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = [ maintainers.leenaars ];
+    platforms = stdenv.lib.platforms.gnu;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15511,6 +15511,8 @@ with pkgs;
   # 0.5.7 segfaults when opening the main panel with qt 5.7 and fails to compile with qt 5.8
   qsyncthingtray = libsForQt56.callPackage ../applications/misc/qsyncthingtray { };
 
+  qstopmotion = callPackage ../applications/video/qstopmotion { };
+
   qsynth = callPackage ../applications/audio/qsynth { };
 
   qtbitcointrader = callPackage ../applications/misc/qtbitcointrader { };


### PR DESCRIPTION
###### Motivation for this change

Current stop motion tools in Nixos were not able to correctly handle our camera, so I packaged qstopmotion, a descendant of Linux Stopmotion that is actively being developed.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

