### PR TITLE
ncmpcpp: 0.7.7 -> 0.8

### DIFF
--- a/pkgs/applications/audio/ncmpcpp/default.nix
+++ b/pkgs/applications/audio/ncmpcpp/default.nix
@@ -1,39 +1,33 @@
 { stdenv, fetchurl, boost, mpd_clientlib, ncurses, pkgconfig, readline
-, libiconv, icu
+, libiconv, icu, curl
 , outputsSupport ? false # outputs screen
 , visualizerSupport ? false, fftw ? null # visualizer screen
 , clockSupport ? false # clock screen
-, unicodeSupport ? true # utf8 support
-, curlSupport ? true, curl ? null # allow fetching lyrics from the internet
 , taglibSupport ? true, taglib ? null # tag editor
 }:
 
 assert visualizerSupport -> (fftw != null);
-assert curlSupport -> (curl != null);
 assert taglibSupport -> (taglib != null);
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "ncmpcpp-${version}";
-  version = "0.7.7";
+  version = "0.8";
 
   src = fetchurl {
     url = "http://ncmpcpp.rybczak.net/stable/${name}.tar.bz2";
-    sha256 = "1vq19m36608pvw1g8nbcaqqb89wsw05v35pi45xwr20z7g4bxg5p";
+    sha256 = "0nj6ky805a55acj0w57sbn3vfmmkbqp97rhbi0q9848n10f2l3rg";
   };
 
   configureFlags = [ "BOOST_LIB_SUFFIX=" ]
     ++ optional outputsSupport "--enable-outputs"
     ++ optional visualizerSupport "--enable-visualizer --with-fftw"
     ++ optional clockSupport "--enable-clock"
-    ++ optional unicodeSupport "--enable-unicode"
-    ++ optional curlSupport "--with-curl"
     ++ optional taglibSupport "--with-taglib";
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ boost mpd_clientlib ncurses readline libiconv icu ]
-    ++ optional curlSupport curl
+  buildInputs = [ boost mpd_clientlib ncurses readline libiconv icu curl ]
     ++ optional visualizerSupport fftw
     ++ optional taglibSupport taglib;
 
@@ -41,7 +35,7 @@ stdenv.mkDerivation rec {
     description = "A featureful ncurses based MPD client inspired by ncmpc";
     homepage    = http://ncmpcpp.rybczak.net/;
     license     = licenses.gpl2Plus;
-    maintainers = with maintainers; [ lovek323 mornfall koral ];
-    platforms   = platforms.linux;
+    maintainers = with maintainers; [ jfrankenau koral lovek323 mornfall ];
+    platforms   = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update.

Note: Curl is now a hard dependency and Unicode is not configurable anymore due to ncursesw being used by default.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @lovek323 @mornfall @koral