### PR TITLE
Openslp: Fix patch references.

### DIFF
--- a/pkgs/development/libraries/openslp/default.nix
+++ b/pkgs/development/libraries/openslp/default.nix
@@ -11,13 +11,13 @@ stdenv.mkDerivation {
   patches = [
     (fetchpatch {
       name = "openslp-2.0.0-null-pointer-deref.patch";
-      url = "https://svnweb.mageia.org/packages/cauldron/openslp/current/SOURCES/openslp-2.0.0-null-pointer-deref.patch?revision=1019712&view=co";
+      url = "https://src.fedoraproject.org/cgit/rpms/openslp.git/plain/openslp-2.0.0-null-pointer-deref.patch";
       sha256 = "186f3rj3z2lf5h1lpbhqk0szj2a9far1p3mjqg6422f29yjfnz6a";
     })
     (fetchpatch {
       name = "openslp-2.0.0-CVE-2016-7567.patch";
-      url = "https://svnweb.mageia.org/packages/cauldron/openslp/current/SOURCES/openslp-2.0.0-CVE-2016-7567.patch?revision=1057233&view=co";
-      sha256 = "1zrgql91vjjl2v7brlibc8jqndnjz9fclqbdn0b6fklkpwznprny";
+      url = "https://src.fedoraproject.org/cgit/rpms/openslp.git/plain/openslp-2.0.0-cve-2016-7567.patch";
+      sha256 = "0zp61axx93b7nrbsyhn2x4dnw7n9y6g4rys21hyqxk4khrnc2yr9";
     })
   ];
 


### PR DESCRIPTION
The previous sources for these files have gone away, making this derivation
unbuildable from scratch. We change the URLs to point at locations that will
still serve those patches.
This involves updating one of the hashes, also; I couldn't find an address
that will serve the patch with the original hash, but my best guess is that these
only differ in irrelevant metadata.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

