### PR TITLE
toxvpn: 20161230 -> 2017-06-25

### DIFF
--- a/nixos/modules/services/networking/toxvpn.nix
+++ b/nixos/modules/services/networking/toxvpn.nix
@@ -18,6 +18,13 @@ with lib;
         default     = 33445;
         description = "udp port for toxcore, port-forward to help with connectivity if you run many nodes behind one NAT";
       };
+
+      auto_add_peers = mkOption {
+        type        = types.listOf types.string;
+        default     = [];
+        example     = ''[ "toxid1" "toxid2" ]'';
+        description = "peers to automacally connect to on startup";
+      };
     };
   };
 
@@ -33,8 +40,13 @@ with lib;
         chown toxvpn /run/toxvpn
       '';
 
+      path = [ pkgs.toxvpn ];
+
+      script = ''
+        exec toxvpn -i ${config.services.toxvpn.localip} -l /run/toxvpn/control -u toxvpn -p ${toString config.services.toxvpn.port} ${lib.concatMapStringsSep " " (x: "-a ${x}") config.services.toxvpn.auto_add_peers}
+      '';
+
       serviceConfig = {
-        ExecStart = "${pkgs.toxvpn}/bin/toxvpn -i ${config.services.toxvpn.localip} -l /run/toxvpn/control -u toxvpn -p ${toString config.services.toxvpn.port}";
         KillMode  = "process";
         Restart   = "on-success";
         Type      = "notify";
@@ -42,6 +54,8 @@ with lib;
 
       restartIfChanged = false; # Likely to be used for remote admin
     };
+
+    environment.systemPackages = [ pkgs.toxvpn ];
 
     users.extraUsers = {
       toxvpn = {

--- a/pkgs/tools/networking/toxvpn/default.nix
+++ b/pkgs/tools/networking/toxvpn/default.nix
@@ -1,29 +1,36 @@
-{ stdenv, fetchFromGitHub, cmake, lib
-, libtoxcore, jsoncpp, libsodium, systemd, libcap }:
+{ stdenv, fetchFromGitHub, cmake, nlohmann_json,
+libtoxcore, libsodium, systemd, libcap, zeromq }:
 
-with lib;
+with stdenv.lib;
 
-stdenv.mkDerivation rec {
+let
+  systemdOrNull = if stdenv.system == "x86_64-darwin" then null else systemd;
+  if_systemd = optional (systemdOrNull != null);
+in stdenv.mkDerivation rec {
   name = "toxvpn-${version}";
-  version = "20161230";
+  version = "2017-06-25";
 
   src = fetchFromGitHub {
     owner  = "cleverca22";
     repo   = "toxvpn";
-    rev    = "4b7498a5fae680484cb5779ac01fb08ad3089bdd";
-    sha256 = "0bazdspiym9xyzms7pd6i1f2gph13rnf764nm3jc27fbfwmc98rp";
+    rev    = "7bd6f169d69c511affa8c9672e8f794e4e205a44";
+    sha256 = "1km8hkrxmrnca1b49vbw5kyldayaln5plvz78vhf8325r6c5san0";
   };
 
-  buildInputs = [ libtoxcore jsoncpp libsodium libcap ] ++ optional stdenv.isLinux systemd;
+  buildInputs = [ libtoxcore nlohmann_json libsodium zeromq ]
+    ++ if_systemd systemd
+    ++ optional (stdenv.system != "x86_64-darwin") libcap;
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = optional stdenv.isLinux [ "-DSYSTEMD=1" ];
+
+  postInstall = "$out/bin/toxvpn -h";
 
   meta = with stdenv.lib; {
     description = "A powerful tool that allows one to make tunneled point to point connections over Tox";
     homepage    = https://github.com/cleverca22/toxvpn;
     license     = licenses.gpl3;
     maintainers = with maintainers; [ cleverca22 obadz ];
-    platforms   = platforms.linux;
+    platforms   = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

