### PR TITLE
cdemu: 3.0.x -> 3.1.0

### DIFF
--- a/pkgs/misc/emulators/cdemu/analyzer.nix
+++ b/pkgs/misc/emulators/cdemu/analyzer.nix
@@ -1,8 +1,8 @@
 { callPackage, gtk3, glib, libxml2, gnuplot, makeWrapper, stdenv, gnome3, gdk_pixbuf, librsvg, intltool }:
 let pkg = import ./base.nix {
-  version = "3.0.1";
+  version = "3.1.0";
   pkgName = "image-analyzer";
-  pkgSha256 = "19x5hx991pl55ddm2wjd2ylm2hiz9yvzgrwmpnsqr9zqc4lja682";
+  pkgSha256 = "1pr23kxx83xp83h27fkdv86f3bxclkx056f9jx8jhnpn113xp7r2";
 };
 in callPackage pkg {
   buildInputs = [ glib gtk3 libxml2 gnuplot (callPackage ./libmirage.nix {}) makeWrapper

--- a/pkgs/misc/emulators/cdemu/client.nix
+++ b/pkgs/misc/emulators/cdemu/client.nix
@@ -1,11 +1,12 @@
 { callPackage, pythonPackages, intltool, makeWrapper }:
 let pkg = import ./base.nix {
-  version = "3.0.3";
+  version = "3.1.0";
   pkgName = "cdemu-client";
-  pkgSha256 = "1bfj7bc10z20isdg0h8sfdvnwbn6c49494mrmq6jwrfbqvby25x9";
+  pkgSha256 = "0s6q923g5vkahw5fki6c7a25f68y78zfx4pfsy0xww0z1f5hfsik";
 };
 in callPackage pkg {
-  buildInputs = [ pythonPackages.python pythonPackages.dbus-python intltool makeWrapper ];
+  buildInputs = [ pythonPackages.python pythonPackages.dbus-python pythonPackages.pygobject3
+                  intltool makeWrapper ];
   drvParams = {
     postFixup = ''
       wrapProgram $out/bin/cdemu \

--- a/pkgs/misc/emulators/cdemu/daemon.nix
+++ b/pkgs/misc/emulators/cdemu/daemon.nix
@@ -1,9 +1,9 @@
-{ callPackage, glib, libao }:
+{ callPackage, glib, libao, intltool }:
 let pkg = import ./base.nix {
-  version = "3.0.5";
+  version = "3.1.0";
   pkgName = "cdemu-daemon";
-  pkgSha256 = "1cc0yxf1y5dxinv7md1cqhdjsbqb69v9jygrdq5c20mrkqaajz1i";
+  pkgSha256 = "0kxwhwjvcr40sjlrvln9gasjwkkfc3wxpcz0rxmffp92w8phz3s9";
 };
 in callPackage pkg {
-  buildInputs = [ glib libao (callPackage ./libmirage.nix {}) ];
+  buildInputs = [ glib libao (callPackage ./libmirage.nix {}) intltool ];
 }

--- a/pkgs/misc/emulators/cdemu/gui.nix
+++ b/pkgs/misc/emulators/cdemu/gui.nix
@@ -1,9 +1,9 @@
 { callPackage, pythonPackages, gtk3, glib, libnotify, intltool, makeWrapper, gobjectIntrospection, gnome3, gdk_pixbuf, librsvg }:
 let
   pkg = import ./base.nix {
-    version = "3.0.2";
+    version = "3.1.0";
     pkgName = "gcdemu";
-    pkgSha256 = "1kmcr2a0inaddx8wrjh3l1v5ymgwv3r6nv2w05lia51r1yzvb44p";
+    pkgSha256 = "0rmnw302fk9vli22v54qx19lqxy23syxi154klxz2vma009q0p02";
   };
   inherit (pythonPackages) python pygobject3;
 in callPackage pkg {

--- a/pkgs/misc/emulators/cdemu/libmirage.nix
+++ b/pkgs/misc/emulators/cdemu/libmirage.nix
@@ -1,9 +1,9 @@
-{ callPackage, glib, libsndfile, zlib, bzip2, lzma, libsamplerate }:
+{ callPackage, glib, libsndfile, zlib, bzip2, lzma, libsamplerate, intltool }:
 let pkg = import ./base.nix {
-  version = "3.0.5";
+  version = "3.1.0";
   pkgName = "libmirage";
-  pkgSha256 = "01wfxlyviank7k3p27grl1r40rzm744rr80zr9lcjk3y8i5g8ni2";
+  pkgSha256 = "0qvkvnvxqx8hqzcqzh7sqjzgbc1nrd91lzv33lr8c6fgaq8cqzmn";
 };
 in callPackage pkg {
-  buildInputs = [ glib libsndfile zlib bzip2 lzma libsamplerate ];
+  buildInputs = [ glib libsndfile zlib bzip2 lzma libsamplerate intltool ];
 }

--- a/pkgs/misc/emulators/cdemu/vhba.nix
+++ b/pkgs/misc/emulators/cdemu/vhba.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "vhba-${version}";
-  version = "20161009";
+  version = "20170610";
 
   src  = fetchurl {
     url = "mirror://sourceforge/cdemu/vhba-module-${version}.tar.bz2";
-    sha256 = "1n9k3z8hppnl5b5vrn41b69wqwdpml6pm0rgc8vq3jqwss5js1nd";
+    sha256 = "1v6r0bgx0a65vlh36b1l2965xybngbpga6rp54k4z74xk0zwjw3r";
   };
 
   makeFlags = [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" "INSTALL_MOD_PATH=$(out)" ];


### PR DESCRIPTION
fixes cdemu for kernel >= 4.11
fixes client by adding pygobject3

###### Motivation for this change

regular maintenance, fixes

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

