### PR TITLE
plv8: init at 2.0.3

### DIFF
--- a/pkgs/servers/sql/postgresql/plv8/default.nix
+++ b/pkgs/servers/sql/postgresql/plv8/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, v8, perl, postgresql }:
+
+stdenv.mkDerivation rec {
+  name = "plv8-${version}";
+  version = "2.0.3";
+
+  nativeBuildInputs = [ perl ];
+  buildInputs = [ v8 postgresql ];
+
+  src = fetchFromGitHub {
+    owner = "plv8";
+    repo = "plv8";
+    rev = "v${version}";
+    sha256 = "0cn7ynckmdb08dkzjilvc55xz61d1jiya7yrnphizw404j84y3qc";
+  };
+
+  preConfigure = ''
+    substituteInPlace Makefile --replace '-lv8_libplatform' '-lv8_libplatform -lv8_libbase'
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D plv8.so                                         -t $out/lib
+    install -D {plls,plcoffee,plv8}{--${version}.sql,.control} -t $out/share/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "PL/v8 - A Procedural Language in JavaScript powered by V8";
+    homepage = https://pgxn.org/dist/plv8/;
+    maintainers = with maintainers; [ volth ];
+    platforms = platforms.linux;
+    license = licenses.postgresql;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9588,6 +9588,8 @@ with pkgs;
 
   pgroonga = callPackage ../servers/sql/postgresql/pgroonga {};
 
+  plv8 = callPackage ../servers/sql/postgresql/plv8 {};
+
   phonon = callPackage ../development/libraries/phonon {};
 
   phonon-backend-gstreamer = callPackage ../development/libraries/phonon/backends/gstreamer.nix {};


### PR DESCRIPTION
###### Motivation for this change

To write PostgreSQL stored procedures in JavaScript.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

