### PR TITLE
gnutls: Fix broken darwin build

### DIFF
--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -1,6 +1,6 @@
 { lib, fetchurl, stdenv, zlib, lzo, libtasn1, nettle, pkgconfig, lzip
 , guileBindings, guile, perl, gmp, autogen, libidn, p11_kit, libiconv
-, tpmSupport ? false, trousers, which, nettools, libunistring
+, tpmSupport ? false, trousers, which, nettools, libunistring, darwin
 
 # Version dependent args
 , version, src, patches ? [], postPatch ? "", nativeBuildInputs ? []
@@ -39,6 +39,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ lzo lzip libtasn1 libidn p11_kit zlib gmp autogen libunistring ]
     ++ lib.optional (stdenv.isFreeBSD || stdenv.isDarwin) libiconv
+    ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security
     ++ lib.optional (tpmSupport && stdenv.isLinux) trousers
     ++ lib.optional guileBindings guile
     ++ buildInputs;


### PR DESCRIPTION
###### Motivation for this change

`gnutls` wasn't building on darwin. This stopped `emacs` from building as well.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

