### PR TITLE
papirus-icon-theme: init at 20170616

### DIFF
--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+    name = "papirus-icon-theme-${version}";
+    version = "20170616";
+
+    src = fetchFromGitHub {
+        owner = "PapirusDevelopmentTeam";
+        repo = "papirus-icon-theme";
+        rev = "9be3f0f688f33d538f135b590579466946d0bf4c";
+        sha256 = "008nkmxp3f9qqljif3v9ns3a8mflzffv2mm5zgjng9pmdl5x70j4";
+    };
+
+    dontBuild = true;
+
+    installPhase = ''
+        install -dm 755 $out/share/icons
+        cp -dr --no-preserve='ownership' Papirus{,-Dark,-Light} $out/share/icons/
+        cp -dr --no-preserve='ownership' ePapirus $out/share/icons/
+        
+    '';
+
+    meta = with stdenv.lib; {
+        description = "Papirus icon theme for Linux";
+        homepage = "https://github.com/PapirusDevelopmentTeam/papirus-icon-theme";
+        license = licenses.lgpl3;
+        platforms = platforms.all;
+    };
+}

--- a/pkgs/tools/misc/partition-manager/default.nix
+++ b/pkgs/tools/misc/partition-manager/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, fetchurl, lib
 , extra-cmake-modules, kdoctools, wrapGAppsHook
 , kconfig, kinit, kpmcore
-, eject, libatasmart }:
+, kcrash, eject, libatasmart }:
 
 let
   pname = "partitionmanager";
@@ -22,5 +22,5 @@ in mkDerivation rec {
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
   # refer to kpmcore for the use of eject
   buildInputs = [ eject libatasmart ];
-  propagatedBuildInputs = [ kconfig kinit kpmcore ];
+  propagatedBuildInputs = [ kconfig kcrash kinit kpmcore ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12961,6 +12961,8 @@ with pkgs;
 
   paper-icon-theme = callPackage ../data/icons/paper-icon-theme { };
 
+  papirus-icon-theme = callPackage ../data/icons/papirus-icon-theme { };
+
   pecita = callPackage ../data/fonts/pecita {};
 
   paratype-pt-mono = callPackage ../data/fonts/paratype-pt/mono.nix {};


### PR DESCRIPTION
###### Motivation for this change
Wanted to add papirus icon theme

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

