### PR TITLE
pythonPackage.markdownsuperscript: init at 2.0.0

### DIFF
--- a/pkgs/development/python-modules/markdownsuperscript/default.nix
+++ b/pkgs/development/python-modules/markdownsuperscript/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, markdown }:
+
+buildPythonPackage rec {
+  pname = "MarkdownSuperscript";
+  version = "2.0.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1dsx21h9hkx098d5azpw81dcz23rrgzrwlymwv7jri348q26p748";
+  };
+
+  propagatedBuildInputs = [ markdown ];
+
+  doCheck = false; # See https://github.com/NixOS/nixpkgs/pull/26985
+
+  meta = {
+    description = "An extension to the Python Markdown package enabling superscript text";
+    homepage = https://github.com/jambonrose/markdown_superscript_extension;
+    license = stdenv.lib.licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13451,6 +13451,8 @@ in {
     };
   };
 
+  markdownsuperscript = callPackage ../development/python-modules/markdownsuperscript {};
+
   markdown-macros = buildPythonPackage rec {
     name = "markdown-macros-${version}";
     version = "0.1.2";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

