### PR TITLE
darkhttpd: update homepage

### DIFF
--- a/pkgs/servers/http/darkhttpd/default.nix
+++ b/pkgs/servers/http/darkhttpd/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Small and secure static webserver";
-    homepage = http://dmr.ath.cx/net/darkhttpd/;
+    homepage = https://unix4lyfe.org/darkhttpd/;
     license = stdenv.lib.licenses.bsd3;
     platforms = platforms.all;
     maintainers = [ maintainers.bobvanderlinden ];


### PR DESCRIPTION
###### Motivation for this change

Project's homepage has been moved, the previous URL now responds with a permanent redirect (301).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
