### PR TITLE
kmod-debian-aliases: Fix source tarball URL.

### DIFF
--- a/pkgs/os-specific/linux/kmod-debian-aliases/default.nix
+++ b/pkgs/os-specific/linux/kmod-debian-aliases/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "22-1.1";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/k/kmod/kmod_${version}.debian.tar.xz";
+    url = "http://snapshot.debian.org/archive/debian/20160404T220610Z/pool/main/k/kmod/kmod_${version}.debian.tar.xz";
     sha256 = "0daap2n4bvjqcnksaayy6csmdb1px4r02w3xp36bcp6w3lbnqamh";
   };
 


### PR DESCRIPTION
The original URL for this package was pointed at a location that wasn't
longterm-stable, and has by now been removed by Debian.
This commit fixes the URL to point at a debian snapshot entry, which should
stick around for the long run.

Hash is unchanged, so this is safe.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

