### PR TITLE
exfat-nofuse: 2017-01-03 -> 2017-06-19

### DIFF
--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -1,21 +1,18 @@
 { stdenv, lib, fetchFromGitHub, kernel }:
 
-# Upstream build for kernel > 4.10 is currently broken
-# Reference: https://github.com/dorimanx/exfat-nofuse/issues/103
-assert lib.versionOlder kernel.version "4.10";
 
 # Upstream build for kernel 4.1 is broken, 3.12 and below seems to be working
 assert lib.versionAtLeast kernel.version  "4.2" || lib.versionOlder kernel.version "4.0";
 
 stdenv.mkDerivation rec {
   name = "exfat-nofuse-${version}-${kernel.version}";
-  version = "2017-01-03";
+  version = "2017-06-19";
 
   src = fetchFromGitHub {
     owner = "dorimanx";
     repo = "exfat-nofuse";
-    rev = "8d291f5";
-    sha256 = "0lg1mykglayswli2aliw8chsbr4g629v9chki5975avh43jn47w9";
+    rev = "de4c760bc9a05ead83bc3ec6eec6cf1fb106f523";
+    sha256 = "0v979d8sbcb70lakm4jal2ck3gspkdgq9108k127f7ph08vf8djm";
   };
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

