### PR TITLE
btrfs-progs : fix bash-completion

### DIFF
--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
   # This should be fine on all platforms so apply universally
   patchPhase = "sed -i s/-O1/-O2/ configure";
 
+  postInstall = ''
+    install -v -m 444 -D btrfs-completion $out/etc/bash_completion.d/btrfs
+  '';
+
   meta = with stdenv.lib; {
     description = "Utilities for the btrfs filesystem";
     homepage = https://btrfs.wiki.kernel.org/;


### PR DESCRIPTION
###### Motivation for this change
add btrfs-progs bash-completion, fix #25793

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (nixos-rebuild switch -I nixpkgs=[my_repo])
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

