### PR TITLE
android-studio-preview: init at 3.0.0.5 canary 6

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -1,3 +1,4 @@
+{ pname, version, build, src, meta }:
 { bash
 , buildFHSUserEnv
 , coreutils
@@ -32,12 +33,9 @@
 }:
 
 let
-
-  version = "2.3.3.0";
-  build = "162.4069837";
-
   androidStudio = stdenv.mkDerivation {
-    name = "android-studio";
+    inherit src meta;
+    name = "${pname}";
     buildInputs = [
       makeWrapper
       unzip
@@ -96,32 +94,21 @@ let
         --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb" \
         --set FONTCONFIG_FILE ${fontsConf}
     '';
-    src = fetchurl {
-      url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";
-      sha256 = "0zzis9m2xp44xwkj0zvcqw5rh3iyd3finyi5nqhgira1fkacz0qk";
-    };
-    meta = with stdenv.lib; {
-      description = "The Official IDE for Android";
-      homepage = https://developer.android.com/studio/index.html;
-      license = licenses.asl20;
-      platforms = [ "x86_64-linux" ];
-      maintainers = with maintainers; [ primeos ];
-    };
   };
 
   # Android Studio downloads prebuilt binaries as part of the SDK. These tools
   # (e.g. `mksdcard`) have `/lib/ld-linux.so.2` set as the interpreter. An FHS
   # environment is used as a work around for that.
   fhsEnv = buildFHSUserEnv {
-    name = "android-studio-fhs-env";
+    name = "${pname}-fhs-env";
   };
 
 in writeTextFile {
-  name = "android-studio-${version}";
-  destination = "/bin/android-studio";
+  name = "${pname}-${version}";
+  destination = "/bin/${pname}";
   executable = true;
   text = ''
     #!${bash}/bin/bash
-    ${fhsEnv}/bin/android-studio-fhs-env ${androidStudio}/bin/studio.sh
+    ${fhsEnv}/bin/${pname}-fhs-env ${androidStudio}/bin/studio.sh
   '';
 }

--- a/pkgs/applications/editors/android-studio/packages.nix
+++ b/pkgs/applications/editors/android-studio/packages.nix
@@ -1,0 +1,46 @@
+{  stdenv, callPackage, fetchurl, makeFontsConf }:
+let
+  mkStudio = opts: callPackage (import ./common.nix opts);
+in rec {
+  stable = mkStudio rec {
+    pname = "android-studio";
+    version = "2.3.3.0";
+    build = "162.4069837";
+
+    src = fetchurl {
+      url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";
+      sha256 = "0zzis9m2xp44xwkj0zvcqw5rh3iyd3finyi5nqhgira1fkacz0qk";
+    };
+
+    meta = with stdenv.lib; {
+      description = "The Official IDE for Android";
+      homepage = https://developer.android.com/studio/index.html;
+      license = licenses.asl20;
+      platforms = [ "x86_64-linux" ];
+      maintainers = with maintainers; [ primeos ];
+    };
+  } {
+    fontsConf = makeFontsConf {
+      fontDirectories = [];
+    };
+  };
+
+  preview = mkStudio rec {
+    pname = "android-studio-preview";
+    version = "3.0.0.5";
+    build = "171.4163606";
+
+    src = fetchurl {
+      url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";
+      sha256 = "1gxnpw4jf3iic9d47sjbndpysq8kk8pgnb8l7azkc2rba5cj8skg";
+    };
+
+    meta = stable.meta // {
+      homepage = https://developer.android.com/studio/preview/index.html;
+    };
+  } {
+    fontsConf = makeFontsConf {
+      fontDirectories = [];
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13253,11 +13253,9 @@ with pkgs;
 
   amsn = callPackage ../applications/networking/instant-messengers/amsn { };
 
-  android-studio = callPackage ../applications/editors/android-studio {
-    fontsConf = makeFontsConf {
-      fontDirectories = [];
-    };
-  };
+  androidStudioPackages = callPackage ../applications/editors/android-studio/packages.nix {};
+  android-studio = androidStudioPackages.stable;
+  android-studio-preview = androidStudioPackages.preview;
 
   antfs-cli = callPackage ../applications/misc/antfs-cli {};
 


### PR DESCRIPTION
I have tested this package using the new koltin support.
No issues found yet.

###### Things done
Added the `androidStudioPackages` attribute containing both
the `stable` and `preview` channels.
Changed the attribute `andorid-studio` to point to
  `androidStudioPackages.stable`
Added the attribute `andorid-studio-preview` pointing to
  `androidStudioPackages.preview`

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

