### PR TITLE
mopidy-spotify: 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/applications/audio/mopidy-spotify/default.nix
+++ b/pkgs/applications/audio/mopidy-spotify/default.nix
@@ -2,11 +2,11 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "mopidy-spotify-${version}";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchurl {
     url = "https://github.com/mopidy/mopidy-spotify/archive/v${version}.tar.gz";
-    sha256 = "0w7bhq6nz2xly5g72xd98r7lyzmx7nzfdpghk7vklkx0x41qccz8";
+    sha256 = "1mh87w4j0ypvsrnax7kkjgfxfpnw3l290jvfzg56b8qlwf20khjl";
   };
 
   propagatedBuildInputs = [ mopidy pythonPackages.pyspotify ];


### PR DESCRIPTION
###### Motivation for this change

[mopidy-spotify recently was updated to 3.1.0](https://github.com/mopidy/mopidy-spotify/blob/develop/CHANGES.rst), which use OAuth to authenticate Spotify Web API requests and is the required authentication since 2017-05-29.


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

