### PR TITLE
Bump slurm, add pyslurm

### DIFF
--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -36,9 +36,9 @@ in
 
       package = mkOption {
         type = types.package;
-        default = pkgs.slurm-llnl;
-        defaultText = "pkgs.slurm-llnl";
-        example = literalExample "pkgs.slurm-llnl-full";
+        default = pkgs.slurm;
+        defaultText = "pkgs.slurm";
+        example = literalExample "pkgs.slurm-full";
         description = ''
           The package to use for slurm binaries.
         '';

--- a/pkgs/development/python-modules/pyslurm/default.nix
+++ b/pkgs/development/python-modules/pyslurm/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, buildPythonPackage, cython, slurm }:
+
+buildPythonPackage rec {
+  name = "pyslurm";
+
+  src = fetchFromGitHub {
+    repo = "pyslurm";
+    owner = "PySlurm";
+    rev = "69e4f4fd66003b98ddb7da25613fe641d4ae160d";
+    sha256 = "051kafkndbniklxyf0drb360aiblnqcf9rqjbvmqh66zrfya1m28";
+  };
+
+  patches = [ ./pyslurm-dlfcn.patch ];
+
+  buildInputs = [ cython slurm ];
+  setupPyBuildFlags = [ "--slurm-lib=${slurm}/lib" "--slurm-inc=${slurm.dev}/include" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/PySlurm/pyslurm";
+    description = "Python bindings to Slurm";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.veprbl ];
+  };
+}

--- a/pkgs/development/python-modules/pyslurm/pyslurm-dlfcn.patch
+++ b/pkgs/development/python-modules/pyslurm/pyslurm-dlfcn.patch
@@ -1,0 +1,18 @@
+diff --git a/pyslurm/__init__.py b/pyslurm/__init__.py
+index 81643e1..e8b6836 100644
+--- a/pyslurm/__init__.py
++++ b/pyslurm/__init__.py
+@@ -11,8 +11,11 @@ import sys
+ old_dlopen_flags = ''
+ if hasattr(sys, "setdlopenflags"):
+     old_dlopen_flags = sys.getdlopenflags()
+-    import DLFCN
+-    sys.setdlopenflags(old_dlopen_flags | DLFCN.RTLD_GLOBAL)
++    if sys.version_info >= (3,6):
++        from os import RTLD_GLOBAL
++    else:
++        from DLFCN import RTLD_GLOBAL
++    sys.setdlopenflags(old_dlopen_flags | RTLD_GLOBAL)
+ 
+ from .pyslurm import *
+ 

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -1,19 +1,24 @@
-{ stdenv, fetchurl, pkgconfig, curl, python, munge, perl, pam, openssl
+{ stdenv, fetchurl, pkgconfig, libtool, curl, python, munge, perl, pam, openssl
 , ncurses, mysql, gtk2, lua, hwloc, numactl
 }:
 
 stdenv.mkDerivation rec {
-  name = "slurm-llnl-${version}";
-  version = "15-08-5-1";
+  name = "slurm-${version}";
+  version = "17.02.6";
 
   src = fetchurl {
-    url = "https://github.com/SchedMD/slurm/archive/slurm-${version}.tar.gz";
-    sha256 = "05si1cn7zivggan25brsqfdw0ilvrlnhj96pwv16dh6vfkggzjr1";
+    url = "https://www.schedmd.com/downloads/latest/slurm-17.02.6.tar.bz2";
+    sha256 = "1sp4xg15jc569r6dh61svgk2fmy3ndcgr5358yryajslf1w14mzh";
   };
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  # nixos test fails to start slurmd with 'undefined symbol: slurm_job_preempt_mode'
+  # https://groups.google.com/forum/#!topic/slurm-devel/QHOajQ84_Es
+  # this doesn't fix tests completely at least makes slurmd to launch
+  hardeningDisable = [ "bindnow" ];
+
+  nativeBuildInputs = [ pkgconfig libtool ];
   buildInputs = [
     curl python munge perl pam openssl mysql.lib ncurses gtk2 lua hwloc numactl
   ];
@@ -25,8 +30,8 @@ stdenv.mkDerivation rec {
     ] ++ stdenv.lib.optional (gtk2 == null)  "--disable-gtktest";
 
   preConfigure = ''
-    substituteInPlace ./doc/html/shtml2html.py --replace "/usr/bin/env python" "${python.interpreter}"
-    substituteInPlace ./doc/man/man2html.py --replace "/usr/bin/env python" "${python.interpreter}"
+    patchShebangs ./doc/html/shtml2html.py
+    patchShebangs ./doc/man/man2html.py
   '';
 
   postInstall = ''

--- a/pkgs/tools/security/munge/default.nix
+++ b/pkgs/tools/security/munge/default.nix
@@ -1,31 +1,33 @@
-{ stdenv, fetchFromGitHub, gnused, perl, libgcrypt, zlib, bzip2 }:
+{ stdenv, fetchFromGitHub, autoreconfHook, gawk, gnused, libgcrypt, zlib, bzip2 }:
 
 stdenv.mkDerivation rec {
-  name = "munge-0.5.11";
+  name = "munge-0.5.12";
 
   src = fetchFromGitHub {
     owner = "dun";
     repo = "munge";
     rev = "${name}";
-    sha256 = "02847p742nq3cb8ayf5blrdicybq72nfsnggqkxr33cpppmsfwg9";
+    sha256 = "1wvkc63bqclpm5xmp3rn199x3jqd99255yicyydgz83cixp7wdbh";
   };
 
-  buildInputs = [ gnused perl libgcrypt zlib bzip2 ];
+  nativeBuildInputs = [ autoreconfHook gawk gnused ];
+  buildInputs = [ libgcrypt zlib bzip2 ];
 
-  preConfigure = ''
+  preAutoreconf = ''
     # Remove the install-data stuff, since it tries to write to /var
-    sed -i '505,511d' src/etc/Makefile.in
+    substituteInPlace src/Makefile.am --replace "etc \\" "\\"
   '';
 
   configureFlags = [
     "--localstatedir=/var"
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = ''
       An authentication service for creating and validating credentials
     '';
-    maintainers = [ stdenv.lib.maintainers.rickynils ];
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.lgpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.rickynils ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11485,9 +11485,9 @@ with pkgs;
 
   storm = callPackage ../servers/computing/storm { };
 
-  slurm-llnl = callPackage ../servers/computing/slurm { gtk2 = null; };
+  slurm = callPackage ../servers/computing/slurm { gtk2 = null; };
 
-  slurm-llnl-full = appendToName "full" (callPackage ../servers/computing/slurm { });
+  slurm-full = appendToName "full" (callPackage ../servers/computing/slurm { });
 
   systemd-journal2gelf = callPackage ../tools/system/systemd-journal2gelf { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -324,6 +324,10 @@ in {
 
   pysideTools = callPackage ../development/python-modules/pyside/tools.nix { };
 
+  pyslurm = callPackage ../development/python-modules/pyslurm {
+    slurm = pkgs.slurm;
+  };
+
   python-sql = callPackage ../development/python-modules/python-sql { };
 
   python-stdnum = callPackage ../development/python-modules/python-stdnum { };


### PR DESCRIPTION
###### Motivation for this change

I needed pyslurm client which is based on slurm version from 2017, so hence the version bump.
I don't use nixos or daemon, but I've tried to look at the test that was broken even before. The problem seems to be that slurmd wouldn't start. I fixed that, so now ```nix-build ./nixos/tests/slurm.nix``` produces an output path. So, I guess, it's fixed?

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
