### PR TITLE
ttyrec: fix build on Darwin

### DIFF
--- a/pkgs/tools/misc/ttyrec/default.nix
+++ b/pkgs/tools/misc/ttyrec/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, buildPlatform }:
 
 stdenv.mkDerivation rec {
   name = "ttyrec-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./clang-fixes.patch ];
 
-  makeFlags = [ "CFLAGS=-DSVR4" ]
+  makeFlags = [] ++ stdenv.lib.optional buildPlatform.isLinux "CFLAGS=-DSVR4"
     ++ stdenv.lib.optional stdenv.cc.isClang "CC=clang";
 
   installPhase = ''

--- a/pkgs/tools/misc/ttyrec/default.nix
+++ b/pkgs/tools/misc/ttyrec/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./clang-fixes.patch ];
 
-  makeFlags = [] ++ stdenv.lib.optional buildPlatform.isLinux "CFLAGS=-DSVR4"
+  makeFlags = stdenv.lib.optional buildPlatform.isLinux "CFLAGS=-DSVR4"
     ++ stdenv.lib.optional stdenv.cc.isClang "CC=clang";
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
ttyrec doesn't build on Darwin

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

