### PR TITLE
git-fame: init at 2.5.2

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -32,6 +32,8 @@ rec {
 
   git = appendToName "minimal" gitBase;
 
+  git-fame = callPackage ./git-fame {};
+
   # The full-featured Git.
   gitFull = gitBase.override {
     svnSupport = true;

--- a/pkgs/applications/version-management/git-and-tools/git-fame/Gemfile
+++ b/pkgs/applications/version-management/git-and-tools/git-fame/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in git_fame.gemspec
+gem "git_fame"

--- a/pkgs/applications/version-management/git-and-tools/git-fame/Gemfile.lock
+++ b/pkgs/applications/version-management/git-and-tools/git-fame/Gemfile.lock
@@ -1,0 +1,73 @@
+PATH
+  remote: .
+  specs:
+    git_fame (2.5.2)
+      hirb (~> 0.7.3)
+      memoist (~> 0.14.0)
+      method_profiler (~> 2.0.1)
+      progressbar (~> 0.21.0)
+      scrub_rb (~> 1.0.1)
+      trollop (~> 2.1.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colorize (0.8.1)
+    coveralls (0.8.21)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.14.1)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.4)
+      tins (~> 1.6)
+    diff-lcs (1.3)
+    docile (1.1.5)
+    hirb (0.7.3)
+    json (1.8.6)
+    memoist (0.14.0)
+    method_profiler (2.0.1)
+      hirb (>= 0.6.0)
+    progressbar (0.21.0)
+    rake (10.4.2)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-collection_matchers (1.1.3)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
+    scrub_rb (1.0.1)
+    simplecov (0.14.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.1)
+    term-ansicolor (1.3.2)
+      tins (~> 1.0)
+    thor (0.19.4)
+    tins (1.6.0)
+    trollop (2.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  colorize
+  coveralls (~> 0.8.1)
+  git_fame!
+  json (~> 1.8.3)
+  rake (~> 10.4.2)
+  rspec (~> 3.4.0)
+  rspec-collection_matchers (~> 1.1.2)
+  term-ansicolor (~> 1.3.2)
+  tins (~> 1.6.0)
+
+BUNDLED WITH
+   1.14.6

--- a/pkgs/applications/version-management/git-and-tools/git-fame/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-fame/default.nix
@@ -1,10 +1,10 @@
 { lib, bundlerEnv, ruby, fetchFromGitHub }:
 
 bundlerEnv rec {
-  name = "git-fame-${version}";
-
-  version = "2.5.2";
   inherit ruby;
+
+  pname = "git_fame";
+
   gemdir = ./.;
 
   meta = with lib; {

--- a/pkgs/applications/version-management/git-and-tools/git-fame/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-fame/default.nix
@@ -1,0 +1,17 @@
+{ lib, bundlerEnv, ruby, fetchFromGitHub }:
+
+bundlerEnv rec {
+  name = "git-fame-${version}";
+
+  version = "2.5.2";
+  inherit ruby;
+  gemdir = ./.;
+
+  meta = with lib; {
+    description = "A command-line tool that helps you summarize and pretty-print collaborators based on contributions";
+    homepage    = http://oleander.io/git-fame-rb;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ expipiplus1 ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/applications/version-management/git-and-tools/git-fame/gemset.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-fame/gemset.nix
@@ -1,0 +1,195 @@
+{
+  colorize = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "133rqj85n400qk6g3dhf2bmfws34mak1wqihvh3bgy9jhajw580b";
+      type = "gem";
+    };
+    version = "0.8.1";
+  };
+  coveralls = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0akifzdykdbjlawkk3vbc9pxrw76g7dz5g9ankrvq8xhbw4crdnv";
+      type = "gem";
+    };
+    version = "0.8.21";
+  };
+  diff-lcs = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18w22bjz424gzafv6nzv98h0aqkwz3d9xhm7cbr1wfbyas8zayza";
+      type = "gem";
+    };
+    version = "1.3";
+  };
+  docile = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m8j31whq7bm5ljgmsrlfkiqvacrw6iz9wq10r3gwrv5785y8gjx";
+      type = "gem";
+    };
+    version = "1.1.5";
+  };
+  git_fame = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02k5ls5zyif8skdbnym6zw9y76whlnksw2m94jsh2n1ygk98izdd";
+      type = "gem";
+    };
+
+    version = "2.5.2";
+  };
+  hirb = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mzch3c2lvmf8gskgzlx6j53d10j42ir6ik2dkrl27sblhy76cji";
+      type = "gem";
+    };
+    version = "0.7.3";
+  };
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qmj7fypgb9vag723w1a49qihxrcf5shzars106ynw2zk352gbv5";
+      type = "gem";
+    };
+    version = "1.8.6";
+  };
+  memoist = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "03d3h6kp16bf0crqg1cxdgp1d2iyzn53d3phbmjh4pjybqls0gcm";
+      type = "gem";
+    };
+    version = "0.14.0";
+  };
+  method_profiler = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1ax04qrrv7fqp5ayxaxhn72660pybdkpkvmgiwbg7bs7x5ijjzd8";
+      type = "gem";
+    };
+    version = "2.0.1";
+  };
+  progressbar = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17haw9c6c9q6imsn83pii32jnihpg76jgd09x7y4hjqq45n3qcdh";
+      type = "gem";
+    };
+    version = "0.21.0";
+  };
+  rake = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rn03rqlf1iv6n87a78hkda2yqparhhaivfjpizblmxvlw2hk5r8";
+      type = "gem";
+    };
+    version = "10.4.2";
+  };
+  rspec = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "12axhz2nj2m0dy350lxym76m36m1hq48hc59mf00z9dajbpnj78s";
+      type = "gem";
+    };
+    version = "3.4.0";
+  };
+  rspec-collection_matchers = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "139qn3mlafwyl8d58hx8q9pafk19hbcgkygxf1a1y1h3714x048b";
+      type = "gem";
+    };
+    version = "1.1.3";
+  };
+  rspec-core = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1z2zmy3xaq00v20ykamqvnynzv2qrrnbixc6dn0jw1c5q9mqq9fp";
+      type = "gem";
+    };
+    version = "3.4.4";
+  };
+  rspec-expectations = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07pz570glwg87zpyagxxal0daa1jrnjkiksnn410s6846884fk8h";
+      type = "gem";
+    };
+    version = "3.4.0";
+  };
+  rspec-mocks = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0sk8ijq5d6bwhvjq94gfm02fssxkm99bgpasqazsmmll5m1cn7vr";
+      type = "gem";
+    };
+    version = "3.4.1";
+  };
+  rspec-support = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0l6zzlf22hn3pcwnxswsjsiwhqjg7a8mhvm680k5vq98307bkikr";
+      type = "gem";
+    };
+    version = "3.4.1";
+  };
+  scrub_rb = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dwg33w83w17aiij9kcbi7irj7lh045nh9prjgkzjya3f1j60d3x";
+      type = "gem";
+    };
+    version = "1.0.1";
+  };
+  simplecov = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1r9fnsnsqj432cmrpafryn8nif3x0qg9mdnvrcf0wr01prkdlnww";
+      type = "gem";
+    };
+    version = "0.14.1";
+  };
+  simplecov-html = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0f3psphismgp6jp1fxxz09zbswh7m2xxxr6gqlzdh7sgv415clvm";
+      type = "gem";
+    };
+    version = "0.10.1";
+  };
+  term-ansicolor = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ydbbyjmk5p7fsi55ffnkq79jnfqx65c3nj8d9rpgl6sw85ahyys";
+      type = "gem";
+    };
+    version = "1.3.2";
+  };
+  thor = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01n5dv9kql60m6a00zc0r66jvaxx98qhdny3klyj0p3w34pad2ns";
+      type = "gem";
+    };
+    version = "0.19.4";
+  };
+  tins = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02qarvy17nbwvslfgqam8y6y7479cwmb1a6di9z18hzka4cf90hz";
+      type = "gem";
+    };
+    version = "1.6.0";
+  };
+  trollop = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0415y63df86sqj43c0l82and65ia5h64if7n0znkbrmi6y0jwhl8";
+      type = "gem";
+    };
+    version = "2.1.2";
+  };
+}


### PR DESCRIPTION
If some ruby boffin could help with this that would be super. At the moment the
git-fame binary doesn't end up in `/bin`. calling
`/nix/store/jxq90d7jlfj1d457lkasmi03g9l0vykh-ruby2.3.3-git_fame-2017-01-14/lib/ruby/gems/2.3.0/bundler/gems/git-fame-rb-64748dfb18b0/bin/git-fame`
works however.