### PR TITLE
haskellPackages.inline-java: Add jdk build dependency

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -198,6 +198,8 @@ self: super: {
         '';
       })) pkgs.libcxx;
 
+  inline-java = addBuildDepend super.inline-java pkgs.jdk;
+
   # tests don't compile for some odd reason
   jwt = dontCheck super.jwt;
 


### PR DESCRIPTION
###### Motivation for this change
haskellPackages.inline-java fails building on nixos-unstable

###### Things done
Added jdk build dependency to inline-java. I believe that configuration-common.nix is the right place to avoid being clobbered by automatic updates.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

