### PR TITLE
lib/types.nix: add intBetween

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -336,7 +336,7 @@ rec {
     # Type-check the remaining definitions, and merge them.
     mergedValue = foldl' (res: def:
       if type.check def.value then res
-      else throw "The option value `${showOption loc}' in `${def.file}' is not a ${type.description}.")
+      else throw "The option value `${showOption loc}' in `${def.file}' is not of type `${type.description}'.")
       (type.merge loc defsFinal) defsFinal;
 
     isDefined = defsFinal != [];

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -114,6 +114,12 @@ rec {
       merge = mergeOneOption;
     };
 
+    intBetween = min: max:
+      addCheck types.int (x: x >= min && x <= max) // {
+        name = "intBetween";
+        description = "integer between ${toString min} and ${toString max} (both inclusively)";
+      };
+
     str = mkOptionType {
       name = "str";
       description = "string";

--- a/nixos/doc/manual/development/option-types.xml
+++ b/nixos/doc/manual/development/option-types.xml
@@ -27,6 +27,17 @@
     <listitem><para>An integer.</para></listitem>
   </varlistentry>
   <varlistentry>
+    <term>
+      <varname>types.intBetween</varname>
+      <replaceable>min</replaceable>
+      <replaceable>max</replaceable>
+    </term>
+    <listitem><para>An integer between <replaceable>min</replaceable>
+        and <replaceable>max</replaceable> (both inclusive).
+        Useful for e.g. port ranges.
+    </para></listitem>
+  </varlistentry>
+  <varlistentry>
     <term><varname>types.path</varname></term>
     <listitem><para>A filesystem path, defined as anything that when coerced to 
         a string starts with a slash. Even if derivations can be considered as 


### PR DESCRIPTION
Add a type for integers between a min and max value; also improve the type error message, see commit message.

- [x] tested manually