### PR TITLE
qesteidutil: 3.12.2.1206 -> 3.12.5.1233

### DIFF
--- a/pkgs/tools/security/qesteidutil/default.nix
+++ b/pkgs/tools/security/qesteidutil/default.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
 
-  version = "3.12.2.1206";
+  version = "3.12.5.1233";
   name = "qesteidutil-${version}";
   
   src = fetchurl {
-    url = "https://installer.id.ee/media/ubuntu/pool/main/q/qesteidutil/qesteidutil_3.12.2.1206.orig.tar.xz";
-    sha256 = "1v1i0jlycjjdg6wi4cpm1il5v1zn8dfj82mrfvsjy6j9rfzinkda";
+    url = "https://installer.id.ee/media/ubuntu/pool/main/q/qesteidutil/qesteidutil_${version}.orig.tar.xz";
+    sha256 = "b5f0361af1891cfab6f9113d6b2fab677cc4772fc18b62df7d6e997f13b97857";
   };
 
   unpackPhase = ''


### PR DESCRIPTION
###### Motivation for this change

The old (3.12.2.1206) version seems to have an issue regarding the certificates which seem to be unavailable.

![qesteidutil-before](https://user-images.githubusercontent.com/335406/28503825-c0dee744-700d-11e7-9e53-bb2a59c9c32a.png)

All screendumps from the official website display some information of the certificates being displayed within the main screen, also clicking certificates on the application seems to trigger an "empty certificates" error message.

After the update to 3.12.5.1233, the tools seems to retrieve the certificates necessary to use the e-Residency card.

![qesteidutil-after-scaleddown](https://user-images.githubusercontent.com/335406/28503845-da13f9ac-700d-11e7-825e-8e1584b90425.png)


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @jagajaga 
