### PR TITLE
Gnuradio: Enable Darwin Support

### DIFF
--- a/pkgs/applications/misc/gnuradio-ais/default.nix
+++ b/pkgs/applications/misc/gnuradio-ais/default.nix
@@ -7,13 +7,14 @@ assert pythonSupport -> python != null && swig != null;
 
 stdenv.mkDerivation rec {
   name = "gnuradio-ais-${version}";
-  version = "2016-08-26";
+  version = "2015-12-20";
 
   src = fetchFromGitHub {
     owner = "bistromath";
     repo = "gr-ais";
-    rev = "1863d1bf8a7709a8dfedb3ddb8e2b99112e7c872";
-    sha256 = "1vl3kk8xr2mh5lf31zdld7yzmwywqffffah8iblxdzblgsdwxfl6";
+    # Upstream PR: https://github.com/bistromath/gr-ais/commit/8502d0252a2a1a9b8d1a71795eaeb5d820684054
+    "rev" = "8502d0252a2a1a9b8d1a71795eaeb5d820684054";
+    "sha256" = "1b9j0kc74cw12a7jv4lii77dgzqzg2s8ndzp4xmisxksgva1qfvh";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/gnuradio-ais/default.nix
+++ b/pkgs/applications/misc/gnuradio-ais/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "Gnuradio block for ais";
     homepage = https://github.com/bistromath/gr-ais;

--- a/pkgs/applications/misc/gnuradio-ais/default.nix
+++ b/pkgs/applications/misc/gnuradio-ais/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     description = "Gnuradio block for ais";
     homepage = https://github.com/bistromath/gr-ais;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ mog ];
   };
 }

--- a/pkgs/applications/misc/gnuradio-gsm/default.nix
+++ b/pkgs/applications/misc/gnuradio-gsm/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "Gnuradio block for gsm";
     homepage = https://github.com/ptrkrysik/gr-gsm;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ mog ];
   };
 }

--- a/pkgs/applications/misc/gnuradio-gsm/default.nix
+++ b/pkgs/applications/misc/gnuradio-gsm/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "Gnuradio block for gsm";
     homepage = https://github.com/ptrkrysik/gr-gsm;

--- a/pkgs/applications/misc/gnuradio-nacl/default.nix
+++ b/pkgs/applications/misc/gnuradio-nacl/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "Gnuradio block for encryption";
     homepage = https://github.com/stwunsch/gr-nacl;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ mog ];
   };
 }

--- a/pkgs/applications/misc/gnuradio-nacl/default.nix
+++ b/pkgs/applications/misc/gnuradio-nacl/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "Gnuradio block for encryption";
     homepage = https://github.com/stwunsch/gr-nacl;

--- a/pkgs/applications/misc/gnuradio-osmosdr/default.nix
+++ b/pkgs/applications/misc/gnuradio-osmosdr/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "Gnuradio block for OsmoSDR and rtl-sdr";
     homepage = http://sdr.osmocom.org/trac/wiki/GrOsmoSDR;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ bjornfor the-kenny ];
   };
 }

--- a/pkgs/applications/misc/gnuradio-osmosdr/default.nix
+++ b/pkgs/applications/misc/gnuradio-osmosdr/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Gnuradio block for OsmoSDR and rtl-sdr";
-    homepage = http://sdr.osmocom.org/trac/wiki/GrOsmoSDR;
+    homepage = https://sdr.osmocom.org/trac/wiki/GrOsmoSDR;
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ bjornfor the-kenny ];

--- a/pkgs/applications/misc/gnuradio-osmosdr/default.nix
+++ b/pkgs/applications/misc/gnuradio-osmosdr/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "Gnuradio block for OsmoSDR and rtl-sdr";
     homepage = http://sdr.osmocom.org/trac/wiki/GrOsmoSDR;

--- a/pkgs/applications/misc/gnuradio-rds/default.nix
+++ b/pkgs/applications/misc/gnuradio-rds/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "Gnuradio block for radio data system";
     homepage = https://github.com/bastibl/gr-rds;

--- a/pkgs/applications/misc/gnuradio-rds/default.nix
+++ b/pkgs/applications/misc/gnuradio-rds/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "Gnuradio block for radio data system";
     homepage = https://github.com/bastibl/gr-rds;
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ mog ];
   };
 }

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper
+{ stdenv, fetchurl, writeText, makeWrapper
 # Dependencies documented @ https://gnuradio.org/doc/doxygen/build_guide.html
 # => core dependencies
 , cmake, pkgconfig, git, boost, cppunit, fftw
@@ -54,6 +54,16 @@ stdenv.mkDerivation rec {
         gr-fec/include/gnuradio/fec/polar_decoder_common.h \
         --replace BOOST_CONSTEXPR_OR_CONST const
   '';
+
+  # Enables composition with nix-shell
+  grcSetupHook = writeText "grcSetupHook.sh" ''
+    addGRCBlocksPath() {
+      addToSearchPath GRC_BLOCKS_PATH $1/share/gnuradio/grc/blocks
+    }
+    envHooks+=(addGRCBlocksPath)
+  '';
+
+  setupHook = [ grcSetupHook ];
 
   preConfigure = ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-unused-variable -std=c++11"

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -32,12 +32,14 @@ stdenv.mkDerivation rec {
     sha256 = "1m2jf8lafr6pr2dlm40nbvr6az8gwjfkzpbs4fxzv3l5hcqvmnc7";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    cmake git boost cppunit fftw python swig2 orc lxml qt4
-    qwt alsaLib SDL libusb1 uhd gsl makeWrapper
+  nativeBuildInputs = [
+    cmake pkgconfig git makeWrapper cppunit orc
   ];
 
+  buildInputs = [
+    boost fftw python swig2 lxml qt4
+    qwt SDL libusb1 uhd gsl
+  ] ++ stdenv.lib.optionals stdenv.isLinux  [ alsaLib   ];
   propagatedBuildInputs = [
     cheetah numpy scipy matplotlib pyqt4 pygtk wxPython pyopengl
   ];

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -54,6 +54,10 @@ stdenv.mkDerivation rec {
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-unused-variable -std=c++11"
   '';
 
+  # Framework path needed for qwt6_qt4 but not qwt5
+  cmakeFlags =
+    stdenv.lib.optionals stdenv.isDarwin [ "-DCMAKE_FRAMEWORK_PATH=${qwt}/lib" ];
+
   # - Ensure we get an interactive backend for matplotlib. If not the gr_plot_*
   #   programs will not display anything. Yes, $MATPLOTLIBRC must point to the
   #   *dirname* where matplotlibrc is located, not the file itself.

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -15,6 +15,7 @@
 , wxPython, lxml
 # => gr-audio: audio subsystems (system/OS dependent)
 , alsaLib   # linux   'audio-alsa'
+, CoreAudio # darwin  'audio-osx'
 # => uhd: the Ettus USRP Hardware Driver Interface
 , uhd
 # => gr-video-sdl: PAL and NTSC display
@@ -39,7 +40,9 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boost fftw python swig2 lxml qt4
     qwt SDL libusb1 uhd gsl
-  ] ++ stdenv.lib.optionals stdenv.isLinux  [ alsaLib   ];
+  ] ++ stdenv.lib.optionals stdenv.isLinux  [ alsaLib   ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ CoreAudio ];
+
   propagatedBuildInputs = [
     cheetah numpy scipy matplotlib pyqt4 pygtk wxPython pyopengl
   ];

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -1,24 +1,26 @@
-{ stdenv, fetchurl
-# core dependencies
+{ stdenv, fetchurl, makeWrapper
+# Dependencies documented @ https://gnuradio.org/doc/doxygen/build_guide.html
+# => core dependencies
 , cmake, pkgconfig, git, boost, cppunit, fftw
-# python wrappers
+# => python wrappers
+# May be able to upgrade to swig3
 , python, swig2, numpy, scipy, matplotlib
-# grc - the gnu radio companion
+# => grc - the gnu radio companion
 , cheetah, pygtk
-# gr-wavelet: collection of wavelet blocks
+# => gr-wavelet: collection of wavelet blocks
 , gsl
-# gr-qtgui: the Qt-based GUI
-, qt4, qwt, pyqt4 #, pyqwt
-# gr-wxgui: the Wx-based GUI
+# => gr-qtgui: the Qt-based GUI
+, qt4, qwt, pyqt4
+# => gr-wxgui: the Wx-based GUI
 , wxPython, lxml
-# gr-audio: audio subsystems (system/OS dependent)
-, alsaLib
-# uhd: the Ettus USRP Hardware Driver Interface
+# => gr-audio: audio subsystems (system/OS dependent)
+, alsaLib   # linux   'audio-alsa'
+# => uhd: the Ettus USRP Hardware Driver Interface
 , uhd
-# gr-video-sdl: PAL and NTSC display
+# => gr-video-sdl: PAL and NTSC display
 , SDL
+# Other
 , libusb1, orc, pyopengl
-, makeWrapper
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -67,9 +67,10 @@ stdenv.mkDerivation rec {
 
   # patch wxgui and pygtk check due to python importerror in a headless environment
   preConfigure = ''
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-unused-variable -std=c++11"
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-unused-variable ${stdenv.lib.optionalString (!stdenv.isDarwin) "-std=c++11"}"
     sed -i 's/.*wx\.version.*/set(WX_FOUND TRUE)/g' gr-wxgui/CMakeLists.txt
     sed -i 's/.*pygtk_version.*/set(PYGTK_FOUND TRUE)/g' grc/CMakeLists.txt
+    find . -name "CMakeLists.txt" -exec sed -i '1iadd_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=c++11>)' "{}" ";"
   '';
 
   # Framework path needed for qwt6_qt4 but not qwt5

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://www.gnuradio.org;
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ bjornfor fpletz ];
   };
 }

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, writeText, makeWrapper
+{ stdenv, fetchFromGitHub, writeText, makeWrapper
 # Dependencies documented @ https://gnuradio.org/doc/doxygen/build_guide.html
 # => core dependencies
 , cmake, pkgconfig, git, boost, cppunit, fftw
@@ -26,11 +26,14 @@
 
 stdenv.mkDerivation rec {
   name = "gnuradio-${version}";
-  version = "3.7.11";
+  version = "3.7.11.1";
 
-  src = fetchurl {
-    url = "https://gnuradio.org/releases/gnuradio/${name}.tar.gz";
-    sha256 = "1m2jf8lafr6pr2dlm40nbvr6az8gwjfkzpbs4fxzv3l5hcqvmnc7";
+  src = fetchFromGitHub {
+    owner = "gnuradio";
+    repo = "gnuradio";
+    rev = "6d2221196082a4954c249dc6955e33d5832a56f2";
+    sha256 = "1fkrb8cnjbriy2x94lz73q6aqxar1rkvfbafp266ykdpm29b4xgm";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -65,8 +65,11 @@ stdenv.mkDerivation rec {
 
   setupHook = [ grcSetupHook ];
 
+  # patch wxgui and pygtk check due to python importerror in a headless environment
   preConfigure = ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-unused-variable -std=c++11"
+    sed -i 's/.*wx\.version.*/set(WX_FOUND TRUE)/g' gr-wxgui/CMakeLists.txt
+    sed -i 's/.*pygtk_version.*/set(PYGTK_FOUND TRUE)/g' grc/CMakeLists.txt
   '';
 
   # Framework path needed for qwt6_qt4 but not qwt5

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -74,7 +74,8 @@ stdenv.mkDerivation rec {
     for file in $(find $out/bin $out/share/gnuradio/examples -type f -executable); do
         wrapProgram "$file" \
             --prefix PYTHONPATH : $PYTHONPATH:$(toPythonPath "$out") \
-            --set MATPLOTLIBRC "$out/share/gnuradio"
+            --set MATPLOTLIBRC "$out/share/gnuradio" \
+            ${stdenv.lib.optionalString stdenv.isDarwin "--set DYLD_FRAMEWORK_PATH /System/Library/Frameworks"}
     done
   '';
 

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -68,6 +68,11 @@ stdenv.mkDerivation rec {
   #   *dirname* where matplotlibrc is located, not the file itself.
   # - GNU Radio core is C++ but the user interface (GUI and API) is Python, so
   #   we must wrap the stuff in bin/.
+  # Notes:
+  # - May want to use makeWrapper instead of wrapProgram
+  # - may want to change interpreter path on Python examples instead of wrapping
+  # - see https://github.com/NixOS/nixpkgs/issues/22688 regarding use of --prefix / python.withPackages
+  # - see https://github.com/NixOS/nixpkgs/issues/24693 regarding use of DYLD_FRAMEWORK_PATH on Darwin
   postInstall = ''
     printf "backend : Qt4Agg\n" > "$out/share/gnuradio/matplotlibrc"
 

--- a/pkgs/applications/misc/libosmocore/default.nix
+++ b/pkgs/applications/misc/libosmocore/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "libosmocore";
     homepage = https://github.com/osmocom/libosmocore;
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ mog ];
   };
 }

--- a/pkgs/applications/misc/libosmocore/default.nix
+++ b/pkgs/applications/misc/libosmocore/default.nix
@@ -1,25 +1,31 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pcsclite, pkgconfig
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, pcsclite, talloc, python2
 }:
 
 stdenv.mkDerivation rec {
   name = "libosmocore-${version}";
-  version = "0.9.0";
+  version = "0.9.6";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "libosmocore";
-    rev = "8649d57f507d359c99a89654aac7e19ce22db282";
-    sha256 = "08mcpy9ljwb1i3l4cmlwn024q2psk5gg9f0ylgh99hy1ffx0n7am";
+    rev = "3cc757df1822114bf446dc2d5f6a95da92321a25";
+    sha256 = "0dk7065qcy2kjra0p8q2124p73jcyvvzz3cmhid1kx5scyxmr017";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [
-    pcsclite
+  propagatedBuildInputs = [
+    talloc
   ];
 
-  preConfigure = ''
-    autoreconf -i -f
-  '';
+  nativeBuildInputs = [
+    autoreconfHook pkgconfig
+  ];
+
+  buildInputs = [
+    pcsclite python2
+  ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "libosmocore";

--- a/pkgs/applications/misc/rtl-sdr/default.nix
+++ b/pkgs/applications/misc/rtl-sdr/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   #   /etc/udev/rules.d/, and there is no option to install elsewhere. So install
   #   rules manually.
   # * Propagate libusb-1.0 dependency in pkg-config file.
-  postInstall = ''
+  postInstall = stdenv.lib.optionalString stdenv.isLinux ''
     mkdir -p "$out/etc/udev/rules.d/"
     cp ../rtl-sdr.rules "$out/etc/udev/rules.d/99-rtl-sdr.rules"
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "Turns your Realtek RTL2832 based DVB dongle into a SDR receiver";
     homepage = http://sdr.osmocom.org/trac/wiki/rtl-sdr;
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/applications/misc/urh/default.nix
+++ b/pkgs/applications/misc/urh/default.nix
@@ -22,7 +22,7 @@ python3Packages.buildPythonApplication rec {
     inherit (src.meta) homepage;
     description = "Universal Radio Hacker: investigate wireless protocols like a boss";
     license = licenses.asl20;
-    platforms = platforms.all;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/development/libraries/qwt/6_qt4.nix
+++ b/pkgs/development/libraries/qwt/6_qt4.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ qmake4Hook ];
 
+  enableParallelBuilding = true;
+
   postPatch = ''
     sed -e "s|QWT_INSTALL_PREFIX.*=.*|QWT_INSTALL_PREFIX = $out|g" -i qwtconfig.pri
   '';

--- a/pkgs/development/libraries/qwt/6_qt4.nix
+++ b/pkgs/development/libraries/qwt/6_qt4.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, qt4, qmake4Hook }:
+{ stdenv, fetchurl, qt4, qmake4Hook, AGL }:
 
 stdenv.mkDerivation rec {
   name = "qwt-6.1.3";
@@ -8,7 +8,10 @@ stdenv.mkDerivation rec {
     sha256 = "0cwp63s03dw351xavb3pzbjlqvx7kj88wv7v4a2b18m9f97d7v7k";
   };
 
-  buildInputs = [ qt4 ];
+  buildInputs = [
+    qt4
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ AGL ];
+
   nativeBuildInputs = [ qmake4Hook ];
 
   postPatch = ''

--- a/pkgs/development/libraries/qwt/6_qt4.nix
+++ b/pkgs/development/libraries/qwt/6_qt4.nix
@@ -18,6 +18,13 @@ stdenv.mkDerivation rec {
     sed -e "s|QWT_INSTALL_PREFIX.*=.*|QWT_INSTALL_PREFIX = $out|g" -i qwtconfig.pri
   '';
 
+  # qwt.framework output includes a relative reference to itself, which breaks dependents
+  preFixup =
+    stdenv.lib.optionalString stdenv.isDarwin ''
+      echo "Attempting to repair qwt"
+      install_name_tool -id "$out/lib/qwt.framework/Versions/6/qwt" "$out/lib/qwt.framework/Versions/6/qwt"
+    '';
+
   qmakeFlags = [ "-after doc.path=$out/share/doc/${name}" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/qwt/6_qt4.nix
+++ b/pkgs/development/libraries/qwt/6_qt4.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, qt4, qmake4Hook }:
 
 stdenv.mkDerivation rec {
-  name = "qwt-6.1.2";
+  name = "qwt-6.1.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/qwt/${name}.tar.bz2";
-    sha256 = "031x4hz1jpbirv9k35rqb52bb9mf2w7qav89qv1yfw1r3n6z221b";
+    sha256 = "0cwp63s03dw351xavb3pzbjlqvx7kj88wv7v4a2b18m9f97d7v7k";
   };
 
   buildInputs = [ qt4 ];

--- a/pkgs/development/tools/misc/uhd/default.nix
+++ b/pkgs/development/tools/misc/uhd/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://uhd.ettus.com/;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ bjornfor fpletz ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14648,6 +14648,7 @@ with pkgs;
 
   gnuradio = callPackage ../applications/misc/gnuradio {
     inherit (python2Packages) cheetah lxml matplotlib numpy python pyopengl pyqt4 scipy wxPython pygtk;
+    inherit (darwin.apple_sdk.frameworks) CoreAudio;
     fftw = fftwFloat;
     qwt = qwt6_qt4;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10507,7 +10507,9 @@ with pkgs;
 
   qwt = callPackage ../development/libraries/qwt {};
 
-  qwt6_qt4 = callPackage ../development/libraries/qwt/6_qt4.nix { };
+  qwt6_qt4 = callPackage ../development/libraries/qwt/6_qt4.nix {
+    inherit (darwin.apple_sdk.frameworks) AGL;
+  };
 
   qxt = callPackage ../development/libraries/qxt {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14649,6 +14649,7 @@ with pkgs;
   gnuradio = callPackage ../applications/misc/gnuradio {
     inherit (python2Packages) cheetah lxml matplotlib numpy python pyopengl pyqt4 scipy wxPython pygtk;
     fftw = fftwFloat;
+    qwt = qwt6_qt4;
   };
 
   gnuradio-with-packages = callPackage ../applications/misc/gnuradio/wrapper.nix {


### PR DESCRIPTION
###### Motivation for this change
This PR enables Darwin build support for Gnuradio. 

To accomplish this, it also:
- fixes qwt6_qt4 package on Darwin
- Upgrades libosmocore [0.9.0->0.9.6], with required changes
- minor changes including enableParallelBuilding to others

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Continuation of #26144

