### PR TITLE
Fix systemd resolved nsswitch loading and clearly state NSS module's dependency on nscd

### DIFF
--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -6,26 +6,29 @@ with lib;
 
 let
 
-  inherit (config.services.avahi) nssmdns;
-  inherit (config.services.samba) nsswins;
-  ldap = (config.users.ldap.enable && config.users.ldap.nsswitch);
-  sssd = config.services.sssd.enable;
-  resolved = config.services.resolved.enable;
   # only with nscd up and running we can load NSS modules that are not integrated in NSS
   canLoadExternalModules = config.services.nscd.enable;
+  myhostname = canLoadExternalModules;
+  mymachines = canLoadExternalModules;
+  nssmdns = canLoadExternalModules && config.services.avahi.nssmdns;
+  nsswins = canLoadExternalModules && config.services.samba.nsswins;
+  ldap = canLoadExternalModules && (config.users.ldap.enable && config.users.ldap.nsswitch);
+  sssd = canLoadExternalModules && config.services.sssd.enable;
+  resolved = canLoadExternalModules && config.services.resolved.enable;
 
-  hostArray = [ "files" "mymachines" ]
+  hostArray = [ "files" ]
+    ++ optionals mymachines [ "mymachines" ]
     ++ optionals nssmdns [ "mdns_minimal [!UNAVAIL=return]" ]
     ++ optionals nsswins [ "wins" ]
     ++ optionals resolved ["resolve [!UNAVAIL=return]"]
     ++ [ "dns" ]
     ++ optionals nssmdns [ "mdns" ]
-    ++ ["myhostname" ];
+    ++ optionals myhostname ["myhostname" ];
 
   passwdArray = [ "files" ]
     ++ optional sssd "sss"
     ++ optionals ldap [ "ldap" ]
-    ++ [ "mymachines" ];
+    ++ optionals mymachines [ "mymachines" ];
 
   shadowArray = [ "files" ]
     ++ optional sssd "sss"

--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -15,7 +15,7 @@ let
   hostArray = [ "files" "mymachines" ]
     ++ optionals nssmdns [ "mdns_minimal [!UNAVAIL=return]" ]
     ++ optionals nsswins [ "wins" ]
-    ++ optionals resolved ["resolv [!UNAVAIL=return]"]
+    ++ optionals resolved ["resolve [!UNAVAIL=return]"]
     ++ [ "dns" ]
     ++ optionals nssmdns [ "mdns" ]
     ++ ["myhostname" ];


### PR DESCRIPTION
###### Motivation for this change
`nss-resolve` fails silently to get loaded when `resolved` is enabled because of a typo.

I spent way too much time investigating the source DNS issue leading to this typo because the first thing I did was *disabling nscd to exclude cashing problems*, therefore the note that nscd is required for any not-included modules to be loaded.

I thought about only adding the dynamic modules only if their respective service like `resolved` *and* `nscd` is enabled to make potential issues more obvious when looking at `/etc/nsswitch.conf` which then would not contain modules that it cannot load, but I'm not sure about that and wanted to discuss it first.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

