### PR TITLE
scyther: init at 1.1.3

### DIFF
--- a/pkgs/tools/security/scyther/default.nix
+++ b/pkgs/tools/security/scyther/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, fetchFromGitHub
+, glibc
+, cmake
+, flex
+, bison
+, python2
+}:
+
+let
+  version = "1.1.3";
+in stdenv.mkDerivation rec {
+  name = "scyther-${version}";
+
+  src = fetchFromGitHub {
+    owner = "cascremers";
+    repo = "scyther";
+    rev = "v${version}";
+    sha256 = "0rb4ha5bnjxnwj4f3hciq7kyj96fhw14hqbwl5kr9cdw8q62mx0h";
+  };
+
+  preConfigure = ''
+    pushd src
+    echo "#define TAGVERSION \"${src.rev}\"" >> version.h
+    for file in *.*
+    do
+      substituteInPlace $file --replace "__inline__ " ""
+    done
+  '';
+
+  postPatch = ''
+    patchShebangs src
+  '';
+
+  dontUseCmakeBuildDir = true;
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE:STRING=Release" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp scyther-linux $out/bin/
+  '';
+
+  buildInputs = [
+    python2
+    glibc.static
+    cmake
+    flex
+    bison
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Scyther is a tool for the automatic verification of security protocols.";
+    homepage = "https://www.cs.ox.ac.uk/people/cas.cremers/scyther/";
+    maintainers = with maintainers; [ infinisil ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+
+  passthru = {
+    inherit version;
+  };
+
+}

--- a/pkgs/tools/security/scyther/gui.nix
+++ b/pkgs/tools/security/scyther/gui.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, scyther
+, python2
+, graphviz
+}:
+
+let
+  version = scyther.version;
+  pythonEnv = python2.withPackages(ps: with ps; [ wxPython graphviz ]);
+in stdenv.mkDerivation rec {
+  name = "scyther-gui-${version}";
+
+  inherit (scyther) src;
+
+  buildInputs = [ pythonEnv ];
+
+  postPatch = ''
+    substituteInPlace gui/Scyther/FindDot.py --replace "DOTLOCATION = scanLocations()" "DOTLOCATION = '${graphviz}/bin'"
+  '';
+
+  buildPhase = "true";
+
+  installPhase = ''
+    # Install GUI files.
+    mkdir -p $out/share
+    cp -r gui $out/share/scyther
+    ln -s ${scyther}/bin/scyther-linux $out/share/scyther/scyther-linux
+
+    # Install executable
+    mkdir -p $out/bin
+    ln -s $out/share/scyther/scyther-gui.py $out/bin/scyther-gui
+
+  '';
+
+  passthru = {
+    inherit version;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15141,6 +15141,10 @@ with pkgs;
 
   scudcloud = callPackage ../applications/networking/instant-messengers/scudcloud { };
 
+  scyther = callPackage_i686 ../tools/security/scyther { };
+
+  scyther-gui = callPackage ../tools/security/scyther/gui.nix { };
+
   shotcut = libsForQt5.callPackage ../applications/video/shotcut { };
 
   smplayer = libsForQt5.callPackage ../applications/video/smplayer { };


### PR DESCRIPTION
###### Motivation for this change

@Infinisil was trying to package this. Now it seems to be working.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

