### PR TITLE
dunst: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/applications/misc/dunst/default.nix
+++ b/pkgs/applications/misc/dunst/default.nix
@@ -1,32 +1,25 @@
 { stdenv, fetchFromGitHub, fetchpatch
-, pkgconfig, which, perl
-, cairo, dbus, freetype, gdk_pixbuf, glib, libX11, libXScrnSaver
-, libXext, libXinerama, libnotify, libxdg_basedir, pango, xproto
-, librsvg
+, pkgconfig, which, perl, gtk2, xrandr
+, cairo, dbus, gdk_pixbuf, glib, libX11, libXScrnSaver
+, libXinerama, libnotify, libxdg_basedir, pango, xproto, librsvg
 }:
 
 stdenv.mkDerivation rec {
   name = "dunst-${version}";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
-    owner = "knopwob";
+    owner = "dunst-project";
     repo = "dunst";
     rev = "v${version}";
-    sha256 = "102s0rkcdz22hnacsi3dhm7kj3lsw9gnikmh3a7wk862nkvvwjmk";
+    sha256 = "0jncnb4z4hg92ws08bkf52jswsd4vqlzyznwbynhh2jh6q0sl18b";
   };
-
-  patches = [(fetchpatch {
-    name = "add-svg-support.patch";
-    url = "https://github.com/knopwob/dunst/commit/63b11141185d1d07a6d12212257a543e182d250a.patch";
-    sha256 = "0giiaj5zjim7xqcav5ij5gn4x6nnchkllwcx0ln16j0p3vbi4y4x";
-  })];
 
   nativeBuildInputs = [ perl pkgconfig which ];
 
   buildInputs = [
-    cairo dbus freetype gdk_pixbuf glib libX11 libXScrnSaver libXext
-    libXinerama libnotify libxdg_basedir pango xproto librsvg
+    cairo dbus gdk_pixbuf glib libX11 libXScrnSaver
+    libXinerama libnotify libxdg_basedir pango xproto librsvg gtk2 xrandr
   ];
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
###### Motivation for this change

New version after a long time of stalled development.

As far as I can read from the changelog, SVGs are supported in this version as well, so no more patching necessary.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

