### PR TITLE
ghc: apply a patch to fix common gold linker problem

### DIFF
--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "1c8qc4fhkycynk4g1f9hvk53dj6a1vvqi6bklqznns6hw59m8qhi";
   };
 
-  patches = []
+  patches = [ ./ghc-gold-linker.patch ]
     ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch
     ++ stdenv.lib.optional stdenv.isDarwin ./ghc-8.0.2-no-cpp-warnings.patch;
 

--- a/pkgs/development/compilers/ghc/8.2.1.nix
+++ b/pkgs/development/compilers/ghc/8.2.1.nix
@@ -32,6 +32,8 @@ in stdenv.mkDerivation (rec {
 
   postPatch = "patchShebangs .";
 
+  patches = [ ./ghc-gold-linker.patch ];
+
   preConfigure = commonPreConfigure;
 
   buildInputs = commonBuildInputs;

--- a/pkgs/development/compilers/ghc/ghc-gold-linker.patch
+++ b/pkgs/development/compilers/ghc/ghc-gold-linker.patch
@@ -1,0 +1,54 @@
+From 46fe80ab7c0013a929d0934e61429820042a70a9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Niklas=20Hamb=C3=BCchen?= <mail@nh2.me>
+Date: Fri, 21 Jul 2017 20:09:11 +0200
+Subject: [PATCH 1/2] base: Add `extra-libraries: m` because base uses libm
+ functions.
+
+Linking with gold needs this because in contrast to ld, gold
+doesn't implicitly link libm.
+
+Found by Michael Bishop <cleverca22@gmail.com>.
+---
+ libraries/base/base.cabal | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/libraries/base/base.cabal b/libraries/base/base.cabal
+index f00fb8768e5..fd91f268ffe 100644
+--- a/libraries/base/base.cabal
++++ b/libraries/base/base.cabal
+@@ -342,6 +342,10 @@ Library
+         WCsubst.h
+         consUtils.h
+ 
++    -- Base uses libm functions. ld.bfd links libm implicitly when necessary.
++    -- Other linkers, like gold, don't, so we have to declare it explicitly.
++    extra-libraries: m
++
+     -- OS Specific
+     if os(windows)
+         -- Windows requires some extra libraries for linking because the RTS
+
+From 900a8f4931e9bc6d3219d9263cfecfc6af8fc766 Mon Sep 17 00:00:00 2001
+From: michael bishop <cleverca22@gmail.com>
+Date: Sat, 22 Jul 2017 13:12:39 -0300
+Subject: [PATCH 2/2] also add -lm to ghc-prim
+
+---
+ libraries/ghc-prim/ghc-prim.cabal | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/libraries/ghc-prim/ghc-prim.cabal b/libraries/ghc-prim/ghc-prim.cabal
+index 00a029efedf..6db85dd69fc 100644
+--- a/libraries/ghc-prim/ghc-prim.cabal
++++ b/libraries/ghc-prim/ghc-prim.cabal
+@@ -42,6 +42,10 @@ Library
+         UnliftedFFITypes
+ 
+     build-depends: rts == 1.0.*
++    
++    -- Base uses libm functions. ld.bfd links libm implicitly when necessary.
++    -- Other linkers, like gold, don't, so we have to declare it explicitly.
++    extra-libraries: m
+ 
+     exposed-modules:
+         GHC.CString


### PR DESCRIPTION
It would otherwise result into undefined referenecs for some functions
in the base when using the gold linker:

   error: undefined reference to 'sqrt'

Fixes https://github.com/bos/double-conversion/pull/17

Previously ghc option -optl=-lm was used for packages depending on
such functions, but that could result into

   fatal error: cannot mix -r with dynamic object /nix/store/7crrmih8c52r8fbnqb933dxrsp44md93-glibc-2.25/lib/libm.so.6

in some situations like profiling builds.

Patch was prepared by Michael Bishop and Niklas Hambüchen

NOTE: this hasn't been tested on macOS yet.

cc @peti 