### PR TITLE
nixos/tinc: remove restartTriggers

### DIFF
--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -164,8 +164,6 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
         path = [ data.package ];
-        restartTriggers = [ config.environment.etc."tinc/${network}/tinc.conf".source ]
-          ++ mapAttrsToList (host: _ : config.environment.etc."tinc/${network}/hosts/${host}".source) data.hosts;
         serviceConfig = {
           Type = "simple";
           PIDFile = "/run/tinc.${network}.pid";


### PR DESCRIPTION
###### Motivation for this change

```restartTriggers``` pointed to the constant files in ```/nix/store/``` and had to effect.
