### PR TITLE
helm: 0.8.6 -> 0.9.0

### DIFF
--- a/pkgs/applications/audio/helm/default.nix
+++ b/pkgs/applications/audio/helm/default.nix
@@ -1,21 +1,21 @@
-  { stdenv, fetchFromGitHub , xorg, freetype, alsaLib, libjack2
+  { stdenv, fetchFromGitHub , xorg, freetype, alsaLib, curl, libjack2
   , lv2, pkgconfig, mesa }:
 
   stdenv.mkDerivation rec {
-  version = "0.8.6";
+  version = "0.9.0";
   name = "helm-${version}";
 
   src = fetchFromGitHub {
     owner = "mtytel";
     repo = "helm";
-    rev = "19f86e6b4db83c1c6b143fc27883592ac4e43489";
-    sha256 = "0a46wnbfqkns8l136v79rr9gv4hhba065igjwkjddf045c9l94l8";
+    rev = "927d2ed27f71a735c3ff2a1226ce3129d1544e7e";
+    sha256 = "17ys2vvhncx9i3ydg3xwgz1d3gqv4yr5mqi7vr0i0ca6nad6x3d4";
   };
 
   buildInputs = [
     xorg.libX11 xorg.libXcomposite xorg.libXcursor xorg.libXext
     xorg.libXinerama xorg.libXrender xorg.libXrandr
-    freetype alsaLib libjack2 pkgconfig mesa lv2
+    freetype alsaLib curl libjack2 pkgconfig mesa lv2
   ];
 
   CXXFLAGS = "-DHAVE_LROUND";
@@ -26,6 +26,7 @@
 
   buildPhase = ''
     make lv2
+    make standalone
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

