### PR TITLE
xst: init at 0.7.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -585,6 +585,7 @@
   volth = "Jaroslavas Pocepko <jaroslavas@volth.com>";
   vozz = "Oliver Hunt <oliver.huntuk@gmail.com>";
   vrthra = "Rahul Gopinath <rahul@gopinath.org>";
+  vyp = "vyp <elisp.vim@gmail.com>";
   wedens = "wedens <kirill.wedens@gmail.com>";
   willtim = "Tim Philip Williams <tim.williams.public@gmail.com>";
   winden = "Antonio Vargas Gonzalez <windenntw@gmail.com>";

--- a/pkgs/applications/misc/st/default.nix
+++ b/pkgs/applications/misc/st/default.nix
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://st.suckless.org/;
-    license = stdenv.lib.licenses.mit;
+    license = licenses.mit;
     maintainers = with maintainers; [viric andsild];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/st/default.nix
+++ b/pkgs/applications/misc/st/default.nix
@@ -3,7 +3,7 @@
 
 with stdenv.lib;
 
-let patches' = if isNull patches then [] else patches;
+let patches' = if patches == null then [] else patches;
 in stdenv.mkDerivation rec {
   name = "st-0.7";
 

--- a/pkgs/applications/misc/st/wayland.nix
+++ b/pkgs/applications/misc/st/wayland.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://st.suckless.org/;
-    license = stdenv.lib.licenses.mit;
+    license = licenses.mit;
     maintainers = with maintainers; [ ];
     platforms = with platforms; linux;
   };

--- a/pkgs/applications/misc/st/xst.nix
+++ b/pkgs/applications/misc/st/xst.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, pkgconfig, libX11, ncurses, libXext, libXft, fontconfig }:
+
+with stdenv.lib;
+
+let
+  version = "0.7.1";
+  name = "xst-${version}";
+in stdenv.mkDerivation {
+  inherit name;
+
+  src = fetchurl {
+    url = "https://github.com/neeasade/xst/archive/v${version}.tar.gz";
+    sha256 = "19ayx1753f2s6k7f6yn256bsssm20ggffs1diakgjqwcyjcxxn7q";
+  };
+
+  buildInputs = [ pkgconfig libX11 ncurses libXext libXft fontconfig ];
+
+  installPhase = ''
+    TERMINFO=$out/share/terminfo make install PREFIX=$out
+  '';
+
+  meta = {
+    homepage = "https://github.com/neeasade/xst";
+    description = "Simple terminal fork that can load config from Xresources";
+    license = licenses.mit;
+    maintainers = maintainers.vyp;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/st/xst.nix
+++ b/pkgs/applications/misc/st/xst.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libX11, ncurses, libXext, libXft, fontconfig }:
+{ stdenv, fetchFromGitHub, pkgconfig, libX11, ncurses, libXext, libXft, fontconfig }:
 
 with stdenv.lib;
 
@@ -8,9 +8,11 @@ let
 in stdenv.mkDerivation {
   inherit name;
 
-  src = fetchurl {
-    url = "https://github.com/neeasade/xst/archive/v${version}.tar.gz";
-    sha256 = "19ayx1753f2s6k7f6yn256bsssm20ggffs1diakgjqwcyjcxxn7q";
+  src = fetchFromGitHub {
+    owner = "neeasade";
+    repo = "xst";
+    rev = "v${version}";
+    sha256 = "1fh4y2w0icaij99kihl3w8j5d5b38d72afp17c81pi57f43ss6pc";
   };
 
   buildInputs = [ pkgconfig libX11 ncurses libXext libXft fontconfig ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15887,6 +15887,8 @@ with pkgs;
     patches = config.st.patches or null;
   };
 
+  xst = callPackage ../applications/misc/st/xst.nix { };
+
   stag = callPackage ../applications/misc/stag {
     curses = ncurses;
   };


### PR DESCRIPTION
###### Motivation for this change

[xst](https://github.com/neeasade/xst) is a fork of [st](http://st.suckless.org/).

st is a "simple terminal" emulator which requires editing the source code and rebuilding for changing it's configuration (much like other suckless software).

xst however can load configuration options from `Xresources`, and also live-reload them too. I feel as though this warrants packaging it. It also has some useful [st-patches](http://st.suckless.org/patches/) bundled by default. FWIW relatively speaking, given that it's a fork of suckless software, it's quite popular too with 100+ github stars.

I put the `xst.nix` under `pkgs/applications/misc/st/` instead of creating an `xst` directory because the binary for xst is still `st`.  But I can put it in it's own `xst` directory if that's preferred? Does NixOS/Nix prevent installing two packages with the same binary name in the same profile? Or should there be a comment warning about this somewhere?

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

