### PR TITLE
groff: Add site.tmac to fix man page coloring

### DIFF
--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -59,6 +59,9 @@ stdenv.mkDerivation rec {
   postInstall = ''
     rm $doc/share/doc/groff/examples/hdtbl/*color*ps
     find $doc/share/doc/groff/ -type f -print0 | xargs -0 sed -i -e 's/%%CreationDate: .*//'
+    for f in 'man.local' 'mdoc.local'; do
+        cat '${./site.tmac}' >>"$out/share/groff/site-tmac/$f"
+    done
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/text/groff/site.tmac
+++ b/pkgs/tools/text/groff/site.tmac
@@ -1,0 +1,16 @@
+.
+.if n \{\
+.  \" Character translations for non-keyboard
+.  \" characters - to make them searchable
+.  if '\*[.T]'utf8' \{\
+.    char \- \N'45'
+.    char - \N'45'
+.    char ' \N'39'
+.    char \' \N'39'
+.  \}
+.
+.  \" Shut off SGR by default (groff colors)
+.  \" Require GROFF_SGR envvar defined to turn it on
+.  if '\V[GROFF_SGR]'' \
+.    output x X tty: sgr 0
+.\}


### PR DESCRIPTION
This enables groff to correctly respond to the LESS_TERMCAP_*
environment variables, allowing colorized man pages.

Patch is taken from Arch Linux;
see https://bugs.archlinux.org/task/33760.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).