### PR TITLE
Envoy: init at 1.3.0

### DIFF
--- a/pkgs/development/libraries/backward-cpp/default.nix
+++ b/pkgs/development/libraries/backward-cpp/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "backward-${version}";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "bombela";
+    repo = "backward-cpp";
+    rev = "v${version}";
+    sha256 = "1nx77qamal53rq8qxsjzax6ljawb345a1v3cqmfwa0hx26srxcln";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/include
+    cp backward.hpp $out/include
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Beautiful stack trace pretty printer for C++";
+    homepage = "https://github.com/bombela/backward-cpp";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+}

--- a/pkgs/development/libraries/boringssl/default.nix
+++ b/pkgs/development/libraries/boringssl/default.nix
@@ -1,13 +1,14 @@
 { stdenv, fetchgit, cmake, perl, go }:
 
+# reference: https://boringssl.googlesource.com/boringssl/+/2661/BUILDING.md
 stdenv.mkDerivation rec {
   name = "boringssl-${version}";
-  version = "2016-03-08";
+  version = "2017-02-23";
 
   src = fetchgit {
     url    = "https://boringssl.googlesource.com/boringssl";
-    rev    = "bfb38b1a3c5e37d43188bbd02365a87bebc8d122";
-    sha256 = "0bm7vqg3bk716xmw2af99p44zizfhknq9z3cphf7klfdrr7ibqm5";
+    rev    = "be2ee342d3781ddb954f91f8a7e660c6f59e87e5";
+    sha256 = "022zq7wlkhrg6al7drr3555lam3zw5bb10ylf9mznp83s854f975";
   };
 
   buildInputs = [ cmake perl go ];
@@ -17,8 +18,12 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin $out/include $out/lib
 
-    mv tool/bssl    $out/bin
-    mv ssl/libssl.a $out/lib
+    mv tool/bssl $out/bin
+
+    mv ssl/libssl.a           $out/lib
+    mv crypto/libcrypto.a     $out/lib
+    mv decrepit/libdecrepit.a $out/lib
+
     mv ../include/openssl $out/include
   '';
 

--- a/pkgs/development/libraries/libevent/default.nix
+++ b/pkgs/development/libraries/libevent/default.nix
@@ -1,27 +1,13 @@
 { stdenv, fetchurl, openssl, findutils }:
 
-let version = "2.0.22"; in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "libevent-${version}";
+  version = "2.1.8";
 
   src = fetchurl {
     url = "https://github.com/libevent/libevent/releases/download/release-${version}-stable/libevent-${version}-stable.tar.gz";
-    sha256 = "18qz9qfwrkakmazdlwxvjmw8p76g70n3faikwvdwznns1agw9hki";
+    sha256 = "1hhxnxlr0fsdv7bdmzsnhdz16fxf3jg2r6vyljcl3kj6pflcap4n";
   };
-
-  prePatch = let
-      # https://lwn.net/Vulnerabilities/714581/
-      debian = fetchurl {
-        url = "http://http.debian.net/debian/pool/main/libe/libevent/"
-            + "libevent_2.0.21-stable-3.debian.tar.xz";
-        sha256 = "0b2syswiq3cvfbdvi4lbca15c31lilxnahax4a4b4qxi5fcab7h5";
-      };
-    in ''
-      tar xf '${debian}'
-      patches="$patches $(cat debian/patches/series | grep -v '^$\|^#' \
-                          | grep -v '^20d6d445.patch' \
-                          | grep -v '^dh-autoreconf' | sed 's|^|debian/patches/|')"
-    '';
 
   # libevent_openssl is moved into its own output, so that openssl isn't present
   # in the default closure.

--- a/pkgs/development/libraries/lightstep-tracer-cpp/default.nix
+++ b/pkgs/development/libraries/lightstep-tracer-cpp/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, lib, fetchFromGitHub, pkgconfig, protobuf3_2, automake
+, autoreconfHook, zlib
+, enableGrpc ? false
+}:
+
+let
+  # be sure to use the right revision based on the submodule!
+  common =
+    fetchFromGitHub {
+      owner = "lightstep";
+      repo = "lightstep-tracer-common";
+      rev = "fe1f65f4a221746f9fffe8bf544c81d4e1b8aded";
+      sha256 = "1qqpjxfrjmhnhs15nhbfv28fsgzi57vmfabxlzc99j4vl78h5iln";
+    };
+
+in
+
+stdenv.mkDerivation rec {
+  name = "lightstep-tracer-cpp-${version}";
+  version = "0.36";
+
+  src = fetchFromGitHub {
+    owner = "lightstep";
+    repo = "lightstep-tracer-cpp";
+    rev = "v0_36";
+    sha256 = "1sfj91bn7gw7fga7xawag076c8j9l7kiwhm4x3zh17qhycmaqq16";
+  };
+
+  postUnpack = ''
+    cp -r ${common}/* $sourceRoot/lightstep-tracer-common
+  '';
+
+  preConfigure = lib.optionalString (!enableGrpc) ''
+    configureFlagsArray+=("--disable-grpc")
+  '';
+
+  nativeBuildInputs = [
+    pkgconfig automake autoreconfHook
+  ];
+
+  buildInputs = [
+    protobuf3_2 zlib
+  ];
+
+  meta = with lib; {
+    description = "Distributed tracing system built on top of the OpenTracing standard";
+    homepage = "http://lightstep.com/";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+}

--- a/pkgs/development/libraries/rapidjson/default.nix
+++ b/pkgs/development/libraries/rapidjson/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "rapidjson-${version}";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "miloyip";
+    repo = "rapidjson";
+    rev = "v${version}";
+    sha256 = "1jixgb8w97l9gdh3inihz7avz7i770gy2j2irvvlyrq3wi41f5ab";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  meta = with lib; {
+    description = "Fast JSON parser/generator for C++ with both SAX/DOM style API";
+    homepage = "http://rapidjson.org/";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+}

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -2,14 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "spdlog-${version}";
-  version = stdenv.lib.strings.substring 0 7 rev;
-  rev = "292bdc5eb4929f183c78d2c67082b715306f81c9";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "gabime";
     repo = "spdlog";
-    inherit rev;
-    sha256 = "1b6b0c81a8hisaibqlzj5mrk3snrfl8p5sqa056q2f02i62zksbn";
+    rev = "v${version}";
+    sha256 = "0pfagrkq6afpkl269vbi1fd6ckakzpr5b5cbapb8rr7hgsrilxza";
   };
 
   buildInputs = [ cmake ];

--- a/pkgs/tools/networking/envoy/default.nix
+++ b/pkgs/tools/networking/envoy/default.nix
@@ -1,0 +1,303 @@
+{ stdenv, lib, fetchFromGitHub, pkgconfig, bazel, c-ares, backward-cpp
+, libevent, gtest, gperftools, http-parser, lightstep-tracer-cpp
+, nghttp2, protobuf3_2, tclap, rapidjson, spdlog, boringssl, buildEnv
+}:
+
+let
+  protobuf_bzl =
+    fetchFromGitHub {
+      owner = "htuch";
+      repo = "protobuf";
+      rev = "d490587268931da78c942a6372ef57bb53db80da";
+      sha256 = "100494s66xclw88bdnpb6d386vgw0gwz90sni37q7fqmi9w99z6v";
+    };
+
+  # Based on ci/prebuilt/BUILD
+  #
+  # The paths have been fixed up, and the static archives have been replaced
+  # with dynamic libraries where presently possible.
+  #
+  # At the moment, this doesn't _need_ to be a map that we dynamically create a
+  # BUILD file from (we could instead just include the contents directly);
+  # however, this sets us up to be ready if we (or upstream) decide to split
+  # things into multiple bazel repos, instead of one.
+  ccTargets = {
+    ares = {
+      pkg = c-ares;
+      srcs = ''["lib/libcares.so"]'';
+      hdrs = ''glob(["include/ares*.h"])'';
+      includes = ''["include"]'';
+    };
+
+    backward = {
+      pkg = backward-cpp;
+      hdrs = ''["include/backward.hpp"]'';
+      includes = ''["include"]'';
+    };
+
+    crypto = {
+      pkg = boringssl;
+      srcs = ''["lib/libcrypto.a"]'';
+      hdrs = ''glob(["include/openssl/**/*.h"])'';
+      includes = ''["include"]'';
+    };
+
+    event = {
+      pkg = libevent;
+      srcs = ''["lib/libevent.so"]'';
+      hdrs = ''glob(["include/event2/**/*.h"])'';
+      includes = ''["include"]'';
+    };
+
+    event_pthreads = {
+      pkg = libevent;
+      srcs = ''["lib/libevent_pthreads.so"]'';
+      deps = ''[":event"]'';
+    };
+
+    googletest = {
+      pkg = gtest;
+      srcs = ''[ "lib/libgmock.so", "lib/libgtest.so" ]'';
+      hdrs = ''glob(["include/gmock/**/*.h", "include/gtest/**/*.h"])'';
+      includes = ''["include"]'';
+    };
+
+    http_parser = {
+      pkg = http-parser;
+      srcs = ''["lib/libhttp_parser.so"]'';
+      hdrs = ''glob(["include/http_parser.h"])'';
+      includes = ''["include"]'';
+    };
+
+    lightstep = {
+      pkg = lightstep-tracer-cpp;
+      srcs = ''["lib/liblightstep_core_cxx11.a"]'';
+      hdrs = ''glob([ "include/lightstep/**/*.h", "include/mapbox_variant/**/*.hpp" ]) + [ "include/collector.pb.h", "include/lightstep_carrier.pb.h" ]'';
+      includes = ''["include"]'';
+      deps = ''[":protobuf"]'';
+    };
+
+    nghttp2 = {
+      pkg = nghttp2;
+      srcs = ''["lib/libnghttp2.so"]'';
+      hdrs = ''glob(["include/nghttp2/**/*.h"])'';
+      includes = ''["include"]'';
+    };
+
+    protobuf = {
+      pkg = protobuf3_2;
+      srcs = ''glob(["lib/libproto*.so"])'';
+      hdrs = ''glob(["include/google/protobuf/**/*.h"])'';
+      includes = ''["include"]'';
+    };
+
+    rapidjson = {
+      pkg = rapidjson;
+      hdrs = ''glob(["include/rapidjson/**/*.h"])'';
+      includes = ''["include"]'';
+    };
+
+    spdlog = {
+      pkg = spdlog;
+      name = "spdlog";
+      hdrs = ''glob([ "include/spdlog/**/*.cc", "include/spdlog/**/*.h" ])'';
+      includes = ''["include"]'';
+    };
+
+    ssl = {
+      pkg = boringssl;
+      srcs = ''["lib/libssl.a"]'';
+      deps = ''[":crypto"]'';
+    };
+
+    tclap = {
+      pkg = tclap;
+      hdrs = ''glob(["include/tclap/**/*.h"])'';
+      includes = ''["include"]'';
+    };
+
+    tcmalloc_and_profiler = {
+      pkg = gperftools;
+      srcs = ''["lib/libtcmalloc_and_profiler.so"]'';
+      hdrs = ''glob(["include/gperftools/**/*.h"])'';
+      strip_include_prefix = ''"include"'';
+    };
+  };
+
+  # Generate the BUILD file.
+  buildFile =
+    let field = name: attrs:
+      if attrs ? "${name}" then "    ${name} = ${attrs.${name}},\n" else "";
+    in
+    ''
+    licenses(["notice"])  # Apache 2
+
+    package(default_visibility = ["//visibility:public"])
+
+    '' +
+    lib.concatStringsSep "\n\n" (
+      lib.mapAttrsToList (name: value:
+          "cc_library(\n"
+        + "    name = \"${name}\",\n"
+        + field "srcs" value
+        + field "hdrs" value
+        + field "deps" value
+        + field "includes" value
+        + field "strip_include_prefix" value
+        + ")"
+      ) ccTargets
+    ) + ''
+
+    filegroup(
+        name = "protoc",
+        srcs = ["bin/protoc"],
+    )
+    '';
+
+  workspaceFile = 
+    ''
+    workspace(name = "nix")
+
+    load("//bazel:repositories.bzl", "envoy_dependencies")
+    load("//bazel:cc_configure.bzl", "cc_configure")
+
+    new_local_repository(
+        name = "nix_envoy_deps",
+        path = "${repoEnv}",
+        build_file = "nix_envoy_deps.BUILD"
+    )
+
+    envoy_dependencies(
+        path = "@nix_envoy_deps//",
+        skip_protobuf_bzl = True,
+    )
+
+    new_local_repository(
+        name = "protobuf_bzl",
+        path = "${protobuf_bzl}",
+        # We only want protobuf.bzl, so don't support building out of this repo.
+        build_file_content = "",
+    )
+
+    cc_configure()
+    '';
+
+  # The tree we'll use for our new_local_repository in our generated WORKSPACE.
+  repoEnv = buildEnv {
+    name = "repo-env";
+    paths = lib.concatMap (p:
+      lib.unique [(lib.getBin p) (lib.getLib p) (lib.getDev p)]
+    ) allDeps;
+  };
+
+  rpath = stdenv.lib.makeLibraryPath (allDeps ++ [ stdenv.cc.cc ]);
+
+  allDeps = [
+    c-ares
+    backward-cpp
+    libevent
+    gtest
+    gperftools
+    http-parser
+    lightstep-tracer-cpp
+    nghttp2
+    protobuf3_2
+    tclap
+    rapidjson
+    spdlog
+    boringssl
+  ];
+
+  # Envoy checks at runtime that the git sha is valid,
+  # so we really can't avoid putting some sort of sha here.
+  rev = "3afc7712a04907ffd25ed497626639febfe65735";
+
+in
+
+stdenv.mkDerivation rec {
+  name = "envoy-${version}";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "lyft";
+    repo = "envoy";
+    rev = "v${version}";
+    sha256 = "0j1c9lyvncyhiq3kyhx91ckcjd2h68x56js7xb6ni6bzxinv6zb6";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig bazel
+  ];
+
+  buildInputs = allDeps;
+
+  patches = [ ./nixos.patch ];
+
+  hardeningDisable = "all";
+  dontPatchELF = true;
+  dontStrip = true;
+
+  # set up our workspace,
+  # and prevent an error where bazel/get_workspace_status tries to determine the
+  # version by invoking git.
+  postUnpack = ''
+    cat <<'EOF' > $sourceRoot/WORKSPACE
+    ${workspaceFile}
+    EOF
+
+    cat <<'EOF' > $sourceRoot/nix_envoy_deps.BUILD
+    ${buildFile}
+    EOF
+
+    cat <<'EOF' > $sourceRoot/bazel/get_workspace_status
+    #!${stdenv.shell}
+    echo "BUILD_SCM_REVISION ${rev}"
+    echo "BUILD_SCM_STATUS Modified"
+    EOF
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir .home
+    export HOME=$PWD/.home
+
+    BAZEL_OPTIONS="--package_path %workspace%:$PWD"
+    BAZEL_BUILD_OPTIONS="\
+      --strategy=Genrule=standalone \
+      --spawn_strategy=standalone \
+      --verbose_failures \
+      $BAZEL_OPTIONS \
+      --action_env=HOME \
+      --action_env=PYTHONUSERBASE \
+      --show_task_finish"
+
+    bazel \
+      --batch \
+      build \
+      -s --verbose_failures \
+      --experimental_ui \
+      $BAZEL_BUILD_OPTIONS \
+      -c opt \
+      //source/exe:envoy-static
+
+    exe=bazel-bin/source/exe/envoy-static
+    chmod +w $exe
+    patchelf --set-rpath ${rpath} $exe
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv $exe $out/bin/envoy
+  '';
+
+  meta = with lib; {
+    description = "L7 proxy and communication bus designed for large modern service oriented architectures";
+    homepage = "https://lyft.github.io/envoy/";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+}

--- a/pkgs/tools/networking/envoy/nixos.patch
+++ b/pkgs/tools/networking/envoy/nixos.patch
@@ -1,0 +1,41 @@
+diff --git a/bazel/cc_configure.bzl b/bazel/cc_configure.bzl
+index 8a7a69c4f..75526520c 100644
+--- a/bazel/cc_configure.bzl
++++ b/bazel/cc_configure.bzl
+@@ -292,6 +292,8 @@ def _crosstool_content(repository_ctx, cc, cpu_value, darwin):
+           "-fstack-protector",
+           # All warnings are enabled. Maybe enable -Werror as well?
+           "-Wall",
++
++          "-Wno-error=strict-aliasing"
+           # Enable a few more warnings that aren't part of -Wall.
+       ] + (["-Wthread-safety", "-Wself-assign"] if darwin else [
+           "-B" + str(repository_ctx.path(cc).dirname),
+@@ -365,10 +367,6 @@ def _opt_content(darwin):
+           # Profile first and / or use FDO if you need better performance than this.
+           "-O2",
+ 
+-          # Security hardening on by default.
+-          # Conservative choice; -D_FORTIFY_SOURCE=2 may be unsafe in some cases.
+-          "-D_FORTIFY_SOURCE=1",
+-
+           # Disable assertions
+           "-DNDEBUG",
+ 
+diff --git a/bazel/envoy_build_system.bzl b/bazel/envoy_build_system.bzl
+index f17671035..7938047bd 100644
+--- a/bazel/envoy_build_system.bzl
++++ b/bazel/envoy_build_system.bzl
+@@ -131,11 +131,9 @@ def envoy_cc_binary(name,
+             # --build-id and avoid doing the following.
+             '-Wl,--build-id=md5',
+             '-Wl,--hash-style=gnu',
+-            "-static-libstdc++",
+-            "-static-libgcc",
+         ],
+         testonly = testonly,
+-        linkstatic = 1,
++        linkstatic = 0,
+         visibility = visibility,
+         malloc = tcmalloc_external_dep(repository),
+         # See above comment on MD5 hash, this is another "force MD5 stamps" to make sure our

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9381,6 +9381,8 @@ with pkgs;
 
   lightlocker = callPackage ../misc/screensavers/light-locker { };
 
+  lightstep-tracer-cpp = callPackage ../development/libraries/lightstep-tracer-cpp { };
+
   linenoise = callPackage ../development/libraries/linenoise { };
 
   linenoise-ng = callPackage ../development/libraries/linenoise-ng { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7469,6 +7469,8 @@ with pkgs;
 
   babl = callPackage ../development/libraries/babl { };
 
+  backward-cpp = callPackage ../development/libraries/backward-cpp { };
+
   bctoolbox = callPackage ../development/libraries/bctoolbox {
     mbedtls = mbedtls_1_3;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1816,6 +1816,8 @@ with pkgs;
 
   entr = callPackage ../tools/misc/entr { };
 
+  envoy = callPackage ../tools/networking/envoy { };
+
   eot_utilities = callPackage ../tools/misc/eot-utilities { };
 
   eplot = callPackage ../tools/graphics/eplot { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10065,6 +10065,8 @@ with pkgs;
 
   rabbitmq-java-client = callPackage ../development/libraries/rabbitmq-java-client {};
 
+  rapidjson = callPackage ../development/libraries/rapidjson {};
+
   raul = callPackage ../development/libraries/audio/raul { };
 
   readline = readline6;


### PR DESCRIPTION
###### Motivation for this change

I'm using Envoy at work.

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I don't know if the `libevent` bump breaks anything, or possibly causes a mass rebuild.

Requisite package updates (and additions) have been split into separate commits.