### PR TITLE
programs.thefuck: support shells that don't use `/etc/profile`

### DIFF
--- a/nixos/modules/programs/thefuck.nix
+++ b/nixos/modules/programs/thefuck.nix
@@ -3,7 +3,12 @@
 with lib;
 
 let
-  cfg = config.programs.thefuck;
+  prg = config.programs;
+  cfg = prg.thefuck;
+
+  initScript = ''
+    eval $(${pkgs.thefuck}/bin/thefuck --alias ${cfg.alias})
+  '';
 in
   {
     options = {
@@ -24,8 +29,11 @@ in
 
     config = mkIf cfg.enable {
       environment.systemPackages = with pkgs; [ thefuck ];
-      environment.shellInit = ''
-        eval $(${pkgs.thefuck}/bin/thefuck --alias ${cfg.alias})
+      environment.shellInit = initScript;
+
+      programs.zsh.shellInit = mkIf prg.zsh.enable initScript;
+      programs.fish.shellInit = mkIf prg.fish.enable ''
+        ${pkgs.thefuck}/bin/thefuck --alias | source
       '';
     };
   }


### PR DESCRIPTION
###### Motivation for this change

The alias for `thefuck` is placed in `/etc/profile`. However shell emulators like `zsh` or `fish` don't use these scripts due to known incompatibilities with `bash`.

Therefore an optional expression which detects which shells are enable in NixOS is needed which configures the alias in all needed shell envs.

I confirmed the change using an expression like this:

``` nix
{
  zsh = { pkgs, lib, ... }: with lib; {
    programs.zsh.enable = true;
    programs.thefuck.enable = true;
    users.extraUsers.vm = {
      extraGroups = [ "wheel" ];
      password = "vm";
      isNormalUser = true;
      shell = "/run/current-system/sw/bin/zsh";
    };
  };
}
```

When booting into this generated VM (built with `nixos-build-vms`) `zsh` works fine when running `fuck` on the CLI without complaining about missing aliases.

After that I confirmed that the alias is only in the env scripts for bash and zsh (`/etc/static/zshenv`) by running `grep -R 'fuck' /etc`.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

