### PR TITLE
geogebra: make `language` configurable

### DIFF
--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeDesktopItem, makeWrapper }:
+{ stdenv, fetchurl, jre, makeDesktopItem, makeWrapper, language ? "en_US" }:
 
 stdenv.mkDerivation rec {
   name = "geogebra-${version}";
@@ -34,7 +34,8 @@ stdenv.mkDerivation rec {
 
     makeWrapper "$out/libexec/geogebra/geogebra" "$out/bin/geogebra" \
       --set JAVACMD "${jre}/bin/java" \
-      --set GG_PATH "$out/libexec/geogebra"
+      --set GG_PATH "$out/libexec/geogebra" \
+      --add-flags "--language=${language}"
 
     install -Dm644 "${desktopItem}/share/applications/"* \
       -t $out/share/applications/


### PR DESCRIPTION
###### Motivation for this change

As a German I'm used to the `de_DE` GUI of GeoGebra (which contains different function names for several math features). In order to avoid switching between languages I added a parameter to the `geogebra` derivation which expects an ISO code for the GUI language.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

