### PR TITLE
[wip] docker: 17.03.2-ce -> 17.06.0-ce

### DIFF
--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ removeReferencesTo go ];
 
   preBuild = ''
-    ln -s $(pwd) vendor/src/github.com/docker/containerd
+    ln -s $(pwd) vendor/src/github.com/containerd/containerd
   '';
 
   installPhase = ''

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -1,12 +1,9 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper, removeReferencesTo, pkgconfig
-, go-md2man, go, containerd, runc, docker-proxy, tini
+, go-md2man, go, containerd, runc, docker-proxy, tini, libtool
 , sqlite, iproute, bridge-utils, devicemapper, systemd
 , btrfs-progs, iptables, e2fsprogs, xz, utillinux, xfsprogs
 , procps
 }:
-
-# https://github.com/docker/docker/blob/master/project/PACKAGERS.md
-# https://github.com/docker/docker/blob/TAG/hack/dockerfile/binaries-commits
 
 with lib;
 
@@ -23,7 +20,7 @@ rec {
 
     src = fetchFromGitHub {
       owner = "docker";
-      repo = "docker";
+      repo = "docker-ce";
       rev = "v${version}";
       sha256 = sha256;
     };
@@ -68,7 +65,7 @@ rec {
 
     buildInputs = [
       makeWrapper removeReferencesTo pkgconfig go-md2man go
-      sqlite devicemapper btrfs-progs systemd
+      sqlite devicemapper btrfs-progs systemd libtool
     ];
 
     dontStrip = true;
@@ -78,26 +75,43 @@ rec {
       ++ optional (btrfs-progs == null) "exclude_graphdriver_btrfs"
       ++ optional (devicemapper == null) "exclude_graphdriver_devicemapper";
 
-    # systemd 230 no longer has libsystemd-journal as a separate entity from libsystemd
-    postPatch = ''
-      substituteInPlace ./hack/make.sh                   --replace libsystemd-journal libsystemd
-      substituteInPlace ./daemon/logger/journald/read.go --replace libsystemd-journal libsystemd
-    '';
-
     buildPhase = ''
-      patchShebangs .
+      # build engine
+      cd ./components/engine
       export AUTO_GOPATH=1
       export DOCKER_GITCOMMIT="${rev}"
       ./hack/make.sh dynbinary
+      cd -
+
+      # build cli
+      cd ./components/cli
+      # Mimic AUTO_GOPATH
+      mkdir -p .gopath/src/github.com/docker/
+      ln -sf $PWD .gopath/src/github.com/docker/cli
+      export GOPATH="$PWD/.gopath:$GOPATH"
+      export GITCOMMIT="${rev}"
+      export VERSION="${version}"
+      source ./scripts/build/.variables
+      export CGO_ENABLED=1
+      go build -tags pkcs11 --ldflags "$LDFLAGS" github.com/docker/cli/cmd/docker
+      cd -
     '';
+
+    # systemd 230 no longer has libsystemd-journal as a separate entity from libsystemd
+    patchPhase = ''
+      patchShebangs .
+      substituteInPlace ./components/engine/hack/make.sh                   --replace libsystemd-journal libsystemd
+      substituteInPlace ./components/engine/daemon/logger/journald/read.go --replace libsystemd-journal libsystemd
+      substituteInPlace ./components/cli/scripts/build/.variables --replace "set -eu" ""
+     '';
 
     outputs = ["out" "man"];
 
     extraPath = makeBinPath [ iproute iptables e2fsprogs xz xfsprogs procps utillinux ];
 
     installPhase = ''
-      install -Dm755 ./bundles/${version}/dynbinary-client/docker-${version} $out/libexec/docker/docker
-      install -Dm755 ./bundles/${version}/dynbinary-daemon/dockerd-${version} $out/libexec/docker/dockerd
+      install -Dm755 ./components/cli/docker $out/libexec/docker/docker
+      install -Dm755 ./components/engine/bundles/${version}/dynbinary-daemon/dockerd-${version} $out/libexec/docker/dockerd
       makeWrapper $out/libexec/docker/docker $out/bin/docker \
         --prefix PATH : "$out/libexec/docker:$extraPath"
       makeWrapper $out/libexec/docker/dockerd $out/bin/dockerd \
@@ -111,18 +125,28 @@ rec {
       ln -s ${docker-tini}/bin/tini-static $out/libexec/docker/docker-init
 
       # systemd
-      install -Dm644 ./contrib/init/systemd/docker.service $out/etc/systemd/system/docker.service
+      install -Dm644 ./components/engine/contrib/init/systemd/docker.service $out/etc/systemd/system/docker.service
 
-      # completion
-      install -Dm644 ./contrib/completion/bash/docker $out/share/bash-completion/completions/docker
-      install -Dm644 ./contrib/completion/fish/docker.fish $out/share/fish/vendor_completions.d/docker.fish
-      install -Dm644 ./contrib/completion/zsh/_docker $out/share/zsh/site-functions/_docker
+      # completion (cli)
+      install -Dm644 ./components/cli/contrib/completion/bash/docker $out/share/bash-completion/completions/docker
+      install -Dm644 ./components/cli/contrib/completion/fish/docker.fish $out/share/fish/vendor_completions.d/docker.fish
+      install -Dm644 ./components/cli/contrib/completion/zsh/_docker $out/share/zsh/site-functions/_docker
 
-      # Include contributed man pages
-      man/md2man-all.sh -q
+      # Include contributed man pages (cli)
+      # Generate man pages from cobra commands
+      echo "Generate man pages from cobra"
+      cd ./components/cli
+      mkdir -p ./man/man1
+      go build -o /tmp/gen-manpages github.com/docker/cli/man
+      /tmp/gen-manpages --root . --target ./man/man1
+
+      # Generate legacy pages from markdown
+      echo "Generate legacy manpages"
+      ./man/md2man-all.sh -q
+
       manRoot="$man/share/man"
       mkdir -p "$manRoot"
-      for manDir in man/man?; do
+      for manDir in ./man/man?; do
         manBase="$(basename "$manDir")" # "man1"
         for manFile in "$manDir"/*; do
           manName="$(basename "$manFile")" # "docker-build.1"
@@ -140,31 +164,19 @@ rec {
       homepage = http://www.docker.com/;
       description = "An open source project to pack, ship and run any application as a lightweight container";
       license = licenses.asl20;
-      maintainers = with maintainers; [ offline tailhook ];
+      maintainers = with maintainers; [ offline tailhook vdemeester ];
       platforms = platforms.linux;
     };
   };
 
-  docker_17_03 = dockerGen rec {
-    version = "17.03.2-ce";
-    rev = "f5ec1e2"; # git commit
-    sha256 = "1y3rkzgg8vpjq61y473lnh0qyc6msl4ixw7ci2p56fyqrhkmhf96";
-    runcRev = "54296cf40ad8143b62dbcaa1d90e520a2136ddfe";
-    runcSha256 = "0ylymx7pi4jmvbqj94j2i8qspy8cpq0m91l6a0xiqlx43yx6qi2m";
-    containerdRev = "4ab9917febca54791c5f071a9d1f404867857fcc";
-    containerdSha256 = "06f2gsx4w9z4wwjhrpafmz6c829wi8p7crj6sya6x9ii50bkn8p6";
-    tiniRev = "949e6facb77383876aeff8a6944dde66b3089574";
-    tiniSha256 = "0zj4kdis1vvc6dwn4gplqna0bs7v6d1y2zc8v80s3zi018inhznw";
-  };
-
-  docker_17_05 = dockerGen rec {
-    version = "17.05.0-ce";
-    rev = "90d35abf7b3535c1c319c872900fbd76374e521c"; # git commit
-    sha256 = "1m4fcawjj14qws57813wjxjwgnrfxgxnnzlj61csklp0s9dhg7df";
-    runcRev = "9c2d8d184e5da67c95d601382adf14862e4f2228";
-    runcSha256 = "131jv8f77pbdlx88ar0zjwdsp0a5v8kydaw0w0cl3i0j3622ydjl";
-    containerdRev = "9048e5e50717ea4497b757314bad98ea3763c145";
-    containerdSha256 = "1r9xhvzzh7md08nqb0rbp5d1rdr7jylb3da954d0267i0kh2iksa";
+  docker_17_06 = dockerGen rec {
+    version = "17.06.0-ce";
+    rev = "02c1d876176546b5f069dae758d6a7d2ead6bd48"; # git commit
+    sha256 = "0wrg4ygcq4c7f2bwa7pgc7y33idg0hijavx40588jaglz4k8sqpm";
+    runcRev = "992a5be178a62e026f4069f443c6164912adbf09";
+    runcSha256 = "0ylkbn5rprw5cgxazvrwj7balikpfm8vlybwdbfpwnsqk3gc6p8k";
+    containerdRev = "cfb82a876ecc11b5ca0977d1733adbe58599088a";
+    containerdSha256 = "0rix0mv203fn3rcxmpqdpb54l1a0paqplg2xgldpd943qi1rm552";
     tiniRev = "949e6facb77383876aeff8a6944dde66b3089574";
     tiniSha256 = "0zj4kdis1vvc6dwn4gplqna0bs7v6d1y2zc8v80s3zi018inhznw";
   };

--- a/pkgs/applications/virtualization/docker/proxy.nix
+++ b/pkgs/applications/virtualization/docker/proxy.nix
@@ -27,4 +27,3 @@ buildGoPackage rec {
     platforms = docker.meta.platforms;
   };
 }
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13685,11 +13685,10 @@ with pkgs;
   };
 
   inherit (callPackage ../applications/virtualization/docker { })
-    docker_17_03
-    docker_17_05;
+    docker_17_06;
 
-  docker = docker_17_03;
-  docker-edge = docker_17_05;
+  docker = docker_17_06;
+  docker-edge = docker_17_06;
 
   docker-proxy = callPackage ../applications/virtualization/docker/proxy.nix { };
 


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Release of `docker-ce` happened *and* the repository where the release happens has changed 😅 … 

It's still a `WIP` 

- because I'm getting an error I can't make sense of (and I don't see how to fix it)

```
/nix/store/bl48w7h24n6379fa200yv60n4pwynd9c-stdenv/setup: line 923: tracePhases: unbound variable
/nix/store/bl48w7h24n6379fa200yv60n4pwynd9c-stdenv/setup: line 125: showBuildStats: unbound variable
builder for ‘/nix/store/s67017nsynrhwipg9amhz1254z1245z0-docker-17.06.0-ce-rc2.drv’ failed with exit code 1
```

- I need to update `containerd` (probably elsewhere)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

