### PR TITLE
xsv: 0.11.0 -> 0.12.1

### DIFF
--- a/pkgs/tools/text/xsv/default.nix
+++ b/pkgs/tools/text/xsv/default.nix
@@ -4,16 +4,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "xsv-${version}";
-  version = "0.11.0";
+  version = "0.12.1";
 
   src = fetchFromGitHub {
     owner = "BurntSushi";
     repo = "xsv";
     rev = "${version}";
-    sha256 = "169rp4izcjhhlrqrhvlvsbiz7wqfi6g3kjfgrddgvahp0ls29hls";
+    sha256 = "0xmjx5grwjrx2zsqmpblid9pqpwkk9pv468ffqlza3w35n9x5dax";
   };
 
-  depsSha256 = "006sp66l2gybyk1n7lxp645k6drz5cgxcix376k8qr0v9jwadlqa";
+  depsSha256 = "0gdbxgykhy6wm89mbdvl7ck2v0f66hwlm0m1q7r64bkb7i10fmkd";
 
   meta = with stdenv.lib; {
     description = "A fast CSV toolkit written in Rust";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

