### PR TITLE
networkmanager_l2tp: fix build without Gnome

### DIFF
--- a/pkgs/tools/networking/network-manager/l2tp.nix
+++ b/pkgs/tools/networking/network-manager/l2tp.nix
@@ -27,7 +27,13 @@ stdenv.mkDerivation rec {
       --replace /sbin/xl2tpd ${xl2tpd}/bin/xl2tpd
   '';
 
-  preConfigure = "./autogen.sh";
+  # The package provides an `autogen.sh' script for this, but it insists on
+  # configuring the build without our flags.
+  preConfigure = ''
+    autoreconf --install --symlink
+    intltoolize --force
+    autoreconf
+  '';
 
   configureFlags =
     if withGnome then "--with-gnome" else "--without-gnome";


### PR DESCRIPTION
### Motivation

`networkmanager_l2tp` fails to build if `withGnome = false` because the included `autogen.sh` script is not run with our `configureFlags`. To avoid running `configure` twice, I copied the relevant commands from `autogen.sh` into `preConfigure`.

### Testing

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

