### PR TITLE
Define {build,host,target}Platform in stdenv

### DIFF
--- a/doc/cross-compilation.xml
+++ b/doc/cross-compilation.xml
@@ -37,8 +37,9 @@
     </para>
     <para>
       In Nixpkgs, these three platforms are defined as attribute sets under the names <literal>buildPlatform</literal>, <literal>hostPlatform</literal>, and <literal>targetPlatform</literal>.
-      All three are always defined at the top level, so one can get at them just like a dependency in a function that is imported with <literal>callPackage</literal>:
-      <programlisting>{ stdenv, buildPlatform, hostPlatform, fooDep, barDep, .. }: ...</programlisting>
+      All three are always defined as attributes in the standard environment, and at the top level. That means one can get at them just like a dependency in a function that is imported with <literal>callPackage</literal>:
+      <programlisting>{ stdenv, buildPlatform, hostPlatform, fooDep, barDep, .. }: ...buildPlatform...</programlisting>, or just off <varname>stdenv</varname>:
+      <programlisting>{ stdenv, fooDep, barDep, .. }: ...stdenv.buildPlatform...</programlisting>.
     </para>
     <variablelist>
       <varlistentry>

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -10,7 +10,6 @@
 , zlib ? null, extraPackages ? [], extraBuildCommands ? ""
 , dyld ? null # TODO: should this be a setup-hook on dyld?
 , isGNU ? false, isClang ? cc.isClang or false, gnugrep ? null
-, hostPlatform, targetPlatform
 , runCommand ? null
 }:
 
@@ -22,12 +21,14 @@ assert !nativeTools ->
 assert !(nativeLibc && noLibc);
 assert (noLibc || nativeLibc) == (libc == null);
 
-assert targetPlatform != hostPlatform -> runCommand != null;
+assert stdenv.targetPlatform != stdenv.hostPlatform -> runCommand != null;
 
 # For ghdl (the vhdl language provider to gcc) we need zlib in the wrapper.
 assert cc.langVhdl or false -> zlib != null;
 
 let
+  inherit (stdenv) hostPlatform targetPlatform;
+
   # Prefix for binaries. Customarily ends with a dash separator.
   #
   # TODO(@Ericson2314) Make unconditional, or optional but always true by

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -61,11 +61,9 @@ rec {
                     , buildPlatform, hostPlatform, targetPlatform
                     } @ overrideArgs: let
     stdenv = overrideArgs.stdenv.override {
-      # TODO(@Ericson2314): Cannot do this for now because then Nix thinks the
-      # resulting derivation should be built on the host platform.
-      #hostPlatform = buildPlatform;
-      #targetPlatform = hostPlatform;
-      inherit cc;
+      inherit
+        buildPlatform hostPlatform targetPlatform
+        cc;
 
       allowedRequisites = null;
 

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -14,21 +14,18 @@ in bootStages ++ [
 
   # Build Packages
   (vanillaPackages: {
-    buildPlatform = localSystem;
-    hostPlatform = localSystem;
-    targetPlatform = crossSystem;
     inherit config overlays;
     selfBuild = false;
+    stdenv =
+      assert vanillaPackages.hostPlatform == localSystem;
+      assert vanillaPackages.targetPlatform == localSystem;
+      vanillaPackages.stdenv.override { targetPlatform = crossSystem; };
     # It's OK to change the built-time dependencies
     allowCustomOverrides = true;
-    inherit (vanillaPackages) stdenv;
   })
 
   # Run Packages
   (buildPackages: {
-    buildPlatform = localSystem;
-    hostPlatform = crossSystem;
-    targetPlatform = crossSystem;
     inherit config overlays;
     selfBuild = false;
     stdenv = buildPackages.makeStdenvCross {

--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -15,11 +15,11 @@ in bootStages ++ [
 
   # Additional stage, built using custom stdenv
   (vanillaPackages: {
-    buildPlatform = localSystem;
-    hostPlatform = localSystem;
-    targetPlatform = localSystem;
     inherit config overlays;
-    stdenv = config.replaceStdenv { pkgs = vanillaPackages; };
+    stdenv =
+      assert vanillaPackages.hostPlatform == localSystem;
+      assert vanillaPackages.targetPlatform == localSystem;
+      config.replaceStdenv { pkgs = vanillaPackages; };
   })
 
 ]

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -65,6 +65,10 @@ in rec {
 
         name = "stdenv-darwin-boot-${toString step}";
 
+        buildPlatform = localSystem;
+        hostPlatform = localSystem;
+        targetPlatform = localSystem;
+
         cc = if isNull last then "/dev/null" else import ../../build-support/cc-wrapper {
           inherit shell;
           inherit (last) stdenv;
@@ -73,8 +77,6 @@ in rec {
           nativeTools  = true;
           nativePrefix = bootstrapTools;
           nativeLibc   = false;
-          hostPlatform = localSystem;
-          targetPlatform = localSystem;
           libc         = last.pkgs.darwin.Libsystem;
           isClang      = true;
           cc           = { name = "clang-9.9.9"; outPath = bootstrapTools; };
@@ -90,9 +92,6 @@ in rec {
         '';
         initialPath  = [ bootstrapTools ];
 
-        hostPlatform = localSystem;
-        targetPlatform = localSystem;
-
         fetchurlBoot = import ../../build-support/fetchurl {
           stdenv = stage0.stdenv;
           curl   = bootstrapTools;
@@ -107,9 +106,6 @@ in rec {
       };
 
     in {
-      buildPlatform = localSystem;
-      hostPlatform = localSystem;
-      targetPlatform = localSystem;
       inherit config overlays;
       stdenv = thisStdenv;
     };
@@ -279,15 +275,16 @@ in rec {
 
     name = "stdenv-darwin";
 
+    buildPlatform = localSystem;
+    hostPlatform = localSystem;
+    targetPlatform = localSystem;
+
     preHook = commonPreHook + ''
       export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
     '';
 
     stdenvSandboxProfile = binShClosure + libSystemProfile;
     extraSandboxProfile  = binShClosure + libSystemProfile;
-
-    hostPlatform = localSystem;
-    targetPlatform = localSystem;
 
     initialPath = import ../common-path.nix { inherit pkgs; };
     shell       = "${pkgs.bash}/bin/bash";
@@ -297,8 +294,6 @@ in rec {
       inherit shell;
       nativeTools = false;
       nativeLibc  = false;
-      hostPlatform = localSystem;
-      targetPlatform = localSystem;
       inherit (pkgs) coreutils binutils gnugrep;
       inherit (pkgs.darwin) dyld;
       cc   = pkgs.llvmPackages.clang-unwrapped;
@@ -338,9 +333,6 @@ in rec {
     stage3
     stage4
     (prevStage: {
-      buildPlatform = localSystem;
-      hostPlatform = localSystem;
-      targetPlatform = localSystem;
       inherit config overlays;
       stdenv = stdenvDarwin prevStage;
     })

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -35,6 +35,9 @@ let inherit (localSystem) system; in
 
     stdenv = import ../generic {
       name = "stdenv-freebsd-boot-1";
+      buildPlatform = localSystem;
+      hostPlatform = localSystem;
+      targetPlatform = localSystem;
       inherit config;
       initialPath = [ "/" "/usr" ];
       hostPlatform = localSystem;
@@ -52,6 +55,9 @@ let inherit (localSystem) system; in
 
     stdenv = import ../generic {
       name = "stdenv-freebsd-boot-0";
+      buildPlatform = localSystem;
+      hostPlatform = localSystem;
+      targetPlatform = localSystem;
       inherit config;
       initialPath = [ prevStage.bootstrapTools ];
       inherit (prevStage.stdenv)
@@ -62,12 +68,12 @@ let inherit (localSystem) system; in
   })
 
   (prevStage: {
-    buildPlatform = localSystem;
-    hostPlatform = localSystem;
-    targetPlatform = localSystem;
     inherit config overlays;
     stdenv = import ../generic {
       name = "stdenv-freebsd-boot-3";
+      buildPlatform = localSystem;
+      hostPlatform = localSystem;
+      targetPlatform = localSystem;
       inherit config;
 
       inherit (prevStage.stdenv)
@@ -77,8 +83,6 @@ let inherit (localSystem) system; in
         nativeTools  = true;
         nativePrefix = "/usr";
         nativeLibc   = true;
-        hostPlatform = localSystem;
-        targetPlatform = localSystem;
         inherit (prevStage) stdenv;
         cc           = {
           name    = "clang-9.9.9";

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -27,8 +27,6 @@ let lib = import ../../../lib; in lib.makeOverridable (
 let
   inherit (targetPlatform) system;
 
-  ifDarwin = attrs: if system == "x86_64-darwin" then attrs else {};
-
   defaultNativeBuildInputs = extraBuildInputs ++
     [ ../../build-support/setup-hooks/move-docs.sh
       ../../build-support/setup-hooks/compress-man-pages.sh
@@ -37,7 +35,7 @@ let
     ]
       # FIXME this on Darwin; see
       # https://github.com/NixOS/nixpkgs/commit/94d164dd7#commitcomment-22030369
-    ++ lib.optional result.isLinux ../../build-support/setup-hooks/audit-tmpdir.sh
+    ++ lib.optional hostPlatform.isLinux ../../build-support/setup-hooks/audit-tmpdir.sh
     ++ [
       ../../build-support/setup-hooks/multiple-outputs.sh
       ../../build-support/setup-hooks/move-sbin.sh
@@ -46,153 +44,8 @@ let
       cc
     ];
 
-  # `mkDerivation` wraps the builtin `derivation` function to
-  # produce derivations that use this stdenv and its shell.
-  #
-  # See also:
-  #
-  # * https://nixos.org/nixpkgs/manual/#sec-using-stdenv
-  #   Details on how to use this mkDerivation function
-  #
-  # * https://nixos.org/nix/manual/#ssec-derivation
-  #   Explanation about derivations in general
-  mkDerivation =
-    { nativeBuildInputs ? []
-    , buildInputs ? []
-
-    , propagatedNativeBuildInputs ? []
-    , propagatedBuildInputs ? []
-
-    , crossConfig ? null
-    , meta ? {}
-    , passthru ? {}
-    , pos ? # position used in error messages and for meta.position
-        (if attrs.meta.description or null != null
-          then builtins.unsafeGetAttrPos "description" attrs.meta
-          else builtins.unsafeGetAttrPos "name" attrs)
-    , separateDebugInfo ? false
-    , outputs ? [ "out" ]
-    , __impureHostDeps ? []
-    , __propagatedImpureHostDeps ? []
-    , sandboxProfile ? ""
-    , propagatedSandboxProfile ? ""
-    , ... } @ attrs:
-    let
-      dependencies = [
-        (map (drv: drv.nativeDrv or drv) nativeBuildInputs)
-        (map (drv: drv.crossDrv or drv) buildInputs)
-      ];
-      propagatedDependencies = [
-        (map (drv: drv.nativeDrv or drv) propagatedNativeBuildInputs)
-        (map (drv: drv.crossDrv or drv) propagatedBuildInputs)
-      ];
-    in let
-
-      outputs' =
-        outputs ++
-        (if separateDebugInfo then assert targetPlatform.isLinux; [ "debug" ] else []);
-
-      dependencies' = let
-          justMap = map lib.chooseDevOutputs dependencies;
-          nativeBuildInputs = lib.elemAt justMap 0
-            ++ lib.optional targetPlatform.isWindows ../../build-support/setup-hooks/win-dll-link.sh;
-          buildInputs = lib.elemAt justMap 1
-               # TODO(@Ericson2314): Should instead also be appended to `nativeBuildInputs`.
-            ++ lib.optional separateDebugInfo ../../build-support/setup-hooks/separate-debug-info.sh;
-        in [ nativeBuildInputs buildInputs ];
-
-      propagatedDependencies' = map lib.chooseDevOutputs propagatedDependencies;
-
-      derivationArg =
-        (removeAttrs attrs
-          ["meta" "passthru" "crossAttrs" "pos"
-           "__impureHostDeps" "__propagatedImpureHostDeps"
-           "sandboxProfile" "propagatedSandboxProfile"])
-        // (let
-          # TODO(@Ericson2314): Reversing of dep lists is just temporary to avoid Darwin mass rebuild.
-          computedSandboxProfile =
-            lib.concatMap (input: input.__propagatedSandboxProfile or []) (extraBuildInputs ++ lib.concatLists (lib.reverseList dependencies'));
-          computedPropagatedSandboxProfile =
-            lib.concatMap (input: input.__propagatedSandboxProfile or []) (lib.concatLists (lib.reverseList propagatedDependencies'));
-          computedImpureHostDeps =
-            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (extraBuildInputs ++ lib.concatLists (lib.reverseList dependencies')));
-          computedPropagatedImpureHostDeps =
-            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (lib.concatLists (lib.reverseList propagatedDependencies')));
-        in
-        {
-          builder = attrs.realBuilder or shell;
-          args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
-          stdenv = result;
-          system = result.system;
-          userHook = config.stdenv.userHook or null;
-          __ignoreNulls = true;
-
-          nativeBuildInputs = lib.elemAt dependencies' 0;
-          buildInputs = lib.elemAt dependencies' 1;
-
-          propagatedNativeBuildInputs = lib.elemAt propagatedDependencies' 0;
-          propagatedBuildInputs = lib.elemAt propagatedDependencies' 1;
-        } // ifDarwin {
-          # TODO: remove lib.unique once nix has a list canonicalization primitive
-          __sandboxProfile =
-          let profiles = [ extraSandboxProfile ] ++ computedSandboxProfile ++ computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile sandboxProfile ];
-              final = lib.concatStringsSep "\n" (lib.filter (x: x != "") (lib.unique profiles));
-          in final;
-          __propagatedSandboxProfile = lib.unique (computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile ]);
-          __impureHostDeps = computedImpureHostDeps ++ computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps ++ __impureHostDeps ++ __extraImpureHostDeps ++ [
-            "/dev/zero"
-            "/dev/random"
-            "/dev/urandom"
-            "/bin/sh"
-          ];
-          __propagatedImpureHostDeps = computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps;
-        } // (if outputs' != [ "out" ] then {
-          outputs = outputs';
-        } else { }));
-
-      # The meta attribute is passed in the resulting attribute set,
-      # but it's not part of the actual derivation, i.e., it's not
-      # passed to the builder and is not a dependency.  But since we
-      # include it in the result, it *is* available to nix-env for queries.
-      meta = { }
-          # If the packager hasn't specified `outputsToInstall`, choose a default,
-          # which is the name of `p.bin or p.out or p`;
-          # if he has specified it, it will be overridden below in `// meta`.
-          #   Note: This default probably shouldn't be globally configurable.
-          #   Services and users should specify outputs explicitly,
-          #   unless they are comfortable with this default.
-        // { outputsToInstall =
-          let
-            outs = outputs'; # the value passed to derivation primitive
-            hasOutput = out: builtins.elem out outs;
-          in [( lib.findFirst hasOutput null (["bin" "out"] ++ outs) )];
-        }
-        // attrs.meta or {}
-          # Fill `meta.position` to identify the source location of the package.
-        // lib.optionalAttrs (pos != null)
-          { position = pos.file + ":" + toString pos.line; }
-        ;
-
-    in
-
-      lib.addPassthru
-        (derivation (import ./check-meta.nix
-          {
-            inherit lib config meta derivationArg;
-            mkDerivationArg = attrs;
-            inherit system; # TODO: cross-compilation?
-          }))
-        ( {
-            overrideAttrs = f: mkDerivation (attrs // (f attrs));
-            inherit meta passthru;
-          } //
-          # Pass through extra attributes that are not inputs, but
-          # should be made available to Nix expressions using the
-          # derivation (e.g., in assertions).
-          passthru);
-
   # The stdenv that we are producing.
-  result =
+  stdenv =
     derivation (
     (if isNull allowedRequisites then {} else { allowedRequisites = allowedRequisites ++ defaultNativeBuildInputs; }) //
     {
@@ -206,7 +59,7 @@ let
 
       inherit preHook initialPath shell defaultNativeBuildInputs;
     }
-    // ifDarwin {
+    // lib.optionalAttrs hostPlatform.isDarwin {
       __sandboxProfile = stdenvSandboxProfile;
       __impureHostDeps = __stdenvImpureHostDeps;
     })
@@ -228,7 +81,15 @@ let
       # Whether we should run paxctl to pax-mark binaries.
       needsPax = isLinux;
 
-      inherit mkDerivation;
+      inherit (import ./make-derivation.nix {
+        inherit lib config stdenv;
+        # TODO(@Ericson2314): Remove
+        inherit
+          extraBuildInputs
+          __extraImpureHostDeps
+          extraSandboxProfile
+          hostPlatform targetPlatform;
+      }) mkDerivation;
 
       # For convenience, bring in the library functions in lib/ so
       # packages don't have to do that themselves.
@@ -247,4 +108,4 @@ let
     # like curl = if stdenv ? curl then stdenv.curl else ...).
     // extraAttrs;
 
-in result)
+in stdenv)

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -71,6 +71,8 @@ let
         platforms = lib.platforms.all;
       };
 
+      inherit extraBuildInputs __extraImpureHostDeps extraSandboxProfile;
+
       # Utility flags to test the type of platform.
       inherit (hostPlatform)
         isDarwin isLinux isSunOS isHurd isCygwin isFreeBSD isOpenBSD
@@ -85,9 +87,6 @@ let
         inherit lib config stdenv;
         # TODO(@Ericson2314): Remove
         inherit
-          extraBuildInputs
-          __extraImpureHostDeps
-          extraSandboxProfile
           hostPlatform targetPlatform;
       }) mkDerivation;
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -1,9 +1,6 @@
 { lib, config, stdenv
 
 # TODO(@Ericson2314): get off stdenv
-, extraBuildInputs
-, __extraImpureHostDeps
-, extraSandboxProfile
 , hostPlatform, targetPlatform
 }:
 
@@ -73,11 +70,11 @@ rec {
         // (let
           # TODO(@Ericson2314): Reversing of dep lists is just temporary to avoid Darwin mass rebuild.
           computedSandboxProfile =
-            lib.concatMap (input: input.__propagatedSandboxProfile or []) (extraBuildInputs ++ lib.concatLists (lib.reverseList dependencies'));
+            lib.concatMap (input: input.__propagatedSandboxProfile or []) (stdenv.extraBuildInputs ++ lib.concatLists (lib.reverseList dependencies'));
           computedPropagatedSandboxProfile =
             lib.concatMap (input: input.__propagatedSandboxProfile or []) (lib.concatLists (lib.reverseList propagatedDependencies'));
           computedImpureHostDeps =
-            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (extraBuildInputs ++ lib.concatLists (lib.reverseList dependencies')));
+            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (stdenv.extraBuildInputs ++ lib.concatLists (lib.reverseList dependencies')));
           computedPropagatedImpureHostDeps =
             lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (lib.concatLists (lib.reverseList propagatedDependencies')));
         in
@@ -97,11 +94,11 @@ rec {
         } // lib.optionalAttrs (hostPlatform.isDarwin) {
           # TODO: remove lib.unique once nix has a list canonicalization primitive
           __sandboxProfile =
-          let profiles = [ extraSandboxProfile ] ++ computedSandboxProfile ++ computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile sandboxProfile ];
+          let profiles = [ stdenv.extraSandboxProfile ] ++ computedSandboxProfile ++ computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile sandboxProfile ];
               final = lib.concatStringsSep "\n" (lib.filter (x: x != "") (lib.unique profiles));
           in final;
           __propagatedSandboxProfile = lib.unique (computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile ]);
-          __impureHostDeps = computedImpureHostDeps ++ computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps ++ __impureHostDeps ++ __extraImpureHostDeps ++ [
+          __impureHostDeps = computedImpureHostDeps ++ computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps ++ __impureHostDeps ++ stdenv.__extraImpureHostDeps ++ [
             "/dev/zero"
             "/dev/random"
             "/dev/urandom"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -1,0 +1,155 @@
+{ lib, config, stdenv
+
+# TODO(@Ericson2314): get off stdenv
+, extraBuildInputs
+, __extraImpureHostDeps
+, extraSandboxProfile
+, hostPlatform, targetPlatform
+}:
+
+rec {
+  # `mkDerivation` wraps the builtin `derivation` function to
+  # produce derivations that use this stdenv and its shell.
+  #
+  # See also:
+  #
+  # * https://nixos.org/nixpkgs/manual/#sec-using-stdenv
+  #   Details on how to use this mkDerivation function
+  #
+  # * https://nixos.org/nix/manual/#ssec-derivation
+  #   Explanation about derivations in general
+  mkDerivation =
+    { nativeBuildInputs ? []
+    , buildInputs ? []
+
+    , propagatedNativeBuildInputs ? []
+    , propagatedBuildInputs ? []
+
+    , crossConfig ? null
+    , meta ? {}
+    , passthru ? {}
+    , pos ? # position used in error messages and for meta.position
+        (if attrs.meta.description or null != null
+          then builtins.unsafeGetAttrPos "description" attrs.meta
+          else builtins.unsafeGetAttrPos "name" attrs)
+    , separateDebugInfo ? false
+    , outputs ? [ "out" ]
+    , __impureHostDeps ? []
+    , __propagatedImpureHostDeps ? []
+    , sandboxProfile ? ""
+    , propagatedSandboxProfile ? ""
+    , ... } @ attrs:
+    let
+      dependencies = [
+        (map (drv: drv.nativeDrv or drv) nativeBuildInputs)
+        (map (drv: drv.crossDrv or drv) buildInputs)
+      ];
+      propagatedDependencies = [
+        (map (drv: drv.nativeDrv or drv) propagatedNativeBuildInputs)
+        (map (drv: drv.crossDrv or drv) propagatedBuildInputs)
+      ];
+    in let
+
+      outputs' =
+        outputs ++
+        (if separateDebugInfo then assert targetPlatform.isLinux; [ "debug" ] else []);
+
+      dependencies' = let
+          justMap = map lib.chooseDevOutputs dependencies;
+          nativeBuildInputs = lib.elemAt justMap 0
+            ++ lib.optional targetPlatform.isWindows ../../build-support/setup-hooks/win-dll-link.sh;
+          buildInputs = lib.elemAt justMap 1
+               # TODO(@Ericson2314): Should instead also be appended to `nativeBuildInputs`.
+            ++ lib.optional separateDebugInfo ../../build-support/setup-hooks/separate-debug-info.sh;
+        in [ nativeBuildInputs buildInputs ];
+
+      propagatedDependencies' = map lib.chooseDevOutputs propagatedDependencies;
+
+      derivationArg =
+        (removeAttrs attrs
+          ["meta" "passthru" "crossAttrs" "pos"
+           "__impureHostDeps" "__propagatedImpureHostDeps"
+           "sandboxProfile" "propagatedSandboxProfile"])
+        // (let
+          # TODO(@Ericson2314): Reversing of dep lists is just temporary to avoid Darwin mass rebuild.
+          computedSandboxProfile =
+            lib.concatMap (input: input.__propagatedSandboxProfile or []) (extraBuildInputs ++ lib.concatLists (lib.reverseList dependencies'));
+          computedPropagatedSandboxProfile =
+            lib.concatMap (input: input.__propagatedSandboxProfile or []) (lib.concatLists (lib.reverseList propagatedDependencies'));
+          computedImpureHostDeps =
+            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (extraBuildInputs ++ lib.concatLists (lib.reverseList dependencies')));
+          computedPropagatedImpureHostDeps =
+            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (lib.concatLists (lib.reverseList propagatedDependencies')));
+        in
+        {
+          builder = attrs.realBuilder or stdenv.shell;
+          args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
+          inherit stdenv;
+          system = stdenv.system; # TODO(@Ericson2314): be correct about cross compilation
+          userHook = config.stdenv.userHook or null;
+          __ignoreNulls = true;
+
+          nativeBuildInputs = lib.elemAt dependencies' 0;
+          buildInputs = lib.elemAt dependencies' 1;
+
+          propagatedNativeBuildInputs = lib.elemAt propagatedDependencies' 0;
+          propagatedBuildInputs = lib.elemAt propagatedDependencies' 1;
+        } // lib.optionalAttrs (hostPlatform.isDarwin) {
+          # TODO: remove lib.unique once nix has a list canonicalization primitive
+          __sandboxProfile =
+          let profiles = [ extraSandboxProfile ] ++ computedSandboxProfile ++ computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile sandboxProfile ];
+              final = lib.concatStringsSep "\n" (lib.filter (x: x != "") (lib.unique profiles));
+          in final;
+          __propagatedSandboxProfile = lib.unique (computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile ]);
+          __impureHostDeps = computedImpureHostDeps ++ computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps ++ __impureHostDeps ++ __extraImpureHostDeps ++ [
+            "/dev/zero"
+            "/dev/random"
+            "/dev/urandom"
+            "/bin/sh"
+          ];
+          __propagatedImpureHostDeps = computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps;
+        } // (if outputs' != [ "out" ] then {
+          outputs = outputs';
+        } else { }));
+
+      # The meta attribute is passed in the resulting attribute set,
+      # but it's not part of the actual derivation, i.e., it's not
+      # passed to the builder and is not a dependency.  But since we
+      # include it in the result, it *is* available to nix-env for queries.
+      meta = { }
+          # If the packager hasn't specified `outputsToInstall`, choose a default,
+          # which is the name of `p.bin or p.out or p`;
+          # if he has specified it, it will be overridden below in `// meta`.
+          #   Note: This default probably shouldn't be globally configurable.
+          #   Services and users should specify outputs explicitly,
+          #   unless they are comfortable with this default.
+        // { outputsToInstall =
+          let
+            outs = outputs'; # the value passed to derivation primitive
+            hasOutput = out: builtins.elem out outs;
+          in [( lib.findFirst hasOutput null (["bin" "out"] ++ outs) )];
+        }
+        // attrs.meta or {}
+          # Fill `meta.position` to identify the source location of the package.
+        // lib.optionalAttrs (pos != null)
+          { position = pos.file + ":" + toString pos.line; }
+        ;
+
+    in
+
+      lib.addPassthru
+        (derivation (import ./check-meta.nix
+          {
+            inherit lib config meta derivationArg;
+            mkDerivationArg = attrs;
+            inherit (stdenv) system; # TODO: cross-compilation?
+          }))
+        ( {
+            overrideAttrs = f: mkDerivation (attrs // (f attrs));
+            inherit meta passthru;
+          } //
+          # Pass through extra attributes that are not inputs, but
+          # should be made available to Nix expressions using the
+          # derivation (e.g., in assertions).
+          passthru);
+}

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -52,8 +52,11 @@ let
     let
 
       thisStdenv = import ../generic {
-        inherit config extraBuildInputs;
         name = "stdenv-linux-boot";
+        buildPlatform = localSystem;
+        hostPlatform = localSystem;
+        targetPlatform = localSystem;
+        inherit config extraBuildInputs;
         preHook =
           ''
             # Don't patch #!/interpreter because it leads to retained
@@ -64,9 +67,6 @@ let
         shell = "${bootstrapTools}/bin/bash";
         initialPath = [bootstrapTools];
 
-        hostPlatform = localSystem;
-        targetPlatform = localSystem;
-
         fetchurlBoot = import ../../build-support/fetchurl/boot.nix {
           inherit system;
         };
@@ -76,8 +76,6 @@ let
              else lib.makeOverridable (import ../../build-support/cc-wrapper) {
           nativeTools = false;
           nativeLibc = false;
-          hostPlatform = localSystem;
-          targetPlatform = localSystem;
           cc = prevStage.gcc-unwrapped;
           isGNU = true;
           libc = prevStage.glibc;
@@ -99,9 +97,6 @@ let
       };
 
     in {
-      buildPlatform = localSystem;
-      hostPlatform = localSystem;
-      targetPlatform = localSystem;
       inherit config overlays;
       stdenv = thisStdenv;
     };
@@ -241,8 +236,6 @@ in
         nativeTools = false;
         nativeLibc = false;
         isGNU = true;
-        hostPlatform = localSystem;
-        targetPlatform = localSystem;
         cc = prevStage.gcc-unwrapped;
         libc = self.glibc;
         inherit (self) stdenv binutils coreutils gnugrep;
@@ -263,11 +256,11 @@ in
   # dependency (`nix-store -qR') on bootstrapTools or the first
   # binutils built.
   (prevStage: {
-    buildPlatform = localSystem;
-    hostPlatform = localSystem;
-    targetPlatform = localSystem;
     inherit config overlays;
     stdenv = import ../generic rec {
+      buildPlatform = localSystem;
+      hostPlatform = localSystem;
+      targetPlatform = localSystem;
       inherit config;
 
       preHook = ''
@@ -279,9 +272,6 @@ in
 
       initialPath =
         ((import ../common-path.nix) {pkgs = prevStage;});
-
-      hostPlatform = localSystem;
-      targetPlatform = localSystem;
 
       extraBuildInputs = [ prevStage.patchelf prevStage.paxctl ] ++
         # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -81,6 +81,7 @@ let
     { cc, fetchurl, extraPath ? [], overrides ? (self: super: { }) }:
 
     import ../generic {
+      buildPlatform = localSystem;
       hostPlatform = localSystem;
       targetPlatform = localSystem;
 
@@ -125,8 +126,6 @@ in
         "i686-solaris" = "/usr/gnu";
         "x86_64-solaris" = "/opt/local/gcc47";
       }.${system} or "/usr";
-      hostPlatform = localSystem;
-      targetPlatform = localSystem;
       inherit stdenv;
     };
 
@@ -140,9 +139,6 @@ in
 
   # First build a stdenv based only on tools outside the store.
   (prevStage: {
-    buildPlatform = localSystem;
-    hostPlatform = localSystem;
-    targetPlatform = localSystem;
     inherit config overlays;
     stdenv = makeStdenv {
       inherit (prevStage) cc fetchurl;
@@ -152,9 +148,6 @@ in
   # Using that, build a stdenv that adds the ‘xz’ command (which most systems
   # don't have, so we mustn't rely on the native environment providing it).
   (prevStage: {
-    buildPlatform = localSystem;
-    hostPlatform = localSystem;
-    targetPlatform = localSystem;
     inherit config overlays;
     stdenv = makeStdenv {
       inherit (prevStage.stdenv) cc fetchurl;

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -10,10 +10,13 @@ bootStages ++ [
   (prevStage: let
     inherit (prevStage) stdenv;
   in {
-    inherit (prevStage) buildPlatform hostPlatform targetPlatform;
     inherit config overlays;
 
     stdenv = import ../generic rec {
+      buildPlatform = localSystem;
+      hostPlatform = localSystem;
+      targetPlatform = localSystem;
+
       inherit config;
 
       preHook = ''
@@ -30,8 +33,6 @@ bootStages ++ [
         nativeTools = false;
         nativePrefix = stdenv.lib.optionalString hostPlatform.isSunOS "/usr";
         nativeLibc = true;
-        hostPlatform = localSystem;
-        targetPlatform = localSystem;
         inherit stdenv;
         inherit (prevStage) binutils coreutils gnugrep;
         cc = prevStage.gcc.cc;

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -18,30 +18,6 @@
 , # Use to reevaluate Nixpkgs; a dirty hack that should be removed
   nixpkgsFun
 
-  ## Platform parameters
-  ##
-  ## The "build" "host" "target" terminology below comes from GNU Autotools. See
-  ## its documentation for more information on what those words mean. Note that
-  ## each should always be defined, even when not cross compiling.
-  ##
-  ## For purposes of bootstrapping, think of each stage as a "sliding window"
-  ## over a list of platforms. Specifically, the host platform of the previous
-  ## stage becomes the build platform of the current one, and likewise the
-  ## target platform of the previous stage becomes the host platform of the
-  ## current one.
-  ##
-
-, # The platform on which packages are built. Consists of `system`, a
-  # string (e.g.,`i686-linux') identifying the most import attributes of the
-  # build platform, and `platform` a set of other details.
-  buildPlatform
-
-, # The platform on which packages run.
-  hostPlatform
-
-, # The platform which build tools (especially compilers) build for in this stage,
-  targetPlatform
-
   ## Other parameters
   ##
 
@@ -69,10 +45,10 @@
 , # Non-GNU/Linux OSes are currently "impure" platforms, with their libc
   # outside of the store.  Thus, GCC, GFortran, & co. must always look for files
   # in standard system directories (/usr/include, etc.)
-  noSysDirs ? buildPlatform.system != "x86_64-freebsd"
-           && buildPlatform.system != "i686-freebsd"
-           && buildPlatform.system != "x86_64-solaris"
-           && buildPlatform.system != "x86_64-kfreebsd-gnu"
+  noSysDirs ? stdenv.buildPlatform.system != "x86_64-freebsd"
+           && stdenv.buildPlatform.system != "i686-freebsd"
+           && stdenv.buildPlatform.system != "x86_64-solaris"
+           && stdenv.buildPlatform.system != "x86_64-kfreebsd-gnu"
 
 , # The configuration attribute set
   config
@@ -98,19 +74,18 @@ let
       // { recurseForDerivations = false; };
     __targetPackages = (if __targetPackages == null then self else __targetPackages)
       // { recurseForDerivations = false; };
-    inherit stdenv
-      buildPlatform hostPlatform targetPlatform;
+    inherit stdenv;
   };
 
   # The old identifiers for cross-compiling. These should eventually be removed,
   # and the packages that rely on them refactored accordingly.
   platformCompat = self: super: let
-    # TODO(@Ericson2314) this causes infinite recursion
-    #inherit (self) buildPlatform hostPlatform targetPlatform;
+    inherit (super.stdenv) buildPlatform hostPlatform targetPlatform;
   in {
     stdenv = super.stdenv // {
-      inherit (buildPlatform) platform;
+      inherit (super.stdenv.buildPlatform) platform;
     };
+    inherit buildPlatform hostPlatform targetPlatform;
     inherit (buildPlatform) system platform;
   };
 


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nixpkgs/issues/27069 In particular, make derivation needs to be aware of the target platforms sometimes, and right now it can't be. An alternative would be to make stdenv unaware, but tack on `mkDerivation` separately so it alone is aware.

This depends on https://github.com/NixOS/nixpkgs/pull/27045 to be merged first.

###### Things done

No native hashes are changed. Some cross hashes are changed, but only changed because `stdenv.is*` properly evaluates to the host platform when cross compiling too.

[I had PR that was supposed to fix that `stdenv.is*` behavior before, but it only did so natively when `hostPlatform == buildPlatform`. This partial fix was necessary because `meta.platform` and it were coupled, and `meta.platform` still needs to be checked against the build platform until I can audit the packages we cross compile today. Down the road I'll fix those packages, but also teach meta checking that there's 3 platforms, not 1.]

Built the manual locally (along with the other Travis-built derivations for Linux).

---

CC @vcunat 
