### PR TITLE
grammalecte: 0.5.17 -> 0.5.17.2

### DIFF
--- a/pkgs/development/python-modules/grammalecte/default.nix
+++ b/pkgs/development/python-modules/grammalecte/default.nix
@@ -7,15 +7,17 @@
 
 buildPythonPackage rec {
   pname = "grammalecte";
-  version = "0.5.17";
+  version = "0.5.17.2";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "http://www.dicollecte.org/grammalecte/oxt/Grammalecte-fr-v${version}.zip";
-    sha256 = "0ccvj8p8bwvrj8bp370dzjs16pwm755a7364lvk8bp4505n7g0b6";
+    sha256 = "1g5i978cdz14rfdi4z2ayb2c1rf8cq991slwsv0krhpvl9ripl9c";
   };
 
   propagatedBuildInputs = [ bottle ];
+
+  doCheck = false;
 
   preBuild = "cd ..";
   postInstall = ''

--- a/pkgs/development/python-modules/grammalecte/default.nix
+++ b/pkgs/development/python-modules/grammalecte/default.nix
@@ -17,10 +17,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ bottle ];
 
-  doCheck = false;
-
   preBuild = "cd ..";
   postInstall = ''
+    substitute grammalecte/spellchecker.py grammalecte/spellchecker.py --replace "import ibdawg" "from grammalecte import ibdawg"
     mkdir $out/bin
     cp $out/cli.py $out/bin/gramalecte
     cp $out/server.py $out/bin/gramalected

--- a/pkgs/development/python-modules/grammalecte/default.nix
+++ b/pkgs/development/python-modules/grammalecte/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "http://www.dicollecte.org/grammalecte/oxt/Grammalecte-fr-v${version}.zip";
+    url = "http://www.dicollecte.org/grammalecte/zip/Grammalecte-fr-v${version}.zip";
     sha256 = "1g5i978cdz14rfdi4z2ayb2c1rf8cq991slwsv0krhpvl9ripl9c";
   };
 

--- a/pkgs/development/python-modules/grammalecte/default.nix
+++ b/pkgs/development/python-modules/grammalecte/default.nix
@@ -17,9 +17,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ bottle ];
 
+  patches = [ ./spellchecker.patch ];
   preBuild = "cd ..";
   postInstall = ''
-    substitute grammalecte/spellchecker.py grammalecte/spellchecker.py --replace "import ibdawg" "from grammalecte import ibdawg"
     mkdir $out/bin
     cp $out/cli.py $out/bin/gramalecte
     cp $out/server.py $out/bin/gramalected

--- a/pkgs/development/python-modules/grammalecte/spellchecker.patch
+++ b/pkgs/development/python-modules/grammalecte/spellchecker.patch
@@ -1,0 +1,13 @@
+diff --git a/spellchecker.py b/spellchecker.py
+index 37ac0ea..a60b3a9 100644
+--- a/spellchecker.py
++++ b/spellchecker.py
+@@ -2,7 +2,7 @@
+ # Wrapper for the IBDAWG class.
+ # Useful to check several dictionaries at once.
+ 
+-import ibdawg
++from grammalecte import ibdawg
+ 
+ 
+ dDictionaries = {


### PR DESCRIPTION
###### Motivation for this change

up to 0.5.17.2

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

