### PR TITLE
Get rid of some usages of osx_private_sdk

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_apple_csp/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_apple_csp/default.nix
@@ -1,4 +1,4 @@
-{ appleDerivation, apple_sdk, libsecurity_asn1, libsecurity_cdsa_plugin, libsecurity_cdsa_utilities, libsecurity_cdsa_utils, libsecurity_utilities, osx_private_sdk, stdenv }:
+{ appleDerivation, apple_sdk, libsecurity_asn1, libsecurity_cdsa_plugin, libsecurity_cdsa_utilities, libsecurity_cdsa_utils, libsecurity_utilities, CommonCrypto, stdenv }:
 appleDerivation {
   buildInputs = [
     libsecurity_cdsa_utilities
@@ -19,7 +19,7 @@ appleDerivation {
     for file in lib/castContext.h lib/gladmanContext.h lib/desContext.h lib/rc4Context.h; do
       substituteInPlace ''$file --replace \
         '/usr/local/include/CommonCrypto/CommonCryptorSPI.h' \
-        '${osx_private_sdk}/PrivateSDK10.9.sparse.sdk/usr/include/CommonCrypto/CommonCryptorSPI.h'
+        '${CommonCrypto}/include/CommonCrypto/CommonCryptorSPI.h'
     done
     
     substituteInPlace lib/opensshWrap.cpp --replace RSA_DSA_Keys.h RSA_DSA_keys.h

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_apple_x509_cl/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_apple_x509_cl/default.nix
@@ -1,4 +1,4 @@
-{ appleDerivation, libsecurity_asn1, libsecurity_cdsa_client, libsecurity_cdsa_plugin, libsecurity_cdsa_utilities, libsecurity_filedb, libsecurity_keychain, libsecurity_utilities, libsecurityd, osx_private_sdk }:
+{ appleDerivation, libsecurity_asn1, libsecurity_cdsa_client, libsecurity_cdsa_plugin, libsecurity_cdsa_utilities, libsecurity_filedb, libsecurity_keychain, libsecurity_utilities, libsecurityd }:
 appleDerivation {
   buildInputs = [
     libsecurity_cdsa_plugin

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_asn1/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_asn1/default.nix
@@ -1,4 +1,4 @@
-{ appleDerivation, libsecurity_cdsa_utilities, libsecurity_utilities, osx_private_sdk }:
+{ appleDerivation, libsecurity_cdsa_utilities, libsecurity_utilities }:
 appleDerivation {
   __propagatedImpureHostDeps = [
     "/System/Library/Frameworks/Security.framework/Security"

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_cdsa_plugin/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_cdsa_plugin/default.nix
@@ -1,4 +1,4 @@
-{ appleDerivation, libsecurity_cdsa_utilities, libsecurity_cssm, libsecurity_utilities, osx_private_sdk, perl }:
+{ appleDerivation, libsecurity_cdsa_utilities, libsecurity_cssm, libsecurity_utilities, perl }:
 appleDerivation {
   buildInputs = [
     libsecurity_cdsa_utilities

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_cdsa_utilities/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_cdsa_utilities/default.nix
@@ -1,4 +1,4 @@
-{ CommonCrypto, appleDerivation, libsecurity_codesigning, libsecurity_utilities, m4, osx_private_sdk }:
+{ CommonCrypto, appleDerivation, libsecurity_codesigning, libsecurity_utilities, m4 }:
 appleDerivation {
   buildInputs = [
     libsecurity_utilities

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_cdsa_utils/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_cdsa_utils/default.nix
@@ -1,4 +1,4 @@
-{ Security, appleDerivation, apple_sdk, cppcheck, libsecurity_cdsa_utilities, libsecurity_utilities, m4, osx_private_sdk }:
+{ Security, appleDerivation, libsecurity_cdsa_utilities, libsecurity_utilities, m4 }:
 appleDerivation {
   buildInputs = [
     libsecurity_utilities

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_ocspd/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_ocspd/default.nix
@@ -1,4 +1,4 @@
-{ appleDerivation, bootstrap_cmds, libsecurity_cdsa_utilities, libsecurity_utilities, osx_private_sdk }:
+{ appleDerivation, bootstrap_cmds, libsecurity_cdsa_utilities, libsecurity_utilities }:
 appleDerivation {
   buildInputs = [
     libsecurity_utilities

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_pkcs12/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_pkcs12/default.nix
@@ -1,4 +1,4 @@
-{ appleDerivation, libsecurity_asn1, libsecurity_cdsa_client, libsecurity_cdsa_utils, libsecurity_keychain, osx_private_sdk }:
+{ appleDerivation, libsecurity_asn1, libsecurity_cdsa_client, libsecurity_cdsa_utils, libsecurity_keychain }:
 appleDerivation {
   patchPhase = ''
     substituteInPlace lib/pkcsoids.h --replace '#error' '#warning'

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_utilities/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_utilities/default.nix
@@ -1,4 +1,4 @@
-{ IOKit, appleDerivation, apple_sdk, libauto, libobjc, libsecurity_codesigning, osx_private_sdk, sqlite, stdenv }:
+{ IOKit, appleDerivation, apple_sdk, libauto, libobjc, libsecurity_codesigning, sqlite, stdenv, osx_private_sdk }:
 appleDerivation {
   buildInputs = [
     libauto
@@ -16,7 +16,7 @@ appleDerivation {
     substituteInPlace lib/ccaudit.cpp --replace '<bsm/libbsm.h>' '"bsm/libbsm.h"'
     substituteInPlace lib/powerwatch.h --replace \
       '<IOKit/pwr_mgt/IOPMLibPrivate.h>' \
-      '"${osx_private_sdk}/PrivateSDK10.9.sparse.sdk/System/Library/Frameworks/IOKit.framework/Versions/A/PrivateHeaders/pwr_mgt/IOPMLibPrivate.h"'
+      '"${IOKit}/Library/Frameworks/IOKit.framework/Headers/pwr_mgt/IOPMLibPrivate.h"'
 
     cp ${osx_private_sdk}/PrivateSDK10.9.sparse.sdk/usr/include/security_utilities/utilities_dtrace.h lib
     cp -R ${osx_private_sdk}/PrivateSDK10.9.sparse.sdk/usr/local/include/bsm lib

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurityd/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurityd/default.nix
@@ -1,4 +1,4 @@
-{ appleDerivation, bootstrap_cmds, libsecurity_cdsa_client, libsecurity_cdsa_utilities, libsecurity_utilities, osx_private_sdk }:
+{ appleDerivation, bootstrap_cmds, libsecurity_cdsa_client, libsecurity_cdsa_utilities, libsecurity_utilities }:
 appleDerivation {
   buildInputs = [
     libsecurity_cdsa_utilities

--- a/pkgs/os-specific/darwin/apple-source-releases/libunwind/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libunwind/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, appleDerivation, dyld, osx_private_sdk }:
+{ stdenv, appleDerivation }:
 
 appleDerivation {
   buildPhase = ":";


### PR DESCRIPTION
Partially addresses #26710, mostly getting haskell closure down from ~600MB to ~100MB (stack, purescript, etc)

Haven't tested anything else.