### PR TITLE
thunderbird-bin: 52.2.0 -> 52.2.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,595 +1,595 @@
 {
-  version = "52.2.0";
+  version = "52.2.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/ar/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/ar/thunderbird-52.2.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "d25bdeda7f5ee563176809811c5373d5232842ddb68315f31992754100e5cc96e5a2d0427897d245fcf9bbfc647331492e9b1fa79e0adb64f4f2169dd66ddc29";
+      sha512 = "5b19b8fb7b7a6a4dd03ee5ab163f07ee664dd7b6d701571e57b6b3943d8aebf69291958d9a51b7720c5e5935daabacfd6149229e7626557927133b00a6c8750d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/ast/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/ast/thunderbird-52.2.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "f7d3f2caa404fa5b97b7c966bb4ddd6fc0f26531802d4db9930d984d9b4ca635c41f9b025ca3c0ccba93a288da9c229b43b760759969b269082402584eed14f0";
+      sha512 = "d0d2a562834e865cb31648255a94b120419c7cf4bba20d0a43368a05c3590333443da9416f7940eb0ed1fd774bd161d85585154b389d01b468124b6da310d5a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/be/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/be/thunderbird-52.2.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "baa46c3e1d07b284e6cbca0f6c61710d4760f2a33e829056b8fb4e05b63162e4e4c7c8414dd9b3733c6983b74765e2ed2129122feadeb5972f037a1a739eba1e";
+      sha512 = "2809c98f9b64b778c1bced8f91657a9cb8e57963d273ff380740db9be2aa999df5c32eeca7b6e63a4db65854f4e5654cc81f58a35e26eec8038520a9e78f263e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/bg/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/bg/thunderbird-52.2.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "166e64acbb8464142e78222ffb00e5ee421dbfee6789f544439963f4d3476e46795d53050e60195bbce648a3400f24edcef7a8f4cb47d5c3db0441ca564ad6d4";
+      sha512 = "cd6a67c530f7ce0e3da897ed5701ce2b85f5bcb30df8db85af38918e951e7cc75e446f5709d7b02b1f54092cd8cc54c15ec46e5bfe893cd85fccdb0851a4579c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/bn-BD/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/bn-BD/thunderbird-52.2.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "817202f39eb6b0f79d07da92b7ad62c6dda9e8d196021828303030ac5eff97d5574ba99ae8a2d236cddf2eaa6cda4c85a17f23a6f84461654e8f0856156dc6bb";
+      sha512 = "f117b3f56a79b5fd4a947a83ae6a3d28f0bd83f5ecb65cde674c12191517f51956535e1872547b985a35a9c0c398abc610a3f2fc2d7c9893bf7299222e5fbad7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/br/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/br/thunderbird-52.2.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "46eab89538b48e02237950207ce8e3d955ba87c7ffa7a030812bafa4bb54da5113a3ff53bfa1e1b243a77c1dcf32b5aa475382e824538536a759da0448cca305";
+      sha512 = "72af56a4376a28ec2f3c091614b2d5907b12c2e66f2d3dda27b46ceb8b199a32d495454a2ea167180e44b1f9ef7aba89aea47bfed0976892d5d9af7102d5f5df";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/ca/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/ca/thunderbird-52.2.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "7bcb35886fd0344c18f29d5221d765a91da48db3c32f7be4c4ca0e9808dee2f6577bfafff32e8b9676a00e488f7617c66dc6e2cce5238569c24fc1679ac6c1d8";
+      sha512 = "85da428c53f3a2467f5be661c4f40e0f9434609fd6509e01e3c28dec522f5342d225a4f19c30a59187e42540905f156897b1f0e0ab76b2419d263923be844b3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/cs/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/cs/thunderbird-52.2.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "8bda94fbe1043168894fb70edc3d87b670830377faee7397c26805bf8c2dd23bbbb5c4b1d797468875fb653fa02b8bc211aa3766793d3f9b21a139265651692b";
+      sha512 = "f1fc63e25fd30b1f379689fbc9d7f24e94f061b39d3b0494226f25702dd6bd610dc031e2105957e2abefab1d7f8e90e81f4381f6d69cb43b815d8b80b9588715";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/cy/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/cy/thunderbird-52.2.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "65818715e994ab314ef4ac8a7d3e7c61e8918cd1d0d0ea4f51461f50d207d1c998c6452740c6f3fc07d70ebc1d24e5bebef622787d8e6f79f57ace1fc85e1e16";
+      sha512 = "b15b4c2766ef32b5e8023e8002f05fa82fd1e71784d5b5f2d63c62c4b20076c46d470a253f8e0a59f1bb1425a2d297b403c32117e43ce2e4851795511604cfb2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/da/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/da/thunderbird-52.2.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "1b7166d185ff6fc8cbe826d11e7b96ccc4528ce6421a7ad73f82d9c9c0f35a8de043b30fdec1e6ea3cc6d48645f42173b941cd6f8cc6d526264d4301c2943ade";
+      sha512 = "98750936e15b469d489e31eb65935d9013a0f4250543267f03b5eb9615587f8fe592b84bddf51176ecfe0864bc5c35ad5408e42861d45ed3af61f43764f5f9b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/de/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/de/thunderbird-52.2.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "af6005f229a4cbc84c4f99ea1b13413d5a40ab506163786cacf513460170f77b3cb866a4b76b0691facc43cdccc39de68e9010550220f9d6cf288aac53909a40";
+      sha512 = "7653e5e9e02aba7cacaaeb82e7106dfd7e49e4611eb3fb347c8192fcab3749ed98b2a2342788fe8f0e23c932ae5f9ae71266464d3d6b83629231f83ef8efa7c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/dsb/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/dsb/thunderbird-52.2.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "c326aa0c775e414fbfab466be742b804dbb364f60b084b4890c783f6c9e7bbe5da05b09b1608d51535ec3b60eaad5f775eb36834dd69d66f18a4746b7fe55c68";
+      sha512 = "abf52e2f55f9582a5a1f5243a35e3fc2196beddb128a690479d6e82ac5f3cb7967640418f02fcc57c5525debce716345da23e4105e551ab0682dc5df5b6b3cc1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/el/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/el/thunderbird-52.2.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "b18fe1345c27095b2ea0afdec088b56d2cfccd57e285e881f1bbae4bd6eed6e39e76d24ada963d2337729eb93775d948195139815f694cb45978978a33682e08";
+      sha512 = "e86bfe27cddf7b1deb2fe499df2c37488863e5af24614986ced8f9063eb8494f64e637691fe3f69f6b448a50a655725f866313cf0a881425ba5cb669c9fb9940";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/en-GB/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/en-GB/thunderbird-52.2.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "622c2c3979b30f724be73b5c6bc54f944f24a797cb1c3cafd11c2a08381e692621b29eadf64438b8207dd9254bddfa8b524211f7802e83453c1eeec99ab27108";
+      sha512 = "57970ed60a24e6c02383b99ff4886ea9d90f49fe466f8175b3b9ec16294acd5900191b4a8fd7be08f5d987eebe547a9fd5004e516d13da8bfd702b82baeb7b8b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/en-US/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/en-US/thunderbird-52.2.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "76505876b7a408cc296ee575dea6f89db9cafd31f58e961bd0c1c5cf021771cdaa8bb4dfa508a4bde386846f97be6eccbd499725dab8e5a692bfd48125f1bf82";
+      sha512 = "787b0c18e5cf7115ee7f317d0949f7c8d35be15f3f0c6a07b75372c07992601194a860568879164b2c5a49c276b1b48c4a723b68be46b8cd4d3bdb4144db2606";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/es-AR/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/es-AR/thunderbird-52.2.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "38f32cb430c679c63b8c6ab7d22bf5cb2af85bfa17fcbedc94d9fafa27874b917c7f34d7ddaa6a4dfa5d1674c09b3901cc19de5e217a965890eac5ef9246b22f";
+      sha512 = "65e6d0726d733b9f4929a946bc9890e5eff5ad9e22d50bbaad40d2dc259028643e666b619eef25ba7d906f5a05d0e9ea456ab0d298cab5ecccc9a4a494a6f4bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/es-ES/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/es-ES/thunderbird-52.2.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "049e9445a850da0df09a0675cc9524d1bcb6ac4dc0ba8178df07ae4fcb9b4d9ff4677229968573119c5ca2c61a6f35da96167ece9d2da97e6b4e541bd9fc04b1";
+      sha512 = "7266fe0dfcdc7f119e521873ea0ddc3106c6ca3d147a9cc8f9a88d563a6647d97f4c46d26547a24afaa6b10d115a3d4effc58fe2621c62395c7fc99f9587e2d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/et/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/et/thunderbird-52.2.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "e2bb4aaa7e6a447f63456adbc35feb56e5e6ceac791ae54a2f34eb283cf3a61565c06cc09f66fcf01d722b8ed0972e51da33a94dfd333108fee2e967346eb9cd";
+      sha512 = "048cd4d824ddc0b075bcc6d9e7a8a3905031c3333ab8bc55893278435316fd310d6002b9fa1d7b270f8b94f3bf79679e96571b083305d687c36106b903389066";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/eu/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/eu/thunderbird-52.2.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "eacfbee76dc62b15e9a807db9409d63b2991f976faa109ef5991b2a6befadfeed8c341a448c0af84d1fc8f6914e4d515860294f2e54bb97f4ce2727c4d73a030";
+      sha512 = "09b4d12b0a09de492082dc315173baccf603b387d391317a350fa67c04339b0d720a6c682e4d1c7fc7ea54e04569b004b6697d9e27a14c4f5095449f2f4e4471";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/fi/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/fi/thunderbird-52.2.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "c6ba259c3729535199905773674800f2772bf952a8596e11eb73785a9176072434ae47abb40c35e8cb0f66b4c46162d48ae699985857ad9a208c645cf76f0189";
+      sha512 = "21f1069f46a8dd2dc54326bfa32d0722dd5d139f3ac10702a3cfba7d5ba462362c126ac2656ddae8c2071b20e7f96ce8fddd8049b4df9d66438e7f32f53f9316";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/fr/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/fr/thunderbird-52.2.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "eacdc3ce1967ef7913012c448c4a4898463c80fac41fb5bf16d924eb31ea2e68e7ad46ee88b5ce107e85a18789a19e05006ae4786a5d9e9a2f93c05013aa9f4a";
+      sha512 = "ae30bd2a9eccb925ed4cf6acda17363e9cbbca0b185b9477a9b5611b613e332647907bc4653f6d677677dfca9347026d02f0aec3a42f29ed532a4b71b2c207ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/fy-NL/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/fy-NL/thunderbird-52.2.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "450011ce8012918dc8196b68a32f4b2ab27dd893a15ebd621fa17923ba5a63bff6fb634e1cc22cca3fa64d61dcc23565ceda518e04e7f92d91a0bc86fcd0dda7";
+      sha512 = "7d35d3a78f9ab79fa8528260160d8b5fa1ee0198b53b94fdeb86e400f95320aa0d695bf1b4e1c73733ba09d6bc78d8d39f1825744e49cef1a22873f35d8a30fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/ga-IE/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/ga-IE/thunderbird-52.2.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "ba8271e67b61e92bb819b0739351cfbfb128ecd3842f1c7ad69f7e9c26f4d52c10cf71f5d8cb45dc1f30d3168dc0acb991be4ef208e6947c3c36f4e5c0071f69";
+      sha512 = "9886d5b9654e7cfaedd5dd60c59a6888929bc2001d4c43a2cf40f92a098ca725cfee8fc819af13c5ea2c9eeeeb3d6103289124b8fd05a234eba04f4570b5986c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/gd/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/gd/thunderbird-52.2.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "324044728236a52fe136c62f250218d6d2e364bda7b9f781a5f1c05561e37e09c9180733be0dd69f170e2229924c9ff7f2db10def13b86a7d21d5801d171a3b0";
+      sha512 = "18f62933d213197ae618226aea192e30875f76568fc0a17343b49152526a32c10ad79ed4d6eb36feda0c8e287d915a99bdbff70ca942b4a313ea81ca04b257c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/gl/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/gl/thunderbird-52.2.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "a31f01bf15d17d8efc645ebe4184bf4b5f02107f24765721eee87dc10463c7e8219a1ba3d60468e132f6b934f6f138b441f94d3d3e790f2fbad45107210f69d9";
+      sha512 = "c6e447722e284beba304b42d643a16b835f525d053714577425660087b03aebdcb93c57071a2e9f143ec5393616f7a0cde9a52f5bdaf42c9df1aed8b509de415";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/he/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/he/thunderbird-52.2.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "c8356bc183eb9837c3049288d63e1c13098143cf7a80cc5452d9852ffd2407eb85aa5ed574063700f93fb503c53c2b733a1bebc62cb890d408af75f8e4970856";
+      sha512 = "7445dc1299038b412a39baf594c11444875d29332afd1c36a8ec603893c3f34d442566c2c18cfcee60c5b84e1bd1bf53675d1a32530dee7fc801554605d7fe4b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/hr/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/hr/thunderbird-52.2.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "8ed3f1c84f28a4435a3a6c9b136d4c27f6fdd3a41089b34afa04b74d5ca15cd535e179070cfdc862d3b3f5559fbafa7ae6c620f448afc8279765aa6518cdbd9c";
+      sha512 = "9812c41f77cc76a6de78ca009989623071a3b95f992658f584bfc58b5be65a3db48d9135025f578f8877bc2f9426182f3f2dff39f50f1018ffb7b6ff272affc3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/hsb/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/hsb/thunderbird-52.2.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "bd14c07d1c2f5b8aebbee64914db544823ab90b70cc2a4e5d9fda28e9611310a5d6a6fb0f17d07e60534e9d5082506f0ffe22b1b4da1351f5657620612add6b5";
+      sha512 = "af4fb4ca49ac982e28fb5b77d1ec7ec5be69cb097138bb7de865d8a0167b8ce13074d2b2ca80e11dbd68c7fec8533163b9285ed4495545da833f726dac484e7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/hu/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/hu/thunderbird-52.2.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "9cb1430ef3036f4ce06d0734775e83ec09c551ce573cf3b50b5a2484f411e76ca09ae0295d6285d15e1f8a71f27c804f9dc328a4e4b534fbad34a97676ec2d7e";
+      sha512 = "f1026a8fb44424b95e29051ab778313c417b6119fb9959d3116d6fcace96f1786f26b419eedd7f83790c13c89aba2c339c52ca5b5cfa2d62572518cebd12db9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/hy-AM/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/hy-AM/thunderbird-52.2.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "0c1d84777286fb55c2d8d25d5f5abf5498575bd09261331cca680e1f18497dab80597e5a132618019c5d03350cc4d49f4856053b8d255f8a1d56d1029434b776";
+      sha512 = "fa18a6113852d231dfcecdf682c6c1fd18f2ec5176fd9fd694a3134deb511ebaf01e00c0a336dac4a79918606136232d62f2b443ba60d25e40c573f696fca7ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/id/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/id/thunderbird-52.2.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "8adfabb7885b2442c9dd8ee1128675865690bc632185da20caa894b38c388cfff34a696c4932ffaab2217dd4c742e8c35acb2e10bee39a561aa83b19cce1ad6d";
+      sha512 = "313e713ae5d1b4bc48789c2c33850b5177d8f497d9965606ad2530f26075cded2943351da7c13057aaeab72a60d4dca193b2fc8c4b8cc97734132b721d4df8fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/is/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/is/thunderbird-52.2.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "b5608a993d5a2a50a38516ba346cef8aa5f173f81eda2b29c06b77e8cc8964dc174fbd9a67294a66caa366956a0ae79aaf8c0e0d612935e871174b1073647f70";
+      sha512 = "6f0f8444d230cbdb5dcc81530cd05fe08ea9e2482ea7560157ece9ef938d12b7cf86a259bcc72e132717ac143a6f3e203c869f1c37715bb87fd7b248366c7554";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/it/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/it/thunderbird-52.2.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "06bb846f018d1f8cc1bbda5e707b9aff31bf94ddd8a7aaa699c67f1c18ea8a4c92657587ae6c9a07571d2a6371d50e31b1000bec719aa432404924938a162274";
+      sha512 = "f0633c2a46c66b4db18b2e70fffd9459d1c6732e872afaf8a1ef7fcac20114a09d32ec666305963acefa6caf6ec9b902d3f9d2143f68951674c12af462cb3673";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/ja/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/ja/thunderbird-52.2.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "9019ec44f39918796c5da7fb2b23e19918e20d5688b8e55aa986e2b8a4f2abaf6ae87149b1bbbdedd2227c3152f48e4042078c979930db5d521d3a641312599e";
+      sha512 = "5893bd100cc44aefe160a8ecfc5e9e5b581e1b9c59a1aab02ea9c63f8c062d8dc0f0c069a4a8adf4b11e5be614b3390d195df91ba3c2f3845f13ae7734e7295e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/kab/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/kab/thunderbird-52.2.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "1ed0950fd1b5cf82efe2c031abbb8d34ab3a0ef93182467592a9f77610bf494ed61a2e1d0117132abd5bd0f835bdcad75bf202588097210acdfbd67a1be5caf0";
+      sha512 = "3777a5caf8208f429db9e828b6812dd16c549511e539375ff2ecb74ddeea8b8823f93194c73fc8e708ab17f8fe37c72af6ca36b5ed0ecaa2994620be7ab21de9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/ko/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/ko/thunderbird-52.2.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "65ae48fbc79da6e3e20f5d325d4c93b2e945a95eaffe572c83cee08cefbe6718bd202c7e54095ef74d3069148b58aea1d2b0b795e94230b4da99b9a42fb39155";
+      sha512 = "6a3e800d909db23c7abcc10a9e07feb5df47c57c072544ba84246c84ad364c8027e6b383a65867d9d0f1523682c45a929fb1c628999b18df2c959e32d374a15a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/lt/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/lt/thunderbird-52.2.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "f8870ee532dd73a0a387c00a1295209ebb965b3e7a63abcce7f17457c38636a07334ff7f4dd99c60349e748510645487ab3761efdbde985d1f3cd9038613cd05";
+      sha512 = "486691138c9548343e6841ab1e84d2e795f280fbcfbef06769c7ad816e2dec79381a1d7bc0a4bdf0d5723d48f62ffa1acb7170ff6f1f1a5364ba6872a7b34fbc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/nb-NO/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/nb-NO/thunderbird-52.2.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "d4316434d0e8a824b3502bd413abe112bdb9b6da28acb39127ca83b43f8fa3f7b80bdde15758f2ca5a5013abcb374382ce79dd16ea48342fb6f6283eb242e162";
+      sha512 = "0f3745ef22be9cb7fab9d5540a1ba9433e4450511398442debce3909577ca97e1ad5ec3a41c834b31ff60852a8479321dba44559fa2262afeadc16947f69eca9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/nl/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/nl/thunderbird-52.2.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "da6c7cf68f5502ea29a1600f2040953dcd064859a9b82856ae419472ae039bff5c2b31f56c282961eb02ae0c86c8ce63131fdc4aaaa712da03d76ee05726ba0c";
+      sha512 = "6ad18ac7eb19eee591b64d6118de057ec49736e93f60b18ad979536a722a2d5df4b55a8b3d69a335eb0ef96451d2516c0a160a9218fd2ccd92c290752fca61fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/nn-NO/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/nn-NO/thunderbird-52.2.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "9a5203e6f451aab318500eea9b7fcbdf70fcd22d6cf42e838926fa9fae14176f1abee875ac085823adeb40d2fd2e2992d538c34ad817b408fdae19248302aa88";
+      sha512 = "879e402e2dade3acaf1354b8566d1abc11994b749c90f5c1169b1fdff5ea5dd19ae31fbfd1628adaa02c93f2346c02cc69a8625de8302e9965724d8f79c5d384";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/pa-IN/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/pa-IN/thunderbird-52.2.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "43e86e758f547363bfd5bb1c9c16506bbf6314354aee4265fed588fc29759d87482a86c442ba9d3e16c50477c4a5542b02a1539de8833052ee23811d61bcdba8";
+      sha512 = "f23942c425238016e1a13b84e6407badac50efa6f11960c9996e4bf7845d3a56537721bb4b6e1c1002870739534f2dd7ce6fb74781bb8e9986e744f36b704c8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/pl/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/pl/thunderbird-52.2.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "d418735505f1152a3cf1a1c2ff36d4cba4801327b1f01e3743c6411d30b7fdad7f0ae72fa78de9b356bfb712bc834c6eef46df9c251be7d18119f5da423f3ca1";
+      sha512 = "0ce3854480f0d9969e6c836e92ba7aecca8f662aec5c7784d8e0e9986239cd8e721baf0aae1142f43dcdc54d66708fe7b7d8f1d32c3410c69306e57e1d663159";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/pt-BR/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/pt-BR/thunderbird-52.2.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "3e33431860b0f815153845ebde36de52d8bd0c2e1828e127009b467c33710c70d38c4b9f70c5572e09778b17c30f7688f1e802e48ce7cb0a6a015d0fa1e26648";
+      sha512 = "13d2b36dcbc85016066b4fecd61b695eabdcfdf729996eb37ee3aabac3b6b06fb619db915fbca6d59e4827b9e724e9ce0f8308e033c5469ac906d8766bf7021c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/pt-PT/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/pt-PT/thunderbird-52.2.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "953143e100d3ffcb76224da98ee5ae1d98342d2806565ab048fbb6d8de65f6a02c3b6dd87aec4cecff676ff724d4790964b2e82ebbc64a3eae8beb343ebab211";
+      sha512 = "9bce5873c1266fece8d14df41d44dfed545eaa7a9435336650cf102f765a99978d117c787d1ea0f0987407139bfd07765728c6fb188699e8e70dea557e4b4f12";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/rm/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/rm/thunderbird-52.2.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "b5aa940b99282bd84748e47d8f51a53e250d20cf0c7b68e5f66719ae88d9c241f290b2d637fe3e711948f9a6c6df8304cf9514599d73e387eb268a1c8f8c8397";
+      sha512 = "d15bcd925d9be3d0a27478c62d178c99ed1ee474799dfb1a63b505cff3560f1d4a287a5067d6ed4b67cd05c6e8a7398a09468269f262fc001b934e5e6cef1bc7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/ro/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/ro/thunderbird-52.2.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "26dc1b0c57b468ba815154b035c3fe382051b638bdc673db69a88c879a8524f55a24626c655026cb67c2688a29b6c946e2b495cd7dec4f16d8fbba21d5a493bb";
+      sha512 = "7ef381e722553644d8f3842be5c0fcd1c2f08b4128a53380a6aeb54f4d7d8dba5f73ccecc60d5212429ccac96045eb9dffd77b39b42b637020ea0142daf98097";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/ru/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/ru/thunderbird-52.2.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "5d17e85ec3eeac8ea3916f0dc71be7560bb1c4877c505a1f29421a9d496d8aafe48b9236c225f1de48a4dffbc9ed536f91dffed7d6c823480ef1e0c5b6e400be";
+      sha512 = "1f71926edd82ba36e98045e8135b4c60fcc59ab0b0a097385231a5dcc40a2d7628d6f3f3691981056f013d01a4a3b1765a58d3cab683ecd55fcfdbf1b974d138";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/si/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/si/thunderbird-52.2.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "d4599a3814173d8bce2f24b6b015492d7b24547d4e53d17cad45cc9c01c8b65be3447f8b89ab8ef2f573140ef7e1aae7eef7943102e21611525abc6efcd02694";
+      sha512 = "453b2d6898cfe04580f2846da0d534eedb77aa9627a39d7e7b6af1287c9e2feb695bf3d1e5b51b9d15f293579df2ebb1d2f9afb6cfdc3071ad24618e43ae925c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/sk/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/sk/thunderbird-52.2.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "a990104e68df9c2bf833c821eefdc1cbefc16f6e782bb8202683261f395f33c419afb967119ced710dc08966978043731c1adcf16dc716ff6eac8275b03f1834";
+      sha512 = "c604c83470157e881f3563c04e3e5ad368fb2d0d1cc3fb58b176cfd03953141fe037baa14120f857e238071f55ab1a3d2c1ca06c847eaabf8012b96de1409c8c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/sl/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/sl/thunderbird-52.2.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "2fab7f52ceebee1895e520c6d185bbb92793a31c52ed2398731c0cf36e3888a58d945d92f5777fc87a0a55b96418406a0be15cdd95b0f54482e821ea1cf29ced";
+      sha512 = "da7a37a7fe21a338ed2ebbe13e46a2395cebde8036a5544e8678083cddf092fd47ee80ad7e7fef66dcae59567cecb1bd15b99d470d4ee083d328e5c2932ad518";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/sq/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/sq/thunderbird-52.2.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "f201861a30f993306378043ecab288970c4a311a91a3d232cdfe9a4d9339052f026ceb35bc6dbc2bb452f58faa5e3eccd273b87e96af5cfcf292dfcf94612077";
+      sha512 = "1b1e592b2eeab57e843eb4fd6745886946dbba451b5bc78e2212400a4e10fffaa5159034e8ea5d32a0f3dab7527e91b642209a7233140e0fd9c1c44363da9fef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/sr/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/sr/thunderbird-52.2.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "6f8962d8c30086434764f0d037801bfefeef13c67e46f2b639bc4f5a93ac0094630af375bffcc54574d50ecd8c7b5c5decdd9e2083666dc4394e6237fac0b746";
+      sha512 = "836d1b2c786e787e07be4df837efb2051f8fb5a964facc94e82cbc05aca77ae54e1553e285a868f4703b48e72e2a0b739ae5e92e7b3da55e4ffc70567e1ce992";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/sv-SE/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/sv-SE/thunderbird-52.2.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "b29f506138f62350717ba2d2881cf8852dbef0c9797da64b9d5d9affa884cd1057483e2d0e357e967d9567ff4e861d1ad79596b39aa02a36087041e1f94d9d67";
+      sha512 = "ddb52211226353c021350dd94014061a42ce1ee06d2b4e8c612bcfb5e17525bf41ead152f91c466e69ae3041136fb7350ec58de21ed2726cab2d6695dacac332";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/ta-LK/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/ta-LK/thunderbird-52.2.1.tar.bz2";
       locale = "ta-LK";
       arch = "linux-x86_64";
-      sha512 = "3bc50fdc95776aeca2de94fa1b895d5a17cedafb95aa08f2d0100fbb4c3acd31990b96a57fad451c82b56d8cab7ea5066642da7b000857f00ba8f0bf94051f5a";
+      sha512 = "c8c79641c7d80391d5007155b4ec3bb0ff36c2ae3e1dfb908013274ce6c64e03563a68a2ed4fbfed8e4684c4c49e7f9710050aab6851cbff2e77609ce6e25f34";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/tr/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/tr/thunderbird-52.2.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "8e1481a03ba5de00bc64aa252f779dc0ceb14c238985d11bb49467a719ca88bc4e7946086b039951f03ed43e11a15a5bbe98139d158f63dc3cdbf01686ec91e2";
+      sha512 = "3c6740c9512b0d2d7f809312ba9f375be8635dc41a477e5084007cdffec9fae3c3677faf96745b61a384a4b899f48c5e9c239f52549faea00e198539181f8ba8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/uk/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/uk/thunderbird-52.2.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "e9bfce635b1d56d646baf06bc642a7914846a6a796e983c4b0f78b912833ccee850719f0857ceb7199d328415a976b436706d72c95f01da1d0d0b4c0c5d0d732";
+      sha512 = "0950bfca73dd4907e493e9b15667f70be1f1174ca755baeefbd2ed40160bec3f41e1c67207454e31afed919bc72314e671ed47492509c9b2c0c207bfe3e22088";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/vi/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/vi/thunderbird-52.2.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "ea989bcf275162c8d72ad595bee767b9652f192ac18f61119cae8f084f9a25c0d0a83caa14cbbf901fa675f1a0c0a6b40ef46454f9c8f1fc3d5173a0ef1397be";
+      sha512 = "0107c16694feaffb18160e4eac666ec840b7efda706ddd04596cd4f54feaad07a95e9168eb8eb78cf800b4c60f3f4d229d6d217e3d3c681d2a2b0182ff65251b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/zh-CN/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/zh-CN/thunderbird-52.2.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "35637dedad6da1662057fc1506b2e21bc6269eb0256e332ff6b12bcdb71906e28dc0f361bd7aded2fa52d982589f0e319667acb7ccd405e2fbfa8ba991e5aeb2";
+      sha512 = "879cd62661967b85919fddc90658d40a3119715eb2cfa95edfa60e7ef3dbc3eb23c2d317a9c632d1c2055900f03e8437af635d72efbf14d7b9fee7f87ed5b19e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-x86_64/zh-TW/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-x86_64/zh-TW/thunderbird-52.2.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "286ed00a024029f7e6ce30709cac3da3d6bf00576248622a09bd9ce1ae2e965a0fe158d718d35f1e088f51ac4e271d57aaa98446c87c0bdcdecfa0d36d988e92";
+      sha512 = "2c26ff8ed886aa5abf82511bb61fe96fc5817b211dcbfaf91deabb992b1cc968baccafcf1787b6f11b26052e18ff7f0da1d86de7ce45579bf2f6f403b11e9613";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/ar/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/ar/thunderbird-52.2.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "8783d0cfba31ead11e49bf1a8afb5b66b1387b29681acf3c63217ba4a399a6fe496eb0357e0871c98e8b6465abc6539e6ccbd9d40e799e04674f3ab2dee25390";
+      sha512 = "5d0971ab1c51c50a9f44967a13ea7c8cd7828f14625c5d5fc02ef001adbf69f7895ec6aa691a05c7a5ce5b038854d4dcfda0204c50533b028c2458adf5a6de97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/ast/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/ast/thunderbird-52.2.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "213f0457760072fd2e6cd2daa56677d8b67b8c345f44faebb2623f073ecf141ba4d30d2176fd5680efe91e46086b4add86462385fe5b9e72978cf2828eb8ed68";
+      sha512 = "26e55787bc6e7a9fa8e3a40d0cee9912201026ec04454cbb117dbbad97d448dab1de9aba0c84e8cb10dda5cf818fd0c98116590b9e62849b5b714e63029d0fd7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/be/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/be/thunderbird-52.2.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "645d7eceac4d98ab37b8c85c2d0c58499bdba1c8db495690bc665c80b5aae414b0a8caad16931a74768137812f3ba8ce173f5080e95bd44e95e51d6f544cbf03";
+      sha512 = "432295c9cbcbd59ea6bfca3d3509f9ba3ea07bc4004cd96bdfaff468210f30f9401e372c1f19c6504895e35db907d35c282d39666eb1c99e5362f46fe6dd9ecd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/bg/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/bg/thunderbird-52.2.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "b9030a61e8d964dd18362e472d18d7a9d6a7636679c016bca82b254b06e221c6551aebb166f829977fb4f0d1809b18b820cb1d842e6949f44dd4e5becbf98651";
+      sha512 = "137f4baad093df14da263ec707aaa64edfe0972b36e6441b864722a1577cc1683d4205649f79fac9262c5a53f7adcf045991bbdd3168cde74365ca2938bc8df5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/bn-BD/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/bn-BD/thunderbird-52.2.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "fcf50581bb2f1548f4aab01b8f7a89e351e642a49ca76e05fc47d77b9e2459f2ff700501079180b92120727ab2ba74c3c6990fc7d6d9018b9ee4ec1d27c42aaf";
+      sha512 = "fc33faeec367b1161c969b82c0ec703fd4f443908284b0cae309f44942473cf6042723de8895442ca21da40d404f24a8c1a490313352b95cb949e568db56b953";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/br/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/br/thunderbird-52.2.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "5359fa3b6f745db0da286a0180773d3fd43c446c78d8351cc0c5589ade332fec5ccb6106a84ed3bc96e34ec7ca2d72f93c22f6653aa39250df05b0e39108fa89";
+      sha512 = "69c71b3af91d6bd5c63198937f43d5ac4c29c1c075b9faa64a94362cc544d5abd9182b339936a88da87bb69ec3201c6b54185c67d0dff1defede541a48d721a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/ca/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/ca/thunderbird-52.2.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "e5d6d77ad204d279abcd34b9734ef5489d5b8522558af7cfb26de77fc0d22a5ce669dd6ff9fce7046745aa9ef75323fadaa70ad3ca4fa0f05aad85add6c1e7fd";
+      sha512 = "b3b33c69e411cb4e920a72cb9a4eaf41469c709e0b04199e53094856121ed7fefe84d3987045442317dfed27069686692e9e0ea00562856a15c916c74c4f8e90";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/cs/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/cs/thunderbird-52.2.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "4bee0154e7f1658ea88c7cf7cb5d89e354d29516c727090bd704945ecb2c0988551e98de2c8b44d5899e44ae141a6e3c230550392d34b5dac121cd1c4d6ce994";
+      sha512 = "c38deac7a95fe30166f8a22e6e4c76039fa3ec31ddc4ffb4e84f78c549bd76ced476efeb0b4abac0d73b4f5ab54e6f9a7181804450f882c123f41b8c2dfa9f25";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/cy/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/cy/thunderbird-52.2.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "23779727198092d4d8e7ed1d40615b020858999ae5023ebf81553dfdc62b7cc03cf864eae262450d75d6088f6b283ef7f791073901f5fda367df96e291e9537f";
+      sha512 = "0ad5a4e40d03d0f329c479c56ad43a6151e262faa225e6f0280e4e60c7a13dd2ea949695f84514034031b796a8cf190fdab519cd58d998a254ad9238c337057e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/da/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/da/thunderbird-52.2.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "e780597823f156e273832ff731adb2cb39a58e6e232d910f9f0a3b05dee68411ee3e8345462137d74a8aa2a6dd0c3d5e93bb889bd425c051ed7befcd4da5c711";
+      sha512 = "e681d601bbeebad6c2abbd7784041b700bf0d2abcd490fa41165b608334e3a98ab2a8bd2291935622788c506c475de89ab5a868be734225219c499ad147d02be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/de/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/de/thunderbird-52.2.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "1c35b4aab4bb27569955f3c29034e8c301c32d24547075c4662e162bfe1c19feb602b3fcc3c561956651328fa33605f60ed29ae52b50b06eecf39e43e82663e6";
+      sha512 = "f6388f6992e1057906e5343adcef5d3cc08c983d3319b2880190d7ad3a42266c1635f5a04914f44edea6487dbba64ec8a916383938d6c1c064eb06ead06da39d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/dsb/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/dsb/thunderbird-52.2.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "59fb994bd8b2db74ae5024e8c2f6c859b93afd247a159c552bffe8c2337a0d4229bd17433635f8c87420af614c7725af7b0ecd144938654f9372fe6d39a4152c";
+      sha512 = "661f1eef600803d2c76f623be25a0b3143dceda01e146c12075b8aab32112922bdfbdafcb0d1f9be88ec1414f8447a7804494d1b5e6ab91873eb5ab00039e29b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/el/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/el/thunderbird-52.2.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "87e43e3c66db44c6c1d659eff81b72bae4d6961045c37ce776531ab6e4f4a3e6c8d3774f39fd437e5ca4cc289bbae25fae8dbf8ed3e21aa2327cc166d4f17f47";
+      sha512 = "7c6cfdd5c97c7a721ccd02ecc6d000d759aafd9c1a05dd77da09ff077f2a284a5349a5c14371af35a5a9ab4829e4fb93d93042d75fd9eeefb95e2fc368dc458f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/en-GB/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/en-GB/thunderbird-52.2.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "b397fb3142c0693282405d9e6d4515f368b3c6aba581e6eb0712c3d161f8fc9dbe034a913a67ea034dd89860b32072f82dbf2b767bd0c360f3bc9c0c8944d045";
+      sha512 = "a76afaab47e279ebf5ebacf510a1ad39cebc7f1abfda826bb9b5a6af9d4de9a02066f040affe33238aba40e875402a35aa819ab1f4895ebafe370bb3d32e7d74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/en-US/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/en-US/thunderbird-52.2.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "05926a74f6ecef5caa43884a3fa2cdf85f40c53da58ffa24cdd2c8c31efd1b3e90a0d06ddba33d612a3b88f31d4c72fe92f49e31b4f3ba3479c510a02d91eb33";
+      sha512 = "09e72c7a26e52973bf63e18e8c85f49c0aed00a7b4ea238bcb82c55964a019965cc24f5e71d3a7ab6f5d8f288a64609ce15bb584a2fddc08aea03ff5e6d071b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/es-AR/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/es-AR/thunderbird-52.2.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "4652c005c0c28760d1a2657b691b13fcf7882763cff4ff05313d1dc5786661e76ca74a4fa23e1e71e4315818c9c2a386407151a996fab4d2f3bf343a353038db";
+      sha512 = "412cf566707a02d62cc8a60d65a1974c608eaaf4ed666830facf137f7611a0346319a2cb560ae04742bffe776299facb7ea214e637248774bf406d5e7aab08ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/es-ES/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/es-ES/thunderbird-52.2.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "64e8eedb59df8ebc5a568aa05d0df5217a3c91311455a090b4614dddbb2bd0d09add02e11c712b84696f3d203bb5503959dee9ec8e0aee7ba5d0ef2e606942a4";
+      sha512 = "a56988ffdae668c2321f999b0cebf8008bbddbfc3469f053135d848d4cbfaccfac75ae2db325b6a080eacdb8ede5dc91e8c2fa2be255b2e72c3a47c761e63f02";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/et/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/et/thunderbird-52.2.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "2773894ea50cb0bc889ad1cd887bd7c34d594a19ae69fe48cc181d5bb31a9a15bf6e0e41fa1493ff86e481715e888d35db5b100b22516b187cbbb4e35f36fdbb";
+      sha512 = "0df3306cebff726d26cd3b46e8ef14ccbe730ff2002b80c463185c6fa1b491eec1c3262dc792db8fd96da2b4394e00ed8abe21700f85cf2f969dc8bc9b548421";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/eu/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/eu/thunderbird-52.2.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "8a73144e9085f4f07db7d24da388808ebe94b4cbd2c3cb1f327ed0c44a3144c94fd61171b74c18c3e4ee72fd809791a8c942adc0a4b3bcaebaa2f02dbf26d572";
+      sha512 = "ddf6542c17196aa7877409a4e37948eb351ea4fa7e10dfae21e4b8c21aa92b8bb3065c504b526784efcaa41c621889bc5ecebe4cf95ff56b0f2788d3b5cb7190";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/fi/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/fi/thunderbird-52.2.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "ba53c735c136901bbcfebff6fa646d884aaeb919a77744c1ec412a109f39853b2d74d70a56f85e4bdc3b7780475283284c46b0db79c64980a7655eb8f0bbe0f6";
+      sha512 = "e86c14d4416939cd04d2a23849afc3cb991c352b9bdc3ecbc8f83aaa14360b30c706aa74ffbfef2bd369f62610c057232ec9e621871010d187965c177ed06e85";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/fr/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/fr/thunderbird-52.2.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "fe93f41bbf357eb1b60c0418dd64afbb37310ec25aeb66521472f84eebc6205d87d19090df6f38de3d9fee29f7f961e68e9794a65f51a0fcd103a40a16a919fa";
+      sha512 = "b0fdd4da60b3278e4639a17e896d1c817ab80a44207edf21845614a8c32c70bc2094184e8d90e1b831a3516dd5b18088f21a35b09e9e8c52d72ee41764bb45d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/fy-NL/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/fy-NL/thunderbird-52.2.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "1739f96789414049ebb5a8fa47f0455a630bdfbc9757fd96f81a8fe0fbf6c0b522bdf04a315b590c968d1832ee2faa2bdd98fa4ef6e86cd8ab2d0a338e8a47f2";
+      sha512 = "b314386f0cf27ee7f46f703c50eec9bbd879e0bc6c304c07f75f2b1455bb29c067c9c3c3d168fe3986f3018c406cf10815edde01a74764aa6d3f48a3999ff409";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/ga-IE/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/ga-IE/thunderbird-52.2.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "b42fb3d2cb8ba5be74d3f4212aa80fbf2af0366bdd9eceba69555eb766f0a96c1a8092a3b1e39c0ddc8bae7cc7efb59f56806f90c0de95d3073db15e3d894a20";
+      sha512 = "0dafbe71c9f8da9bb6b2c2ea29498a9e6f120e59d6f352d96c89a2e3c5ea1b2b072e91943490320ba52e070fe5b2a39332945edf34c729b672a83a2afe16a86c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/gd/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/gd/thunderbird-52.2.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "0921d25bd235d2a234c75f24297ef38568d0532fbe1dbfe98f2b9ca3641ea95db6c4df0dba3f8a8313a2fd169d2d86f7adab21db795a96f68fa566117db2c2e9";
+      sha512 = "50809368c1fdde1181e163c9d77c79191454a68d0ebf4429d52c4e95ebf651adbfb7769b07ba4e3b365312ff12ed2fbb96be60dc3d90c6b8fc6fe35f3ea8c1de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/gl/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/gl/thunderbird-52.2.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "7fe9346fcb26a7d4a96cb6cd2d804874bdf2f3f89c9b9791742f9a2a03a7a865fc20766f8618c04e7d7fbe1fcf0fc907b4db5834770218f4e1fbe8d8df37e94f";
+      sha512 = "f08d5bf61cca0e2fce5894619736a267be1851e8ad66fe2800b7a1dea2d847300bfa434c9dd539eaf966a63ee32a383cdede9029ce71758fb88e3fa6b35670d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/he/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/he/thunderbird-52.2.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "7082a591a52e8a0e7bf112dec08dc3e130791eebee6e7d39baf052f40b8b9fbc350518b7785f3bf7ec62df8dbe05a256fa322714ba7a4f704a9cddf40cd4b11c";
+      sha512 = "0a0a502e8da5945057c30f5a3de0fb623111e48d585cb7707addf0ea608e8683a882c0525e19ef4300f3d827e8d7989f09ff643955b3dc9379fcd6506e1415f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/hr/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/hr/thunderbird-52.2.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "397a1214ab27b187df6129f6f2f863ec1b76ce2af41c0ef5650f255451c57f07741f6a7d0674ad38432c7ea9c95fc2b36606d31defc698fffa4b676549b2c197";
+      sha512 = "954cc5c1f3687945c6a66698ddb45ce74731bdc72f34b9ed874883b732149ad9a50773acfa1f19eec16840be3aeeec7d37ca140158def750c68d7ef6d5a2ffd4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/hsb/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/hsb/thunderbird-52.2.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "f0c76d90ae2b47e8d5c66a536ee1b2572f60164f76424b61b491326e719f4454448a9af4b6ceb8e1055f7e44adb6490a0fc4df086c344d160861d877766e227f";
+      sha512 = "15b7f0ae3741e6578e492b14ba3e43dd60e6d9f3768053cb43cd88d91d40fa247b6035b9746c173d272f752d86da2f5778779b3e3677792b976da68ff460c542";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/hu/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/hu/thunderbird-52.2.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "d26eb645574d9298c75bd334371fc7a4baaa9b358b37c5d8da6e61b6d8fdf3fe165a5ea1855a840a742c6b19e3a15fbe7879e43bb29b187daffa63c59a863e06";
+      sha512 = "32938f7f6a4f2f611a6e057a5eef8a1af67eee710f8de6053d4c9d1ef9b92fef5af29dfcc3c37939811f07dbdf89c529a9481ef4823aacfab7fa753f47144a5b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/hy-AM/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/hy-AM/thunderbird-52.2.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "add66a00fd3a8be7c71276d02588ffafd0ed0a8b2e4875dab3b82e4fe9b2be3964096509ce6b0e67350f62cc814b7c7ed069f481516f72f19a8039967123346a";
+      sha512 = "0cceb38a1b6d679b3a5dfa63a44b90255a271ad0b9808d55408fb18cfa1e034b7010365b32a86cd72a29020fe211f404b7fc640f2b24428c3bc3945b4970ce8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/id/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/id/thunderbird-52.2.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "b793e65e9e9f8d30ad0193f019acf33bfbfb165313a960f120bfabeb4df0c769cc9fc5b7e34ea05eaa085a5c0872134d606862b381852d04748c2e97ed1bf9f7";
+      sha512 = "89b8172a07ae809b153ea6c48dca1bf0ae7fcbc7dea6e13b78bce99f2e84d6bb3d23e3d7955344e71c918b1c26729b920429c1efdb6a4bd5db1bb24001220ccd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/is/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/is/thunderbird-52.2.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "d4f163358a2c8830e3a77a5a82b8ee42d2aff39f19fb95171a249d1cde5119c66ee29bc894f5e6ea023c34e030282194025b25c04af25f647df8745d2b8aa2b9";
+      sha512 = "54875ec1b89501f52ad3525233ee8f7c9f50b1cf0b3061dc734a0733c0cf72c537f7279729b1c3afcfcdc411f708a519a4585877858c5c040e7455a0c5d30342";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/it/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/it/thunderbird-52.2.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "9e73d51cfac30480fe0ef46c02df12c771fdd827bf4c2971b99cad7b3db42d3d60a2355c20c0b3601c7d27be5b9c2d1748a1e3b8954523ef919d120429153103";
+      sha512 = "4766a810c7c49049ff20e52045100ab4a46a687e37613cb6161e680cdffe6fce708251a830c2b38f9fa5e93d6c31c5afa0856a79a20a9ac972c1624e77da932e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/ja/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/ja/thunderbird-52.2.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "ce3d8342c0fc63a9c6ab10a2d15f6ef79d8d827cbf542cf0eead9d01d1a26567edb48269ba2ed66dcf81bf83e35a120190614f740898181a3b2cd7fcbfd5e739";
+      sha512 = "ef031bb68f1edf02c43887ec3c7d092c43e3b0694b18951997a3e2356675e09cd1f6be12a33945f8ebf877678c86266e61e1d3802ffbb42c7a7d1c3832f25eed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/kab/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/kab/thunderbird-52.2.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "9ef94353b58ade84737debbd58a26aca9b8c5358c3fb852f2dd925e9c8eec46f091d4edeb0a4fe46da45eb9860ab76f43a97605085907fa79d2ba90751ea64e7";
+      sha512 = "6876c464c3e23640a3a03cc977b727fd1fea9925efacf9bb8a14afa575ef88041b85dc30569035fab700663eca1224928584b98b99735fdd6a68d9f00071e75a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/ko/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/ko/thunderbird-52.2.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "651ab9ae9b966e10f420802937140a689a3c925a67732cc3082e8f265d2f98fe88195188632386d64f892338b1c4ba659c7e475951810d5b6ee48a7339155413";
+      sha512 = "0e2f64e9499d0cfc7597fe76214de6d9312804eaafdaef07d95e8ab84927db1d27232c9ac8b9283f24cf04e8bfac8667a253e7e229116e9241005ea433476019";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/lt/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/lt/thunderbird-52.2.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "f64c0869033ac939538f982ff66b0a88cb566e7000838e549d63fa6509afe8a29865fce3cb6c7fea84c78b5ffd07a4f8b11b44b14c234ae957f22439f7a84a99";
+      sha512 = "6e3c400dacb213a767699263a7106e08183d7c8b0fa06976ff5626aeb35be1d839a4383fb7cd61cf2437a1ab33e6315fdac8b921b2f0967bfd991a90ca2fe157";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/nb-NO/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/nb-NO/thunderbird-52.2.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "9dbd31177470ba94a646d7d63890dcc2465681a4c6fc684f7cbe61eeebc788c03a863ed5a01a1baeb26ffa61d7af4631bebd74261c22ee1a109ceaf928ce4925";
+      sha512 = "dce647bac69f3d7d7bee0e3ef622eedc6f7d97adf991a244718f24d8ba2c33a75c470c05e95d66109535a832c65d6cd2c064157e4e9806e44cd0f6f950de6de6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/nl/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/nl/thunderbird-52.2.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "3616bce4895db1c2f3b02773b05586bf6e38550ad7abd5beb3b31a6c5b414120972b5475c080bed782e7f2b09fe47bde3e5b41f4c3fdb7ffd823767c976dca0a";
+      sha512 = "e797cf5d6300b6478435c554ed39d4d1ef5ff9a61cd47557a2db1766912f8da9b1e60599b66e35ca9138d3e04e234b2f443a675d0329639b21f37cd787faea4c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/nn-NO/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/nn-NO/thunderbird-52.2.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "4ec009d5aca053ffbbb6cd5c84572f0305f22f33cd24eec13eb3fd04aa4eccd3447701edb53e4929914ebd2f7acc8e3d7f8e5d91c9e7a7f0b9e9c18493f74d55";
+      sha512 = "f30cf85b92a024a2c7133e97203c60ed18d2ddba2ddf081779962ea1af2be893cd820638b08dbbb09304ff1412df94a4dd5f6e9e05b49527a5d6d15011a4f024";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/pa-IN/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/pa-IN/thunderbird-52.2.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "584c5cf7fc62f4f6435d9ed2ba9aa200012aa65e7fcd249aae10dc2b3dde8b4db724b11beb206a727f3eb2f60e4a8c0e5e1abbd4e621645d651cba449bc4a474";
+      sha512 = "b6256747abfe759c0c65a0dd3431e9e498339259caff450b0988e1936ce10e9f2f019a241b21d7f2c1e9911e4396a055ab9640fcfd9a22d5f520ed461d476411";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/pl/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/pl/thunderbird-52.2.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "aa02a2910513159c2621dc17aff373a8c2124bf9aebb24bf54c239d823d0080a1c05c330185af5dce21084d7ac9060a2b8daf890a3227650416d82afd0fa8e9a";
+      sha512 = "a6cd073fd83eb0a31e1cbcadd149e5c1be90e0bd8d890cde0ceec19bf4be15582fcceb5d6987c1682492a4e6370c215995c3ea49f3ae25529be6c5b1534c198b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/pt-BR/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/pt-BR/thunderbird-52.2.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "b5b2654bf153bd7f7c85534b95f836892550e519e254312584b22981bcdf7205f31babb5cf32033f7d676eee2bf2400f88503b52268f2ef10286da82b2713704";
+      sha512 = "016eeaa8804945f34a89d0fbb60133f1e0beca5c6ccd695201f09ab8fe529b85f98f0d992875ba8ce866d147ce9f92807773d44f9932ba1de73fdb1398fdece1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/pt-PT/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/pt-PT/thunderbird-52.2.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "3d557b432531a757bad6f18754b9d2fb2359bdba49f20faf797f7eba821926aeb8476c89a93b475273514bf26a6f471637505c5eb8a1cc08d1cf830b28b21fca";
+      sha512 = "e76b5313089da90a6cb34190bd07e65cb7fda4a34ee0581009fcdf9d0135c42b698f2a6c575cc13e63d749ca0ee0f3485fb05308419b5f7e72c9a1ff89601a69";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/rm/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/rm/thunderbird-52.2.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "434122ff7524630ec45a7e6a0e5f90e74ea1397b31bf67ce9e3046f8a31114a8320e56a5dedf1686e2eebc8c648e4a94fd0cdbe523bdcd6312448100d548e302";
+      sha512 = "fcb0fc5ef00a370396f01bdb885f3bedd551344849f6eba53057506a573486af5ec781f2850aaf1e6fede9a3613c9c94629511c0a7d445565db8fe1cabcec29c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/ro/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/ro/thunderbird-52.2.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "6f2c74d119ad7380961c50d5bb91afd4bb9455737776a08eb5168c17e83143fefacfeaa3b98e1816d1fe96a7f2022256cd2acf7b697508e4139d792562be2176";
+      sha512 = "fafff899f366c17bc81b4432a4b1c6cae8fd6bff6c307bd377a314b9b4f520fbce4ba23b144a816d24fad65e90b33e17b25767c60f4ef10136dac6701f3d326f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/ru/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/ru/thunderbird-52.2.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "d9eff15876619a1bf0b8467847df18b0dba20c598e05428037b81e0cd90797b8baafc44541fed2a29dfb27075da19730919159495712099a54c9b488a693e3ca";
+      sha512 = "0a0598479ced443e18d9b29bd0e0deca39176303f81e25999282af9fa1d67ffe5d0e66ad4f4461a24fbd94ca960876e2836ad2d69ba0fb4bbe81c1e471555625";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/si/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/si/thunderbird-52.2.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "a2e58a6b2632f8c2f6eaf6113e2af9e98ea222c5d2c98f0cfb4443804ce260bb3dba64bd5165590563fa946b500bbaed4341629eb25ea0c5388c61c69f4be5cf";
+      sha512 = "5aff4f01e7902140e817b206dd543a73b003a808bea448478918be7214de0601568151814baa96c4ae2ea193c76e7c8daa411f742b719df34dc275b4e9f8d52b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/sk/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/sk/thunderbird-52.2.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "0b26b3848864def3a5b485c2d67d3c907b58d9977ae91db58d91218da278243c04eeac781fe0063b762d0797809dcbee18010824aa5d25926f8f48011e2a5bb4";
+      sha512 = "560557b1662f58311a2ba694544a6b329a4fa709bc1702e12351c90b2647b974ffca4ac7c78e0c2430193cd6fcf194fb40f078c8c7c4cbb628e9b8e4a8abc37f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/sl/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/sl/thunderbird-52.2.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "7158c776ec3776ac269402973482e2dfedb3c17aeac11fcae3bee6a982717443068223cc901ee71e6b7a42a8073f05d2a54047804997d992761fbe71d46bd223";
+      sha512 = "c3689c69bad7cd2f8ae58e430de4141b593db86adfc58e1f4b65258aa2a74c68595bbdaa966437a732502aae8f8c6952e10a27e453e632e2a162457261426a55";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/sq/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/sq/thunderbird-52.2.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "1a838db31f4db574669987614dfcbd5f7f1eb061dc4f2fd0c9ca206d5a5291ac348efce3ce59b30f89fdc375e72467531d9d96b8ce43ffe28e92916f2864908c";
+      sha512 = "6ab246a7878e68204c2d4548a1583edb7293a7d7c671ad2be4767e098d7e5ab2308e5f5d8f02a7081bf6aead42207e88b16a38667ebde5f76bfb8fcf398545d3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/sr/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/sr/thunderbird-52.2.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "beb9eee26aa5474ac5e70c168e2ee32c84216d919528c9edce4d45ab6c522d5fc888ba2f8c57cfcd47d299367ddb7c367dafc9ccd3d29c5700de28eb2efe08fe";
+      sha512 = "923fd4d862bb8c363f20a5f05dc67a98de3266b961790299c667492c1c528b860524bf7197377c73f68c849dca8a96ac7adccfd32b0e9513d631550e786c43b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/sv-SE/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/sv-SE/thunderbird-52.2.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "e4c2320e547b2e61991feb586b7f9e4180cbeb88dc90cd0dfd2c026b062e4e1858d1d1b331cfde1e373cacec2231f7cb2ba61b5e4ef02a36802edbc96b39cf72";
+      sha512 = "81d7662ebaa211208f435b8d66a5766289ca9bc897c81aeef9666f10157a5c6b3cd5226585e144ceb2ac3a2ca9edb336e82e4b3d9097e4a4097e5b6de5626e1a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/ta-LK/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/ta-LK/thunderbird-52.2.1.tar.bz2";
       locale = "ta-LK";
       arch = "linux-i686";
-      sha512 = "aa42add8ba31edb5a40fd62304f10ac55006918d5196f71ca0330c3ca52dbbf4d9b5d39a07e977ee89c6b913e6ac4d4a4c9460da194b41760826d96e89e7bffb";
+      sha512 = "dd8bd65fe029cb0fa7016119b354fc0e2d1a3bac2b89e899edcdc03e3514aad4ae91707f72d19156b1d24e778f0b7a54fbbdff049e553a3daeaf56c6486dec47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/tr/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/tr/thunderbird-52.2.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "ceb90e08e906d5a2520152c40c4e32ab85da31c746ea285280b6e9bfbd60e9178886799357f39d54e0e072c616059ae7fe1948c39f6152b5f0d1b196185c8475";
+      sha512 = "3a71dcf6e9562d2e196e7bd76c662f5181f11cc6cc121a1ed1724e13e5e897777f1c36a4eeef36bf8a606ab8f13fbe8c4b3b345e9c70f42f8c22155ac7da3963";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/uk/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/uk/thunderbird-52.2.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "9d9fc486d556dbe3a216a3d4e822750cfa1cd0348af37ddaa5a19f9c390170e348a41b8251fff1499d2dc6d92feb34061286ff5400a4f9b6ed4fdee27064078c";
+      sha512 = "6094592ebae6b37073e7c15da36f5fd39ccbbfbc104dac8faea889ebf00f9c6e7cd5f0a2bbd54b53c0495a7166ed871b7aa4c3abe4b97827d15646b4d002b010";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/vi/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/vi/thunderbird-52.2.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "010bc7ce4ee4329857291796e2077e0872593f2b52799b1524720fa7fca11f2f4b760610bc97db171421552eb59a36725f80d4852cd77d30c8e7eb6c6c523d2d";
+      sha512 = "f96d09771ebd3ff63d35f95e42e77b2227c5b48a459f6e1e782a1259a845c2d6d819afb3a12333f19d5440cc6098db98b502514c5bb68c509a5a4778a5b88501";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/zh-CN/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/zh-CN/thunderbird-52.2.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "c07d2559296acb160c19af2db9f516254d33e1d55c78b2397d2c28764a8296e3da0b74409d48702e889bbf34f06115b493bbcea2666ad8b4884ea01fed6ad12f";
+      sha512 = "eba8d0ee4cc69f386dc114019501fac6b5ebeb3828755062167519ca062fa1e60d2327aec6db647459efd9ce83d31dbfeff28ea7821f52e9254de362a46ee472";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.0/linux-i686/zh-TW/thunderbird-52.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.2.1/linux-i686/zh-TW/thunderbird-52.2.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "8fa1da0c35584cfb8013df9e86a37268e6ffed1ee5ba4617d3db185975b874af5dba3f3af5498b8ebfdf85e40409fb9fee8d517f84f4942cf69deaa94f3c64a1";
+      sha512 = "f0af41f4faa7259f6caa2a675e60880aea434b0f2bcbde3db00001c32362c001c92b10c14d06d1ea344390d16e20f87f0cb5a7e7ecfcfbb0b3ec1da9ece8f5dd";
     }
     ];
 }


### PR DESCRIPTION
References #26816.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

