### PR TITLE
Manual: Add paragraph on xserver keyboard layout

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -45,6 +45,13 @@ services.xserver.displayManager.lightdm.enable = true;
 </programlisting>
 </para>
 
+<para>You can set the keyboard layout (and optionally the layout variant):
+<programlisting>
+services.xserver.layout = "de";
+services.xserver.xkbVariant = "neo";
+</programlisting>
+</para>
+
 <para>The X server is started automatically at boot time.  If you
 don’t want this to happen, you can set:
 <programlisting>


### PR DESCRIPTION
###### Motivation for this change

When I installed nixos for the first time, I was confused why the xserver keyboard layout didn't work out as expected, so I wanted to give the kind of correct example in  the manual that would have been helpful.

###### Things done

- [x] Built and tested manual
