### PR TITLE
neofetch: 3.0.1 -> 3.2.0

### DIFF
--- a/pkgs/tools/misc/neofetch/default.nix
+++ b/pkgs/tools/misc/neofetch/default.nix
@@ -1,26 +1,33 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "neofetch-${version}";
-  version = "3.0.1";
+  version = "3.2.0";
   src = fetchFromGitHub {
     owner = "dylanaraps";
     repo = "neofetch";
     rev = version;
-    sha256 = "0ccdgyn9m7vbrmjlsxdwv7cagsdg8hy8x4n1mx334pkqvl820jjn";
+    sha256 = "1skkclvkqayqsbywja2fhv18l4rn9kg2da6bkip82zrwd713akl3";
   };
 
-  patchPhase = ''
-    substituteInPlace ./neofetch \
-    --replace "/usr/share" "$out/share"
-  '';
+  # This patch is only needed so that Neofetch 3.2.0 can look for
+  # configuration file, w3m directory (for fetching images) and ASCII
+  # directory properly. It won't be needed in subsequent releases.
+  patches = [
+    (fetchpatch {
+      name = "nixos.patch";
+      url = "https://github.com/konimex/neofetch/releases/download/3.2.0/nixos.patch";
+      sha256 = "096l1r5ll7gxqjv9fnxi7cs0iphl83yi3a9ldf7bfxavjaz2lkb9";
+    })
+  ];
+
 
   dontBuild = true;
 
 
   makeFlags = [
-    "DESTDIR=$(out)"
-    "PREFIX="
+    "PREFIX=$(out)"
+    "SYSCONFDIR=$(out)/etc"
   ];
 
   meta = with stdenv.lib; {
@@ -28,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/dylanaraps/neofetch;
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ alibabzo ];
+    maintainers = with maintainers; [ alibabzo konimex ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The patch is needed to address https://github.com/dylanaraps/neofetch/issues/752. The patches are in upstream, but not in 3.2.0. The patch won't be needed in any subsequent releases.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc: @alibabzo
