### PR TITLE
polari: unbreak

### DIFF
--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
@@ -39,7 +39,7 @@ wrapGAppsHook() {
     targetDirs=( "${prefix}/bin" "${prefix}/libexec" )
     for targetDir in "${targetDirs[@]}"; do
       if [[ -d "${targetDir}" ]]; then
-        find "${targetDir}" -type f -executable -print0 \
+        find -L "${targetDir}" -type f -executable -print0 \
           | while IFS= read -r -d '' file; do
           echo "Wrapping program ${file}"
           wrapProgram "${file}" "${gappsWrapperArgs[@]}"

--- a/pkgs/desktops/gnome-3/3.22/apps/polari/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/apps/polari/default.nix
@@ -1,15 +1,15 @@
 { stdenv, intltool, fetchurl, gdk_pixbuf, adwaita-icon-theme
 , telepathy_glib, gjs, itstool, telepathy_idle, libxml2
 , pkgconfig, gtk3, glib, librsvg, libsecret, libsoup
-, gnome3, wrapGAppsHook }:
+, gnome3, wrapGAppsHook, telepathy_logger }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
-  propagatedUserEnvPkgs = [ telepathy_idle ];
+  propagatedUserEnvPkgs = [ telepathy_idle telepathy_logger ];
 
-  buildInputs = [ pkgconfig gtk3 glib intltool itstool adwaita-icon-theme wrapGAppsHook
-                  telepathy_glib gjs gdk_pixbuf librsvg libxml2 libsecret libsoup ];
+  buildInputs = [ pkgconfig gtk3 glib intltool itstool adwaita-icon-theme wrapGAppsHook gnome3.gsettings_desktop_schemas
+                  telepathy_glib telepathy_logger gjs gdk_pixbuf librsvg libxml2 libsecret libsoup ];
 
   enableParallelBuilding = true;
 
@@ -19,6 +19,5 @@ stdenv.mkDerivation rec {
     maintainers = gnome3.maintainers;
     license = licenses.gpl2;
     platforms = platforms.linux;
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Things done

1. The build was failing due to missing telepathy_logger dependency. I added it.

2. Since bin/polari file is actually a symbolic link, `wrapGAppsHook` did not wrap it, making it unable to access GObject introspection definitions required for running the program. I made the wrapping script follow symlinks to fix this corner case.

3. ~~GNOME expects the executable to have the same base name as the associated desktop file. When I wrapped the executable, I broke this correspondence. That is why I renamed the executable. For convenience, I also created a symlink with the original name.~~ Edit: This was probably just an issuel with dbus needing to be restarted to find the service file for launching from GNOME Shell.

###### What is missing

The app is now running but it cannot connect to server due to in-memory gsettings (#26131).

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
