### PR TITLE
tdesktop: 1.0.27 -> 1.1.7

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16024,6 +16024,7 @@ with pkgs;
 
   tdesktop = qt5.callPackage ../applications/networking/instant-messengers/telegram/tdesktop {
     inherit (pythonPackages) gyp;
+    gcc = gcc6;
   };
 
   telegram-cli = callPackage ../applications/networking/instant-messengers/telegram/telegram-cli { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done
Now using gcc6 as per official recommendation, and some pushd/popd magic to apply a patch that's not supposed to be applied from root. Do tell if there's a better way to do that.
Also, GYP_DEFINES didn't look like they were being used, since compilation was failing at some doUpdateCheck invocation (which is supposed to be disabled), so I copied the `-Dbuild_defines=${GYP_DEFINES}` line from Arch's PKGBUILD and is now working.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

