### PR TITLE
gen-oath-safe: init at 2017-01-23

### DIFF
--- a/pkgs/tools/security/gen-oath-safe/default.nix
+++ b/pkgs/tools/security/gen-oath-safe/default.nix
@@ -1,0 +1,41 @@
+{ coreutils, fetchFromGitHub, libcaca, makeWrapper, python, openssl, qrencode, stdenv, yubikey-manager }:
+
+stdenv.mkDerivation {
+  name = "gen-oath-safe-2017-01-23";
+  src = fetchFromGitHub {
+    owner = "mcepl";
+    repo = "gen-oath-safe";
+    rev = "fb53841";
+    sha256 = "0018kqmhg0861r5xkbis2a1rx49gyn0dxcyj05wap5ms7zz69m0m";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  buildPhase = ":";
+
+  installPhase =
+    let
+      path = stdenv.lib.makeBinPath [
+        coreutils
+        libcaca.bin
+        openssl.bin
+        python
+        qrencode
+        yubikey-manager
+      ];
+    in
+    ''
+      mkdir -p $out/bin
+      cp gen-oath-safe $out/bin/
+      wrapProgram $out/bin/gen-oath-safe \
+        --prefix PATH : ${path}
+    '';
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mcepl/gen-oath-safe;
+    description = "Script for generating HOTP/TOTP keys (and QR code)";
+    platforms =  platforms.unix;
+    license = licenses.mit;
+    maintainers = [ maintainers.makefu ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2030,6 +2030,8 @@ with pkgs;
 
   gdmap = callPackage ../tools/system/gdmap { };
 
+  gen-oath-safe = callPackage ../tools/security/gen-oath-safe { };
+
   genext2fs = callPackage ../tools/filesystems/genext2fs { };
 
   gengetopt = callPackage ../development/tools/misc/gengetopt { };


### PR DESCRIPTION
###### Motivation for this change

add package from private repo to upstream

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

