### PR TITLE
android-studio-preview: 3.0.0.5 -> 3.0.0.6

### DIFF
--- a/pkgs/applications/editors/android-studio/packages.nix
+++ b/pkgs/applications/editors/android-studio/packages.nix
@@ -27,16 +27,17 @@ in rec {
 
   preview = mkStudio rec {
     pname = "android-studio-preview";
-    version = "3.0.0.5";
-    build = "171.4163606";
+    version = "3.0.0.6";
+    build = "171.4182969";
 
     src = fetchurl {
       url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";
-      sha256 = "1gxnpw4jf3iic9d47sjbndpysq8kk8pgnb8l7azkc2rba5cj8skg";
+      sha256 = "0s26k5qr0qg6az77yw2mvnhavwi4aza4ifvd45ljank8aqr6sp5i";
     };
 
     meta = stable.meta // {
       homepage = https://developer.android.com/studio/preview/index.html;
+      maintainers = with stdenv.lib.maintainers; [ tomsmeets ];
     };
   } {
     fontsConf = makeFontsConf {


### PR DESCRIPTION
###### Motivation for this change
Update `android-studio-preview` to Canary 7.
I also set myself as the maintainer of the `preview` channel for `android-studio`.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

