### PR TITLE
jd: init at 0.3.1

### DIFF
--- a/pkgs/development/tools/jd/default.nix
+++ b/pkgs/development/tools/jd/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildGoPackage, fetchgit }:
+
+buildGoPackage rec {
+  name = "jd-${version}";
+  version = "0.3.1";
+  rev = "2729b5af166cfd72bd953ef8959b456c4db940fc";
+
+  goPackagePath = "github.com/tidwall/jd";
+
+  src = fetchgit {
+    inherit rev;
+    url = "https://github.com/tidwall/jd";
+    sha256 = "0dj4k38pf80dl77jns29vx2dj265s4ksg2q2s9n240b7b8z8mn5h";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Interactive JSON Editor";
+    license = licenses.mit;
+    maintainers = [ maintainers.np ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2562,6 +2562,8 @@ with pkgs;
 
   jade = callPackage ../tools/text/sgml/jade { };
 
+  jd = callPackage ../development/tools/jd { };
+
   jd-gui = callPackage_i686 ../tools/security/jd-gui { };
 
   jdiskreport = callPackage ../tools/misc/jdiskreport { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

