### PR TITLE
Fixup various setuid/setgid permission problems, part 2

### DIFF
--- a/pkgs/development/libraries/libutempter/default.nix
+++ b/pkgs/development/libraries/libutempter/default.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ glib ];
 
+  prePatch = ''
+    substituteInPlace Makefile --replace 2711 0711
+  '';
+
   installFlags = [
     "libdir=\${out}/lib"
     "libexecdir=\${out}/lib"

--- a/pkgs/development/libraries/wcslib/default.nix
+++ b/pkgs/development/libraries/wcslib/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
     sha256 ="1s2nig327g4bimd9xshlk11ww09a7mrjmsbpdcd8smsmn2kl1glb";
   };
 
+  prePatch = ''
+    substituteInPlace GNUmakefile --replace 2775 0775
+    substituteInPlace C/GNUmakefile --replace 2775 0775
+  '';
+
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
   '';
 
   preBuild = ''
-    sed -e "s@/etc/@$out/etc/@g" -i Makefile
+    sed -e "s@/etc/@$out/etc/@g" -e "/chmod u+s/d" -i Makefile
   '';
 
   meta = {

--- a/pkgs/os-specific/linux/kbdlight/default.nix
+++ b/pkgs/os-specific/linux/kbdlight/default.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace Makefile \
-      --replace /usr/local $out
+      --replace /usr/local $out \
+      --replace 4755 0755
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/mail/mailman/default.nix
+++ b/pkgs/servers/mail/mailman/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   installTargets = "doinstall";         # Leave out the 'update' target that's implied by 'install'.
 
+  makeFlags = [ "DIRSETGID=:" ];
+
   meta = {
     homepage = "http://www.gnu.org/software/mailman/";
     description = "Free software for managing electronic mail discussion and e-newsletter lists";

--- a/pkgs/servers/news/leafnode/default.nix
+++ b/pkgs/servers/news/leafnode/default.nix
@@ -10,6 +10,10 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--enable-runas-user=nobody";
 
+  prePatch = ''
+    substituteInPlace Makefile.in --replace 02770 0770
+  '';
+
   preConfigure = ''
     # configure uses id to check environment; we don't want this check
     sed -re 's/^ID[=].*/ID="echo whatever"/' -i configure

--- a/pkgs/tools/filesystems/irods/default.nix
+++ b/pkgs/tools/filesystems/irods/default.nix
@@ -40,6 +40,8 @@ in rec {
         -DCMAKE_MODULE_LINKER_FLAGS=-Wl,-rpath,$out/lib
         -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-rpath,$out/lib
         "
+
+      substituteInPlace cmake/server.cmake --replace SETUID ""
     '';
 
     meta = common.meta // {

--- a/pkgs/tools/misc/ddccontrol/default.nix
+++ b/pkgs/tools/misc/ddccontrol/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation {
       oldPath+="{datadir}\/ddccontrol-db"
       sed "s/$oldPath/$newPath/" <configure.ac.old >configure.ac
       rm configure.ac.old
+
+      sed -e "s/chmod 4711/chmod 0711/" -i src/ddcpci/Makefile*
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/networking/mailutils/default.nix
+++ b/pkgs/tools/networking/mailutils/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
 
   patches = [ ./path-to-cat.patch ./no-gets.patch ./scm_c_string.patch ];
 
+  postPatch = ''
+    sed -i -e '/chown root:mail/d' \
+           -e 's/chmod [24]755/chmod 0755/' \
+      */Makefile{,.in,.am}
+  '';
+
   configureFlags = [
     "--with-gsasl"
     "--with-gssapi=${gss}"

--- a/pkgs/tools/networking/netselect/default.nix
+++ b/pkgs/tools/networking/netselect/default.nix
@@ -8,10 +8,13 @@ stdenv.mkDerivation {
     sha256 = "0y69z59vylj9x9nk5jqn6ihx7dkzg09gpv2w1q1rs8fmi4jr90gy";
   };
 
-  preBuild = "
+  preBuild = ''
     makeFlagsArray=(PREFIX=$out)
-    substituteInPlace Makefile --replace '-o root' '' --replace '-g root' ''
-  ";
+    substituteInPlace Makefile \
+      --replace "-o root" "" \
+      --replace "-g root" "" \
+      --replace "4755"    "0755"
+  '';
   
   meta = {
     homepage = http://alumnit.ca/~apenwarr/netselect/;

--- a/pkgs/tools/system/mcron/default.nix
+++ b/pkgs/tools/system/mcron/default.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
 
   patches = [ ./install-vixie-programs.patch ];
 
+  # don't attempt to chmod +s files in the nix store
+  postPatch = ''
+    substituteInPlace makefile.in --replace "rwxs" "rwx"
+  '';
+
   buildInputs = [ guile which ed ];
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

Fixes all but the Darwin-specific failure in qtsvg from the list of packages in #26600.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

