### PR TITLE
stdenv: Store one package per line in nix-support/propagated-*

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -275,9 +275,9 @@ stdenv.mkDerivation {
       # Propagate the wrapped cc so that if you install the wrapper,
       # you get tools like gcov, the manpages, etc. as well (including
       # for binutils and Glibc).
-      echo ${cc} ${cc.man or ""} ${binutils_bin} ${if libc == null then "" else libc_bin} > $out/nix-support/propagated-user-env-packages
+      printLines ${cc} ${cc.man or ""} ${binutils_bin} ${if libc == null then "" else libc_bin} > $out/nix-support/propagated-user-env-packages
 
-      echo ${toString extraPackages} > $out/nix-support/propagated-native-build-inputs
+      printLines ${toString extraPackages} > $out/nix-support/propagated-native-build-inputs
     ''
 
     + optionalString (targetPlatform.isSunOS && nativePrefix != "") ''

--- a/pkgs/build-support/gcc-wrapper-old/builder.sh
+++ b/pkgs/build-support/gcc-wrapper-old/builder.sh
@@ -211,5 +211,5 @@ cp -p $utils $out/nix-support/utils.sh
 # tools like gcov, the manpages, etc. as well (including for binutils
 # and Glibc).
 if test -z "$nativeTools"; then
-    echo $gcc $binutils $libc $libc_bin > $out/nix-support/propagated-user-env-packages
+    printLines $gcc $binutils $libc $libc_bin > $out/nix-support/propagated-user-env-packages
 fi

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -202,7 +202,7 @@ _multioutPropagateDev() {
 
     mkdir -p "${!propagaterOutput}"/nix-support
     for output in $propagatedBuildOutputs; do
-        echo -n " ${!output}" >> "${!propagaterOutput}"/nix-support/$propagatedBuildInputsFile
+        echo "${!output}" >> "${!propagaterOutput}"/nix-support/$propagatedBuildInputsFile
     done
 }
 

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -84,7 +84,7 @@ rec {
         mkdir -p $out/nix-support
         cp ${script} $out/nix-support/setup-hook
       '' + lib.optionalString (deps != []) ''
-        echo ${toString deps} > $out/nix-support/propagated-native-build-inputs
+        printLines ${toString deps} > $out/nix-support/propagated-native-build-inputs
       '' + lib.optionalString (substitutions != {}) ''
         substituteAll ${script} $out/nix-support/setup-hook
       '');

--- a/pkgs/desktops/kde-4.14/kde-package/default.nix
+++ b/pkgs/desktops/kde-4.14/kde-package/default.nix
@@ -86,7 +86,7 @@ rec {
        };})
         ''
           mkdir -pv $out/nix-support
-          echo "${toString list}" | tee $out/nix-support/propagated-user-env-packages
+          printLines ${toString list} | tee $out/nix-support/propagated-user-env-packages
         '';
 
   # Given manifest module data, return the module

--- a/pkgs/development/compilers/openjdk-darwin/8.nix
+++ b/pkgs/development/compilers/openjdk-darwin/8.nix
@@ -33,7 +33,7 @@ let
       # any package that depends on the JRE has $CLASSPATH set up
       # properly.
       mkdir -p $out/nix-support
-      echo -n "${setJavaClassPath}" > $out/nix-support/propagated-native-build-inputs
+      printLines ${setJavaClassPath} > $out/nix-support/propagated-native-build-inputs
 
       install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/jre/lib/libfontmanager.dylib
 

--- a/pkgs/development/compilers/openjdk-darwin/default.nix
+++ b/pkgs/development/compilers/openjdk-darwin/default.nix
@@ -23,7 +23,7 @@ let
       # any package that depends on the JRE has $CLASSPATH set up
       # properly.
       mkdir -p $out/nix-support
-      echo -n "${setJavaClassPath}" > $out/nix-support/propagated-native-build-inputs
+      printLines ${setJavaClassPath} > $out/nix-support/propagated-native-build-inputs
 
       install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/jre/lib/libfontmanager.dylib
 

--- a/pkgs/development/compilers/openjdk/7.nix
+++ b/pkgs/development/compilers/openjdk/7.nix
@@ -190,7 +190,7 @@ let
       # any package that depends on the JRE has $CLASSPATH set up
       # properly.
       mkdir -p $jre/nix-support
-      echo -n "${setJavaClassPath}" > $jre/nix-support/propagated-native-build-inputs
+      printLines ${setJavaClassPath} > $jre/nix-support/propagated-native-build-inputs
 
       # Set JAVA_HOME automatically.
       mkdir -p $out/nix-support

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -202,7 +202,7 @@ let
       # any package that depends on the JRE has $CLASSPATH set up
       # properly.
       mkdir -p $jre/nix-support
-      echo -n "${setJavaClassPath}" > $jre/nix-support/propagated-native-build-inputs
+      printLines ${setJavaClassPath} > $jre/nix-support/propagated-native-build-inputs
 
       # Set JAVA_HOME automatically.
       mkdir -p $out/nix-support

--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -157,7 +157,7 @@ let result = stdenv.mkDerivation rec {
     ln -s $jrePath/lib/${architecture}/libnpjp2.so $jrePath/lib/${architecture}/plugins
 
     mkdir -p $out/nix-support
-    echo -n "${setJavaClassPath}" > $out/nix-support/propagated-native-build-inputs
+    printLines ${setJavaClassPath} > $out/nix-support/propagated-native-build-inputs
 
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook

--- a/pkgs/development/compilers/zulu/default.nix
+++ b/pkgs/development/compilers/zulu/default.nix
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
     find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
 
     mkdir -p $out/nix-support
-    echo -n "${setJavaClassPath}" > $out/nix-support/propagated-native-build-inputs
+    printLines ${setJavaClassPath} > $out/nix-support/propagated-native-build-inputs
 
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -311,7 +311,7 @@ stdenv.mkDerivation ({
     ${optionalString isGhcjs ''
       for exeDir in "$out/bin/"*.jsexe; do
         exe="''${exeDir%.jsexe}"
-        printf '%s\n' '#!${nodejs}/bin/node' > "$exe"
+        printLines '#!${nodejs}/bin/node' > "$exe"
         cat "$exeDir/all.js" >> "$exe"
         chmod +x "$exe"
       done

--- a/pkgs/misc/misc.nix
+++ b/pkgs/misc/misc.nix
@@ -23,7 +23,7 @@ in
   */
   collection = {list, name} : runCommand "collection-${name}" {} ''
     mkdir -p $out/nix-support
-    echo ${builtins.toString list} > $out/nix-support/propagated-user-env-packages
+    printLines ${builtins.toString list} > $out/nix-support/propagated-user-env-packages
   '';
 
   /* creates a derivation symlinking references C/C++ libs into one include and lib directory called $out/cdt-envs/${name}

--- a/pkgs/stdenv/generic/builder.sh
+++ b/pkgs/stdenv/generic/builder.sh
@@ -1,4 +1,3 @@
-export PATH=
 for i in $initialPath; do
     if [ "$i" = / ]; then i=; fi
     PATH=$PATH${PATH:+:}$i/bin
@@ -15,4 +14,6 @@ cat "$setup" >> $out/setup
 # Allow the user to install stdenv using nix-env and get the packages
 # in stdenv.
 mkdir $out/nix-support
-echo $propagatedUserEnvPkgs > $out/nix-support/propagated-user-env-packages
+if [ "$propagatedUserEnvPkgs" ]; then
+    printf '%s\n' $propagatedUserEnvPkgs > $out/nix-support/propagated-user-env-packages
+fi

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -215,6 +215,11 @@ isScript() {
     if [[ "$magic" =~ \#! ]]; then return 0; else return 1; fi
 }
 
+# printf unfortunately will print a trailing newline regardless
+printLines() {
+    [[ $# -gt 0 ]] || return 0
+    printf '%s\n' "$@"
+}
 
 ######################################################################
 # Initialisation.
@@ -300,9 +305,12 @@ findInputs() {
     fi
 
     if [ -f "$pkg/nix-support/$propagatedBuildInputsFile" ]; then
-        for i in $(cat "$pkg/nix-support/$propagatedBuildInputsFile"); do
-            findInputs "$i" $var $propagatedBuildInputsFile
+        local fd pkgNext
+        exec {fd}<"$pkg/nix-support/$propagatedBuildInputsFile"
+        while IFS= read -r -u $fd pkgNext; do
+            findInputs "$pkgNext" $var $propagatedBuildInputsFile
         done
+        exec {fd}<&-
     fi
 }
 
@@ -794,17 +802,17 @@ fixupPhase() {
         fi
         if [ -n "$propagated" ]; then
             mkdir -p "${!outputDev}/nix-support"
-            echo "$propagated" > "${!outputDev}/nix-support/propagated-native-build-inputs"
+            printLines $propagated > "${!outputDev}/nix-support/propagated-native-build-inputs"
         fi
     else
         if [ -n "$propagatedBuildInputs" ]; then
             mkdir -p "${!outputDev}/nix-support"
-            echo "$propagatedBuildInputs" > "${!outputDev}/nix-support/propagated-build-inputs"
+            printLines $propagatedBuildInputs > "${!outputDev}/nix-support/propagated-build-inputs"
         fi
 
         if [ -n "$propagatedNativeBuildInputs" ]; then
             mkdir -p "${!outputDev}/nix-support"
-            echo "$propagatedNativeBuildInputs" > "${!outputDev}/nix-support/propagated-native-build-inputs"
+            printLines $propagatedNativeBuildInputs > "${!outputDev}/nix-support/propagated-native-build-inputs"
         fi
     fi
 
@@ -817,7 +825,7 @@ fixupPhase() {
 
     if [ -n "$propagatedUserEnvPkgs" ]; then
         mkdir -p "${!outputBin}/nix-support"
-        echo "$propagatedUserEnvPkgs" > "${!outputBin}/nix-support/propagated-user-env-packages"
+        printLines $propagatedUserEnvPkgs > "${!outputBin}/nix-support/propagated-user-env-packages"
     fi
 
     runHook postFixup


### PR DESCRIPTION
###### Motivation for this change

This makes those files a bit easier to read. Also, for what it's worth, it brings us one tiny step closer to handling spaces in store paths.

Also, I optimized handling of many transitive deps with read. Probably, not very beneficial, but nice to enforce the pkg-per-line structure. Doing so let me find much dubious code and fix it.

Two misc notes:

 - `propagated-user-env-packages` also needed to be adjusted as sometimes it is copied to/from the propagated input files.

 - `local fd` should ensure that file descriptors aren't clobbered during recursion.

###### Things done

Built stdenv on Darwin and Linux

