### PR TITLE
ion: init at 1.0.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -155,6 +155,7 @@
   drewkett = "Andrew Burkett <burkett.andrew@gmail.com>";
   dsferruzza = "David Sferruzza <david.sferruzza@gmail.com>";
   dtzWill = "Will Dietz <nix@wdtz.org>";
+  dywedir = "Vladyslav M. <dywedir@protonmail.ch>";
   e-user = "Alexander Kahl <nixos@sodosopa.io>";
   ebzzry = "Rommel Martinez <ebzzry@gmail.com>";
   edanaher = "Evan Danaher <nixos@edanaher.net>";

--- a/pkgs/shells/ion/default.nix
+++ b/pkgs/shells/ion/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "ion-${version}";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "redox-os";
+    repo = "ion";
+    rev = version;
+    sha256 = "0c2haw9qiwysyp1xj6qla8d6zpsdlygagzh86sk04c2b4ssyaca3";
+  };
+
+  depsSha256 = "0w2jgbrcx57js8ihzs5acp6b1niw1c7khdxrv14y3z9mmm9j55hs";
+
+  meta = with stdenv.lib; {
+    description = "Modern system shell with simple (and powerful) syntax";
+    homepage = https://github.com/redox-os/ion;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dywedir ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5032,6 +5032,8 @@ with pkgs;
 
   fish-foreign-env = callPackage ../shells/fish-foreign-env { };
 
+  ion = callPackage ../shells/ion { };
+
   mksh = callPackage ../shells/mksh { };
 
   oh = callPackage ../shells/oh { };


### PR DESCRIPTION
###### Motivation for this change

Add [ion](https://github.com/redox-os/ion)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

