### PR TITLE
lambda-mod-zsh-theme: 2017-05-21 -> 2017-07-05

### DIFF
--- a/pkgs/shells/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/lambda-mod-zsh-theme/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  name = "lambda-mod-zsh-theme-unstable-2017-05-21";
+  name = "lambda-mod-zsh-theme-unstable-2017-07-05";
 
   src = fetchFromGitHub {
     owner = "halfo";
     repo = "lambda-mod-zsh-theme";
-    sha256 = "1410ryc22i20na5ypa1q6f106lkjj8n1qfjmb77q4rspi0ydaiy4";
-    rev = "6fa277361ec2c84e612b5b6d876797ebe72102a5";
+    sha256 = "03kdhifxsnfbly6hqpr1h6kf52kyhdbh82nvwkkyrz1lw2cxl89n";
+    rev = "ba7d5fea16db91fc8de887e69250f4e501b1e36d";
   };
 
   buildPhases = [ "unpackPhase" "installPhase" ];


### PR DESCRIPTION
###### Motivation for this change

`lambda-mod` contains a bugfix to ensure compatibility with all terminal emulators (see https://github.com/halfo/lambda-mod-zsh-theme/pull/18 for further reference)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

