### PR TITLE
pinentry: add GNOME frontend

### DIFF
--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -35,7 +35,7 @@ with lib;
       networkmanager_pptp = pkgs.networkmanager_pptp.override { withGnome = false; };
       networkmanager_vpnc = pkgs.networkmanager_vpnc.override { withGnome = false; };
       networkmanager_iodine = pkgs.networkmanager_iodine.override { withGnome = false; };
-      pinentry = pkgs.pinentry.override { gtk2 = null; qt4 = null; };
+      pinentry = pkgs.pinentry.override { gcr = null; gtk2 = null; qt4 = null; };
     };
   };
 }

--- a/pkgs/desktops/gnome-3/core/gcr/default.nix
+++ b/pkgs/desktops/gnome-3/core/gcr/default.nix
@@ -8,11 +8,11 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   buildInputs = [
-    pkgconfig intltool gnupg glib gobjectIntrospection libxslt
-    libgcrypt libtasn1 dbus_glib gtk pango gdk_pixbuf atk makeWrapper vala_0_32
+    pkgconfig intltool gnupg gobjectIntrospection libxslt
+    libgcrypt libtasn1 dbus_glib pango gdk_pixbuf atk makeWrapper vala_0_32
   ];
 
-  propagatedBuildInputs = [ p11_kit ];
+  propagatedBuildInputs = [ glib gtk p11_kit ];
 
   #doCheck = true;
 

--- a/pkgs/desktops/gnome-3/core/gcr/default.nix
+++ b/pkgs/desktops/gnome-3/core/gcr/default.nix
@@ -7,8 +7,10 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  buildInputs = [
-    pkgconfig intltool gnupg gobjectIntrospection libxslt
+  buildInputs = let
+    gpg = gnupg.override { guiSupport = false; }; # prevent build cycle with pinentry_gnome
+  in [
+    pkgconfig intltool gpg gobjectIntrospection libxslt
     libgcrypt libtasn1 dbus_glib pango gdk_pixbuf atk makeWrapper vala_0_32
   ];
 

--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -6,7 +6,6 @@ let
   mkFlag = pfxTrue: pfxFalse: cond: name: "--${if cond then pfxTrue else pfxFalse}-${name}";
   mkEnable = mkFlag "enable" "disable";
   mkWith = mkFlag "with" "without";
-  hasX = gtk2 != null || gcr != null || qt4 != null;
 in
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -40,12 +39,11 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     (mkWith   (libcap != null)  "libcap")
-    (mkWith   (hasX)            "x")
     (mkEnable (ncurses != null) "pinentry-curses")
     (mkEnable true              "pinentry-tty")
     (mkEnable (gtk2 != null)    "pinentry-gtk2")
     (mkEnable (gcr != null)     "pinentry-gnome3")
-    (mkEnable (qt4 != null)     "pinentry-qt4")
+    (mkEnable (qt4 != null)     "pinentry-qt")
   ];
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -1,12 +1,12 @@
 { fetchurl, fetchpatch, stdenv, lib, pkgconfig
-, libgpgerror, libassuan, libcap ? null, ncurses ? null, gtk2 ? null, qt4 ? null
+, libgpgerror, libassuan, libcap ? null, ncurses ? null, gtk2 ? null, gcr ? null, qt4 ? null
 }:
 
 let
   mkFlag = pfxTrue: pfxFalse: cond: name: "--${if cond then pfxTrue else pfxFalse}-${name}";
   mkEnable = mkFlag "enable" "disable";
   mkWith = mkFlag "with" "without";
-  hasX = gtk2 != null || qt4 != null;
+  hasX = gtk2 != null || gcr != null || qt4 != null;
 in
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "0ni7g4plq6x78p32al7m8h2zsakvg1rhfz0qbc3kdc7yq7nw4whn";
   };
 
-  buildInputs = [ libgpgerror libassuan libcap gtk2 ncurses qt4 ];
+  buildInputs = [ libgpgerror libassuan libcap gtk2 gcr ncurses qt4 ];
 
   prePatch = ''
     substituteInPlace pinentry/pinentry-curses.c --replace ncursesw ncurses
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
     (mkEnable (ncurses != null) "pinentry-curses")
     (mkEnable true              "pinentry-tty")
     (mkEnable (gtk2 != null)    "pinentry-gtk2")
+    (mkEnable (gcr != null)     "pinentry-gnome3")
     (mkEnable (qt4 != null)     "pinentry-qt4")
   ];
 

--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, fetchpatch, stdenv, lib, pkgconfig
-, libgpgerror, libassuan, libcap ? null, ncurses ? null, gtk2 ? null, gcr ? null, qt4 ? null
+, libgpgerror, libassuan, libcap ? null, libsecret ? null, ncurses ? null, gtk2 ? null, gcr ? null, qt4 ? null
 }:
 
 let
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "0ni7g4plq6x78p32al7m8h2zsakvg1rhfz0qbc3kdc7yq7nw4whn";
   };
 
-  buildInputs = [ libgpgerror libassuan libcap gtk2 gcr ncurses qt4 ];
+  buildInputs = [ libgpgerror libassuan libcap libsecret gtk2 gcr ncurses qt4 ];
 
   prePatch = ''
     substituteInPlace pinentry/pinentry-curses.c --replace ncursesw ncurses
@@ -38,12 +38,13 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    (mkWith   (libcap != null)  "libcap")
-    (mkEnable (ncurses != null) "pinentry-curses")
-    (mkEnable true              "pinentry-tty")
-    (mkEnable (gtk2 != null)    "pinentry-gtk2")
-    (mkEnable (gcr != null)     "pinentry-gnome3")
-    (mkEnable (qt4 != null)     "pinentry-qt")
+    (mkWith   (libcap != null)    "libcap")
+    (mkEnable (libsecret != null) "libsecret")
+    (mkEnable (ncurses != null)   "pinentry-curses")
+    (mkEnable true                "pinentry-tty")
+    (mkEnable (gtk2 != null)      "pinentry-gtk2")
+    (mkEnable (gcr != null)       "pinentry-gnome3")
+    (mkEnable (qt4 != null)       "pinentry-qt")
   ];
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3860,14 +3860,16 @@ with pkgs;
   pinentry = callPackage ../tools/security/pinentry {
     libcap = if stdenv.isDarwin then null else libcap;
     qt4 = null;
+    gtk2 = null;
+    gcr = gnome3.gcr;
   };
 
   pinentry_ncurses = pinentry.override {
-    gtk2 = null;
+    gcr = null;
   };
 
-  pinentry_gnome = pinentry_ncurses.override {
-    gcr = gnome3.gcr;
+  pinentry_gtk2 = pinentry_ncurses.override {
+    inherit gtk2;
   };
 
   pinentry_qt4 = pinentry_ncurses.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3866,6 +3866,10 @@ with pkgs;
     gtk2 = null;
   };
 
+  pinentry_gnome = pinentry_ncurses.override {
+    gcr = gnome3.gcr;
+  };
+
   pinentry_qt4 = pinentry_ncurses.override {
     inherit qt4;
   };


### PR DESCRIPTION
This pull request introduces GNOME 3 frontend for pinentry, `pinentry_gnome`. Because `gnupg` depends on `pinentry` and `pinentry_gnome` depends on `gnupg` via `gcr`, I had to modify `gcr` to prevent building GUI. I also added libsecret dependency for caching passwords.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).