### PR TITLE
gnomeExtensions.topicons-plus: init at v20

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/topicons-plus/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/topicons-plus/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, glib, gettext, bash }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extension-topicons-plus-${version}";
+  version = "v20";
+
+  src = fetchFromGitHub {
+    owner = "phocean";
+    repo = "TopIcons-plus";
+    rev = "01535328bd43ecb3f2c71376de6fc8d1d8a88577";
+    sha256 = "0pwpg72ihgj2jl9pg63y0hibdsl27srr3mab881w0gh17vwyixzi";
+  };
+
+  nativeBuildInputs = [
+    glib gettext
+  ];
+
+  makeFlags = [ "INSTALL_PATH=$(out)/share/gnome-shell/extensions" ];
+
+  meta = with stdenv.lib; {
+    description = "Brings all icons back to the top panel, so that it's easier to keep track of apps running in the backround";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ eperuffo ];
+    homepage = https://github.com/phocean/TopIcons-plus;
+  };
+}

--- a/pkgs/desktops/gnome-3/extensions/topicons-plus/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/topicons-plus/default.nix
@@ -11,9 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "0pwpg72ihgj2jl9pg63y0hibdsl27srr3mab881w0gh17vwyixzi";
   };
 
-  nativeBuildInputs = [
-    glib gettext
-  ];
+  buildInputs = [ glib ];
+
+  nativeBuildInputs = [ gettext ];
 
   makeFlags = [ "INSTALL_PATH=$(out)/share/gnome-shell/extensions" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17591,6 +17591,7 @@ with pkgs;
   gnomeExtensions = {
     caffeine = callPackage ../desktops/gnome-3/extensions/caffeine { };
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
+    topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
   };
 
   hsetroot = callPackage ../tools/X11/hsetroot { };


### PR DESCRIPTION
###### Motivation for this change
TopIcons extension for Gnome 3

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

