### PR TITLE
linode-api: init at 4.1.1b2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -213,6 +213,7 @@
   gilligan = "Tobias Pflug <tobias.pflug@gmail.com>";
   giogadi = "Luis G. Torres <lgtorres42@gmail.com>";
   gleber = "Gleb Peregud <gleber.p@gmail.com>";
+  glenns = "Glenn Searby <glenn.searby@gmail.com>";
   globin = "Robin Gloster <mail@glob.in>";
   gnidorah = "Alex Ivanov <yourbestfriend@opmbx.org>";
   goibhniu = "Cillian de Róiste <cillian.deroiste@gmail.com>";

--- a/pkgs/development/python-modules/linode-api/default.nix
+++ b/pkgs/development/python-modules/linode-api/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "linode-api";
-  version = "4.1.1b1";
+  version = "4.1.1b2";
   name = "${pname}-${version}";
 
   disabled = (pythonOlder "2.7");
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1psf4sknxrjqiz833x4nmh2pw7xi2rvcm7l9lv8jfdwxza63sny5";
+    sha256 = "1lfqsll3wv1wzn98ymmcbw0yawj8ab3mxniws6kaxf99jd4a0xp4";
   };
 
   meta = {

--- a/pkgs/development/python-modules/linode-api/default.nix
+++ b/pkgs/development/python-modules/linode-api/default.nix
@@ -1,0 +1,34 @@
+{ stdenv,
+  buildPythonPackage,
+  fetchPypi,
+  isPy3k,
+  pythonOlder,
+  lib,
+  requests,
+  future,
+  enum34 }:
+
+buildPythonPackage rec {
+  pname = "linode-api";
+  version = "4.1.1b1";
+  name = "${pname}-${version}";
+
+  disabled = (pythonOlder "2.7");
+
+  buildInputs = [];
+  propagatedBuildInputs = [ requests ]
+                             ++ stdenv.lib.optionals (!isPy3k) [ future ]
+                             ++ stdenv.lib.optionals (pythonOlder "3.4") [ enum34 ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1psf4sknxrjqiz833x4nmh2pw7xi2rvcm7l9lv8jfdwxza63sny5";
+  };
+
+  meta = {
+    homepage = "https://github.com/linode/python-linode-api";
+    description = "The official python library for the Linode API v4 in python.";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ glenns ];
+  };
+}

--- a/pkgs/development/python-modules/linode-api/default.nix
+++ b/pkgs/development/python-modules/linode-api/default.nix
@@ -15,13 +15,10 @@ buildPythonPackage rec {
 
   disabled = (pythonOlder "2.7");
 
-  propagatedBuildInputs = [ requests ]
-                             ++ stdenv.lib.optionals (!isPy3k) [ future ]
+  propagatedBuildInputs = [ requests future ]
                              ++ stdenv.lib.optionals (pythonOlder "3.4") [ enum34 ];
 
-  postPatch = (stdenv.lib.optionalString (isPy3k) ''
-    sed -i -e '/"future",/d' setup.py
-  '') + (stdenv.lib.optionalString (!pythonOlder "3.4") ''
+  postPatch = (stdenv.lib.optionalString (!pythonOlder "3.4") ''
     sed -i -e '/"enum34",/d' setup.py
   '');
 

--- a/pkgs/development/python-modules/linode-api/default.nix
+++ b/pkgs/development/python-modules/linode-api/default.nix
@@ -15,10 +15,15 @@ buildPythonPackage rec {
 
   disabled = (pythonOlder "2.7");
 
-  buildInputs = [];
   propagatedBuildInputs = [ requests ]
                              ++ stdenv.lib.optionals (!isPy3k) [ future ]
                              ++ stdenv.lib.optionals (pythonOlder "3.4") [ enum34 ];
+
+  postPatch = (stdenv.lib.optionalString (isPy3k) ''
+    sed -i -e '/"future",/d' setup.py
+  '') + (stdenv.lib.optionalString (!pythonOlder "3.4") ''
+    sed -i -e '/"enum34",/d' setup.py
+  '');
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/linode-api/default.nix
+++ b/pkgs/development/python-modules/linode-api/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "linode-api";
-  version = "4.1.1b2";
+  version = "4.1.1b2"; # NOTE: this is a beta, and the API may change in future versions.
   name = "${pname}-${version}";
 
   disabled = (pythonOlder "2.7");
@@ -21,6 +21,8 @@ buildPythonPackage rec {
   postPatch = (stdenv.lib.optionalString (!pythonOlder "3.4") ''
     sed -i -e '/"enum34",/d' setup.py
   '');
+
+  doCheck = false; # This library does not have any tests at this point.
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12589,6 +12589,8 @@ in {
     };
   };
 
+  linode-api = callPackage ../development/python-modules/linode-api { };
+
   livereload = buildPythonPackage rec {
     name = "livereload-${version}";
     version = "2.5.0";


### PR DESCRIPTION
Added Linode's official Python library for their v4 API.

Note that this API is still in beta and subject to changes.

###### Motivation for this change

This should assist with adding Linode support to Nixops (see:
https://github.com/NixOS/nixops/issues/198).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

