### PR TITLE
gitlab-runner service: add graceful termination

### DIFF
--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -15,6 +15,23 @@ in
       description = "Verbatim config.toml to use";
     };
 
+    gracefulTermination = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Finish all remaining jobs before stopping, restarting or reconfiguring.
+        If not set gitlab-runner will stop immediatly without waiting for jobs to finish,
+        which will lead to failed builds.
+      '';
+    };
+
+    gracefulTimeout = mkOption {
+      default = "infinity";
+      type = types.str;
+      example = "5min 20s";
+      description = ''Time to wait until a graceful shutdown is turned into a forceful one.'';
+    };
+
     workDir = mkOption {
       default = "/var/lib/gitlab-runner";
       type = types.path;
@@ -45,6 +62,11 @@ in
           --service gitlab-runner \
           --user gitlab-runner \
         '';
+
+      } //  optionalAttrs (cfg.gracefulTermination) {
+        TimeoutStopSec = "${cfg.gracefulTimeout}";
+        KillSignal = "SIGQUIT";
+        KillMode = "process";
       };
     };
 


### PR DESCRIPTION
###### Motivation for this change
The current behavior was for gitlab-runner is to immediately terminate when there
was a restart required. This can lead to aborted builds and is annoying to users.

By enabling graceful mode gitlab-runner will wait for all builds to finish before
terminating. The disadvantage is that a nixos-rebuild switch needs to wait till
all jobs are done. Because of that it is not enabled by default.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

