### PR TITLE
boost-build: update to version 2016.03

### DIFF
--- a/pkgs/development/tools/boost-build/default.nix
+++ b/pkgs/development/tools/boost-build/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "boost-build-2.0-${version}";
+  name = "boost-build-${version}";
   version = "2016.03";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/boost-build/default.nix
+++ b/pkgs/development/tools/boost-build/default.nix
@@ -1,11 +1,14 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "boost-build-2.0-m12";
+  name = "boost-build-2.0-${version}";
+  version = "2016.03";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/boost/${name}.tar.bz2";
-    sha256 = "10sbbkx2752r4i1yshyp47nw29lyi1p34sy6hj7ivvnddiliayca";
+  src = fetchFromGitHub {
+    owner = "boostorg";
+    repo = "build";
+    rev = version;
+    sha256 = "1qw5marmp7z09nwcjlqrmqdg9b6myfqj3zvfz888x9mbidrmhn6p";
   };
 
   hardeningDisable = [ "format" ];
@@ -17,30 +20,17 @@ stdenv.mkDerivation rec {
   '';
 
   buildPhase = ''
-    cd jam_src
-    ./build.sh
+    ./bootstrap.sh
   '';
 
   installPhase = ''
-    # Install Bjam
-    mkdir -p $out/bin
-    cd "$(ls | grep bin)"
-    cp -a bjam $out/bin
-
-    # Bjam is B2
-    ln -s bjam $out/bin/b2
-
-    # Install the shared files (don't include jam_src)
-    cd ../..
-    rm -rf jam_src
-    mkdir -p $out/share
-    cp -a . $out/share/boost-build
+    ./b2 install --prefix=$out
   '';
 
   meta = with stdenv.lib; {
     homepage = http://www.boost.org/boost-build2/;
     license = stdenv.lib.licenses.boost;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
+    maintainers = with maintainers; [ ivan-tkatchev ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Boost-build as currently in nixpkgs is severely out of date. (Missing support for clang, for example.)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

