### PR TITLE
nixos-install: quote nixos-prepare-root arguments

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -140,7 +140,7 @@ channel_closure="$tmpdir/channel.closure"
 nix-store --export $channel_root > $channel_closure
 
 # Populate the target root directory with the basics
-@prepare_root@/bin/nixos-prepare-root $mountPoint $channel_root $system_root @nixClosure@ $system_closure $channel_closure
+@prepare_root@/bin/nixos-prepare-root "$mountPoint" "$channel_root" "$system_root" @nixClosure@ "$system_closure" "$channel_closure"
 
 # nixos-prepare-root doesn't currently do anything with file ownership, so we set it up here instead
 chown @root_uid@:@nixbld_gid@ $mountPoint/nix/store


### PR DESCRIPTION
###### Motivation for this change
This prevents the script from breaking when channel_root is empty.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


I've only tested this very informally while messing about with building my own images. Proper testing is still needed!