### PR TITLE
ezstream: init at 0.6.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -63,6 +63,7 @@
   bachp = "Pascal Bach <pascal.bach@nextrem.ch>";
   badi = "Badi' Abdul-Wahid <abdulwahidc@gmail.com>";
   balajisivaraman = "Balaji Sivaraman<sivaraman.balaji@gmail.com>";
+  barrucadu = "Michael Walker <mike@barrucadu.co.uk>";
   basvandijk = "Bas van Dijk <v.dijk.bas@gmail.com>";
   Baughn = "Svein Ove Aas <sveina@gmail.com>";
   bcarrell = "Brandon Carrell <brandoncarrell@gmail.com>";

--- a/pkgs/tools/audio/ezstream/default.nix
+++ b/pkgs/tools/audio/ezstream/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, libiconv, libshout, taglib, libxml2, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "ezstream-${version}";
+  version = "0.6.0";
+
+  src = fetchurl {
+    url = "https://ftp.osuosl.org/pub/xiph/releases/ezstream/${name}.tar.gz";
+    sha256 = "f86eb8163b470c3acbc182b42406f08313f85187bd9017afb8b79b02f03635c9";
+  };
+
+  buildInputs = [ libiconv libshout taglib libxml2 pkgconfig ];
+
+  doCheck = true;
+
+  meta = {
+    description = "A command line source client for Icecast media streaming servers";
+    longDescription = ''
+      Ezstream is a command line source client for Icecast media
+      streaming servers. It began as the successor of the old "shout"
+      utility, and has since gained a lot of useful features.
+
+      In its basic mode of operation, it streams media files or data
+      from standard input without reencoding and thus requires only
+      very little CPU resources.
+    '';
+    homepage = http://icecast.org/ezstream/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.barrucadu ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/tools/audio/ezstream/default.nix
+++ b/pkgs/tools/audio/ezstream/default.nix
@@ -9,11 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "f86eb8163b470c3acbc182b42406f08313f85187bd9017afb8b79b02f03635c9";
   };
 
-  buildInputs = [ libiconv libshout taglib libxml2 pkgconfig ];
+  buildInputs = [ libiconv libshout taglib libxml2 ];
+  nativeBuildInputs = [ pkgconfig ];
 
   doCheck = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A command line source client for Icecast media streaming servers";
     longDescription = ''
       Ezstream is a command line source client for Icecast media
@@ -25,8 +26,8 @@ stdenv.mkDerivation rec {
       very little CPU resources.
     '';
     homepage = http://icecast.org/ezstream/;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.barrucadu ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.barrucadu ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -545,6 +545,8 @@ with pkgs;
 
   enpass = callPackage ../tools/security/enpass { };
 
+  ezstream = callPackage ../tools/audio/ezstream { };
+
   genymotion = callPackage ../development/mobile/genymotion { };
 
   grc = callPackage ../tools/misc/grc { };


### PR DESCRIPTION
###### Motivation for this change

It's a simple little audio source from the Icecast people.  I wanted a program other than MPD to send a fallback stream to my Icecast server in case I accidentally broke MPD.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

