### PR TITLE
emacs-all-the-icons-fonts: 2.6.4 -> 3.1.1

### DIFF
--- a/pkgs/data/fonts/emacs-all-the-icons-fonts/default.nix
+++ b/pkgs/data/fonts/emacs-all-the-icons-fonts/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "emacs-all-the-icons-fonts-${version}";
-  version = "2.6.4";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "domtronn";
     repo = "all-the-icons.el";
     rev = version;
-    sha256 = "0xwj8wyj0ywpy4rcqxz15hkr8jnffn7nrp5fnq56j360v8858q8x";
+    sha256 = "0h8a2jvn2wfi3bqd35scmhm8wh20mlk09sy68m1whi9binzkm8rf";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

