### PR TITLE
html-tidy: 5.2.0 -> 5.4.0

### DIFF
--- a/pkgs/tools/text/html-tidy/default.nix
+++ b/pkgs/tools/text/html-tidy/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "html-tidy-${version}";
-  version = "5.2.0";
+  version = "5.4.0";
 
   src = fetchFromGitHub {
     owner = "htacg";
     repo = "tidy-html5";
     rev = version;
-    sha256 = "1yxp3kjsxd5zwwn4r5rpyq5ndyylbcnb9pisdyf7dxjqd47z64bc";
+    sha256 = "1q9ag2dh2j636fw9vyz6gg0kiss8p6lvj22h25nqsw0daan57c32";
   };
 
   nativeBuildInputs = [ cmake libxslt/*manpage*/ ];
@@ -33,4 +33,3 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ edwtjo ];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change
new upstream release

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

