### PR TITLE
PostGIS/GDAL/hdf4: Make unfree szip dependency optional.

### DIFF
--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -2,8 +2,8 @@
 , fetchurl
 , cmake
 , libjpeg
-, szip
 , zlib
+, szip ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  preConfigure = "export SZIP_INSTALL=${szip}";
+  preConfigure = stdenv.lib.optionalString (szip != null) "export SZIP_INSTALL=${szip}";
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
@@ -31,11 +31,12 @@ stdenv.mkDerivation rec {
     "-DHDF4_BUILD_WITH_INSTALL_NAME=OFF"
     "-DHDF4_ENABLE_JPEG_LIB_SUPPORT=ON"
     "-DHDF4_ENABLE_NETCDF=OFF"
-    "-DHDF4_ENABLE_SZIP_ENCODING=ON"
-    "-DHDF4_ENABLE_SZIP_SUPPORT=ON"
     "-DHDF4_ENABLE_Z_LIB_SUPPORT=ON"
     "-DHDF4_BUILD_FORTRAN=OFF"
     "-DJPEG_DIR=${libjpeg}"
+  ] ++ stdenv.lib.optionals (szip != null) [
+    "-DHDF4_ENABLE_SZIP_ENCODING=ON"
+    "-DHDF4_ENABLE_SZIP_SUPPORT=ON"
   ];
 
   doCheck = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2363,7 +2363,9 @@ with pkgs;
 
   hddtemp = callPackage ../tools/misc/hddtemp { };
 
-  hdf4 = callPackage ../tools/misc/hdf4 { };
+  hdf4 = callPackage ../tools/misc/hdf4 {
+    szip = null;
+  };
 
   hdf5 = callPackage ../tools/misc/hdf5 {
     gfortran = null;


### PR DESCRIPTION
###### Motivation for this change

Make unfree dependency of hdf4 optional. Without this change, PostGIS depends on unfree software unconditionally.

https://github.com/NixOS/nixpkgs/issues/27146

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (Postgres service starts fine)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

