### PR TITLE
v8_3_16_14: fix OS X build by passing deployment version

### DIFF
--- a/pkgs/development/python-modules/gyp/no-xcode.patch
+++ b/pkgs/development/python-modules/gyp/no-xcode.patch
@@ -1,66 +1,12 @@
-Index: pylib/gyp/xcode_emulation.py
-diff --git a/pylib/gyp/xcode_emulation.py b/pylib/gyp/xcode_emulation.py
-index b2aab986a427d5285d70558bf97f0a42bfe1556e..20592c73fae660009aac621097cf3c4fb61d6cb6 100644
 --- a/pylib/gyp/xcode_emulation.py
 +++ b/pylib/gyp/xcode_emulation.py
-@@ -236,8 +236,14 @@ class XcodeSettings(object):
-     if sdk_root.startswith('/'):
-       return sdk_root
-     if sdk_root not in XcodeSettings._sdk_path_cache:
--      XcodeSettings._sdk_path_cache[sdk_root] = self._GetSdkVersionInfoItem(
--          sdk_root, 'Path')
-+      try:
-+        XcodeSettings._sdk_path_cache[sdk_root] = self._GetSdkVersionInfoItem(
-+            sdk_root, 'Path')
-+      except:
-+        # if this fails it's because xcodebuild failed, which means
-+        # the user is probably on a CLT-only system, where there
-+        # is no valid SDK root
-+        XcodeSettings._sdk_path_cache[sdk_root] = None
-     return XcodeSettings._sdk_path_cache[sdk_root]
- 
-   def _AppendPlatformVersionMinFlags(self, lst):
-@@ -340,10 +346,11 @@ class XcodeSettings(object):
- 
-     cflags += self._Settings().get('WARNING_CFLAGS', [])
- 
--    config = self.spec['configurations'][self.configname]
--    framework_dirs = config.get('mac_framework_dirs', [])
--    for directory in framework_dirs:
--      cflags.append('-F' + directory.replace('$(SDKROOT)', sdk_root))
+@@ -1470,7 +1470,8 @@
+     sdk_root = xcode_settings._SdkRoot(configuration)
+     if not sdk_root:
+       sdk_root = xcode_settings._XcodeSdkPath('')
+-    env['SDKROOT'] = sdk_root
 +    if sdk_root:
-+      config = self.spec['configurations'][self.configname]
-+      framework_dirs = config.get('mac_framework_dirs', [])
-+      for directory in framework_dirs:
-+        cflags.append('-F' + directory.replace('$(SDKROOT)', sdk_root))
++      env['SDKROOT'] = sdk_root
  
-     self.configname = None
-     return cflags
-@@ -573,10 +580,11 @@ class XcodeSettings(object):
-     for rpath in self._Settings().get('LD_RUNPATH_SEARCH_PATHS', []):
-       ldflags.append('-Wl,-rpath,' + rpath)
- 
--    config = self.spec['configurations'][self.configname]
--    framework_dirs = config.get('mac_framework_dirs', [])
--    for directory in framework_dirs:
--      ldflags.append('-F' + directory.replace('$(SDKROOT)', self._SdkPath()))
-+    if self._SdkPath():
-+      config = self.spec['configurations'][self.configname]
-+      framework_dirs = config.get('mac_framework_dirs', [])
-+      for directory in framework_dirs:
-+        ldflags.append('-F' + directory.replace('$(SDKROOT)', self._SdkPath()))
- 
-     self.configname = None
-     return ldflags
-@@ -701,7 +709,10 @@ class XcodeSettings(object):
-         l = '-l' + m.group(1)
-       else:
-         l = library
--    return l.replace('$(SDKROOT)', self._SdkPath(config_name))
-+    if self._SdkPath():
-+      return l.replace('$(SDKROOT)', self._SdkPath(config_name))
-+    else:
-+      return l
- 
-   def AdjustLibraries(self, libraries, config_name=None):
-     """Transforms entries like 'Cocoa.framework' in libraries into entries like
+   if not additional_settings:
+     additional_settings = {}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10300,6 +10300,7 @@ with pkgs;
 
   v8_3_16_14 = callPackage ../development/libraries/v8/3.16.14.nix {
     inherit (python2Packages) python gyp;
+    cctools = darwin.cctools;
   };
 
   v8_3_24_10 = callPackage ../development/libraries/v8/3.24.10.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11915,6 +11915,7 @@ in {
 
     patches = optionals pkgs.stdenv.isDarwin [
       ../development/python-modules/gyp/no-darwin-cflags.patch
+      ../development/python-modules/gyp/no-xcode.patch
     ];
 
     disabled = isPy3k;


### PR DESCRIPTION
Before this, `nix-build -A v8_3_16_14` failed with a linking error
  ... was built for newer OSX version (10.10) than being linked (10.5)
since build/standalone.gypi sets
  'mac_deployment_target%': '10.5'

This fixes the build to set the GYP mac deployment target to the nix
default as set in pkgs/stdenv/darwin/default.nix.

###### Motivation for this change

v8_3_16_4 was failing to build for me:

```
$ git show
commit 3d52203ab2a2aa31df8ae52efda3b14e75628a57
Author: Joachim Schiele <js@lastlog.de>
Date:   Thu Jun 22 11:50:09 2017 +0200
...
```

```
$ uname -a
Darwin aaaa.local 16.6.0 Darwin Kernel Version 16.6.0: Fri Apr 14 16:21:16 PDT 2017; root:xnu-3789.60.24~6/RELEASE_X86_64 x86_64
```

```
$ nix-build -p v8_3_16_14
...
ld: warning: object file (/nix/store/b70ipgiymp029ggj40hmywg6wswcgrx8-clang-4.0.0/bin/../lib/clang/4.0.0/lib/darwin/libclang_rt.osx.a(gcc_personality_v0.c.o)) was built for newer OSX version (10.10) than being linked (10.5)
Undefined symbols for architecture x86_64:
  "__Unwind_GetIP", referenced from:
      ___gcc_personality_v0 in libclang_rt.osx.a(gcc_personality_v0.c.o)
  "__Unwind_GetLanguageSpecificData", referenced from:
      ___gcc_personality_v0 in libclang_rt.osx.a(gcc_personality_v0.c.o)
  "__Unwind_GetRegionStart", referenced from:
      ___gcc_personality_v0 in libclang_rt.osx.a(gcc_personality_v0.c.o)
  "__Unwind_SetGR", referenced from:
      ___gcc_personality_v0 in libclang_rt.osx.a(gcc_personality_v0.c.o)
  "__Unwind_SetIP", referenced from:
      ___gcc_personality_v0 in libclang_rt.osx.a(gcc_personality_v0.c.o)
ld: symbol(s) not found for architecture x86_64
clang-4.0: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [tools/gyp/v8.target.mk:162: /private/var/folders/rs/k3cmq1b12238c_kx1xg1pndw0000gn/T/nix-build-v8-3.16.14.11.drv-0/v8-3.16.14.11/out/Release/libv8.dylib] Error 1
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

