### PR TITLE
plasma5: 5.10.2 -> 5.10.3

### DIFF
--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma/5.10.2/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/plasma/5.10.3/ -A '*.tar.xz' )

--- a/pkgs/desktops/plasma-5/srcs.nix
+++ b/pkgs/desktops/plasma-5/srcs.nix
@@ -3,339 +3,339 @@
 
 {
   bluedevil = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/bluedevil-5.10.2.tar.xz";
-      sha256 = "1510gjbvyjr4bg00m28hz9ynz7m7h35c859ksq7r1y102kjxgyr7";
-      name = "bluedevil-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/bluedevil-5.10.3.tar.xz";
+      sha256 = "03qkd08nwqkc25wvj4964xgrj40m6vhzqg67fdqamav6d5np106g";
+      name = "bluedevil-5.10.3.tar.xz";
     };
   };
   breeze = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/breeze-5.10.2.tar.xz";
-      sha256 = "1wywa8y07ssxvl59xw4xifi41wj9dd594hy17vjigfp1xi7h62br";
-      name = "breeze-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/breeze-5.10.3.tar.xz";
+      sha256 = "048z84dsrx9ln5whg7vbp0amhhsnggh1jm4z6nmraizms2ay0w8a";
+      name = "breeze-5.10.3.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/breeze-grub-5.10.2.tar.xz";
-      sha256 = "0xb7gvl1yrh8g75w1f97wvwig99fwqfk8azkpxxhrg8j5nr4vaz2";
-      name = "breeze-grub-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/breeze-grub-5.10.3.tar.xz";
+      sha256 = "1ghg7vc9ad6bw0b0q88srjwm8h9khyl93ljr2riaw3wh23slkw5z";
+      name = "breeze-grub-5.10.3.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/breeze-gtk-5.10.2.tar.xz";
-      sha256 = "06pgbkf078zl57vyfvsmm1bll8g2x419fy2waqh9n7jkycihlinx";
-      name = "breeze-gtk-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/breeze-gtk-5.10.3.tar.xz";
+      sha256 = "0ai2hkd79g1y8clk0650qijq5w5fmaamhbapw6yddf4v4a40vspc";
+      name = "breeze-gtk-5.10.3.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/breeze-plymouth-5.10.2.tar.xz";
-      sha256 = "0db00k3h7vsp3pf7xnix8kazsw5wcjzkcj1wfkn4c7vdcvfv48pd";
-      name = "breeze-plymouth-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/breeze-plymouth-5.10.3.tar.xz";
+      sha256 = "1249ywi5s8ba5mzgi2773xz04g3shzc61bwsfcgpvzyc61q3dsl9";
+      name = "breeze-plymouth-5.10.3.tar.xz";
     };
   };
   discover = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/discover-5.10.2.tar.xz";
-      sha256 = "0ky5yk5nknipxy4hamy6i6m46jhv3n1lsmcs149j687jw2l6ryls";
-      name = "discover-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/discover-5.10.3.tar.xz";
+      sha256 = "189pv0zbl7mzswk65nlj8yq5ymj3ska8a52ws852blnccj8x18qn";
+      name = "discover-5.10.3.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kactivitymanagerd-5.10.2.tar.xz";
-      sha256 = "1x7fc3nszg9fcksyf2c9dyagsa9486ybh6yrrn4c6d6z813479qj";
-      name = "kactivitymanagerd-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kactivitymanagerd-5.10.3.tar.xz";
+      sha256 = "1y4xyg5swr2abiiqp67b95jfj4xbmgw1y51vj6njcdrkkkksz7qh";
+      name = "kactivitymanagerd-5.10.3.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kde-cli-tools-5.10.2.tar.xz";
-      sha256 = "0d1vfxgi0anggjirp1ncaqr1l7rlbniiv74gf5npb3f260h6yr0h";
-      name = "kde-cli-tools-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kde-cli-tools-5.10.3.tar.xz";
+      sha256 = "1xmk45hj96qmfcprccsnlzr0hms98yvnnz8wkylgbnj75rcfq7ws";
+      name = "kde-cli-tools-5.10.3.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kdecoration-5.10.2.tar.xz";
-      sha256 = "05mg8aacayfx63mx8yb6g1j6wx7kkk21msl33krks7bdqx0jx9kw";
-      name = "kdecoration-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kdecoration-5.10.3.tar.xz";
+      sha256 = "14ayrnv1q1rhjclh2pbjwnzssqk2m9zlpm64011y258r5q9mw8h3";
+      name = "kdecoration-5.10.3.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kde-gtk-config-5.10.2.tar.xz";
-      sha256 = "096dfl5nm65v6m4m6r1smwbcxv5fkxnbgrgi17x5lfipa9mmrf58";
-      name = "kde-gtk-config-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kde-gtk-config-5.10.3.tar.xz";
+      sha256 = "049dk79wgqgk2jiicqyv32m6nhj6k7hw5qrhagg8js28b6sqkw0m";
+      name = "kde-gtk-config-5.10.3.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kdeplasma-addons-5.10.2.tar.xz";
-      sha256 = "1yznzz0yrjckv4b1h58fsn0sww5iwmkqvsajdqhgzqw1cs4v98p0";
-      name = "kdeplasma-addons-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kdeplasma-addons-5.10.3.tar.xz";
+      sha256 = "1lzkwa51845f97qz43j1k284hwjbg05cry7lj16nlaq0rlwncgps";
+      name = "kdeplasma-addons-5.10.3.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kgamma5-5.10.2.tar.xz";
-      sha256 = "0hwnn057jbqpzbp8jryfcdp2qlypmyvh5zmfay8iy9vy068zzcmc";
-      name = "kgamma5-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kgamma5-5.10.3.tar.xz";
+      sha256 = "19mcdj1xcsf43k3n77ybqj9i99l6m8yryw3bhcbzfxk0c6ccx9cy";
+      name = "kgamma5-5.10.3.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/khotkeys-5.10.2.tar.xz";
-      sha256 = "1kdvdb5i0mjrv4h4m539kikdrb0vybgphaahxk4392npv2zqz1xs";
-      name = "khotkeys-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/khotkeys-5.10.3.tar.xz";
+      sha256 = "1xbxbqvpnci2fanwvdrr6rnwabh3yfamndfhmy4gjik26y0i8yz4";
+      name = "khotkeys-5.10.3.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kinfocenter-5.10.2.tar.xz";
-      sha256 = "1r0q8xmb9m0xgcw21a6klagfh560ywzdcnly6r36fpwj0hjv60hj";
-      name = "kinfocenter-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kinfocenter-5.10.3.tar.xz";
+      sha256 = "0a94wz7fbck08aw3xrvn2hjbj3px5ivfzkh6hhqcxblnc5ahr0fk";
+      name = "kinfocenter-5.10.3.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kmenuedit-5.10.2.tar.xz";
-      sha256 = "0dcy5r829dpzfmkqzmcbwxv5bqdamq0lvz7khd0n08f4h7a32wnz";
-      name = "kmenuedit-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kmenuedit-5.10.3.tar.xz";
+      sha256 = "1y4riijwp1g3bji2wd21m7raf95prajd3sxcgr140sg0lq8zg8h2";
+      name = "kmenuedit-5.10.3.tar.xz";
     };
   };
   kscreen = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kscreen-5.10.2.tar.xz";
-      sha256 = "0304vi87xq7p8l6dibgb74dzcf7721nps18cm6p9a05nnlvpr1l7";
-      name = "kscreen-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kscreen-5.10.3.tar.xz";
+      sha256 = "03l8ammyir82w8kdl4sm8lkp1nr0qghk04g838p34m05ah8hb7nl";
+      name = "kscreen-5.10.3.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kscreenlocker-5.10.2.tar.xz";
-      sha256 = "079vkca9q509qg5qq4kwlzl3dmnqrigs0xm6vyz000589cpg6ib5";
-      name = "kscreenlocker-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kscreenlocker-5.10.3.tar.xz";
+      sha256 = "07k0smksglzq44llpn80xs7p8salfryphihran7frb1mvyg09yzx";
+      name = "kscreenlocker-5.10.3.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/ksshaskpass-5.10.2.tar.xz";
-      sha256 = "1mjbpsaj3qyrd7f5yqnw0y81d8srjjd537sx7yjgvyijaf2v0vyz";
-      name = "ksshaskpass-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/ksshaskpass-5.10.3.tar.xz";
+      sha256 = "10cy8d4dbg8dzkh428x3vl6n2hh73b3fxnal8a2wwx23flhmg04c";
+      name = "ksshaskpass-5.10.3.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/ksysguard-5.10.2.tar.xz";
-      sha256 = "1ndz3l91chq1n3p9xrw57mkdxa7hw778baydk8y9pbdr2yr961cv";
-      name = "ksysguard-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/ksysguard-5.10.3.tar.xz";
+      sha256 = "0mgzqd3abhs03k815kij6n6jpiqhd13vzbyifcp4r0q8kh34b71s";
+      name = "ksysguard-5.10.3.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kwallet-pam-5.10.2.tar.xz";
-      sha256 = "01ki2rfn4sw8m8qh7lwwikcr9kxwiv9x7mv86h86ssd1hfzwzhda";
-      name = "kwallet-pam-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kwallet-pam-5.10.3.tar.xz";
+      sha256 = "0pysv9lfljar4krdkwns7fyyi0zz5629prfmdxs2aww6cq4d2x7m";
+      name = "kwallet-pam-5.10.3.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kwayland-integration-5.10.2.tar.xz";
-      sha256 = "1fna7llnimcqvzhmxb93m92gvicjiddqxd9lwqgyv7fww6bhsj3a";
-      name = "kwayland-integration-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kwayland-integration-5.10.3.tar.xz";
+      sha256 = "1gfx5mxy1zan5shhddi4b6k578l19rkld2zkfa4g97hhvc0h83s9";
+      name = "kwayland-integration-5.10.3.tar.xz";
     };
   };
   kwin = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kwin-5.10.2.tar.xz";
-      sha256 = "1gvby6k865snh6hsrnk53hwhb3242iamclz9nq9fzgy23a6g8mzj";
-      name = "kwin-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kwin-5.10.3.tar.xz";
+      sha256 = "0vbrf7vm8s7hrzkgsjsqggswadvrr1k2g85y7w1pb781way7xwj3";
+      name = "kwin-5.10.3.tar.xz";
     };
   };
   kwrited = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/kwrited-5.10.2.tar.xz";
-      sha256 = "1hz6p6il839c28bkf2bn9fqjpipiqdxk603v0h0iqvspfj00z7n8";
-      name = "kwrited-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/kwrited-5.10.3.tar.xz";
+      sha256 = "0cjyvz5wg37dbnacsf3hz05bkwzpbznmlsy5plhqxr6wmq6q6l9q";
+      name = "kwrited-5.10.3.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/libkscreen-5.10.2.tar.xz";
-      sha256 = "0w1adz5c32si1kcmxy015wzjxkln68f0inya2499jag2v9hd3vhn";
-      name = "libkscreen-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/libkscreen-5.10.3.tar.xz";
+      sha256 = "02hcsfmjzajbpki2pmpdycgccjqadd98vzam56sihsvivgxykw4h";
+      name = "libkscreen-5.10.3.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/libksysguard-5.10.2.tar.xz";
-      sha256 = "1x13mb3c5bzbi5nw3ahgy12x1df50qirr2h4c7igacxrv4m3zrih";
-      name = "libksysguard-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/libksysguard-5.10.3.tar.xz";
+      sha256 = "13s7j53jjyhd5kryyd1sy6yrx69h5smi7xg49d8as8zbf3rki08h";
+      name = "libksysguard-5.10.3.tar.xz";
     };
   };
   milou = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/milou-5.10.2.tar.xz";
-      sha256 = "06c4pb3gls1bgk1sffh6vj035i5vhiy04rmifypcp8gps98j6izw";
-      name = "milou-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/milou-5.10.3.tar.xz";
+      sha256 = "18bgwpxfv5n4nxvs6xj6ihk22bpmb1b4cs9dxhfn931r8lnzzixb";
+      name = "milou-5.10.3.tar.xz";
     };
   };
   oxygen = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/oxygen-5.10.2.tar.xz";
-      sha256 = "08d3rdj5vabrxrrlbzhw3ixnb3msm99idbhnpyzdkaw00l444f1p";
-      name = "oxygen-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/oxygen-5.10.3.tar.xz";
+      sha256 = "07jqm9nl84b2s9i461mz4b8i1x22376k9n1g9prcjzxyy3494flv";
+      name = "oxygen-5.10.3.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/plasma-desktop-5.10.2.tar.xz";
-      sha256 = "1mjz52n6jm1vi3v7432g9v9rh6bbgcwkrg12yahpzlz026hsyxrn";
-      name = "plasma-desktop-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/plasma-desktop-5.10.3.tar.xz";
+      sha256 = "1vwls9gavcipv8k2fwx9kzzldfcxch3g61nsc77dw0lrhcaf301d";
+      name = "plasma-desktop-5.10.3.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/plasma-integration-5.10.2.tar.xz";
-      sha256 = "0gzrv3plcn35rkwr7izn0363zbp91rdjw9k8n9s50p9rdx3rx8ly";
-      name = "plasma-integration-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/plasma-integration-5.10.3.tar.xz";
+      sha256 = "1vpgwzvqjcr6hgrh57777i21fbmixl6vrlyscdyk0912mdzplf5n";
+      name = "plasma-integration-5.10.3.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/plasma-nm-5.10.2.tar.xz";
-      sha256 = "0bw5vyzzvpklhgq02yhcq1sv7pz00kffvgvfjkgk45g5x47h7hw1";
-      name = "plasma-nm-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/plasma-nm-5.10.3.tar.xz";
+      sha256 = "1d8kncwcxw601n73m7igr2h09mk54qa2zgshrbd0h3496dw4xzxq";
+      name = "plasma-nm-5.10.3.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/plasma-pa-5.10.2.tar.xz";
-      sha256 = "1bbmlp5i2k4ygcn76frijjxzy88v3m5cpydslv7i5y41apm8bvip";
-      name = "plasma-pa-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/plasma-pa-5.10.3.tar.xz";
+      sha256 = "1dhkkfl39x17bd0hv3w0lclzlsialg7a7zydcjm345izpdgd11vx";
+      name = "plasma-pa-5.10.3.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/plasma-sdk-5.10.2.tar.xz";
-      sha256 = "0npccg4zzrd2cx4qa5qi0yr722x2yh8v0zd8dv76znqf8lsgwpj4";
-      name = "plasma-sdk-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/plasma-sdk-5.10.3.tar.xz";
+      sha256 = "0m426fj5d07bqj0n1gxcn7brjwf7xrsj50hy14hky246wchvqh43";
+      name = "plasma-sdk-5.10.3.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/plasma-tests-5.10.2.tar.xz";
-      sha256 = "1kyah0r138x3i35glb2slacwivdwbwvq19xp1hz2zrmiy52zq65i";
-      name = "plasma-tests-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/plasma-tests-5.10.3.tar.xz";
+      sha256 = "04pn5bzhs0y6msir2px985jghhswas9zn37jb4zdy0sxd9yhabqb";
+      name = "plasma-tests-5.10.3.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/plasma-workspace-5.10.2.tar.xz";
-      sha256 = "11q1p3ifs2fwrhm8ylvqacshz746dhl68w0s4dfykvr2r7mqqqf2";
-      name = "plasma-workspace-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/plasma-workspace-5.10.3.tar.xz";
+      sha256 = "0wfzdjpgd9fwycy4ww2j7xryh82wg4jfipnh9hicq2mss0x53mv9";
+      name = "plasma-workspace-5.10.3.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/plasma-workspace-wallpapers-5.10.2.tar.xz";
-      sha256 = "1hsm731fckv5bnl7faz7bbizi80df5zb35hmiz90fhdz4x2i7krp";
-      name = "plasma-workspace-wallpapers-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/plasma-workspace-wallpapers-5.10.3.tar.xz";
+      sha256 = "0vhdypkkcranpb7zv2ghh0d5x5698d7vvyv1k7xcgsd1bwf3037f";
+      name = "plasma-workspace-wallpapers-5.10.3.tar.xz";
     };
   };
   plymouth-kcm = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/plymouth-kcm-5.10.2.tar.xz";
-      sha256 = "1fxz15yc081i6y3qvpxqy8ca6khm492hxxmji87ds30634d0033a";
-      name = "plymouth-kcm-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/plymouth-kcm-5.10.3.tar.xz";
+      sha256 = "0ss5wkqa729f2bs8s9ss4bslpj0946kylbg2g2vmfzzr5a68ri6d";
+      name = "plymouth-kcm-5.10.3.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.10.2";
+    version = "1-5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/polkit-kde-agent-1-5.10.2.tar.xz";
-      sha256 = "04s9338c8y7krqsp5k812vrwphx0ibplh5gg0w6n38m8am78cxnz";
-      name = "polkit-kde-agent-1-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/polkit-kde-agent-1-5.10.3.tar.xz";
+      sha256 = "0csllzr47f173f8dymfhhplig7w55j3kfqr14i12lc3yhy5g5ns6";
+      name = "polkit-kde-agent-1-5.10.3.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/powerdevil-5.10.2.tar.xz";
-      sha256 = "1gw9swqi2wsdb8wbjf3ns7j4bj3a1mc06ynk7xklb7wan5psa9my";
-      name = "powerdevil-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/powerdevil-5.10.3.tar.xz";
+      sha256 = "0xjk8andskvygmb8ll0hxk8spc9ac0v3kyzyrd444va3q617zbi7";
+      name = "powerdevil-5.10.3.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/sddm-kcm-5.10.2.tar.xz";
-      sha256 = "10pg414ddx86nx46zkhl3fbvsijk4sifsh5cim17rp4b5wjay38y";
-      name = "sddm-kcm-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/sddm-kcm-5.10.3.tar.xz";
+      sha256 = "1gcla1lk8idxj4j4sr13wv3q2v6c4ylhgjqj1ik9qr9rk7r2ny8c";
+      name = "sddm-kcm-5.10.3.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/systemsettings-5.10.2.tar.xz";
-      sha256 = "1p6jg1vaa9svz4liqpb2435wbirdhjsqd6l1qd1lsp1r5szmwpz8";
-      name = "systemsettings-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/systemsettings-5.10.3.tar.xz";
+      sha256 = "0mfcyvzl5z3yqq0bbpwzhphir0vjjhvpifp17ra4w80j3f2c14jh";
+      name = "systemsettings-5.10.3.tar.xz";
     };
   };
   user-manager = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/user-manager-5.10.2.tar.xz";
-      sha256 = "1ac10z44y7d2n618j04r00cnklxglyk7xdh5vp0pl4zfcm4cx98w";
-      name = "user-manager-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/user-manager-5.10.3.tar.xz";
+      sha256 = "10iis34bpi0vic3x4r6gss8frfxg4zv9v8mg1rpbmrrs5q8799fn";
+      name = "user-manager-5.10.3.tar.xz";
     };
   };
   xdg-desktop-portal-kde = {
-    version = "5.10.2";
+    version = "5.10.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.10.2/xdg-desktop-portal-kde-5.10.2.tar.xz";
-      sha256 = "16qdvds3k4cjv3dvvxr26r5rjnysqabv4zqf18g52z9lsbc46imv";
-      name = "xdg-desktop-portal-kde-5.10.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.10.3/xdg-desktop-portal-kde-5.10.3.tar.xz";
+      sha256 = "1hnbw211fn6aayx46h92nmjvdc0ar1bsy1dn1lg2a5575kq2lzgd";
+      name = "xdg-desktop-portal-kde-5.10.3.tar.xz";
     };
   };
 }


### PR DESCRIPTION
This is a scheduled bugfix release. Several fixes are related to integrating
Plasma 5.10 and Qt 5.9, particularly a serious bug in KWin.

### Testing

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

