### PR TITLE
kbd: fix unicode_start and unicode_stop scripts

### DIFF
--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoreconfHook, gzip, bzip2, pkgconfig, flex, check, pam }:
+{ stdenv, fetchurl, autoreconfHook, gzip, bzip2, pkgconfig, flex, check, pam, coreutils }:
 
 stdenv.mkDerivation rec {
   name = "kbd-${version}";
@@ -26,6 +26,14 @@ stdenv.mkDerivation rec {
       substituteInPlace src/libkeymap/findfile.c \
         --replace gzip ${gzip}/bin/gzip \
         --replace bzip2 ${bzip2.bin}/bin/bzip2 \
+
+      # Fix the path to the tty command in unicode_start
+      substituteInPlace src/unicode_start \
+        --replace /usr/bin/tty ${coreutils}/bin/tty
+      
+      # Fix the path to the tty command in unicode_start
+      substituteInPlace src/unicode_stop \
+        --replace /usr/bin/tty ${coreutils}/bin/tty
 
       # We get a warning in armv5tel-linux and the fuloong2f, so we
       # disable -Werror in it.


### PR DESCRIPTION
###### Motivation for this change
previously, the `unicode_start` and `unicode_stop` scripts were looking for the `tty` command in `/usr/bin/tty`, which means they could never run successfully on NixOS

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

