### PR TITLE
zoom-us: don't add mesa to the LD_LIBRARY_PATH

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -29,7 +29,6 @@ in stdenv.mkDerivation {
     libpulseaudio
     libxml2
     libxslt
-    mesa
     nspr
     nss
     sqlite


### PR DESCRIPTION
###### Motivation for this change

zoom-us was failing to launch under the proprietary nvidia drivers, as described in the comments of #26596.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

