### PR TITLE
boolector: 1.{5,6} -> 2.4.1

### DIFF
--- a/pkgs/applications/science/logic/boolector/default.nix
+++ b/pkgs/applications/science/logic/boolector/default.nix
@@ -1,48 +1,23 @@
-{ stdenv, fetchurl, zlib, useV16 ? false }:
+{ stdenv, fetchurl }:
 
-let
-  v15 = rec {
-    name    = "boolector-${version}";
-    version = "1.5.118";
-    src = fetchurl {
-      url    = "http://fmv.jku.at/boolector/${name}-with-sat-solvers.tar.gz";
-      sha256 = "17j7q02rryvfwgvglxnhx0kv8hxwy8wbhzawn48lw05i98vxlmk9";
-    };
+stdenv.mkDerivation rec {
+  name    = "boolector-${version}";
+  version = "2.4.1";
+  src = fetchurl {
+    url    = "http://fmv.jku.at/boolector/boolector-${version}-with-lingeling-bbc.tar.bz2";
+    sha256 = "0mdf7hwix237pvknvrpazcx6s3ininj5k7vhysqjqgxa7lxgq045";
   };
-
-  v16 = rec {
-    name    = "boolector-${version}";
-    version = "1.6.0";
-    src = fetchurl {
-      url    = "http://fmv.jku.at/boolector/${name}-with-sat-solvers.tar.gz";
-      sha256 = "0jka4r6bc3i24axgdp6qbq6gjadwz9kvi11s2c5sbwmdnjd7cp85";
-    };
-  };
-
-  boolectorPkg = if useV16 then v16 else v15;
-  license = with stdenv.lib.licenses; if useV16 then unfreeRedistributable else gpl3;
-in
-stdenv.mkDerivation (boolectorPkg // {
-  buildInputs = [
-    zlib zlib.static (stdenv.lib.getOutput "static" stdenv.cc.libc)
-  ];
-
-  enableParallelBuilding = false;
 
   installPhase = ''
-    mkdir -p $out/bin $out/lib $out/include
-    cp boolector/boolector      $out/bin
-    cp boolector/deltabtor      $out/bin
-    cp boolector/synthebtor     $out/bin
-    cp boolector/libboolector.a $out/lib
-    cp boolector/boolector.h    $out/include
+    mkdir $out
+    mv boolector/bin $out
   '';
 
   meta = {
-    inherit license;
+    license = stdenv.lib.licenses.unfreeRedistributable;
     description = "An extremely fast SMT solver for bit-vectors and arrays";
     homepage    = "http://fmv.jku.at/boolector";
     platforms   = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
   };
-})
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18180,11 +18180,7 @@ with pkgs;
   z3 = callPackage ../applications/science/logic/z3 {};
   z3_opt = callPackage ../applications/science/logic/z3_opt {};
 
-  boolector   = boolector15;
-  boolector15 = callPackage ../applications/science/logic/boolector {};
-  boolector16 = lowPrio (callPackage ../applications/science/logic/boolector {
-    useV16 = true;
-  });
+  boolector = callPackage ../applications/science/logic/boolector {};
 
   ### SCIENCE / ELECTRONICS
 


### PR DESCRIPTION
###### Motivation for this change

update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

