### PR TITLE
ranger: fix absolute paths in scope.sh

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -28,6 +28,9 @@ pythonPackages.buildPythonApplication rec {
   '';
 
   preConfigure = ''
+    substituteInPlace ranger/data/scope.sh \
+      --replace "/bin/echo" "echo"
+
     substituteInPlace ranger/__init__.py \
       --replace "DEFAULT_PAGER = 'less'" "DEFAULT_PAGER = '${stdenv.lib.getBin less}/bin/less'"
 


### PR DESCRIPTION
###### Motivation for this change
For me, previews didn't work, unless I make this change locally, in my config. 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

