### PR TITLE
mpd service: Create playlist directory

### DIFF
--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -10,9 +10,11 @@ let
   gid = config.ids.gids.mpd;
   cfg = config.services.mpd;
 
+  playlistDir = "${cfg.dataDir}/playlists";
+
   mpdConf = pkgs.writeText "mpd.conf" ''
     music_directory     "${cfg.musicDirectory}"
-    playlist_directory  "${cfg.dataDir}/playlists"
+    playlist_directory  "${playlistDir}"
     db_file             "${cfg.dbFile}"
     state_file          "${cfg.dataDir}/state"
     sticker_file        "${cfg.dataDir}/sticker.sql"
@@ -126,7 +128,10 @@ in {
       description = "Music Player Daemon";
       wantedBy = [ "multi-user.target" ];
 
-      preStart = "mkdir -p ${cfg.dataDir} && chown -R ${cfg.user}:${cfg.group} ${cfg.dataDir}";
+      preStart = ''
+        mkdir -p "${cfg.dataDir}" && chown -R ${cfg.user}:${cfg.group} "${cfg.dataDir}"
+        mkdir -p "${playlistDir}" && chown -R ${cfg.user}:${cfg.group} "${playlistDir}"
+      '';
       serviceConfig = {
         User = "${cfg.user}";
         PermissionsStartOnly = true;


### PR DESCRIPTION
###### Motivation for this change

Currently the playlist directory is hard coded in the configuration but not automatically created. Thus MPD will emit error messages and it is not possible to create playlists.

Alternatively, we could make the playlist directory an configurable option. However, then it is up to the user to make this directory read and writeable by MPD.

###### Things done

- [x] Tested using sandboxing
- [x]  Built on NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---