### PR TITLE
sway: 0.12.2 -> 0.13.0

### DIFF
--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -26,6 +26,7 @@ in
     '';
 
     makeFlags = "PREFIX=$(out)";
+    cmakeFlags = "-DVERSION=${version}";
     installPhase = "PREFIX=$out make install";
 
     LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath [ wlc dbus_libs ];

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pango, libinput
 , makeWrapper, cmake, pkgconfig, asciidoc, libxslt, docbook_xsl, cairo
 , wayland, wlc, libxkbcommon, pixman, fontconfig, pcre, json_c, dbus_libs, libcap
-, xwayland
+, xwayland, pam, gdk_pixbuf
 }:
 
 let
@@ -19,7 +19,7 @@ in
 
     nativeBuildInputs = [ makeWrapper cmake pkgconfig asciidoc libxslt docbook_xsl ];
 
-    buildInputs = [ wayland wlc libxkbcommon pixman fontconfig pcre json_c dbus_libs pango cairo libinput libcap xwayland ];
+    buildInputs = [ wayland wlc libxkbcommon pixman fontconfig pcre json_c dbus_libs pango cairo libinput libcap xwayland pam gdk_pixbuf ];
 
     patchPhase = ''
       sed -i s@/etc/sway@$out/etc/sway@g CMakeLists.txt;

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  version = "0.12.2";
+  version = "0.13.0";
 in
   stdenv.mkDerivation rec {
     name = "sway-${version}";
@@ -14,7 +14,7 @@ in
       owner = "Sircmpwn";
       repo = "sway";
       rev = "${version}";
-      sha256 = "1hkr6pmz45xa5w5y21ijz7i2dwb62rifhcy28r8kh5r2hwbil2hs";
+      sha256 = "1vgk4rl51nx66yzpwg4yhnbj7wc30k5q0hh5lf8y0i1nvpal0p3q";
     };
 
     nativeBuildInputs = [ makeWrapper cmake pkgconfig asciidoc libxslt docbook_xsl ];


### PR DESCRIPTION
###### Motivation for this change

1. Upgrade to version 0.13.
2. Allow swaylock lock screen utility to be built by adding build inputs pam and gdk_pixbuf. This was not getting built by the previous package derivation.
3. Allow swaybg to work correctly by including gdk_pixbuf. Background setting did not work for me using the previous package.
4. Add version number via cmake flag so that sway -v displays the version number instead of a date and branch.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

