### PR TITLE
dotsies: init

### DIFF
--- a/pkgs/data/fonts/dotsies/default.nix
+++ b/pkgs/data/fonts/dotsies/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "dotsies";
+
+  regular = fetchurl {
+    name = "dotsies-regular";
+    url = "http://dotsies.org/Dotsies.ttf";
+    sha256 = "0cg0ay1524k178rzaipx6nw7pv15ibwynpx2w4lp8h9xb10k40nn";
+  };
+
+  training-wheels = fetchurl {
+    name = "dotsies-training-wheel";
+    url = "http://dotsies.org/Dotsies%20Training%20Wheels.ttf";
+    sha256 = "10igqaw5c7a50vcyfnfm66bgx5vl4chb8a6kd9vsinpr2mc5ywnm";
+  };
+
+  wide = fetchurl {
+    name = "dotsies-wide";
+    url = "http://dotsies.org/Dotsies%20Wide.ttf";
+    sha256 = "0xpn0b5mvmilr3llmg0qf6a9dip4nwzllkzdg5svpz15i3kb2x39";
+  };
+
+  context = fetchurl {
+    name = "dotsies-context";
+    url = "http://dotsies.org/Dotsies%20Context.ttf";
+    sha256 = "11z834ipcfv7xp9znp1afsfgahbi5vgp863izlkksylp2wgm52dp";
+  };
+
+  striped = fetchurl {
+    name = "dotsies-striped";
+    url = "http://dotsies.org/Dotsies%20Striped.ttf";
+    sha256 = "1yf3b44ipi4fyvr56ac7bbm9id70bgsv63wr2iz4xc8a8wr18sli";
+  };
+
+  roman = fetchurl {
+    name = "dotsies-roman";
+    url = "http://dotsies.org/Dotsies%20Roman.ttf";
+    sha256 = "11n11m7wpnqa72i4dh7qx4lnpd183mljm1ir8asyncyvll1x2a5i";
+  };
+
+  unpackPhase = "true";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp ${regular} $out/share/fonts/truetype/Dotsies.ttf
+    cp ${training-wheels} $out/share/fonts/truetype/Dotsies\ Training\ Wheels.ttf
+    cp ${wide} $out/share/fonts/truetype/Dotsies\ Wide.ttf
+    cp ${context} $out/share/fonts/truetype/Dotsies\ Context.ttf
+    cp ${striped} $out/share/fonts/truetype/Dotsies\ Striped.ttf
+    cp ${roman} $out/share/fonts/truetype/Dotsies\ Roman.ttf
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://dotsies.org/;
+    description = "Dotsies is a font that uses dots instead of letters.";
+    longDescription = ''
+      Dotsies is a font that uses dots instead of letters. Dotsies is optimized for reading. The letters in each word smoosh together, so words look like shapes.
+    '';
+    license = with licenses; [ unfree ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18876,4 +18876,6 @@ with pkgs;
   linode-cli = callPackage ../tools/virtualization/linode-cli { };
 
   hss = callPackage ../tools/networking/hss {};
+
+  dotsies = callPackage ../data/fonts/dotsies { };
 }


### PR DESCRIPTION
Dotsies is an experimental font, designed for fast reading.
I did'nt find any licensing information, so dotsies is added as unfree.

Also there originally exists no versioning, so I thought it would'nt be helpful to introduce it in nixpkgs.

http://dotsies.org/

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

