### PR TITLE
wolfssl: 3.10.3 -> 3.11.0

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "wolfssl-${version}";
-  version = "3.10.3";
+  version = "3.11.0";
 
   src = fetchFromGitHub {
     owner = "wolfSSL";
     repo = "wolfssl";
-    rev = "v${version}";
-    sha256 = "05j3sg4vdzir89qy6y566wyfpqaz3mn53fiqg7ia4r7wjwhzbzrw";
+    rev = "v${version}-stable";
+    sha256 = "0s4s9adni2q1sgqpavbmxhkl8i98bmlw6gla6dnifgsm1dirv75w";
   };
 
   outputs = [ "out" "dev" "doc" "lib" ];


### PR DESCRIPTION
###### Motivation for this change

Sync with latest upstream.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux (Fedora 24)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

No package currently depends on wolfssl, so for testing I recompiled curl against wolfssl using the following shell.nix:

```.nix
with import <nixpkgs> {};
let
  curlwolfssl = (curl.override {
    openssl = wolfssl;
  }).overrideDerivation (oldAttrs: {
    configureFlags =
      (builtins.filter (x: x != "--with-ca-fallback") oldAttrs.configureFlags)
      ++ ["--with-cyassl=${wolfssl}"];
  });
in
{
  my-env = stdenv.mkDerivation {
    name = "my-env";
    buildInputs = [
      curlwolfssl
    ];
  };
}
```

I tested the resulting curl binary and compared its output against my local curl binary provided by Fedora:

```.bash
curl -2 https://nixos.org
curl https://nixos.org > 1.txt
/usr/bin/curl https://nixos.org > 2.txt
diff 1.txt 2.txt
```

The first line gives an error message "curl: (35) CyaSSL does not support SSLv2" confirming that CyaSSL - which is the old name for wolfssl still referred to by curl - is indeed used. Diff of output of local curl and this new curl shows identical outputs as expected.