### PR TITLE
kdiff3: add dependency to kcrash

### DIFF
--- a/pkgs/tools/text/kdiff3/default.nix
+++ b/pkgs/tools/text/kdiff3/default.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib, fetchgit, fetchpatch,
   extra-cmake-modules, kdoctools, wrapGAppsHook,
-  kconfig, kinit, kparts
+  kcrash, kconfig, kinit, kparts
 }:
 
 mkDerivation rec {
@@ -32,7 +32,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
 
-  propagatedBuildInputs = [ kconfig kinit kparts ];
+  propagatedBuildInputs = [ kconfig kcrash kinit kparts ];
 
   meta = with lib; {
     homepage = http://kdiff3.sourceforge.net/;


### PR DESCRIPTION
###### Motivation for this change

During the build of kdiff3 I was getting the following error:

```
CMake Error at /nix/store/5dh82kd6qppsap7b12llcbp6w4d2i6a9-cmake-3.8.2/share/cmake-3.8/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find KF5 (missing: Crash) (found suitable version "5.34.0",
  minimum required is "5.16.0")
Call Stack (most recent call first):
  /nix/store/5dh82kd6qppsap7b12llcbp6w4d2i6a9-cmake-3.8.2/share/cmake-3.8/Modules/FindPackageHandleStandardArgs.cmake:377 (_FPHSA_FAILURE_MESSAGE)
  /nix/store/yk2v9qp15989i9pnb7bmik9y3fbly8kk-extra-cmake-modules-5.34.0/share/ECM/find-modules/FindKF5.cmake:110 (find_package_handle_standard_args)
  CMakeLists.txt:34 (find_package)
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

