### PR TITLE
pypy: 5.6 -> 5.8

### DIFF
--- a/pkgs/development/interpreters/python/pypy/2.7/2604-skip-urandom-fd-test.patch
+++ b/pkgs/development/interpreters/python/pypy/2.7/2604-skip-urandom-fd-test.patch
@@ -1,0 +1,21 @@
+# HG changeset patch
+# User Armin Rigo <arigo@tunes.org>
+# Date 1500108588 -7200
+# Node ID 20f7723ff895430c2f45647e7d0c0ca56d93e40a
+# Parent  d135217574a6bd2e87a883e1d495f82c5e89bc8b
+(ronan, arigo)
+
+Issue #2604: skip this test (fails on some Linux because pypy uses the
+new getrandom() syscall)
+
+diff --git a/lib-python/2.7/test/test_os.py b/lib-python/2.7/test/test_os.py
+--- a/lib-python/2.7/test/test_os.py
++++ b/lib-python/2.7/test/test_os.py
+@@ -580,6 +580,7 @@
+                  "getentropy() does not use a file descriptor")
+ class URandomFDTests(unittest.TestCase):
+     @unittest.skipUnless(resource, "test requires the resource module")
++    @test_support.impl_detail(pypy=False)    # on Linux, may use getrandom()
+     def test_urandom_failure(self):
+         # Check urandom() failing when it is not able to open /dev/random.
+         # We spawn a new process to make the test more robust (if getrlimit()

--- a/pkgs/development/interpreters/python/pypy/2.7/default.nix
+++ b/pkgs/development/interpreters/python/pypy/2.7/default.nix
@@ -3,13 +3,13 @@
 , makeWrapper, callPackage, self, gdbm, db
 , python-setup-hook
 # For the Python package set
-, pkgs, packageOverrides ? (self: super: {})
+, pkgs, pythonPackages, packageOverrides ? (self: super: {})
 }:
 
 assert zlibSupport -> zlib != null;
 
 let
-  majorVersion = "5.6";
+  majorVersion = "5.8";
   minorVersion = "0";
   minorVersionSuffix = "";
   pythonVersion = "2.7";
@@ -23,22 +23,20 @@ in stdenv.mkDerivation rec {
 
     src = fetchurl {
       url = "https://bitbucket.org/pypy/pypy/get/release-pypy${pythonVersion}-v${version}.tar.bz2";
-      sha256 = "145a0kd5c0s1v2rpavw9ihncfb05s2x7chc70v8fssvyxq601911";
+      sha256 = "0dibf1bx4icrbi8zsqk7cfwgwsd3hfx6biz59k8j5rys3fx9z418";
     };
 
-   # http://bugs.python.org/issue27369
-    postPatch = let
-      expatch = fetchurl {
-        name = "tests-expat-2.2.0.patch";
-        url = "http://bugs.python.org/file43514/0001-Fix-Python-2.7.11-tests-for-Expat-2.2.0.patch";
-        sha256 = "1j3pa7ly9xrhp8jjwg5l77z7i3y68gx8f8jchqk6zc39d9glq3il";
-      };
-      in ''
-      patch lib-python/2.7/test/test_pyexpat.py < '${expatch}'
+    patches = [
+      # https://bitbucket.org/pypy/pypy/issues/2604/lib-python-27-test-test_ospy
+      ./2604-skip-urandom-fd-test.patch
+    ];
+
+    postPatch = ''
       substituteInPlace "lib-python/2.7/lib-tk/Tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
     '';
 
     buildInputs = [ bzip2 openssl pkgconfig python libffi ncurses expat sqlite tk tcl xlibsWrapper libX11 makeWrapper gdbm db ]
+      ++ (with pythonPackages; [ pycparser ])
       ++ stdenv.lib.optional (stdenv ? cc && stdenv.cc.libc != null) stdenv.cc.libc
       ++ stdenv.lib.optional zlibSupport zlib;
 
@@ -92,8 +90,7 @@ in stdenv.mkDerivation rec {
        # disable test_urllib2net, test_urllib2_localnet, and test_urllibnet because they require networking (example.com)
        # disable test_ssl because no shared cipher' not found in '[Errno 1] error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure
        # disable test_zipfile64 because it causes ENOSPACE
-       # disable test_epoll because of invalid arg, should be fixed in as of version 5.1.2
-      ./pypy-c ./pypy/test_all.py --pypy=./pypy-c -k 'not ( test_ssl or test_urllib2net or test_urllibnet or test_urllib2_localnet or test_socket or test_shutil or test_zipfile64 or test_epoll )' lib-python
+      ./pypy-c ./pypy/test_all.py --pypy=./pypy-c -k 'not ( test_ssl or test_urllib2net or test_urllibnet or test_urllib2_localnet or test_socket or test_shutil or test_zipfile64 )' lib-python
     '';
 
     installPhase = ''
@@ -140,7 +137,7 @@ in stdenv.mkDerivation rec {
 
     meta = with stdenv.lib; {
       homepage = http://pypy.org/;
-      description = "Fast, compliant alternative implementation of the Python language (2.7.8)";
+      description = "Fast, compliant alternative implementation of the Python language (2.7.13)";
       license = licenses.mit;
       platforms = platforms.linux;
       maintainers = with maintainers; [ domenkozar ];


### PR DESCRIPTION
this commit includes a patch, backported from master, to skip a
failing test

###### Motivation for this change

maintenance

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

