### PR TITLE
elm-github-install: init at 1.0.1

### DIFF
--- a/pkgs/tools/package-management/elm-github-install/Gemfile
+++ b/pkgs/tools/package-management/elm-github-install/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'elm_install'

--- a/pkgs/tools/package-management/elm-github-install/Gemfile.lock
+++ b/pkgs/tools/package-management/elm-github-install/Gemfile.lock
@@ -1,0 +1,39 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    adts (0.1.2)
+    commander (4.4.3)
+      highline (~> 1.7.2)
+    contracts (0.16.0)
+    elm_install (1.0.1)
+      adts (~> 0.1.2)
+      commander (~> 4.4, >= 4.4.2)
+      contracts (~> 0.16.0)
+      git (~> 1.3)
+      git_clone_url (~> 2.0)
+      hashdiff (~> 0.3.1)
+      indentation (~> 0.1.1)
+      smart_colored (~> 1.1, >= 1.1.1)
+      solve (~> 3.1)
+    git (1.3.0)
+    git_clone_url (2.0.0)
+      uri-ssh_git (>= 2.0)
+    hashdiff (0.3.4)
+    highline (1.7.8)
+    indentation (0.1.1)
+    molinillo (0.5.7)
+    semverse (2.0.0)
+    smart_colored (1.1.1)
+    solve (3.1.0)
+      molinillo (>= 0.5)
+      semverse (>= 1.1, < 3.0)
+    uri-ssh_git (2.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  elm_install
+
+BUNDLED WITH
+   1.14.4

--- a/pkgs/tools/package-management/elm-github-install/default.nix
+++ b/pkgs/tools/package-management/elm-github-install/default.nix
@@ -1,0 +1,17 @@
+{ lib, bundlerEnv, ruby }:
+
+bundlerEnv rec {
+  name = "elm-github-install-${version}";
+
+  version = (import ./gemset.nix).elm_install.version;
+  inherit ruby;
+  gemdir = ./.;
+
+  meta = with lib; {
+    description = "Install Elm packages from git repositories.";
+    homepage    = https://github.com/gdotdesign/elm-github-install;
+    license     = licenses.unfree;
+    maintainers = [ maintainers.roberth ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/tools/package-management/elm-github-install/gemset.nix
+++ b/pkgs/tools/package-management/elm-github-install/gemset.nix
@@ -1,0 +1,114 @@
+{
+  adts = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1793bfsgg8ca58b70xas9rglnspig41ih0iwqcad62s0grxzrjwz";
+      type = "gem";
+    };
+    version = "0.1.2";
+  };
+  commander = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01qx76y05v29kgyjsfkai73gwfnqhypp1k8v024m9w7qzpv4mpxf";
+      type = "gem";
+    };
+    version = "4.4.3";
+  };
+  contracts = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "119f5p1n6r5svbx8h09za6a4vrsnj5i1pzr9cqdn9hj3wrxvyl3a";
+      type = "gem";
+    };
+    version = "0.16.0";
+  };
+  elm_install = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0d3fwhj54madabmzamss865kj8czicgaq5fbdll9kpapqvy6a2j5";
+      type = "gem";
+    };
+    version = "1.0.1";
+  };
+  git = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1waikaggw7a1d24nw0sh8fd419gbf7awh000qhsf411valycj6q3";
+      type = "gem";
+    };
+    version = "1.3.0";
+  };
+  git_clone_url = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qgq7pjl461si3m2gr28vwbx47dcbpyy682mcwra5y1klpkbcvr5";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+  hashdiff = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n6hj7k7b9hazac0j48ypbak2nqi5wy4nh5cjra6xl3a92r8db0a";
+      type = "gem";
+    };
+    version = "0.3.4";
+  };
+  highline = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nf5lgdn6ni2lpfdn4gk3gi47fmnca2bdirabbjbz1fk9w4p8lkr";
+      type = "gem";
+    };
+    version = "1.7.8";
+  };
+  indentation = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ix64qgmm91xm1yiqxdcn9bqb1l6gwvkv7322yni34b3bd16lgvc";
+      type = "gem";
+    };
+    version = "0.1.1";
+  };
+  molinillo = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "19h1nks0x2ljwyijs2rd1f9sh05j8xqvjaqk1rslp5nyy6h4a758";
+      type = "gem";
+    };
+    version = "0.5.7";
+  };
+  semverse = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1cf6iv5wgwb7b8jf7il751223k9yahz9aym06s9r0prda5mwddyy";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+  smart_colored = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hccah5iwsvn9rf7zdgl7mdbh0h63vfwy1c6d280cb9qkfj8rdny";
+      type = "gem";
+    };
+    version = "1.1.1";
+  };
+  solve = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bbzny2bl94mv1xwcfrxbi3fjhxxawlz6la7mip2wwz9kkaf376h";
+      type = "gem";
+    };
+    version = "3.1.0";
+  };
+  uri-ssh_git = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0klyyvivbjll2ry18d8fhm1rbxbzd4kqa9lskxyiha4ndlb22cqj";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -957,6 +957,8 @@ with pkgs;
 
   elementary-icon-theme = callPackage ../data/icons/elementary-icon-theme { };
 
+  elm-github-install = callPackage ../tools/package-management/elm-github-install { };
+
   emby = callPackage ../servers/emby { };
 
   enca = callPackage ../tools/text/enca { };


### PR DESCRIPTION
###### Motivation for this change

This add elm-github-install, an alternative package manager for elm.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

