### PR TITLE
NixOS Manual: Make it easier to debug

### DIFF
--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -65,7 +65,7 @@ let
       chmod -R u+w .
       ln -s ${modulesDoc} configuration/modules.xml
       ln -s ${optionsDocBook} options-db.xml
-      echo "${version}" > version
+      printf "%s" "${version}" > version
     '';
 
   toc = builtins.toFile "toc.xml"

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -94,25 +94,43 @@ let
     "--stringparam chunk.toc ${toc}"
   ];
 
+  manual-combined = runCommand "nixos-manual-combined"
+    { inherit sources;
+      buildInputs = [ libxml2 libxslt ];
+      meta.description = "The NixOS manual as plain docbook XML";
+    }
+    ''
+      ${copySources}
+
+      xmllint --xinclude --output ./manual-combined.xml ./manual.xml
+      xmllint --xinclude --noxincludenode \
+         --output ./man-pages-combined.xml ./man-pages.xml
+
+      xmllint --debug --noout --nonet \
+        --relaxng ${docbook5}/xml/rng/docbook/docbook.rng \
+        manual-combined.xml
+      xmllint --debug --noout --nonet \
+        --relaxng ${docbook5}/xml/rng/docbook/docbook.rng \
+        man-pages-combined.xml
+
+
+      mkdir $out
+      cp manual-combined.xml $out/
+      cp man-pages-combined.xml $out/
+    '';
+
   olinkDB = runCommand "manual-olinkdb"
     { inherit sources;
       buildInputs = [ libxml2 libxslt ];
     }
     ''
-      ${copySources}
-
       xsltproc \
         ${manualXsltprocOptions} \
         --stringparam collect.xref.targets only \
         --stringparam targets.filename "$out/manual.db" \
-        --nonet --xinclude \
+        --nonet \
         ${docbook5_xsl}/xml/xsl/docbook/xhtml/chunktoc.xsl \
-        ./manual.xml
-
-      # Check the validity of the man pages sources.
-      xmllint --noout --nonet --xinclude --noxincludenode \
-        --relaxng ${docbook5}/xml/rng/docbook/docbook.rng \
-        ./man-pages.xml
+        ${manual-combined}/manual-combined.xml
 
       cat > "$out/olinkdb.xml" <<EOF
       <?xml version="1.0" encoding="utf-8"?>
@@ -158,21 +176,15 @@ in rec {
       allowedReferences = ["out"];
     }
     ''
-      ${copySources}
-
-      # Check the validity of the manual sources.
-      xmllint --noout --nonet --xinclude --noxincludenode \
-        --relaxng ${docbook5}/xml/rng/docbook/docbook.rng \
-        manual.xml
-
       # Generate the HTML manual.
       dst=$out/share/doc/nixos
       mkdir -p $dst
       xsltproc \
         ${manualXsltprocOptions} \
         --stringparam target.database.document "${olinkDB}/olinkdb.xml" \
-        --nonet --xinclude --output $dst/ \
-        ${docbook5_xsl}/xml/xsl/docbook/xhtml/chunktoc.xsl ./manual.xml
+        --nonet --output $dst/ \
+        ${docbook5_xsl}/xml/xsl/docbook/xhtml/chunktoc.xsl \
+        ${manual-combined}/manual-combined.xml
 
       mkdir -p $dst/images/callouts
       cp ${docbook5_xsl}/xml/xsl/docbook/images/callouts/*.gif $dst/images/callouts/
@@ -190,13 +202,6 @@ in rec {
       buildInputs = [ libxml2 libxslt zip ];
     }
     ''
-      ${copySources}
-
-      # Check the validity of the manual sources.
-      xmllint --noout --nonet --xinclude --noxincludenode \
-        --relaxng ${docbook5}/xml/rng/docbook/docbook.rng \
-        manual.xml
-
       # Generate the epub manual.
       dst=$out/share/doc/nixos
 
@@ -204,10 +209,11 @@ in rec {
         ${manualXsltprocOptions} \
         --stringparam target.database.document "${olinkDB}/olinkdb.xml" \
         --nonet --xinclude --output $dst/epub/ \
-        ${docbook5_xsl}/xml/xsl/docbook/epub/docbook.xsl ./manual.xml
+        ${docbook5_xsl}/xml/xsl/docbook/epub/docbook.xsl \
+        ${manual-combined}/manual-combined.xml
 
       mkdir -p $dst/epub/OEBPS/images/callouts
-      cp -r ${docbook5_xsl}/xml/xsl/docbook/images/callouts/*.gif $dst/epub/OEBPS/images/callouts
+      cp -r ${docbook5_xsl}/xml/xsl/docbook/images/callouts/*.gif $dst/epub/OEBPS/images/callouts # */
       echo "application/epub+zip" > mimetype
       manual="$dst/nixos-manual.epub"
       zip -0Xq "$manual" mimetype
@@ -227,23 +233,16 @@ in rec {
       allowedReferences = ["out"];
     }
     ''
-      ${copySources}
-
-      # Check the validity of the man pages sources.
-      xmllint --noout --nonet --xinclude --noxincludenode \
-        --relaxng ${docbook5}/xml/rng/docbook/docbook.rng \
-        ./man-pages.xml
-
       # Generate manpages.
       mkdir -p $out/share/man
-      xsltproc --nonet --xinclude \
+      xsltproc --nonet \
         --param man.output.in.separate.dir 1 \
         --param man.output.base.dir "'$out/share/man/'" \
         --param man.endnotes.are.numbered 0 \
         --param man.break.after.slash 1 \
         --stringparam target.database.document "${olinkDB}/olinkdb.xml" \
         ${docbook5_xsl}/xml/xsl/docbook/manpages/docbook.xsl \
-        ./man-pages.xml
+        ${manual-combined}/man-pages-combined.xml
     '';
 
 }


### PR DESCRIPTION
###### Motivation for this change

When hacking on the manual, if you make an markup error like an invalid tag you get bogus validation results:

```
manual.xml:5: element chapter: Relax-NG validity error : Element part has extra content: chapter
```

except I added that to `installation/installing.xml`!

Debugging this further, I found `jing` makes a much better error message. First I perform the `xincludes` and produce a single monolithic manual file, then run jing, and get:

```
/tmp/nix-build-nixos-manual-combined.drv-0/./manual-combined.xml:313:10: error: element "chapter" not allowed here; expected element "address", "anchor", ...
```

With `--keep-failed`:

```
$ cat /tmp/nix-build-nixos-manual-combined.drv-0/./manual-combined.xml | head -n 318 | tail -n10
typical sequence of commands for installing NixOS on an empty hard
drive (here <filename>/dev/sda</filename>).  <xref linkend="ex-config"/> shows a corresponding configuration Nix expression.</para>

<example xml:id="ex-install-sequence"><title>Commands for Installing NixOS on <filename>/dev/sda</filename></title>
<chapter><screen>
# fdisk /dev/sda # <lineannotation>(or whatever device you want to install on)</lineannotation>
# mkfs.ext4 -L nixos /dev/sda1
# mkswap -L swap /dev/sda2
# swapon /dev/sda2
# mount /dev/disk/by-label/nixos /mnt
```

Bingo! I added the chapter in the wrong place.

By performing xinclude in one place, this also means the error is only outputted once, and not many times (once per manual type.)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Additionally, I word-diffed the results of this to the current process, and received effectively identical output, for each of the following:

`nix-build ./nixos/release.nix -A manual.x86_64-linux -A manualEpub.x86_64-linux -A manpages.x86_64-linux -A options`

---

