### PR TITLE
nsd: Send stderr to /dev/null

### DIFF
--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -811,6 +811,7 @@ in
 
       serviceConfig = {
         ExecStart = "${nsdPkg}/sbin/nsd -d -c ${nsdEnv}/nsd.conf";
+        StandardError = "null";
         PIDFile = pidFile;
         Restart = "always";
         RestartSec = "4s";


### PR DESCRIPTION
nsd by default logs _both_ to syslog and to standard error which results
in all the messages ending up in the journal twice, the ones from stderr
with an ugly timestamp sticked in front of them.