### PR TITLE
ntfs3g: change package name

### DIFF
--- a/pkgs/tools/filesystems/ntfs-3g/default.nix
+++ b/pkgs/tools/filesystems/ntfs-3g/default.nix
@@ -2,7 +2,7 @@
 , crypto ? false, libgcrypt, gnutls, pkgconfig}:
 
 stdenv.mkDerivation rec {
-  pname = "ntfs-3g";
+  pname = "ntfs3g";
   version = "2017.3.23";
   name = "${pname}-${version}";
 


### PR DESCRIPTION
It was being parsed incorrectly, as noted on
https://github.com/NixOS/nix/issues/1440
nix-repl> builtins.parseDrvName ntfs3g.name
{ name = "ntfs"; version = "3g-2017.3.23"; }

@dezgeg: any better idea?