### PR TITLE
zipkin-server: init at 1.28.1

### DIFF
--- a/pkgs/servers/monitoring/zipkin/default.nix
+++ b/pkgs/servers/monitoring/zipkin/default.nix
@@ -1,0 +1,26 @@
+{stdenv, fetchurl, makeWrapper, jre}:
+stdenv.mkDerivation rec {
+  version = "1.28.1";
+  name = "zipkin-server-${version}";
+  src = fetchurl {
+    url = "https://search.maven.org/remotecontent?filepath=io/zipkin/java/zipkin-server/${version}/zipkin-server-${version}-exec.jar";
+    sha256 = "02369fkv0kbl1isq6y26fh2zj5wxv3zck522m5wypsjlcfcw2apa";
+  };
+  buildInputs = [ makeWrapper ];
+
+  buildCommand =
+  ''
+    mkdir -p $out/share/java
+    cp ${src} $out/share/java/zipkin-server-${version}-exec.jar
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/zipkin-server \
+      --add-flags "-cp $out/share/java/zipkin-server-${version}-exec.jar org.springframework.boot.loader.JarLauncher"
+  '';
+  meta = with stdenv.lib; {
+    description = "Zipkin distributed tracing system";
+    homepage = "http://zipkin.io/";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.hectorj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11560,7 +11560,7 @@ with pkgs;
   zabbix20 = callPackage ../servers/monitoring/zabbix/2.0.nix { };
   zabbix22 = callPackage ../servers/monitoring/zabbix/2.2.nix { };
 
-  zipkin-server = callPackage ../servers/monitoring/zipkin { };
+  zipkin = callPackage ../servers/monitoring/zipkin { };
 
   ### OS-SPECIFIC
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11560,6 +11560,8 @@ with pkgs;
   zabbix20 = callPackage ../servers/monitoring/zabbix/2.0.nix { };
   zabbix22 = callPackage ../servers/monitoring/zabbix/2.2.nix { };
 
+  zipkin-server = callPackage ../servers/monitoring/zipkin { };
+
 
   ### OS-SPECIFIC
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11562,7 +11562,6 @@ with pkgs;
 
   zipkin-server = callPackage ../servers/monitoring/zipkin { };
 
-
   ### OS-SPECIFIC
 
   afuse = callPackage ../os-specific/linux/afuse { };


### PR DESCRIPTION
###### Motivation for this change

I need to install a [Zipkin](http://zipkin.io/) server.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Result:

```
result
├── bin
│   └── zipkin-server
└── share
    └── java
        └── zipkin-server-1.28.1-exec.jar
```

I used `makeWrapper` as instructed in https://nixos.org/nixpkgs/manual/#sec-language-java (though not in `installPhase`, as this was not working for some reason).