### PR TITLE
nixos: replaced "userns" with "user namespaces" for clarity

### DIFF
--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -55,7 +55,7 @@ with lib;
   # same privileges as it would have inside it.  This is particularly
   # bad in the common case of running as root within the namespace.
   #
-  # Setting the number of allowed userns to 0 effectively disables
+  # Setting the number of allowed user namespaces to 0 effectively disables
   # the feature at runtime.  Attempting to create a user namespace
   # with unshare will then fail with "no space left on device".
   boot.kernel.sysctl."user.max_user_namespaces" = mkDefault 0;


### PR DESCRIPTION
###### Motivation for this change

"userns" wasn't introduces as an abbreviation elsewhere as far as I can see, and I wasn't sure what was meant at first.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

