### PR TITLE
darkhttpd: platforms.linux → platforms.all

### DIFF
--- a/pkgs/servers/http/darkhttpd/default.nix
+++ b/pkgs/servers/http/darkhttpd/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "Small and secure static webserver";
     homepage = http://dmr.ath.cx/net/darkhttpd/;
     license = stdenv.lib.licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = [ maintainers.bobvanderlinden ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Personally tested to work on macOS.

Cygwin port: https://github.com/fd00/yacp/tree/master/darkhttpd
OpenBSD port: http://ports.su/www/darkhttpd

From [darkhttpd's site](https://unix4lyfe.org/darkhttpd/):

> At some point worked on FreeBSD, Linux, OpenBSD, Solaris.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
