### PR TITLE
wine: add missing dependency

### DIFF
--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   ];
 
   buildInputs = toBuildInputs pkgArches (with supportFlags; (pkgs:
-  [ pkgs.freetype ]
+  [ pkgs.freetype pkgs.libcap ]
   ++ lib.optional pngSupport             pkgs.libpng
   ++ lib.optional jpegSupport            pkgs.libjpeg
   ++ lib.optional cupsSupport            pkgs.cups


### PR DESCRIPTION
###### Motivation for this change
See #27242.
This fix the error but I don't know whether it's ok to add libcap unconditionally to the build inputs.

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [ ] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @avnik @7c6f434c
