### PR TITLE
nixos/…/swap.nix: don't create a LUKS header for randomEncryption

### DIFF
--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -149,9 +149,7 @@ in
                   fi
                 ''}
                 ${optionalString sw.randomEncryption ''
-                  echo "secretkey" | cryptsetup luksFormat --batch-mode ${sw.device}
-                  echo "secretkey" | cryptsetup luksOpen ${sw.device} ${sw.deviceName}
-                  cryptsetup luksErase --batch-mode ${sw.device}
+                  cryptsetup open ${sw.device} ${sw.deviceName} --type plain --key-file /dev/urandom
                   mkswap ${sw.realDevice}
                 ''}
               '';


### PR DESCRIPTION
Creating and then erasing the key relies on the disk erasing data
correctly, and otherwise allows attackers to simply decrypt swap just
using "secretkey". We don't actually need a LUKS header, so we can save
ourselves some pointless disk writes and identifiability.

In addition, I wouldn't have made the awful mistake of backing up my swap partition's LUKS header instead of my zpool's. May my data rest in peace.