### PR TITLE
Fixes for gnupg agent module

### DIFF
--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -55,79 +55,24 @@ in
   };
 
   config = mkIf cfg.agent.enable {
-    systemd.user.services.gpg-agent = {
-      serviceConfig = {
-        ExecStart = [
-          ""
-          ("${pkgs.gnupg}/bin/gpg-agent --supervised "
-            + optionalString cfg.agent.enableSSHSupport "--enable-ssh-support")
-        ];
-        ExecReload = "${pkgs.gnupg}/bin/gpgconf --reload gpg-agent";
-      };
-    };
-
     systemd.user.sockets.gpg-agent = {
       wantedBy = [ "sockets.target" ];
-      listenStreams = [ "%t/gnupg/S.gpg-agent" ];
-      socketConfig = {
-        FileDescriptorName = "std";
-        SocketMode = "0600";
-        DirectoryMode = "0700";
-      };
     };
 
     systemd.user.sockets.gpg-agent-ssh = mkIf cfg.agent.enableSSHSupport {
       wantedBy = [ "sockets.target" ];
-      listenStreams = [ "%t/gnupg/S.gpg-agent.ssh" ];
-      socketConfig = {
-        FileDescriptorName = "ssh";
-        Service = "gpg-agent.service";
-        SocketMode = "0600";
-        DirectoryMode = "0700";
-      };
     };
 
     systemd.user.sockets.gpg-agent-extra = mkIf cfg.agent.enableExtraSocket {
       wantedBy = [ "sockets.target" ];
-      listenStreams = [ "%t/gnupg/S.gpg-agent.extra" ];
-      socketConfig = {
-        FileDescriptorName = "extra";
-        Service = "gpg-agent.service";
-        SocketMode = "0600";
-        DirectoryMode = "0700";
-      };
     };
 
     systemd.user.sockets.gpg-agent-browser = mkIf cfg.agent.enableBrowserSocket {
       wantedBy = [ "sockets.target" ];
-      listenStreams = [ "%t/gnupg/S.gpg-agent.browser" ];
-      socketConfig = {
-        FileDescriptorName = "browser";
-        Service = "gpg-agent.service";
-        SocketMode = "0600";
-        DirectoryMode = "0700";
-      };
-    };
-
-    systemd.user.services.dirmngr = {
-      requires = [ "dirmngr.socket" ];
-      after = [ "dirmngr.socket" ];
-      unitConfig = {
-        RefuseManualStart = "true";
-      };
-      serviceConfig = {
-        ExecStart = "${pkgs.gnupg}/bin/dirmngr --supervised";
-        ExecReload = "${pkgs.gnupg}/bin/gpgconf --reload dirmngr";
-      };
     };
 
     systemd.user.sockets.dirmngr = {
       wantedBy = [ "sockets.target" ];
-      listenStreams = [ "%t/gnupg/S.dirmngr" ];
-      socketConfig = {
-        SocketMode = "0600";
-        DirectoryMode = "0700";
-      };
     };
 
     systemd.packages = [ pkgs.gnupg ];

--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -71,7 +71,7 @@ in
       wantedBy = [ "sockets.target" ];
     };
 
-    systemd.user.sockets.dirmngr = {
+    systemd.user.sockets.dirmngr = mkIf cfg.dirmngr.enable {
       wantedBy = [ "sockets.target" ];
     };
 

--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -77,7 +77,7 @@ in
 
     systemd.packages = [ pkgs.gnupg ];
 
-    environment.extraInit = ''
+    environment.interactiveShellInit = ''
       # Bind gpg-agent to this TTY if gpg commands are used.
       export GPG_TTY=$(tty)
 


### PR DESCRIPTION
###### Motivation for this change

1b6176e45b05cbb89cac49359ba15a15c9187f68 caused a few problems for me with the gnupg agent module in nixos.
With `programs.gnupg.agent.enable` and `programs.gnupg.agent.enableSSHSupport` both set to `true`, logging in freezes for me while running `gpg-connect-agent`.

Additionally, I get the following messages in the journal:
> machine# [    6.342172] gpg-agent[837]: gpg-agent (GnuPG) 2.1.21 starting in supervised mode.
> machine# [    6.343164] gpg-agent[837]: using fd 3 for std socket (/run/user/1000/gnupg/S.gpg-agent)
> machine# [    6.344159] gpg-agent[837]: cannot listen on more than one std socket
> machine# [    6.345041] gpg-agent[837]: using fd 5 for ssh socket (/run/user/1000/gnupg/S.gpg-agent.ssh)
> machine# [    6.346120] gpg-agent[837]: cannot listen on more than one ssh socket
> machine# [    6.347068] gpg-agent[837]: listening on: std=3 extra=-1 browser=-1 ssh=5

It appears that duplicating the systemd units in both `systemd.packages` as well as `systemd.user.{sockets,services}` causes gpg-agent to try to bind to multiple sockets. Perhaps this causes gpg-connect-agent to freeze? In any case, I don't see why we can't just use the upstream systemd units, which fixes the problem for me anyway.

In case it's useful, I'll mention that I also wrote some nixos tests to ensure the gpg agent config is working properly, since this seems to break for me frequently. These tests ensure pinentry displays properly when invoked through gpg-agent, both for console and x11 usage:
https://github.com/danielfullmer/nixos-config/blob/master/tests/gpg-agent.nix
https://github.com/danielfullmer/nixos-config/blob/master/tests/gpg-agent-x11.nix

While writing these tests, I also noticed that the nixos test driver fails with:
> machine# [    3.697077] backdoor-start[669]: gpg-connect-agent: failed to create temporary file '/root/.gnupg/.#lk0x0000000001795470.machine.675': No such file or directory

I can't think of any reason why noninteractive shells would need to call `gpg-connect-agent`, so I restricted that to `interactiveShellInit`, but I might be overlooking something by doing so.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @CMCDragonkai @fpletz 

