### PR TITLE
buildenv: read propagated-user-env-packages line-by-line

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -141,12 +141,11 @@ sub addPkg {
     my $propagatedFN = "$pkgDir/nix-support/propagated-user-env-packages";
     if (-e $propagatedFN) {
         open PROP, "<$propagatedFN" or die;
-        my $propagated = <PROP>;
-        close PROP;
-        my @propagated = split ' ', $propagated;
-        foreach my $p (@propagated) {
+        while (my $p = <PROP>) {
+            chomp $p;
             $postponed{$p} = 1 unless defined $done{$p};
         }
+        close PROP;
     }
 }
 


### PR DESCRIPTION
### Motivation

Since 3cb745d5a69018829ac15f7d5a508135f6bda123, the format of
propagated-user-env-packages has changed and propagated packages have not been
included by buildenv, including in the system environment.

The buildenv builder is modified to read propagated-user-env-packages
line-by-line, instead of expecting all packages on one line.

###### Testing

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is a rebuild-the-world bugfix, so nobody is going to merge this into `staging` until those boxes above are checked.

Input from any Perl experts is welcome. I *think* this will work now, but even with 16 cores it will take me a minute or two to find out. 🙄 

@Ericson2314 Several things were broken by this. I expect if you had run the NixOS tests before merging, you would have discovered that and prevented this.