### PR TITLE
cups: add perl to bindir

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -34,7 +34,7 @@ let
   bindir = pkgs.buildEnv {
     name = "cups-progs";
     paths =
-      [ cups.out additionalBackends cups-filters pkgs.ghostscript ]
+      [ cups.out additionalBackends cups-filters pkgs.ghostscript pkgs.perl ]
       ++ optional cfg.gutenprint gutenprint
       ++ cfg.drivers;
     pathsToLink = [ "/lib" "/share/cups" "/bin" ];


### PR DESCRIPTION
###### Motivation for this change

My printer's ppd calls perl as part of the foomatic-rip command:

```
cupsd[10516]: /nix/store/lpk84rsbha199vm3k54498lqv2jswqj8-bash-4.4-p5/bin/bash: perl: command not found
cupsd[10516]: renderer exited with status 127
cupsd[10516]: PID 10946 (/nix/store/k69v6wfncnbr4kw0p6f06j3bh9lpl8d0-cups-progs/lib/cups/filter/foomatic-rip) stopped with status 9.
```

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

