### PR TITLE
mailhog: init at 1.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -141,6 +141,7 @@
   dfoxfranke = "Daniel Fox Franke <dfoxfranke@gmail.com>";
   dgonyeo = "Derek Gonyeo <derek@gonyeo.com>";
   dipinhora = "Dipin Hora <dipinhora+github@gmail.com>";
+  disassembler = "Samuel Leathers <disasm@gmail.com>";
   dmalikov = "Dmitry Malikov <malikov.d.y@gmail.com>";
   DmitryTsygankov = "Dmitry Tsygankov <dmitry.tsygankov@gmail.com>";
   dmjio = "David Johnson <djohnson.m@gmail.com>";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -252,6 +252,7 @@
   ./services/mail/exim.nix
   ./services/mail/freepops.nix
   ./services/mail/mail.nix
+  ./services/mail/mailhog.nix
   ./services/mail/mlmmj.nix
   ./services/mail/offlineimap.nix
   ./services/mail/opendkim.nix

--- a/nixos/modules/services/mail/mailhog.nix
+++ b/nixos/modules/services/mail/mailhog.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.mailhog;
+in {
+  ###### interface
+
+  options = {
+
+    services.mailhog = {
+      enable = mkEnableOption "MailHog";
+      user = mkOption {
+        type = types.str;
+        default = "mailhog";
+        description = "User account under which mailhog runs.";
+      };
+    };
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    users.extraUsers.mailhog =
+    {
+      name = cfg.user;
+      description = "MailHog service user";
+    };
+
+    systemd.services.mailhog =
+    {
+      description = "MailHog service";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.mailhog}/bin/MailHog";
+        User = cfg.user;
+      };
+    };
+  };
+}

--- a/nixos/modules/services/mail/mailhog.nix
+++ b/nixos/modules/services/mail/mailhog.nix
@@ -24,14 +24,12 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.mailhog =
-    {
+    users.extraUsers.mailhog = {
       name = cfg.user;
       description = "MailHog service user";
     };
 
-    systemd.services.mailhog =
-    {
+    systemd.services.mailhog = {
       description = "MailHog service";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];

--- a/pkgs/servers/mail/mailhog/default.nix
+++ b/pkgs/servers/mail/mailhog/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "MailHog-${version}";
+  version = "1.0.0";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/mailhog/MailHog";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "mailhog";
+    repo = "MailHog";
+    sha256 = "0r6zidkffb8q12zyxd063jy0ig2x93llna4zb5i2qjh9gb971i83";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "Web and API based SMTP testing";
+    homepage = "https://github.com/mailhog/MailHog";
+    maintainers = with maintainers; [ disassembler ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/mail/mailhog/deps.nix
+++ b/pkgs/servers/mail/mailhog/deps.nix
@@ -1,0 +1,191 @@
+[
+  {
+    goPackagePath = "github.com/gorilla/pat";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/pat";
+      rev = "cf955c3d1f2c27ee96f93e9738085c762ff5f49d";
+      sha256 = "1jnhdhba3cwgsgv6qf7shvmk2nbbp8z30n9cimz9w6vd940ipisf";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/context";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/context";
+      rev = "1ea25387ff6f684839d82767c1733ff4d4d15d0a";
+      sha256 = "1nh1nzxcsgd215x4xn59wc4cbqfa8zvhvnnx5p8fkrn4bj1cgak4";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/mux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/mux";
+      rev = "bcd8bc72b08df0f70df986b97f95590779502d31";
+      sha256 = "0majd18zn8v1b1agn015vnk3xk2v8j5nyckczlf72gm3kaq3icga";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/websocket";
+      rev = "3ab3a8b8831546bd18fd182c20687ca853b2bb13";
+      sha256 = "17y94ngp1yrswq5pxxy97naiw6jgxz2yvm8zydi83gfixdgs99fc";
+    };
+  }
+  {
+    goPackagePath = "github.com/ian-kent/go-log";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ian-kent/go-log";
+      rev = "5731446c36ab9f716106ce0731f484c50fdf1ad1";
+      sha256 = "1qr0myg68r9zq43fnx0rbnxcny2jpyg3gc269pc2riskqk0a731d";
+    };
+  }
+  {
+    goPackagePath = "github.com/ian-kent/envconf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ian-kent/envconf";
+      rev = "c19809918c02ab33dc8635d68c77649313185275";
+      sha256 = "1085863rnx4h0q9xvg4zlsc7xf7jngfmjrq83cpcv1ayi664mzdx";
+    };
+  }
+  {
+    goPackagePath = "github.com/ian-kent/goose";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ian-kent/goose";
+      rev = "c3541ea826ad9e0f8a4a8c15ca831e8b0adde58c";
+      sha256 = "0v98d2554vlrm8mzk2zx8wj3daq076273w0zs8ww1aa57a1l74qv";
+    };
+  }
+  {
+    goPackagePath = "github.com/ian-kent/linkio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ian-kent/linkio";
+      rev = "77fb4b01842cb4b019137c0227df9a8f9779d0bd";
+      sha256 = "0fixidplxzmw7aakw19d64nvrykwm5xk55fj1q74n70s8j5d8hiq";
+    };
+  }
+  {
+    goPackagePath = "github.com/mailhog/MailHog-Server";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mailhog/MailHog-Server";
+      rev = "50f74a1aa2991b96313144d1ac718ce4d6739dfd";
+      sha256 = "1h0qs66bvgygpq0sz3w6y445vm3pvlrljr5x7xr13y0087mrpjla";
+    };
+  }
+  {
+    goPackagePath = "github.com/mailhog/MailHog-UI";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mailhog/MailHog-UI";
+      rev = "24b31a47cc5b65d23576bb9884c941d2b88381f7";
+      sha256 = "0309jmryhx3n0yksssk2j4xkh1xb01468i5f2sy3a83xkz9p3d54";
+    };
+  }
+  {
+    goPackagePath = "github.com/mailhog/http";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mailhog/http";
+      rev = "2e653938bf190d0e2fbe4825ce74e5bc149a62f2";
+      sha256 = "18j03lvyis7z0mv3fym3j9a7pi2qvnhggmhpxnjbwvwb86dhxjm8";
+    };
+  }
+  {
+    goPackagePath = "github.com/mailhog/mhsendmail";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mailhog/mhsendmail";
+      rev = "002527025ef50364446d7560600aedc5daaa1997";
+      sha256 = "11l2y0xb7hwk0zs7pwif3xkclhz32sc0jff3jkaxi3jdf3q3kz91";
+    };
+  }
+  {
+    goPackagePath = "github.com/mailhog/data";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mailhog/data";
+      rev = "024d554958b5bea5db220bfd84922a584d878ded";
+      sha256 = "0dgh0pcsn0xrxsn1qlxgdssaimch57kxj5vyvhqjnsdnh814g9vf";
+    };
+  }
+  {
+    goPackagePath = "github.com/mailhog/smtp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mailhog/smtp";
+      rev = "0c4e9b7e0625fec61d0c30d7b2f6c62852be6c54";
+      sha256 = "1w46w3asdxsgzyall16hi2s4jvkka1k3a1l52ryfhrzg187krir6";
+    };
+  }
+  {
+    goPackagePath = "github.com/mailhog/storage";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mailhog/storage";
+      rev = "6d871fb23ecd873cb10cdfc3a8dec5f50d2af8fa";
+      sha256 = "1ya0xigm2xysin59zlp2sbqncnmw9h77r9dn9k7vxhf0z8vvbibk";
+    };
+  }
+  {
+    goPackagePath = "github.com/ogier/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ogier/pflag";
+      rev = "32a05c62658bd1d7c7e75cbc8195de5d585fde0f";
+      sha256 = "1lyrr9wx0j087mnpsxcbspjcgh9a5c6bqwrasd8s237jlyc50qmj";
+    };
+  }
+  {
+    goPackagePath = "github.com/tinylib/msgp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tinylib/msgp";
+      rev = "02d047e07459c5a7b02b1244161d0f2f6d8f660d";
+      sha256 = "12y7qz1x266m0a0w3zwd49achxbh036yhkmx93xfs2283xh70q1r";
+    };
+  }
+  {
+    goPackagePath = "github.com/philhofer/fwd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/philhofer/fwd";
+      rev = "1612a298117663d7bc9a760ae20d383413859798";
+      sha256 = "155l0nvvblpx0fy683q6bzins7csh8fw7yf64hbia8hc7wh0gjdl";
+    };
+  }
+  {
+    goPackagePath = "github.com/t-k/fluent-logger-golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/t-k/fluent-logger-golang";
+      rev = "0f8ec08f2057a61574b6943e75045fffbeae894e";
+      sha256 = "0ic5bj87wpq1kncixd5mklwqn1jjwqfqfvkyl0mrnwp3p5p24v5c";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6";
+      sha256 = "1y2bbghi594m8p4pcm9pwrzql06179xj6zvhaghwcc6y0l48rbgp";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/mgo.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/mgo.v2";
+      rev = "d90005c5262a3463800497ea5a89aed5fe22c886";
+      sha256 = "1z81k6mnfk07hkrkw31l16qycyiwa6wzyhysmywgkh58sm5dc9m7";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2994,6 +2994,8 @@ with pkgs;
 
   maildrop = callPackage ../tools/networking/maildrop { };
 
+  mailhog = callPackage ../servers/mail/mailhog {};
+
   mailnag = callPackage ../applications/networking/mailreaders/mailnag { };
 
   mailsend = callPackage ../tools/networking/mailsend { };


### PR DESCRIPTION
###### Motivation for this change
Adds mailhog for capturing mail in dev environments.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

