### PR TITLE
fish: 2.5.0 -> 2.6.0

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -89,13 +89,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "fish-${version}";
-  version = "2.5.0";
+  version = "2.6.0";
 
   etcConfigAppendix = builtins.toFile "etc-config.appendix.fish" etcConfigAppendixText;
 
   src = fetchurl {
     url = "http://fishshell.com/files/${version}/${name}.tar.gz";
-    sha256 = "19djav128nkhjxgfhwhc32i5y9d9c3karbh5yg67kqrdranyvh7q";
+    sha256 = "1yzx73kg5ng5ivhi68756sl5hpb8869110l9fwim6gn7f7bbprby";
   };
 
   buildInputs = [ ncurses libiconv pcre2 ];
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
   # Python: Autocompletion generated from manpages and config editing
   propagatedBuildInputs = [
     coreutils gnugrep gnused bc
-    python which groff gettext
+    python groff gettext
   ] ++ optional (!stdenv.isDarwin) man-db;
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change
new upstream release!

This release implements `which` as a builtin, so that is no longer a dependency :-)

I'm currently using this as my login shell day-to-day on macOS and NixOS. It appears quite fine on both.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

