### PR TITLE
vivaldi: 1.9.818.44-1 -> 1.10.867.38-1

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -4,31 +4,19 @@
 , freetype, fontconfig, libXft, libXrender, libxcb, expat, libXau, libXdmcp
 , libuuid, xz
 , gstreamer, gst-plugins-base, libxml2
-, glib, gtk2, pango, gdk_pixbuf, cairo, atk, gnome3
+, glib, gtk3, pango, gdk_pixbuf, cairo, atk, gnome3
 , nss, nspr
 , patchelf
 }:
 
-let
-  version = "1.9";
-  build = "818.44-1";
-  fullVersion = "stable_${version}.${build}";
-
-  info = if stdenv.is64bit then {
-      arch = "amd64";
-      sha256 = "0apkwgd98ld5k77nplzmk67nz6mb5pi8jyrnkp96m93mr41b08bq";
-    } else {
-      arch = "i386";
-      sha256 = "0xyf0z1cnzmb3pv6rgsbd7jdjf1v137priz4kkymr8jgmpq0mmfx";
-    };
-
-in stdenv.mkDerivation rec {
-  product    = "vivaldi";
-  name       = "${product}-${version}";
+stdenv.mkDerivation rec {
+  name = "${product}-${version}";
+  product = "vivaldi";
+  version = "1.10.867.38-1";
 
   src = fetchurl {
-    inherit (info) sha256;
-    url = "https://downloads.vivaldi.com/stable/${product}-${fullVersion}_${info.arch}.deb";
+    url = "https://downloads.vivaldi.com/stable/${product}-stable_${version}_amd64.deb";
+    sha256 = "1h3iygzvw3rb5kmn0pam6gqy9baq6l630yllff1vnvychdg8d9vi";
   };
 
   unpackPhase = ''
@@ -36,14 +24,15 @@ in stdenv.mkDerivation rec {
     tar -xvf data.tar.xz
   '';
 
-  buildInputs =
-    [ stdenv.cc.cc stdenv.cc.libc zlib libX11 libXt libXext libSM libICE libxcb
-      libXi libXft libXcursor libXfixes libXScrnSaver libXcomposite libXdamage libXtst libXrandr
-      atk alsaLib dbus_libs cups gtk2 gdk_pixbuf libexif ffmpeg systemd
-      freetype fontconfig libXrender libuuid expat glib nss nspr
-      gstreamer libxml2 gst-plugins-base pango cairo gnome3.gconf
-      patchelf
-    ];
+  nativeBuildInputs = [ patchelf ];
+
+  buildInputs = [
+    stdenv.cc.cc stdenv.cc.libc zlib libX11 libXt libXext libSM libICE libxcb
+    libXi libXft libXcursor libXfixes libXScrnSaver libXcomposite libXdamage libXtst libXrandr
+    atk alsaLib dbus_libs cups gtk3 gdk_pixbuf libexif ffmpeg systemd
+    freetype fontconfig libXrender libuuid expat glib nss nspr
+    gstreamer libxml2 gst-plugins-base pango cairo gnome3.gconf
+  ];
 
   libPath = stdenv.lib.makeLibraryPath buildInputs
     + stdenv.lib.optionalString (stdenv.is64bit)
@@ -85,6 +74,6 @@ in stdenv.mkDerivation rec {
     homepage    = "https://vivaldi.com";
     license     = licenses.unfree;
     maintainers = with maintainers; [ otwieracz nequissimus ];
-    platforms   = platforms.linux;
+    platforms   = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- Update to version 1.10.867.38-1
- Drop i386 arch. Vivaldi has suspended support for Linux 32-bit for Vivaldi 1.10. Unfortunately, this is due to Chromium suspending support for it and maintaining it themselves would take too much resources. See https://forum.vivaldi.net/post/142489.
- Update dependency on gtk2 to gtk3.
- Move dependency patchelf from buildInputs to nativeBuildInputs.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).