### PR TITLE
alock: 20150418 -> 20160713

### DIFF
--- a/pkgs/misc/screensavers/alock/default.nix
+++ b/pkgs/misc/screensavers/alock/default.nix
@@ -2,13 +2,15 @@
 , libX11, pam, libgcrypt, libXrender, imlib2 }:
 
 stdenv.mkDerivation rec {
-  date = "20150418";
+  date = "20160713";
   name = "alock-${date}";
 
+  # Please consider https://github.com/Arkq/alock/issues/5
+  # before upgrading past this revision.
   src = fetchgit {
     url = https://github.com/Arkq/alock;
-    rev = "69b547602d965733d415f877eb59d05966bd158d";
-    sha256 = "0lv2ng5qxzcq0vwbl61dbwigv79sin4zg90y9cgsz6ydvm4ncpas";
+    rev = "329ac152426639fe3c9e53debfc3f973c2988f50";
+    sha256 = "078nf2afyqv7hpk5kw50i57anm7qqd8jnczygnwimh2q40bljm7x";
   };
 
   configureFlags = [
@@ -17,12 +19,13 @@ stdenv.mkDerivation rec {
     "--enable-xrender"
     "--enable-imlib2"
   ];
+
   buildInputs = [
     pkgconfig autoreconfHook libX11
     pam libgcrypt libXrender imlib2
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/Arkq/alock;
     description = "Simple screen lock application for X server";
     longDescription = ''
@@ -31,10 +34,10 @@ stdenv.mkDerivation rec {
       the X server is unlocked and the user can continue to work.
 
       alock does not provide any fancy animations like xlock or
-      xscreensaver and never will. Its just for locking the current
+      xscreensaver and never will. It's just for locking the current
       X session.
     '';
-    platforms = with stdenv.lib.platforms; allBut cygwin;
-    maintainers = [ stdenv.lib.maintainers.ftrvxmtrx ];
+    platforms = with platforms; allBut cygwin;
+    maintainers = with maintainers; [ ftrvxmtrx chris-martin ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upgrades `alock` to one commit behind the latest version.

I didn't include the latest revision because it introduces a breaking change; I've opened https://github.com/Arkq/alock/issues/5 to request a remedy, and included a comment linking to this issue in the Nix code.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

