### PR TITLE
houdini: change sha256, add missing libs, fix license dir patch, fix …

### DIFF
--- a/pkgs/applications/misc/houdini/default.nix
+++ b/pkgs/applications/misc/houdini/default.nix
@@ -1,10 +1,9 @@
 { zsh, stdenv, callPackage, buildFHSUserEnv, undaemonize }:
 
 let
-  version = "16.0.633";
   houdini-runtime = callPackage ./runtime.nix { };
 in buildFHSUserEnv rec {
-  name = "houdini-${version}";
+  name = "houdini-${houdini-runtime.version}";
 
   extraBuildCommands = ''
     mkdir -p $out/usr/lib/sesi

--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -29,11 +29,11 @@ let
   license_dir = "~/.config/houdini";
 in
 stdenv.mkDerivation rec {
-  version = "16.0.633";
+  version = "16.0.671";
   name = "houdini-runtime-${version}";
   src = requireFile rec {
-    name = "houdini-16.0.633-linux_x86_64_gcc4.8.tar.gz";
-    sha256 = "1wwm3gqmwn7xbm2qrpb4al44kzgswmsvmjndjkbqskwinxqmg9y2";
+    name = "houdini-${version}-linux_x86_64_gcc4.8.tar.gz";
+    sha256 = "1d3c1a1128szlgaf3ilw5y20plz5azwp37v0ljawgm80y64hq15r";
     message = ''
       This nix expression requires that ${name} is already part of the store.
       Download it from https://sidefx.com and add it to the nix store with:

--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -1,4 +1,4 @@
-{ stdenv, requireFile, zlib, libpng, libSM, libICE, fontconfig, xorg, mesa_glu, bc }:
+{ stdenv, requireFile, zlib, libpng, libSM, libICE, fontconfig, xorg, mesa_glu, alsaLib, dbus, xkeyboardconfig, bc }:
 
 let
   ld_library_path = builtins.concatStringsSep ":" [
@@ -11,11 +11,19 @@ let
       xorg.libXext
       xorg.libX11
       xorg.libXrender
+      xorg.libXcursor
+      xorg.libXfixes
+      xorg.libXrender
+      xorg.libXcomposite
+      xorg.libXdamage
+      xorg.libXtst
+      alsaLib
       fontconfig
       libSM
       libICE
       zlib
       libpng
+      dbus
     ])
   ];
   license_dir = "~/.config/houdini";
@@ -25,7 +33,7 @@ stdenv.mkDerivation rec {
   name = "houdini-runtime-${version}";
   src = requireFile rec {
     name = "houdini-16.0.633-linux_x86_64_gcc4.8.tar.gz";
-    sha256 = "1laxncwgsr4hj53bn4pn9ibv3pkrpliwxlx0558wgnhq42js3wvl";
+    sha256 = "1wwm3gqmwn7xbm2qrpb4al44kzgswmsvmjndjkbqskwinxqmg9y2";
     message = ''
       This nix expression requires that ${name} is already part of the store.
       Download it from https://sidefx.com and add it to the nix store with:
@@ -50,11 +58,13 @@ stdenv.mkDerivation rec {
                       --no-root-check \
                       --accept-EULA \
                       $out
-    sed -i "s|/usr/lib/sesi|${license_dir}|g" $out/houdini/Licensing.opt
+    echo -e "localValidatorDir = ${license_dir}\nlicensingMode = localValidator" > $out/houdini/Licensing.opt
     sed -i "s|/usr/lib/sesi|${license_dir}|g" $out/houdini/sbin/sesinetd_safe
     sed -i "s|/usr/lib/sesi|${license_dir}|g" $out/houdini/sbin/sesinetd.startup
     echo "export LD_LIBRARY_PATH=${ld_library_path}" >> $out/bin/app_init.sh
+    echo "export QT_XKB_CONFIG_ROOT="${xkeyboardconfig}/share/X11/xkb"" >> $out/bin/app_init.sh
     echo "export LD_LIBRARY_PATH=${ld_library_path}" >> $out/houdini/sbin/app_init.sh
+    echo "export QT_XKB_CONFIG_ROOT="${xkeyboardconfig}/share/X11/xkb"" >> $out/houdini/sbin/app_init.sh
   '';
   postFixup = ''
     INTERPRETER="$(cat "$NIX_CC"/nix-support/dynamic-linker)"


### PR DESCRIPTION
…keyboard input

- Changed sha256 of src file, as this was apparantly changed on the
website

- Added missing libs: some X libs, alsa, dbus

- Changed patch to $out/houdini/Licensing.opt
localValidatorDir = ... was commented out in original file
so sed had no effect

- add export QT_XKB_CONFIG_ROOT
Without it only modifier keys worked, no text input

###### Motivation for this change

I wanted to try houdini today but it did not work out of the box. With these changes I got it working.


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

