### PR TITLE
monoid: init at 2016-07-21

### DIFF
--- a/pkgs/data/fonts/monoid/default.nix
+++ b/pkgs/data/fonts/monoid/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, python, fontforge }:
+
+stdenv.mkDerivation rec {
+  name = "monoid-${version}";
+  version = "2016-07-21";
+
+  src = fetchFromGitHub {
+    owner = "larsenwork";
+    repo = "monoid";
+    rev = "e9d77ec18c337dc78ceae787a673328615f0b120";
+    sha256 = "07h5q6cn6jjpmxp9vyag1bxx481waz344sr2kfs7d37bba8yjydj";
+  };
+
+  nativeBuildInputs = [ python fontforge ];
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+    local _d=""
+    local _l=""
+    for _d in {Monoisome,Source}/*.sfdir; do
+      _l="''${_d##*/}.log"
+      echo "Building $_d (log at $_l)"
+      python Scripts/build.py ${if enableParallelBuilding then "$NIX_BUILD_CORES" else "1"} 0 $_d > $_l
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/{doc,fonts/truetype}
+    cp -va _release/* $out/share/fonts/truetype
+    cp -va Readme.md $out/share/doc
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://larsenwork.com/monoid;
+    description = "Customisable coding font with alternates, ligatures and contextual positioning";
+    license = [ licenses.ofl licenses.mit ];
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12860,6 +12860,8 @@ with pkgs;
 
   mobile_broadband_provider_info = callPackage ../data/misc/mobile-broadband-provider-info { };
 
+  monoid = callPackage ../data/fonts/monoid { };
+
   mononoki = callPackage ../data/fonts/mononoki { };
 
   moka-icon-theme = callPackage ../data/icons/moka-icon-theme { };


### PR DESCRIPTION
###### Motivation for this change

Add a package for the monoid font.

[Monoid](http://larsenwork.com/monoid/)

> Monoid is a font customizable and optimized for coding with bitmap-like sharpness at 12px/9pt even on low res displays.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).