### PR TITLE
kubernetes: 1.5.6 -> 1.6.6

### DIFF
--- a/nixos/modules/services/cluster/kubernetes.nix
+++ b/nixos/modules/services/cluster/kubernetes.nix
@@ -633,7 +633,6 @@ in {
             ${optionalString (cfg.kubelet.networkPlugin != null)
               "--network-plugin=${cfg.kubelet.networkPlugin}"} \
             --cni-conf-dir=${cniConfig} \
-            --reconcile-cidr \
             --hairpin-mode=hairpin-veth \
             ${optionalString cfg.verbose "--v=6 --log_flush_frequency=1s"} \
             ${cfg.kubelet.extraOpts}

--- a/nixos/modules/services/cluster/kubernetes.nix
+++ b/nixos/modules/services/cluster/kubernetes.nix
@@ -794,7 +794,7 @@ in {
         after = [ "kube-apiserver.service" ];
         serviceConfig = {
           Slice = "kubernetes.slice";
-          ExecStart = ''${cfg.package}/bin/kube-dns \
+          ExecStart = ''${cfg.package.dns}/bin/kube-dns \
             --kubecfg-file=${kubeconfig} \
             --dns-port=${toString cfg.dns.port} \
             --domain=${cfg.dns.domain} \

--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchFromGitHub, removeReferencesTo, which, go, go-bindata, makeWrapper, rsync
-, iptables, coreutils
+{ stdenv, fetchFromGitHub, removeReferencesTo
+, coreutils, go, go-bindata, iptables, rsync, which
 , components ? [
     "cmd/kubeadm"
     "cmd/kubectl"
@@ -8,40 +8,36 @@
     "cmd/kube-controller-manager"
     "cmd/kube-proxy"
     "plugin/cmd/kube-scheduler"
-    "cmd/kube-dns"
     "federation/cmd/federation-apiserver"
     "federation/cmd/federation-controller-manager"
   ]
 }:
 
-with lib;
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "kubernetes-${version}";
-  version = "1.5.6";
+  version = "1.6.6";
 
   src = fetchFromGitHub {
     owner = "kubernetes";
     repo = "kubernetes";
     rev = "v${version}";
-    sha256 = "0mkg4vgz9szgq1k5ignkdr5gmg703xlq8zsrr422a1qfqb8zp15w";
+    sha256 = "0yj0c7k5v6ri1pnh7cmfqf0ckf8psh9929im1liy0lhlga7yipx4";
   };
 
-  buildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata ];
+  buildInputs = [ removeReferencesTo which go rsync go-bindata ];
 
-  outputs = ["out" "man" "pause"];
+  outputs = [ "out" "man" "pause" ];
 
   postPatch = ''
     substituteInPlace "hack/lib/golang.sh" --replace "_cgo" ""
     substituteInPlace "hack/generate-docs.sh" --replace "make" "make SHELL=${stdenv.shell}"
-    # hack/update-munge-docs.sh only performs some tests on the documentation.
-    # They broke building k8s; disabled for now.
-    echo "true" > "hack/update-munge-docs.sh"
 
     patchShebangs ./hack
   '';
 
-  WHAT="--use_go_build ${concatStringsSep " " components}";
+  WHAT = "--use_go_build ${concatStringsSep " " components}";
 
   postBuild = ''
     ./hack/generate-docs.sh
@@ -66,7 +62,7 @@ stdenv.mkDerivation rec {
     description = "Production-Grade Container Scheduling and Management";
     license = licenses.asl20;
     homepage = http://kubernetes.io;
-    maintainers = with maintainers; [offline];
+    maintainers = with maintainers; [ offline lnl7 ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, removeReferencesTo
-, coreutils, go, go-bindata, iptables, rsync, which
+, coreutils, go, go-bindata, iptables, kube-dns, rsync, which
 , components ? [
     "cmd/kubeadm"
     "cmd/kubectl"
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ removeReferencesTo which go rsync go-bindata ];
 
   outputs = [ "out" "man" "pause" ];
+  passthru.dns = kube-dns;
 
   postPatch = ''
     substituteInPlace "hack/lib/golang.sh" --replace "_cgo" ""

--- a/pkgs/applications/networking/cluster/kubernetes/dns.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/dns.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "kube-dns-${version}";
+  version = "1.14.2";
+
+  goPackagePath = "k8s.io/dns";
+
+  src = fetchFromGitHub {
+    owner = "kubernetes";
+    repo = "dns";
+    rev = "${version}";
+    sha256 = "0ap67hdmd6fa95aw0al920rnrr1abdd2cxd4ziaq1xclr2fjn632";
+  };
+
+  meta = with stdenv.lib; {
+    description = "DNS Server for Kubernetes Containers";
+    license = licenses.asl20;
+    homepage = http://kubernetes.io;
+    maintainers = with maintainers; [ offline lnl7 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14773,6 +14773,10 @@ with pkgs;
     go = go_1_7;
   };
 
+  kube-dns = callPackage ../applications/networking/cluster/kubernetes/dns.nix {
+    buildGoPackage = buildGo17Package;
+  };
+
   lame = callPackage ../development/libraries/lame { };
 
   larswm = callPackage ../applications/window-managers/larswm { };


### PR DESCRIPTION
###### Motivation for this change

The nixos test fails for me, both before an after these changes.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

