### PR TITLE
python-gflags: 2.0 -> 3.1.1

### DIFF
--- a/pkgs/development/python-modules/gflags/default.nix
+++ b/pkgs/development/python-modules/gflags/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  version = "3.1.1";
+  name = "gflags-${version}";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "python-gflags";
+    sha256 = "0qvcizlz6r4511kl4jlg6fr34y1ka956dr2jj1q0qcklr94n9zxa";
+  };
+
+  meta = {
+    homepage = https://github.com/google/python-gflags;
+    description = "A module for command line handling, similar to Google's gflags for C++";
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/gflags/default.nix
+++ b/pkgs/development/python-modules/gflags/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchPypi, six, pytest }:
 
 buildPythonPackage rec {
   version = "3.1.1";
@@ -9,6 +9,16 @@ buildPythonPackage rec {
     pname = "python-gflags";
     sha256 = "0qvcizlz6r4511kl4jlg6fr34y1ka956dr2jj1q0qcklr94n9zxa";
   };
+
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ six ];
+
+  checkPhase = ''
+    # clashes with our pythhon wrapper (which is in argv0)
+    # AssertionError: 'gflags._helpers_test' != 'nix_run_setup.py'
+    py.test -k 'not testGetCallingModule'
+  '';
 
   meta = {
     homepage = https://github.com/google/python-gflags;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11607,15 +11607,17 @@ in {
 
 
   gflags = buildPythonPackage rec {
-    name = "gflags-2.0";
+    version = "3.1.1";
+    name = "gflags-${version}";
 
-    src = pkgs.fetchurl {
-      url = "http://python-gflags.googlecode.com/files/python-${name}.tar.gz";
-      sha256 = "1mkc7315bpmh39vbn0jq237jpw34zsrjr1sck98xi36bg8hnc41i";
+    src = fetchPypi {
+      inherit version;
+      pname = "python-gflags";
+      sha256 = "0qvcizlz6r4511kl4jlg6fr34y1ka956dr2jj1q0qcklr94n9zxa";
     };
 
     meta = {
-      homepage = http://code.google.com/p/python-gflags/;
+      homepage = https://github.com/google/python-gflags;
       description = "A module for command line handling, similar to Google's gflags for C++";
     };
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11606,21 +11606,7 @@ in {
   };
 
 
-  gflags = buildPythonPackage rec {
-    version = "3.1.1";
-    name = "gflags-${version}";
-
-    src = fetchPypi {
-      inherit version;
-      pname = "python-gflags";
-      sha256 = "0qvcizlz6r4511kl4jlg6fr34y1ka956dr2jj1q0qcklr94n9zxa";
-    };
-
-    meta = {
-      homepage = https://github.com/google/python-gflags;
-      description = "A module for command line handling, similar to Google's gflags for C++";
-    };
-  };
+  gflags = callPackage ../development/python-modules/gflags { };
 
   ghdiff = callPackage ../development/python-modules/ghdiff.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
gflags doesn't work with python 3 until version 3.1

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

