### PR TITLE
lumina: 1.2.0-p1 -> 1.3.0

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/lumina.nix
+++ b/nixos/modules/services/x11/desktop-managers/lumina.nix
@@ -33,7 +33,6 @@ in
     environment.systemPackages = [
       pkgs.fluxbox
       pkgs.libsForQt5.kwindowsystem
-      pkgs.kdeFrameworks.oxygen-icons5
       pkgs.lumina
       pkgs.numlockx
       pkgs.qt5.qtsvg

--- a/pkgs/desktops/lumina/default.nix
+++ b/pkgs/desktops/lumina/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchFromGitHub, fluxbox, xscreensaver, desktop_file_utils, numlockx,
-  xorg, qtbase, qtsvg, qtmultimedia, qtx11extras, qmake, qttools, oxygen-icons5
+  xorg, qtbase, qtsvg, qtmultimedia, qtx11extras, qmake, qttools
 }:
 
 stdenv.mkDerivation rec {
   name = "lumina-${version}";
-  version = "1.2.0-p1";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "trueos";
     repo = "lumina";
     rev = "v${version}";
-    sha256 = "0k16lcpxp9avwkadbbyqficd1wxsmwian5ji38wyax76v22yq7p6";
+    sha256 = "13kwlhv2qscrn52xvx0n1sqbl96fkcb5r1ixa0wazflx8dfl9ndn";
   };
 
   nativeBuildInputs = [
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
     qtsvg
     qtmultimedia
     qtx11extras
-    oxygen-icons5
     fluxbox
     xscreensaver
     desktop_file_utils


### PR DESCRIPTION
###### Motivation for this change

- Update to version 1.3.0

- Remove dependency on `oxygen-icons5`, as Lumina desktop now distributes it’s own "material-design-[light/dark]" icon themes and uses them as the default icon sets.

See the [announcement](https://lumina-desktop.org/version-1-3-0-released/).
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).