### PR TITLE
add system.copySystemNixpkgs nixos option

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -190,6 +190,18 @@ in
       '';
     };
 
+
+    system.copySystemNixpkgs = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If enabled, copies the Nixpkgs that was used to build this system
+        and links it from the resulting system
+        (getting to <filename>/run/current-system/nixpkgs</filename>).
+        Note that the `.git` directory is not copied (should it exist) to avoid large build times.
+      '';
+    };
+
     system.extraSystemBuilderCmds = mkOption {
       type = types.lines;
       internal = true;
@@ -241,12 +253,19 @@ in
 
   config = {
 
-    system.extraSystemBuilderCmds =
-      optionalString
+    system.extraSystemBuilderCmds = concatStringsSep "\n" [
+      (optionalString
         config.system.copySystemConfiguration
         ''ln -s '${import ../../../lib/from-env.nix "NIXOS_CONFIG" <nixos-config>}' \
             "$out/configuration.nix"
-        '';
+        '')
+      (optionalString
+        config.system.copySystemNixpkgs
+        ''
+          ln -s '${builtins.filterSource (name: _: baseNameOf name != ".git" && baseNameOf name != "nixpkgs") pkgs.path}' \
+            "$out/nixpkgs"
+        '')
+    ];
 
     system.build.toplevel = system;
 


### PR DESCRIPTION
This option copies the version of nixpkgs that was used to build the system to
the system path. This is useful for two reasons:

* it allows for reproducing a given system state
* you can easily keep the nixpkgs version that your user uses and that the
  system uses in sync

---

If no one disagrees, I will merge this in 2 weeks (2017-25-07).