### PR TITLE
megacli: Fix missing libncurses.so.5

### DIFF
--- a/pkgs/tools/misc/megacli/default.nix
+++ b/pkgs/tools/misc/megacli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, rpmextract, ncurses, patchelf, makeWrapper, requireFile, unzip }:
+{ stdenv, rpmextract, ncurses5, patchelf, makeWrapper, requireFile, unzip }:
 
 assert stdenv.system == "x86_64-linux";
 
@@ -12,10 +12,10 @@ stdenv.mkDerivation rec {
       sha256 = "11jzvh25mlygflazd37gi05xv67im4rgq7sbs5nwgw3gxdh4xfjj";
     };
 
-  buildInputs = [rpmextract ncurses unzip makeWrapper];
+  buildInputs = [rpmextract ncurses5 unzip makeWrapper];
   libPath =
     stdenv.lib.makeLibraryPath
-       [ stdenv.cc.cc stdenv.cc.libc ncurses ];
+       [ stdenv.cc.cc stdenv.cc.libc ncurses5 ];
 
   buildCommand = ''
     mkdir -p $out/bin


### PR DESCRIPTION
###### Motivation for this change

megacli is unusable as is, due to linking against ncurses5:

```
/run/current-system/sw/bin/MegaCli64: error while loading shared libraries: libncurses.so.5: cannot open shared object file: No such file or directory
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

