### PR TITLE
fetchMavenArtifact: prevent leaking nix hash to jar name

### DIFF
--- a/pkgs/build-support/fetchmavenartifact/default.nix
+++ b/pkgs/build-support/fetchmavenartifact/default.nix
@@ -67,7 +67,7 @@ in
     # packages packages that mention this derivation in their buildInputs.
     installPhase = ''
       mkdir -p $out/share/java
-      ln -s ${jar} $out/share/java
+      ln -s ${jar} $out/share/java/${artifactId}-${version}.jar
     '';
     # We also add a `jar` attribute that can be used to easily obtain the path
     # to the downloaded jar file.


### PR DESCRIPTION
###### Motivation for this change

```fetchMavenArtifact``` produces weird and long names of jar symlinks.

For example:
```
  nailgun-server = fetchMavenArtifact {
    groupId = "com.martiansoftware";
    artifactId = "nailgun-server";
    version = "0.9.1";
    sha256 = "09ggkkd1s58jmpc74s6m10d3hyf6bmif31advk66zljbpykgl625";
  };
```
creates symlink

```/nix/store/1gxsihlgnyijr113yfq6rnlv7wr9s71q-com_martiansoftware_nailgun-server-0.9.1/share/java/r49vdxhw54i3gb8c1xi8gh45d2zrzyxl-com_martiansoftware_nailgun-server-0.9.1.jar```

which points to

```/nix/store/r49vdxhw54i3gb8c1xi8gh45d2zrzyxl-com_martiansoftware_nailgun-server-0.9.1.jar```

