### PR TITLE
pythonPackages.django_raster: fix and 0.4 -> 0.5

### DIFF
--- a/pkgs/development/python-modules/celery/fix_endless_python3.6_loop_logger_isa.patch
+++ b/pkgs/development/python-modules/celery/fix_endless_python3.6_loop_logger_isa.patch
@@ -1,0 +1,18 @@
+Description: Fix endless loop in logger_isa (Python 3.6)
+Author: George Psarakis <giwrgos.psarakis@gmail.com>
+Origin: upstream, https://github.com/celery/celery/commit/9c950b47eca2b4e93fd2fe52cf80f158e6cf97ad
+Forwarded: not-needed
+Reviewed-By: Nishanth Aravamudan <nish.aravamudan@canonical.com>
+Last-Update: 2017-06-12
+
+--- celery-4.0.2.orig/celery/utils/log.py
++++ celery-4.0.2/celery/utils/log.py
+@@ -82,7 +82,7 @@ def logger_isa(l, p, max=1000):
+         else:
+             if this in seen:
+                 raise RuntimeError(
+-                    'Logger {0!r} parents recursive'.format(l),
++                    'Logger {0!r} parents recursive'.format(l.name),
+                 )
+             seen.add(this)
+             this = this.parent

--- a/pkgs/development/python-modules/django-raster/default.nix
+++ b/pkgs/development/python-modules/django-raster/default.nix
@@ -3,13 +3,13 @@
   pyparsing, django, celery
 }:
 buildPythonPackage rec {
-  version = "0.4";
+  version = "0.5";
   pname = "django-raster";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://pypi/d/django-raster/${name}.tar.gz";
-    sha256 = "7fd6afa42b07ac51a3873e3d4840325dd3a8a631fdb5b853c76fbbfe59a2b17f";
+    sha256 = "0v1jldb13s4dqq1vaq8ghfv3743jpi9a9n05bqgjm8szlkq8s7ah";
   };
 
   # Tests require a postgresql + postgis server

--- a/pkgs/development/python-modules/olefile/default.nix
+++ b/pkgs/development/python-modules/olefile/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+  pname = "olefile";
+  version = "0.44";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "1bbk1xplmrhymqpk6rkb15sg7v9qfih7zh23p6g2fxxas06cmwk1";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Python package to parse, read and write Microsoft OLE2 files";
+    homepage = https://www.decalage.info/python/olefileio;
+    # BSD like + reference to Pillow
+    license = "http://olefile.readthedocs.io/en/latest/License.html";
+  };
+}

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPyPy,
+  nose, olefile,
+  freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2, tk, libX11}:
+buildPythonPackage rec {
+  pname = "Pillow";
+  version = "4.2.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wq0fiw964bj5rdmw66mhbfsjnmb13bcdr42krpk2ig5f1cgc967";
+  };
+
+  doCheck = !stdenv.isDarwin && !isPyPy;
+
+  # Disable imagefont tests, because they don't work well with infinality:
+  # https://github.com/python-pillow/Pillow/issues/1259
+  postPatch = ''
+    rm Tests/test_imagefont.py
+  '';
+
+  propagatedBuildInputs = [ olefile ];
+
+  buildInputs = [
+    freetype libjpeg zlib libtiff libwebp tcl nose lcms2 ]
+    ++ stdenv.lib.optionals (isPyPy) [ tk libX11 ];
+
+  # NOTE: we use LCMS_ROOT as WEBP root since there is not other setting for webp.
+  preConfigure = let
+    libinclude' = pkg: ''"${pkg.out}/lib", "${pkg.out}/include"'';
+    libinclude = pkg: ''"${pkg.out}/lib", "${pkg.dev}/include"'';
+  in ''
+    sed -i "setup.py" \
+        -e 's|^FREETYPE_ROOT =.*$|FREETYPE_ROOT = ${libinclude freetype}|g ;
+            s|^JPEG_ROOT =.*$|JPEG_ROOT = ${libinclude libjpeg}|g ;
+            s|^ZLIB_ROOT =.*$|ZLIB_ROOT = ${libinclude zlib}|g ;
+            s|^LCMS_ROOT =.*$|LCMS_ROOT = ${libinclude lcms2}|g ;
+            s|^TIFF_ROOT =.*$|TIFF_ROOT = ${libinclude libtiff}|g ;
+            s|^TCL_ROOT=.*$|TCL_ROOT = ${libinclude' tcl}|g ;'
+    export LDFLAGS="-L${libwebp}/lib"
+    export CFLAGS="-I${libwebp}/include"
+  ''
+  # Remove impurities
+  + stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace setup.py \
+      --replace '"/Library/Frameworks",' "" \
+      --replace '"/System/Library/Frameworks"' ""
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://python-pillow.github.io/";
+    description = "Fork of The Python Imaging Library (PIL)";
+    longDescription = ''
+      The Python Imaging Library (PIL) adds image processing
+      capabilities to your Python interpreter.  This library
+      supports many file formats, and provides powerful image
+      processing and graphics capabilities.
+    '';
+    license = "http://www.pythonware.com/products/pil/license.htm";
+    maintainers = with maintainers; [ goibhniu prikhi ];
+  };
+}

--- a/pkgs/development/python-modules/pyparsing/default.nix
+++ b/pkgs/development/python-modules/pyparsing/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+    pname = "pyparsing";
+    name = "${pname}-${version}";
+    version = "2.2.0";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "016b9gh606aa44sq92jslm89bg874ia0yyiyb643fa6dgbsbqch8";
+    };
+
+    # Not everything necessary to run the tests is included in the distribution
+    doCheck = false;
+
+    meta = with stdenv.lib; {
+      homepage = http://pyparsing.wikispaces.com/;
+      description = "An alternative approach to creating and executing simple grammars, vs. the traditional lex/yacc approach, or the use of regular expressions";
+      license = licenses.mit;
+    };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12852,6 +12852,14 @@ in {
       sha256 = "18hiricdnbnlz6hx3hbaa4dni6npv8rbid4dhf7k02k16qm6zz6h";
     };
 
+    # Backport fix for python-3.6 from master (see issue https://github.com/celery/kombu/issues/675)
+    # TODO remove at next update
+    patches = [ (pkgs.fetchpatch {
+      url = "https://github.com/celery/kombu/commit/dc3fceff59d79ceac3f8f11a5d697beabb4b7a7f.patch";
+      sha256 = "0s6gsihzjvmpffc7xrrcijw00r56yb74jg0sbjgng2v1324z1da9";
+      name = "don-t-modify-dict-size-while-iterating-over-it";
+    }) ];
+
     buildInputs = with self; [ pytest case pytz ];
 
     propagatedBuildInputs = with self; [ amqp ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19564,23 +19564,7 @@ in {
     };
   };
 
-  pyparsing = buildPythonPackage rec {
-    name = "pyparsing-${version}";
-    version = "2.1.10";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pyparsing/${name}.tar.gz";
-      sha256 = "811c3e7b0031021137fc83e051795025fcb98674d07eb8fe922ba4de53d39188";
-    };
-
-    # Not everything necessary to run the tests is included in the distribution
-    doCheck = false;
-
-    meta = {
-      homepage = http://pyparsing.wikispaces.com/;
-      description = "An alternative approach to creating and executing simple grammars, vs. the traditional lex/yacc approach, or the use of regular expressions";
-    };
-  };
+  pyparsing = callPackage ../development/python-modules/pyparsing { };
 
   pyparted = buildPythonPackage rec {
     name = "pyparted-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3466,6 +3466,12 @@ in {
       sha256 = "0kgmbs3fl9879n48p4m79nxy9by2yhvxq1jdvlnqzzvkdb2sdmg3";
     };
 
+    # Fixes testsuite for python-3.6
+    # From ubuntu packaging: https://launchpad.net/ubuntu/+archive/primary/+files/celery_4.0.2-0ubuntu1.debian.tar.xz
+    # (linked from https://launchpad.net/ubuntu/+source/celery)
+    # https://github.com/celery/celery/pull/3736#issuecomment-274155454 from upstream
+    patches = [ ../development/python-modules/celery/fix_endless_python3.6_loop_logger_isa.patch ];
+
     buildInputs = with self; [ pytest case ];
     propagatedBuildInputs = with self; [ kombu billiard pytz anyjson amqp eventlet ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17883,61 +17883,9 @@ in {
 
   pystringtemplate = callPackage ../development/python-modules/stringtemplate { };
 
-  pillow = buildPythonPackage rec {
-    name = "Pillow-${version}";
-    version = "3.4.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/P/Pillow/${name}.tar.gz";
-      sha256 = "0ee9975c05602e755ff5000232e0335ba30d507f6261922a658ee11b1cec36d1";
-    };
-
-    doCheck = !stdenv.isDarwin && !isPyPy;
-
-    # Disable imagefont tests, because they don't work well with infinality:
-    # https://github.com/python-pillow/Pillow/issues/1259
-    postPatch = ''
-      rm Tests/test_imagefont.py
-    '';
-
-    buildInputs = with self; [
-      pkgs.freetype pkgs.libjpeg pkgs.zlib pkgs.libtiff pkgs.libwebp pkgs.tcl nose pkgs.lcms2 ]
-      ++ optionals (isPyPy) [ pkgs.tk pkgs.xorg.libX11 ];
-
-    # NOTE: we use LCMS_ROOT as WEBP root since there is not other setting for webp.
-    preConfigure = let
-      libinclude' = pkg: ''"${pkg.out}/lib", "${pkg.out}/include"'';
-      libinclude = pkg: ''"${pkg.out}/lib", "${pkg.dev}/include"'';
-    in ''
-      sed -i "setup.py" \
-          -e 's|^FREETYPE_ROOT =.*$|FREETYPE_ROOT = ${libinclude pkgs.freetype}|g ;
-              s|^JPEG_ROOT =.*$|JPEG_ROOT = ${libinclude pkgs.libjpeg}|g ;
-              s|^ZLIB_ROOT =.*$|ZLIB_ROOT = ${libinclude pkgs.zlib}|g ;
-              s|^LCMS_ROOT =.*$|LCMS_ROOT = ${libinclude pkgs.lcms2}|g ;
-              s|^TIFF_ROOT =.*$|TIFF_ROOT = ${libinclude pkgs.libtiff}|g ;
-              s|^TCL_ROOT=.*$|TCL_ROOT = ${libinclude' pkgs.tcl}|g ;'
-      export LDFLAGS="-L${pkgs.libwebp}/lib"
-      export CFLAGS="-I${pkgs.libwebp}/include"
-    ''
-    # Remove impurities
-    + stdenv.lib.optionalString stdenv.isDarwin ''
-      substituteInPlace setup.py \
-        --replace '"/Library/Frameworks",' "" \
-        --replace '"/System/Library/Frameworks"' ""
-    '';
-
-    meta = {
-      homepage = "https://python-pillow.github.io/";
-      description = "Fork of The Python Imaging Library (PIL)";
-      longDescription = ''
-        The Python Imaging Library (PIL) adds image processing
-        capabilities to your Python interpreter.  This library
-        supports many file formats, and provides powerful image
-        processing and graphics capabilities.
-      '';
-      license = "http://www.pythonware.com/products/pil/license.htm";
-      maintainers = with maintainers; [ goibhniu prikhi ];
-    };
+  pillow = callPackage ../development/python-modules/pillow {
+    inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
+    inherit (pkgs.xorg) libX11;
   };
 
   pkgconfig = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16892,6 +16892,8 @@ in {
     };
   };
 
+  olefile = callPackage ../development/python-modules/olefile { };
+
   oslo-log = buildPythonPackage rec {
     name = "oslo.log-${version}";
     version = "1.12.1";


### PR DESCRIPTION
###### Motivation for this change

`pythonPackages.django-raster` have been broken by 6b999f3c42607342231b6fe119fcf0f934f40fd8. This PR fixes it (and updates it while I am at it).

It also includes updates and fixes for python-3.6 related issues where necessary.

I have not yet rebuilt all dependencies impacted by the Pillow update (not enough space disk here to build them all).

cc @FRidh 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

