### PR TITLE
nailgun: init at 0.9.1

### DIFF
--- a/pkgs/development/tools/nailgun/default.nix
+++ b/pkgs/development/tools/nailgun/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchMavenArtifact, fetchFromGitHub, bash, jre }:
+
+let
+  version = "0.9.1";
+  nailgun-server = fetchMavenArtifact {
+    groupId = "com.martiansoftware";
+    artifactId = "nailgun-server";
+    inherit version;
+    sha256 = "09ggkkd1s58jmpc74s6m10d3hyf6bmif31advk66zljbpykgl625";
+  };
+in
+stdenv.mkDerivation rec {
+  name = "nailgun-${version}";
+
+  src = fetchFromGitHub {
+    owner = "martylamb";
+    repo = "nailgun";
+    rev = "1ad9ad9d2d17c895144a9ee0e7acb1d3d90fb66f";
+    sha256 = "1f8ac5kg7imhix9kqdzwiav1bxh8vljv2hb1mq8yz4rqsrx2r4w3";
+  };
+
+  makeFlags = "PREFIX=$(out)";
+
+  installPhase = ''
+    install -D ng $out/bin/ng
+    install -D ${nailgun-server.jar} $out/share/java/nailgun-server-${version}.jar
+
+    cat > $out/bin/ng-server << EOF
+    #!${bash}/bin/bash
+
+    ${jre}/bin/java -cp $out/share/java/nailgun-server-${version}.jar:\$CLASSPATH com.martiansoftware.nailgun.NGServer "\$@"
+    EOF
+    chmod +x $out/bin/ng-server
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Client, protocol, and server for running Java programs from the command line without incurring the JVM startup overhead";
+    homepage = http://martiansoftware.com/nailgun/;
+    license = licenses.apsl20;
+    platforms = platforms.linux;
+    maintainer = with maintainers; [ volth ];
+  };
+}

--- a/pkgs/development/tools/nailgun/default.nix
+++ b/pkgs/development/tools/nailgun/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchMavenArtifact, fetchFromGitHub, bash, jre }:
+{ stdenv, fetchMavenArtifact, fetchFromGitHub, bash, jre, makeWrapper }:
 
 let
   version = "0.9.1";
@@ -21,16 +21,13 @@ stdenv.mkDerivation rec {
 
   makeFlags = "PREFIX=$(out)";
 
+  buildInputs = [ makeWrapper ];
+
   installPhase = ''
     install -D ng $out/bin/ng
-    install -D ${nailgun-server.jar} $out/share/java/nailgun-server-${version}.jar
 
-    cat > $out/bin/ng-server << EOF
-    #!${bash}/bin/bash
-
-    ${jre}/bin/java -cp $out/share/java/nailgun-server-${version}.jar:\$CLASSPATH com.martiansoftware.nailgun.NGServer "\$@"
-    EOF
-    chmod +x $out/bin/ng-server
+    makeWrapper ${jre}/bin/java $out/bin/ng-server \
+      --add-flags '-cp ${nailgun-server.jar}:$CLASSPATH com.martiansoftware.nailgun.NGServer'
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6931,6 +6931,8 @@ with pkgs;
     };
   };
 
+  nailgun = callPackage ../development/tools/nailgun { };
+
   nant = callPackage ../development/tools/build-managers/nant { };
 
   ninja = callPackage ../development/tools/build-managers/ninja { };


### PR DESCRIPTION
###### Motivation for this change

It speeds up JVM startup by keeping it in memory between launches of Java programs.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

