### PR TITLE
gnss-sdr: init at 0.0.9 (and patch armadillo's buildInputs)

### DIFF
--- a/pkgs/applications/misc/gnss-sdr/default.nix
+++ b/pkgs/applications/misc/gnss-sdr/default.nix
@@ -1,0 +1,67 @@
+{ stdenv, fetchFromGitHub
+, armadillo
+, boost
+, cmake
+, glog
+, gmock
+, openssl
+, google-gflags
+, gnuradio
+, orc
+, pkgconfig
+, pythonPackages
+, uhd
+}:
+
+stdenv.mkDerivation rec {
+  name = "gnss-sdr-${version}";
+  version = "0.0.9";
+
+  src = fetchFromGitHub {
+    owner = "gnss-sdr";
+    repo = "gnss-sdr";
+    rev = "v${version}";
+    sha256 = "0gis932ly3vk7d5qvznffp54pkmbw3m6v60mxjfdj5dd3r7vf975";
+  };
+
+  buildInputs = [
+    armadillo
+    boost.dev
+    cmake
+    glog
+    gmock
+    openssl.dev
+    google-gflags
+    gnuradio
+    orc
+    pkgconfig
+    pythonPackages.Mako
+
+    # UHD support is optional, but gnuradio is built with it, so there's
+    # nothing to be gained by leaving it out.
+    uhd
+  ];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-DGFlags_ROOT_DIR=${google-gflags}/lib"
+    "-DGLOG_INCLUDE_DIR=${glog}/include"
+
+    # gnss-sdr doesn't truly depend on BLAS or LAPACK, as long as
+    # armadillo is built using both, so skip checking for them.
+    "-DBLAS=YES"
+    "-DLAPACK=YES"
+
+    # Similarly, it doesn't actually use gfortran despite checking for
+    # its presence.
+    "-DGFORTRAN=YES"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "An open source Global Navigation Satellite Systems software-defined receiver";
+    homepage = http://gnss-sdr.org/;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14130,6 +14130,8 @@ with pkgs;
 
   gksu = callPackage ../applications/misc/gksu { };
 
+  gnss-sdr = callPackage ../applications/misc/gnss-sdr { };
+
   gnuradio = callPackage ../applications/misc/gnuradio {
     inherit (python2Packages) cheetah lxml matplotlib numpy python pyopengl pyqt4 scipy wxPython pygtk;
     fftw = fftwFloat;


### PR DESCRIPTION
###### Motivation for this change

This open-source implementation of a software-defined radio receiver for GPS and other GNSS signals was not yet packaged.

In order to get a usable build of `gnss-sdr`, I had to change `armadillo`'s `buildInputs` to add `liblapack`; otherwise several important functions fail at runtime. Perhaps @juliendehos or @knedlsepp will want to comment on that change?

I've tested the resulting `gnss-sdr` binary against the sample `2013_04_04_GNSS_SIGNAL_at_CTTC_SPAIN` dataset linked from <http://gnss-sdr.org/my-first-fix/>.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

