### PR TITLE
mergerfs: 2.16.1 -> 2.22.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -247,6 +247,7 @@
   jensbin = "Jens Binkert <jensbin@protonmail.com>";
   jerith666 = "Matt McHenry <github@matt.mchenryfamily.org>";
   jfb = "James Felix Black <james@yamtime.com>";
+  jfrankenau = "Johannes Frankenau <johannes@frankenau.net>";
   jgeerds = "Jascha Geerds <jascha@jgeerds.name>";
   jgertm = "Tim Jaeger <jger.tm@gmail.com>";
   jgillich = "Jakob Gillich <jakob@gillich.me>";

--- a/pkgs/tools/filesystems/mergerfs/default.nix
+++ b/pkgs/tools/filesystems/mergerfs/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, fetchgit, fuse, pkgconfig, which, attr, pandoc, git }:
+{ stdenv, fetchgit, autoconf, automake, pkgconfig, gettext, libtool, git, pandoc, which, attr, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "mergerfs-${version}";
-  version = "2.16.1";
+  version = "2.22.1";
 
   # not using fetchFromGitHub because of changelog being built with git log
   src = fetchgit {
     url = "https://github.com/trapexit/mergerfs";
     rev = "refs/tags/${version}";
-    sha256 = "12fqgk54fnnibqiq82p4g2k6qnw3iy6dd64csmlf73yi67za5iwf";
+    sha256 = "12dm64l74wyagbwxsz57p8j3dwl9hgi0j3b6i0pn9m5ar7qrnv00";
     deepClone = true;
+    leaveDotGit = true;
   };
 
-  buildInputs = [ fuse pkgconfig which attr pandoc git ];
+  nativeBuildInputs = [ autoconf automake pkgconfig gettext libtool git pandoc which ];
+  buildInputs = [ attr libiconv ];
 
   makeFlags = [ "PREFIX=$(out)" "XATTR_AVAILABLE=1" ];
 
@@ -21,6 +23,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/trapexit/mergerfs;
     license = stdenv.lib.licenses.isc;
     platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ makefu ];
+    maintainers = with stdenv.lib.maintainers; [ jfrankenau makefu ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

mergerfs: 2.16.1 -> 2.22.1

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @makefu