### PR TITLE
i3: add `configFile` to enable cutom configuration locations

### DIFF
--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -1,72 +1,85 @@
 { fetchurl, stdenv, which, pkgconfig, makeWrapper, libxcb, xcbutilkeysyms
 , xcbutil, xcbutilwm, xcbutilxrm, libstartup_notification, libX11, pcre, libev
 , yajl, xcb-util-cursor, coreutils, perl, pango, perlPackages, libxkbcommon
-, xorgserver, xvfb_run }:
+, xorgserver, xvfb_run, symlinkJoin, configFile ? null }:
 
-stdenv.mkDerivation rec {
-  name = "i3-${version}";
+let
   version = "4.13";
 
-  src = fetchurl {
-    url = "http://i3wm.org/downloads/${name}.tar.bz2";
-    sha256 = "12ngz32swh9n85xy0cz1lq16aqi9ys5hq19v589q9a97wn1k3hcl";
-  };
+  i3 = stdenv.mkDerivation rec {
+    name = "i3-${version}";
 
-  nativeBuildInputs = [ which pkgconfig makeWrapper ];
+    src = fetchurl {
+      url = "http://i3wm.org/downloads/${name}.tar.bz2";
+      sha256 = "12ngz32swh9n85xy0cz1lq16aqi9ys5hq19v589q9a97wn1k3hcl";
+    };
 
-  buildInputs = [
-    libxcb xcbutilkeysyms xcbutil xcbutilwm xcbutilxrm libxkbcommon
-    libstartup_notification libX11 pcre libev yajl xcb-util-cursor perl pango
-    perlPackages.AnyEventI3 perlPackages.X11XCB perlPackages.IPCRun
-    perlPackages.ExtUtilsPkgConfig perlPackages.TestMore perlPackages.InlineC
-    xorgserver xvfb_run
-  ];
+    nativeBuildInputs = [ which pkgconfig makeWrapper ];
 
-  configureFlags = [ "--disable-builddir" ];
+    buildInputs = [
+      libxcb xcbutilkeysyms xcbutil xcbutilwm xcbutilxrm libxkbcommon
+      libstartup_notification libX11 pcre libev yajl xcb-util-cursor perl pango
+      perlPackages.AnyEventI3 perlPackages.X11XCB perlPackages.IPCRun
+      perlPackages.ExtUtilsPkgConfig perlPackages.TestMore perlPackages.InlineC
+      xorgserver xvfb_run
+    ];
 
-  enableParallelBuilding = true;
+    configureFlags = [ "--disable-builddir" ];
 
-  postPatch = ''
-    patchShebangs .
-  '';
+    enableParallelBuilding = true;
 
-  # Tests have been failing (at least for some people in some cases)
-  # and have been disabled until someone wants to fix them. Some
-  # initial digging uncovers that the tests call out to `git`, which
-  # they shouldn't, and then even once that's fixed have some
-  # perl-related errors later on. For more, see
-  # https://github.com/NixOS/nixpkgs/issues/7957
-  doCheck = false; # stdenv.system == "x86_64-linux";
-
-  checkPhase = stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
-  ''
-    (cd testcases && xvfb-run ./complete-run.pl -p 1 --keep-xserver-output)
-    ! grep -q '^not ok' testcases/latest/complete-run.log
-  '';
-
-  postInstall = ''
-    wrapProgram "$out/bin/i3-save-tree" --prefix PERL5LIB ":" "$PERL5LIB"
-    for program in $out/bin/i3-sensible-*; do
-      sed -i 's/which/command -v/' $program
-    done
-  '';
-
-  separateDebugInfo = true;
-
-  meta = with stdenv.lib; {
-    description = "A tiling window manager";
-    homepage    = "http://i3wm.org";
-    maintainers = with maintainers; [ garbas modulistic fpletz ];
-    license     = licenses.bsd3;
-    platforms   = platforms.all;
-
-    longDescription = ''
-      A tiling window manager primarily targeted at advanced users and
-      developers. Based on a tree as data structure, supports tiling,
-      stacking, and tabbing layouts, handled dynamically, as well as
-      floating windows. Configured via plain text file. Multi-monitor.
-      UTF-8 clean.
+    postPatch = ''
+      patchShebangs .
     '';
-  };
 
+    # Tests have been failing (at least for some people in some cases)
+    # and have been disabled until someone wants to fix them. Some
+    # initial digging uncovers that the tests call out to `git`, which
+    # they shouldn't, and then even once that's fixed have some
+    # perl-related errors later on. For more, see
+    # https://github.com/NixOS/nixpkgs/issues/7957
+    doCheck = false; # stdenv.system == "x86_64-linux";
+
+    checkPhase = stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
+    ''
+      (cd testcases && xvfb-run ./complete-run.pl -p 1 --keep-xserver-output)
+      ! grep -q '^not ok' testcases/latest/complete-run.log
+    '';
+
+    postInstall = ''
+      wrapProgram "$out/bin/i3-save-tree" --prefix PERL5LIB ":" "$PERL5LIB"
+      for program in $out/bin/i3-sensible-*; do
+        sed -i 's/which/command -v/' $program
+      done
+    '';
+
+    separateDebugInfo = true;
+
+    meta = with stdenv.lib; {
+      description = "A tiling window manager";
+      homepage    = "http://i3wm.org";
+      maintainers = with maintainers; [ garbas modulistic fpletz ];
+      license     = licenses.bsd3;
+      platforms   = platforms.all;
+
+      longDescription = ''
+        A tiling window manager primarily targeted at advanced users and
+        developers. Based on a tree as data structure, supports tiling,
+        stacking, and tabbing layouts, handled dynamically, as well as
+        floating windows. Configured via plain text file. Multi-monitor.
+        UTF-8 clean.
+      '';
+    };
+
+  };
+in if configFile == null then i3 else symlinkJoin {
+  name = "i3-with-config-${version}";
+  paths = [ i3 ];
+
+  buildInputs = [ makeWrapper ];
+
+  postBuild = ''
+      wrapProgram $out/bin/i3 \
+      --add-flags "-c ${configFile}"
+  '';
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14483,6 +14483,8 @@ with pkgs;
 
   i3 = callPackage ../applications/window-managers/i3 {
     xcb-util-cursor = if stdenv.isDarwin then xcb-util-cursor-HEAD else xcb-util-cursor;
+
+    configFile = config.i3.configFile or null;
   };
 
   i3-gaps = callPackage ../applications/window-managers/i3/gaps.nix { };


### PR DESCRIPTION
###### Motivation for this change

i3 loads its configuration from `~/.config/i3`, but in nix-based systems
you might want to build the config in `~/.nix-profile` using a nix
derivation, so `i3` needs to know where to look for the configuration
file.

I confirmed the change running `nix-build -A i3` with a `i3.configFile` parameter in `config.nix` to ensure that `i3` builds properly and I created a test VM using the following configuration:

``` nix
{
  test = { pkgs, lib, ... }: with lib; {
    users.extraUsers.vm = {
      isNormalUser = true;
      password = "vm";
      extraGroups = [ "wheel" ];
    };

    nixpkgs.config = {
      i3.configFile = "/home/vm/i3.conf";
    };

    services.xserver = {
      enable = true;
      windowManager = {
        i3.enable = true;
        default = "i3";
      };
      desktopManager = {
        xterm.enable = false;
        default = "none";
      };
    };
  };
}
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

