### PR TITLE
certstrap: init at 1.0.1

### DIFF
--- a/pkgs/tools/security/certstrap/default.nix
+++ b/pkgs/tools/security/certstrap/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "certstrap-${version}";
+  version = "1.0.1";
+
+  goPackagePath = "github.com/square/certstrap";
+
+  src = fetchFromGitHub {
+    owner = "square";
+    repo = "certstrap";
+    rev = "v${version}";
+    sha256 = "0pw1g6nyb212ayic42rkm6i0cf4n2003f02qym6zp130m6aysb47";
+  };
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Tools to bootstrap CAs, certificate requests, and signed certificates";
+    platforms = platforms.all;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ volth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1388,6 +1388,8 @@ with pkgs;
 
   c14 = callPackage ../applications/networking/c14 { };
 
+  certstrap = callPackage ../tools/security/certstrap { };
+
   cfssl = callPackage ../tools/security/cfssl { };
 
   checkbashisms = callPackage ../development/tools/misc/checkbashisms { };


### PR DESCRIPTION
###### Motivation for this change

Square's tools to bootstrap CAs, certificate requests, and signed certificates

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

