### PR TITLE
scyther: init at 1.1.3

### DIFF
--- a/pkgs/applications/science/programming/scyther/cli.nix
+++ b/pkgs/applications/science/programming/scyther/cli.nix
@@ -1,0 +1,32 @@
+{ stdenv, glibc, flex, bison, cmake
+, version, src, meta }:
+stdenv.mkDerivation {
+  name = "scyther-cli-${version}";
+
+  inherit src meta;
+
+  buildInputs = [
+    cmake
+    glibc.static
+    flex
+    bison
+  ];
+
+  patchPhase = ''
+    # Since we're not in a git dir, the normal command this project uses to create this file wouldn't work
+    printf "%s\n" "#define TAGVERSION \"${version}\"" > src/version.h
+  '';
+
+  configurePhase = ''
+    (cd src && cmakeConfigurePhase)
+  '';
+
+  dontUseCmakeBuildDir = true;
+  cmakeFlags = [ "-DCMAKE_C_FLAGS=-std=gnu89" ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mv src/scyther-linux "$out/bin/scyther-cli"
+    ln -s "$out/bin/scyther-cli" "$out/bin/scyther-linux"
+  '';
+}

--- a/pkgs/applications/science/programming/scyther/default.nix
+++ b/pkgs/applications/science/programming/scyther/default.nix
@@ -1,0 +1,82 @@
+{ stdenv, lib, fetchFromGitHub, glibc, flex, bison, python27Packages, graphviz, cmake
+, includeGUI ? true
+, includeProtocols ? true
+}:
+let
+  version = "1.1.3";
+in
+stdenv.mkDerivation {
+  name = "scyther-${version}";
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    sha256 = "0rb4ha5bnjxnwj4f3hciq7kyj96fhw14hqbwl5kr9cdw8q62mx0h";
+    owner = "cascremers";
+    repo = "scyther";
+  };
+
+  buildInputs = [
+    cmake
+    glibc.static
+    flex
+    bison
+  ] ++ lib.optional includeGUI [
+    python27Packages.wrapPython
+  ];
+
+  patchPhase = ''
+    # Since we're not in a git dir, the normal command this project uses to create this file wouldn't work
+    printf "%s\n" "#define TAGVERSION \"${version}\"" > src/version.h
+  '' + lib.optionalString includeGUI ''
+    file=gui/Scyther/Scyther.py
+    
+    # By default the scyther binary is looked for in the directory of the python script ($out/gui), but we want to have it look where our cli package is
+    substituteInPlace $file --replace "return getMyDir()" "return \"$out/bin\""
+
+    # Removes the Shebang from the file, as this would be wrapped wrongly
+    sed -i -e "1d" $file
+  '';
+
+  configurePhase = ''
+    (cd src && cmakeConfigurePhase)
+  '';
+
+  propagatedBuildInputs = lib.optional includeGUI [
+    python27Packages.wxPython
+    graphviz
+  ];
+  
+  dontUseCmakeBuildDir = true;
+  cmakeFlags = [ "-DCMAKE_C_FLAGS=-std=gnu89" ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp src/scyther-linux "$out/bin/scyther-cli"
+  '' + lib.optionalString includeGUI ''
+    mkdir -p "$out/gui"
+    cp -r gui/* "$out/gui"
+    ln -s ../gui/scyther-gui.py "$out/bin/scyther-gui"
+    ln -s ../bin/scyther-cli "$out/bin/scyther-linux"
+  '' + lib.optionalString includeProtocols (if includeGUI then ''
+      ln -s ./gui/Protocols "$out/protocols"
+    '' else ''
+      mkdir -p "$out/protocols"
+      cp -r gui/Protocols/* "$out/protocols"
+    '');
+
+  postFixup = lib.optionalString includeGUI ''
+    wrapPythonProgramsIn "$out/gui" "$out $pythonPath"
+  '';
+
+  doInstallCheck = includeGUI;
+  installCheckPhase = ''
+    "$out/gui/scyther.py" "$src/gui/Protocols/Demo/ns3.spdl"
+  '';
+
+  meta = with lib; {
+    description = "Scyther is a tool for the automatic verification of security protocols.";
+    homepage = https://www.cs.ox.ac.uk/people/cas.cremers/scyther/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ infinisil ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/science/programming/scyther/default.nix
+++ b/pkgs/applications/science/programming/scyther/default.nix
@@ -1,76 +1,16 @@
-{ stdenv, lib, fetchFromGitHub, glibc, flex, bison, python27Packages, graphviz, cmake
+{ stdenv, lib, buildEnv, callPackage_i686, fetchFromGitHub, python27Packages, graphviz
 , includeGUI ? true
 , includeProtocols ? true
 }:
 let
   version = "1.1.3";
-in
-stdenv.mkDerivation {
-  name = "scyther-${version}";
+
   src = fetchFromGitHub {
     rev = "v${version}";
     sha256 = "0rb4ha5bnjxnwj4f3hciq7kyj96fhw14hqbwl5kr9cdw8q62mx0h";
     owner = "cascremers";
     repo = "scyther";
   };
-
-  buildInputs = [
-    cmake
-    glibc.static
-    flex
-    bison
-  ] ++ lib.optional includeGUI [
-    python27Packages.wrapPython
-  ];
-
-  patchPhase = ''
-    # Since we're not in a git dir, the normal command this project uses to create this file wouldn't work
-    printf "%s\n" "#define TAGVERSION \"${version}\"" > src/version.h
-  '' + lib.optionalString includeGUI ''
-    file=gui/Scyther/Scyther.py
-    
-    # By default the scyther binary is looked for in the directory of the python script ($out/gui), but we want to have it look where our cli package is
-    substituteInPlace $file --replace "return getMyDir()" "return \"$out/bin\""
-
-    # Removes the Shebang from the file, as this would be wrapped wrongly
-    sed -i -e "1d" $file
-  '';
-
-  configurePhase = ''
-    (cd src && cmakeConfigurePhase)
-  '';
-
-  propagatedBuildInputs = lib.optional includeGUI [
-    python27Packages.wxPython
-    graphviz
-  ];
-  
-  dontUseCmakeBuildDir = true;
-  cmakeFlags = [ "-DCMAKE_C_FLAGS=-std=gnu89" ];
-
-  installPhase = ''
-    mkdir -p "$out/bin"
-    cp src/scyther-linux "$out/bin/scyther-cli"
-  '' + lib.optionalString includeGUI ''
-    mkdir -p "$out/gui"
-    cp -r gui/* "$out/gui"
-    ln -s ../gui/scyther-gui.py "$out/bin/scyther-gui"
-    ln -s ../bin/scyther-cli "$out/bin/scyther-linux"
-  '' + lib.optionalString includeProtocols (if includeGUI then ''
-      ln -s ./gui/Protocols "$out/protocols"
-    '' else ''
-      mkdir -p "$out/protocols"
-      cp -r gui/Protocols/* "$out/protocols"
-    '');
-
-  postFixup = lib.optionalString includeGUI ''
-    wrapPythonProgramsIn "$out/gui" "$out $pythonPath"
-  '';
-
-  doInstallCheck = includeGUI;
-  installCheckPhase = ''
-    "$out/gui/scyther.py" "$src/gui/Protocols/Demo/ns3.spdl"
-  '';
 
   meta = with lib; {
     description = "Scyther is a tool for the automatic verification of security protocols.";
@@ -79,4 +19,61 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ infinisil ];
     platforms = platforms.linux;
   };
-}
+
+  cli = callPackage_i686 ./cli.nix {
+    inherit version src meta;
+  };
+
+  gui = stdenv.mkDerivation {
+    name = "scyther-gui-${version}";
+    inherit src meta;
+    buildInputs = [
+      python27Packages.wrapPython
+    ];
+
+    patchPhase = ''
+      file=gui/Scyther/Scyther.py
+
+      # By default the scyther binary is looked for in the directory of the python script ($out/gui), but we want to have it look where our cli package is
+      substituteInPlace $file --replace "return getMyDir()" "return \"${cli}/bin\""
+
+      # Removes the Shebang from the file, as this would be wrapped wrongly
+      sed -i -e "1d" $file
+    '';
+
+    dontBuild = true;
+
+    propagatedBuildInputs = [
+      python27Packages.wxPython
+      graphviz
+    ];
+ 
+    installPhase = ''
+      mkdir -p "$out"/gui "$out"/bin
+      cp -r gui/* "$out"/gui
+      ln -s "$out"/gui/scyther-gui.py "$out/bin/scyther-gui"
+    '';
+
+    postFixup = ''
+      wrapPythonProgramsIn "$out/gui" "$out $pythonPath"
+    '';
+
+    doInstallCheck = true;
+    installCheckPhase = ''
+      "$out/gui/scyther.py" "$src/gui/Protocols/Demo/ns3.spdl"
+    '';
+  };
+in
+  buildEnv {
+    name = "scyther-${version}";
+    inherit meta;
+    paths = [ cli ] ++ lib.optional includeGUI gui;
+    pathsToLink = [ "/bin" ];
+
+    postBuild = ''
+      rm "$out/bin/scyther-linux"
+    '' + lib.optionalString includeProtocols ''
+      mkdir -p "$out/protocols"
+      cp -rv ${src}/protocols/* "$out/protocols"
+    '';
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17852,7 +17852,7 @@ with pkgs;
 
   plm = callPackage ../applications/science/programming/plm { };
 
-  scyther = callPackage_i686 ../applications/science/programming/scyther { };
+  scyther = callPackage ../applications/science/programming/scyther { };
 
   ### SCIENCE/LOGIC
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17852,6 +17852,8 @@ with pkgs;
 
   plm = callPackage ../applications/science/programming/plm { };
 
+  scyther = callPackage_i686 ../applications/science/programming/scyther { };
+
   ### SCIENCE/LOGIC
 
   abc-verifier = callPackage ../applications/science/logic/abc {};


### PR DESCRIPTION
This PR adds the [scyther](https://www.cs.ox.ac.uk/people/cas.cremers/scyther/) application, a tool for automatic verification of security protocols. [On GitHub](https://github.com/cascremers/scyther/)

This is the first time I wrote a non-trivial amount of nix code, I tried to structure it well :)

I split the package up into 4 files:
- `sources.nix` contains different versions of the package. The official latest release is 1.1.3, there is also a Compromise-0.9.2 version which has some different performance characteristics which may not everybody want. Then I also included the latest commit from master, as the project [hasn't seen a new release in a while](https://github.com/cascremers/scyther/releases) and there were some bug fixes.
- `cli.nix` contains the 32bit package for building the C part, which generates a single executable, usable by itself.
- `gui.nix` contains the python GUI frontend, which uses the CLI at runtime
- `default.nix` contains the actual package which builds a single environment. Using the `includeGUI` (default `true`) option, one can choose to not to have the GUI, while the `version` option lets you select one of the three above mentioned versions.

This split into multiple derivations is made to reduce build time and output path size.

###### Motivation for this change

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

