### PR TITLE
dapp: init at v0.5.2

### DIFF
--- a/pkgs/applications/altcoins/dapp.nix
+++ b/pkgs/applications/altcoins/dapp.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, makeWrapper
+, seth, git, solc, shellcheck, nodejs, hsevm }:
+
+stdenv.mkDerivation rec {
+  name = "dapp";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "dapphub";
+    repo = "dapp";
+    rev = "v${version}";
+    sha256 = "1529ml5r1l5g6xcak7k3h3ih214mgnk87jsxyk0rvk245jkard1y";
+  };
+
+  nativeBuildInputs = [makeWrapper shellcheck];
+  buildPhase = "true";
+  doCheck = false;
+  checkPhase = "make test";
+  makeFlags = ["prefix=$(out)"];
+  postInstall = let path = lib.makeBinPath [
+    nodejs solc git seth hsevm
+  ]; in ''
+    wrapProgram "$out/bin/dapp" --prefix PATH : "${path}"
+  '';
+
+  meta = {
+    description = "Simple tool for creating Ethereum-based dapps";
+    homepage = https://github.com/dapphub/dapp/;
+    maintainers = [stdenv.lib.maintainers.dbrock];
+    license = lib.licenses.gpl3;
+    inherit version;
+  };
+}

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -38,6 +38,7 @@ rec {
   ethabi = callPackage ./ethabi.nix { };
   ethrun = callPackage ./ethrun.nix { };
   seth = callPackage ./seth.nix { };
+  dapp = callPackage ./dapp.nix { };
 
   hsevm = (pkgs.haskellPackages.callPackage ./hsevm.nix {});
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13337,6 +13337,7 @@ with pkgs;
   ethabi = self.altcoins.ethabi;
   ethrun = self.altcoins.ethrun;
   seth = self.altcoins.seth;
+  dapp = self.altcoins.dapp;
   hsevm = self.altcoins.hsevm;
 
   stellar-core = self.altcoins.stellar-core;


### PR DESCRIPTION
###### Motivation for this change

Simple tool for creating Ethereum-based dapps

(cc @dbrock)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

