### PR TITLE
rust uplift for 17.03

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/cargo-fix.patch
+++ b/pkgs/applications/networking/browsers/firefox/cargo-fix.patch
@@ -1,0 +1,33 @@
+diff --git a/media/libstagefright/binding/mp4parse-cargo.patch b/media/libstagefright/binding/mp4parse-cargo.patch
+index 1dd13d2..f98b722 100644
+--- a/media/libstagefright/binding/mp4parse-cargo.patch
++++ b/media/libstagefright/binding/mp4parse-cargo.patch
+@@ -27,12 +27,13 @@ diff --git a/media/libstagefright/binding/mp4parse_capi/Cargo.toml b/media/libst
+ index aeeebc65..5c0836a 100644
+ --- a/media/libstagefright/binding/mp4parse_capi/Cargo.toml
+ +++ b/media/libstagefright/binding/mp4parse_capi/Cargo.toml
+-@@ -18,18 +18,10 @@ exclude = [
++@@ -18,17 +18,12 @@ exclude = [
+    "*.mp4",
+  ]
+  
+ -build = "build.rs"
+--
+++build = false
+++
+  [dependencies]
+  byteorder = "1.0.0"
+  "mp4parse" = {version = "0.6.0", path = "../mp4parse"}
+diff --git a/media/libstagefright/binding/mp4parse_capi/Cargo.toml b/media/libstagefright/binding/mp4parse_capi/Cargo.toml
+index aee7ee9..d7e3f55 100644
+--- a/media/libstagefright/binding/mp4parse_capi/Cargo.toml
++++ b/media/libstagefright/binding/mp4parse_capi/Cargo.toml
+@@ -18,6 +18,8 @@ exclude = [
+   "*.mp4",
+ ]
+ 
++build = false
++
+ [dependencies]
+ byteorder = "1.0.0"
+ "mp4parse" = {version = "0.6.0", path = "../mp4parse"}

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -13,6 +13,8 @@ rec {
       sha512 = "0ff6960804e7f6d3e15faeb14b237fee45acae31b4652a6cc5cafa1a1b1eab3537616c3e8ea6d8f3109c87dcc8f86f0df3da2627903b80061c8a62fb11598ed9";
     };
 
+    patches = [ ./cargo-fix.patch ];
+
     meta = {
       description = "A web browser built from Firefox source tree";
       homepage = http://www.mozilla.com/en-US/firefox/;

--- a/pkgs/development/compilers/rust/beta.nix
+++ b/pkgs/development/compilers/rust/beta.nix
@@ -1,56 +1,37 @@
-{ stdenv, callPackage, rustPlatform, cacert, gdb,
-  targets ? [], targetToolchains ? [], targetPatches ? [] }:
+{ stdenv, callPackage, recurseIntoAttrs, makeRustPlatform, llvm, fetchurl
+, targets ? []
+, targetToolchains ? []
+, targetPatches ? []
+}:
 
+let
+  rustPlatform = recurseIntoAttrs (makeRustPlatform (callPackage ./bootstrap.nix {}));
+in
 rec {
-  rustc = stdenv.lib.overrideDerivation (callPackage ./rustc.nix {
-    shortVersion = "beta-2017-01-07";
-    forceBundledLLVM = true; # TODO: figure out why linking fails without this
+  rustc = callPackage ./rustc.nix {
+    inherit llvm targets targetPatches targetToolchains rustPlatform;
+
+    version = "beta-2017-05-27";
+
     configureFlags = [ "--release-channel=beta" ];
-    srcRev = "a035041ba450ce3061d78a2bdb9c446eb5321d0d";
-    srcSha = "12xsm0yp1y39fvf9j218gxv73j8hhahc53jyv3q58kiriyqvfc1s";
+
+    src = fetchurl {
+      url = "https://static.rust-lang.org/dist/2017-05-27/rustc-beta-src.tar.gz";
+      sha256 = "9f3f92efef7fb2b4bf38e57e4ff1f416dc221880b90841c4bdaee350801c0b57";
+    };
+
     patches = [
-     ./patches/disable-lockfile-check-nightly.patch
+      ./patches/darwin-disable-fragile-tcp-tests.patch
     ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
-    inherit targets;
-    inherit targetPatches;
-    inherit targetToolchains;
-    inherit rustPlatform;
-  }) (oldAttrs: {
-    nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ gdb rustPlatform.rust.cargo ];
-    postUnpack = ''
-      export CARGO_HOME="$(realpath deps)"
-      export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
-    '';
-    postPatch = ''
-      ${oldAttrs.postPatch}
 
-      # Remove failing debuginfo tests because of old gdb version: https://github.com/rust-lang/rust/issues/38948#issuecomment-271443596
-      rm -vr src/test/debuginfo/borrowed-enum.rs || true
-      rm -vr src/test/debuginfo/generic-struct-style-enum.rs || true
-      rm -vr src/test/debuginfo/generic-tuple-style-enum.rs || true
-      rm -vr src/test/debuginfo/packed-struct.rs || true
-      rm -vr src/test/debuginfo/recursive-struct.rs || true
-      rm -vr src/test/debuginfo/struct-in-enum.rs || true
-      rm -vr src/test/debuginfo/struct-style-enum.rs || true
-      rm -vr src/test/debuginfo/tuple-style-enum.rs || true
-      rm -vr src/test/debuginfo/union-smoke.rs || true
-      rm -vr src/test/debuginfo/unique-enum.rs || true
-
-      # make external cargo work until https://github.com/rust-lang/rust/issues/38950 is fixed
-      sed -i "s#    def cargo(self):#    def cargo(self):\n        return \"${rustPlatform.rust.cargo}/bin/cargo\"#g" src/bootstrap/bootstrap.py
-      substituteInPlace \
-        src/bootstrap/config.rs \
-        --replace \
-        'self.cargo = Some(push_exe_path(path, &["bin", "cargo"]));' \
-        ''$'self.cargo = Some(\n                        "${rustPlatform.rust.cargo}\\\n                        /bin/cargo".into());'
-    '';
-  });
+    doCheck = false;
+  };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "beta-2017-01-10";
-    srcRev = "6dd4ff0f5b59fff524762c4a7b65882adda713c0";
-    srcSha = "1x6d42qq2zhr1iaw0m0nslhv6c1w6x6schmd96max0p9xb47l9zj";
-    depsSha256 = "1sywnhzgambmqsjs2xlnzracfv7vjljha55hgf8wca2marafr5dp";
+    version = "0.18.0";
+    srcRev = "fe7b0cdcf5ca7aab81630706ce40b70f6aa2e666";
+    srcSha = "164iywv1l3v87b0pznf5kkzxigd6w19myv9d7ka4c65zgrk9n9px";
+    depsSha256 = "1mrgd8ib48vxxbhkvsqqq4p19sc6b74x3cd8p6lhhlm6plrajrvm";
 
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo

--- a/pkgs/development/compilers/rust/binaryBuild.nix
+++ b/pkgs/development/compilers/rust/binaryBuild.nix
@@ -1,0 +1,99 @@
+{ stdenv, fetchurl, makeWrapper, cacert, zlib, buildRustPackage, curl
+, version
+, src
+, platform
+, versionType
+}:
+
+let
+  inherit (stdenv.lib) optionalString;
+
+  needsPatchelf = stdenv.isLinux;
+
+  bootstrapping = versionType == "bootstrap";
+
+  installComponents
+    = "rustc,rust-std-${platform}"
+    + (optionalString bootstrapping ",rust-docs,cargo")
+    ;
+in
+
+rec {
+  inherit buildRustPackage;
+
+  rustc = stdenv.mkDerivation rec {
+    name = "rustc-${versionType}-${version}";
+
+    inherit version;
+    inherit src;
+
+    meta = with stdenv.lib; {
+      homepage = http://www.rust-lang.org/;
+      description = "A safe, concurrent, practical language";
+      maintainers = with maintainers; [ qknight ];
+      license = [ licenses.mit licenses.asl20 ];
+    };
+
+    phases = ["unpackPhase" "installPhase"];
+
+    installPhase = ''
+      ./install.sh --prefix=$out \
+        --components=${installComponents}
+
+      ${optionalString (needsPatchelf && bootstrapping) ''
+        patchelf \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          "$out/bin/rustdoc"
+        patchelf \
+          --set-rpath "${stdenv.lib.makeLibraryPath [ curl zlib ]}" \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          "$out/bin/cargo"
+      ''}
+
+      ${optionalString needsPatchelf ''
+        patchelf \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          "$out/bin/rustc"
+
+      # Do NOT, I repeat, DO NOT use `wrapProgram` on $out/bin/rustc
+      # (or similar) here. It causes strange effects where rustc loads
+      # the wrong libraries in a bootstrap-build causing failures that
+      # are very hard to track dow. For details, see
+      # https://github.com/rust-lang/rust/issues/34722#issuecomment-232164943
+      ''}
+    '';
+
+  };
+
+  cargo = stdenv.mkDerivation rec {
+    name = "cargo-${versionType}-${version}";
+
+    inherit version;
+    inherit src;
+
+    meta = with stdenv.lib; {
+      homepage = http://www.rust-lang.org/;
+      description = "A safe, concurrent, practical language";
+      maintainers = with maintainers; [ qknight ];
+      license = [ licenses.mit licenses.asl20 ];
+    };
+
+    buildInputs = [ makeWrapper ];
+    phases = ["unpackPhase" "installPhase"];
+
+    installPhase = ''
+      ./install.sh --prefix=$out \
+        --components=cargo
+
+      ${optionalString needsPatchelf ''
+        patchelf \
+          --set-rpath "${stdenv.lib.makeLibraryPath [ curl zlib ]}" \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          "$out/bin/cargo"
+      ''}
+
+      wrapProgram "$out/bin/cargo" \
+        --suffix PATH : "${rustc}/bin"
+    '';
+  };
+}

--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -12,7 +12,7 @@ let
     then "i686-apple-darwin"
     else if stdenv.system == "x86_64-darwin"
     then "x86_64-apple-darwin"
-    else abort "missing boostrap url for platform ${stdenv.system}";
+    else throw "missing bootstrap url for platform ${stdenv.system}";
 
   # fetch hashes by running `print-hashes.sh 1.14.0`
   bootstrapHash =
@@ -24,7 +24,7 @@ let
     then "fe1b3d67329a22d67e3b8db8858a43022e2e746dde60ef4a2db3f2cac16ea9bd"
     else if stdenv.system == "x86_64-darwin"
     then "3381341524b0184da5ed2cdcddc2a25e2e335e87f1cf676f64d98ee5e6479f20"
-    else throw "missing boostrap hash for platform ${stdenv.system}";
+    else throw "missing bootstrap hash for platform ${stdenv.system}";
 
   needsPatchelf = stdenv.isLinux;
 

--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -12,16 +12,17 @@ let
     then "x86_64-apple-darwin"
     else throw "missing bootstrap url for platform ${stdenv.system}";
 
-  # fetch hashes by running `print-hashes.sh 1.17.0`
+  # fetch hashes by patching print-hashes.sh to not use the "$DATE" variable
+  # then running `print-hashes.sh 1.16.0`
   bootstrapHash =
     if stdenv.system == "i686-linux"
-    then "39d16ce0f618ba37ee1024b83e4822a2d38e6ba9f341ff2020d34df94c7a6beb"
+    then "b5859161ebb182d3b75fa14a5741e5de87b088146fb0ef4a30f3b2439c6179c5"
     else if stdenv.system == "x86_64-linux"
-    then "bbb0e249a7a3e8143b569706c7d2e7e5f51932c753b7fd26c58ccd2015b02c6b"
+    then "48621912c242753ba37cad5145df375eeba41c81079df46f93ffb4896542e8fd"
     else if stdenv.system == "i686-darwin"
-    then "308132b33d4002f95a725c2d31b975ff37905e3644894ed86e614b03ded70265"
+    then "26356b14164354725bd0351e8084f9b164abab134fb05cddb7758af35aad2065"
     else if stdenv.system == "x86_64-darwin"
-    then "1689060c07ec727e9756f19c9373045668471ab56fd8f53e92701150bbe2032b"
+    then "2d08259ee038d3a2c77a93f1a31fc59e7a1d6d1bbfcba3dba3c8213b2e5d1926"
     else throw "missing bootstrap hash for platform ${stdenv.system}";
 
   src = fetchurl {
@@ -29,7 +30,9 @@ let
      sha256 = bootstrapHash;
   };
 
-  version = "1.17.0";
+  # Note: the version  MUST be one version prior to the version we're
+  # building
+  version = "1.16.0";
 in import ./binaryBuild.nix
   { inherit stdenv fetchurl makeWrapper cacert zlib curl;
     buildRustPackage = null;

--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -1,8 +1,6 @@
-{ stdenv, fetchurl, makeWrapper, cacert, zlib }:
+{ stdenv, fetchurl, makeWrapper, cacert, zlib, curl }:
 
 let
-  inherit (stdenv.lib) optionalString;
-
   platform =
     if stdenv.system == "i686-linux"
     then "i686-unknown-linux-gnu"
@@ -14,77 +12,27 @@ let
     then "x86_64-apple-darwin"
     else throw "missing bootstrap url for platform ${stdenv.system}";
 
-  # fetch hashes by running `print-hashes.sh 1.14.0`
+  # fetch hashes by running `print-hashes.sh 1.17.0`
   bootstrapHash =
     if stdenv.system == "i686-linux"
-    then "8d5c75728b44468216f99651dfae9d60ae0696a77105dd2b02942d75f3256840"
+    then "39d16ce0f618ba37ee1024b83e4822a2d38e6ba9f341ff2020d34df94c7a6beb"
     else if stdenv.system == "x86_64-linux"
-    then "c71325cfea1b6f0bdc5189fa4c50ff96f828096ff3f7b5056367f9685d6a4d04"
+    then "bbb0e249a7a3e8143b569706c7d2e7e5f51932c753b7fd26c58ccd2015b02c6b"
     else if stdenv.system == "i686-darwin"
-    then "fe1b3d67329a22d67e3b8db8858a43022e2e746dde60ef4a2db3f2cac16ea9bd"
+    then "308132b33d4002f95a725c2d31b975ff37905e3644894ed86e614b03ded70265"
     else if stdenv.system == "x86_64-darwin"
-    then "3381341524b0184da5ed2cdcddc2a25e2e335e87f1cf676f64d98ee5e6479f20"
+    then "1689060c07ec727e9756f19c9373045668471ab56fd8f53e92701150bbe2032b"
     else throw "missing bootstrap hash for platform ${stdenv.system}";
-
-  needsPatchelf = stdenv.isLinux;
 
   src = fetchurl {
      url = "https://static.rust-lang.org/dist/rust-${version}-${platform}.tar.gz";
      sha256 = bootstrapHash;
   };
 
-  version = "1.14.0";
-in
-
-rec {
-  rustc = stdenv.mkDerivation rec {
-    name = "rustc-bootstrap-${version}";
-
-    inherit version;
-    inherit src;
-
-    buildInputs = [ makeWrapper ];
-    phases = ["unpackPhase" "installPhase"];
-
-    installPhase = ''
-      ./install.sh --prefix=$out \
-        --components=rustc,rust-std-${platform},rust-docs
-
-      ${optionalString needsPatchelf ''
-        patchelf \
-          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-          "$out/bin/rustc"
-      ''}
-
-      # Do NOT, I repeat, DO NOT use `wrapProgram` on $out/bin/rustc
-      # (or similar) here. It causes strange effects where rustc loads
-      # the wrong libraries in a bootstrap-build causing failures that
-      # are very hard to track dow. For details, see
-      # https://github.com/rust-lang/rust/issues/34722#issuecomment-232164943
-    '';
-  };
-
-  cargo = stdenv.mkDerivation rec {
-    name = "cargo-bootstrap-${version}";
-
-    inherit version;
-    inherit src;
-
-    buildInputs = [ makeWrapper zlib rustc ];
-    phases = ["unpackPhase" "installPhase"];
-
-    installPhase = ''
-      ./install.sh --prefix=$out \
-        --components=cargo
-
-      ${optionalString needsPatchelf ''
-        patchelf \
-          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-          "$out/bin/cargo"
-      ''}
-
-      wrapProgram "$out/bin/cargo" \
-        --suffix PATH : "${rustc}/bin"
-    '';
-  };
-}
+  version = "1.17.0";
+in import ./binaryBuild.nix
+  { inherit stdenv fetchurl makeWrapper cacert zlib curl;
+    buildRustPackage = null;
+    inherit version src platform;
+    versionType = "bootstrap";
+  }

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -24,12 +24,6 @@ rustPlatform.buildRustPackage rec {
   LIBGIT2_SYS_USE_PKG_CONFIG=1;
 
   postInstall = ''
-    rm "$out/lib/rustlib/components" \
-       "$out/lib/rustlib/install.log" \
-       "$out/lib/rustlib/rust-installer-version" \
-       "$out/lib/rustlib/uninstall.sh" \
-       "$out/lib/rustlib/manifest-cargo"
-
     # NOTE: We override the `http.cainfo` option usually specified in
     # `.cargo/config`. This is an issue when users want to specify
     # their own certificate chain as environment variables take

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage, recurseIntoAttrs, makeRustPlatform, llvm
+{ stdenv, callPackage, recurseIntoAttrs, makeRustPlatform, llvm, fetchurl
 , targets ? []
 , targetToolchains ? []
 , targetPatches ? []
@@ -6,32 +6,30 @@
 
 let
   rustPlatform = recurseIntoAttrs (makeRustPlatform (callPackage ./bootstrap.nix {}));
+  version = "1.17.0";
 in
 rec {
   rustc = callPackage ./rustc.nix {
-    shortVersion = "1.15.1";
-    isRelease = true;
-    forceBundledLLVM = false;
+    inherit llvm targets targetPatches targetToolchains rustPlatform version;
+
     configureFlags = [ "--release-channel=stable" ];
-    srcRev = "021bd294c039bd54aa5c4aa85bcdffb0d24bc892";
-    srcSha = "1dp7cjxj8nv960jxkq3p18agh9bpfb69ac14x284jmhwyksim3y7";
+
+    src = fetchurl {
+      url = "https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz";
+      sha256 = "4baba3895b75f2492df6ce5a28a916307ecd1c088dc1fd02dbfa8a8e86174f87";
+    };
 
     patches = [
       ./patches/darwin-disable-fragile-tcp-tests.patch
     ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
 
-    inherit llvm;
-    inherit targets;
-    inherit targetPatches;
-    inherit targetToolchains;
-    inherit rustPlatform;
   };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "0.16.0";
-    srcRev = "6e0c18cccc8b0c06fba8a8d76486f81a792fb420";
-    srcSha = "117ivvs9wz848mwf8bw797n10qpn77agd353z8b0hxgbxhpribya";
-    depsSha256 = "11s2xpgfhl4mb4wa2nk4mzsypr7m9daxxc7l0vraiz5cr77gk7qq";
+    version = "0.18.0";
+    srcRev = "fe7b0cdcf5ca7aab81630706ce40b70f6aa2e666";
+    srcSha = "164iywv1l3v87b0pznf5kkzxigd6w19myv9d7ka4c65zgrk9n9px";
+    depsSha256 = "1mrgd8ib48vxxbhkvsqqq4p19sc6b74x3cd8p6lhhlm6plrajrvm";
 
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -1,5 +1,8 @@
-{ stdenv, callPackage, recurseIntoAttrs, makeRustPlatform,
-  targets ? [], targetToolchains ? [], targetPatches ? [] }:
+{ stdenv, callPackage, recurseIntoAttrs, makeRustPlatform, llvm
+, targets ? []
+, targetToolchains ? []
+, targetPatches ? []
+}:
 
 let
   rustPlatform = recurseIntoAttrs (makeRustPlatform (callPackage ./bootstrap.nix {}));
@@ -17,6 +20,7 @@ rec {
       ./patches/darwin-disable-fragile-tcp-tests.patch
     ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
 
+    inherit llvm;
     inherit targets;
     inherit targetPatches;
     inherit targetToolchains;

--- a/pkgs/development/compilers/rust/nightly.nix
+++ b/pkgs/development/compilers/rust/nightly.nix
@@ -1,56 +1,34 @@
-{ stdenv, callPackage, rustPlatform, cacert, gdb,
-  targets ? [], targetToolchains ? [], targetPatches ? [] }:
+{ stdenv, callPackage, rustPlatform, llvm, fetchurl
+, targets ? []
+, targetToolchains ? []
+, targetPatches ? []
+}:
 
 rec {
-  rustc = stdenv.lib.overrideDerivation (callPackage ./rustc.nix {
-    shortVersion = "nightly-2017-01-10";
-    forceBundledLLVM = true; # TODO: figure out why linking fails without this
+  rustc = callPackage ./rustc.nix {
+    inherit llvm targets targetPatches targetToolchains rustPlatform;
+
+    version = "nightly-2017-05-30";
+
     configureFlags = [ "--release-channel=nightly" ];
-    srcRev = "7bffede97cf58f7159e261eac592f9cf88ce209d";
-    srcSha = "1784jvsf9g03cglwask1zhjmba4ghycbin3rw0hmhb41cz2y4q8v";
+
+    src = fetchurl {
+      url = "https://static.rust-lang.org/dist/2017-05-30/rustc-nightly-src.tar.gz";
+      sha256 = "90ce76db56a93f1b4532f2e62bbf12c243c4d156662b0d80c25319211ee7d0e0";
+    };
+
     patches = [
-     ./patches/disable-lockfile-check-nightly.patch
+      ./patches/darwin-disable-fragile-tcp-tests.patch
     ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
-    inherit targets;
-    inherit targetPatches;
-    inherit targetToolchains;
-    inherit rustPlatform;
-  }) (oldAttrs: {
-    nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ gdb rustPlatform.rust.cargo ];
-    postUnpack = ''
-      export CARGO_HOME="$(realpath deps)"
-      export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
-    '';
-    postPatch = ''
-      ${oldAttrs.postPatch}
 
-      # Remove failing debuginfo tests because of old gdb version: https://github.com/rust-lang/rust/issues/38948#issuecomment-271443596
-      rm -vr src/test/debuginfo/borrowed-enum.rs || true
-      rm -vr src/test/debuginfo/generic-struct-style-enum.rs || true
-      rm -vr src/test/debuginfo/generic-tuple-style-enum.rs || true
-      rm -vr src/test/debuginfo/packed-struct.rs || true
-      rm -vr src/test/debuginfo/recursive-struct.rs || true
-      rm -vr src/test/debuginfo/struct-in-enum.rs || true
-      rm -vr src/test/debuginfo/struct-style-enum.rs || true
-      rm -vr src/test/debuginfo/tuple-style-enum.rs || true
-      rm -vr src/test/debuginfo/union-smoke.rs || true
-      rm -vr src/test/debuginfo/unique-enum.rs || true
-
-      # make external cargo work until https://github.com/rust-lang/rust/issues/38950 is fixed
-      sed -i "s#    def cargo(self):#    def cargo(self):\n        return \"${rustPlatform.rust.cargo}/bin/cargo\"#g" src/bootstrap/bootstrap.py
-      substituteInPlace \
-        src/bootstrap/config.rs \
-        --replace \
-        'self.cargo = Some(push_exe_path(path, &["bin", "cargo"]));' \
-        ''$'self.cargo = Some(\n                        "${rustPlatform.rust.cargo}\\\n                        /bin/cargo".into());'
-    '';
-  });
+    doCheck = false;
+  };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "nightly-2017-01-10";
-    srcRev = "6dd4ff0f5b59fff524762c4a7b65882adda713c0";
-    srcSha = "1x6d42qq2zhr1iaw0m0nslhv6c1w6x6schmd96max0p9xb47l9zj";
-    depsSha256 = "1sywnhzgambmqsjs2xlnzracfv7vjljha55hgf8wca2marafr5dp";
+    version = "0.18.0";
+    srcRev = "fe7b0cdcf5ca7aab81630706ce40b70f6aa2e666";
+    srcSha = "164iywv1l3v87b0pznf5kkzxigd6w19myv9d7ka4c65zgrk9n9px";
+    depsSha256 = "1mrgd8ib48vxxbhkvsqqq4p19sc6b74x3cd8p6lhhlm6plrajrvm";
 
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo

--- a/pkgs/development/compilers/rust/nightlyBin.nix
+++ b/pkgs/development/compilers/rust/nightlyBin.nix
@@ -7,7 +7,7 @@ let
 
   bootstrapHash =
     if stdenv.system == "x86_64-linux"
-    then "21f38f46bf16373d3240a38b775e1acff9bb429f1570a4d4da8b3000315d0085"
+    then "0svlm4bxsdhdn4jsv46f278kid23a9w978q2137qrba4xnyb06kf"
     else throw "missing bootstrap hash for platform ${stdenv.system}";
 
   src = fetchurl {
@@ -15,7 +15,7 @@ let
      sha256 = bootstrapHash;
   };
 
-  version = "2017-05-30";
+  version = "2017-06-26";
 in import ./binaryBuild.nix
   { inherit stdenv fetchurl makeWrapper cacert zlib buildRustPackage curl;
     inherit version src platform;

--- a/pkgs/development/compilers/rust/nightlyBin.nix
+++ b/pkgs/development/compilers/rust/nightlyBin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, cacert, zlib, buildRustPackage }:
+{ stdenv, fetchurl, makeWrapper, cacert, zlib, buildRustPackage, curl }:
 
 let
   inherit (stdenv.lib) optionalString;
@@ -9,7 +9,7 @@ let
 
   bootstrapHash =
     if stdenv.system == "x86_64-linux"
-    then "1v7jvwigb29m15wilzcrk5jmlpaccpzbkhlzf7z5qw08320gvc91"
+    then "1d5h34dkm1r1ff562szygn9xk2qll1pjryvypl0lazzanxdh5gv5"
     else throw "missing bootstrap hash for platform ${stdenv.system}";
 
   needsPatchelf = stdenv.isLinux;
@@ -19,7 +19,7 @@ let
      sha256 = bootstrapHash;
   };
 
-  version = "2017-01-26";
+  version = "2017-03-16";
 in
 
 rec {
@@ -69,7 +69,7 @@ rec {
       license = [ licenses.mit licenses.asl20 ];
     };
 
-    buildInputs = [ makeWrapper ];
+    buildInputs = [ makeWrapper curl ];
     phases = ["unpackPhase" "installPhase"];
 
     installPhase = ''
@@ -78,6 +78,7 @@ rec {
 
       ${optionalString needsPatchelf ''
         patchelf \
+          --set-rpath "${stdenv.lib.makeLibraryPath [ curl zlib ]}" \
           --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
           "$out/bin/cargo"
       ''}

--- a/pkgs/development/compilers/rust/nightlyBin.nix
+++ b/pkgs/development/compilers/rust/nightlyBin.nix
@@ -5,12 +5,12 @@ let
 
   platform = if stdenv.system == "x86_64-linux"
     then "x86_64-unknown-linux-gnu"
-    else abort "missing boostrap url for platform ${stdenv.system}";
+    else throw "missing bootstrap url for platform ${stdenv.system}";
 
   bootstrapHash =
     if stdenv.system == "x86_64-linux"
     then "1v7jvwigb29m15wilzcrk5jmlpaccpzbkhlzf7z5qw08320gvc91"
-    else throw "missing boostrap hash for platform ${stdenv.system}";
+    else throw "missing bootstrap hash for platform ${stdenv.system}";
 
   needsPatchelf = stdenv.isLinux;
 

--- a/pkgs/development/compilers/rust/nightlyBin.nix
+++ b/pkgs/development/compilers/rust/nightlyBin.nix
@@ -1,87 +1,23 @@
 { stdenv, fetchurl, makeWrapper, cacert, zlib, buildRustPackage, curl }:
 
 let
-  inherit (stdenv.lib) optionalString;
-
   platform = if stdenv.system == "x86_64-linux"
     then "x86_64-unknown-linux-gnu"
     else throw "missing bootstrap url for platform ${stdenv.system}";
 
   bootstrapHash =
     if stdenv.system == "x86_64-linux"
-    then "1d5h34dkm1r1ff562szygn9xk2qll1pjryvypl0lazzanxdh5gv5"
+    then "21f38f46bf16373d3240a38b775e1acff9bb429f1570a4d4da8b3000315d0085"
     else throw "missing bootstrap hash for platform ${stdenv.system}";
-
-  needsPatchelf = stdenv.isLinux;
 
   src = fetchurl {
      url = "https://static.rust-lang.org/dist/${version}/rust-nightly-${platform}.tar.gz";
      sha256 = bootstrapHash;
   };
 
-  version = "2017-03-16";
-in
-
-rec {
-  inherit buildRustPackage;
-
-  rustc = stdenv.mkDerivation rec {
-    name = "rustc-nightly-${version}";
-
-    inherit version;
-    inherit src;
-
-    meta = with stdenv.lib; {
-      homepage = http://www.rust-lang.org/;
-      description = "A safe, concurrent, practical language";
-      maintainers = with maintainers; [ qknight ];
-      license = [ licenses.mit licenses.asl20 ];
-    };
-
-    buildInputs = [ makeWrapper ];
-    phases = ["unpackPhase" "installPhase"];
-
-    installPhase = ''
-      ./install.sh --prefix=$out \
-        --components=rustc,rust-std-x86_64-unknown-linux-gnu
-
-      ${optionalString needsPatchelf ''
-        patchelf \
-          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-          "$out/bin/rustc"
-        patchelf \
-          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-          "$out/bin/rustdoc"
-      ''}
-    '';
-
-  };
-  cargo = stdenv.mkDerivation rec {
-    name = "cargo-nightly-${version}";
-
-    inherit version;
-    inherit src;
-
-    meta = with stdenv.lib; {
-      homepage = http://www.rust-lang.org/;
-      description = "A safe, concurrent, practical language";
-      maintainers = with maintainers; [ qknight ];
-      license = [ licenses.mit licenses.asl20 ];
-    };
-
-    buildInputs = [ makeWrapper curl ];
-    phases = ["unpackPhase" "installPhase"];
-
-    installPhase = ''
-      ./install.sh --prefix=$out \
-        --components=cargo
-
-      ${optionalString needsPatchelf ''
-        patchelf \
-          --set-rpath "${stdenv.lib.makeLibraryPath [ curl zlib ]}" \
-          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-          "$out/bin/cargo"
-      ''}
-    '';
-  };
-}
+  version = "2017-05-30";
+in import ./binaryBuild.nix
+  { inherit stdenv fetchurl makeWrapper cacert zlib buildRustPackage curl;
+    inherit version src platform;
+    versionType = "nightly";
+  }

--- a/pkgs/development/compilers/rust/print-hashes.sh
+++ b/pkgs/development/compilers/rust/print-hashes.sh
@@ -1,8 +1,21 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+# All rust-related downloads can be found at
+# https://static.rust-lang.org/dist/index.html.  To find the date on
+# which a particular thing was last updated, look for the *-date.txt
+# file, e.g.
+# https://static.rust-lang.org/dist/channel-rust-beta-date.txt
 
 PLATFORMS="i686-unknown-linux-gnu x86_64-unknown-linux-gnu i686-apple-darwin x86_64-apple-darwin"
 BASEURL="https://static.rust-lang.org/dist"
-VERSION=$1
+DATE=$1
+VERSION=$2
+
+if [[ -z  $DATE ]]
+then
+    echo "No date supplied"
+    exit -1
+fi
 
 if [[ -z  $VERSION ]]
 then
@@ -12,6 +25,6 @@ fi
 
 for PLATFORM in $PLATFORMS
 do
-    URL="$BASEURL/rust-$VERSION-$PLATFORM.tar.gz.sha256"
+    URL="$BASEURL/$DATE/rust-$VERSION-$PLATFORM.tar.gz.sha256"
     curl $URL
 done

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -89,6 +89,7 @@ stdenv.mkDerivation {
     rm src/test/debuginfo/limited-debuginfo.rs
     rm src/test/debuginfo/simple-struct.rs
     rm src/test/debuginfo/simple-tuple.rs
+    rm src/test/debuginfo/union-smoke.rs
     rm src/test/debuginfo/vec-slices.rs
     rm src/test/debuginfo/vec.rs
 

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -99,6 +99,11 @@ stdenv.mkDerivation {
 
     # Useful debugging parameter
     # export VERBOSE=1
+  ''
+  + optionalString stdenv.isDarwin ''
+    # Disable all lldb tests.
+    # error: Can't run LLDB test because LLDB's python path is not set
+    rm -vr src/test/debuginfo/*
   '';
 
   preConfigure = ''

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -1,24 +1,19 @@
 { stdenv, fetchurl, fetchgit, fetchzip, file, python2, tzdata, procps
 , llvm, jemalloc, ncurses, darwin, binutils, rustPlatform, git, cmake, curl
-
-, isRelease ? false
-, shortVersion
+, which, libffi, gdb
+, version
 , forceBundledLLVM ? false
-, srcSha, srcRev
+, src
 , configureFlags ? []
 , patches
 , targets
 , targetPatches
 , targetToolchains
+, doCheck ? true
 } @ args:
 
 let
   inherit (stdenv.lib) optional optionalString;
-
-  version = if isRelease then
-      "${shortVersion}"
-    else
-      "${shortVersion}-g${builtins.substring 0 7 srcRev}";
 
   procps = if stdenv.isDarwin then darwin.ps else args.procps;
 
@@ -31,6 +26,8 @@ in
 stdenv.mkDerivation {
   name = "rustc-${version}";
   inherit version;
+
+  inherit src;
 
   __impureHostDeps = [ "/usr/lib/libedit.3.dylib" ];
 
@@ -45,19 +42,13 @@ stdenv.mkDerivation {
   # Increase codegen units to introduce parallelism within the compiler.
   RUSTFLAGS = "-Ccodegen-units=10";
 
-  src = fetchgit {
-    url = https://github.com/rust-lang/rust;
-    rev = srcRev;
-    sha256 = srcSha;
-  };
-
   # We need rust to build rust. If we don't provide it, configure will try to download it.
   configureFlags = configureFlags
                 ++ [ "--enable-local-rust" "--local-rust-root=${rustPlatform.rust.rustc}" "--enable-rpath" ]
+                ++ [ "--enable-vendor" "--disable-locked-deps" ]
+                ++ [ "--enable-llvm-link-shared" ]
                 # ++ [ "--jemalloc-root=${jemalloc}/lib"
                 ++ [ "--default-linker=${stdenv.cc}/bin/cc" "--default-ar=${binutils.out}/bin/ar" ]
-                # TODO: Remove when fixed build with rustbuild
-                ++ [ "--disable-rustbuild" ]
                 ++ optional (stdenv.cc.cc ? isClang) "--enable-clang"
                 ++ optional (targets != []) "--target=${target}"
                 ++ optional (!forceBundledLLVM) "--llvm-root=${llvmShared}";
@@ -67,17 +58,8 @@ stdenv.mkDerivation {
   passthru.target = target;
 
   postPatch = ''
-    substituteInPlace src/rust-installer/gen-install-script.sh \
-      --replace /bin/echo "$(type -P echo)"
-    substituteInPlace src/rust-installer/gen-installer.sh \
-      --replace /bin/echo "$(type -P echo)"
-
-    # Workaround for NixOS/nixpkgs#8676
-    substituteInPlace mk/rustllvm.mk \
-      --replace "\$\$(subst  /,//," "\$\$(subst /,/,"
-
     # Fix dynamic linking against llvm
-    ${optionalString (!forceBundledLLVM) ''sed -i 's/, kind = \\"static\\"//g' src/etc/mklldeps.py''}
+    #${optionalString (!forceBundledLLVM) ''sed -i 's/, kind = \\"static\\"//g' src/etc/mklldeps.py''}
 
     # Fix the configure script to not require curl as we won't use it
     sed -i configure \
@@ -98,15 +80,25 @@ stdenv.mkDerivation {
     # https://reviews.llvm.org/rL281650
     rm -vr src/test/run-pass/issue-36474.rs || true
 
+    # Disable some failing gdb tests. Try re-enabling these when gdb
+    # is updated past version 7.12.
+    rm src/test/debuginfo/basic-types-globals.rs
+    rm src/test/debuginfo/basic-types-mut-globals.rs
+    rm src/test/debuginfo/c-style-enum.rs
+    rm src/test/debuginfo/lexical-scopes-in-block-expression.rs
+    rm src/test/debuginfo/limited-debuginfo.rs
+    rm src/test/debuginfo/simple-struct.rs
+    rm src/test/debuginfo/simple-tuple.rs
+    rm src/test/debuginfo/vec-slices.rs
+    rm src/test/debuginfo/vec.rs
+
+    # this can probably be removed when rust is updated beyond 1.17
+    # fixes a warning in the test harness (I think?) which fails the build due
+    # to strict warnings
+    sed -i '/static_in_const/d' src/tools/compiletest/src/main.rs
+
     # Useful debugging parameter
     # export VERBOSE=1
-  '' +
-  # In src/compiler-rt/cmake/config-ix.cmake, the cmake build falls
-  # back to darwin 10.4. This causes the OS name to be recorded as
-  # "10.4" rather than the expected "osx". But mk/rt.mk expects the
-  # built library name to have an "_osx" suffix on darwin.
-  optionalString stdenv.isDarwin ''
-    substituteInPlace mk/rt.mk --replace "_osx" "_10.4"
   '';
 
   preConfigure = ''
@@ -120,7 +112,8 @@ stdenv.mkDerivation {
   dontUseCmakeConfigure = true;
 
   # ps is needed for one of the test cases
-  nativeBuildInputs = [ file python2 procps rustPlatform.rust.rustc git cmake ];
+  nativeBuildInputs = [ file python2 procps rustPlatform.rust.rustc git cmake
+    which libffi gdb ];
 
   buildInputs = [ ncurses ] ++ targetToolchains
     ++ optional (!forceBundledLLVM) llvmShared;
@@ -141,7 +134,8 @@ stdenv.mkDerivation {
     sed -i '28s/home_dir().is_some()/true/' ./src/test/run-pass/env-home-dir.rs
   '';
 
-  doCheck = true;
+  inherit doCheck;
+
   dontSetConfigureCross = true;
 
   # https://github.com/NixOS/nixpkgs/pull/21742#issuecomment-272305764
@@ -151,7 +145,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     homepage = http://www.rust-lang.org/;
     description = "A safe, concurrent, practical language";
-    maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington retrry ];
+    maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington ];
     license = [ licenses.mit licenses.asl20 ];
     platforms = platforms.linux ++ platforms.darwin;
   };

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -93,11 +93,6 @@ stdenv.mkDerivation {
     rm src/test/debuginfo/vec-slices.rs
     rm src/test/debuginfo/vec.rs
 
-    # this can probably be removed when rust is updated beyond 1.17
-    # fixes a warning in the test harness (I think?) which fails the build due
-    # to strict warnings
-    sed -i '/static_in_const/d' src/tools/compiletest/src/main.rs
-
     # Useful debugging parameter
     # export VERBOSE=1
   ''

--- a/pkgs/development/tools/misc/kibana/default.nix
+++ b/pkgs/development/tools/misc/kibana/default.nix
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://download.elastic.co/kibana/kibana/${name}-${plat}-${elasticArch}.tar.gz";
-    sha256 = shas."${stdenv.system}";
+    sha256 = shas."${stdenv.system}" or (throw "Unknown architecture");
   };
 
   buildInputs = [ makeWrapper ];

--- a/pkgs/tools/misc/bandwidth/default.nix
+++ b/pkgs/tools/misc/bandwidth/default.nix
@@ -7,7 +7,7 @@ let
     else if stdenv.system == "x86_64-darwin" then "bandwidth-mac64"
     else if stdenv.system == "i686-darwin" then "bandwidth-mac32"
     else if stdenv.system == "i686-cygwin" then "bandwidth-win32"
-    else null;
+    else throw "Unknown architecture";
 in
 stdenv.mkDerivation rec {
   name = "bandwidth-${version}";

--- a/pkgs/tools/misc/grub4dos/default.nix
+++ b/pkgs/tools/misc/grub4dos/default.nix
@@ -3,7 +3,7 @@
 let arch =
   if stdenv.isi686 then "i386"
   else if stdenv.isx86_64 then "x86_64"
-  else abort "Unknown architecture";
+  else throw "Unknown architecture";
 in stdenv.mkDerivation rec {
   name = "grub4dos-${version}";
   version = "0.4.6a-2016-12-24";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5440,12 +5440,19 @@ with pkgs;
 
   rust = rustStable;
   rustStable = callPackage ../development/compilers/rust {
-    inherit (llvmPackages_39) llvm;
+    inherit (llvmPackages_4) llvm;
   };
   rustBeta = lowPrio (recurseIntoAttrs (callPackage ../development/compilers/rust/beta.nix {}));
-  rustNightly = lowPrio (recurseIntoAttrs (callPackage ../development/compilers/rust/nightly.nix {
-    rustPlatform = recurseIntoAttrs (makeRustPlatform rustBeta);
-  }));
+
+  rustNightly = rustBeta;
+
+  # rust support in nixpkgs isn't yet well maintained enough for us to
+  # pretend to support nightlies in a meaningful way.
+
+  # rustNightly = lowPrio (recurseIntoAttrs (callPackage ../development/compilers/rust/nightly.nix {
+  #   rustPlatform = recurseIntoAttrs (makeRustPlatform rustBeta);
+  # }));
+
   rustNightlyBin = lowPrio (callPackage ../development/compilers/rust/nightlyBin.nix {
      buildRustPackage = callPackage ../build-support/rust {
        rust = rustNightlyBin;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5439,7 +5439,9 @@ with pkgs;
   };
 
   rust = rustStable;
-  rustStable = callPackage ../development/compilers/rust {};
+  rustStable = callPackage ../development/compilers/rust {
+    inherit (llvmPackages_39) llvm;
+  };
   rustBeta = lowPrio (recurseIntoAttrs (callPackage ../development/compilers/rust/beta.nix {}));
   rustNightly = lowPrio (recurseIntoAttrs (callPackage ../development/compilers/rust/nightly.nix {
     rustPlatform = recurseIntoAttrs (makeRustPlatform rustBeta);

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,9 +7,9 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2017-02-19";
-  rev = "d822c5853cb14caa5de84a71f6d4ed07ea5e31e1";
-  sha256 = "18m0smlqw3vkn0ljk01l333jj0x32m8rr1dgmpnq621vqvpk5mzp";
+  version = "2017-05-31";
+  rev = "d85037df75a945b5a368d6ceaa7e030b67473a51";
+  sha256 = "0567lfjxvbn4pb39557yfdq1nm4ssgbvzvzkrdqnx9sx5xyx7n4s";
 
   src = fetchFromGitHub {
       inherit rev;


### PR DESCRIPTION
###### Motivation for this change

Rust is keeping backward compatibility in 1.x and it should be safe to uplift all rust related changes to 17.03.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

