### PR TITLE
stdenv-setup: Add quotes that don't do anything for consistency.

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -50,6 +50,8 @@ in rec {
     args    = [ ./unpack-bootstrap-tools.sh ];
 
     inherit (bootstrapFiles) mkdir bzip2 cpio tarball;
+    reexportedLibrariesFile =
+      ../../os-specific/darwin/apple-source-releases/Libsystem/reexported_libraries;
 
     __sandboxProfile = binShClosure + libSystemProfile;
   };

--- a/pkgs/stdenv/darwin/unpack-bootstrap-tools.sh
+++ b/pkgs/stdenv/darwin/unpack-bootstrap-tools.sh
@@ -26,7 +26,7 @@ install_name_tool \
   $out/lib/system/libsystem_kernel.dylib
 
 # TODO: this logic basically duplicates similar logic in the Libsystem expression. Deduplicate them!
-libs=$(otool -arch x86_64 -L /usr/lib/libSystem.dylib | tail -n +3 | awk '{ print $1 }')
+libs=$(cat $reexportedLibrariesFile | grep -v '^#')
 
 for i in $libs; do
   if [ "$i" != "/usr/lib/system/libsystem_kernel.dylib" ] && [ "$i" != "/usr/lib/system/libsystem_c.dylib" ]; then


### PR DESCRIPTION
###### Motivation for this change

@vcunat and others rightly point out that it's easier to quote always than learn Bash's idiosyncrasies enough to know when it doesn't make a difference.

This reverts commit 2743078f664ae07c4bed06a96182c6a86bd7fa32, which removes quotes that don't do anything, and then goes further adding even more quotes.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built stdenv on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

