### PR TITLE
electrum-{ltc,dash}: use protobuf3_2

### DIFF
--- a/pkgs/applications/misc/electrum-dash/default.nix
+++ b/pkgs/applications/misc/electrum-dash/default.nix
@@ -13,7 +13,7 @@ python2Packages.buildPythonApplication rec {
     dns
     ecdsa
     pbkdf2
-    protobuf3_0
+    protobuf3_2
     pyasn1
     pyasn1-modules
     pycrypto

--- a/pkgs/applications/misc/electrum-ltc/default.nix
+++ b/pkgs/applications/misc/electrum-ltc/default.nix
@@ -20,7 +20,7 @@ python2Packages.buildPythonApplication rec {
     requests
     qrcode
     ltc_scrypt
-    protobuf3_0
+    protobuf3_2
     dns
     jsonrpclib
   ];


### PR DESCRIPTION
###### Motivation for this change

Fix buid issues

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

