### PR TITLE
terraform: 0.9.6 -> 0.9.9.

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -63,4 +63,10 @@ in {
     sha256 = "1f6z1zkklzpqgc7akgdz1g306ccmhni5lmg7i6g762n3qai60bnv";
     doCheck = true;
   };
+
+  terraform_0_9_9 = generic {
+    version = "0.9.9";
+    sha256 = "1pa9dd87dcjnn7fm1qn63da5qx87l7xjqlwiczrswcjfbismvl1p";
+    doCheck = true;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18644,10 +18644,11 @@ with pkgs;
     terraform_0_8_5
     terraform_0_8_8
     terraform_0_9_4
-    terraform_0_9_6;
+    terraform_0_9_6
+    terraform_0_9_9;
 
   terraform_0_8 = terraform_0_8_8;
-  terraform_0_9 = terraform_0_9_6;
+  terraform_0_9 = terraform_0_9_9;
   terraform = terraform_0_9;
 
   terraform-inventory = callPackage ../applications/networking/cluster/terraform-inventory {};


### PR DESCRIPTION
###### Motivation for this change

terraform: 0.9.6 -> 0.9.9.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

