### PR TITLE
PULL_REQUEST_TEMPLATE: Ask for docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@
 - [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
 - [ ] Tested execution of all binary files (usually in `./result/bin/`)
 - [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
+- [ ] Assured whether relevant documentation is up to date
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
 
 ---


### PR DESCRIPTION
###### Motivation for this change

Based on a discussion in the `#nixos` IRC channel, we want to put a higher emphasis on docs.

This PR puts `Added/updated the necessary docs` as the first step into the `Things done` list.

We want to make clear to contributors that we care about docs.

A later PR should link to specific instructions (probably in `CONTRIBUTING.md`) that ease beginners into contributing docs to remove any possible barriers.