### PR TITLE
vault: 0.6.5 -> 0.7.3 with service

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -139,6 +139,7 @@
       btsync = 113;
       minecraft = 114;
       #monetdb = 115; # unused (not packaged), removed 2016-09-19
+      vault = 115;
       rippled = 116;
       murmur = 117;
       foundationdb = 118;
@@ -415,6 +416,7 @@
       btsync = 113;
       #minecraft = 114; # unused
       #monetdb = 115; # unused (not packaged), removed 2016-09-19
+      vault = 115;
       #ripped = 116; # unused
       #murmur = 117; # unused
       foundationdb = 118;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -555,6 +555,7 @@
   ./services/security/tor.nix
   ./services/security/torify.nix
   ./services/security/torsocks.nix
+  ./services/security/vault.nix
   ./services/system/cgmanager.nix
   ./services/system/cloud-init.nix
   ./services/system/dbus.nix

--- a/nixos/modules/services/security/vault.nix
+++ b/nixos/modules/services/security/vault.nix
@@ -1,0 +1,208 @@
+{ config, lib, pkgs, utils, ... }:
+
+with lib;
+let
+
+  inherit (pkgs) vault;
+
+  cfg = config.services.vault;
+ 
+  configFile = pkgs.writeText "vault.hcl" ''
+    listener "tcp" {
+      address = "${cfg.listener.address}"
+   
+      ${optionalString (cfg.listener.cluster_address != null)''
+        cluster_address = "${cfg.listener.cluster_address}"
+      ''}
+      
+      ${optionalString (cfg.listener.tls_cert_file != null)''
+        tls_cert_file = "${cfg.listener.tls_cert_file}"
+      ''}
+      
+      ${optionalString (cfg.listener.tls_key_file != null)''
+        tls_key_file = "${cfg.listener.tls_key_file}"
+      ''}
+      
+      ${if cfg.listener.tls_disable then "tls_disable = \"1\"" else "" } 
+
+      tls_min_version = "${cfg.listener.tls_min_version}" 
+
+
+      ${optionalString (cfg.listener.tls_cipher_suites != null)''
+        tls_cipher_suites = \"${cfg.listener.tls_cipher_suites}\"
+      ''}
+
+      tls_prefer_server_cipher_suites = "${boolToString cfg.listener.tls_prefer_server_cipher_suites}"
+
+      tls_require_and_verify_client_cert = "${boolToString cfg.listener.tls_require_and_verify_client_cert}"
+
+    }
+
+    storage "${cfg.storage.backend}" {
+      ${cfg.storage.extraConfig}
+    }
+
+    ${if cfg.telemetry.extraConfig != "" then "
+      telemetry { 
+        ${if cfg.telemetry.disable_hostname then "disable_hostname = \"true\"" else ""}
+        ${cfg.telemetry.extraConfig}
+      }" else ""}
+
+  '';
+
+in
+{
+  options = {
+
+    services.vault = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enables the vault daemon.
+        '';
+      };
+
+      listener = {
+
+        address = mkOption {
+          type = types.str;
+          default = "127.0.0.1:8200";
+          description = ''
+            The name of the ip interface to listen to.
+          '';
+        };
+
+        cluster_address = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+            The name of the address to bind to for cluster server-to-server requests.
+          '';
+        };
+
+        tls_cert_file = mkOption {
+          type = types.str;
+          default = "";
+          description = ''
+            The name of the crt file for the ssl certificate.
+          '';
+        };
+        
+        tls_key_file = mkOption {
+          type = types.str;
+          default = "";
+          description = ''
+            The name of the key file for the ssl certificate.
+          '';
+        };
+
+        tls_disable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Specifies if TLS will be disabled. Vault assumes TLS by default, so you must explicitly disable TLS to opt-in to insecure communication.
+          '';
+        };
+        
+        tls_min_version = mkOption {
+          type = types.enum [ "tls10" "tls11" "tls12" ];
+          default = "tls12";
+          description = ''
+             The minimum supported version of TLS. Accepted values are "tls10", "tls11" or "tls12".
+          '';
+        };
+
+        tls_cipher_suites = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+             The list of supported ciphersuites as a comma-separated-list.
+          '';
+        };
+
+        tls_prefer_server_cipher_suites = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+             Specifies to prefer the server's ciphersuite over the client ciphersuites.
+          '';
+        };
+
+        tls_require_and_verify_client_cert = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+             Turns on client authentication for this listener.
+          '';
+        };
+
+      };
+
+      storage = {
+    
+        backend = mkOption {
+          type =  types.str;
+          default = "inMemory";
+          description = ''
+            The name of the type of storage backend.
+          '';
+        };
+
+        extraConfig = mkOption {
+          type = types.lines;
+          default = "";
+          description = ''
+            Configuration for storage
+          '';
+        };
+ 
+      };
+
+
+      telemetry = {
+
+        disable_hostname = mkOption {
+          type =  types.bool;
+          default = false;
+          description = ''
+            Specifies if gauge values should be prefixed with the local hostname. 
+          '';
+        };
+
+        extraConfig = mkOption {
+          type = types.lines;
+          default = "";
+          description = ''
+            configuration for telemetry
+          '';
+        };        
+
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.vault =
+    { description = "Vault server daemon";
+
+      wantedBy = ["multi-user.target"];
+
+      preStart =
+        ''
+          mkdir -m 0755 -p /var/lib/vault
+        '';
+
+      serviceConfig =
+        { ExecStart =
+            "${pkgs.vault}/bin/vault server -config ${configFile}";
+          KillMode = "process";
+        };
+    };   
+  };
+
+}

--- a/nixos/modules/services/security/vault.nix
+++ b/nixos/modules/services/security/vault.nix
@@ -27,7 +27,6 @@ let
 
       tls_min_version = "${cfg.listener.tls_min_version}" 
 
-
       ${optionalString (cfg.listener.tls_cipher_suites != null)''
         tls_cipher_suites = \"${cfg.listener.tls_cipher_suites}\"
       ''}

--- a/nixos/modules/services/security/vault.nix
+++ b/nixos/modules/services/security/vault.nix
@@ -112,6 +112,8 @@ in
       after = [ "network.target" ]
            ++ optional (config.services.consul.enable && cfg.storageBackend == "consul") "consul.service";
 
+      restartIfChanged = false; # do not restart on "nixos-rebuild switch". It would seal the storage and disrupt the clients.
+
       preStart = optionalString (cfg.storagePath != null) ''
         install -d -m0700 -o vault -g vault "${cfg.storagePath}"
       '';

--- a/nixos/modules/services/security/vault.nix
+++ b/nixos/modules/services/security/vault.nix
@@ -1,207 +1,132 @@
-{ config, lib, pkgs, utils, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 let
-
-  inherit (pkgs) vault;
-
   cfg = config.services.vault;
- 
+
   configFile = pkgs.writeText "vault.hcl" ''
     listener "tcp" {
-      address = "${cfg.listener.address}"
-   
-      ${optionalString (cfg.listener.cluster_address != null)''
-        cluster_address = "${cfg.listener.cluster_address}"
-      ''}
-      
-      ${optionalString (cfg.listener.tls_cert_file != null)''
-        tls_cert_file = "${cfg.listener.tls_cert_file}"
-      ''}
-      
-      ${optionalString (cfg.listener.tls_key_file != null)''
-        tls_key_file = "${cfg.listener.tls_key_file}"
-      ''}
-      
-      ${if cfg.listener.tls_disable then "tls_disable = \"1\"" else "" } 
-
-      tls_min_version = "${cfg.listener.tls_min_version}" 
-
-      ${optionalString (cfg.listener.tls_cipher_suites != null)''
-        tls_cipher_suites = \"${cfg.listener.tls_cipher_suites}\"
-      ''}
-
-      tls_prefer_server_cipher_suites = "${boolToString cfg.listener.tls_prefer_server_cipher_suites}"
-
-      tls_require_and_verify_client_cert = "${boolToString cfg.listener.tls_require_and_verify_client_cert}"
-
+      address = "${cfg.address}"
+      tls_cert_file = "${cfg.tlsCertFile}"
+      tls_key_file = "${cfg.tlsKeyFile}"
+      ${cfg.listenerExtraConfig}
     }
-
-    storage "${cfg.storage.backend}" {
-      ${cfg.storage.extraConfig}
+    storage "${cfg.storageBackend}" {
+      ${cfg.storageConfig}
     }
-
-    ${if cfg.telemetry.extraConfig != "" then "
-      telemetry { 
-        ${if cfg.telemetry.disable_hostname then "disable_hostname = \"true\"" else ""}
-        ${cfg.telemetry.extraConfig}
-      }" else ""}
-
+    ${optionalString (cfg.telemetryConfig != "") ''
+        telemetry {
+          ${cfg.telemetryConfig}
+        }
+      ''}
   '';
-
 in
 {
   options = {
 
     services.vault = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Enables the vault daemon.
+      enable = mkEnableOption "Vault daemon";
+
+      address = mkOption {
+        type = types.str;
+        default = "127.0.0.1:8200";
+        description = "The name of the ip interface to listen to";
+      };
+
+      tlsCertFile = mkOption {
+        type = types.str;
+        default = "/etc/vault/cert.pem";
+        example = "/path/to/your/cert.pem";
+        description = "TLS certificate file. A self-signed certificate will be generated if file not exists";
+      };
+
+      tlsKeyFile = mkOption {
+        type = types.str;
+        default = "/etc/vault/key.pem";
+        example = "/path/to/your/key.pem";
+        description = "TLS private key file. A self-signed certificate will be generated if file not exists";
+      };
+
+      listenerExtraConfig = mkOption {
+        type = types.lines;
+        default = ''
+          tls_min_version = "tls12"
         '';
+        description = "extra configuration";
       };
 
-      listener = {
-
-        address = mkOption {
-          type = types.str;
-          default = "127.0.0.1:8200";
-          description = ''
-            The name of the ip interface to listen to.
-          '';
-        };
-
-        cluster_address = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = ''
-            The name of the address to bind to for cluster server-to-server requests.
-          '';
-        };
-
-        tls_cert_file = mkOption {
-          type = types.str;
-          default = "";
-          description = ''
-            The name of the crt file for the ssl certificate.
-          '';
-        };
-        
-        tls_key_file = mkOption {
-          type = types.str;
-          default = "";
-          description = ''
-            The name of the key file for the ssl certificate.
-          '';
-        };
-
-        tls_disable = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Specifies if TLS will be disabled. Vault assumes TLS by default, so you must explicitly disable TLS to opt-in to insecure communication.
-          '';
-        };
-        
-        tls_min_version = mkOption {
-          type = types.enum [ "tls10" "tls11" "tls12" ];
-          default = "tls12";
-          description = ''
-             The minimum supported version of TLS. Accepted values are "tls10", "tls11" or "tls12".
-          '';
-        };
-
-        tls_cipher_suites = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = ''
-             The list of supported ciphersuites as a comma-separated-list.
-          '';
-        };
-
-        tls_prefer_server_cipher_suites = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-             Specifies to prefer the server's ciphersuite over the client ciphersuites.
-          '';
-        };
-
-        tls_require_and_verify_client_cert = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-             Turns on client authentication for this listener.
-          '';
-        };
-
+      storageBackend = mkOption {
+        type = types.enum ["inmem" "consul" "zookeeper" "file" "s3" "azure" "dynamodb" "etcd" "mssql" "mysql" "postgresql" "swift" "gcs"];
+        default = "inmem";
+        description = "The name of the type of storage backend";
       };
 
-      storage = {
-    
-        backend = mkOption {
-          type =  types.str;
-          default = "inMemory";
-          description = ''
-            The name of the type of storage backend.
-          '';
-        };
-
-        extraConfig = mkOption {
-          type = types.lines;
-          default = "";
-          description = ''
-            Configuration for storage
-          '';
-        };
- 
+      storageConfig = mkOption {
+        type = types.lines;
+        description = "Storage configuration";
+        default = "";
       };
 
-
-      telemetry = {
-
-        disable_hostname = mkOption {
-          type =  types.bool;
-          default = false;
-          description = ''
-            Specifies if gauge values should be prefixed with the local hostname. 
-          '';
-        };
-
-        extraConfig = mkOption {
-          type = types.lines;
-          default = "";
-          description = ''
-            configuration for telemetry
-          '';
-        };        
-
+      telemetryConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Telemetry configuration";
       };
-
     };
-
   };
 
   config = mkIf cfg.enable {
 
-    systemd.services.vault =
-    { description = "Vault server daemon";
+    users.extraUsers.vault = {
+      name = "vault";
+      group = "vault";
+      uid = config.ids.uids.vault;
+      description = "Vault daemon user";
+    };
+    users.extraGroups.vault.gid = config.ids.gids.vault;
+
+    systemd.services.vault = {
+      description = "Vault server daemon";
 
       wantedBy = ["multi-user.target"];
+      after = [ "network.target" ];
 
-      preStart =
-        ''
-          mkdir -m 0755 -p /var/lib/vault
-        '';
+      preStart = ''
+        mkdir -m 0755 -p /var/lib/vault
+        chown -R vault:vault /var/lib/vault
 
-      serviceConfig =
-        { ExecStart =
-            "${pkgs.vault}/bin/vault server -config ${configFile}";
-          KillMode = "process";
-        };
-    };   
+        # generate a self-signed certificate, you will have to set environment variable "VAULT_SKIP_VERIFY=1" in the client
+        if [ ! -s ${cfg.tlsCertFile} -o ! -s ${cfg.tlsKeyFile} ]; then
+          mkdir -p $(dirname ${cfg.tlsCertFile}) || true
+          mkdir -p $(dirname ${cfg.tlsKeyFile }) || true
+          ${pkgs.openssl.bin}/bin/openssl req -x509 -newkey rsa:2048 -sha256 -nodes -days 99999 \
+            -subj /C=US/ST=NY/L=NYC/O=vault/CN=${cfg.address} \
+            -keyout ${cfg.tlsKeyFile} -out ${cfg.tlsCertFile}
+
+          chown root:vault ${cfg.tlsKeyFile} ${cfg.tlsCertFile}
+          chmod 440 ${cfg.tlsKeyFile} ${cfg.tlsCertFile}
+        fi
+      '';
+
+      serviceConfig = {
+        User = "vault";
+        Group = "vault";
+        PermissionsStartOnly = true;
+        ExecStart = "${pkgs.vault}/bin/vault server -config ${configFile}";
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectSystem = "full";
+        ProtectHome = "read-only";
+        AmbientCapabilities = "cap_ipc_lock";
+        NoNewPrivileges = true;
+        KillSignal = "SIGINT";
+        TimeoutStopSec = "30s";
+        Restart = "on-failure";
+        StartLimitInterval = "60s";
+        StartLimitBurst = 3;
+      };
+    };
   };
 
 }

--- a/nixos/modules/services/security/vault.nix
+++ b/nixos/modules/services/security/vault.nix
@@ -93,7 +93,8 @@ in
       description = "Vault server daemon";
 
       wantedBy = ["multi-user.target"];
-      after = [ "network.target" ];
+      after = [ "network.target" ]
+           ++ optional (config.services.consul.enable && cfg.storageBackend == "consul") "consul.service";
 
       preStart =
         optionalString (cfg.storageBackend == "file" || cfg.storageBackend == "file_transactional")

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -9,7 +9,7 @@ let
   };
 in buildGoPackage rec {
   name = "vault-${version}";
-  version = "0.6.5";
+  version = "0.7.2";
 
   goPackagePath = "github.com/hashicorp/vault";
 
@@ -17,7 +17,7 @@ in buildGoPackage rec {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "0ci46zn9d9h26flgjf4inmvk4mb1hlixvx5g7vg02raw0cqvknnb";
+    sha256 = "1kclpyb9a9y5zjvrlbxnkac4fl3lwqsr98v4yydf9ihl5v7wy4f5";
   };
 
   buildFlagsArray = ''

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, go, gox }:
+{ stdenv, fetchFromGitHub, go, gox, removeReferencesTo }:
 
 let
   vaultBashCompletions = fetchFromGitHub {
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
     sha256 = "15wj1pfgzwzjfrqy7b5bx4y9f0hbpqlfif58l5xamwm88229qk4m";
   };
 
-  nativeBuildInputs = [ go gox ];
+  nativeBuildInputs = [ go gox removeReferencesTo ];
 
   buildPhase = ''
     substituteInPlace scripts/build.sh --replace 'git rev-parse HEAD' 'echo ${src.rev}'
@@ -31,7 +31,10 @@ in stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin $out/share/bash-completion/completions
+
     cp pkg/*/* $out/bin/
+    find $out/bin -type f -exec remove-references-to -t ${go} '{}' +
+
     cp ${vaultBashCompletions}/vault-bash-completion.sh $out/share/bash-completion/completions/vault
   '';
 

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -9,7 +9,7 @@ let
   };
 in buildGoPackage rec {
   name = "vault-${version}";
-  version = "0.7.2";
+  version = "0.7.3";
 
   goPackagePath = "github.com/hashicorp/vault";
 
@@ -17,7 +17,7 @@ in buildGoPackage rec {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "1kclpyb9a9y5zjvrlbxnkac4fl3lwqsr98v4yydf9ihl5v7wy4f5";
+    sha256 = "15wj1pfgzwzjfrqy7b5bx4y9f0hbpqlfif58l5xamwm88229qk4m";
   };
 
   buildFlagsArray = ''

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
 let
   vaultBashCompletions = fetchFromGitHub {

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, go, gox }:
 
 let
   vaultBashCompletions = fetchFromGitHub {
@@ -7,11 +7,9 @@ let
     rev = "e2f59b64be1fa5430fa05c91b6274284de4ea77c";
     sha256 = "10m75rp3hy71wlmnd88grmpjhqy0pwb9m8wm19l0f463xla54frd";
   };
-in buildGoPackage rec {
+in stdenv.mkDerivation rec {
   name = "vault-${version}";
   version = "0.7.3";
-
-  goPackagePath = "github.com/hashicorp/vault";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
@@ -20,14 +18,21 @@ in buildGoPackage rec {
     sha256 = "15wj1pfgzwzjfrqy7b5bx4y9f0hbpqlfif58l5xamwm88229qk4m";
   };
 
-  buildFlagsArray = ''
-    -ldflags=
-      -X github.com/hashicorp/vault/version.GitCommit=${version}
+  nativeBuildInputs = [ go gox ];
+
+  buildPhase = ''
+    substituteInPlace scripts/build.sh --replace 'git rev-parse HEAD' 'echo ${src.rev}'
+
+    mkdir -p src/github.com/hashicorp
+    ln -s $(pwd) src/github.com/hashicorp/vault
+
+    GOPATH=$(pwd) make
   '';
 
-  postInstall = ''
-    mkdir -p $bin/share/bash-completion/completions/
-    cp ${vaultBashCompletions}/vault-bash-completion.sh $bin/share/bash-completion/completions/vault
+  installPhase = ''
+    mkdir -p $out/bin $out/share/bash-completion/completions
+    cp pkg/*/* $out/bin/
+    cp ${vaultBashCompletions}/vault-bash-completion.sh $out/share/bash-completion/completions/vault
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

fork of PR #26130 with 
* updated to version 0.7.3
* run service under an unprivileged user instead of root
* <s>generate self-signed TLS certificate if certificate file does exist when the service starts (so ```services.vault.enable = true;``` in ```configuration.nix``` is enough to get some minimal setup up and running)</s> feature removed, see comments
* removed rarely used ```tls_*``` options (they could be set in ```extraConfig```)
* fixed typo (inMemory -> inmem)
* option names made camelCased
* build as a Makefile project, not a Go package

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

