### PR TITLE
pidgin-sipe: 1.22.0 -> 1.22.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/sipe/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/sipe/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pidgin, intltool, libxml2, nss, nspr }:
 
-let version = "1.22.0"; in
+let version = "1.22.1"; in
 
 stdenv.mkDerivation {
   name = "pidgin-sipe-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/sipe/pidgin-sipe-${version}.tar.gz";
-    sha256 = "1aeb348e2ba79b82b1fd102555f86cdc42eaa6f9e761b771d74c4f9c9cf15fc3";
+    sha256 = "f6b7b7475e349c0214eb02814b808b04850113a91dd8e8d2c26e7179a3fd1ae8";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
version 1.22.1 "Bug Fixes I" was released on 2017-06-11

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

