### PR TITLE
jailbreak-cabal: specifically use ghc802 override in ghc821 config

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -248,7 +248,7 @@
   jammerful = "jammerful <jammerful@gmail.com>";
   jansol = "Jan Solanti <jan.solanti@paivola.fi>";
   javaguirre = "Javier Aguirre <contacto@javaguirre.net>";
-  jb55 = "William Casarin <bill@casarin.me>";
+  jb55 = "William Casarin <jb55@jb55.com>";
   jbedo = "Justin Bedő <cu@cua0.org>";
   jcumming = "Jack Cummings <jack@mudshark.org>";
   jdagilliland = "Jason Gilliland <jdagilliland@gmail.com>";

--- a/pkgs/development/haskell-modules/configuration-ghc-8.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.2.x.nix
@@ -40,7 +40,7 @@ self: super: {
   cabal-install = super.cabal-install.override { Cabal = null; };
 
   # jailbreak-cabal doesn't seem to work right with the native Cabal version.
-  jailbreak-cabal = pkgs.haskellPackages.jailbreak-cabal;
+  jailbreak-cabal = pkgs.haskell.packages.ghc802.jailbreak-cabal;
 
   # https://github.com/bmillwood/applicative-quoters/issues/6
   applicative-quoters = appendPatch super.applicative-quoters (pkgs.fetchpatch {


### PR DESCRIPTION
###### Motivation for this change

Otherwise this will infinite loop when:
    
    pkgs.haskellPackages = pkgs.haskell.packages.ghc821

/cc @peti 
