### PR TITLE
microcode-intel: 20161104 -> 20170511

### DIFF
--- a/pkgs/os-specific/linux/microcode/intel.nix
+++ b/pkgs/os-specific/linux/microcode/intel.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "microcode-intel-${version}";
-  version = "20161104";
+  version = "20170511";
 
   src = fetchurl {
-    url = "http://downloadmirror.intel.com/26400/eng/microcode-${version}.tgz";
-    sha256 = "1lg3bvznvwcxf66k038c57brkcxfva8crpnzj5idmczr5yk4q5bh";
+    url = "https://downloadmirror.intel.com/26798/eng/microcode-${version}.tgz";
+    sha256 = "18w1ysklvkf4l9xgnl1wvhbgr3wbdaiphv56056pafs0hwnzsxrg";
   };
 
   buildInputs = [ libarchive ];


### PR DESCRIPTION
###### Motivation for this change

https://lists.debian.org/debian-devel/2017/06/msg00308.html

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested with `hardware.cpu.intel.updateMicrocode = true;`, `dmesg` has
```
[    0.000000] microcode: microcode updated early to revision 0xba, date = 2017-04-09
```