### PR TITLE
tinc: allow the daemon to write to files in /etc/tinc/${network}/hosts

### DIFF
--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -178,6 +178,8 @@ in
             # Tinc 1.0 uses the tincd application
             [ -f "/etc/tinc/${network}/rsa_key.priv" ] || tincd -n ${network} -K 4096
           fi
+          chown tinc.${network} /etc/tinc/${network}/hosts/*
+          chmod 644             /etc/tinc/${network}/hosts/*
         '';
         script = ''
           tincd -D -U tinc.${network} -n ${network} ${optionalString (data.chroot) "-R"} --pidfile /run/tinc.${network}.pid -d ${toString data.debugLevel}


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/27397

tinc daemon needs write access to files in ```/etc/tinc/${network}/hosts```

Welcome to improve, my fix might be not good for the security

