### PR TITLE
glusterfs service: add support for TLS communication

### DIFF
--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -5,6 +5,22 @@ with lib;
 let
   inherit (pkgs) glusterfs rsync;
 
+  tlsCmd = if (cfg.tlsSettings != null) then
+  ''
+    mkdir -p /var/lib/glusterd
+    touch /var/lib/glusterd/secure-access
+  ''
+  else
+  ''
+    rm -f /var/lib/glusterd/secure-access
+  '';
+
+  restartTriggers = if (cfg.tlsSettings != null) then [
+    config.environment.etc."ssl/glusterfs.pem".source
+    config.environment.etc."ssl/glusterfs.key".source
+    config.environment.etc."ssl/glusterfs.ca".source
+  ] else [];
+
   cfg = config.services.glusterfs;
 
 in
@@ -30,6 +46,41 @@ in
         description = "Extra flags passed to the GlusterFS daemon";
         default = [];
       };
+
+      tlsSettings = mkOption {
+        description = ''
+          Make the server communicate via TLS.
+          This means it will only connect to other gluster
+          servers having certificates signed by the same CA.
+
+          Enabling this will create a file <filename>/var/lib/glusterd/secure-access</filename>.
+          Disabling will delete this file again.
+
+          See also: https://gluster.readthedocs.io/en/latest/Administrator%20Guide/SSL/
+        '';
+        default = null;
+        type = types.nullOr (types.submodule {
+          options = {
+            tlsKey = mkOption {
+              default = null;
+              type = types.path;
+              description = "Path to the private key used for TLS.";
+            };
+
+            tlsPem = mkOption {
+              default = null;
+              type = types.path;
+              description = "Path to the certificate used for TLS.";
+            };
+
+            caCert = mkOption {
+              default = null;
+              type = types.path;
+              description = "Path certificate authority used to sign the cluster certificates.";
+            };
+          };
+        });
+      };
     };
   };
 
@@ -40,7 +91,14 @@ in
 
     services.rpcbind.enable = true;
 
+    environment.etc = mkIf (cfg.tlsSettings != null) {
+      "ssl/glusterfs.pem".source = cfg.tlsSettings.tlsPem;
+      "ssl/glusterfs.key".source = cfg.tlsSettings.tlsKey;
+      "ssl/glusterfs.ca".source = cfg.tlsSettings.caCert;
+    };
+
     systemd.services.glusterd = {
+      inherit restartTriggers;
 
       description = "GlusterFS, a clustered file-system server";
 
@@ -57,6 +115,8 @@ in
       + ''
         mkdir -p /var/lib/glusterd/hooks/
         ${rsync}/bin/rsync -a ${glusterfs}/var/lib/glusterd/hooks/ /var/lib/glusterd/hooks/
+
+        ${tlsCmd}
       ''
       # `glusterfind` needs dirs that upstream installs at `make install` phase
       # https://github.com/gluster/glusterfs/blob/v3.10.2/tools/glusterfind/Makefile.am#L16-L17
@@ -75,6 +135,7 @@ in
     };
 
     systemd.services.glustereventsd = {
+      inherit restartTriggers;
 
       description = "Gluster Events Notifier";
 

--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -61,9 +61,9 @@ in
         default = null;
         type = types.nullOr (types.submodule {
           options = {
-            tlsKey = mkOption {
+            tlsKeyPath = mkOption {
               default = null;
-              type = types.path;
+              type = types.str;
               description = "Path to the private key used for TLS.";
             };
 
@@ -93,7 +93,7 @@ in
 
     environment.etc = mkIf (cfg.tlsSettings != null) {
       "ssl/glusterfs.pem".source = cfg.tlsSettings.tlsPem;
-      "ssl/glusterfs.key".source = cfg.tlsSettings.tlsKey;
+      "ssl/glusterfs.key".source = cfg.tlsSettings.tlsKeyPath;
       "ssl/glusterfs.ca".source = cfg.tlsSettings.caCert;
     };
 


### PR DESCRIPTION
###### Motivation for this change

This allows to easily setup glusterfs with TLS support. The user has to provide three files: 
- Private Key
- Certificate
- Certificate Authority

There are still some open points I would appreciate some feedback:

1. Enabling TLS in GlusterFS works by placing the certificates in `/etc/ssl` and creating the marker file `/var/lib/glusterd/secure-access`. This is the same setup for Servers and Clients wanting to mount from a secure server. This PR only activates this for the server part. This means one can mount a TLS secured volume on a machine where the server is also running. To improve this the TLS option should probably be moved out of the service config, but I'm not sure how.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @nh2 