### PR TITLE
minikube: 0.19.0 -> 0.19.1

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -22,7 +22,7 @@ let
 in buildGoPackage rec {
   pname   = "minikube";
   name    = "${pname}-${version}";
-  version = "0.19.0";
+  version = "0.19.1";
 
   goPackagePath = "k8s.io/minikube";
 
@@ -30,7 +30,7 @@ in buildGoPackage rec {
     owner  = "kubernetes";
     repo   = "minikube";
     rev    = "v${version}";
-    sha256 = "060zl5wx9karl0j1w3b1jnr6wkr56p3wgs75r6d5aiz36i8fkg8m";
+    sha256 = "19kw2xhpcbyh32im0lnvajcjf1f8p357vhggk0jl342a23vr3rxl";
   };
 
   # kubernetes is here only to shut up a loud warning when generating the completions below. minikube checks very eagerly


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

