### PR TITLE
nixos: installer.nix test: test ZFS install use case

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -52,6 +52,7 @@ in rec {
         (all nixos.tests.firefox)
         (all nixos.tests.firewall)
         nixos.tests.gnome3.x86_64-linux # FIXME: i686-linux
+        (all nixos.tests.installer.zfsroot)
         (all nixos.tests.installer.lvm)
         (all nixos.tests.installer.luksroot)
         (all nixos.tests.installer.separateBoot)


### PR DESCRIPTION
###### Motivation for this change

NixOS works great with ZFS as the root filesystem, adding an installer test helps create documentation on how to do it, as proved-good instructions. Also helps to make sure we don't break it :)

Had to add support for extra installer-level config, to enable ZFS on the installation host.

cc @Mic92 who was also trying to make this work

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

