### PR TITLE
Update keepass + keepasshttp plugin

### DIFF
--- a/pkgs/applications/misc/keepass-plugins/keepasshttp/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keepasshttp/default.nix
@@ -1,14 +1,17 @@
 { stdenv, buildEnv, fetchFromGitHub, mono }:
 
 let
-  version = "1.8.4.1";
+  version = "1.8.4.2";
   drv = stdenv.mkDerivation {
     name = "keepasshttp-${version}";
     src = fetchFromGitHub {
       owner = "pfn";
       repo = "keepasshttp";
-      rev = "${version}";
-      sha256 = "1074yv0pmzdwfwkx9fh7n2igdqwsyxypv55khkyng6synbv2p2fd";
+      #rev = "${version}";
+      # for 1.8.4.2 the tag is at the wrong commit (they fixed stuff
+      # afterwards and didn't move the tag), hence reference by commitid
+      rev = "c2c4eb5388a02169400cba7a67be325caabdcc37";
+      sha256 = "0bkzxggbqx7sql3sp46bqham6r457in0vrgh3ai3lw2jrw79pwmh";
     };
 
     meta = {

--- a/pkgs/applications/misc/keepass/default.nix
+++ b/pkgs/applications/misc/keepass/default.nix
@@ -8,11 +8,11 @@
 # plugin derivations in the Nix store and nowhere else.
 with builtins; buildDotnetPackage rec {
   baseName = "keepass";
-  version = "2.35";
+  version = "2.36";
 
   src = fetchurl {
     url = "mirror://sourceforge/keepass/KeePass-${version}-Source.zip";
-    sha256 = "1pv3x1lr2kymjpm6z26fqx997jivzy0diqsysq4diygj38wdkajz";
+    sha256 = "1j6qhy8h3z6higbpq3q9v04amvgbn90yj3kbsvj17azdkffkwzny";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
###### Motivation for this change

Update keepass itself 2.35 -> 2.36
and its keepasshttp plugin 1.8.4.1 -> 1.8.4.2

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

