### PR TITLE
cryptodev: 1.8 -> 1.9

### DIFF
--- a/pkgs/os-specific/linux/cryptodev/default.nix
+++ b/pkgs/os-specific/linux/cryptodev/default.nix
@@ -1,25 +1,27 @@
 { fetchurl, stdenv, kernel, onlyHeaders ? false }:
 
 stdenv.mkDerivation rec {
-  pname = "cryptodev-linux-1.8";
+  pname = "cryptodev-linux-1.9";
   name = "${pname}-${kernel.version}";
 
   src = fetchurl {
-    url = "http://download.gna.org/cryptodev-linux/${pname}.tar.gz";
-    sha256 = "0xhkhcdlds9aiz0hams93dv0zkgcn2abaiagdjlqdck7zglvvyk7";
+    urls = [
+      "http://nwl.cc/pub/cryptodev-linux/${pname}.tar.gz"
+      "http://download.gna.org/cryptodev-linux/${pname}.tar.gz"
+    ];
+    sha256 = "0l3r8s71vkd0s2h01r7fhqnc3j8cqw4msibrdxvps9hfnd4hnk4z";
   };
 
   hardeningDisable = [ "pic" ];
 
   KERNEL_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   INSTALL_MOD_PATH = "\${out}";
-  PREFIX = "\${out}";
+  prefix = "\${out}";
 
   meta = {
     description = "Device that allows access to Linux kernel cryptographic drivers";
     homepage = http://home.gna.org/cryptodev-linux/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
-    broken = !stdenv.lib.versionOlder kernel.version "4.9";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update for kernels >= 4.10
The download location seems offline.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Nox review:

```
[...]
Result in /tmp/nox-review-48bn2dud
total 36
lrwxrwxrwx 1 nequi users 72 Jul 23 11:07 result -> /nix/store/ysgxpx3c78dcavjrs9nggb9fr7k84vbp-cryptodev-linux-1.9-3.10.105
lrwxrwxrwx 1 nequi users 70 Jul 23 11:07 result-2 -> /nix/store/g5dkn5g0ydr15g8shv2wqf8f3rr5ifgn-cryptodev-linux-1.9-4.12.3
lrwxrwxrwx 1 nequi users 70 Jul 23 11:07 result-3 -> /nix/store/kr3syqa4cvl3wsgkrx3wdqr4jai2wjkr-cryptodev-linux-1.9-3.18.0
lrwxrwxrwx 1 nequi users 70 Jul 23 11:07 result-4 -> /nix/store/c5pndbl6rc5axh681fz995iizwv1wdkp-cryptodev-linux-1.9-4.12.3
lrwxrwxrwx 1 nequi users 70 Jul 23 11:07 result-5 -> /nix/store/kr3syqa4cvl3wsgkrx3wdqr4jai2wjkr-cryptodev-linux-1.9-3.18.0
lrwxrwxrwx 1 nequi users 70 Jul 23 11:07 result-6 -> /nix/store/3r8rj80msknbc8jk6lywhdz2xgkigvhj-cryptodev-linux-1.9-4.9.39
lrwxrwxrwx 1 nequi users 70 Jul 23 11:07 result-7 -> /nix/store/0szpdcyk5pp3rz4q2lljr65cad6pvhzf-cryptodev-linux-1.9-4.4.78
lrwxrwxrwx 1 nequi users 70 Jul 23 11:07 result-8 -> /nix/store/f69wx81l5w54bi8hd5lhrcg8vrmh8l8g-cryptodev-linux-1.9-4.12.2
lrwxrwxrwx 1 nequi users 70 Jul 23 11:07 result-9 -> /nix/store/g5dkn5g0ydr15g8shv2wqf8f3rr5ifgn-cryptodev-linux-1.9-4.12.3
```