### PR TITLE
google-app-engine-go-sdk: 1.9.53 -> 1.9.55

### DIFF
--- a/pkgs/development/tools/google-app-engine-go-sdk/default.nix
+++ b/pkgs/development/tools/google-app-engine-go-sdk/default.nix
@@ -4,17 +4,17 @@ with python27Packages;
 
 stdenv.mkDerivation rec {
   name = "google-app-engine-go-sdk-${version}";
-  version = "1.9.53";
+  version = "1.9.55";
   src =
     if stdenv.system == "x86_64-linux" then
       fetchzip {
         url = "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-${version}.zip";
-        sha256 = "04lfwf7ad7gi8xn891lz87b7pr2gyycgpaq96i0cgckrj2awayz2";
+        sha256 = "1gwrmqs69h3wbx6z0a7shdr8gn1qiwrkvh3pg6mi7dybwmd1x61h";
       }
     else
       fetchzip {
         url = "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_amd64-${version}.zip";
-        sha256 = "18hgl4wz3rhaklkwaxl8gm70h7l8k225f86da682kafawrr8zhv4";
+        sha256 = "0b8r2fqg9m285ifz0jahd4wasv7cq61nr6p1k664w021r5y5lbvr";
       };
 
   buildInputs = [python27 makeWrapper];


### PR DESCRIPTION
###### Motivation for this change

I'd like to use go1.8 in Google App Engine.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

