### PR TITLE
make-autostartitem: Use the right path for storing the desktop files

### DIFF
--- a/pkgs/build-support/make-startupitem/default.nix
+++ b/pkgs/build-support/make-startupitem/default.nix
@@ -19,14 +19,14 @@ stdenv.mkDerivation {
   priority = 5;
 
   buildCommand = ''
-    mkdir -p $out/share/autostart
+    mkdir -p $out/etc/xdg/autostart
     target=${name}.desktop
     cp ${package}/share/applications/${srcPrefix}${name}.desktop $target
     chmod +rw $target
     echo "X-KDE-autostart-phase=${phase}" >> $target
     ${lib.optionalString (after != null) ''echo "${after}" >> $target''}
     ${lib.optionalString (condition != null) ''echo "${condition}" >> $target''}
-    cp $target $out/share/autostart
+    cp $target $out/etc/xdg/autostart
   '';
 
   # this will automatically put 'package' in the environment when you


### PR DESCRIPTION
The freedesktop specification says that the autostart folder is located at $XDG_CONFIG_DIRS/autostart.
Nixos defines XDG_CONFIG_DIRS as /etc/xdg. So we need to copy the desktop files into the right folder
with make-startupitem.

###### Motivation for this change

Fixes #26115

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

