### PR TITLE
collectd: fix configureFlags and jar location

### DIFF
--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -52,8 +52,20 @@ stdenv.mkDerivation rec {
 
   # for some reason libsigrok isn't auto-detected
   configureFlags =
+    [ "--localstatedir=/var" ] ++
     stdenv.lib.optional (libsigrok != null) "--with-libsigrok" ++
     stdenv.lib.optional (python != null) "--with-python=${python}/bin/python";
+
+  # do not create directories in /var during installPhase
+  postConfigure = ''
+     substituteInPlace Makefile --replace '$(mkinstalldirs) $(DESTDIR)$(localstatedir)/' '#'
+  '';
+
+  postInstall = ''
+    if [ -d $out/share/collectd/java ]; then
+      mv $out/share/collectd/java $out/share/
+    fi
+  '';
 
   meta = with stdenv.lib; {
     description = "Daemon which collects system performance statistics periodically";


### PR DESCRIPTION
###### Motivation for this change

1. Added ```--localstatedir=/var``` to ```configureFlags```
Otherwise the default locations of ephemeral files and sockets are in the nix store:
```
# ./collectdctl
./collectdctl: missing command
Usage: ./collectdctl [options] <command> [cmd options]

Available options:
  -s       Path to collectd's UNIX socket.
           Default: /nix/store/6gz0k2p2v0n3aw7v8hyjf05qkr2dbzki-collectd-5.7.2/var/run/collectd-unixsock

  -h       Display this help and exit.
```

2. jars placed to ```$out/share/java``` (where the nix java hook can find them)
