### PR TITLE
rustc: Provide unpacked source tree derivation for use in tools

### DIFF
--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -56,7 +56,20 @@ stdenv.mkDerivation {
 
   patches = patches ++ targetPatches;
 
-  passthru.target = target;
+  passthru = {
+    unpackedSrc = stdenv.mkDerivation {
+      name = "rust-src-${version}";
+      inherit src;
+      configurePhase = ":";
+      buildPhase = ":";
+      installPhase = ''
+        mkdir -p $out
+        cp -r . $out/
+      '';
+      fixupPhase = ":";
+    };
+    target = target;
+  };
 
   postPatch = ''
     # Fix dynamic linking against llvm

--- a/pkgs/development/tools/rust/racer/default.nix
+++ b/pkgs/development/tools/rust/racer/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ makeWrapper ];
 
   preCheck = ''
-    export RUST_SRC_PATH="${rustPlatform.rust.rustc.src}/src"
+    export RUST_SRC_PATH="${rustPlatform.rust.rustc.unpackedSrc}/src"
   '';
 
   doCheck = true;
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
   installPhase = ''
     mkdir -p $out/bin
     cp -p target/release/racer $out/bin/
-    wrapProgram $out/bin/racer --set RUST_SRC_PATH "${rustPlatform.rust.rustc.src}/src"
+    wrapProgram $out/bin/racer --set RUST_SRC_PATH "${rustPlatform.rust.rustc.unpackedSrc}/src"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/rust/racerd/default.nix
+++ b/pkgs/development/tools/rust/racerd/default.nix
@@ -18,7 +18,7 @@ buildRustPackage rec {
 
   buildInputs = [ makeWrapper ];
 
-  RUST_SRC_PATH = ''${rustPlatform.rust.rustc.src}/src'';
+  RUST_SRC_PATH = ''${rustPlatform.rust.rustc.unpackedSrc}/src'';
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
Racer doesn't function when RUST_SRC_PATH points to the source tarball.

I chose `unpackedSrc` instead of `src` to avoid any possibly breakage, but perhaps it's better to replace `src`?  It could also be made an additional output of the rustc derivation instead.

Any thoughts?

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

