### PR TITLE
armadillo: Make use of openBLAS's built-in LAPACK

### DIFF
--- a/pkgs/development/libraries/armadillo/default.nix
+++ b/pkgs/development/libraries/armadillo/default.nix
@@ -12,9 +12,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ openblasCompat superlu hdf5 ];
 
-  cmakeFlags = [ "-DDETECT_HDF5=ON" ];
+  cmakeFlags = let
+    libSuff = if stdenv.isDarwin then "dylib" else "so";
+  in [
+    "-DLAPACK_LIBRARY=${openblasCompat}/lib/libopenblas.${libSuff}"
+    "-DDETECT_HDF5=ON"
+  ];
 
- patches = [ ./use-unix-config-on-OS-X.patch ];
+  patches = [ ./use-unix-config-on-OS-X.patch ];
 
   meta = with stdenv.lib; {
     description = "C++ linear algebra library";


### PR DESCRIPTION
###### Motivation for this change
Even though the linked openBLAS contains LAPACK, the functionality was
not usable due to armadillo needing to link against it explicitly.
Now one should be able to successfully compile and execute the following minimal program.
```C++
#include <armadillo>
using namespace arma;
using namespace std;
int main() {
  mat X = randu<mat>(8, 9);
  mat U, V;
  vec s;
  svd(U, s, V, X);
  U.print("U");
  s.print("s");
  V.print("V");
  return 0;
}
```
by simply linking against `-larmadillo` without having to introduce an extra LAPACK dependency.
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

