### PR TITLE
add  `tmpOnTmpfs` feature from #23912

### DIFF
--- a/nixos/modules/system/boot/tmp.nix
+++ b/nixos/modules/system/boot/tmp.nix
@@ -2,6 +2,14 @@
 
 with lib;
 
+let
+
+  conf = config.boot.tmpOnTmpfs;
+
+  size = if isString conf then "size=${conf}" else "";
+
+in
+
 {
 
   ###### interface
@@ -17,10 +25,11 @@ with lib;
     };
 
     boot.tmpOnTmpfs = mkOption {
-      type = types.bool;
+      type = with types; either bool string;
       default = false;
       description = ''
          Whether to mount a tmpfs on <filename>/tmp</filename> during boot.
+         Setting this to `true` is equivalent to 50% of available memory. For details about valid strings, see `man mount`.
       '';
     };
 
@@ -30,8 +39,13 @@ with lib;
 
   config = {
 
-    systemd.additionalUpstreamSystemUnits = optional config.boot.tmpOnTmpfs "tmp.mount";
+    systemd.mounts = mkIf (conf != false) [{
+      what = "tmpfs";
+      where = "/tmp";
+      type = "tmpfs";
+      options = concatStringsSep "," (lists.filter (x : x != "") [ "mode=1777" "strictatime" "nosuid" "nodev" size ]);
 
+    }];
     systemd.tmpfiles.rules = optional config.boot.cleanTmpDir "D! /tmp 1777 root root";
 
   };


### PR DESCRIPTION
###### Motivation for this change
wanted this feature already, implemented it now.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

