### PR TITLE
Add ABC verifier library in addition to the executable.

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -286,6 +286,7 @@
   knedlsepp = "Josef Kemetmüller <josef.kemetmueller@gmail.com>";
   koral = "Koral <koral@mailoo.org>";
   kovirobi = "Kovacsics Robert <kovirobi@gmail.com>";
+  kquick = "Kevin Quick <quick@sparq.org>";
   kragniz = "Louis Taylor <louis@kragniz.eu>";
   kristoff3r = "Kristoffer Søholm <k.soeholm@gmail.com>";
   ktosiek = "Tomasz Kontusz <tomasz.kontusz@gmail.com>";

--- a/pkgs/applications/science/logic/abc/libabc.nix
+++ b/pkgs/applications/science/logic/abc/libabc.nix
@@ -1,0 +1,35 @@
+{ fetchhg, stdenv, pkgs }:
+
+stdenv.mkDerivation rec {
+  name = "abc-${version}";
+  version = "20160818";
+
+  src = fetchhg {
+    url    = "https://bitbucket.org/alanmi/abc";
+    rev    = "a2e5bc66a68a72ccd267949e5c9973dd18f8932a";
+    sha256 = "09yvhj53af91nc54gmy7cbp7yljfcyj68a87494r5xvdfnsj11gy";
+  };
+
+  buildInputs = [ ];
+  preBuild = ''
+    export buildFlags="CC=$CC CXX=$CXX LD=$CXX ABC_USE_NO_READLINE=1 libabc.a"
+  '';
+
+  # n.b. the following are documented, but libabc.so is not a valid make target:
+  # ABC_USE_PIC=1 libabc.so
+
+  enableParallelBuilding = true;
+  installPhase = ''
+    mkdir -p $out/lib
+    mv libabc.a $out/lib
+    # mv libabc.so $out/lib
+  '';
+
+  meta = {
+    description = "A tool for sequential logic synthesis and formal verification";
+    homepage    = "https://people.eecs.berkeley.edu/~alanmi/abc/abc.htm";
+    license     = stdenv.lib.licenses.mit;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+  };
+}

--- a/pkgs/applications/science/logic/abc/libabc.nix
+++ b/pkgs/applications/science/logic/abc/libabc.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://people.eecs.berkeley.edu/~alanmi/abc/abc.htm";
     license     = stdenv.lib.licenses.mit;
     platforms   = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/science/logic/abc/libabc.nix
+++ b/pkgs/applications/science/logic/abc/libabc.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://people.eecs.berkeley.edu/~alanmi/abc/abc.htm";
     license     = stdenv.lib.licenses.mit;
     platforms   = stdenv.lib.platforms.unix;
-    maintainers = [ ];
+    maintainers = [ stdenv.lib.maintainers.kquick ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17921,6 +17921,8 @@ with pkgs;
 
   abc-verifier = callPackage ../applications/science/logic/abc {};
 
+  abc = callPackage ../applications/science/logic/abc/libabc.nix {};
+
   abella = callPackage ../applications/science/logic/abella {};
 
   alt-ergo = callPackage ../applications/science/logic/alt-ergo {


### PR DESCRIPTION
###### Motivation for this change

The ABC verifier package will build both an executable and a library.  This adds the nix specification for building the libabc library for applications needing it.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

