### PR TITLE
consul: 0.7.5 -> 0.8.5

### DIFF
--- a/pkgs/servers/consul/default.nix
+++ b/pkgs/servers/consul/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "consul-${version}";
-  version = "0.7.5";
+  version = "0.8.5";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/consul";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "hashicorp";
     repo = "consul";
     inherit rev;
-    sha256 = "0zh4j5p0v41v7i6v084dgsdchx1azjs2mjb3dlfdv671rsnwi54z";
+    sha256 = "0xvkzk147wchvsp8xmmx4fq0kvqc49y9rswzvxzr53mfyiy0d0pf";
   };
 
   # Keep consul.ui for backward compatability

--- a/pkgs/servers/monitoring/consul-alerts/default.nix
+++ b/pkgs/servers/monitoring/consul-alerts/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "consul-alerts-${version}";
-  version = "0.3.3";
+  version = "0.5.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/AcalephStorage/consul-alerts";
@@ -11,6 +11,36 @@ buildGoPackage rec {
     inherit rev;
     owner = "AcalephStorage";
     repo = "consul-alerts";
-    sha256 = "1w0mb20w1yazyh84sa30bsw271c5nm7lsx2qg0g3gf6mxdb63lpq";
+    sha256 = "0dff2cpk3lkgjsh97rvlrpacpka0kwm29691diyvj7lb9ydzlx3r";
   };
+
+  extraSrcs = [
+    {
+      goPackagePath = "github.com/aws/aws-sdk-go";
+      src = fetchFromGitHub {
+        owner = "aws";
+        repo = "aws-sdk-go";
+        rev = "v1.10.4";
+        sha256 = "0jnikx2hjngh6ndv4i60w5nwx2hgnrx0i2av99s8hj8yfkxi3qkb";
+      };
+    }
+    {
+      goPackagePath = "github.com/mitchellh/hashstructure";
+      src = fetchFromGitHub {
+        owner = "mitchellh";
+        repo = "hashstructure";
+        rev = "2bca23e0e452137f789efbc8610126fd8b94f73b";
+        sha256 = "0vpacsls26474wya360fjhzi6l4y8s8s251c4szvqxh17n5f5gk1";
+      };
+    }
+    {
+      goPackagePath = "github.com/imdario/mergo";
+      src = fetchFromGitHub {
+        owner = "imdario";
+        repo = "mergo";
+        rev = "0.2.2";
+        sha256 = "1qnd5lsvsf0p9g1ssd0cy8g6qdkq439a9lqnir374nj7hkx4nl7p";
+      };
+    }
+  ];
 }


### PR DESCRIPTION
###### Motivation for this change

Version update

* consul: 0.7.5 -> 0.8.5
* consul-alerts: 0.3.3 -> 0.5.0
* consul-alerts: added explicit --log-level, it fails to start without
* consul service: removed legacy option 'leaveOnStop', since 0.7 it can be set in 'extraConfig'
* consul service: removed insecure and useless option 'dropPrivileges' which allowed to run consul daemon as root

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

