### PR TITLE
resolved: use resolved's static resolv.conf

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -223,7 +223,9 @@ in
             '';
 
       } // optionalAttrs config.services.resolved.enable {
-        "resolv.conf".source = "/run/systemd/resolve/resolv.conf";
+        # symlink the static version of resolv.conf as recommended by upstream:
+        # https://www.freedesktop.org/software/systemd/man/systemd-resolved.html#/etc/resolv.conf
+        "resolv.conf".source = "${pkgs.systemd}/lib/systemd/resolv.conf";
       } // optionalAttrs (config.services.resolved.enable && dnsmasqResolve) {
         "dnsmasq-resolv.conf".source = "/run/systemd/resolve/resolv.conf";
       };


### PR DESCRIPTION
because it is upstream's recommended mode of operation:
https://www.freedesktop.org/software/systemd/man/systemd-resolved.html#/etc/resolv.conf

###### Motivation for this change
This allows systemd-resolved to intercept programs that don't use `/etc/nsswitch.conf` but `/etc/resolv.conf` directly, to inject records like the virtual `gateway` host or hostnames from LLMNR / MulticastDNS.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

