### PR TITLE
jnettop: patch (from Debian) to use 64bit counters for transfer totals.

### DIFF
--- a/pkgs/tools/networking/jnettop/default.nix
+++ b/pkgs/tools/networking/jnettop/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, autoconf, libpcap, ncurses, pkgconfig, glib }:
+{ fetchurl, fetchpatch, stdenv, autoconf, libpcap, ncurses, pkgconfig, glib }:
 
 stdenv.mkDerivation rec {
   name = "jnettop-0.13.0";
@@ -10,7 +10,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ autoconf libpcap ncurses pkgconfig glib ];
 
-  patches = [ ./no-dns-resolution.patch ];
+  patches = [
+    ./no-dns-resolution.patch
+    (fetchpatch {
+      url = "https://sources.debian.net/data/main/j/jnettop/0.13.0-1/debian/patches/0001-Use-64-bit-integers-for-byte-totals-support-bigger-u.patch";
+      sha256 = "1b0alc12sj8pzcb66f8xslbqlbsvq28kz34v6jfhbb1q25hyr7jg";
+    })
+  ];
+
   preConfigure = '' autoconf '';
 
   meta = {


### PR DESCRIPTION
Otherwise counters overflow at 4GB.

###### Motivation for this change

4GB isn't much these days!

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

