### PR TITLE
qgo: init at unstable-2016-06-23

### DIFF
--- a/pkgs/games/qgo/default.nix
+++ b/pkgs/games/qgo/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, makeWrapper, qmake, qt56 }:
+
+stdenv.mkDerivation rec {
+  name = "qgo-${version}";
+  version = "unstable-2016-06-23";
+
+  meta = with stdenv.lib; {
+    description = "A Go client based on Qt5";
+    longDescription = ''
+      qGo is a Go Client based on Qt 5. It supports playing online at
+      IGS-compatible servers (including some special tweaks for WING and LGS,
+      also NNGS was reported to work) and locally against gnugo (or other
+      GTP-compliant engines). It also has rudimentary support for editing SGF
+      files and parital support for CyberORO/WBaduk, Tygem, Tom, and eWeiqi
+      (developers of these backends are currently inactive, everybody is welcome
+      to take them over).
+
+      Go is an ancient Chinese board game. It's called "圍棋(Wei Qi)" in
+      Chinese, "囲碁(Yi Go)" in Japanese, "바둑(Baduk)" in Korean.
+    '';
+    homepage = "https://github.com/pzorin/qgo";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ zalakain ];
+  };
+
+  src = fetchFromGitHub {
+    owner = "pzorin";
+    repo = "qgo";
+    rev = "1e65b0c74914e534ea4d040f8f0ef8908383e374";
+    sha256 = "1xzkayclmhsi07p9mnbf8185jw8n5ikxp2mik3x8qz1i6rmrfl5b";
+  };
+
+  patches = [ ./fix-paths.patch ];
+  postPatch = ''
+    sed -i 's|@out@|'"''${out}"'|g' src/src.pro src/defines.h
+  '';
+  nativeBuildInputs = [ makeWrapper qmake ];
+  # qt58 does not provide platform plugins
+  # We need lib/qt*/plugins/platforms/libqxcb.so
+  buildInputs = with qt56; [ qtbase.out qtmultimedia qttranslations ];
+  enableParallelBuilding = true;
+  postFixup = ''
+    # libQt5XcbQpa is a platform plugin dependency and doesn't get linked
+    patchelf --add-needed libQt5XcbQpa.so.5 $out/bin/qgo
+    wrapProgram $out/bin/qgo \
+      --set QT_QPA_PLATFORM_PLUGIN_PATH "${qt56.qtbase}/lib/qt-5.6/plugins/platforms/"
+  '';
+}

--- a/pkgs/games/qgo/fix-paths.patch
+++ b/pkgs/games/qgo/fix-paths.patch
@@ -1,0 +1,50 @@
+diff --git a/src/defines.h b/src/defines.h
+index 5d40955..82d0627 100644
+--- a/src/defines.h
++++ b/src/defines.h
+@@ -48,7 +48,7 @@
+ * GNUgo default level
+ */
+ #define DEFAULT_ENGINE "gnugo"
+-#define DEFAULT_ENGINE_PATH "/usr/games/"
++#define DEFAULT_ENGINE_PATH ""
+ #define DEFAULT_ENGINE_OPTIONS "--mode gtp --quiet --level 10"
+ 
+ 
+@@ -220,8 +220,8 @@ extern QString applicationPath;
+ 	#define SOUND_PATH_PREFIX			"qGo.app/Contents/Resources/Sounds/"
+     #define TRANSLATIONS_PATH		"qGo.app/Contents/Resources/Translations/"
+ #else
+-    #define SOUND_PATH_PREFIX		"/usr/share/qgo/sounds/"
+-    #define TRANSLATIONS_PATH		"/usr/share/qgo/languages"
++    #define SOUND_PATH_PREFIX		"/@out@/share/qgo/sounds/"
++    #define TRANSLATIONS_PATH		"/@out@/share/qgo/languages"
+ #endif
+ 
+ #endif
+diff --git a/src/src.pro b/src/src.pro
+index f989ce7..b7d691f 100644
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -165,17 +165,17 @@ SOURCES += displayboard.cpp \
+     newgamedialog.cpp
+ 
+ unix*:!macx-* {
+-    QGO_INSTALL_PATH = /usr/share/qgo
+-    QGO_INSTALL_BIN_PATH = /usr/bin
++    QGO_INSTALL_PATH = @out@/share/qgo
++    QGO_INSTALL_BIN_PATH = /@out@/bin
+ 
+-    icon.path = /usr/share/pixmaps
++    icon.path = @out@/share/pixmaps
+     icon.files = resources/pics/qgo.png
+     icon.files += resources/pics/qgo_16x16.xpm
+     icon.files += resources/pics/qgo_32x32.xpm
+     icon.files += resources/pics/qgo_48x48.png
+     icon.files += resources/pics/qgo_48x48.xpm
+     INSTALLS += icon
+-    desktopfile.path = /usr/share/applications
++    desktopfile.path = @out@/share/applications
+     desktopfile.files = qgo.desktop
+     INSTALLS += desktopfile
+ }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12938,6 +12938,8 @@ with pkgs;
 
   poppler_data = callPackage ../data/misc/poppler-data { };
 
+  qgo = libsForQt5.callPackage ../games/qgo { };
+
   quattrocento = callPackage ../data/fonts/quattrocento {};
 
   quattrocento-sans = callPackage ../data/fonts/quattrocento-sans {};


### PR DESCRIPTION
###### Motivation for this change

I want to play go on something that resembles a go board.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

