### PR TITLE
network-manager-l2tp: fix configure step

### DIFF
--- a/pkgs/tools/networking/network-manager/l2tp.nix
+++ b/pkgs/tools/networking/network-manager/l2tp.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, automake, autoconf, autoreconfHook, libtool, intltool, pkgconfig
+{ stdenv, fetchFromGitHub, autoreconfHook, libtool, intltool, pkgconfig
 , networkmanager, ppp, xl2tpd, strongswan, libsecret
 , withGnome ? true, gnome3, networkmanagerapplet }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ networkmanager ppp libsecret ]
     ++ stdenv.lib.optionals withGnome [ gnome3.gtk gnome3.libgnome_keyring networkmanagerapplet ];
 
-  nativeBuildInputs = [ automake autoconf autoreconfHook libtool intltool pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook libtool intltool pkgconfig ];
 
   postPatch = ''
     sed -i -e 's%"\(/usr/sbin\|/usr/pkg/sbin\|/usr/local/sbin\)/[^"]*",%%g' ./src/nm-l2tp-service.c

--- a/pkgs/tools/networking/network-manager/l2tp.nix
+++ b/pkgs/tools/networking/network-manager/l2tp.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, automake, autoconf, libtool, intltool, pkgconfig
+{ stdenv, fetchFromGitHub, automake, autoconf, autoreconfHook, libtool, intltool, pkgconfig
 , networkmanager, ppp, xl2tpd, strongswan, libsecret
 , withGnome ? true, gnome3, networkmanagerapplet }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ networkmanager ppp libsecret ]
     ++ stdenv.lib.optionals withGnome [ gnome3.gtk gnome3.libgnome_keyring networkmanagerapplet ];
 
-  nativeBuildInputs = [ automake autoconf libtool intltool pkgconfig ];
+  nativeBuildInputs = [ automake autoconf autoreconfHook libtool intltool pkgconfig ];
 
   postPatch = ''
     sed -i -e 's%"\(/usr/sbin\|/usr/pkg/sbin\|/usr/local/sbin\)/[^"]*",%%g' ./src/nm-l2tp-service.c
@@ -27,7 +27,9 @@ stdenv.mkDerivation rec {
       --replace /sbin/xl2tpd ${xl2tpd}/bin/xl2tpd
   '';
 
-  preConfigure = "./autogen.sh";
+  preConfigure = ''
+    intltoolize -f
+  '';
 
   configureFlags =
     if withGnome then "--with-gnome" else "--without-gnome";


### PR DESCRIPTION
###### Motivation for this change
`autogen.sh` script calls `./configure`, which is:
- redundant with the built-in configure step of nix derivations
- incorrect as it will ignore configure flags set in the derivation

I noticed this issue when trying to build the derivation using "withGnome = false", which failed because the "--without-gnome" configure flag wasn't taken into account.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

