### PR TITLE
python-gnupg: 0.4.0 -> 0.4.1 and enable tests

### DIFF
--- a/pkgs/development/python-modules/python-gnupg/default.nix
+++ b/pkgs/development/python-modules/python-gnupg/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonPackage, fetchPypi, gnupg1 }:
+
+buildPythonPackage rec {
+  name    = "${pname}-${version}";
+  pname   = "python-gnupg";
+  version = "0.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06hfw9cmiw5306fyisp3kzg1hww260qzip829g7y7pj1mwpb0izg";
+  };
+
+  propagatedBuildInputs = [ gnupg1 ];
+
+  # Let's make the library default to our gpg binary
+  patchPhase = ''
+    substituteInPlace gnupg.py \
+    --replace "gpgbinary='gpg'" "gpgbinary='${gnupg1}/bin/gpg'"
+    substituteInPlace test_gnupg.py \
+    --replace "gpgbinary=GPGBINARY" "gpgbinary='${gnupg1}/bin/gpg'"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A wrapper for the Gnu Privacy Guard";
+    homepage    = https://pypi.python.org/pypi/python-gnupg;
+    license     = licenses.bsd3;
+    maintainers = with maintainers; [ copumpkin ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -515,33 +515,7 @@ in {
     };
   };
 
-  python-gnupg = buildPythonPackage rec {
-    name    = "python-gnupg-${version}";
-    version = "0.4.1";
-
-    src = pkgs.fetchurl {
-      url    = "mirror://pypi/p/python-gnupg/${name}.tar.gz";
-      sha256 = "06hfw9cmiw5306fyisp3kzg1hww260qzip829g7y7pj1mwpb0izg";
-    };
-
-    propagatedBuildInputs = [ pkgs.gnupg1 ];
-
-    # Let's make the library default to our gpg binary
-    patchPhase = ''
-      substituteInPlace gnupg.py \
-        --replace "gpgbinary='gpg'" "gpgbinary='${pkgs.gnupg1}/bin/gpg'"
-      substituteInPlace test_gnupg.py \
-        --replace "gpgbinary=GPGBINARY" "gpgbinary='${pkgs.gnupg1}/bin/gpg'"
-    '';
-
-    meta = {
-      description = "A wrapper for the Gnu Privacy Guard";
-      homepage    = "https://pypi.python.org/pypi/python-gnupg";
-      license     = licenses.bsd3;
-      maintainers = with maintainers; [ copumpkin ];
-      platforms   = platforms.unix;
-    };
-  };
+  python-gnupg = callPackage ../development/python-modules/python-gnupg {};
 
   python-uinput = buildPythonPackage rec {
     name = "python-uinput-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -517,11 +517,11 @@ in {
 
   python-gnupg = buildPythonPackage rec {
     name    = "python-gnupg-${version}";
-    version = "0.4.0";
+    version = "0.4.1";
 
     src = pkgs.fetchurl {
       url    = "mirror://pypi/p/python-gnupg/${name}.tar.gz";
-      sha256 = "1yd88acafs9nwk6gzpbxjzpx0zd04qrvc6hmwhj1i89ghm2g7ap6";
+      sha256 = "06hfw9cmiw5306fyisp3kzg1hww260qzip829g7y7pj1mwpb0izg";
     };
 
     propagatedBuildInputs = [ pkgs.gnupg1 ];
@@ -530,9 +530,9 @@ in {
     patchPhase = ''
       substituteInPlace gnupg.py \
         --replace "gpgbinary='gpg'" "gpgbinary='${pkgs.gnupg1}/bin/gpg'"
+      substituteInPlace test_gnupg.py \
+        --replace "gpgbinary=GPGBINARY" "gpgbinary='${pkgs.gnupg1}/bin/gpg'"
     '';
-
-    doCheck = false;
 
     meta = {
       description = "A wrapper for the Gnu Privacy Guard";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

This did not work since a couple of tests of `nix-build -A python27Packages.jedi` fail first.

- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

