### PR TITLE
kde-frameworks: 5.33 -> 5.34 and plasma 5.9.5 -> 5.10.2

### DIFF
--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/plasma/5.9.5/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/plasma/5.10.2/ -A '*.tar.xz' )

--- a/pkgs/desktops/plasma-5/plasma-workspace/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-workspace/default.nix
@@ -9,7 +9,7 @@
   kwayland, kwin, kxmlrpcclient, libkscreen, libksysguard, networkmanager-qt,
   phonon, plasma-framework, qtgraphicaleffects, qtquickcontrols,
   qtquickcontrols2, qtscript, qtx11extras, solid, isocodes, libdbusmenu, libSM,
-  libXcursor, pam, wayland
+  libXcursor, libXtst, pam, wayland
 }:
 
 plasmaPackage {
@@ -17,7 +17,7 @@ plasmaPackage {
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
-    isocodes libdbusmenu libSM libXcursor pam wayland
+    isocodes libdbusmenu libSM libXcursor libXtst pam wayland
   ];
   propagatedBuildInputs = [
     baloo kactivities kcmutils kconfig kcrash kdbusaddons kdeclarative

--- a/pkgs/desktops/plasma-5/srcs.nix
+++ b/pkgs/desktops/plasma-5/srcs.nix
@@ -3,323 +3,339 @@
 
 {
   bluedevil = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/bluedevil-5.9.5.tar.xz";
-      sha256 = "0szdfim94c9zjq6jl7n6xpnxf7c4b62wk5b6vv1yfday51gi643r";
-      name = "bluedevil-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/bluedevil-5.10.2.tar.xz";
+      sha256 = "1510gjbvyjr4bg00m28hz9ynz7m7h35c859ksq7r1y102kjxgyr7";
+      name = "bluedevil-5.10.2.tar.xz";
     };
   };
   breeze = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/breeze-5.9.5.tar.xz";
-      sha256 = "0g9y0lsx5c3r7qzrdxbanya86lqkbaf5f7has736nqw28a2jncc3";
-      name = "breeze-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/breeze-5.10.2.tar.xz";
+      sha256 = "1wywa8y07ssxvl59xw4xifi41wj9dd594hy17vjigfp1xi7h62br";
+      name = "breeze-5.10.2.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/breeze-grub-5.9.5.tar.xz";
-      sha256 = "02ml0v3srim4vdw1bwycb3wi6ijdvmf1ph0my3w5ci1k5fj402s4";
-      name = "breeze-grub-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/breeze-grub-5.10.2.tar.xz";
+      sha256 = "0xb7gvl1yrh8g75w1f97wvwig99fwqfk8azkpxxhrg8j5nr4vaz2";
+      name = "breeze-grub-5.10.2.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/breeze-gtk-5.9.5.tar.xz";
-      sha256 = "0na40qrgyml0fc3p8lgxls4zy7ifigns0594q9i3jwfz1izsiprj";
-      name = "breeze-gtk-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/breeze-gtk-5.10.2.tar.xz";
+      sha256 = "06pgbkf078zl57vyfvsmm1bll8g2x419fy2waqh9n7jkycihlinx";
+      name = "breeze-gtk-5.10.2.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/breeze-plymouth-5.9.5.tar.xz";
-      sha256 = "1fnqq4f7pr7bwfgrgk1d2qjai178lxsfsxr1jjdx61wrn1fnc3yk";
-      name = "breeze-plymouth-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/breeze-plymouth-5.10.2.tar.xz";
+      sha256 = "0db00k3h7vsp3pf7xnix8kazsw5wcjzkcj1wfkn4c7vdcvfv48pd";
+      name = "breeze-plymouth-5.10.2.tar.xz";
     };
   };
   discover = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/discover-5.9.5.tar.xz";
-      sha256 = "0846xskdy0sv9p76i78cbj7qy2xcq90lir78haiy6s8pfnxc27i3";
-      name = "discover-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/discover-5.10.2.tar.xz";
+      sha256 = "0ky5yk5nknipxy4hamy6i6m46jhv3n1lsmcs149j687jw2l6ryls";
+      name = "discover-5.10.2.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kactivitymanagerd-5.9.5.tar.xz";
-      sha256 = "0jf0kxwgyc0b3fkr05mz678p99fkr42rljqw57sjq7qhypknzd07";
-      name = "kactivitymanagerd-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kactivitymanagerd-5.10.2.tar.xz";
+      sha256 = "1x7fc3nszg9fcksyf2c9dyagsa9486ybh6yrrn4c6d6z813479qj";
+      name = "kactivitymanagerd-5.10.2.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kde-cli-tools-5.9.5.tar.xz";
-      sha256 = "196h4gsfqx1338jps1rkvaabi6zmsncv7ywylqvirn6mxrfq7r2n";
-      name = "kde-cli-tools-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kde-cli-tools-5.10.2.tar.xz";
+      sha256 = "0d1vfxgi0anggjirp1ncaqr1l7rlbniiv74gf5npb3f260h6yr0h";
+      name = "kde-cli-tools-5.10.2.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kdecoration-5.9.5.tar.xz";
-      sha256 = "1vjj8gjh8ig0bxbfjjmyga7rl497yzqdprgpqfkg92g9pxhr2lnl";
-      name = "kdecoration-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kdecoration-5.10.2.tar.xz";
+      sha256 = "05mg8aacayfx63mx8yb6g1j6wx7kkk21msl33krks7bdqx0jx9kw";
+      name = "kdecoration-5.10.2.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kde-gtk-config-5.9.5.tar.xz";
-      sha256 = "1aafc9zrraqz9x830v9fgyygsqy17iwr2hf2vrcn2ffhw6ix47cy";
-      name = "kde-gtk-config-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kde-gtk-config-5.10.2.tar.xz";
+      sha256 = "096dfl5nm65v6m4m6r1smwbcxv5fkxnbgrgi17x5lfipa9mmrf58";
+      name = "kde-gtk-config-5.10.2.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kdeplasma-addons-5.9.5.tar.xz";
-      sha256 = "107j3szxslc4cqin2f32y25lbwyi0a6lqsp9739113zr0jjrwlll";
-      name = "kdeplasma-addons-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kdeplasma-addons-5.10.2.tar.xz";
+      sha256 = "1yznzz0yrjckv4b1h58fsn0sww5iwmkqvsajdqhgzqw1cs4v98p0";
+      name = "kdeplasma-addons-5.10.2.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kgamma5-5.9.5.tar.xz";
-      sha256 = "1kzqix97qh17lfz9ksqywmas630aw0z4y44mcwp34w9gp79i5dj5";
-      name = "kgamma5-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kgamma5-5.10.2.tar.xz";
+      sha256 = "0hwnn057jbqpzbp8jryfcdp2qlypmyvh5zmfay8iy9vy068zzcmc";
+      name = "kgamma5-5.10.2.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/khotkeys-5.9.5.tar.xz";
-      sha256 = "05y6kbcbalvlrldm9kfkj9aj0r6nbyj1gbj28g37jv58l6qc75d9";
-      name = "khotkeys-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/khotkeys-5.10.2.tar.xz";
+      sha256 = "1kdvdb5i0mjrv4h4m539kikdrb0vybgphaahxk4392npv2zqz1xs";
+      name = "khotkeys-5.10.2.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kinfocenter-5.9.5.tar.xz";
-      sha256 = "0jbi3qavqwvx691biy8gbq4m2c3ksy6p1hpyi41qaaczksr3fvsg";
-      name = "kinfocenter-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kinfocenter-5.10.2.tar.xz";
+      sha256 = "1r0q8xmb9m0xgcw21a6klagfh560ywzdcnly6r36fpwj0hjv60hj";
+      name = "kinfocenter-5.10.2.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kmenuedit-5.9.5.tar.xz";
-      sha256 = "1mfy1z70zfw3x40h8qjp49i7pp5c5fprh7znwwj4hk2qkn1zrn0j";
-      name = "kmenuedit-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kmenuedit-5.10.2.tar.xz";
+      sha256 = "0dcy5r829dpzfmkqzmcbwxv5bqdamq0lvz7khd0n08f4h7a32wnz";
+      name = "kmenuedit-5.10.2.tar.xz";
     };
   };
   kscreen = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kscreen-5.9.5.tar.xz";
-      sha256 = "1df0h1js6b6060cxm27sp70lvk8fak14ibzzrm6f3yv32wlzxwfi";
-      name = "kscreen-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kscreen-5.10.2.tar.xz";
+      sha256 = "0304vi87xq7p8l6dibgb74dzcf7721nps18cm6p9a05nnlvpr1l7";
+      name = "kscreen-5.10.2.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kscreenlocker-5.9.5.tar.xz";
-      sha256 = "1hf0zgfdgd7vinmbk2k73w6mpfbfv830kqfvw23qk4nrrap131bi";
-      name = "kscreenlocker-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kscreenlocker-5.10.2.tar.xz";
+      sha256 = "079vkca9q509qg5qq4kwlzl3dmnqrigs0xm6vyz000589cpg6ib5";
+      name = "kscreenlocker-5.10.2.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/ksshaskpass-5.9.5.tar.xz";
-      sha256 = "1ilydfc64s2yc5xrqcc0k2s9ijnppql32dkb9cpmwfqi608digi1";
-      name = "ksshaskpass-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/ksshaskpass-5.10.2.tar.xz";
+      sha256 = "1mjbpsaj3qyrd7f5yqnw0y81d8srjjd537sx7yjgvyijaf2v0vyz";
+      name = "ksshaskpass-5.10.2.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/ksysguard-5.9.5.tar.xz";
-      sha256 = "1dhzkm3rc8rl92ym0mampf49p8ippbpfbwcvwzg6rakhxxifd4q6";
-      name = "ksysguard-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/ksysguard-5.10.2.tar.xz";
+      sha256 = "1ndz3l91chq1n3p9xrw57mkdxa7hw778baydk8y9pbdr2yr961cv";
+      name = "ksysguard-5.10.2.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kwallet-pam-5.9.5.tar.xz";
-      sha256 = "0nchpbw5yxy7vsz3mx1mx5hk36yvwqarnzzigssh1kz1r19jn6rn";
-      name = "kwallet-pam-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kwallet-pam-5.10.2.tar.xz";
+      sha256 = "01ki2rfn4sw8m8qh7lwwikcr9kxwiv9x7mv86h86ssd1hfzwzhda";
+      name = "kwallet-pam-5.10.2.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kwayland-integration-5.9.5.tar.xz";
-      sha256 = "07la7q6dvmysdv6clk2siq1c3b9jbx5kblgc5qf3233bg57hqw7r";
-      name = "kwayland-integration-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kwayland-integration-5.10.2.tar.xz";
+      sha256 = "1fna7llnimcqvzhmxb93m92gvicjiddqxd9lwqgyv7fww6bhsj3a";
+      name = "kwayland-integration-5.10.2.tar.xz";
     };
   };
   kwin = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kwin-5.9.5.tar.xz";
-      sha256 = "13f9drny8lxpxmgqmirk7k0zapx6bp74jyxxzh7ii36davlhckjd";
-      name = "kwin-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kwin-5.10.2.tar.xz";
+      sha256 = "1gvby6k865snh6hsrnk53hwhb3242iamclz9nq9fzgy23a6g8mzj";
+      name = "kwin-5.10.2.tar.xz";
     };
   };
   kwrited = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/kwrited-5.9.5.tar.xz";
-      sha256 = "1spcsixpcn4g4dm5c1hfqfpkkmma3fgdx0bkm2zzh5q72jzl3bda";
-      name = "kwrited-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/kwrited-5.10.2.tar.xz";
+      sha256 = "1hz6p6il839c28bkf2bn9fqjpipiqdxk603v0h0iqvspfj00z7n8";
+      name = "kwrited-5.10.2.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/libkscreen-5.9.5.tar.xz";
-      sha256 = "1sq078ri8vz3s4r606n3i9j9cb4drga2mwwa5glkirnazps32004";
-      name = "libkscreen-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/libkscreen-5.10.2.tar.xz";
+      sha256 = "0w1adz5c32si1kcmxy015wzjxkln68f0inya2499jag2v9hd3vhn";
+      name = "libkscreen-5.10.2.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/libksysguard-5.9.5.tar.xz";
-      sha256 = "0b0lvpss5sdjnxbrwaa5w7x87mzpbk23n2ly5vyg6imcycnxh7kw";
-      name = "libksysguard-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/libksysguard-5.10.2.tar.xz";
+      sha256 = "1x13mb3c5bzbi5nw3ahgy12x1df50qirr2h4c7igacxrv4m3zrih";
+      name = "libksysguard-5.10.2.tar.xz";
     };
   };
   milou = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/milou-5.9.5.tar.xz";
-      sha256 = "1qzqa26sxggpqw4jkrjasf20xfijpjyjg7x96bvbjs1gcp1fi9gw";
-      name = "milou-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/milou-5.10.2.tar.xz";
+      sha256 = "06c4pb3gls1bgk1sffh6vj035i5vhiy04rmifypcp8gps98j6izw";
+      name = "milou-5.10.2.tar.xz";
     };
   };
   oxygen = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/oxygen-5.9.5.tar.xz";
-      sha256 = "0p73dyyg887by1yi8gjaj366l7vm0p19z10m5fkmhylhmzihv4z3";
-      name = "oxygen-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/oxygen-5.10.2.tar.xz";
+      sha256 = "08d3rdj5vabrxrrlbzhw3ixnb3msm99idbhnpyzdkaw00l444f1p";
+      name = "oxygen-5.10.2.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-desktop-5.9.5.tar.xz";
-      sha256 = "1f9mq7q05abj6xgpchzkhghs0mwf7qycjvg3l4c7y7p9hsn3gx71";
-      name = "plasma-desktop-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/plasma-desktop-5.10.2.tar.xz";
+      sha256 = "1mjz52n6jm1vi3v7432g9v9rh6bbgcwkrg12yahpzlz026hsyxrn";
+      name = "plasma-desktop-5.10.2.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-integration-5.9.5.tar.xz";
-      sha256 = "05qxrrrfhq0m2xq9ig0cgxrl692hmv9lhckhs22m8a1dppsgv10w";
-      name = "plasma-integration-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/plasma-integration-5.10.2.tar.xz";
+      sha256 = "0gzrv3plcn35rkwr7izn0363zbp91rdjw9k8n9s50p9rdx3rx8ly";
+      name = "plasma-integration-5.10.2.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-nm-5.9.5.tar.xz";
-      sha256 = "1bdg7mnfxffzwp7s4hbmk8zj17408fnwj5z4j68l64lbn1lmwq0w";
-      name = "plasma-nm-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/plasma-nm-5.10.2.tar.xz";
+      sha256 = "0bw5vyzzvpklhgq02yhcq1sv7pz00kffvgvfjkgk45g5x47h7hw1";
+      name = "plasma-nm-5.10.2.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-pa-5.9.5.tar.xz";
-      sha256 = "0xam3rnd36mvn7021zzs9y5i02ac8c15alnpag8shrsbdv2cbyry";
-      name = "plasma-pa-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/plasma-pa-5.10.2.tar.xz";
+      sha256 = "1bbmlp5i2k4ygcn76frijjxzy88v3m5cpydslv7i5y41apm8bvip";
+      name = "plasma-pa-5.10.2.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-sdk-5.9.5.tar.xz";
-      sha256 = "0dvxw7b65pn86qzf9j30c4pw0vi12kasgf7idbgmhzwl17k4i1mx";
-      name = "plasma-sdk-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/plasma-sdk-5.10.2.tar.xz";
+      sha256 = "0npccg4zzrd2cx4qa5qi0yr722x2yh8v0zd8dv76znqf8lsgwpj4";
+      name = "plasma-sdk-5.10.2.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-tests-5.9.5.tar.xz";
-      sha256 = "06sn7gz5psmnsilhaprqag2ma03kzj24m7r0gf8wdaqgsla05vwg";
-      name = "plasma-tests-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/plasma-tests-5.10.2.tar.xz";
+      sha256 = "1kyah0r138x3i35glb2slacwivdwbwvq19xp1hz2zrmiy52zq65i";
+      name = "plasma-tests-5.10.2.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.9.5.1";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-workspace-5.9.5.1.tar.xz";
-      sha256 = "07lbq3b3h0ibf4xbk4mxyi3kx17wrqv0s1bqf01azm1wgni70xw5";
-      name = "plasma-workspace-5.9.5.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/plasma-workspace-5.10.2.tar.xz";
+      sha256 = "11q1p3ifs2fwrhm8ylvqacshz746dhl68w0s4dfykvr2r7mqqqf2";
+      name = "plasma-workspace-5.10.2.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/plasma-workspace-wallpapers-5.9.5.tar.xz";
-      sha256 = "05k56vsmhxh0wdz9msk1x3lq2dblladl4002111fi9s92hg4dmsn";
-      name = "plasma-workspace-wallpapers-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/plasma-workspace-wallpapers-5.10.2.tar.xz";
+      sha256 = "1hsm731fckv5bnl7faz7bbizi80df5zb35hmiz90fhdz4x2i7krp";
+      name = "plasma-workspace-wallpapers-5.10.2.tar.xz";
+    };
+  };
+  plymouth-kcm = {
+    version = "5.10.2";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma/5.10.2/plymouth-kcm-5.10.2.tar.xz";
+      sha256 = "1fxz15yc081i6y3qvpxqy8ca6khm492hxxmji87ds30634d0033a";
+      name = "plymouth-kcm-5.10.2.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.9.5";
+    version = "1-5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/polkit-kde-agent-1-5.9.5.tar.xz";
-      sha256 = "05qzq07g7wb6942p6yyrah37vyadbfyz7akk87zrxwiahiighy42";
-      name = "polkit-kde-agent-1-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/polkit-kde-agent-1-5.10.2.tar.xz";
+      sha256 = "04s9338c8y7krqsp5k812vrwphx0ibplh5gg0w6n38m8am78cxnz";
+      name = "polkit-kde-agent-1-5.10.2.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/powerdevil-5.9.5.tar.xz";
-      sha256 = "0i8rri9ndm9ins4ii4qmdsmjkxqf69xpz85lwcdsv0sci6imxhcz";
-      name = "powerdevil-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/powerdevil-5.10.2.tar.xz";
+      sha256 = "1gw9swqi2wsdb8wbjf3ns7j4bj3a1mc06ynk7xklb7wan5psa9my";
+      name = "powerdevil-5.10.2.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/sddm-kcm-5.9.5.tar.xz";
-      sha256 = "0q0q3c439dbrvb4snfjfymgf8pld26gdqbak4gyp3j7nc2gjisk6";
-      name = "sddm-kcm-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/sddm-kcm-5.10.2.tar.xz";
+      sha256 = "10pg414ddx86nx46zkhl3fbvsijk4sifsh5cim17rp4b5wjay38y";
+      name = "sddm-kcm-5.10.2.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/systemsettings-5.9.5.tar.xz";
-      sha256 = "0xg8y8hpm0v2bflsh6l85yx969jn1nqlszwydp3ryvdwliv5hgg9";
-      name = "systemsettings-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/systemsettings-5.10.2.tar.xz";
+      sha256 = "1p6jg1vaa9svz4liqpb2435wbirdhjsqd6l1qd1lsp1r5szmwpz8";
+      name = "systemsettings-5.10.2.tar.xz";
     };
   };
   user-manager = {
-    version = "5.9.5";
+    version = "5.10.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.9.5/user-manager-5.9.5.tar.xz";
-      sha256 = "056rnca3v6vs7sjqz9drndir3csz457qkzf30rp0dh5dl9k9cxxn";
-      name = "user-manager-5.9.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.2/user-manager-5.10.2.tar.xz";
+      sha256 = "1ac10z44y7d2n618j04r00cnklxglyk7xdh5vp0pl4zfcm4cx98w";
+      name = "user-manager-5.10.2.tar.xz";
+    };
+  };
+  xdg-desktop-portal-kde = {
+    version = "5.10.2";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma/5.10.2/xdg-desktop-portal-kde-5.10.2.tar.xz";
+      sha256 = "16qdvds3k4cjv3dvvxr26r5rjnysqabv4zqf18g52z9lsbc46imv";
+      name = "xdg-desktop-portal-kde-5.10.2.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/frameworks/5.33/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/frameworks/5.34/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,595 +3,595 @@
 
 {
   attica = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/attica-5.33.0.tar.xz";
-      sha256 = "1dr5yhg0cy4b6k91mk6w090zjizgxaa808h799m14jqzgj63z5d6";
-      name = "attica-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/attica-5.34.0.tar.xz";
+      sha256 = "0l8gmsmpwzg6nzwwlnsdl6r6qkhnhirpmrkag9xpd2sbmy734x53";
+      name = "attica-5.34.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/baloo-5.33.0.tar.xz";
-      sha256 = "174my99i5mggab98l38y2bk27xp25mpz58rl8rhnb3wsbgxcx7iz";
-      name = "baloo-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/baloo-5.34.0.tar.xz";
+      sha256 = "0z53lnniq9xdk09d73z0p1xs1qmaf71m4znm4hmq956yg4yqa1ya";
+      name = "baloo-5.34.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/bluez-qt-5.33.0.tar.xz";
-      sha256 = "0cpkdv4k68f0rcg3j91418i59dmc94qlnv3xk1chq0fdi0cssrri";
-      name = "bluez-qt-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/bluez-qt-5.34.0.tar.xz";
+      sha256 = "040gs2a1fx996gqdx2pwxh00szb1vb85055z946nqvqfn01921df";
+      name = "bluez-qt-5.34.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/breeze-icons-5.33.0.tar.xz";
-      sha256 = "07nb4xq00fw50r4vf10npa2z690rwkmlxdy42lxx3ixci4qw4204";
-      name = "breeze-icons-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/breeze-icons-5.34.0.tar.xz";
+      sha256 = "1znzlggb6yrkw5rr2n75g7cfv9x5p9d55hss09c4i79lxrh1bk4a";
+      name = "breeze-icons-5.34.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/extra-cmake-modules-5.33.0.tar.xz";
-      sha256 = "013adgrz8s0w7a7z2ahkv28cq4c2cy00cw6y8akpkxazqhv5xzzk";
-      name = "extra-cmake-modules-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/extra-cmake-modules-5.34.0.tar.xz";
+      sha256 = "1r3dyvrv77xrpjlzpa6yazwkknirvx1ccvdyj9x0mlk4vfi05nh5";
+      name = "extra-cmake-modules-5.34.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/frameworkintegration-5.33.0.tar.xz";
-      sha256 = "01c1jq77hm3v5xi84gn5hymlnnn1igcpz9v49yxgyvnihlblb1ll";
-      name = "frameworkintegration-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/frameworkintegration-5.34.0.tar.xz";
+      sha256 = "0hq1r2znjzy0wzm3nsclqmih1aia5300bsf87a2l4919q0ildb20";
+      name = "frameworkintegration-5.34.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kactivities-5.33.0.tar.xz";
-      sha256 = "092gk0zn15qm4pihxf1h4qn2n618wp43k67ffy3saw4fadqmxpsz";
-      name = "kactivities-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kactivities-5.34.0.tar.xz";
+      sha256 = "0dg6bkdxf4sicij4szmi55npn6chp0sfmw27qi1s582ymqzjgf5m";
+      name = "kactivities-5.34.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kactivities-stats-5.33.0.tar.xz";
-      sha256 = "1269nh4l94b3yxyvzdjw6vb8pxjylrvnrv28vnar8dmx0sbh5jpf";
-      name = "kactivities-stats-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kactivities-stats-5.34.0.tar.xz";
+      sha256 = "1dfaq4hsd9wm1ka45dkxbl9wwr7s5ixbnnghqwxhl7a60imc680r";
+      name = "kactivities-stats-5.34.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kapidox-5.33.0.tar.xz";
-      sha256 = "162x868dwl92361ss1dxv0gqh8g4apshcgb1ww4nizy239mfj8h0";
-      name = "kapidox-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kapidox-5.34.0.tar.xz";
+      sha256 = "190d5z6i71jrvfna6vnlim2p9rgc33s1fxl0zarn276683i1rwvg";
+      name = "kapidox-5.34.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/karchive-5.33.0.tar.xz";
-      sha256 = "0i5grm0dhm9z6fd63ppykd6vl45k5nam4q8w1psrz7vjmr6sd924";
-      name = "karchive-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/karchive-5.34.0.tar.xz";
+      sha256 = "0g8jskdar2znviwh9bs3kia093wgfnhl04x4jcg2rvh78ylkpvxw";
+      name = "karchive-5.34.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kauth-5.33.0.tar.xz";
-      sha256 = "1lfi4w4jgc9m83q6v3jf8p91x12vvcc3g59dlg7dh2agrh07r9y7";
-      name = "kauth-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kauth-5.34.0.tar.xz";
+      sha256 = "06cw1bsp7inh5wglajm8aahy17p35ixgnijb7d74gjqzbj4cv93d";
+      name = "kauth-5.34.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kbookmarks-5.33.0.tar.xz";
-      sha256 = "186difbzrpqlbi140ylkzb50d3fmn2pdz8i0r3gbc71726fqld82";
-      name = "kbookmarks-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kbookmarks-5.34.0.tar.xz";
+      sha256 = "0ggn4rz8ch82ph64q6yik9fb1mp6kmsd7n33p769zl1lw7fldn0v";
+      name = "kbookmarks-5.34.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kcmutils-5.33.0.tar.xz";
-      sha256 = "0n0cmjxlp0kkgrxng2ympnl1v5a1bjr2d9c20hf31xhvmya3y9nd";
-      name = "kcmutils-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kcmutils-5.34.0.tar.xz";
+      sha256 = "1b52lwn7qjqrn06va7j1jswlzs6bx0drs90myf3607k52ffbf4hy";
+      name = "kcmutils-5.34.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kcodecs-5.33.0.tar.xz";
-      sha256 = "1pdijdlrl9p5w6dixqx0lmkzwsk5xarzjhpwh616j2sinfra0w31";
-      name = "kcodecs-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kcodecs-5.34.0.tar.xz";
+      sha256 = "0k51s4qlf0kq6i8f3wrsz5lrkzjqb1j26hrmlmg57vn91r58iash";
+      name = "kcodecs-5.34.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kcompletion-5.33.0.tar.xz";
-      sha256 = "13mv5mm90jv4k56h4n6d7r2a0pax2mhdrm51xd99fjynad129lhi";
-      name = "kcompletion-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kcompletion-5.34.0.tar.xz";
+      sha256 = "18hvdk5b1nkh6b3vx0jajri57rl266b0qjsiwirh5wmjc81xbpcw";
+      name = "kcompletion-5.34.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kconfig-5.33.0.tar.xz";
-      sha256 = "1inhpil19pv3jjf7mz4f5g367n1ciiixndij10p1zxk5zy46zzmf";
-      name = "kconfig-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kconfig-5.34.0.tar.xz";
+      sha256 = "0blbx6b3fk6p8cv2iywk2avn9w1411bb0g5wwv456a9ggi01988x";
+      name = "kconfig-5.34.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kconfigwidgets-5.33.0.tar.xz";
-      sha256 = "0sd974r7xrpnhyqabgix0zb1rlis32ijj0wiabbqi4ns0nhhi3qf";
-      name = "kconfigwidgets-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kconfigwidgets-5.34.0.tar.xz";
+      sha256 = "0h4kappsffrp2qgg8wza1ybgah2dlcgpz591llfvaz31ldsml9hk";
+      name = "kconfigwidgets-5.34.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kcoreaddons-5.33.0.tar.xz";
-      sha256 = "1906jscfc2kpd22d7yk88ziy3ky3hcfxy5y593pfzjl41gyhsiyl";
-      name = "kcoreaddons-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kcoreaddons-5.34.0.tar.xz";
+      sha256 = "1ybr4bv8rhp4cxpf8mfsc4dk0klzrfh1z8g2cw6zasmksxmmwi90";
+      name = "kcoreaddons-5.34.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kcrash-5.33.0.tar.xz";
-      sha256 = "136wlvaf4r54k8x0z0jvs7l35m0v22y6zqkhc8f91dr1y2ym2jnk";
-      name = "kcrash-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kcrash-5.34.0.tar.xz";
+      sha256 = "1cshay7dhbqgh62nq85vd9sm20gq9s9f70mdnzjjh1q7cajybkp3";
+      name = "kcrash-5.34.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdbusaddons-5.33.0.tar.xz";
-      sha256 = "1xxbmr88w7hqxsrhjbgic0pn4adkydhv9xd77vwbzjj47123mph2";
-      name = "kdbusaddons-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdbusaddons-5.34.0.tar.xz";
+      sha256 = "1skblxfnjhbyiwavsfhksc2ybc2sikw3xr0js6mlfbpmvqzghn6h";
+      name = "kdbusaddons-5.34.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdeclarative-5.33.0.tar.xz";
-      sha256 = "1333vv6kbdk4sdkkc8lnncgmm3203ca8ybn9nj6ch3zqwyxcaagk";
-      name = "kdeclarative-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdeclarative-5.34.0.tar.xz";
+      sha256 = "1mfj32p631zvwz9ldk8536ifb4n825zxbhx69bfllhw2vn1am7z2";
+      name = "kdeclarative-5.34.0.tar.xz";
     };
   };
   kded = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kded-5.33.0.tar.xz";
-      sha256 = "02g66ip0d0cwb8grb6f3z1j7178w76pfs2f8d2dl1rax4hnjppd0";
-      name = "kded-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kded-5.34.0.tar.xz";
+      sha256 = "0qy4w7bcg60gyf6y6c11kqcshnld55a8w4fzglpwgqfbliyi5yzq";
+      name = "kded-5.34.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/portingAids/kdelibs4support-5.33.0.tar.xz";
-      sha256 = "1gyyvp4kqnjaf764y2z24jk68h5h0ax1z9h25msczy6bd4ify5v9";
-      name = "kdelibs4support-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/portingAids/kdelibs4support-5.34.0.tar.xz";
+      sha256 = "0q9jjsjcvc43va4yvfay2xi40vb95lnqhgzavpqcndzjihixwmi0";
+      name = "kdelibs4support-5.34.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdesignerplugin-5.33.0.tar.xz";
-      sha256 = "1f4f53xag6xbvacpn5j0zrsdwimksnckdza6kswcri5q258yb6ks";
-      name = "kdesignerplugin-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdesignerplugin-5.34.0.tar.xz";
+      sha256 = "1jnarg7wrhdjfq73q4wplazxsz927mpf0l6m0i4akq4dlp1b7aah";
+      name = "kdesignerplugin-5.34.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdesu-5.33.0.tar.xz";
-      sha256 = "06scns6jgs372xx7fssdj63110nrnvy9dmm1k7gc0pyhn0a5yk8a";
-      name = "kdesu-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdesu-5.34.0.tar.xz";
+      sha256 = "04mx0d6kf8slgkkgbna3cyv4c491jvlwcwqxc7zikz0i03l341id";
+      name = "kdesu-5.34.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdewebkit-5.33.0.tar.xz";
-      sha256 = "0lxca56ib5pldc6f3z2gw05jbi2kyd9rqp52pgzfs4kgvvs6gblh";
-      name = "kdewebkit-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdewebkit-5.34.0.tar.xz";
+      sha256 = "155rn5bib4jq1ml35l4hll9cv30bp83wva4kgrhfc4y8cp46p9wk";
+      name = "kdewebkit-5.34.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdnssd-5.33.0.tar.xz";
-      sha256 = "11pnh18z030zzkiibvd9lfp5i194qwk3pccncc9968nnc0bgghxa";
-      name = "kdnssd-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdnssd-5.34.0.tar.xz";
+      sha256 = "082mdim9wykdap4fmjfayk443rbarsk1p8cn3mspx2nw047yja80";
+      name = "kdnssd-5.34.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kdoctools-5.33.0.tar.xz";
-      sha256 = "04d48gi5d273x3p7572szlpyiz8iyw1ic53b9jblhyfyp93gvpb9";
-      name = "kdoctools-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kdoctools-5.34.0.tar.xz";
+      sha256 = "145jjhsd0whmcj91zbjz2b1jyj4wasw60hbwyd4xvqds8cp0l02h";
+      name = "kdoctools-5.34.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kemoticons-5.33.0.tar.xz";
-      sha256 = "0p9320zln553wi055ql04j8kk329l3wiksprg9rkgzya2gynflyl";
-      name = "kemoticons-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kemoticons-5.34.0.tar.xz";
+      sha256 = "02h12qy0w6mcgkczi3md1znnvp7r47l8h416nd080ljpsydalgx8";
+      name = "kemoticons-5.34.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kfilemetadata-5.33.0.tar.xz";
-      sha256 = "1bbw1h8kml8glnck8hh4s13abbksw2fa7g93p25vbhdcyr7zgkr0";
-      name = "kfilemetadata-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kfilemetadata-5.34.0.tar.xz";
+      sha256 = "1rvlg6by8daiq5ff3qlxcw9k2iq4qicsj0c8a00xfy3w4h9ip9h5";
+      name = "kfilemetadata-5.34.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kglobalaccel-5.33.0.tar.xz";
-      sha256 = "0hc46vwiz81iqzkrc0qahd7gn71kh5wc32kjvh6h4ijlnfmdih07";
-      name = "kglobalaccel-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kglobalaccel-5.34.0.tar.xz";
+      sha256 = "1i32dq70qxjbfvlw0wqxvqvl6ysydmpg3zbiflff4z1qrmvmpw6a";
+      name = "kglobalaccel-5.34.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kguiaddons-5.33.0.tar.xz";
-      sha256 = "171lvykvznrrqdi1frm9akzx5rsrj04vvav3sv64x7hfsas0a7p1";
-      name = "kguiaddons-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kguiaddons-5.34.0.tar.xz";
+      sha256 = "1nmlwvy2jdmh0m6bmahvk68vl2rs9s28c10dkncpi6gvhsdkigqx";
+      name = "kguiaddons-5.34.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/portingAids/khtml-5.33.0.tar.xz";
-      sha256 = "0j9viw8fydh1x548wx39bphk5bf11fyrghshxz14a79rll8w7qmc";
-      name = "khtml-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/portingAids/khtml-5.34.0.tar.xz";
+      sha256 = "0j490jfnz8pbfl1i11wj514nw0skpnxr2fvi9pqpfql9lfhsanxv";
+      name = "khtml-5.34.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/ki18n-5.33.0.tar.xz";
-      sha256 = "02xf9q3vnw8nn2if6a3pfj8v96414j7gnc6097k0wxfyis9i46k1";
-      name = "ki18n-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/ki18n-5.34.0.tar.xz";
+      sha256 = "0glvmmy01mp6hnix79aichgwjq842kgf5q5zynkg6mch85y4ary7";
+      name = "ki18n-5.34.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kiconthemes-5.33.0.tar.xz";
-      sha256 = "1zys55d7jjjjllyi9p4difnr6xg9580bgcg5pnm966ak6zhj6682";
-      name = "kiconthemes-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kiconthemes-5.34.0.tar.xz";
+      sha256 = "0hbl82r6qc8dh9v9n9xjkx966czkq5yjxx2rx7sbilj2p9v3saii";
+      name = "kiconthemes-5.34.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kidletime-5.33.0.tar.xz";
-      sha256 = "0z6i224kmj9l15x923pa30mlhjw66chm9v8qvzg1vhmk36jyw789";
-      name = "kidletime-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kidletime-5.34.0.tar.xz";
+      sha256 = "0z8x6iz52y2m8llsp2q4qayxswkzay7ksimzy47crfag442bw24g";
+      name = "kidletime-5.34.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kimageformats-5.33.0.tar.xz";
-      sha256 = "1m9d51pvrc7fa38mp4jn4cdn558nd6kvik3ry6gvv8im67qyq4ga";
-      name = "kimageformats-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kimageformats-5.34.0.tar.xz";
+      sha256 = "0q9ng4clqk2dqw43nk1pmq1d61rahc3qr4dmg4y3kjvz3ahnnijw";
+      name = "kimageformats-5.34.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kinit-5.33.0.tar.xz";
-      sha256 = "0v3dcgbi5qwg9nmn668r2v1b257qhmkdb2l3p7hhx06ygypk4yjp";
-      name = "kinit-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kinit-5.34.0.tar.xz";
+      sha256 = "08429kjihpaip73wszr3rsii8sdlwgm3kxx7g0hpjhkj9d2jq3m1";
+      name = "kinit-5.34.0.tar.xz";
     };
   };
   kio = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kio-5.33.0.tar.xz";
-      sha256 = "1pls5yjkhz7fkawks4c0lmsix0nafv7hyp33yh7dm4hijd8zy5cf";
-      name = "kio-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kio-5.34.0.tar.xz";
+      sha256 = "1i23ld5b9gafh2x3lv79jbggbd92xyhk7rg3n765w3bsfpg2ijva";
+      name = "kio-5.34.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kitemmodels-5.33.0.tar.xz";
-      sha256 = "1ma21qydbmj2qr4ib4qv13wip99lq3lm8d6p137bg9x6nqfa4qzn";
-      name = "kitemmodels-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kitemmodels-5.34.0.tar.xz";
+      sha256 = "1liq1ppa7xb1dcncv25c2a0xy3l9bvb2a56cff90c0b0vwr239q5";
+      name = "kitemmodels-5.34.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kitemviews-5.33.0.tar.xz";
-      sha256 = "1nc07lxh37l1fwz6xmsrcplimgmrna9ij2dq3pnfrxr319c29890";
-      name = "kitemviews-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kitemviews-5.34.0.tar.xz";
+      sha256 = "054accbis471zj1gbfxbc99062r2hvpb04i6w3r8fa4ml8s6brqk";
+      name = "kitemviews-5.34.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kjobwidgets-5.33.0.tar.xz";
-      sha256 = "01adg7axi1bp59z1c7xnxg2p1ahhrzxwxrjn3ci805m8ns6d40cz";
-      name = "kjobwidgets-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kjobwidgets-5.34.0.tar.xz";
+      sha256 = "0lrx761vf947mb2q1l2jgi0wgwj8cz2nn1xg0j38bh99sgddmzpf";
+      name = "kjobwidgets-5.34.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/portingAids/kjs-5.33.0.tar.xz";
-      sha256 = "1w0kdxnzcwmgskl4qsw6aq5189yxqyhq9qajihr2yga0hyglf3iv";
-      name = "kjs-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/portingAids/kjs-5.34.0.tar.xz";
+      sha256 = "18b7k1hi73iqn06c1ryy9lcmvscr9d08q7n1wwkrn0l2xmy05xsq";
+      name = "kjs-5.34.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/portingAids/kjsembed-5.33.0.tar.xz";
-      sha256 = "1vk2m8i315nrys9c4kk3hdlp8hdn2ils0lb8v4nnkvbj3s1f4a8p";
-      name = "kjsembed-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/portingAids/kjsembed-5.34.0.tar.xz";
+      sha256 = "17w8i370pqks1fj3pcziz7j014chnc6yi7md7w2p4xprw54pbmbk";
+      name = "kjsembed-5.34.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/portingAids/kmediaplayer-5.33.0.tar.xz";
-      sha256 = "13xpvi0vxd3vva2d64x8l1knj270al4329kwf9xaays66g6gshgs";
-      name = "kmediaplayer-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/portingAids/kmediaplayer-5.34.0.tar.xz";
+      sha256 = "1mq87qf86sdvwhas4w7rspd221qp4x9kds4nd0lpldiay4483k86";
+      name = "kmediaplayer-5.34.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/knewstuff-5.33.0.tar.xz";
-      sha256 = "1j4jj2k6jngcp98mfxq1cdp7x0j43rgr5gxn9viqp92liak68lsh";
-      name = "knewstuff-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/knewstuff-5.34.0.tar.xz";
+      sha256 = "19d53ylwr92dzl9agk4j765zvb897rcm55z7pr6841aj58jk9b82";
+      name = "knewstuff-5.34.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/knotifications-5.33.0.tar.xz";
-      sha256 = "17ppfwhl3mqd3l4r56whqcxagx6br02hdwlqy7npn32g797hkayd";
-      name = "knotifications-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/knotifications-5.34.0.tar.xz";
+      sha256 = "12z5hza0n5zr6mv3gkwhzb8zkrmk6dvgq8hrzwm8rzkgphjr6pi9";
+      name = "knotifications-5.34.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/knotifyconfig-5.33.0.tar.xz";
-      sha256 = "0m9fdvbakv0plq3m7sj6wj980wfd3m37cabximz9gmi0zkcadzmw";
-      name = "knotifyconfig-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/knotifyconfig-5.34.0.tar.xz";
+      sha256 = "0lwl22vq770jyp45j32s0ss8yiqdwbink6cdhkbapg3pzbiwklyk";
+      name = "knotifyconfig-5.34.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kpackage-5.33.0.tar.xz";
-      sha256 = "03ls567fj54fzibc8fafffas97abyanl0sn041z51sr7mjp425cs";
-      name = "kpackage-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kpackage-5.34.0.tar.xz";
+      sha256 = "0wdymhcrjggxb7andz36cfk9f240vvbq5yahlxyhfp9z69lriw5q";
+      name = "kpackage-5.34.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kparts-5.33.0.tar.xz";
-      sha256 = "0fd0dqmaf8ksx3czzihjd4z0yg682a9bcy09vdhj2grki7w9fxha";
-      name = "kparts-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kparts-5.34.0.tar.xz";
+      sha256 = "1a5n0f7ljdc2bm6vggzwbvpblyxjqn9m9pam70iab964pqqalgp7";
+      name = "kparts-5.34.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kpeople-5.33.0.tar.xz";
-      sha256 = "19vag6ci82jh5lw5c7734rlp89wr7xb0d8as98ykz2wmkk0mqql7";
-      name = "kpeople-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kpeople-5.34.0.tar.xz";
+      sha256 = "0krm74dl80s48nhiygga4dvkvqqimxdx4nczbk4qvj7j1g9p2rsh";
+      name = "kpeople-5.34.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kplotting-5.33.0.tar.xz";
-      sha256 = "0niqhj270l36il3ql6xljg9gbb0yw25ky8wsc7l0021mxvhficri";
-      name = "kplotting-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kplotting-5.34.0.tar.xz";
+      sha256 = "1ffy9b08128ym024wlfgnzk52vpy0mbaa91dhndpr40qcz0i67sh";
+      name = "kplotting-5.34.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kpty-5.33.0.tar.xz";
-      sha256 = "0xcmqdphqy2a44bksqiv8cjlzfkjpbpazfk5f8ml97vdqvwa6qp5";
-      name = "kpty-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kpty-5.34.0.tar.xz";
+      sha256 = "00k5hhz7nf3nf47xb003ni1chi03imyrfajap6ay4zp90l8fr950";
+      name = "kpty-5.34.0.tar.xz";
     };
   };
   kross = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/portingAids/kross-5.33.0.tar.xz";
-      sha256 = "13dldb4df4spsqr3878bimv009fzq4pdvmwlaw753c0lrp97pd9l";
-      name = "kross-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/portingAids/kross-5.34.0.tar.xz";
+      sha256 = "092qz8vyiialv9fvk4wvn8mrfhz5i5hnbq0xnz6nvi1pk3db6bxq";
+      name = "kross-5.34.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/krunner-5.33.0.tar.xz";
-      sha256 = "0za052rsqf5kaz1c48k63a905b3x953wi6f07m44m6dm38p5ixq8";
-      name = "krunner-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/krunner-5.34.0.tar.xz";
+      sha256 = "0n527p708k719zgmvvbmp20xmg72f85cll05q05p4h317g7wz6i5";
+      name = "krunner-5.34.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kservice-5.33.0.tar.xz";
-      sha256 = "0jqq4ahscnqvzv8inhfzb9s6x97s60c4w8chpg16qwc7dqag887h";
-      name = "kservice-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kservice-5.34.0.tar.xz";
+      sha256 = "0sikwn49s2iq1nj518q55m2p0hvdvwm98cpf0dkjb1z1v6fgjc37";
+      name = "kservice-5.34.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/ktexteditor-5.33.0.tar.xz";
-      sha256 = "12fcqcxamkxv38w4j9waqmim7k801v6r6izlyg59iiy56yks4ms5";
-      name = "ktexteditor-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/ktexteditor-5.34.0.tar.xz";
+      sha256 = "182a0swfgdqr0faq3ksk6hlfvdi1afd0hpys5vayjjf263m19xxw";
+      name = "ktexteditor-5.34.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/ktextwidgets-5.33.0.tar.xz";
-      sha256 = "09rjr3655pbzwgjsmwbjsm7jwrxydl2jwhgbk8ziv1bgcg6cjrjy";
-      name = "ktextwidgets-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/ktextwidgets-5.34.0.tar.xz";
+      sha256 = "1hri34b373bww5gv14qli2nm77k05pk170nbb2vv2zvzv93g25gw";
+      name = "ktextwidgets-5.34.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kunitconversion-5.33.0.tar.xz";
-      sha256 = "0bflic2va9bc17q0smc4dzmgh72cjfjjaahhsvvnj54g2qggznkq";
-      name = "kunitconversion-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kunitconversion-5.34.0.tar.xz";
+      sha256 = "0v4x0flbfavrzfiqh71mdkqgp1fzk4f52msvq6w60i2s3sz7hcsm";
+      name = "kunitconversion-5.34.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kwallet-5.33.0.tar.xz";
-      sha256 = "1jpybsksai9gm2bihcgl5m56rjfd0crj9i8j0l2s4vmmzxyflczj";
-      name = "kwallet-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kwallet-5.34.0.tar.xz";
+      sha256 = "08z3ddsam5n5qn2svscp4hgksf6qd1h8lqw1v382p01nnmhxadz5";
+      name = "kwallet-5.34.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kwayland-5.33.0.tar.xz";
-      sha256 = "18nvdhfijnvzjiy0vjmqvf2nwz64ymxpnhlhs75y1d2ib8rm8qfq";
-      name = "kwayland-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kwayland-5.34.0.tar.xz";
+      sha256 = "1zxb9ram47vbiik8h0czyvacrdiijhnslkpcm61l4r1rb0ybb0ib";
+      name = "kwayland-5.34.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kwidgetsaddons-5.33.0.tar.xz";
-      sha256 = "1dnspi7zf57lsihdynbik2iwvnhv8098vqyz0rps8s8pnjl7x8k4";
-      name = "kwidgetsaddons-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kwidgetsaddons-5.34.0.tar.xz";
+      sha256 = "0hw87iig75mfgl5p3ph6zkwap31h357bm7rlyv5d9nnp10bq0hfg";
+      name = "kwidgetsaddons-5.34.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kwindowsystem-5.33.0.tar.xz";
-      sha256 = "1dj18774rlpxh9p8a07shhb4dzc0zpv4qvmh4j2y4c1g6v7n6b3p";
-      name = "kwindowsystem-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kwindowsystem-5.34.0.tar.xz";
+      sha256 = "1sp2x7afhw19vmhdp2qyrmljz8h0875xjk95n8c5gzypk7sr0l83";
+      name = "kwindowsystem-5.34.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kxmlgui-5.33.0.tar.xz";
-      sha256 = "1q89xsrdhrsz7jb68hq8r3xdmhz0s19zwvd06skn6cfqx7r32ng0";
-      name = "kxmlgui-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kxmlgui-5.34.0.tar.xz";
+      sha256 = "1v8m6qzjqg3ic14a5ki37bf13kifzcbhly68zcxgs5b92hr953iy";
+      name = "kxmlgui-5.34.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/kxmlrpcclient-5.33.0.tar.xz";
-      sha256 = "1zc6pn412day923k22br82xypvk24znb0ns1qsdlmrd2cnmv8l28";
-      name = "kxmlrpcclient-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/kxmlrpcclient-5.34.0.tar.xz";
+      sha256 = "0kp3ab50m5jl2jgw883ip67s6gs0l3saprzrqa9r3hydn2c4s3md";
+      name = "kxmlrpcclient-5.34.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/modemmanager-qt-5.33.0.tar.xz";
-      sha256 = "098l3plck45bn7lph7mfkm03q18zxl1s8aa3pyh6b69wk45r7j54";
-      name = "modemmanager-qt-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/modemmanager-qt-5.34.0.tar.xz";
+      sha256 = "1cf5nsc8h7djvr19fm5dphzplh1wm3asvn0a7r71spg0i7lzi89h";
+      name = "modemmanager-qt-5.34.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/networkmanager-qt-5.33.0.tar.xz";
-      sha256 = "0pc4n4m93ypx1ryasw8n3bqll7v4yqa3749ir0qi096y5vysdd2m";
-      name = "networkmanager-qt-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/networkmanager-qt-5.34.0.tar.xz";
+      sha256 = "05s0irvkg0g57acriablyha2wb9c7w3xhq223vdddjqpcdx0pnkl";
+      name = "networkmanager-qt-5.34.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/oxygen-icons5-5.33.0.tar.xz";
-      sha256 = "17kp66hra0vfkcvd7fh5q23wr040h0z6di4gdrm2zi1w5jbhw9kn";
-      name = "oxygen-icons5-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/oxygen-icons5-5.34.0.tar.xz";
+      sha256 = "0cmxxssir5zbp5nlxq81h2xfd6wrxbbkydyw93dby7r56isl7ga5";
+      name = "oxygen-icons5-5.34.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/plasma-framework-5.33.0.tar.xz";
-      sha256 = "0rqm773n2r6vwmv41x27lr2zmx26s5s27ym3a6qy0w18fr86fxsd";
-      name = "plasma-framework-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/plasma-framework-5.34.0.tar.xz";
+      sha256 = "0waicqskfwc8xpmrym165hwlfv6nzbwc783sac5vrhbyk4bwk8x9";
+      name = "plasma-framework-5.34.0.tar.xz";
     };
   };
   prison = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/prison-5.33.0.tar.xz";
-      sha256 = "0hh065294s7sjj34vfwwb8zgagf1sa09l9filadl1ly0ig9f6h1r";
-      name = "prison-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/prison-5.34.0.tar.xz";
+      sha256 = "00wj4yyfhhcq9b54civ5hy1grz70mmi676x50y12crcbbgkxm1lx";
+      name = "prison-5.34.0.tar.xz";
     };
   };
   solid = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/solid-5.33.0.tar.xz";
-      sha256 = "0jb8jjv6mhwriqxfkd9fj0b7y1ab6vnwqi53sk4w4vw53d0wkqxm";
-      name = "solid-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/solid-5.34.0.tar.xz";
+      sha256 = "02kz21p3p1s1rg7gf34fr6ynhji6x97yvsfdpvbfxbhijabbh4ib";
+      name = "solid-5.34.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/sonnet-5.33.0.tar.xz";
-      sha256 = "096ybf95rx5ybvl74nlnn9x2yb2j1akn8g8ywv1vwi2ckfpnp3sd";
-      name = "sonnet-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/sonnet-5.34.0.tar.xz";
+      sha256 = "06gxrh8rb75ydkqxk5dhlmwndnczp264jx588ryfwlf3vlnk99vs";
+      name = "sonnet-5.34.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/syntax-highlighting-5.33.0.tar.xz";
-      sha256 = "0nn078sw0bkw1m5vsv02n46sc05blg3qnhxpmph2cikz5y86x9jq";
-      name = "syntax-highlighting-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/syntax-highlighting-5.34.0.tar.xz";
+      sha256 = "0ryfwblvzj9rd5jj7l8scmbb49ygzk77ng05hrznsipczin2cjw8";
+      name = "syntax-highlighting-5.34.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.33.0";
+    version = "5.34.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.33/threadweaver-5.33.0.tar.xz";
-      sha256 = "16y7irjyyp4smy7nm7j4zc3gk9a046bwxvv51l7rfs7n4z0550ki";
-      name = "threadweaver-5.33.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.34/threadweaver-5.34.0.tar.xz";
+      sha256 = "1gylpl283qf1jcfyib4q5xwnpdq13hnd2cp2i7xjazdw2jp40zhr";
+      name = "threadweaver-5.34.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Plasma 5.10 needs frameworks 5.34 so it doesn't make much sense to split them up.

```nox``` is currently broken for me so I couldn't do ```nox-review --wip``` but I'm running this version here and so far there's been no problems.

Cc: @ttuegel 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

