### PR TITLE
stdenv: Don't put man pages into `doc` outputs

### DIFF
--- a/doc/multiple-output.xml
+++ b/doc/multiple-output.xml
@@ -83,7 +83,7 @@
 
       <varlistentry><term><varname>
         $outputInfo</varname></term><listitem><para>
-        is for info pages. They go to <varname>info</varname> or <varname>$outputMan</varname> by default.
+        is for info pages. They go to <varname>info</varname> or <varname>$outputBin</varname> by default.
       </para></listitem></varlistentry>
 
     </variablelist>

--- a/doc/multiple-output.xml
+++ b/doc/multiple-output.xml
@@ -73,7 +73,7 @@
 
       <varlistentry><term><varname>
         $outputMan</varname></term><listitem><para>
-        is for man pages (except for section 3). They go to <varname>man</varname> or <varname>doc</varname> or <varname>$outputBin</varname> by default.
+        is for man pages (except for section 3). They go to <varname>man</varname> or <varname>$outputBin</varname> by default.
       </para></listitem></varlistentry>
 
       <varlistentry><term><varname>
@@ -83,7 +83,7 @@
 
       <varlistentry><term><varname>
         $outputInfo</varname></term><listitem><para>
-        is for info pages. They go to <varname>info</varname> or <varname>doc</varname> or <varname>$outputMan</varname> by default.
+        is for info pages. They go to <varname>info</varname> or <varname>$outputMan</varname> by default.
       </para></listitem></varlistentry>
 
     </variablelist>

--- a/pkgs/applications/audio/flac/default.nix
+++ b/pkgs/applications/audio/flac/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   #doCheck = true; # takes lots of time
 
-  outputs = [ "bin" "dev" "out" "doc" ];
+  outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   meta = with stdenv.lib; {
     homepage = http://xiph.org/flac/;

--- a/pkgs/applications/graphics/meh/default.nix
+++ b/pkgs/applications/graphics/meh/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     make PREFIX=$out install
   '';
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" ];
 
   buildInputs = [ libXext libX11 libjpeg libpng giflib ];
 

--- a/pkgs/applications/misc/moonlight-embedded/default.nix
+++ b/pkgs/applications/misc/moonlight-embedded/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "0khdbwfclvpjgyk5ar1fs4j66zsjikaj422wlvrvqhyzi1v5arpr";
   };
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" ];
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "prefix=$(out)" ];
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ zlib libX11 libXcursor libXext harfbuzz mesa libXrandr libXinerama freetype libjpeg jbig2dec openjpeg ];
-  outputs = [ "bin" "dev" "out" "doc" ];
+  outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   preConfigure = ''
     # Don't remove mujs because upstream version is incompatible

--- a/pkgs/applications/misc/xrq/default.nix
+++ b/pkgs/applications/misc/xrq/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     make PREFIX=$out install
   '';
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" ];
 
   buildInputs = [ libX11 ];
 

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     sha256 = "0xfnhaxmvxdxs3ic0qs5lwq3yl4pi5ib99p0p5lv3v2vldqlm4lc";
   };
 
-  outputs = [ "out" ]; # "doc" was here but was not produced
+  outputs = [ "out" "man" ];
 
   enableParallelBuilding = true;
   cmakeFlags = with stdenv.lib; [

--- a/pkgs/applications/window-managers/ratpoison/default.nix
+++ b/pkgs/applications/window-managers/ratpoison/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1wfir1gvh5h7izgvx2kd1pr2k7wlncd33zq7qi9s9k2y0aza93yr";
   };
 
-  outputs = [ "out" "contrib" "doc" "info" ];
+  outputs = [ "out" "contrib" "man" "doc" "info" ];
 
   configureFlags = [
     # >=1.4.9 requires this even with readline in inputs

--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -3,8 +3,8 @@
 # assertExecutable FILE
 assertExecutable() {
     local file="$1"
-    [[ -f "${file}" && -x "${file}" ]] || \
-        die "Cannot wrap ${file} because it is not an executable file"
+    [[ -f "$file" && -x "$file" ]] || \
+        die "Cannot wrap '$file' because it is not an executable file"
 }
 
 # construct an executable file that wraps the actual executable
@@ -33,7 +33,7 @@ makeWrapper() {
     local params varName value command separator n fileNames
     local argv0 flagsBefore flags
 
-    assertExecutable "${original}"
+    assertExecutable "$original"
 
     mkdir -p "$(dirname "$wrapper")"
 
@@ -131,7 +131,7 @@ wrapProgram() {
     local prog="$1"
     local hidden
 
-    assertExecutable "${prog}"
+    assertExecutable "$prog"
 
     hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
     while [ -e "$hidden" ]; do

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -40,9 +40,9 @@ _overrideFirst outputLib "lib" "out"
 _overrideFirst outputDoc "doc" "out"
 _overrideFirst outputDevdoc "devdoc" REMOVE # documentation for developers
 # man and info pages are small and often useful to distribute with binaries
-_overrideFirst outputMan "man" "doc" "$outputBin"
+_overrideFirst outputMan "man" "$outputBin"
 _overrideFirst outputDevman "devman" "devdoc" "$outputMan"
-_overrideFirst outputInfo "info" "doc" "$outputMan"
+_overrideFirst outputInfo "info" "$outputMan"
 
 
 # Add standard flags to put files into the desired outputs.

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -42,7 +42,7 @@ _overrideFirst outputDevdoc "devdoc" REMOVE # documentation for developers
 # man and info pages are small and often useful to distribute with binaries
 _overrideFirst outputMan "man" "$outputBin"
 _overrideFirst outputDevman "devman" "devdoc" "$outputMan"
-_overrideFirst outputInfo "info" "$outputMan"
+_overrideFirst outputInfo "info" "$outputBin"
 
 
 # Add standard flags to put files into the desired outputs.

--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     "TZDIR=$(out)/share/zoneinfo"
     "ETCDIR=$(TMPDIR)/etc"
     "LIBDIR=$(dev)/lib"
-    "MANDIR=$(man)/man"
+    "MANDIR=$(man)/share/man"
     "AWK=awk"
     "CFLAGS=-DHAVE_LINK=0"
   ];

--- a/pkgs/desktops/gnome-2/platform/GConf/default.nix
+++ b/pkgs/desktops/gnome-2/platform/GConf/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "09ch709cb9fniwc4221xgkq0jf0x0lxs814sqig8p2dcll0llvzk";
   };
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "dev" "man" ];
 
   buildInputs = [ ORBit2 dbus_libs dbus_glib libxml2 ]
     # polkit requires pam, which requires shadow.h, which is not available on

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" "doc" ];
 
   preConfigure = ''
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation {
   buildInputs = [ ncurses ] ++ targetToolchains
     ++ optional (!forceBundledLLVM) llvmShared;
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" "doc" ];
   setOutputFlags = false;
 
   # Disable codegen units for the tests.

--- a/pkgs/development/libraries/aalib/default.nix
+++ b/pkgs/development/libraries/aalib/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1vkh19gb76agvh4h87ysbrgy82hrw88lnsvhynjf4vng629dmpgv";
   };
 
-  outputs = [ "bin" "dev" "out" "doc" ];
+  outputs = [ "bin" "dev" "out" "man" "info" ];
   setOutputFlags = false; # Doesn't support all the flags
 
   patches = stdenv.lib.optionals stdenv.isDarwin [ ./darwin.patch ];

--- a/pkgs/development/libraries/acl/default.nix
+++ b/pkgs/development/libraries/acl/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "08qd9s3wfhv0ajswsylnfwr5h0d7j9d4rgip855nrh400nxp940p";
   };
 
-  outputs = [ "bin" "dev" "out" "doc" ];
+  outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   nativeBuildInputs = [ gettext ];
   buildInputs = [ attr ];

--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0nd8y0m6awc9ahv0ciiwf8gy54c8d3j51pw9xg7f7cn579jjyxr5";
   };
 
-  outputs = [ "bin" "dev" "out" "doc" ];
+  outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   nativeBuildInputs = [ gettext ];
 

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
   postPatch = ''patchShebangs .'';
   inherit patches;
 
-  outputs = [ "bin" "dev" "out" ]
+  outputs = [ "bin" "dev" "out" "man" ]
     ++ optional (reqMin "1.0") "doc" ; # just dev-doc
   setOutputFlags = false; # doesn't accept all and stores configureFlags in libs!
 

--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "0g8qk98lgq770ixdf7n36yd5xjsgm2v3wzvnphwmhy6r4y2amx0y";
   };
 
-  outputs = [ "out" "dev" "doc" ]; # it's dev-doc only
+  outputs = [ "out" "dev" "man" "info" ]; # it's dev-doc only
   outputBin = "dev"; # fftw-wisdom
 
   configureFlags =

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
   patches = [ ./absolute-paths.diff ];
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" "doc" "info" ];
 
   # FIXME stackprotector needs gcc 4.9 in bootstrap tools
   hardeningDisable = [ "format" "stackprotector" ];

--- a/pkgs/development/libraries/libao/default.nix
+++ b/pkgs/development/libraries/libao/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1bwwv1g9lchaq6qmhvj1pp3hnyqr64ydd4j38x94pmprs4d27b83";
   };
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "dev" "man" "doc" ];
 
   buildInputs =
     [ pkgconfig ] ++

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   patches = stdenv.lib.optional stdenv.isCygwin ./3.2.1-cygwin.patch;
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "dev" "man" "info" ];
 
   buildInputs = stdenv.lib.optional doCheck dejagnu;
 

--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     stdenv.lib.optional (hostPlatform.libc or null == "msvcrt")
       ./mingw-boolean.patch;
 
-  outputs = [ "bin" "dev" "out" "doc" ];
+  outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   nativeBuildInputs = [ nasm ];
 

--- a/pkgs/development/libraries/libksba/default.nix
+++ b/pkgs/development/libraries/libksba/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0h53q4sns1jz1pkmhcz5wp9qrfn9f5g9i3vjv6dafwzzlvblyi21";
   };
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "dev" "info" ];
 
   propagatedBuildInputs = [ libgpgerror ];
 

--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0nxb4x8l092xckk4dy84cn5qhviif8akzy0miypapjqqbalm53fa";
   };
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "dev" "man" ];
 
   preConfigure = ''
     patchShebangs .

--- a/pkgs/development/libraries/libsndfile/default.nix
+++ b/pkgs/development/libraries/libsndfile/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  outputs = [ "bin" "dev" "out" "doc" ];
+  outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   # need headers from the Carbon.framework in /System/Library/Frameworks to
   # compile this on darwin -- not sure how to handle

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       patches="$patches $(cat debian/patches/series | sed 's|^|debian/patches/|')"
     '';
 
-  outputs = [ "bin" "dev" "out" "doc" ];
+  outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
     })
   ];
 
-  outputs = [ "bin" "dev" "out" "doc" ]
+  outputs = [ "bin" "dev" "out" "man" "doc" ]
     ++ lib.optional pythonSupport "py";
   propagatedBuildOutputs = "out bin" + lib.optionalString pythonSupport " py";
 

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       --replace 'la_LDFLAGS =' 'la_LDFLAGS = $(WIN32_EXTRA_LDFLAGS)'
   '';
 
-  outputs = [ "bin" "dev" "out" "doc" ] ++ stdenv.lib.optional pythonSupport "py";
+  outputs = [ "bin" "dev" "out" "man" "doc" ] ++ stdenv.lib.optional pythonSupport "py";
 
   buildInputs = [ libxml2.dev ] ++ stdenv.lib.optionals pythonSupport [ libxml2.py python2 ];
 

--- a/pkgs/development/libraries/mpfr/default.nix
+++ b/pkgs/development/libraries/mpfr/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./upstream.patch ];
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "dev" "doc" "info" ];
 
   # mpfr.h requires gmp.h
   propagatedBuildInputs = [ gmp ];

--- a/pkgs/development/libraries/readline/6.3.nix
+++ b/pkgs/development/libraries/readline/6.3.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0hzxr9jxqqx5sxsv9vmlxdnvlr9vi4ih1avjb869hbs6p5qn1fjn";
   };
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "dev" "man" "doc" "info" ];
 
   propagatedBuildInputs = [ncurses];
 

--- a/pkgs/development/libraries/readline/7.0.nix
+++ b/pkgs/development/libraries/readline/7.0.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0d13sg9ksf982rrrmv5mb6a2p4ys9rvg9r71d6il0vr8hmql63bm";
   };
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "dev" "man" "doc" "info" ];
 
   propagatedBuildInputs = [ncurses];
 

--- a/pkgs/development/libraries/slang/default.nix
+++ b/pkgs/development/libraries/slang/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     sha256 = "0dlcy0hn0j6cj9qj5x6hpb0axifnvzzmv5jqq0wq14fygw0c7w2l";
   };
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "dev" "man" "doc" ];
 
   # Fix some wrong hardcoded paths
   preConfigure = ''

--- a/pkgs/development/libraries/xapian/default.nix
+++ b/pkgs/development/libraries/xapian/default.nix
@@ -11,7 +11,7 @@ let
       inherit sha256;
     };
 
-    outputs = [ "out" "doc" ];
+    outputs = [ "out" "man" "doc" ];
 
     buildInputs = [ libuuid zlib ];
     nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   configureFlags = stdenv.lib.optional guileSupport "--with-guile";
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" "info" ];
 
   meta = with stdenv.lib; {
     homepage = http://www.gnu.org/software/make/;

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" "doc" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/libcap/default.nix
+++ b/pkgs/os-specific/linux/libcap/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0qjiqc5pknaal57453nxcbz3mn1r4hkyywam41wfcglq3v2qlg39";
   };
 
-  outputs = [ "out" "dev" "lib" "doc" ]
+  outputs = [ "out" "dev" "lib" "man" "doc" ]
     ++ stdenv.lib.optional (pam != null) "pam";
 
   nativeBuildInputs = [ perl ];

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0spl155k0g2l2hvqf8xyjv08i68gfyhzpjva6cwlzxx0bz4gbify";
   };
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" ];
 
   patches = [ ./force-path.patch ];
 

--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   # FIXME: -dev depends on -doc
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "dev" "man" "doc" ];
   setOutputFlags = false; # it would move $out/modules, etc.
 
   buildInputs = [perl] ++

--- a/pkgs/servers/uftp/default.nix
+++ b/pkgs/servers/uftp/default.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin $doc/share/man/man1
+    mkdir -p $out/bin $man/share/man/man1
     cp {uftp,uftpd,uftp_keymgt,uftpproxyd} $out/bin/
-    cp {uftp.1,uftpd.1,uftp_keymgt.1,uftpproxyd.1} $doc/share/man/man1
+    cp {uftp.1,uftpd.1,uftp_keymgt.1,uftpproxyd.1} $man/share/man/man1
   '';
 
   meta = {

--- a/pkgs/servers/uftp/default.nix
+++ b/pkgs/servers/uftp/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl ];
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" ];
 
   patchPhase = ''
     substituteInPlace makefile --replace gcc cc

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -73,7 +73,7 @@ in
   libxcb = attrs : attrs // {
     nativeBuildInputs = [ args.python ];
     configureFlags = "--enable-xkb --enable-xinput";
-    outputs = [ "out" "dev" "doc" ];
+    outputs = [ "out" "dev" "man" "doc" ];
   };
 
   xcbproto = attrs : attrs // {
@@ -177,7 +177,7 @@ in
   };
 
   libXext = attrs: attrs // {
-    outputs = [ "out" "dev" "doc" ];
+    outputs = [ "out" "dev" "man" "doc" ];
     propagatedBuildInputs = [ xorg.xproto xorg.libXau ];
     preConfigure = setMalloc0ReturnsNullCrossCompiling;
   };
@@ -187,7 +187,7 @@ in
   };
 
   libXi = attrs: attrs // {
-    outputs = [ "out" "dev" "doc" ];
+    outputs = [ "out" "dev" "man" "doc" ];
     propagatedBuildInputs = [ xorg.libXfixes ];
   };
 

--- a/pkgs/shells/bash/4.4.nix
+++ b/pkgs/shells/bash/4.4.nix
@@ -36,10 +36,9 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  outputs = [ "out" "dev" "man" "doc" "info" ];
-
-  # the man pages are small and useful enough
-  outputMan = if interactive then "out" else null;
+  outputs = [ "out" "dev" "doc" "info" ]
+    # the man pages are small and useful enough, so include them in $out in interactive builds
+    ++ stdenv.lib.optional (!interactive) "man";
 
   NIX_CFLAGS_COMPILE = ''
     -DSYS_BASHRC="/etc/bashrc"

--- a/pkgs/shells/bash/4.4.nix
+++ b/pkgs/shells/bash/4.4.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  outputs = [ "out" "dev" "doc" "info" ];
+  outputs = [ "out" "dev" "man" "doc" "info" ];
 
   # the man pages are small and useful enough
   outputMan = if interactive then "out" else null;

--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libuuid, gettext }:
+{ stdenv, fetchurl, pkgconfig, libuuid, gettext, texinfo }:
 
 stdenv.mkDerivation rec {
   name = "e2fsprogs-1.43.4";
@@ -8,9 +8,9 @@ stdenv.mkDerivation rec {
     sha256 = "a648a90a513f1b25113c7f981af978b8a19f832b3a32bd10707af3ff682ba66d";
   };
 
-  outputs = [ "bin" "dev" "out" "man" ];
+  outputs = [ "bin" "dev" "out" "man" "info" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig texinfo ];
   buildInputs = [ libuuid ] ++ stdenv.lib.optional (!stdenv.isLinux) gettext;
 
   crossAttrs = {

--- a/pkgs/tools/graphics/pfstools/default.nix
+++ b/pkgs/tools/graphics/pfstools/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1fyc2c7jzr7k797c2dqyyvapzc3szxwcp48r382yxz2yq558xgd9";
   };
 
-  outputs = [ "out" "dev" "doc"];
+  outputs = [ "out" "dev" "man"];
 
   cmakeFlags = ''
     -DWITH_MATLAB=false 

--- a/pkgs/tools/networking/dnsperf/default.nix
+++ b/pkgs/tools/networking/dnsperf/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "03kfc65s5a9csa5i7xjsv0psq144k8d9yw7xlny61bg1h2kg1db4";
   };
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" "doc" ];
 
   buildInputs = [ bind libseccomp zlib ];
 

--- a/pkgs/tools/networking/tinc/pre.nix
+++ b/pkgs/tools/networking/tinc/pre.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "05an2vj0a3wjv5w672wgzyixbydin5jpja5zv6x81bc72dms0ymc";
   };
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" "info" ];
 
   nativeBuildInputs = [ autoreconfHook texinfo ];
   buildInputs = [ ncurses readline zlib lzo openssl ];

--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1998v2kcs288d3y7kfxpvl369nqi06zbbvjzafyvyl3pr7bajj1s";
   };
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "man" "doc" "info" ];
 
   enableParallelBuilding = false;
 

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -132,8 +132,7 @@ core = stdenv.mkDerivation rec {
         '')
   + /* doc location identical with individual TeX pkgs */ ''
     mkdir -p "$doc/doc"
-    mv "$doc"/share/{man,info} "$doc"/doc
-    rmdir "$doc"/share
+    mv "$out"/share/{man,info} "$doc"/doc
   '' + cleanBrokenLinks;
 
   setupHook = ./setup-hook.sh; # TODO: maybe texmf-nix -> texmf (and all references)

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30,7 +30,7 @@ let self = _self // overrides; _self = with self; {
       url = "mirror://cpan/authors/id/P/PE/PETDANCE/${name}.tar.gz";
       sha256 = "0ifbmbfvagfi76i7vjpggs2hrbqqisd14f5zizan6cbdn8dl5z2g";
     };
-    outputs = ["out" "doc"];
+    outputs = ["out" "man"];
     # use gnused so that the preCheck command passes
     buildInputs = stdenv.lib.optional stdenv.isDarwin gnused;
     propagatedBuildInputs = [ FileNext ];


### PR DESCRIPTION
These changes make stdenv no longer put manpages into the `doc` output, as that output is not installed into user environments by default. Also GNU info pages aren't put into the `man` output anymore because if `programs.man.enable = false`, the `man` outputs won't be installed and such info pages would again disappear.

Affected packages have been compile tested.