### PR TITLE
rsync: build with own zlib again

### DIFF
--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   buildInputs = [libiconv zlib popt] ++ stdenv.lib.optional enableACLs acl;
   nativeBuildInputs = [perl];
 
-  configureFlags = ["--with-nobody-group=nogroup" "--without-included-zlib"];
+  configureFlags = ["--with-nobody-group=nogroup"];
 
   meta = base.meta // {
     description = "A fast incremental file transfer utility";


### PR DESCRIPTION
Rsync has its own patched compress function, and to be able to use the `-z` flag, it needs to use that one.

With `-zz` rsync can use an external zlib, but then it can't talk to older rsync versions.

More details at https://bugs.mageia.org/show_bug.cgi?id=13669
