### PR TITLE
ios-cross: Just properly use the cc-wrapper

### DIFF
--- a/pkgs/os-specific/darwin/ios-cross/default.nix
+++ b/pkgs/os-specific/darwin/ios-cross/default.nix
@@ -6,7 +6,7 @@
 , stdenv
 , coreutils
 , gnugrep
-, targetPlatform
+, hostPlatform, targetPlatform
 }:
 
 /* As of this writing, known-good prefix/arch/simulator triples:
@@ -28,14 +28,14 @@ let
 
   sdk = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhone${sdkType}.platform/Developer/SDKs/iPhone${sdkType}${sdkVer}.sdk";
 
-  /* TODO: Properly integrate with gcc-cross-wrapper */
-  wrapper = import ../../../build-support/cc-wrapper {
-    inherit stdenv coreutils gnugrep;
+in (import ../../../build-support/cc-wrapper {
+    inherit stdenv coreutils gnugrep runCommand;
     nativeTools = false;
     nativeLibc = false;
     inherit binutils;
     libc = runCommand "empty-libc" {} "mkdir -p $out/{lib,include}";
-    cc = clang;
+    inherit (clang) cc;
+    inherit hostPlatform targetPlatform;
     extraBuildCommands = ''
       if ! [ -d ${sdk} ]; then
           echo "You must have ${sdkVer} of the iPhone${sdkType} sdk installed at ${sdk}" >&2
@@ -49,27 +49,6 @@ let
       # Purposefully overwrite libc-ldflags-before, cctools ld doesn't know dynamic-linker and cc-wrapper doesn't do cross-compilation well enough to adjust
       echo "-arch ${arch} -L${sdk}/usr/lib ${lib.optionalString simulator "-L${sdk}/usr/lib/system "}-i${if simulator then "os_simulator" else "phoneos"}_version_min 7.0.0" > $out/nix-support/libc-ldflags-before
     '';
-  };
-in {
-  cc = runCommand "${prefix}-cc" { passthru = { inherit sdkType sdkVer sdk; }; } ''
-    mkdir -p $out/bin
-    ln -sv ${wrapper}/bin/clang $out/bin/${prefix}-cc
-    mkdir -p $out/nix-support
-    echo ${llvm} > $out/nix-support/propagated-native-build-inputs
-    cat > $out/nix-support/setup-hook <<EOF
-    if test "\$dontSetConfigureCross" != "1"; then
-        configureFlags="\$configureFlags --host=${prefix}"
-    fi
-    EOF
-    fixupPhase
-  '';
-
-  binutils = runCommand "${prefix}-binutils" {} ''
-    mkdir -p $out/bin
-    ln -sv ${wrapper}/bin/ld $out/bin/${prefix}-ld
-    for prog in ar nm ranlib; do
-      ln -s ${binutils}/bin/$prog $out/bin/${prefix}-$prog
-    done
-    fixupPhase
-  '';
-}
+  }) // {
+    inherit sdkType sdkVer sdk;
+  }


### PR DESCRIPTION
###### Motivation for this change

No other downstream derivations are needed anymore, now that cc-wrapper understands cross compilation.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

