### PR TITLE
bundix: 2.2.0 -> 2.3.1

### DIFF
--- a/pkgs/development/ruby-modules/bundix/default.nix
+++ b/pkgs/development/ruby-modules/bundix/default.nix
@@ -1,35 +1,30 @@
-{ buildRubyGem, fetchFromGitHub, lib, bundler, ruby, nix, nix-prefetch-git }:
+{ buildRubyGem, fetchFromGitHub, makeWrapper, lib, bundler, ruby, nix,
+  nix-prefetch-git }:
 
 buildRubyGem rec {
   inherit ruby;
 
   name = "${gemName}-${version}";
   gemName = "bundix";
-  version = "2.2.1";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "manveru";
     repo = "bundix";
     rev = version;
-    sha256 = "1gh90yxm4k27jdjdl3r31fcg4sk7k54jlbw1zfm1p9q3i7k8x4i7";
+    sha256 = "0ap23abv6chiv7v97ic6b1qf5by6b26as5yrpxg5q7p2giyiv33v";
   };
 
-  buildInputs = [bundler];
+  buildInputs = [ ruby bundler ];
+  nativeBuildInputs = [ makeWrapper ];
 
-  postInstall = ''
-    substituteInPlace $GEM_HOME/gems/${gemName}-${version}/lib/bundix.rb \
-      --replace \
-        "'nix-instantiate'" \
-        "'${nix.out}/bin/nix-instantiate'" \
-      --replace \
-        "'nix-hash'" \
-        "'${nix.out}/bin/nix-hash'" \
-      --replace \
-        "'nix-prefetch-url'" \
-        "'${nix.out}/bin/nix-prefetch-url'" \
-      --replace \
-        "'nix-prefetch-git'" \
-        "'${nix-prefetch-git}/bin/nix-prefetch-git'"
+  preFixup = ''
+    wrapProgram $out/bin/bundix \
+                --prefix PATH : "${nix.out}/bin" \
+                --prefix PATH : "${nix-prefetch-git.out}/bin" \
+                --prefix PATH : "${bundler.out}/bin" \
+                --set GEM_HOME "${bundler}/${bundler.ruby.gemPath}" \
+                --set GEM_PATH "${bundler}/${bundler.ruby.gemPath}"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

This should make bundix work for pretty much all environments again.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

