### PR TITLE
llvm-packages: get rid of extra build depedencies for manpages

### DIFF
--- a/pkgs/development/compilers/llvm/4/clang/default.nix
+++ b/pkgs/development/compilers/llvm/4/clang/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetch, cmake, libxml2, libedit, llvm, version, release_version, clang-tools-extra_src, python
 , fixDarwinDylibNames
-, enableManpages ? true
+, enableManpages ? false
 }:
 
 let

--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -1,4 +1,4 @@
-{ newScope, stdenv, cmake, libxml2, python2, isl, fetchurl, overrideCC, wrapCC, darwin, ccWrapperFun }:
+{ lowPrio, newScope, stdenv, cmake, libxml2, python2, isl, fetchurl, overrideCC, wrapCC, darwin, ccWrapperFun }:
 let
   callPackage = newScope (self // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
 
@@ -30,8 +30,8 @@ let
     llvm = overrideManOutput llvm;
     clang-unwrapped = overrideManOutput clang-unwrapped;
 
-    llvm-manpages = self.llvm.man;
-    clang-manpages = self.clang-unwrapped.man;
+    llvm-manpages = lowPrio self.llvm.man;
+    clang-manpages = lowPrio self.clang-unwrapped.man;
 
     clang = wrapCC self.clang-unwrapped;
 

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -16,7 +16,7 @@
 , compiler-rt_src
 , libcxxabi
 , debugVersion ? false
-, enableManpages ? true
+, enableManpages ? false
 , enableSharedLibraries ? true
 , darwin
 }:

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -235,11 +235,11 @@ in rec {
       libcxxabi libcxx ncurses libffi zlib gmp pcre gnugrep
       coreutils findutils diffutils patchutils;
 
-    llvmPackages = let llvmOverride = llvmPackages.llvm.override { enableManpages = false; inherit libcxxabi; }; in
-      super.llvmPackages // {
-        llvm = llvmOverride;
-        clang-unwrapped = llvmPackages.clang-unwrapped.override { enableManpages = false; llvm = llvmOverride; };
-      };
+     llvmPackages = let llvmOverride = llvmPackages.llvm.override { inherit libcxxabi; };
+     in super.llvmPackages // {
+       llvm = llvmOverride;
+       clang-unwrapped = llvmPackages.clang-unwrapped.override { llvm = llvmOverride; };
+     };
 
     darwin = super.darwin // {
       inherit (darwin) dyld Libsystem libiconv locale;


### PR DESCRIPTION
###### Motivation for this change

Fixes #26756

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
Estimating rebuild amount by counting changed Hydra jobs.
  31 x86_64-darwin
3658 x86_64-linux
```