### PR TITLE
go_1_6: Fix darwin (sierra) compile, backport systime syscall fix

### DIFF
--- a/pkgs/development/compilers/go/1.6.nix
+++ b/pkgs/development/compilers/go/1.6.nix
@@ -113,6 +113,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./remove-tools-1.5.patch
     ./creds-test.patch
+    ./fix-systime-1.6.patch
 
     # This test checks for the wrong thing with recent tzdata. It's been fixed in master but the patch
     # actually works on old versions too.

--- a/pkgs/development/compilers/go/fix-systime-1.6.patch
+++ b/pkgs/development/compilers/go/fix-systime-1.6.patch
@@ -1,0 +1,45 @@
+diff --git a/src/runtime/sys_darwin_amd64.s b/src/runtime/sys_darwin_amd64.s
+index e09b906ba5..fa8ff2f65c 100644
+--- a/src/runtime/sys_darwin_amd64.s
++++ b/src/runtime/sys_darwin_amd64.s
+@@ -157,6 +157,7 @@ systime:
+ 	// Fall back to system call (usually first call in this thread).
+ 	MOVQ	SP, DI
+ 	MOVQ	$0, SI
++	MOVQ	$0, DX  // required as of Sierra; Issue 16570
+ 	MOVL	$(0x2000000+116), AX
+ 	SYSCALL
+ 	CMPQ	AX, $0
+diff --git a/src/syscall/syscall_darwin_amd64.go b/src/syscall/syscall_darwin_amd64.go
+index 70b53b87f4..79083117b6 100644
+--- a/src/syscall/syscall_darwin_amd64.go
++++ b/src/syscall/syscall_darwin_amd64.go
+@@ -26,14 +26,21 @@ func NsecToTimeval(nsec int64) (tv Timeval) {
+ }
+ 
+ //sysnb	gettimeofday(tp *Timeval) (sec int64, usec int32, err error)
+-func Gettimeofday(tv *Timeval) (err error) {
+-	// The tv passed to gettimeofday must be non-nil
+-	// but is otherwise unused.  The answers come back
+-	// in the two registers.
++func Gettimeofday(tv *Timeval) error {
++	// The tv passed to gettimeofday must be non-nil.
++	// Before macOS Sierra (10.12), tv was otherwise unused and
++	// the answers came back in the two registers.
++	// As of Sierra, gettimeofday return zeros and populates
++	// tv itself.
+ 	sec, usec, err := gettimeofday(tv)
+-	tv.Sec = sec
+-	tv.Usec = usec
+-	return err
++	if err != nil {
++		return err
++	}
++	if sec != 0 || usec != 0 {
++		tv.Sec = sec
++		tv.Usec = usec
++	}
++	return nil
+ }
+ 
+ func SetKevent(k *Kevent_t, fd, mode, flags int) {


### PR DESCRIPTION
This patches go1.6 minimally with a change that was backported
to upstream go1.4.

###### Motivation for this change

Trying to reproduce #18223, the build failed for me quite a bit worse, with stack traces such as in this golang issue: https://github.com/golang/go/issues/16627

It turns out that go1.6 is broken on macOS sierra. Not sure to what extent it makes sense to keep go1.6 working, but this adds a patch that fixes the build on my system.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
