### PR TITLE
iptstate: init at 2.2.6

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -550,6 +550,7 @@
   tokudan = "Daniel Frank <git@danielfrank.net>";
   tomberek = "Thomas Bereknyei <tomberek@gmail.com>";
   travisbhartwell = "Travis B. Hartwell <nafai@travishartwell.net>";
+  trevorj = "Trevor Joynson <nix@trevor.joynson.io>";
   trino = "Hubert Mühlhans <muehlhans.hubert@ekodia.de>";
   tstrobel = "Thomas Strobel <4ZKTUB6TEP74PYJOPWIR013S2AV29YUBW5F9ZH2F4D5UMJUJ6S@hash.domains>";
   ttuegel = "Thomas Tuegel <ttuegel@mailbox.org>";

--- a/pkgs/os-specific/linux/iptstate/default.nix
+++ b/pkgs/os-specific/linux/iptstate/default.nix
@@ -20,8 +20,7 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp -av iptstate $out/bin/
+    install -m755 -D iptstate $out/bin/iptstate
   '';
 }
 

--- a/pkgs/os-specific/linux/iptstate/default.nix
+++ b/pkgs/os-specific/linux/iptstate/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, libnetfilter_conntrack, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "iptstate-${version}";
+  version = "2.2.6";
+
+  src = fetchurl {
+    url = "https://github.com/jaymzh/iptstate/releases/download/v${version}/${name}.tar.bz2";
+    sha256 = "bef8eb67a4533e53079f397b71e91dd34da23f8cbd65cb2d5b67cb907b00c068";
+  };
+
+  buildInputs = [ libnetfilter_conntrack ncurses ];
+
+  meta = with stdenv.lib; {
+    description = "Conntrack top like tool";
+    homepage = https://github.com/jaymzh/iptstate;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ trevorj ];
+    downloadPage = "https://github.com/jaymzh/iptstate/releases";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -av iptstate $out/bin/
+  '';
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11769,6 +11769,8 @@ with pkgs;
     flex = flex_2_5_35;
   };
 
+  iptstate = callPackage ../os-specific/linux/iptstate { } ;
+
   ipset = callPackage ../os-specific/linux/ipset { };
 
   irqbalance = callPackage ../os-specific/linux/irqbalance { };


### PR DESCRIPTION
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [M] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---