### PR TITLE
libreoffice: fix #25831

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -72,6 +72,8 @@ in stdenv.mkDerivation rec {
   configureScript = "./autogen.sh";
   dontUseCmakeConfigure = true;
 
+  patches = [ ./xdg-open.patch ];
+
   postUnpack = ''
     mkdir -v $sourceRoot/src
   '' + (stdenv.lib.concatMapStrings (f: "ln -sfv ${f} $sourceRoot/src/${f.md5 or f.outputHash}-${f.name}\nln -sfv ${f} $sourceRoot/src/${f.name}\n") srcs.third_party)

--- a/pkgs/applications/office/libreoffice/still.nix
+++ b/pkgs/applications/office/libreoffice/still.nix
@@ -73,11 +73,14 @@ in stdenv.mkDerivation rec {
   dontUseCmakeConfigure = true;
 
   # ICU 58, included in 5.3.x
-  patches = [(fetchurl {
-    url = "https://gerrit.libreoffice.org/gitweb?p=core.git;a=patch;h=3e42714c76b1347babfdea0564009d8d82a83af4";
-    sha256 = "10bid0jdw1rpdsqwzzk3r4rp6bjs2cvi82h7anz2m1amfjdv86my";
-    name = "libreoffice-5.2.x-icu4c-58.patch";
-  })];
+  patches = [
+    (fetchurl {
+      url = "https://gerrit.libreoffice.org/gitweb?p=core.git;a=patch;h=3e42714c76b1347babfdea0564009d8d82a83af4";
+      sha256 = "10bid0jdw1rpdsqwzzk3r4rp6bjs2cvi82h7anz2m1amfjdv86my";
+      name = "libreoffice-5.2.x-icu4c-58.patch";}
+    )
+    ./xdg-open.patch
+  ];
 
   postUnpack = ''
     mkdir -v $sourceRoot/src

--- a/pkgs/applications/office/libreoffice/xdg-open.patch
+++ b/pkgs/applications/office/libreoffice/xdg-open.patch
@@ -1,0 +1,25 @@
+diff --git a/shell/source/unix/exec/shellexec.cxx b/shell/source/unix/exec/shellexec.cxx
+--- a/shell/source/unix/exec/shellexec.cxx
++++ b/shell/source/unix/exec/shellexec.cxx
+@@ -150,7 +150,7 @@ void SAL_CALL ShellExec::execute( const OUString& aCommand, const OUString& aPar
+         if (std::getenv("LIBO_FLATPAK") != nullptr) {
+             aBuffer.append("/app/bin/xdg-open");
+         } else {
+-            aBuffer.append("/usr/bin/xdg-open");
++            aBuffer.append("xdg-open");
+         }
+ #endif
+         aBuffer.append(" ");
+diff --git a/shell/source/unix/misc/senddoc.sh b/shell/source/unix/misc/senddoc.sh
+index 4519e01f26e2..8985711a2c01 100755
+--- a/shell/source/unix/misc/senddoc.sh
++++ b/shell/source/unix/misc/senddoc.sh
+@@ -393,6 +393,8 @@ case `basename "$MAILER" | sed 's/-.*$//'` in
+             MAILER=/usr/bin/kde-open
+         elif [ -x /usr/bin/xdg-open ] ; then
+             MAILER=/usr/bin/xdg-open
++        elif type -p xdg-open >/dev/null 2>&1 ; then
++            MAILER="$(type -p xdg-open)"
+         else
+             echo "Unsupported mail client: `basename $MAILER | sed 's/-.*^//'`"
+             exit 2


### PR DESCRIPTION
###### Motivation for this change

Closes #25831. 

Allows users to click on links in LibreOffice and have them opened in their default browser. Also allows them to use the `File > Send > ...` menu to send documents with their default mail program.

I really think this is an upstream bug and have [reported](https://bugs.documentfoundation.org/show_bug.cgi?id=108591) it.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS *LibreOffice doesn't use xdg-open on macOS*
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files. They all work except for `spadmin`, but this is not a regression.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

