### PR TITLE
seth: 0.5.1 -> 0.5.6

### DIFF
--- a/pkgs/applications/altcoins/seth.nix
+++ b/pkgs/applications/altcoins/seth.nix
@@ -1,22 +1,22 @@
 { stdenv, makeWrapper, lib, fetchFromGitHub
-, bc, coreutils, curl, ethabi, git, gnused, jshon, solc, which }:
+, bc, coreutils, curl, ethabi, git, gnused, jshon, perl, solc, which }:
 
 stdenv.mkDerivation rec {
   name = "seth-${version}";
-  version = "0.5.1";
+  version = "0.5.6";
 
   src = fetchFromGitHub {
     owner = "dapphub";
     repo = "seth";
     rev = "v${version}";
-    sha256 = "1qph1gldj24r8l6aswb1w133lrm8zsxmmxl4krjik0a73bm4ghdm";
+    sha256 = "1zl70xy7njjwy4k4g84v7lpf9a2nnnbxh4mkpw7jzqfs2mr636z6";
   };
 
   nativeBuildInputs = [makeWrapper];
   buildPhase = "true";
   makeFlags = ["prefix=$(out)"];
   postInstall = let path = lib.makeBinPath [
-    bc coreutils curl ethabi git gnused jshon solc which
+    bc coreutils curl ethabi git gnused jshon perl solc which
   ]; in ''
     wrapProgram "$out/bin/seth" --prefix PATH : "${path}"
   '';


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

