### PR TITLE
xfce.terminal: 0.6.3 -> 0.8.5.1

### DIFF
--- a/pkgs/desktops/gnome-3/3.22/core/vte/2.91.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/vte/2.91.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, intltool, pkgconfig, gnome3, ncurses, gobjectIntrospection, gnutls, pcre2, vala, gperf, libxml2}:
+
+stdenv.mkDerivation rec {
+  versionMajor = "0.48";
+  versionMinor = "3";
+  moduleName   = "vte";
+
+  name = "${moduleName}-${versionMajor}.${versionMinor}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${moduleName}/${versionMajor}/${name}.tar.xz";
+    sha256 = "1hsqc7238862mqnva5qqdfxnhpwq3ak6zx6kbjj95cs04wcgpad3";
+  };
+
+  buildInputs = [ gobjectIntrospection intltool pkgconfig gnome3.glib gnome3.gtk3 ncurses vala gperf libxml2];
+
+  propagatedBuildInputs = [ pcre2 gnutls ];
+
+  configureFlags = [ "--enable-introspection" ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    substituteInPlace $out/lib/libvte-2.91.la --replace "-lncurses" "-L${ncurses.out}/lib -lncurses"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.gnome.org/;
+    description = "A library implementing a terminal emulator widget for GTK+";
+    longDescription = ''
+      VTE is a library (libvte) implementing a terminal emulator widget for
+      GTK+, and a minimal sample application (vte) using that.  Vte is
+      mainly used in gnome-terminal, but can also be used to embed a
+      console/terminal in games, editors, IDEs, etc. VTE supports Unicode and
+      character set conversion, as well as emulating any terminal known to
+      the system's terminfo database.
+    '';
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ astsmtl antono lethalman ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/3.22/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/default.nix
@@ -238,6 +238,8 @@ let
 
   vte_290 = callPackage ./core/vte/2.90.nix { };
 
+  vte_291 = callPackage ./core/vte/2.91.nix { };
+
   vte-ng = callPackage ./core/vte/ng.nix { };
 
   vino = callPackage ./core/vino { };

--- a/pkgs/desktops/xfce/applications/terminal.nix
+++ b/pkgs/desktops/xfce/applications/terminal.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchurl, pkgconfig, intltool, ncurses, gtk, vte, dbus_glib
-, exo, libxfce4util, libxfce4ui
+{ stdenv, fetchurl, pkgconfig, intltool, ncurses, gnome3, gtk3, dbus_glib
+, exo, libxfce4util, libxfce4ui_gtk3
 }:
 
 stdenv.mkDerivation rec {
   p_name  = "xfce4-terminal";
-  ver_maj = "0.6";
-  ver_min = "3";
+  ver_maj = "0.8";
+  ver_min = "5.1";
 
   src = fetchurl {
     url = "mirror://xfce/src/apps/${p_name}/${ver_maj}/${name}.tar.bz2";
-    sha256 = "023y0lkfijifh05yz8grimxadqpi98mrivr00sl18nirq8b4fbwi";
+    sha256 = "0r70kdi4cx3q5cf6kqiy6k4ik3wkrma2qq44g6ankxmbg27mcd4a";
   };
   name = "${p_name}-${ver_maj}.${ver_min}";
 
-  buildInputs = [ pkgconfig intltool exo gtk vte libxfce4util ncurses dbus_glib libxfce4ui ];
+  buildInputs = [ pkgconfig intltool exo gtk3 gnome3.vte_291 libxfce4util ncurses dbus_glib libxfce4ui_gtk3 ];
 
   meta = {
     homepage = http://www.xfce.org/projects/terminal;


### PR DESCRIPTION

This is my first (possible) contribution to nixpkgs, so be aware of any beginner mistakes.

Particular doubts that I have are:

* The upgrade pulls in vte-2.91; taking a look at how nixpkgs deals with vte-2.90 I have made yet another duplicate of the vte library. So now there's the default, 2.90 (used by a few other packages still) and 2.91. I have the feeling a deduplication is in order, but I'm not sure which one it is.
* The new file for vte 2.91 was created with the user-pattern copy/paste/adapt - I do not pretend to fully understand what I've built.
* VTE 2.91 adds the following 2 `propagatedBuildInputs`: pcre2 & gnutls. As far as I understand this might be not good practice. The reason I've added them is because `pkg-config`, when run in the build context of `xfce.terminal`, cannot otherwise find the package `vte-2.91` because of a dependency error. Someone more

Feel free to clean up my work or point me in the right direction for doing so. If nothing else, this PR might serve as a point of reference for someone else doing it right.



###### Motivation for this change

Motivated by 0.6.3 being several years old



###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

