### PR TITLE
pytorch: init at 0.1.12

### DIFF
--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -1,0 +1,41 @@
+{ buildPythonPackage, fetchFromGitHub, lib, numpy, pyyaml, cffi, cmake,
+  gcc, git, openblas, stdenv }:
+buildPythonPackage rec {
+  version = "v0.1.12";
+  name = "pytorch-${version}";
+
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "pytorch";
+    rev = version;
+    sha256 = "0r8mf4xya76gz83y5z3hfxh0rydkydafhipl8g7d0bfrgw961jy9";
+  };
+
+  checkPhase = ''
+    ${stdenv.shell} test/run_test.sh
+  '';
+
+  buildInputs = [
+     cmake
+     git
+     numpy.blas
+  ];
+  
+  propagatedBuildInputs = [
+    cffi
+    numpy
+    pyyaml
+  ];
+
+  preConfigure = ''
+    export NO_CUDA=1
+  '';
+  
+  meta = {
+    description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration.";
+    homepage = http://pytorch.org/;
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ teh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10762,6 +10762,8 @@ in {
     };
   };
 
+  pytorch = callPackage ../development/python-modules/pytorch { };
+
   python_tvrage = buildPythonPackage (rec {
     version = "0.4.1";
     name = "tvrage-${version}";


### PR DESCRIPTION
I've only tested this on Linux and without cuda. 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

