### PR TITLE
x11idle: init at unstable-2017-07-01

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -530,6 +530,7 @@
   steveej = "Stefan Junker <mail@stefanjunker.de>";
   SuprDewd = "Bjarki Ágúst Guðmundsson <suprdewd@gmail.com>";
   swarren83 = "Shawn Warren <shawn.w.warren@gmail.com>";
+  swflint = "Samuel W. Flint <swflint@flintfam.org>";
   swistak35 = "Rafał Łasocha <me@swistak35.com>";
   szczyp = "Szczyp <qb@szczyp.com>";
   sztupi = "Attila Sztupak <attila.sztupak@gmail.com>";

--- a/pkgs/tools/misc/x11idle/default.nix
+++ b/pkgs/tools/misc/x11idle/default.nix
@@ -8,7 +8,10 @@ stdenv.mkDerivation { name = "x11idle";
       unpackPhase = ":";
       buildInputs = [ xlibs.libXScrnSaver xlibs.libX11 ];
       meta = {
-           description = "Gather the current idle time from X11.";
+           description = "Compute consecutive idle time for current X11 session with millisecond resolution";
+           longDescription = ''
+             Idle time passes when the user does not act, i.e. when the user doesn't move the mouse or use the keyboard.
+           '';
            homepage = "http://orgmode.org/";
            license = stdenv.lib.licenses.free;
            platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/misc/x11idle/default.nix
+++ b/pkgs/tools/misc/x11idle/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, xlibs, fetchgit }:
+
+stdenv.mkDerivation { name = "x11idle";
+      src = fetchgit{ url = "git://orgmode.org/org-mode.git";
+                      rev = "fbd865941f3105f689f78bf053bb3b353b9b8a23";
+                      sha256 = "0ma3m48f4s38xln0gl1ww9i5x28ij0ipxc94kx5h2931zy7lqzvz"; };
+      installPhase = "mkdir -p $out/bin; gcc -lXss -lX11 $src/contrib/scripts/x11idle.c -o $out/bin/x11idle";
+      unpackPhase = ":";
+      buildInputs = [ xlibs.libXScrnSaver xlibs.libX11 ];
+      meta = {
+           description = "Gather the current idle time from X11.";
+           homepage = "http://orgmode.org/";
+           license = stdenv.lib.licenses.free;
+           platforms = stdenv.lib.platforms.linux;
+           maintainers = [ stdenv.lib.maintainers.swflint ];
+      }; }

--- a/pkgs/tools/misc/x11idle/default.nix
+++ b/pkgs/tools/misc/x11idle/default.nix
@@ -1,19 +1,33 @@
-{ stdenv, xlibs, fetchgit }:
+{ stdenv, xlibs, fetchgit, libXScrnSaver, libX11 }:
 
-stdenv.mkDerivation { name = "x11idle";
-      src = fetchgit{ url = "git://orgmode.org/org-mode.git";
-                      rev = "fbd865941f3105f689f78bf053bb3b353b9b8a23";
-                      sha256 = "0ma3m48f4s38xln0gl1ww9i5x28ij0ipxc94kx5h2931zy7lqzvz"; };
-      installPhase = "mkdir -p $out/bin; gcc -lXss -lX11 $src/contrib/scripts/x11idle.c -o $out/bin/x11idle";
-      unpackPhase = ":";
-      buildInputs = [ xlibs.libXScrnSaver xlibs.libX11 ];
-      meta = {
-           description = "Compute consecutive idle time for current X11 session with millisecond resolution";
-           longDescription = ''
-             Idle time passes when the user does not act, i.e. when the user doesn't move the mouse or use the keyboard.
-           '';
-           homepage = "http://orgmode.org/";
-           license = stdenv.lib.licenses.free;
-           platforms = stdenv.lib.platforms.linux;
-           maintainers = [ stdenv.lib.maintainers.swflint ];
-      }; }
+stdenv.mkDerivation {
+  name = "x11idle-unstable-2017-07-01";
+
+  src = fetchgit {
+    url = "git://orgmode.org/org-mode.git";
+    rev = "fbd865941f3105f689f78bf053bb3b353b9b8a23";
+    sha256 = "0ma3m48f4s38xln0gl1ww9i5x28ij0ipxc94kx5h2931zy7lqzvz";
+  };
+
+  buildInputs = [ libXScrnSaver libX11 ];
+
+  unpackPhase = ":";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    gcc -lXss -lX11 $src/contrib/scripts/x11idle.c -o $out/bin/x11idle
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+      Compute consecutive idle time for current X11 session with millisecond resolution
+    '';
+    longDescription = ''
+      Idle time passes when the user does not act, i.e. when the user doesn't move the mouse or use the keyboard.
+    '';
+    homepage = "http://orgmode.org/";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.swflint ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13217,7 +13217,7 @@ with pkgs;
   audio-recorder = callPackage ../applications/audio/audio-recorder { };
 
   autotrace = callPackage ../applications/graphics/autotrace {};
-  
+
   milkytracker = callPackage ../applications/audio/milkytracker { };
 
   schismtracker = callPackage ../applications/audio/schismtracker { };
@@ -18877,6 +18877,8 @@ with pkgs;
   wxsqliteplus = callPackage ../development/libraries/wxsqliteplus {
     wxGTK = wxGTK30;
   };
+
+  x11idle = callPackage ../tools/misc/x11idle {};
 
   x2x = callPackage ../tools/X11/x2x { };
 


### PR DESCRIPTION
###### Motivation for this change
Define the x11idle package from Emacs Org Mode to make use easier.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

