### PR TITLE
pythonPackages.django_compressor: 1.5 -> 2.1.1

### DIFF
--- a/pkgs/development/python-modules/django_appconf/default.nix
+++ b/pkgs/development/python-modules/django_appconf/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, six }:
+buildPythonPackage rec {
+  pname = "django-appconf";
+  version = "1.0.2";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qdjdx35g66xjsc50v0c5h3kg6njs8df33mbjx6j4k1vd3m9lkba";
+  };
+
+  # No tests in archive
+  doCheck = false;
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    description = "A helper class for handling configuration defaults of packaged apps gracefully";
+    homepage = http://django-appconf.readthedocs.org/;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ desiderius ];
+  };
+}

--- a/pkgs/development/python-modules/django_compressor/default.nix
+++ b/pkgs/development/python-modules/django_compressor/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi,
+  rcssmin, rjsmin, django_appconf }:
+buildPythonPackage rec {
+    pname = "django_compressor";
+    version = "2.1.1";
+    name = "${pname}-${version}";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "1s42dkq3qp1niaf69markd7m3ljgf2bspyz2nk0sa07f8q04004j";
+    };
+
+    # Need to setup django testing
+    doCheck = false;
+
+    propagatedBuildInputs = [ rcssmin rjsmin django_appconf ];
+
+    meta = with stdenv.lib; {
+      description = "Compresses linked and inline JavaScript or CSS into single cached files";
+      homepage = http://django-compressor.readthedocs.org/en/latest/;
+      license = licenses.mit;
+      maintainers = with maintainers; [ desiderius ];
+    };
+}

--- a/pkgs/development/python-modules/rcssmin/default.nix
+++ b/pkgs/development/python-modules/rcssmin/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+  pname = "rcssmin";
+  version = "1.0.6";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0w42l4dhxghcz7pj3q7hkxp015mvb8z2cq9sfxbl31npsfavd1ya";
+  };
+
+  # The package does not ship tests, and the setup machinary confuses
+  # tests auto-discovery
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://opensource.perlig.de/rcssmin/;
+    license = licenses.asl20;
+    description = "CSS minifier written in pure python";
+  };
+}

--- a/pkgs/development/python-modules/rjsmin/default.nix
+++ b/pkgs/development/python-modules/rjsmin/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+  pname = "rjsmin";
+  version = "1.0.12";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wc62d0f80kw1kjv8nlxychh0iy66a6pydi4vfvhh2shffm935fx";
+  };
+
+  # The package does not ship tests, and the setup machinary confuses
+  # tests auto-discovery
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://opensource.perlig.de/rjsmin/;
+    license = licenses.asl20;
+    description = "Javascript minifier written in python";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21222,6 +21222,8 @@ in {
     };
   };
 
+  rjsmin = callPackage ../development/python-modules/rjsmin { };
+
   pysolr = buildPythonPackage rec {
     name = "pysolr-${version}";
     version = "3.3.3";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21072,6 +21072,8 @@ in {
     };
   };
 
+  rcssmin = callPackage ../development/python-modules/rcssmin { };
+
   recommonmark = buildPythonPackage rec {
     name = "recommonmark-${version}";
     version = "0.4.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9889,27 +9889,7 @@ in {
     };
   };
 
-  django_compressor = buildPythonPackage rec {
-    name = "django-compressor-${version}";
-    version = "1.5";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/django_compressor/django_compressor-${version}.tar.gz";
-      sha256 = "0bp2acagc6b1mmcajlmjf5vvp6zj429bq7p2wks05n47pwfzv281";
-    };
-
-    # Need to setup django testing
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [ django_appconf ];
-
-    meta = {
-      description = "Compresses linked and inline JavaScript or CSS into single cached files";
-      homepage = http://django-compressor.readthedocs.org/en/latest/;
-      license = licenses.mit;
-      maintainers = with maintainers; [ desiderius ];
-    };
-  };
+  django_compressor = callPackage ../development/python-modules/django_compressor { };
 
   django_compat = callPackage ../development/python-modules/django-compat { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9865,27 +9865,7 @@ in {
     };
   };
 
-  django_appconf = buildPythonPackage rec {
-    name = "django-appconf-${version}";
-    version = "1.0.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/django-appconf/django-appconf-${version}.tar.gz";
-      sha256 = "0q3fg17qi4vwpipbj075zn4wk58p6a946kah8wayks1423xpa4xs";
-    };
-
-    # No tests in archive
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [ six ];
-
-    meta = {
-      description = "A helper class for handling configuration defaults of packaged apps gracefully";
-      homepage = http://django-appconf.readthedocs.org/;
-      license = licenses.bsd2;
-      maintainers = with maintainers; [ desiderius ];
-    };
-  };
+  django_appconf = callPackage ../development/python-modules/django_appconf { };
 
   django_colorful = buildPythonPackage rec {
     name = "django-colorful-${version}";


### PR DESCRIPTION
###### Motivation for this change

`django_compressor` is outdated and not working. This makes it up to date as well as its dependencies.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

