### PR TITLE
jdupes: init at 1.8

### DIFF
--- a/pkgs/tools/misc/jdupes/default.nix
+++ b/pkgs/tools/misc/jdupes/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "jdupes-${version}";
+  version = "1.8";
+
+  src = fetchFromGitHub {
+    owner = "jbruchon";
+    repo  = "jdupes";
+    rev   = "v${version}";
+    sha256 = "17cgh3j6z4rl8ay06s8387a2c49awfv1w3b2a11z4hidwry37aiq";
+    # Unicode file names lead to different checksums on HFS+ vs. other
+    # filesystems because of unicode normalisation. The testdir
+    # directories have such files and will be removed.
+    extraPostFetch = "rm -r $out/testdir";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ] ++ stdenv.lib.optional stdenv.isLinux "ENABLE_BTRFS=1";
+
+  meta = with stdenv.lib; {
+    description = "A powerful duplicate file finder and an enhanced fork of 'fdupes'";
+    longDescription = ''
+      jdupes is a program for identifying and taking actions upon
+      duplicate files. This fork known as 'jdupes' is heavily modified
+      from and improved over the original.
+    '';
+    homepage = https://github.com/jbruchon/jdupes;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14614,6 +14614,8 @@ with pkgs;
 
   japa = callPackage ../applications/audio/japa { };
 
+  jdupes = callPackage ../tools/misc/jdupes { };
+
   jedit = callPackage ../applications/editors/jedit { };
 
   jigdo = callPackage ../applications/misc/jigdo { };


### PR DESCRIPTION
###### Motivation for this change

- ~~Rename from `fdupes` to `jdupes`. The repository `fdupes-jody` previously
used does not exist anymore. The fork has been renamed to `jdupes`.~~

- ~~Update to version 1.8.~~

- Add `jdupes` to the package collection.

[~~Changes~~ Release notes](https://github.com/jbruchon/jdupes/releases)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).