### PR TITLE
haskell-packages: use older version of apply-refact with ghc-8.0.x

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -58,4 +58,6 @@ self: super: {
   # https://github.com/nominolo/ghc-syb/issues/20
   ghc-syb-utils = dontCheck super.ghc-syb-utils;
 
+  # Newer versions require ghc>=8.2
+  apply-refact = super.apply-refact_0_3_0_1;
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2432,6 +2432,7 @@ extra-packages:
   - aeson < 0.8                         # newer versions don't work with GHC 7.6.x or earlier
   - aeson < 1                           # required by liquidhaskell-0.8.0.0
   - aeson-pretty < 0.8                  # required by elm compiler
+  - apply-refact < 0.4                  # newer versions don't work with GHC 8.0.x
   - binary > 0.7 && < 0.8               # keep a 7.x major release around for older compilers
   - binary > 0.8 && < 0.9               # keep a 8.x major release around for older compilers
   - Cabal == 1.18.*                     # required for cabal-install et al on old GHC versions


### PR DESCRIPTION
Version 0.4 of apply-refact doesn't compile with GHC 8.0.x. This patch
updates configurations-ghc-8.0.x to use apply-refact version 0.3.0.1.

Fix #26895

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

