### PR TITLE
cnijfilter: init at 2.80

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -37,7 +37,7 @@ let
       [ cups.out additionalBackends cups-filters pkgs.ghostscript ]
       ++ optional cfg.gutenprint gutenprint
       ++ cfg.drivers;
-    pathsToLink = [ "/lib/cups" "/share/cups" "/bin" ];
+    pathsToLink = [ "/lib" "/share/cups" "/bin" ];
     postBuild = cfg.bindirCmds;
     ignoreCollisions = true;
   };

--- a/pkgs/misc/cups/drivers/cnijfilter_2_80/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter_2_80/default.nix
@@ -1,0 +1,109 @@
+{ stdenv, lib, fetchzip,
+  autoconf, automake, libtool,
+  cups, popt, libtiff, libpng,
+  ghostscript }:
+
+/* this derivation is basically just a transcription of the rpm .spec
+   file included in the tarball */
+
+stdenv.mkDerivation rec {
+  name = "cnijfilter-${version}";
+
+  /* important note about versions: cnijfilter packages seem to use
+     versions in a non-standard way.  the version indicates which
+     printers are supported in the package.  so this package should
+     not be "upgraded" in the usual way.
+
+     instead, if you want to include another version supporting your
+     printer, you should try to abstract out the common things (which
+     should be pretty much everything except the version and the 'pr'
+     and 'pr_id' values to loop over). */
+  version = "2.80";
+
+  src = fetchzip {
+    url = "http://gdlp01.c-wss.com/gds/1/0100000841/01/cnijfilter-common-2.80-1.tar.gz";
+    sha256 = "06s9nl155yxmx56056y22kz1p5b2sb5fhr3gf4ddlczjkd1xch53";
+  };
+
+  buildInputs = [ autoconf libtool automake
+                  cups popt libtiff libpng
+                  ghostscript ];
+
+  patches = [ ./patches/missing-include.patch
+              ./patches/libpng15.patch ];
+
+  postPatch = ''
+    sed -i "s|/usr/lib/cups/backend|$out/lib/cups/backend|" backend/src/Makefile.am;
+    sed -i "s|/usr|$out|" backend/src/cnij_backend_common.c;
+    sed -i "s|/usr/bin|${ghostscript}/bin|" pstocanonij/filter/pstocanonij.c;
+    sed -i "s|/usr/local|$out|" libs/bjexec/bjexec.c;
+  '';
+
+  configurePhase = ''
+    cd libs
+    ./autogen.sh --prefix=$out;
+
+    cd ../cngpij
+    ./autogen.sh --prefix=$out --enable-progpath=$out/bin;
+
+    cd ../pstocanonij
+    ./autogen.sh --prefix=$out --enable-progpath=$out/bin;
+
+    cd ../backend
+    ./autogen.sh --prefix=$out;
+    cd ..;
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin $out/lib/cups/filter $out/share/cups/model;
+  '';
+
+  postInstall = ''
+    for pr in mp140 mp210 ip3500 mp520 ip4500 mp610; do
+      cd ppd;
+      ./autogen.sh --prefix=$out --program-suffix=$pr
+      make clean;
+      make;
+      make install;
+
+      cd ../cnijfilter;
+      ./autogen.sh --prefix=$out --program-suffix=$pr --enable-libpath=/var/lib/cups/path/lib/bjlib --enable-binpath=$out/bin;
+      make clean;
+      make;
+      make install;
+
+      cd ..;
+    done;
+
+    mkdir -p $out/lib/bjlib;
+    for pr_id in 315 316 319 328 326 327; do
+      install -c -m 755 $pr_id/database/* $out/lib/bjlib;
+      install -c -s -m 755 $pr_id/libs_bin/*.so.* $out/lib;
+    done;
+
+    pushd $out/lib;
+    for so_file in *.so.*; do
+      ln -s $so_file ''${so_file/.so.*/}.so;
+      patchelf --set-rpath $out/lib $so_file;
+    done;
+    popd;
+  '';
+
+  /* the tarball includes some pre-built shared libraries.  we run
+     'patchelf --set-rpath' on them just a few lines above, so that
+     they can find each other.  but that's not quite enough.  some of
+     those libraries load each other in non-standard ways -- they
+     don't list each other in the DT_NEEDED section.  so, if the
+     standard 'patchelf --shrink-rpath' (from
+     pkgs/development/tools/misc/patchelf/setup-hook.sh) is run on
+     them, it undoes the --set-rpath.  this prevents that. */
+  dontPatchELF = true;
+
+  meta = with lib; {
+    description = "Canon InkJet printer drivers for the iP5400, MP520, MP210, MP140, iP3500, and MP610 series.  (MP520 drivers also work for MX700.)";
+    homepage = "http://support-asia.canon-asia.com/content/EN/0100084101.html";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jerith666 ];
+  };
+}

--- a/pkgs/misc/cups/drivers/cnijfilter_2_80/patches/libpng15.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter_2_80/patches/libpng15.patch
@@ -1,0 +1,23 @@
+diff -aur cnijfilter-source-3.20-1/cnijfilter/src/bjfimage.c cnijfilter-source-3.20-1.new/cnijfilter/src/bjfimage.c
+--- cnijfilter-source-3.20-1/cnijfilter/src/bjfimage.c	2009-03-26 06:11:05.000000000 +0100
++++ cnijfilter-source-3.20-1.new/cnijfilter/src/bjfimage.c	2012-02-10 09:33:52.512334139 +0100
+@@ -1520,8 +1520,8 @@
+ 	short			tmpformat;
+ 	short			retbyte = 0;
+ 	short			bpp = 3;
+-	long			width = 0;
+-	long			length = 0;
++	png_uint_32		width = 0;
++	png_uint_32		length = 0;
+ 	long			rstep = 0;
+ 	long			RasterLength = 0;
+ 	long			i;
+@@ -1574,7 +1574,7 @@
+ 		goto onErr;
+ 	}
+ 
+-	if (setjmp (png_p->jmpbuf))
++	if (setjmp (png_jmpbuf(png_p)))
+ 	{
+ 		png_destroy_read_struct(&png_p, &info_p, (png_infopp)NULL);
+ 		goto onErr;

--- a/pkgs/misc/cups/drivers/cnijfilter_2_80/patches/missing-include.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter_2_80/patches/missing-include.patch
@@ -1,0 +1,20 @@
+--- a/backend/src/cnij_backend_common.c	2008-09-01 10:05:44.000000000 +0200
++++ b/backend/src/cnij_backend_common.c	2012-05-06 17:38:40.000000000 +0200
+@@ -39,6 +39,7 @@
+ // CUPS Header
+ #include <cups/cups.h>
+ #include <cups/ipp.h>
++#include <cups/ppd.h>
+ 
+ // Header file for CANON
+ #include "cnij_backend_common.h"
+--- a/cngpijmon/src/bjcupsmon_cups.c	2008-09-02 12:28:24.000000000 +0200
++++ b/cngpijmon/src/bjcupsmon_cups.c	2012-05-06 17:39:20.000000000 +0200
+@@ -21,6 +21,7 @@
+ /*** Includes ***/
+ #include <cups/cups.h>
+ #include <cups/language.h>
++#include <cups/ppd.h>
+ #include <sys/types.h>
+ #include <unistd.h>
+ #include <pwd.h>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18255,6 +18255,9 @@ with pkgs;
 
   cups-bjnp = callPackage ../misc/cups/drivers/cups-bjnp { };
 
+  # this driver ships with pre-compiled 32-bit binary libraries
+  cnijfilter_2_80 = callPackage_i686 ../misc/cups/drivers/cnijfilter_2_80 { };
+
   cnijfilter2 = callPackage ../misc/cups/drivers/cnijfilter2 {
     libusb = libusb1;
   };


### PR DESCRIPTION
this driver reads libraries from `lib/bjlib` as well as `lib/cups`,
which is why the path in `cupsd.nix` is tweaked

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).