### PR TITLE
ttf_envy_code_r: init at preview7

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -315,6 +315,7 @@
   luispedro = "Luis Pedro Coelho <luis@luispedro.org>";
   lukego = "Luke Gorrie <luke@snabb.co>";
   lw = "Sergey Sofeychuk <lw@fmap.me>";
+  lyt = "Tim Liou <wheatdoge@gmail.com>";
   m3tti = "Mathaeus Sander <mathaeus.peter.sander@gmail.com>";
   ma27 = "Maximilian Bosch <maximilian@mbosch.me>";
   madjar = "Georges Dubus <georges.dubus@compiletoi.net>";

--- a/pkgs/data/fonts/ttf-envy-code-r/default.nix
+++ b/pkgs/data/fonts/ttf-envy-code-r/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "ttf-envy-code-r";
+  version = "PR7";
+
+  src = fetchurl {
+    url = "http://download.damieng.com/fonts/original/EnvyCodeR-${version}.zip";
+    sha256 = "9f7e9703aaf21110b4e1a54d954d57d4092727546348598a5a8e8101e4597aff";
+  };
+
+  buildInputs = [unzip];
+
+  installPhase = ''
+    for f in *.ttf; do
+        install -Dm 644 "$f" "$out/share/fonts/truetype/$f"
+    done
+    install -Dm 644 Read\ Me.txt "$out/share/doc/readme.txt"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://damieng.com/blog/tag/envy-code-r;
+    description = "Free scalable coding font by DamienG";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.lyt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13096,6 +13096,8 @@ with pkgs;
 
   ttf_bitstream_vera = callPackage ../data/fonts/ttf-bitstream-vera { };
 
+  ttf-envy-code-r = callPackage ../data/fonts/ttf-envy-code-r {};
+
   tzdata = callPackage ../data/misc/tzdata { };
 
   ubuntu_font_family = callPackage ../data/fonts/ubuntu-font-family { };


### PR DESCRIPTION
###### Motivation for this change
I want to use Envy Code R.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] This package has no commands but fonts are stored in `share/fonts/truetype`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

