### PR TITLE
mopidy-local-sqlite: init at 1.0.0

### DIFF
--- a/pkgs/applications/audio/mopidy-local-sqlite/default.nix
+++ b/pkgs/applications/audio/mopidy-local-sqlite/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, pythonPackages, mopidy }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "mopidy-local-sqlite-${version}";
+
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "mopidy";
+    repo = "mopidy-local-sqlite";
+    rev = "v${version}";
+    sha256 = "1fjd9ydbfwd1n9b9zw8zjn4l7c5hpam2n0xs51pjkjn82m3zq9zv";
+  };
+
+  propagatedBuildInputs = [
+    mopidy
+    pythonPackages.uritools
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mopidy/mopidy-local-sqlite";
+    description = "Mopidy SQLite local library extension";
+    license = licenses.asl20;
+    maintainers = [ maintainers.rvolosatovs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14991,6 +14991,8 @@ with pkgs;
 
   mopidy-local-images = callPackage ../applications/audio/mopidy-local-images { };
 
+  mopidy-local-sqlite = callPackage ../applications/audio/mopidy-local-sqlite { };
+
   mopidy-spotify = callPackage ../applications/audio/mopidy-spotify { };
 
   mopidy-moped = callPackage ../applications/audio/mopidy-moped { };


### PR DESCRIPTION
###### Motivation for this change
Adds new Mopidy extension.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

