### PR TITLE
nixos manual: segment into pages

### DIFF
--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -172,7 +172,7 @@ in rec {
         ${manualXsltprocOptions} \
         --stringparam target.database.document "${olinkDB}/olinkdb.xml" \
         --nonet --xinclude --output $dst/ \
-        ${docbook5_xsl}/xml/xsl/docbook/xhtml/chunktoc.xsl ./manual.xml
+        ${docbook5_xsl}/xml/xsl/docbook/xhtml/chunk.xsl ./manual.xml
 
       mkdir -p $dst/images/callouts
       cp ${docbook5_xsl}/xml/xsl/docbook/images/callouts/*.gif $dst/images/callouts/


### PR DESCRIPTION
At the moment we have one unnavigable large page.
This pull request puts each chapter into a separate file.
The idea solution would be to have a navigation side-bar were only
first-level chapters are shown (or even a page search like sphinx).
However docbook seems to be too inflexible to do that.

Is there a way to get nicer looking templates like the guix manual has?
https://www.gnu.org/software/guix/manual/guix.html

**Update** the template used on the website would be already enough.

---

