### PR TITLE
dpdk: 16.07.2 -> 17.05.1

### DIFF
--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -4,11 +4,11 @@ assert lib.versionAtLeast kernel.version "3.18";
 
 stdenv.mkDerivation rec {
   name = "dpdk-${version}-${kernel.version}";
-  version = "16.07.2";
+  version = "17.05.1";
 
   src = fetchurl {
     url = "http://fast.dpdk.org/rel/dpdk-${version}.tar.xz";
-    sha256 = "1mzwazmzpq8mvwiham80y6h53qpvjpp76v0d58gz9bfiphbi9876";
+    sha256 = "1w3nx5cqf8z600bdlbwz7brmdb5yn233qrqvv24kbmmxhbwp7qld";
   };
 
   buildInputs = [ pkgconfig libvirt ];
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     install -m 0755 -d $out/${RTE_TARGET}/include
     install -m 0644 ${RTE_TARGET}/include/rte_config.h $out/${RTE_TARGET}/include
 
-    cp -pr mk scripts $out/
+    cp -pr mk $out/
 
     mkdir -p $kmod/lib/modules/${kernel.modDirVersion}/kernel/drivers/net
     cp ${RTE_TARGET}/kmod/*.ko $kmod/lib/modules/${kernel.modDirVersion}/kernel/drivers/net


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

