### PR TITLE
setroot: 1.4.4 -> 2.0.1

### DIFF
--- a/pkgs/tools/X11/setroot/default.nix
+++ b/pkgs/tools/X11/setroot/default.nix
@@ -5,14 +5,14 @@
 assert enableXinerama -> libXinerama != null;
 
 stdenv.mkDerivation rec {
-  version = "1.4.4";
+  version = "2.0.1";
   name = "setroot-${version}";
 
   src = fetchFromGitHub {
     owner = "ttzhou";
     repo = "setroot";
     rev = "v${version}";
-    sha256 = "0vphma0as8pnqrakdw6gaiiz7xawb4y72sc9dna755kkclgbyl8m";
+    sha256 = "01krjfc3xpp0wbqz9nvf1n34gkpd41gysn289sj1wcjxia4n4gsi";
   };
 
   buildInputs = [ libX11 imlib2 ]
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     description = "Simple X background setter inspired by imlibsetroot and feh";
     homepage = https://github.com/ttzhou/setroot;
     license = licenses.gpl3Plus;
+    maintainers = maintainers.vyp;
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

