### PR TITLE
qsyncthingtray: 0.5.7 -> 0.5.8

### DIFF
--- a/pkgs/applications/misc/qsyncthingtray/default.nix
+++ b/pkgs/applications/misc/qsyncthingtray/default.nix
@@ -5,14 +5,14 @@
 , preferQWebView ? false }:
 
 mkDerivation rec {
-  version = "0.5.7";
+  version = "0.5.8";
   name = "qsyncthingtray-${version}";
 
   src = fetchFromGitHub {
     owner  = "sieren";
     repo   = "QSyncthingTray";
     rev    = "${version}";
-    sha256 = "0crrdpdmlc4ahkvp5znzc4zhfwsdih655q1kfjf0g231mmynxhvq";
+    sha256 = "1n9g4j7qznvg9zl6x163pi9f7wsc3x6q76i33psnm7x2v1i22x5w";
   };
 
   buildInputs = [ qtbase qtwebengine ] ++ lib.optional preferQWebView qtwebkit;


### PR DESCRIPTION
###### Motivation for this change



###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

