### PR TITLE
noice: init at 0.6

### DIFF
--- a/pkgs/applications/misc/noice/default.nix
+++ b/pkgs/applications/misc/noice/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchgit, ncurses, conf ? null }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "noice-${version}";
+  version = "0.6";
+
+  src = fetchgit {
+    url = "git://git.2f30.org/noice.git";
+    rev = "refs/tags/v${version}";
+    sha256 = "03rwglcy47fh6rb630vws10m95bxpcfv47nxrlws2li2ljam8prw";
+  };
+
+  configFile = optionalString (conf!=null) (builtins.toFile "config.def.h" conf);
+  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
+
+  buildInputs = [ ncurses ];
+
+  buildFlags = [ "LDLIBS=-lncurses" ];
+
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+
+  meta = {
+    description = "Small ncurses-based file browser";
+    homepage = https://git.2f30.org/noice/;
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3323,6 +3323,8 @@ with pkgs;
 
   ngrok = callPackage ../tools/networking/ngrok { };
 
+  noice = callPackage ../applications/misc/noice { };
+
   noip = callPackage ../tools/networking/noip { };
 
   nomad = callPackage ../applications/networking/cluster/nomad { };


### PR DESCRIPTION
###### Motivation for this change

This is a small and fast TUI file browser.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---