### PR TITLE
openldap: 2.4.44 -> 2.4.45 ; minikube: 0.19.1 -> 0.20.0

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -14,15 +14,15 @@ let
   # instead, we download localkube ourselves and shove it into the minikube binary. The versions URL that minikube uses is
   # currently https://storage.googleapis.com/minikube/k8s_releases.json
 
-  localkube-version = "1.6.0";
+  localkube-version = "1.6.3";
   localkube-binary = fetchurl {
     url = "https://storage.googleapis.com/minikube/k8sReleases/v${localkube-version}/localkube-linux-amd64";
-    sha256 = "0zx0c9fwairvga1g1112l5g5pspm2m9wxb42qgfxfgyidywvirha";
+    sha256 = "1fmxxjv1bxrfngc4ykfgg76b79dh8pq0k1gsbzhiy3hhrppfqylm";
   };
 in buildGoPackage rec {
   pname   = "minikube";
   name    = "${pname}-${version}";
-  version = "0.19.1";
+  version = "0.20.0";
 
   goPackagePath = "k8s.io/minikube";
 
@@ -30,7 +30,7 @@ in buildGoPackage rec {
     owner  = "kubernetes";
     repo   = "minikube";
     rev    = "v${version}";
-    sha256 = "19kw2xhpcbyh32im0lnvajcjf1f8p357vhggk0jl342a23vr3rxl";
+    sha256 = "0bly2phy67x4ckcg46g6r4kqfdpjfs1cb3588a900m8b4xyavvvb";
   };
 
   # kubernetes is here only to shut up a loud warning when generating the completions below. minikube checks very eagerly

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, openssl, cyrus_sasl, db, groff, libtool }:
 
 stdenv.mkDerivation rec {
-  name = "openldap-2.4.44";
+  name = "openldap-2.4.45";
 
   src = fetchurl {
     url = "http://www.openldap.org/software/download/OpenLDAP/openldap-release/${name}.tgz";
-    sha256 = "0044p20hx07fwgw2mbwj1fkx04615hhs1qyx4mawj2bhqvrnppnp";
+    sha256 = "091qvwk5dkcpp17ziabcnh3rg3m7qwzw2pihfcd1d5fdxgywzmnd";
   };
 
   # TODO: separate "out" and "bin"


### PR DESCRIPTION
###### Motivation for this change
Wanted to update minikube.
The openldap build failed with curl errors.
Noticed there is an update to openldap, updated it.
Things work.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

