### PR TITLE
hid-listen: init at 1.01

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -558,6 +558,7 @@
   tohl = "Tomas Hlavaty <tom@logand.com>";
   tokudan = "Daniel Frank <git@danielfrank.net>";
   tomberek = "Thomas Bereknyei <tomberek@gmail.com>";
+  tomsmeets = "Tom Smeets <tom@tsmeets.nl>";
   travisbhartwell = "Travis B. Hartwell <nafai@travishartwell.net>";
   trevorj = "Trevor Joynson <nix@trevor.joynson.io>";
   trino = "Hubert Mühlhans <muehlhans.hubert@ekodia.de>";

--- a/pkgs/tools/misc/hid-listen/default.nix
+++ b/pkgs/tools/misc/hid-listen/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    mv ./hid_listen $out/bin/$hid_listen
+    mv ./hid_listen $out/bin/hid_listen
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/hid-listen/default.nix
+++ b/pkgs/tools/misc/hid-listen/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchzip }:
+stdenv.mkDerivation rec {
+  name = "hid-listen";
+  version = "1.01";
+
+  src = fetchzip {
+    name = "hid_listen_${version}";
+    url = "https://www.pjrc.com/teensy/hid_listen_${version}.zip";
+    sha256 = "0sd4dvi39fl4vy880mg531ryks5zglfz5mdyyqr7x6qv056ffx9w";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv ./hid_listen $out/bin/$hid_listen
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A tool thats prints debugging information from usb HID devices";
+    homepage = https://www.pjrc.com/teensy/hid_listen.html;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ tomsmeets ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/hid-listen/default.nix
+++ b/pkgs/tools/misc/hid-listen/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.pjrc.com/teensy/hid_listen.html;
     license = licenses.gpl3;
     maintainers = with maintainers; [ tomsmeets ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1033,6 +1033,8 @@ with pkgs;
 
   hexio = callPackage ../development/tools/hexio { };
 
+  hid-listen = callPackage ../tools/misc/hid-listen { };
+
   hostsblock = callPackage ../tools/misc/hostsblock { };
 
   hr = callPackage ../applications/misc/hr { };


### PR DESCRIPTION
This tool has to be run as root.

taken from the [homepage](https://www.pjrc.com/teensy/hid_listen.html):
> On Ubuntu Linux, the /dev/hidraw device files are not readable by default for normal users. You could create a custom udev rule, or simply run hid_listen with sudo.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

