### PR TITLE
doc: Add note about possible cause of rebase onto master failing

### DIFF
--- a/doc/submitting-changes.xml
+++ b/doc/submitting-changes.xml
@@ -179,6 +179,10 @@ Additional information.
 
 <listitem>
 <para>Rebase you branch against current <command>master</command>.</para>
+<note>
+  <para>If the rebase fails it might be because the commit from <command>nixos-version</command> happened to be cherry-picked (not an ancestor of master). This is usually mentioned in the commit message.</para>
+  <para>To correct: <command>git rebase --onto upstream/master &lt;SHA_FIRST_COMMIT&gt; HEAD</command> (Where <command>upstream</command> is the nixpkgs remote (not your fork))</para>
+</note>
 </listitem>
 </itemizedlist>
 </section>
@@ -329,4 +333,3 @@ the stone age.
 
 </section>
 </chapter>
-


### PR DESCRIPTION
If you base your branch off `nixos-version` and that commit happens to be cherry picked the rebase onto master will fail.

###### Motivation for this change

I experience this case (72c9ed78d0) and even though I resolved it quite easily someone less versed in git might have more trouble.

Not sure if it common enough to make it worth adding though? Now that we have a wiki it might be a better place.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---