### PR TITLE
flask-restplus: update to 0.10

### DIFF
--- a/pkgs/development/python-modules/flask-restplus/default.nix
+++ b/pkgs/development/python-modules/flask-restplus/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+, blinker
+, tzlocal
+, mock
+, rednose
+, flask
+, six
+, jsonschema
+, pytz
+, aniso8601
+, flask-restful
+}:
+
+buildPythonPackage rec {
+  pname = "flask-restplus";
+  version = "0.10.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qs9c3fzidd0m3r8rhw0zqrlsaqr2561z45xs6kg19l7c2x6g5qj";
+  };
+
+  checkInputs = [ nose blinker tzlocal mock rednose ];
+  propagatedBuildInputs = [ flask six jsonschema pytz aniso8601 flask-restful ];
+
+  # RuntimeError: Working outside of application context.
+  doCheck = false;
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = {
+    homepage = "https://github.com/noirbizarre/flask-restplus";
+    description = "Fast, easy and documented API development with Flask";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10945,6 +10945,7 @@ in {
     };
   };
 
+  flask-restplus = callPackage ../development/python-modules/flask-restplus/default.nix { };
   # Exactly 0.8.6 is required by flexget
   flask-restplus_0_8 = callPackage ../development/python-modules/flask-restplus/0.8.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
Tested and working

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

