### PR TITLE
hebcal: init at 4.13

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -231,6 +231,7 @@
   hectorj = "Hector Jusforgues <hector.jusforgues+nixos@gmail.com>";
   heel = "Sergii Paryzhskyi <parizhskiy@gmail.com>";
   henrytill = "Henry Till <henrytill@gmail.com>";
+  hhm = "hhm <heehooman+nixpkgs@gmail.com>";
   hinton = "Tom Hinton <t@larkery.com>";
   hodapp = "Chris Hodapp <hodapp87@gmail.com>";
   hrdinka = "Christoph Hrdinka <c.nix@hrdinka.at>";

--- a/pkgs/tools/misc/hebcal/default.nix
+++ b/pkgs/tools/misc/hebcal/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, autoconf, automake }:
+
+stdenv.mkDerivation rec {
+  version = "4.13";
+  name = "hebcal-${version}";
+
+  src = fetchFromGitHub {
+    owner = "hebcal";
+    repo = "hebcal";
+    rev = "v${version}";
+    sha256 = "0h9hbfkbq620sw9gnnkivv7yi7dnp1k6axzwr0yccbv5cg67xs3h";
+  };
+
+  nativeBuildInputs = [ autoconf automake ];
+
+  preConfigure = "aclocal && autoconf && automake --foreign --add-missing";
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://hebcal.github.io";
+    description = "A perpetual Jewish Calendar";
+    longDescription = "Hebcal is a program which prints out the days in the Jewish calendar for a given Gregorian year. Hebcal is fairly flexible in terms of which events in the Jewish calendar it displays.";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.hhm ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1035,6 +1035,8 @@ with pkgs;
 
   heatseeker = callPackage ../tools/misc/heatseeker { };
 
+  hebcal = callPackage ../tools/misc/hebcal {};
+
   hexio = callPackage ../development/tools/hexio { };
 
   hostsblock = callPackage ../tools/misc/hostsblock { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

