### PR TITLE
alock: 20160713 -> 20170720

### DIFF
--- a/pkgs/misc/screensavers/alock/default.nix
+++ b/pkgs/misc/screensavers/alock/default.nix
@@ -2,16 +2,16 @@
 , libX11, pam, libgcrypt, libXrender, imlib2 }:
 
 stdenv.mkDerivation rec {
-  date = "20160713";
+  date = "20170720";
   name = "alock-${date}";
 
-  # Please consider https://github.com/Arkq/alock/issues/5
-  # before upgrading past this revision.
   src = fetchgit {
     url = https://github.com/Arkq/alock;
-    rev = "329ac152426639fe3c9e53debfc3f973c2988f50";
-    sha256 = "078nf2afyqv7hpk5kw50i57anm7qqd8jnczygnwimh2q40bljm7x";
+    rev = "2035e1d4a2293432f5503e82d10f899232eb0f38";
+    sha256 = "1by954fjn0ryqda89zlmq3gclakg3gz7zy1wjrbgw4lzsk538va6";
   };
+
+  PAM_DEFAULT_SERVICE = "login";
 
   configureFlags = [
     "--enable-pam"


### PR DESCRIPTION
###### Motivation for this change

The `alock` issue I referred to in #27482 has just been resolved, so we can now update to the latest version.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

