### PR TITLE
emsciptenStdenv: allow reuse without ./autogen.sh

### DIFF
--- a/pkgs/development/em-modules/generic/default.nix
+++ b/pkgs/development/em-modules/generic/default.nix
@@ -22,8 +22,6 @@ pkgs.stdenv.mkDerivation (
     HOME=$TMPDIR
     runHook preConfigure
 
-    # probably requires autotools as dependency
-    ./autogen.sh
     emconfigure ./configure --prefix=$out
 
     runHook postConfigure


### PR DESCRIPTION
The configure phase of emscriptenStdenv expects an ./autogen.sh script,
which is annoying when this step is not needed. Good example is
emscriptenPackages.zlib which needs to override configurePhase.

###### Testing
I built all emscriptenPackages (json_c, zlib, libxml2) without regression.
Libxml2 still failes and the rest is building, but the output is not usable.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

