### PR TITLE
docker-tools: set user/group when creating a pure layer

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -234,11 +234,10 @@ rec {
     # Files to add to the layer.
     contents ? null,
     # Additional commands to run on the layer before it is tar'd up.
-    extraCommands ? ""
+    extraCommands ? "", uid ? 0, gid ? 0
   }:
     runCommand "docker-layer-${name}" {
       inherit baseJson contents extraCommands;
-
       buildInputs = [ jshon rsync ];
     }
     ''
@@ -260,7 +259,7 @@ rec {
       # Tar up the layer and throw it into 'layer.tar'.
       echo "Packing layer..."
       mkdir $out
-      tar -C layer --mtime="@$SOURCE_DATE_EPOCH" -cf $out/layer.tar .
+      tar -C layer --mtime="@$SOURCE_DATE_EPOCH" --owner=${toString uid} --group=${toString gid} -cf $out/layer.tar .
 
       # Compute a checksum of the tarball.
       echo "Computing layer checksum..."
@@ -297,7 +296,7 @@ rec {
     # How much disk to allocate for the temporary virtual machine.
     diskSize ? 1024,
     # Commands (bash) to run on the layer; these do not require sudo.
-    extraCommands ? ""
+    extraCommands ? "", uid ? 0, gid ? 0
   }:
     # Generate an executable script from the `runAsRoot` text.
     let runAsRootScript = shellScript "run-as-root.sh" runAsRoot;
@@ -375,7 +374,7 @@ rec {
     # Docker config; e.g. what command to run on the container.
     config ? null,
     # Optional bash script to run on the files prior to fixturizing the layer.
-    extraCommands ? "",
+    extraCommands ? "", uid ? 0, gid ? 0,
     # Optional bash script to run as root on the image when provisioning.
     runAsRoot ? null,
     # Size of the virtual machine disk to provision when building the image.
@@ -398,7 +397,7 @@ rec {
         if runAsRoot == null
         then mkPureLayer {
           name = baseName;
-          inherit baseJson contents extraCommands;
+          inherit baseJson contents extraCommands uid gid;
         } else mkRootLayer {
           name = baseName;
           inherit baseJson fromImage fromImageName fromImageTag
@@ -498,7 +497,7 @@ rec {
         chmod -R a-w image
 
         echo "Cooking the image..."
-        tar -C image --mtime="@$SOURCE_DATE_EPOCH" -c . | pigz -nT > $out
+        tar -C image --mtime="@$SOURCE_DATE_EPOCH" --owner=0 --group=0 -c . | pigz -nT > $out
 
         echo "Finished."
       '';

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -252,6 +252,8 @@ rec {
         echo "No contents to add to layer."
       fi
 
+      chmod ug+w layer
+
       if [[ -n $extraCommands ]]; then
         (cd layer; eval "$extraCommands")
       fi
@@ -296,7 +298,7 @@ rec {
     # How much disk to allocate for the temporary virtual machine.
     diskSize ? 1024,
     # Commands (bash) to run on the layer; these do not require sudo.
-    extraCommands ? "", uid ? 0, gid ? 0
+    extraCommands ? ""
   }:
     # Generate an executable script from the `runAsRoot` text.
     let runAsRootScript = shellScript "run-as-root.sh" runAsRoot;
@@ -311,6 +313,8 @@ rec {
           echo "Adding $item..."
           rsync -ak --chown=0:0 $item/ layer/
         done
+
+        chmod ug+w layer
       '';
 
       postMount = ''


### PR DESCRIPTION
###### Motivation for this change

Currently the uid of the build user ends up in the image, this makes the permissions deterministic and configurable.

```nix
dockerTools.buildImage {
  name = "foo";
  contents = [ pkgs.busybox ];

  uid = 42;
  extraCommands = ''
    touch foo
  '';
}
```

```bash
docker run --rm -it foo /bin/ls -l foo
# -rw-r--r--    1 42        0                0 Jan  1  1970 foo
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
