### PR TITLE
git-big-picture: init at 0.9.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
@@ -1,0 +1,23 @@
+{ fetchgit, python2Packages, stdenv, git, graphviz }:
+
+python2Packages.buildPythonApplication rec {
+    pname = "git-big-picture";
+    version = "0.9.0";
+
+    name = "${pname}-${version}";
+
+    src = fetchgit {
+      url = "https://github.com/esc/${pname}.git";
+      rev = "fbe3b9504e255da859067fd58e90d849d63e5381";
+      sha256 = "1h283gzs4nx8lrarmr454zza52cilmnbdrqn1n33v3cn1rayl3c9";
+    };
+
+  propagatedBuildInputs = [ git graphviz ];
+
+  meta = {
+    description = "Tool for visualization of Git repositories.";
+    homepage = https://github.com/esc/git-big-picture;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
@@ -1,23 +1,30 @@
-{ fetchgit, python2Packages, stdenv, git, graphviz }:
+{ fetchFromGitHub, python2Packages, stdenv, git, graphviz }:
 
 python2Packages.buildPythonApplication rec {
-    pname = "git-big-picture";
-    version = "0.9.0";
+  pname = "git-big-picture";
+  version = "0.9.0";
 
-    name = "${pname}-${version}";
+  name = "${pname}-${version}";
 
-    src = fetchgit {
-      url = "https://github.com/esc/${pname}.git";
-      rev = "fbe3b9504e255da859067fd58e90d849d63e5381";
-      sha256 = "1h283gzs4nx8lrarmr454zza52cilmnbdrqn1n33v3cn1rayl3c9";
-    };
+  src = fetchFromGitHub {
+    owner = "esc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1h283gzs4nx8lrarmr454zza52cilmnbdrqn1n33v3cn1rayl3c9";
+  };
 
-  propagatedBuildInputs = [ git graphviz ];
+  buildInputs = [ git graphviz ];
+
+  postFixup = ''
+    wrapProgram $out/bin/git-big-picture \
+      --prefix PATH ":" ${ stdenv.lib.makeBinPath buildInputs  }
+    '';
 
   meta = {
     description = "Tool for visualization of Git repositories.";
     homepage = https://github.com/esc/git-big-picture;
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.nthorne ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2063,6 +2063,8 @@ with pkgs;
 
   gifsicle = callPackage ../tools/graphics/gifsicle { };
 
+  git-big-picture = callPackage ../applications/version-management/git-and-tools/git-big-picture { };
+
   git-crecord = callPackage ../applications/version-management/git-crecord { };
 
   git-lfs = callPackage ../applications/version-management/git-lfs { };


### PR DESCRIPTION
###### Motivation for this change

To introduce git-big-picture; a Git repository visualization tool. Visualizes branches, commits and tags, using  Git and Graphviz.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

