### PR TITLE
qtstyleplugin-kvantum: init at 0.10.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -86,6 +86,7 @@
   bradediger = "Brad Ediger <brad@bradediger.com>";
   bramd = "Bram Duvigneau <bram@bramd.nl>";
   bstrik = "Berno Strik <dutchman55@gmx.com>";
+  bugworm = "Roman Gerasimenko <bugworm@zoho.com>";
   bzizou = "Bruno Bzeznik <Bruno@bzizou.net>";
   c0dehero = "CodeHero <codehero@nerdpol.ch>";
   calrama = "Moritz Maxeiner <moritz@ucworks.org>";

--- a/pkgs/development/libraries/qtstyleplugin-kvantum-qt4/default.nix
+++ b/pkgs/development/libraries/qtstyleplugin-kvantum-qt4/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, qmake4Hook , qt4, libX11, libXext }:
+
+stdenv.mkDerivation rec {
+  name = "qtstyleplugin-kvantum-qt4-${version}";
+  version = "0.10.4";
+
+  src = fetchFromGitHub {
+    owner = "tsujan";
+    repo = "Kvantum";
+    rev = "0527bb03f2252269fd382e11181a34ca72c96b4b";
+    sha256 = "0ky44s1fgqxraywagx1mv07yz76ppgiz3prq447db78wkwqg2d8p";
+  };
+
+  nativeBuildInputs = [ qmake4Hook ];
+  buildInputs = [ qt4 libX11 libXext ];
+
+  postUnpack = "sourceRoot=\${sourceRoot}/Kvantum";
+
+  buildPhase = ''
+    qmake kvantum.pro
+    make
+  '';
+
+  installPhase = ''
+    mkdir $TMP/kvantum
+    make INSTALL_ROOT="$TMP/kvantum" install
+    mv $TMP/kvantum/usr/ $out
+    mv $TMP/kvantum/${qt4}/lib $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "SVG-based Qt4 theme engine";
+    homepage = "https://github.com/tsujan/Kvantum";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/qtstyleplugin-kvantum-qt4/default.nix
+++ b/pkgs/development/libraries/qtstyleplugin-kvantum-qt4/default.nix
@@ -33,5 +33,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/tsujan/Kvantum";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    maintainers = [ maintainers.bugworm ];
   };
 }

--- a/pkgs/development/libraries/qtstyleplugin-kvantum/default.nix
+++ b/pkgs/development/libraries/qtstyleplugin-kvantum/default.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/tsujan/Kvantum";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    maintainers = [ maintainers.bugworm ];
   };
 }

--- a/pkgs/development/libraries/qtstyleplugin-kvantum/default.nix
+++ b/pkgs/development/libraries/qtstyleplugin-kvantum/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, qmake, qtbase, qtsvg, qtx11extras, libX11, libXext, qttools }:
+
+stdenv.mkDerivation rec {
+  name = "qtstyleplugin-kvantum-${version}";
+  version = "0.10.4";
+
+  src = fetchFromGitHub {
+    owner = "tsujan";
+    repo = "Kvantum";
+    rev = "0527bb03f2252269fd382e11181a34ca72c96b4b";
+    sha256 = "0ky44s1fgqxraywagx1mv07yz76ppgiz3prq447db78wkwqg2d8p";
+  };
+
+  nativeBuildInputs = [ qmake qttools ];
+  buildInputs = [ qtbase qtsvg qtx11extras libX11 libXext  ];
+
+  postUnpack = "sourceRoot=\${sourceRoot}/Kvantum";
+
+  postInstall= ''
+    mkdir -p $out/$qtPluginPrefix/styles
+    mv $NIX_QT5_TMP/$qtPluginPrefix/styles/libkvantum.so $out/$qtPluginPrefix/styles/libkvantum.so
+  '';
+
+  meta = with stdenv.lib; {
+    description = "SVG-based Qt5 theme engine plus a config tool and extra themes";
+    homepage = "https://github.com/tsujan/Kvantum";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8069,6 +8069,8 @@ with pkgs;
 
   qt-gstreamer1 = callPackage ../development/libraries/gstreamer/qt-gstreamer { boost = boost155;};
 
+  qtstyleplugin-kvantum-qt4 = callPackage ../development/libraries/qtstyleplugin-kvantum-qt4 { };
+
   gnet = callPackage ../development/libraries/gnet { };
 
   gnu-config = callPackage ../development/libraries/gnu-config { };
@@ -9985,6 +9987,8 @@ with pkgs;
     };
 
     qtstyleplugins = callPackage ../development/libraries/qtstyleplugins { };
+
+    qtstyleplugin-kvantum = libsForQt5.callPackage ../development/libraries/qtstyleplugin-kvantum { };
 
     quazip = callPackage ../development/libraries/quazip { };
 


### PR DESCRIPTION
###### Motivation for this change
Wanted to add kvantum qt style

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

