### PR TITLE
bundix: upgrade to 2.2.1

### DIFF
--- a/pkgs/development/ruby-modules/bundix/default.nix
+++ b/pkgs/development/ruby-modules/bundix/default.nix
@@ -5,13 +5,13 @@ buildRubyGem rec {
 
   name = "${gemName}-${version}";
   gemName = "bundix";
-  version = "2.2.0";
+  version = "2.2.1";
 
   src = fetchFromGitHub {
     owner = "manveru";
     repo = "bundix";
     rev = version;
-    sha256 = "0lnzkwxprdz73axk54y5p5xkw56n3lra9v2dsvqjfw0ab66ld0iy";
+    sha256 = "1gh90yxm4k27jdjdl3r31fcg4sk7k54jlbw1zfm1p9q3i7k8x4i7";
   };
 
   buildInputs = [bundler];


### PR DESCRIPTION
This fixes `fetchurl-force.nix` not being installed, which breaks
bundix for some gems.

E.g.

```
$ nix-build --argstr url https://rubygems.org/gems/nio4r-2.1.0.gem /nix/store/y6959dxal86l3alc0ryf7752prbbkzxg-bundix-2.2.0/lib/ruby/gems/2.3.0/gems/bundix-2.2.0/lib/bundix/fetchurl-force.nix
error: getting status of ‘/nix/store/y6959dxal86l3alc0ryf7752prbbkzxg-bundix-2.2.0/lib/ruby/gems/2.3.0/gems/bundix-2.2.0/lib/bundix/fetchurl-force.nix’: No such file or directory
```

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

