### PR TITLE
slock: Avoid chmod u+s

### DIFF
--- a/pkgs/misc/screensavers/slock/default.nix
+++ b/pkgs/misc/screensavers/slock/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   installFlags = "DESTDIR=\${out} PREFIX=";
 
+  patchPhase = "sed -i '/chmod u+s/d' Makefile";
+
   preBuild = optionalString (conf != null) ''
     cp ${writeText "config.def.h" conf} config.def.h
   '';


### PR DESCRIPTION
###### Motivation for this change
Fix the issue mentioned in #26600 
This fixes the build of `slock` on my machine.

(Not sure if open a pr is the right way to submit this patch)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

