### PR TITLE
qbittorrent: fix build

### DIFF
--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, which
-, boost, libtorrentRasterbar, qmake, qtbase, qttools
+, boost, libtorrentRasterbar, qtbase, qttools
 , debugSupport ? false # Debugging
 , guiSupport ? true, dbus_libs ? null # GUI (disable to run headless)
 , webuiSupport ? true # WebUI
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "0vs626khavhqqnq2hrwrxyc8ihbngharcf1fd37nwccvy13qqljn";
   };
 
-  nativeBuildInputs = [ pkgconfig which qmake ];
+  nativeBuildInputs = [ pkgconfig which ];
 
   buildInputs = [ boost libtorrentRasterbar qtbase qttools ]
     ++ optional guiSupport dbus_libs;
@@ -34,9 +34,9 @@ stdenv.mkDerivation rec {
   ] ++ optional debugSupport "--enable-debug";
 
   # The lrelease binary is named lrelease instead of lrelease-qt4
-  patches = [ ./fix-lrelease.patch];
+  patches = [ ./fix-lrelease.patch ];
 
-  # https://github.com/qbittorrent/qBittorrent/issues/1992 
+  # https://github.com/qbittorrent/qBittorrent/issues/1992
   enableParallelBuilding = false;
 
   meta = {


### PR DESCRIPTION
The qbittorrent has been broken by 210f6888023c1df8aff2d053a5e41f5e1effdfe7, which adds `qmake` as a
build input. `qmake` is overriding the default configure phase (which
should be `./configure ...` for qbittorrent) so build goes wrong.

Remove `qmake` from build inputs (basically, reverting the said
commit).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ttuegel who has broken the package
cc maintainer @viric 