### PR TITLE
mopidy-local-images: init at 1.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -479,6 +479,7 @@
   rushmorem = "Rushmore Mushambi <rushmore@webenchanter.com>";
   rvl = "Rodney Lorrimar <dev+nix@rodney.id.au>";
   rvlander = "Gaëtan André <rvlander@gaetanandre.eu>";
+  rvolosatovs = "Roman Volosatovs <rvolosatovs@riseup.net";
   ryanartecona = "Ryan Artecona <ryanartecona@gmail.com>";
   ryansydnor = "Ryan Sydnor <ryan.t.sydnor@gmail.com>";
   ryantm = "Ryan Mulligan <ryan@ryantm.com>";

--- a/pkgs/applications/audio/mopidy-local-images/default.nix
+++ b/pkgs/applications/audio/mopidy-local-images/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, pythonPackages, mopidy }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "mopidy-local-images-${version}";
+
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "mopidy";
+    repo = "mopidy-local-images";
+    rev = "v${version}";
+    sha256 = "0gdqxws0jish50mmi57mlqcs659wrllzv00czl18niz94vzvyc0d";
+  };
+
+  propagatedBuildInputs = [
+    mopidy
+    pythonPackages.pykka
+    pythonPackages.uritools
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mopidy/mopidy-local-images";
+    description = "Mopidy local library proxy extension for handling embedded album art";
+    license = licenses.asl20;
+    maintainers = [ maintainers.rvolosatovs ];
+  };
+}

--- a/pkgs/development/python-modules/uritools/default.nix
+++ b/pkgs/development/python-modules/uritools/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, ipaddress }:
+
+buildPythonPackage rec {
+  pname = "uritools";
+  name = "uritools-${version}";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "20d7881a947cd3c3bb452e2b541f44acc52febe9c4e3f6d05c55d559fb208c50";
+  };
+
+  propagatedBuildInputs = [ ipaddress ];
+
+  meta = with stdenv.lib; {
+    description = "RFC 3986 compliant, Unicode-aware, scheme-agnostic replacement for urlparse";
+    license = licenses.mit;
+    maintainers = [ maintainers.rvolosatovs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14986,6 +14986,8 @@ with pkgs;
 
   mopidy-gmusic = callPackage ../applications/audio/mopidy-gmusic { };
 
+  mopidy-local-images = callPackage ../applications/audio/mopidy-local-images { };
+
   mopidy-spotify = callPackage ../applications/audio/mopidy-spotify { };
 
   mopidy-moped = callPackage ../applications/audio/mopidy-moped { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -30444,6 +30444,8 @@ EOF
 
   gensim = callPackage  ../development/python-modules/gensim { };
 
+  uritools = callPackage ../development/python-modules/uritools { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change
Adds a new Mopidy extension.
Requires 90f85a2 from #26826.
_Extracted from #26518_

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

