### PR TITLE
terminal-notifier: add shebang line to wrapper

### DIFF
--- a/pkgs/applications/misc/terminal-notifier/default.nix
+++ b/pkgs/applications/misc/terminal-notifier/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp -r terminal-notifier.app $out/Applications
     cat >$out/bin/terminal-notifier <<EOF
+    #!${stdenv.shell}
     cd $out/Applications/terminal-notifier.app
     exec ./Contents/MacOS/terminal-notifier "\$@"
     EOF


### PR DESCRIPTION
Add shebang line to terminal-notifier to wrapper script. Without this line, the
script fails with "Exec format error" when called outside a shell (e.g. from
the Emacs alert package).

###### Motivation for this change

When terminal-notifier get called from the Emacs alert package, it fails with "Exec format error". Adding a shebang line fixes this error.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

