### PR TITLE
rrdtool: 1.7.0 -> 1.7.0.2017-06-11 (bugfix in upstream)

### DIFF
--- a/pkgs/tools/misc/rrdtool/default.nix
+++ b/pkgs/tools/misc/rrdtool/default.nix
@@ -1,15 +1,24 @@
-{ fetchFromGitHub, stdenv, gettext, perl, pkgconfig, libxml2, pango, cairo, groff
+{ fetchFromGitHub, fetchpatch, stdenv, gettext, perl, pkgconfig, libxml2, pango, cairo, groff
 , tcl-8_5, darwin }:
 
 stdenv.mkDerivation rec {
-  name = "rrdtool-1.7.0.2017-06-23";
+  version = "1.7.0";
+  name = "rrdtool-${version}.2017-06-11";
 
   src = fetchFromGitHub {
     owner = "oetiker";
     repo = "rrdtool-1.x";
-    rev = "e0eb6257ad9b150636ef0ccc3797b71e6a3e822a";
-    sha256 = "0szjnvwailsianlhxvvgzr97d78nvkkid3imcfvawy5w4x6bvasv";
+    rev = "v${version}";
+    sha256 = "1p8x717w4cgjcyr5kcd0s6vf1n94arif1w9pkbcl708j7gdi5gx1";
   };
+
+  patches = [
+    # fix regression https://github.com/oetiker/rrdtool-1.x/issues/794
+    (fetchpatch {
+      url = "https://github.com/oetiker/rrdtool-1.x/compare/0f28f99...f1edd12.patch";
+      sha256 = "10g56zy0rdjpv3kvvmf6vvaysmla05wi8byy3l0xrz2x8m02ylqq";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/tools/misc/rrdtool/default.nix
+++ b/pkgs/tools/misc/rrdtool/default.nix
@@ -1,12 +1,14 @@
-{ fetchurl, stdenv, gettext, perl, pkgconfig, libxml2, pango, cairo, groff
+{ fetchFromGitHub, stdenv, gettext, perl, pkgconfig, libxml2, pango, cairo, groff
 , tcl-8_5, darwin }:
 
 stdenv.mkDerivation rec {
-  name = "rrdtool-1.7.0";
+  name = "rrdtool-1.7.0.2017-06-23";
 
-  src = fetchurl {
-    url = "http://oss.oetiker.ch/rrdtool/pub/${name}.tar.gz";
-    sha256 = "0ssjqpa0dwwzbylc0drmlbq922qcw8crffc0rpr805xr6n4k8zgr";
+  src = fetchFromGitHub {
+    owner = "oetiker";
+    repo = "rrdtool-1.x";
+    rev = "e0eb6257ad9b150636ef0ccc3797b71e6a3e822a";
+    sha256 = "0szjnvwailsianlhxvvgzr97d78nvkkid3imcfvawy5w4x6bvasv";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

```1.7.0``` is unusable because of bug https://github.com/NixOS/nixpkgs/issues/26780

Fixes https://github.com/NixOS/nixpkgs/issues/26780

cc: @pSub 
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

