### PR TITLE
erlangR20: init

### DIFF
--- a/pkgs/development/interpreters/erlang/R20.nix
+++ b/pkgs/development/interpreters/erlang/R20.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, fetchurl }:
+
+mkDerivation rec {
+  version = "20.0";
+  sha256 = "12dbay254ivnakwknjn5h55wndb0a0wqx55p156h8hwjhykj2kn0";
+
+  prePatch = ''
+    substituteInPlace configure.in --replace '`sw_vers -productVersion`' '10.10'
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5984,7 +5984,8 @@ with pkgs;
     erlang_basho_R16B02 erlang_basho_R16B02_odbc
     erlangR17 erlangR17_odbc erlangR17_javac erlangR17_odbc_javac
     erlangR18 erlangR18_odbc erlangR18_javac erlangR18_odbc_javac
-    erlangR19 erlangR19_odbc erlangR19_javac erlangR19_odbc_javac;
+    erlangR19 erlangR19_odbc erlangR19_javac erlangR19_odbc_javac
+    erlangR20;
 
   inherit (beam.packages)
     rebar rebar3-open rebar3

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -36,6 +36,14 @@ rec {
     erlangR19_odbc_javac = erlangR19.override {
       javacSupport = true; odbcSupport = true;
     };
+    erlangR20 = lib.callErlang ../development/interpreters/erlang/R20.nix {
+      wxGTK = wxGTK30;
+    };
+    erlangR20_odbc = erlangR20.override { odbcSupport = true; };
+    erlangR20_javac = erlangR20.override { javacSupport = true; };
+    erlangR20_odbc_javac = erlangR20.override {
+      javacSupport = true; odbcSupport = true;
+    };
 
     # Bash fork, using custom builder.
     erlang_basho_R16B02 = lib.callErlang ../development/interpreters/erlang/R16B02-8-basho.nix {


### PR DESCRIPTION
###### Motivation for this change
Add Erlang interpreter version R20 into the main repository.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

