### PR TITLE
partition-manager: fix build

### DIFF
--- a/pkgs/tools/misc/partition-manager/default.nix
+++ b/pkgs/tools/misc/partition-manager/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, fetchurl, lib
 , extra-cmake-modules, kdoctools, wrapGAppsHook
 , kconfig, kinit, kpmcore
-, eject, libatasmart }:
+, kcrash, eject, libatasmart }:
 
 let
   pname = "partitionmanager";
@@ -22,5 +22,5 @@ in mkDerivation rec {
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
   # refer to kpmcore for the use of eject
   buildInputs = [ eject libatasmart ];
-  propagatedBuildInputs = [ kconfig kinit kpmcore ];
+  propagatedBuildInputs = [ kconfig kcrash kinit kpmcore ];
 }


### PR DESCRIPTION
###### Motivation for this change
Build doesn't work, so I've used approach similar to https://github.com/NixOS/nixpkgs/issues/26860

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

