### PR TITLE
pqiv: 2.8.3 -> 2.9

### DIFF
--- a/pkgs/applications/graphics/pqiv/default.nix
+++ b/pkgs/applications/graphics/pqiv/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation (rec {
   name = "pqiv-${version}";
-  version = "2.8.3";
+  version = "2.9";
 
   src = fetchFromGitHub {
     owner = "phillipberndt";
     repo = "pqiv";
     rev = version;
-    sha256 = "0fhmqa1q1y5y0ivrgx9xv864zqvd5dk4fiqi4bgi1ybdfx7vv2fy";
+    sha256 = "1xncf6aq52zpxpmz3ikmlkinz7y3nmbpgfxjb7q40sqs00n0mfsd";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @ndowens 
