### PR TITLE
moka-icon-theme: 2017-02-13 -> 5.3.6

### DIFF
--- a/pkgs/data/icons/moka-icon-theme/default.nix
+++ b/pkgs/data/icons/moka-icon-theme/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${package-name}-${version}";
   package-name = "moka-icon-theme";
-  version = "2017-02-13";
+  version = "5.3.6";
 
   src = fetchFromGitHub {
     owner = "snwh";
     repo = package-name;
-    rev = "5ac530d2394574bdbd5360de46391d0dfc7aa2ab";
-    sha256 = "1zw1jm03706086gnplkkrdlrcyhgwm9kp4qax57wwc1s27bhc90n";
+    rev = "v${version}";
+    sha256 = "17f8k8z8xvib4hkxq0cw9j7bhdpqpv5frrkyc4sbyildcbavzzbr";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).