### PR TITLE
libextractor: 1.3 -> 1.4

### DIFF
--- a/pkgs/development/libraries/libextractor/default.nix
+++ b/pkgs/development/libraries/libextractor/default.nix
@@ -7,11 +7,11 @@ assert gtkSupport -> glib != null && gtk3 != null;
 assert videoSupport -> ffmpeg != null && libmpeg2 != null;
 
 stdenv.mkDerivation rec {
-  name = "libextractor-1.3";
+  name = "libextractor-1.4";
 
   src = fetchurl {
     url = "mirror://gnu/libextractor/${name}.tar.gz";
-    sha256 = "0zvv7wd011npcx7yphw9bpgivyxz6mlp87a57n96nv85k96dd2l6";
+    sha256 = "0v7ns5jhsyp1wzvbaydfgxnva5zd63gkzm9djhckmam9liq824l4";
   };
 
   preConfigure =


### PR DESCRIPTION
###### Motivation for this change

exiv2 was upgraded to 0.26 a week ago by c2e9f45df2387c4b809793c77639ec209b53efb9.

libextractor 1.3 is incompatible with exiv2 0.26 so this broke the build (see http://hydra.nixos.org/build/56507915) but libextractor 1.4 adds compatibility.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

