### PR TITLE
dapp: v0.5.2 -> v0.5.3

### DIFF
--- a/pkgs/applications/altcoins/dapp.nix
+++ b/pkgs/applications/altcoins/dapp.nix
@@ -3,18 +3,18 @@
 
 stdenv.mkDerivation rec {
   name = "dapp";
-  version = "0.5.2";
+  version = "0.5.3";
 
   src = fetchFromGitHub {
     owner = "dapphub";
     repo = "dapp";
     rev = "v${version}";
-    sha256 = "1529ml5r1l5g6xcak7k3h3ih214mgnk87jsxyk0rvk245jkard1y";
+    sha256 = "13b2krd02py8jnzjis44lay5i31d95z0myrsy5afzw7fa25giird";
   };
 
   nativeBuildInputs = [makeWrapper shellcheck];
   buildPhase = "true";
-  doCheck = false;
+  doCheck = true;
   checkPhase = "make test";
   makeFlags = ["prefix=$(out)"];
   postInstall = let path = lib.makeBinPath [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

