### PR TITLE
environment.etc: allow usernames in environment.etc.*.{uid,gid}

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -527,7 +527,7 @@ in {
       input.gid = ids.gids.input;
     };
 
-    system.activationScripts.users = stringAfter [ "etc" ]
+    system.activationScripts.users = stringAfter [ "stdio" ]
       ''
         ${pkgs.perl}/bin/perl -w \
           -I${pkgs.perlPackages.FileSlurp}/lib/perl5/site_perl \

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -148,7 +148,7 @@ in
 
     system.build.etc = etc;
 
-    system.activationScripts.etc = stringAfter [ "stdio" ]
+    system.activationScripts.etc = stringAfter [ "users" "groups" ]
       ''
         # Set up the statically computed bits of /etc.
         echo "setting up /etc..."

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -20,8 +20,8 @@ let
     sources = map (x: x.source) etc';
     targets = map (x: x.target) etc';
     modes = map (x: x.mode) etc';
-    uids  = map (x: x.uid) etc';
-    gids  = map (x: x.gid) etc';
+    users  = map (x: x.user) etc';
+    groups  = map (x: x.group) etc';
   };
 
 in
@@ -92,19 +92,37 @@ in
 
             uid = mkOption {
               default = 0;
-              type = types.either types.int types.str;
+              type = types.int;
               description = ''
-                UID or user name of created file. Only takes affect when the file is
+                UID of created file. Only takes affect when the file is
                 copied (that is, the mode is not 'symlink').
                 '';
             };
 
             gid = mkOption {
               default = 0;
-              type = types.either types.int types.str;
+              type = types.int;
               description = ''
-                GID or group name of created file. Only takes affect when the file is
+                GID of created file. Only takes affect when the file is
                 copied (that is, the mode is not 'symlink').
+              '';
+            };
+
+            user = mkOption {
+              default = "+${toString config.uid}";
+              type = types.str;
+              description = ''
+                User name of created file.
+                Only takes affect when the file is copied (that is, the mode is not 'symlink').
+              '';
+            };
+
+            group = mkOption {
+              default = "+${toString config.gid}";
+              type = types.str;
+              description = ''
+                Group name of created file.
+                Only takes affect when the file is copied (that is, the mode is not 'symlink').
               '';
             };
 

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -92,18 +92,18 @@ in
 
             uid = mkOption {
               default = 0;
-              type = types.int;
+              type = types.either types.int types.str;
               description = ''
-                UID of created file. Only takes affect when the file is
+                UID or user name of created file. Only takes affect when the file is
                 copied (that is, the mode is not 'symlink').
                 '';
             };
 
             gid = mkOption {
               default = 0;
-              type = types.int;
+              type = types.either types.int types.str;
               description = ''
-                GID of created file. Only takes affect when the file is
+                GID or group name of created file. Only takes affect when the file is
                 copied (that is, the mode is not 'symlink').
               '';
             };

--- a/nixos/modules/system/etc/make-etc.sh
+++ b/nixos/modules/system/etc/make-etc.sh
@@ -6,8 +6,8 @@ set -f
 sources_=($sources)
 targets_=($targets)
 modes_=($modes)
-uids_=($uids)
-gids_=($gids)
+users_=($users)
+groups_=($groups)
 set +f
 
 for ((i = 0; i < ${#targets_[@]}; i++)); do
@@ -36,9 +36,9 @@ for ((i = 0; i < ${#targets_[@]}; i++)); do
         fi
         
         if test "${modes_[$i]}" != symlink; then
-            echo "${modes_[$i]}" > $out/etc/$target.mode
-            echo "${uids_[$i]}" > $out/etc/$target.uid
-            echo "${gids_[$i]}" > $out/etc/$target.gid
+            echo "${modes_[$i]}"  > $out/etc/$target.mode
+            echo "${users_[$i]}"  > $out/etc/$target.uid
+            echo "${groups_[$i]}" > $out/etc/$target.gid
         fi
         
     fi

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -108,6 +108,8 @@ sub link {
             my $uid = read_file("$_.uid"); chomp $uid;
             my $gid = read_file("$_.gid"); chomp $gid;
             copy "$static/$fn", "$target.tmp" or warn;
+            $uid = getpwnam $uid unless $uid =~ /^\d+$/;
+            $gid = getgrnam $gid unless $gid =~ /^\d+$/;
             chown int($uid), int($gid), "$target.tmp" or warn;
             chmod oct($mode), "$target.tmp" or warn;
             rename "$target.tmp", $target or warn;

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -108,8 +108,8 @@ sub link {
             my $uid = read_file("$_.uid"); chomp $uid;
             my $gid = read_file("$_.gid"); chomp $gid;
             copy "$static/$fn", "$target.tmp" or warn;
-            $uid = getpwnam $uid unless $uid =~ /^\d+$/;
-            $gid = getgrnam $gid unless $gid =~ /^\d+$/;
+            $uid = getpwnam $uid unless $uid =~ /^\+/;
+            $gid = getgrnam $gid unless $gid =~ /^\+/;
             chown int($uid), int($gid), "$target.tmp" or warn;
             chmod oct($mode), "$target.tmp" or warn;
             rename "$target.tmp", $target or warn;


### PR DESCRIPTION
###### Motivation for this change

Prerequisite to fix https://github.com/NixOS/nixpkgs/issues/27397
Tinc's files in ```/etc``` to be owned by users with unpredictable ids and names like ```tinc.$netname``` so it could be fixed with something like https://github.com/NixOS/nixpkgs/compare/master...volth:tinc-fix

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

