### PR TITLE
python-modules/protobuf: fix darwin build by passing C++ includes exp…

### DIFF
--- a/pkgs/development/python-modules/protobuf.nix
+++ b/pkgs/development/python-modules/protobuf.nix
@@ -1,5 +1,5 @@
 { stdenv, python, buildPythonPackage
-, protobuf, google_apputils, pyext
+, protobuf, google_apputils, pyext, libcxx
 , disabled, doCheck ? true }:
 
 with stdenv.lib;
@@ -7,6 +7,9 @@ with stdenv.lib;
 buildPythonPackage rec {
   inherit (protobuf) name src;
   inherit disabled doCheck;
+
+  # work around python distutils compiling C++ with $CC
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
   propagatedBuildInputs = [ protobuf google_apputils ];
   buildInputs = [ google_apputils pyext ];


### PR DESCRIPTION
…licitly

Fixes #26531.

Copies the matplotlib solution, as mentioned by @knedlsepp.

###### Motivation for this change

To fix the python-protobuf build on darwin. Obsoletes #26606.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

