### PR TITLE
backport "gnutls: use 3.5.10 on Darwin for now" to stable

### DIFF
--- a/pkgs/development/libraries/gnutls/3.5.10.nix
+++ b/pkgs/development/libraries/gnutls/3.5.10.nix
@@ -1,0 +1,10 @@
+{ callPackage, fetchurl, libunistring, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "3.5.10";
+
+  src = fetchurl {
+    url = "ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5/gnutls-${version}.tar.xz";
+    sha256 = "17apwvdkkazh5w8z8mbanpj2yj8s2002qwy46wz4v3akpa33wi5g";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7579,9 +7579,15 @@ with pkgs;
 
   gnutls = gnutls35;
 
-  gnutls35 = callPackage ../development/libraries/gnutls/3.5.nix {
-    guileBindings = config.gnutls.guile or false;
-  };
+  gnutls35 = callPackage
+    (if stdenv.isDarwin
+      # Avoid > 3.5.10 due to frameworks for now; see discussion on:
+      # https://github.com/NixOS/nixpkgs/commit/d6454e6a1
+      then ../development/libraries/gnutls/3.5.10.nix
+      else ../development/libraries/gnutls/3.5.nix)
+    {
+      guileBindings = config.gnutls.guile or false;
+    };
 
   gpac = callPackage ../applications/video/gpac { };
 


### PR DESCRIPTION
###### Motivation for this change

Without this, `gnutls` doesn't build.

Backport of 42fd72091e09b52b19efbbb99c89e832a9202311

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [] macOS --- in progress
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

