### PR TITLE
cc-wrapper: Always export environment variables for binutils

### DIFF
--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -52,9 +52,9 @@ for CMD in \
     ar as nm objcopy ranlib strip strings size ld windres
 do
     if
-        PATH=$_PATH type -p @binPrefix@$CMD > /dev/null
+        PATH=$_PATH type -p "@binPrefix@$CMD" > /dev/null
     then
-        export ${ENV_PREFIX}$(echo "$CMD" | tr "[:lower:]" "[:upper:]")=@binPrefix@${CMD};
+        export "${ENV_PREFIX}${CMD^^}=@binPrefix@${CMD}";
     fi
 done
 


### PR DESCRIPTION
###### Motivation for this change

Before, this only happened when cross compiling. This is less of a hack (and soon the entire `preWrap` script will go), uniformity is good.

###### Things done

Built Linux and Darwin stdenvs.

----

CC @ali-abrar This narrows down the bugs we've seen to the `infixSalt`-ing, basically.