### PR TITLE
Kwallet: Fixes bug that dbus could not find the kwallet service

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kwallet-dbus.patch
+++ b/pkgs/development/libraries/kde-frameworks/kwallet-dbus.patch
@@ -1,0 +1,9 @@
+diff --git a/src/runtime/kwalletd/org.kde.kwalletd5.service.in b/src/runtime/kwalletd/org.kde.kwalletd5.service.in
+index 76eb90e..7a78e83 100644
+--- a/src/runtime/kwalletd/org.kde.kwalletd5.service.in
++++ b/src/runtime/kwalletd/org.kde.kwalletd5.service.in
+@@ -1,3 +1,3 @@
+ [D-BUS Service]
+ Name=org.kde.kwalletd5
+-Exec=@CMAKE_INSTALL_PREFIX@/bin/kwalletd5
++Exec=@CMAKE_INSTALL_BINDIR@/kwalletd5

--- a/pkgs/development/libraries/kde-frameworks/kwallet.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwallet.nix
@@ -15,4 +15,5 @@ mkDerivation {
     knotifications kservice kwidgetsaddons kwindowsystem libgcrypt qgpgme
   ];
   propagatedBuildInputs = [ qtbase ];
+  patches = [ ./kwallet-dbus.patch ];
 }


### PR DESCRIPTION
###### Motivation for this change
By using this patch, dbus is able to find the kwallet5d executable. I also submitted the patch upstream(https://phabricator.kde.org/D6519).

Fixes: #27038

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

