### PR TITLE
redshift-plasma-applet: 1.0.17 -> 1.0.18

### DIFF
--- a/pkgs/applications/misc/redshift-plasma-applet/default.nix
+++ b/pkgs/applications/misc/redshift-plasma-applet/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, cmake, plasma-framework, redshift, fetchFromGitHub, }:
+{ stdenv, cmake, extra-cmake-modules, plasma-framework, redshift, fetchFromGitHub, }:
 
-let version = "1.0.17"; in
+let version = "1.0.18"; in
 
 stdenv.mkDerivation {
   name = "redshift-plasma-applet-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     owner = "kotelnik";
     repo = "plasma-applet-redshift-control";
     rev = "v${version}";
-    sha256 = "1lp1rb7i6c18lrgqxsglbvyvzh71qbm591abrbhw675ii0ca9hgj";
+    sha256 = "122nnbafa596rxdxlfshxk45lzch8c9342bzj7kzrsjkjg0xr9pq";
   };
 
   patchPhase = ''
@@ -24,17 +24,18 @@ stdenv.mkDerivation {
                 "'${redshift}/bin/redshift -V'"
   '';
 
-  buildInputs = [
+  nativeBuildInputs = [
     cmake
-    plasma-framework
+    extra-cmake-modules
   ];
 
+  buildInputs = [ plasma-framework ];
 
   meta = with stdenv.lib; {
     description = "KDE Plasma 5 widget for controlling Redshift";
     homepage = https://github.com/kotelnik/plasma-applet-redshift-control;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ benley ];
+    maintainers = with maintainers; [ benley zraexy ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to the latest version
Add `extra-cmake-modules` to fix the build

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

