### PR TITLE
nodejs: 8.1.4 -> 8.2.0

### DIFF
--- a/pkgs/development/web/nodejs/v8.nix
+++ b/pkgs/development/web/nodejs/v8.nix
@@ -10,11 +10,11 @@ let
   baseName = if enableNpm then "nodejs" else "nodejs-slim";
 in
   stdenv.mkDerivation (nodejs // rec {
-    version = "8.1.4";
+    version = "8.2.0";
     name = "${baseName}-${version}";
     src = fetchurl {
       url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
-      sha256 = "00f38bif8f6ws6pcfpfy5cdvanry39l4wb2gzm39qx3rbx28cg58";
+      sha256 = "10a72gl24kzdhf598wnlpvld1lz175h6l9fsr06bc3k3fr8rgs2c";
     };
 
     patches = stdenv.lib.optionals stdenv.isDarwin [ ./no-xcode-v7.patch ];


### PR DESCRIPTION
###### Motivation for this change

[Release Notes](https://nodejs.org/en/blog/release/v8.2.0/)

npm 5.3.0 (which is bundled with nodejs 8.2.0) is now bundled with [`npx`](https://www.npmjs.com/package/npx), so the non-slim variant of nodejs 8.2.0 will also expose the new `npx` binary.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

