### PR TITLE
Fix "mv: argument list too long" for fetchzip in darwin.

### DIFF
--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -23,7 +23,6 @@ lib.overrideDerivation (fetchurl ({
   postFetch =
     ''
       export PATH=${unzip}/bin:$PATH
-      mkdir $out
 
       unpackDir="$TMPDIR/unpack"
       mkdir "$unpackDir"
@@ -32,8 +31,6 @@ lib.overrideDerivation (fetchurl ({
       renamed="$TMPDIR/${baseNameOf url}"
       mv "$downloadedFile" "$renamed"
       unpackFile "$renamed"
-
-      shopt -s dotglob
     ''
     + (if stripRoot then ''
       if [ $(ls "$unpackDir" | wc -l) != 1 ]; then
@@ -43,12 +40,11 @@ lib.overrideDerivation (fetchurl ({
       fi
       fn=$(cd "$unpackDir" && echo *)
       if [ -f "$unpackDir/$fn" ]; then
-        mv "$unpackDir/$fn" "$out"
-      else
-        mv "$unpackDir/$fn"/* "$out/"
+        mkdir $out
       fi
+      mv "$unpackDir/$fn" "$out"
     '' else ''
-      mv "$unpackDir"/* "$out/"
+      mv "$unpackDir" "$out"
     '') #*/
     + extraPostFetch;
 } // removeAttrs args [ "stripRoot" "extraPostFetch" ]))


### PR DESCRIPTION
###### Motivation for this change
Fixes #27448 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

