### PR TITLE
factorio: authenticatedFetch now handles 404 properly

### DIFF
--- a/pkgs/games/factorio/fetch.sh
+++ b/pkgs/games/factorio/fetch.sh
@@ -33,7 +33,7 @@ $curl --data-urlencode csrf_token="$csrf" \
 
 if grep -q 'Location: https://' headers; then
     # Now download. We need --insecure for this, but the sha256 should cover us.
-    $curl --insecure --location $url > $out
+    $curl --insecure --location --fail $url > $out || { echo "Login succeeded, but subsequent fetch failed."; exit 1; }
     set +x
 else
     set +x


### PR DESCRIPTION
###### Motivation for this change

This addresses the root cause of #27411; `curl --fail` will now properly handle the 404 condition, instead of downloading the 404 page instead of the tarball, then failing the sha256 check.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

