### PR TITLE
csmith: init at 2.3.0, pull in Sys::CPU as dependency.

### DIFF
--- a/pkgs/development/tools/misc/csmith/default.nix
+++ b/pkgs/development/tools/misc/csmith/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, m4, makeWrapper, libbsd, perl, SysCPU }:
+
+stdenv.mkDerivation rec {
+  name = "csmith-${version}";
+  version = "2.3.0";
+
+  src = fetchurl {
+    url = "http://embed.cs.utah.edu/csmith/${name}.tar.gz";
+    sha256 = "1mb5zgixsyf86slggs756k8a5ddmj980md3ic9sa1y75xl5cqizj";
+  };
+
+  nativeBuildInputs = [ m4 makeWrapper ];
+  buildInputs = [ libbsd perl SysCPU ];
+
+  postInstall = ''
+    substituteInPlace $out/bin/compiler_test.pl \
+      --replace '$CSMITH_HOME/runtime' $out/include/${name} \
+      --replace ' ''${CSMITH_HOME}/runtime' " $out/include/${name}" \
+      --replace '$CSMITH_HOME/src/csmith' $out/bin/csmith
+
+    substituteInPlace $out/bin/launchn.pl \
+      --replace '../compiler_test.pl' $out/bin/compiler_test.pl \
+      --replace '../$CONFIG_FILE' '$CONFIG_FILE'
+
+    wrapProgram $out/bin/launchn.pl --prefix PERL5LIB : "$PERL5LIB" $out/bin/launchn.pl
+
+    mkdir -p $out/share/csmith
+    mv $out/bin/compiler_test.in $out/share/csmith/
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A random generator of C programs";
+    homepage = "https://embed.cs.utah.edu/csmith";
+    # Officially, the license is this: https://github.com/csmith-project/csmith/blob/master/COPYING
+    license = licenses.bsd2;
+    longDescription = ''
+      Csmith is a tool that can generate random C programs that statically and
+      dynamically conform to the C99 standard. It is useful for stress-testing
+      compilers, static analyzers, and other tools that process C code.
+      Csmith has found bugs in every tool that it has tested, and has been used
+      to find and report more than 400 previously unknown compiler bugs.
+    '';
+    maintainers = [ maintainers.dtzWill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6666,6 +6666,9 @@ with pkgs;
 
   csmith = callPackage ../development/tools/misc/csmith {
     inherit (perlPackages) perl SysCPU;
+    # Workaround optional dependency on libbsd that's
+    # currently broken on Darwin.
+    libbsd = if stdenv.isDarwin then null else libbsd;
   };
 
   csslint = callPackage ../development/web/csslint { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6664,6 +6664,10 @@ with pkgs;
 
   cscope = callPackage ../development/tools/misc/cscope { };
 
+  csmith = callPackage ../development/tools/misc/csmith {
+    inherit (perlPackages) perl SysCPU;
+  };
+
   csslint = callPackage ../development/web/csslint { };
 
   libcxx = llvmPackages.libcxx;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12622,6 +12622,14 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  SysCPU = buildPerlPackage rec {
+    name = "Sys-CPU-0.61";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MZ/MZSANFORD/${name}.tar.gz";
+      sha256 = "1r6976bs86j7zp51m5vh42xlyah951jgdlkimv202413kjvqc2i5";
+    };
+  };
+
   SysHostnameLong = buildPerlPackage rec {
     name = "Sys-Hostname-Long-1.4";
     src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (new package, there aren't any)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

