### PR TITLE
consul_exporter: init at 0.3.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -224,6 +224,7 @@
   havvy = "Ryan Scheel <ryan.havvy@gmail.com>";
   hbunke = "Hendrik Bunke <bunke.hendrik@gmail.com>";
   hce = "Hans-Christian Esperer <hc@hcesperer.org>";
+  hectorj = "Hector Jusforgues <hector.jusforgues+nixos@gmail.com>";
   heel = "Sergii Paryzhskyi <parizhskiy@gmail.com>";
   henrytill = "Henry Till <henrytill@gmail.com>";
   hinton = "Tom Hinton <t@larkery.com>";

--- a/pkgs/servers/monitoring/prometheus/consul-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/consul-exporter.nix
@@ -3,14 +3,13 @@
 buildGoPackage rec {
   name = "consul_exporter-${version}";
   version = "0.3.0";
-  rev = "v${version}";
 
   goPackagePath = "github.com/prometheus/consul_exporter";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "prometheus";
     repo = "consul_exporter";
+    rev = "v${version}";
     sha256 = "1zffbxyfmqpbdqkx5rb5vjgd9j4p4zcrh6jvn1zhbdzrcs7khnd9";
   };
 

--- a/pkgs/servers/monitoring/prometheus/consul-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/consul-exporter.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "consul_exporter-${version}";
+  version = "0.3.0";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/prometheus/consul_exporter";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "prometheus";
+    repo = "consul_exporter";
+    sha256 = "1zffbxyfmqpbdqkx5rb5vjgd9j4p4zcrh6jvn1zhbdzrcs7khnd9";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Prometheus exporter for Consul metrics";
+    homepage = https://github.com/prometheus/consul_exporter;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hectorj ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11317,6 +11317,7 @@ with pkgs;
   prometheus-bind-exporter = callPackage ../servers/monitoring/prometheus/bind-exporter.nix { };
   prometheus-blackbox-exporter = callPackage ../servers/monitoring/prometheus/blackbox-exporter.nix { };
   prometheus-collectd-exporter = callPackage ../servers/monitoring/prometheus/collectd-exporter.nix { };
+  prometheus-consul-exporter = callPackage ../servers/monitoring/prometheus/consul-exporter.nix { };
   prometheus-fritzbox-exporter = callPackage ../servers/monitoring/prometheus/fritzbox-exporter.nix { };
   prometheus-haproxy-exporter = callPackage ../servers/monitoring/prometheus/haproxy-exporter.nix { };
   prometheus-json-exporter = callPackage ../servers/monitoring/prometheus/json-exporter.nix { };


### PR DESCRIPTION
Nearly fully copy-pasted from https://github.com/NixOS/nixpkgs/blob/05aa2a58db2de248cc2ef516b21fa319ca72613e/pkgs/servers/monitoring/prometheus/node-exporter.nix

It's my first contribution to Nixpkgs.

###### Motivation for this change

`nixpkgs` already contains various Prometheus exporters, but `consul_exporter` was missing

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

