### PR TITLE
oraclejdk8: armv7l support

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -3,6 +3,7 @@
 , downloadUrl
 , sha256_i686
 , sha256_x86_64
+, sha256_armv7l
 , jceName
 , jceDownloadUrl
 , sha256JCE
@@ -34,10 +35,13 @@
 , setJavaClassPath
 }:
 
-assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
+assert stdenv.system == "i686-linux"
+    || stdenv.system == "x86_64-linux"
+    || stdenv.system == "armv7l-linux";
 assert swingSupport -> xorg != null;
 
 let
+  abortArch = abort "jdk requires i686-linux, x86_64-linux, or armv7l-linux";
 
   /**
    * The JRE libraries are in directories that depend on the CPU.
@@ -47,8 +51,10 @@ let
       "i386"
     else if stdenv.system == "x86_64-linux" then
       "amd64"
+    else if stdenv.system == "armv7l-linux" then
+      "arm"
     else
-      abort "jdk requires i686-linux or x86_64 linux";
+      abortArch;
 
   jce =
     if installjce then
@@ -59,6 +65,14 @@ let
       }
     else
       "";
+
+  rSubPaths = [
+    "lib/${architecture}/jli"
+    "lib/${architecture}/server"
+    "lib/${architecture}/xawt"
+    "lib/${architecture}"
+  ];
+
 in
 
 let result = stdenv.mkDerivation rec {
@@ -78,8 +92,14 @@ let result = stdenv.mkDerivation rec {
         url = downloadUrl;
         sha256 = sha256_x86_64;
       }
+    else if stdenv.system == "armv7l-linux" then
+      requireFile {
+        name = "jdk-${productVersion}u${patchVersion}-linux-arm32-vfp-hflt.tar.gz";
+        url = downloadUrl;
+        sha256 = sha256_armv7l;
+      }
     else
-      abort "jdk requires i686-linux or x86_64 linux";
+      abortArch;
 
   nativeBuildInputs = [ file ]
     ++ stdenv.lib.optional installjce unzip;
@@ -134,18 +154,6 @@ let result = stdenv.mkDerivation rec {
       cp -v UnlimitedJCEPolicy*/*.jar $jrePath/lib/security
     fi
 
-    rpath=$rpath''${rpath:+:}$jrePath/lib/${architecture}/jli
-    rpath=$rpath''${rpath:+:}$jrePath/lib/${architecture}/server
-    rpath=$rpath''${rpath:+:}$jrePath/lib/${architecture}/xawt
-    rpath=$rpath''${rpath:+:}$jrePath/lib/${architecture}
-
-    # set all the dynamic linkers
-    find $out -type f -perm -0100 \
-        -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "$rpath" {} \;
-
-    find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
-
     if test -z "$pluginSupport"; then
       rm -f $out/bin/javaws
       if test -n "$installjdk"; then
@@ -163,11 +171,22 @@ let result = stdenv.mkDerivation rec {
     cat <<EOF >> $out/nix-support/setup-hook
     if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
     EOF
+  '';
+
+  postFixup = ''
+    rpath+="''${rpath:+:}${stdenv.lib.concatStringsSep ":" (map (a: "$jrePath/${a}") rSubPaths)}"
+
+    # set all the dynamic linkers
+    find $out -type f -perm -0100 \
+        -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "$rpath" {} \;
+
+    find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
 
     # Oracle Java Mission Control needs to know where libgtk-x11 and related is
-    if test -n "$installjdk"; then
+    if test -n "$installjdk" -a -x $out/bin/jmc; then
       wrapProgram "$out/bin/jmc" \
-          --suffix-each LD_LIBRARY_PATH ':' "${rpath}"
+          --suffix-each LD_LIBRARY_PATH ':' "$rpath"
     fi
   '';
 
@@ -192,7 +211,7 @@ let result = stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     license = licenses.unfree;
-    platforms = [ "i686-linux" "x86_64-linux" ]; # some inherit jre.meta.platforms
+    platforms = [ "i686-linux" "x86_64-linux" "armv7l-linux" ]; # some inherit jre.meta.platforms
   };
 
 }; in result

--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -4,6 +4,7 @@ import ./jdk-linux-base.nix {
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
   sha256_i686 = "0m3i1n1im1nlwb06wlsdajv19cd3zhrjkw8zbyjfznydn6qs4s80";
   sha256_x86_64 = "0dhj623ya01glcl3iir9ajifcrf6awhvpk936x9cxfj8zfyibck2";
+  sha256_armv7l = "0ja97nqn4x0ji16c7r6i9nnnj3745br7qlbj97jg1s8m2wk7f9jd";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -4,6 +4,7 @@ import ./jdk-linux-base.nix {
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
   sha256_i686 = "0m3i1n1im1nlwb06wlsdajv19cd3zhrjkw8zbyjfznydn6qs4s80";
   sha256_x86_64 = "0dhj623ya01glcl3iir9ajifcrf6awhvpk936x9cxfj8zfyibck2";
+  sha256_armv7l = "0ja97nqn4x0ji16c7r6i9nnnj3745br7qlbj97jg1s8m2wk7f9jd";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5619,8 +5619,8 @@ with pkgs;
     (lib.addMetaAttrs { outputsToInstall = [ "jre" ]; }
       (openjdk7.jre // { outputs = [ "jre" ]; }));
 
-  jdk8 = openjdk8 // { outputs = [ "out" ]; };
-  jre8 = lib.setName "openjre-${lib.getVersion pkgs.openjdk8.jre}"
+  jdk8 = if stdenv.isArm then oraclejdk8 else openjdk8 // { outputs = [ "out" ]; };
+  jre8 = if stdenv.isArm then oraclejre8 else lib.setName "openjre-${lib.getVersion pkgs.openjdk8.jre}"
     (lib.addMetaAttrs { outputsToInstall = [ "jre" ]; }
       (openjdk8.jre // { outputs = [ "jre" ]; }));
   jre8_headless =
@@ -5653,7 +5653,8 @@ with pkgs;
 
   supportsJDK =
     system == "i686-linux" ||
-    system == "x86_64-linux";
+    system == "x86_64-linux" ||
+    system == "armv7l-linux";
 
   jdkdistro = oraclejdk8distro;
 


### PR DESCRIPTION
###### Motivation for this change
I wanted to run i2p on ARM, so this was needed.

###### Things done

Added the conditional branches to support armv7l hosts and did a little cleanup in hooks (will trigger rebuilds of oraclejdk on all archs).

Tested with 'services.i2p.enable = true;`. i2p seemed to work okay.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

