### PR TITLE
go-ethereum: 1.4.7 -> 1.6.6

### DIFF
--- a/pkgs/applications/altcoins/go-ethereum.nix
+++ b/pkgs/applications/altcoins/go-ethereum.nix
@@ -1,30 +1,19 @@
-{ stdenv, lib, go, fetchgit }:
+{ stdenv, lib, clang, buildGoPackage, fetchgit }:
 
-stdenv.mkDerivation rec {
+buildGoPackage rec {
   name = "go-ethereum-${version}";
-  version = "1.4.7";
+  version = "1.6.6";
   rev = "refs/tags/v${version}";
   goPackagePath = "github.com/ethereum/go-ethereum";
 
-  buildInputs = [ go ];
+  buildInputs = [ clang ];
+  preBuild = "export CC=clang";
 
   src = fetchgit {
     inherit rev;
     url = "https://${goPackagePath}";
-    sha256 = "19q518kxkvrr44cvsph4wv3lr6ivqsckz1f22r62932s3sq6gyd8";
+    sha256 = "066s7fp9pbyq670xwnib4p7zaxs941r9kpvj2hm6bkr28yrpvp1a";
   };
-
-  buildPhase = ''
-    export GOROOT=$(mktemp -d --suffix=-goroot)
-    ln -sv ${go}/share/go/* $GOROOT
-    ln -svf ${go}/bin $GOROOT
-    make all
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp -v build/bin/* $out/bin
-  '';
 
   meta = {
     homepage = "https://ethereum.github.io/go-ethereum/";


### PR DESCRIPTION
###### Motivation for this change

Need to use the same C compiler as Go.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

