### PR TITLE
creduce: 2.6.0 -> 2.7.0, now uses LLVM 4

### DIFF
--- a/pkgs/development/tools/misc/creduce/default.nix
+++ b/pkgs/development/tools/misc/creduce/default.nix
@@ -10,11 +10,11 @@ assert stdenv.isLinux -> (utillinux != null);
 
 stdenv.mkDerivation rec {
   name = "creduce-${version}";
-  version = "2.6.0";
+  version = "2.7.0";
 
   src = fetchurl {
     url = "http://embed.cs.utah.edu/creduce/${name}.tar.gz";
-    sha256 = "0pf5q0n8vkdcr1wrkxn2jzxv0xkrir13bwmqfw3jpbm3dh2c3b6d";
+    sha256 = "0h8s4d54q6cl6i45x3143l2xmr29b2yhr3m0n5qqx63sr5csip1n";
   };
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6619,7 +6619,7 @@ with pkgs;
   creduce = callPackage ../development/tools/misc/creduce {
     inherit (perlPackages) perl
       ExporterLite FileWhich GetoptTabular RegexpCommon TermReadKey;
-    inherit (llvmPackages_39) llvm clang-unwrapped;
+    inherit (llvmPackages_4) llvm clang-unwrapped;
     utillinux = if stdenv.isLinux then utillinuxMinimal else null;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Update.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested using creduce in derivations to conduct the reductions [described on their website](https://embed.cs.utah.edu/creduce/using/), LGTM.

