### PR TITLE
 pythonPackages.zc_lockfile: 1.0.2 -> 1.2.1

### DIFF
--- a/pkgs/development/python-modules/zc_lockfile/default.nix
+++ b/pkgs/development/python-modules/zc_lockfile/default.nix
@@ -1,0 +1,19 @@
+{ buildPythonPackage, fetchPypi, stdenv }:
+
+buildPythonPackage rec {
+  pname = "zc.lockfile";
+  version = "1.2.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "11db91ada7f22fe8aae268d4bfdeae012c4fe655f66bbb315b00822ec00d043e";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Inter-process locks";
+    homepage =  http://www.python.org/pypi/zc.lockfile;
+    license = licenses.zpt20;
+    maintainers = [ maintainers.goibhniu ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25680,22 +25680,7 @@ EOF
   };
 
 
-  zc_lockfile = buildPythonPackage rec {
-    name = "zc.lockfile-${version}";
-    version = "1.0.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/z/zc.lockfile/${name}.tar.gz";
-      sha256 = "96bb2aa0438f3e29a31e4702316f832ec1482837daef729a92e28c202d8fba5c";
-    };
-
-    meta = {
-      description = "Inter-process locks";
-      homepage =  http://www.python.org/pypi/zc.lockfile;
-      license = licenses.zpt20;
-      maintainers = with maintainers; [ goibhniu ];
-    };
-  };
+  zc_lockfile = callPackage ../development/python-modules/zc_lockfile {};
 
 
   zdaemon = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change
Bugfixes

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

