### PR TITLE
aws-auth: init at unstable-2017-07-24

### DIFF
--- a/pkgs/tools/admin/aws-auth/default.nix
+++ b/pkgs/tools/admin/aws-auth/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, makeWrapper, jq, awscli }:
+
+stdenv.mkDerivation rec {
+  version = "unstable-2017-07-24";
+  name = "aws-auth-${version}";
+
+  src = fetchFromGitHub {
+    owner = "alphagov";
+    repo = "aws-auth";
+    rev = "5a4c9673f9f00ebaa4bb538827e1c2f277c475e1";
+    sha256 = "095j9zqxra8hi2iyz0y4azs9yigy5f6alqkfmv180pm75nbc031g";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  # copy script and set $PATH
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/aws-auth.sh $out/bin/aws-auth
+    wrapProgram $out/bin/aws-auth --prefix PATH : ${awscli}/bin:${jq}/bin
+  '';
+
+  meta = {
+    homepage = https://github.com/alphagov/aws-auth;
+    description = "AWS authentication wrapper to handle MFA and IAM roles";
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ ris ];
+  };
+}

--- a/pkgs/tools/admin/aws-auth/default.nix
+++ b/pkgs/tools/admin/aws-auth/default.nix
@@ -11,15 +11,15 @@ stdenv.mkDerivation rec {
     sha256 = "095j9zqxra8hi2iyz0y4azs9yigy5f6alqkfmv180pm75nbc031g";
   };
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
-  phases = [ "installPhase" ];
+  dontBuild = true;
 
   # copy script and set $PATH
   installPhase = ''
-    mkdir -p $out/bin
-    cp $src/aws-auth.sh $out/bin/aws-auth
-    wrapProgram $out/bin/aws-auth --prefix PATH : ${awscli}/bin:${jq}/bin
+    install -D $src/aws-auth.sh $out/bin/aws-auth
+    wrapProgram $out/bin/aws-auth \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ awscli jq ]}
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -511,6 +511,8 @@ with pkgs;
 
   awless = callPackage ../tools/virtualization/awless { };
 
+  aws-auth = callPackage ../tools/admin/aws-auth { };
+
   ec2_api_tools = callPackage ../tools/virtualization/ec2-api-tools { };
 
   ec2_ami_tools = callPackage ../tools/virtualization/ec2-ami-tools { };


### PR DESCRIPTION
###### Motivation for this change

Add new package for `aws-auth` script.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

