### PR TITLE
calibre: 2.84.0 -> 3.1.1

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -5,28 +5,22 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.84.0";
+  version = "3.1.1";
   name = "calibre-${version}";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${name}.tar.xz";
-    sha256 = "1kvnmb6hsby4bdnx70bcy32f4dz1axzlr310dr6mkvnc8bqw59km";
+    sha256 = "1lh1gz0915r49igfhy1icz79qx36s3d8m32qlih0g3zn7jahp86g";
   };
 
   patches = [
     # Patches from Debian that:
     # - disable plugin installation (very insecure)
-    # - disables loading of web bug for privacy
     # - switches the version update from enabled to disabled by default
     (fetchpatch {
       name = "disable_plugins.patch";
       url = "http://bazaar.launchpad.net/~calibre-packagers/calibre/debian/download/head:/disable_plugins.py-20111220183043-dcl08ccfagjxt1dv-1/disable_plugins.py";
       sha256 = "19spdx52dhbrfn9lm084yl3cfwm6f90imd51k97sf7flmpl569pk";
-    })
-    (fetchpatch {
-      name = "links_privacy.patch";
-      url = "http://bazaar.launchpad.net/~calibre-packagers/calibre/debian/download/head:/linksprivacy.patch-20160417214308-6hvive72pc0r4awc-1/links-privacy.patch";
-      sha256 = "0f6pq2b7q56pxrq2j8yqd7bksc623q2zgq29qcli30f13vga1w60";
     })
     (fetchpatch {
       name = "no_updates_dialog.patch";
@@ -57,6 +51,7 @@ stdenv.mkDerivation rec {
   ] ++ (with python2Packages; [
     apsw cssselect cssutils dateutil lxml mechanize netifaces pillow
     python pyqt5 sip
+    regex msgpack
     # the following are distributed with calibre, but we use upstream instead
     chardet cherrypy html5lib_0_9999999 odfpy routes
   ]);

--- a/pkgs/applications/misc/calibre/dont_build_unrar_plugin.patch
+++ b/pkgs/applications/misc/calibre/dont_build_unrar_plugin.patch
@@ -1,34 +1,12 @@
-diff --git a/setup/extensions.json b/setup/extensions.json
-index 1f6d1fb..1273904 100644
---- a/setup/extensions.json
-+++ b/setup/extensions.json
-@@ -211,16 +211,5 @@
-         "sources": "calibre/devices/mtp/unix/devices.c calibre/devices/mtp/unix/libmtp.c",
-         "headers": "calibre/devices/mtp/unix/devices.h calibre/devices/mtp/unix/upstream/music-players.h calibre/devices/mtp/unix/upstream/device-flags.h",
-         "libraries": "mtp"
--    },
--    {
--        "name": "unrar",
--        "sources": "unrar/rar.cpp unrar/strlist.cpp unrar/strfn.cpp unrar/pathfn.cpp unrar/savepos.cpp unrar/smallfn.cpp unrar/global.cpp unrar/file.cpp unrar/filefn.cpp unrar/filcreat.cpp unrar/archive.cpp unrar/arcread.cpp unrar/unicode.cpp unrar/system.cpp unrar/isnt.cpp unrar/crypt.cpp unrar/crc.cpp unrar/rawread.cpp unrar/encname.cpp unrar/resource.cpp unrar/match.cpp unrar/timefn.cpp unrar/rdwrfn.cpp unrar/consio.cpp unrar/options.cpp unrar/ulinks.cpp unrar/errhnd.cpp unrar/rarvm.cpp unrar/secpassword.cpp unrar/rijndael.cpp unrar/getbits.cpp unrar/sha1.cpp unrar/extinfo.cpp unrar/extract.cpp unrar/volume.cpp unrar/list.cpp unrar/find.cpp unrar/unpack.cpp unrar/cmddata.cpp unrar/filestr.cpp unrar/scantree.cpp calibre/utils/unrar.cpp",
--        "inc_dirs": "unrar",
--        "defines": "SILENT RARDLL UNRAR _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE",
--        "windows_defines": "SILENT RARDLL UNRAR",
--        "haiku_defines": "LITTLE_ENDIAN SILENT RARDLL UNRAR _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE _BSD_SOURCE",
--        "haiku_libraries": "bsd",
--        "optimize_level": 2,
--        "windows_libraries": "User32 Advapi32 kernel32 Shell32"
-     }
- ]
 diff --git a/src/calibre/ebooks/metadata/archive.py b/src/calibre/ebooks/metadata/archive.py
 index 938ab24..1e095f8 100644
 --- a/src/calibre/ebooks/metadata/archive.py
 +++ b/src/calibre/ebooks/metadata/archive.py
-@@ -44,7 +44,7 @@ class ArchiveExtract(FileTypePlugin):
-     description = _('Extract common e-book formats from archives '
-         '(zip/rar) files. Also try to autodetect if they are actually '
-         'cbz/cbr files.')
+@@ -44,7 +44,7 @@
+     description = _('Extract common e-book formats from archive files '
+         '(ZIP/RAR). Also try to autodetect if they are actually '
+         'CBZ/CBR files.')
 -    file_types = set(['zip', 'rar'])
 +    file_types = set(['zip'])
      supported_platforms = ['windows', 'osx', 'linux']
      on_import = True
- 


### PR DESCRIPTION
Version bump.

The links-privacy patch was removed as the content server was
rewritten in calibre 3.0, so this code no longer exists.

The rewrite also needed additional python packages: regex and msgparse.

Regarding the unrar plugin, the first part (exceptions.json) was applied, and the second part needed to be updated to apply cleanly.

###### Motivation for this change
New version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

