### PR TITLE
lib: Include darwin in isUnix

### DIFF
--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -15,7 +15,7 @@ rec {
     LittleEndian = { cpu = { significantByte = significantBytes.littleEndian; }; };
 
     BSD          = { kernel = { families = { inherit (kernelFamilies) bsd; }; }; };
-    Unix         = [ BSD Linux SunOS Hurd Cygwin ];
+    Unix         = [ BSD Darwin Linux SunOS Hurd Cygwin ];
 
     Darwin       = { kernel = kernels.darwin; };
     Linux        = { kernel = kernels.linux; };


### PR DESCRIPTION
###### Motivation for this change

This should fix darwin package evaluation, which was broken by 4ac1901d54f4301df2f09b85e2f69769ee61dfc1


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

