### PR TITLE
Harden stdenv in two misc ways

### DIFF
--- a/pkgs/development/compilers/swift/patches/build-script-pax.patch
+++ b/pkgs/development/compilers/swift/patches/build-script-pax.patch
@@ -1,12 +1,13 @@
 --- swift/utils/build-script-impl	2017-01-23 12:47:20.401326309 -0600
 +++ swift-pax/utils/build-script-impl	2017-01-23 13:24:10.339366996 -0600
-@@ -1823,6 +1823,16 @@ function set_lldb_xcodebuild_options() {
+@@ -1823,6 +1823,17 @@ function set_lldb_xcodebuild_options() {
      fi
  }
  
 +## XXX: Taken from nixpkgs /pkgs/stdenv/generic/setup.sh
 +isELF() {
 +    local fn="$1"
++    local fd
 +    local magic
 +    exec {fd}< "$fn"
 +    read -n 4 -u $fd magic

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -194,6 +194,7 @@ _addRpathPrefix() {
 # Return success if the specified file is an ELF object.
 isELF() {
     local fn="$1"
+    local fd
     local magic
     exec {fd}< "$fn"
     read -n 4 -u $fd magic
@@ -205,6 +206,7 @@ isELF() {
 # "#!").
 isScript() {
     local fn="$1"
+    local fd
     local magic
     if ! [ -x /bin/sh ]; then return 0; fi
     exec {fd}< "$fn"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -17,8 +17,9 @@ runHook() {
     shift
     local var="$hookName"
     if [[ "$hookName" =~ Hook$ ]]; then var+=s; else var+=Hooks; fi
-    eval "local -a dummy=(\"\${$var[@]}\")"
-    for hook in "_callImplicitHook 0 $hookName" "${dummy[@]}"; do
+    local -n var
+    local hook
+    for hook in "_callImplicitHook 0 $hookName" "${var[@]}"; do
         _eval "$hook" "$@"
     done
     return 0
@@ -32,8 +33,9 @@ runOneHook() {
     shift
     local var="$hookName"
     if [[ "$hookName" =~ Hook$ ]]; then var+=s; else var+=Hooks; fi
-    eval "local -a dummy=(\"\${$var[@]}\")"
-    for hook in "_callImplicitHook 1 $hookName" "${dummy[@]}"; do
+    local -n var
+    local hook
+    for hook in "_callImplicitHook 1 $hookName" "${var[@]}"; do
         if _eval "$hook" "$@"; then
             return 0
         fi


### PR DESCRIPTION
###### Motivation for this change

This is a few easy things pulled out of https://github.com/NixOS/nixpkgs/pull/26805 . The one downside is that a fairly new system bash will be required for impure `nix-shell` to work with these "namerefs"---this affects MacOS last I checked.

###### Things done

Manually built part of the linux stdenv with the original PR.

---

CC @Dridus