### PR TITLE
gitlab-runner_1_11: 1.11.4 -> 1.11.5

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitlab-runner/v1.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/v1.nix
@@ -1,16 +1,16 @@
 { lib, buildGoPackage, fetchFromGitLab, fetchurl, go-bindata }:
 
 let
-  version = "1.11.4";
+  version = "1.11.5";
   # Gitlab runner embeds some docker images these are prebuilt for arm and x86_64
   docker_x86_64 = fetchurl {
     url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-x86_64.tar.xz";
-    sha256 = "1ijkzn8jkzx1dzxhkf17987ligyf758xzas6ysix5b781jnkdm8z";
+    sha256 = "0qy3xrq574c1lhkqw1zrkcn32w0ky3f4fppzdjhb5zwqvnaz7kx0";
   };
 
   docker_arm = fetchurl {
     url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-arm.tar.xz";
-    sha256 = "0sq2nndnkzqv2yjljg08xwa3ppddn6vqcivhfh43zwwmansvb9ha";
+    sha256 = "12clc28yc157s2kaa8239p0g086vq062jfjh2m1bxqmaypw9pyla";
   };
 in
 buildGoPackage rec {
@@ -29,7 +29,7 @@ buildGoPackage rec {
     owner = "gitlab-org";
     repo = "gitlab-ci-multi-runner";
     rev = "v${version}";
-    sha256 = "1pm88546cijmrrcvvrajp2g6rsrzxhy83cwwwky8jjkl5w4hhmz4";
+    sha256 = "1xgx8jbgcc3ga7dkjxa2i8nj4afsdavzpfrgpdzma03jkcq1g2sv";
   };
 
   patches = [ ./fix-shell-path.patch ];


### PR DESCRIPTION
###### Motivation for this change

Update to latest patch version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

