### PR TITLE
gnomeExtensions.caffeine: init at revision unstable-2017-06-21

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/caffeine/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/caffeine/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extension-caffeine-${version}";
-  version = "ce0d0d4d3a9fed4b35b82cf59609a00502862271";
+  version = "unstable-2017-06-21";
 
   src = fetchFromGitHub {
     owner = "eonpatapon";

--- a/pkgs/desktops/gnome-3/extensions/caffeine/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/caffeine/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, glib, gettext, bash }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extension-caffeine-${version}";
+  version = "ce0d0d4d3a9fed4b35b82cf59609a00502862271";
+
+  src = fetchFromGitHub {
+    owner = "eonpatapon";
+    repo = "gnome-shell-extension-caffeine";
+    rev = "ce0d0d4d3a9fed4b35b82cf59609a00502862271";
+    sha256 = "01gf9c8nhhm78iakqf30900y6lywxks1pm5h2cs0jvp8d3ygd7sd";
+  };
+
+  uuid = "caffeine@patapon.info";
+
+  nativeBuildInputs = [
+    glib gettext
+  ];
+
+  buildPhase = ''
+    ${bash}/bin/bash ./update-locale.sh
+    ${glib.dev}/bin/glib-compile-schemas --strict --targetdir=caffeine@patapon.info/schemas/ caffeine@patapon.info/schemas
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -r ${uuid} $out/share/gnome-shell/extensions
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Fill the cup to inhibit auto suspend and screensaver";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ eperuffo ];
+    homepage = https://github.com/eonpatapon/gnome-shell-extension-caffeine;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17494,6 +17494,7 @@ with pkgs;
   gnome3 = gnome3_22;
 
   gnomeExtensions = {
+    caffeine = callPackage ../desktops/gnome-3/extensions/caffeine { };
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Caffeine extension for Gnome 3

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

