### PR TITLE
diffoscope: wrap executable and include tools in PATH

### DIFF
--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -5,7 +5,13 @@
 , enableBloat ? false
 }:
 
-python3.pkgs.buildPythonApplication rec {
+    # Still missing these tools: enjarify, otool & lipo (maybe OS X only), showttf
+    # Also these libraries: python3-guestfs
+    # FIXME: move xxd into a separate package so we don't have to pull in all of vim.
+let tools = [ acl binutils bzip2 cbfstool cdrkit cpio diffutils e2fsprogs file gettext
+              gzip libcaca poppler_utils sng sqlite squashfsTools unzip vim xz colordiff
+            ] ++ lib.optionals enableBloat [ colord fpc ghc gnupg1 jdk mono pdftk ];
+in python3.pkgs.buildPythonApplication rec {
   pname = "diffoscope";
   name = "${pname}-${version}";
   version = "77";
@@ -26,14 +32,6 @@ python3.pkgs.buildPythonApplication rec {
     sed -i setup.py -e "/'rpm-python',/d"
   '';
 
-  # Still missing these tools: enjarify, otool & lipo (maybe OS X only), showttf
-  # Also these libraries: python3-guestfs
-  # FIXME: move xxd into a separate package so we don't have to pull in all of vim.
-  buildInputs =
-    map lib.getBin ([ acl binutils bzip2 cbfstool cdrkit cpio diffutils e2fsprogs file gettext
-      gzip libcaca poppler_utils sng sqlite squashfsTools unzip vim xz colordiff
-    ] ++ lib.optionals enableBloat [ colord fpc ghc gnupg1 jdk mono pdftk ]);
-
   pythonPath = with python3.pkgs; [ debian libarchive-c python_magic tlsh rpm ];
 
   doCheck = false; # Calls 'mknod' in squashfs tests, which needs root
@@ -41,6 +39,7 @@ python3.pkgs.buildPythonApplication rec {
   postInstall = ''
     mkdir -p $out/share/man/man1
     ${docutils}/bin/rst2man.py debian/diffoscope.1.rst $out/share/man/man1/diffoscope.1
+    wrapProgram $out/bin/diffoscope --prefix PATH : ${lib.makeBinPath tools}
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

diffoscope was looking for the tools it uses during runtime, but the
tools there neither part of the closure nor were they in the
PATH. This commit fixes this.


###### Things done

Wrapped the diffoscope executable.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

