### PR TITLE
elixir: 1.5.0-rc.1 -> 1.5.0-rc.2

### DIFF
--- a/pkgs/development/interpreters/elixir/1.5.nix
+++ b/pkgs/development/interpreters/elixir/1.5.nix
@@ -1,7 +1,7 @@
 { mkDerivation }:
 
 mkDerivation rec {
-  version = "1.5.0-rc.1";
-  sha256 = "1aqbhyzwjqg57f99kwqzxkk4gjaqgwb7nmgpgdp7psa0ly742i9q";
+  version = "1.5.0-rc.2";
+  sha256 = "0wfxsfz1qbb6iapg8j1qskva6j4mccxqvv79xbz08fzzb6n1wvxa";
   minimumOTPVersion = "18";
 }


### PR DESCRIPTION
###### Motivation for this change

New elixir 1.5 rc release

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

