### PR TITLE
dosbox: 0.74 -> svn

### DIFF
--- a/pkgs/misc/emulators/dosbox/default.nix
+++ b/pkgs/misc/emulators/dosbox/default.nix
@@ -1,11 +1,13 @@
-{ stdenv, fetchurl, SDL, makeDesktopItem, mesa }:
+{ stdenv, fetchurl, fetchsvn, SDL, SDL_net, SDL_sound, libpng, makeDesktopItem, mesa, autoreconfHook }:
 
-stdenv.mkDerivation rec { 
-  name = "dosbox-0.74";
+let revision = "4024";
+in stdenv.mkDerivation rec {
+  name = "dosbox-0.74-${revision}";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/dosbox/${name}.tar.gz";
-    sha256 = "01cfjc5bs08m4w79nbxyv7rnvzq2yckmgrbq36njn06lw8b4kxqk";
+  src = fetchsvn {
+    url = "https://dosbox.svn.sourceforge.net/svnroot/dosbox/dosbox/trunk";
+    rev = revision;
+    sha256 = "16s6xwmz7992l0kg6cj9aqk21cc0p6c0dn0x0sx5iadbbll7ma6p";
   };
 
   patches =
@@ -20,7 +22,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  buildInputs = [ SDL mesa ];
+  buildInputs = [ SDL SDL_net SDL_sound libpng mesa autoreconfHook ];
 
   desktopItem = makeDesktopItem {
     name = "dosbox";


### PR DESCRIPTION
Version 0.74 (released in 2012) of dosbox segfaults, as described at:
https://www.reddit.com/r/linux_gaming/comments/4dxfei/dosbox_segmentation_fault_core_dumped/

dosbox versioning scheme uses only 2 components, so I assume that
using "0.74-4024" is a future-proof method (see the list of existing
https://sourceforge.net/projects/dosbox/files/dosbox/).

Missing dependencies were added:
- SDL_sound - for mounting .cue files with compressed sound
- SDL_net - for IPX support
- libpng - for making screenshots

###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

