### PR TITLE
p7zip: Update CVE-2016-9296 patch URL.

### DIFF
--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://sources.debian.net/data/main/p/p7zip/16.02+dfsg-2/debian/patches/12-CVE-2016-9296.patch";
-      sha256 = "1i7099h27gmb9dv0lb7jnqfm504gs1c3129r6kvi94yb2gzrzk41";
+      url = "https://src.fedoraproject.org/cgit/rpms/p7zip.git/plain/CVE-2016-9296.patch";
+      sha256 = "09wbkzai46bwm8zmplsz0m4jck3qn7snr68i9p1gsih300zidj0m";
     })
   ];
 


### PR DESCRIPTION
The debian source for this patch file has gone away, rendering this derivation
unbuildable from scratch.
This change updates the URL to a src.fedoraproject.org location that is still
serving a p7zip patch. This file is not the same bytewise, so I'm also updating
the hash; I didn't manage to find a location still serving a file with the
original hash, and my best guess is that this one is functionally equivalent.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

