### PR TITLE
hotspot: init at 1.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -385,6 +385,7 @@
   neeasade = "Nathan Isom <nathanisom27@gmail.com>";
   nequissimus = "Tim Steinbach <tim@nequissimus.com>";
   nfjinjing = "Jinjing Wang <nfjinjing@gmail.com>";
+  nh2 = "Niklas Hambüchen <mail@nh2.me>";
   nhooyr = "Anmol Sethi <anmol@aubble.com>";
   nickhu = "Nick Hu <me@nickhu.co.uk>";
   nicknovitski = "Nick Novitski <nixpkgs@nicknovitski.com>";

--- a/pkgs/development/tools/analysis/hotspot/default.nix
+++ b/pkgs/development/tools/analysis/hotspot/default.nix
@@ -1,0 +1,64 @@
+{ stdenv,
+  cmake,
+  elfutils,
+  extra-cmake-modules,
+  fetchFromGitHub,
+  kconfigwidgets,
+  ki18n,
+  kitemmodels,
+  kitemviews,
+  libelf,
+  qtbase,
+  threadweaver,
+}:
+
+stdenv.mkDerivation rec {
+  name = "hotspot-${version}";
+  version = "1.0.0"; # don't forget to bump `rev` below when you change this
+
+  src = fetchFromGitHub {
+    owner = "KDAB";
+    repo = "hotspot";
+    # TODO: For some reason, `fetchSubmodules` doesn't work when using `rev = "v${version}";`,
+    #       so using an explicit commit instead. See #15559
+    rev = "352687bf620529e9887616651f123f922cb421a4";
+    sha256 = "09ly15yafpk31p3w7h2xixf1xdmx803w9fyb2aq7mhmc7pcxqjsx";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    cmake
+    elfutils
+    extra-cmake-modules
+    kconfigwidgets
+    ki18n
+    kitemmodels
+    kitemviews
+    libelf
+    qtbase
+    threadweaver
+  ];
+
+  # hotspot checks for the presence of third party libraries'
+  # git directory to give a nice warning when you forgot to clone
+  # submodules; but Nix clones them and removes .git (for reproducibility).
+  # So we need to fake their existence here.
+  postPatch = ''
+    mkdir -p 3rdparty/perfparser/.git
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A GUI for Linux perf";
+    longDescription = ''
+      hotspot is a GUI replacement for `perf report`.
+      It takes a perf.data file, parses and evaluates its contents and
+      then displays the result in a graphical way.
+    '';
+    homepage = "https://github.com/KDAB/hotspot";
+    license = with stdenv.lib.licenses; [ gpl2 gpl3 ];
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ nh2 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2424,6 +2424,8 @@ with pkgs;
 
   host = bind.host;
 
+  hotspot = libsForQt56.callPackage ../development/tools/analysis/hotspot { };
+
   hping = callPackage ../tools/networking/hping { };
 
   htpdate = callPackage ../tools/networking/htpdate { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

