### PR TITLE
expat: 2.2.0 -> 2.2.1

### DIFF
--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "expat-2.2.0";
+  name = "expat-2.2.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/expat/${name}.tar.bz2";
-    sha256 = "1zq4lnwjlw8s9mmachwfvfjf2x3lk24jm41746ykhdcvs7r0zrfr";
+    sha256 = "11c8jy1wvllvlk7xdc5cm8hdhg0hvs8j0aqy6s702an8wkdcls0q";
   };
 
   outputs = [ "out" "dev" ]; # TODO: fix referrers
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
   outputMan = "dev"; # tiny page for a dev tool
 
   doCheck = true;
+
+  preCheck = "patchShebangs ./run.sh";
 
   meta = with stdenv.lib; {
     homepage = http://www.libexpat.org/;


### PR DESCRIPTION
###### Motivation for this change

To bump to latest version. Also includes fixes for CVE-2017-9233 and CVE-2016-9063.

I did not do a `nox-review wip` since it wanted to rebuild 7000+ packages, should be perfectly backwards compatible, though.

CC @grahamc for security expertise

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).