### PR TITLE
vim_configurable: add ".../after" plugin dirs to runtimepath

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -24,6 +24,10 @@ let
           let pluginname = substitute(d, ".*/", "", "")
           if !has_key(seen, pluginname)
             exec 'set runtimepath^='.d
+            let after = d."/after"
+            if isdirectory(after)
+              exec 'set runtimepath^='.after
+            endif
             let seen[pluginname] = 1
           endif
         endfor


### PR DESCRIPTION
###### Motivation for this change
This fixes using e.g. CSApprox when installed with nix.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

