### PR TITLE
pythonPackages.django_extensions : init at 1.8.1

### DIFF
--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, django, six }:
+
+buildPythonPackage rec {
+  pname = "django-extensions";
+  version = "1.8.1";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "${pname}";
+    repo = "${pname}";
+    rev = "${version}";
+    sha256 = "08rd9zswvjb9dixzyd3p3l3hw3wwhqkgyjvid65niybzjl1xdb5h";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = [ django six ];
+
+  meta = with stdenv.lib; {
+    description = "A collection of custom extensions for the Django Framework";
+    homepage = https://github.com/django-extensions/django-extensions;
+    licenses = [ licenses.mit ];
+  };
+}

--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, django, six }:
+{
+  stdenv, buildPythonPackage, fetchFromGitHub,
+  vobject, mock, tox, pytestcov, pytest-django, pytest, shortuuid, django
+}:
 
 buildPythonPackage rec {
   pname = "django-extensions";
@@ -12,9 +15,7 @@ buildPythonPackage rec {
     sha256 = "08rd9zswvjb9dixzyd3p3l3hw3wwhqkgyjvid65niybzjl1xdb5h";
   };
 
-  doCheck = false;
-
-  propagatedBuildInputs = [ django six ];
+  buildInputs = [ django vobject mock tox pytestcov pytest-django pytest shortuuid];
 
   meta = with stdenv.lib; {
     description = "A collection of custom extensions for the Django Framework";

--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -1,6 +1,6 @@
-{
-  stdenv, buildPythonPackage, fetchFromGitHub,
-  vobject, mock, tox, pytestcov, pytest-django, pytest, shortuuid, django
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, vobject, mock, tox, pytestcov, pytest-django, pytest, shortuuid
+, django, six
 }:
 
 buildPythonPackage rec {
@@ -15,7 +15,9 @@ buildPythonPackage rec {
     sha256 = "08rd9zswvjb9dixzyd3p3l3hw3wwhqkgyjvid65niybzjl1xdb5h";
   };
 
-  buildInputs = [ django vobject mock tox pytestcov pytest-django pytest shortuuid];
+  buildInputs = [ vobject mock tox pytestcov pytest-django pytest shortuuid ];
+
+  propagatedBuildInputs = [ django six ];
 
   meta = with stdenv.lib; {
     description = "A collection of custom extensions for the Django Framework";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9474,6 +9474,8 @@ in {
     };
   };
 
+  django_extensions = callPackage ../development/python-modules/django-extensions { };
+
   django_guardian = callPackage ../development/python-modules/django_guardian.nix { };
 
   django_polymorphic = callPackage ../development/python-modules/django-polymorphic { };


### PR DESCRIPTION
###### Motivation for this change
To add [django-extensions](https://github.com/django-extensions/django-extensions) to python-modules

###### Things done

- [X] Tested using sandboxing : [nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested installation : `nix-shell -I nixpkgs=/nix/nixpkgs -p python27Packages.django_extensions python36Packages.django_extensions`
- [X] Tested execution : tested `manage.py` with `shell_plus` and `graph_models`
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

