### PR TITLE
collectd service: minor refactoring

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -166,7 +166,7 @@
       dnsmasq = 141;
       uhub = 142;
       yandexdisk = 143;
-      collectd = 144;
+      #collectd = 144; #unused
       consul = 145;
       mailpile = 146;
       redmine = 147;

--- a/nixos/modules/services/monitoring/collectd.nix
+++ b/nixos/modules/services/monitoring/collectd.nix
@@ -87,7 +87,6 @@ in {
       serviceConfig = {
         ExecStart = "${cfg.package}/sbin/collectd -C ${conf} -f";
         User = cfg.user;
-        AmbientCapabilities = "cap_net_raw cap_dac_override"; # cap_net_raw for ping, cap_dac_override for smart
         PermissionsStartOnly = true;
       };
 

--- a/nixos/modules/services/monitoring/collectd.nix
+++ b/nixos/modules/services/monitoring/collectd.nix
@@ -7,7 +7,6 @@ let
 
   conf = pkgs.writeText "collectd.conf" ''
     BaseDir "${cfg.dataDir}"
-    PIDFile "${cfg.pidFile}"
     AutoLoadPlugin ${boolToString cfg.autoLoadPlugin}
     Hostname "${config.networking.hostName}"
 
@@ -26,13 +25,7 @@ let
 
 in {
   options.services.collectd = with types; {
-    enable = mkOption {
-      default = false;
-      description = ''
-        Whether to enable collectd agent.
-      '';
-      type = bool;
-    };
+    enable = mkEnableOption "collectd agent";
 
     package = mkOption {
       default = pkgs.collectd;
@@ -55,14 +48,6 @@ in {
       default = "/var/lib/collectd";
       description = ''
         Data directory for collectd agent.
-      '';
-      type = path;
-    };
-
-    pidFile = mkOption {
-      default = "/var/run/collectd.pid";
-      description = ''
-        Location of collectd pid file.
       '';
       type = path;
     };
@@ -100,27 +85,21 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
-        ExecStart = "${cfg.package}/sbin/collectd -C ${conf} -P ${cfg.pidFile}";
-        Type = "forking";
-        PIDFile = cfg.pidFile;
-        User = optional (cfg.user!="root") cfg.user;
+        ExecStart = "${cfg.package}/sbin/collectd -C ${conf} -f";
+        User = cfg.user;
+        AmbientCapabilities = "cap_net_raw cap_dac_override"; # cap_net_raw for ping, cap_dac_override for smart
         PermissionsStartOnly = true;
       };
 
       preStart = ''
-        mkdir -p ${cfg.dataDir}
-        chmod 755 ${cfg.dataDir}
-        install -D /dev/null ${cfg.pidFile}
-        if [ "$(id -u)" = 0 ]; then
-          chown -R ${cfg.user} ${cfg.dataDir};
-          chown ${cfg.user} ${cfg.pidFile}
-        fi
+        mkdir -p "${cfg.dataDir}"
+        chmod 755 "${cfg.dataDir}"
+        chown -R ${cfg.user} "${cfg.dataDir}"
       '';
-    }; 
+    };
 
     users.extraUsers = optional (cfg.user == "collectd") {
       name = "collectd";
-      uid = config.ids.uids.collectd;
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

* removed pid-file support, it is needless to run collectd as systemd service
* removed static user id, as all the files reowned on the service start
* <s>added ambient capabilities for ping and smart (hdd health) functions</s> removed

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

