### PR TITLE
Keybase updates

### DIFF
--- a/pkgs/tools/security/kbfs/default.nix
+++ b/pkgs/tools/security/kbfs/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "kbfs-${version}";
-  version = "20170209.d1db463";
+  version = "20170429.44efa06";
 
   goPackagePath = "github.com/keybase/kbfs";
   subPackages = [ "kbfsfuse" ];
@@ -12,8 +12,8 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "keybase";
     repo = "kbfs";
-    rev = "d1db46315d9271f21ca2700a84ca19767e638296";
-    sha256 = "12i2m370r27mmn37s55krdkhr5k8kpl3x8y3gzg7w5zn2wiw8i1g";
+    rev = "44efa0682d931d8489f5e84542e8d00baeb12592";
+    sha256 = "1q6hklyr6zq3xr1azz1c6rlpsjc036f222cd20vf79m58dn906n5";
   };
 
   buildFlags = [ "-tags production" ];
@@ -22,6 +22,6 @@ buildGoPackage rec {
     homepage = https://www.keybase.io;
     description = "The Keybase FS FUSE driver";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ bennofs ];
+    maintainers = with maintainers; [ bennofs np ];
   };
 }

--- a/pkgs/tools/security/keybase-gui/default.nix
+++ b/pkgs/tools/security/keybase-gui/default.nix
@@ -22,7 +22,7 @@ let
     pango
     systemd
     xorg.libX11
-    xorg.libXScrnSaver
+    xorg.libxcb
     xorg.libXcomposite
     xorg.libXcursor
     xorg.libXdamage
@@ -31,15 +31,16 @@ let
     xorg.libXi
     xorg.libXrandr
     xorg.libXrender
+    xorg.libXScrnSaver
     xorg.libXtst
   ];
 in
 stdenv.mkDerivation rec {
   name = "keybase-gui-${version}";
-  version = "1.0.23-20170519175207.d6c5e9e";
+  version = "1.0.25-20170714172717.73f9070";
   src = fetchurl {
     url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version}_amd64.deb";
-    sha256 = "14nylwpd64ngx1kdb4pk2laghslx9872fb2a9jgkbgbgnan5nkmm";
+    sha256 = "0yrq18rrc30f7ymajvd71r29z1by7h6abyaxx2gmrg648qgc6zv4";
   };
   phases = ["unpackPhase" "installPhase" "fixupPhase"];
   unpackPhase = ''
@@ -86,6 +87,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.keybase.io/;
     description = "The Keybase official GUI.";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ puffnfresh ];
+    maintainers = with maintainers; [ puffnfresh np ];
   };
 }

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "keybase-${version}";
-  version = "1.0.20";
+  version = "1.0.22";
 
   goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/keybase" ];
@@ -13,7 +13,7 @@ buildGoPackage rec {
     owner  = "keybase";
     repo   = "client";
     rev    = "v${version}";
-    sha256 = "1418x2z1j4bzq29qab8pmqrvg8piycqcabdjmq2inkvlll3s5n3v";
+    sha256 = "1642d11gjgkdklppmm1j3vwc2r3qg9qqw5x07jnqs819i57mr47f";
   };
 
   buildFlags = [ "-tags production" ];
@@ -22,6 +22,6 @@ buildGoPackage rec {
     homepage = https://www.keybase.io/;
     description = "The Keybase official command-line utility and service.";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ carlsverre ];
+    maintainers = with maintainers; [ carlsverre np ];
   };
 }


### PR DESCRIPTION
keybase: 1.0.20 -> 1.0.22
keybase-gui: 1.0.23-20170519175207.d6c5e9e -> 1.0.25-20170714172717.73f9070
kbfs: 20170209.d1db463 -> 20170429.44efa06

###### Motivation for this change

This was outdated and now the three packages are working at the same time (didn't work for me before).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

