### PR TITLE
haskell infra: Fix cross compilation to work with new system

### DIFF
--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -96,7 +96,11 @@ stdenv.mkDerivation rec {
     [ $(./main) == "yes" ]
   '';
 
-  passthru = { targetPrefix = ""; };
+  passthru = {
+    targetPrefix = "";
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
+  };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/6.10.4.nix
+++ b/pkgs/development/compilers/ghc/6.10.4.nix
@@ -25,7 +25,12 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";
 
-  passthru = { targetPrefix = ""; };
+  passthru = {
+    targetPrefix = "";
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
+  };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/6.12.3.nix
+++ b/pkgs/development/compilers/ghc/6.12.3.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
 
   preConfigure = ''
-    echo "${buildMK}" > mk/build.mk
+    echo -n "${buildMK}" > mk/build.mk
   '';
 
   configureFlags = [

--- a/pkgs/development/compilers/ghc/6.12.3.nix
+++ b/pkgs/development/compilers/ghc/6.12.3.nix
@@ -36,7 +36,12 @@ stdenv.mkDerivation rec {
   # that in turn causes GHCi to abort
   stripDebugFlags=["-S" "--keep-file-symbols"];
 
-  passthru = { targetPrefix = ""; };
+  passthru = {
+    targetPrefix = "";
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
+  };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/7.0.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.0.4-binary.nix
@@ -134,7 +134,12 @@ stdenv.mkDerivation rec {
     [ $(./main) == "yes" ]
   '';
 
-  passthru = { targetPrefix = ""; };
+  passthru = {
+    targetPrefix = "";
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
+  };
 
   meta.license = stdenv.lib.licenses.bsd3;
   meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];

--- a/pkgs/development/compilers/ghc/7.0.4.nix
+++ b/pkgs/development/compilers/ghc/7.0.4.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   preConfigure = ''
-    echo "${buildMK}" > mk/build.mk
+    echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     find . -name '*.hs'  | xargs sed -i -e 's|ASSERT (|ASSERT(|' -e 's|ASSERT2 (|ASSERT2(|' -e 's|WARN (|WARN(|'

--- a/pkgs/development/compilers/ghc/7.0.4.nix
+++ b/pkgs/development/compilers/ghc/7.0.4.nix
@@ -45,7 +45,12 @@ stdenv.mkDerivation rec {
   # that in turn causes GHCi to abort
   stripDebugFlags=["-S" "--keep-file-symbols"];
 
-  passthru = { targetPrefix = ""; };
+  passthru = {
+    targetPrefix = "";
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
+  };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "doc" ];
 
   preConfigure = ''
-    echo "${buildMK}" > mk/build.mk
+    echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -28,6 +28,12 @@ let
     sha256 = "1j45z4kcd3w1rzm4hapap2xc16bbh942qnzzdbdjcwqznsccznf0";
   };
 
+  buildMK = stdenv.lib.optionalString enableIntegerSimple ''
+    INTEGER_LIBRARY = integer-simple
+  '' + stdenv.lib.optionalString (targetPlatform != hostPlatform) ''
+    BuildFlavour = perf-cross
+  '';
+
 in
 
 stdenv.mkDerivation rec {
@@ -51,13 +57,12 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "doc" ];
 
   preConfigure = ''
+    echo "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+    export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export NIX_LDFLAGS+=" -no_dtrace_dof"
-  '' + stdenv.lib.optionalString enableIntegerSimple ''
-    echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
   '';
 
   configureFlags = [

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -87,7 +87,22 @@ stdenv.mkDerivation rec {
     ./relocation.patch
   ];
 
+  # GHC is a bit confused on its cross terminology.
   preConfigure = ''
+    for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
+      export "''${env#TARGET_}=''${!env}"
+    done
+    # GHC is a bit confused on its cross terminology, as these would normally be
+    # the *host* tools.
+    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld"
+    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -57,7 +57,7 @@ let
   # Splicer will pull out correct variations
   libDeps = platform: [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
-    ++ stdenv.lib.optional (platform.libc == "libSystem") libiconv;
+    ++ stdenv.lib.optional (platform.libc != "glibc") libiconv;
 
   toolsForTarget =
     if hostPlatform == buildPlatform then
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && ! enableIntegerSimple) [
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
-  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.isDarwin) [
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc") [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -169,6 +169,9 @@ stdenv.mkDerivation rec {
     inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/7.2.2.nix
+++ b/pkgs/development/compilers/ghc/7.2.2.nix
@@ -55,7 +55,12 @@ stdenv.mkDerivation rec {
   # that in turn causes GHCi to abort
   stripDebugFlags=["-S" "--keep-file-symbols"];
 
-  passthru = { targetPrefix = ""; };
+  passthru = {
+    targetPprefix = "";
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
+  };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/7.2.2.nix
+++ b/pkgs/development/compilers/ghc/7.2.2.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   '');
 
   preConfigure = ''
-    echo "${buildMK}" > mk/build.mk
+    echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     find . -name '*.hs'  | xargs sed -i -e 's|ASSERT (|ASSERT(|' -e 's|ASSERT2 (|ASSERT2(|' -e 's|WARN (|WARN(|'

--- a/pkgs/development/compilers/ghc/7.2.2.nix
+++ b/pkgs/development/compilers/ghc/7.2.2.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"
     ''}
   '' + (if enableIntegerSimple then ''
-    INTEGER_LIBRARY=integer-simple
+    INTEGER_LIBRARY = integer-simple
   '' else ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"

--- a/pkgs/development/compilers/ghc/7.4.2-binary.nix
+++ b/pkgs/development/compilers/ghc/7.4.2-binary.nix
@@ -136,7 +136,12 @@ stdenv.mkDerivation rec {
     [ $(./main) == "yes" ]
   '';
 
-  passthru = { targetPrefix = ""; };
+  passthru = {
+    targetPrefix = "";
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
+  };
 
   meta.license = stdenv.lib.licenses.bsd3;
   meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];

--- a/pkgs/development/compilers/ghc/7.4.2.nix
+++ b/pkgs/development/compilers/ghc/7.4.2.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   '');
 
   preConfigure = ''
-    echo "${buildMK}" > mk/build.mk
+    echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"

--- a/pkgs/development/compilers/ghc/7.4.2.nix
+++ b/pkgs/development/compilers/ghc/7.4.2.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"
     ''}
   '' + (if enableIntegerSimple then ''
-    INTEGER_LIBRARY=integer-simple
+    INTEGER_LIBRARY = integer-simple
   '' else ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     echo "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+    export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     find . -name '*.hs'  | xargs sed -i -e 's|ASSERT (|ASSERT(|' -e 's|ASSERT2 (|ASSERT2(|' -e 's|WARN (|WARN(|'
     find . -name '*.lhs' | xargs sed -i -e 's|ASSERT (|ASSERT(|' -e 's|ASSERT2 (|ASSERT2(|' -e 's|WARN (|WARN(|'

--- a/pkgs/development/compilers/ghc/7.4.2.nix
+++ b/pkgs/development/compilers/ghc/7.4.2.nix
@@ -56,7 +56,12 @@ stdenv.mkDerivation rec {
   # that in turn causes GHCi to abort
   stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
 
-  passthru = { targetPrefix = ""; };
+  passthru = {
+    targetPrefix = "";
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
+  };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/7.6.3.nix
+++ b/pkgs/development/compilers/ghc/7.6.3.nix
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
     SRC_HC_OPTS += ${ghcFlags}
     SRC_CC_OPTS += ${cFlags}
   '' + (if enableIntegerSimple then ''
-    INTEGER_LIBRARY=integer-simple
+    INTEGER_LIBRARY = integer-simple
   '' else ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
@@ -58,7 +58,7 @@ in stdenv.mkDerivation rec {
     sed -i -e 's|"\$topdir"|"\$topdir" ${ghcFlags}|' ghc/ghc.wrapper
 
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+    export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     find . -name '*.hs'  | xargs sed -i -e 's|ASSERT (|ASSERT(|' -e 's|ASSERT2 (|ASSERT2(|' -e 's|WARN (|WARN(|'
     find . -name '*.lhs' | xargs sed -i -e 's|ASSERT (|ASSERT(|' -e 's|ASSERT2 (|ASSERT2(|' -e 's|WARN (|WARN(|'

--- a/pkgs/development/compilers/ghc/7.6.3.nix
+++ b/pkgs/development/compilers/ghc/7.6.3.nix
@@ -50,7 +50,7 @@ in stdenv.mkDerivation rec {
   '');
 
   preConfigure = ''
-    echo "${buildMK}" > mk/build.mk
+    echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
 
   '' + stdenv.lib.optionalString stdenv.isLinux ''

--- a/pkgs/development/compilers/ghc/7.6.3.nix
+++ b/pkgs/development/compilers/ghc/7.6.3.nix
@@ -82,7 +82,12 @@ in stdenv.mkDerivation rec {
   # that in turn causes GHCi to abort
   stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
 
-  passthru = { targetPrefix = ""; };
+  passthru = {
+    targetPrefix = "";
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
+  };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/7.8.4.nix
+++ b/pkgs/development/compilers/ghc/7.8.4.nix
@@ -17,7 +17,7 @@ let
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     DYNAMIC_BY_DEFAULT = NO
-    ${stdenv.lib.optionalString stdenv.isDarwin ''
+    ${stdenv.lib.optionalString (stdenv.hostPlatform.libc != "glibc") ''
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"
     ''}
@@ -31,7 +31,7 @@ let
   # Splicer will pull out correct variations
   libDeps = [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
-    ++ stdenv.lib.optional (stdenv.hostPlatform.libc == "libSystem") libiconv;
+    ++ stdenv.lib.optional (stdenv.hostPlatform.libc != "glibc") libiconv;
 
 in
 

--- a/pkgs/development/compilers/ghc/7.8.4.nix
+++ b/pkgs/development/compilers/ghc/7.8.4.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (rec {
   '');
 
   preConfigure = ''
-    echo "${buildMK}" > mk/build.mk
+    echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"

--- a/pkgs/development/compilers/ghc/7.8.4.nix
+++ b/pkgs/development/compilers/ghc/7.8.4.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (rec {
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"
     ''}
   '' + (if enableIntegerSimple then ''
-    INTEGER_LIBRARY=integer-simple
+    INTEGER_LIBRARY = integer-simple
   '' else ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
@@ -44,7 +44,7 @@ stdenv.mkDerivation (rec {
     echo "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+    export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export NIX_LDFLAGS+=" -no_dtrace_dof"
   '';

--- a/pkgs/development/compilers/ghc/7.8.4.nix
+++ b/pkgs/development/compilers/ghc/7.8.4.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, ghc, perl, ncurses, libiconv
+{ stdenv, targetPackages
+
+, fetchurl, ghc, perl
+, libffi, libiconv ? null, ncurses
 
 , # If enabled, GHC will be built with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
@@ -9,22 +12,7 @@
 assert stdenv.targetPlatform == stdenv.hostPlatform;
 assert !enableIntegerSimple -> gmp != null;
 
-stdenv.mkDerivation (rec {
-  version = "7.8.4";
-  name = "ghc-${version}";
-
-  src = fetchurl {
-    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-    sha256 = "1i4254akbb4ym437rf469gc0m40bxm31blp6s1z1g15jmnacs6f3";
-  };
-
-  patches = [ ./relocation.patch ];
-
-  buildInputs = [ ghc perl ncurses ]
-                ++ stdenv.lib.optional (!enableIntegerSimple) gmp;
-
-  enableParallelBuilding = true;
-
+let
   buildMK = ''
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
@@ -40,6 +28,27 @@ stdenv.mkDerivation (rec {
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
   '');
 
+  # Splicer will pull out correct variations
+  libDeps = [ ncurses ]
+    ++ stdenv.lib.optional (!enableIntegerSimple) gmp
+    ++ stdenv.lib.optional (stdenv.hostPlatform.libc == "libSystem") libiconv;
+
+in
+
+stdenv.mkDerivation rec {
+  version = "7.8.4";
+  name = "ghc-${version}";
+
+  src = fetchurl {
+    url = "http://www.haskell.org/ghc/dist/${version}/${name}-src.tar.xz";
+    sha256 = "1i4254akbb4ym437rf469gc0m40bxm31blp6s1z1g15jmnacs6f3";
+  };
+
+  enableParallelBuilding = true;
+
+  patches = [ ./relocation.patch ]
+    ++ stdenv.lib.optional stdenv.isDarwin ./hpc-7.8.4.patch;
+
   preConfigure = ''
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
@@ -48,6 +57,18 @@ stdenv.mkDerivation (rec {
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export NIX_LDFLAGS+=" -no_dtrace_dof"
   '';
+
+  # TODO(@Ericson2314): Always pass "--target" and always prefix.
+  configurePlatforms = [ "build" "host" ];
+
+  nativeBuildInputs = [ ghc perl ];
+  depsBuildTarget = [ targetPackages.stdenv.cc ];
+
+  buildInputs = libDeps;
+  propagatedBuildInputs = [ targetPackages.stdenv.cc ];
+
+  depsTargetTarget = map stdenv.lib.getDev libDeps;
+  depsTargetTargetPropagated = map (stdenv.lib.getOutput "out") libDeps;
 
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
@@ -62,7 +83,4 @@ stdenv.mkDerivation (rec {
     inherit (ghc.meta) license platforms;
   };
 
-} // stdenv.lib.optionalAttrs stdenv.isDarwin {
-  # https://ghc.haskell.org/trac/ghc/ticket/9762
-  patches = [ ./hpc-7.8.4.patch ];
-})
+}

--- a/pkgs/development/compilers/ghc/7.8.4.nix
+++ b/pkgs/development/compilers/ghc/7.8.4.nix
@@ -74,7 +74,12 @@ stdenv.mkDerivation rec {
   # that in turn causes GHCi to abort
   stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
 
-  passthru = { targetPrefix = ""; };
+  passthru = {
+    targetPrefix = "";
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
+  };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "man" "doc" ];
 
   preConfigure = ''
-    echo "${buildMK}" > mk/build.mk
+    echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -79,7 +79,22 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch
     ++ stdenv.lib.optional stdenv.isDarwin ./ghc-8.0.2-no-cpp-warnings.patch;
 
+  # GHC is a bit confused on its cross terminology.
   preConfigure = ''
+    for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
+      export "''${env#TARGET_}=''${!env}"
+    done
+    # GHC is a bit confused on its cross terminology, as these would normally be
+    # the *host* tools.
+    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld"
+    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -51,7 +51,7 @@ let
   # Splicer will pull out correct variations
   libDeps = platform: [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
-    ++ stdenv.lib.optional (platform.libc == "libSystem") libiconv;
+    ++ stdenv.lib.optional (platform.libc != "glibc") libiconv;
 
   toolsForTarget =
     if hostPlatform == buildPlatform then
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && ! enableIntegerSimple) [
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
-  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.isDarwin) [
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc") [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -170,6 +170,9 @@ stdenv.mkDerivation rec {
     inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -21,6 +21,12 @@ let
   targetPrefix = stdenv.lib.optionalString
     (targetPlatform != hostPlatform)
     "${targetPlatform.config}-";
+
+  buildMK = stdenv.lib.optionalString enableIntegerSimple ''
+    INTEGER_LIBRARY = integer-simple
+  '' + stdenv.lib.optionalString (targetPlatform != hostPlatform) ''
+    BuildFlavour = perf-cross
+  '';
 in
 stdenv.mkDerivation rec {
   version = "8.0.2";
@@ -42,13 +48,12 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "man" "doc" ];
 
   preConfigure = ''
+    echo "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+    export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export NIX_LDFLAGS+=" -no_dtrace_dof"
-  '' + stdenv.lib.optionalString enableIntegerSimple ''
-    echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
   '';
 
   configureFlags = [

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -2,14 +2,27 @@
 , buildPlatform, hostPlatform, targetPlatform
 
 # build-tools
-, bootPkgs, hscolour, llvm_37
-, coreutils, fetchurl, fetchpatch, patchutils, perl, sphinx
+, bootPkgs, hscolour
+, coreutils, fetchurl, perl, sphinx
 
-, libiconv ? null, ncurses
+, libffi, libiconv ? null, ncurses
+
+, useLLVM ? !targetPlatform.isx86
+, # LLVM is conceptually a run-time-only depedendency, but for
+  # non-x86, we need LLVM to bootstrap later stages, so it becomes a
+  # build-time dependency too.
+  buildLlvmPackages, llvmPackages
 
 , # If enabled, GHC will be built with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
   enableIntegerSimple ? false, gmp ? null
+
+, # If enabled, use -fPIC when compiling static libs.
+  enableRelocatedStaticLibs ? targetPlatform != hostPlatform
+
+, # Whether to build dynamic libs for the standard library (on the target
+  # platform). Static libs are always built.
+  enableShared ? true
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -22,11 +35,32 @@ let
     (targetPlatform != hostPlatform)
     "${targetPlatform.config}-";
 
-  buildMK = stdenv.lib.optionalString enableIntegerSimple ''
+  buildMK = ''
+    DYNAMIC_GHC_PROGRAMS = ${if enableShared then "YES" else "NO"}
+  '' + stdenv.lib.optionalString enableIntegerSimple ''
     INTEGER_LIBRARY = integer-simple
   '' + stdenv.lib.optionalString (targetPlatform != hostPlatform) ''
     BuildFlavour = perf-cross
+    Stage1Only = YES
+    HADDOCK_DOCS = NO
+  '' + stdenv.lib.optionalString enableRelocatedStaticLibs ''
+    GhcLibHcOpts += -fPIC
+    GhcRtsHcOpts += -fPIC
   '';
+
+  # Splicer will pull out correct variations
+  libDeps = platform: [ ncurses ]
+    ++ stdenv.lib.optional (!enableIntegerSimple) gmp
+    ++ stdenv.lib.optional (platform.libc == "libSystem") libiconv;
+
+  toolsForTarget =
+    if hostPlatform == buildPlatform then
+      [ targetPackages.stdenv.cc ] ++ stdenv.lib.optional useLLVM llvmPackages.llvm
+    else assert targetPlatform == hostPlatform; # build != host == target
+      [ stdenv.cc ] ++ stdenv.lib.optional useLLVM buildLlvmPackages.llvm;
+
+  targetCC = builtins.head toolsForTarget;
+
 in
 stdenv.mkDerivation rec {
   version = "8.0.2";
@@ -37,15 +71,13 @@ stdenv.mkDerivation rec {
     sha256 = "1c8qc4fhkycynk4g1f9hvk53dj6a1vvqi6bklqznns6hw59m8qhi";
   };
 
-  patches = [ ./ghc-gold-linker.patch ]
-    ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch
-    ++ stdenv.lib.optional stdenv.isDarwin ./ghc-8.0.2-no-cpp-warnings.patch;
-
-  buildInputs = [ ghc perl hscolour sphinx ] ++ stdenv.lib.optionals (stdenv.isArm || stdenv.isAarch64) [ llvm_37 ];
-
   enableParallelBuilding = true;
 
   outputs = [ "out" "man" "doc" ];
+
+  patches = [ ./ghc-gold-linker.patch ]
+    ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch
+    ++ stdenv.lib.optional stdenv.isDarwin ./ghc-8.0.2-no-cpp-warnings.patch;
 
   preConfigure = ''
     echo -n "${buildMK}" > mk/build.mk
@@ -56,23 +88,48 @@ stdenv.mkDerivation rec {
     export NIX_LDFLAGS+=" -no_dtrace_dof"
   '';
 
+  # TODO(@Ericson2314): Always pass "--target" and always prefix.
+  configurePlatforms = [ "build" "host" ]
+    ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  # `--with` flags for libraries needed for RTS linker
   configureFlags = [
-    "--with-gcc=${stdenv.cc}/bin/cc"
-    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
     "--datadir=$doc/share/doc/ghc"
-  ] ++ stdenv.lib.optional (! enableIntegerSimple) [
+    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && ! enableIntegerSimple) [
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
-  ] ++ stdenv.lib.optional stdenv.isDarwin [
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.isDarwin) [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
+  ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
+    "--enable-bootstrap-with-devel-snapshot"
   ] ++ stdenv.lib.optionals (targetPlatform.isDarwin && targetPlatform.isAarch64) [
     # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
     "--disable-large-address-space"
   ];
 
+  # Hack to make sure we never to the relaxation `$PATH` and hooks support for
+  # compatability. This will be replaced with something clearer in a future
+  # masss-rebuild.
+  crossConfig = true;
+
+  nativeBuildInputs = [ ghc perl hscolour sphinx ];
+
+  # For building runtime libs
+  depsBuildTarget = toolsForTarget;
+
+  buildInputs = libDeps hostPlatform;
+
+  propagatedBuildInputs = [ targetPackages.stdenv.cc ]
+    ++ stdenv.lib.optional useLLVM llvmPackages.llvm;
+
+  depsTargetTarget = map stdenv.lib.getDev (libDeps targetPlatform);
+  depsTargetTargetPropagated = map (stdenv.lib.getOutput "out") (libDeps targetPlatform);
+
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
   stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!targetPlatform.isDarwin) "--keep-file-symbols";
 
+  # zsh and other shells are smart about `{ghc}` but bash isn't, and doesn't
+  # treat that as a unary `{x,y,z,..}` repetition.
   postInstall = ''
     paxmark m $out/lib/${name}/bin/${if targetPlatform != hostPlatform then "ghc" else "{ghc,haddock}"}
 
@@ -89,6 +146,8 @@ stdenv.mkDerivation rec {
 
   passthru = {
     inherit bootPkgs targetPrefix;
+
+    inherit llvmPackages;
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -3,7 +3,7 @@
 
 # build-tools
 , bootPkgs, hscolour
-, coreutils, fetchurl, perl, sphinx
+, coreutils, fetchpatch, fetchurl, perl, sphinx
 
 , libffi, libiconv ? null, ncurses
 
@@ -75,8 +75,15 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" "doc" ];
 
-  patches = [ ./ghc-gold-linker.patch ]
-    ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch
+  patches = [
+    ./ghc-gold-linker.patch
+    (fetchpatch { # Unreleased 1.24.x commit
+      url = "https://github.com/haskell/cabal/commit/6394cb0b6eba91a8692a3d04b2b56935aed7cccd.patch";
+      sha256 = "14xxjg0nb1j1pw0riac3v385ka92qhxxblfmwyvbghz7kry6axy0";
+      stripLen = 1;
+      extraPrefix = "libraries/Cabal/";
+    })
+  ] ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch
     ++ stdenv.lib.optional stdenv.isDarwin ./ghc-8.0.2-no-cpp-warnings.patch;
 
   # GHC is a bit confused on its cross terminology.

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -2,14 +2,30 @@
 , buildPlatform, hostPlatform, targetPlatform
 
 # build-tools
-, bootPkgs, alex, happy, hscolour, llvm_39
+, bootPkgs, alex, happy, hscolour
 , autoconf, automake, coreutils, fetchurl, perl, python3, sphinx
 
-, libiconv ? null, ncurses
+, libffi, libiconv ? null, ncurses
+
+, useLLVM ? !targetPlatform.isx86
+, # LLVM is conceptually a run-time-only depedendency, but for
+  # non-x86, we need LLVM to bootstrap later stages, so it becomes a
+  # build-time dependency too.
+  buildLlvmPackages, llvmPackages
 
 , # If enabled, GHC will be built with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
   enableIntegerSimple ? false, gmp ? null
+
+, # If enabled, use -fPIC when compiling static libs.
+  enableRelocatedStaticLibs ? targetPlatform != hostPlatform
+
+, # Whether to build dynamic libs for the standard library (on the target
+  # platform). Static libs are always built.
+  enableShared ?
+    !(targetPlatform.isDarwin
+      # On iOS, dynamic linking is not supported
+      && (targetPlatform.isAarch64 || targetPlatform.isArm))
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -22,11 +38,34 @@ let
     (targetPlatform != hostPlatform)
     "${targetPlatform.config}-";
 
-  buildMK = stdenv.lib.optionalString enableIntegerSimple ''
+  buildMK = ''
+    DYNAMIC_GHC_PROGRAMS = ${if enableShared then "YES" else "NO"}
+  '' + stdenv.lib.optionalString enableIntegerSimple ''
     INTEGER_LIBRARY = integer-simple
   '' + stdenv.lib.optionalString (targetPlatform != hostPlatform) ''
     BuildFlavour = perf-cross
+    Stage1Only = YES
+    HADDOCK_DOCS = NO
+    BUILD_SPHINX_HTML = NO
+    BUILD_SPHINX_PDF = NO
+  '' + stdenv.lib.optionalString enableRelocatedStaticLibs ''
+    GhcLibHcOpts += -fPIC
+    GhcRtsHcOpts += -fPIC
   '';
+
+  # Splicer will pull out correct variations
+  libDeps = platform: [ ncurses ]
+    ++ stdenv.lib.optional (!enableIntegerSimple) gmp
+    ++ stdenv.lib.optional (platform.libc == "libSystem") libiconv;
+
+  toolsForTarget =
+    if hostPlatform == buildPlatform then
+      [ targetPackages.stdenv.cc ] ++ stdenv.lib.optional useLLVM llvmPackages.llvm
+    else assert targetPlatform == hostPlatform; # build != host == target
+      [ stdenv.cc ] ++ stdenv.lib.optional useLLVM buildLlvmPackages.llvm;
+
+  targetCC = builtins.head toolsForTarget;
+
 in
 stdenv.mkDerivation rec {
   version = "8.2.2";
@@ -36,6 +75,10 @@ stdenv.mkDerivation rec {
     url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
     sha256 = "1z05vkpaj54xdypmaml50hgsdpw29dhbs2r7magx0cm199iw73mv";
   };
+
+  enableParallelBuilding = true;
+
+  outputs = [ "out" "doc" ];
 
   postPatch = "patchShebangs .";
 
@@ -48,21 +91,43 @@ stdenv.mkDerivation rec {
     export NIX_LDFLAGS+=" -no_dtrace_dof"
   '';
 
-  buildInputs = [ alex autoconf automake ghc happy hscolour perl python3 sphinx ] ++ stdenv.lib.optionals (targetPlatform.isArm || targetPlatform.isAarch64) [ llvm_39 ];
-
-  enableParallelBuilding = true;
-
+  # TODO(@Ericson2314): Always pass "--target" and always prefix.
+  configurePlatforms = [ "build" "host" ]
+    ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  # `--with` flags for libraries needed for RTS linker
   configureFlags = [
-    "CC=${stdenv.cc}/bin/cc"
-    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
     "--datadir=$doc/share/doc/ghc"
-  ] ++ stdenv.lib.optional (! enableIntegerSimple) [
+    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && ! enableIntegerSimple) [
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
-  ] ++ stdenv.lib.optional stdenv.isDarwin [
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.isDarwin) [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
-  ] ++ stdenv.lib.optional stdenv.isArm [
+  ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
+    "--enable-bootstrap-with-devel-snapshot"
+  ] ++ stdenv.lib.optionals (targetPlatform.isDarwin && targetPlatform.isAarch64) [
+    # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
+    "--disable-large-address-space"
+  ] ++ stdenv.lib.optional targetPlatform.isArm [
     "LD=${stdenv.cc}/bin/ld.gold"
   ];
+
+  # Hack to make sure we never to the relaxation `$PATH` and hooks support for
+  # compatability. This will be replaced with something clearer in a future
+  # masss-rebuild.
+  crossConfig = true;
+
+  nativeBuildInputs = [ alex autoconf automake ghc happy hscolour perl python3 sphinx ];
+
+  # For building runtime libs
+  depsBuildTarget = toolsForTarget;
+
+  buildInputs = libDeps hostPlatform;
+
+  propagatedBuildInputs = [ targetPackages.stdenv.cc ]
+    ++ stdenv.lib.optional useLLVM llvmPackages.llvm;
+
+  depsTargetTarget = map stdenv.lib.getDev (libDeps targetPlatform);
+  depsTargetTargetPropagated = map (stdenv.lib.getOutput "out") (libDeps targetPlatform);
 
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
@@ -70,6 +135,8 @@ stdenv.mkDerivation rec {
 
   checkTarget = "test";
 
+  # zsh and other shells are smart about `{ghc}` but bash isn't, and doesn't
+  # treat that as a unary `{x,y,z,..}` repetition.
   postInstall = ''
     paxmark m $out/lib/${name}/bin/${if targetPlatform != hostPlatform then "ghc" else "{ghc,haddock}"}
 
@@ -84,10 +151,10 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  outputs = [ "out" "doc" ];
-
   passthru = {
     inherit bootPkgs targetPrefix;
+
+    inherit llvmPackages;
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -82,7 +82,23 @@ stdenv.mkDerivation rec {
 
   postPatch = "patchShebangs .";
 
+  # GHC is a bit confused on its cross terminology.
   preConfigure = ''
+    for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
+      export "''${env#TARGET_}=''${!env}"
+    done
+    # GHC is a bit confused on its cross terminology, as these would normally be
+    # the *host* tools.
+    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld"
+    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
+
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -181,6 +181,9 @@ stdenv.mkDerivation rec {
     inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (rec {
   postPatch = "patchShebangs .";
 
   preConfigure = ''
-    echo "${buildMK}" > mk/build.mk
+    echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -56,7 +56,7 @@ let
   # Splicer will pull out correct variations
   libDeps = platform: [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
-    ++ stdenv.lib.optional (platform.libc == "libSystem") libiconv;
+    ++ stdenv.lib.optional (platform.libc != "glibc") libiconv;
 
   toolsForTarget =
     if hostPlatform == buildPlatform then
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && ! enableIntegerSimple) [
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
-  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.isDarwin) [
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc") [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -3,7 +3,7 @@
 
 # build-tools
 , bootPkgs, alex, happy, hscolour
-, autoconf, automake, coreutils, fetchurl, perl, python3, sphinx
+, autoconf, autoreconfHook, automake, coreutils, fetchurl, fetchpatch, perl, python3, sphinx
 
 , libffi, libiconv ? null, ncurses
 
@@ -80,6 +80,13 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "doc" ];
 
+  patches = [
+    (fetchpatch { # Fix STRIP to be substituted from configure
+      url = "https://git.haskell.org/ghc.git/commitdiff_plain/2fc8ce5f0c8c81771c26266ac0b150ca9b75c5f3";
+      sha256 = "03253ci40np1v6k0wmi4aypj3nmj3rdyvb1k6rwqipb30nfc719f";
+    })
+  ];
+
   postPatch = "patchShebangs .";
 
   # GHC is a bit confused on its cross terminology.
@@ -135,7 +142,7 @@ stdenv.mkDerivation rec {
   # masss-rebuild.
   crossConfig = true;
 
-  nativeBuildInputs = [ alex autoconf automake ghc happy hscolour perl python3 sphinx ];
+  nativeBuildInputs = [ alex autoconf autoreconfHook automake ghc happy hscolour perl python3 sphinx ];
 
   # For building runtime libs
   depsBuildTarget = toolsForTarget;

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (rec {
   postPatch = "patchShebangs .";
 
   preConfigure = ''
-    echo "${buildMK}" > mk/build.mk
+    echo -n "${buildMK}" > mk/build.mk
     echo ${version} >VERSION
     echo ${rev} >GIT_COMMIT_ID
     ./boot

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -84,7 +84,23 @@ stdenv.mkDerivation rec {
 
   postPatch = "patchShebangs .";
 
+  # GHC is a bit confused on its cross terminology.
   preConfigure = ''
+    for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
+      export "''${env#TARGET_}=''${!env}"
+    done
+    # GHC is a bit confused on its cross terminology, as these would normally be
+    # the *host* tools.
+    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld"
+    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
+
     echo -n "${buildMK}" > mk/build.mk
     echo ${version} >VERSION
     echo ${rev} >GIT_COMMIT_ID

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -26,6 +26,12 @@ let
   targetPrefix = stdenv.lib.optionalString
     (targetPlatform != hostPlatform)
     "${targetPlatform.config}-";
+
+  buildMK = stdenv.lib.optionalString enableIntegerSimple ''
+    INTEGER_LIBRARY = integer-simple
+  '' + stdenv.lib.optionalString (targetPlatform != hostPlatform) ''
+    BuildFlavour = perf-cross
+  '';
 in
 stdenv.mkDerivation (rec {
   inherit version rev;
@@ -40,18 +46,15 @@ stdenv.mkDerivation (rec {
   postPatch = "patchShebangs .";
 
   preConfigure = ''
+    echo "${buildMK}" > mk/build.mk
     echo ${version} >VERSION
     echo ${rev} >GIT_COMMIT_ID
     ./boot
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+    export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export NIX_LDFLAGS+=" -no_dtrace_dof"
-  '' + stdenv.lib.optionalString enableIntegerSimple ''
-    echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
-  '' + stdenv.lib.optionalString (targetPlatform != hostPlatform) ''
-    sed 's|#BuildFlavour  = quick-cross|BuildFlavour  = perf-cross|' mk/build.mk.sample > mk/build.mk
   '';
 
   buildInputs = [ ghc perl autoconf automake happy alex python3 ];

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -178,6 +178,9 @@ stdenv.mkDerivation rec {
     inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -32,8 +32,6 @@ assert !enableIntegerSimple -> gmp != null;
 let
   inherit (bootPkgs) ghc;
 
-  rev = "3e3a096885c0fcd0703edbeffb4e47f5cbd8f4cc";
-
   # TODO(@Ericson2314) Make unconditional
   targetPrefix = stdenv.lib.optionalString
     (targetPlatform != hostPlatform)
@@ -69,12 +67,13 @@ let
 
 in
 stdenv.mkDerivation rec {
-  inherit version rev;
+  inherit version;
+  inherit (src) rev;
   name = "${targetPrefix}ghc-${version}";
 
   src = fetchgit {
     url = "git://git.haskell.org/ghc.git";
-    inherit rev;
+    rev = "3e3a096885c0fcd0703edbeffb4e47f5cbd8f4cc";
     sha256 = "06slymbsd7vsfp4hh40v7cxf7nmp0kvlni2wfq7ag5wlqh04slgs";
   };
 
@@ -104,7 +103,7 @@ stdenv.mkDerivation rec {
 
     echo -n "${buildMK}" > mk/build.mk
     echo ${version} >VERSION
-    echo ${rev} >GIT_COMMIT_ID
+    echo ${src.rev} >GIT_COMMIT_ID
     ./boot
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -57,7 +57,7 @@ let
   # Splicer will pull out correct variations
   libDeps = platform: [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
-    ++ stdenv.lib.optional (platform.libc == "libSystem") libiconv;
+    ++ stdenv.lib.optional (platform.libc != "glibc") libiconv;
 
   toolsForTarget =
     if hostPlatform == buildPlatform then
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && ! enableIntegerSimple) [
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
-  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.isDarwin) [
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc") [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -93,7 +93,8 @@ stdenv.mkDerivation rec {
     # the *host* tools.
     export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
     export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld"
+    # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isArm ".gold"}"
     export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
     export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
     export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
@@ -125,6 +126,10 @@ stdenv.mkDerivation rec {
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"
+  ] ++ stdenv.lib.optionals (targetPlatform.isArm) [
+    "CFLAGS=-fuse-ld=gold"
+    "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
+    "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
   ] ++ stdenv.lib.optionals (targetPlatform.isDarwin && targetPlatform.isAarch64) [
     # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
     "--disable-large-address-space"

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -1,6 +1,5 @@
 { stdenv, targetPackages
 , buildPlatform, hostPlatform, targetPlatform
-, selfPkgs, cross ? null
 
 # build-tools
 , bootPkgs, alex, happy
@@ -33,7 +32,7 @@ let
     BuildFlavour = perf-cross
   '';
 in
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   inherit version rev;
   name = "${targetPrefix}ghc-${version}";
 
@@ -95,11 +94,6 @@ stdenv.mkDerivation (rec {
 
   passthru = {
     inherit bootPkgs targetPrefix;
-  } // stdenv.lib.optionalAttrs (targetPlatform != buildPlatform) {
-    crossCompiler = selfPkgs.ghc.override {
-      cross = targetPlatform;
-      bootPkgs = selfPkgs;
-    };
   };
 
   meta = {
@@ -109,24 +103,4 @@ stdenv.mkDerivation (rec {
     inherit (ghc.meta) license platforms;
   };
 
-} // stdenv.lib.optionalAttrs (cross != null) {
-  configureFlags = [
-    "CC=${stdenv.cc}/bin/${cross.config}-cc"
-    "LD=${stdenv.cc.bintools}/bin/${cross.config}-ld"
-    "AR=${stdenv.cc.bintools}/bin/${cross.config}-ar"
-    "NM=${stdenv.cc.bintools}/bin/${cross.config}-nm"
-    "RANLIB=${stdenv.cc.bintools}/bin/${cross.config}-ranlib"
-    "--target=${cross.config}"
-    "--enable-bootstrap-with-devel-snapshot"
-  ] ++
-    # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
-    stdenv.lib.optional (cross.config or null == "aarch64-apple-darwin14") "--disable-large-address-space";
-
-  configurePlatforms = [];
-
-  passthru = {
-    inherit bootPkgs cross;
-    cc = "${stdenv.cc}/bin/${cross.config}-cc";
-    ld = "${stdenv.cc}/bin/${cross.config}-ld";
-  };
-})
+}

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (rec {
   postPatch = "patchShebangs .";
 
   preConfigure = ''
-    echo "${buildMK}" > mk/build.mk
+    echo -n "${buildMK}" > mk/build.mk
     echo ${version} >VERSION
     echo ${rev} >GIT_COMMIT_ID
     ./boot

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -84,7 +84,23 @@ stdenv.mkDerivation rec {
 
   postPatch = "patchShebangs .";
 
+  # GHC is a bit confused on its cross terminology.
   preConfigure = ''
+    for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
+      export "''${env#TARGET_}=''${!env}"
+    done
+    # GHC is a bit confused on its cross terminology, as these would normally be
+    # the *host* tools.
+    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld"
+    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
+
     echo -n "${buildMK}" > mk/build.mk
     echo ${version} >VERSION
     echo ${rev} >GIT_COMMIT_ID

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -24,15 +24,13 @@
   # platform). Static libs are always built.
   enableShared ? true
 
-, version ? "8.5.20171209"
+, version ? "8.5.20180118"
 }:
 
 assert !enableIntegerSimple -> gmp != null;
 
 let
   inherit (bootPkgs) ghc;
-
-  rev = "4335c07ca7e64624819b22644d7591853826bd75";
 
   # TODO(@Ericson2314) Make unconditional
   targetPrefix = stdenv.lib.optionalString
@@ -69,13 +67,14 @@ let
 
 in
 stdenv.mkDerivation rec {
-  inherit version rev;
+  inherit version;
+  inherit (src) rev;
   name = "${targetPrefix}ghc-${version}";
 
   src = fetchgit {
     url = "git://git.haskell.org/ghc.git";
-    inherit rev;
-    sha256 = "19csad94sk0bw2nj97ppmnwh4c193jg0jmg5w2sx9rqm9ih4yg85";
+    rev = "e1d4140be4d2a1508015093b69e1ef53516e1eb6";
+    sha256 = "1gdcr10dd968d40qgljdwx9vfkva3yrvjm9a4nis7whaaac3ag58";
   };
 
   enableParallelBuilding = true;
@@ -104,7 +103,7 @@ stdenv.mkDerivation rec {
 
     echo -n "${buildMK}" > mk/build.mk
     echo ${version} >VERSION
-    echo ${rev} >GIT_COMMIT_ID
+    echo ${src.rev} >GIT_COMMIT_ID
     ./boot
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -5,11 +5,24 @@
 , bootPkgs, alex, happy
 , autoconf, automake, coreutils, fetchgit, perl, python3
 
-, libiconv ? null, ncurses
+, libffi, libiconv ? null, ncurses
+
+, useLLVM ? !targetPlatform.isx86
+, # LLVM is conceptually a run-time-only depedendency, but for
+  # non-x86, we need LLVM to bootstrap later stages, so it becomes a
+  # build-time dependency too.
+  buildLlvmPackages, llvmPackages
 
 , # If enabled, GHC will be built with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
   enableIntegerSimple ? false, gmp ? null
+
+, # If enabled, use -fPIC when compiling static libs.
+  enableRelocatedStaticLibs ? targetPlatform != hostPlatform
+
+, # Whether to build dynamic libs for the standard library (on the target
+  # platform). Static libs are always built.
+  enableShared ? true
 
 , version ? "8.5.20171209"
 }:
@@ -26,11 +39,34 @@ let
     (targetPlatform != hostPlatform)
     "${targetPlatform.config}-";
 
-  buildMK = stdenv.lib.optionalString enableIntegerSimple ''
+  buildMK = ''
+    DYNAMIC_GHC_PROGRAMS = ${if enableShared then "YES" else "NO"}
+  '' + stdenv.lib.optionalString enableIntegerSimple ''
     INTEGER_LIBRARY = integer-simple
   '' + stdenv.lib.optionalString (targetPlatform != hostPlatform) ''
     BuildFlavour = perf-cross
+    Stage1Only = YES
+    HADDOCK_DOCS = NO
+    BUILD_SPHINX_HTML = NO
+    BUILD_SPHINX_PDF = NO
+  '' + stdenv.lib.optionalString enableRelocatedStaticLibs ''
+    GhcLibHcOpts += -fPIC
+    GhcRtsHcOpts += -fPIC
   '';
+
+  # Splicer will pull out correct variations
+  libDeps = platform: [ ncurses ]
+    ++ stdenv.lib.optional (!enableIntegerSimple) gmp
+    ++ stdenv.lib.optional (platform.libc == "libSystem") libiconv;
+
+  toolsForTarget =
+    if hostPlatform == buildPlatform then
+      [ targetPackages.stdenv.cc ] ++ stdenv.lib.optional useLLVM llvmPackages.llvm
+    else assert targetPlatform == hostPlatform; # build != host == target
+      [ stdenv.cc ] ++ stdenv.lib.optional useLLVM buildLlvmPackages.llvm;
+
+  targetCC = builtins.head toolsForTarget;
+
 in
 stdenv.mkDerivation rec {
   inherit version rev;
@@ -41,6 +77,10 @@ stdenv.mkDerivation rec {
     inherit rev;
     sha256 = "19csad94sk0bw2nj97ppmnwh4c193jg0jmg5w2sx9rqm9ih4yg85";
   };
+
+  enableParallelBuilding = true;
+
+  outputs = [ "out" "doc" ];
 
   postPatch = "patchShebangs .";
 
@@ -56,19 +96,41 @@ stdenv.mkDerivation rec {
     export NIX_LDFLAGS+=" -no_dtrace_dof"
   '';
 
-  buildInputs = [ ghc perl autoconf automake happy alex python3 ];
-
-  enableParallelBuilding = true;
-
+  # TODO(@Ericson2314): Always pass "--target" and always prefix.
+  configurePlatforms = [ "build" "host" ]
+    ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  # `--with` flags for libraries needed for RTS linker
   configureFlags = [
-    "CC=${stdenv.cc}/bin/cc"
-    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
     "--datadir=$doc/share/doc/ghc"
-  ] ++ stdenv.lib.optional (! enableIntegerSimple) [
+    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && ! enableIntegerSimple) [
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
-  ] ++ stdenv.lib.optional stdenv.isDarwin [
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.isDarwin) [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
+  ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
+    "--enable-bootstrap-with-devel-snapshot"
+  ] ++ stdenv.lib.optionals (targetPlatform.isDarwin && targetPlatform.isAarch64) [
+    # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
+    "--disable-large-address-space"
   ];
+
+  # Hack to make sure we never to the relaxation `$PATH` and hooks support for
+  # compatability. This will be replaced with something clearer in a future
+  # masss-rebuild.
+  crossConfig = true;
+
+  nativeBuildInputs = [ ghc perl autoconf automake happy alex python3 ];
+
+  # For building runtime libs
+  depsBuildTarget = toolsForTarget;
+
+  buildInputs = libDeps hostPlatform;
+
+  propagatedBuildInputs = [ targetPackages.stdenv.cc ]
+    ++ stdenv.lib.optional useLLVM llvmPackages.llvm;
+
+  depsTargetTarget = map stdenv.lib.getDev (libDeps targetPlatform);
+  depsTargetTargetPropagated = map (stdenv.lib.getOutput "out") (libDeps targetPlatform);
 
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
@@ -76,6 +138,8 @@ stdenv.mkDerivation rec {
 
   checkTarget = "test";
 
+  # zsh and other shells are smart about `{ghc}` but bash isn't, and doesn't
+  # treat that as a unary `{x,y,z,..}` repetition.
   postInstall = ''
     paxmark m $out/lib/${name}/bin/${if targetPlatform != hostPlatform then "ghc" else "{ghc,haddock}"}
 
@@ -90,10 +154,10 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  outputs = [ "out" "doc" ];
-
   passthru = {
     inherit bootPkgs targetPrefix;
+
+    inherit llvmPackages;
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -26,6 +26,12 @@ let
   targetPrefix = stdenv.lib.optionalString
     (targetPlatform != hostPlatform)
     "${targetPlatform.config}-";
+
+  buildMK = stdenv.lib.optionalString enableIntegerSimple ''
+    INTEGER_LIBRARY = integer-simple
+  '' + stdenv.lib.optionalString (targetPlatform != hostPlatform) ''
+    BuildFlavour = perf-cross
+  '';
 in
 stdenv.mkDerivation (rec {
   inherit version rev;
@@ -40,18 +46,15 @@ stdenv.mkDerivation (rec {
   postPatch = "patchShebangs .";
 
   preConfigure = ''
+    echo "${buildMK}" > mk/build.mk
     echo ${version} >VERSION
     echo ${rev} >GIT_COMMIT_ID
     ./boot
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+    export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export NIX_LDFLAGS+=" -no_dtrace_dof"
-  '' + stdenv.lib.optionalString enableIntegerSimple ''
-    echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
-  '' + stdenv.lib.optionalString (targetPlatform != hostPlatform) ''
-    sed 's|#BuildFlavour  = quick-cross|BuildFlavour  = perf-cross|' mk/build.mk.sample > mk/build.mk
   '';
 
   buildInputs = [ ghc perl autoconf automake happy alex python3 ];

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -178,6 +178,9 @@ stdenv.mkDerivation rec {
     inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -57,7 +57,7 @@ let
   # Splicer will pull out correct variations
   libDeps = platform: [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
-    ++ stdenv.lib.optional (platform.libc == "libSystem") libiconv;
+    ++ stdenv.lib.optional (platform.libc != "glibc") libiconv;
 
   toolsForTarget =
     if hostPlatform == buildPlatform then
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && ! enableIntegerSimple) [
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
-  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.isDarwin) [
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc") [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -93,7 +93,8 @@ stdenv.mkDerivation rec {
     # the *host* tools.
     export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
     export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld"
+    # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isArm ".gold"}"
     export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
     export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
     export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
@@ -125,6 +126,10 @@ stdenv.mkDerivation rec {
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"
+  ] ++ stdenv.lib.optionals (targetPlatform.isArm) [
+    "CFLAGS=-fuse-ld=gold"
+    "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
+    "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
   ] ++ stdenv.lib.optionals (targetPlatform.isDarwin && targetPlatform.isAarch64) [
     # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
     "--disable-large-address-space"

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -1,6 +1,5 @@
 { stdenv, targetPackages
 , buildPlatform, hostPlatform, targetPlatform
-, selfPkgs, cross ? null
 
 # build-tools
 , bootPkgs, alex, happy
@@ -33,7 +32,7 @@ let
     BuildFlavour = perf-cross
   '';
 in
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   inherit version rev;
   name = "${targetPrefix}ghc-${version}";
 
@@ -95,11 +94,6 @@ stdenv.mkDerivation (rec {
 
   passthru = {
     inherit bootPkgs targetPrefix;
-  } // stdenv.lib.optionalAttrs (targetPlatform != buildPlatform) {
-    crossCompiler = selfPkgs.ghc.override {
-      cross = targetPlatform;
-      bootPkgs = selfPkgs;
-    };
   };
 
   meta = {
@@ -109,24 +103,4 @@ stdenv.mkDerivation (rec {
     inherit (ghc.meta) license platforms;
   };
 
-} // stdenv.lib.optionalAttrs (cross != null) {
-  configureFlags = [
-    "CC=${stdenv.cc}/bin/${cross.config}-cc"
-    "LD=${stdenv.cc.bintools}/bin/${cross.config}-ld"
-    "AR=${stdenv.cc.bintools}/bin/${cross.config}-ar"
-    "NM=${stdenv.cc.bintools}/bin/${cross.config}-nm"
-    "RANLIB=${stdenv.cc.bintools}/bin/${cross.config}-ranlib"
-    "--target=${cross.config}"
-    "--enable-bootstrap-with-devel-snapshot"
-  ] ++
-    # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
-    stdenv.lib.optional (cross.config or null == "aarch64-apple-darwin14") "--disable-large-address-space";
-
-  configurePlatforms = [];
-
-  passthru = {
-    inherit bootPkgs cross;
-    cc = "${stdenv.cc}/bin/${cross.config}-cc";
-    ld = "${stdenv.cc}/bin/${cross.config}-ld";
-  };
-})
+}

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -1,4 +1,5 @@
 { pkgs, stdenv, lib, haskellLib, ghc, all-cabal-hashes
+, buildHaskellPackages
 , compilerConfig ? (self: super: {})
 , packageSetConfig ? (self: super: {})
 , overrides ? (self: super: {})
@@ -14,7 +15,7 @@ let
 
   haskellPackages = pkgs.callPackage makePackageSet {
     package-set = initialPackages;
-    inherit stdenv haskellLib ghc extensible-self;
+    inherit stdenv haskellLib ghc buildHaskellPackages extensible-self;
   };
 
   commonConfiguration = configurationCommon { inherit pkgs haskellLib; };

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -160,8 +160,8 @@ let
   allPkgconfigDepends = pkgconfigDepends ++ libraryPkgconfigDepends ++ executablePkgconfigDepends ++
                         optionals doCheck testPkgconfigDepends ++ optionals doBenchmark benchmarkPkgconfigDepends;
 
-  nativeBuildInputs = optional (allPkgconfigDepends != []) pkgconfig ++
-                      buildTools ++ libraryToolDepends ++ executableToolDepends ++ [ removeReferencesTo ];
+  nativeBuildInputs = [ ghc removeReferencesTo ] ++ optional (allPkgconfigDepends != []) pkgconfig ++
+                      buildTools ++ libraryToolDepends ++ executableToolDepends;
   propagatedBuildInputs = buildDepends ++ libraryHaskellDepends ++ executableHaskellDepends;
   otherBuildInputs = setupHaskellDepends ++ extraLibraries ++ librarySystemDepends ++ executableSystemDepends ++
                      optionals (allPkgconfigDepends != []) allPkgconfigDepends ++
@@ -220,7 +220,6 @@ stdenv.mkDerivation ({
     runHook preSetupCompilerEnvironment
 
     echo "Build with ${ghc}."
-    export PATH="${ghc}/bin:$PATH"
     ${optionalString (hasActiveLibrary && hyperlinkSource) "export PATH=${hscolour}/bin:$PATH"}
 
     packageConfDir="$TMPDIR/package.conf.d"
@@ -276,6 +275,8 @@ stdenv.mkDerivation ({
     runHook postCompileBuildDriver
   '';
 
+  # Cabal takes flags like `--configure-option=--host=...` instead
+  configurePlatforms = [];
   inherit configureFlags;
 
   configurePhase = ''

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, ghc
+{ stdenv, buildPackages, buildHaskellPackages, ghc
 , jailbreak-cabal, hscolour, cpphs, nodejs
 , buildPlatform, hostPlatform
 }:
@@ -81,7 +81,11 @@ let
                   then "package-db"
                   else "package-conf";
 
-  nativeGhc = if isCross || isGhcjs then ghc.bootPkgs.ghc else ghc;
+  # GHC used for building Setup.hs
+  #
+  # Same as our GHC, unless we're cross, in which case it is native GHC with the
+  # same version, or ghcjs, in which case its the ghc used to build ghcjs.
+  nativeGhc = buildHaskellPackages.ghc;
   nativePackageDbFlag = if versionOlder "7.6" nativeGhc.version
                         then "package-db"
                         else "package-conf";
@@ -147,8 +151,7 @@ let
   ] ++ crossCabalFlags);
 
   setupCompileFlags = [
-    (optionalString (!coreSetup) "-${packageDbFlag}=$packageConfDir")
-    (optionalString isGhcjs "-build-runner")
+    (optionalString (!coreSetup) "-${nativePackageDbFlag}=$packageConfDir")
     (optionalString (isGhcjs || isHaLVM || versionOlder "7.8" ghc.version) "-j$NIX_BUILD_CORES")
     # https://github.com/haskell/cabal/issues/2398
     (optionalString (versionOlder "7.10" ghc.version && !isHaLVM) "-threaded")
@@ -160,14 +163,12 @@ let
   allPkgconfigDepends = pkgconfigDepends ++ libraryPkgconfigDepends ++ executablePkgconfigDepends ++
                         optionals doCheck testPkgconfigDepends ++ optionals doBenchmark benchmarkPkgconfigDepends;
 
-  nativeBuildInputs = [ ghc removeReferencesTo ] ++ optional (allPkgconfigDepends != []) pkgconfig ++
+  nativeBuildInputs = [ ghc nativeGhc removeReferencesTo ] ++ optional (allPkgconfigDepends != []) pkgconfig ++
                       buildTools ++ libraryToolDepends ++ executableToolDepends;
   propagatedBuildInputs = buildDepends ++ libraryHaskellDepends ++ executableHaskellDepends;
   otherBuildInputs = setupHaskellDepends ++ extraLibraries ++ librarySystemDepends ++ executableSystemDepends ++
                      optionals (allPkgconfigDepends != []) allPkgconfigDepends ++
                      optionals doCheck (testDepends ++ testHaskellDepends ++ testSystemDepends ++ testToolDepends) ++
-                     # ghcjs's hsc2hs calls out to the native hsc2hs
-                     optional isGhcjs nativeGhc ++
                      optionals doBenchmark (benchmarkDepends ++ benchmarkHaskellDepends ++ benchmarkSystemDepends ++ benchmarkToolDepends);
   allBuildInputs = propagatedBuildInputs ++ otherBuildInputs;
 
@@ -176,11 +177,13 @@ let
 
   ghcEnv = ghc.withPackages (p: haskellBuildInputs);
 
-  setupBuilder = if isCross then "${nativeGhc}/bin/ghc" else ghcCommand;
   setupCommand = "./Setup";
+
   ghcCommand' = if isGhcjs then "ghcjs" else "ghc";
   ghcCommand = "${ghc.targetPrefix}${ghcCommand'}";
   ghcCommandCaps= toUpper ghcCommand';
+
+  nativeGhcCommand = "${nativeGhc.targetPrefix}ghc";
 
 in
 
@@ -270,7 +273,7 @@ stdenv.mkDerivation ({
     done
 
     echo setupCompileFlags: $setupCompileFlags
-    ${setupBuilder} $setupCompileFlags --make -o Setup -odir $TMPDIR -hidir $TMPDIR $i
+    ${nativeGhcCommand} $setupCompileFlags --make -o Setup -odir $TMPDIR -hidir $TMPDIR $i
 
     runHook postCompileBuildDriver
   '';

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -4,6 +4,10 @@
 { # package-set used for build tools (all of nixpkgs)
   buildPackages
 
+, # A haskell package set for Setup.hs, compiler plugins, and similar
+  # build-time uses.
+  buildHaskellPackages
+
 , # package-set used for non-haskell dependencies (all of nixpkgs)
   pkgs
 
@@ -18,8 +22,8 @@
 , # compiler to use
   ghc
 
-, # A function that takes `{ pkgs, stdenv, callPackage }` as the first arg and `self`
-  # as second, and returns a set of haskell packages
+, # A function that takes `{ pkgs, stdenv, callPackage }` as the first arg and
+  # `self` as second, and returns a set of haskell packages
   package-set
 
 , # The final, fully overriden package set usable with the nixpkgs fixpoint
@@ -36,15 +40,12 @@ let
   inherit (stdenv.lib) fix' extends makeOverridable;
   inherit (haskellLib) overrideCabal;
 
-  buildHaskellPackages = if hostPlatform != buildPlatform
-                         then self.ghc.bootPkgs
-                         else self;
-
   mkDerivationImpl = pkgs.callPackage ./generic-builder.nix {
     inherit stdenv;
     nodejs = buildPackages.nodejs-slim;
-    inherit (buildHaskellPackages) jailbreak-cabal;
+    inherit buildHaskellPackages;
     inherit (self) ghc;
+    inherit (buildHaskellPackages) jailbreak-cabal;
     hscolour = overrideCabal buildHaskellPackages.hscolour (drv: {
       isLibrary = false;
       doHaddock = false;

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -120,7 +120,7 @@ let
       installPhase = ''
         export HOME="$TMP"
         mkdir -p "$out"
-        cabal2nix --compiler=${self.ghc.name} --system=${stdenv.system} ${sha256Arg} "${src}" > "$out/default.nix"
+        cabal2nix --compiler=${ghc.haskellCompilerName} --system=${stdenv.system} ${sha256Arg} "${src}" > "$out/default.nix"
       '';
   };
 

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -68,25 +68,35 @@ in rec {
     ghc7103 = callPackage ../development/compilers/ghc/7.10.3.nix rec {
       bootPkgs = packages.ghc7103Binary;
       inherit (bootPkgs) hscolour;
+      buildLlvmPackages = buildPackages.llvmPackages_35;
+      llvmPackages = pkgs.llvmPackages_35;
     };
     ghc802 = callPackage ../development/compilers/ghc/8.0.2.nix rec {
       bootPkgs = packages.ghc7103Binary;
       inherit (bootPkgs) hscolour;
       sphinx = pkgs.python27Packages.sphinx;
+      buildLlvmPackages = buildPackages.llvmPackages_37;
+      llvmPackages = pkgs.llvmPackages_37;
     };
     ghc822 = callPackage ../development/compilers/ghc/8.2.2.nix rec {
       bootPkgs = packages.ghc821Binary;
       inherit (bootPkgs) hscolour alex happy;
       inherit buildPlatform targetPlatform;
       sphinx = pkgs.python3Packages.sphinx;
+      buildLlvmPackages = buildPackages.llvmPackages_39;
+      llvmPackages = pkgs.llvmPackages_39;
     };
     ghc841 = callPackage ../development/compilers/ghc/8.4.1.nix rec {
       bootPkgs = packages.ghc821Binary;
       inherit (bootPkgs) alex happy;
+      buildLlvmPackages = buildPackages.llvmPackages_5;
+      llvmPackages = pkgs.llvmPackages_5;
     };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix rec {
       bootPkgs = packages.ghc821Binary;
       inherit (bootPkgs) alex happy;
+      buildLlvmPackages = buildPackages.llvmPackages_5;
+      llvmPackages = pkgs.llvmPackages_5;
     };
     ghcjs = packages.ghc7103.callPackage ../development/compilers/ghcjs {
       bootPkgs = packages.ghc7103;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -128,48 +128,58 @@ in rec {
   };
 
   # Always get compilers from `buildPackages`
-  packages = let inherit (buildPackages.haskell) compiler; in {
+  packages = let bh = buildPackages.haskell; in {
 
     ghc7103 = callPackage ../development/haskell-modules {
-      ghc = compiler.ghc7103;
+      buildHaskellPackages = bh.packages.ghc7103;
+      ghc = bh.compiler.ghc7103;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-7.10.x.nix { };
     };
     ghc7103Binary = callPackage ../development/haskell-modules {
-      ghc = compiler.ghc7103Binary;
+      buildHaskellPackages = bh.packages.ghc7103Binary;
+      ghc = bh.compiler.ghc7103Binary;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-7.10.x.nix { };
     };
     ghc802 = callPackage ../development/haskell-modules {
-      ghc = compiler.ghc802;
+      buildHaskellPackages = bh.packages.ghc802;
+      ghc = bh.compiler.ghc802;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.0.x.nix { };
     };
-    ghc822 = callPackage ../development/haskell-modules {
-      ghc = compiler.ghc822;
+    ghc821Binary = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc821Binary;
+      ghc = bh.compiler.ghc821Binary;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
     };
-    ghc821Binary = callPackage ../development/haskell-modules {
-      ghc = compiler.ghc821Binary;
+    ghc822 = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc822;
+      ghc = bh.compiler.ghc822;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
     };
     ghc841 = callPackage ../development/haskell-modules {
-      ghc = compiler.ghc841;
+      buildHaskellPackages = bh.packages.ghc841;
+      ghc = bh.compiler.ghc841;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.4.x.nix { };
     };
     ghcHEAD = callPackage ../development/haskell-modules {
-      ghc = compiler.ghcHEAD;
+      buildHaskellPackages = bh.packages.ghcHEAD;
+      ghc = bh.compiler.ghcHEAD;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-head.nix { };
     };
-    ghcjs = callPackage ../development/haskell-modules {
-      ghc = compiler.ghcjs;
+    ghcjs = callPackage ../development/haskell-modules rec {
+      buildHaskellPackages = ghc.bootPkgs;
+      ghc = bh.compiler.ghcjs;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-7.10.x.nix { };
       packageSetConfig = callPackage ../development/haskell-modules/configuration-ghcjs.nix { };
     };
-    ghcjsHEAD = callPackage ../development/haskell-modules {
-      ghc = compiler.ghcjsHEAD;
+    ghcjsHEAD = callPackage ../development/haskell-modules rec {
+      buildHaskellPackages = ghc.bootPkgs;
+      ghc = bh.compiler.ghcjsHEAD;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.0.x.nix { };
       packageSetConfig = callPackage ../development/haskell-modules/configuration-ghcjs.nix { };
     };
     ghcHaLVM240 = callPackage ../development/haskell-modules {
-      ghc = compiler.ghcHaLVM240;
+      buildHaskellPackages = bh.packages.ghcHaLVM240;
+      ghc = bh.compiler.ghcHaLVM240;
       compilerConfig = callPackage ../development/haskell-modules/configuration-halvm-2.4.0.nix { };
     };
 

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -117,8 +117,15 @@ in
     patchelf = nativePlatforms;
     buildPackages.binutils = nativePlatforms;
     mpg123 = nativePlatforms;
+    haskell.packages.ghcHEAD.hello = nativePlatforms;
+    haskell.packages.ghc822.hello = nativePlatforms;
   });
 
+  /* Linux on Aarch64 (TODO make android for real)  */
+  android = mapTestOnCross lib.systems.examples.aarch64-multiplatform (linuxCommon // {
+    haskell.packages.ghcHEAD.hello = nativePlatforms;
+    haskell.packages.ghc822.hello = nativePlatforms;
+  });
 
   /* Cross-built bootstrap tools for every supported platform */
   bootstrapTools = let

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -21,6 +21,8 @@ let
   gnuCommon = lib.recursiveUpdate common {
     buildPackages.gcc = nativePlatforms;
     coreutils = nativePlatforms;
+    haskell.packages.ghcHEAD.hello = nativePlatforms;
+    haskell.packages.ghc822.hello = nativePlatforms;
   };
 
   linuxCommon = lib.recursiveUpdate gnuCommon {
@@ -117,14 +119,10 @@ in
     patchelf = nativePlatforms;
     buildPackages.binutils = nativePlatforms;
     mpg123 = nativePlatforms;
-    haskell.packages.ghcHEAD.hello = nativePlatforms;
-    haskell.packages.ghc822.hello = nativePlatforms;
   });
 
   /* Linux on Aarch64 (TODO make android for real)  */
   android = mapTestOnCross lib.systems.examples.aarch64-multiplatform (linuxCommon // {
-    haskell.packages.ghcHEAD.hello = nativePlatforms;
-    haskell.packages.ghc822.hello = nativePlatforms;
   });
 
   /* Cross-built bootstrap tools for every supported platform */


### PR DESCRIPTION
##### Motivation for this change

This is a re-doing of the Haskell support for cross compilation to fit in with my other cross refactoring. As a cheat sheet, with the new system:

 - Getting a cross compiler: `haskell.packages.ghc{HEAD,821}.ghc`, or `buildPackages.haskell.compiler.ghc{HEAD,821}.ghc`
 - Getting a cross-compiled package: `haskell.packages.ghc{HEAD,821}.fooBarBaz`

There's other PRs that need to be merged first, but I am opening this now so people can get a flavor for what's to come.

Fixes #21874

##### Things to do

###### Optional changes

- [x] ~~Get rid of `--with` flags.~~ Actually, the `--with` flags are needed for GHC's own dynamic linker, long story short.

- [x] Add tests (for both Linux and Darwin) in `pkgs/top-level/release-cross.nix`. Linux should work right now, and darwin Later. Done for GHC 8.2.2 and GHC HEAD from x86_64 linux to 32-bit and 64-bit arm.

- [x] Update to a newer GHC commit with @bgamari's and @angerman's fixes (thanks!) so this actually builds. GHC HEAD is good to go, but GHC 822 needs one more patch to land to I have a more permanent URL: https://phabricator.haskell.org/D4287

###### Misc simple things

- [x] Update other GHCs likewise
- [x] Use `configurePlatforms` to control passing of `--build`, `--host`, and `--target`.
- [x] A few more misc changes to utilities like `hackage2nix`.
- [x] Break history into more separate commits?
- [x] `targetPrefix` is bound on GHC, so we don't need to recompute it all over the place.
- [x] Do make sure all `crossPrefix` or `prefix`, from earlier versions, are gone

------

CC @expipiplus1 @dtzWill @dhess