### PR TITLE
[NixOS] Fix + update `hardware.parallels` config option

### DIFF
--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -55,7 +55,7 @@ in
 
     boot.extraModulePackages = [ prl-tools ];
 
-    boot.kernelModules = [ "prl_tg" "prl_eth" "prl_fs" "prl_fs_freeze" "acpi_memhotplug" ];
+    boot.kernelModules = [ "prl_tg" "prl_eth" "prl_fs" "prl_fs_freeze" ];
 
     services.timesyncd.enable = false;
 

--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -27,7 +27,6 @@ in
   };
 
   config = mkIf config.hardware.parallels.enable {
-
     services.xserver = {
       drivers = singleton
         { name = "prlvideo"; modules = [ prl-tools ]; libPath = [ prl-tools ]; };
@@ -89,14 +88,6 @@ in
       };
     };
 
-    systemd.services.prlcc = {
-      description = "Parallels Control Center";
-      wantedBy = [ "graphical.target" ];
-      serviceConfig = {
-        ExecStart = "${prl-tools}/bin/prlcc";
-      };
-    };
-  
     systemd.user.services = {
       prlcc = {
         description = "Parallels Control Center";

--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -89,5 +89,58 @@ in
       };
     };
 
+    systemd.services.prlcc = {
+      description = "Parallels Control Center";
+      wantedBy = [ "graphical.target" ];
+      serviceConfig = {
+        ExecStart = "${prl-tools}/bin/prlcc";
+      };
+    };
+  
+    systemd.user.services = {
+      prlcc = {
+        description = "Parallels Control Center";
+        wantedBy = [ "graphical-session.target" ];
+        serviceConfig = {
+          ExecStart = "${prl-tools}/bin/prlcc";
+        };
+      };
+      prldnd = {
+        description = "Parallels Control Center";
+        wantedBy = [ "graphical-session.target" ];
+        serviceConfig = {
+          ExecStart = "${prl-tools}/bin/prldnd";
+        };
+      };
+      prl_wmouse_d  = {
+        description = "Parallels Walking Mouse Daemon";
+        wantedBy = [ "graphical-session.target" ];
+        serviceConfig = {
+          ExecStart = "${prl-tools}/bin/prl_wmouse_d";
+        };
+      };
+      prlcp = {
+        description = "Parallels CopyPaste Tool";
+        wantedBy = [ "graphical-session.target" ];
+        serviceConfig = {
+          ExecStart = "${prl-tools}/bin/prlcp";
+        };
+      };
+      prlsga = {
+        description = "Parallels Shared Guest Applications Tool";
+        wantedBy = [ "graphical-session.target" ];
+        serviceConfig = {
+          ExecStart = "${prl-tools}/bin/prlsga";
+        };
+      };
+      prlshprof = {
+        description = "Parallels Shared Profile Tool";
+        wantedBy = [ "graphical-session.target" ];
+        serviceConfig = {
+          ExecStart = "${prl-tools}/bin/prlshprof";
+        };
+      };
+    };
+
   };
 }

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation rec {
           patchelf \
             --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
             --set-rpath "$out/lib:$libPath" \
-            $i
+            $i || true
         done
 
         mkdir -p $out/bin

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -189,8 +189,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Parallels Tools for Linux guests";
-    homepage = http://parallels.com;
-    platforms = platforms.linux;
+    homepage = https://parallels.com;
+    platforms = [ "i686-linux" "x86_64-linux" ];
     license = licenses.unfree;
     # I was making this package blindly and requesting testing from the real user,
     # so I can't even test it by myself and won't provide future updates.

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -11,26 +11,6 @@ let xorgFullVer = (builtins.parseDrvName xorg.xorgserver.name).version;
     x64 = if stdenv.system == "x86_64-linux" then true
           else if stdenv.system == "i686-linux" then false
           else abort "Parallels Tools for Linux only support {x86-64,i686}-linux targets";
-    # We autostart user services by ourselves, because prlcc uses hardcoded paths.
-    autostart = [ { exec = "prlcc";
-                    description = "Parallels Control Center";
-                  }
-                  { exec = "prldhd";
-                    description = "Parallels Control Center"; # not a mistake
-                  }
-                  { exec = "prl_wmouse_d";
-                    description = "Parallels Walking Mouse Daemon";
-                  }
-                  { exec = "prlcp";
-                    description = "Parallels CopyPaste Tool";
-                  }
-                  { exec = "prlsga";
-                    description = "Parallels Shared Guest Applications Tool";
-                  }
-                  { exec = "prlshprof";
-                    description = "Parallels Shared Profile Tool";
-                  }
-                ];
 in
 stdenv.mkDerivation rec {
   version = "${prl_major}.2.1-41615";
@@ -87,11 +67,6 @@ stdenv.mkDerivation rec {
             stdenv.lib.makeLibraryPath ([ stdenv.cc.cc libXrandr libXext libX11 libXcomposite libXinerama ]
             ++ lib.optionals (!libsOnly) [ libXi glib dbus_glib zlib ]);
 
-  desktops = map (x: substituteAll ({
-               src = ./autostart.desktop;
-               name = x.exec + ".desktop";
-               version = version;
-             } // x)) autostart;
 
   installPhase = ''
     if test -z "$libsOnly"; then
@@ -142,11 +117,6 @@ stdenv.mkDerivation rec {
         mkdir -p $out/lib/udev/rules.d
         for i in *.rules; do
           sed 's,/bin/bash,${stdenv.shell},g' $i > $out/lib/udev/rules.d/$i
-        done
-
-        mkdir -p $out/share/autostart
-        for i in $desktops; do
-          cat $i | sed "s,^Exec=,Exec=$out/bin/," > $out/share/autostart/$(basename $i)
         done
 
         (

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -32,19 +32,15 @@ let xorgFullVer = (builtins.parseDrvName xorg.xorgserver.name).version;
                 ];
 in
 stdenv.mkDerivation rec {
-  version = "10.0.2.27712";
+  version = "${prl_major}.2.1-41615";
+  prl_major = "12";
   name = "prl-tools-${version}";
 
-  src = requireFile rec {
-    name = "prl-tools-lin.iso";
-    sha256 = "07960jvyv7gihjlg922znjm6db6l6bd23x9mg6ympwibzf2mylmx";
-    message = ''
-      Please, place Parallels Tools for Linux image into Nix store
-      using either
-        nix-store --add-fixed sha256 ${name}
-      or
-        nix-prefetch-url file://path/to/${name}
-    '';
+  # We download the full distribution to extract prl-tools-lin.iso from
+  # => ${dmg}/Parallels\ Desktop.app/Contents/Resources/Tools/prl-tools-lin.iso
+  src = fetchurl {
+    url =  "https://download.parallels.com/desktop/v${prl_major}/${version}/ParallelsDesktop-${version}.dmg";
+    sha256 = "1jwzwif69qlhmfky9kigjaxpxfj0lyrl1iyrpqy4iwqvajdgbbym";
   };
 
   hardeningDisable = [ "pic" ];

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     sha256 = "1jwzwif69qlhmfky9kigjaxpxfj0lyrl1iyrpqy4iwqvajdgbbym";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "format" ];
 
   # also maybe python2 to generate xorg.conf
   nativeBuildInputs = [ p7zip undmg ] ++ lib.optionals (!libsOnly) [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
This PR enables support for Parallels 12, and also removes the need to provide prl-tools-lin.iso. It fixes dynamic resolution/coherence/clipboard support.


It may be a good idea to add:
```
hardware.parallels.version = {
    major = "12";
    minor = "2.1-41615";
    releaseSha256 = "1jwzwif69qlhmfky9kigjaxpxfj0lyrl1iyrpqy4iwqvajdgbbym";
};
# or
hardware.parallels.version = {
    full = "12.2.1-41615";
    major = lib.splitString "." full
    minor = lib.removePrefix major full
    releaseSha256 = "1jwzwif69qlhmfky9kigjaxpxfj0lyrl1iyrpqy4iwqvajdgbbym";
};

```
to allow the use of newer prl-tools versions in configuration.nix without forking nixpkgs

Squash before committing:
743485f6579422b1115986d40522d820b67b5b8f
041ae372c9531682118cdb5de99768a84fcc7a0c
c6700487d7d02453774c49bb42e2e25997a63999
I left them as separate commits for clarity
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
TODO: possibly add tests ala [Virtualbox](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/virtualbox.nix)
