### PR TITLE
nixpkgs: poor mans doc blocks wip / rfc / etc

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -100,16 +100,23 @@ let
           <refpurpose>${typeDocbook}</refpurpose>
         </refnamediv>
 
+        <refsect1>
+          <title></title>
+          <para>${mkGithubLink pos.file pos.line}</para>
+        </refsect1>
+
         <refsect1 role="description">
           <title>Description</title>
           <para>${description}</para>
         </refsect1>
 
         ${paramsDocbook}
-        <!--<para>${mkGithubLink pos.file pos.line}</para>-->
+
         ${returnDocbook}
 
         ${exampleDocbook}
+
+
       </refentry>
 
     '';

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -22,7 +22,6 @@ let
         # MUST match lib/doc.nix's mkDoc function signaturex
         description,
         examples ? [],
-        type ? false,
         params ? [],
         return ? null
       }:
@@ -45,6 +44,13 @@ let
         ${exampleInner}
         </refsect1>
       '';
+
+      type = if return == null then ""
+        else lib.strings.concatMapStringsSep " -> "
+          (param: if builtins.match ".*->.*" param.type == []
+                  then "(${param.type})"
+                  else param.type)
+          (params ++ [return]);
 
       typeDocbook = if type == false then ""
         else ''

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -1,170 +1,10 @@
 let
-  rootDir = toString ./..;
-  commitHash = lib.sources.commitIdFromGitRepo ./../.git;
-
-  mkGithubLink = file: line:
-    let
-      filePath = lib.strings.removePrefix "${rootDir}/" file;
-      rootUrl = "https://github.com/NixOS/nixpkgs/blob/";
-      ghUrl = "${rootUrl}${commitHash}/${filePath}#L${toString line}";
-    in "<link xlink:href=\"${ghUrl}\">${filePath}:${toString line}</link>";
-
-  cleanId = lib.strings.replaceChars [ "'" ] [ "-prime" ];
-
   pkgs = import ./.. { };
   lib = pkgs.lib;
   sources = lib.sourceFilesBySuffices ./. [".xml"];
   sources-langs = ./languages-frameworks;
 
-  attrsOnly = attrset: lib.filterAttrs (k: v: builtins.isAttrs v) attrset;
-
-  docbookFromDoc = { name, pos, libgroupname }: {
-        # MUST match lib/doc.nix's mkDoc function signaturex
-        description,
-        examples ? [],
-        params ? [],
-        return ? null
-      }:
-    let
-      exampleDocbook = if examples == [] then ""
-      else let
-        exampleInner = lib.strings.concatMapStrings ({title, body}:
-        ''
-        <para>
-          <example>
-            <title>${title}</title>
-            <programlisting role="nix"><![CDATA[${body}]]></programlisting>
-          </example>
-        </para>
-
-      '') examples;
-      in ''
-        <refsect1 role="examples">
-        <title>Examples</title>
-        ${exampleInner}
-        </refsect1>
-      '';
-
-      type = if return == null then ""
-        else lib.strings.concatMapStringsSep " -> "
-          (param: if builtins.match ".*->.*" param.type == []
-                  then "(${param.type})"
-                  else param.type)
-          (params ++ [return]);
-
-      typeDocbook = if type == "" then ""
-        else ''
-        <literal>${type}</literal>
-        '';
-
-      paramsDocbook = if params == [] then ""
-        else let
-          paramDocbook = lib.concatMapStrings
-            (param:
-              let
-                type = if param.type == ""
-                  then ""
-                  else " <type>${param.type}</type>";
-
-              in ''
-              <varlistentry>
-                <term><parameter>${param.name}</parameter>${type}</term>
-                <listitem>
-                  <para>${param.description}</para>
-                </listitem>
-              </varlistentry>
-            '')
-            params;
-        in ''
-          <refsect1 role="parameters">
-            <title>Parameters</title>
-            <para>
-              <variablelist>
-                ${paramDocbook}
-              </variablelist>
-            </para>
-          </refsect1>
-        '';
-
-      returnDocbook = if return == null then ""
-        else let
-
-        in ''
-          <refsect1 role="returnvalues">
-           <title>Return Values</title>
-           <para>
-             <type>${return.type}</type>
-             ${return.description}
-           </para>
-          </refsect1>
-        '';
-
-    in ''
-      <refentry xml:id="fn-${cleanId libgroupname}-${cleanId name}">
-        <refnamediv>
-          <refname>${name}</refname>
-          <refpurpose>${typeDocbook}</refpurpose>
-        </refnamediv>
-
-        <refsect1>
-          <title></title>
-          <para>${mkGithubLink pos.file pos.line}</para>
-        </refsect1>
-
-        <refsect1 role="description">
-          <title>Description</title>
-          <para>${description}</para>
-        </refsect1>
-
-        ${paramsDocbook}
-
-        ${returnDocbook}
-
-        ${exampleDocbook}
-
-
-      </refentry>
-
-    '';
-
-
-
-  libSetDocFragments = libgroupname: libset: lib.mapAttrsToList
-    (name: value:
-      let
-        pos = builtins.unsafeGetAttrPos name libset;
-      in docbookFromDoc { inherit pos name libgroupname; } value
-    )
-    (if builtins.hasAttr "docs" libset then libset.docs else {});
-
-  libDocFragments = lib.mapAttrsToList
-    (name: value:
-      let
-        docs = (lib.strings.concatStrings (libSetDocFragments name value));
-      in if builtins.stringLength docs == 0
-      then ""
-      else ''
-        <section xml:id="fn-${cleanId name}">
-          <title>${name}</title>
-
-          ${docs}
-        </section>
-      ''
-    )
-    (attrsOnly lib);
-
-  libListDocs = pkgs.writeTextDir "lib-funcs.xml"
-    ''
-      <chapter xmlns="http://docbook.org/ns/docbook"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-        xml:id="chap-lib-functions">
-
-        <title>Functions reference</title>
-
-        ${lib.concatStringsSep "\n" libDocFragments}
-      </chapter>
-    '';
-
+  lib_docs = pkgs.callPackage ./lib.nix {};
 in
 pkgs.stdenv.mkDerivation {
   name = "nixpkgs-manual";
@@ -204,7 +44,7 @@ pkgs.stdenv.mkDerivation {
   ''
     ln -s '${sources}/'*.xml .
     mkdir ./languages-frameworks
-    cp -s '${libListDocs}'/* ./
+    cp -s '${lib_docs}'/* ./
     cp -s '${sources-langs}'/* ./languages-frameworks
   ''
   + toDocbook {

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -52,7 +52,7 @@ let
                   else param.type)
           (params ++ [return]);
 
-      typeDocbook = if type == false then ""
+      typeDocbook = if type == "" then ""
         else ''
         <literal>${type}</literal>
         '';
@@ -174,6 +174,8 @@ pkgs.stdenv.mkDerivation {
   xsltFlags = ''
     --param section.autolabel 1
     --param section.label.includes.component.label 1
+    --param refentry.generate.name 0
+    --param refentry.generate.title 1
     --param html.stylesheet 'style.css'
     --param xref.with.number.and.title 1
     --param toc.section.depth 3

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -1,4 +1,14 @@
 let
+  rootDir = toString ./..;
+  commitHash = lib.sources.commitIdFromGitRepo ./../.git;
+
+  mkGithubLink = file: line:
+    let
+      filePath = lib.strings.removePrefix "${rootDir}/" file;
+      rootUrl = "https://github.com/NixOS/nixpkgs/blob/";
+      ghUrl = "${rootUrl}${commitHash}/${filePath}#L${toString line}";
+    in "<link xlink:href=\"${ghUrl}\">${filePath}:${toString line}</link>";
+
   pkgs = import ./.. { };
   lib = pkgs.lib;
   sources = lib.sourceFilesBySuffices ./. [".xml"];
@@ -31,7 +41,7 @@ let
       <section>
         <title>${name}</title>
         ${typeDocbook}
-        <para>${pos.file}:${toString pos.line}</para>
+        <para>${mkGithubLink pos.file pos.line}</para>
 
 
         <para>${description}</para>

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -13,7 +13,8 @@ let
         type ? false
       }:
     let
-      exampleDocbook = lib.strings.concatMapStrings ({title, body}: ''
+      exampleDocbook = lib.strings.concatMapStrings ({title, body}:
+        ''
         <example>
           <title>${title}</title>
           <programlisting><![CDATA[${body}]]></programlisting>

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -19,10 +19,12 @@ let
   attrsOnly = attrset: lib.filterAttrs (k: v: builtins.isAttrs v) attrset;
 
   docbookFromDoc = { name, pos, libgroupname }: {
-        # MUST match lib/doc.nix's mkDoc function signature
+        # MUST match lib/doc.nix's mkDoc function signaturex
         description,
         examples ? [],
-        type ? false
+        type ? false,
+        params ? [],
+        return ? null
       }:
     let
       exampleDocbook = lib.strings.concatMapStrings ({title, body}:
@@ -39,14 +41,25 @@ let
         <subtitle><literal>${type}</literal></subtitle>
         '';
 
+      paramsDocbook = if params == [] then ""
+        else let
+          paramDocbook = lib.concatMapStrings
+            (param: ''
+              <listitem>
+                <para><parameter>${param.name}</parameter> <type>${param.type}</type> ${param.description}</para>
+              </listitem>
+            '')
+            params;
+        in "<orderedlist>${paramDocbook}</orderedlist>";
+
     in ''
       <section xml:id="fn-${cleanId libgroupname}-${cleanId name}">
-        <title>${name}</title>
+        <title><methodname>${name}</methodname></title>
         ${typeDocbook}
         <para>${mkGithubLink pos.file pos.line}</para>
 
-
         <para>${description}</para>
+        ${paramsDocbook}
 
         ${exampleDocbook}
       </section>

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -23,7 +23,7 @@ let
 
       typeDocbook = if type == false then ""
         else ''
-        <para>${type}</para>
+        <subtitle><literal>${type}</literal></subtitle>
         '';
 
     in ''
@@ -31,6 +31,7 @@ let
         <title>${name}</title>
         ${typeDocbook}
         <para>${pos.file}:${toString pos.line}</para>
+
 
         <para>${description}</para>
 

--- a/doc/lib.nix
+++ b/doc/lib.nix
@@ -99,7 +99,7 @@ let
     in ''
       <refentry xml:id="fn-${cleanId libgroupname}-${cleanId name}">
         <refnamediv>
-          <refname>${name}</refname>
+          <refname>${libgroupname}.${name}</refname>
           <refpurpose>${typeDocbook}</refpurpose>
         </refnamediv>
 

--- a/doc/lib.nix
+++ b/doc/lib.nix
@@ -88,11 +88,11 @@ let
 
         in ''
           <refsect1 role="returnvalues">
-           <title>Return Values</title>
-           <para>
-             <type>${return.type}</type>
-             ${return.description}
-           </para>
+            <title>Return Values</title>
+            <para>Type: <type>${return.type}</type></para>
+            <para>
+              ${return.description}
+            </para>
           </refsect1>
         '';
 

--- a/doc/lib.nix
+++ b/doc/lib.nix
@@ -1,0 +1,162 @@
+{ writeTextDir, lib }:
+let
+  rootDir = toString ./..;
+  commitHash = lib.sources.commitIdFromGitRepo ./../.git;
+
+  mkGithubLink = file: line:
+    let
+      filePath = lib.strings.removePrefix "${rootDir}/" file;
+      rootUrl = "https://github.com/NixOS/nixpkgs/blob/";
+      ghUrl = "${rootUrl}${commitHash}/${filePath}#L${toString line}";
+    in "<link xlink:href=\"${ghUrl}\">${filePath}:${toString line}</link>";
+
+  cleanId = lib.strings.replaceChars [ "'" ] [ "-prime" ];
+
+
+  attrsOnly = attrset: lib.filterAttrs (k: v: builtins.isAttrs v) attrset;
+
+  docbookFromDoc = { name, pos, libgroupname }: {
+        # MUST match lib/doc.nix's mkDoc function signaturex
+        description,
+        examples ? [],
+        params ? [],
+        return ? null
+      }:
+    let
+      exampleDocbook = if examples == [] then ""
+      else let
+        exampleInner = lib.strings.concatMapStrings ({title, body}:
+        ''
+        <para>
+          <example>
+            <title>${title}</title>
+            <programlisting role="nix"><![CDATA[${body}]]></programlisting>
+          </example>
+        </para>
+
+      '') examples;
+      in ''
+        <refsect1 role="examples">
+        <title>Examples</title>
+        ${exampleInner}
+        </refsect1>
+      '';
+
+      type = if return == null then ""
+        else lib.strings.concatMapStringsSep " -> "
+          (param: if builtins.match ".*->.*" param.type == []
+                  then "(${param.type})"
+                  else param.type)
+          (params ++ [return]);
+
+      typeDocbook = if type == "" then ""
+        else ''
+        <literal>${type}</literal>
+        '';
+
+      paramsDocbook = if params == [] then ""
+        else let
+          paramDocbook = lib.concatMapStrings
+            (param:
+              let
+                type = if param.type == ""
+                  then ""
+                  else " <type>${param.type}</type>";
+
+              in ''
+              <varlistentry>
+                <term><parameter>${param.name}</parameter>${type}</term>
+                <listitem>
+                  <para>${param.description}</para>
+                </listitem>
+              </varlistentry>
+            '')
+            params;
+        in ''
+          <refsect1 role="parameters">
+            <title>Parameters</title>
+            <para>
+              <variablelist>
+                ${paramDocbook}
+              </variablelist>
+            </para>
+          </refsect1>
+        '';
+
+      returnDocbook = if return == null then ""
+        else let
+
+        in ''
+          <refsect1 role="returnvalues">
+           <title>Return Values</title>
+           <para>
+             <type>${return.type}</type>
+             ${return.description}
+           </para>
+          </refsect1>
+        '';
+
+    in ''
+      <refentry xml:id="fn-${cleanId libgroupname}-${cleanId name}">
+        <refnamediv>
+          <refname>${name}</refname>
+          <refpurpose>${typeDocbook}</refpurpose>
+        </refnamediv>
+
+        <refsect1>
+          <title></title>
+          <para>${mkGithubLink pos.file pos.line}</para>
+        </refsect1>
+
+        <refsect1 role="description">
+          <title>Description</title>
+          <para>${description}</para>
+        </refsect1>
+
+        ${paramsDocbook}
+
+        ${returnDocbook}
+
+        ${exampleDocbook}
+
+
+      </refentry>
+
+    '';
+
+
+
+  libSetDocFragments = libgroupname: libset: lib.mapAttrsToList
+    (name: value:
+      let
+        pos = builtins.unsafeGetAttrPos name libset;
+      in docbookFromDoc { inherit pos name libgroupname; } value
+    )
+    (if builtins.hasAttr "docs" libset then libset.docs else {});
+
+  libDocFragments = lib.mapAttrsToList
+    (name: value:
+      let
+        docs = (lib.strings.concatStrings (libSetDocFragments name value));
+      in if builtins.stringLength docs == 0
+      then ""
+      else ''
+        <section xml:id="fn-${cleanId name}">
+          <title>${name}</title>
+
+          ${docs}
+        </section>
+      ''
+    )
+    (attrsOnly lib);
+in writeTextDir "lib-funcs.xml"
+  ''
+    <chapter xmlns="http://docbook.org/ns/docbook"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      xml:id="chap-lib-functions">
+
+      <title>Library Function Reference</title>
+
+      ${lib.concatStringsSep "\n" libDocFragments}
+    </chapter>
+  ''

--- a/doc/lib.nix
+++ b/doc/lib.nix
@@ -103,14 +103,10 @@ let
           <refpurpose>${typeDocbook}</refpurpose>
         </refnamediv>
 
-        <refsect1>
-          <title></title>
-          <para>${mkGithubLink pos.file pos.line}</para>
-        </refsect1>
-
         <refsect1 role="description">
           <title>Description</title>
           <para>${description}</para>
+          <para>Source: ${mkGithubLink pos.file pos.line}</para>
         </refsect1>
 
         ${paramsDocbook}

--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -16,6 +16,7 @@
   <xi:include href="cross-compilation.xml" />
   <xi:include href="configuration.xml" />
   <xi:include href="functions.xml" />
+  <xi:include href="lib-funcs.xml" />
   <xi:include href="meta.xml" />
   <xi:include href="languages-frameworks/index.xml" />
   <xi:include href="package-notes.xml" />

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -6,6 +6,7 @@ let
   inherit (lib.trivial) and or;
   inherit (lib.strings) concatStringsSep;
   inherit (lib.lists) fold concatMap concatLists all deepSeqList;
+  inherit (lib.docs) mkDoc mkP mkR;
 in
 
 rec {
@@ -150,22 +151,36 @@ rec {
     ) {} list_of_attrs;
 
 
-  /* Recursively collect sets that verify a given predicate named `pred'
-     from the set `attrs'.  The recursion is stopped when the predicate is
-     verified.
+  docs.collect = mkDoc {
+    description = ''
+      Recursively collect sets that verify a given predicate named
+      <parameter>pred</parameter> from the set
+      <parameter>attrs</parameter>. The recursion is stopped when the
+      predicate is verified.
+    '';
 
-     Type:
-       collect ::
-         (AttrSet -> Bool) -> AttrSet -> [x]
+    params = [
+      (mkP "pred" "AttrSet -> Bool" "")
+      (mkP "attrs" "AttrSet" "")
+    ];
+    return = mkR "[x]" "";
 
-     Example:
-       collect isList { a = { b = ["b"]; }; c = [1]; }
-       => [["b"] [1]]
-
-       collect (x: x ? outPath)
-          { a = { outPath = "a/"; }; b = { outPath = "b/"; }; }
-       => [{ outPath = "a/"; } { outPath = "b/"; }]
-  */
+    examples = [
+      { title = "Collect all values in the AttrSet which is a list.";
+        body = ''
+          collect isList { a = { b = ["b"]; }; c = [1]; }
+          => [["b"] [1]]
+        '';
+      }
+      { title = "Collect all AttrSets with an attribute named outPath.";
+        body = ''
+          collect (x: x ? outPath)
+             { a = { outPath = "a/"; }; b = { outPath = "b/"; }; }
+          => [{ outPath = "a/"; } { outPath = "b/"; }]
+        '';
+      }
+    ];
+  };
   collect = pred: attrs:
     if pred attrs then
       [ attrs ]

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -37,6 +37,7 @@ let
 
     # misc
     debug = callLibs ./debug.nix;
+    docs = callLibs ./docs.nix;
 
     generators = callLibs ./generators.nix;
     misc = callLibs ./deprecated.nix;

--- a/lib/docs.nix
+++ b/lib/docs.nix
@@ -1,0 +1,12 @@
+{ lib }:
+{
+  mkDoc = x:
+
+    let
+      validate = {
+        description,
+        examples ? [],
+        type ? false
+      }: x;
+    in validate x;
+}

--- a/lib/docs.nix
+++ b/lib/docs.nix
@@ -7,7 +7,6 @@
         # MUST match doc/default.nix's docbookFromDoc function signature
         description,
         examples ? [],
-        type ? false,
         params ? [],
         return ? null
       }: x;

--- a/lib/docs.nix
+++ b/lib/docs.nix
@@ -4,9 +4,18 @@
 
     let
       validate = {
+        # MUST match doc/default.nix's docbookFromDoc function signature
         description,
         examples ? [],
-        type ? false
+        type ? false,
+        params ? [],
+        return ? null
       }: x;
     in validate x;
+
+  mkP = name: type: description:
+    { inherit name type description; };
+
+  mkR = type: description:
+    { inherit type description; };
 }

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -164,40 +164,85 @@ rec {
   };
   concatMap = f: list: concatLists (map f list);
 
-  /* Flatten the argument into a single list; that is, nested lists are
-     spliced into the top-level lists.
+  docs.flatten = mkDoc {
+    description = ''
+      Flatten the argument into a single list; that is, nested lists are
+      spliced into the top-level lists.
+    '';
 
-     Example:
-       flatten [1 [2 [3] 4] 5]
-       => [1 2 3 4 5]
-       flatten 1
-       => [1]
-  */
+    examples = [
+      { title = "Flattens lists of lists in to a single list";
+        body = ''
+          flatten [1 [2 [3] 4] 5]
+          => [1 2 3 4 5]
+        '';
+      }
+      { title = "Encapsulates single value in a list";
+        body = ''
+          flatten 1
+          => [1]
+        '';
+      }
+    ];
+  };
   flatten = x:
     if isList x
     then concatMap (y: flatten y) x
     else [x];
 
-  /* Remove elements equal to 'e' from a list.  Useful for buildInputs.
+  docs.remove = mkDoc {
+    description = ''
+      Remove elements equal to 'e' from a list.  Useful for buildInputs.
+    '';
 
-     Example:
-       remove 3 [ 1 3 4 3 ]
-       => [ 1 4 ]
-  */
+    examples = [
+      { title = "Remove multiple 3s";
+        body = ''
+          remove 3 [ 1 3 4 3 ]
+          => [ 1 4 ]
+        '';
+      }
+    ];
+  };
   remove = e: filter (x: x != e);
 
-  /* Find the sole element in the list matching the specified
+  docs.findSingle = mkDoc {
+    description = ''
+     Find the sole element in the list matching the specified
      predicate, returns `default' if no such element exists, or
      `multiple' if there are multiple matching elements.
+   '';
 
-     Example:
-       findSingle (x: x == 3) "none" "multiple" [ 1 3 3 ]
-       => "multiple"
-       findSingle (x: x == 3) "none" "multiple" [ 1 3 ]
-       => 3
-       findSingle (x: x == 3) "none" "multiple" [ 1 9 ]
-       => "none"
-  */
+    examples = [
+      { title = ''
+          If the predicate matches one element, the element is
+          returned.
+        '';
+        body = ''
+          findSingle (x: x == 3) "none" "multiple" [ 1 3 ]
+          => 3
+        '';
+      }
+      { title = ''
+          If the predicate matches multiple elements, the
+          <parameter>multiple</parameter> parameter is returned.
+        '';
+        body = ''
+          findSingle (x: x == 3) "none" "multiple" [ 1 3 3 ]
+          => "multiple"
+        '';
+      }
+      { title = ''
+          If the parameter matches no elements, the
+          <parameter>default</parameter> parameter is returned.
+        '';
+        body = ''
+          findSingle (x: x == 3) "none" "multiple" [ 1 9 ]
+          => "none"
+        '';
+      }
+    ];
+  };
   findSingle = pred: default: multiple: list:
     let found = filter pred list; len = length found;
     in if len == 0 then default

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -43,7 +43,7 @@ rec {
       (mkP "nul" "b" "initial value")
       (mkP "list" "[a]" "")
     ];
-    return = mkP "b" "";
+    return = mkR "b" "";
     examples =[
       { title = "constructing a concat function with foldr";
         body = ''
@@ -214,8 +214,21 @@ rec {
   docs.findSingle = mkDoc {
     description = ''
      Find the sole element in the list matching the specified
-     predicate, returns `default' if no such element exists, or
-     `multiple' if there are multiple matching elements.
+     predicate.
+   '';
+
+   type = "(a -> Bool) -> a -> a -> [a] -> a";
+   params = [
+     (mkP "pred" "a -> Bool" "")
+     (mkP "default" "a" "The default if <parameter>pred</parameter> never returns <literal>true</literal>")
+     (mkP "multiple" "a" "The value if <parameter>pred</parameter> returns <literal>true</literal> multiple times")
+     (mkP "list" "[a]" "The list of values to search with <parameter>pred</parameter>")
+   ];
+   return = mkR "a" ''
+     If <parameter>pred</parameter> matches once, it returns the
+     matching value from the list. If no matching element exists, it
+     returns <parameter>default</parameter>. If there are multiple
+     matching elements, it returns <parameter>multiple</parameter>.
    '';
 
     examples = [

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -29,14 +29,14 @@ rec {
 
 
   docs.foldr = mkDoc {
+    type = "foldr :: (a -> b -> b) -> b -> [a] -> b";
+
     description = ''
       "Right fold" a binary function <literal>op</literal> between
       successive elements of <literal>list</literal> with
       <literal>nul</literal> as the starting value, i.e.,
       <literal>fold op nul [x_1 x_2 ... x_n] == op x_1 (op x_2 ... (op x_n nul))</literal>.
       (This is Haskell's <literal>foldr</literal>).
-
-      Type: foldr :: (a -> b -> b) -> b -> [a] -> b
     '';
 
     examples =[

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -38,7 +38,12 @@ rec {
       <literal>fold op nul [x_1 x_2 ... x_n] == op x_1 (op x_2 ... (op x_n nul))</literal>.
       (This is Haskell's <literal>foldr</literal>).
     '';
-
+    params = [
+      (mkP "op" "a -> b -> b" "")
+      (mkP "nul" "b" "initial value")
+      (mkP "list" "[a]" "")
+    ];
+    return = mkP "b" "";
     examples =[
       { title = "constructing a concat function with foldr";
         body = ''

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -29,8 +29,6 @@ rec {
 
 
   docs.foldr = mkDoc {
-    type = "foldr :: (a -> b -> b) -> b -> [a] -> b";
-
     description = ''
       "Right fold" a binary function <literal>op</literal> between
       successive elements of <literal>list</literal> with
@@ -217,7 +215,6 @@ rec {
      predicate.
    '';
 
-   type = "(a -> Bool) -> a -> a -> [a] -> a";
    params = [
      (mkP "pred" "a -> Bool" "")
      (mkP "default" "a" "The default if <parameter>pred</parameter> never returns <literal>true</literal>")

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -74,6 +74,7 @@ rec {
   };
   fold = foldr;
 
+
   docs.foldl = mkDoc {
     description = ''
       Left fold, like <literal>foldr</literal>, but from the left:
@@ -108,6 +109,7 @@ rec {
         else op (foldl' (n - 1)) (elemAt list n);
     in foldl' (length list - 1);
 
+
   docs.foldl' = mkDoc {
     description = ''
       Strict version of <literal>foldl</literal>.
@@ -119,28 +121,47 @@ rec {
   };
   foldl' = builtins.foldl' or foldl;
 
-  /* Map with index starting from 0
 
-     Example:
-       imap0 (i: v: "${v}-${toString i}") ["a" "b"]
-       => [ "a-0" "b-1" ]
-  */
+  docs.imap0 = mkDoc {
+    description = "Map with index starting from 0";
+
+    examples = [
+      { title = "";
+        body = ''
+         imap0 (i: v: "''${v}-''${toString i}") ["a" "b"]
+         => [ "a-0" "b-1" ]
+      '';
+      }
+    ];
+  };
   imap0 = f: list: genList (n: f n (elemAt list n)) (length list);
 
-  /* Map with index starting from 1
+  docs.imap1 = mkDoc {
+    description = "Map with index starting from 1";
 
-     Example:
-       imap1 (i: v: "${v}-${toString i}") ["a" "b"]
-       => [ "a-1" "b-2" ]
-  */
+    examples = [
+      { title = "";
+        body = ''
+         imap1 (i: v: "''${v}-''${toString i}") ["a" "b"]
+         => [ "a-1" "b-2" ]
+      '';
+      }
+    ];
+  };
   imap1 = f: list: genList (n: f (n + 1) (elemAt list n)) (length list);
 
-  /* Map and concatenate the result.
+  docs.concatMap = mkDoc {
+    description = "Map and concatenate the result.";
 
-     Example:
-       concatMap (x: [x] ++ ["z"]) ["a" "b"]
-       => [ "a" "z" "b" "z" ]
-  */
+    examples = [
+      { title = "";
+        body = ''
+          concatMap (x: [x] ++ ["z"]) ["a" "b"]
+          => [ "a" "z" "b" "z" ]
+        '';
+      }
+    ];
+  };
   concatMap = f: list: concatLists (map f list);
 
   /* Flatten the argument into a single list; that is, nested lists are

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1,36 +1,61 @@
 # General list operations.
 { lib }:
 with lib.trivial;
+with lib.docs;
 
 rec {
 
   inherit (builtins) head tail length isList elemAt concatLists filter elem genList;
 
-  /*  Create a list consisting of a single element.  `singleton x' is
-      sometimes more convenient with respect to indentation than `[x]'
-      when x spans multiple lines.
 
-      Example:
-        singleton "foo"
-        => [ "foo" ]
-  */
+  docs.singleton = mkDoc {
+    description = ''
+      Create a list consisting of a single element. <literal>singleton
+      x</literal> is sometimes more convenient with respect to
+      indentation than <literal>[x]</literal> when
+      <literal>x</literal> spans multiple lines.
+    '';
+
+    examples =[
+      { title = "singleton returns a single-element list";
+        body = ''
+          singleton "foo"
+          => [ "foo" ]
+        '';
+      }
+    ];
+  };
   singleton = x: [x];
 
-  /* “right fold” a binary function `op' between successive elements of
-     `list' with `nul' as the starting value, i.e.,
-     `foldr op nul [x_1 x_2 ... x_n] == op x_1 (op x_2 ... (op x_n nul))'.
-     Type:
-       foldr :: (a -> b -> b) -> b -> [a] -> b
 
-     Example:
-       concat = foldr (a: b: a + b) "z"
-       concat [ "a" "b" "c" ]
-       => "abcz"
-       # different types
-       strange = foldr (int: str: toString (int + 1) + str) "a"
-       strange [ 1 2 3 4 ]
-       => "2345a"
-  */
+  docs.foldr = mkDoc {
+    description = ''
+      "Right fold" a binary function <literal>op</literal> between
+      successive elements of <literal>list</literal> with
+      <literal>nul</literal> as the starting value, i.e.,
+      <literal>fold op nul [x_1 x_2 ... x_n] == op x_1 (op x_2 ... (op x_n nul))</literal>.
+      (This is Haskell's <literal>foldr</literal>).
+
+      Type: foldr :: (a -> b -> b) -> b -> [a] -> b
+    '';
+
+    examples =[
+      { title = "constructing a concat function with foldr";
+        body = ''
+          concat = fold (a: b: a + b) "z"
+          concat [ "a" "b" "c" ]
+          => "abcz"
+        '';
+      }
+      { title = "foldr across different types";
+        body = ''
+          strange = foldr (int: str: toString (int + 1) + str) "a"
+          strange [ 1 2 3 4 ]
+          => "2345a"
+        '';
+      }
+    ];
+  };
   foldr = op: nul: list:
     let
       len = length list;
@@ -40,26 +65,40 @@ rec {
         else op (elemAt list n) (fold' (n + 1));
     in fold' 0;
 
-  /* `fold' is an alias of `foldr' for historic reasons */
-  # FIXME(Profpatsch): deprecate?
+
+  docs.fold = mkDoc {
+    description = ''
+      <literal>fold</literal> is a deprecated alias of
+      <literal>foldr</literal>.
+    '';
+  };
   fold = foldr;
 
+  docs.foldl = mkDoc {
+    description = ''
+      Left fold, like <literal>foldr</literal>, but from the left:
+      <literal>foldl op nul [x_1 x_2 ... x_n] == op (... (op (op nul x_1) x_2) ... x_n)</literal>.
 
-  /* “left fold”, like `foldr', but from the left:
-     `foldl op nul [x_1 x_2 ... x_n] == op (... (op (op nul x_1) x_2) ... x_n)`.
+      Type: foldl :: (b -> a -> b) -> b -> [a] -> b
+    '';
 
-     Type:
-       foldl :: (b -> a -> b) -> b -> [a] -> b
-
-     Example:
-       lconcat = foldl (a: b: a + b) "z"
-       lconcat [ "a" "b" "c" ]
-       => "zabc"
-       # different types
-       lstrange = foldl (str: int: str + toString (int + 1)) ""
-       strange [ 1 2 3 4 ]
-       => "a2345"
-  */
+    examples =[
+      { title = "implementing an lconcat with foldl";
+        body = ''
+          lconcat = foldl (a: b: a + b) "z"
+          lconcat [ "a" "b" "c" ]
+          => "zabc"
+        '';
+      }
+      { title = "foldr with different types";
+        body = ''
+          lstrange = foldl (str: int: str + toString (int + 1)) ""
+          strange [ 1 2 3 4 ]
+          => "a2345"
+        '';
+      }
+    ];
+  };
   foldl = op: nul: list:
     let
       len = length list;
@@ -69,12 +108,15 @@ rec {
         else op (foldl' (n - 1)) (elemAt list n);
     in foldl' (length list - 1);
 
-  /* Strict version of `foldl'.
+  docs.foldl' = mkDoc {
+    description = ''
+      Strict version of <literal>foldl</literal>.
 
-     The difference is that evaluation is forced upon access. Usually used
-     with small whole results (in contract with lazily-generated list or large
-     lists where only a part is consumed.)
-  */
+      The difference is that evaluation is forced upon access. Usually
+      used with small whole results (in contract with lazily-generated
+      list or large lists where only a part is consumed.)
+    '';
+  };
   foldl' = builtins.foldl' or foldl;
 
   /* Map with index starting from 0


### PR DESCRIPTION
There has been a lot of chatter around doc blocks in Nix. Since Nix is almost purely expression based, it is likely very challenging to actually make that work. We might look in to how JSDoc handles it, as they have similar challenges I think.

However, that is complicated. I decided to get creative and try something simple out. Maybe you'll like it, maybe you'll hate it ;)

Basically, where we have:

```
  /* id returns its parameter
     Example:

    id x
    => x
*/
  id = x: x;
```

I changed it to:

```
  docs.id = mkDoc {
    description = "id returns its parameter";
    examples = [
      { title = "basic example";
        body = ''
          id x
          => x
        '';
    ];
  };
  id = x: x;
```

which get dumped to a docbook file and included in the manual. Currently very WIP, I spent an hour on this, looking for ways to solve this that are easier and more actionable than "we need a better parser."

Example result:
![screenshot-2017-7-15 nixpkgs contributors guide](https://user-images.githubusercontent.com/76716/28236083-7d0e1bc2-68ea-11e7-8777-6169b156be6f.png)

What do y'all think?

cc @joepie91 @domenkozar @edolstra @copumpkin @Profpatsch @zimbatm @vcunat @everyoneelse.