### PR TITLE
firefox-beta-bin and firefox-devedition-bin update

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,945 +1,955 @@
 {
-  version = "54.0b13";
+  version = "55.0b2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ach/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ach/firefox-55.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "b76584a4027ae3c05b4350952bf231e1701c3f161355d86f028379a04cf7f3f1fcefd67736dfd2cbc02fffca670ea7e62b1729ba1647746da62dff30969d74dc";
+      sha512 = "7164db8b579c12976ab86770f3c238d8b4b4334a41107f995d03b87c77e7998e1c7d48b36b2305d67f1eddb4d3cbe0b9bfb9c27169abaac00839d90a0e80d38f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/af/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/af/firefox-55.0b2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "c8cfb40ba81947254a58dde6438a5e6eac9b4279701800353b8538ca74776fe09da4f6e5384d93a197bfbd3c88b30e3b56231aa4d9530c61da84a712d0ba0473";
+      sha512 = "994024e45c16b1dda3680ad4d73fa7a2a84bf43ce3be8df4fa61a695b9041fcdf88ae750c0ab34bf9dd814cbcde10b14832d5b03682e8c83e4dc43a316b6c75f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/an/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/an/firefox-55.0b2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "072e89337c05b9dc4f82eb4746464cb19b897d3c4eda1f50c9d0c7d1d38e9c1b2301f9c0416ad26809c31e0bb5099872cc577540ce722ad5e54ca04ef3b7c003";
+      sha512 = "dc4a8db0c9bd87ef140d8c2fa2e4deb63e664a97353d88f94f99fd10ed358091a6215b62f8a441ef65dfa6774989ede451e55749bdffb0f670904959f5e8bb70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ar/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ar/firefox-55.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "4c63f391b072b5d33f61020dd2bd5f2fbaf644b0a411070297ecc31ea5c7059af373cc58d6b49e377ce6db239ef4df64f301612db0c45b118662178b750fb069";
+      sha512 = "94d018fe2116733bd14daf51d9d9f09022a745b3797773422ac79511a8fd1e14e9fea879f7873c1043e0b63d2df4425c806645467764325400f71600a2f1cc1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/as/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/as/firefox-55.0b2.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "22e95dba78581460159f24130bda330557348516ea9442644055159a6c7cae3ad4529890676fdc43f8a8cd902d4a75fb06de50262db72fc1297e08d9e14e2d0d";
+      sha512 = "6b5811c9ec50be18a34e0102438e95fea58c8667a0a19c9c4c5f4ac93c8ae8b9cd929252c81de7f19a15b82ed6a01e8fe37fda7aafc63cac223cc09b1d9dbd11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ast/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ast/firefox-55.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "527ff1bd64649b475a863f3d3e40e900d40d5c1e5a404e0dcc2678e7708fd24dd0a68fa85f1f3cc8e23f12edac41530310d0f65e1eea390f5e01460c2ac90e0c";
+      sha512 = "4deb4aff290277f870d5c3148e375a9bd2071b455ff93f10e28c9afe149a8f11689bef936db8a87c0fd4cda5bdda70aced4580395343916e7510ab7970269fdd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/az/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/az/firefox-55.0b2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "c3184445a3a4cd205140a43adbd498571a0339175fc9ba05ebc2306fb37990095f4c66dba0eec1a121a7b5aafb6c3d6d5f5ff68485382ee61ad7ebfba190fd8d";
+      sha512 = "3cf69626fbcd8667c83978e540cf0e8e0123408dd080073e95f543a0c98085320bd95caf77fb814002e45694cefa5542c6d436d258c66abb8435d52ce85f111c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/bg/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/be/firefox-55.0b2.tar.bz2";
+      locale = "be";
+      arch = "linux-x86_64";
+      sha512 = "0318b4bbf69fda1586665dbe7626d4ba1c4768acf310b5bcb0d49c1212199704d4f0c0da6dcd99f75dd7871d39a4725497c47ec2f980b1c458b101a4e18531e5";
+    }
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/bg/firefox-55.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "e1eb42e04be44f4b091fd6675af506c80098886a20be0b37eadbd907dc8925b1bbc0c99145417e16534d6a59f1f6ef718769819d9f79ebbfac22f05ba5ad95a3";
+      sha512 = "0de32e72eba0fae0e19c1d1cf8e8f8f99926d66df6831317742a74bd0e90f909cd4a55432f9fde3e25c33e37160f5e92d0ca97b2236089d4059c5789e89823f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/bn-BD/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/bn-BD/firefox-55.0b2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "9d09de31bb8207533a2e222a1fa8888f3a323046dbf8521f6cad0aaffc9d91ebe35b0ce766fa2b292d1058f370298f60479312a5f8c749bef5599c60e88777d8";
+      sha512 = "333b28b03e6a4612b0e5636e14bc83d6e152237fbcd4129acf25767f3049835bf262040caacba1976d2791ec06fa89e3c70ed1abea414bbf4289729296099993";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/bn-IN/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/bn-IN/firefox-55.0b2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "1656bdd3844c968d448fafffb7b1fa5994e8dc4a590f4b39965df095ca29a8914fa4f8dee1fea4a15b6c4716a6555841f4b9c72b432adc1b60b02f561cd3ef7d";
+      sha512 = "ba989a0555fdc40e9ce9d834eef26b19c30b19616d85b5864d26253572fd79bf02b7a0b9bfd00dddaa192950c7f9d52c20887569b7cad8b03622ac0df55baadb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/br/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/br/firefox-55.0b2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "945f866e86a8ff5e6a8d2216abb3fef9a1a93b585599267f54a38b5acb0843c1cab5ecb4440f6277e7604fd4fe730b5d2b57b4708bc1639ad2adcc0e217ca716";
+      sha512 = "e43ec7e1ba0d977938e5a1bc3f985196211fb6587c44018958f750b35fea78f2dd94a8fbd1b91f70e41c3f3cc0da194bed76306d4b63bca3dfde7a65a6a7532a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/bs/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/bs/firefox-55.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "cd555e3638139d6e36b59fbc72a53a4e233e33557c7000e9c308cc292d963d458261c0404d130353abd071e23927c11d8232add50b455063fb3c261faac35594";
+      sha512 = "7ed042ecf92e7f873f93e0f6a7ab27418e960adcc2417e18fe9ee8b468157af85dfbd8e56df7f0dba97027b3a38aeb6279d81451579cc97a9fec814064b74e58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ca/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ca/firefox-55.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "ffce1a6bba525cd67880f695f6c21b1078fe419ee32cb878519f5f36d4d403b5cd2dfc6f1d9ed02f4f38dd2f7404670f63b34484180137c6a597f407c24b638b";
+      sha512 = "0953320dfdebfda3b2f135fb5277ebbdcae1c13f431b4452e0398515d990fd6faa8137dd4f49bf4336b385c70422f340e0bd8a466c07f76146d9ff32655cbe1d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/cak/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/cak/firefox-55.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "e1d2750edd967f15a51af0daae4599f78add80211ddcfb13c7480ba696426e0e69da3bbd5331979aaf88ec6f611aa33c98f7924c1428e7cc37f2d9fb30c3ac6d";
+      sha512 = "e79e1e6a2784e3e61637624ddd8b628b784090c61daa35d36a3ebbb68db1801ead01b86bb04d7b2bb3037fb53b42197a50de78013afcc2443136b65df6f0b9dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/cs/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/cs/firefox-55.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "c8ca0cdea3742f5a18992c9743c994d9676bfd6765b458d0f13e03038f61a9add04b48f434c41fcacc67c303be2488e8833aaa8d8d68150e00e3ccd2affd6a0e";
+      sha512 = "c48991f37c786982f90ba12d43120dbefdc046d30c9ccbba630224b1f08dbce2b73eb4456e1b588f5ca0518ad19b8148e9dd5cf4a9f47f8d4ca0e90e2988f18d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/cy/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/cy/firefox-55.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "954ba8941fb42595fb05ee03ced136b1dfd3617c08d14042b63fc2e53984b71f490471e3e680bb67f2ee31ae72ca329198272b9c354681e1ad9fa6e12bd32b16";
+      sha512 = "a01937ba6f1e56b34ed4d16acbfa336338391c8fe4e33e5f06ec2a35c3c6010a35f20f7949ef1f6d50c9d6f6d9db115eb95cac50762d7d6a3b642f78192a6b4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/da/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/da/firefox-55.0b2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "144d754470b59b95e3706516224e21c1c53b0d2260541cf4a4a2afdfc7af39dcd0ae97204e8558e29d627853e1667f2f0a337cd257d05409c355f96f9ffbb453";
+      sha512 = "d7861e3765acac1e8e5a1b302986fcfbdc262a22308ead2239e7acb3617534f1b8bc101c2ca6d5aa1758bc13a6cac5f31fa062dd31ef239113cc815c9d4d22a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/de/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/de/firefox-55.0b2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "1bbe368dc61546c4d2cfb09ba0d0b8414abbaff2a58ddc60e6961fc3f387a8d90a75a44c3b4736df1ee3d2777cc6732c02b42a897486bde9b9f030e8a599aabc";
+      sha512 = "2b6efac1ab738f42fe52a6c8e4bd20fea1e044577a4dd82fea54ef403adf2ea9f7cb64268de68dc55799afd3f5e90f724c98b9f705affc704e1a58118c674dac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/dsb/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/dsb/firefox-55.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "407728ddb4062f0961a856e34d7f4db5f137f9674b95a7cd509c57878813e4dd469487ceb91e3f0a182f08e2e95116348d7f9f12e23a6c45d5911f3c8af3c0bf";
+      sha512 = "c5de911eea687279d6d14b8dc745597c6450c733cc332e104de6ebd9a7a64b877474fb0da0bbe59ef4c8424549eff4fc6b57a93379c09df00fda761bc7347e54";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/el/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/el/firefox-55.0b2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "5473cb886a94aaf59065f65029c01e31e162d38e54e85b19109fa29929c97a7872149e802fa131ffdd1189ba5a20184f081f483cb783de90d287469f6300a0de";
+      sha512 = "b531426207bf42f74f87ba8807441926f9476f0f15caf8a21594d099992c7c91d2cda6d71d318d899863185bdf776f4bf46820fff77b37f8a95c52f570f9247d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/en-GB/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/en-GB/firefox-55.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "8fb73d0a889c33fe2163f51847054c5d8dfd491ff4ae3c5e1333b93aada953a03d376b1f3afcf26189b3a333639a28dc380ff967cbfbb2a2f11a92c1750a59a5";
+      sha512 = "4c1c99501cf1ff1320d27c7709d9572837a1a1fb7d8dea4578075836e013b5fd79c84afababb45bbb5cf95655b51b0503ac45023746ff6d4831bda93c493e539";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/en-US/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/en-US/firefox-55.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "66b68bdb3043436548d057d435a065b896a815c4c0eaf7f4c072c306ee379de4e98aa750362175df822767786b2202744586fd6aacf789f987ee7528b6bae865";
+      sha512 = "82678293b35fe73c27c5842589de97858a8cb5186d7f1309693f16a516ddd62a59bd96e84358571367b706354625a98bec7fff9f7c598c96f025594baad44aa2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/en-ZA/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/en-ZA/firefox-55.0b2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "4f3917809ad8b62bdf6bfcae453b297d956e938c346b48613758c362d0c32be098d158fd660ec24ffd000a9f8f6be0cf026ea6533878c756e6b476135d0483a4";
+      sha512 = "ded063ef65018cb0b138298b9e9df9a2aedaadf92d5c77248120cee6504542d18967b01c1bf497e264a9aeac7c119c8bc9885fb202dd0abcb0ba00344ad30397";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/eo/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/eo/firefox-55.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "bc0682dfdb05432df784ae6abc1202f638e16c04e0deb53211118cd0890bfcc07608dd94feacbcd4e6abfb3f6403c9d1c1746579834ab1111e4870396bf0dd41";
+      sha512 = "205dc910f37c5501b27ff044f5bbb197fd4bbc3d8a5512ea01b0b4c155cd8b2f19eb6c400cb999a6136f2534ac0ede511ddf827ffd59f97ba00b538852c9a0a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/es-AR/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/es-AR/firefox-55.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "b9490b0a0fa01e7e8e09b8af4d77ec42ab89a7859b70106e0c4294dc0a03df215de2a34854fe48f8e033138d9dc5b553e2a71b629c0e351712e1d66afc0aaeb8";
+      sha512 = "95a026ce800722d1e89237a675a58fee8243e5b4a900d1ce42a4f139dbb43e940478660f78d9c4593b9d09af7c3dc843984b7a362b465d99317aba9bb213b371";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/es-CL/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/es-CL/firefox-55.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "524a89e97ccd1919a86b2ba38beaaa42b6664af46d36e4da0f5f17f7d8f9b1c428be8fcd111a42c3fa951108724c139f54aa5e4f4a7577dd6f58895b3a3d99ed";
+      sha512 = "42f0703824210feedd7da2f78a4d0823d1d0f3b23d4edaa07d63a5021847ba55871fec33676915b9f2b411ebd9cdf31de155f2de0a47586428bf0e1a3fe7457e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/es-ES/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/es-ES/firefox-55.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "58660dea649a468e97d12d054a59dce61d7abf33e4a5620c40f1c42eb30ec3411738aecec666f0334e46b3458a48caab97b5dd7e9e1b0699f5c16330401b5aac";
+      sha512 = "d11dd1264e4692da710d18ef5c18d7f5bc1db36214cfd28a7f567d56a35ac6e56f838a58ef6ebfc2d68b115417cdd19fd49ae2f6a13f1a57bb2eacd122945f1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/es-MX/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/es-MX/firefox-55.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "2c5cfc09b15daedf69ce16ecb12b07aab99cbd0b68d7ff5b65ac9116a59790d32aa1f0c3a931e9837b381c82d4e50f3e14237c39cb5c45e652d11310d0e01faa";
+      sha512 = "ab33b21aaacb43f4676856e74f4d93e2d449b67095500907669db42f678fe0d7448f2205f42c3f85885cef0a2c262818368808ecc336205411dc27b99e42f272";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/et/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/et/firefox-55.0b2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "6301197a08de0912a9195b0d78d95df338f3c2ee2c90045108d220c9309edc8504a6ff6aa5f0c8db21df33d6bb0e624d713d59c6e49fceada3a510d22613d59f";
+      sha512 = "2a87e6a9bd6c3aa22d278f114d0bd18779c7847cab2e6257c4e601f3749df703f2d0a25f5646ad91802a2cd093bd1734305fb350aa2be269c1fc5fd2d621d4db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/eu/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/eu/firefox-55.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "2ca00edb210c879a48f1107137378818e6f4beeb2f3a2b1941d12a7da6f474bc164d07158ef3713cf9e79c222b4f2f9a243ce924b21802dfb4374f48c18954cc";
+      sha512 = "9017cc8bed387b103f78870b157a50c18f8e36858eca1bcbce8ac5ceb06f6d7b178760f7dc733ce570cdbdc3204d277a98a4b4324a0d3691d1fe3f6b1e9725df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/fa/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/fa/firefox-55.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "ded6f7d1daaaa417ca62dede3e6a0ae4acc66852dbbf6230e8b1ff5ad74ce4438369fe6c3280f9c8abd3a1c22fa05f2c9e36dee20531fb5d3eeae3c736984b63";
+      sha512 = "d70f1a793d67f1b52f740bbcdc4fb01056495fdc5b14672b35a48a500c71ac7cd0cc6272e7f6b4b4fcac65874f32ee64338435f76131c1d74ef82ca7a512eab7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ff/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ff/firefox-55.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "59c5c0604faf14bc0478cebdfe09982d0a184a5735c791458254b14ba1031fb9e18c09dcfada0e921a088fd7168d231cef52dd45eb703553a5e5624ca38b9363";
+      sha512 = "c16463456725b2f0263b8fee2d0729bd4951a352b1dfdee819bc2af0e138cda73d169eec63a27ed2900a0703648db0c784969a41df874336b1a84170ddaa71a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/fi/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/fi/firefox-55.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "10e9aa82198338f1bb21c6fd5663a939b14d1db5b1a5b672d0c81aea26d910e9b6c8b53d7e40105e5dbd9e4b67bbaaa50803b323dd648ff85699cb88384c3c23";
+      sha512 = "00bf17dab47261470f57b94a18fcd5fcca0344be1b1d6352968e132c7f3fdfc5b5229c80eaca1a9802e75d432e09bb6e0dd3dbd40ee9f0c783ca007da61b52de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/fr/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/fr/firefox-55.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "b267baea7bf0c9fefab7bca2b32aee9dd0d6f9e435c477ecbdc622e9cb2a08ac4adc1c26db88e2f61b1ef55416c079e49d4af6a4366f2b893504fe814021b674";
+      sha512 = "7599fed77975a7b4667c9d3456a5536e3b7eb1725acd624c504d061330ea84c3a19dd72914a0f7644068972b94a7a058708e3b1e3618e084315b920e8f671f13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/fy-NL/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/fy-NL/firefox-55.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "afaa720f4b935ee8674b61362972a90ed9aeabddac17e5768eb05f72eccb1b54ab6836524bb8a189e08cd06f6b24c8863208f9917d02d12f622b7a3c4b96ca8b";
+      sha512 = "c665bb33f04b7d3b9790580b0db992ce223e75fdd3915b16f79125a72bac91cec098b1ae73b1223f5b03597c1e19522b46fe11c5c05a7cfe0c932a21bf94f90c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ga-IE/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ga-IE/firefox-55.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "c60fa858865ba80ca17fdfc29f2ae85c77528d570f8b4f43b890eb0316807ddb2049fbb4c6005fedfc0f05ed85b211901e88a6d06fa51f9cda214b2999b7de76";
+      sha512 = "c775e3e6858732104ba3251de42a0e9ba5031ade5f89207b357e93c6f6e4acd07bcc91a5fa558a9884f07438ca0de6bf10065ff7e37d980914da392428bc57e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/gd/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/gd/firefox-55.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "37d7f0b8159e7c23454b0f1a15902280fe5def086001befbed3d17d21e4e3684c40609a5888fef3cc22888bf57860302633a680a4d01ad1ad0e765ef14a3cce5";
+      sha512 = "c8df95449757099a7c8d50c04f42aace7ce25297c78622296feb336352cecb53726f3873210af6cab96d90f65e21daa084b08f6b943e1130c75f68e6de1168a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/gl/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/gl/firefox-55.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "2749dd7a2379c3eb2e2f52441717ef065d3bb07c6cc58aab02bcb3c050e3f1fc14310c479bd58da5bfe9a17a91fd0ca44d032aa81f2f098cec1bd2922876cdae";
+      sha512 = "4488db080b8bbf7e437a684d1d7cbe219d1d730db055cd9988706cd71deb110b9496a87684ca32d172f3eeb3308ec1ee2ad0ab3b1e206d012c62311db45db911";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/gn/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/gn/firefox-55.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "28f3f810fe9e2ef555d5f72714284eda44750f5525a560f93b9e47bc56f5f2b83d2c73af3da8245b387260e4c82341272518034aa6b8c968665ef9ae0a201a9b";
+      sha512 = "272c43aabe7c63b769df2aea4eac5350c9cf90326ece8ac2f096db421f7785e630cbdcfdb84e41c516e36165f1a67d9b22ee0090d84ca9d58fef275d119c2dad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/gu-IN/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/gu-IN/firefox-55.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "76a246d75ac07afdf824307706b9834c2d7eb558448097c9b078e37b61973447fce723c3b697aa4ba464f93d584901bc174a635aaaf7bbc27efa21f923dd7452";
+      sha512 = "415b1ff89552f6bb83458a96905c2c6b7b6b25a974b72ab4a4d4a0a1a5b1e431b82e519466393bd6a8e8031954eacbca97529cb0e4513d722563e13eb97a8fbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/he/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/he/firefox-55.0b2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "e0de309d1c0f1e9f3182eb95e91b0384bef6a52e26a921d47e896f16e9c58b270ef30b6c1b4e4007c1eb3b75fe41c12be5193a4fcf88d15bbd7f2892c0d5bb40";
+      sha512 = "1110e4c1c6121a00fd76f25bc513f0c877bfdc7751af2b5958f38f2a7892d8a00c9b5eaa6adab34213535480228a4e0b3aef3ec3a3ab4adde74bfa2fc7dbde94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/hi-IN/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/hi-IN/firefox-55.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "1b9e63cac216f3f043c17b8b4a701ea5e8fb5522a25f6e21d0b5ddee07210ab0ae1afcb8419b0e6018abdc25b989a5a3fe554d1d04f52c38f545172869d95e08";
+      sha512 = "b1279b0f0a97413799598fbd3c6efca475b8aef7a0b05c401cddf283722ba423ad2524341962360845951798d9083019a5b8b431e658513001c3046b6a3fedff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/hr/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/hr/firefox-55.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "959a5760577f5ef026f3230a196ee26de93425a452ced9cf9770b5bff8f3f44c2dae2cdda7e01f68cba2297b320d2df299cb774e9fce2b68adaf986a1af26a09";
+      sha512 = "77474e40120fd4ad50a109c6b46fa93c070bfaf899e187bd4bac0ad4a53fc12c7f7d9d2a2003a871e8666dcfc60de4f3ea26b79008f4fe7ee1c5a358307b2eb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/hsb/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/hsb/firefox-55.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "50390a8d09b6a19fd8441f55a1d0310ca279fec250557124271e3791ad8869b1a4b361176c0ac95f8acfefb8a00c80095c2422314c5da557895a85bf194fc011";
+      sha512 = "b1e440f25ef20da7fd6e3d6a403b7c448e5493bfa410e09c3b9d59b32450883a938967b167a8e84cbfcaee546d36e28c8152a6c048070b543479072bb8df6189";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/hu/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/hu/firefox-55.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "8ca51f25ee3c06b918fb4a4c034ffaf493c30c67f1c3eebc0fc268f09ac6fe62ac163ad260f4a4ca592a7bdd80bcf3a916660ffbfc8681e46b40e416e3e7380b";
+      sha512 = "7ce8bedd243fb6d8cfe28eea17aafda028d1b85d96dd60c734f239f258dad8e7c132439614d48494e58088f99903f8a2a8824fc4878366400d9affffed203b84";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/hy-AM/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/hy-AM/firefox-55.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "49da49d63b28110d98156df0d07528e6261a01f5db9aefcb1ba1f04dd1b45e812bb026b6bc183fa27bac57a9a735009278ac86394ad43c54ba5760b9d4a05de9";
+      sha512 = "ab5054bc6cbc515af08763e61351275411edb2507b7013152185c49e3c7bad0263def5ad187cfe5fc4bb0f93e86a1596e131746646b25e452293f24216116543";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/id/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/id/firefox-55.0b2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "6cf45812cfd16071b12c3b87226a37e5353fd0f331b65a575a4fc094709b20f3b0fe00064af1a82bb4c9430caabf2d2c4361f90cb2e90b1d5385a57a171c5955";
+      sha512 = "122b20868a4ee4d1bd42efb3bd281f137bda130d4328e830b3b21176777c6b993f562948671fd8e020d039b5e5798b150f1fbcf734f245615a2a3beda8d44e85";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/is/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/is/firefox-55.0b2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "db48948f72641b83078dc44354dc3bf6a0919695a69c155d836154f260a4d32b8d325c138d6db863006dcc80f75d6cefcde0f9e445eeed89d9d8f89a7aa5a048";
+      sha512 = "033451b816392acf472f6f62f3367f929e4d4c2b749629138120580b7bb854c5409251c49650d3359e6f48929eeb62bb9a475ff46a8b57cf11c34d6035c67f70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/it/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/it/firefox-55.0b2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "2d63a2dd3d5b56c3c630b3badd764ca50e6bf4eb0ba551cb1207c849f0d3006de96781c59b8ba86ef93659487be74e2c5ce0621b3df921e3091debded91b6a56";
+      sha512 = "99bccadd7b8994c20ade9907301ac695ef01542407032588bb17cd3353e4941ed70944c8f9a28aa0fee5b49990d2bfbc5ac37d9c3d4fb88d13c473d50ecaf849";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ja/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ja/firefox-55.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "f7bb1e8cc1cd72363f8be0d25173f8abca5383277c101585198e6941c4b4fddd222942fa6711f5ccdcb2dde97dcdf974229392ced1488d37bad30274987decac";
+      sha512 = "ec7193a6eb610bf1ee67791f1f7ed9ab951cc8a53bdcbddffb1078479919d5a70c43235e3b4ec4c20eb89514f283dc8223a4f61835f039f347744d07727058ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ka/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ka/firefox-55.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "a36808e207a1277bada5793ac8431a381dddf11a600c795d077d0136997380d294a59f7606ed2a64643df53675b607ea249e6ac9518d57b91b2f905c76a2cb1f";
+      sha512 = "753c48c6dc9de12787705574fe0319ca9e4d5f9db67166d62fe0391fe5b8867d7f5da9d21f829420bee034444762a6ac3166c109a36e0001e6e7752c93304f77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/kab/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/kab/firefox-55.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "498ac5ac757560c131e21a5b03e956e63e329a3ba9b3d7085d1448e722a78ef17c022cbe22a5786931c9190d79081806f408ecd79b3538b6c042e91f04baf65d";
+      sha512 = "a64d1b1f69d18d06810d72ad10aaae40153e696a29efaba4327d44e45d167a4526cc00811cfb764288df8971576c281fee1d8b737597f1de0f0755a4d2e78126";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/kk/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/kk/firefox-55.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "2b3abe204415dc66119edf9d09dbeb26b026b89a9bbf06cdcc9d624281f96269f2e0cb39f8bdc0a21be373ab4b0cd41aa93f9db556dbc910dda58e44619c2f73";
+      sha512 = "e95905b00476f33a8e5c39b427e592f844f04d267263dec65f9edee3e2a91790382cfde6731e2eec0193d535267d041d2254c4645a7f8cb6b1e3ecbaa40f37aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/km/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/km/firefox-55.0b2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "27d3ca7572fea00b1bb6409b55262ac85fdbf8a0a3a49146fc158636780cea266bb2eb52885eee25d198a5b6484476532f6a4d6e9f1e0f2c479bfd0c82ce3943";
+      sha512 = "3dd5c83d82e6a47aebecee97c49e94018169a06a9f81ac61bcfa7d6ff337b5c4ca66d10ae552f5642cda20ce545752ffa0f2589163fd1e01bd7e61c24c88e7fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/kn/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/kn/firefox-55.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "d98e7a94cdb367ffa7c2f3453e7f2530acc09562a28139b431c17424c68973b27293a18cbdcdefd86bb9d3348fc37a4938502affc1b18e2f2e1e4c36fbea0d62";
+      sha512 = "cfcc5d048fbfa18aa0030114c445b40ada42064ac56194add35d51340173b3f6dffa1c9faca87fe4ca2f5aee608d7d05903ac8540095236d19aed3f939f88914";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ko/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ko/firefox-55.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "55eac7a2667f90789e148f0dff06492c80253ee6a7d65af2e9897a7fef5209a64c4a9a018c6d5b8e137ebed60780ffdd1932287d1d5e174462f9208dfd181581";
+      sha512 = "9e7b63568e745d5299fa0315dac87478bef0a30cdad42b05e33acdf188f8346e23ccac0ca3c544f1284e4cd216d8b5c792ef448d6cac31318ad711ec21ec4b05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/lij/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/lij/firefox-55.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "e86ee02d85ab92f61544f590692bb00ea49fcdf3b1d0475dff6dc0fc003663582fc3e87f1ea03cda90e20fd073da9e2663795e620b9e6adae2ecd98f434ae9e6";
+      sha512 = "1c8ffd773a5c259d32a6bb6ed6472c041f5337f01f21f6e5e18f774ddb04480cf0772ccc6bac7710e9c22f760d7bd2b234d6d21e1281d9ce2a26483ccd6e928b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/lt/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/lt/firefox-55.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "57659b95a6421d0db8370dd17e5ee767433136eb939dd69ff5a29e7ee351c0c05a3339c70984d5146c198e6922f8c2f41a9d164dc1690b779a25d62d4e1b7edc";
+      sha512 = "2f087692eba683bb0e865b5d4abc712edff5cffae647e8bfe382b2c15acfca481bb56c20f6b14742e7f16dedaf27848e8ae4d5078492762185d36c040c7e33ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/lv/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/lv/firefox-55.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "ae547b8db7236199787cf455d2277d5dcfa7cbd88dcfc226b5f1552054313a4d56144d828ff1819aa341ecdcd84609e30e4c4ce22884493031fde62cc8d523d8";
+      sha512 = "0f6869d9528ba56a8e03e2dd85d8b76d74a359a17eb84c575a94580f965fa8c3d253933b798e2c426f742fe5d8d0d7709a7280e21e7eb41ce3799ee98cdd3af1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/mai/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/mai/firefox-55.0b2.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "61aeb8fe7c8af0b411435868f6ef540e575a5ad6ae353d2d40538c1d50f154534e8216c3d479f838f4eab4d76b07280a8d1a76d2e73ec6a8d32d99bf79f9f14c";
+      sha512 = "31c2449b7127b4b537d407330cb618e1ffc24259f9bb455f95e2b535a4ca17aff8249c77e98e8f36375671390d4225552b18ba21346e3f1062482e8b8d3cc288";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/mk/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/mk/firefox-55.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "778ed9879a57b2e6a8e7fc48bfe109a3b60c4686163ede1b8df225a3daaa9e2a854af79caa3f83e2e756b32fd2d6f5177dd145eaad1d670c4420a4482a6c7baa";
+      sha512 = "0722b24e72fb8d0423e37d47035be6c2e90db45d99590961dea6cd5be6dbc7f1851234f20e4d8d741c4a36b82c31675b2e39884d2949f5134954b53ae6db6ac5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ml/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ml/firefox-55.0b2.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "3a3058ac0a0dac34a601e82209482dbadd2cbfe9228ee64726fe1ec60d3e6c0029b6cedf243f0a82bbb57c8ffdaa17a14f3c75c8300c31ffa41a07a9c390c83a";
+      sha512 = "4944473b377fabc233f30a6269ebf02aff87ecdd02a75e528b8f0c737dba37ad9eb322f99b1ffae1392a67144b737307bfedf0c6d45e65562f964bcb9dd3fdc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/mr/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/mr/firefox-55.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "a2218eae78eb1cd9e27af11dc578302e5ba47530cfb8e05b8518b3c9378eb0397e6409d093742e00708955144e4d6574366f70253ddc9753dbbad53230f27882";
+      sha512 = "5b2bf5731f4a988d1bdcdac74abf00b0633b4f9b63c1b999309d5c4eb5390d0e823d170b7cedc278b49d018d74e6eaa83373ad5c2a26151b78e9e831bf38f14c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ms/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ms/firefox-55.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "46c04289d100455e926c9e54d77ad9ee9f920bb7d928ab11dc346872bbc6fc888e3e4e8e66e1cc2e169b33a4aedb9fb7d0d205ccbb052d9846b14af9772f9679";
+      sha512 = "e96483b5e5800a6a33a9e9d065a90476ad76c94b6e75fe006881c209469e2f37173ef6d67b4f2b2cb216c46ad44bd0db9dcfb9d2e5afe864297e26eee93898d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/my/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/my/firefox-55.0b2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "84e9fa1ae7ead0f9ed4240c4923fb6a4485f81d3a725793c490c644ac0b8bcbf8e2fc0b7675b3d146dbb3f14adae243f1e10fd0b95ff08a90d674166c3af72ad";
+      sha512 = "4d145815f5cdd37666a60b0db476925b89495b1add8bfba42cd15580a294610f20fa340c449c04fa9cd2714a62e09c61e742037cbe26b5f11671eb72dc8a5008";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/nb-NO/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/nb-NO/firefox-55.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "0fea5208d74fc9d4b184413e3f6437130beb816cc21425555108ffbe1c15d2b5bfb4478fd81d81f5a57fb8ab2c90ec8efced100b9c022940b7ac6db701829088";
+      sha512 = "3763bbc87d2ff21b6db0d45b684b91f1080e3dd9fa1b2240edd56c2db1100b66ae04748c67df410cc9c0802e83fcb2a6661fa35fce6e8615a787c280ded8ebd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/nl/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/nl/firefox-55.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "b125f32a93e2509e404cf0e7ae8f21d227d863586869f83fcdb577da76bcbc5c4457bd7c79ca4c1d51046aed6cf68c772c9dfd6447da139dd4abae1ffe97d952";
+      sha512 = "eaaccd4746477ff10af5ee15b6e18020e8e1bf36bea7176cd3ca92903d983b97cea4d73a516a976827ad46dc4a03b000935f1d1d353af90ae205df435cdc3004";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/nn-NO/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/nn-NO/firefox-55.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "155e45030d15bdd1db33cfb862df509cdadea5dd9425c8639bace7ec8bbca4265ed501c608911454001022ed01fd27600ad0b9c526e721b6faca9d30f30236c8";
+      sha512 = "7df043f3e917978b9d2c3ec6128275daed830d1402a4bcb98160b2bbdb98012e5db116b7ae6537206de95f65b3c7472326b7739979a12e452bc045e738071ffa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/or/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/or/firefox-55.0b2.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "dc1590c5d3a51b2a1d3cead15d432df33f58a4de6ca57ca0ff207a10e239575d177f931c31e03294c6a5f6d4938de04dcbeb7e356c73f25a7b9a187481d0a8f2";
+      sha512 = "04e46a2cc75b662404fd5c107a7df37761c6cde2bbe93f040d2b1b745ca6e3fad978ae868536aeb526e26b4af1f7b961e9327a3a9660e1ae9823c9688a8ab3fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/pa-IN/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/pa-IN/firefox-55.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "c02641857f7742ee2eff502ce47cebc00548efd54521f73760c0afda0dbd59190a2364862f3589d2b5caacda451811bdc19bbf381ae849065fd5af4e715d72ca";
+      sha512 = "a5a7a0ce8df208b595f895428030fab8e19eca9b88ae2484e915766376d249e0455986b3a79fb4314889b35f52abb6aeca7e7b979ee86672b85ec777f8ad9a5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/pl/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/pl/firefox-55.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "1baa6b00ee15366413a081172a67fc835eaead6b053268ed7bbfb093c6d3cd0ba4168f10f88d2a3451c3fdb421c3a91962b8ae2523d5b32c7ca6f774c3041419";
+      sha512 = "427a76174ed62b38ab83fdca0c64eab60c8d8626bf350d15c269056d126a3eb2263ce75f6cdd476ffed3c59b27a77119bc28317640d3407e54a2d17497207a5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/pt-BR/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/pt-BR/firefox-55.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "c74567b9c3ba8fdceb309b72c6dc267c8ae81fb5281e9903ddb19f45ca0c10b988b548fcbb7abe7ec67ed4cd314ce9c9d75ef11f1cc6ae3e411f807d8b9a5fbe";
+      sha512 = "6f93c44b4e3990680eb37af208a1040de5a77008485e7163db861443334cd8fbc86ce387341737699dd0f9197df4ec9aa7668a2b3862c133f0df983d1abab0c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/pt-PT/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/pt-PT/firefox-55.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "aa7b19c3f40c376c82945ae4e3a7136127d0be75502e143bfd206e738be1def4edb9173d4defbe0cbcfef59c2c168bcf983a23d721ec61311fcccb4b3dc8ebf6";
+      sha512 = "255a1297cd0c2c8c3f872173276a81a0847f9991d1dd4180555e3299379740a1a65318596c66c8d464dd74bb2b4c6a395fba3f905c98eac3a97a0b0cb4ebf45d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/rm/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/rm/firefox-55.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "0f2452d45e213daefc3fdbf68f92f3ac9d4644dfa33f880f9a0e2597c58e93998011ce4e7a6b6d4add46ed205f5234f5ca7d5d0161336480ec0013bc33582815";
+      sha512 = "69c0e8248a17c54879e3e50b6bbf2054afa8d2f85a7006e6201d6dadf5112ba558d4f8e2839bf65c622dfc55f537aeaaf6fe267e6861317cda6bcf86eb9a3ddc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ro/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ro/firefox-55.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "7de63c520fa69a218bdd602ff17418e8f586343c676d5f0880fd5dbc7185e9272ce75b39bed5d949ecf4112b2787e72b02643c6be7fae2a87ec3124f2ecd71f3";
+      sha512 = "dd696d3f948e3fc5a6330fef299c93d2958daf96eb688826d58f76457931cd69b0a68cd9e1366e52407a2bcc650542c42f592c0b10c682d07faeaae968b0d74c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ru/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ru/firefox-55.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "788a723a5fdadf2cf4149575c860d883858b798af34fb429b3d74d7542d230198c6ffdff20d07b224dd1f140ef84801dbc52962447a26dac9999c397b78da0d5";
+      sha512 = "5c788e031ab302a82cc4b7d51f7f2c7d1aeb9a32be241f4001fc8bb64c2331db391b5013480b15ae9426d970eb80fb95d72e3e2819c3ede8d54f9e47c6bfc76b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/si/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/si/firefox-55.0b2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "3ce0498800ffff07caf920dfb8bb32838f519d6111574a687c2c6e864d0e99d644c2f2c33d2f312560f0c0c3fc50b7b592b3bca8cdd87ed700503323d7398b92";
+      sha512 = "2a87bd1040627364b6830604b9148df4b9c826ff9c8d6a9b8709ffa491503ea25ba32f8e186946021358d66129f0b84be98561be9682369a701bd56ca13d990a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/sk/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/sk/firefox-55.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "73966742be3916d1a9ff31d55071bf50fcb21bc8913d27109f75b3fe63849dd982bbe9329733e9f050d1c884468bd91ed0b8a47cb713dee79929cfc8c1417d96";
+      sha512 = "defa6ba4b5f00922a45d173fd85982e13a099760ef025c202cd3096366e6fa236ecda704ab97fdc3460f1c66c83e3e8cccfaa313a752f6a038118e2420626039";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/sl/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/sl/firefox-55.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "1550d741812085658fbfe82212b0a10408d5dc1ae23fc77441d4559bbc5fefdc54052fc62387aedd7fca0a81902de068a9fe24aeca9cfc338e64ba43e8513a51";
+      sha512 = "adf3e6886f3e500e62f3706ef79e03924e6e9390775b16fe20799d5f7fd6618e5d0c520a8b409b3ee4eb737d8bd2e0f87e1aa8c2b34ee2e0cae1651913215593";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/son/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/son/firefox-55.0b2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "25816528ca8907e502a7fe3533bbd3c8dd3448ad9fcb8149ceeac0c397fcb28c7f92965b76f1586e3a7be53575999c6e013064454f6dc2aaf1405b0633e68676";
+      sha512 = "d6e1e6b2b0fda67a38eb9f7eb8c3bc50f1274fe81118491974372b46fe323419ddb990549c74be040900b372fd52c2cfc193e417714215f8a1b3b07259f2dd79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/sq/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/sq/firefox-55.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "22980b382acae61fcd6cf5ba65fc0f969231a8e4d1cb3dc6d09d1773ebd23eda2b6bdb5da10e752f0f69991e45938046b0ecc0bddd377f7e458146f3de387dd1";
+      sha512 = "a787b2df5b1fd9ba57bfe5cc66bc4b774dd4a4b81d11c0d5f0b9c54e1c72590e58d11688ca0ea64d9775a3e4f65524cbfa9740d990197a0b6972034bd4bac9b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/sr/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/sr/firefox-55.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "db418099ecb1f34efe3fe3fecefcd40dd2ee720a8dc46da1c10ccca7eb27f3e062756a78c9b6c86314f66be641362e8a82cf344c18721300a432a792c9f71530";
+      sha512 = "3127231295510a1681808d4c65735f2581991ef04fc7af8ee705ccf57b556f3e085a3abf0fe105533c608a27273bc659b8ac8941f2b044a1ec8a9b085b0a2124";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/sv-SE/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/sv-SE/firefox-55.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "8ae1fb40b7b2240a014d1f25547f8afb8dbcafaae62cdbb84b027887427fbec6111fc3ff1325d692341b3d9800bcfd8c9036ecfe32a9fc9146b511668c03d67e";
+      sha512 = "a1bcf79292ddd3efa08d2382a35ca00022e7be2930d832523a4f94db9f25b7ca45054d6d6b6c456f3793038fe4167d8659496f4b0bc812ddc8c58a1e83e279c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ta/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ta/firefox-55.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "2e22c50f9905aa744b2cef1fe087332cc17cc7ab51c144e34327153bca833cf5b5783f0adfe5315e2965f30c237729f2093f670c9a00e39a1db8659a94297528";
+      sha512 = "c3ce64381471908f7aa7d4004c8c00d1b05d852c200343ce48cf7d428558d0182c4b13b23190e266269c556165c6f51ed55baa1bad9f55f3c355935c09bc9f3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/te/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/te/firefox-55.0b2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "c2add5e606be0a210ed6af6c06c3e916905d3053dc63e282ae54e5d4209b800906ccfe0b23279ec2cce1e2eec7f40b6604cf21652fdf626dd0e261881552724b";
+      sha512 = "9427ada27b5ad79a556f4e0f7d1fccecec7bafcb44ee19af9257c16e4235bc2078af94acf9e0c0240d11a32a59176040ac54721fa7b934ba12320a67c3207183";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/th/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/th/firefox-55.0b2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "2c5b5e170e75dd7ec9b4e98fdfb2cd6f228ca6aec0907b6ecf837855a2084b9d2e0ec6000e6f82d1bd9b7b09db23afba8ffa6e813060df3f69dae7a5f04d4907";
+      sha512 = "83276f41443e931b7e55914fbf32547ab01d58f9d5bce5335cb931b783fd9845f20514b76889f82e357e489b65afa3dd0894544d4004625df08bd2021aeba8e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/tr/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/tr/firefox-55.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "a16330055ddce9502e69b8ddd6381ac421836ad98d0002591cf0ad28ea199ee607ff747651228fd2e5528a9be773aa9fa6f0ac58e57d13996e104a0c2c6fcb34";
+      sha512 = "c93877ccb3a0d4ba9164363b869577a5cd36d85cb05a8d1ff882fac21e333b7ff8c4597647243de753c037525f1ad7fba21dc1acb2ad212802b514af9402896d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/uk/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/uk/firefox-55.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "e9537030c06093d21230cf8e07913f05d9b02a89d31d952debf558c346d77b2cb95f3129a9ff6a249e3abfd769d41d0d67a57335d4dd39b1ca1c13eb9bd6cc9e";
+      sha512 = "1512592dc0ec9a19e2e92fd39db30b50fb5b26886c1683038885c9d7b18a863182dbe1cef7b8265aaa82e60dcf94c45b84892ae19a25a8a9339382ddab13e327";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/ur/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/ur/firefox-55.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "754c986845dfc0d376fdaad04bef71498982259524a458cf1b89ab84439cfa4bd0ad6d7092e7499cc91e3eb45dcfed3f93a2fd1bbcde5f2b678d17fa4d62ee99";
+      sha512 = "3a90c751054ce848aae996641133e2aa573c4d6329d3dc58465562e45ff450bdbe820828c551de71f0719210458cc71aaa4d0d3745a7feb27731f91befcff3d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/uz/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/uz/firefox-55.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "ced181d692de83928a297f18bc62391c9ad9c05b27d0d9e2db3b9f0c7d37d726eb4406837a4e223534e15358fce4daec1961fafe284ed032916c39e49c0880f4";
+      sha512 = "33d3c67687b235c231e09b6564fa525049e1d99c37c3a5fd6905feee5674c305af313d381eef5af990e878fca36f6af0cddbb399a5a297affa4e3aab5f3c103d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/vi/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/vi/firefox-55.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "ebd4bcacff95dcb7ac6a58da2ede2b4fa7d44598cc96761e870e49d65c827f89d5fb7b2b144252026475379b3dcc88801a46de8793a8b75f17997edd56f90679";
+      sha512 = "8dc83c33bf9e27dd0605c945a746035bf16a189b6d5f0e52a9d65e4f45964d8fadead1b539d9b906ab13cd43a7b2157b4c7040c1d155f4eb7aa67dc987819a3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/xh/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/xh/firefox-55.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "80d32cc0d735e54691b1c4cd59cc1a46b187dbe4e2b2dc3d3738b66b5355324313c7c5e61c778ad058b236e48dbd8238a1bb796cff6185398515a9fe5ca42385";
+      sha512 = "b0535a8704b8879b86d27cb4867f13269395ffafd54a5acdf49124808f9c606f52cdf9e64a6378fc0cc37a6eb4f955b3613af07076567a6bde71a5e61a521c9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/zh-CN/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/zh-CN/firefox-55.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "c63f0fc1174d40dbd2c1c57d92cf02d594c1a64ff12e90b5a58b28d7ea991fcb615a0e8029f96ebad12c59ef1fcea39575ac58b69eb25f31ec4d5c9de5cf72b8";
+      sha512 = "17c5996c8002cdfd0b07ac796be9b437582cb0c5401fbe0f405dd0f8b4aa3f45aab24bb5a8f364320d62550eba7d228e1c20bc7805e741a86666c225db3046cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-x86_64/zh-TW/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-x86_64/zh-TW/firefox-55.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "54fed20629960f34306e290eb60fddb7cdf20dd7b95a21a632557a41c99ca24cfa03215924138debe7c6aab9772197a0680f6afa3f35da841ae8df553349ea18";
+      sha512 = "68d9b507ac39d9e175285e5bb4f4f24396687e57622ff31448cf77d73ea8e8817230b65e70c493121b40f4ae91b145be59eda2ab9d572be3d48c14ddacfb28d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ach/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ach/firefox-55.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "baf49f88f15e62a5b2a60c8c09f1cdf8e414083dd816403df8ccc4fd760e74e66b2b86cbed075ee78a504e03cf6de5e90d92a0228fe0b3e889ea301758c8e95b";
+      sha512 = "e6b59ce7c5c6289d57edbf019e74d2529b2d38f09552110a50d94eb82e7470103791c69c59066405b8e5d1cbf5058730c3bef780cab7b95444eee756b593eabc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/af/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/af/firefox-55.0b2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "39d3f8fe582222fdcb2e2435cc02806bd34637deb2377276faac5dc30a7df0bccaba1636e9d04e86ff1ee4f376e7da4eab2d63cdaf00c4a20e7c048c76a39e38";
+      sha512 = "38393317412a3310ce7984e77a5dd12a70edc3da8691ca38b5133355c1c60e2ee61a12ecd5af7ea7b47d20f2718da2bce56c9b6b8b056fd75f9b93d1e196f52f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/an/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/an/firefox-55.0b2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "3045e008ec29253728d6dd9fe99f220aa00555c721747dd684a6806bc87d60539e79c7b547fee0d3b740df09ebb8febec9e44961369d8f614b9fb34b8d04f1e0";
+      sha512 = "584ffa243d0d070aa642d3b0e5fa4b7db553f68032d1f0f251034f4c636529f382451930217da9a3fcfa62e7912108f41e280a2f277b5ca9faa2b05ee0a86487";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ar/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ar/firefox-55.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "c4b147f35e18d3ae864d641b686af9dfe25d5ed58e1b84df16c2ed0f4574039549f71b019d2102bfe60a5c84f2bef9ec20bcb4f56d914ec69b5d91910e7b6378";
+      sha512 = "b04ec9e9698e2c70149c772818a8c4ba2e0516e3049b31ea8fe9db3b1f69724094bd2c05685a864f3364978362eb89a51b0e15e7931c61ab3cd4693dfa8d7517";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/as/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/as/firefox-55.0b2.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "3f8b2001af4064b4273dfd543f4df1f6b534df9b5b56fa6f3ba2eda0f924757b4ccd567295ff5874e463e330be1669ef4d5850f33a1e081b0f077b571fd90dd4";
+      sha512 = "2f76402d2333572483ac9441faf070bf55f39bc22a7d995c6e6f06e7f478e54209b1b61fdea9a350f1466b508c35a5640a3db0c4f5f0451de14e535dbc4760e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ast/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ast/firefox-55.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "20575f29d9409afb7c9cbc78b1f2a16e975b9844fa9d47946fc36fc3d9cec14c340b97643147a6d021a53daea07b22e0d9b791caa954686ecf573c98136176c9";
+      sha512 = "1b5c6de905494d0773a7089df87987435b70b5c734de77a6ec44ffb941709d0e8713c54de8293c0f84a77a96fc3b7ca11e9ad892c870236c24a86031e62e35e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/az/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/az/firefox-55.0b2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "29f374dddf442ae9abcce6be49a234a45b95987dc547e76eb9d3ff7e48781a58bf00303b72cf13624ebda702d9dfdda70ed594f17d59d1573783b643b54f2241";
+      sha512 = "d1ed01e6854e3ab1f8e8f339e7d4c3bbe4941ccda88090e09a44eb8828a62e59749218072fa248358c073ab76e84b18d59cbb3cd39550834de9e8c91b81a8477";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/bg/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/be/firefox-55.0b2.tar.bz2";
+      locale = "be";
+      arch = "linux-i686";
+      sha512 = "807a7bbdfe7e556c4f8071ea8e148cd3cdf2cc32c6c00d91a0563ebbb378599debd0d3e0a5f96f75f4ef0bde552c5050c8e798f6d1bb65a37019aa0b1b61b55b";
+    }
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/bg/firefox-55.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "a2126b3a3875ae62b21eb2a0ec840f0b5f0ccf8c81c945b0b6f80fc0ff5e2aca3cb6cb9554bcc8737b85d65fc6494fd80effe9fbff277f6f5a7fbbe4b8eb6477";
+      sha512 = "fe499058210285f65d81397d182b7e37ede56e60ee21cc7e0680fba8c9dff58a0e8747d6c99e789cc2b7578bba62b5a04b83d1cd1f8e533213ee3ece4957acba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/bn-BD/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/bn-BD/firefox-55.0b2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "7bd043b9bb24fffb8f2a8a288ccd67195d36ef5e3908ce83b559efd37278c2d7275a85341c03edb42763cddfe2c95b917387f536738b7f8b54c743361045a2f9";
+      sha512 = "df14ba0acae51673edcee4e2da4ebcbde1f44e615a56777712b4bf1261c49a1007249b4b547d378906b64e4b97959b53285bd5d0c074fd3e0080537a5ef24c1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/bn-IN/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/bn-IN/firefox-55.0b2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "62218d525722f55e1ed9ebe86961311573e53a08eb87f8a459d44e08f2a2e627fd0bb8b67c4a8de1b63fa14aebede187428bd728ffa68caaa8390c46d5bf148d";
+      sha512 = "5db62ceaf945411c01066e244fd08a95ac72134867619c488f54df05659e6e335af77c6a5341370cbcdfc7c9142a5654aa843b1a392a1531c10062052cf97c5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/br/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/br/firefox-55.0b2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "1638a7b3091f243adcbbb87566eaa8d95c5a6c315b8c67263181e33d5e014342e3f062da4a749972dc36da029d15cf10a4762ed607cccff934c19a9acc3d6e72";
+      sha512 = "02d4f4a010cc1ec71d93c1b6236bf891b290bddfca87ce9502f12f530033b26b94a1ea993f591911cb48d52145f2351a34be8b63b67a74498f6a10ee7744cc75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/bs/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/bs/firefox-55.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "e577bf44f0f0cafb96a33f8aae0a2b538ebf46d6bf3be51e4bd59e77261b4022f45619ae098c66c11546dcfe6baf4b596f1d9ae7f4bd1266c3786310567a0487";
+      sha512 = "458d234394e79ffb87fa3181c6722c63eecf19af4e6c10eaba372f01f4209db60ee01d932fddb335f0f1dfd2781cb3e651e98ab4e69b71974316be78693d05e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ca/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ca/firefox-55.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "dc0dbc0b86ab3079863dc37d62851fdeda415728546bc0a2799c9c0546df258de0ea47968ef2b941e443ee4110cc8aec632eefd6879b4e76be905f66981d0290";
+      sha512 = "cb0e2dce6a8dc0c211a72bb4e868bc3d04c2baf19478ddb4af6f6adf6c97b7a0ac334017d7faca08d51185e3352140b13c818b2a64f1c74956dca8aaba1edda4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/cak/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/cak/firefox-55.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "c1c02e89db0421c9f1355c618cf2831ab54eac9fdc8bd61efa5aadc37999b28e2cb91c56edef23748141becc36c4e315a9670856323ab7abf64fa5b37432add0";
+      sha512 = "984b28925fdf204b1d0dfb4080f503a520ae38288370ab2e36ac1f32e579b5fcfbce3106896a351472dad078de42656c566bdd56b32088b52fe4bc6ffbada247";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/cs/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/cs/firefox-55.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "8d8d2f7cb0f352c70681b2deff30b23caaee1247e11e0b6ff977fe4f12352db8a3fcf2f4c9463ccd8c3a8631be7432295fd82f74aa2ade8a67bdb89916e5c57a";
+      sha512 = "18bfdd25f92324a7ca00183f47ec0c43eebf582ba4493a36b6b39b7f178974333df29a2238fec5974baeba271a3f83ff3f274ffc15488c24e89cc2d17766ef64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/cy/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/cy/firefox-55.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "9ec90347d3ec2a1d23db120f309bb6a5266b8c6cf85004a97cef798c7ce14169e28f752dcd6d89bccce7947cf0be04457c8e96a8cdee6cd2e4bfbfc84193fd4d";
+      sha512 = "1aad954d11eb33704782e1ae502d86fe9c428c9cd0d7dfad020e7510348443adcdc7db789fbcffe96691e68880da2dde1ee331d5f51503dc90b839f14aa44ebe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/da/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/da/firefox-55.0b2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "ad20e0ca46c567d8cd27a44af43c7c8855be4cb50905f7697a102af7378009449ad940cbb66e24b9326136ec98b90782fd569ee411951b5313c9444a516a4184";
+      sha512 = "0dd9a02adc2aa39fe5ec4ebbd0b6cfa0968b0daf50b558d088f1f0680cb06a8baa526ebf96fe63babdd8dc85561910a5a6645ac11e02e641361491a2c9185738";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/de/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/de/firefox-55.0b2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "21d414a1c906675cc8eab081f499438c5b01fa1b535a048ca0538815403f18226fe8c7fda818afeb05128497dbe1c53d17868418c1e0efb92dd41bb112496ec8";
+      sha512 = "a3f13abc0d8ccc445a495cd87cc690e5875c9c79aebdf6adb04f469483a5870d45fe7a61231bcb3ce07eb64c38ef04ff6e16e75c4852864a3ed1f385d3dfb79d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/dsb/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/dsb/firefox-55.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "d7472be94b33967a8f65764e5afcf6ffc8762d507d6fdebdc87aaddba28bf0aaf1b31a546c69adca4e53effa0a349f5795ba2ac52d51f2726094a4901263a042";
+      sha512 = "e5bcf46a200adfa34191063503dc5875bcad0cc298f9ccecee7a1346c15b22dad5aeffee2ab7d17b98bd3cd659544422c05ee9f79ff8a0702e592b7d1b8e5b32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/el/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/el/firefox-55.0b2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "ea5e5520cf1559e92bbd0b94f5c7f8451e1fd53c09b92d5aaf2ee2e48c1693cd9b22abdf418ee1bb1551768a7ebc220903c1b0476935fbd95cf9476b7b6e5a30";
+      sha512 = "eefcc3ebb84bd75472ee0614d386a5bfe718a77b2fcb7e4296dae1131415e6541f3158b072314e8aaf46851ab718d0bef12339cdfcbf1ce4d1ae19004fc82153";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/en-GB/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/en-GB/firefox-55.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "3e685d42bf1156dd736622b6ecba811dd4b3333f6be268ec616961088b2784eefda7ea0fae8440d9ddbc2a54507e90f33a801aa885baa70bbd82f0d2e0b206da";
+      sha512 = "c03a785ece38365eb69893ff4346f468199ce8753329c781241bf6ed96f595696c0927285db41fb00a15cb548eb74c66696e3962560c5add5b0be7a29936c8a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/en-US/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/en-US/firefox-55.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "f9fce327dc51338160dfcfa22733f299df0598e4f2f2d0f86b7376e7582d10a183bc8eaece746bd7b598ebf0f07efa35f61ce1c5996e35d4d4d60a891a14d01f";
+      sha512 = "26d4b175dd8ce02cee25c2f8d6eea4e60ec3ebbf4858a185d38d3593f4397131fbb60208043f4c53affbd075299c69d5916b4ad55b910cbc8cc15952c78d9b2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/en-ZA/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/en-ZA/firefox-55.0b2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "1c6378b8c5ec23b8988b9232175213151adcf6b60c9d7d8f36874e21bdac58b55d788d588ca99ac7dbb235de619cd62fdd66f607f467fd681dc0c0dfc48e4a0a";
+      sha512 = "f99136eb3831a304ec84044cda5d5fdcdefd1a4814f6372c9edfbffb98d93b551d0cbc8fb45e8386f251eeb0f0a4aebcc12013267a901c2533bcca197ca6b5d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/eo/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/eo/firefox-55.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "8f991d8e5a85e7890d868cdd5683f24ebd5fea2ddd01de9efdaeb1d8978c81ef36084603e76f487fc844a4261d65a467471bf30910ac9b0c33dad874cd1a5094";
+      sha512 = "3ede053c3018b41f113d64f5d5dc14ee1d2bf219e1d7b37ae7ae8b36aab349b1364331d7364850cf40f7913294119c85468a8441f524cfa6f18fbb55c4bb2644";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/es-AR/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/es-AR/firefox-55.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "65c1099c7fd660ad90d12a0297729c6212336b9e06f96128fbfe7c52e419869d8db443cc19f4b61e86e4f7ad275952a7e7d570361e7829927d4507e20b95a964";
+      sha512 = "51736e77004f5c9cbe4f303f00ac6c32c9459e55a1cdcab958ece590ae8d575f119ded5bb013600f077fe388e3572d01f31a41f462defc5407d9bcb6da743fde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/es-CL/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/es-CL/firefox-55.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "ffc3863b8e25fcbcebbe01fa0ba28070bb97813f87a5f4f80eb25c7bc96df133140ed9a646438618ab297749890d0860c65ea77284ca101903b064b975a5e2a9";
+      sha512 = "9ea21d6a5b9d0eab81eafa1a5757aa566b806fd16a925609e46002ad126a633d2373fa8ef27db9388c3f6f4680dc76b946b5ad9f71afa8dc69382323cf1dae22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/es-ES/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/es-ES/firefox-55.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "6cb1a2b2c1da715733ca83e9a1af5e20c313887b1973010b1871be3e5b1faa35ef81c4e3c1c0084d23bbfb2b9151cc684179fc285852115cf3f79fc3538e93ce";
+      sha512 = "3d77e61ddb1738c24af8edfd8a2b9905732626ffb51d1c64b2a27c229121ec8df0e7ad61389ffc0c78ed545a6ce8ad9deb424f65c6d6fcad427753f9cee6f1fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/es-MX/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/es-MX/firefox-55.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "f54c7a2da3a00cbe3c744e0234ff8f258a37f67590f92a271df313a87de1f15c05387b83525dc01029fcfa2db536809ce24cce1d067c765441d6fe6909aa6eca";
+      sha512 = "155eae1468c3f4ad4a38e3ab135f79e352da4e96b1f1bd2a20771d9eca6e4ee89a0bf6db92c2a3aa4ea92df8fa41cc63f35d3b78c3f14fa4ccb4521d7fddf102";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/et/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/et/firefox-55.0b2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "af3ec37d2edf1d0f0f7da6de779923b0bc446a066443484241783b8a76fd96a8b2ae7044967b3d4854349fc6f0bd18b2032a50272ffbebb1a53f851ec3d2ef19";
+      sha512 = "08f8ff1dfc92fbf4d26eef4ed6b05caa6b911fc8a2ef1c655fd6a6216a5469e3086a514deed1b6722e6207a439feac717d3df851caa08f71a9796033b6292a90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/eu/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/eu/firefox-55.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "504764ad92b0250b203bcf8b42c6c2eaf0ddf4ac0b5a3419b9c4d84f4ef4e50e3275079514aa89595a3127162c139078262bc90e0b998922bd2c06f8a90f9f7a";
+      sha512 = "407844c56a06d6464446390d35cba2b0ef983084beecd03f4cb9ea93607e0571be882b4ebd35bb25c6f2fc4f65bc64321c1e6f522838c1dd68bab46ea9bee779";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/fa/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/fa/firefox-55.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "8c632dc5b05a2b0711e917a4d3599775bdbb59aba448f408660e7df02f3aa21313301b4ff8b4237ab7ef9c6e61c5b3331860d79413abfe447dfd262ca4d817f2";
+      sha512 = "f5c27b8987623ce46979083aeb2c7cbe0efb9e92c2df6909fefb54e78a25ac3792d78605fcbd50fcf71dca8d09b60c5e92dc4ffce22f3a24130a0e1e5fc13918";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ff/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ff/firefox-55.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "b37986236fa7467d513b643534e0b4fb7e9676dda8856b6600ee2287b671cef974c4fd781ea1254e20ae66445168e2fdf2fff1e761f489e2a0fd6d0138adcdaf";
+      sha512 = "12367b1f896f88a06c3eb906a10a5b288fa6b3d689fb1a452ae93677e37ed89957499937025d50f29ed808b93c359bc9cffced49e013e95a588e2828a4bd3d65";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/fi/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/fi/firefox-55.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "57164b97daf88d76e7e3fe73463d1b583893165dcd79ddaf824e76e0e8fc182f9e4c168ba5a78091d5f2cc7af0b36bf538b056d5837a5dbf1d53d0c29c0de5b2";
+      sha512 = "40ccce97079cc5ca9a7db1ab2aba581c4e92d10c83748c654e48d922ca14d28632bec850d138b97c847e9325162bc34a20d4e672aab9b191aed7f5784dbdf814";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/fr/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/fr/firefox-55.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "5e29ce0a9890cd6679a0f7b2b074f27d8a0f4c0df00c0bf15fb07dc5ae7d4d5147a3a21412d7916c00c67befee21febc8399045ef90f9c776d77853488551d1c";
+      sha512 = "5639d6800f4e8265bae4b3b49fac10312fceb04be944a51c11b37c33b49c4f418f0c2a6481ff0860652adfd7a0259612be93d784a802769465fb29cf02780c6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/fy-NL/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/fy-NL/firefox-55.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "023e82bd8d6fd4378d88f063b28b92254440c9eea4306fa046b1abf31ea91d43259ed55c330f788cd686d152e17c1f94626eb05ffd0cb27857070ddb8d546298";
+      sha512 = "f73acd20403e4cf38d365f9b49de1879a750f73ec2842a3ee91da657c5fdb6eaf0695540efdbf3e67cd72234cb9007c2620b3d146a5bee72e30453c9fc6264b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ga-IE/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ga-IE/firefox-55.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "249f6f582f5cf7adc8cd755e26c44a3d48712b10f65a436cbb43332dc7a72b3d11ad20c4d456c7c685d174243166ef1ca11a834c155f691249bb1de4a157b996";
+      sha512 = "b588a3a9782621b33d9b43e252311e78bee1a49b290bbe055cb01b45eed1ecaa79c8cbe326a4a462a632a4452978a2978d6ac73f7d56d9b4b51aac479bcc5c0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/gd/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/gd/firefox-55.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "447a9ecb093576cad7dd24f9c9d8656d31d4b23db33f76ac35325bdd8cacbf0d64625734aaee4d5849b9f450dc7f4300af8ea284ccb0fdf9d1532cfa74556613";
+      sha512 = "ecc2d97c4713a3646a3c38ea5cc1245ca7a0bc690305bbe0ac3d9b09d903e27265cf87b73f1baf98b50547b321ae4ff984bcb4f9afc788efef9b17962c9ac28b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/gl/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/gl/firefox-55.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "cd0ad5f227caa5bd3213ac35b9cb73c315b23d9eba789a192ae21265a81ad85a5718ab088c1ab9ef7242df5c3e03271be333a59c40db55744de1b5be3e066e33";
+      sha512 = "0715dd37ac757f9c70d41bdd0faa26cb6f45745ed17b9e627d51bfc040d9d637f236546cf1eae77c8cabad59f82bf2bf95758e5eb675dd9fb6813eb43214163c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/gn/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/gn/firefox-55.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "918afbfa4fb7cb8a553cea7638f0ae26ed6cd360e5d1dde81c2699e4d9de24583a126cd75ebde7a6b4a42cd9b220ac1472a1b96d9c63ce5c53f241f6008a2264";
+      sha512 = "7617f00ec13a6a672b80fda28108e467124d0ee22b5e0dc366e2bc04d5be5eab91c9ec4edc275df7bc7ccf45197629fea909e945c633f58f88c8165ef2628b37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/gu-IN/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/gu-IN/firefox-55.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "d680af2d9e62d7460d1c683bd17ca079022e3641b14d2c51ab1deb226c6f68a9f0228a0a394b683d4adf27268cb68af87122725f4b3e6556a61f231a1472f2e4";
+      sha512 = "15e94de3500b185668ee87880667ebebeccb23bf69c324cd64c9a5f94e6ad1844861c773eb0a7b7479c169de63c8612845902c8c468ff670b37684b1d6059d1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/he/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/he/firefox-55.0b2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "a2e79d3e819c6f161d9d03b3c2614968de2d7ae266c56ef928051a8682e3edae2cb76f850de3a33e475757570f79d2c6cb580781424c03f1453d9f82c558e7fc";
+      sha512 = "86a94619d93861ad797bd9457a768f62472f980076d0d526a95e1caff52cbb0136abad76825e191003ec55611429f2b35bab9dcf4a1d62aa226db89261e234f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/hi-IN/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/hi-IN/firefox-55.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "7a4b6a513e70b0645a9b96d2b08dacee9f14ab2d6209b82937fe4bbb7b08b4af64e513921baa17384e66a5f61c18f5fb20c4f70a99afd878cbfa1f42a33befc9";
+      sha512 = "639469d7c987b366a5be59b45058f8aaa2e5322e0534a4784c19f434d48ba5cc7e6d2da824de48d49e09a56085521e16680e1cc29261c97cf18cd4dcdfc79c27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/hr/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/hr/firefox-55.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "102726454dbed95a25e17a5bc438fa5c78f3c17fac6cb91537007c58e3d12199e0341e6726c16dbc899a6bed37efcb9acafba6ab1b73347a7efbbd7b9e049143";
+      sha512 = "8c4021a8591de29704240d152bfe3283901b405e8b4296196eda3f0b9591b33fe8c08871c3248afa82c3967c7d025896d584478d1ec3b761ec5f97cff498e098";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/hsb/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/hsb/firefox-55.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "6aa930b7658d9347b2f17acd829d71791e289aade826614d6515ff5f8596ed9a95fce0a63df18a98ca28e1dec7bc15661f2f55905241e698c27ba4ae20303fa9";
+      sha512 = "7316554b2d0d3b1cd559057374b67e9cf805bc827a40652e70d00bbddbc892f68c7e65fff08af2d4742115df124185c3e3ca862901a85ef56ccd658f799ac757";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/hu/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/hu/firefox-55.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "c4db23836c13f371027145bcc1e6c9e8096c8299c0007fac948ddf46ce2099f7c1a5f0d8415d6cf42ca83cb08cb61f86fd3927f07a974055517e8bbec72a7894";
+      sha512 = "1365f7b1e55eed2fb7d579fb2d9a2efb57d93a4e78051d57980e7b1bf3213b2f577eef6c0f1c53dcb47a7af92ea0b0ba9558e25e84c72e0f32e573c393dc8d4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/hy-AM/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/hy-AM/firefox-55.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "b66112e99b41c2c357d285789f636b9f6f4da848ba4ca013c7d24f7338b1f724f6f81651faa9f82bb082a9182ff9d4fab442eae581117d2d02493f215bca621e";
+      sha512 = "14e0a798b4fd9af769a464ff8c2fc87ea69116f7ec66326cb623f4fbdcf4c99f285bb8e65492e9b65cbb86dcf66a52669bd81df37ed00359546072a3709f20f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/id/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/id/firefox-55.0b2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "d0d9b990e145730396a8b88bacbecbd320f3ab9f2e07bc9f56493900b93693ea7ca04ffd077229e488c847014de8cf16d481ec078a4b30058eef73903c5dff9f";
+      sha512 = "dc15d01a33d3fbd10f26bb9a1758df13f53aeb9f6b0a62abfe8bca1e7a3e233aa0a06981d04085e79e91c629a1cb51510bdb744ff34a6522f374444c9bbb84ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/is/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/is/firefox-55.0b2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "a23c64f8dbfa1c5a6bb2e31fe2fbc80d02485abeebe57e091cf101355e07532fa2e1d75ba91f4c5a0cb112dd941440f8f2b83cbeceb17eea026f29bfcaa37779";
+      sha512 = "13761e766b5fede7eb123f304bca45bc3a7cf5ffa4661e2a961ece5653c2986a61aee742cca3dc0cdc8bef54b38a66b08e9a45223e42cce9c0a99a857d6bf45b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/it/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/it/firefox-55.0b2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "e7084183c5bcadad2eab62db7276c1342522da64996f442eb9ea0dfb3354c5f75f19acb53d937d055d8723b68b4445580b7bcb8328a063abd601614cff501542";
+      sha512 = "23dc06fc36ef32c148990692ea5bc5266f1ae61aab4a3853034f85f3debee5ea5a5a71d741ffa29136db54d63857edeeca75805f9c7f75c278f06a6c930ac248";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ja/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ja/firefox-55.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "0f8e6cdb01c5aef004ea12b63bf24797276676ec4ef0a3bd63b596552322a33cd8905efb075259955189ff5952c99738a1017cfab8dde90ffe90d978182f193e";
+      sha512 = "f33b38709a7c4701debf19a901e36302b364c911405d96f952c0510fbf95fc4e24869a34e3a336718a0e0f26b5c7fc88fd1a3955c329a352bc1077b73cede937";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ka/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ka/firefox-55.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "6e1556802092f186cd57edc995ce53b596ebcc70fbf37dfde19fc8884441b5f84431e9c8b023c93578c538ac14d5d17caec96cbb6178f330f6105f21133fa07c";
+      sha512 = "7b684624e52e189ccfd31d6d910b18148f9040eddfe0518710388dbc1160c2ac068f0de39faa42eccfba7823372290f932d3693ad898a0c7ce20f6368e696f1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/kab/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/kab/firefox-55.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "9e25fcd718b65c66c8e99a5d63d06603e120f518c36cabe47cbea3ba9d2b4b61d9baa805a13c7860cb22405d8a5c2978fb2fee1e911dbd2d3d87ed2d25b4aa95";
+      sha512 = "9a9f8ec3cb7b86866dfca4a4f5ac25e13135896144af816ed2242091fa8719535a7d2c225be6650cdbe17a9bdc7bd2bdb962e40abd16428702c2570cd06a798f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/kk/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/kk/firefox-55.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "0411b45af993bc0df101640db9c13b8a041f9e73712b3b41ce8c3b92e0174d366279e8e61a286982ba0214ed2dbbd6b23bc940a2f06947bfa534d8fa9f3574f6";
+      sha512 = "c7aa9195a8bf39d65deeb4233139c6941433a7bef77797532fa346b509cf91c8e2041a24569996f7a5e7d2fb0e4a108bb40337cf1283195b257a5526d89b3bf0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/km/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/km/firefox-55.0b2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "621de21c64bb7a10aaae1bf277d2a869a2897270f6075dce9c543b6864be03221d278aae9b6ce7d67af5024fd9c5ce807e7f6c9e9c5b9eb8206c5ada0460fc70";
+      sha512 = "45a5dbd1ecbfbc69a4ff99327a234e9b26f06b9e280cdb2e0689b4378a84eefc4fe3a511bf8b111db873ccf39f7b99c1d256218accf190975d53ed574d565747";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/kn/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/kn/firefox-55.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "f446dbacccb0bb89c48137166aaeb2ecb781f11441b6610508cf3119759cc8a1c12ea713e231e6c05ea4001c2e7a750d2880765ba09315d3c593975a7bec8035";
+      sha512 = "75574a88816ff42e8f20555a55f41bacb9d33d2535843b38d3079d0487bd1190b392e07e7d97f288c51f38c053bbbacc7acb34a835a7ae39814d6ff2ebfb1510";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ko/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ko/firefox-55.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "2d941257c88db0617c230e877a48fa54a6753cb1c46897b92c752159e9ccb0300cd7916d9854e7671688394d2e147330fa97e16a716ce1133b0f0c37727a1553";
+      sha512 = "2bbe4f990e2265e1d210c52987759486e6127a875ee55707bdd8fbceb44943215c28faa5f6c06161db7b7f18c2c2c3864882ffcc1eda286edc59aec7e33aca0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/lij/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/lij/firefox-55.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "6705fa1ad8aa7fb4a463561a2c91c8f6a70d491418877d3dc6a9d98c903f3367e649d66a6f1b7b1ad417fa65b0cb44a792a49db479842eda27ab5bc5791bef5c";
+      sha512 = "9c3580a05057f7e04f6efbf60b281c50b64970064dac547cf6a84ed305c8dab5d014f96719e70c87e67124f61afa3e1a44ecc3627fd6a3181e3dbfc28ed175c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/lt/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/lt/firefox-55.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "246416023a4a2c8231ac60a5339c3164301f2d51a2ed6bb23f58f0715b6eb834f874b992268639e7d2000ec41a404b61c5ad191a218a3fe68f09244bc8fd8b3a";
+      sha512 = "37b30fdf603cd41617db37cc9ba7e546c58a6bb58833b461fdced4caaf128bbc1a36ed774370548b8249da884302bfedf52681af61348313c5599628576e9c57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/lv/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/lv/firefox-55.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "e47f984c68e98927e15d66b62588f8a159c012bbfbff931625e297e28c8a1b2ca06eaea60a13d62392d8fd5285b2fb0cc42c9e4d68c1123dedf87964401d39de";
+      sha512 = "7d075198482100a338105bb80d2d40d97d24460f2a6b15b72b349d249ebb638112e69bcecbf32578375d5621f3a46e6267401629d2fbe1ab6dc5d72dba454086";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/mai/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/mai/firefox-55.0b2.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "7bb51a53327f85883b3aeb58a00cd78a5921fd6746f2110a22eccd38d735262c05d97cdd84dac1dfa29502bbfe333ff365d7ca163ed4f6c946156df11dd5d9ca";
+      sha512 = "7e052470a133931183439deba29a16097ad50383b63f97d5a1c03b7a3ce0c6485811c1afa2ea78bf9f03def2b0678bb43acefb2c1b944d8c12ee18e44b5d520c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/mk/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/mk/firefox-55.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "e94346e4b53c26523f2de965f4e0de11b835cba2dc19553a3a58cb789b9b1bcd146f37fb932184b9fef6d991db04f7dffdb9b838db758e159f654f6c24beb196";
+      sha512 = "ef6b8ad5fdeb7300c9676a2232accca1cac1b47896987455ec93ae8b8cf46dc092e224b417f922bc4cc0c41ce941d607c4c3fde6e305e274750af72b8c405389";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ml/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ml/firefox-55.0b2.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "1c2aabf2587e312ef071acd5e97a508ad2c5d61f3bed5ea36eaf47758ff60d5f46f9966e09954c15a0bd389d2351f3cc4fd36ccbbdf8fdfcb1cff92d8832e56d";
+      sha512 = "79dd88442e22ec9b98d432985deafc68b6b5c3dcadf6fa0a04292b019b3245c24b2fd08784d4c4d804c3b913bdf379753df4ba24ec69cdfcf9fdd659c8a18e4b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/mr/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/mr/firefox-55.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "0f04e81a05c37ef0919dc03787ec069a78de21154fc167ebde8c256738cbe23bfe2585e0c76eb8a4687b6d17bf69efa6fc142de27b30c519aa446e34ff6c52e0";
+      sha512 = "d474b05fc960f2c12319bbf994027945ed655bb8b6e766e1ba04f9c863e4d5b6d1ab8d632e0051d1191bbaab87e4793e8c1240372b9b0e0f170da03856c5d8d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ms/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ms/firefox-55.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "82c95552769bbde10239ceed7c5f37d3d2dca19c7ca4556404e5340253f8396e66f88577b475f7f0d6a367a6ab1df556bcdfb1859ac9b673604555a396e391b3";
+      sha512 = "c5372584abf3c3ccf858c50927d26099504efa43feecf487639ab7a73e87da6137e29f31a440d7b6eae43092701e68c02325a39207f95c73fa2db303c3b402d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/my/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/my/firefox-55.0b2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "af03cfbcfd4594129a6e8812136c5984a62ac09aae238432ae69e825e767ab22c720005350fad22a0d3b774bf58e460f567c7d4438d32bfd6370b44f5fc19869";
+      sha512 = "e5374a80b05eab9dd8b4a279ac96edc52930ee730a9108f76a022e3908f5d81c3e5db9ffedcad492edee532c2606982a6c76733a971cb5d8f64ce68d04b113ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/nb-NO/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/nb-NO/firefox-55.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "33216bfcff1cbdcbd1aa656614d442a1dde16e033954065f7cbabf5ef065cf9f1722f4ce17989c3dbb822aa7b2e21818b9e7b25e0ea0da9bdfe157d6e7713547";
+      sha512 = "5077c2c497fda39bca53fd140241fd9bd3cde4f4e1ce3e7fbb101fed4a24d61df81d99db40453d4745750e24499382afd83e78cb67e82bbbf91158505472472f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/nl/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/nl/firefox-55.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "520e225e72413a9649ac0025a1c3fb9b58a2bbda0d28aad15c2608feba53e53e61dbc7f06ef22e655c3c2b77c0b1be853a79057cb08afc75900bd852ae8077f0";
+      sha512 = "9eb8e46b9ea30e2865a009beed1c4c515830b1acddf79c2a0c035e8005dc646f2ec1d011474cfe53c07f3bbc73071765e7a88aaf0ce24378b1501cf5f246b106";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/nn-NO/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/nn-NO/firefox-55.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "c564b555844d104a82d6b02e35349778fd0afdc7dad20d8560713a1f32614557fe3009bed29bcabc16da245825cc6a4281a64ee0bc82a78d4b45b21a887e8d23";
+      sha512 = "afe2b9c41cdd692b9166ddfecdb78ab94a3bb91d60b91e3e79a203a1f928a92d40eaf7889ceef19427dda1464155f85d0e166e98bd9eace6b071d3b30f954071";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/or/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/or/firefox-55.0b2.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "1ee6ca370ab28f36fd379daa2ba4259e715d6dd5905c72ae6ba05eef5eafd4ce08511c4c4134ccf640834e053d1993bee85688c108ee4cbe89ea5f8acad11f9d";
+      sha512 = "5eb2662445fa000b626e5f4a0195a44d8e00c630e09fe386eb7d77fb514b2ea939c07c23f299ae050260c06e6e68abda8e32a2ca8c5155e5f1d5e223add04e48";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/pa-IN/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/pa-IN/firefox-55.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "d66120b15473b145f8b5429a1a683950eb5766372f5f1a98c3a3ed69c68b9220f5dc45e5d114a6bea83851dc9b4941ea735c75ac45ceb661e601c6069d9d7534";
+      sha512 = "7e6ab9ace1aff3de1209992336567da167a3d6681af81354b05e36012545df1ff06e1a825668de7146e843a56c4e3a110ea530351ed83b129f9989d24bf86a2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/pl/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/pl/firefox-55.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "4b6f5155e5b763a7a19cd230cb37a6864beb07b29e4181aaaf5cfbb9fc7bf9fc67cdb8bcd9b0a35780b40a7dc8744ba04fc73acebeba49e32bbf53250a78d395";
+      sha512 = "fbddea93b51eb530f26de74d16a1d373ca9b86a8fc89b7f12c8ee4e2f3c3af8be22560ec11ee4afc7d93c305eb8f352931a06b2e7dcc11eb1e9ec755a2afc2a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/pt-BR/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/pt-BR/firefox-55.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "1b74ef30b836d7490b155b194ea6a9b1e4461d955f5f16ff0afaf1c1f1980dc1e7f60b600c2ceab1e655038e84574e4408c15fe0c7cf48ac99c0961e8a04b135";
+      sha512 = "6ae90c6b37258ef9e9b93fdad261c7b2522ee3b251c36f03dc6bf964d91da86a05937b0a65c75bb3531b7c10be6d5ada3a88b2240dbcf1c64c5b3f624acedcb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/pt-PT/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/pt-PT/firefox-55.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "3c5a2881d06820a3f54d3a2e73be720d1c0f06233114766196ac344f5f9f0ddaf0f9056367b5f2a7199ce7852e81ad77f5c55dafa3626afbda92a4bfdbf5db47";
+      sha512 = "0f1d035f72a3f0739f843e97e1ab27c3b5b5901e88eb8adb9d8b343f6b5f571133fb8e9f40b3df14e4d7e1144aa7f1af86e7100df5786602185e4ebe425c8f97";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/rm/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/rm/firefox-55.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "d8b5fa46c953746a7feabf4dc0fd7526128f3268cc3fb92962d67d2c03afb61088cd82d7e5054ff14a4f8e0ea411e0734af8745f743412cad1368414593e0162";
+      sha512 = "7ec0f5792e812fb2d57d420ecdca006f5242f6c3599b58da01e3ee65df896d1853fb61ae0413ff59834a669690ab40b74244a31be5033ca215bbe784a7a8cb3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ro/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ro/firefox-55.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "070ad441190f46741ac49c15d72264ac81d9a0576d382f5696e940482f6de6634bd5f8bdc1855d3e3da6040b632100d333cc06058414eb7f25acb12914de5e3c";
+      sha512 = "653e8942d04dc440d998229ad8a10ec8a1098ef85331abd8e1676c05398dd4b514f5fbdfd15c1b20ab0fa83216d7ad0b0e4d20b6555aab9a02f7fdf139d11e35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ru/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ru/firefox-55.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "935cbe5dd97db312ecf7045bd38d8d3ac84e812da507256e9c5abe465e5111bd20131373c6aa43bcc8b6848dfb6d77e72df60b19d6378d808a6f8a095eeb1b03";
+      sha512 = "66c45ddea853348cf0084fb64710ce0b077dc6521767a27a83eadfc237becf05e26335d85fd1701ba4790e80a2f5f971986c1a3847cc84efa2aaa8623d0b3556";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/si/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/si/firefox-55.0b2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "a4db271cf567f9010fb8c3ac1bd859c4bad8772dd26a068eed1c5f7c048fa969b5492f0b4e12ee221da6be9581790348253ae8838b4e21a8824718efb14b6ec8";
+      sha512 = "69bc89b863e9a4ffde9ff478331a88b93a42a2cc5d51114acc995189c63301144093b4cd156864e6094940d64285797f83ef920b3231a427a149c5f6dac37dc9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/sk/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/sk/firefox-55.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "a617d8bd5cd8827f7858dc4a881c4da326e7909caa9dc20194f4a150340897bbb07e397918057265573f35c6cbda269b857cec31b90a9c41535d65f8c2e5f22c";
+      sha512 = "6b36b64b3edd9a16ba7051727a8ef326473859a07006159cd2b8a6fff25b0cd9649511dad03e5286e384ed74fca4b80d257cb0e754ee4ecd6eaa7c589478a5b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/sl/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/sl/firefox-55.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "3ef4245014e3eebb31207e084d9c50b39ebfe16408f6b96bf0ddf66c9c69e9d717266152c643e2412358bef30d517f84ec482ffc57bc826a9d1a9474848fac7c";
+      sha512 = "19a6c7c7d7f8cc2a2f03bbb23f28c4691152ffda292399b6e438dbc3afe89dee98be86ea4d7f27d9d4f736e68a6ff21db1cbb746bcbcb9cd6ba9d7e23155cc21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/son/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/son/firefox-55.0b2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "2bbfcbd5945be669b779e58c0ac925b4d83836a3117732d5c85f9cc009cd87302e8ea5793d286951ec830ee4b8996413b3fb004b9d48eeca506cb289b99efa6c";
+      sha512 = "df598c9156ba76218f4f0d87ff301a3220979abb3a4f5af19d0545b6a3ad48719a8267da22a31f646e6d20ad1f6f090579c9587e949be91559aa58455502a156";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/sq/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/sq/firefox-55.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "c59ab2f574e605528d90ff4c25b67f1815e778458aac7ca4a7ed105668d8f59daa9ee4e4df33e62c359ce3818c4d717a520d99cb367c84f329321357083e1ae6";
+      sha512 = "e8d53fa58ce1d34d22c7460c9b9d9111233047148e503e5a628d8d8e1c689b2c4a302048931dab44ee33ba2c4831362d3e74c294e907f1c5eee23d464007343d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/sr/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/sr/firefox-55.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "80e49c1e72e12f63dabb6a73b3e05de635aa63f8523251a38d9762dd80aacc0ce2db7a37b8e4ba8cb804c2f41540fb5c9790279dd6a02c06bb1a7a1ff944b75d";
+      sha512 = "5d3e8d3741ee0ab535479ded3035379858ba092a8cebbd5ac8bcc525e88159594f5cef90894bb0fdc5eb9c349c435913b89a030ebf942054110d37e57bcc50cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/sv-SE/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/sv-SE/firefox-55.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "47569b272c2b42c0149790fc008894dcadf35dd82d64cfefb07146a75dba85e8052524151d7baf8cc929879342c4af7a8161d6df02aec7582bc3df4cc99e1c57";
+      sha512 = "98da270b0da5091cff599cfdc9a0d241ab8463c1c9e2771f81e8c0dd7ecf567e2cf4ea536b81cfd6b1679e449d7f1d4157b8927f1b1b0a03f3cb7dbfbd267d65";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ta/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ta/firefox-55.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "1c64a7ace3abedcbcaec3d3ca884538aca70bed9c9c736a721152bb3dfa7c7b0a1f12305fb54ca2ba7658ce9c2f42bc2c87049e3e792b8548091bfe4e10824b4";
+      sha512 = "63287a39d325111c7e18b62a9b76cf0e7564709846cad78a946852fce761475edc61e292e31491821215b0cd2f392e8c41b7ecf0ba78ac3440cdd4f7f9b52d21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/te/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/te/firefox-55.0b2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "2a55a67577d2de5dee7b526a716b5061fc4bcbc670db5286cf8290629139d72325f086217689bc55a5d260f3d30b572360d62b01370685028acd9825ae748fc2";
+      sha512 = "476840816b36816b967f86c9796f6df4afdb3d7524f4268cd867393eac83ff868645eb14ed5766aec87ba3c226e593099e15d44aa63a01bf422a12a4bb5c77ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/th/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/th/firefox-55.0b2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "22c796f3d0bfa8ca93654ac73a8e1be30b7d2d02a1700008243d98c4cd367b4b5e5712a2def5fd8b3a40d7deb3e638cdb4edc7e609d37bf7726b9fad69f9225d";
+      sha512 = "b5dd1a09db20a788261a2f6812a6b35be7164d14cce7c700af51dc1cb187801c2ecc0d0b035386ec4340af25c8cf651f9dd4c679bd61b335866fd2d7a531f7ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/tr/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/tr/firefox-55.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "8c50483a7bf1b8016349e9c9a088efac8750bb51bde35d3af78b82827f0ddf951a1605a193b3a1ebf6e03af1224defc48f9d0decfa317f3e1c507e20b1c552b8";
+      sha512 = "08a002ec452956730d02985e74c9c1c615783d19fde6c1ee3da3adaeb1ea021c05c865e72d8dd7c930f9351ee376cd42b20fb90916d276344e7b2d17eda6f458";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/uk/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/uk/firefox-55.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "2dbcf145a1ec46a2239f0340e881228f887e8ada2c8cfdd4f77a0229440f3de7c4e7f40706973dde6171ccf45e2da41e77c1e5fc4375d857e4a2a74722dd9d10";
+      sha512 = "7c75010a3a15f2208774f3e92317dd88c2a821c468a84a5855e4db193c5fa6d639d4b6969d3ef72bbc90c47212854abd0002295f163b06998285d439f50ccde4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/ur/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/ur/firefox-55.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "69acb4094d4a302c4c62328dcfeac0733576188b3e4548dfcd3ca9d3cf7e49379771122090bf99acf6e47624d2216a790b3593dec4d4a578b346139027e9d619";
+      sha512 = "2d94f170a3eb66ef776c0c78c53d16716aef47218122bd5a9c7910fc6f821a5ae54192cee0314c48c7d6c5336f442532594c31e4e0821cb427f617590b8b7ae7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/uz/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/uz/firefox-55.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "287dc219c456f2bd60cd4a1552d42f7656f6321780cfe11ef7b67772601d55c03eb8cc83d239b90e45a47869e5104a1c1aab77131c788693aad8bc86c61ec53e";
+      sha512 = "21880c1a14e339e7b716f742c2910451662712a3870605db9eac00729b6cf9c2043cc49035c86044af8512239fbf05ea51ef476aebd234a7fa9317cefbd43a29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/vi/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/vi/firefox-55.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "8cc0f6c83328a67cbad2dc3427678a985fb74863b0f7baf4bf65074771c1e5a18576e274f725d65901c1627d0a9a0b6ae1d815d28dcaf5c4b9b6d830dbf3c245";
+      sha512 = "5efca9a9fac37440d41c444497ecb2a5eb56b47881b46c66cf65b3b78353fd8a18d37c93d83400be1207193c7dc3a901402d679c50ebe55ddb93687439d4874e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/xh/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/xh/firefox-55.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "28d803a22ec0d5061edd6a8185638842e55ba5748b0f1ed5fca85ea9e7ceac33319e9d5b282b308f092c2583e747ed981dd731a0f375eb826d878eecd31f65a5";
+      sha512 = "03927d0b8bf3c261fd00a043d8499e3686c7abc51eedac63f049d100095da2b858a2cea582c8aa2e3f65e1269b7094559709c22fd633a0cda29c6b21f3987eb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/zh-CN/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/zh-CN/firefox-55.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "0fd9414050a69c8731e1ca8fc8f1a5f721d7aad48114a9680550b133b149da043bf550d42102c6fc066392a5463697afd55d3f08a5f94cc755d961bb29e261d7";
+      sha512 = "75a77fff929aa72700b9af9452e2d0fa93f21136cd7651a32970fec24332d3c9a7afd58a823e3dffe1aa63ca49057c62ba5ce579021a783a096733c23c71bbfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0b13/linux-i686/zh-TW/firefox-54.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0b2/linux-i686/zh-TW/firefox-55.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "3e460f2eae2ee0c40dc32138d6102aea4b47471f320dad3cff9884efa6e3bd23dba1c5b825a7a907ff6f7f7a08f145854de3d82bbe9bb85d518538822918c547";
+      sha512 = "d83bb672b5587b6fc8e2c4028f144821282b1596ca88f1aa889f4a2601d46fac44c7302d30f23179db6540e84e878244c4291dceadb56045f3edbdd41bc42a19";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,945 +1,955 @@
 {
-  version = "54.0b14";
+  version = "55.0b2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ach/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ach/firefox-55.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "8f19c1210c95d5dbb845caa05ceb90bfee3dbc8e7ee630849766fea2e06b5eb20660d1c7387a89112daeb4b11bc6a05e274429bf48dfd9b6c010700c6998da14";
+      sha512 = "003297708bc29bdfd471ae4af99a39f3c4732a067ad56e7f5a49fe8caff7a88dbff9245a4e8843f504f80c0defd2c2fa62819e6b71c176da6cd0cfe9d1c614d2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/af/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/af/firefox-55.0b2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "daade55b9ed5a4390ec65498680b600fb1ee0ad9f73f73066236a376c8b86687480f11cd5c97c254681d3b227759e84ed292b3050ee368337514338ba918a688";
+      sha512 = "4f32ca70b0891bf25fe68196f5e78fc9368cef5dd2016f8cb0c0b099fca34b154bbc6b8faee831320fd0bbfd35f81ad379e44c7778d78b1b517175b3d5a42dd4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/an/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/an/firefox-55.0b2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "41836c83842fb5429938964faca59a763a7bf7fc1d38611274d7bfc559ac9f167841d1b43deddfd9494508bdce515e2842684482bb808b2509ca27eb5a4937d1";
+      sha512 = "01d1d9df2c24c6e41ab6a29028ef0c38630c7a786cb310eefa93adbd334d8b1e65335225b3fdb9f21bd8740d4d9710085d750144b2670b4a30e326bae0d96d78";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ar/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ar/firefox-55.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "b97e47a261bee9e512ea2478c4c1447de4144928adc84ab251b951a650c20774b9c42fae2da4d033120a7830129e2c9196ee960a8de58a112c06704dee2e8451";
+      sha512 = "731ab03cf719f8181c097a40436c5123c2fac528a4c420b5564d79d094bd506dfe58c8718d7fa1a0d3e3223b67173de1826046fe09c763248bea79b7e1485c4b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/as/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/as/firefox-55.0b2.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "c60ffa06a01ea84f28bbeb5a48ce4c60a95332fb90534465bb6a66d9aeac99d23ca7f8b8c38aea706b245f5abc482829365e7cc20dd683534e93dca14d89b3d3";
+      sha512 = "78f9203b0cae15830ee289b540d56e6664a486f107f99b42020809375ead3193da2e4e1bc7bc25ac20256ac07c55e4c619302615220b0a1ae742ded4f4d6afe7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ast/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ast/firefox-55.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "e0d798c61111c7fa8ec59ca54bdff1375576d83c94063edd2fd9a2fb9f15603e864f2daef85e760578305574f69e475930a7d276c1f4ce5cf2fc82af338fb276";
+      sha512 = "401afbb8c2945724b0754d95b0385822d77a9018874c067b83864546c5565735d403ccd1a9f999af0be10b806ec2b64bda5f28306f90e5171406b8a79dfe5975";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/az/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/az/firefox-55.0b2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "262a818ff21e88763626ee9d1bff84308efd3fa06695b3f011007f808657ddca8b4b7de82542e43a4e4264beae88885923dee7571a542c9bcaf1a1a1be782242";
+      sha512 = "953b91a7681e033219fe80d63ec41ed50025f1bda91cde9f6124bee46ed89e38c8470257e1791878443adfda94a579c9261c2ada6c8d415a62dc27b38cf6cb66";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/bg/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/be/firefox-55.0b2.tar.bz2";
+      locale = "be";
+      arch = "linux-x86_64";
+      sha512 = "366f951b05f62a0f158bd1a345fe1540647c3a1d5b91c49c2d104f76974a64030e830dda3afc15828309f88100c4f12d5dfee98827565c96acd62a4e0db24e74";
+    }
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/bg/firefox-55.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "43a5df2c83b731e5983938a69f636ee3cf0977de21cffe57792313f30740dba696a71a8e93c8addf5d13ae1402d83a8bf4eb20fb18d174e5777fbfbddffc2ffe";
+      sha512 = "51542bf88583b2f2dba75e1abfc892c0595737e74ccc6844cb470513bbad7c337e1ccfaa628f08a8d5ce09b91812ea07758831d5bab54ac961652f905c9b216b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/bn-BD/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/bn-BD/firefox-55.0b2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "6797547ba2d94a14d0b5409e51104b8622aca1b6ec988a16deff7e8528b4a77b571484bf2f92a72716f565bbf707c4c72fbb59d67476e22ffabf23c7db1e7b96";
+      sha512 = "9f41fae202b3a38115b1efccb0358f3b8896d8f44730f4e53896fc48c9048d6a1ca8904217312c6bd9f9ebeee1514a85c1723acae8e293559289aaa6b63661ac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/bn-IN/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/bn-IN/firefox-55.0b2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "733c9889f7dc782656846bba3cadc0b0197c03233428b966f638ef3c8ad64881379e78742c2afbd4f9fc14f42de77145a24e26d4742294b589d2011f8cb65aa3";
+      sha512 = "6c617687ee2e1460addc86c383a9967803a6900845a2c98d4ef67f2007d3cbe82e6e8b046e4d990b59b8a001f60eaaaa34a50494cc1c8b9d5bfdf3951494022b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/br/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/br/firefox-55.0b2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "c3baa5e4f44c8e7fae99323494d0364b933231b67d164cfc5eb3bbe919e2cbeceb0d9d9838922def26639becdeadde5101bcb514250b8335d1fdd0081158cde4";
+      sha512 = "23cc36ad34c20003cd3a4c11eb22e6b35ba1fc43ec81fbbef0ca3c7aee445920d66620d355b60e6439296ff19805d29f7266060c2abc5937b266fe45f5af251c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/bs/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/bs/firefox-55.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "2fb80dec95921067a879cf836bd2b191d6f628122d813f22b242f1d6a0e605d71f74dece30c51c18bbbf35e64b20df4ad3fe11e8812f11f44fd98ced49fbd792";
+      sha512 = "97b1bac5f6637c07578e689011721e261feef2535feabef4a86856a45c3a48c34da692dcff7aedd4c381159ce016eaec0b6c50acf21f9e045a4679e494c01a3e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ca/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ca/firefox-55.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "276a1b0ff9df2606d6626203de6e22d3eab41f853e29dc87d478825cab41e0c8a93feef4dced6b731025135103922140b3e7c5f9e1fe49f02a1a3e09f3f3351c";
+      sha512 = "e188a8de2f0fb240655f88176a138a7816929a5acc708fd66960b8f51798fb240e63932498eb7db64868eab95d2b9c95935eb6475a0752e1525c5c6403a78616";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/cak/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/cak/firefox-55.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "a20244e8aa7a7d935fc948eb474f265a3695b23dac6dfbf585d782ab1c224f4a922de43c52317966ffa735e3dd38d0b4742f6a3b87edd545bbb8608fa0827ca8";
+      sha512 = "f98825c86e87c3010a48e2e71752b4b61d118e72fc4ef16f2c3eecba54e6af37671ba18c4a7564157b8f65eb552c92c461ca190b80b344103714946dec00da3b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/cs/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/cs/firefox-55.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "a2bfb5f97fb367e16c2737f60ee269447a9ee92a9b2917183053d602713fece31706e7f1c64742893496c881d11b62c34e594eb5fd17b92bd41082a0f09cb7f5";
+      sha512 = "b5e007f882126d7c1e40d9750c9016dcf98674177cec15185ee340ac779cfb81efca0d23486bf7bcada25654e7bc15dd2cc78ad948981e668d0a00a5f138f62f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/cy/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/cy/firefox-55.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "336c46fdb5a8dab5dbcd6b75c3f82805defb0f8be45465ade68f5d3c5ebf0b080fb0694a220efaf9f7e5e1265c1e0cb151066f53542f8534c29260efd2e4e2b2";
+      sha512 = "ceb4f5eff71192a8be67ca79feb3a42390501e11c2c2d2c3a9bbda42a6fcb71362665e991a84fae660442269eb4b91ce1cd8c860a6b801eeda2569a1e7800291";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/da/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/da/firefox-55.0b2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "c3bbcaf4ac2dc38a2903d48596ee5c836baab94bdba016074eb8138c1f22e0d30281de862abd6823b0c4918660226e66abcb8946a26c30156f47efc946f860a2";
+      sha512 = "c0cf7ef6fcad94ba4ac44ca8b4d272fb88c0e63a477b4829a675585204e19c88086b8f21f89c52c1954624dfc1f0f9a836d3333ad8c6989fd398afe2eb92234a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/de/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/de/firefox-55.0b2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "f871bbc4cce559fad162d4579c46623a81c8a9faec2b0328f5f3e9492bfcdb64d5311cc8aa75ec3e8ebb2c0f2823193fff163a345e3cca43e70df0bd355e998a";
+      sha512 = "fb4423b8f154f0f124ad0a36ae692ad8962564aa9ff7747d412a73ca983e1164bec45d8ae6f983f91f2e657701bb268b96d4ddbe8261d68bd41e07d4f7c9fd5a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/dsb/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/dsb/firefox-55.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "29b063bd654d9704a999c27265a79dd75dedab388b1b4ec3c52ca89a8d99e82de59a7f552f7ab0eac6b03b1469cf8882a70e439806be97bf3e0e70b3e34df950";
+      sha512 = "f17bcbd5885a0caa72380f1dafc65c4e104897abaa03f89703501af9dce33ab9e9dd133ea8fd518809e02f99ef6c10a9c5f516b56e05d700b6324b3a101de18d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/el/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/el/firefox-55.0b2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "a11b8d9bf8ea151d62a33bc0630570098babc02a09bb355d0f0c3ac0d316ebfcd9dcc786115ef1cc36e447f3697fec57511f77e678b401d2c75294429a4c66c4";
+      sha512 = "cf0304640af1f3b27b992b32e59a215d5cf95e8b0744266a86ac7738988faa8e2fcbe6b22a50990298cd7a6512747a0000e9788e50b1c32684fa616a7159cbcf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/en-GB/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/en-GB/firefox-55.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "9ddeaa9e89c08ef7e918d5d480e35e34df5feeaeeff2500c2a8a48bf5bb685fd29d74ee1aafdc4c3ff8dba0da7baad20ef0fcd522f14ab9a9e6eb739f8d1fb26";
+      sha512 = "dde0c233b45cd72b63b39a4a99e0d3c0a2f0a63999fb6ba9bf8bddeb686afe6b03a441215e5f2d5d192a19e49b63dc3cb14555c2aaac4efe196e7d58ee83fb27";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/en-US/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/en-US/firefox-55.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "ad39e7bd5164c754d596c15eb14a07f32985dc86486774bf76fbc60f8eda4a9690df37295b1cb99411e2bd1c83af89498b133404c7180fe5819befcc194b517e";
+      sha512 = "d5e35480eac87eb0f073e0ca413eec6ba6f54c7b14b0ffbaace7a130e07703215d5f7ed3c6f7356154f6a0388f4ddd695419a4d84e4ea42a85c967202110016c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/en-ZA/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/en-ZA/firefox-55.0b2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "2a80bec8e181242482d5dd4f28b41a3290a473ca380f7a85138eca7814192fff70b8ee24c6f613fce201d5eacbbd221ba3dbac571801586af2a5c771a1a3d992";
+      sha512 = "3831f3003fa5376b88fa216dc309a15b2332d4a9ba332d78b0067a38b774f7db40cb86d82daf7e0dbe5785ed72f603feb3542a84fe219bd4798cfeef1c46a268";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/eo/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/eo/firefox-55.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "6b47ecbc39d16e1d142440ef58aa375f7987284e5b85cf7edb802405127dff89e3fcdffcc47a23148daa925e58af17f538c3f5520347d0ca8391ed6ef51a5a96";
+      sha512 = "5dddcc0fefb98d0364097fc374f033b8063cfe07ed77b0ef0f8f3c58cd907b27c860ee2776952d3900b99f0084494c304aa38eb07f659dd60765d991f86ff69b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/es-AR/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/es-AR/firefox-55.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "67e0fd7cd860951656b6dcf60450dc9ed5439afc0be8d6be0c549521c6f92bb90fbb2f941a8f9d1d96cfdbd6d1ba9ca3590a8866a4b48062f878917a570913eb";
+      sha512 = "4c1f58fb03e85a96ae339447135712ac59a5280643035f2b1ad684858d58147e62dccb9d793829a30160056891538c56df5f8a73b3342b8aaceca8a8c8b7ec40";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/es-CL/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/es-CL/firefox-55.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "90ec508d87a799c3e3b6a26582cd1c6b6b81923d715ff6e2cb2b6cc7a88c4db78bcee0b5e53f27513aa763ca7368f5a23093e62a5be2b41289b4631464179a50";
+      sha512 = "b96414975770592a829fa95c46dbd9c14cf1509bcbd8787442d23b55765dc3abf406cbd3fd100ad3f8ba243103798e1b060a6bbc1deabcdce24d52401b6e065a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/es-ES/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/es-ES/firefox-55.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "cae140a83a1be44b0e1d42e37d9718dde01ed3f9241cf98c62fce2319a9c73c724d94c65f6eb6f066bff644ad591111334ccaf32986c0d79f01194066ccaf6f2";
+      sha512 = "bb5d87a32d9c9c10a54273cab014caee57a68d5b1ad3de3ea10ccfd9517118a97d351b789e171514720d684e4d1c5fd89554f3c776f832d69e546d729bffa01b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/es-MX/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/es-MX/firefox-55.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "778abfde377ec538ce3e1cf6bf65a30de7c5d6f5a1748f6e587bff5a182419577bb305dedcaa01a650c4c8cd1f078279e192d9a4c807f7afd38f4dfbacc55071";
+      sha512 = "5136699c8ec08604d1b8040bea67477dc021a50af8eaf7cb30dc9d5462fd1fbf6be2e418ad531056a033c5a661d47e9c8841e3087b8ebca3f9b1eee24d0cc20a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/et/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/et/firefox-55.0b2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "2a832ab5fde11c3728d4ab8f4802413f5da0aec9faabe3dfc58b1558f741182d093ba351f8b6c7cca846a014132770eb13775d9d7f345f57c7f4f817e2877fd8";
+      sha512 = "77b0dc7274c941efb10f25ef80d2cbc70c3d3243e6ecc07459bba933fbb01382e6d8757c77c0fc26fa42f39be0761cf07d783a1e2cf5064a73910adb420556ba";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/eu/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/eu/firefox-55.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "ee0af554a7bab3a6661424b42360cd7ed85e68fa1436c893fd5796a54b0eaf01b86af77b6b33d3ce722ad897fc403187a55da3557c0ad767e70488a24f4c5b7c";
+      sha512 = "f842af2f0b7e1894d49da17dcfa910df6976976cc59e58603d119adbc1fd7e4a4316ade167896b57a40e6480acf54f168a5630d3b30a7136360b3e9a6dd10d05";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/fa/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/fa/firefox-55.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "11944b7afe0df66d929760ad2bb7af3d1058573083c2f710ce52a1ddf607b6b4b28926a7c140044135fd7cbecffd338be08a94991b08a81edbbcfbf8e5b00ac0";
+      sha512 = "37899d6ed1c16785d9b41dd2593f504c5fd9169210b6f4bf79e4f8c3a7f00dbce74e88eca4884fbf08c28191408d886d0762f2d79928bac1820181321a53ebd8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ff/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ff/firefox-55.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "ae4b81503613f9ca69de12e86131bc507d7eb6c10a26ee5ec702fc7a98e22aae6254f04fb8a11c553cf1b0836c1112ac41797920a54988a2753c91f2d1f7ab87";
+      sha512 = "3a0a3cb965822ccfe51c662986fe2acea2802a72bdb9506f48c3b58e70e55f7c283ef590946e4c5c6b9aeec026980a43846dbe2fbe41744d4c9cadfabfef79f6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/fi/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/fi/firefox-55.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "3049f77695c0eda7f77f4c6a785b5d5a70a6d961618f99ff4364e062efeb8629e966e222e4fdcb1f85b652358854cd7ef859e7e7d9f657c7157a43911fbd00c3";
+      sha512 = "a1d3bb077e396caa2df99a1b95a8eebb32d929980273c8f748958b7ffa6f1f7eabbf486afb195cad613d2012f3af0a355152a631066215d717bb7e270c05b72b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/fr/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/fr/firefox-55.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "d45cbecd191b05d219e71ca77a190a43b3f4ea2acaad12e442e960ce1df3fa3552378f5e5c8cfceca5b0cbba66eb6f7652986d4c907db8cd662f45d91b1216be";
+      sha512 = "012bb9748fa46c6a61d958bdcbce045ae050b1571ba4cc19a91314468f2144976a804183340f3ec0c249eb548ea323db872529a0a3cae391b840069ab43ef397";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/fy-NL/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/fy-NL/firefox-55.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "701271caa493338d73a6a6fbafd0f48c8d6b548ea400146339155aaf723e8f28c3a3e4154cb79cb7a9aac3a77c6fcbc4aa155793a27a8f46a58a43ab6443f1b0";
+      sha512 = "f78c749867899de82295aa928a4afd256f5749f1a02b149eb2bb26660b9073e3bc4ba6a7acbb02a050ca54a1961541b2b9458e5827cbf7cc4a31e813234940ef";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ga-IE/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ga-IE/firefox-55.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "0dfa071841e5609302dee5525788fe37e705b7c4ee78c05b718356eacdf48870a00cda237c78a5eff6c55d403ed0688cf64ba3895b7e687f87fe86d0f2e223dd";
+      sha512 = "88652cc3006f731ffa9549cce2ed3d21553753105eacd7260e0274bd63acc4f77b5ee60ee2967cf963c37779e27290f95f61731701666d22d5ca3dcee257cf5f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/gd/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/gd/firefox-55.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "03a29bf45820adeb9bb792e599dbbe8fdcfeefc7ffd2003d5fd9516951e8f19fd340fb0c0d05beb026de880806b206e3805184a6b5976848235ed97b110a05ef";
+      sha512 = "a0eb1f4e1ba442deeffee4cf074ced94844e167fe58ecb2985555ae233f22990b11ea5eed9a219f407adfcd8fc18ca6c21f191802cbb12fbf767a0d2742154a1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/gl/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/gl/firefox-55.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "0f479c94f552c72c20581913bbaf2c0b832765f8cef3fa18e649940c5e4a4678dfb82e6fa61fc5dd70295c3de68556b671fa66238fe0b1de9afc4725c353689d";
+      sha512 = "51363ace7df993022052162a5eb6b1ad65bf66eb48e1cb713deac1594f3883401f42f0a2f5c1bd7a73eef1d45f34df7a8d1976bc1d115bec134d9c7cd671b1f3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/gn/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/gn/firefox-55.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "23290b9d07bc7ebf6b0ad4977fc1ce8a2314867c240f3f139acb43e7bb2fd44e127cc89dc338ca960096605db72667fc40a31824e8e915ec9ea6d89012d334fb";
+      sha512 = "93549b7a3ffdb275a4f4dba8a80f292cae039506990085484a9f6a54665a7588ff04c29ff5746f8c76e9d387272e18312ca58313cc255327b0fbfab53598515b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/gu-IN/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/gu-IN/firefox-55.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "52479a691379fa2793932380ad54f14019818158653e4a6e00e63298cf7eee489eb8fcfb62999d90c726e990a8df95b190cd59c7ddb54bf2eb04ec3181839054";
+      sha512 = "5da0acb3b9c1588f971cfd3b40041a46cd32102b619984e3e9b16ce9f6b950c37ccd16990cd6b912bdc5af42e9cbbdf6849fd7b3716a85b2217f890b5241233c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/he/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/he/firefox-55.0b2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "e440421111559ba38dae4c1b2a5a02b551050426b8d294405a4cdc1f8e05ee226c0959ee1fcce894398eb3f9b146bb8cdbdaa44f57cfb4ef921f720864f74e75";
+      sha512 = "f5e703361f106f63d101df3c591c0f63930df88b72bcaa0a93ca1ab0709c325edb1680d1955eb678103343c97719fa0b38b1ab8f12458538087f4a5f31080060";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/hi-IN/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/hi-IN/firefox-55.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "a911950fd9299543a95391fe280a0fa88147aabb0ed8cb1ada320537d3b02bd77c2528c018480039653be44a9a18878dd6cd0b91266ed30be0190dd365fff890";
+      sha512 = "237e1fb08f8dba0bf72cfa32de252af6cde28820ae0f46d4756fa4a82893752a343d9cabfa4c719a4e39897fd6e41a32349ce2fdce61824a0dcc101cf9254681";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/hr/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/hr/firefox-55.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "085277f8e4949a6f3484f2e374ff82ff215d91772357e2f91327334f9045d97f42bea3e7cdb2eb8a0d25655d4a5001c3ae287134329fec209add20d24fe9a1f6";
+      sha512 = "908dc023c384b447af89b7dda7c60d2d2cdac3f386d1c4005d78490b4df5b69400b72ac743e9cbd0c700e4989583945cc2da0f2b8c0e1a87917ab1d37c842f4d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/hsb/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/hsb/firefox-55.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "02b9a28af54c9abf5f6bc0bed73e9ea6e14bc12bb23c3bd92673fa5422b4f77263690ba5f83a45cde0d6edb1cb67007f951b13b5bbf6f5c6bc7cecc43830f3e5";
+      sha512 = "c4a91ab0f38eb0f565d021e798c30dd07e4d259624a50ba1f51969b46e257396b9faf8a0676675799f476ed9c71fab540d0bede002e4ff6e63d3114a7114c47b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/hu/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/hu/firefox-55.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "6760b7e056e61e25f439cb6aba0de3e3624693097578e392c8f4b3a2fe3a0447cdeade3aed421bd6693059d9d6d52ba4df183e77edb499ff5bb1b440fbd95b9b";
+      sha512 = "cc8d632d7b9aa675f60780d0d16bc5da2f9853813917d6e89a7e0f47db288092fd2da94bbe28c0959d4589c23422df1d15101ed340059a3e5ebb9c622aaf9c46";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/hy-AM/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/hy-AM/firefox-55.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "4a5b0c868a2ae6ea6b1b133182c8c147dc10995f69b31e83517f05d150616d3c2c92daeee767ee44d22a691446683d6729de786efbd37429e52038ffc3b08910";
+      sha512 = "aa37883c2b1b880f807ab3bf2ce4cdc99e83cd8a80e5856055f33a0eed68eed21a3f8b5d20394ad706b0ae707d2469918bfc70c52e270b2b0303953d560e34b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/id/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/id/firefox-55.0b2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "245a1856af9fd7345e4925c560de1efa8b786483415431ec3a7bd22a7216296cb6d74756d8300d06d5b1c86ce1fa04eb807c050698d4777e9c9fd58308823ced";
+      sha512 = "cad8f320178124b82fa27947908191b02536691e9129fbfe9b782ca0a15a6d7adbfeccd2b6bf2bdbb4aa1d4b3d4949cb55b4188b49078685e4d07ce2a90eac20";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/is/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/is/firefox-55.0b2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "63e14be658c33020dc32bc974578f4b329fcfba60ed070e11c833135c25ebf8039f6fe968fcd3ee2a5d33b13f1ba8c23bb3e268eae20d86f56b9cfe83bb34a3a";
+      sha512 = "7f64839be67ff5709d4ee08838a4c15e9e7971032a89390335e27781176c9d1fe555a070968f23a9cf786c3515ef028cb4911b4fb6615c38f94fdc700d35c169";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/it/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/it/firefox-55.0b2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "992610d09e22da69f6425b4a427181a2c69ef9bca7f94aaec8175d9f2e35885f03852f45d4b692ee780c470f3304e66696c33ea4f2abac6c4c928f1919280773";
+      sha512 = "bd1f6c79c108f1fa1c01b445acd9f9ecb0a9f088cda0a113b48e1ebeb7503fdf36789881643cef359407e587eaad6d0dbe27298554b5025602f90d11e3c9ae0b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ja/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ja/firefox-55.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "c26f7772fb0b5f45b9aa5cfa8f1d7b34bdc97e7e7bc3e841ee39614cc5f345d6c45b5053827b5fd4f62180a36b1229034570d23e3f4734d276ff33916d8fb68d";
+      sha512 = "2f9eb69e4f1db37c46a63eb3f71edd461727ab98e5fd2ea6925cab501c2f7aa81b8870bd42af2d4e30410e8d6083cd103baa83f07177ab7370a0d96afeaf424a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ka/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ka/firefox-55.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "4d6b1b599ec6006fe1f5d4365c4ccab4b3d496ef412986a9afc1a646d596ed2269b2d67f4c42af95afcbaeeaa4b8d5f4eaece649a22097484bf0971b8e90ddf2";
+      sha512 = "b6b2728e9b74bf6c1eec3859c1dd8ee7d2ee98ccbc45fc28e2caaf45f1bb71e05b42361a25e3c4e5d71138b5b23b764d9e8e5288874cfc7b96b8b0db33088147";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/kab/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/kab/firefox-55.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "0e1d510b7f1e7e345d119c41f31f8ded78ac61c6a05258bf6c6671aca1b4dddb16508e1baa68c130bdbe959f038a9add353c58fe3b1d02e76cd1630b87324897";
+      sha512 = "a4c3dd17640fff69deff932488c7322c687263c28d8bb352af37f7bec8ae442aa821782f011953e07b34c37ebd62f55c1b913a6fe6d634af41a41137c57e89ac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/kk/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/kk/firefox-55.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "61ee97413139b6e794fcfe1d318cca08f4b726dcb3f0ea21c7f9cb6cda16957d24db360f6cd547a2e0e6a6e031d1a200f4c8bcb9afaaf7e297fd80aec10d0f9e";
+      sha512 = "ddda306e1944d9ed37f9372ee247a2008c362235eacdc1f85ee2b875b88c968736e111b8db8d9954a3c6b0d31b76822b69968bf54394269f426ab3d4a3b11e50";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/km/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/km/firefox-55.0b2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "e6ff303470ccd2f5f98b722746b191d0a60cf53569e37f6d8f62366d975a1e7f71bcee51afd47766566561c1869956e81feaa7040add09bb512c0578714283e8";
+      sha512 = "651cb45d7efbf85dfd081c0358def68cf1b98f9ac0025a00a112ea43c034d974a8caddc07460ffa2bf4638cf2e9c8730408cc2d5907e74645f3509861f2ee5eb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/kn/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/kn/firefox-55.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "be552d120b3a39241ab90c64673974f27ac10576328448f7b23c4b4d395190ce32f4f215336e86450f07f5a222492467b7b481a55e7bd9aed6c131e23c09f756";
+      sha512 = "ace13edd7b784ae7496e6c6e7959e8c343cca43ef77cf9cb9fc43895720db85989b794228296af05068c6326e8704929bd2d3568b475429a839765c9c9bb18b2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ko/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ko/firefox-55.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "cfa83333a94c0227b97a7fc0381894d97afef80aaa0808031d95b12d79acfc144de525350c1b29a7f53d10fbcf53ecf0029c9203c7d4511af071ab0c93e55127";
+      sha512 = "4cc11703b836f50e5797638922bd5c3fd79dcce4b200c1eb2036876569d317733dbc38dfaf10eaa3fbd4309a1a131dddb62ce360608f82aa08c78b1a383981df";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/lij/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/lij/firefox-55.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "8332db66b531b2d685e9d9a3349f1d82c4185c0fdd79bf3383112b38cfddcf24c2379031443eba19dc5cd51e602fd9a508c09c7622b92f4423376393163c5824";
+      sha512 = "4f57f8ebb8a2d2d2237b23f703e791daa92f4692c0801fd63a1079c82f658c96b33d4c64be5b05c976f05cce74321d3cc0a3d09350461830fe89361b23a71916";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/lt/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/lt/firefox-55.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "00cc56db7b2711b8f8c91459b9e1cb19bc158b09566d9218663411adb084f967d7ca2f312fa023e26da31a2d016168ca748ad7fa7a81eefc1444474babbe338d";
+      sha512 = "1dc3fedf53e70e5a299ea925484e3c995a670fba7227b56767a4887422aa4da7d536baad2655432fee86b89404fad7cd239b4c814a545e7be27db6a2ed91b725";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/lv/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/lv/firefox-55.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "2eeb912b4b787f82d0b997646d13e019dd8762b08ccde5d2823358df0515fd05855caf991ededc17aa9cef1c3524d59cf651f14a4c592c70fecf44f3b2fb0f1b";
+      sha512 = "c97cdde91fe876bfb5da846e486d1f34ac9ba9f14d39ecdd53bd397c37fbe44254df3110d0854b3598c3a6e89883c220afc69293e09877fdaa49d7c286be5cdf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/mai/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/mai/firefox-55.0b2.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "4e61c996041804cfac7c62c410fe0315f153e592cb423b57ac9b96070bda7d37cdad02e3e047319951c4a2c7fe1b41f06b98af0f71f876949611f7a52cff3c72";
+      sha512 = "afe506e36a228dbf1c8a3918077bade8a69d51c801cbb274209055e6062c9cbca340e153842d9a24637c62cb6833f99e69fcf3b92b82ec16afa882d566cf44c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/mk/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/mk/firefox-55.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "338d4b3fc0ec34edb5acb3a4e86b9e8b64d16c470303f0ed127d060c1d38b176bd51251eccb3ab3df19c140007d44ab6649983c0c9aab8daa5ea348f5b34dfde";
+      sha512 = "b9cbec5c7f75d6dd2fc69aea6f182bd8682cc2974425973b5d7f42982fa7f69b384bafae1bdab4fa225f7965f9d2a37c0e127ff12d7ad1991f998b19deaded63";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ml/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ml/firefox-55.0b2.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "1c7f8fcf9a0cb5a8a18a21ef5c258d6edd26cf0b6b847eb64b0c4d8bb963b4814df06be0b9adaf4ebe1d384afbe76c9bb60609c9f9773e466ad8fdf36e4e5d88";
+      sha512 = "2e7cffa6991ee2ee8018dfbed50163c6c905e1e9394ec880d92f12bde8d180ef6445a8f20c217f620b3ed19efc5505ab2b158a679adc97a904b83d46561ba0e1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/mr/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/mr/firefox-55.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "ceeccd3c53a1bf3d3cff32cbdc8a3845db7c383e98b7666fbab71ee748ea57b8f103ab337e8cc08cc25a0b5c28c57748864ed098259ceff167faf4cf5e3bff8f";
+      sha512 = "9e3ffcb028a9809dc34969587585fec94c31e3f8561c969bec5a1f6d9c436ac02648185a56c4cb95a16b400d6abcb1c01293505c51b8e9149625bdd910523aca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ms/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ms/firefox-55.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "d08fff37dfc1ab4ad2a629562a3294aeca275a4f86110e9a21839653849cdce9ab709228bea30e33b3b1695cf7a84fc0cacd1b068a060c5ad1cbb39553eb1299";
+      sha512 = "29f08c10050013832f709bb0b42ea1f6a3ed191ba979efaeffba44e5ff27220c7bae9717d68a9478c2a452eaf0ef1e8da390eced1f5f7a37ce1ae5ee6f4bfa6a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/my/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/my/firefox-55.0b2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "fd5cad2fe03a2029b1cb63fff9807cdeb5555ce7b3e84f0a8ef334a41ee15f2d499221e1280c68fdb846393bc5aee86e2dbb1a5373873e4c50cda495cbac3475";
+      sha512 = "5f58e403b72cff6963a51a4e32ae55f94680460a658ff5ede90e859aa1de849c89abab33036cc194b9a3eded23b61d53ff9e9f98bb653785a1e60848e32533dc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/nb-NO/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/nb-NO/firefox-55.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "baef1e2bded7e56a4fb3d1104548ca5e9b9a8a9ab5650c39ebf822199feafd960d24859bd24cdf652edaac8276a7b235110d1e3a7ef6219f6152d6e0a6c48e7b";
+      sha512 = "2e6c4cbc3a73c4669e7703b9847a52849bdde3a5cf332ff0aa76cf5336f21f62177daf050d655250e552c7beb4a05043cfddc276896feae1e03b5dade016e0c7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/nl/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/nl/firefox-55.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "ea47b33ab1b2b7de0d461f50d0784157ed3ff0eef3ce6753d9ba5c11372d182b887cb521afdd8697ade0c077c9a329ac0c47dae928aae68dc6e49b45071d45d5";
+      sha512 = "bd0afc4ef24c68e1a503ac93ecdb969a29427548d5991f47b86583941d2a1bd8d9af88e3a46b74b52b5957cc80d05a2dde659cae2c33028f87fc48beea637366";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/nn-NO/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/nn-NO/firefox-55.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "54df10b892ff31a6decc0c4d3dda5687499512e21f42d69ea68823ee99dcf41e8f1f1aa99cb210f6d3e01bc07aff5b0a7b6e55b2b6a41627e654efc02645a461";
+      sha512 = "c342102835e18d7d14e18e1f7185547d1b2385ce4157554ee65e76766885edc62d1d7e4a911af206d2bf34caa0377b6e256e18c06c41082074a868c5a6367f45";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/or/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/or/firefox-55.0b2.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "eac033a46ab0de8deddd1a4ee88c8c4eb7d814ce559862b92fdc7a2f8a0549913208d4ba151a1a746acaff3d627916e6d09bafe2ad6d78ad54f01aa691be75c1";
+      sha512 = "154b729897c7fa4e243eb42c7e365f658f3857b0b799a633e446ed1ef7257e6387d755c0534ce2cf81e0008caaa205c18ba512a3b3c4e6f31f6a5789674e16f7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/pa-IN/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/pa-IN/firefox-55.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "cd6f0d6f30627d50011e0f193754815256b45200fe743e820b6bb6b98120a29936cfeb84676e92e9d90ec8f71774d8bebd57dd68860d4bd77339bea154cdf28d";
+      sha512 = "39cb1b7546ba00c9f2a7f5794c7920f6a110ccddc20605b829945cd85dd5172465f03fff0dfd3d22f67769c15f43130d5f034fe48e52659b864bed7cd5e869a5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/pl/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/pl/firefox-55.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "749592aea4e2c18472981ee9d7b6d3cfdbe9c41fe2c0566c3e7eb62c0d910104a6301dfdefb19ac2972edfa65aac509ff485af7ecb73aed365d1a0b052ae63c0";
+      sha512 = "a5d30cc38ec170a5d23fc721a91802c09ce913356217c34684887b292c523f9da5b0d2a16e882d324a38cac871f541e08c86446c36f8dd69cf2c6a60d0a2dfd0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/pt-BR/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/pt-BR/firefox-55.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "d6e8ce82e79368c9fde059e8763bc9a5b4b6927672f503f52f525a86eec4e39829790d63a009477d1cb4f27be7ef5624c9ee3b2ad58603d76eb5400a8a758754";
+      sha512 = "0ac69c4cd827cb724507202bb88ef00cddebc10e7785a23ed3adfc0fc537e981c45d8141d299f6d6e6c84017cb16361022357750b69c5cf70e643d14e12c99a8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/pt-PT/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/pt-PT/firefox-55.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "d3ec8279b1c4ce984cfc57b4b9dd67b923aa73314c21b87f5800e9c1d64d4d23ec8077dc571bdad068e9ce6ce7aeca2b358cf1b12cc6a05c24a58fb876630a4f";
+      sha512 = "34ce2df0f0501610a73b4faff1fee7cc60c0c0d675c60a769b99362c7ea82a5f780804f1fd5d1b010063b0ec5fa67db5d6dcf661b0638274563c0af588c86238";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/rm/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/rm/firefox-55.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "49310bc21921933c4daeb096c059730d69c22696121af66a4db8b305376fa2cdba73ac58201c12b8afffa751ac30e0f7668d6fbd811077bde055baebfe106bf1";
+      sha512 = "8053d904c427dbe66837445b471793c80e23fcabc673f2df5090b9acde7f29ba38f74d786183b8d4a1808c5af0c7ec147a02735a0aab3a8d812c7e8d541e2167";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ro/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ro/firefox-55.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "44bb06eb3de9dc5ba0b6446c782335a50ac058bfdd0dbe69801c7e1b2b55af8ce1a846527baa65afa251c062ad4e325403970b04e939aa9b25ae317b6354ac8f";
+      sha512 = "6faf8c31b8457e11e627309c851ffac67821966e7d2f363ea54e133f25195fe35eb593de6b8f6698b01940604b4b5ba13b37259de6e24a817fc4cb402cebb52f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ru/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ru/firefox-55.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "1278da77065621c5738a66bd7c8bf8fc361f6bfc8ae7b2d47a454bee53bb3ce47118b490ef0219f9fb56cd956d34f9b24ecb50ef2b5290f8731192b64cbcf413";
+      sha512 = "1ef8163cbffdc6887cbc5bc26e999adeecb43d9ce45bc805da9c3d307659100a83038038cac411aaae384cf20c45be081ad1fc1211110a68d023ec1551e52b2b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/si/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/si/firefox-55.0b2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "5537d26bff86ee2d7249809cd47d093f980a4b882e72dbe0d97dab3c368000c2e25b6fbb762bcbf7249524c7fa40e65c9fc15a79004825cbc09be4ed62ee54a0";
+      sha512 = "556eded9643cd1f482e6b4f83fb52e73d2a182065df441e7244256472dca276903a76e19ede5bdcd02c9facdbd09c7c2d533163e3165c68e54087b592dec4fc5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/sk/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/sk/firefox-55.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "85a544edb4948f0d828908da796f0d6bed5ee0370cba310acd31adc5adc3786f639bc86563904194302e9198f61c9d266aeebd48cf3a2b7d6a96f7dcfa35a75d";
+      sha512 = "8b1cb4342ed920bba9e3770b6679817475205e9b18f94892cf86af0348a10530616622ace83173ad71b7889917dd0e6fdfce391b5a4c667230bcc63ee14f5050";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/sl/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/sl/firefox-55.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "aac17e2a1ef5166aacabe96933d7179165a185da27da11d1810bec8ce15f9c738eebd3b1e079f03fea30b7079602e110a7c1d536a91ecc513cecbd20cebffc44";
+      sha512 = "69aa0ed87116ab8c1d0b0ef1c086d014b55b7e1441c1c41a10377eab81ae0ff66516dff7be201faec156e541d17262aa1f46d82f4041eda791086906c7795826";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/son/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/son/firefox-55.0b2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "23dfa3759617bc04758c779b47323edf9a96f3d3fa655b72c6f2cd885fc9e6b19b1b34ba39ec8ad6a4395a6d502d8689fdcefbe489cc0673ca3df8bf9b64cb64";
+      sha512 = "4bd0d7510c9977013a9fdfd3453361380b497dc600b1418856a0652ead5625c67b1aaa554d75fa8c10dc1ff4c3e60fe2218a421c623ace151e8ad078c63fdb74";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/sq/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/sq/firefox-55.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "bc7bc6da2111e0a211a75aa3f37736b7ee6d4c2193f7c884d0ce1b5b0d88019b24de9f7cdc2da1eb4649ac3ee7d06b3c4a580c4f6797ecaf65067178fca7a63d";
+      sha512 = "37c7bbeaff9004b3facad06afdaffb2ce75e1a49147a3801113124f1e6827e96ccd41b38b59f5230e97c1f9060e9db4cbfd399b362bc8d3619e9f4c4786e7f65";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/sr/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/sr/firefox-55.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "50a6875b26453414dcb61860f6f595ea46e7563cc9231d00e1df97b6a940570a0bc370c99a76ef97d03dddf75b75842102b3d63062aad989b3620426c880978d";
+      sha512 = "ca2f26e74b20fa6e1d9d43517a26426817bfd40f0d73fc487f7341485bc1ffec6a722cd1c3212fee03f0584fb7807b554465979bf8d8228f1870eca139baf752";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/sv-SE/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/sv-SE/firefox-55.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "e8c400e7250e1d4f03072c674762d7eba488f6e9526139657ac4bae7ceedb6eb85b070acf7b94c609492bdc74534f4d1fa2404dadf3ec3c0732804afbd6d6d11";
+      sha512 = "9233da6de53b4304e19b27a8188314ee42ebccf49c65b48c3bfc5a06f9ffcd2cabc4843f2995f881eaa2262a9a0d8f1e6b68943d5e1d81c1290dc1d21adf3e14";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ta/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ta/firefox-55.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "7896fda2249da5444d3dcbb4dc6381005c79c9e93e2275261ee46f8b9b7a586250ac8722acccf1e4a0d5a4ef8a0c3d7b4cea1518e4dd9ff3d99ba49e9f9a99db";
+      sha512 = "12ada3e1b3816c257538deacb8138819b4924a900f71397c95286f37e2e941c3705db504ae4f5a964d6af142a39305cb9ab5a63cd2a3060047aa55fb6c288f4f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/te/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/te/firefox-55.0b2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "0868096328171e221db7a5ec57121682dbe0134300da0b520b68379e23a88e88817b2480673d508b76d61a91b010ea2daeefe711444c931352775d96b51e7e67";
+      sha512 = "cf2bd733d492edefe19af9ab68f36298e825d66cdfb89995bd20ffc3a405e078af26e6a7f07bdb1b04bd09daa516b9dfced7fe524cbeace8b9aec324b8826ba9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/th/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/th/firefox-55.0b2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "8bbdba7486615b3591bf396b0997c74e0bb3da0547d4f9aa40a1c2274d7eee6f11a866a1176167e38614d9f182c853f2ed884d982dc2219069a4051f7b41ca35";
+      sha512 = "dd6c976d58a61a50bd6f6ab3773c43f778ddb08b2dbef7ca3709219ec4ddf14db479fa8b9a9136d28875bb71c493b085b9e668c5f4d02dc307c0e350be2b81f3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/tr/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/tr/firefox-55.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "948888566da0b04eadc9135989f8c4940c6fe8edf25e3f093fcf81e39bd09b730e105f07c461844ab72a69e7782b6dfa24996768caa99fdf4dfe5082f1613583";
+      sha512 = "6bcb6a25b985261506e47bf984302153074811c88f2134987a15651f96d2e373ca6867c3509eddd34690e2731ea0552c575097b3e083e9fed8d9aaf03b95da75";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/uk/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/uk/firefox-55.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "d12e0c53ea756b4406e650f1b11010ec6c0682afcf6edc7eec4732322e82e0e2e4904aa5b3587f87b5124f98a3712bfcf60adab62ea0c8309e03f80e83d7ba19";
+      sha512 = "403ab45582319cc2ded9c5f6c39791cc35e040cba808ab416a4d6104accfa75df56f858597c714bb5087f41471e4dac54d0f6ab62ee767de6925ccf0a10097a7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/ur/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/ur/firefox-55.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "648267564541e466291a055180d2aed657931be70674e51c204f46c9effd5133d4bc35064902692194e433d609b727822d9bc9a0221aed0e538371acf6343032";
+      sha512 = "4dcd348076640ae39ee104cde115e6b207aca400cf9fdfc65d00334271e18ba78fd185136ff54211a162f32f0eec46d696f3c5a02ae969addcce95b839f45260";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/uz/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/uz/firefox-55.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "afbc0b0af8882b8f14a965475ee9b4421b315dfea064b3d00bce51879448d8a22f64af95991e4290a545a2db77dccc97ea6beeb22ac10298ab71d9f423011467";
+      sha512 = "f6d38f2de149b4fb2494582e6ee3a562d4c7af71aa957ba30fedc9c1cfea314d11849fc1c8a11d19cc43045d73c1939845f1fb3e334c4d32eeb0c2881b9ca724";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/vi/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/vi/firefox-55.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "1caddc6f94250d9142d99b9ba221f52f157e252b7b36bfce253b0ed1de68e38d859c6afd0be23e642c9aa7d51a82f04ff0ad1d63397bbcb6bf47b918a6d7826f";
+      sha512 = "277f09e65c5d07539346282b9f70a662494a2c5640c78ad56089e0c50c651ab0c0fadabfb67148bdcc5de190ea83d1abe70c3aa5fc50ae1cb870937d10d95be4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/xh/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/xh/firefox-55.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "c03d230edc7078a3efa322d359e10b45b129689702704c8ec6ed869c7db1cf99b7f57d50442e2ff64b730ed5c72f39ced56efd9ac2ba65654b3a735f3a381866";
+      sha512 = "e541a068ccd072724fb19a0bd830a2a95665a20a08ad9e398be02545a0a6ae8488d3f30f8dfa25c1149df2a90eca5f586fbe116740cfe630efbe00f002d3278b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/zh-CN/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/zh-CN/firefox-55.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "0ee7ab138d09638b9ef34c7e5dd155c4bfcc13414fe91696ccba38bc0df3ec7cbbedc39f02c790448d9b0079a20b49c3ec47b02c29469ee6a1d53fcc7b9046a1";
+      sha512 = "3f9163e25fd67048456bcae71c86c287d5052c45caedbb19d6fc65e421d1dbc66cafd61582137b7e3a6a5535fb19be110f93d11ea1cd6462f5e4a16ac2bac182";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-x86_64/zh-TW/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-x86_64/zh-TW/firefox-55.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "0dd312831aaa9801246e0124d80f239b4e7311a64d64823111e32a93b3165401fb27f484d0023751af87b204df22e4a7961db0f37787025babe195f185ac920e";
+      sha512 = "12508fd22dc5ec22cb272ad8c62150ca2d7ed680e91d398e304ea07633b55eba1b44ef7668e3b0510f0ef2bd21c8d83c28ae07d2f519e138b4100c5f8fb35ae1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ach/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ach/firefox-55.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "a97800319c06e5433e3b31ea80c153d03f203804c9013eff166b57b7dba3edbab74ae565a57565c36371f609d53a76ac2657965d8e2da936ee753d614ceb6de8";
+      sha512 = "de723b9dca94cc4f35c329e2e31596df20e8d873b54cfc0c4d0cba1ce27b25bbe7af37f50cb360e933b4ae69b1e9d9d2874a84d4357d39d7ec06dbd62fbe9187";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/af/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/af/firefox-55.0b2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "50ba89db1ba882fb84be61875caf147d29e0c7c64402088a95293b58f98065d49228d47fcedf0a2ecee9cf5d994303c2b8576cfa9fe1939eaf9ac2ae5ff89266";
+      sha512 = "ff3da99e585bcf41f1205e62e2d2a0f7aeaf09a8d06472d6d26c74555ffbb8600fff7266730459cd2596766029ef968f613dd2e793f444ece9967a793754de14";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/an/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/an/firefox-55.0b2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "fa33fb132888398d38d1ce923c2740b0976f3f87f661c1c30b016a8e8cd60fa8b57d3f53e20b008fc6b6adfcd6b5c632f0550361b078248495dea8ccacccd274";
+      sha512 = "8c9d07c589a2fd0f6fb6229a3c83ebf26d07e4535b915fbc737e8a54c64985731a7101e6474023e03c048d30c34c57e6d0a47c530a642072167093671a67f144";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ar/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ar/firefox-55.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "463593d809774306e88fcc3484aae8dc329580e5327f48f463f487493b3cfdc73ae6b943bc301227244d12869acf0c766c234868981b38c63bea673dec204b36";
+      sha512 = "f8242f8bbfd54bef69d9480c1a3b78811c91332ed26b1ab3db731e9a2b4633b4db1e5dace3f8351210f38f383d9396d6372dde7b1c3c20a99a4631d095c387ea";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/as/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/as/firefox-55.0b2.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "7d804ad62497a7fa22e418826677db500dd59bd6583729c8c1ff8d49fd13eb8979e35749055b707c0d9ef98af3c78a7e80f3b0609cbd34868efbe0bf7c7f166e";
+      sha512 = "830cd3edabf5584fad8e5f77201b0980859b2fe8a2c6ec5c0ec886a5b7fe1c81c3513d93a9e99b6ad350d3d699376ba3a027caea1b8b092137f580379cc34d59";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ast/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ast/firefox-55.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "bbc13a6cf87e047243a6aa17bda1ecb13aafb00f3c8baf84cd5e64db0cd0fb2dfc679cc8f1dcd1d877c7bf42503d716049c5fec163a946dc47f1ff72f495ab7b";
+      sha512 = "5ef46e285b2c7015f8c0de1a4cbf59883f1ad0a98ae9bd4fe2a5ebbaf9f27ca5522233517d7a50281cf75375a3cba0036a0d77d493e28fa8230e4af3b888456d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/az/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/az/firefox-55.0b2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "b9357217c5f1ebe06fb6c1a399ac94637388e8866a291ad6bdcbdd0c6d2820bb2beb8b66d6e1c6557abd87835e857b50f01a45f8fe21aa8c053d44417b8466fa";
+      sha512 = "6db4270e17b883c6970988287a365497a5905f12c581ed40e442712cc61f61cb78f82dc67c5d1806f61d31302f6e914df95f3116c96404c09c07945de13e6556";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/bg/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/be/firefox-55.0b2.tar.bz2";
+      locale = "be";
+      arch = "linux-i686";
+      sha512 = "779561717f27e6090de5d63646ae0ee7de5b029422889a9b8701f30cee2ab1e1c7737f6d61a6f8bfb7106b7f05cccb060a7cb30f8bb593210ed7a04d72137c98";
+    }
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/bg/firefox-55.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "bb94f0186705cf5a0d9b377b1ed9b465cbf6632a0528dc6fb9697409a85ea1963f53b5517cc97fc16db13022da69d8bc43682dc80b54fb7b4bbb8650d8723935";
+      sha512 = "889172aef9743e4a38cbbca387528e03b3a3c9882b2a2459acb0da697bec2080a51491cc0998955921ebbfad4b272f0f82ae7029313209a887984a768552fcb5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/bn-BD/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/bn-BD/firefox-55.0b2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "c25f755fe5a82a2bad51c8060e6c152a4e66901e9c2adb53b79e08f64bf2e673b83aead21ef83b28390b9506b65685a8c373b62ba1002f3f8ba59ecdcd530b73";
+      sha512 = "0b93d432172814b44e5d879f044799c0d6002e8c631766a43e892d76fee156614fb64ec5333ade7bb65451c73d04443d30202d054b8c7dc2d82d3e63b196d472";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/bn-IN/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/bn-IN/firefox-55.0b2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "7291294306a82b9c6ebd2861715a9954169192909e096391ca342d7b82cf7b45855b1f9315e2f447749209b0c3979ea1545532b61b52ccefd68031028473f0a4";
+      sha512 = "708637cca38914670df1a237fb5b3d30cc6fa93f75c9b13585fc1d80b11b986511139aac1a984e0ce27143e554092be538d91a9e54841ea44fb5feec9128eeee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/br/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/br/firefox-55.0b2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "1c14ef7d74da4c9925b1891a60480e7cae632f95ed46180c77eae8706aeb3e778a6a131f670abeb2b2d4640edb265da4d3b848d993d17f604cc0fe6d3e322c29";
+      sha512 = "0343c096b3b9c98ca65a4934aaeff8d08166a2b6c806ed81cf89cd1942cea9bfd2464a42cd54037c5bd78b3c05951f29710894e852ba65f24c5f7bb0cff3f885";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/bs/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/bs/firefox-55.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "426384268d285b1c4e4ef14edc348cc2e6be1bd27abbdfd1eb1ac4cd4a9cf36c2e0af269ec778a36d413da40186adeaeede3aed6695fc7fc9699fbc57a48b956";
+      sha512 = "00d309e92d80941318ac41a56ad41ffe3fce590ab084974bf2745ed7be2637192829c4cebf230a86d77d2eebf9aebd19495b4674a5d469563ba00b124f526a9e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ca/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ca/firefox-55.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "6c20671af78f50aee715e9d9583923c9df086232e9fbb6dcb7211ad2a2c605671fb1d5484a9b1fc35062bf568aae2d15c79af26e9d56692ed3ec51eee0584254";
+      sha512 = "ad25a897f3d9a58156f1ad95bb17da94a3fef84603da874cbd12db8b0f51868b95e8157b71cc8c1b88253b043bcfb5f58897f052c20f4ee703afcdcf3279a15b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/cak/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/cak/firefox-55.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "d4c5b4e344caf327a261e06fb0aff1d8071ec2ee61fb77ce2008eacb0ce4937b53d91bfd8e0369979de996c9db665302fec8278e6d024857fabe975b3f01b4d6";
+      sha512 = "d10a6222212fac4f69b2cbf5fd82954160dc6495a901f2e790fb5dfdbac5548f017d611df93b5ee74d688b53a0002f8927c2d360a7c2a907e2ce72d3961c06f9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/cs/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/cs/firefox-55.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "c0e10ef87dcf787a337f7f5dd14eaf1f327d248cf3cf2cc0b42b5e9fa426a19c65fcd83cf6ad5898b84f1d8cb70390aafc8e3b7b5cbf2880d9713e854f070b9f";
+      sha512 = "f18dff7152d0b83955ad8221f1b3e46ad0b34c082f0be17296eb459639addd076060b26036548b79aa1da73ac11a53ad82ea2e6069e12babc90570e23ea8681a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/cy/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/cy/firefox-55.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "b9d8bcd6e05d9a975fe9947d766012150fe504e26384b4cf42591b009201cb1d035ba1157eeaf8dde4c08e7d37814b7177eb46df0f4fb5cc775a62ccbccb06b4";
+      sha512 = "04aeeac12aa2ea1ee0064daba05f33147c376c3f6acec38abd64e794ec78f72783ae865ec17b855c165c80990812ee3e0555ec55e24592806cfb02854379e32d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/da/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/da/firefox-55.0b2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "3676798548d36ddb1ae0e9b17c970e21572882ec75d81f78d4d63d6ee6581338f75a934b257764c3d43129d139fc8d9be585568d105550b61b5c1146aedb3071";
+      sha512 = "53034182c7115b8f2a24662823571b290f86977e2be663dfd40c02d9a8f2cd5db3d3563873af5cfff89bdb67e7a2e60c14c21e755b070bea0a5942c2821140ec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/de/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/de/firefox-55.0b2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "f42a2d8acdd380157bf145ba5341b574f5b065705e3ca536f99b23784ff4763c16decc784b62c6d0c6a98ffe088526cbbd6b07cc97c5e0a62268f073c8b8945b";
+      sha512 = "9a1ee91fa95b6ca8e0618dfd84930c2e41cb03a1daf33b03ac8ac9a92e113d43ab41e922537eee477bb5e706c7f018a817dd640460df5cf10288684811eb9585";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/dsb/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/dsb/firefox-55.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "80bcfed6c5788919b2ddd85942dd47ba4a0de1de33840fcc2a7b4ed18dff748c2665d12dcbf3a68ae09f9199292a466be02cf141478e303912c2efed4aab3f33";
+      sha512 = "935e7ee75c34045393dde791d14be3f4f7c5d57bcef5c4b8a6e291941acdb21550e6b5aa54bb559f3deb64cc6922f4709bec360fd62273b4b693718b69de532b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/el/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/el/firefox-55.0b2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "42bc0ce9c2b9a8e5d9655b921009820c1e0e05a48ff104e68533df9cd4e17e9acd19c8d9bd88d4dff48f851c9532f4e58bdc175f8c0cd14d1b98bedcb96fec17";
+      sha512 = "371d5b023d63923bb65acfdf3d4d7efb5acfff3b2b6de7ba94e0b475b7e45b268612303373e7b10b420ca2c398e9eaf340dd481390f36c5a0b50beb54ddcfc1e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/en-GB/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/en-GB/firefox-55.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "cc4ae041a4595d6386a1dd24ca83440497e04f552d748566d4fcc1a17aeecc63771a130ac212d2f5a12f2691128c201f673edc3ca3ea76c808a44bb0a771c8f3";
+      sha512 = "c99cfd1283ab71d78ab8311616ea6645cc1d492dfb5091d2bee19299ecaa9455228639f85ea366e7b4ebd28270f06446897b1a99c9c9b54bb2c69b4f4d3fec1d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/en-US/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/en-US/firefox-55.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "dcdc0828e37d46046c4793440d1ce236b53b67426bb9395f4134700d78027d01670b0948fc668f7ba38c2daa3f1909882441d056f1f8f4216773ff4151f2cb56";
+      sha512 = "7a81c06e4b85e7e839aba4ea4fb41f1da871c3de705a843c013965648b1bedea86f0ab73a616b7b864da10da0c47624819178063f2894508fefd34d7971e3714";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/en-ZA/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/en-ZA/firefox-55.0b2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "f8f1629e0824f14dad1d315e0a02356cc6581fb09cbfc89899071e376a5fc359820bf5c0fefad003cf714c344a4fdbcbfa6117e618e9d01fbdb6bce4ec2b0cd7";
+      sha512 = "4f0b171169b73fa526e25a7c7c9dfa1a0fd557fec07b69e761a948de71172f733bc2a1d2e3d1f44d6deed0f42568279e78541e32352ba1a27fb45274d76768e0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/eo/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/eo/firefox-55.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "5360d73ea0fb4bf9ac0312a9f636ff3c350bf3332e1051a24b69b9f2abea038c9924055ff6b1b8ead926e20d6f4a56349312184bdb6d8977b3e8325a76e8491b";
+      sha512 = "d992ef007b02ec7c33b8efb7d69f71a9656d410dbb30ddd3c2a7e39ec6f358ea02fa9404af84bde1bf0da524d5a359655847d729f10a877e81b3846c77a74a15";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/es-AR/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/es-AR/firefox-55.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "242cf9863fdeac1bce45d307ea666b3c1903778704f0e417f39a37afc22395d3ce231f4dd33b6e4e9ac31d256d3ad8926bee3ae2c22f062a981061443607b2d2";
+      sha512 = "5e4303d24df249bf07a84e6f76bedefb906e8846db787c12422890240faa3c231e9b87afb1fc210ccb1e8b3abc7aafa84f1896d535d7e1c24854d87971be8bb3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/es-CL/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/es-CL/firefox-55.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "4978958d499534a8c6f330dfd56e1ef40c0a92bfa27115019855d8630d9c1b1bd4f26fecfd5fec866e44f7c93f8dbf93feb7e1247af5285c62562ff7e449cbb1";
+      sha512 = "0be7306ad2da4072abebea8e93ae7a826e7f4be78855400fadd930e9d7d4f114b7c0e6d830a571da17d3c67d9fd3ba7b0d3fb861ed8f61c7681b3f23dd8bf381";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/es-ES/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/es-ES/firefox-55.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "e321bf3bdac860f2bd2e163e05fecbbd002fdd5f7ac068ece7bf2352aa5a5efee184d47b0d4b95c2323cd786cc874ef81fcb772cc585b0bc217886e6cf588791";
+      sha512 = "df9e70df387da42984bd27e5f032e2194eaac20605c2c50be0b41bfbba2a1b71237380e7ad68ba02da3ab426575f5dcdcaa7a31b3871b9e565239571699d9fcd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/es-MX/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/es-MX/firefox-55.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "3a38e786861f16a6c228ea5416d2bd0ba643f27fa02bcc0621f705db537ba6e89eeae1f1c191bee6b499e4c6a1ef9af66df80979f32598b54db118bfe963ec79";
+      sha512 = "cb021bb04ed655c92120a6dee9f65109ce5951d1496c5acd2aee2ff0e8204e36e3b226cc08a1aa947cebc693e84b41c87de91edddcd47265835c883f6078dbb4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/et/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/et/firefox-55.0b2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "d452515192a70bc20640d3cb6443c91dcd878ca354288d825426c6b395a8a299ee18b781da1f210acca58799ef34f6c6149f4fb758609ae7264dcc698e810d76";
+      sha512 = "c3199f20eb4db23791bc7ce076b97bf08bffa447efb15542c34f2e6def2ee64bc6e2bdaf9de094eac35ace1bab6693bfab4f0ea0bccb2754948cc9fb13a99989";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/eu/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/eu/firefox-55.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "41939bc714c4cf0ee9a58ec99851329495a6eebfb8d6e7b3429a246497d7e917457958eecb273e2d4adc65d70a018534ed5692a1b2b6d018b0a03bf5d3babbe1";
+      sha512 = "8c168058d15a7b0f7fcb72bf8e25de041a6c8ff8b70744645dc03c57b7380a273d419090779ca755ee114b997e6beabea060542df53adf6b4dbb32527425b15f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/fa/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/fa/firefox-55.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "7834266f460d0a98a4f863f03f77770a1a76a107dd9bd3cc44e5e26c40a310a08cbc51518aac8db989dc843ddd31f0bf342b58ee065565a06e00d81470d8eb13";
+      sha512 = "2c263b26f64e565fc4873201e21cc2cae483ae691f628b4252928f3277d919eda1a5b3b0504da04a6da3df8875dbfd86d2aca440c9fd65fdf31992d87842a3b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ff/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ff/firefox-55.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "f89b33dbc852913b44658691c558a98881c5b9a6dde0a60caa7dcaf9cf7d833bb841216f9217616be8ef0f4343d5221cdf64bccca4960bb39430d2629ad4f592";
+      sha512 = "089903272e4245ac8cc4b3a2f60809a2b11affeee2ba1befe03031bf05c8cbef239189f2a729d0489cf5593ceb9ea5356a21039b464b25c8f4613bb7ac787e17";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/fi/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/fi/firefox-55.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "2bf12c99f929224dccb1937ca241610a741af9ff5af92fa06752c27857cbb7e3c6f9bee5cd453d7e88e9cdbe2dd57940a6b00069a2f795447fce943eca84a15d";
+      sha512 = "a9f5bcded43b63766ec18f2a846b3c4c57fdfab15a0a570eaa10b9b09b817abe63eb7e9ed67bd6e1bc31805582b8458ecb3249c125aaae1803ed5036a66460c6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/fr/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/fr/firefox-55.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "a14d18ee73bb8665d86b603c8806391ab937f3571808034216d69aa2f8ab1a6b97d52d47c34f44ca0f6eecd48e5ae58142d25e840a6c14721f8948c387795c37";
+      sha512 = "4689fba26647f5ba64eef2e8b188366747df8c2e957fc903845de131969e25aeb25b8f4528210be0c6d4a6a5db8a21079e1627aa8edcf087a5eafc8f9b0f8f2a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/fy-NL/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/fy-NL/firefox-55.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "6cffe5d50a37469b7a1f2ca62b9e05d8c2f2e5d9686a07ac365e34357c2827d95c767044a7f5f5fe1124e38690560cd99adf8b733df9d76275049032196a1af1";
+      sha512 = "c9ccaf00b75d0032f3fa7c79bad37e672b944dddcf07cb6783b401a4115e283ef11c90684f3a1a589a745e08f2dff9e27456509fb78a6f894e83c24cab141185";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ga-IE/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ga-IE/firefox-55.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "619489d201b72f96d23be570e8b02654f851f4eac81cccc65e978b0ee69d4af5b205dcda42d95e3b2539959fd697807a0519a1da64acb3784830aeb53e263469";
+      sha512 = "a62af4ccedf1b6c443a13efd6c41b6d6f492f31d1d7701946871ffbbf00df000eef59eac69292f6ea8be64d9512d064ea86d7cdf07656b8ab2bc234106468db2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/gd/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/gd/firefox-55.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "9e198c4392396379057570a5200e41eb44ecf8c7b427a4cf9d307404d58d23ab440aa1f29798b38887959beea217bf3ab12a80012da66479260438ce45bb12dd";
+      sha512 = "177f3584b81bd03ceceb0f7083114b38ba826974b115e962d8c6065c001aefda7c65c273c1a833cf7dabd24b69e0c42079ccd6842f882f196de1a2fdb7ce8605";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/gl/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/gl/firefox-55.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "6a8439062f17c97e76a7f660ce9d25461e92089494bd8b12857e08bd712e9c4ef300252fb6145335884dcae8ef867e562f0e4cb901f07c8a037eb7f03615d562";
+      sha512 = "6dd9fc8420093f8faf0eaafbb1cf4326360d610593fc8642e488a3850d9f94a249e27c89123eb3a25e476100b63fff1a88dc85f3e5714080ebc9078dc9309ca4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/gn/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/gn/firefox-55.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "6be9a7cf4c3727aa603747476a2033b24be6e848ab2e5f8ea834fa07e96af05774b7a06d8e004be975f6ffd83ded606486a996d0b7132e7759f81da43bf5f003";
+      sha512 = "3badcdbd0642ac510cf978e978ea7a9fbd1d6a0de7ca541aa2eba16bd2b788b5616fbdaec06a3d29975c6b4fbe8894b6f38e2522a6495b4d8d1564efd4c2c656";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/gu-IN/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/gu-IN/firefox-55.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "c97c4ac9a0359a040d07e3a62fe0200c7eb767d4f4748801241a0aeaed930761ea306dad1789c8c6cbbea75a90e55a4f00e04c450a528e8242a3821af803a19a";
+      sha512 = "85b254c78925a8f30798e37afe5e452c50bbdfdac683a16cb0407c8cdeb1a9dfc23be4f7bedd44c8f434d2d1b16b65603448e356e5d82ca41bd698bc275da80b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/he/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/he/firefox-55.0b2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "27597aa4743b1bc4dfc8c26e79d5ccdccab812b576ed8d2a1d6cdd5c6971fffe00dd10f69fe13e00cb972ca78ddf47822485c1e053e81c179d2a187c9b46590b";
+      sha512 = "49c6aad468a893d77f9b158883095fa0429e4acc0a18aff2b284cc90036f11a04de9951a2fc18ba87ecf1d3fa6c55673e9e0e69428bce980638fc270356e11c3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/hi-IN/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/hi-IN/firefox-55.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "5e9e484fded08a42b2499417327b2373e92d2321cc3550cec25e4f0462c7c4e22a1490c972f6b31c30776b858faf50345a03ee52c6a67e2e0da062837c07d245";
+      sha512 = "6f64ce83bfd5156c6fef02fbd0e7bac47f8a04848ba5da619c9809510b1f1eefba396c3c9f48ad6f9d0ee700e2b19a6edf1f0b104ec05bc798c22b8dd2b4a6e7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/hr/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/hr/firefox-55.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "44a49025664ff4e5fb34a5d8d02e1dd7dbe581b0aa5d014c2c9e9c052be9957bb04d6d9bfaa0aab15963b2eafda2f2e414fcabe826c73d9286923eb5e8ce1300";
+      sha512 = "0c4f520f2da27b1a5a59bfef7fc9648b9794bf0e4e471082f0527471bc824ce999ca668ac6cfe39566eee81cdcc66d5a09a15dc4aaa528345786288fc4ee4531";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/hsb/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/hsb/firefox-55.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "6a71f8e721270d1c450c19c627ed1212f56a7f4d1b3f3cfb5e72609c58f6e040d76aea4e57f8f15c912c5f35c7f7e91c604f2355b51551808399593548724b24";
+      sha512 = "b7753e082c93d169aa559bbb9314de29cedfb3bed336e9b2bf2f4514269fca3ffef52e5298322c9f5d354aea160bf0e1538cb51f570a2c29d504d398c6fbe262";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/hu/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/hu/firefox-55.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "8ac3c4c1b078daf9a671f22cb77f7bd056175b11d20606e710017b1cf564ed648264d3ce23c9e28ee507ff0c0f5bf78cf897a62df03c5ab5e25571c1c04d546f";
+      sha512 = "84642ded2af2d558cf93960af568cd224ebff05f13f26d4fca84425df14f6ea8ad3ff459df16b0f035f28697723a264d2f3ecf8121022ba9659ed47163faee7f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/hy-AM/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/hy-AM/firefox-55.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "6a97cc2fbbf92050d1055dc288ccd5346284ff6927b05aa0467bb369dfdb1a2b54c0b57f3356add342e1221c391a7d381d2fa895bb0aded5d82cb85071582a76";
+      sha512 = "fbb79684d496b4780bfeedd2d682fda002bd190f5148343d3f3720673d2dc26609fdafe402feb96093de0db960135293dada87218612bec562a6be2760514a77";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/id/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/id/firefox-55.0b2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "19c32f612c53bf98bfc108f02adfd6345ba3d7c544d1ae93168f57d95e9360718fb57fffd8f205550417fb237639dc4e21e098f2a95bccf8598a11b464497a2a";
+      sha512 = "405635feea5949d6ef58632809fc69ade5f77f6dd19f0c190059698558c429f28f94fdf08612c0346ffac4e54bbe806dd6c01ebceb9202a4c7911f86ccb1f747";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/is/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/is/firefox-55.0b2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "570c0832f57f46b398b6370a3f80439d3ea5bad1877af242f6c57b9a35f6bb148946b13475ef95c60a920cb51505887c09b6e2530fa2c802d09e4a1967847d1f";
+      sha512 = "5c6e9021355b7e9bf4d13db20d7bbb09dbcb94c4c8213e2aa313b6a451ace1bb394e31ded52d36ac80770b64bbd7b9cee93c7df233338a6ca9e4e5a8f0a8fa80";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/it/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/it/firefox-55.0b2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "54e6f03f1e8473d407ac31267378eb5432ba7c366a309a646076ca2d02e342cc586ded7dbadc83117bd71a24d1654cfae63ee5b1b1ecda2cbafcdbca8009ab94";
+      sha512 = "2fc8eb314a9328cd91029aa28234acded5ee1318b2708fc167171f4ea8cbe25a87e0130ce3c13300fb15bc5e8d09ce504da9ea5ab46cb5b01498b083d067499a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ja/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ja/firefox-55.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "e73625a90586b9b845f9a2870838a3ac4f1b194fd04202b60d00805506102f65fd1ab69a3781e86f5db5580c881b7570c1d611c3933c271c43d32e15c3214db7";
+      sha512 = "5cd5fe41c714f9efcd7a0d4aef259c01ff4a3a0ac05ebfd6b011fb2984f1399803199f7f91703fb55e3e4cd8d0032bc6469065dade99a4290dc2af1109fce044";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ka/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ka/firefox-55.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "72c070a815511e483eba416ba4172f6ad4d026f2469d1b2b0beaa07cb49f219275b7612e3eb39140601c7d9aa55b0fa687f768ed358a3245c1d467100b6c0cd5";
+      sha512 = "1e84b3d9fd78c884a125a18b003dd03834b6ffc8cffae93644bac3d78e6041cddb831ceda58d5d4d461e3fe900204d3916a917d5e5056e12684a8ec471df9d20";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/kab/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/kab/firefox-55.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "15a2566f74412625329444b2b95fa3c8d0873da9b40a0305b9d2add6a9494574e9350860e87ede63daed36f3347d617b0901aecfe7c3c20a8fe0e44e2117c085";
+      sha512 = "a650cdebc1c89f5f65d60f36449650ed36f9ab79b4e5bd084717f88c089312a105388bc6cf6cb6b05aaa05ef4168225ec1378d574f82b0c7ae2fcadd9ba549b6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/kk/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/kk/firefox-55.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "f56ffefb3278b3cf580fd6506a1d1b69fe5a693f259cf630a33f0fab8ec413fbb49f1dc118ff389ec513288f346cbebf379dd4c6da6475c740de3133e5b53130";
+      sha512 = "901a7f524fb6cab92a6f686ae2951ac4668b2373f0306572b4214b9dff76762e36372afb6d5eb319eafb0c1595a62a8020078938a650531dedf26e4951f7e519";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/km/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/km/firefox-55.0b2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "bb26a6a7a90cd0925f0e809ae904e7d81f9bbdb5a0e56b084f5c5bf22647ea19ef8d445917a03d5924ae551affae375eb2706c83efc930e7027f0753db168638";
+      sha512 = "a86ad7c74e87ebe0e4885914a07e352349d353507708e79e37be2af57653f4778f0203b1d72580909a725aa696e8e8f491fc817237f553f526400aa47da0f03c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/kn/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/kn/firefox-55.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "b500573653885e3452aa4e05a4dbf7bc9631fc9751b62e23dea013fc4f845a4e370848b53b999d416552c44a176304187ec2333bb51b2c4231fb52b6fcf3d429";
+      sha512 = "6f8e697482ac61565c2030164ea08fb92803e91cbd3f562ba70f982b2db7c0d9effea7347acf3a4cdaa7c7cbe393a3455b4a7333957ac2ee707f5b542ecefabf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ko/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ko/firefox-55.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "51e6ff26f2721d8750e230aac93def8579c9fbf066413977c8c8216b435c77ee45e597864b778b2e79ba01dfc9e994578920a75e67269c379f767f662bafcdcc";
+      sha512 = "83a7ce342c38ee014142e60590d59e42373a38475a36f4c9e03dfd12890e4649e34a0ab5c3153c93ee9eeab9810c78ddb5332e4bd92c891c462e1df2a2305bfe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/lij/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/lij/firefox-55.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "8cbf424675d8289648d77b3a4b3b37150762647b08941ca7f78fc67e2a5d6a96e800985f8861d5515d6d5339008962066dd5bd5fb16a04789a9101a158fb6d4a";
+      sha512 = "8a8b686894ac4c211381e31e29d0020f43b11c92edf8158c89838e73713576e21e3d25349d8f3bfa1da3a9b232a1c058f6252af15e0f2181a77cc24fd046ef7e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/lt/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/lt/firefox-55.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "0344d94606aa384757bbfd07982762a66683cc27ea446c16ec3206fa2c0b299fab06462cc203a25cd0db5070e160daeda11047b2dcb8b4af2bcae130b6a1ed2e";
+      sha512 = "141f50e9bcb95e456204620f25e670ba3299b3cc06f86afe7bda652dc59745d09e9014737f70caf12c5f6a52c8b5f0777405969b92efe272a579d2eca817e22b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/lv/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/lv/firefox-55.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "8b80056b0d6897cca46fbcd3836096cfdc3c4824154b71837573eec75b5f4ee1d0e82cdf0dd1d73a651707aad7888d2413505154bffb0e56beabb379f5b96105";
+      sha512 = "c51ff24bf9ecf43e49064aede96d9487240e3a14bf5b6e61da1c83de01b5d5e974432e43b93d28fef0c473311f528cd06ea2d2a3fb09cc7a7e8fbbcc07c7e4f7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/mai/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/mai/firefox-55.0b2.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "365cc9a52dae47e9391c95dcd84230d0667816266e561b5a26dec8e21b1b82fa891acb851cfcc70a162a852d2ce21492701fa277d3fe98d6dcd6f3cad1c704f4";
+      sha512 = "2307008568c8140d7b90ff4dce3d4c6fa6bf5f1776d93fd7979b14ffc384916f15261f611dfd3c0e83e5d1e8980bff9c551ae9978ed16540a399f6cc7ff64c84";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/mk/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/mk/firefox-55.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "2ee12219fcee798550da2dccebe800fc67b81a41ca7aa543d0a39cdc10fcc4db5d2503a9053fb2f46e76c34e3300a1c025aa87a639f74a2b14e8585487b7f949";
+      sha512 = "b6746b827a3c45e0f8a7bdf4423f63197ae728fe0bcaf0a6781e44fc42dc6c31cbe1e4ec4f1b97f96f1534550aa6921f453ad9732e62ea8fa0737a36a10e3479";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ml/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ml/firefox-55.0b2.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "38bab91c0e1019369f9aaf84abf145045810a3f89b1f437dd3851fc2267524f1b23daa0668f60740678ed659e5ae1990d2e6798944e7f81621cccfcce60b0da0";
+      sha512 = "7f1a44de725ba6ae31eb21e005fccf6434e7987acd8a480493fe872163ceb5d7052e9fed2475ce65ff487f0824b3a090c917b2a8119b4b9b47a3c6e5f7fc43a1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/mr/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/mr/firefox-55.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "011868a403e71693274139de118051dbd0d0c6771a5c780406672f373e5b7470183836bcc0c6aa67c3e9369d401e919def3d6889d0e1758ff2b5152a8f118bca";
+      sha512 = "e751aebda7834a0532fb0885da223316e19f4c0606a88b5a70956d0a72bf37069370d0478c2809400ac09f76822b34706d776f5ee6237b7b33ad4237ee4f7fd8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ms/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ms/firefox-55.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "d4a4891090b122f5ed2462c9c42f148f431c9b9eaad831698479ac1eb15ae41fa4355740f3fb44d7367a34e552c3313a44f43c76ebd2889990a546ba2ed5d61a";
+      sha512 = "ceaf89d467075799f95ebbf7b93bddf4c1961fead16fb86962bc857caf3ace620c42e2d11152b9cb2819f9a8a16625e5e276263ebe9066dba0840696a2a0a052";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/my/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/my/firefox-55.0b2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "ec14ee7fdef28210a232fc7a0fa4ab3e891d1bf59be498a1842fae465b1ea8738bb6bf24297ffe8b77e043772be3c5a4bdfeea4ef13ace543b050a25418544ff";
+      sha512 = "d7d6ca947e04fc99d28abfa9d9fb07e85f4f71b71b381cda0c8587460c6274a860ae26b60432566ac9af25c752e8d5edbf8cda515cd523521958e2f3bae4cbe4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/nb-NO/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/nb-NO/firefox-55.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "7cea11945a09933f75efb1385224f49ff08f395669ef3b6cab296b02ac2e597e9b424c6ff7c08180b0cd3763b2772a7c288e9cc9c42dbe27e1eb285d209a62d3";
+      sha512 = "4d5f7c260011e00a202c841f2ef103aa9fb6b6e329a51175656bf9cc3952664da5c0e90de571f9bb6c0886363e1988b8a81a8fe3ce0daddcd1ae284b68b8be34";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/nl/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/nl/firefox-55.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "25418b1377a9ed0a0389f5d4a04099197a2e364e7337368ca8c096f30b249a16d4988f3bdf941661f548bb7c478be5a74169dca9fd5d4800c56af5a6c93b9728";
+      sha512 = "994ee217f580dd8bf8eb06cea6f9ab509f7a430e8f74946d518465ec26b6b2d7c61e775374a9c1c3101c3a7c663326903226af0b585b01b40cd57151aa909a39";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/nn-NO/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/nn-NO/firefox-55.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "eaad38fae776a49f53448bd9e652f75299946b19839f440ba470afe5aa813c5e8230ce62388d923b411f662011c72cdc5d6a0c400024677b92183d13aa3af585";
+      sha512 = "ae39cb50182999233a46c6a5326ead7b5e2f363cfc10505f246d14e70fa52bab5f51804a03a7f20485b9761dbc4dfba3596feefe27e6026dc530646da0cc4b14";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/or/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/or/firefox-55.0b2.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "a055a1bba667fb338c55f015e5380fdea48bcb7a6311060412171a7dc573c76c087b74108d505b35b7738998516632df54143ddb5949946ffced477d408d3f99";
+      sha512 = "9b8346e09115651b58a2aca7a7ee2f4346155fbe6d77dda6c06f3a3e92ad4956ee5775dfcdd9c193a36a00407132aa2041311ba92e7b59c10cab287f8c8c4716";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/pa-IN/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/pa-IN/firefox-55.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "d93f23ac36daef173869ca9a0ab32d986b1acfeda96b2d277a6a555fda14f501c4f3c98f4dc8e77905098a0d20073e801f83e245b2654aa6c4e6519fd1ce3be1";
+      sha512 = "64bda267943ca748f6151498d477687bfe06f52110ef10e5bb2a744548878f3cbdbb5dd707bda4607c45e8ea1037981a2ced01143ffa596a3847792db4849371";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/pl/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/pl/firefox-55.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "586a4162866ba6f4b0851278cc987389aeb5f4f2582241fae9337cb00a62fd909348046f57492af9872e0a41f0e3167698f80cb7e37ef98a8dc7cb8c13fecd66";
+      sha512 = "dd38f64466c58cd4aee750d4489e598c0e934c6eb904ca8eccf1c2c1c092bb87af739a624f5f210e6c4ed25a6ac3dff233f13f1de5abf7a9bc831e02b4630f60";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/pt-BR/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/pt-BR/firefox-55.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "69ef7b9bc482bd073471383258b15e8bec77a4513502ae797bd1428e618525c8d2e037eca4ee957f6537ef4f3fd261d1a0e9c14d8597bd354652c482f315ab7f";
+      sha512 = "b1265e3274779c415db96c6a8c2518b159311d4f7aa638c030d90ec4169db70b6388df9b5c94fe31c4e41417cce2e65a227a6f6e9c47322a365fc6941d50e1e5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/pt-PT/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/pt-PT/firefox-55.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "ad7bb1f211b5167c3a091f832248ff14c5f9d197e7065bd962245f8c2e1e54c0835d148f63b2760fdfb2e6720f4ac3f64c6f154267b5fae29683bf9d88a7d232";
+      sha512 = "30e5d4ed87cc28fd51340d407e506b56fcda3cc23fc382d1c471af2c3b990222a5d2fb7b645373c1f067825df56875ec6c2f9bd7b2b259bcf0e466f5070bbb2e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/rm/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/rm/firefox-55.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "e25b7a201fa2a77f6f8b9dbe815e59548c598218cab74919d726281e27a8cd4b1dce0a89beff79ac21ff0bcd5c1faea3f436acea5405dd1a899e66fb5a7a7754";
+      sha512 = "c3d31a0e8704bd7dbf6aab569aaba68df60489ee38001905f445849fc9bd1eb4666cfba8bef959a8559dd0dd9c16222429f64b398a55502b4d8dfd7fbc8d614d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ro/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ro/firefox-55.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "12419f032ccbc2a7bd54f1f04de77d5318531426b6ed0030076b52d4330037ca606f1319606831f485ab994d0bbeec50455a770b0448c24c1731e137f9cae51a";
+      sha512 = "d9833be482f828da584c2d30480230e5f79432bf3479f05b5be978d7068e11d76f07f697f85ab8c84b68f49e78593cd1a3fd9067b888f11657e96ca8a2dc3872";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ru/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ru/firefox-55.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "79a76a1d54d4449031755a2298efeb60d94290f77a003263dea2d771975bcfd66a7a81e1eaab298f9c72eafc1cdf28060554a901a01bdf26ca8f39b1b927d375";
+      sha512 = "e1f1778d4e7d019f2a945a8c83338bd3af7b6db0277af921e869c6c94fa22579240570f6d7edbf5f42c28044b6537f724bd33719d4d7cbaedca77ca7e17dfc20";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/si/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/si/firefox-55.0b2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "d93baf7dc43228f94f2e38e9884f37ac638f69fe367998b86c75f5cd735f012b408b270cc86a78b18f86ba344739baef22ee022dcb8397d83dd341e8da63be05";
+      sha512 = "63580c6e8820bdc3ea48dca090ab3ba2393d02051ce26905fc3097a36dd9e76efbd19b704145a0d3960a86d52462c7c58497591fbe50f6351e7d727871ec77c3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/sk/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/sk/firefox-55.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "61e6388daa5f1ce30a313d2d93378bdd8119ae0c3d84b60f1b7caf5e78033e30602a808b0a1169d4017d581daab2e905dd03c202ef394ae765b083518b45a890";
+      sha512 = "9df80f36ecb8607613f30254aa8c3af5b6d417575c937dd6f428b5e62989ba9bf9237d7244b0ea598127ccd4bd2aa35db31a54412506022fbe4f2e65eb603d4b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/sl/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/sl/firefox-55.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "3d72f18632eb1142da5ea6b9423a7832b030d246af261cd46516810c721bc9024cc147cfd5fbc7c3cfbbd8fbf920b543d23c203325baaac024e726a040715809";
+      sha512 = "820cebffee19a05c2c03ab25b5c86ac7468989dd2a1118d3324dd7be5d3827675a791e3ec0b92ec32907fc585666b5b1050c81c5e16f57ffadc11da3b6de013b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/son/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/son/firefox-55.0b2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "6a7a960468213dad0970e6793716aa4882f82c3dae1cc24c875190dcbd93953fe89a862d6141744d1cf7fafc6aae723c3d271094242b82d4fe76738aaaeeacd3";
+      sha512 = "b70dc6963e44a225254aa8b9487c40abd03ba1e1cb96cc2ab4a8b24908b26f5093bc715ae2dfc727257465ef8cd01bb5b15628a328a9cf5fd6b78b7f35771855";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/sq/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/sq/firefox-55.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "170b0ff5fcd665c50dd33cc05ef5ba79d4b6b7b66c04c0e679c294e03395aac07ff8b47b7178f2b7075aee4e42e9398e911c670671cdf15f1f1a465f57c95ef9";
+      sha512 = "ce2d445084c4db468e1a116fa9e4b741ff44ba994ebe5c575295bb6cd69cb72e5305b8a0326f7b43ee620a5e219279696b862ef512f3c4bfc32d3b6b2ab2321b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/sr/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/sr/firefox-55.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "3f57ec3fe394f1a39bb4cf2f7017b52680d3d13b3147c6385edcf36885afdec0a0613919c27c276994fe30fd1f28b53ffdee99ed0701688b65cb6a0ce4ec6010";
+      sha512 = "4a5b4f4e8e9aa944d7dff5e1bc40f44141b04672666663c8c4a1b7844faf2289d3323427efec373f5f4fdc7ef5c79494dba416db8ced23b1a5f387b462d609b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/sv-SE/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/sv-SE/firefox-55.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "021ecd06e900dfe961a527d7ac80e02d74cbe12daaa79db293b3c88d638fa46407523a5e80de193d6f9733954c8c309ec51337abf30c6f3679d54443c6f8247d";
+      sha512 = "56ca783a26d7c4c022001c72c96f02f79fc78bea625a73e3fb2be7602c96cb3753a718a184b7c1c5d154a755fdb4862a53137e4f8d1795345d6e5855cfe3faf5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ta/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ta/firefox-55.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "f5d624139725c96dea05a2bed5430f004da09c5e6cde7e82226589889ed6a6bbf5cde458cda787463eb7a71366678213fb04ca75f05c10385d9ae7c3e2144f39";
+      sha512 = "9fe7f93308392fe970aeca2fa72fc7d709c592ebab1bbae768a511c6928c914c4679eadf3832f416dad9e23cadb241de6fba3345739b419d8118523b0c35aec9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/te/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/te/firefox-55.0b2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "d024a530ad5adffab0077644f119d0bd6fe538d9849ef2db4fedf0af299375de4b0035926041288957367d77ed868c85f95fba426e2c5d8a3021865d603204ff";
+      sha512 = "0d1333de541d617aa61741b03368c82ec8c76374741c086866d1d53832d97b9b0ad115d406914bed8061d348c0ea1bb5ce84a61e57596afd5ae318022b8f50b6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/th/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/th/firefox-55.0b2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "37e4be8ecff2e594778710c4ee1f779a4e53ccce4fe38644122850f55071f9be025346ac3efd74dd8d7789a6772638cfa6d0e32028025269a8b1de1c4c39127a";
+      sha512 = "cb607b0394cb81e6db0f52b080866fb26f4776d3f81ba9b040553fcb087817795049b4c12128b9c00bc17d9d0554dc428f680de531f80cadcf24fc3dc1f15a89";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/tr/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/tr/firefox-55.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "a7897a83625bd5b7d0121ea62bb97bd0e6f802e6e010d27ef2f535438c62a7aafbb91b0a1194571e9bd35a673aea1527949b5da0ddafb721c82662ecd1f8db59";
+      sha512 = "3549abe03ea546bbdb0c0837829c7c9402a2d791f1fecfd7d8b9f3a3c14f496c26f758096cef959f9f9e5538397526b8d500e4d97062363f6c370cb7b8ea2b95";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/uk/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/uk/firefox-55.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "a4f133b7184d8a80777b0032012007ef12edb3fc9ffece00774deea31836e0b4ff9d8f372454db3c2d9a167298e304055fe59488996a2f3fcfd93aef77715f8e";
+      sha512 = "f65108c24e28daa73d79d52bb2c58c0d590c6bee90f4a57202954d556ea04cb082ab61f588747bdbdd7d1c752272d83e47708bb5a2c7e346f6bbd5f1bc8e5746";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/ur/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/ur/firefox-55.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "71d75174c843d68cb677676b318b2239b6f2e295b8014c13f2be5ef5d050d91182f5c60d95491e6e1afc25df98b431f6eee0b058607289baf14e28ea60716938";
+      sha512 = "f138ec6164a608d03d7873af6f4ee8fd51f553912c06841e41214b24890f232bb342c2c33df388a58a958d932ca803ac671f2daf139ceba4f46c8fe5cd038bf0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/uz/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/uz/firefox-55.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "fd317b715c9a2eaf995ab95293652f61984f63b47e487e7e0c4e226d65163ee26ef13725d29357beab6555015fae0a6bb9dd273996bcbc0d60463cfee9b2af0d";
+      sha512 = "7c427f89f4aa7462a2e3a35755c5dd82cfc5ced2d82fbfbfaf8804d152326d02e88fec8230d4905f89eaf27020f522c4096cdb844d38fbb0ef4c5c54c250745f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/vi/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/vi/firefox-55.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "a964992502ef7f2e32c9a525fdede156a5e9e0eb88224b9112541f706bb9162b5ba68dab049c99206b5afa3bf232489e8cf25149e012f42f9d299176e48ab990";
+      sha512 = "6bd2810d6683ff537aa47b97dd8e4778604a8aa58e7cd8f5a1aeea7cebdabc8f7111c025131ad6255428711a5a6ae69bd1118b3636f6f4ab3ce4022aef293de0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/xh/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/xh/firefox-55.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "ae4d335ceaa94e4b95a2fd6223d08087d20ddc666253bdbae17290f50fa0d425243aefab62d25362f2efee1dbf2abd7df4cf6acb5704ba487395e139060df6ef";
+      sha512 = "d23be8509fc11f3726efdcad75847390055e2d4d9fe775e9ea007290e21e9e9583dbe5a2a74dca0866f7d0cc2d3066f9afc4bb1e6665e94cb808b3e9f3250439";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/zh-CN/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/zh-CN/firefox-55.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "c4975f9645aa875df6d948d9f89a00a1758843b7ec706814b6632d5e2b5f8ef272f25ba48ba9ea0b4b00e41d5d2fb7094aa1c7e2d1dd8b5e0715c51adbdd6e6b";
+      sha512 = "42361dd8de84b011d860b0fd4a7f7ae59b3cd8297c57275283f61ecf51275e8263a67af9730e82251c1c9f19c5216b0e2d65adde5987c4dfa88f3f95eea8086f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/54.0b14/linux-i686/zh-TW/firefox-54.0b14.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/55.0b2/linux-i686/zh-TW/firefox-55.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "ce2050031406d912f6c812ed6b29a07d0c41c1569eb28a4e4280544ba286fa088967b16113181ef5d2be14e00ac84c89d0bfa9b4c25c700874d1b514493260cb";
+      sha512 = "44735872e5600fbfe03a5ecafc0f25b8f193572b067a8a18a598ea4972952747023a93c10727887e6f598922691bbf2bd90a76c8a966abc69ae946ab09aa0c81";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

