### PR TITLE
firejail: 0.9.44.10 -> 0.9.48

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -3,11 +3,11 @@ let
   s = # Generated upstream information
   rec {
     baseName="firejail";
-    version="0.9.44.10";
+    version="0.9.48";
     name="${baseName}-${version}";
-    hash="19wln3h54wcscqgcmkm8sprdh7vrn5k91rr0hagv055y1i52c7mj";
-    url="https://netix.dl.sourceforge.net/project/firejail/firejail/firejail-0.9.44.10.tar.xz";
-    sha256="19wln3h54wcscqgcmkm8sprdh7vrn5k91rr0hagv055y1i52c7mj";
+    hash="02a74nx8p2gbpd6ffnr52p02pxxllw3yy5fy4083a77r3wia8zb3";
+    url="https://vorboss.dl.sourceforge.net/project/firejail/firejail/firejail-0.9.48.tar.xz";
+    sha256="02a74nx8p2gbpd6ffnr52p02pxxllw3yy5fy4083a77r3wia8zb3";
   };
   buildInputs = [
     which
@@ -20,6 +20,13 @@ stdenv.mkDerivation {
     inherit (s) url sha256;
     name = "${s.name}.tar.bz2";
   };
+
+  prePatch = ''
+    # Allow whitelisting ~/.nix-profile
+    substituteInPlace etc/firejail.config --replace \
+      '# follow-symlink-as-user yes' \
+      'follow-symlink-as-user no'
+  '';
 
   preConfigure = ''
     sed -e 's@/bin/bash@${stdenv.shell}@g' -i $( grep -lr /bin/bash .)


### PR DESCRIPTION
###### Motivation for this change

Update and fix #24542 and netblue30/firejail#1098: When a Firejail profile uses a whitelist it is necessary to whitelist `~/.nix-profile` as well. However because `~/.nix-profile` is a symlink to the Nix store which is owned by root, by default Firejail does not read it. In Firejail version 0.9.46 the option `follow-symlink-as-user` was introduced to address this problem.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @lheckemann @tilpner @tex @r-raymond @7c6f434c
