### PR TITLE
ocamlPackages.{benchmark,obuild,ptmap,rope}: init at 1.4, 0.1.8, 2.0.…

### DIFF
--- a/pkgs/development/ocaml-modules/benchmark/default.nix
+++ b/pkgs/development/ocaml-modules/benchmark/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, camlp4, ocaml_pcre }:
+
+let version = "1.4"; in
+
+stdenv.mkDerivation {
+  name = "benchmark-${version}";
+
+  src = fetchzip {
+    url = "https://github.com/Chris00/ocaml-benchmark/releases/download/${version}/benchmark-${version}.tar.gz";
+    sha256 = "16wi8ld7c3mq77ylpgbnj8qqqqimyzwxs47v06vyrwpma5pab5xa";
+  };
+
+  buildInputs = [ ocaml findlib ocamlbuild camlp4 ocaml_pcre ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    homepage = http://ocaml-benchmark.forge.ocamlcore.org/;
+    platforms = ocaml.meta.platforms or [];
+    description = "Benchmark running times of code";
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = with stdenv.lib.maintainers; [ volth ];
+  };
+}

--- a/pkgs/development/ocaml-modules/obuild/default.nix
+++ b/pkgs/development/ocaml-modules/obuild/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchzip, ocaml, findlib }:
+
+let version = "0.1.8"; in
+
+stdenv.mkDerivation {
+  name = "obuild-${version}";
+
+  src = fetchzip {
+    url = "https://github.com/ocaml-obuild/obuild/archive/obuild-v${version}.tar.gz";
+    sha256 = "1q1k2qqd08j1zakvydgvwgwpyn0ll7rs65gap0pvg3amnh5cp3wd";
+  };
+
+  buildInputs = [ ocaml findlib ];
+
+  buildPhase = ''
+    ./bootstrap
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp dist/build/obuild/obuild dist/build/obuild-from-oasis/obuild-from-oasis dist/build/obuild-simple/obuild-simple $out/bin/
+  '';
+
+  meta = {
+    homepage = https://github.com/ocaml-obuild/obuild;
+    platforms = ocaml.meta.platforms or [];
+    description = "Simple package build system for OCaml";
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = with stdenv.lib.maintainers; [ volth ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ptmap/default.nix
+++ b/pkgs/development/ocaml-modules/ptmap/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchzip, ocaml, findlib, obuild }:
+
+let version = "2.0.1"; in
+
+stdenv.mkDerivation {
+  name = "ptmap-${version}";
+
+  src = fetchzip {
+    url = "https://github.com/UnixJunkie/ptmap/archive/v${version}.tar.gz";
+    sha256 = "09ib4q5amkac2yy0hr7yn1n1j6y10v08chh82qc70wl7s473if15";
+  };
+
+  buildInputs = [ ocaml findlib obuild ];
+
+  createFindlibDestdir = true;
+
+  buildPhase = ''
+    substituteInPlace ptmap.obuild --replace 'build-deps: qcheck' ""
+    obuild configure
+    obuild build lib-ptmap
+  '';
+
+  installPhase = ''
+    obuild install --destdir $out/lib/ocaml/${ocaml.version}/site-lib
+  '';
+
+  meta = {
+    homepage = https://www.lri.fr/~filliatr/software.en.html;
+    platforms = ocaml.meta.platforms or [];
+    description = "Maps over integers implemented as Patricia trees";
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = with stdenv.lib.maintainers; [ volth ];
+  };
+}

--- a/pkgs/development/ocaml-modules/rope/default.nix
+++ b/pkgs/development/ocaml-modules/rope/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, camlp4, benchmark }:
+
+let version = "0.5"; in
+
+stdenv.mkDerivation {
+  name = "rope-${version}";
+
+  src = fetchzip {
+    url = "https://forge.ocamlcore.org/frs/download.php/1156/rope-${version}.tar.gz";
+    sha256 = "1i8kzg19jrapl30mq8m91vy09z0r0dl4bnpw24ga96w8pxqf9qhd";
+  };
+
+  buildInputs = [ ocaml findlib ocamlbuild camlp4 benchmark ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    homepage = http://rope.forge.ocamlcore.org/;
+    platforms = ocaml.meta.platforms or [];
+    description = ''Ropes ("heavyweight strings") in OCaml'';
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = with stdenv.lib.maintainers; [ volth ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -114,6 +114,8 @@ let
     };
     camlimages = camlimages_4_1;
 
+    benchmark = callPackage ../development/ocaml-modules/benchmark { };
+
     biniou = callPackage ../development/ocaml-modules/biniou { };
 
     bin_prot_p4 = callPackage ../development/ocaml-modules/bin_prot { };
@@ -362,6 +364,8 @@ let
 
     core_p4 = callPackage ../development/ocaml-modules/core { };
 
+    obuild = callPackage ../development/ocaml-modules/obuild { };
+
     ocamlbuild =
     if lib.versionOlder "4.03" ocaml.version then
     callPackage ../development/tools/ocaml/ocamlbuild { }
@@ -551,6 +555,8 @@ let
 
     ppx_tools_versioned = callPackage ../development/ocaml-modules/ppx_tools_versioned { };
 
+    ptmap = callPackage ../development/ocaml-modules/ptmap { };
+
     pycaml = callPackage ../development/ocaml-modules/pycaml { };
 
     qcheck = callPackage ../development/ocaml-modules/qcheck { };
@@ -560,6 +566,8 @@ let
     re = callPackage ../development/ocaml-modules/re { };
 
     reason = callPackage ../development/compilers/reason { };
+
+    rope = callPackage ../development/ocaml-modules/rope { };
 
     rresult = callPackage ../development/ocaml-modules/rresult { };
 


### PR DESCRIPTION
…1, 0.5

###### Motivation for this change

Dependencies for coming Haxe 4.0 (current git master).


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

