### PR TITLE
Purge stdenv.cross

### DIFF
--- a/doc/cross-compilation.xml
+++ b/doc/cross-compilation.xml
@@ -79,11 +79,6 @@
         </listitem>
       </varlistentry>
     </variablelist>
-    <note><para>
-      If you dig around nixpkgs, you may notice there is also <varname>stdenv.cross</varname>.
-      This field defined as <varname>hostPlatform</varname> when the host and build platforms differ, but otherwise not defined at all.
-      This field is obsolete and will soon disappear—please do not use it.
-    </para></note>
     <para>
       The exact schema these fields follow is a bit ill-defined due to a long and convoluted evolution, but this is slowly being cleaned up.
       You can see examples of ones used in practice in <literal>lib.systems.examples</literal>; note how they are not all very consistent.

--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -36,9 +36,6 @@ stdenv.mkDerivation rec {
     "ac_cv_sizeof_int=4"
     "vim_cv_memmove_handles_overlap=yes"
     "vim_cv_memmove_handles_overlap=yes"
-
-    # TODO(@Ericson2314): wont' be needed soon.
-    "STRIP=${hostPlatform.config}-strip"
   ];
 
   postInstall = ''

--- a/pkgs/applications/graphics/ImageMagick/7.0.nix
+++ b/pkgs/applications/graphics/ImageMagick/7.0.nix
@@ -2,6 +2,7 @@
 , bzip2, zlib, libX11, libXext, libXt, fontconfig, freetype, ghostscript, libjpeg
 , lcms2, openexr, libpng, librsvg, libtiff, libxml2, openjpeg, libwebp
 , ApplicationServices
+, buildPlatform, hostPlatform
 }:
 
 let
@@ -47,7 +48,7 @@ stdenv.mkDerivation rec {
       [ "--with-gs-font-dir=${ghostscript}/share/ghostscript/fonts"
         "--with-gslib"
       ]
-    ++ lib.optionals (stdenv.cross.libc or null == "msvcrt")
+    ++ lib.optionals hostPlatform.isMinGW
       [ "--enable-static" "--disable-shared" ] # due to libxml2 being without DLLs ATM
     ;
 
@@ -57,13 +58,13 @@ stdenv.mkDerivation rec {
     [ zlib fontconfig freetype ghostscript
       libpng libtiff libxml2
     ]
-    ++ lib.optionals (stdenv.cross.libc or null != "msvcrt")
+    ++ lib.optionals (!hostPlatform.isMinGW)
       [ openexr librsvg openjpeg ]
     ++ lib.optional stdenv.isDarwin ApplicationServices;
 
   propagatedBuildInputs =
     [ bzip2 freetype libjpeg lcms2 ]
-    ++ lib.optionals (stdenv.cross.libc or null != "msvcrt")
+    ++ lib.optionals (!hostPlatform.isMinGW)
       [ libX11 libXext libXt libwebp ]
     ;
 

--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -2,6 +2,7 @@
 , bzip2, zlib, libX11, libXext, libXt, fontconfig, freetype, ghostscript, libjpeg
 , lcms2, openexr, libpng, librsvg, libtiff, libxml2, openjpeg, libwebp
 , ApplicationServices
+, buildPlatform, hostPlatform
 }:
 
 let
@@ -18,7 +19,7 @@ let
   }
     # Freeze version on mingw so we don't need to port the patch too often.
     # FIXME: This version has multiple security vulnerabilities
-    // lib.optionalAttrs (stdenv.cross.libc or null == "msvcrt") {
+    // lib.optionalAttrs (hostPlatform.isMinGW) {
         version = "6.9.2-0";
         sha256 = "17ir8bw1j7g7srqmsz3rx780sgnc21zfn0kwyj78iazrywldx8h7";
         patches = [(fetchpatch {
@@ -59,7 +60,7 @@ stdenv.mkDerivation rec {
       [ "--with-gs-font-dir=${ghostscript}/share/ghostscript/fonts"
         "--with-gslib"
       ]
-    ++ lib.optionals (stdenv.cross.libc or null == "msvcrt")
+    ++ lib.optionals (hostPlatform.isMinGW)
       [ "--enable-static" "--disable-shared" ] # due to libxml2 being without DLLs ATM
     ;
 
@@ -69,13 +70,13 @@ stdenv.mkDerivation rec {
     [ zlib fontconfig freetype ghostscript
       libpng libtiff libxml2
     ]
-    ++ lib.optionals (stdenv.cross.libc or null != "msvcrt")
+    ++ lib.optionals (!hostPlatform.isMinGW)
       [ openexr librsvg openjpeg ]
     ++ lib.optional stdenv.isDarwin ApplicationServices;
 
   propagatedBuildInputs =
     [ bzip2 freetype libjpeg lcms2 ]
-    ++ lib.optionals (stdenv.cross.libc or null != "msvcrt")
+    ++ lib.optionals (!hostPlatform.isMinGW)
       [ libX11 libXext libXt libwebp ]
     ;
 

--- a/pkgs/applications/graphics/fbida/default.nix
+++ b/pkgs/applications/graphics/fbida/default.nix
@@ -21,10 +21,6 @@ stdenv.mkDerivation rec {
     sed -e 's@ cpp\>@ gcc -E -@' -i GNUmakefile
     '';
 
-  crossAttrs = {
-    makeFlags = makeFlags ++ [ "CC=${stdenv.cross.config}-gcc" "STRIP=" ];
-  };
-
   meta = with stdenv.lib; {
     description = "Image viewing and manipulation programs";
     homepage = https://www.kraxel.org/blog/linux/fbida/;

--- a/pkgs/applications/networking/offrss/default.nix
+++ b/pkgs/applications/networking/offrss/default.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation {
     preConfigure = ''
       sed 's/^PDF/#PDF/' -i Makefile
     '';
-    makeFlags = "CC=${stdenv.cross.config}-gcc";
   };
 
   buildInputs = [ curl libmrss podofo ]

--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   crossAttrs = {
     doCheck = false;
-    makeFlagsArray = [ "TCC=${stdenv.cross.config}-gcc" ];
+    makeFlags = [ "TCC=$CC" ];
   };
 
   meta = {

--- a/pkgs/applications/video/omxplayer/default.nix
+++ b/pkgs/applications/video/omxplayer/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, raspberrypifw, pcre, boost, freetype, zlib }:
+{ stdenv, fetchurl
+, raspberrypifw, pcre, boost, freetype, zlib
+, hostPlatform
+}:
 
 let
   ffmpeg = stdenv.mkDerivation rec {
@@ -46,10 +49,10 @@ let
     crossAttrs = {
       configurePlatforms = [];
       configureFlags = configureFlags ++ [
-        "--cross-prefix=${stdenv.cross.config}-"
+        "--cross-prefix=${stdenv.cc.prefix}"
         "--enable-cross-compile"
         "--target_os=linux"
-        "--arch=${stdenv.cross.arch}"
+        "--arch=${hostPlatform.arch}"
         ];
     };
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -71,7 +71,7 @@ let
 
     '' + stdenv.lib.optionalString (textFile == ./setup-hook.sh) ''
       cat << 'EOF' >> $out
-        for CMD in ar as nm objcopy ranlib strip strings size ld
+        for CMD in ar as nm objcopy ranlib strip strings size ld windres
         do
           # which is not part of stdenv, but compgen will do for now
           if

--- a/pkgs/build-support/gcc-wrapper-old/default.nix
+++ b/pkgs/build-support/gcc-wrapper-old/default.nix
@@ -8,6 +8,7 @@
 { name ? "", stdenv, lib, nativeTools, nativeLibc, nativePrefix ? ""
 , gcc ? null, libc ? null, binutils ? null, coreutils ? null, shell ? ""
 , zlib ? null
+, hostPlatform, targetPlatform
 }:
 
 assert nativeTools -> nativePrefix != "";
@@ -69,9 +70,9 @@ stdenv.mkDerivation {
     # the style in the gcc-cross-wrapper, but to keep a stable stdenv now I
     # do this sufficient if/else.
     dynamicLinker =
-      (if stdenv.cross.arch == "arm" then "ld-linux.so.3" else
-       if stdenv.cross.arch == "mips" then "ld.so.1" else
-       if stdenv.lib.hasSuffix "pc-gnu" stdenv.cross.config then "ld.so.1" else
+      (if hostPlatform.arch == "arm" then "ld-linux.so.3" else
+       if hostPlatform.arch == "mips" then "ld.so.1" else
+       if stdenv.lib.hasSuffix "pc-gnu" hostPlatform.config then "ld.so.1" else
        abort "don't know the name of the dynamic linker for this platform");
   };
 
@@ -85,15 +86,20 @@ stdenv.mkDerivation {
         + " (wrapper script)";
     };
 
-  # The dynamic linker has different names on different Linux platforms.
+  # The dynamic linker has different names on different platforms.
   dynamicLinker =
     if !nativeLibc then
-      (if stdenv.system == "i686-linux" then "ld-linux.so.2" else
-       if stdenv.system == "x86_64-linux" then "ld-linux-x86-64.so.2" else
+      (if targetPlatform.system == "i686-linux"     then "ld-linux.so.2" else
+       if targetPlatform.system == "x86_64-linux"   then "ld-linux-x86-64.so.2" else
        # ARM with a wildcard, which can be "" or "-armhf".
-       if stdenv.isArm then "ld-linux*.so.3" else
-       if stdenv.system == "powerpc-linux" then "ld.so.1" else
-       if stdenv.system == "mips64el-linux" then "ld.so.1" else
-       abort "don't know the name of the dynamic linker for this platform")
+       if targetPlatform.isArm32                    then "ld-linux*.so.3" else
+       if targetPlatform.system == "aarch64-linux"  then "ld-linux-aarch64.so.1" else
+       if targetPlatform.system == "powerpc-linux"  then "ld.so.1" else
+       if targetPlatform.system == "mips64el-linux" then "ld.so.1" else
+       if targetPlatform.system == "x86_64-darwin"  then "/usr/lib/dyld" else
+       if stdenv.lib.hasSuffix "pc-gnu" targetPlatform.config then "ld.so.1" else
+       builtins.trace
+         "Don't know the name of the dynamic linker for platform ${targetPlatform.config}, so guessing instead."
+         null)
     else "";
 }

--- a/pkgs/build-support/kernel/make-initrd.nix
+++ b/pkgs/build-support/kernel/make-initrd.nix
@@ -12,7 +12,9 @@
 # `contents = {object = ...; symlink = /init;}' is a typical
 # argument.
 
-{ stdenv, perl, cpio, contents, ubootChooser, compressor, prepend }:
+{ stdenv, perl, cpio, contents, ubootChooser, compressor, prepend
+, hostPlatform
+}:
 
 let
   inputsFun = ubootName : [ perl cpio ]
@@ -22,9 +24,9 @@ in
 stdenv.mkDerivation {
   name = "initrd";
   builder = ./make-initrd.sh;
-  nativeBuildInputs = inputsFun stdenv.platform.uboot;
+  nativeBuildInputs = inputsFun hostPlatform.platform.uboot;
 
-  makeUInitrd = makeUInitrdFun stdenv.platform.uboot;
+  makeUInitrd = makeUInitrdFun hostPlatform.platform.uboot;
 
   # !!! should use XML.
   objects = map (x: x.object) contents;
@@ -36,9 +38,5 @@ stdenv.mkDerivation {
     map (x: [("closure-" + baseNameOf x.symlink) x.object]) contents;
   pathsFromGraph = ./paths-from-graph.pl;
 
-  crossAttrs = {
-    nativeBuildInputs = inputsFun stdenv.cross.platform.uboot;
-    makeUInitrd = makeUInitrdFun stdenv.cross.platform.uboot;
-  };
   inherit compressor prepend;
 }

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -1,5 +1,7 @@
 { fetchurl, stdenv, libtool, readline, gmp, pkgconfig, boehmgc, libunistring
-, libffi, gawk, makeWrapper, fetchpatch, coverageAnalysis ? null, gnu ? null }:
+, libffi, gawk, makeWrapper, fetchpatch, coverageAnalysis ? null, gnu ? null
+, hostPlatform
+}:
 
 # Do either a coverage analysis build or a standard build.
 (if coverageAnalysis != null
@@ -84,7 +86,7 @@
   setupHook = ./setup-hook-2.0.sh;
 
   crossAttrs.preConfigure =
-    stdenv.lib.optionalString (stdenv.cross.config == "i586-pc-gnu")
+    stdenv.lib.optionalString (hostPlatform.isHurd)
        # On GNU, libgc depends on libpthread, but the cross linker doesn't
        # know where to find libpthread, which leads to erroneous test failures
        # in `configure', where `-pthread' and `-lpthread' aren't explicitly

--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -1,5 +1,7 @@
 { fetchurl, stdenv, libtool, readline, gmp, pkgconfig, boehmgc, libunistring
-, libffi, gawk, makeWrapper, fetchpatch, coverageAnalysis ? null, gnu ? null }:
+, libffi, gawk, makeWrapper, fetchpatch, coverageAnalysis ? null, gnu ? null
+, hostPlatform
+}:
 
 # Do either a coverage analysis build or a standard build.
 (if coverageAnalysis != null
@@ -80,7 +82,7 @@
   setupHook = ./setup-hook-2.2.sh;
 
   crossAttrs.preConfigure =
-    stdenv.lib.optionalString (stdenv.cross.config == "i586-pc-gnu")
+    stdenv.lib.optionalString (hostPlatform.isHurd)
        # On GNU, libgc depends on libpthread, but the cross linker doesn't
        # know where to find libpthread, which leads to erroneous test failures
        # in `configure', where `-pthread' and `-lpthread' aren't explicitly

--- a/pkgs/development/interpreters/lua-5/5.2.nix
+++ b/pkgs/development/interpreters/lua-5/5.2.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, readline, compat ? false }:
+{ stdenv, fetchurl, readline, compat ? false
+, hostPlatform
+}:
 
 let
   dsoPatch = fetchurl {
@@ -55,21 +57,15 @@ stdenv.mkDerivation rec {
   '';
 
   crossAttrs = let
-    isMingw = stdenv.cross.libc == "msvcrt";
-    isDarwin = stdenv.cross.libc == "libSystem";
+    inherit (hostPlatform) isDarwin isMingw;
   in {
     configurePhase = ''
       makeFlagsArray=(
         INSTALL_TOP=$out
         INSTALL_MAN=$out/share/man/man1
-        CC=${stdenv.cross.config}-gcc
-        STRIP=:
-        RANLIB=${stdenv.cross.config}-ranlib
         V=${luaversion}
         R=${version}
         ${if isMingw then "mingw" else stdenv.lib.optionalString isDarwin ''
-        AR="${stdenv.cross.config}-ar rcu"
-        macosx
         ''}
       )
     '' + stdenv.lib.optionalString isMingw ''

--- a/pkgs/development/interpreters/lua-5/5.3.nix
+++ b/pkgs/development/interpreters/lua-5/5.3.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, readline, compat ? false }:
+{ stdenv, fetchurl, readline, compat ? false
+, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "lua-${version}";
@@ -54,21 +56,15 @@ stdenv.mkDerivation rec {
   '';
 
   crossAttrs = let
-    isMingw = stdenv.cross.libc == "msvcrt";
-    isDarwin = stdenv.cross.libc == "libSystem";
+    inherit (hostPlatform) isDarwin isMingw;
   in {
     configurePhase = ''
       makeFlagsArray=(
         INSTALL_TOP=$out
         INSTALL_MAN=$out/share/man/man1
-        CC=${stdenv.cross.config}-gcc
-        STRIP=:
-        RANLIB=${stdenv.cross.config}-ranlib
         V=${luaversion}
         R=${version}
         ${if isMingw then "mingw" else stdenv.lib.optionalString isDarwin ''
-        AR="${stdenv.cross.config}-ar rcu"
-        macosx
         ''}
       )
     '' + stdenv.lib.optionalString isMingw ''

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -4,6 +4,7 @@
 , x11Support ? true, libXext, libICE, libXrandr
 , pulseaudioSupport ? true, libpulseaudio
 , OpenGL, CoreAudio, CoreServices, AudioUnit, Kernel, Cocoa
+, hostPlatform
 }:
 
 # OSS is no longer supported, for it's much crappier than ALSA and
@@ -37,7 +38,7 @@ stdenv.mkDerivation rec {
     optional stdenv.isDarwin Cocoa;
 
   buildInputs = let
-    notMingw = !(stdenv ? cross) || stdenv.cross.libc != "msvcrt";
+    notMingw = !hostPlatform.isMinGW;
   in optional notMingw audiofile
   ++ optionals stdenv.isDarwin [ OpenGL CoreAudio CoreServices AudioUnit Kernel ];
 

--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchurl, pkgconfig, libatomic_ops, enableLargeConfig ? false }:
+{ lib, stdenv, fetchurl, pkgconfig, libatomic_ops, enableLargeConfig ? false
+, buildPlatform, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "boehm-gc-7.6.0";
@@ -20,7 +22,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   # Don't run the native `strip' when cross-compiling.
-  dontStrip = stdenv ? cross;
+  dontStrip = hostPlatform != buildPlatform;
 
   postInstall =
     ''

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, icu, expat, zlib, bzip2, python, fixDarwinDylibNames, libiconv
-, hostPlatform
+, buildPlatform, hostPlatform
 , toolset ? if stdenv.cc.isClang then "clang" else null
 , enableRelease ? true
 , enableDebug ? false
@@ -148,13 +148,13 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   buildInputs = [ expat zlib bzip2 libiconv ]
-    ++ stdenv.lib.optionals (! stdenv ? cross) [ python icu ]
+    ++ stdenv.lib.optionals (hostPlatform == buildPlatform) [ python icu ]
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   configureScript = "./bootstrap.sh";
   configureFlags = commonConfigureFlags
     ++ [ "--with-python=${python.interpreter}" ]
-    ++ optional (! stdenv ? cross) "--with-icu=${icu.dev}"
+    ++ optional (hostPlatform == buildPlatform) "--with-icu=${icu.dev}"
     ++ optional (toolset != null) "--with-toolset=${toolset}";
 
   buildPhase = builder nativeB2Args;

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, icu, expat, zlib, bzip2, python, fixDarwinDylibNames, libiconv
+, hostPlatform
 , toolset ? if stdenv.cc.isClang then "clang" else null
 , enableRelease ? true
 , enableDebug ? false
 , enableSingleThreaded ? false
 , enableMultiThreaded ? true
-, enableShared ? !(stdenv.cross.libc or null == "msvcrt") # problems for now
+, enableShared ? !(hostPlatform.libc == "msvcrt") # problems for now
 , enableStatic ? !enableShared
 , enablePIC ? false
 , enableExceptions ? false
@@ -76,11 +77,11 @@ let
     "--user-config=user-config.jam"
     "toolset=gcc-cross"
     "--without-python"
-  ] ++ optionals (stdenv.cross.libc == "msvcrt") [
+  ] ++ optionals (hostPlatform.libc == "msvcrt") [
     "target-os=windows"
     "threadapi=win32"
     "binary-format=pe"
-    "address-model=${if hasPrefix "x86_64-" stdenv.cross.config then "64" else "32"}"
+    "address-model=${toString hostPlatform.parsed.cpu.bits}"
     "architecture=x86"
   ];
   crossB2Args = concatStringsSep " " (genericB2Flags ++ crossB2Flags);
@@ -110,8 +111,8 @@ let
       find include \( -name '*.hpp' -or -name '*.h' -or -name '*.ipp' \) \
         -exec sed '1i#line 1 "{}"' -i '{}' \;
     )
-  '' + optionalString (stdenv.cross.libc or null == "msvcrt") ''
-    ${stdenv.cross.config}-ranlib "$out/lib/"*.a
+  '' + optionalString (hostPlatform.libc == "msvcrt") ''
+    ${stdenv.cc.prefix}ranlib "$out/lib/"*.a
   '';
 
 in
@@ -177,7 +178,7 @@ stdenv.mkDerivation {
     buildPhase = builder crossB2Args;
     installPhase = installer crossB2Args;
     postFixup = fixup;
-  } // optionalAttrs (stdenv.cross.libc == "msvcrt") {
+  } // optionalAttrs (hostPlatform.libc == "msvcrt") {
     patches = fetchurl {
       url = "https://svn.boost.org/trac/boost/raw-attachment/ticket/7262/"
           + "boost-mingw.patch";

--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, pkgconfig, perl, texinfo, yasm
+, hostPlatform
 /*
  *  Licensing options (yes some are listed twice, filters and such are not listed)
  */
@@ -428,30 +429,13 @@ stdenv.mkDerivation rec {
 
   /* Cross-compilation is untested, consider this an outline, more work
      needs to be done to portions of the build to get it to work correctly */
-  crossAttrs = let
-    os = ''
-      if [ "${stdenv.cross.config}" = "*cygwin*" ] ; then
-        # Probably should look for mingw too
-        echo "cygwin"
-      elif [ "${stdenv.cross.config}" = "*darwin*" ] ; then
-        echo "darwin"
-      elif [ "${stdenv.cross.config}" = "*freebsd*" ] ; then
-        echo "freebsd"
-      elif [ "${stdenv.cross.config}" = "*linux*" ] ; then
-        echo "linux"
-      elif [ "${stdenv.cross.config}" = "*netbsd*" ] ; then
-        echo "netbsd"
-      elif [ "${stdenv.cross.config}" = "*openbsd*" ] ; then
-        echo "openbsd"
-      fi
-    '';
-  in {
+  crossAttrs = {
     configurePlatforms = [];
     configureFlags = configureFlags ++ [
-      "--cross-prefix=${stdenv.cross.config}-"
+      "--cross-prefix=${stdenv.cc.prefix}"
       "--enable-cross-compile"
-      "--target_os=${os}"
-      "--arch=${stdenv.cross.arch}"
+      "--target_os=${hostPlatform.parsed.kernel.name}"
+      "--arch=${hostPlatform.arch}"
     ];
   };
 

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -2,6 +2,7 @@
 , alsaLib, bzip2, fontconfig, freetype, gnutls, libiconv, lame, libass, libogg
 , libtheora, libva, libvorbis, libvpx, lzma, libpulseaudio, soxr
 , x264, x265, xvidcore, zlib, libopus
+, hostPlatform
 , openglSupport ? false, mesa ? null
 # Build options
 , runtimeCpuDetectBuild ? true # Detect CPU capabilities at runtime
@@ -169,30 +170,13 @@ stdenv.mkDerivation rec {
 
   /* Cross-compilation is untested, consider this an outline, more work
      needs to be done to portions of the build to get it to work correctly */
-  crossAttrs = let
-    os = ''
-      if [ "${stdenv.cross.config}" = "*cygwin*" ] ; then
-        # Probably should look for mingw too
-        echo "cygwin"
-      elif [ "${stdenv.cross.config}" = "*darwin*" ] ; then
-        echo "darwin"
-      elif [ "${stdenv.cross.config}" = "*freebsd*" ] ; then
-        echo "freebsd"
-      elif [ "${stdenv.cross.config}" = "*linux*" ] ; then
-        echo "linux"
-      elif [ "${stdenv.cross.config}" = "*netbsd*" ] ; then
-        echo "netbsd"
-      elif [ "${stdenv.cross.config}" = "*openbsd*" ] ; then
-        echo "openbsd"
-      fi
-    '';
-  in {
+  crossAttrs = {
     configurePlatforms = [];
     configureFlags = configureFlags ++ [
-      "--cross-prefix=${stdenv.cross.config}-"
+      "--cross-prefix=${stdenv.cc.prefix}"
       "--enable-cross-compile"
-      "--target_os=${os}"
-      "--arch=${stdenv.cross.arch}"
+      "--target_os=${hostPlatform.parsed.kernel}"
+      "--arch=${hostPlatform.arch}"
     ];
   };
 

--- a/pkgs/development/libraries/fontconfig/2.10.nix
+++ b/pkgs/development/libraries/fontconfig/2.10.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, freetype, expat }:
+{ stdenv, fetchurl, pkgconfig, freetype, expat
+, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "fontconfig-2.10.2";
@@ -21,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
 
   # We should find a better way to access the arch reliably.
-  crossArch = stdenv.cross.arch or null;
+  crossArch = hostPlatform.arch or null;
 
   preConfigure = ''
     if test -n "$crossConfig"; then

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -1,5 +1,7 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, freetype, expat, libxslt, dejavu_fonts
-, substituteAll }:
+{ stdenv, substituteAll, fetchurl, fetchpatch
+, pkgconfig, freetype, expat, libxslt, dejavu_fonts
+, hostPlatform
+}:
 
 /** Font configuration scheme
  - ./config-compat.patch makes fontconfig try the following root configs, in order:
@@ -53,7 +55,7 @@ stdenv.mkDerivation rec {
   ];
 
   # We should find a better way to access the arch reliably.
-  crossArch = stdenv.cross.arch or null;
+  crossArch = hostPlatform.arch or null;
 
   preConfigure = ''
     if test -n "$crossConfig"; then

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -1,12 +1,12 @@
-{
-  stdenv, lib, fetchurl, copyPathsToStore,
-  pkgconfig, which,
-  zlib, bzip2, libpng, gnumake, glib,
+{ stdenv, lib, fetchurl, copyPathsToStore
+, hostPlatform
+, pkgconfig, which
+, zlib, bzip2, libpng, gnumake, glib
 
-  # FreeType supports LCD filtering (colloquially referred to as sub-pixel rendering).
+, # FreeType supports LCD filtering (colloquially referred to as sub-pixel rendering).
   # LCD filtering is also known as ClearType and covered by several Microsoft patents.
   # This option allows it to be disabled. See http://www.freetype.org/patents.html.
-  useEncumberedCode ? true,
+  useEncumberedCode ? true
 }:
 
 let
@@ -67,7 +67,7 @@ in stdenv.mkDerivation {
 
   postInstall = glib.flattenInclude;
 
-  crossAttrs = stdenv.lib.optionalAttrs (stdenv.cross.libc or null != "msvcrt") {
+  crossAttrs = stdenv.lib.optionalAttrs (hostPlatform.libc or null != "msvcrt") {
     # Somehow it calls the unwrapped gcc, "i686-pc-linux-gnu-gcc", instead
     # of gcc. I think it's due to the unwrapped gcc being in the PATH. I don't
     # know why it's on the PATH.

--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -1,5 +1,7 @@
 { stdenv, fetchurl, mesa_glu, x11, libXmu, libXi
-, AGL ? null }:
+, buildPlatform, hostPlatform
+, AGL ? null
+}:
 
 with stdenv.lib;
 
@@ -36,13 +38,9 @@ stdenv.mkDerivation rec {
     cp -r README.txt LICENSE.txt doc $out/share/doc/glew
   '';
 
-  crossAttrs.makeFlags = [
-    "CC=${stdenv.cross.config}-gcc"
-    "LD=${stdenv.cross.config}-gcc"
-    "AR=${stdenv.cross.config}-ar"
-    "STRIP="
-  ] ++ optional (stdenv.cross.libc == "msvcrt") "SYSTEM=mingw"
-    ++ optional (stdenv.cross.libc == "libSystem") "SYSTEM=darwin";
+  makeFlags = if hostPlatform == buildPlatform then null else [
+    "SYSTEM=${if hostPlatform.isMinGW then "mingw" else hostPlatform.parsed.kernel}"
+  ];
 
   meta = with stdenv.lib; {
     description = "An OpenGL extension loading library for C(++)";

--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     sed -i 's|lib64|lib|' config/Makefile.linux
-    ${optionalString (stdenv ? cross) ''
+    ${optionalString (hostPlatform != buildPlatform) ''
     sed -i -e 's/\(INSTALL.*\)-s/\1/' Makefile
     ''}
   '';

--- a/pkgs/development/libraries/glew/default.nix
+++ b/pkgs/development/libraries/glew/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     sed -i 's|lib64|lib|' config/Makefile.linux
-    ${optionalString (stdenv ? cross) ''
+    ${optionalString (hostPlatform != buildPlatform) ''
     sed -i -e 's/\(INSTALL.*\)-s/\1/' Makefile
     ''}
   '';

--- a/pkgs/development/libraries/glew/default.nix
+++ b/pkgs/development/libraries/glew/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, mesa_glu, xlibsWrapper, libXmu, libXi }:
+{ stdenv, fetchurl, mesa_glu, xlibsWrapper, libXmu, libXi
+, buildPlatform, hostPlatform
+}:
 
 with stdenv.lib;
 
@@ -37,13 +39,9 @@ stdenv.mkDerivation rec {
     rm $out/lib/*.a
   '';
 
-  crossAttrs.makeFlags = [
-    "CC=${stdenv.cross.config}-gcc"
-    "LD=${stdenv.cross.config}-gcc"
-    "AR=${stdenv.cross.config}-ar"
-    "STRIP="
-  ] ++ optional (stdenv.cross.libc == "msvcrt") "SYSTEM=mingw"
-    ++ optional (stdenv.cross.libc == "libSystem") "SYSTEM=darwin";
+  makeFlags = if hostPlatform == buildPlatform then null else [
+    "SYSTEM=${if hostPlatform.isMinGW then "mingw" else hostPlatform.parsed.kernel}"
+  ];
 
   meta = with stdenv.lib; {
     description = "An OpenGL extension loading library for C(++)";

--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -13,6 +13,7 @@
 , SDL # only for avplay in $bin, adds nontrivial closure to it
 , enableGPL ? true # ToDo: some additional default stuff may need GPL
 , enableUnfree ? faacSupport
+, hostPlatform
 }:
 
 assert faacSupport -> enableUnfree;
@@ -107,10 +108,10 @@ let
     crossAttrs = {
       configurePlatforms = [];
       configureFlags = configureFlags ++ [
-        "--cross-prefix=${stdenv.cross.config}-"
+        "--cross-prefix=${stdenv.cc.prefix}"
         "--enable-cross-compile"
         "--target_os=linux"
-        "--arch=${stdenv.cross.arch}"
+        "--arch=${hostPlatform.arch}"
         ];
     };
 

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -1,4 +1,6 @@
-{ fetchurl, stdenv, dejagnu, doCheck ? false }:
+{ fetchurl, stdenv, dejagnu, doCheck ? false
+, buildPlatform, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "libffi-3.2.1";
@@ -21,7 +23,7 @@ stdenv.mkDerivation rec {
 
   inherit doCheck;
 
-  dontStrip = stdenv ? cross; # Don't run the native `strip' when cross-compiling.
+  dontStrip = hostPlatform != buildPlatform; # Don't run the native `strip' when cross-compiling.
 
   # Install headers and libs in the right places.
   postFixup = ''

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -1,6 +1,8 @@
-{ fetchurl, stdenv, lib }:
+{ fetchurl, stdenv, lib
+, buildPlatform, hostPlatform
+}:
 
-assert !stdenv.isLinux || stdenv ? cross; # TODO: improve on cross
+assert !stdenv.isLinux || hostPlatform != buildPlatform; # TODO: improve on cross
 
 stdenv.mkDerivation rec {
   name = "libiconv-${version}";
@@ -17,7 +19,7 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch =
-    lib.optionalString ((stdenv ? cross && stdenv.cross.libc == "msvcrt") || stdenv.cc.nativeLibc)
+    lib.optionalString ((hostPlatform != buildPlatform && hostPlatform.libc == "msvcrt") || stdenv.cc.nativeLibc)
       ''
         sed '/^_GL_WARN_ON_USE (gets/d' -i srclib/stdio.in.h
       '';

--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, nasm }:
+{ stdenv, fetchurl, nasm
+, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "libjpeg-turbo-${version}";
@@ -10,7 +12,7 @@ stdenv.mkDerivation rec {
   }; # github releases still need autotools, surprisingly
 
   patches =
-    stdenv.lib.optional (stdenv.cross.libc or null == "msvcrt")
+    stdenv.lib.optional (hostPlatform.libc or null == "msvcrt")
       ./mingw-boolean.patch;
 
   outputs = [ "bin" "dev" "out" "doc" ];

--- a/pkgs/development/libraries/libmsgpack/generic.nix
+++ b/pkgs/development/libraries/libmsgpack/generic.nix
@@ -1,5 +1,6 @@
 { stdenv, cmake
 , version, src, patches ? [ ]
+, hostPlatform
 , ...
 }:
 
@@ -11,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   crossAttrs = {
-  } // stdenv.lib.optionalAttrs (stdenv.cross.libc == "msvcrt") {
+  } // stdenv.lib.optionalAttrs (hostPlatform.libc == "msvcrt") {
     cmakeFlags = "-DMSGPACK_BUILD_EXAMPLES=OFF -DCMAKE_SYSTEM_NAME=Windows";
   };
 

--- a/pkgs/development/libraries/libpng/12.nix
+++ b/pkgs/development/libraries/libpng/12.nix
@@ -1,6 +1,8 @@
-{ stdenv, fetchurl, zlib }:
+{ stdenv, fetchurl, zlib
+, buildPlatform, hostPlatform
+}:
 
-assert !(stdenv ? cross) -> zlib != null;
+assert hostPlatform == buildPlatform -> zlib != null;
 
 stdenv.mkDerivation rec {
   name = "libpng-1.2.57";
@@ -16,7 +18,7 @@ stdenv.mkDerivation rec {
 
   passthru = { inherit zlib; };
 
-  crossAttrs = stdenv.lib.optionalAttrs (stdenv.cross.libc == "libSystem") {
+  crossAttrs = stdenv.lib.optionalAttrs (hostPlatform.libc == "libSystem") {
     propagatedBuildInputs = [];
     passthru = {};
   };

--- a/pkgs/development/libraries/libpng/default.nix
+++ b/pkgs/development/libraries/libpng/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, zlib, apngSupport ? true }:
+{ stdenv, fetchurl, zlib, apngSupport ? true
+, buildPlatform, hostPlatform
+}:
 
 assert zlib != null;
 
@@ -29,7 +31,7 @@ in stdenv.mkDerivation rec {
 
   # it's hard to cross-run tests and some check programs didn't compile anyway
   makeFlags = stdenv.lib.optional (!doCheck) "check_PROGRAMS=";
-  doCheck = ! stdenv ? cross;
+  doCheck = hostPlatform == buildPlatform;
 
   passthru = { inherit zlib; };
 

--- a/pkgs/development/libraries/libssh2/default.nix
+++ b/pkgs/development/libraries/libssh2/default.nix
@@ -1,4 +1,6 @@
-{stdenv, fetchurlBoot, openssl, zlib, windows}:
+{ stdenv, fetchurlBoot, openssl, zlib, windows
+, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "libssh2-1.8.0";
@@ -20,7 +22,7 @@ stdenv.mkDerivation rec {
       "--with-libz"
       "--with-libz-prefix=${zlib.crossDrv}"
     ];
-  } // stdenv.lib.optionalAttrs (stdenv.cross.libc == "msvcrt") {
+  } // stdenv.lib.optionalAttrs (hostPlatform.libc == "msvcrt") {
     # mingw needs import library of ws2_32 to build the shared library
     preConfigure = ''
       export LDFLAGS="-L${windows.mingw_w64}/lib $LDFLAGS"

--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -1,4 +1,5 @@
-{stdenv, fetchFromGitHub, perl, yasm
+{ stdenv, fetchFromGitHub, perl, yasm
+, hostPlatform
 , vp8DecoderSupport ? true # VP8 decoder
 , vp8EncoderSupport ? true # VP8 encoder
 , vp9DecoderSupport ? true # VP9 decoder
@@ -144,10 +145,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''moveToOutput bin "$bin" '';
 
-  crossAttrs = let
-    isCygwin = stdenv.cross.libc == "msvcrt";
-    isDarwin = stdenv.cross.libc == "libSystem";
-  in {
+  crossAttrs = {
     configurePlatforms = [];
     configureFlags = configureFlags ++ [
       #"--extra-cflags="
@@ -159,17 +157,17 @@ stdenv.mkDerivation rec {
       # libvpx darwin targets include darwin version (ie. ARCH-darwinXX-gcc, XX being the darwin version)
       # See all_platforms: https://github.com/webmproject/libvpx/blob/master/configure
       # Darwin versions: 10.4=8, 10.5=9, 10.6=10, 10.7=11, 10.8=12, 10.9=13, 10.10=14
-      "--force-target=${stdenv.cross.config}${(
-              if isDarwin then (
-                if      stdenv.cross.osxMinVersion == "10.10" then "14"
-                else if stdenv.cross.osxMinVersion == "10.9"  then "13"
-                else if stdenv.cross.osxMinVersion == "10.8"  then "12"
-                else if stdenv.cross.osxMinVersion == "10.7"  then "11"
-                else if stdenv.cross.osxMinVersion == "10.6"  then "10"
-                else if stdenv.cross.osxMinVersion == "10.5"  then "9"
-                else "8")
-              else "")}-gcc"
-      (if isCygwin then "--enable-static-msvcrt" else "")
+      "--force-target=${hostPlatform.config}${
+              if hostPlatform.isDarwin then
+                if      hostPlatform.osxMinVersion == "10.10" then "14"
+                else if hostPlatform.osxMinVersion == "10.9"  then "13"
+                else if hostPlatform.osxMinVersion == "10.8"  then "12"
+                else if hostPlatform.osxMinVersion == "10.7"  then "11"
+                else if hostPlatform.osxMinVersion == "10.6"  then "10"
+                else if hostPlatform.osxMinVersion == "10.5"  then "9"
+                else "8"
+              else ""}-gcc"
+      (if hostPlatform.isCygwin then "--enable-static-msvcrt" else "")
     ];
   };
 

--- a/pkgs/development/libraries/libvpx/git.nix
+++ b/pkgs/development/libraries/libvpx/git.nix
@@ -1,4 +1,5 @@
-{stdenv, fetchgit, perl, yasm
+{ stdenv, fetchgit, perl, yasm
+, hostPlatform
 , vp8DecoderSupport ? true # VP8 decoder
 , vp8EncoderSupport ? true # VP8 encoder
 , vp9DecoderSupport ? true # VP9 decoder
@@ -152,10 +153,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''moveToOutput bin "$bin" '';
 
-  crossAttrs = let
-    isCygwin = stdenv.cross.libc == "msvcrt";
-    isDarwin = stdenv.cross.libc == "libSystem";
-  in {
+  crossAttrs = {
     configurePlatforms = [];
     configureFlags = configureFlags ++ [
       #"--extra-cflags="
@@ -166,17 +164,17 @@ stdenv.mkDerivation rec {
       # libvpx darwin targets include darwin version (ie. ARCH-darwinXX-gcc, XX being the darwin version)
       # See all_platforms: https://github.com/webmproject/libvpx/blob/master/configure
       # Darwin versions: 10.4=8, 10.5=9, 10.6=10, 10.7=11, 10.8=12, 10.9=13, 10.10=14
-      "--force-target=${stdenv.cross.config}${(
-              if isDarwin then (
-                if      stdenv.cross.osxMinVersion == "10.10" then "14"
-                else if stdenv.cross.osxMinVersion == "10.9"  then "13"
-                else if stdenv.cross.osxMinVersion == "10.8"  then "12"
-                else if stdenv.cross.osxMinVersion == "10.7"  then "11"
-                else if stdenv.cross.osxMinVersion == "10.6"  then "10"
-                else if stdenv.cross.osxMinVersion == "10.5"  then "9"
-                else "8")
-              else "")}-gcc"
-      (if isCygwin then "--enable-static-msvcrt" else "")
+      "--force-target=${hostPlatform.config}${
+              if hostPlatform.isDarwin then
+                if      hostPlatform.osxMinVersion == "10.10" then "14"
+                else if hostPlatform.osxMinVersion == "10.9"  then "13"
+                else if hostPlatform.osxMinVersion == "10.8"  then "12"
+                else if hostPlatform.osxMinVersion == "10.7"  then "11"
+                else if hostPlatform.osxMinVersion == "10.6"  then "10"
+                else if hostPlatform.osxMinVersion == "10.5"  then "9"
+                else "8"
+              else ""}-gcc"
+      (if hostPlatform.isCygwin then "--enable-static-msvcrt" else "")
     ];
   };
 

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -1,7 +1,9 @@
 { stdenv, lib, fetchurl, fetchpatch
 , zlib, xz, python2, findXMLCatalogs, libiconv
-, pythonSupport ? (! stdenv ? cross)
-, icuSupport ? false, icu ? null }:
+, buildPlatform, hostPlatform
+, pythonSupport ? buildPlatform == hostPlatform
+, icuSupport ? false, icu ? null
+}:
 
 let
   python = python2;
@@ -45,7 +47,7 @@ in stdenv.mkDerivation rec {
 
   doCheck = !stdenv.isDarwin;
 
-  crossAttrs = lib.optionalAttrs (stdenv.cross.libc == "msvcrt") {
+  crossAttrs = lib.optionalAttrs (hostPlatform.libc == "msvcrt") {
     # creating the DLL is broken ATM
     dontDisableStatic = true;
     configureFlags = configureFlags ++ [ "--disable-shared" ];

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, fetchpatch, libxml2, findXMLCatalogs, python2
+, buildPlatform, hostPlatform
 , cryptoSupport ? false
-, pythonSupport ? (! stdenv ? cross)
+, pythonSupport ? buildPlatform == hostPlatform
 }:
 
 assert pythonSupport -> python2 != null;

--- a/pkgs/development/libraries/newt/default.nix
+++ b/pkgs/development/libraries/newt/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = "-lncurses";
 
   crossAttrs = {
-    makeFlags = "CROSS_COMPILE=${stdenv.cross.config}-";
+    makeFlags = "CROSS_COMPILE=${stdenv.cc.prefix}";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv, fetchFromGitHub, cmake
+, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "nlohmann_json-${version}";
@@ -21,7 +23,7 @@ stdenv.mkDerivation rec {
   crossAttrs = {
     cmakeFlags = "-DBuildTests=OFF";
     doCheck = false;
-  } // stdenv.lib.optionalAttrs (stdenv.cross.libc == "msvcrt") {
+  } // stdenv.lib.optionalAttrs (hostPlatform.libc == "msvcrt") {
     cmakeFlags = "-DBuildTests=OFF -DCMAKE_SYSTEM_NAME=Windows";
   };
 

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -1,12 +1,14 @@
 { stdenv, fetchurl, buildPackages, perl
+, hostPlatform
 , withCryptodev ? false, cryptodevHeaders
-, enableSSL2 ? false }:
+, enableSSL2 ? false
+}:
 
 with stdenv.lib;
 
 let
 
-  opensslCrossSystem = stdenv.cross.openssl.system or
+  opensslCrossSystem = hostPlatform.openssl.system or
     (throw "openssl needs its platform name cross building");
 
   common = args@{ version, sha256, patches ? [] }: stdenv.mkDerivation rec {
@@ -23,8 +25,7 @@ let
       ++ optional (versionOlder version "1.1.0")
           (if stdenv.isDarwin then ./use-etc-ssl-certs-darwin.patch else ./use-etc-ssl-certs.patch)
       ++ optional stdenv.isCygwin ./1.0.1-cygwin64.patch
-      ++ optional
-           (versionOlder version "1.0.2" && (stdenv.isDarwin || (stdenv ? cross && stdenv.cross.libc == "libSystem")))
+      ++ optional (versionOlder version "1.0.2" && hostPlatform.isDarwin)
            ./darwin-arch.patch;
 
     outputs = [ "bin" "dev" "out" "man" ];
@@ -89,10 +90,6 @@ let
       preConfigure=''
         # It's configure does not like --build or --host
         export configureFlags="${concatStringsSep " " (configureFlags ++ [ opensslCrossSystem ])}"
-        # WINDRES and RANLIB need to be prefixed when cross compiling;
-        # the openssl configure script doesn't do that for us
-        export WINDRES=${stdenv.cross.config}-windres
-        export RANLIB=${stdenv.cross.config}-ranlib
       '';
       configureScript = "./Configure";
     };

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -6,6 +6,7 @@
 , introspectionSupport ? false, gobjectIntrospection ? null
 , utils ? false
 , minimal ? false, suffix ? "glib"
+, hostPlatform
 }:
 
 let # beware: updates often break cups-filters build
@@ -56,7 +57,7 @@ stdenv.mkDerivation rec {
 
   crossAttrs.postPatch =
     # there are tests using `strXXX_s` functions that are missing apparently
-    stdenv.lib.optionalString (stdenv.cross.libc or null == "msvcrt")
+    stdenv.lib.optionalString (hostPlatform.libc or null == "msvcrt")
       "sed '/^SUBDIRS =/s/ test / /' -i Makefile.in";
 
   meta = with lib; {

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, fetchpatch, substituteAll
+, hostPlatform
 , libXrender, libXinerama, libXcursor, libXmu, libXv, libXext
 , libXfixes, libXrandr, libSM, freetype, fontconfig, zlib, libjpeg, libpng
 , libmng, which, mesaSupported, mesa, mesa_glu, openssl, dbus, cups, pkgconfig
@@ -182,9 +183,7 @@ stdenv.mkDerivation rec {
       rm -rf $out/tests
     '';
 
-  crossAttrs = let
-    isMingw = stdenv.cross.libc == "msvcrt";
-  in {
+  crossAttrs = {
     # I've not tried any case other than i686-pc-mingw32.
     # -nomake tools:   it fails linking some asian language symbols
     # -no-svg: it fails to build on mingw64
@@ -194,14 +193,14 @@ stdenv.mkDerivation rec {
       -no-svg
       -make qmake -make libs -nomake tools
       -nomake demos -nomake examples -nomake docs
-    '' + optionalString isMingw " -xplatform win32-g++-4.6";
+    '' + optionalString hostPlatform.isMinGW " -xplatform win32-g++-4.6";
     patches = [];
     preConfigure = ''
-      sed -i -e 's/ g++/ ${stdenv.cross.config}-g++/' \
-        -e 's/ gcc/ ${stdenv.cross.config}-gcc/' \
-        -e 's/ ar/ ${stdenv.cross.config}-ar/' \
-        -e 's/ strip/ ${stdenv.cross.config}-strip/' \
-        -e 's/ windres/ ${stdenv.cross.config}-windres/' \
+      sed -i -e 's/ g++/ ${stdenv.cc.prefix}g++/' \
+        -e 's/ gcc/ ${stdenv.cc.prefix}gcc/' \
+        -e 's/ ar/ ${stdenv.cc.prefix}ar/' \
+        -e 's/ strip/ ${stdenv.cc.prefix}strip/' \
+        -e 's/ windres/ ${stdenv.cc.prefix}windres/' \
         mkspecs/win32-g++/qmake.conf
     '';
 
@@ -211,7 +210,7 @@ stdenv.mkDerivation rec {
     '';
     configurePlatforms = [];
     dontStrip = true;
-  } // optionalAttrs isMingw {
+  } // optionalAttrs hostPlatform.isMinGW {
     propagatedBuildInputs = [ ];
   };
 

--- a/pkgs/development/libraries/readline/6.2.nix
+++ b/pkgs/development/libraries/readline/6.2.nix
@@ -1,4 +1,6 @@
-{ fetchurl, stdenv, ncurses }:
+{ fetchurl, stdenv, ncurses
+, buildPlatform, hostPlatform
+}:
 
 stdenv.mkDerivation (rec {
   name = "readline-6.2";
@@ -57,6 +59,6 @@ stdenv.mkDerivation (rec {
 //
 
 # Don't run the native `strip' when cross-compiling.
-(if (stdenv ? cross)
+(if hostPlatform != buildPlatform
  then { dontStrip = true; }
  else { }))

--- a/pkgs/development/libraries/readline/6.3.nix
+++ b/pkgs/development/libraries/readline/6.3.nix
@@ -1,4 +1,6 @@
-{ fetchurl, stdenv, ncurses }:
+{ fetchurl, stdenv, ncurses
+, buildPlatform, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "readline-6.3p08";
@@ -29,7 +31,7 @@ stdenv.mkDerivation rec {
        import ./readline-6.3-patches.nix patch);
 
   # Don't run the native `strip' when cross-compiling.
-  dontStrip = stdenv ? cross;
+  dontStrip = hostPlatform != buildPlatform;
   bash_cv_func_sigsetjmp = if stdenv.isCygwin then "missing" else null;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/readline/7.0.nix
+++ b/pkgs/development/libraries/readline/7.0.nix
@@ -1,4 +1,6 @@
-{ fetchurl, stdenv, ncurses }:
+{ fetchurl, stdenv, ncurses
+, buildPlatform, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "readline-${version}";
@@ -33,7 +35,7 @@ stdenv.mkDerivation rec {
     */
 
   # Don't run the native `strip' when cross-compiling.
-  dontStrip = stdenv ? cross;
+  dontStrip = hostPlatform != buildPlatform;
   bash_cv_func_sigsetjmp = if stdenv.isCygwin then "missing" else null;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   crossAttrs = {
     dontStrip = static;
     configurePlatforms = [];
-  } // stdenv.lib.optionalAttrs (stdenv.cross.libc == "msvcrt") {
+  } // stdenv.lib.optionalAttrs (hostPlatform.libc == "msvcrt") {
     installFlags = [
       "BINARY_PATH=$(out)/bin"
       "INCLUDE_PATH=$(dev)/include"
@@ -68,14 +68,12 @@ stdenv.mkDerivation rec {
     ];
     makeFlags = [
       "-f" "win32/Makefile.gcc"
-      "PREFIX=${stdenv.cross.config}-"
+      "PREFIX=${stdenv.cc.prefix}"
     ] ++ stdenv.lib.optional (!static) "SHARED_MODE=1";
 
     # Non-typical naming confuses libtool which then refuses to use zlib's DLL
     # in some cases, e.g. when compiling libpng.
     postInstall = postInstall + "ln -s zlib1.dll $out/bin/libz.dll";
-  } // stdenv.lib.optionalAttrs (stdenv.cross.libc == "libSystem") {
-    makeFlags = [ "RANLIB=${stdenv.cross.config}-ranlib" ];
   };
 
   passthru.version = version;

--- a/pkgs/development/tools/build-managers/cmake/2.8.nix
+++ b/pkgs/development/tools/build-managers/cmake/2.8.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, fetchpatch, replace, curl, expat, zlib, bzip2
 , useNcurses ? false, ncurses, useQt4 ? false, qt4, wantPS ? false, ps ? null
+, buildPlatform, hostPlatform
 }:
 
 with stdenv.lib;
@@ -35,7 +36,7 @@ stdenv.mkDerivation rec {
     })] ++
     # Don't search in non-Nix locations such as /usr, but do search in our libc.
     [ ./search-path.patch ] ++
-    optional (stdenv ? cross) (fetchurl {
+    optional (hostPlatform != buildPlatform) (fetchurl {
       name = "fix-darwin-cross-compile.patch";
       url = "http://public.kitware.com/Bug/file_download.php?"
           + "file_id=4981&type=bug";

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, m4, perl, help2man }:
+{ stdenv, fetchurl, m4, perl, help2man
+, buildPlatform, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "libtool-2.4.6";
@@ -23,7 +25,7 @@ stdenv.mkDerivation rec {
 
   # Don't run the native `strip' when cross-compiling.  This breaks at least
   # with `.a' files for MinGW.
-  dontStrip = stdenv ? cross;
+  dontStrip = hostPlatform != buildPlatform;
 
   meta = {
     description = "GNU Libtool, a generic library support script";

--- a/pkgs/games/scummvm/default.nix
+++ b/pkgs/games/scummvm/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, SDL, zlib, libmpeg2, libmad, libogg, libvorbis, flac, alsaLib, mesa }:
+{ stdenv
+, fetchurl, SDL, zlib, libmpeg2, libmad, libogg, libvorbis, flac, alsaLib, mesa
+, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "scummvm-1.9.0";
@@ -16,7 +19,7 @@ stdenv.mkDerivation rec {
     preConfigure = ''
       # Remove the --build flag set by the gcc cross wrapper setup
       # hook
-      export configureFlags="--host=${stdenv.cross.config}"
+      export configureFlags="--host=${hostPlatform.config}"
     '';
     postConfigure = ''
       # They use 'install -s', that calls the native strip instead of the cross

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, bc, dtc, python2 }:
+{ stdenv, fetchurl, bc, dtc, python2
+, hostPlatform
+}:
 
 let
   buildUBoot = { targetPlatforms
@@ -43,8 +45,8 @@ let
 
     crossAttrs = {
       makeFlags = [
-        "ARCH=${stdenv.cross.platform.kernelArch}"
-        "CROSS_COMPILE=${stdenv.cross.config}-"
+        "ARCH=${hostPlatform.platform.kernelArch}"
+        "CROSS_COMPILE=${stdenv.cc.prefix}"
       ];
     };
 

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, kernel, perl }:
+{ stdenv, kernel, perl
+, hostPlatform
+}:
 
 let
   baseBuildFlags = [ "INSTALL_HDR_PATH=$(out)" "headers_install" ];
@@ -13,7 +15,7 @@ in stdenv.mkDerivation {
 
   crossAttrs = {
     inherit (kernel.crossDrv) src patches;
-    buildFlags = [ "ARCH=${stdenv.cross.platform.kernelArch}" ] ++ baseBuildFlags;
+    buildFlags = [ "ARCH=${hostPlatform.platform.kernelArch}" ] ++ baseBuildFlags;
   };
 
   installPhase = ''

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -25,6 +25,7 @@
   kernelPatches ? []
 , ignoreConfigErrors ? stdenv.platform.name != "pc"
 , extraMeta ? {}
+, hostPlatform
 , ...
 }:
 
@@ -59,7 +60,7 @@ let
     arch = stdenv.platform.kernelArch;
 
     crossAttrs = let
-        cp = stdenv.cross.platform;
+        cp = hostPlatform.platform;
       in {
         arch = cp.kernelArch;
         platformName = cp.name;
@@ -128,7 +129,7 @@ let
     };
 
   config = configWithPlatform stdenv.platform;
-  configCross = configWithPlatform stdenv.cross.platform;
+  configCross = configWithPlatform hostPlatform.platform;
 
   nativeDrv = lib.addPassthru kernel.nativeDrv passthru;
 

--- a/pkgs/os-specific/linux/kernel/linux-3.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.10.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "3.10.105";

--- a/pkgs/os-specific/linux/kernel/linux-4.11.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.11.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.11.7";

--- a/pkgs/os-specific/linux/kernel/linux-4.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.4.73";

--- a/pkgs/os-specific/linux/kernel/linux-4.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.9.34";

--- a/pkgs/os-specific/linux/kernel/linux-chromiumos-3.18.nix
+++ b/pkgs/os-specific/linux/kernel/linux-chromiumos-3.18.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, perl, buildLinux, ncurses, ... } @ args:
+{ stdenv, hostPlatform, fetchgit, perl, buildLinux, ncurses, ... } @ args:
 
 # ChromiumOS requires a 64bit build host
 assert stdenv.is64bit;

--- a/pkgs/os-specific/linux/kernel/linux-hardened-copperhead.nix
+++ b/pkgs/os-specific/linux/kernel/linux-hardened-copperhead.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 let
   version = "4.11.7";

--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   mptcpVersion = "0.91.3";

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 let
   modDirVersion = "4.9.24";

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.12-rc6";

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -1,5 +1,6 @@
 { stdenv, runCommand, nettools, bc, perl, gmp, libmpc, mpfr, kmod, openssl
 , writeTextFile, ubootChooser
+, hostPlatform
 }:
 
 let
@@ -232,7 +233,7 @@ stdenv.mkDerivation ((drvAttrs config stdenv.platform (kernelPatches ++ nativeKe
 
   karch = stdenv.platform.kernelArch;
 
-  crossAttrs = let cp = stdenv.cross.platform; in
+  crossAttrs = let cp = hostPlatform.platform; in
     (drvAttrs crossConfig cp (kernelPatches ++ crossKernelPatches) crossConfigfile) // {
       makeFlags = commonMakeFlags ++ [
         "ARCH=${cp.kernelArch}"

--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
     /* I don't want cross-python or cross-perl -
        I don't know if cross-python even works */
     propagatedBuildInputs = [ elfutils.crossDrv newt.crossDrv ];
-    makeFlags = "CROSS_COMPILE=${stdenv.cross.config}-";
+    makeFlags = "CROSS_COMPILE=${stdenv.cc.prefix}";
     elfutils = elfutils.crossDrv;
     inherit (kernel.crossDrv) src patches;
   };

--- a/pkgs/os-specific/linux/mdadm/4.nix
+++ b/pkgs/os-specific/linux/mdadm/4.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, groff }:
+{ stdenv
+, fetchurl, groff
+, buildPlatform, hostPlatform
+}:
 
 assert stdenv.isLinux;
 
@@ -19,8 +22,8 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "NIXOS=1" "INSTALL=install" "INSTALL_BINDIR=$(out)/sbin"
     "MANDIR=$(out)/share/man" "RUN_DIR=/dev/.mdadm"
-  ] ++ stdenv.lib.optionals (stdenv ? cross) [
-    "CROSS_COMPILE=${stdenv.cross.config}-"
+  ] ++ stdenv.lib.optionals (hostPlatform != buildPlatform) [
+    "CROSS_COMPILE=${stdenv.cc.prefix}"
   ];
 
   nativeBuildInputs = [ groff ];

--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, groff }:
+{ stdenv
+, fetchurl, groff
+, buildPlatform, hostPlatform
+}:
 
 assert stdenv.isLinux;
 
@@ -19,8 +22,8 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "NIXOS=1" "INSTALL=install" "INSTALL_BINDIR=$(out)/sbin"
     "MANDIR=$(out)/share/man" "RUN_DIR=/dev/.mdadm"
-  ] ++ stdenv.lib.optionals (stdenv ? cross) [
-    "CROSS_COMPILE=${stdenv.cross.config}-"
+  ] ++ stdenv.lib.optionals (hostPlatform != buildPlatform) [
+    "CROSS_COMPILE=${stdenv.cc.prefix}"
   ];
 
   nativeBuildInputs = [ groff ];

--- a/pkgs/os-specific/linux/mingetty/default.nix
+++ b/pkgs/os-specific/linux/mingetty/default.nix
@@ -8,10 +8,6 @@ stdenv.mkDerivation {
     sha256 = "05yxrp44ky2kg6qknk1ih0kvwkgbn9fbz77r3vci7agslh5wjm8g";
   };
 
-  crossAttrs = {
-    makeFlags = "CC=${stdenv.cross.config}-gcc";
-  };
-
   preInstall = ''
     mkdir -p $out/sbin $out/share/man/man8
     makeFlagsArray=(SBINDIR=$out/sbin MANDIR=$out/share/man/man8)

--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -15,10 +15,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  crossAttrs = {
-    CC = stdenv.cross.config + "-gcc";
-  };
-
   # Too red
   configureFlags = [ "--disable-modern-top" ];
 

--- a/pkgs/os-specific/linux/procps/watch.nix
+++ b/pkgs/os-specific/linux/procps/watch.nix
@@ -15,10 +15,6 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  crossAttrs = {
-    CC = stdenv.cross.config + "-gcc";
-  };
-
   installPhase = "mkdir $out; mkdir -p $out/bin; cp -p watch $out/bin";
 
   meta = {

--- a/pkgs/os-specific/linux/shadow/default.nix
+++ b/pkgs/os-specific/linux/shadow/default.nix
@@ -1,11 +1,13 @@
 { stdenv, fetchpatch, fetchFromGitHub, autoreconfHook, libxslt, libxml2
 , docbook_xml_dtd_412, docbook_xsl, gnome_doc_utils, flex, bison
-, pam ? null, glibcCross ? null }:
+, pam ? null, glibcCross ? null
+, buildPlatform, hostPlatform
+}:
 
 let
 
   glibc =
-    if stdenv ? cross
+    if hostPlatform != buildPlatform
     then glibcCross
     else assert stdenv ? glibc; stdenv.glibc;
 

--- a/pkgs/os-specific/linux/sysvinit/default.nix
+++ b/pkgs/os-specific/linux/sysvinit/default.nix
@@ -15,11 +15,7 @@ stdenv.mkDerivation {
     sed -i -e "s,/sbin/,$out/sbin/," src/halt.c src/init.c src/paths.h
   '';
 
-  makeFlags = "SULOGINLIBS=-lcrypt ROOT=$(out) MANDIR=/share/man";
-
-  crossAttrs = {
-    makeFlags = "SULOGINLIBS=-lcrypt ROOT=$(out) MANDIR=/share/man CC=${stdenv.cross.config}-gcc";
-  };
+  makeFlags = [ "SULOGINLIBS=-lcrypt" "ROOT=$(out)" "MANDIR=/share/man" ];
 
   preInstall =
     ''

--- a/pkgs/os-specific/windows/jom/default.nix
+++ b/pkgs/os-specific/windows/jom/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   QTDIR = qt48;
   
   crossAttrs = {
-    # cmakeFlags = "-DWIN32=1 -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_RC_COMPILER=${stdenv.cross.config}-windres";
+    # cmakeFlags = "-DWIN32=1 -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_RC_COMPILER=${stdenv.cc.prefix}windres";
     QTDIR = qt48.crossDrv;
     preBuild = ''
       export NIX_CROSS_CFLAGS_COMPILE=-fpermissive

--- a/pkgs/os-specific/windows/pthread-w32/default.nix
+++ b/pkgs/os-specific/windows/pthread-w32/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, mingw_headers }:
 
 # This file is tweaked for cross-compilation only.
-assert stdenv ? cross;
+assert hostPlatform != buildPlatform;
 
 stdenv.mkDerivation {
   name = "pthread-w32-1.10.0";

--- a/pkgs/os-specific/windows/wxMSW-2.8/default.nix
+++ b/pkgs/os-specific/windows/wxMSW-2.8/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, compat24 ? false, compat26 ? true, unicode ? true,
+, hostPlatform
 }:
 
-assert stdenv ? cross -> stdenv.cross.libc == "msvcrt";
+assert hostPlatform.isWindows;
 
 stdenv.mkDerivation {
   name = "wxMSW-2.8.11";
@@ -18,12 +19,6 @@ stdenv.mkDerivation {
     (if unicode then "--enable-unicode" else "")
     "--with-opengl"
   ];
-
-  # Cross build only tested for mingw32
-  checkCross = throw "This package can only be cross-built" false;
-  crossAttrs = {
-    checkCross = true;
-  };
 
   preConfigure = "
     substituteInPlace configure --replace /usr /no-such-path

--- a/pkgs/tools/filesystems/mtdutils/default.nix
+++ b/pkgs/tools/filesystems/mtdutils/default.nix
@@ -15,10 +15,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libuuid lzo zlib acl ];
 
-  crossAttrs = {
-    makeFlags = "CC=${stdenv.cross.config}-gcc";
-  };
-
   meta = {
     description = "Tools for MTD filesystems";
     license = stdenv.lib.licenses.gpl2Plus;

--- a/pkgs/tools/networking/tcpdump/default.nix
+++ b/pkgs/tools/networking/tcpdump/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, libpcap, enableStatic ? false }:
+{ stdenv, fetchurl, libpcap, enableStatic ? false
+, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "tcpdump-${version}";
@@ -15,7 +17,7 @@ stdenv.mkDerivation rec {
   crossAttrs = {
     LDFLAGS = if enableStatic then "-static" else "";
     configureFlags = [ "ac_cv_linux_vers=2" ] ++ (stdenv.lib.optional
-      (stdenv.cross.platform.kernelMajor == "2.4") "--disable-ipv6");
+      (hostPlatform.platform.kernelMajor == "2.4") "--disable-ipv6");
   };
 
   meta = {

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -2,6 +2,7 @@
 , pkgconfig, boehmgc, perlPackages, libsodium, aws-sdk-cpp, brotli, readline
 , autoreconfHook, autoconf-archive, bison, flex, libxml2, libxslt, docbook5, docbook5_xsl
 , libseccomp, busybox
+, hostPlatform
 , storeDir ? "/nix/store"
 , stateDir ? "/nix/var"
 , confDir ? "/etc"
@@ -95,8 +96,8 @@ let
           --disable-init-state
           --enable-gc
         '' + stdenv.lib.optionalString (
-            stdenv.cross ? nix && stdenv.cross.nix ? system
-        ) ''--with-system=${stdenv.cross.nix.system}'';
+            hostPlatform ? nix && hostPlatform.nix ? system
+        ) ''--with-system=${hostPlatform.nix.system}'';
 
       doInstallCheck = false;
     };

--- a/pkgs/tools/system/tm/default.nix
+++ b/pkgs/tools/system/tm/default.nix
@@ -10,10 +10,6 @@ stdenv.mkDerivation {
     sed -i 's@/usr/bin/install@install@g ; s/gcc/cc/g' Makefile
   '';
 
-  crossAttrs = {
-    makeFlags = "CC=${stdenv.cross.config}-gcc";
-  };
-
   src = fetchurl {
     url = http://vicerveza.homeunix.net/~viric/soft/tm/tm-0.4.1.tar.gz;
     sha256 = "3b389bc03b6964ad5ffa57a344b891fdbcf7c9b2604adda723a863f83657c4a0";

--- a/pkgs/tools/system/ts/default.nix
+++ b/pkgs/tools/system/ts/default.nix
@@ -1,15 +1,12 @@
-{stdenv, fetchurl,
-sendmailPath ? "/run/wrappers/bin/sendmail" }:
+{ stdenv, fetchurl
+, sendmailPath ? "/run/wrappers/bin/sendmail"
+}:
 
 stdenv.mkDerivation rec {
 
   name = "ts-0.7.6";
 
   installPhase=''make install "PREFIX=$out"'';
-
-  crossAttrs = {
-    makeFlags = "CC=${stdenv.cross.config}-gcc";
-  };
 
   patchPhase = ''
     sed -i s,/usr/sbin/sendmail,${sendmailPath}, mail.c ts.1

--- a/pkgs/tools/text/html-tidy/default.nix
+++ b/pkgs/tools/text/html-tidy/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, libxslt }:
+{ stdenv, fetchFromGitHub, cmake, libxslt
+, hostPlatform
+}:
 
 stdenv.mkDerivation rec {
   name = "html-tidy-${version}";
@@ -14,7 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake libxslt/*manpage*/ ];
 
   cmakeFlags = stdenv.lib.optional
-    (stdenv.cross.libc or null == "msvcrt") "-DCMAKE_SYSTEM_NAME=Windows";
+    (hostPlatform.libc or null == "msvcrt") "-DCMAKE_SYSTEM_NAME=Windows";
 
   # ATM bin/tidy is statically linked, as upstream provides no other option yet.
   # https://github.com/htacg/tidy-html5/issues/326#issuecomment-160322107

--- a/pkgs/tools/text/replace/default.nix
+++ b/pkgs/tools/text/replace/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl}:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation {
   name = "replace-2.24";
@@ -9,10 +9,6 @@ stdenv.mkDerivation {
   };
 
   makeFlags = "TREE=\$(out) MANTREE=\$(TREE)/share/man";
-
-  crossAttrs = {
-    makeFlags = "TREE=\$(out) MANTREE=\$(TREE)/share/man CC=${stdenv.cross.config}-gcc";
-  };
 
   preBuild = ''
     sed -e "s@/bin/mv@$(type -P mv)@" -i replace.h

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -110,8 +110,6 @@ let
   in {
     stdenv = super.stdenv // {
       inherit (buildPlatform) platform;
-    } // lib.optionalAttrs (hostPlatform != buildPlatform) {
-      cross = hostPlatform;
     };
     inherit (buildPlatform) system platform;
   };


### PR DESCRIPTION
###### Motivation for this change

`stdenv.cross` is vague: better to use `buildPlatform`, `hostPlatform` or `targetPlatform`. This is a rather tedious task so anyone that sees this, feel free to push to this PR (if you are a contributor) or send a PR against the PR (if you are not).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @bjornfor @matthewbauer @Dridus 

