### PR TITLE
opendht: init at 1.3.4

### DIFF
--- a/pkgs/tools/security/opendht/default.nix
+++ b/pkgs/tools/security/opendht/default.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, fetchFromGitHub
+, autoconf
+, automake
+, libtool
+, pkgconfig
+, nettle
+, gnutls
+, libmsgpack
+, readline
+, libargon2
+}:
+
+stdenv.mkDerivation rec {
+  name = "opendht-${version}";
+  version = "1.3.4";
+
+  src = fetchFromGitHub {
+    owner = "savoirfairelinux";
+    repo = "opendht";
+    rev = "${version}";
+    sha256 = "0karj37f0zq39w0ip8ahrjr6lcrrn9jd6bpzylp1m92jzs8pfki8";
+  };
+
+  buildInputs = [
+    autoconf
+    automake
+    libtool
+    pkgconfig
+    nettle
+    gnutls
+    libmsgpack
+    readline
+    libargon2
+  ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A C++11 Kademlia distributed hash table implementation";
+    homepage = https://github.com/savoirfairelinux/opendht;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ taeer olynch ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3460,6 +3460,8 @@ with pkgs;
 
   opendbx = callPackage ../development/libraries/opendbx { };
 
+  opendht = callPackage ../tools/security/opendht {};
+
   opendkim = callPackage ../development/libraries/opendkim { };
 
   opendylan = callPackage ../development/compilers/opendylan {


### PR DESCRIPTION
###### Motivation for this change
needed for ring-daemon

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

