### PR TITLE
flac123: init at 0.0.12

### DIFF
--- a/pkgs/applications/audio/flac123/default.nix
+++ b/pkgs/applications/audio/flac123/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf, automake, flac, libao, libogg, popt }:
+{ stdenv, fetchurl, autoreconfHook, flac, libao, libogg, popt }:
 
 stdenv.mkDerivation rec {
   name = "flac123-${version}";
@@ -9,13 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0zg4ahkg7v81za518x32wldf42g0rrvlrcqhrg9sv3li9bayyxhr";
   };
 
-  preConfigure = ''
-    aclocal
-    autoconf
-    automake -a
-  '';
-
-  buildInputs = [ autoconf automake flac libao libogg popt ];
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ flac libao libogg popt ];
 
   meta = with stdenv.lib; {
     homepage = http://flac-tools.sourceforge.net/;

--- a/pkgs/applications/audio/flac123/default.nix
+++ b/pkgs/applications/audio/flac123/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, autoconf, automake, flac, libao, libogg, popt }:
+
+stdenv.mkDerivation rec {
+  name = "flac123-${version}";
+  version = "0.0.12";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/flac-tools/${name}-release.tar.gz";
+    sha256 = "0zg4ahkg7v81za518x32wldf42g0rrvlrcqhrg9sv3li9bayyxhr";
+  };
+
+  preConfigure = ''
+    aclocal
+    autoconf
+    automake -a
+  '';
+
+  buildInputs = [ autoconf automake flac libao libogg popt ];
+
+  meta = with stdenv.lib; {
+    homepage = http://flac-tools.sourceforge.net/;
+    description = "A command-line program for playing FLAC audio files";
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1918,6 +1918,8 @@ with pkgs;
 
   fdk_aac = callPackage ../development/libraries/fdk-aac { };
 
+  flac123 = callPackage ../applications/audio/flac123 { };
+
   flamegraph = callPackage ../development/tools/flamegraph { };
 
   # Awkward historical capitalization for flamegraph. Remove eventually


### PR DESCRIPTION
###### Motivation for this change

`flac123` is a command-line FLAC player. I want to use it to play music. It is available as an installable package in many mainstream Unix-like operating systems:

Arch: https://www.archlinux.org/packages/community/x86_64/flac123/
Gentoo: https://packages.gentoo.org/packages/media-sound/flac123
FreeBSD: https://svnweb.freebsd.org/ports/head/audio/flac123/
OpenBSD: http://ports.su/audio/flac123

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

