### PR TITLE
nova-filters: bug fix and add maintainer

### DIFF
--- a/pkgs/applications/audio/nova-filters/default.nix
+++ b/pkgs/applications/audio/nova-filters/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     sed -i -e '4d' SConstruct
     sed -i "s@mfpmath=sse@mfpmath=sse -I ${boost.dev}/include@g" SConstruct
     sed -i "s@ladspa.h@${ladspaH}/include/ladspa.h@g" filters.cpp
+    sed -i "s@LADSPA_HINT_SAMPLE_RATE, 0, 0.5@LADSPA_HINT_SAMPLE_RATE, 0.0001, 0.5@g" filters.cpp
     sed -i "s/= check/= detail::filter_base<internal_type, checked>::check/" nova/source/dsp/filter.hpp
   '';
 
@@ -27,10 +28,11 @@ stdenv.mkDerivation rec {
     scons $sconsFlags "prefix=$out" install
   '';
 
-  meta = {
-    homepage = http://klingt.org/~tim/nova-filters/;
+  meta = with stdenv.lib; {
     description = "LADSPA plugins based on filters of nova";
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.linux;
+    homepage = http://klingt.org/~tim/nova-filters/;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This software isn't maintained anymore, but I'm still using it heavily.
So I fixed a bug in the pkg.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

