### PR TITLE
breeze-icons: generate icon cache

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/breeze-icons.nix
+++ b/pkgs/development/libraries/kde-frameworks/breeze-icons.nix
@@ -1,9 +1,13 @@
-{ mkDerivation, lib, extra-cmake-modules, qtsvg }:
+{ mkDerivation, lib, extra-cmake-modules, gtk3, qtsvg }:
 
 mkDerivation {
   name = "breeze-icons";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ extra-cmake-modules gtk3 ];
   buildInputs = [ qtsvg ];
   outputs = [ "out" ]; # only runtime outputs
+  postInstall = ''
+    gtk-update-icon-cache "''${out:?}/share/icons/breeze"
+    gtk-update-icon-cache "''${out:?}/share/icons/breeze-dark"
+  '';
 }


### PR DESCRIPTION
### Motivation

Fixes #21345 by generating the icon cache when the theme is installed.

### Testing

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

