### PR TITLE
Bump Zope packages to support Python 3.6

### DIFF
--- a/pkgs/development/python-modules/zconfig/default.nix
+++ b/pkgs/development/python-modules/zconfig/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+, zope_testrunner
+}:
+
+buildPythonPackage rec {
+  pname = "ZConfig";
+  version = "3.2.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "de0a802e5dfea3c0b3497ccdbe33a5023c4265f950f33e35dd4cf078d2a81b19";
+  };
+
+  patches = [ ./skip-broken-test.patch ];
+
+  propagatedBuildInputs = [ zope_testrunner ];
+
+  meta = with stdenv.lib; {
+    description = "Structured Configuration Library";
+    homepage = http://pypi.python.org/pypi/ZConfig;
+    license = licenses.zpt20;
+    maintainers = [ maintainers.goibhniu ];
+  };
+}

--- a/pkgs/development/python-modules/zconfig/skip-broken-test.patch
+++ b/pkgs/development/python-modules/zconfig/skip-broken-test.patch
@@ -1,0 +1,12 @@
+diff --git a/ZConfig/tests/test_schema2html.py b/ZConfig/tests/test_schema2html.py
+index 838cf7c..52daf4e 100644
+--- a/ZConfig/tests/test_schema2html.py
++++ b/ZConfig/tests/test_schema2html.py
+@@ -74,6 +74,7 @@ else:
+ 
+ class TestSchema2HTML(unittest.TestCase):
+ 
++    @unittest.skip('broken test (https://github.com/zopefoundation/ZConfig/issues/34)')
+     def test_no_schema(self):
+         self.assertRaises(SystemExit,
+                           run_transform)

--- a/pkgs/development/python-modules/zope_interface/default.nix
+++ b/pkgs/development/python-modules/zope_interface/default.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, zope_event
+}:
+
+buildPythonPackage rec {
+  pname = "zope.interface";
+  version = "4.4.2";
+  name = "${pname}-${version}";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4e59e427200201f69ef82956ddf9e527891becf5b7cde8ec3ce39e1d0e262eb0";
+  };
+
+  propagatedBuildInputs = [ zope_event ];
+
+  meta = with stdenv.lib; {
+    description = "Zope.Interface";
+    homepage = http://zope.org/Products/ZopeInterface;
+    license = licenses.zpt20;
+    maintainers = [ maintainers.goibhniu ];
+  };
+}

--- a/pkgs/development/python-modules/zope_testrunner/default.nix
+++ b/pkgs/development/python-modules/zope_testrunner/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, zope_interface
+, zope_exceptions
+, zope_testing
+, six
+, subunit
+}:
+
+
+buildPythonPackage rec {
+  pname = "zope.testrunner";
+  version = "4.7.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8ffcb4989829544a83d27e42b2eeb28f8fc134bd847d71ce8dca54f710526ef0";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ zope_interface zope_exceptions zope_testing six ] ++ stdenv.lib.optional (!isPy3k) subunit;
+
+  meta = with stdenv.lib; {
+    description = "A flexible test runner with layer support";
+    homepage = http://pypi.python.org/pypi/zope.testrunner;
+    license = licenses.zpt20;
+    maintainers = [ maintainers.goibhniu ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26277,25 +26277,7 @@ EOF
   };
 
 
-  zope_testrunner = buildPythonPackage rec {
-    name = "zope.testrunner-${version}";
-    version = "4.4.10";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/z/zope.testrunner/${name}.zip";
-      sha256 = "1w09wbqiqmq6hvrammi4fzc7fr129v63gdnzlk4qi2b1xy5qpqab";
-    };
-
-    propagatedBuildInputs = with self; [ zope_interface zope_exceptions zope_testing six ] ++ optional (!python.is_py3k or false) subunit;
-
-    meta = {
-      description = "A flexible test runner with layer support";
-      homepage = http://pypi.python.org/pypi/zope.testrunner;
-      license = licenses.zpt20;
-      maintainers = with maintainers; [ goibhniu ];
-    };
-  };
-
+  zope_testrunner = callPackage ../development/python-modules/zope_testrunner { };
 
   zope_traversing = buildPythonPackage rec {
     name = "zope.traversing-4.0.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25660,24 +25660,8 @@ EOF
     };
   });
 
-  zconfig = buildPythonPackage rec {
-    name = "zconfig-${version}";
-    version = "3.0.3";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/Z/ZConfig/ZConfig-${version}.tar.gz";
-      sha256 = "6577da957511d8c2f805fefd2e31cacc4117bb5c54aec03ad8ce374020c021f3";
-    };
-
-    propagatedBuildInputs = with self; [ zope_testrunner ];
-
-    meta = {
-      description = "Structured Configuration Library";
-      homepage = http://pypi.python.org/pypi/ZConfig;
-      license = licenses.zpt20;
-      maintainers = with maintainers; [ goibhniu ];
-    };
-  };
+  zconfig = callPackage ../development/python-modules/zconfig { };
 
 
   zc_lockfile = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26298,23 +26298,8 @@ EOF
   };
 
 
-  zope_interface = buildPythonPackage rec {
-    name = "zope.interface-4.1.3";
+  zope_interface = callPackage ../development/python-modules/zope_interface { };
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/z/zope.interface/${name}.tar.gz";
-      sha256 = "0ks8h73b2g4bkad821qbv0wzjppdrwys33i7ka45ik3wxjg1l8if";
-    };
-
-    propagatedBuildInputs = with self; [ zope_event ];
-
-    meta = {
-      description = "Zope.Interface";
-      homepage = http://zope.org/Products/ZopeInterface;
-      license = licenses.zpt20;
-      maintainers = with maintainers; [ goibhniu ];
-    };
-  };
 
   hgsvn = buildPythonPackage rec {
     name = "hgsvn-0.3.11";


### PR DESCRIPTION
pythonpackages.zope_testrunner: 4.4.10 -> 4.7.0
pythonpackages.zope_interface: 4.1.3 -> 4.4.2
pythonPackages.zconfig: 3.0.3 -> 3.2.0

###### Motivation for this change

This fixes build failures on Python 3.6

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

