### PR TITLE
opensmtpd: Fix attempt to set unsupported permissions during install

### DIFF
--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
       substituteInPlace smtpd/smtpctl.c --replace \
         'if (geteuid())' \
         'if (geteuid() != 0 && !(argc > 1 && !strcmp(argv[1], "encrypt")))'
+      substituteInPlace mk/smtpctl/Makefile.in --replace "chmod 2555" "chmod 0555"
     '';
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

#26600

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I don't know enough about this software to test the resulting binaries, but the change is straightforward and we already patch the software to cope with smtpctl not having special permissions, so I think this is pretty safe.

