### PR TITLE
miso: init at 0.2.0.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -150,6 +150,17 @@ self: super:
   http2 = addBuildDepends super.http2 [ self.aeson self.aeson-pretty self.hex self.unordered-containers self.vector self.word8 ];
   # ghcjsBoot uses async 2.0.1.6, protolude wants 2.1.*
 
+  # These are the correct dependencies specified when calling `cabal2nix --compiler ghcjs`
+  # By default, the `miso` derivation present in hackage-packages.nix
+  # does not contain dependencies suitable for ghcjs
+  miso = overrideCabal super.miso (drv: {
+      libraryHaskellDepends = with self; [
+        BoundedChan bytestring containers ghcjs-base aeson base
+        http-api-data http-types network-uri scientific servant text
+        transformers unordered-containers vector
+      ];
+    });
+
   pqueue = overrideCabal super.pqueue (drv: {
     postPatch = ''
       sed -i -e '12s|null|Data.PQueue.Internals.null|' Data/PQueue/Internals.hs


### PR DESCRIPTION
Adds `miso-0.2.0.0` to `ghcjs` overrides
cc @peti 

###### Motivation for this change
To add the correct dependencies to the ghcjs version of [miso](https://github.com/dmjio/miso).

Currently, the version of `miso` in `hackage-packages.nix` is for `ghc` only (i.e. doesn't have correct `ghcjs` depedencies -- since it wasn't generated with `cabal2nix` appropriately. It needs to specify the correct compiler flag, `cabal2nix --compiler ghcjs`, otherwise it will not build). This override specifies a new derivation with the correct client dependencies when using `haskell.packages.ghcjs.miso` (basically same as calling `cabal2nix --compiler ghcjs`)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

