### PR TITLE
git: add missing deps for filter-branch etc

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -107,12 +107,21 @@ stdenv.mkDerivation {
 
       # Fix references to the perl, sed, awk and various coreutil binaries used by
       # shell scripts that git calls (e.g. filter-branch)
-      perl -0777 -i -pe \
-"BEGIN{@a=('${perl}/bin/perl', '${gnugrep}/bin/grep', '${gnused}/bin/sed', '${gawk}/bin/awk',"\
-"'${coreutils}/bin/cut', '${coreutils}/bin/basename', '${coreutils}/bin/dirname',"\
-"'${coreutils}/bin/wc', '${coreutils}/bin/tr');}"\
-'foreach $c (@a) { $n=(split("/", $c))[-1]; s|(?<=[^#][^/.-])\b''${n}(?=\s)|''${c}|g }' \
-           $out/libexec/git-core/git-{sh-setup,filter-branch,merge-octopus,mergetool,quiltimport,request-pull,stash,submodule,subtree,web--browse}
+      read -r -d ''' SCRIPT <<'EOS'
+        BEGIN{
+          @a=(
+            '${perl}/bin/perl', '${gnugrep}/bin/grep', '${gnused}/bin/sed', '${gawk}/bin/awk',
+            '${coreutils}/bin/cut', '${coreutils}/bin/basename', '${coreutils}/bin/dirname',
+            '${coreutils}/bin/wc', '${coreutils}/bin/tr'
+          );
+        }
+        foreach $c (@a) {
+          $n=(split("/", $c))[-1];
+          s|(?<=[^#][^/.-])\b''${n}(?=\s)|''${c}|g
+        }
+      EOS
+      perl -0777 -i -pe "$SCRIPT" \
+        $out/libexec/git-core/git-{sh-setup,filter-branch,merge-octopus,mergetool,quiltimport,request-pull,stash,submodule,subtree,web--browse}
 
       # Fix references to gettext.
       substituteInPlace $out/libexec/git-core/git-sh-i18n \

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -1,5 +1,6 @@
 { fetchurl, stdenv, curl, openssl, zlib, expat, perl, python, gettext, cpio
-, gnugrep, gzip, openssh
+, gnugrep, gnused, gawk, coreutils # needed at runtime by git-filter-branch etc
+, gzip, openssh
 , asciidoc, texinfo, xmlto, docbook2x, docbook_xsl, docbook_xml_dtd_45
 , libxslt, tcl, tk, makeWrapper, libiconv
 , svnSupport, subversionClient, perlLibs, smtpPerlLibs, gitwebPerlLibs
@@ -104,11 +105,14 @@ stdenv.mkDerivation {
           --replace ' grep' ' ${gnugrep}/bin/grep' \
           --replace ' egrep' ' ${gnugrep}/bin/egrep'
 
-      # Fix references to the perl binary. Note that the tab character
-      # in the patterns is important.
-      sed -i -e 's|	perl -ne|	${perl}/bin/perl -ne|g' \
-             -e 's|	perl -e|	${perl}/bin/perl -e|g' \
-             $out/libexec/git-core/{git-am,git-submodule}
+      # Fix references to the perl, sed, awk and various coreutil binaries used by
+      # shell scripts that git calls (e.g. filter-branch)
+      perl -0777 -i -pe \
+"BEGIN{@a=('${perl}/bin/perl', '${gnugrep}/bin/grep', '${gnused}/bin/sed', '${gawk}/bin/awk',"\
+"'${coreutils}/bin/cut', '${coreutils}/bin/basename', '${coreutils}/bin/dirname',"\
+"'${coreutils}/bin/wc', '${coreutils}/bin/tr');}"\
+'foreach $c (@a) { $n=(split("/", $c))[-1]; s|(?<=[^#][^/.-])\b''${n}(?=\s)|''${c}|g }' \
+           $out/libexec/git-core/git-{sh-setup,filter-branch,merge-octopus,mergetool,quiltimport,request-pull,stash,submodule,subtree,web--browse}
 
       # Fix references to gettext.
       substituteInPlace $out/libexec/git-core/git-sh-i18n \

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation {
 
       # Fix references to the perl, sed, awk and various coreutil binaries used by
       # shell scripts that git calls (e.g. filter-branch)
-      read -r -d ''' SCRIPT <<'EOS'
+      SCRIPT="$(cat <<'EOS'
         BEGIN{
           @a=(
             '${perl}/bin/perl', '${gnugrep}/bin/grep', '${gnused}/bin/sed', '${gawk}/bin/awk',
@@ -120,6 +120,7 @@ stdenv.mkDerivation {
           s|(?<=[^#][^/.-])\b''${n}(?=\s)|''${c}|g
         }
       EOS
+      )"
       perl -0777 -i -pe "$SCRIPT" \
         $out/libexec/git-core/git-{sh-setup,filter-branch,merge-octopus,mergetool,quiltimport,request-pull,stash,submodule,subtree,web--browse}
 


### PR DESCRIPTION
###### Motivation for this change

Several git commands are implemented as shell scripts that run awk, sed, grep
and perl as well as coreutils such as cut, wc, basedir and dirname. There is some existing patching in the postinstall for perl to rewrite
it to an absolute reference to pkgs.perl, but several other packages are both
missing as a dependency and have no rewrite logic.

In particular git filter-branch depends on sed and grep.

Additionally, the perl logic also seds git-am, which is now a binary not a shell
script anymore (see <github.com/git/git/blob/master/builtin/am.c>), so this part
was obsolete.

I tested this by grepping all shell scripts for the relevant commands and then
comparing the diffs of the new version to what is produced in master. All
changes in the scripts seem good to me. I'll attach the patch in a comment. I als

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (tried to but I got fatal: reference is not a tree: 3d89df66b3f00f8d7d744eb865b857c7f2d69cf5)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

