### PR TITLE
ucspi-tcp: remove setuid from install script

### DIFF
--- a/pkgs/tools/networking/ucspi-tcp/default.nix
+++ b/pkgs/tools/networking/ucspi-tcp/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
       url = "http://ftp.de.debian.org/debian/pool/main/u/ucspi-tcp/ucspi-tcp_0.88-3.diff.gz";
       sha256 = "0mzmhz8hjkrs0khmkzs5i0s1kgmgaqz07h493bd5jj5fm5njxln6";
     })
+    ./remove-setuid.patch
   ];
 
   # Apply Debian patches

--- a/pkgs/tools/networking/ucspi-tcp/remove-setuid.patch
+++ b/pkgs/tools/networking/ucspi-tcp/remove-setuid.patch
@@ -1,0 +1,15 @@
+diff --git a/hier.c b/hier.c
+index 5663ada..1d73b84 100644
+--- a/hier.c
++++ b/hier.c
+@@ -2,8 +2,8 @@
+ 
+ void hier()
+ {
+-  h(auto_home,-1,-1,02755);
+-  d(auto_home,"bin",-1,-1,02755);
++  h(auto_home,-1,-1,0755);
++  d(auto_home,"bin",-1,-1,0755);
+ 
+   c(auto_home,"bin","tcpserver",-1,-1,0755);
+   c(auto_home,"bin","tcprules",-1,-1,0755);


### PR DESCRIPTION
###### Motivation for this change

fixes https://github.com/NixOS/nixpkgs/issues/27063

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

