### PR TITLE
NixOS snapper integration

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -324,6 +324,7 @@
   ./services/misc/ripple-data-api.nix
   ./services/misc/rogue.nix
   ./services/misc/siproxd.nix
+  ./services/misc/snapper.nix
   ./services/misc/sonarr.nix
   ./services/misc/spice-vdagentd.nix
   ./services/misc/ssm-agent.nix

--- a/nixos/modules/services/misc/snapper.nix
+++ b/nixos/modules/services/misc/snapper.nix
@@ -52,6 +52,10 @@ in
         };
       };
 
+      description = ''
+        Subvolume configuration
+      '';
+
       type = types.attrsOf (types.submodule {
         options = {
           subvolume = mkOption {

--- a/nixos/modules/services/misc/snapper.nix
+++ b/nixos/modules/services/misc/snapper.nix
@@ -131,7 +131,7 @@ in
       description = "Timeline of Snapper Snapshots";
       inherit documentation;
       wantedBy = [ "basic.target" ];
-      timerConfig.OnCalender = cfg.snapshotInterval;
+      timerConfig.OnCalendar = cfg.snapshotInterval;
     };
 
     systemd.services.snapper-cleanup = {

--- a/nixos/modules/services/misc/snapper.nix
+++ b/nixos/modules/services/misc/snapper.nix
@@ -62,7 +62,7 @@ in
             type = types.path;
             description = ''
               Path of the subvolume or mount point.
-              This path is a subvolume and has to contain a subvolumed named
+              This path is a subvolume and has to contain a subvolume named
               .snapshots.
               See also man:snapper(8) section PERMISSIONS.
             '';

--- a/nixos/modules/services/misc/snapper.nix
+++ b/nixos/modules/services/misc/snapper.nix
@@ -1,0 +1,132 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.snapper;
+in
+
+{
+  options.services.snapper = {
+
+    snapshotInterval = mkOption {
+      type = types.str;
+      default = "hourly";
+      description = ''
+        Snapshot interval.
+
+        The format is described in
+        <citerefentry><refentrytitle>systemd.time</refentrytitle>
+        <manvolnum>7</manvolnum></citerefentry>.
+      '';
+    };
+
+    cleanupInterval = mkOption {
+      type = types.str;
+      default = "1d";
+      description = ''
+        Cleanup interval.
+
+        The format is described in
+        <citerefentry><refentrytitle>systemd.time</refentrytitle>
+        <manvolnum>7</manvolnum></citerefentry>.
+      '';
+    };
+
+    configs = mkOption {
+      default = { };
+      example = literalExample {
+        "home" = {
+          mountPoint = "/home";
+          extraConfig = ''
+            ALLOW_USERS="alice"
+          '';
+        };
+      };
+
+      type = types.attrsOf (types.submodule {
+        options = {
+          mountPoint = mkOption {
+            type = types.string;
+          };
+
+          extraConfig = mkOption {
+            type = types.lines;
+            default = "";
+            description = ''
+              see man:snapper(8)
+
+              Note: FSTYPE and SUBVOLUME are already set
+            '';
+          };
+        };
+      });
+    };
+  };
+
+  config = mkIf (cfg.configs != {}) (let
+    documentation = [ "man:snapper(8)" "man:snapper-configs(5)" ];
+  in {
+
+    environment = {
+
+      systemPackages = [ pkgs.snapper ];
+
+      # Note: snapper/config-templates/default is not needed
+      etc = {
+
+        "sysconfig/snapper".text = ''
+          SNAPPER_CONFIGS="${lib.concatStringsSep " " (builtins.attrNames cfg.configs)}"
+        '';
+
+      } // mapAttrs' (name: subvolume: nameValuePair "snapper/configs/${name}" (
+      {
+        text = ''
+          ${subvolume.extraConfig}
+
+          # mandatory for rollback!
+          FSTYPE="${(builtins.getAttr subvolume.mountPoint config.fileSystems).fsType}"
+
+          SUBVOLUME="${subvolume.mountPoint}"
+        '';
+      })) cfg.configs;
+
+    };
+
+    # TODO: automatically create subvolume .snapshots for each config
+    #
+    # Only possible if filesystem is mounted
+    #   system.activationScripts is executed during boot before mounting
+    #   systemd.mounts.<mountPoint> could be a way to go
+
+    services.dbus.packages = [ pkgs.snapper ];
+
+    systemd.services.snapper-timeline = {
+      description = "Timeline of Snapper Snapshots";
+      inherit documentation;
+      serviceConfig.ExecStart = "${pkgs.snapper}/lib/snapper/systemd-helper --timeline";
+    };
+
+    systemd.timers.snapper-timeline = {
+      description = "Timeline of Snapper Snapshots";
+      inherit documentation;
+      wantedBy = [ "basic.target" ];
+      timerConfig.OnCalender = cfg.snapshotInterval;
+    };
+
+    systemd.services.snapper-cleanup = {
+      description = "Cleanup of Snapper Snapshots";
+      inherit documentation;
+      serviceConfig.ExecStart = "${pkgs.snapper}/lib/snapper/systemd-helper --cleanup";
+    };
+
+    systemd.timers.snapper-cleanup = {
+      description = "Cleanup of Snapper Snapshots";
+      inherit documentation;
+      wantedBy = [ "basic.target" ];
+      timerConfig.OnBootSec = "10m";
+      timerConfig.OnUnitActiveSec = cfg.cleanupInterval;
+    };
+  });
+}
+

--- a/nixos/modules/services/misc/snapper.nix
+++ b/nixos/modules/services/misc/snapper.nix
@@ -45,7 +45,7 @@ in
       default = { };
       example = literalExample {
         "home" = {
-          snapshot = "/home";
+          subvolume = "/home";
           extraConfig = ''
             ALLOW_USERS="alice"
           '';

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -303,6 +303,7 @@ in rec {
   tests.simple = callTest tests/simple.nix {};
   tests.slim = callTest tests/slim.nix {};
   tests.smokeping = callTest tests/smokeping.nix {};
+  tests.snapper = callTest tests/snapper.nix {};
   tests.taskserver = callTest tests/taskserver.nix {};
   tests.tomcat = callTest tests/tomcat.nix {};
   tests.udisks2 = callTest tests/udisks2.nix {};

--- a/nixos/tests/snapper.nix
+++ b/nixos/tests/snapper.nix
@@ -1,0 +1,42 @@
+import ./make-test.nix ({ ... }:
+{
+  name = "snapper";
+
+  machine = { pkgs, lib, ... }: {
+    boot.initrd.postDeviceCommands = ''
+      ${pkgs.btrfs-progs}/bin/mkfs.btrfs -f -L aux /dev/vdb
+    '';
+
+    virtualisation.emptyDiskImages = [ 4096 ];
+
+    fileSystems = lib.mkVMOverride {
+      "/home" = {
+        device = "/dev/disk/by-label/aux";
+        fsType = "btrfs";
+      };
+    };
+    services.snapper.configs.home.mountPoint = "/home";
+  };
+
+  testScript = ''
+    $machine->succeed("btrfs subvolume create /home/.snapshots");
+
+    $machine->succeed("snapper -c home list");
+
+    $machine->succeed("snapper -c home create --description empty");
+
+    $machine->succeed("echo test > /home/file");
+    $machine->succeed("snapper -c home create --description file");
+
+    $machine->succeed("snapper -c home status 1..2");
+
+    $machine->succeed("snapper -c home undochange 1..2");
+    $machine->fail("ls /home/file");
+
+    $machine->succeed("snapper -c home delete 2");
+
+    $machine->succeed("systemctl --wait start snapper-timeline.service");
+
+    $machine->succeed("systemctl --wait start snapper-cleanup.service");
+  '';
+})

--- a/nixos/tests/snapper.nix
+++ b/nixos/tests/snapper.nix
@@ -15,7 +15,8 @@ import ./make-test.nix ({ ... }:
         fsType = "btrfs";
       };
     };
-    services.snapper.configs.home.mountPoint = "/home";
+    services.snapper.configs.home.subvolume = "/home";
+    services.snapper.filters = "/nix";
   };
 
   testScript = ''


### PR DESCRIPTION
Integrated snapper into NixOS

###### Motivation for this change
Integrate the existing snapper package into NixOS

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

