### PR TITLE
mailcatcher: init at 0.6.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -605,6 +605,7 @@
   z77z = "Marco Maggesi <maggesi@math.unifi.it>";
   zagy = "Christian Zagrodnick <cz@flyingcircus.io>";
   zalakain = "Unai Zalakain <contact@unaizalakain.info>";
+  zarelit = "David Costa <david@zarel.net>";
   zauberpony = "Elmar Athmer <elmar@athmer.org>";
   zef = "Zef Hemel <zef@zef.me>";
   zimbatm = "zimbatm <zimbatm@zimbatm.com>";

--- a/pkgs/development/web/mailcatcher/Gemfile
+++ b/pkgs/development/web/mailcatcher/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'mailcatcher'

--- a/pkgs/development/web/mailcatcher/Gemfile.lock
+++ b/pkgs/development/web/mailcatcher/Gemfile.lock
@@ -1,0 +1,43 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    daemons (1.2.4)
+    eventmachine (1.0.9.1)
+    mail (2.6.6)
+      mime-types (>= 1.16, < 4)
+    mailcatcher (0.6.5)
+      eventmachine (= 1.0.9.1)
+      mail (~> 2.3)
+      rack (~> 1.5)
+      sinatra (~> 1.2)
+      skinny (~> 0.2.3)
+      sqlite3 (~> 1.3)
+      thin (~> 1.5.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    rack (1.6.8)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    skinny (0.2.4)
+      eventmachine (~> 1.0.0)
+      thin (>= 1.5, < 1.7)
+    sqlite3 (1.3.13)
+    thin (1.5.1)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
+    tilt (2.0.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mailcatcher
+
+BUNDLED WITH
+   1.14.4

--- a/pkgs/development/web/mailcatcher/default.nix
+++ b/pkgs/development/web/mailcatcher/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ makeWrapper ];
 
-  phases = ["installPhase"];
+  unpackPhase = ":";
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/development/web/mailcatcher/default.nix
+++ b/pkgs/development/web/mailcatcher/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, bundlerEnv, ruby, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "mailcatcher-${version}";
+
+  version = (import ./gemset.nix).mailcatcher.version;
+
+  env = bundlerEnv {
+    name = "${name}-gems";
+
+    inherit ruby;
+
+    gemdir = ./.;
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  phases = ["installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper ${env}/bin/mailcatcher $out/bin/mailcatcher
+    makeWrapper ${env}/bin/catchmail $out/bin/catchmail
+  '';
+
+  meta = with stdenv.lib; {
+    description = "SMTP server and web interface to locally test outbound emails";
+    homepage    = https://mailcatcher.me/;
+    license     = licenses.mit;
+    maintainers = [ maintainers.zarelit ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/web/mailcatcher/gemset.nix
+++ b/pkgs/development/web/mailcatcher/gemset.nix
@@ -1,0 +1,106 @@
+{
+  daemons = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bmb4qrd95b5gl3ym5j3q6mf090209f4vkczggn49n56w6s6zldz";
+      type = "gem";
+    };
+    version = "1.2.4";
+  };
+  eventmachine = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17jr1caa3ggg696dd02g2zqzdjqj9x9q2nl7va82l36f7c5v6k4z";
+      type = "gem";
+    };
+    version = "1.0.9.1";
+  };
+  mail = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0d7lhj2dw52ycls6xigkfz6zvfhc6qggply9iycjmcyj9760yvz9";
+      type = "gem";
+    };
+    version = "2.6.6";
+  };
+  mailcatcher = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0h6gk8n18i5f651f244al1hscjzl27fpma4vqw0qhszqqpd5p3bx";
+      type = "gem";
+    };
+    version = "0.6.5";
+  };
+  mime-types = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0087z9kbnlqhci7fxh9f6il63hj1k02icq2rs0c6cppmqchr753m";
+      type = "gem";
+    };
+    version = "3.1";
+  };
+  mime-types-data = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04my3746hwa4yvbx1ranhfaqkgf6vavi1kyijjnw8w3dy37vqhkm";
+      type = "gem";
+    };
+    version = "3.2016.0521";
+  };
+  rack = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "19m7aixb2ri7p1n0iqaqx8ldi97xdhvbxijbyrrcdcl6fv5prqza";
+      type = "gem";
+    };
+    version = "1.6.8";
+  };
+  rack-protection = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cvb21zz7p9wy23wdav63z5qzfn4nialik22yqp6gihkgfqqrh5r";
+      type = "gem";
+    };
+    version = "1.5.3";
+  };
+  sinatra = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0byxzl7rx3ki0xd7aiv1x8mbah7hzd8f81l65nq8857kmgzj1jqq";
+      type = "gem";
+    };
+    version = "1.4.8";
+  };
+  skinny = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1y3yvx88ylgz4d2s1wskjk5rkmrcr15q3ibzp1q88qwzr5y493a9";
+      type = "gem";
+    };
+    version = "0.2.4";
+  };
+  sqlite3 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01ifzp8nwzqppda419c9wcvr8n82ysmisrs0hph9pdmv1lpa4f5i";
+      type = "gem";
+    };
+    version = "1.3.13";
+  };
+  thin = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hrq9m3hb6pm8yrqshhg0gafkphdpvwcqmr7k722kgdisp3w91ga";
+      type = "gem";
+    };
+    version = "1.5.1";
+  };
+  tilt = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1is1ayw5049z8pd7slsk870bddyy5g2imp4z78lnvl8qsl8l0s7b";
+      type = "gem";
+    };
+    version = "2.0.7";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2731,6 +2731,8 @@ with pkgs;
 
   kzipmix = callPackage_i686 ../tools/compression/kzipmix { };
 
+  mailcatcher = callPackage ../development/web/mailcatcher { };
+
   makebootfat = callPackage ../tools/misc/makebootfat { };
 
   matrix-synapse = callPackage ../servers/matrix-synapse { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

