### PR TITLE
mopidy-mpris: init at 1.3.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -479,6 +479,7 @@
   rushmorem = "Rushmore Mushambi <rushmore@webenchanter.com>";
   rvl = "Rodney Lorrimar <dev+nix@rodney.id.au>";
   rvlander = "Gaëtan André <rvlander@gaetanandre.eu>";
+  rvolosatovs = "Roman Volosatovs <rvolosatovs@riseup.net";
   ryanartecona = "Ryan Artecona <ryanartecona@gmail.com>";
   ryansydnor = "Ryan Sydnor <ryan.t.sydnor@gmail.com>";
   ryantm = "Ryan Mulligan <ryan@ryantm.com>";

--- a/pkgs/applications/audio/mopidy-mpris/default.nix
+++ b/pkgs/applications/audio/mopidy-mpris/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, pythonPackages, mopidy }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "mopidy-mpris-${version}";
+
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "mopidy";
+    repo = "mopidy-mpris";
+    rev = "v${version}";
+    sha256 = "0adpfnphn5px7wcbv9z5nxwhaq0hj4khzv1vkmv5g3ag9c6cv01l";
+  };
+
+  propagatedBuildInputs = [
+    mopidy
+    pythonPackages.pykka
+  ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mopidy/mopidy-mpris";
+    description = "Mopidy extension for controlling Mopidy through the MPRIS D-Bus interface";
+    license = licenses.asl20;
+    maintainers = [ maintainers.rvolosatovs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15000,6 +15000,8 @@ with pkgs;
 
   mopidy-musicbox-webclient = callPackage ../applications/audio/mopidy-musicbox-webclient { };
 
+  mopidy-mpris = callPackage ../applications/audio/mopidy-mpris { };
+
   motif = callPackage ../development/libraries/motif { };
 
   mozplugger = callPackage ../applications/networking/browsers/mozilla-plugins/mozplugger {};


### PR DESCRIPTION
###### Motivation for this change
Adds new Mopidy extension

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

