### PR TITLE
citrix-receiver: 13.4.0 -> 13.6.0

### DIFF
--- a/pkgs/applications/networking/remote/citrix-receiver/default.nix
+++ b/pkgs/applications/networking/remote/citrix-receiver/default.nix
@@ -20,9 +20,11 @@
 , fontconfig
 , gtk_engines
 , alsaLib
+, libidn
+, zlib
 }:
 
-let versionRec = { major = "13"; minor = "4"; patch = "0"; };
+let versionRec = { major = "13"; minor = "6"; patch = "0"; };
 in stdenv.mkDerivation rec {
   name = "citrix-receiver-${version}";
   version = with versionRec; "${major}.${minor}.${patch}";
@@ -31,11 +33,11 @@ in stdenv.mkDerivation rec {
   prefixWithBitness = if stdenv.is64bit then "linuxx64" else "linuxx86";
 
   src = with versionRec; requireFile rec {
-    name = "${prefixWithBitness}-${version}.10109380.tar.gz";
+    name = "${prefixWithBitness}-${version}.10243651.tar.gz";
     sha256 =
       if stdenv.is64bit
-      then "133brs0sq6d0mgr19rc6ig1n9ahm3ryi23v5nrgqfh0hgxqcrrjb"
-      else "0r7jfl5yqv1s2npy8l9gsn0gbb82f6raa092ppkc8xy5pni5sh7l";
+      then "6e423be41d5bb8186bcca3fbb4ede54dc3f00b8d2aeb216ae4aabffef9310d34"
+      else "0ba3eba208b37844904d540b3011075ed5cecf429a0ab6c6cd52f2d0fd841ad2";
     message = ''
       In order to use Citrix Receiver, you need to comply with the Citrix EULA and download
       the ${if stdenv.is64bit then "64-bit" else "32-bit"} binaries, .tar.gz from:
@@ -83,6 +85,8 @@ in stdenv.mkDerivation rec {
     freetype
     fontconfig
     alsaLib
+    libidn
+    zlib
     stdenv.cc.cc # Fixes: Can not load [..]/opt/citrix-icaclient/lib/ctxh264_fb.so:(null)
   ];
 


### PR DESCRIPTION
###### Motivation for this change
New Citrix receiver release. Fixed the no keyboard bug introduced in 13.5.0.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

