### PR TITLE
calibre: fix html5lib error

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
     # Remove unneeded files and libs
     rm -rf resources/calibre-portable.* \
-           src/{chardet,cherrypy,odf,routes}
+           src/{chardet,cherrypy,html5lib,odf,routes}
   '';
 
   dontUseQmakeConfigure = true;
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
     poppler_utils libpng imagemagick libjpeg
     fontconfig podofo qtbase chmlib icu sqlite libusb1 libmtp xdg_utils wrapGAppsHook
   ] ++ (with python2Packages; [
+    html5lib_0_9999999 # needs to be before mechanize ?
     apsw cssselect cssutils dateutil lxml mechanize netifaces pillow
     python pyqt5 sip
     regex msgpack


### PR DESCRIPTION
###### Motivation for this change

Commit ff5423cdca4adc5a18463be1aa1dd1603453c724 broke calibre with stacktraces like [this one for ebook-edit](https://gist.github.com/calvertvl/cd105fd91f0b7d5dc4e87f0d8d350476). The main executable help page does work, but doesn't show this error until you actually try to start the GUI.

It took a number of attempts to identify the cause: basically, the newer html5lib associated with mechanize is found first, rather than the bundled one, and having the old html5lib in the prior location (late in the buildInputs list) causes the same behavior.

Putting the legacy version first in the python package list resolved the issue.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Edited for commit hash.
