### PR TITLE
xautomation: init at 1.09

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -573,6 +573,7 @@
   utdemir = "Utku Demir <me@utdemir.com>";
   #urkud = "Yury G. Kudryashov <urkud+nix@ya.ru>"; inactive since 2012
   uwap = "uwap <me@uwap.name>";
+  vaibhavsagar = "Vaibhav Sagar <vaibhavsagar@gmail.com>";
   vandenoever = "Jos van den Oever <jos@vandenoever.info>";
   vanzef = "Ivan Solyankin <vanzef@gmail.com>";
   vbgl = "Vincent Laporte <Vincent.Laporte@gmail.com>";

--- a/pkgs/tools/X11/xautomation/default.nix
+++ b/pkgs/tools/X11/xautomation/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, pkgconfig, libpng, libX11, libXext, libXi, libXtst }:
+
+let version = "1.09"; in
+stdenv.mkDerivation {
+  name = "xautomation-${version}";
+  src = fetchurl {
+    url = "https://www.hoopajoo.net/static/projects/xautomation-${version}.tar.gz";
+    sha256 = "03azv5wpg65h40ip2kk1kdh58vix4vy1r9bihgsq59jx2rhjr3zf";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libpng libX11 libXext libXi libXtst ];
+
+  meta = {
+    homepage = https://www.hoopajoo.net/projects/xautomation.html;
+    description = "Control X from the command line for scripts, and do \"visual scraping\" to find things on the screen";
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = with stdenv.lib.maintainers; [ vaibhavsagar ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16694,6 +16694,8 @@ with pkgs;
     inherit (xorg) libXt;
   };
 
+  xautomation = callPackage ../tools/X11/xautomation { };
+
   xawtv = callPackage ../applications/video/xawtv { };
 
   xbindkeys = callPackage ../tools/X11/xbindkeys { };


### PR DESCRIPTION
###### Motivation for this change

This provides `xte` and related tools for X automation.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

