### PR TITLE
drumgizmo: 9.12 -> 9.14

### DIFF
--- a/pkgs/applications/audio/drumgizmo/default.nix
+++ b/pkgs/applications/audio/drumgizmo/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, fetchurl, alsaLib, expat, glib, libjack2, libX11, libpng
+{ stdenv, fetchurl, alsaLib, expat, glib, libjack2, libXext, libX11, libpng
 , libpthreadstubs, libsmf, libsndfile, lv2, pkgconfig, zita-resampler
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.9.12";
+  version = "0.9.14";
   name = "drumgizmo-${version}";
 
   src = fetchurl {
     url = "http://www.drumgizmo.org/releases/${name}/${name}.tar.gz";
-    sha256 = "0kqrss9v3vpznmh4jgi3783wmprr645s3i485jlvdscpysjfkh6z";
+    sha256 = "1q2jghjz0ygaja8dgvxp914if8yyzpa204amdcwb9yyinpxsahz4";
   };
 
   configureFlags = [ "--enable-lv2" ];
 
   buildInputs = [
-    alsaLib expat glib libjack2 libX11 libpng libpthreadstubs libsmf
-    libsndfile lv2 pkgconfig zita-resampler
+    alsaLib expat glib libjack2 libXext libX11 libpng libpthreadstubs
+    libsmf libsndfile lv2 pkgconfig zita-resampler
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
https://www.drumgizmo.org/wiki/doku.php?id=getting_drumgizmo#latest_version
new libXext dependency