### PR TITLE
Generalize building of Elixir interpreter

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -42,6 +42,7 @@
   andrewrk = "Andrew Kelley <superjoe30@gmail.com>";
   andsild = "Anders Sildnes <andsild@gmail.com>";
   aneeshusa = "Aneesh Agrawal <aneeshusa@gmail.com>";
+  ankhers = "Justin Wood <justin.k.wood@gmail.com>";
   antono = "Antono Vasiljev <self@antono.info>";
   apeschar = "Albert Peschar <albert@peschar.net>";
   apeyroux = "Alexandre Peyroux <alex@px.io>";

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -16,7 +16,7 @@ let
     in
       import ./hex-packages.nix {
         inherit pkgs stdenv callPackage;
-      } // {
+      } // rec {
         inherit callPackage erlang;
         beamPackages = self;
 
@@ -37,18 +37,16 @@ let
         buildMix = callPackage ./build-mix.nix {};
 
         # BEAM-based languages.
-        elixir = defaultScope.elixir-1_4;
+        elixir = elixir-1_4;
 
         elixir-1_4 = lib.callElixir ../interpreters/elixir/1.4.nix "18" {
+                       inherit rebar erlang;
                        debugInfo = true;
-                       erlang = erlang;
-                       rebar = defaultScope.rebar;
                      };
 
         elixir-1_3 = lib.callElixir ../interpreters/elixir/1.3.nix "18" {
+                       inherit rebar erlang;
                        debugInfo = true;
-                       erlang = erlang;
-                       rebar = defaultScope.rebar;
                      };
 
         lfe = callPackage ../interpreters/lfe { };

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -39,21 +39,17 @@ let
         # BEAM-based languages.
         elixir = defaultScope.elixir-1_4;
 
-        elixir-1_4 = if versionAtLeast (lib.getVersion erlang) "18"
-                     then
-                       lib.callElixir ../interpreters/elixir/1.4.nix {
-                         debugInfo = true;
-                         erlang = erlang;
-                       }
-                     else throw "Elixir requires at least Erlang/OTP R18.";
+        elixir-1_4 = lib.callElixir ../interpreters/elixir/1.4.nix "18" {
+                       debugInfo = true;
+                       erlang = erlang;
+                       rebar = defaultScope.rebar;
+                     };
 
-        elixir-1_3 = if versionAtLeast (lib.getVersion erlang) "18"
-                     then
-                       lib.callElixir ../interpreters/elixir/1.3.nix {
-                         debugInfo = true;
-                         erlang = erlang;
-                       }
-                     else throw "Elixir requires at least Erlang/OTP R18.";
+        elixir-1_3 = lib.callElixir ../interpreters/elixir/1.3.nix "18" {
+                       debugInfo = true;
+                       erlang = erlang;
+                       rebar = defaultScope.rebar;
+                     };
 
         lfe = callPackage ../interpreters/lfe { };
 

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -37,19 +37,19 @@ let
         buildMix = callPackage ./build-mix.nix {};
 
         # BEAM-based languages.
-        elixir = elixir-1_4;
+        elixir = elixir_1_4;
 
-        elixir-1_5 = lib.callElixir ../interpreters/elixir/1.5.nix "18" {
+        elixir_1_5_rc = lib.callElixir ../interpreters/elixir/1.5.nix "18" {
                        inherit rebar erlang;
                        debugInfo = true;
                      };
 
-        elixir-1_4 = lib.callElixir ../interpreters/elixir/1.4.nix "18" {
+        elixir_1_4 = lib.callElixir ../interpreters/elixir/1.4.nix "18" {
                        inherit rebar erlang;
                        debugInfo = true;
                      };
 
-        elixir-1_3 = lib.callElixir ../interpreters/elixir/1.3.nix "18" {
+        elixir_1_3 = lib.callElixir ../interpreters/elixir/1.3.nix "18" {
                        inherit rebar erlang;
                        debugInfo = true;
                      };

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -40,11 +40,19 @@ let
         elixir = defaultScope.elixir-1_4;
 
         elixir-1_4 = if versionAtLeast (lib.getVersion erlang) "18"
-                     then lib.callElixir ../interpreters/elixir/1.4.nix { debugInfo = true; }
+                     then
+                       lib.callElixir ../interpreters/elixir/1.4.nix {
+                         debugInfo = true;
+                         erlang = erlang;
+                       }
                      else throw "Elixir requires at least Erlang/OTP R18.";
 
         elixir-1_3 = if versionAtLeast (lib.getVersion erlang) "18"
-                     then lib.callElixir ../interpreters/elixir/1.3.nix { debugInfo = true; }
+                     then
+                       lib.callElixir ../interpreters/elixir/1.3.nix {
+                         debugInfo = true;
+                         erlang = erlang;
+                       }
                      else throw "Elixir requires at least Erlang/OTP R18.";
 
         lfe = callPackage ../interpreters/lfe { };

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -39,6 +39,11 @@ let
         # BEAM-based languages.
         elixir = elixir-1_4;
 
+        elixir-1_5 = lib.callElixir ../interpreters/elixir/1.5.nix "18" {
+                       inherit rebar erlang;
+                       debugInfo = true;
+                     };
+
         elixir-1_4 = lib.callElixir ../interpreters/elixir/1.4.nix "18" {
                        inherit rebar erlang;
                        debugInfo = true;

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -39,17 +39,17 @@ let
         # BEAM-based languages.
         elixir = elixir_1_4;
 
-        elixir_1_5_rc = lib.callElixir ../interpreters/elixir/1.5.nix "18" {
+        elixir_1_5_rc = lib.callElixir ../interpreters/elixir/1.5.nix {
                        inherit rebar erlang;
                        debugInfo = true;
                      };
 
-        elixir_1_4 = lib.callElixir ../interpreters/elixir/1.4.nix "18" {
+        elixir_1_4 = lib.callElixir ../interpreters/elixir/1.4.nix {
                        inherit rebar erlang;
                        debugInfo = true;
                      };
 
-        elixir_1_3 = lib.callElixir ../interpreters/elixir/1.3.nix "18" {
+        elixir_1_3 = lib.callElixir ../interpreters/elixir/1.3.nix {
                        inherit rebar erlang;
                        debugInfo = true;
                      };

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -37,9 +37,16 @@ let
         buildMix = callPackage ./build-mix.nix {};
 
         # BEAM-based languages.
-        elixir = if versionAtLeast (lib.getVersion erlang) "18"
-                 then callPackage ../interpreters/elixir { debugInfo = true; }
-                 else throw "Elixir requires at least Erlang/OTP R18.";
+        elixir = defaultScope.elixir-1_4;
+
+        elixir-1_4 = if versionAtLeast (lib.getVersion erlang) "18"
+                     then lib.callElixir ../interpreters/elixir/1.4.nix { debugInfo = true; }
+                     else throw "Elixir requires at least Erlang/OTP R18.";
+
+        elixir-1_3 = if versionAtLeast (lib.getVersion erlang) "18"
+                     then lib.callElixir ../interpreters/elixir/1.3.nix { debugInfo = true; }
+                     else throw "Elixir requires at least Erlang/OTP R18.";
+
         lfe = callPackage ../interpreters/lfe { };
 
         # Non hex packages

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -43,4 +43,12 @@ rec {
         mkDerivation = pkgs.makeOverridable builder;
       };
 
+  callElixir = drv: args:
+    let
+      builder = callPackage ../../development/interpreters/elixir/generic-builder.nix args;
+    in
+      callPackage drv {
+        mkDerivation = pkgs.makeOverridable builder;
+      };
+
 }

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -47,7 +47,6 @@ rec {
   specific data.
 
   drv: package containing version-specific args;
-  vsn: minimum OTP version that Elixir will build on;
   builder: generic builder for all Erlang versions;
   args: arguments merged into version-specific args, used mostly to customize
         dependencies;
@@ -57,7 +56,7 @@ rec {
   Please note that "mkDerivation" defined here is the one called from 1.4.nix
   and similar files.
   */
-  callElixir = drv: vsn: args:
+  callElixir = drv: args:
     let
       inherit (stdenv.lib) versionAtLeast;
       builder = callPackage ../interpreters/elixir/generic-builder.nix args;

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -62,12 +62,8 @@ rec {
       inherit (stdenv.lib) versionAtLeast;
       builder = callPackage ../interpreters/elixir/generic-builder.nix args;
     in
-      if versionAtLeast (getVersion args.erlang) vsn
-      then
-        callPackage drv {
-          mkDerivation = pkgs.makeOverridable builder;
-        }
-      else
-        throw "Elixir requires at least Erlang/OTP R${vsn}.";
+      callPackage drv {
+        mkDerivation = pkgs.makeOverridable builder;
+      };
 
 }

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -60,7 +60,7 @@ rec {
   callElixir = drv: vsn: args:
     let
       inherit (stdenv.lib) versionAtLeast;
-      builder = callPackage ../../development/interpreters/elixir/generic-builder.nix args;
+      builder = callPackage ../interpreters/elixir/generic-builder.nix args;
     in
       if versionAtLeast (getVersion args.erlang) vsn
       then

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -12,15 +12,6 @@ rec {
 
   callPackage = callPackageWith pkgs;
 
-  /* Erlang/OTP-specific version retrieval, returns 19 for OTP R19 */
-  getVersion = x:
-   let
-     parse = drv: (builtins.parseDrvName drv).version;
-   in builtins.replaceStrings ["B" "-"] ["." "."] (
-      if builtins.isString x
-      then parse x
-      else x.version or (parse x.name));
-
   /* Uses generic-builder to evaluate provided drv containing OTP-version
   specific data.
 

--- a/pkgs/development/interpreters/elixir/1.3.nix
+++ b/pkgs/development/interpreters/elixir/1.3.nix
@@ -3,4 +3,5 @@
 mkDerivation rec {
   version = "1.3.4";
   sha256 = "01qqv1ghvfadcwcr5p88w8j217cgaf094pmpqllij3l0q1yg104l";
+  minimumOTPVersion = "18";
 }

--- a/pkgs/development/interpreters/elixir/1.3.nix
+++ b/pkgs/development/interpreters/elixir/1.3.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+
+mkDerivation rec {
+  version = "1.3.4";
+  sha256 = "01qqv1ghvfadcwcr5p88w8j217cgaf094pmpqllij3l0q1yg104l";
+}

--- a/pkgs/development/interpreters/elixir/1.4.nix
+++ b/pkgs/development/interpreters/elixir/1.4.nix
@@ -3,4 +3,5 @@
 mkDerivation rec {
   version = "1.4.5";
   sha256 = "18ivcxmh5bak13k3rjy7jjzin57rgb2nffhwnqb2wl7bpi8mrarw";
+  minimumOTPVersion = "18";
 }

--- a/pkgs/development/interpreters/elixir/1.4.nix
+++ b/pkgs/development/interpreters/elixir/1.4.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+
+mkDerivation rec {
+  version = "1.4.5";
+  sha256 = "18ivcxmh5bak13k3rjy7jjzin57rgb2nffhwnqb2wl7bpi8mrarw";
+}

--- a/pkgs/development/interpreters/elixir/1.5.nix
+++ b/pkgs/development/interpreters/elixir/1.5.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+
+mkDerivation rec {
+  version = "1.5.0-rc.0";
+  sha256 = "1p0sawz86w9na56c42ivdacqxzldjb9s9cvl2isj3sy4nwsa0l0j";
+}

--- a/pkgs/development/interpreters/elixir/1.5.nix
+++ b/pkgs/development/interpreters/elixir/1.5.nix
@@ -3,4 +3,5 @@
 mkDerivation rec {
   version = "1.5.0-rc.0";
   sha256 = "1p0sawz86w9na56c42ivdacqxzldjb9s9cvl2isj3sy4nwsa0l0j";
+  minimumOTPVersion = "18";
 }

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -48,7 +48,7 @@ in
 
       for f in $out/bin/*; do
        b=$(basename $f)
-        if [ $b == "mix" ]; then continue; fi
+        if [ "$b" = mix ]; then continue; fi
         wrapProgram $f \
           --prefix PATH ":" "${stdenv.lib.makeBinPath [ erlang coreutils curl bash ]}" \
           --set CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -1,70 +1,77 @@
-{ pkgs, stdenv, fetchFromGitHub, erlang, rebar, makeWrapper, coreutils, curl
-, bash, debugInfo ? false }:
+{ pkgs, stdenv, fetchFromGitHub, erlang, rebar, makeWrapper,
+  coreutils, curl, bash, debugInfo ? false }:
 
 { baseName ? "elixir"
 , version
+, minimumOTPVersion
 , sha256 ? null
 , rev ? "v${version}"
 , src ? fetchFromGitHub { inherit rev sha256; owner = "elixir-lang"; repo = "elixir"; }
 }:
 
-stdenv.mkDerivation ({
-  name = "${baseName}-${version}";
+let
+  inherit (stdenv.lib) getVersion versionAtLeast;
 
-  inherit src version;
+in
+  assert versionAtLeast (getVersion erlang) minimumOTPVersion;
 
-  buildInputs = [ erlang rebar makeWrapper ];
+  stdenv.mkDerivation ({
+    name = "${baseName}-${version}";
 
-  LANG = "en_US.UTF-8";
-  LC_TYPE = "en_US.UTF-8";
+    inherit src version;
 
-  setupHook = ./setup-hook.sh;
+    buildInputs = [ erlang rebar makeWrapper ];
 
-  inherit debugInfo;
+    LANG = "en_US.UTF-8";
+    LC_TYPE = "en_US.UTF-8";
 
-  buildFlags = if debugInfo
-   then "ERL_COMPILER_OPTIONS=debug_info"
-   else "";
+    setupHook = ./setup-hook.sh;
 
-  preBuild = ''
-    # The build process uses ./rebar. Link it to the nixpkgs rebar
-    rm -v rebar
-    ln -s ${rebar}/bin/rebar rebar
+    inherit debugInfo;
 
-    substituteInPlace Makefile \
-      --replace "/usr/local" $out
-  '';
+    buildFlags = if debugInfo
+     then "ERL_COMPILER_OPTIONS=debug_info"
+     else "";
 
-  postFixup = ''
-    # Elixir binaries are shell scripts which run erl. Add some stuff
-    # to PATH so the scripts can run without problems.
+    preBuild = ''
+      # The build process uses ./rebar. Link it to the nixpkgs rebar
+      rm -v rebar
+      ln -s ${rebar}/bin/rebar rebar
 
-    for f in $out/bin/*; do
-     b=$(basename $f)
-      if [ $b == "mix" ]; then continue; fi
-      wrapProgram $f \
-        --prefix PATH ":" "${stdenv.lib.makeBinPath [ erlang coreutils curl bash ]}" \
-        --set CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
-    done
-
-    substituteInPlace $out/bin/mix \
-          --replace "/usr/bin/env elixir" "${coreutils}/bin/env elixir"
-  '';
-
-  meta = with stdenv.lib; {
-    homepage = "http://elixir-lang.org/";
-    description = "A functional, meta-programming aware language built on top of the Erlang VM";
-
-    longDescription = ''
-      Elixir is a functional, meta-programming aware language built on
-      top of the Erlang VM. It is a dynamic language with flexible
-      syntax and macro support that leverages Erlang's abilities to
-      build concurrent, distributed and fault-tolerant applications
-      with hot code upgrades.
+      substituteInPlace Makefile \
+        --replace "/usr/local" $out
     '';
 
-    license = licenses.epl10;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ the-kenny havvy couchemar ankhers ];
-  };
-})
+    postFixup = ''
+      # Elixir binaries are shell scripts which run erl. Add some stuff
+      # to PATH so the scripts can run without problems.
+
+      for f in $out/bin/*; do
+       b=$(basename $f)
+        if [ $b == "mix" ]; then continue; fi
+        wrapProgram $f \
+          --prefix PATH ":" "${stdenv.lib.makeBinPath [ erlang coreutils curl bash ]}" \
+          --set CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
+      done
+
+      substituteInPlace $out/bin/mix \
+            --replace "/usr/bin/env elixir" "${coreutils}/bin/env elixir"
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = "http://elixir-lang.org/";
+      description = "A functional, meta-programming aware language built on top of the Erlang VM";
+
+      longDescription = ''
+        Elixir is a functional, meta-programming aware language built on
+        top of the Erlang VM. It is a dynamic language with flexible
+        syntax and macro support that leverages Erlang's abilities to
+        build concurrent, distributed and fault-tolerant applications
+        with hot code upgrades.
+      '';
+
+      license = licenses.epl10;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ the-kenny havvy couchemar ankhers ];
+    };
+  })

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -1,21 +1,20 @@
-{ stdenv, fetchFromGitHub, erlang, rebar, makeWrapper, coreutils, curl, bash,
-  debugInfo ? false }:
+{ pkgs, stdenv, fetchFromGitHub, erlang, rebar, makeWrapper, coreutils, curl
+, bash, debugInfo ? false }:
 
-stdenv.mkDerivation rec {
-  name = "elixir-${version}";
-  version = "1.4.4";
+{ baseName ? "elixir"
+, version
+, sha256 ? null
+, rev ? "v${version}"
+, src ? fetchFromGitHub { inherit rev sha256; owner = "elixir-lang"; repo = "elixir"; }
+}:
 
-  src = fetchFromGitHub {
-    owner = "elixir-lang";
-    repo = "elixir";
-    rev = "v${version}";
-    sha256 = "0m51cirkv1dahw4z2jlmz58cwmpy0dya88myx4wykq0v5bh1xbq8";
-  };
+stdenv.mkDerivation ({
+  name = "${baseName}-${version}";
+
+  inherit src version;
 
   buildInputs = [ erlang rebar makeWrapper ];
 
-  # Elixir expects that UTF-8 locale to be set (see https://github.com/elixir-lang/elixir/issues/3548).
-  # In other cases there is warnings during compilation.
   LANG = "en_US.UTF-8";
   LC_TYPE = "en_US.UTF-8";
 
@@ -66,6 +65,6 @@ stdenv.mkDerivation rec {
 
     license = licenses.epl10;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ the-kenny havvy couchemar ];
+    maintainers = with maintainers; [ the-kenny havvy couchemar ankhers ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5990,8 +5990,14 @@ with pkgs;
 
   inherit (beam.interpreters)
     erlang erlang_odbc erlang_javac erlang_odbc_javac
-    erlangR17 erlangR18 erlangR19 erlangR20
-    erlang_basho_R16B02 elixir lfe;
+    elixir elixir_1_5_rc elixir_1_4 elixir_1_3
+    lfe
+    erlangR16 erlangR16_odbc
+    erlang_basho_R16B02 erlang_basho_R16B02_odbc
+    erlangR17 erlangR17_odbc erlangR17_javac erlangR17_odbc_javac
+    erlangR18 erlangR18_odbc erlangR18_javac erlangR18_odbc_javac
+    erlangR19 erlangR19_odbc erlangR19_javac erlangR19_odbc_javac
+    erlangR20 erlangR20_odbc erlangR20_javac erlangR20_odbc_javac;
 
   inherit (beam.packages.erlang)
     rebar rebar3-open rebar3

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -56,10 +56,7 @@ rec {
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR19.elixir`.
-    elixir = packages.erlang.elixir;
-    elixir-1_5 = packages.erlang.elixir-1_5;
-    elixir-1_4 = packages.erlang.elixir-1_4;
-    elixir-1_3 = packages.erlang.elixir-1_3;
+    inherit (packages.erlang) elixir elixir_1_5_rc elixir_1_4 elixir_1_3;
 
     lfe = packages.erlang.lfe;
   };

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -57,6 +57,7 @@ rec {
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR19.elixir`.
     elixir = packages.erlang.elixir;
+    elixir-1_5 = packages.erlang.elixir-1_5;
     elixir-1_4 = packages.erlang.elixir-1_4;
     elixir-1_3 = packages.erlang.elixir-1_3;
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -57,6 +57,9 @@ rec {
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR19.elixir`.
     elixir = packages.erlang.elixir;
+    elixir-1_4 = packages.erlang.elixir-1_4;
+    elixir-1_3 = packages.erlang.elixir-1_3;
+
     lfe = packages.erlang.lfe;
   };
 


### PR DESCRIPTION
###### Motivation for this change

This is a continuation of #26381 based on #17240

This only includes Elixir generalization. It also includes derivations for Elixir 1.3 and 1.4

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

