### PR TITLE
pythonPackages.codecov: init at 2.0.9

### DIFF
--- a/pkgs/development/python-modules/codecov/default.nix
+++ b/pkgs/development/python-modules/codecov/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, requests, coverage, unittest2 }:
+
+buildPythonPackage rec {
+  pname = "codecov";
+  version = "2.0.9";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "037h4dcl8xshlq3rj8409p11rpgnyqrhlhfq8j34s94nm0n1h76v";
+  };
+
+  buildInputs = [ unittest2 ]; # Tests only
+
+  propagatedBuildInputs = [ requests coverage ];
+
+  patchPhase = ''
+    sed -i 's/, "argparse"//' setup.py
+  '';
+
+  meta = {
+    description = "Python report uploader for Codecov";
+    homepage = https://codecov.io/;
+    license = stdenv.lib.licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/codecov/default.nix
+++ b/pkgs/development/python-modules/codecov/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ requests coverage ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's/, "argparse"//' setup.py
   '';
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3809,6 +3809,8 @@ in {
     };
   };
 
+  codecov = callPackage ../development/python-modules/codecov {};
+
   cogapp = buildPythonPackage rec {
     version = "2.3";
     name    = "cogapp-${version}";


### PR DESCRIPTION
###### Motivation for this change

I added this package because the tests for MarkdownSuperscripts (see #26985) depend on it.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

