### PR TITLE
module auditd: break ordering cycle on basic.target/start #11864

### DIFF
--- a/nixos/modules/security/auditd.nix
+++ b/nixos/modules/security/auditd.nix
@@ -13,6 +13,7 @@ with lib;
       unitConfig = {
         ConditionVirtualization = "!container";
         ConditionSecurity = [ "audit" ];
+        DefaultDependencies = false;
       };
 
       path = [ pkgs.audit ];


### PR DESCRIPTION
auditd creates an ordering cycle by adding wantedBy = [ "basic.target" ],
because of this the job job systemd-update-utmp.service/start is deleted.

adding unitConfig.DefaultDependencies = false; to the auditd service breaks the cycle.

###### Motivation for this change


###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

