### PR TITLE
sxiv: Add support for custom config

### DIFF
--- a/pkgs/applications/graphics/sxiv/default.nix
+++ b/pkgs/applications/graphics/sxiv/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, libX11, imlib2, giflib, libexif }:
+{ stdenv, fetchFromGitHub, libX11, imlib2, giflib, libexif, conf ? null }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "sxiv-${version}";
@@ -16,12 +18,16 @@ stdenv.mkDerivation rec {
       --replace /usr/local $out
   '';
 
+  configFile = optionalString (conf!=null) (builtins.toFile "config.def.h" conf);
+  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
+
   buildInputs = [ libX11 imlib2 giflib libexif ];
+
   meta = {
     description = "Simple X Image Viewer";
     homepage = "https://github.com/muennich/sxiv";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
+    maintainers = with maintainers; [ jfrankenau fuuzetsu ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

sxiv does not have support for runtime configuration. It however can be configured at build time by using a `config.def.h`. This commit adds support for specifiying a custom configuration.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @Fuuzetsu 
