### PR TITLE
libatomic_ops: Provide alternate URL

### DIFF
--- a/pkgs/development/libraries/libatomic_ops/default.nix
+++ b/pkgs/development/libraries/libatomic_ops/default.nix
@@ -5,7 +5,10 @@ stdenv.mkDerivation rec {
   version = "7.6.0";
 
   src = fetchurl {
-    url = "http://www.ivmaisoft.com/_bin/atomic_ops/libatomic_ops-${version}.tar.gz";
+    urls = [
+      "http://www.ivmaisoft.com/_bin/atomic_ops/libatomic_ops-${version}.tar.gz"
+      "https://github.com/ivmai/libatomic_ops/releases/download/v${version}/libatomic_ops-${version}.tar.gz"
+    ];
     sha256 ="03ylfr29g9zc0r6b6axz3i68alj5qmxgzknxwam3jlx0sz8hcb4f";
   };
 


### PR DESCRIPTION
###### Motivation for this change

www.ivmaisoft.com is currently down.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

