### PR TITLE
undaemonize: init at 2017-07-11

### DIFF
--- a/pkgs/tools/system/undaemonize/default.nix
+++ b/pkgs/tools/system/undaemonize/default.nix
@@ -9,8 +9,7 @@ stdenv.mkDerivation {
     sha256 = "1fkrgj3xfhj820qagh5p0rabl8z2hpad6yp984v92h9pgbfwxs33";
   };
   installPhase = ''
-    mkdir -p $out/bin
-    cp undaemonize $out/bin/
+    install -D undaemonize $out/bin/undaemonize
   '';
   meta = {
     description = "Tiny helper utility to force programs which insist on daemonizing themselves to run in the foreground";

--- a/pkgs/tools/system/undaemonize/default.nix
+++ b/pkgs/tools/system/undaemonize/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  name = "undaemonize";
+  name = "undaemonize-2017-07-11";
   src = fetchFromGitHub {
     repo = "undaemonize";
     owner = "nickstenning";

--- a/pkgs/tools/system/undaemonize/default.nix
+++ b/pkgs/tools/system/undaemonize/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  name = "undaemonize";
+  src = fetchFromGitHub {
+    repo = "undaemonize";
+    owner = "nickstenning";
+    rev = "master";
+    sha256 = "1fkrgj3xfhj820qagh5p0rabl8z2hpad6yp984v92h9pgbfwxs33";
+  };
+  installPhase = ''
+    mkdir -p $out/bin
+    cp undaemonize $out/bin/
+  '';
+  meta = {
+    description = "Tiny helper utility to force programs which insist on daemonizing themselves to run in the foreground";
+    homepage = "https://github.com/nickstenning/undaemonize";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.canndrew ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}
+

--- a/pkgs/tools/system/undaemonize/default.nix
+++ b/pkgs/tools/system/undaemonize/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     repo = "undaemonize";
     owner = "nickstenning";
-    rev = "master";
+    rev = "a181cfd900851543ee1f85fe8f76bc8916b446d4";
     sha256 = "1fkrgj3xfhj820qagh5p0rabl8z2hpad6yp984v92h9pgbfwxs33";
   };
   installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19091,4 +19091,6 @@ with pkgs;
   linode-cli = callPackage ../tools/virtualization/linode-cli { };
 
   hss = callPackage ../tools/networking/hss {};
+
+  undaemonize = callPackage ../tools/system/undaemonize {};
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

