### PR TITLE
solvespace: Fix path in desktop entry file

### DIFF
--- a/pkgs/applications/graphics/solvespace/default.nix
+++ b/pkgs/applications/graphics/solvespace/default.nix
@@ -32,6 +32,11 @@ stdenv.mkDerivation rec {
     EOF
   '';
 
+  postInstall = ''
+    substituteInPlace $out/share/applications/solvespace.desktop \
+      --replace /usr/bin/ $out/bin/ \
+  '';
+
   meta = {
     description = "A parametric 3d CAD program";
     license = stdenv.lib.licenses.gpl3;


### PR DESCRIPTION
###### Motivation for this change

The desktop entry file used `Exec=/usr/bin/solvespace` before.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @edef
