### PR TITLE
vulnix: use zope.interface from pythonPackages

### DIFF
--- a/pkgs/tools/security/vulnix/requirements.nix
+++ b/pkgs/tools/security/vulnix/requirements.nix
@@ -10,8 +10,7 @@ rec {
     propagatedBuildInputs = [
       persistent
       transaction
-      zope_interface
-    ] ++ (with pythonPackages; [ coverage ]);
+    ] ++ (with pythonPackages; [ zope_interface coverage ]);
 
     meta = with stdenv.lib; {
       homepage = "";
@@ -62,9 +61,7 @@ rec {
       url = "https://pypi.python.org/packages/3d/71/3302512282b606ec4d054e09be24c065915518903b29380b6573bff79c24/persistent-4.2.2.tar.gz";
       sha256 = "52ececc6dbba5ef572d3435189318b4dff07675bafa9620e32f785e147c6563c";
     };
-    propagatedBuildInputs = [
-      zope_interface
-    ] ++ (with pythonPackages; [ six wheel ]);
+    propagatedBuildInputs = with pythonPackages; [ zope_interface six wheel ];
     meta = with stdenv.lib; {
       homepage = "";
       license = licenses.zpt21;
@@ -78,9 +75,7 @@ rec {
       url = "https://pypi.python.org/packages/8c/af/3ffafe85bcc93ecb09459f3f2bd8fbe142e9ab34048f9e2774543b470cbd/transaction-2.0.3.tar.gz";
       sha256 = "67bfb81309ba9717edbb2ca2e5717c325b78beec0bf19f44e5b4b9410f82df7f";
     };
-    propagatedBuildInputs = [
-      zope_interface
-    ] ++ (with pythonPackages; [ six wheel ]);
+    propagatedBuildInputs = with pythonPackages; [ zope_interface six wheel ];
     meta = with stdenv.lib; {
       homepage = "";
       license = licenses.zpt21;
@@ -113,20 +108,6 @@ rec {
       homepage = "";
       license = licenses.zpt21;
       description = "Fork of Python 3 pickle module.";
-    };
-  };
-
-  zope_interface = pythonPackages.buildPythonPackage {
-    name = "zope.interface-4.3.3";
-    src = fetchurl {
-      url = "https://pypi.python.org/packages/44/af/cea1e18bc0d3be0e0824762d3236f0e61088eeed75287e7b854d65ec9916/zope.interface-4.3.3.tar.gz";
-      sha256 = "8780ef68ca8c3fe1abb30c058a59015129d6e04a6b02c2e56b9c7de6078dfa88";
-    };
-    propagatedBuildInputs = [ ];
-    meta = with stdenv.lib; {
-      homepage = "";
-      license = licenses.zpt21;
-      description = "Interfaces for Python";
     };
   };
 }


### PR DESCRIPTION
Depends on https://github.com/NixOS/nixpkgs/pull/27351

###### Motivation for this change
This together with https://github.com/NixOS/nixpkgs/pull/27351 makes it possible to use vulnix with Python 3.6.
Currently building from nixpkgs master results in build failures related to Zope dependencies.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

