### PR TITLE
Arelle: init at 2017-06-01

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -467,6 +467,7 @@
   rob = "Rob Vermaas <rob.vermaas@gmail.com>";
   robberer = "Longrin Wischnewski <robberer@freakmail.de>";
   robbinch = "Robbin C. <robbinch33@gmail.com>";
+  roberth = "Robert Hensing <nixpkgs@roberthensing.nl>";
   robgssp = "Rob Glossop <robgssp@gmail.com>";
   roblabla = "Robin Lambertz <robinlambertz+dev@gmail.com>";
   roconnor = "Russell O'Connor <roconnor@theorem.ca>";

--- a/pkgs/development/python-modules/arelle/default.nix
+++ b/pkgs/development/python-modules/arelle/default.nix
@@ -1,0 +1,55 @@
+{ gui ? true,
+  buildPythonPackage, fetchFromGitHub, lib,
+  sphinx_1_2, lxml, isodate, numpy, pytest,
+  tkinter ? null,
+  ... }:
+
+let
+  # Releases are published at http://arelle.org/download/ but sadly no
+  # tags are published on github.
+  version = "2017-06-01";
+
+  src = fetchFromGitHub {
+    owner = "Arelle";
+    repo = "Arelle";
+    rev = "c883f843d55bb48f03a15afceb4cc823cd4601bd";
+    sha256 = "1h48qdj0anv541rd3kna8bmcwfrl1l3yw76wsx8p6hx5prbmzg4v";
+  };
+
+in
+
+buildPythonPackage {
+  name = "arelle-${version}${lib.optionalString (!gui) "-headless"}";
+  inherit src;
+  outputs = ["out" "doc"];
+  postPatch = "rm testParser2.py";
+  buildInputs = [
+    sphinx_1_2
+    pytest
+  ];
+  propagatedBuildInputs = [
+    lxml
+    isodate
+    numpy
+  ] ++ lib.optional gui [
+    tkinter
+  ];
+
+  # arelle-gui is useless without gui dependencies, so delete it when !gui.
+  postInstall = lib.optionalString (!gui) ''
+    find $out/bin -name "*arelle-gui*" -delete
+  '';
+
+  # Documentation
+  postBuild = ''
+    (cd apidocs && make html && cp -r _build $doc)
+    '';
+
+  meta = {
+    description = "An open source facility for XBRL, the eXtensible Business Reporting Language supporting various standards, exposed through a python or REST API" + lib.optionalString gui " and a graphical user interface";
+    homepage = http://arelle.org/;
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ roberth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13124,6 +13124,8 @@ with pkgs;
     inherit (vamp) vampSDK;
   };
 
+  inherit (python34Packages) arelle;
+
   ario = callPackage ../applications/audio/ario { };
 
   arora = callPackage ../applications/networking/browsers/arora { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1184,6 +1184,15 @@ in {
     };
   };
 
+  arelle = callPackage ../development/python-modules/arelle {
+    gui = true;
+  };
+
+  arelle-headless = callPackage ../development/python-modules/arelle {
+    gui = false;
+  };
+
+
   arrow = buildPythonPackage rec {
     name = "arrow-${version}";
     version = "0.7.0";


### PR DESCRIPTION
###### Motivation for this change

Arelle was not packaged previously. It is the open source implementation of the W3C XBRL specifications.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

