### PR TITLE
groff: split out perl dependencies

### DIFF
--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -5,14 +5,15 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "groff-1.22.3";
+  name = "groff-${version}";
+  version = "1.22.3";
 
   src = fetchurl {
     url = "mirror://gnu/groff/${name}.tar.gz";
     sha256 = "1998v2kcs288d3y7kfxpvl369nqi06zbbvjzafyvyl3pr7bajj1s";
   };
 
-  outputs = [ "out" "man" "doc" "info" ];
+  outputs = [ "out" "man" "doc" "info" "perl" ];
 
   enableParallelBuilding = false;
 
@@ -30,8 +31,7 @@ stdenv.mkDerivation rec {
       --replace "@PNMTOPS_NOSETPAGE@" "${netpbm}/bin/pnmtops -nosetpage"
   '';
 
-  buildInputs = [ ghostscript psutils netpbm ];
-  nativeBuildInputs = [ perl ];
+  buildInputs = [ ghostscript psutils netpbm perl ];
 
   # Builds running without a chroot environment may detect the presence
   # of /usr/X11 in the host system, leading to an impure build of the
@@ -62,6 +62,41 @@ stdenv.mkDerivation rec {
     for f in 'man.local' 'mdoc.local'; do
         cat '${./site.tmac}' >>"$out/share/groff/site-tmac/$f"
     done
+
+    moveToOutput bin/gropdf $perl
+    moveToOutput bin/pdfmom $perl
+    moveToOutput bin/roff2text $perl
+    moveToOutput bin/roff2pdf $perl
+    moveToOutput bin/roff2ps $perl
+    moveToOutput bin/roff2dvi $perl
+    moveToOutput bin/roff2ps $perl
+    moveToOutput bin/roff2html $perl
+    moveToOutput bin/glilypond $perl
+    moveToOutput bin/mmroff $perl
+    moveToOutput bin/roff2x $perl
+    moveToOutput bin/afmtodit $perl
+    moveToOutput bin/gperl $perl
+    moveToOutput bin/chem $perl
+    moveToOutput share/groff/${version}/font/devpdf $perl
+
+    # idk if this is needed, but Fedora does it
+    moveToOutput share/groff/${version}/tmac/pdf.tmac $perl
+
+    moveToOutput bin/gpinyin $perl
+    moveToOutput lib/groff/gpinyin $perl
+    substituteInPlace $perl/bin/gpinyin \
+      --replace $out/lib/groff/gpinyin $perl/lib/groff/gpinyin
+
+    moveToOutput bin/groffer $perl
+    moveToOutput lib/groff/groffer $perl
+    substituteInPlace $perl/bin/groffer \
+      --replace $out/lib/groff/groffer $perl/lib/groff/groffer
+
+    moveToOutput bin/grog $perl
+    moveToOutput lib/groff/grog $perl
+    substituteInPlace $perl/bin/grog \
+      --replace $out/lib/groff/grog $perl/lib/groff/grog
+
   '';
 
   meta = with stdenv.lib; {
@@ -82,5 +117,7 @@ stdenv.mkDerivation rec {
       version gxditview of the X11 xditview previewer, and an
       implementation of the -mm macros.
     '';
+
+    outputsToInstall = [ "out" "perl" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This resolves issue https://github.com/NixOS/nixpkgs/issues/26892 , and results in a ~50MB closure reduction for some packages including the `fish` shell!

I tried at least running all of the executables that use perl, although I'm not really sure what inputs they use. I've grepped through the nixpkgs tree a little bit and none of the perl-dependent executables are directly referenced in any packages, although they may be in use there. There seem to be several which only use groff's `nroff` command, which means this PR will benefit those packages w/r/t closure reduction as well.

I will try to do some more testing this week of the individual perl-dependent groff executables to make sure their output in some simple cases is complete and correct; I'm not sure that I've adequately tested this but would like to put it up at this point for advice nonetheless. 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

