### PR TITLE
libunwind: fix version macros

### DIFF
--- a/pkgs/development/libraries/libunwind/default.nix
+++ b/pkgs/development/libraries/libunwind/default.nix
@@ -9,6 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "1jsslwkilwrsj959dc8b479qildawz67r8m4lzxm7glcwa8cngiz";
   };
 
+  patches = [
+    ./version-1.2.1.patch
+  ];
+
   nativeBuildInputs = [ autoreconfHook ];
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/libunwind/version-1.2.1.patch
+++ b/pkgs/development/libraries/libunwind/version-1.2.1.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index a254bbe..fe0247b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,6 +1,6 @@
+ define(pkg_major, 1)
+-define(pkg_minor, 2.1)
+-define(pkg_extra, )
++define(pkg_minor, 2)
++define(pkg_extra, 1)
+ define(pkg_maintainer, libunwind-devel@nongnu.org)
+ define(mkvers, $1.$2$3)
+ dnl Process this file with autoconf to produce a configure script.


### PR DESCRIPTION
###### Motivation for this change

Fixes julia_05 build: https://github.com/NixOS/nixpkgs/pull/26891#issuecomment-312704756
Upstream bug: https://github.com/libunwind/libunwind/issues/30

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

