### PR TITLE
Use more Vulnix dependencies from pythonPackages

### DIFF
--- a/pkgs/development/python-modules/btrees/default.nix
+++ b/pkgs/development/python-modules/btrees/default.nix
@@ -5,7 +5,8 @@ buildPythonPackage rec {
   version = "4.4.1";
   name = "${pname}-${version}";
 
-  propagatedBuildInputs = [ persistent zope_interface transaction ];
+  buildInputs = [ transaction ];
+  propagatedBuildInputs = [ persistent zope_interface ];
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/persistent/default.nix
+++ b/pkgs/development/python-modules/persistent/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage
+, fetchPypi
+, zope_interface
+, pkgs
+}:
+
+buildPythonPackage rec {
+  pname = "persistent";
+  version = "4.2.4.2";
+  name = "${pname}-${version}";
+
+  propagatedBuildInputs = [ zope_interface ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "cf264cd55866c7ffbcbe1328f8d8b28fd042a5dd0c03a03f68c0887df3aa1964";
+  };
+
+  meta = {
+    description = "Automatic persistence for Python objects";
+    homepage = http://www.zope.org/Products/ZODB;
+  };
+}

--- a/pkgs/development/python-modules/zc_lockfile/default.nix
+++ b/pkgs/development/python-modules/zc_lockfile/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage
+, fetchPypi
+, mock
+, zope_testing
+, stdenv
+}:
+
+buildPythonPackage rec {
+  pname = "zc.lockfile";
+  version = "1.2.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "11db91ada7f22fe8aae268d4bfdeae012c4fe655f66bbb315b00822ec00d043e";
+  };
+
+  buildInputs = [ mock ];
+  propagatedBuildInputs = [ zope_testing ];
+
+  meta = with stdenv.lib; {
+    description = "Inter-process locks";
+    homepage =  http://www.python.org/pypi/zc.lockfile;
+    license = licenses.zpt20;
+    maintainers = with maintainers; [ goibhniu ];
+  };
+}

--- a/pkgs/development/python-modules/zconfig/default.nix
+++ b/pkgs/development/python-modules/zconfig/default.nix
@@ -2,6 +2,8 @@
 , fetchPypi
 , buildPythonPackage
 , zope_testrunner
+, manuel
+, docutils
 }:
 
 buildPythonPackage rec {
@@ -16,6 +18,7 @@ buildPythonPackage rec {
 
   patches = [ ./skip-broken-test.patch ];
 
+  buildInputs = [ manuel docutils ];
   propagatedBuildInputs = [ zope_testrunner ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/zodbpickle/default.nix
+++ b/pkgs/development/python-modules/zodbpickle/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage
+, isPyPy
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "zodbpickle";
+  version = "0.6.0";
+  name = "${pname}-${version}";
+  disabled = isPyPy; # https://github.com/zopefoundation/zodbpickle/issues/10
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ea3248be966159e7791e3db0e35ea992b9235d52e7d39835438686741d196665";
+  };
+
+  # fails..
+  doCheck = false;
+
+  meta = {
+    homepage = http://pypi.python.org/pypi/zodbpickle;
+  };
+}

--- a/pkgs/tools/security/vulnix/requirements.nix
+++ b/pkgs/tools/security/vulnix/requirements.nix
@@ -1,38 +1,6 @@
 { pythonPackages, fetchurl, stdenv }:
 
 rec {
-  BTrees = pythonPackages.buildPythonPackage {
-    name = "BTrees-4.3.1";
-    src = fetchurl {
-      url = "https://pypi.python.org/packages/24/76/cd6f225f2180c22af5cdb6656f51aec5fca45e45bdc4fa75c0a32f161a61/BTrees-4.3.1.tar.gz";
-      sha256 = "2565b7d35260dfc6b1e2934470fd0a2f9326c58c535a2b4cb396289d1c195a95";
-    };
-    propagatedBuildInputs = [
-      persistent
-      transaction
-    ] ++ (with pythonPackages; [ zope_interface coverage ]);
-
-    meta = with stdenv.lib; {
-      homepage = "";
-      license = licenses.zpt21;
-      description = "Scalable persistent object containers";
-    };
-  };
-
-  ZConfig = pythonPackages.buildPythonPackage {
-    name = "ZConfig-3.1.0";
-    src = fetchurl {
-      url = "https://pypi.python.org/packages/52/b3/a96d62711a26d8cfbe546519975dc9ed54d2eb50b3238d2e6de045764796/ZConfig-3.1.0.tar.gz";
-      sha256 = "c21fa3a073a56925a8098036d46717392994a92cffea1b3cda3176b70c0a842e";
-    };
-    propagatedBuildInputs = with pythonPackages; [ zope_testrunner ];
-    meta = with stdenv.lib; {
-      homepage = "";
-      license = licenses.zpt21;
-      description = "Structured Configuration Library";
-    };
-  };
-
   zodb = pythonPackages.buildPythonPackage {
     name = "ZODB-5.2.0";
     src = fetchurl {
@@ -41,31 +9,22 @@ rec {
     };
     doCheck = false;
     propagatedBuildInputs = [
-      BTrees
-      persistent
       transaction
-      ZConfig
-      zc.lockfile
+    ] ++ (with pythonPackages; [
+      six
+      wheel
+      zope_interface
       zodbpickle
-    ] ++ (with pythonPackages; [ six wheel zope_interface ]);
+      zconfig
+      persistent
+      zc_lockfile
+      BTrees
+    ]);
+
     meta = with stdenv.lib; {
       homepage = "";
       license = licenses.zpt21;
       description = "Zope Object Database: object database and persistence";
-    };
-  };
-
-  persistent = pythonPackages.buildPythonPackage {
-    name = "persistent-4.2.2";
-    src = fetchurl {
-      url = "https://pypi.python.org/packages/3d/71/3302512282b606ec4d054e09be24c065915518903b29380b6573bff79c24/persistent-4.2.2.tar.gz";
-      sha256 = "52ececc6dbba5ef572d3435189318b4dff07675bafa9620e32f785e147c6563c";
-    };
-    propagatedBuildInputs = with pythonPackages; [ zope_interface six wheel ];
-    meta = with stdenv.lib; {
-      homepage = "";
-      license = licenses.zpt21;
-      description = "Translucent persistent objects";
     };
   };
 
@@ -75,39 +34,16 @@ rec {
       url = "https://pypi.python.org/packages/8c/af/3ffafe85bcc93ecb09459f3f2bd8fbe142e9ab34048f9e2774543b470cbd/transaction-2.0.3.tar.gz";
       sha256 = "67bfb81309ba9717edbb2ca2e5717c325b78beec0bf19f44e5b4b9410f82df7f";
     };
-    propagatedBuildInputs = with pythonPackages; [ zope_interface six wheel ];
+    propagatedBuildInputs = with pythonPackages; [
+      zope_interface
+      six
+      wheel
+      mock
+    ];
     meta = with stdenv.lib; {
       homepage = "";
       license = licenses.zpt21;
       description = "Transaction management for Python";
-    };
-  };
-
-  zc.lockfile = pythonPackages.buildPythonPackage {
-    name = "zc.lockfile-1.2.1";
-    src = fetchurl {
-      url = "https://pypi.python.org/packages/bd/84/0299bbabbc9d3f84f718ba1039cc068030d3ad723c08f82a64337edf901e/zc.lockfile-1.2.1.tar.gz";
-      sha256 = "11db91ada7f22fe8aae268d4bfdeae012c4fe655f66bbb315b00822ec00d043e";
-    };
-    meta = with stdenv.lib; {
-      homepage = "";
-      license = licenses.zpt21;
-      description = "Basic inter-process locks";
-    };
-  };
-
-  zodbpickle = pythonPackages.buildPythonPackage {
-    name = "zodbpickle-0.6.0";
-    src = fetchurl {
-      url = "https://pypi.python.org/packages/7a/fc/f6f437a5222b330735eaf8f1e67a6845bd1b600e9a9455e552d3c13c4902/zodbpickle-0.6.0.tar.gz";
-      sha256 = "ea3248be966159e7791e3db0e35ea992b9235d52e7d39835438686741d196665";
-    };
-    doCheck = false;
-
-    meta = with stdenv.lib; {
-      homepage = "";
-      license = licenses.zpt21;
-      description = "Fork of Python 3 pickle module.";
     };
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25163,23 +25163,7 @@ EOF
   zconfig = callPackage ../development/python-modules/zconfig { };
 
 
-  zc_lockfile = buildPythonPackage rec {
-    name = "zc.lockfile-${version}";
-    version = "1.0.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/z/zc.lockfile/${name}.tar.gz";
-      sha256 = "96bb2aa0438f3e29a31e4702316f832ec1482837daef729a92e28c202d8fba5c";
-    };
-
-    meta = {
-      description = "Inter-process locks";
-      homepage =  http://www.python.org/pypi/zc.lockfile;
-      license = licenses.zpt20;
-      maintainers = with maintainers; [ goibhniu ];
-    };
-  };
-
+  zc_lockfile = callPackage ../development/python-modules/zc_lockfile { };
 
   zdaemon = buildPythonPackage rec {
     name = "zdaemon-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25269,21 +25269,7 @@ EOF
 
   BTrees = callPackage ../development/python-modules/btrees {};
 
-  persistent = self.buildPythonPackage rec {
-    name = "persistent-4.0.8";
-
-    propagatedBuildInputs = with self; [ zope_interface ];
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/persistent/${name}.tar.gz";
-      sha256 = "678902217c5370d33694c6dc95b89e1e6284b4dc41f04c056326194a3f6f3e22";
-    };
-
-    meta = {
-      description = "Automatic persistence for Python objects";
-      homepage = http://www.zope.org/Products/ZODB;
-    };
-  };
+  persistent = callPackage ../development/python-modules/persistent {};
 
   xdot = buildPythonPackage rec {
     name = "xdot-0.7";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25265,22 +25265,7 @@ EOF
     };
   };
 
-  zodbpickle = self.buildPythonPackage rec {
-    name = "zodbpickle-0.5.2";
-    disabled = isPyPy; # https://github.com/zopefoundation/zodbpickle/issues/10
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/z/zodbpickle/${name}.tar.gz";
-      sha256 = "f65c00fbc13523fced63de6cc11747aa1a6343aeb2895c89838ed55a5ab12cca";
-    };
-
-    # fails..
-    doCheck = false;
-
-    meta = {
-      homepage = http://pypi.python.org/pypi/zodbpickle;
-    };
-  };
+  zodbpickle = callPackage ../development/python-modules/zodbpickle {};
 
   BTrees = callPackage ../development/python-modules/btrees {};
 


### PR DESCRIPTION
###### Motivation for this change
Moving a lot of Vulnix dependencies to depend on pythonPackages instead of it's own pinned ones.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

