### PR TITLE
bashSnippets: init at 1.12.0

### DIFF
--- a/pkgs/applications/misc/bashSnippets/default.nix
+++ b/pkgs/applications/misc/bashSnippets/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub
+, curl, netcat, mpv, python, bind, iproute, bc, gitMinimal, ... }:
+let
+  version = "1.12.0";
+in
+stdenv.mkDerivation {
+  name = "bashSnippets-${version}";
+
+  src = fetchFromGitHub {
+    owner = "alexanderepstein";
+    repo = "Bash-Snippets";
+    rev = "v${version}";
+    sha256 = "0kx2a8z3jbmmardw9z8fpghbw5mrbz4knb3wdihq35iarcbrddrg";
+  };
+
+  propagatedBuildInputs = [
+    curl
+    mpv
+    python
+    bind.dnsutils
+    iproute
+    bc
+    gitMinimal
+  ];
+
+  patchPhase = ''
+    patchShebangs install.sh
+    substituteInPlace install.sh --replace /usr/local "$out"
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p "$out/bin" "$out/man"
+    ./install.sh all
+  '';
+
+  outputs = [ "out" "man" ];
+
+  meta = with stdenv.lib; {
+    description = "A collection of small bash scripts for heavy terminal users";
+    homepage = https://github.com/alexanderepstein/Bash-Snippets;
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/misc/bashSnippets/default.nix
+++ b/pkgs/applications/misc/bashSnippets/default.nix
@@ -32,14 +32,12 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p "$out/bin" "$out/man"
+    mkdir -p "$out/bin" "$out/man/man1"
     ./install.sh all
     for file in "$out"/bin/*; do
       wrapProgram "$file" --prefix PATH : "${deps}"
     done
   '';
-
-  outputs = [ "out" "man" ];
 
   meta = with lib; {
     description = "A collection of small bash scripts for heavy terminal users";

--- a/pkgs/applications/misc/bashSnippets/default.nix
+++ b/pkgs/applications/misc/bashSnippets/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p "$out/bin" "$out/man/man1"
+    mkdir -p "$out"/bin "$out"/man/man1
     ./install.sh all
     for file in "$out"/bin/*; do
       wrapProgram "$file" --prefix PATH : "${deps}"
@@ -43,6 +43,7 @@ stdenv.mkDerivation {
     description = "A collection of small bash scripts for heavy terminal users";
     homepage = https://github.com/alexanderepstein/Bash-Snippets;
     license = licenses.mit;
+    maintainers = with maintainers; [ infinisil ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13397,6 +13397,8 @@ with pkgs;
     libgpod = pkgs.libgpod.override { monoSupport = true; };
   };
 
+  bashSnippets = callPackage ../applications/misc/bashSnippets { };
+
   batik = callPackage ../applications/graphics/batik { };
 
   batti = callPackage ../applications/misc/batti { };


### PR DESCRIPTION
###### Motivation for this change
Adds the [Bash-Snippets](https://github.com/alexanderepstein/Bash-Snippets) package. I'm not sure if the capitalization is okay like this, I used `bashSnippets`.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

