### PR TITLE
terminfo: symlink terminfo to /etc for ncurses

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -115,7 +115,6 @@ in
         "/share/mime"
         "/share/nano"
         "/share/org"
-        "/share/terminfo"
         "/share/themes"
         "/share/vim-plugins"
         "/share/vulkan"

--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -1,0 +1,33 @@
+# This module manages the terminfo database
+# and its integration in the system.
+{ config, ... }:
+{
+  config = {
+
+    environment.pathsToLink = [
+      "/share/terminfo"
+    ];
+
+    environment.etc."terminfo" = {
+      source = "${config.system.path}/share/terminfo";
+    };
+
+    environment.profileRelativeEnvVars = {
+      TERMINFO_DIRS = [ "/share/terminfo" ];
+    };
+
+    environment.extraInit = ''
+
+      # reset TERM with new TERMINFO available (if any)
+      export TERM=$TERM
+    '';
+
+    security.sudo.extraConfig = ''
+
+      # Keep terminfo database for root and %wheel.
+      Defaults:root,%wheel env_keep+=TERMINFO_DIRS
+      Defaults:root,%wheel env_keep+=TERMINFO
+    '';
+
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -21,6 +21,7 @@
   ./config/sysctl.nix
   ./config/system-environment.nix
   ./config/system-path.nix
+  ./config/terminfo.nix
   ./config/timezone.nix
   ./config/unix-odbc-drivers.nix
   ./config/users-groups.nix

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -34,7 +34,6 @@ in
       { PATH = [ "/bin" ];
         INFOPATH = [ "/info" "/share/info" ];
         PKG_CONFIG_PATH = [ "/lib/pkgconfig" ];
-        TERMINFO_DIRS = [ "/share/terminfo" ];
         PERL5LIB = [ "/lib/perl5/site_perl" ];
         KDEDIRS = [ "" ];
         STRIGI_PLUGIN_PATH = [ "/lib/strigi/" ];
@@ -50,9 +49,6 @@ in
 
     environment.extraInit =
       ''
-         # reset TERM with new TERMINFO available (if any)
-         export TERM=$TERM
-
          unset ASPELL_CONF
          for i in ${concatStringsSep " " (reverseList cfg.profiles)} ; do
            if [ -d "$i/lib/aspell" ]; then

--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -66,10 +66,6 @@ in
         # Don't edit this file. Set the NixOS options ‘security.sudo.configFile’
         # or ‘security.sudo.extraConfig’ instead.
 
-        # Environment variables to keep for root and %wheel.
-        Defaults:root,%wheel env_keep+=TERMINFO_DIRS
-        Defaults:root,%wheel env_keep+=TERMINFO
-
         # Keep SSH_AUTH_SOCK so that pam_ssh_agent_auth.so can do its magic.
         Defaults env_keep+=SSH_AUTH_SOCK
 

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -46,6 +46,9 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optional (mouseSupport && stdenv.isLinux) gpm;
 
   preConfigure = ''
+    # These paths end up in the default lookup chain.
+    export TERMINFO_DIRS=/etc/terminfo
+
     export PKG_CONFIG_LIBDIR="$dev/lib/pkgconfig"
     mkdir -p "$PKG_CONFIG_LIBDIR"
     configureFlagsArray+=(


### PR DESCRIPTION
Terminfo was bundled in the system path, but not made available via /etc/terminfo
This PR also collects all the scattered config in nixos/modules/config/terminfo.nix

This makes #19785 work for system-wide packages on NixOS.