### PR TITLE
libreoffice: remove spadmin wrapper

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -158,7 +158,7 @@ in stdenv.mkDerivation rec {
 
     mkdir -p "$out/share/gsettings-schemas/collected-for-libreoffice/glib-2.0/schemas/"
 
-    for a in sbase scalc sdraw smath swriter spadmin simpress soffice; do
+    for a in sbase scalc sdraw smath swriter simpress soffice; do
       ln -s $out/lib/libreoffice/program/$a $out/bin/$a
       wrapProgram "$out/bin/$a" \
          --prefix XDG_DATA_DIRS : \


### PR DESCRIPTION
This change removes the spadmin wrapper because the utility was removed from LibreOffice in release 4.3. See https://wiki.documentfoundation.org/ReleaseNotes/4.3#CUPS.2C_fax_machines_and_spadmin which states:

 > The graphical utility spadmin is now removed in favor of these new features and the operating system's standard printer administration tools. (Caolán McNamara)

 Closes #26671

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

