### PR TITLE
ipfs: fix fusermount: executable file not found

### DIFF
--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, fetchgx }:
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchgx, fuse }:
 
 buildGoPackage rec {
   name = "ipfs-${version}";
@@ -20,6 +20,8 @@ buildGoPackage rec {
     inherit rev;
     sha256 = "1j3az0nhjisb5dxp1a4g8w17y17xjikvcsy4qrg0fm43ybpkhhvw";
   };
+
+  buildDepends = [ fuse ];
 
   meta = with stdenv.lib; {
     description = "A global, versioned, peer-to-peer filesystem";


### PR DESCRIPTION
###### Motivation for this change

A proposal to fix #27414 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (`$SRC/result-bin/bin/ipfs mount -f $HOME/ipfs/ -n $HOME/ipns/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

