### PR TITLE
vcsh: Patch for Git 2.13.2

### DIFF
--- a/pkgs/applications/version-management/vcsh/default.nix
+++ b/pkgs/applications/version-management/vcsh/default.nix
@@ -12,9 +12,15 @@ stdenv.mkDerivation rec {
   };
 
   patches =
-    [ (fetchpatch { url = "https://patch-diff.githubusercontent.com/raw/RichiH/vcsh/pull/222.patch";
-                    sha256 = "0grdbiwq04x5qj0a1yd9a78g5v28dxhwl6mwxvgvvmzs6k5wnl3k";
-                  })
+    [
+      (fetchpatch {
+        url = "https://patch-diff.githubusercontent.com/raw/RichiH/vcsh/pull/222.patch";
+        sha256 = "0grdbiwq04x5qj0a1yd9a78g5v28dxhwl6mwxvgvvmzs6k5wnl3k";
+      })
+      (fetchpatch {
+        url = "https://patch-diff.githubusercontent.com/raw/RichiH/vcsh/pull/228.patch";
+        sha256 = "04djxdqzrza3p6q7qm9c84inlj34khabz90j5smnjv5gyzc43c90";
+      })
     ];
 
   buildInputs = [ which git ronn perl ShellCommand TestMost ];


### PR DESCRIPTION
### Motivation

Fixes #27134.

### Testing

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

