### PR TITLE
gst_all_1.gst-plugins-bad: build gtksink plugin

### DIFF
--- a/pkgs/applications/networking/corebird/default.nix
+++ b/pkgs/applications/networking/corebird/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3 json_glib sqlite libsoup gettext vala_0_32 gnome3.rest gnome3.dconf gnome3.gspell glib_networking
-  ] ++ (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav ]);
+  ] ++ (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good (gst-plugins-bad.override { gtkSupport = true; }) gst-libav ]);
 
   meta = {
     description = "Native Gtk+ Twitter client for the Linux desktop";

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, pkgconfig, python, gst-plugins-base, orc
 , faacSupport ? false, faac ? null
+, gtkSupport ? false, gtk3 ? null
 , faad2, libass, libkate, libmms
 , libmodplug, mpeg2dec, mpg123
 , openjpeg, libopus, librsvg
@@ -10,6 +11,7 @@
 }:
 
 assert faacSupport -> faac != null;
+assert gtkSupport -> gtk3 != null;
 
 let
   inherit (stdenv.lib) optional optionalString;
@@ -41,7 +43,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gst-plugins-base orc
-    faad2 libass libkate libmms
+    faad2 gtk3 libass libkate libmms
     libmodplug mpeg2dec mpg123
     openjpeg libopus librsvg
     fluidsynth libvdpau
@@ -50,6 +52,8 @@ stdenv.mkDerivation rec {
   ]
     ++ libintlOrEmpty
     ++ optional faacSupport faac
+    # for gtksink
+    ++ optional gtkSupport gtk3
     ++ optional stdenv.isLinux wayland
     # wildmidi requires apple's OpenAL
     # TODO: package apple's OpenAL, fix wildmidi, include on Darwin


### PR DESCRIPTION
###### Motivation for this change
Corebird requires gtksink gstreamer plugin to play videos.[¹] The plugin, however, is only built when GTK is available.

This patch adds gtk3 as a dependency to gstreamer-plugins-bad package, enabling the build of gtksink.

[¹]: https://github.com/baedert/corebird/issues/431

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Tested by running Corebird and playing a video
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

