### PR TITLE
antigen: init at 2.2.1

### DIFF
--- a/pkgs/shells/antigen/default.nix
+++ b/pkgs/shells/antigen/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   version = "2.2.1";
-  name = "antigen";
+  name = "antigen-${version}";
 
   src = fetchurl {
-    url = "git.io/antigen";
-    sha256 = "0phnijkdl6w3cfbwakdvc86hazdn6y42bqnr1g3wynax5jr56xqm";
+    url = "https://github.com/zsh-users/antigen/releases/download/v${version}/antigen.zsh";
+    sha256 = "0s32280ak0gd0rr66g5dj6r5px0si8w47bcxlqfpaijg7i8xk1i7";
   };
   phases = "installPhase";
 

--- a/pkgs/shells/antigen/default.nix
+++ b/pkgs/shells/antigen/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "2.2.1";
+  name = "antigen";
+
+  src = fetchurl {
+    url = "git.io/antigen";
+    sha256 = "0phnijkdl6w3cfbwakdvc86hazdn6y42bqnr1g3wynax5jr56xqm";
+  };
+  phases = "installPhase";
+
+  installPhase = ''
+    outdir=$out/share/antigen
+
+    mkdir -p $outdir
+    cp $src $outdir/antigen.zsh
+  '';
+
+  meta = {
+    description = "The plugin manager for zsh.";
+    homepage = http://antigen.sharats.me;
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1139,6 +1139,8 @@ with pkgs;
     utillinux = utillinuxMinimal;
   };
 
+  antigen = callPackage ../shells/antigen { };
+
   apparix = callPackage ../tools/misc/apparix { };
 
   appdata-tools = callPackage ../tools/misc/appdata-tools { };


### PR DESCRIPTION
###### Motivation for this change
Want to add antigen. Also I've planned to add module for it, similar to oh-my-zsh

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

