### PR TITLE
html-xml-utils: 6.9 → 7.1, macOS support

### DIFF
--- a/pkgs/tools/text/xml/html-xml-utils/default.nix
+++ b/pkgs/tools/text/xml/html-xml-utils/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, curl, libiconv }:
 
 stdenv.mkDerivation rec {
-  name = "html-xml-utils-6.9";
+  name = "html-xml-utils-${version}";
+  version = "7.1";
 
   src = fetchurl {
     url = "http://www.w3.org/Tools/HTML-XML-utils/${name}.tar.gz";
-
-    sha256 = "1cpshwz60h7xsw1rvv84jl4bn9zjqii9hb8zvwm7a0fahkf03x4w";
+    sha256 = "0vnmcrbnc7irrszx5h71s3mqlp9wqh19zig519zbnr5qccigs3pc";
   };
 
-  meta = {
+  buildInputs = [curl libiconv];
+
+  meta = with stdenv.lib; {
     description = "Utilities for manipulating HTML and XML files";
     homepage = http://www.w3.org/Tools/HTML-XML-utils/;
-    license = stdenv.lib.licenses.w3c;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.w3c;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

html-xml-utils in Nix packages is two versions behind, lacks macOS support and essential functionality (fetching URLs) that requires external dependencies (curl, libiconv).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

