### PR TITLE
fetchFromGitHub: fix fetchSubmodules when revision is not hexadecimal

### DIFF
--- a/pkgs/applications/audio/sisco.lv2/default.nix
+++ b/pkgs/applications/audio/sisco.lv2/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   inherit name;
 
   srcs = [ src robtkSrc ];
-  sourceRoot = "sisco.lv2-${src.rev}-src";
+  sourceRoot = src.name;
 
   buildInputs = [ pkgconfig lv2 pango cairo libjack2 mesa ];
 

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -1,21 +1,9 @@
-{stdenv, git, cacert}: let
-  urlToName = url: rev: let
-    inherit (stdenv.lib) removeSuffix splitString last;
-    base = last (splitString ":" (baseNameOf (removeSuffix "/" url)));
+{stdenv, git, cacert, gitRepoToName}:
 
-    matched = builtins.match "(.*).git" base;
-
-    short = builtins.substring 0 7 rev;
-
-    appendShort = if (builtins.match "[a-f0-9]*" rev) != null
-      then "-${short}"
-      else "";
-  in "${if matched == null then base else builtins.head matched}${appendShort}";
-in
 { url, rev ? "HEAD", md5 ? "", sha256 ? "", leaveDotGit ? deepClone
 , fetchSubmodules ? true, deepClone ? false
 , branchName ? null
-, name ? urlToName url rev
+, name ? gitRepoToName url rev
 , # Shell code executed after the file has been fetched
   # successfully. This can do things like check or transform the file.
   postFetch ? ""

--- a/pkgs/build-support/fetchgit/gitrepotoname.nix
+++ b/pkgs/build-support/fetchgit/gitrepotoname.nix
@@ -1,0 +1,14 @@
+{ lib }:
+
+urlOrRepo: rev: let
+  inherit (lib) removeSuffix splitString last;
+  base = last (splitString ":" (baseNameOf (removeSuffix "/" urlOrRepo)));
+
+  matched = builtins.match "(.*).git" base;
+
+  short = builtins.substring 0 7 rev;
+
+  appendShort = if (builtins.match "[a-f0-9]*" rev) != null
+    then "-${short}"
+    else "";
+in "${if matched == null then base else builtins.head matched}${appendShort}"

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -282,8 +282,8 @@ _clone_user_rev() {
             if test -z "$(echo "$rev" | tr -d 0123456789abcdef)"; then
                 clone "$dir" "$url" "$rev" "" 1>&2
             else
-                echo 1>&2 "Bad commit hash or bad reference."
-                exit 1
+                # if revision is not hexadecimal it might be a tag
+                clone "$dir" "$url" "" "refs/tags/$rev" 1>&2
             fi;;
     esac
 

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -59,7 +59,7 @@ let
         srcs = [ rubySrc rubygemsSrc ];
         sourceRoot =
           if useRailsExpress then
-            "ruby-${tag}-src"
+            rubySrc.name
           else
             unpackdir rubySrc;
 

--- a/pkgs/servers/mail/postfix/pfixtools.nix
+++ b/pkgs/servers/mail/postfix/pfixtools.nix
@@ -10,7 +10,7 @@ let
     sha256 = "1vmbrw686f41n6xfjphfshn96vl07ynvnsyjdw9yfn9bfnldcjcq";
   };
 
-  srcRoot = "pfixtools-${pfixtoolsSrc.rev}-src";
+  srcRoot = pfixtoolsSrc.name;
 
   libCommonSrc = fetchFromGitHub {
     owner = "Fruneau";

--- a/pkgs/tools/networking/email/default.nix
+++ b/pkgs/tools/networking/email/default.nix
@@ -8,7 +8,7 @@ let
     sha256 = "1cxxzhm36civ6vjdgrk7mfmlzkih44kdii6l2xgy4r434s8rzcpn";
   };
 
-  srcRoot = "eMail-${eMailSrc.rev}-src";
+  srcRoot = eMailSrc.name;
 
   dlibSrc = fetchFromGitHub {
     owner = "deanproxy";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -185,8 +185,10 @@ with pkgs;
 
   fetchzip = callPackage ../build-support/fetchzip { };
 
+  gitRepoToName = callPackage ../build-support/fetchgit/gitrepotoname.nix { };
+
   fetchFromGitHub = {
-    owner, repo, rev, name ? "${repo}-${rev}-src",
+    owner, repo, rev, name ? gitRepoToName repo rev,
     fetchSubmodules ? false, private ? false,
     githubBase ? "github.com", varPrefix ? null,
     ... # For hash agility
@@ -223,7 +225,7 @@ with pkgs;
     } // passthruAttrs) // { inherit rev; };
 
   fetchFromBitbucket = {
-    owner, repo, rev, name ? "${repo}-${rev}-src",
+    owner, repo, rev, name ? gitRepoToName repo rev,
     ... # For hash agility
   }@args: fetchzip ({
     inherit name;
@@ -234,7 +236,7 @@ with pkgs;
 
   # cgit example, snapshot support is optional in cgit
   fetchFromSavannah = {
-    repo, rev, name ? "${repo}-${rev}-src",
+    repo, rev, name ? gitRepoToName repo rev,
     ... # For hash agility
   }@args: fetchzip ({
     inherit name;
@@ -244,7 +246,7 @@ with pkgs;
 
   # gitlab example
   fetchFromGitLab = {
-    owner, repo, rev, name ? "${repo}-${rev}-src",
+    owner, repo, rev, name ? gitRepoToName repo rev,
     ... # For hash agility
   }@args: fetchzip ({
     inherit name;
@@ -254,7 +256,7 @@ with pkgs;
 
   # gitweb example, snapshot support is optional in gitweb
   fetchFromRepoOrCz = {
-    repo, rev, name ? "${repo}-${rev}-src",
+    repo, rev, name ? gitRepoToName repo rev,
     ... # For hash agility
   }@args: fetchzip ({
     inherit name;


### PR DESCRIPTION
###### Motivation for this change

Fixes #21620

Both failed examples from #21620 work well now:
```nix
fetchFromGitHub {
  owner = "aerospike";
  repo = "aerospike-server";
  rev = "3.14.0.1";
  sha256 = "1kzkwvir9j9jdlwp8gi9p3wkv3qhbrn62x1mb1xlnrdc7rk32kyn";
  fetchSubmodules = true;
}
```
which failed with ```Bad commit hash or bad reference```

```nix
fetchFromGitHub {
  owner = "aerospike";
  repo = "aerospike-server";
  rev = "refs/tags/3.14.0.1";
  sha256 = "1kzkwvir9j9jdlwp8gi9p3wkv3qhbrn62x1mb1xlnrdc7rk32kyn";
  fetchSubmodules = true;
}
```
which failed with ```invalid character ‘/’ in name ‘aerospike-server-refs/tags/3.14.0.1-src’```


###### Things done
1. use the same ```urlToName``` for ```fetchgit``` and ```fetchFromGitHub``` to avoid producing nix store names containing forbidden characters (for example ```/```) by simplified implementation used in ```fetchFromGitHub``` (```"${repo}-${rev}-src"``` where ```rev``` could be ```"refs/tags/tagname"```).
2. do not fail when ```rev``` containing non-hexadecimal characters, try to interpret it as a tag name.


- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

