### PR TITLE
dfhack: 0.43.05-alpha4 -> 0.43.05-r1

### DIFF
--- a/pkgs/games/dwarf-fortress/dfhack/default.nix
+++ b/pkgs/games/dwarf-fortress/dfhack/default.nix
@@ -7,12 +7,12 @@ let
   dfVersion = "0.43.05";
   # version = "${dfVersion}-r1";
   # rev = "refs/tags/${version}";
-  version = "${dfVersion}-alpha4";
+  version = "${dfVersion}-r1";
   rev = "refs/tags/${version}";
-  sha256 = "0wnwdapw955k69ds5xh5qsh7h0l547wjxgcy8hkvly6wp5c16sls";
+  sha256 = "1hw0miimzx52p36jm9bimsm5j68rb7dd9kw0yivcwbwixbajsi1w";
 
   # revision of library/xml submodule
-  xmlRev = "bb4228f58b1601c4868c95be6763f5ff2e5d0a08";
+  xmlRev = "a8e80088b9cc934da993dc244ece2d0ae14143da";
 
   arch =
     if stdenv.system == "x86_64-linux" then "64"

--- a/pkgs/games/dwarf-fortress/dfhack/skip-ruby.patch
+++ b/pkgs/games/dwarf-fortress/dfhack/skip-ruby.patch
@@ -1,16 +1,10 @@
-diff -ru3 dfhack-ae59b4f/plugins/ruby/CMakeLists.txt dfhack-ae59b4f-new/plugins/ruby/CMakeLists.txt
---- dfhack-ae59b4f/plugins/ruby/CMakeLists.txt	1970-01-01 03:00:01.000000000 +0300
-+++ dfhack-ae59b4f-new/plugins/ruby/CMakeLists.txt	2016-11-23 15:29:09.907286546 +0300
-@@ -1,3 +1,4 @@
-+IF(FALSE)
- IF (APPLE)
-     SET(RUBYLIB ${CMAKE_CURRENT_SOURCE_DIR}/osx${DFHACK_BUILD_ARCH}/libruby.dylib)
-     SET(RUBYLIB_INSTALL_NAME "libruby.dylib")
-@@ -48,6 +49,7 @@
-             "482c1c418f4ee1a5f04203eee1cda0ef")
-     ENDIF()
- ENDIF()
-+ENDIF()
+diff --git a/plugins/ruby/CMakeLists.txt b/plugins/ruby/CMakeLists.txt
+index f1ef12ac..0976e18a 100644
+--- a/plugins/ruby/CMakeLists.txt
++++ b/plugins/ruby/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # Allow build system to turn off downloading of libruby.so.
+-OPTION(DOWNLOAD_RUBY "Download prebuilt libruby.so for ruby plugin." ON)
++OPTION(DOWNLOAD_RUBY "Download prebuilt libruby.so for ruby plugin." OFF)
  
- IF (APPLE OR UNIX)
-     SET(RUBYAUTOGEN ruby-autogen-gcc.rb)
+ IF (DOWNLOAD_RUBY)


### PR DESCRIPTION
###### Motivation for this change

Updating dfhack

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

