### PR TITLE
CONTRIBUTING.md: suggest "nixos/<module>" prefix for NixOS changes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@ under the terms of [COPYING](../COPYING), which is an MIT-like license.
 * Format the commits in the following way:
 
   ```
-  (pkg-name | service-name): (from -> to | init at version | refactor | etc)
+  (pkg-name | nixos/<module>): (from -> to | init at version | refactor | etc)
   
   (Motivation for change. Additional information.)
   ```
@@ -24,10 +24,10 @@ under the terms of [COPYING](../COPYING), which is an MIT-like license.
 
   * nginx: init at 2.0.1
   * firefox: 3.0 -> 3.1.1
-  * hydra service: add bazBaz option
+  * nixos/hydra: add bazBaz option
   
     Dual baz behavior is needed to do foo.
-  * nginx service: refactor config generation
+  * nixos/nginx: refactor config generation
     
     The old config generation system used impure shell scripts and could break in specific circumstances (see #1234).
 


### PR DESCRIPTION
###### Motivation for this change

Suggest prefixing commit messages that touches NixOS code with
"nixos/\<module\>" instead of the current "\<name\> service" prefix.

"\<name\> service" is limiting in that NixOS code is more than the
services. It is also easier to spot NixOS changes with explicit
"nixos/..." prefix.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

