### PR TITLE
stdenv/setup.sh: undo `local -n` change

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -17,9 +17,10 @@ runHook() {
     shift
     local var="$hookName"
     if [[ "$hookName" =~ Hook$ ]]; then var+=s; else var+=Hooks; fi
-    local -n var
+
+    eval "local -a dummy=(\"\${$var[@]}\")"
     local hook
-    for hook in "_callImplicitHook 0 $hookName" "${var[@]}"; do
+    for hook in "_callImplicitHook 0 $hookName" "${dummy[@]}"; do
         _eval "$hook" "$@"
     done
     return 0
@@ -33,9 +34,9 @@ runOneHook() {
     shift
     local var="$hookName"
     if [[ "$hookName" =~ Hook$ ]]; then var+=s; else var+=Hooks; fi
-    local -n var
+    eval "local -a dummy=(\"\${$var[@]}\")"
     local hook
-    for hook in "_callImplicitHook 1 $hookName" "${var[@]}"; do
+    for hook in "_callImplicitHook 1 $hookName" "${dummy[@]}"; do
         if _eval "$hook" "$@"; then
             return 0
         fi


### PR DESCRIPTION
`local -n` is theoretically better than the eval solution this is adding back, but until we can rely on a particular version of bash in nix-shell, this just breaks too much stuff.

See https://github.com/NixOS/nix/commit/c94f3d5575d7af5403274d1e9e2f3c9d72989751 and https://github.com/NixOS/nix/pull/1483 for the better long-term solution.

###### Motivation for this change

macOS and CentOS (among probably others) have `nix-shell` broken by default right now. Until `nixpkgs-unstable` gets rid of `local -n`, this will cause (and is causing) a ton of pain. I'm doing this directly against master because I want to get a successful Hydra build to bump `nixpkgs-unstable` back to a good state ASAP.

We'll also need to do this to other `local -n` instances on staging