### PR TITLE
krfb: add new qtx11extras dependency

### DIFF
--- a/pkgs/applications/kde/krfb.nix
+++ b/pkgs/applications/kde/krfb.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib,
   extra-cmake-modules, kdoctools,
-  kdelibs4support, kdnssd, libvncserver, libXtst
+  kdelibs4support, kdnssd, libvncserver, libXtst, qtx11extras
 }:
 
 mkDerivation {
@@ -11,6 +11,6 @@ mkDerivation {
     maintainers = with lib.maintainers; [ jerith666 ];
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
-  buildInputs = [ libvncserver libXtst ];
+  buildInputs = [ libvncserver libXtst qtx11extras ];
   propagatedBuildInputs = [ kdelibs4support kdnssd ];
 }


### PR DESCRIPTION
###### Motivation for this change

fixes the build.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This KDE application doesn't seem to want to run outside of a fully-rebuilt system, as seen in https://github.com/NixOS/nixpkgs/pull/24007.  But this at least gets it to build.  :)

I *think* this is likely caused by https://github.com/NixOS/nixpkgs/pull/26336, but haven't finished bisecting to say for sure yet.  So, cc @ttuegel.