### PR TITLE
python-dogpile-cache: do not depend on dogpile_core

### DIFF
--- a/pkgs/development/python-modules/dogpile.cache/default.nix
+++ b/pkgs/development/python-modules/dogpile.cache/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, dogpile_core, pytest, pytestcov, mock, Mako
+, pytest, pytestcov, mock, Mako
 }:
 
 buildPythonPackage rec {
@@ -18,7 +18,6 @@ buildPythonPackage rec {
     rm tests/test_lock.py
   '';
 
-  propagatedBuildInputs = [ dogpile_core ];
   buildInputs = [ pytest pytestcov mock Mako ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

> As of dogpile.cache 0.6.0, dogpile.core as a separate package is no longer used by dogpile.cache.

— https://bitbucket.org/zzzeek/dogpile.cache/src/22574be17ad336ce5900f543c22ec5cd044d90ee/dogpile/core.py?at=master&fileviewer=file-view-default#core.py-3:4

Otherwise `nox` somehow fails to import `dogpile.cache`: after `import dogpile`, `dogpile.__path__` contains only `dogpile.core` directory, even though it has no `__init__.py` and `dogpile.cache` has one.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
