### PR TITLE
dr14_tmeter: init at 1.0.16

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -16,6 +16,7 @@
   acowley = "Anthony Cowley <acowley@gmail.com>";
   adelbertc = "Adelbert Chang <adelbertc@gmail.com>";
   adev = "Adrien Devresse <adev@adev.name>";
+  adisbladis = "Adam Hose <adis@blad.is>";
   Adjective-Object = "Maxwell Huang-Hobbs <mhuan13@gmail.com>";
   adnelson = "Allen Nelson <ithinkican@gmail.com>";
   adolfogc = "Adolfo E. García Castro <adolfo.garcia.cr@gmail.com>";

--- a/pkgs/applications/audio/dr14_tmeter/default.nix
+++ b/pkgs/applications/audio/dr14_tmeter/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, python3Packages, pkgs }:
+
+python3Packages.buildPythonApplication rec {
+  name = "dr14_tmeter-${version}";
+  version = "1.0.16";
+
+  disabled = !python3Packages.isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "simon-r";
+    repo = "dr14_t.meter";
+    rev = "v${version}";
+    sha256 = "1nfsasi7kx0myxkahbd7rz8796mcf5nsadrsjjpx2kgaaw5nkv1m";
+  };
+
+  propagatedBuildInputs = with pkgs; [
+    python3Packages.numpy flac vorbis-tools ffmpeg faad2 lame
+  ];
+
+  # There are no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Compute the DR14 of a given audio file according to the procedure described by the Pleasurize Music Foundation";
+    license = licenses.gpl3Plus;
+    homepage = http://dr14tmeter.sourceforge.net/;
+    maintainers = [ maintainers.adisbladis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13643,6 +13643,8 @@ with pkgs;
 
   doodle = callPackage ../applications/search/doodle { };
 
+  dr14_tmeter = callPackage ../applications/audio/dr14_tmeter { };
+
   draftsight = callPackage ../applications/graphics/draftsight { };
 
   droopy = callPackage ../applications/networking/droopy {


### PR DESCRIPTION
###### Motivation for this change
Useful tool for checking dynamic range (DR14) of audio files.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

