### PR TITLE
Generalize building of LFE

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -55,7 +55,7 @@ let
                      };
 
         lfe = lfe_1_2;
-        lfe_1_2 = lib.callLFE ../interpreters/lfe/1.2.nix { inherit erlang buildRebar3; };
+        lfe_1_2 = lib.callLFE ../interpreters/lfe/1.2.nix { inherit erlang buildRebar3 buildHex; };
 
         # Non hex packages
         hex = callPackage ./hex {};

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -54,7 +54,8 @@ let
                        debugInfo = true;
                      };
 
-        lfe = callPackage ../interpreters/lfe { };
+        lfe = lfe_1_2;
+        lfe_1_2 = lib.callLFE ../interpreters/lfe/1.2.nix { inherit erlang buildRebar3; };
 
         # Non hex packages
         hex = callPackage ./hex {};

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -56,4 +56,26 @@ rec {
         mkDerivation = pkgs.makeOverridable builder;
       };
 
+  /* Uses generic-builder to evaluate provided drv containing Elixir version
+  specific data.
+
+  drv: package containing version-specific args;
+  builder: generic builder for all Erlang versions;
+  args: arguments merged into version-specific args, used mostly to customize
+        dependencies;
+
+  Arguments passed to the generic-builder are overridable.
+
+  Please note that "mkDerivation" defined here is the one called from 1.2.nix
+  and similar files.
+  */
+  callLFE = drv: args:
+    let
+      inherit (stdenv.lib) versionAtLeast;
+      builder = callPackage ../interpreters/lfe/generic-builder.nix args;
+    in
+      callPackage drv {
+        mkDerivation = pkgs.makeOverridable builder;
+      };
+
 }

--- a/pkgs/development/interpreters/lfe/1.2.nix
+++ b/pkgs/development/interpreters/lfe/1.2.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+
+mkDerivation {
+  version = "1.2.1";
+  sha256 = "0j5gjlsk92y14kxgvd80q9vwyhmjkphpzadcswyjxikgahwg1avz";
+}

--- a/pkgs/development/interpreters/lfe/1.2.nix
+++ b/pkgs/development/interpreters/lfe/1.2.nix
@@ -3,4 +3,5 @@
 mkDerivation {
   version = "1.2.1";
   sha256 = "0j5gjlsk92y14kxgvd80q9vwyhmjkphpzadcswyjxikgahwg1avz";
+  maximumOTPVersion = "19";
 }

--- a/pkgs/development/interpreters/lfe/generic-builder.nix
+++ b/pkgs/development/interpreters/lfe/generic-builder.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, erlang, makeWrapper, coreutils, bash, buildRebar3 }:
+{ stdenv, fetchFromGitHub, erlang, makeWrapper, coreutils, bash, buildRebar3, buildHex }:
 
 { baseName ? "lfe"
 , version
@@ -7,13 +7,30 @@
 , src ? fetchFromGitHub { inherit rev sha256; owner = "rvirding"; repo = "lfe"; }
 }:
 
+let
+  proper = buildHex {
+    name = "proper";
+    version = "1.1.1-beta";
+
+    sha256  = "0hnkhs761yjynw9382w8wm4j3x0r7lllzavaq2kh9n7qy3zc1rdx";
+
+    configurePhase = ''
+      ${erlang}/bin/escript write_compile_flags include/compile_flags.hrl
+    '';
+  };
+
+in
+
 buildRebar3 {
-  name = "${baseName}";
+  name = baseName;
 
   inherit src version;
 
   buildInputs = [ erlang makeWrapper ];
+  beamDeps    = [ proper ];
   patches     = [ ./no-test-deps.patch ];
+  doCheck     = true;
+  checkTarget = "travis";
 
   # These installPhase tricks are based on Elixir's Makefile.
   # TODO: Make, upload, and apply a patch.

--- a/pkgs/development/interpreters/lfe/generic-builder.nix
+++ b/pkgs/development/interpreters/lfe/generic-builder.nix
@@ -2,12 +2,17 @@
 
 { baseName ? "lfe"
 , version
+, maximumOTPVersion
 , sha256 ? null
 , rev ? version
 , src ? fetchFromGitHub { inherit rev sha256; owner = "rvirding"; repo = "lfe"; }
 }:
 
 let
+  inherit (stdenv.lib) getVersion versionAtLeast splitString head;
+
+  mainVersion = head (splitString "." (getVersion erlang));
+
   proper = buildHex {
     name = "proper";
     version = "1.1.1-beta";
@@ -20,6 +25,7 @@ let
   };
 
 in
+assert versionAtLeast maximumOTPVersion mainVersion;
 
 buildRebar3 {
   name = baseName;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6049,7 +6049,7 @@ with pkgs;
   inherit (beam.interpreters)
     erlang erlang_odbc erlang_javac erlang_odbc_javac
     elixir elixir_1_5_rc elixir_1_4 elixir_1_3
-    lfe
+    lfe lfe_1_2
     erlangR16 erlangR16_odbc
     erlang_basho_R16B02 erlang_basho_R16B02_odbc
     erlangR17 erlangR17_odbc erlangR17_javac erlangR17_odbc_javac

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -58,7 +58,7 @@ rec {
     # `beam.packages.erlangR19.elixir`.
     inherit (packages.erlang) elixir elixir_1_5_rc elixir_1_4 elixir_1_3;
 
-    lfe = packages.erlang.lfe;
+    inherit (packages.erlang) lfe lfe_1_2;
   };
 
   # Helper function to generate package set with a specific Erlang version.


### PR DESCRIPTION
###### Motivation for this change
This is based on #17240

This only includes LFE generalization. It only includes a derivation for 1.2. I am holding off on 1.3 for now as there is apparently an issue with it.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @LnL7 @gleber @yurrriq
