### PR TITLE
skrooge: drop kdelibs4support dependency

### DIFF
--- a/pkgs/applications/office/skrooge/default.nix
+++ b/pkgs/applications/office/skrooge/default.nix
@@ -1,8 +1,9 @@
 { mkDerivation, lib, fetchurl,
   cmake, extra-cmake-modules, qtwebkit, qtscript, grantlee,
   kxmlgui, kwallet, kparts, kdoctools, kjobwidgets, kdesignerplugin,
-  kiconthemes, knewstuff, sqlcipher, qca-qt5, kdelibs4support, kactivities,
-  knotifyconfig, krunner, libofx, shared_mime_info }:
+  kiconthemes, knewstuff, sqlcipher, qca-qt5, kactivities, karchive,
+  kguiaddons, knotifyconfig, krunner, kwindowsystem, libofx, shared_mime_info
+}:
 
 mkDerivation rec {
   name = "skrooge-${version}";
@@ -17,7 +18,7 @@ mkDerivation rec {
 
   buildInputs = [ qtwebkit qtscript grantlee kxmlgui kwallet kparts kdoctools
     kjobwidgets kdesignerplugin kiconthemes knewstuff sqlcipher qca-qt5
-    kdelibs4support kactivities knotifyconfig krunner libofx
+    kactivities karchive kguiaddons knotifyconfig krunner kwindowsystem libofx
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Since Qt 5.7 and Skrooge v2.5.0, the latter can be built without KDELibs4Support.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

