### PR TITLE
fetchnixpkgs: init

### DIFF
--- a/pkgs/build-support/fetchnixpkgs/default.nix
+++ b/pkgs/build-support/fetchnixpkgs/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub }:
+
+{ owner ? "NixOS"
+, repo ? "nixpkgs"
+, patches ? []
+, ...
+} @ args:
+
+let
+  src = fetchFromGitHub (stdenv.lib.filterAttrs (n: _: !builtins.elem n ["patches"]) (args // { inherit owner repo; }));
+
+  drv = stdenv.mkDerivation rec {
+    inherit (src) name;
+    inherit src patches;
+
+    dontSubstitute = true;
+    preferLocalBuild = true;
+    phases = [ "unpackPhase" "patchPhase" "installPhase" ];
+
+    installPhase = ''
+      mkdir $out
+      cp -a . $out
+    '';
+  };
+
+in
+  if patches == [] then src else drv

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -151,6 +151,8 @@ with pkgs;
 
   fetchMavenArtifact = callPackage ../build-support/fetchmavenartifact { };
 
+  fetchnixpkgs = callPackage ../build-support/fetchnixpkgs { };
+
   packer = callPackage ../development/tools/packer { };
 
   fetchpatch = callPackage ../build-support/fetchpatch { };


### PR DESCRIPTION
###### Motivation for this change

example

```nix
fetchnixpkgs {
  rev = "06271b6eba7ce754a305df1d90925de976b915d2";
  sha256 = "0w3mwggyc6ypjn07rsfcrmwlfmql96rvfz6436hm2vmnplpnylq3";
  patches = [ ./foo.patch ];
}
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

