### PR TITLE
vaapiIntelG45H264: init at 1.8.2

### DIFF
--- a/pkgs/development/libraries/vaapi-intel/fix_surface_querys.patch
+++ b/pkgs/development/libraries/vaapi-intel/fix_surface_querys.patch
@@ -1,0 +1,57 @@
+--- intel-vaapi-driver/src/i965_drv_video.c.orig	2017-04-20 00:11:01.000000000 +0200
++++ intel-vaapi-driver/src/i965_drv_video.c	2017-04-22 15:33:21.986238617 +0200
+@@ -5459,15 +5459,7 @@
+             attrib_list[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
+ 
+             if (attrib_list[i].value.value.i == 0) {
+-                if (IS_G4X(i965->intel.device_info)) {
+-                    if (obj_config->profile == VAProfileMPEG2Simple ||
+-                        obj_config->profile == VAProfileMPEG2Main) {
+-                        attrib_list[i].value.value.i = VA_FOURCC_I420;
+-                    } else {
+-                        assert(0);
+-                        attrib_list[i].flags = VA_SURFACE_ATTRIB_NOT_SUPPORTED;
+-                    }
+-                } else if (IS_IRONLAKE(i965->intel.device_info)) {
++                if (IS_G4X(i965->intel.device_info) || IS_IRONLAKE(i965->intel.device_info)) {
+                     if (obj_config->profile == VAProfileMPEG2Simple ||
+                         obj_config->profile == VAProfileMPEG2Main) {
+                         attrib_list[i].value.value.i = VA_FOURCC_I420;
+@@ -5492,18 +5484,7 @@
+                         attrib_list[i].value.value.i = VA_FOURCC_NV12;
+                 }
+             } else {
+-                if (IS_G4X(i965->intel.device_info)) {
+-                    if (obj_config->profile == VAProfileMPEG2Simple ||
+-                        obj_config->profile == VAProfileMPEG2Main) {
+-                        if (attrib_list[i].value.value.i != VA_FOURCC_I420) {
+-                            attrib_list[i].value.value.i = 0;
+-                            attrib_list[i].flags &= ~VA_SURFACE_ATTRIB_SETTABLE;
+-                        }
+-                    } else {
+-                        assert(0);
+-                        attrib_list[i].flags = VA_SURFACE_ATTRIB_NOT_SUPPORTED;
+-                    }
+-                } else if (IS_IRONLAKE(i965->intel.device_info)) {
++                if (IS_G4X(i965->intel.device_info) || IS_IRONLAKE(i965->intel.device_info)) {
+                     if (obj_config->profile == VAProfileMPEG2Simple ||
+                         obj_config->profile == VAProfileMPEG2Main) {
+                         if (attrib_list[i].value.value.i != VA_FOURCC_I420) {
+@@ -5649,16 +5630,7 @@
+     if (attribs == NULL)
+         return VA_STATUS_ERROR_ALLOCATION_FAILED;
+ 
+-    if (IS_G4X(i965->intel.device_info)) {
+-        if (obj_config->profile == VAProfileMPEG2Simple ||
+-            obj_config->profile == VAProfileMPEG2Main) {
+-            attribs[i].type = VASurfaceAttribPixelFormat;
+-            attribs[i].value.type = VAGenericValueTypeInteger;
+-            attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
+-            attribs[i].value.value.i = VA_FOURCC_I420;
+-            i++;
+-        }
+-    } else if (IS_IRONLAKE(i965->intel.device_info)) {
++    if (IS_G4X(i965->intel.device_info) || IS_IRONLAKE(i965->intel.device_info)) {
+         switch (obj_config->profile) {
+         case VAProfileMPEG2Simple:
+         case VAProfileMPEG2Main:

--- a/pkgs/development/libraries/vaapi-intel/g45-h264.nix
+++ b/pkgs/development/libraries/vaapi-intel/g45-h264.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, gnum4, pkgconfig, python2, autoreconfHook
+, intel-gpu-tools, libdrm, libva, libX11, mesa_noglu, wayland
+}:
+
+stdenv.mkDerivation rec {
+  name = "libva-intel-driver-g45-h264-${version}";
+  version = "1.8.2";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/alium/g45-h264/downloads/intel-driver-g45-h264-${version}.tar.gz";
+    sha256 = "0a93nbznnikkqf3ry417jzpzwz1s3hc9ys0jckqsnm9mr29cxbw6";
+  };
+
+  patches = [ ./fix_surface_querys.patch ];
+
+  postPatch = ''
+    patchShebangs ./src/shaders/gpp.py
+  '';
+
+  preConfigure = ''
+    sed -i -e "s,LIBVA_DRIVERS_PATH=.*,LIBVA_DRIVERS_PATH=$out/lib/dri," configure
+  '';
+
+  configureFlags = [
+    "--enable-drm"
+    "--enable-x11"
+    "--enable-wayland"
+  ];
+
+  nativeBuildInputs = [ gnum4 pkgconfig python2 autoreconfHook ];
+
+  buildInputs = [ intel-gpu-tools libdrm libva libX11 mesa_noglu wayland ];
+
+  meta = with stdenv.lib; {
+    homepage = https://bitbucket.org/alium/g45-h264/downloads/;
+    license = licenses.mit;
+    description = "VAAPI library driver with H264 support for Intel G45 chipsets";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10338,6 +10338,10 @@ with pkgs;
     libva = libva-full; # also wants libva-{x11,drm,wayland}
   };
 
+  vaapiIntelG45H264 = callPackage ../development/libraries/vaapi-intel/g45-h264.nix {
+    libva = libva-full; # also wants libva-{x11,drm,wayland}
+  };
+
   vaapiVdpau = callPackage ../development/libraries/vaapi-vdpau {
     libva = libva-full; # needs libva-{x11,glx}
   };


### PR DESCRIPTION
###### Motivation for this change

The `vaapiIntel` package provides MPEG-2 decoding only for GMA 4500 series GPUs. The experimental g45-h264 branch enables H.264 decoding for those chipsets.

I've based this package upon the original `vaapiIntel` package as well as the [libva-intel-driver-g45-h264](https://aur.archlinux.org/packages/libva-intel-driver-g45-h264/) package in the Arch Linux User Repository which includes a patch for Ironlake graphics as well. The latter one is only available as an anonymous gist which is why I've added it here.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

