### PR TITLE
gildas: init at jul17a

### DIFF
--- a/pkgs/applications/science/astronomy/gildas/default.nix
+++ b/pkgs/applications/science/astronomy/gildas/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchurl, gtk2 , pkgconfig , python27 , gfortran , python27Packages , lesstif , cfitsio , getopt , perl , groff }:
+
+stdenv.mkDerivation rec {
+  srcVersion = "jul17a";
+  version = "20170701_a";
+  name = "gildas-${version}";
+
+  src = fetchurl {
+    url = "http://www.iram.fr/~gildas/dist/gildas-src-${srcVersion}.tar.gz";
+    sha256 = "060vha4af2xamk0fvriqr6rgq4zayy4k6l5y6kj3h5cv9b4yiqzq";
+  };
+
+  enableParallelBuilding = false;
+
+  nativeBuildInputs = [ pkgconfig groff perl getopt gfortran python27 python27Packages.numpy ];
+
+  buildInputs = [ gtk2 lesstif cfitsio ];
+
+  patches = [ ./format-security.patch ./wrapper.patch ];
+
+  configurePhase=''
+    substituteInPlace admin/wrapper.sh --replace '%%OUT%%' $out
+    source admin/gildas-env.sh -b gcc -c gfortran -o openmp
+    export GAG_INC_FLAGS=""
+  '';
+
+  buildPhase="make install";
+
+  installPhase=''
+    mkdir -p $out/bin
+    cp -a ../gildas-exe-${srcVersion}/* $out
+    mv $out/$GAG_EXEC_SYSTEM $out/libexec
+    cp admin/wrapper.sh $out/bin/gildas-wrapper.sh
+    chmod 755 $out/bin/gildas-wrapper.sh
+    for i in $out/libexec/bin/* ; do
+      ln -s $out/bin/gildas-wrapper.sh $out/bin/$(basename "$i")
+    done
+  '';
+
+  meta = {
+    description = "Radioastronomy data analysis software";
+    longDescription = ''
+      GILDAS is a collection of state-of-the-art software
+      oriented toward (sub-)millimeter radioastronomical
+      applications (either single-dish or interferometer).
+      It is daily used to reduce all data acquired with the
+      IRAM 30M telescope and Plateau de Bure Interferometer
+      PDBI (except VLBI observations). GILDAS is easily
+      extensible. GILDAS is written in Fortran-90, with a
+      few parts in C/C++ (mainly keyboard interaction,
+      plotting, widgets).'';
+    homepage = http://www.iram.fr/IRAMFR/GILDAS/gildas.html;
+    license = stdenv.lib.licenses.free;
+    maintainers = [ stdenv.lib.maintainers.bzizou ];
+    platforms = stdenv.lib.platforms.all;
+  };
+
+}

--- a/pkgs/applications/science/astronomy/gildas/format-security.patch
+++ b/pkgs/applications/science/astronomy/gildas/format-security.patch
@@ -1,0 +1,32 @@
+diff -u -r gildas-src-feb17d.orig/kernel/lib/gcore/gcomm.c gildas-src-feb17d/kernel/lib/gcore/gcomm.c
+--- gildas-src-feb17d.orig/kernel/lib/gcore/gcomm.c	2017-05-18 00:23:07.482284541 +0200
++++ gildas-src-feb17d/kernel/lib/gcore/gcomm.c	2017-05-18 00:24:03.043396641 +0200
+@@ -973,12 +973,12 @@
+     i = 0;
+     sprintf( exec_argv[i++], "xterm");
+     sprintf( exec_argv[i++], "-T");
+-    sprintf( exec_argv[i++], app_name);
++    sprintf( exec_argv[i++], "%s", app_name);
+     sprintf( exec_argv[i++], "-e");
+     sprintf( exec_argv[i++], "gdb");
+     sprintf( exec_argv[i++], "-x");
+-    sprintf( exec_argv[i++], gdb_cmd_file);
+-    sprintf( exec_argv[i++], app_name);
++    sprintf( exec_argv[i++], "%s", gdb_cmd_file);
++    sprintf( exec_argv[i++], "%s", app_name);
+     exec_argv[i++] = NULL;
+     if (i >= MAX_ARGC) {
+         gcore_c_message(seve_e, "SIC", "Too much arguments, exiting");
+diff -u -r gildas-src-feb17d.orig/kernel/lib/ggtk/gtk-menu.c gildas-src-feb17d/kernel/lib/ggtk/gtk-menu.c
+--- gildas-src-feb17d.orig/kernel/lib/ggtk/gtk-menu.c	2017-05-18 00:21:47.656686708 +0200
++++ gildas-src-feb17d/kernel/lib/ggtk/gtk-menu.c	2017-05-18 00:20:36.227256914 +0200
+@@ -219,7 +219,7 @@
+     i = 0;
+     sprintf( argv[i++], "undefined");
+     sprintf( argv[i++], "0");
+-    sprintf( argv[i++], file);
++    sprintf( argv[i++], "%s", file);
+     argv[i] = NULL;
+ 
+     //run_gtk_menu_args( i, argv);
+Only in gildas-src-feb17d/kernel/lib/ggtk: gtk-menu.c.orig

--- a/pkgs/applications/science/astronomy/gildas/wrapper.patch
+++ b/pkgs/applications/science/astronomy/gildas/wrapper.patch
@@ -1,0 +1,18 @@
+diff --new-file -r -u gildas-src-feb17d.orig/admin/wrapper.sh gildas-src-feb17d/admin/wrapper.sh
+--- gildas-src-feb17d.orig/admin/wrapper.sh	1970-01-01 01:00:00.000000000 +0100
++++ gildas-src-feb17d/admin/wrapper.sh	2017-05-18 21:00:01.660778782 +0200
+@@ -0,0 +1,14 @@
++#!/bin/sh -e
++
++export GAG_ROOT_DIR="%%OUT%%"
++export GAG_PATH="${GAG_ROOT_DIR}/etc"
++export GAG_EXEC_SYSTEM="libexec"
++if [ -z "\$PYTHONPATH" ]; then
++  PYTHONPATH="${GAG_ROOT_DIR}/${GAG_EXEC_SYSTEM}/python"
++else
++  PYTHONPATH="${GAG_ROOT_DIR}/${GAG_EXEC_SYSTEM}/python:${PYTHONPATH}"
++fi
++export PYTHONPATH
++export LD_LIBRARY_PATH=${GAG_ROOT_DIR}/${GAG_EXEC_SYSTEM}/lib/
++me=`basename $0`
++exec ${GAG_ROOT_DIR}/${GAG_EXEC_SYSTEM}/bin/${me} ${*}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18116,6 +18116,8 @@ with pkgs;
   cytoscape = callPackage ../applications/science/misc/cytoscape { };
 
   fityk = callPackage ../applications/science/misc/fityk { };
+  
+  gildas = callPackage ../applications/science/astronomy/gildas { };
 
   gplates = callPackage ../applications/science/misc/gplates {
     boost = boost160;


### PR DESCRIPTION
###### Motivation for this change

Gildas is a radio-astronomy code that is used into my HPC center.
This package has been successfully tested by our users and is now in production since a few weeks into our local channel.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

