### PR TITLE
hsevm: init at 0.3.2

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -39,6 +39,8 @@ rec {
   ethrun = callPackage ./ethrun.nix { };
   seth = callPackage ./seth.nix { };
 
+  hsevm = (pkgs.haskellPackages.callPackage ./hsevm.nix {});
+
   primecoin  = callPackage ./primecoin.nix { withGui = true; };
   primecoind = callPackage ./primecoin.nix { withGui = false; };
 

--- a/pkgs/applications/altcoins/hsevm.nix
+++ b/pkgs/applications/altcoins/hsevm.nix
@@ -1,0 +1,53 @@
+{ aeson, ansi-wl-pprint, base, base16-bytestring
+, base64-bytestring, binary, brick, bytestring, containers
+, cryptonite, data-dword, deepseq, directory, filepath, ghci-pretty
+, here, HUnit, lens, lens-aeson, memory, mtl, optparse-generic
+, process, QuickCheck, quickcheck-text, readline, rosezipper
+, stdenv, tasty, tasty-hunit, tasty-quickcheck, temporary, text
+, text-format, unordered-containers, vector, vty
+, mkDerivation, fetchFromGitHub, lib
+, ncurses, zlib, bzip2, solc
+}:
+
+lib.overrideDerivation (mkDerivation rec {
+  pname = "hsevm";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "dapphub";
+    repo = "hsevm";
+    rev = "v${version}";
+    sha256 = "1c6zpphs03yfvyfbv1cjf04qh5q2miq7rpd7kx2cil77msi8hxw4";
+  };
+
+  isLibrary = false;
+  isExecutable = true;
+  enableSharedExecutables = false;
+
+  postInstall = ''
+    rm -rf $out/{lib,share}
+  '';
+
+  extraLibraries = [
+    aeson ansi-wl-pprint base base16-bytestring base64-bytestring
+    binary brick bytestring containers cryptonite data-dword deepseq
+    directory filepath ghci-pretty lens lens-aeson memory mtl
+    optparse-generic process QuickCheck quickcheck-text readline
+    rosezipper temporary text text-format unordered-containers vector
+    vty
+  ];
+  executableHaskellDepends = [
+    readline zlib bzip2
+  ];
+  testHaskellDepends = [
+    base binary bytestring ghci-pretty here HUnit lens mtl QuickCheck
+    tasty tasty-hunit tasty-quickcheck text vector
+  ];
+
+  homepage = "https://github.com/dapphub/hsevm";
+  description = "Ethereum virtual machine evaluator";
+  license = stdenv.lib.licenses.agpl3;
+  maintainers = [stdenv.lib.maintainers.dbrock];
+}) (attrs: {
+  buildInputs = attrs.buildInputs ++ [solc];
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13272,6 +13272,7 @@ with pkgs;
   ethabi = self.altcoins.ethabi;
   ethrun = self.altcoins.ethrun;
   seth = self.altcoins.seth;
+  hsevm = self.altcoins.hsevm;
 
   stellar-core = self.altcoins.stellar-core;
 


### PR DESCRIPTION
###### Motivation for this change

HSEVM is a debug-oriented implementation of the Ethereum VM (EVM).

https://github.com/dapphub/hsevm

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

