### PR TITLE
draftsight: 2017-SP1 to 2017-SP2

### DIFF
--- a/pkgs/applications/graphics/draftsight/default.nix
+++ b/pkgs/applications/graphics/draftsight/default.nix
@@ -6,7 +6,7 @@
 
 assert stdenv.system == "x86_64-linux";
 
-let version = "2017-SP1"; in
+let version = "2017-SP2"; in
 stdenv.mkDerivation {
   name = "draftsight-${version}";
 
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
   src = requireFile {
     name = "draftSight.deb";
     url = "https://www.3ds.com/?eID=3ds_brand_download&uid=41&pidDown=13426&L=0";
-    sha256 = "0s7b74685r0961kd59hxpdp9s5yhvzx8307imsxm66f99s8rswdv";
+    sha256 = "04i3dqza6y4p2059pqg5inp3qzr5jmiqplzzk7h1a6gh380v1rbr";
   };
 
   libPath = stdenv.lib.makeLibraryPath [ gcc.cc mesa xdg_utils


### PR DESCRIPTION
###### Motivation for this change

The Debian package for DraftSight updated silently to 2017-SP2 without changing URLs.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

