### PR TITLE
splix: enable JBIG

### DIFF
--- a/pkgs/misc/cups/drivers/splix/default.nix
+++ b/pkgs/misc/cups/drivers/splix/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   preBuild = ''
-    makeFlags="V=1 DISABLE_JBIG=1 CUPSFILTER=$out/lib/cups/filter CUPSPPD=$out/share/cups/model"
+    makeFlags="V=1 CUPSFILTER=$out/lib/cups/filter CUPSPPD=$out/share/cups/model"
   '';
 
   buildInputs = [cups zlib];


### PR DESCRIPTION
Enables JBIG given that according to OpenPrinting.org, the patents have expired.
See https://www.openprinting.org/driver/splix/license/

Closes #25929

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

