### PR TITLE
Support High Sierra on Darwin

### DIFF
--- a/pkgs/applications/editors/nano/default.nix
+++ b/pkgs/applications/editors/nano/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub
+{ stdenv, hostPlatform, fetchurl, fetchFromGitHub
 , ncurses
 , texinfo
 , gettext ? null
@@ -26,6 +26,8 @@ in stdenv.mkDerivation rec {
     url = "mirror://gnu/nano/${name}.tar.xz";
     sha256 = "1hl9gni3qmblr062a7w6vz16gvxbswgc5c19c923ja0bk48vyhyb";
   };
+
+  patches = stdenv.lib.optional hostPlatform.isDarwin stdenv.secure-format-patch;
 
   nativeBuildInputs = [ texinfo ] ++ optional enableNls gettext;
   buildInputs = [ ncurses ];

--- a/pkgs/development/libraries/libunistring/default.nix
+++ b/pkgs/development/libraries/libunistring/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ra1baz2187kbw9im47g6kqb5mx9plq703mkjxaval8rxv5q3q4w";
   };
 
-  patches = stdenv.lib.optional stdenv.isDarwin [ ./clang.patch ];
+  patches = stdenv.lib.optionals stdenv.isDarwin [ ./clang.patch stdenv.secure-format-patch ];
 
   outputs = [ "out" "dev" "info" "doc" ];
 

--- a/pkgs/development/tools/misc/gnum4/default.nix
+++ b/pkgs/development/tools/misc/gnum4/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, hostPlatform, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "gnum4-1.4.18";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   configureFlags = "--with-syscmd-shell=${stdenv.shell}";
 
   # Upstream is aware of it; it may be in the next release.
-  patches = [ ./s_isdir.patch ];
+  patches = [ ./s_isdir.patch ] ++ stdenv.lib.optional hostPlatform.isDarwin stdenv.secure-format-patch;
 
   # FIXME needs gcc 4.9 in bootstrap tools
   hardeningDisable = [ "stackprotector" ];

--- a/pkgs/development/tools/parsing/bison/3.x.nix
+++ b/pkgs/development/tools/parsing/bison/3.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, m4, perl, help2man }:
+{ stdenv, hostPlatform, fetchurl, m4, perl, help2man }:
 
 stdenv.mkDerivation rec {
   name = "bison-3.0.4";
@@ -7,6 +7,8 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/bison/${name}.tar.gz";
     sha256 = "b67fd2daae7a64b5ba862c66c07c1addb9e6b1b05c5f2049392cfd8a2172952e";
   };
+
+  patches = stdenv.lib.optional hostPlatform.isDarwin stdenv.secure-format-patch;
 
   nativeBuildInputs = [ m4 perl ] ++ stdenv.lib.optional stdenv.isSunOS help2man;
   propagatedBuildInputs = [ m4 ];

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/reexported_libraries
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/reexported_libraries
@@ -19,7 +19,7 @@
 
 /usr/lib/system/libsystem_configuration.dylib
 /usr/lib/system/libsystem_coreservices.dylib
-/usr/lib/system/libsystem_coretls.dylib
+# /usr/lib/system/libsystem_coretls.dylib # Removed in 10.13
 /usr/lib/system/libsystem_dnssd.dylib
 /usr/lib/system/libsystem_info.dylib
 

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/system_kernel_symbols
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/system_kernel_symbols
@@ -376,7 +376,6 @@ _fsync
 _fsync$NOCANCEL
 _ftruncate
 _futimes
-_get_dp_control_port
 _getattrlist
 _getattrlistat
 _getattrlistbulk
@@ -838,7 +837,6 @@ _sendmsg$NOCANCEL
 _sendmsg_x
 _sendto
 _sendto$NOCANCEL
-_set_dp_control_port
 _setattrlist
 _setaudit
 _setaudit_addr

--- a/pkgs/stdenv/darwin/darwin-secure-format.patch
+++ b/pkgs/stdenv/darwin/darwin-secure-format.patch
@@ -1,0 +1,15 @@
+With format string strictness, High Sierra also enforces that %n isn't used
+in dynamic format strings, but we should just disable its use on darwin in
+general.
+
+--- a/lib/vasnprintf.c	2017-06-22 15:19:15.000000000 -0700
++++ b/lib/vasnprintf.c	2017-06-22 15:20:20.000000000 -0700
+@@ -4869,7 +4869,7 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !defined(__APPLE__) && !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -4,15 +4,15 @@
 # Allow passing in bootstrap files directly so we can test the stdenv bootstrap process when changing the bootstrap tools
 , bootstrapFiles ? let
   fetch = { file, sha256, executable ? true }: import <nix/fetchurl.nix> {
-    url = "http://tarballs.nixos.org/stdenv-darwin/x86_64/c4effbe806be9a0a3727fdbbc9a5e28149347532/${file}";
+    url = "http://tarballs.nixos.org/stdenv-darwin/x86_64/10cbca5b30c6cb421ce15139f32ae3a4977292cf/${file}";
     inherit (localSystem) system;
     inherit sha256 executable;
   }; in {
-    sh      = fetch { file = "sh";    sha256 = "1b9r3dksj907bpxp589yhc4217cas73vni8sng4r57f04ydjcinr"; };
-    bzip2   = fetch { file = "bzip2"; sha256 = "1wm28jgap4cbr8hf4ambg6h9flr2b4mcbh7fw20i0l51v6n8igky"; };
-    mkdir   = fetch { file = "mkdir"; sha256 = "0jc32mzx2whhx2xh70grvvgz4jj26118p9yxmhjqcysagc0k7y66"; };
-    cpio    = fetch { file = "cpio";  sha256 = "0x5dcczkzn0g8yb4pah449jmgy3nmpzrqy4s480grcx05b6v6hkp"; };
-    tarball = fetch { file = "bootstrap-tools.cpio.bz2"; sha256 = "0ifdc8bwxdhmpbhx2vd3lwjg71gqm6pi5mfm0fkcsbqavl8hd8hz"; executable = false; };
+    sh      = fetch { file = "sh";    sha256 = "0s8a9vpzj6vadq4jmf4r8cargwnsf327hdjydxgqsfxb8y1q39w3"; };
+    bzip2   = fetch { file = "bzip2"; sha256 = "1jqljpjr8mkiv7g5rl5impqx3all8vn1mxxdwa004pr3h48c1zgg"; };
+    mkdir   = fetch { file = "mkdir"; sha256 = "17zsjiwnq07i5r85q1hg7f6cnkcgllwy2amz9klaqwjy4vzz4vwh"; };
+    cpio    = fetch { file = "cpio";  sha256 = "04hrair58dgja6syh442pswiga5an9nl58ls57yknkn2pq51nx9m"; };
+    tarball = fetch { file = "bootstrap-tools.cpio.bz2"; sha256 = "103833hrci0vwi1gi978hkp69rncicvpdszn87ffpf1cq0jzpa14"; executable = false; };
   }
 }:
 
@@ -109,7 +109,13 @@ in rec {
         stdenvSandboxProfile = binShClosure + libSystemProfile;
         extraSandboxProfile  = binShClosure + libSystemProfile;
 
-        extraAttrs = { inherit platform; parent = last; };
+        extraAttrs = {
+          inherit platform;
+          parent = last;
+
+          # This is used all over the place so I figured I'd just leave it here for now
+          secure-format-patch = ./darwin-secure-format.patch;
+        };
         overrides  = self: super: (overrides self super) // { fetchurl = thisStdenv.fetchurlBoot; };
       };
 
@@ -319,6 +325,9 @@ in rec {
       inherit platform bootstrapTools;
       libc         = pkgs.darwin.Libsystem;
       shellPackage = pkgs.bash;
+
+      # This is used all over the place so I figured I'd just leave it here for now
+      secure-format-patch = ./darwin-secure-format.patch;
     };
 
     allowedRequisites = (with pkgs; [

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, xz }:
+{ stdenv, hostPlatform, fetchurl, xz }:
 
 stdenv.mkDerivation rec {
   name = "gzip-${version}";
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/gzip/${name}.tar.xz";
     sha256 = "1lxv3p4iyx7833mlihkn5wfwmz4cys5nybwpz3dfawag8kn6f5zz";
   };
+
+  patches = stdenv.lib.optional hostPlatform.isDarwin stdenv.secure-format-patch;
 
   outputs = [ "out" "man" "info" ];
 

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -24,7 +24,8 @@ stdenv.mkDerivation rec {
   # FIXME needs gcc 4.9 in bootstrap tools
   hardeningDisable = [ "stackprotector" ];
 
-  patches = optional hostPlatform.isCygwin ./coreutils-8.23-4.cygwin.patch;
+  patches = optional hostPlatform.isCygwin ./coreutils-8.23-4.cygwin.patch
+    ++ optional hostPlatform.isDarwin stdenv.secure-format-patch;
 
   # The test tends to fail on btrfs and maybe other unusual filesystems.
   postPatch = optionalString (!hostPlatform.isDarwin) ''


### PR DESCRIPTION
###### Motivation for this change

An upcoming macOS 10.13 release breaks the current nixpkgs. This should fix it. Please test on 10.11, 10.12, and even 10.10 (which is a best effort, but should still probably work).

Should fix https://github.com/NixOS/nix/issues/1414 https://github.com/NixOS/nix/issues/1451 once this flows through to the Nix build.

This could be done without a linux mass-rebuild, but I figured I'd just send to staging since that lets me use `lib.optional` rather than `null` in derivation attributes.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (10.13)
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

