### PR TITLE
wla-dx-git: 2016-02-27 -> 2017-06-05

### DIFF
--- a/pkgs/development/compilers/wla-dx/default.nix
+++ b/pkgs/development/compilers/wla-dx/default.nix
@@ -1,13 +1,14 @@
 {stdenv, fetchFromGitHub, cmake}:
 
 stdenv.mkDerivation rec {
-  name = "wla-dx-git-2016-02-27";
+  version = "2017-06-05";
+  name = "wla-dx-git-${version}";
 
   src = fetchFromGitHub {
     owner = "vhelin";
     repo = "wla-dx";
-    rev = "8189fe8d5620584ea16563875ff3c5430527c86a";
-    sha256 = "02zgkcyfx7y8j6jvyi12lm29fydnd7m3rxv6g2psv23fyzmpkkir";
+    rev = "ae6843f9711cbc2fa6dd8c200877b40bd2bcad7f";
+    sha256 = "09c2kz12ld97ad41j6r8r65jknllrak1x8r43fgr26x7hdlxz5c6";
   };
 
   hardeningDisable = [ "format" ];


### PR DESCRIPTION
- Change to version 2017-06-05
- Add version attribute

###### Motivation for this change
Added version attribute as it is easier:
- to know that the package name is "wla-dx-git"
- to update the version from now on

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @matthewbauer 