### PR TITLE
More correct form of /etc/hosts

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -199,6 +199,9 @@ in
 
   config = {
 
+    warnings = optional (cfg.extraHosts != "")
+      "networking.extraHosts is deprecated, please use networking.hosts instead";
+
     environment.etc =
       { # /etc/services: TCP/UDP port assignments.
         "services".source = pkgs.iana-etc + "/etc/services";

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -34,12 +34,12 @@ in
       default = {};
       example = ''
         {
-          "localhost" = [ "foo.bar" ];
+          "127.0.0.1" = [ "foo.bar.baz" ];
           "192.168.0.2" = [ "fileserver.local" "nameserver.local" ];
         };
       '';
       description = ''
-        Locally defined maps of IP addresses to hostnames'
+        Locally defined maps of hostnames to IP addresses.
       '';
     };
 

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -32,7 +32,7 @@ in
     networking.hosts = lib.mkOption {
       type = types.attrsOf ( types.listOf types.str );
       default = {};
-      example = ''
+      example = literalExample ''
         {
           "127.0.0.1" = [ "foo.bar.baz" ];
           "192.168.0.2" = [ "fileserver.local" "nameserver.local" ];

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -25,7 +25,7 @@ in
       default = null;
       example = "foo.example.com";
       description = ''
-        Full qualified domain name, if any.
+        Fully qualified domain name, if any.
       '';
     };
 

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -212,13 +212,13 @@ in
         # /etc/hosts: Hostname-to-IP mappings.
         "hosts".text =
           let oneToString = set : ip : ip + " " + concatStringsSep " " ( getAttr ip set );
-              allToString = set : concatStringsSep "\n" ( map ( oneToString set ) ( builtins.attrNames set ));
+              allToString = set : concatMapStringsSep "\n" ( oneToString set ) ( attrNames set );
               userLocalHosts = optionalString
                 ( builtins.hasAttr "127.0.0.1" cfg.hosts )
-                ( concatStringsSep " " ( filter (x : x != "localhost" ) ( getAttr "127.0.0.1" cfg.hosts)));
+                ( concatStringsSep " " ( remove "localhost" cfg.hosts."127.0.0.1" ));
               userLocalHosts6 = optionalString
                 ( builtins.hasAttr "::1" cfg.hosts )
-                ( concatStringsSep " " ( filter (x : x != "localhost" ) ( getAttr "::1" cfg.hosts)));
+                ( concatStringsSep " " ( remove "localhost" cfg.hosts."::1" ));
               otherHosts = allToString ( removeAttrs cfg.hosts [ "127.0.0.1" "::1" ]);
               maybeFQDN = optionalString ( cfg.fqdn != null ) cfg.fqdn;
           in

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -20,12 +20,24 @@ in
 
   options = {
 
+    networking.extraLocalHosts = lib.mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = [ "localhost.localdomain" "workinprogress.example.com" ];
+      description = ''
+        Additional entries to be appended to 127.0.0.1 entry in <filename>/etc/hosts</filename>.
+      '';
+    };
+
+
     networking.extraHosts = lib.mkOption {
       type = types.lines;
       default = "";
       example = "192.168.0.1 lanlocalhost";
       description = ''
         Additional entries to be appended to <filename>/etc/hosts</filename>.
+        Note that entries for 127.0.0.1 will not always work correctly if added from here.
+        They should be added via <literal>networking.extraLocalHosts</literal>.
       '';
     };
 
@@ -187,11 +199,11 @@ in
         "rpc".source = pkgs.glibc.out + "/etc/rpc";
 
         # /etc/hosts: Hostname-to-IP mappings.
-        "hosts".text =
+        "hosts".text = let foo = concatStringsSep " " cfg.extraLocalHosts; in
           ''
-            127.0.0.1 localhost
+            127.0.0.1 localhost ${foo}
             ${optionalString cfg.enableIPv6 ''
-              ::1 localhost
+              ::1 localhost ${foo}
             ''}
             ${cfg.extraHosts}
           '';

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -213,16 +213,14 @@ in
         "hosts".text =
           let oneToString = set : ip : ip + " " + concatStringsSep " " ( getAttr ip set );
               allToString = set : concatStringsSep "\n" ( map ( oneToString set ) ( builtins.attrNames set ));
-              userLocalHosts =
-                if builtins.hasAttr "127.0.0.1" cfg.hosts
-                then concatStringsSep " " ( filter (x : x != "localhost" ) ( getAttr "127.0.0.1" cfg.hosts))
-                else "";
-              userLocalHosts6 =
-                if builtins.hasAttr "::1" cfg.hosts
-                then concatStringsSep " " ( filter (x : x != "localhost" ) ( getAttr "::1" cfg.hosts))
-                else "";
+              userLocalHosts = optionalString
+                ( builtins.hasAttr "127.0.0.1" cfg.hosts )
+                ( concatStringsSep " " ( filter (x : x != "localhost" ) ( getAttr "127.0.0.1" cfg.hosts)));
+              userLocalHosts6 = optionalString
+                ( builtins.hasAttr "::1" cfg.hosts )
+                ( concatStringsSep " " ( filter (x : x != "localhost" ) ( getAttr "::1" cfg.hosts)));
               otherHosts = allToString ( removeAttrs cfg.hosts [ "127.0.0.1" "::1" ]);
-              maybeFQDN = if cfg.fqdn == null then "" else cfq.fqdn;
+              maybeFQDN = optionalString ( cfg.fqdn != null ) cfg.fqdn;
           in
           ''
             127.0.0.1 ${maybeFQDN} ${userLocalHosts} localhost


### PR DESCRIPTION
Makes management of `/etc/hosts` more declarative by using `networking.hosts`.

###### Motivation for this change

It makes possible to point multiple domains to `localhost` in correct way: just adding `127.0.0.1 localhost.localdomain` to `networking.extraHosts` will not always work and is [incorrect](https://unix.stackexchange.com/questions/102660/hosts-file-is-it-incorrect-to-have-the-same-ip-address-on-multiple-lines).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

