### PR TITLE
lib/string: added parseDomain and parseEmail

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -87,6 +87,40 @@ runTests {
     expected = [ "2001" "db8" "0" "0042" "" "8a2e" "370" "" ];
   };
 
+  testParseDomain = {
+    expr = map strings.parseDomain [
+      "nixos.org" "foo.bar.baz" "foo" ""
+      "...." "foo..bar" "foo." ".foo"
+    ];
+    expected = [
+      { components = ["nixos" "org"]; }
+      { components = ["foo" "bar" "baz"]; }
+      { components = ["foo"]; }
+      { components = []; }
+      null null null null
+    ];
+  };
+
+  testParseEmail = {
+    expr = map strings.parseEmail [
+      "hydra@nixos.org"
+      "hydra(comment)@nixos.org"
+      "\"quoted\"@nixos.org"
+      ""
+      "invalid"
+      "invalid@"
+      ".invalid@nixos.org"
+      "invalid.@nixos.org"
+      "invalid@garbage@nixos.org"
+    ];
+    expected = [
+      { localPart = "hydra";          domain = "nixos.org"; }
+      { localPart = "hydra(comment)"; domain = "nixos.org"; }
+      { localPart = "\"quoted\"";     domain = "nixos.org"; }
+      null null null null null null
+    ];
+  };
+
   testIsStorePath =  {
     expr =
       let goodPath =


### PR DESCRIPTION
###### Motivation for this change

This adds two functions to `lib.strings`: `parseDomain` and `parseEmail`, which parse domains and emails under RFC 1035 and RFC 5322 respectively (the email parser accepts a superset of what is allowed under RFC 5322, but the domain parser should be tight).

I found myself in need of functions to parse domains and emails, so I thought I would upstream what I wrote.

###### Things done

- Tested on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Definition has associated documentation.
- [x] Implemented unit tests in `lib/tests/misc.nix`.
- [x] Successfully ran `nix-build lib/tests/release.nix`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

