### PR TITLE
fossil: 1.36 -> 2.2

### DIFF
--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -2,15 +2,15 @@
 , tcllib, withJson ? true}:
 
 stdenv.mkDerivation rec {
-  name = "fossil-1.36";
+  name = "fossil-2.2";
 
   src = fetchurl {
     urls = 
       [
-        https://fossil-scm.org/index.html/uv/download/fossil-src-1.36.tar.gz
+        https://www.fossil-scm.org/index.html/uv/fossil-src-2.2.tar.gz
       ];
     name = "${name}.tar.gz";
-    sha256 = "04px1mnq5dlc6gaihxj5nj6k7ac43wfryzifaairjh74qmgc6xi6";
+    sha256 = "0wfgacfg29dkl0c3l1rp5ji0kraa64gcbg5lh8p4m7mqdqcq53wv";
   };
 
   buildInputs = [ zlib openssl readline sqlite which ed ]


### PR DESCRIPTION
###### Motivation for this change
Upstream update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


**Some of the tests fail** — I don't know if the failures are meaningful in the context of nix and they don't seem to cause the test runner to return a bad exit code but hopefully someone who knows more about fossil can work that out before this gets merged?