### PR TITLE
hydra: 2017-06-22 -> 2017-07-24 (NixOS-17.03)

### DIFF
--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -62,15 +62,15 @@ let
   };
 in releaseTools.nixBuild rec {
   name = "hydra-${version}";
-  version = "2017-06-22";
+  version = "2017-07-24";
 
   inherit stdenv;
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "hydra";
-    rev = "803833aba77e1082c14857aa26933fc7fe5ae190";
-    sha256 = "1cnxpsan8l6fnbr73n0qxxq1szlda1n3qfkk9k9ic8ijk7md4pvs";
+    rev = "a6d9201947aa1468d31ef5c2651251ceeefceb5c";
+    sha256 = "0hk5pxzn94ip3nyccxl91zc5n6wd1h2zcbhdq9p38wa4lrnnm5zv";
   };
 
   buildInputs =


### PR DESCRIPTION
hydra-2017-06-22 fails to build because of the nixUnstable upgrade.
hydra-2017-07-24 builds successfully.

Cherry-pick of https://github.com/NixOS/nixpkgs/pull/27625.