### PR TITLE
veracrypt: 1.19 -> 1.21

### DIFF
--- a/pkgs/applications/misc/veracrypt/default.nix
+++ b/pkgs/applications/misc/veracrypt/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, nasm, fuse, wxGTK30, devicemapper, makeself,
+{ fetchurl, stdenv, pkgconfig, yasm, fuse, wxGTK30, devicemapper, makeself,
   wxGUI ? true
 }:
 
@@ -6,21 +6,20 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "veracrypt-${version}";
-  version = "1.19";
+  version = "1.21";
 
   src = fetchurl {
-    url = "https://launchpad.net/veracrypt/trunk/${version}/+download/VeraCrypt_${version}_Source.tar.gz";
-    sha256 = "111xs1zmic82lpn5spn0ca33q0g4za04a2k4cvjwdb7k3vcicq6v";
+    url = "https://launchpad.net/veracrypt/trunk/${version}/+download/VeraCrypt_${version}_Source.tar.bz2";
+    sha256 = "0n036znmwnv70wy8r2j3b55bx2z3cch5fr83vnwjvzyyp0j7swa4";
   };
 
-  # The source archive appears to be compressed twice ...
   unpackPhase =
     ''
-      gzip -dc $src | tar xz
-      cd Vera*/src
+      tar xjf $src
+      cd src
     '';
 
-  nativeBuildInputs = [ makeself nasm pkgconfig ];
+  nativeBuildInputs = [ makeself yasm pkgconfig ];
   buildInputs = [ fuse devicemapper ]
     ++ optional wxGUI wxGTK30;
   makeFlags = optionalString (!wxGUI) "NOGUI=1";


### PR DESCRIPTION
###### Motivation for this change

Veracrypt 1.21 has been released on 9th July.
Source archive format changed from `tar.gz` to `tar.bz2`.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

