### PR TITLE
qt: fix qmakeHook -> qmake in few packages.

### DIFF
--- a/pkgs/applications/networking/feedreaders/rssguard/default.nix
+++ b/pkgs/applications/networking/feedreaders/rssguard/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, qmakeHook, qtwebengine, qttools, wrapGAppsHook }:
+{ stdenv, fetchgit, qmake, qtwebengine, qttools, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "rssguard-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =  [ qtwebengine qttools ];
-  nativeBuildInputs = [ qmakeHook wrapGAppsHook ];
+  nativeBuildInputs = [ qmake wrapGAppsHook ];
   qmakeFlags = [ "CONFIG+=release" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/ultrastar-creator/default.nix
+++ b/pkgs/tools/misc/ultrastar-creator/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, qmakeHook, qtbase, makeQtWrapper
+, qmake, qtbase, makeQtWrapper
 , pkgconfig, taglib, libbass, libbass_fx }:
 
 stdenv.mkDerivation rec {
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     cd src
   '';
 
-  nativeBuildInputs = [ qmakeHook makeQtWrapper pkgconfig ];
+  nativeBuildInputs = [ qmake makeQtWrapper pkgconfig ];
   buildInputs = [ qtbase taglib libbass libbass_fx ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/ultrastar-manager/default.nix
+++ b/pkgs/tools/misc/ultrastar-manager/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, symlinkJoin, qmakeHook, diffPlugins
+{ stdenv, fetchFromGitHub, pkgconfig, symlinkJoin, qmake, diffPlugins
 , qtbase, qtmultimedia, makeQtWrapper
 , taglib, libmediainfo, libzen, libbass }:
 
@@ -60,7 +60,7 @@ let
     name = "ultrastar-manager-${name}-plugin-${version}";
     src = patchedSrc;
 
-    buildInputs = [ qmakeHook ] ++ buildInputs;
+    buildInputs = [ qmake ] ++ buildInputs;
 
     postPatch = ''
       sed -e "s|DESTDIR = .*$|DESTDIR = $out|" \


### PR DESCRIPTION
This seem to have been broken in #26336.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] `nix-shell -p nox --run "nox-review wip"` - does not work because of the issue this PR fixes
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

