### PR TITLE
phraseapp-client: 1.4.3 -> 1.4.5

### DIFF
--- a/pkgs/tools/misc/phraseapp-client/default.nix
+++ b/pkgs/tools/misc/phraseapp-client/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "phraseapp-client-${version}";
-  version = "1.4.3";
+  version = "1.4.5";
 
   goPackagePath = "github.com/phrase/phraseapp-client";
   subPackages = [ "." ];
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "phrase";
     repo = "phraseapp-client";
     rev = version;
-    sha256 = "1nfab7y75vl0vg9vy8gc46h7wikk94nky1n415im1xbpsnqg77wz";
+    sha256 = "0zky7jcs7h6zmvkb0na4la6h7g63jlrziifqk831fd1gspdzgajp";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

minor upgrade

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

