### PR TITLE
crashplan: move version and rev inside 'mkDerivation rec', simplify src

### DIFF
--- a/pkgs/applications/backup/crashplan/default.nix
+++ b/pkgs/applications/backup/crashplan/default.nix
@@ -1,18 +1,14 @@
 { stdenv, fetchurl, makeWrapper, jre, cpio, gawk, gnugrep, gnused, procps, swt, gtk2, glib, libXtst }:
 
-let
+stdenv.mkDerivation rec {
   version = "4.8.2";
   rev = "1"; #tracks unversioned changes that occur on download.code42.com from time to time
-
-in stdenv.mkDerivation rec {
   name = "crashplan-${version}-r${rev}";
 
-  crashPlanArchive = fetchurl {
+  src = fetchurl {
     url = "https://download.code42.com/installs/linux/install/CrashPlan/CrashPlan_${version}_Linux.tgz";
     sha256 = "0wh8lcm06ilcyncnp4ckg4yhyf9z3gb6v1kr111j4bpgmnd0v1yf";
   };
-
-  srcs = [ crashPlanArchive ];
 
   meta = with stdenv.lib; {
     description = "An online/offline backup solution";


### PR DESCRIPTION
###### Motivation for this change

Allows local overrides, as discussed in https://github.com/NixOS/nixpkgs/pull/26666#issuecomment-309312206

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).