### PR TITLE
Stdenv setup misc cleanups

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -211,7 +211,7 @@ stdenv.mkDerivation ({
     configureFlags="${concatStringsSep " " defaultConfigureFlags} $configureFlags"
 
     # nativePkgs defined in stdenv/setup.hs
-    for p in $nativePkgs; do
+    for p in "''${!nativePkgs[@]}"; do
       if [ -d "$p/lib/${ghc.name}/package.conf.d" ]; then
         cp -f "$p/lib/${ghc.name}/package.conf.d/"*.conf $packageConfDir/
         continue

--- a/pkgs/development/interpreters/python/wrap.sh
+++ b/pkgs/development/interpreters/python/wrap.sh
@@ -86,7 +86,7 @@ wrapPythonProgramsIn() {
 _addToPythonPath() {
     local dir="$1"
     # Stop if we've already visited here.
-    if [ -n "${pythonPathsSeen[$dir]}" ]; then return; fi
+    [ -n "${pythonPathsSeen[$dir]}" ] || return 0
     pythonPathsSeen[$dir]=1
     # addToSearchPath is defined in stdenv/generic/setup.sh. It will have
     # the effect of calling `export program_X=$dir/...:$program_X`.

--- a/pkgs/servers/x11/xorg/builder.sh
+++ b/pkgs/servers/x11/xorg/builder.sh
@@ -18,14 +18,14 @@ postInstall() {
 
     for r in $requires; do
         if test -n "$crossConfig"; then
-            for p in $crossPkgs; do
+            for p in "${!crossPkgs[@]}"; do
                 if test -e $p/lib/pkgconfig/$r.pc; then
                     echo "  found requisite $r in $p"
                     propagatedBuildInputs="$propagatedBuildInputs $p"
                 fi
             done
         else
-            for p in $nativePkgs; do
+            for p in "${!nativePkgs[@]}"; do
                 if test -e $p/lib/pkgconfig/$r.pc; then
                     echo "  found requisite $r in $p"
                     propagatedNativeBuildInputs="$propagatedNativeBuildInputs $p"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -13,10 +13,10 @@ set -o pipefail
 # code). The hooks for <hookName> are the shell function or variable
 # <hookName>, and the values of the shell array ‘<hookName>Hooks’.
 runHook() {
-    local hookName="$1"
+    local hookName=$1
     shift
     local var="$hookName"
-    if [[ "$hookName" =~ Hook$ ]]; then var+=s; else var+=Hooks; fi
+    if [[ $hookName =~ Hook$ ]]; then var+=s; else var+=Hooks; fi
     local -n var
     local hook
     for hook in "_callImplicitHook 0 $hookName" "${var[@]}"; do
@@ -29,10 +29,10 @@ runHook() {
 # Run all hooks with the specified name, until one succeeds (returns a
 # zero exit code). If none succeed, return a non-zero exit code.
 runOneHook() {
-    local hookName="$1"
+    local hookName=$1
     shift
     local var="$hookName"
-    if [[ "$hookName" =~ Hook$ ]]; then var+=s; else var+=Hooks; fi
+    if [[ $hookName =~ Hook$ ]]; then var+=s; else var+=Hooks; fi
     local -n var
     local hook
     for hook in "_callImplicitHook 1 $hookName" "${var[@]}"; do
@@ -50,8 +50,8 @@ runOneHook() {
 # environment variables) and from shell scripts (as functions). If you
 # want to allow multiple hooks, use runHook instead.
 _callImplicitHook() {
-    local def="$1"
-    local hookName="$2"
+    local def=$1
+    local hookName=$2
     case "$(type -t "$hookName")" in
         (function|alias|builtin) "$hookName";;
         (file) source "$hookName";;
@@ -64,7 +64,7 @@ _callImplicitHook() {
 # A function wrapper around ‘eval’ that ensures that ‘return’ inside
 # hooks exits the hook, not the caller.
 _eval() {
-    local code="$1"
+    local code=$1
     shift
     if [ "$(type -t "$code")" = function ]; then
         eval "$code \"\$@\""
@@ -195,26 +195,26 @@ _addRpathPrefix() {
 
 # Return success if the specified file is an ELF object.
 isELF() {
-    local fn="$1"
+    local fn=$1
     local fd
     local magic
     exec {fd}< "$fn"
     read -r -n 4 -u $fd magic
     exec {fd}<&-
-    if [[ "$magic" =~ ELF ]]; then return 0; else return 1; fi
+    if [[ $magic =~ ELF ]]; then return 0; else return 1; fi
 }
 
 # Return success if the specified file is a script (i.e. starts with
 # "#!").
 isScript() {
-    local fn="$1"
+    local fn=$1
     local fd
     local magic
     if ! [ -x /bin/sh ]; then return 0; fi
     exec {fd}< "$fn"
     read -r -n 2 -u $fd magic
     exec {fd}<&-
-    if [[ "$magic" =~ \#! ]]; then return 0; else return 1; fi
+    if [[ $magic =~ \#! ]]; then return 0; else return 1; fi
 }
 
 # printf unfortunately will print a trailing newline regardless
@@ -255,8 +255,8 @@ fi
 
 # Check that the pre-hook initialised SHELL.
 if [ -z "$SHELL" ]; then echo "SHELL not set"; exit 1; fi
-BASH="$SHELL"
-export CONFIG_SHELL="$SHELL"
+BASH=$SHELL
+export CONFIG_SHELL=$SHELL
 
 
 # Dummy implementation of the paxmark function. On Linux, this is
@@ -283,7 +283,7 @@ findInputs() {
     local propagatedBuildInputsFile=$3
 
     # Stop if we've already added this one
-    [[ -z "${varDeref["$pkg"]}" ]] || return 0
+    [[ -z ${varDeref[$pkg]} ]] || return 0
     varDeref["$pkg"]=1
 
     if ! [ -e "$pkg" ]; then
@@ -373,7 +373,7 @@ export TZ=UTC
 # for instance if we just want to perform a test build/install to a
 # temporary location and write a build report to $out.
 if [ -z "$prefix" ]; then
-    prefix="$out";
+    prefix=$out;
 fi
 
 if [ "$useTempPrefix" = 1 ]; then
@@ -449,7 +449,7 @@ substitute() {
                 local varName=$2
                 shift 2
                 # check if the used nix attribute name is a valid bash name
-                if ! [[ "$varName" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+                if ! [[ $varName =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
                     echo "${FUNCNAME[0]}(): WARNING: substitution variables should be valid bash names," >&2
                     echo "  \"$varName\" isn't and therefore was skipped; it might be caused" >&2
                     echo "  by multi-line phases in variables - see #14907 for details." >&2
@@ -480,7 +480,7 @@ substitute() {
 
 
 substituteInPlace() {
-    local fileName="$1"
+    local fileName=$1
     shift
     substitute "$fileName" "$fileName" "$@"
 }
@@ -490,8 +490,8 @@ substituteInPlace() {
 # character or underscore. Note: other names that aren't bash-valid
 # will cause an error during `substitute --subst-var`.
 substituteAll() {
-    local input="$1"
-    local output="$2"
+    local input=$1
+    local output=$2
     local -a args=()
 
     # Select all environment variables that start with a lowercase character.
@@ -507,7 +507,7 @@ substituteAll() {
 
 
 substituteAllInPlace() {
-    local fileName="$1"
+    local fileName=$1
     shift
     substituteAll "$fileName" "$fileName" "$@"
 }
@@ -534,7 +534,7 @@ dumpVars() {
 stripHash() {
     local strippedName
     # On separate line for `set -e`
-    strippedName="$(basename "$1")"
+    strippedName=$(basename "$1")
     if echo "$strippedName" | grep -q '^[a-z0-9]\{32\}-'; then
         echo "$strippedName" | cut -c34-
     else
@@ -545,7 +545,7 @@ stripHash() {
 
 unpackCmdHooks+=(_defaultUnpack)
 _defaultUnpack() {
-    local fn="$1"
+    local fn=$1
 
     if [ -d "$fn" ]; then
 
@@ -576,7 +576,7 @@ _defaultUnpack() {
 
 
 unpackFile() {
-    curSrc="$1"
+    curSrc=$1
     header "unpacking source archive $curSrc" 3
     if ! runOneHook unpackCmd "$curSrc"; then
         echo "do not know how to unpack source archive $curSrc"
@@ -595,7 +595,7 @@ unpackPhase() {
             echo 'variable $src or $srcs should point to the source'
             exit 1
         fi
-        srcs="$src"
+        srcs=$src
     fi
 
     # To determine the source directory created by unpacking the
@@ -629,7 +629,7 @@ unpackPhase() {
                             echo "unpacker produced multiple directories"
                             exit 1
                         fi
-                        sourceRoot="$i"
+                        sourceRoot=$i
                         ;;
                 esac
             fi
@@ -692,7 +692,7 @@ fixLibtool() {
 configurePhase() {
     runHook preConfigure
 
-    if [[ -z "$configureScript" && -x ./configure ]]; then
+    if [[ -z $configureScript && -x ./configure ]]; then
         configureScript=./configure
     fi
 
@@ -704,7 +704,7 @@ configurePhase() {
         done
     fi
 
-    if [[ -z "$dontAddPrefix" && -n "$prefix" ]]; then
+    if [[ -z $dontAddPrefix && -n $prefix ]]; then
         configureFlags="${prefixKey:---prefix=}$prefix $configureFlags"
     fi
 
@@ -912,7 +912,7 @@ distPhase() {
 
 
 showPhaseHeader() {
-    local phase="$1"
+    local phase=$1
     case $phase in
         unpackPhase) header "unpacking sources";;
         patchPhase) header "patching sources";;
@@ -945,14 +945,14 @@ genericBuild() {
     fi
 
     for curPhase in $phases; do
-        if [[ "$curPhase" = buildPhase && -n "$dontBuild" ]]; then continue; fi
-        if [[ "$curPhase" = checkPhase && -z "$doCheck" ]]; then continue; fi
-        if [[ "$curPhase" = installPhase && -n "$dontInstall" ]]; then continue; fi
-        if [[ "$curPhase" = fixupPhase && -n "$dontFixup" ]]; then continue; fi
-        if [[ "$curPhase" = installCheckPhase && -z "$doInstallCheck" ]]; then continue; fi
-        if [[ "$curPhase" = distPhase && -z "$doDist" ]]; then continue; fi
+        if [[ $curPhase = buildPhase && -n $dontBuild ]]; then continue; fi
+        if [[ $curPhase = checkPhase && -z $doCheck ]]; then continue; fi
+        if [[ $curPhase = installPhase && -n $dontInstall ]]; then continue; fi
+        if [[ $curPhase = fixupPhase && -n $dontFixup ]]; then continue; fi
+        if [[ $curPhase = installCheckPhase && -z $doInstallCheck ]]; then continue; fi
+        if [[ $curPhase = distPhase && -z $doDist ]]; then continue; fi
 
-        if [[ -n "$tracePhases" ]]; then
+        if [[ -n $tracePhases ]]; then
             echo
             echo "@ phase-started $out $curPhase"
         fi

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -104,6 +104,17 @@ closeNest() {
     done
 }
 
+# Prints a command such that all word splits are unambiguous. We need
+# to split the command in three parts because the middle format string
+# will be, and must be, repeated for each argument. The first argument
+# goes before the ':' and is just for convenience.
+echoCmd() {
+    printf "%s:" "$1"
+    shift
+    printf ' %q' "$@"
+    echo
+}
+
 
 ######################################################################
 # Error handling.
@@ -725,9 +736,7 @@ configurePhase() {
     if [ -n "$configureScript" ]; then
         # shellcheck disable=SC2086
         local flagsArray=($configureFlags "${configureFlagsArray[@]}")
-        printf 'configure flags:'
-        printf ' %q' "${flagsArray[@]}"
-        echo
+        echoCmd 'configure flags' "${flagsArray[@]}"
         # shellcheck disable=SC2086
         $configureScript "${flagsArray[@]}"
         unset flagsArray
@@ -754,9 +763,7 @@ buildPhase() {
             $makeFlags "${makeFlagsArray[@]}" \
             $buildFlags "${buildFlagsArray[@]}")
 
-        printf 'build flags:'
-        printf ' %q' "${flagsArray[@]}"
-        echo
+        echoCmd 'build flags' "${flagsArray[@]}"
         make ${makefile:+-f $makefile} "${flagsArray[@]}"
         unset flagsArray
     fi
@@ -774,9 +781,7 @@ checkPhase() {
         $makeFlags "${makeFlagsArray[@]}" \
         ${checkFlags:-VERBOSE=y} "${checkFlagsArray[@]}" ${checkTarget:-check})
 
-    printf 'check flags:'
-    printf ' %q' "${flagsArray[@]}"
-    echo
+    echoCmd 'check flags' "${flagsArray[@]}"
     make ${makefile:+-f $makefile} "${flagsArray[@]}"
     unset flagsArray
 
@@ -798,9 +803,7 @@ installPhase() {
         $makeFlags "${makeFlagsArray[@]}" \
         $installFlags "${installFlagsArray[@]}")
 
-    printf 'install flags:'
-    printf ' %q' "${flagsArray[@]}"
-    echo
+    echoCmd 'install flags' "${flagsArray[@]}"
     make ${makefile:+-f $makefile} "${flagsArray[@]}"
     unset flagsArray
 
@@ -879,9 +882,7 @@ installCheckPhase() {
         $makeFlags "${makeFlagsArray[@]}" \
         $installCheckFlags "${installCheckFlagsArray[@]}" ${installCheckTarget:-installcheck})
 
-    printf 'installcheck flags:'
-    printf ' %q' "${flagsArray[@]}"
-    echo
+    echoCmd 'installcheck flags' "${flagsArray[@]}"
     make ${makefile:+-f $makefile} "${flagsArray[@]}"
     unset flagsArray
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -742,7 +742,7 @@ configurePhase() {
 buildPhase() {
     runHook preBuild
 
-    if [ -z "$makeFlags" ] && ! [[ -n "$makefile" || -e "Makefile" || -e "makefile" || -e "GNUmakefile" ]]; then
+    if [[ -z $makeFlags && ! ( -n $makefile || -e Makefile || -e makefile || -e GNUmakefile[[ ) ]]; then
         echo "no Makefile, doing nothing"
     else
         # See https://github.com/NixOS/nixpkgs/pull/1354#issuecomment-31260409


### PR DESCRIPTION
###### Motivation for this change

@grahamc showed me shellcheck, which I am now quite fond of. In order to tightening things up so https://github.com/NixOS/nixpkgs/pull/26805 is easier to debug, I did these clean ups.

I left the `# shellcheck disable=...` in there in hopes we can eventually make it a test. A lot of this quoting doesn't by us much since other things block store paths with whitespace, but shellcheck can also make switching to`set -u` feasible, which is definitely worthy of static analysis.

This is easiest to review commit-by-commit:

1. Use associative arrays to accumulate deps. Then instead of doing huge pattern match just check the key, and do get out deps iterator through keys.
2. Shell check
3. Few style + error handling things on `substitue`

###### Things done

Rebuilt Linux and Darwin stdenvs.