### PR TITLE
skopeo: 0.1.18 -> 0.1.22

### DIFF
--- a/pkgs/development/tools/skopeo/default.nix
+++ b/pkgs/development/tools/skopeo/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub, gpgme, libgpgerror, devicemapper, btrfs-progs }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, gpgme, libgpgerror, devicemapper, btrfs-progs, pkgconfig, ostree }:
 
 with stdenv.lib;
 
 buildGoPackage rec {
   name = "skopeo-${version}";
-  version = "0.1.18";
+  version = "0.1.22";
   rev = "v${version}";
 
   goPackagePath = "github.com/projectatomic/skopeo";
   excludedPackages = "integration";
 
-  buildInputs = [ gpgme libgpgerror devicemapper btrfs-progs ];
+  buildInputs = [ gpgme libgpgerror devicemapper btrfs-progs pkgconfig ostree ];
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "projectatomic";
     repo = "skopeo";
-    sha256 = "13k29i5hx909hvddl2xkyw4qzxq2q20ay9bkal3xi063s6l0sh0z";
+    sha256 = "0aivs37bcvx3g22a9r3q1vj2ahw323g1vaq9jzbmifm9k0pb07jy";
   };
 
   patches = [

--- a/pkgs/development/tools/skopeo/path.patch
+++ b/pkgs/development/tools/skopeo/path.patch
@@ -6,7 +6,7 @@ index 50e29b2..7108df5 100644
  import (
  	"fmt"
  	"os"
-+        "path/filepath"
++	"path/filepath"
  
  	"github.com/Sirupsen/logrus"
  	"github.com/containers/image/signature"
@@ -14,11 +14,11 @@ index 50e29b2..7108df5 100644
  	policyPath := c.GlobalString("policy")
  	var policy *signature.Policy // This could be cached across calls, if we had an application context.
  	var err error
-+        var dir string
-+        if policyPath == "" {
-+              dir, err = filepath.Abs(filepath.Dir(os.Args[0]))
-+              policyPath = dir + "/../etc/default-policy.json"
-+        }
++	var dir string
++	if policyPath == "" {
++		dir, err = filepath.Abs(filepath.Dir(os.Args[0]))
++		policyPath = dir + "/../etc/default-policy.json"
++	}
  	if c.GlobalBool("insecure-policy") {
  		policy = &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
  	} else if policyPath == "" {

--- a/pkgs/development/tools/skopeo/path.patch
+++ b/pkgs/development/tools/skopeo/path.patch
@@ -1,25 +1,24 @@
 diff --git a/cmd/skopeo/main.go b/cmd/skopeo/main.go
-index 51f918d..6681d73 100644
+index 50e29b2..7108df5 100644
 --- a/cmd/skopeo/main.go
 +++ b/cmd/skopeo/main.go
 @@ -3,6 +3,7 @@ package main
  import (
  	"fmt"
  	"os"
-+  "path/filepath"
-
++        "path/filepath"
+ 
  	"github.com/Sirupsen/logrus"
  	"github.com/containers/image/signature"
-@@ -84,6 +85,12 @@ func getPolicyContext(c *cli.Context) (*signature.PolicyContext, error) {
+@@ -88,6 +89,11 @@ func getPolicyContext(c *cli.Context) (*signature.PolicyContext, error) {
  	policyPath := c.GlobalString("policy")
  	var policy *signature.Policy // This could be cached across calls, if we had an application context.
  	var err error
-+  var dir string
-+  if policyPath == "" {
-+    dir, err = filepath.Abs(filepath.Dir(os.Args[0]))
-+    policyPath = dir + "/../etc/default-policy.json"
-+  }
-+
- 	if policyPath == "" {
- 		policy, err = signature.DefaultPolicy(nil)
- 	} else {
++        var dir string
++        if policyPath == "" {
++              dir, err = filepath.Abs(filepath.Dir(os.Args[0]))
++              policyPath = dir + "/../etc/default-policy.json"
++        }
+ 	if c.GlobalBool("insecure-policy") {
+ 		policy = &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+ 	} else if policyPath == "" {

--- a/pkgs/development/tools/skopeo/path.patch
+++ b/pkgs/development/tools/skopeo/path.patch
@@ -22,3 +22,17 @@ index 50e29b2..7108df5 100644
  	if c.GlobalBool("insecure-policy") {
  		policy = &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
  	} else if policyPath == "" {
+diff --git a/vendor/github.com/containers/image/docker/docker_client.go b/vendor/github.com/containers/image/docker/docker_client.go
+index b989770..697d2ee 100644
+--- a/vendor/github.com/containers/image/docker/docker_client.go
++++ b/vendor/github.com/containers/image/docker/docker_client.go
+@@ -154,6 +154,9 @@ func setupCertificates(dir string, tlsc *tls.Config) error {
+ 		if os.IsNotExist(err) {
+ 			return nil
+ 		}
++		if os.IsPermission(err) {
++			return nil
++		}
+ 		return err
+ 	}
+ 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

