### PR TITLE
jruby: changes to make it possible to use in development environment

### DIFF
--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
      rm $out/bin/*.{bat,dll,exe,sh}
      mv $out/COPYING $out/LICENSE* $out/docs
 
-     for i in $out/bin/*; do
+     for i in $out/bin/jruby{,.bash}; do
        wrapProgram $i \
          --set JAVA_HOME ${jre}
      done

--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -1,6 +1,9 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, callPackage, fetchurl, makeWrapper, jre }:
 
-stdenv.mkDerivation rec {
+let
+# The version number here is whatever is reported by the RUBY_VERSION string
+rubyVersion = callPackage ../ruby/ruby-version.nix {} "2" "3" "3" "";
+jruby = stdenv.mkDerivation rec {
   name = "jruby-${version}";
 
   version = "9.1.12.0";
@@ -22,7 +25,26 @@ stdenv.mkDerivation rec {
        wrapProgram $i \
          --set JAVA_HOME ${jre}
      done
+
+     ln -s $out/bin/jruby $out/bin/ruby
+
+     # Bundler tries to create this directory
+     mkdir -pv $out/${passthru.gemPath}
+     mkdir -p $out/nix-support
+     cat > $out/nix-support/setup-hook <<EOF
+       addGemPath() {
+         addToSearchPath GEM_PATH \$1/${passthru.gemPath}
+       }
+
+       envHooks+=(addGemPath)
+     EOF
   '';
+
+  passthru = rec {
+    rubyEngine = "jruby";
+    gemPath = "lib/${rubyEngine}/gems/${rubyVersion.libDir}";
+    libPath = "lib/${rubyEngine}/${rubyVersion.libDir}";
+  };
 
   meta = {
     description = "Ruby interpreter written in Java";
@@ -30,4 +52,11 @@ stdenv.mkDerivation rec {
     license = with stdenv.lib.licenses; [ cpl10 gpl2 lgpl21 ];
     platforms = stdenv.lib.platforms.unix;
   };
-}
+};
+in jruby.overrideAttrs (oldAttrs: {
+  passthru = oldAttrs.passthru // {
+    devEnv = callPackage ../ruby/dev.nix {
+      ruby = jruby;
+    };
+  };
+})

--- a/pkgs/development/ruby-modules/bundix/default.nix
+++ b/pkgs/development/ruby-modules/bundix/default.nix
@@ -1,8 +1,8 @@
-{ buildRubyGem, fetchFromGitHub, makeWrapper, lib, bundler, ruby, nix,
+{ buildRubyGem, fetchFromGitHub, makeWrapper, lib, bundler, nix,
   nix-prefetch-git }:
 
 buildRubyGem rec {
-  inherit ruby;
+  inherit (bundler) ruby;
 
   name = "${gemName}-${version}";
   gemName = "bundix";


### PR DESCRIPTION
###### Motivation for this change

When attempting to run JRuby (in Linux), I encountered a number of issues:

* running `gem` errored out with `syntax error, unexpected tSTRING_BEG`;
* it was not possible to use the jruby package with the bundler and bundix packages, due to errors to do with missing attributes in the jruby derivation, and missing environment variables.

This pull request does the following:

- Updates jruby to the latest version;
- Removes unnecessary `JAVA_HOME` wrapping from some jruby executables, such as `gem`;
- Adds the `rubyEngine` and `gemPath` attributes, required by gem packages (e.g. bundler);
- Copies some `GEM_PATH` envvar magic from the `ruby` package;
- Adds a `ruby -> jruby` symlink, so that `/usr/bin/env ruby` hashbangs get resolved correctly; 
- Fixes the bundix package to inherit its ruby runtime from bundler (otherwise bundler could be built with one ruby, and bundix with another);

These changes make it possible for me to create a development environment for jruby as follows:

~~~
myJRubyEnv = callPackage <nixpkgs/pkgs/development/interpreters/ruby/dev.nix> {
  ruby = jruby;
};
~~~

I haven't been able to run nox-review due to some errors to do with golang and GHC.  I am presuming that these are not errors caused by my patch.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

