### PR TITLE
languagetool: fix arguments passing

### DIFF
--- a/pkgs/tools/text/languagetool/default.nix
+++ b/pkgs/tools/text/languagetool/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     for lt in languagetool{,-commandline,-server};do
     cat > $out/bin/$lt <<EXE
     #!${stdenv.shell}
-    ${jdk}/bin/java -cp $out/share/ -jar $out/share/$lt.jar $@
+    ${jdk}/bin/java -cp $out/share/ -jar $out/share/$lt.jar "\$@"
     EXE
     chmod +x $out/bin/$lt
     done


### PR DESCRIPTION
###### Motivation for this change
Correctly support arguments in scripts.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested locally:
```sh
[22:28] igor@nixos-pc nixpkgs (languagetool) [nix-shell] ✗ (1) % languagetool-commandline --version
LanguageTool version 3.7 (2017-03-27 10:50)
[22:29] igor@nixos-pc nixpkgs (languagetool) [nix-shell] % languagetool-commandline --list
ast-ES Asturian
be-BY Belarusian
br-FR Breton
ca-ES Catalan
ca-ES-valencia Catalan (Valencian)
da-DK Danish
de German
...
```