### PR TITLE
django-polymorphic: init at 1.2

### DIFF
--- a/pkgs/development/python-modules/django-polymorphic/default.nix
+++ b/pkgs/development/python-modules/django-polymorphic/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi, django }:
+
+buildPythonPackage rec {
+  pname = "django-polymorphic";
+  version = "1.2";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bz86711sx2b66rl2xz141xppsfmlxilkgjgq0jsavpw37vg7r3r";
+  };
+
+  checkInputs = [ django ];
+  propagatedBuildInputs = [ django ];
+
+  meta = {
+    homepage = "https://github.com/django-polymorphic/django-polymorphic";
+    description = "Improved Django model inheritance with automatic downcasting";
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10005,6 +10005,8 @@ in {
 
   django_guardian = callPackage ../development/python-modules/django_guardian.nix { };
 
+  django_polymorphic = callPackage ../development/python-modules/django-polymorphic { };
+
   django_tagging = buildPythonPackage rec {
     name = "django-tagging-0.4.5";
 


### PR DESCRIPTION
###### Motivation for this change
Tested compilation with both Python2 and Python3

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).