### PR TITLE
godot 2.1.1-stable -> 2.1.3-stable

### DIFF
--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name    = "godot-${version}";
-  version = "2.1.1-stable";
+  version = "2.1.3-stable";
 
   src = fetchFromGitHub {
     owner  = "godotengine";
     repo   = "godot";
     rev    = version;
-    sha256 = "071qkm1l6yn2s9ha67y15w2phvy5m5wl3wqvrslhfmnsir3q3k01";
+    sha256 = "04qbab0icpv3ascr4dqgj18sqvw04a1jypcngb0ji8npa8q9wxb2";
   };
 
   buildInputs = [

--- a/pkgs/development/tools/godot/pkg_config_additions.patch
+++ b/pkgs/development/tools/godot/pkg_config_additions.patch
@@ -1,5 +1,5 @@
 +++ build/platform/x11/detect.py
-@@ -132,6 +132,10 @@
+@@ -139,6 +139,10 @@
      env.ParseConfig('pkg-config xinerama --cflags --libs')
      env.ParseConfig('pkg-config xcursor --cflags --libs')
      env.ParseConfig('pkg-config xrandr --cflags --libs')
@@ -9,4 +9,4 @@
 +    env.ParseConfig('pkg-config zlib --cflags --libs')
 
      if (env['builtin_openssl'] == 'no'):
-         env.ParseConfig('pkg-config openssl --cflags --libs')
+         # Currently not compatible with OpenSSL 1.1.0+


### PR DESCRIPTION
###### Motivation for this change

- godot 2.1.1 -> 2.1.3

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

