### PR TITLE
buku: Enabled tests and added shell completion

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -11,7 +11,7 @@ with pythonPackages; buildPythonApplication rec {
     sha256 = "1a33x3197vi5s8rq5fvhy021jdlsc8ww8zc4kysss6r9mvdlk7ax";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     pytestcov
     pytest-catchlog
     hypothesis
@@ -29,7 +29,7 @@ with pythonPackages; buildPythonApplication rec {
     # Fixes two tests for wrong encoding
     export PYTHONIOENCODING=utf-8
 
-    # https://github.com/jarun/Buku/pull/167
+    # Should be upstream, see https://github.com/jarun/Buku/pull/167
     substituteInPlace setup.py \
       --replace "hypothesis==3.7.0" "hypothesis>=3.7.0"
 

--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -1,7 +1,7 @@
 { stdenv, pythonPackages, fetchFromGitHub }:
 
 with pythonPackages; buildPythonApplication rec {
-  version = "3.0";
+  version = "3.0"; # When updating to 3.1, make sure to remove the marked line in preCheck
   name = "buku-${version}";
 
   src = fetchFromGitHub {
@@ -29,7 +29,8 @@ with pythonPackages; buildPythonApplication rec {
     # Fixes two tests for wrong encoding
     export PYTHONIOENCODING=utf-8
 
-    # Should be upstream, see https://github.com/jarun/Buku/pull/167
+    ### Remove this for 3.1 ###
+    # See https://github.com/jarun/Buku/pull/167 (merged)
     substituteInPlace setup.py \
       --replace "hypothesis==3.7.0" "hypothesis>=3.7.0"
 


### PR DESCRIPTION
###### Motivation for this change
Completion wasn't being installed for buku which provides one for zsh, fish and bash. Tests were disabled previously because they failed. Since buku has a lot more test cases since 3.0 it's nice to have them run and succeed.

Had to patch 3 things in the tests though:
- One which requires internet connection I disabled
- One test dependency was version freezed (see https://github.com/jarun/Buku/pull/167) which I patched (can be removed when that PR is merged and new version released)
- Another issue was due to locale issues.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

