### PR TITLE
hugo: 0.24 -> 0.24.1

### DIFF
--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "hugo-${version}";
-  version = "0.24";
+  version = "0.24.1";
 
   goPackagePath = "github.com/gohugoio/hugo";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "gohugoio";
     repo = "hugo";
     rev = "v${version}";
-    sha256 = "1q398afrkmg480c2an9pyhqkbi9iw266q4svwqrvm408gzjprdzp";
+    sha256 = "0zphxi11rny6wh1ysz7508fdrsbxj3n138q2bkkqaz0rrdab710a";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/applications/misc/hugo/deps.nix
+++ b/pkgs/applications/misc/hugo/deps.nix
@@ -4,8 +4,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/BurntSushi/toml";
-      rev = "b26d9c308763d68093482582cea63d69be07a0f0";
-      sha256 = "0k7v2i1d2d6si8gswn83qb84czhhia53v2wdy33yz9ppdidxk0ry";
+      rev = "8fb9fdc4f82fd3495b9086c911b86cc3d50cb7ab";
+      sha256 = "0igg0cwc0cihsxrii203h1r5y2lmaclc164cjhyv2hpfsvb11zlg";
     };
   }
   {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

