### PR TITLE
exhibitor: Fix bugs in previous package

### DIFF
--- a/pkgs/servers/exhibitor/default.nix
+++ b/pkgs/servers/exhibitor/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     name = "exhibitor-${version}-maven-deps";
     inherit src nativeBuildInputs;
     buildPhase = ''
-      cd $pomFileDir;
+      cd ${pomFileDir};
       while timeout --kill-after=21m 20m mvn package -Dmaven.repo.local=$out/.m2; [ $? = 124 ]; do
         echo "maven hangs while downloading :("
       done
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ maven ];
   buildInputs = [ makeWrapper ];
   buildPhase = ''
-      cd $pomFileDir
+      cd ${pomFileDir}
       mvn package --offline -Dmaven.repo.local=$(cp -dpR ${fetchedMavenDeps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
   '';
   meta = with stdenv.lib; {


### PR DESCRIPTION
The previous package didn't build properly due to a bug in the build
script, and the nixos module didn't evaluate due to missing descriptions
in the options. This fixes both issues.

It also adds missing command-line options that weren't able to be set
and properly converts bools to the strings exhibitor expects.

###### Motivation for this change

Fix issues with #27508

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @copumpkin