### PR TITLE
skrooge: 2.7.0 -> 2.8.1

### DIFF
--- a/pkgs/applications/office/skrooge/default.nix
+++ b/pkgs/applications/office/skrooge/default.nix
@@ -2,18 +2,18 @@
   cmake, extra-cmake-modules, qtwebkit, qtscript, grantlee,
   kxmlgui, kwallet, kparts, kdoctools, kjobwidgets, kdesignerplugin,
   kiconthemes, knewstuff, sqlcipher, qca-qt5, kdelibs4support, kactivities,
-  knotifyconfig, krunner, libofx }:
+  knotifyconfig, krunner, libofx, shared_mime_info }:
 
 mkDerivation rec {
   name = "skrooge-${version}";
-  version = "2.7.0";
+  version = "2.8.1";
 
   src = fetchurl {
     url = "http://download.kde.org/stable/skrooge/${name}.tar.xz";
-    sha256 = "1xrh9nal122rzlv4m0x8qah6zpqb6891al3351piarpk2xgjgj4x";
+    sha256 = "0q34fh86yjd471jf6xa87vy4l8i1s3gqjzqrxbh0rnr79avns5lg";
   };
 
-  nativeBuildInputs = [ cmake extra-cmake-modules ];
+  nativeBuildInputs = [ cmake extra-cmake-modules shared_mime_info ];
 
   buildInputs = [ qtwebkit qtscript grantlee kxmlgui kwallet kparts kdoctools
     kjobwidgets kdesignerplugin kiconthemes knewstuff sqlcipher qca-qt5


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I put `shared_mime_info` in `nativeBuildInputs`. I’m not sure if this is correct.