### PR TITLE
bash-completion: 2.5 -> 2.7

### DIFF
--- a/pkgs/shells/bash-completion/default.nix
+++ b/pkgs/shells/bash-completion/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "bash-completion-${version}";
-  version = "2.5";
+  version = "2.7";
 
   src = fetchurl {
     url = "https://github.com/scop/bash-completion/releases/download/${version}/${name}.tar.xz";
-    sha256 = "1kwmii1z1ljx5i4z702ynsr8jgrq64bj9w9hl3n2aa2kcl659fdh";
+    sha256 = "07j484vb3k90f4989xh1g1x99g01akrp69p3dml4lza27wnqkfj1";
   };
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

To bump bash-completion to latest version.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).