### PR TITLE
Package sublime-dev build.

### DIFF
--- a/pkgs/applications/editors/sublime3-dev/default.nix
+++ b/pkgs/applications/editors/sublime3-dev/default.nix
@@ -1,0 +1,105 @@
+{ fetchurl, stdenv, glib, xorg, cairo, gtk2, pango, makeWrapper, openssl, bzip2,
+  pkexecPath ? "/run/wrappers/bin/pkexec", libredirect,
+  gksuSupport ? false, gksu, unzip, zip, bash }:
+
+assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
+assert gksuSupport -> gksu != null;
+
+let
+  build = "3136";
+  libPath = stdenv.lib.makeLibraryPath [glib xorg.libX11 gtk2 cairo pango];
+  redirects = [ "/usr/bin/pkexec=${pkexecPath}" ]
+    ++ stdenv.lib.optional gksuSupport "/usr/bin/gksudo=${gksu}/bin/gksudo";
+in let
+  # package with just the binaries
+  sublime = stdenv.mkDerivation {
+    name = "sublimetext3-${build}-bin";
+
+    src =
+      if stdenv.system == "i686-linux" then
+        fetchurl {
+          name = "sublimetext-${build}.tar.bz2";
+          url = "https://download.sublimetext.com/sublime_text_3_build_${build}_x32.tar.bz2";
+          sha256 = "9cbcbecd91b7b90943326ccf76d4662a086973a00e7a18d9bf4444547675473f";
+        }
+      else
+        fetchurl {
+          name = "sublimetext-${build}.tar.bz2";
+          url = "https://download.sublimetext.com/sublime_text_3_build_${build}_x64.tar.bz2";
+          sha256 = "3aedefbf43e8d1e0845d71f32e6d7a8c235c2b818c06bab2bf704adaabce110e";
+        };
+
+    dontStrip = true;
+    dontPatchELF = true;
+    buildInputs = [ makeWrapper ];
+
+    # make exec.py in Default.sublime-package use own bash with
+    # an LD_PRELOAD instead of "/bin/bash"
+    patchPhase = ''
+      mkdir Default.sublime-package-fix
+      ( cd Default.sublime-package-fix
+        ${unzip}/bin/unzip ../Packages/Default.sublime-package > /dev/null
+        substituteInPlace "exec.py" --replace \
+          "[\"/bin/bash\"" \
+          "[\"$out/sublime_bash\""
+      )
+      ${zip}/bin/zip -j Default.sublime-package.zip Default.sublime-package-fix/* > /dev/null
+      mv Default.sublime-package.zip Packages/Default.sublime-package
+      rm -r Default.sublime-package-fix
+    '';
+
+    buildPhase = ''
+      for i in sublime_text plugin_host crash_reporter; do
+        patchelf \
+          --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+          --set-rpath ${libPath}:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"} \
+          $i
+      done
+
+      # Rewrite pkexec|gksudo argument. Note that we can't delete bytes in binary.
+      sed -i -e 's,/bin/cp\x00,cp\x00\x00\x00\x00\x00\x00,g' sublime_text
+    '';
+
+    installPhase = ''
+      # Correct sublime_text.desktop to exec `sublime' instead of /opt/sublime_text
+      sed -e 's,/opt/sublime_text/sublime_text,sublime,' -i sublime_text.desktop
+
+      mkdir -p $out
+      cp -prvd * $out/
+
+      # We can't just call /usr/bin/env bash because a relocation error occurs
+      # when trying to run a build from within Sublime Text
+      ln -s ${bash}/bin/bash $out/sublime_bash
+      wrapProgram $out/sublime_bash \
+        --set LD_PRELOAD "${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}/libgcc_s.so.1"
+
+      wrapProgram $out/sublime_text \
+        --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+        --set NIX_REDIRECTS ${builtins.concatStringsSep ":" redirects}
+
+      # Without this, plugin_host crashes, even though it has the rpath
+      wrapProgram $out/plugin_host --prefix LD_PRELOAD : ${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}/libgcc_s.so.1:${openssl.out}/lib/libssl.so:${bzip2.out}/lib/libbz2.so
+    '';
+  };
+in stdenv.mkDerivation {
+  name = "sublimetext3-${build}";
+
+  phases = [ "installPhase" ];
+  installPhase = ''
+    mkdir -p $out/bin
+    ln -s ${sublime}/sublime_text $out/bin/subl
+    ln -s ${sublime}/sublime_text $out/bin/sublime
+    ln -s ${sublime}/sublime_text $out/bin/sublime3
+    mkdir -p $out/share/applications
+    ln -s ${sublime}/sublime_text.desktop $out/share/applications/sublime_text.desktop
+    ln -s ${sublime}/Icon/256x256/ $out/share/icons
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Sophisticated text editor for code, markup and prose";
+    homepage = https://www.sublimetext.com/;
+    maintainers = with maintainers; [ wmertens demin-dmitriy zimbatm ];
+    license = licenses.unfree;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15948,6 +15948,8 @@ with pkgs;
 
   sublime3 = lowPrio (callPackage ../applications/editors/sublime3 { });
 
+  sublime3-dev = lowPrio (callPackage ../applications/editors/sublime3-dev { });
+
   inherit (callPackages ../applications/version-management/subversion/default.nix {
       bdbSupport = true;
       httpServer = false;


### PR DESCRIPTION
###### Motivation for this change
Additional sublime text 3 builds are available as 'dev' builds, which tend to move ahead of the officially released builds.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

