### PR TITLE
vivaldi: add support for proprietary codecs

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -297,6 +297,7 @@
   lihop = "Leroy Hopson <nixos@leroy.geek.nz>";
   linquize = "Linquize <linquize@yahoo.com.hk>";
   linus = "Linus Arver <linusarver@gmail.com>";
+  lluchs = "Lukas Werling <lukas.werling@gmail.com>";
   lnl7 = "Daiderd Jordan <daiderd@gmail.com>";
   loskutov = "Ignat Loskutov <ignat.loskutov@gmail.com>";
   lovek323 = "Jason O'Conal <jason@oconal.id.au>";

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -7,6 +7,7 @@
 , glib, gtk3, pango, gdk_pixbuf, cairo, atk, gnome3
 , nss, nspr
 , patchelf
+, proprietaryCodecs ? true, vivaldi-ffmpeg-codecs ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -32,7 +33,7 @@ stdenv.mkDerivation rec {
     atk alsaLib dbus_libs cups gtk3 gdk_pixbuf libexif ffmpeg systemd
     freetype fontconfig libXrender libuuid expat glib nss nspr
     gstreamer libxml2 gst-plugins-base pango cairo gnome3.gconf
-  ];
+  ] ++ stdenv.lib.optional proprietaryCodecs vivaldi-ffmpeg-codecs;
 
   libPath = stdenv.lib.makeLibraryPath buildInputs
     + stdenv.lib.optionalString (stdenv.is64bit)
@@ -45,6 +46,10 @@ stdenv.mkDerivation rec {
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath "${libPath}" \
       opt/vivaldi/vivaldi-bin
+  '' + stdenv.lib.optionalString proprietaryCodecs ''
+    sed -i '/^VIVALDI_FFMPEG_FOUND/ a \
+    checkffmpeg "${vivaldi-ffmpeg-codecs}/lib/libffmpeg.so"' opt/vivaldi/vivaldi
+  '' + ''
     echo "Finished patching Vivaldi binaries"
   '';
 

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -6,7 +6,7 @@
 , gstreamer, gst-plugins-base, libxml2
 , glib, gtk3, pango, gdk_pixbuf, cairo, atk, gnome3
 , nss, nspr
-, patchelf
+, patchelf, makeWrapper
 , proprietaryCodecs ? true, vivaldi-ffmpeg-codecs ? null
 }:
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     tar -xvf data.tar.xz
   '';
 
-  nativeBuildInputs = [ patchelf ];
+  nativeBuildInputs = [ patchelf makeWrapper ];
 
   buildInputs = [
     stdenv.cc.cc stdenv.cc.libc zlib libX11 libXt libXext libSM libICE libxcb
@@ -72,6 +72,8 @@ stdenv.mkDerivation rec {
         "$out"/opt/vivaldi/product_logo_''${d}.png \
         "$out"/share/icons/hicolor/''${d}x''${d}/apps/vivaldi.png
     done
+    wrapProgram "$out/bin/vivaldi" \
+      --suffix XDG_DATA_DIRS : ${gtk3}/share/gsettings-schemas/${gtk3.name}/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -12,11 +12,11 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "vivaldi";
-  version = "1.10.867.38-1";
+  version = "1.10.867.48-1";
 
   src = fetchurl {
     url = "https://downloads.vivaldi.com/stable/${product}-stable_${version}_amd64.deb";
-    sha256 = "1h3iygzvw3rb5kmn0pam6gqy9baq6l630yllff1vnvychdg8d9vi";
+    sha256 = "1han45swvv0y2i2kg7xhml1wj5zyrf2c2hc5b07kqsjkfg9iz1lc";
   };
 
   unpackPhase = ''

--- a/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchurl, fetchpatch
+, dbus_glib, gtk2, gtk3, libexif, libpulseaudio, libXScrnSaver, ninja, nss
+, pciutils, pkgconfig, python2, xdg_utils
+}:
+
+stdenv.mkDerivation rec {
+  name = "${product}-${version}";
+  product = "vivaldi-ffmpeg-codecs";
+  version = "59.0.3071.104";
+
+  src = fetchurl {
+    url = "https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz";
+    sha512 = "419cf5bafa80f190cd301c2933502351929c1ef1d5cfedc720ce6762674a0e6af3b4246a8f92e0c29743420338b056061d4e7f9f4a4066a5bdd4d2ee8db3ddbf";
+  };
+
+  buildInputs = [ ];
+
+  nativeBuildInputs = [
+    dbus_glib gtk2 gtk3 libexif libpulseaudio libXScrnSaver ninja nss pciutils pkgconfig
+    python2 xdg_utils
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    local args="ffmpeg_branding=\"ChromeOS\" proprietary_codecs=true enable_hevc_demuxing=true use_gconf=false use_gio=false use_gnome_keyring=false use_kerberos=false use_cups=false use_sysroot=false use_gold=false linux_use_bundled_binutils=false fatal_linker_warnings=false treat_warnings_as_errors=false is_clang=false is_component_build=true is_debug=false symbol_level=0"
+    python tools/gn/bootstrap/bootstrap.py -v -s --no-clean --gn-gen-args "$args"
+    out/Release/gn gen out/Release -v --args="$args"
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    ninja -C out/Release -v libffmpeg.so
+  '';
+
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p "$out/lib"
+    cp out/Release/libffmpeg.so "$out/lib/libffmpeg.so"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Additional support for proprietary codecs for Vivaldi";
+    homepage    = "https://ffmpeg.org/";
+    license     = licenses.lgpl21;
+    maintainers = with maintainers; [ lluchs ];
+    platforms   = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/networking/browsers/vivaldi/update.sh
+++ b/pkgs/applications/networking/browsers/vivaldi/update.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p libarchive curl common-updater-scripts
+
+set -eu -o pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+root=../../../../..
+export NIXPKGS_ALLOW_UNFREE=1
+
+version() {
+	(cd "$root" && nix-instantiate --eval --strict -A "$1.version" | tr -d '"')
+}
+
+vivaldi_version_old=$(version vivaldi)
+vivaldi_version=$(curl -sS https://vivaldi.com/download/ | sed -rne 's/.*vivaldi-stable_([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-[0-9]+)_amd64\.deb.*/\1/p')
+
+if [[ "$vivaldi_version" = "$vivaldi_version_old" ]]; then
+	echo "nothing to do, vivaldi $vivaldi_version is current"
+	exit
+fi
+
+# Download vivaldi and save hash and file path.
+url="https://downloads.vivaldi.com/stable/vivaldi-stable_${vivaldi_version}_amd64.deb"
+mapfile -t prefetch < <(nix-prefetch-url --print-path "$url")
+hash=${prefetch[0]}
+path=${prefetch[1]}
+
+echo "vivaldi: $vivaldi_version_old -> $vivaldi_version"
+(cd "$root" && update-source-version vivaldi "$vivaldi_version" "$hash")
+
+# Check vivaldi-ffmpeg-codecs version.
+chromium_version_old=$(version vivaldi-ffmpeg-codecs)
+chromium_version=$(bsdtar xOf "$path" data.tar.xz | bsdtar xOf - ./opt/vivaldi/vivaldi-bin | strings | grep -A2 -i '^chrome\/' | grep '^[0-9]\+\.[0-9]\+\.[1-9][0-9]\+\.[0-9]\+')
+
+if [[ "$chromium_version" != "$chromium_version_old" ]]; then
+	echo "vivaldi-ffmpeg-codecs: $chromium_version_old -> $chromium_version"
+	(cd "$root" && update-source-version vivaldi-ffmpeg-codecs "$chromium_version")
+fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15305,6 +15305,8 @@ with pkgs;
 
   vivaldi = callPackage ../applications/networking/browsers/vivaldi {};
 
+  vivaldi-ffmpeg-codecs = callPackage ../applications/networking/browsers/vivaldi/ffmpeg-codecs.nix {};
+
   openmpt123 = callPackage ../applications/audio/openmpt123 {};
 
   opusfile = callPackage ../applications/audio/opusfile { };


### PR DESCRIPTION
###### Motivation for this change

As described in #26413, Vivaldi currently doesn't support proprietary codecs such as H.264. This PR adds a `vivaldi-ffmpeg-codecs` package with a libffmpeg.so built from the Chromium source and makes Vivaldi load that library.

The build steps are based on the [AUR package with the same name](https://aur.archlinux.org/packages/vivaldi-ffmpeg-codecs/).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

