### PR TITLE
bitlbee service: Add option to load libpurple plugins into bitlbee

### DIFF
--- a/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
@@ -1,4 +1,5 @@
-{ fetchurl, fetchpatch, stdenv, gnutls, glib, pkgconfig, check, libotr, python }:
+{ fetchurl, fetchpatch, stdenv, gnutls, glib, pkgconfig, check, libotr, python,
+enableLibPurple ? false, pidgin ? null }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -11,20 +12,25 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ] ++ optional doCheck check;
 
-  buildInputs = [ gnutls glib libotr python ];
+  buildInputs = [ gnutls glib libotr python ]
+    ++ optional enableLibPurple pidgin;
+
+  preConfigure = optionalString enableLibPurple
+    "export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${pidgin}/lib/pkgconfig";
 
   configureFlags = [
     "--gcov=1"
     "--otr=1"
     "--ssl=gnutls"
     "--pidfile=/var/lib/bitlbee/bitlbee.pid"
-  ];
+  ]
+  ++ optional enableLibPurple "--purple=1";
 
-  buildPhase = ''
+  buildPhase = optionalString (!enableLibPurple) ''
     make install-dev
   '';
 
-  doCheck = true;
+  doCheck = !enableLibPurple; # Checks fail with libpurple for some reason
 
   meta = {
     description = "IRC instant messaging gateway";


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

