### PR TITLE
noXlibs: enrich package overrides

### DIFF
--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -26,7 +26,15 @@ with lib;
 
     fonts.fontconfig.enable = false;
 
-    nixpkgs.config.packageOverrides = pkgs:
-      { dbus = pkgs.dbus.override { x11Support = false; }; };
+    nixpkgs.config.packageOverrides = pkgs: {
+      dbus = pkgs.dbus.override { x11Support = false; };
+      networkmanager_fortisslvpn = pkgs.networkmanager_fortisslvpn.override { withGnome = false; };
+      networkmanager_l2tp = pkgs.networkmanager_l2tp.override { withGnome = false; };
+      networkmanager_openconnect = pkgs.networkmanager_openconnect.override { withGnome = false; };
+      networkmanager_openvpn = pkgs.networkmanager_openvpn.override { withGnome = false; };
+      networkmanager_pptp = pkgs.networkmanager_pptp.override { withGnome = false; };
+      networkmanager_vpnc = pkgs.networkmanager_vpnc.override { withGnome = false; };
+      pinentry = pkgs.pinentry.override { gtk2 = null; qt4 = null; };
+    };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
When working on a headless server, it is convenient to disable installation of graphical frontends via a single configuration setting. I've only found `noXlibs` to do that, so I've enriched it with a bunch of package overrides.
Note that it may not be a good idea to have `noXlibs` depend on app derivations. Maybe a better way is to invert the dependency: feed a `noXlibs` flag to app derivations so that they can decide what to disable.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

