### PR TITLE
git-ftp: init at 1.4.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -561,6 +561,7 @@
   tv = "Tomislav Viljetić <tv@shackspace.de>";
   tvestelind = "Tomas Vestelind <tomas.vestelind@fripost.org>";
   tvorog = "Marsel Zaripov <marszaripov@gmail.com>";
+  tweber = "Thorsten Weber <tw+nixpkgs@360vier.de>";
   twey = "James ‘Twey’ Kay <twey@twey.co.uk>";
   uralbash = "Svintsov Dmitry <root@uralbash.ru>";
   utdemir = "Utku Demir <me@utdemir.com>";

--- a/pkgs/development/tools/git-ftp/default.nix
+++ b/pkgs/development/tools/git-ftp/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, pandoc, man }:
+stdenv.mkDerivation rec {
+  name = "git-ftp-${version}";
+  version = "1.4.0";
+  src = fetchFromGitHub {
+    owner = "git-ftp";
+    repo = "git-ftp";
+    rev = version;
+    sha256 = "0n8q1azamf10qql8f8c4ppbd3iisy460gwxx09v5d9hji5md27s3";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    make install-all prefix=$out
+  '';
+
+  buildInputs = [pandoc man];
+
+  meta = with stdenv.lib; {
+    description = "Git powered FTP client written as shell script.";
+    homepage = https://git-ftp.github.io/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ tweber ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2066,6 +2066,8 @@ with pkgs;
 
   git-lfs = callPackage ../applications/version-management/git-lfs { };
 
+  git-ftp = callPackage ../development/tools/git-ftp { };
+
   git-series = callPackage ../development/tools/git-series { };
 
   git-up = callPackage ../applications/version-management/git-up { };


### PR DESCRIPTION
###### Motivation for this change

git-ftp is a nice tool when developing for web and hosting is not under your control.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

