### PR TITLE
neomutt: 20170602 -> 20170609

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -1,20 +1,20 @@
 { stdenv, fetchFromGitHub, which, autoreconfHook, ncurses, perl
-, cyrus_sasl, gdbm, gpgme, kerberos, libidn, notmuch, openssl, lmdb, libxslt, docbook_xsl }:
+, cyrus_sasl, gss, gpgme, kerberos, libidn, notmuch, openssl, lmdb, libxslt, docbook_xsl }:
 
 stdenv.mkDerivation rec {
-  version = "20170602";
+  version = "20170609";
   name = "neomutt-${version}";
 
   src = fetchFromGitHub {
     owner  = "neomutt";
     repo   = "neomutt";
     rev    = "neomutt-${version}";
-    sha256 = "0rpvxmv10ypl7la4nmp0s02ixmm9g5pn9g9ms8ygzsix9pa86w45";
+    sha256 = "015dd6rphvqdmnv477f1is22l7n5gvcvyblbyp0ggbp64650k0bz";
   };
 
   nativeBuildInputs = [ autoreconfHook docbook_xsl libxslt.bin which ];
   buildInputs = [
-    cyrus_sasl gdbm gpgme kerberos libidn ncurses
+    cyrus_sasl gss gpgme kerberos libidn ncurses
     notmuch openssl perl lmdb
   ];
 
@@ -28,23 +28,13 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-debug"
     "--enable-gpgme"
-    "--enable-hcache"
-    "--enable-imap"
     "--enable-notmuch"
-    "--enable-pgp"
-    "--enable-pop"
-    "--enable-sidebar"
-    "--enable-keywords"
-    "--enable-smtp"
-    "--enable-nntp"
-    "--enable-compressed"
     "--with-homespool=mailbox"
     "--with-gss"
     "--with-mailpath="
     "--with-ssl"
     "--with-sasl"
     "--with-curses"
-    "--with-regex"
     "--with-idn"
     "--with-lmdb"
 
@@ -61,6 +51,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.neomutt.org;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ cstrahan vrthra erikryb ];
+    maintainers = with maintainers; [ cstrahan erikryb jfrankenau vrthra ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update.
Note: The removed configure flags are either enabled by default or were removed upstream. Also, I have removed the dependency on `gdbm` as we are using `lmbd` for header caches anyway.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @cstrahan @vrthra @erikryb