### PR TITLE
mkDerivation: Fix errors from #27365

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -98,9 +98,11 @@ rec {
           propagatedNativeBuildInputs = lib.elemAt propagatedDependencies' 0;
           propagatedBuildInputs = lib.elemAt propagatedDependencies' 1;
 
-          # This parameter is sometimes a string and sometimes a list, yuck
+          # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
           configureFlags = let inherit (lib) optional elem; in
-            (if lib.isString configureFlags then [configureFlags] else configureFlags)
+            (/**/ if lib.isString configureFlags then [configureFlags]
+             else if configureFlags == null      then []
+             else                                     configureFlags)
             ++ optional (elem "build"  configurePlatforms) "--build=${stdenv.buildPlatform.config}"
             ++ optional (elem "host"   configurePlatforms) "--host=${stdenv.hostPlatform.config}"
             ++ optional (elem "target" configurePlatforms) "--target=${stdenv.targetPlatform.config}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3591,7 +3591,7 @@ with pkgs;
           (attrs: { nativeBuildInputs = attrs.nativeBuildInputs ++ [ gtk3 ];
                     # Fix this build error in ./tests/examples/waylandsink:
                     #   main.c:28:2: error: #error "Wayland is not supported in GTK+"
-                    configureFlags = attrs.configureFlags or "" + "--enable-wayland=no";
+                    configureFlags = attrs.configureFlags or [] ++ [ "--enable-wayland=no" ];
                   });
       };
   };


### PR DESCRIPTION
###### Motivation for this change

`configureFlags = null` lead to a type error, and one overrideDrv needed to be converted to to append a configureFlags list instead of string due to the normalization.

Thanks @vcunat for alerting me to the issues---sorry I did not catch them before merging my own PR.


###### Things done

`nix-build pkgs/top-level/release.nix -A tarball` now succeeds.