### PR TITLE
fswatch: 1.5.0 -> 1.9.3

### DIFF
--- a/pkgs/development/tools/misc/fswatch/default.nix
+++ b/pkgs/development/tools/misc/fswatch/default.nix
@@ -10,23 +10,16 @@
 
 stdenv.mkDerivation rec {
   name = "fswatch-${version}";
-  version = "1.5.0";
+  version = "1.9.3";
 
   src = fetchFromGitHub {
     owner = "emcrisostomo";
     repo = "fswatch";
     rev = version;
-    sha256 = "09np75m9df2nk7lc5y9wgq467ca6jsd2p5666d5rkzjvy6s0a51n";
+    sha256 = "1g329aapdvbzhr39wyh295shpfq5f0nlzsqkjnr8l6zzak7f4yrg";
   };
 
   buildInputs = [ autoreconfHook gettext libtool makeWrapper texinfo ];
-
-  postFixup = ''
-    for prog in fswatch-run fswatch-run-bash; do
-      wrapProgram $out/bin/$prog \
-        --prefix PATH "${findutils}/bin"
-    done
-  '';
 
   meta = with stdenv.lib; {
     description = "A cross-platform file change monitor with multiple backends";
@@ -35,5 +28,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ pSub ];
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change

To make use newer version of `fswatch`.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

