### PR TITLE
networkmanager: fix arping path

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
        --replace /usr/bin/ping ${inetutils}/bin/ping \
        --replace /usr/bin/ping6 ${inetutils}/bin/ping
     substituteInPlace src/devices/nm-arping-manager.c \
-       --replace '("arping", NULL, NULL);' '("arping", "${inetutils}/bin/arping", NULL);'
+       --replace '("arping", NULL, NULL);' '("arping", "${iputils}/bin/arping", NULL);'
     substituteInPlace src/NetworkManagerUtils.c --replace /sbin/modprobe ${kmod}/bin/modprobe
     substituteInPlace data/84-nm-drivers.rules \
       --replace /bin/sh ${stdenv.shell}


### PR DESCRIPTION
###### Motivation for this change

arping belongs to iputils, not inetutils, and this fixes it.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

