### PR TITLE
atop: don't chmod u+s, otherwise Nix build fails

### DIFF
--- a/pkgs/os-specific/linux/atop/default.nix
+++ b/pkgs/os-specific/linux/atop/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     sed -e "/touch.*LOGPATH/s@touch@echo should have created @" -i Makefile
     sed -e 's/chown/true/g' -i Makefile
     sed -e '/chkconfig/d' -i Makefile
+    sed -e 's/chmod 04711/chmod 0711/g' -i Makefile
   '';
 
   preInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Due to a recent Nix change, chmod u+s is not allowed, but the atop build does it during make install, which makes the build fail.

I have tested atop in interactive mode (both as root and as a normal user) and it seems to work fine without the chmod. That said, I haven't tested using atop in non-interactive mode.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

