### PR TITLE
elastix: change platforms to "linux" from "unix"

### DIFF
--- a/pkgs/development/libraries/science/biology/elastix/default.nix
+++ b/pkgs/development/libraries/science/biology/elastix/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     homepage = http://elastix.isi.uu.nl/;
     description = "Image registration toolkit based on ITK";
     maintainers = with maintainers; [ bcdarwin ];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     license = licenses.asl20;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Hydra OS X [build fails](https://hydra.nixos.org/build/56589400/nixlog/1/tail): 

```
[ 70%] Linking CXX executable ../bin/elastix
ld: framework not found Cocoa
clang-4.0: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [src/Core/CMakeFiles/elastix.dir/build.make:329: src/bin/elastix] Error 1
make[1]: *** [CMakeFiles/Makefile2:5262: src/Core/CMakeFiles/elastix.dir/all] Error 2
```

I don't have an OS X machine with Nix installed.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

