### PR TITLE
pythonPackages.arrow: 0.7.0 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/arrow/default.nix
+++ b/pkgs/development/python-modules/arrow/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, nose, chai, simplejson
+, dateutil }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "arrow";
+  version = "0.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08n7q2l69hlainds1byd4lxhwrq7zsw7s640zkqc3bs5jkq0cnc0";
+  };
+
+  checkPhase = ''
+    nosetests --cover-package=arrow
+  '';
+
+  buildInputs = [ nose chai simplejson ];
+  propagatedBuildInputs = [ dateutil ];
+
+  meta = with stdenv.lib; {
+    description = "Python library for date manipulation";
+    license     = "apache";
+    maintainers = with maintainers; [ thoughtpolice ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -763,28 +763,7 @@ in {
   };
 
 
-  arrow = buildPythonPackage rec {
-    name = "arrow-${version}";
-    version = "0.10.0";
-
-    src = pkgs.fetchurl {
-      url    = "mirror://pypi/a/arrow/${name}.tar.gz";
-      sha256 = "08n7q2l69hlainds1byd4lxhwrq7zsw7s640zkqc3bs5jkq0cnc0";
-    };
-
-    checkPhase = ''
-      nosetests --cover-package=arrow
-    '';
-
-    buildInputs = with self; [ nose chai simplejson ];
-    propagatedBuildInputs = with self; [ dateutil ];
-
-    meta = {
-      description = "Python library for date manipulation";
-      license     = "apache";
-      maintainers = with maintainers; [ thoughtpolice ];
-    };
-  };
+  arrow = callPackage ../development/python-modules/arrow { };
 
   async = buildPythonPackage rec {
     name = "async-0.6.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -765,15 +765,15 @@ in {
 
   arrow = buildPythonPackage rec {
     name = "arrow-${version}";
-    version = "0.7.0";
+    version = "0.10.0";
 
     src = pkgs.fetchurl {
       url    = "mirror://pypi/a/arrow/${name}.tar.gz";
-      sha256 = "0yx10dz3hp825fcq9w15zbp26v622npcjscb91da05zig8036lra";
+      sha256 = "08n7q2l69hlainds1byd4lxhwrq7zsw7s640zkqc3bs5jkq0cnc0";
     };
 
     checkPhase = ''
-      nosetests
+      nosetests --cover-package=arrow
     '';
 
     buildInputs = with self; [ nose chai simplejson ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14023,6 +14023,8 @@ in {
      substituteInPlace ./test/asizeof/test_asizeof.py --replace "self.assert_(not e" "#self.assert_(not e"
     '';
 
+    doCheck = stdenv.hostPlatform.isLinux;
+
     meta = {
       description = "Tool to measure, monitor and analyze memory behavior";
       homepage = http://pythonhosted.org/Pympler/;


### PR DESCRIPTION
###### Motivation for this change
The old package is not up to date with PyPi. Additionally, it fails to build on Darwin because one of its dependencies' tests is Linux specific (comparing python the `psutil` package's to the contents of `/proc/something-or-other`. This PR addresses both issues.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

