### PR TITLE
lib: Add isPowerPC predicate, and fix family name

### DIFF
--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -8,6 +8,7 @@ rec {
     "64bit"      = { cpu = { bits = 64; }; };
     i686         = { cpu = cpuTypes.i686; };
     x86_64       = { cpu = cpuTypes.x86_64; };
+    PowerPC      = { cpu = cpuTypes.powerpc; };
     x86          = { cpu = { family = "x86"; }; };
     Arm          = { cpu = { family = "arm"; }; };
     Mips         = { cpu = { family = "mips"; }; };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -44,7 +44,7 @@ rec {
     i686     = { bits = 32; significantByte = littleEndian; family = "x86"; };
     x86_64   = { bits = 64; significantByte = littleEndian; family = "x86"; };
     mips64el = { bits = 32; significantByte = littleEndian; family = "mips"; };
-    powerpc  = { bits = 32; significantByte = bigEndian;    family = "powerpc"; };
+    powerpc  = { bits = 32; significantByte = bigEndian;    family = "power"; };
   };
 
   isVendor = isType "vendor";


### PR DESCRIPTION
It's called https://en.wikipedia.org/wiki/Power_Architecture now, which is convenient because `isPowerPC` should only refer to 32-bit variant(s).