### PR TITLE
pgadmin: make desktop item

### DIFF
--- a/pkgs/applications/misc/pgadmin/default.nix
+++ b/pkgs/applications/misc/pgadmin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, postgresql, wxGTK, libxml2, libxslt, openssl, zlib }:
+{ stdenv, fetchurl, postgresql, wxGTK, libxml2, libxslt, openssl, zlib, makeDesktopItem }:
 
 stdenv.mkDerivation rec {
   name = "pgadmin3-${version}";
@@ -29,4 +29,21 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ domenkozar wmertens ];
     platforms = platforms.unix;
   };
+
+  postFixup = let
+    desktopItem = makeDesktopItem {
+      name = "pgAdmin";
+      desktopName = "pgAdmin III";
+      genericName = "SQL Administration";
+      exec = "pgadmin3";
+      icon = "pgAdmin3";
+      type = "Application";
+      categories = "Application;Development;";
+      mimeType = "text/html";
+    };
+  in ''
+    mkdir -p $out/share/pixmaps;
+    cp pgadmin/include/images/pgAdmin3.png $out/share/pixmaps/;
+    cp -rv ${desktopItem}/share/applications $out/share/
+  '';
 }


### PR DESCRIPTION
This change adds the .desktop file so that pgAdmin shows up in the menu
system of desktop environments (ex. GNOME, XFCE, etc).

Closes #27067

###### Motivation for this change

pgadmin3 not end up on system menu after install, see #27067

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Special request

Please cherry-pick unto release 17.03, since that's where the issue was reported.
---

