### PR TITLE
urlscan: 0.8.3 -> 0.8.6

### DIFF
--- a/pkgs/applications/misc/urlscan/default.nix
+++ b/pkgs/applications/misc/urlscan/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, pythonPackages, fetchFromGitHub }:
+{ stdenv, python3Packages, fetchFromGitHub }:
 
-pythonPackages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   name = "urlscan-${version}";
   version = "0.8.6";
 
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1v26fni64n0lbv37m35plh2bsrvhpb4ibgmg2mv05qfc3df721s5";
   };
 
-  propagatedBuildInputs = [ pythonPackages.urwid ];
+  propagatedBuildInputs = [ python3Packages.urwid ];
 
   meta = with stdenv.lib; {
     description = "Mutt and terminal url selector (similar to urlview)";

--- a/pkgs/applications/misc/urlscan/default.nix
+++ b/pkgs/applications/misc/urlscan/default.nix
@@ -1,25 +1,21 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, urwid, pythonOlder }:
+{ stdenv, pythonPackages, fetchFromGitHub, urwid }:
 
-buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "urlscan-${version}";
-  version = "0.8.3";
+  version = "0.8.6";
 
   src = fetchFromGitHub {
     owner = "firecat53";
     repo = "urlscan";
     rev = version;
-    # (equivalent but less nice(?): rev = "00333f6d03bf3151c9884ec778715fc605f58cc5")
-    sha256 = "0l40anfznam4d3q0q0jp2wwfrvfypz9ppbpjyzjdrhb3r2nizb0y";
+    sha256 = "1v26fni64n0lbv37m35plh2bsrvhpb4ibgmg2mv05qfc3df721s5";
   };
 
   propagatedBuildInputs = [ urwid ];
 
-  # FIXME doesn't work with 2.7; others than 2.7 and 3.5 were not tested (yet)
-  disabled = !pythonOlder "3.5";
-
   meta = with stdenv.lib; {
     description = "Mutt and terminal url selector (similar to urlview)";
     license = licenses.gpl2;
-    maintainers = [ maintainers.dpaetzel ];
+    maintainers = with maintainers; [ dpaetzel jfrankenau ];
   };
 }

--- a/pkgs/applications/misc/urlscan/default.nix
+++ b/pkgs/applications/misc/urlscan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pythonPackages, fetchFromGitHub, urwid }:
+{ stdenv, pythonPackages, fetchFromGitHub }:
 
 pythonPackages.buildPythonApplication rec {
   name = "urlscan-${version}";
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1v26fni64n0lbv37m35plh2bsrvhpb4ibgmg2mv05qfc3df721s5";
   };
 
-  propagatedBuildInputs = [ urwid ];
+  propagatedBuildInputs = [ pythonPackages.urwid ];
 
   meta = with stdenv.lib; {
     description = "Mutt and terminal url selector (similar to urlview)";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4523,9 +4523,7 @@ with pkgs;
 
   uriparser = callPackage ../development/libraries/uriparser {};
 
-  urlscan = callPackage ../applications/misc/urlscan {
-    pythonPackages = python3Packages;
-  };
+  urlscan = callPackage ../applications/misc/urlscan { };
 
   urlview = callPackage ../applications/misc/urlview {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4525,7 +4525,6 @@ with pkgs;
 
   urlscan = callPackage ../applications/misc/urlscan {
     pythonPackages = python3Packages;
-    urwid = python3Packages.urwid;
   };
 
   urlview = callPackage ../applications/misc/urlview {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4523,6 +4523,11 @@ with pkgs;
 
   uriparser = callPackage ../development/libraries/uriparser {};
 
+  urlscan = callPackage ../applications/misc/urlscan {
+    pythonPackages = python3Packages;
+    urwid = python3Packages.urwid;
+  };
+
   urlview = callPackage ../applications/misc/urlview {};
 
   usbmuxd = callPackage ../tools/misc/usbmuxd {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -30308,8 +30308,6 @@ EOF
 
   uranium = callPackage ../development/python-modules/uranium { };
 
-  urlscan = callPackage ../applications/misc/urlscan { };
-
   vine = buildPythonPackage rec {
     name = "vine-${version}";
     version = "1.1.3";


### PR DESCRIPTION
###### Motivation for this change

Update.

Moved from python-packages.nix to all-packages.nix because this is not a Python library but just a Python application.

This package also builds successfully with Python 2 and 3. I've decided to go with Python 3.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @dpaetzel