### PR TITLE
unifont: 10.0.02 -> 10.0.04

### DIFF
--- a/pkgs/data/fonts/unifont/default.nix
+++ b/pkgs/data/fonts/unifont/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "unifont-${version}";
-  version = "10.0.02";
+  version = "10.0.04";
 
   ttf = fetchurl {
     url = "mirror://gnu/unifont/${name}/${name}.ttf";
-    sha256 = "1g7iaw2vx7yq8d3z625p6ainkn35wpfsimbl75lyj3d8206fhx0z";
+    sha256 = "0qp9zf8cx86syr8wl2z8yxlr5r83n156744ylzc0cg3rlmkx6r22";
   };
 
   pcf = fetchurl {
     url = "mirror://gnu/unifont/${name}/${name}.pcf.gz";
-    sha256 = "1l2cnkshpsg3mw5ps1ghzqm2a1nr7jfdn2bxqyvw7d0l5xyxvg3d";
+    sha256 = "1mj2np6j4jdbfnl0i3zlpg95ic9zq8bhvz8wf3pxkc85zmnk6w62";
   };
 
   buildInputs = [ mkfontscale mkfontdir ];


### PR DESCRIPTION
See http://lists.gnu.org/archive/html/info-gnu/2017-07/msg00004.html
for release announcement

###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

