### PR TITLE
blackbox: init at 1.20170611

### DIFF
--- a/pkgs/applications/version-management/blackbox/default.nix
+++ b/pkgs/applications/version-management/blackbox/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  version = "1.20170611";
+  pname   = "blackbox";
+  name    = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "stackexchange";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "1jnzhlj54c0szw9l9wib07i2375pbm402bx9wagspcmwc0qw43p6";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin && cp -r bin/* $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Safely store secrets in a VCS repo";
+    maintainers = with maintainers; [ ericsagnes ];
+    license     = licenses.mit;
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13463,6 +13463,8 @@ with pkgs;
     inherit (gnome2) zenity;
   };
 
+  blackbox = callPackage ../applications/version-management/blackbox { };
+
   bleachbit = callPackage ../applications/misc/bleachbit { };
 
   blender = callPackage  ../applications/misc/blender {


### PR DESCRIPTION
###### Motivation for this change

Add the blackbox VCS secrets management tool to nixpkgs.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

