### PR TITLE
libargon2: init at 20161029

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -409,6 +409,7 @@
   okasu = "Okasu <oka.sux@gmail.com>";
   olcai = "Erik Timan <dev@timan.info>";
   olejorgenb = "Ole Jørgen Brønner <olejorgenb@yahoo.no>";
+  olynch = "Owen Lynch <owen@olynch.me>";
   orbekk = "KJ Ørbekk <kjetil.orbekk@gmail.com>";
   orbitz = "Malcolm Matalka <mmatalka@gmail.com>";
   orivej = "Orivej Desh <orivej@gmx.fr>";

--- a/pkgs/development/libraries/libargon2/default.nix
+++ b/pkgs/development/libraries/libargon2/default.nix
@@ -3,6 +3,7 @@
 stdenv.mkDerivation rec {
   name = "libargon2-${version}";
   version = "20161029";
+
   src = fetchFromGitHub {
     owner = "P-H-C";
     repo = "phc-winner-argon2";
@@ -11,14 +12,16 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out
-    make install PREFIX=$out
+    runHook preInstall
     mkdir -p $out/lib/pkgconfig
     substitute libargon2.pc $out/lib/pkgconfig/libargon2.pc \
       --replace @UPSTREAM_VER@ "${version}"                 \
       --replace @HOST_MULTIARCH@ ""                         \
       --replace 'prefix=/usr' "prefix=$out"
+
+    make install PREFIX=$out
     ln -s $out/lib/libargon2.so $out/lib/libargon2.so.0
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libargon2/default.nix
+++ b/pkgs/development/libraries/libargon2/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "libargon2-${version}";
+  version = "20161029";
+  src = fetchFromGitHub {
+    owner = "P-H-C";
+    repo = "phc-winner-argon2";
+    rev = "${version}";
+    sha256 = "021g8wi4g67ywm8zf3yncqwrmfz7ypgm1ih9wcmnxip5n75rymh5";
+  };
+
+  installPhase = ''
+    mkdir -p $out
+    make install PREFIX=$out
+    mkdir -p $out/lib/pkgconfig
+    substitute libargon2.pc $out/lib/pkgconfig/libargon2.pc \
+      --replace @UPSTREAM_VER@ "${version}"                 \
+      --replace @HOST_MULTIARCH@ ""                         \
+      --replace 'prefix=/usr' "prefix=$out"
+    ln -s $out/lib/libargon2.so $out/lib/libargon2.so.0
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A key derivation function that was selected as the winner of the Password Hashing Competition in July 2015";
+    longDescription = ''
+      A password-hashing function created by by Alex Biryukov, Daniel Dinu, and
+      Dmitry Khovratovich. Argon2 was declared the winner of the Password
+      Hashing Competition (PHC). There were 24 submissions and 9 finalists.
+      Catena, Lyra2, Makwa and yescrypt were given special recognition. The PHC
+      recommends using Argon2 rather than legacy algorithms.
+    '';
+    homepage = https://www.argon2.com/;
+    license = with licenses; [ asl20 cc0 ];
+    maintainers = with maintainers; [ taeer olynch ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11889,6 +11889,8 @@ with pkgs;
 
   libaio = callPackage ../os-specific/linux/libaio { };
 
+  libargon2 = callPackage ../development/libraries/libargon2 { };
+
   libatasmart = callPackage ../os-specific/linux/libatasmart { };
 
   libcgroup = callPackage ../os-specific/linux/libcgroup { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

