### PR TITLE
network-manager: fix hard-coded path for modprobe

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation rec {
        --replace /usr/bin/ping6 ${inetutils}/bin/ping
     substituteInPlace src/devices/nm-arping-manager.c \
        --replace '("arping", NULL, NULL);' '("arping", "${iputils}/bin/arping", NULL);'
-    substituteInPlace src/NetworkManagerUtils.c --replace /sbin/modprobe ${kmod}/bin/modprobe
     substituteInPlace data/84-nm-drivers.rules \
       --replace /bin/sh ${stdenv.shell}
     substituteInPlace data/85-nm-unmanaged.rules \
@@ -43,6 +42,8 @@ stdenv.mkDerivation rec {
       --replace /bin/kill ${coreutils}/bin/kill
     substituteInPlace clients/common/nm-vpn-helpers.c \
       --subst-var-by openconnect ${openconnect}
+    substituteInPlace src/nm-core-utils.c \
+      --subst-var-by modprobeBinPath ${kmod}/bin/modprobe
     # to enable link-local connections
     configureFlags="$configureFlags --with-udev-dir=$out/lib/udev"
   '';
@@ -79,6 +80,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/NetworkManager/NetworkManager/commit/4e8eddd100bbc8429806a70620c90b72cfd29cb1.patch";
     })
     ./openconnect_helper_path.patch
+    ./modprobe.patch
   ];
 
   buildInputs = [ systemd libgudev libnl libuuid polkit ppp libndp

--- a/pkgs/tools/networking/network-manager/modprobe.patch
+++ b/pkgs/tools/networking/network-manager/modprobe.patch
@@ -1,0 +1,11 @@
+--- a/src/nm-core-utils.c	2017-02-15 13:10:27.000000000 +0100
++++ b/src/nm-core-utils.c	2017-07-06 14:28:41.575815695 +0200
+@@ -419,7 +419,7 @@
+ 
+ 	/* construct the argument list */
+ 	argv = g_ptr_array_sized_new (4);
+-	g_ptr_array_add (argv, "/sbin/modprobe");
++	g_ptr_array_add (argv, "@modprobeBinPath@");
+ 	g_ptr_array_add (argv, (char *) arg1);
+ 
+ 	va_start (ap, arg1);


### PR DESCRIPTION
###### Motivation for this change

NetworkManager use a hard-coded path for modprobe, this pull request fix the problem using the real path for modprobe

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

