### PR TITLE
yices library: enable full functionality by adding libpoly polynomial library and fix soname linking.

### DIFF
--- a/pkgs/applications/science/logic/poly/default.nix
+++ b/pkgs/applications/science/logic/poly/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     homepage = https://github.com/SRI-CSL/libpoly;
     description = "C library for manipulating polynomials";
-    license = licenses.gplv3;
+    license = licenses.lgpl3;
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/science/logic/poly/default.nix
+++ b/pkgs/applications/science/logic/poly/default.nix
@@ -1,0 +1,22 @@
+{stdenv, fetchurl, gmp, cmake, python}:
+
+let version = "0.1.3";
+in
+
+stdenv.mkDerivation {
+  name = "libpoly-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/SRI-CSL/libpoly/archive/v${version}.tar.gz";
+    sha256 = "0nd90585imnznyp04vg6a5ixxkd3bavhv1437397aj2k3dfc0y2k";
+  };
+
+  buildInputs = [ cmake gmp python ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/SRI-CSL/libpoly;
+    description = "C library for manipulating polynomials";
+    license = licenses.gplv3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/science/logic/yices/default.nix
+++ b/pkgs/applications/science/logic/yices/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, gmp-static, gperf, autoreconfHook }:
+{ stdenv, fetchurl, gmp-static, gperf, autoreconfHook, libpoly }:
 
 stdenv.mkDerivation rec {
   name    = "yices-${version}";
   version = "2.5.1";
 
   src = fetchurl {
-    url = "http://yices.csl.sri.com/cgi-bin/yices2-newnewdownload.cgi?file=yices-${version}-src.tar.gz&accept=I+Agree";
-    name = "yices-${version}-src.tar.gz";
+    url = "http://yices.csl.sri.com/cgi-bin/yices2-newnewdownload.cgi?file=${name}-src.tar.gz&accept=I+Agree";
+    name = "${name}-src.tar.gz";
     sha256 = "1wfq6hcm54h0mqmbs1ip63i0ywlwnciav86sbzk3gafxyzg1nd0c";
   };
 
@@ -14,13 +14,19 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-static-gmp=${gmp-static.out}/lib/libgmp.a"
                      "--with-static-gmp-include-dir=${gmp-static.dev}/include"
+                     "--enable-mcsat"
                    ];
-  buildInputs = [ gmp-static gperf autoreconfHook ];
+  buildInputs = [ gmp-static gperf autoreconfHook libpoly ];
 
   enableParallelBuilding = true;
   doCheck = true;
 
-  installPhase = ''make install LDCONFIG=true'';
+  # Includes a fix for the embedded soname being libyices.so.2.5, but
+  # only installing the libyices.so.2.5.1 file.
+  installPhase = ''
+      make install LDCONFIG=true
+      (cd $out/lib && ln -s -f libyices.so.2.5.1 libyices.so.2.5)
+  '';
 
   meta = with stdenv.lib; {
     description = "A high-performance theorem prover and SMT solver";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18091,6 +18091,8 @@ with pkgs;
 
   picosat = callPackage ../applications/science/logic/picosat {};
 
+  libpoly = callPackage ../applications/science/logic/poly/default.nix {};
+
   prooftree = (with ocamlPackages_4_01_0;
     callPackage  ../applications/science/logic/prooftree {
       camlp5 = camlp5_transitional;


### PR DESCRIPTION
###### Motivation for this change

Current yices specification builds only a subset of the yices functionality.  In addition, linking to libyices is problematic because the embedded soname doesn't reflect actual files installed by the specification.  This patch adds libpoly, enables the corresponding functionality in yices, and ensures the soname target exists.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

