### PR TITLE
nixos/auditd: init at 2.7.6

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -116,6 +116,7 @@
   ./security/apparmor.nix
   ./security/apparmor-suid.nix
   ./security/audit.nix
+  ./security/auditd.nix
   ./security/ca.nix
   ./security/chromium-suid-sandbox.nix
   ./security/dhparams.nix

--- a/nixos/modules/security/auditd.nix
+++ b/nixos/modules/security/auditd.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.security.auditd;
+in {
+  options = {
+    security.auditd = {
+      enable = mkOption {
+        type        = types.enum [ false true ];
+        default     = false;
+        description = ''
+          Whether to enable the Linux Audit daemon.
+        '';
+      };
+    };
+  };
+
+  config = {
+    systemd.services.auditd = mkIf cfg.enable {
+      description = "Linux Audit daemon";
+      wantedBy = [ "basic.target" ];
+
+      unitConfig = {
+        ConditionVirtualization = "!container";
+        ConditionSecurity = [ "audit" ];
+      };
+
+
+      path = [ pkgs.audit ];
+
+      serviceConfig = {
+        ExecStartPre="${pkgs.coreutils}/bin/mkdir -p /var/log/audit";
+        ExecStart = "${pkgs.audit}/bin/auditd -l -n -s nochange";
+      };
+    };
+  };
+}

--- a/nixos/modules/security/auditd.nix
+++ b/nixos/modules/security/auditd.nix
@@ -2,23 +2,11 @@
 
 with lib;
 
-let
-  cfg = config.security.auditd;
-in {
-  options = {
-    security.auditd = {
-      enable = mkOption {
-        type        = types.bool;
-        default     = false;
-        description = ''
-          Whether to enable the Linux Audit daemon.
-        '';
-      };
-    };
-  };
+{
+  options.security.auditd.enable = mkEnableOption "the Linux Audit daemon";
 
-  config = {
-    systemd.services.auditd = mkIf cfg.enable {
+  config = mkIf config.security.auditd.enable {
+    systemd.services.auditd = {
       description = "Linux Audit daemon";
       wantedBy = [ "basic.target" ];
 
@@ -26,7 +14,6 @@ in {
         ConditionVirtualization = "!container";
         ConditionSecurity = [ "audit" ];
       };
-
 
       path = [ pkgs.audit ];
 

--- a/nixos/modules/security/auditd.nix
+++ b/nixos/modules/security/auditd.nix
@@ -8,7 +8,7 @@ in {
   options = {
     security.auditd = {
       enable = mkOption {
-        type        = types.enum [ false true ];
+        type        = types.bool;
         default     = false;
         description = ''
           Whether to enable the Linux Audit daemon.


### PR DESCRIPTION
#11864 Support Linux audit subsystem
Add the auditd.service as NixOS module to be able to
generate profiles from /var/log/audit/audit.log
with apparmor-utils.

auditd needs the folder /var/log/audit to be present on start
so this is generated in ExecPreStart.

auditd starts with -s nochange so that effective audit processing
is managed by the audit.service.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

