### PR TITLE
nnn: init at 1.2

### DIFF
--- a/pkgs/applications/misc/nnn/default.nix
+++ b/pkgs/applications/misc/nnn/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, pkgconfig, ncurses, readline, conf ? null }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "nnn-${version}";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "jarun";
+    repo = "nnn";
+    rev = "v${version}";
+    sha256 = "1idrwm02218q7qd2pg2m8ld76bg32wbzl8y1h8ch7gzxihgn4559";
+  };
+
+  configFile = optionalString (conf!=null) (builtins.toFile "config.def.h" conf);
+  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ ncurses readline ];
+
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+
+  meta = {
+    description = "Small ncurses-based file browser forked from noice";
+    homepage = https://github.com/jarun/nnn;
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3364,6 +3364,8 @@ with pkgs;
     graphicalSupport = true;
   };
 
+  nnn = callPackage ../applications/misc/nnn { };
+
   notify-osd = callPackage ../applications/misc/notify-osd { };
 
   nox = callPackage ../tools/package-management/nox {


### PR DESCRIPTION
###### Motivation for this change

And another small and fast TUI file browser which was forked from noice.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

