### PR TITLE
nodejs: 6.9.5 -> 6.11.1

### DIFF
--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -10,10 +10,10 @@ let
   baseName = if enableNpm then "nodejs" else "nodejs-slim";
 in
   stdenv.mkDerivation (nodejs // rec {
-    version = "6.9.5";
+    version = "6.11.1";
     name = "${baseName}-${version}";
     src = fetchurl {
       url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
-      sha256 = "1cxnsprv2sy2djskx6yfw14f578s1fwzvmvnw7rh75djajix3znp";
+      sha256 = "6f6655b85919aa54cb045a6d69a226849802fcc26491d0db4ce59873e41cc2b8";
     };
   })


### PR DESCRIPTION
(cherry picked from commit fffe1efa03b4c59cfabf22d672745a373e22aade)

###### Motivation for this change

This cherry-picks the new Node.js 6.11.1 version into the 17.03 channel. This release contains an [important security fix](https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/) and, per semantic versioning, will not break compatibility.

I have not checked whether other maintained branches of Node.js need to be cherry-picked into 17.03 as well, and don't currently have the time to do so.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

