### PR TITLE
cc-wrapper: Hygiene and `set -u`

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -1,37 +1,37 @@
 # `-B@out@/bin' forces cc to use ld-wrapper.sh when calling ld.
-export NIX_CFLAGS_COMPILE="-B@out@/bin/ $NIX_CFLAGS_COMPILE"
+export NIX_@infixSalt@_CFLAGS_COMPILE="-B@out@/bin/ $NIX_@infixSalt@_CFLAGS_COMPILE"
 
 # Export and assign separately in order that a failing $(..) will fail
 # the script.
 
 if [ -e @out@/nix-support/libc-cflags ]; then
-    export NIX_CFLAGS_COMPILE
-    NIX_CFLAGS_COMPILE="$(< @out@/nix-support/libc-cflags) $NIX_CFLAGS_COMPILE"
+    export NIX_@infixSalt@_CFLAGS_COMPILE
+    NIX_@infixSalt@_CFLAGS_COMPILE="$(< @out@/nix-support/libc-cflags) $NIX_@infixSalt@_CFLAGS_COMPILE"
 fi
 
 if [ -e @out@/nix-support/cc-cflags ]; then
-    export NIX_CFLAGS_COMPILE
-    NIX_CFLAGS_COMPILE="$(< @out@/nix-support/cc-cflags) $NIX_CFLAGS_COMPILE"
+    export NIX_@infixSalt@_CFLAGS_COMPILE
+    NIX_@infixSalt@_CFLAGS_COMPILE="$(< @out@/nix-support/cc-cflags) $NIX_@infixSalt@_CFLAGS_COMPILE"
 fi
 
 if [ -e @out@/nix-support/gnat-cflags ]; then
-    export NIX_GNATFLAGS_COMPILE
-    NIX_GNATFLAGS_COMPILE="$(< @out@/nix-support/gnat-cflags) $NIX_GNATFLAGS_COMPILE"
+    export NIX_@infixSalt@_GNATFLAGS_COMPILE
+    NIX_@infixSalt@_GNATFLAGS_COMPILE="$(< @out@/nix-support/gnat-cflags) $NIX_@infixSalt@_GNATFLAGS_COMPILE"
 fi
 
 if [ -e @out@/nix-support/libc-ldflags ]; then
-    export NIX_LDFLAGS
-    NIX_LDFLAGS+=" $(< @out@/nix-support/libc-ldflags)"
+    export NIX_@infixSalt@_LDFLAGS
+    NIX_@infixSalt@_LDFLAGS+=" $(< @out@/nix-support/libc-ldflags)"
 fi
 
 if [ -e @out@/nix-support/cc-ldflags ]; then
-    export NIX_LDFLAGS
-    NIX_LDFLAGS+=" $(< @out@/nix-support/cc-ldflags)"
+    export NIX_@infixSalt@_LDFLAGS
+    NIX_@infixSalt@_LDFLAGS+=" $(< @out@/nix-support/cc-ldflags)"
 fi
 
 if [ -e @out@/nix-support/libc-ldflags-before ]; then
-    export NIX_LDFLAGS_BEFORE
-    NIX_LDFLAGS_BEFORE="$(< @out@/nix-support/libc-ldflags-before) $NIX_LDFLAGS_BEFORE"
+    export NIX_@infixSalt@_LDFLAGS_BEFORE
+    NIX_@infixSalt@_LDFLAGS_BEFORE="$(< @out@/nix-support/libc-ldflags-before) $NIX_@infixSalt@_LDFLAGS_BEFORE"
 fi
 
-export NIX_CC_WRAPPER_FLAGS_SET=1
+export NIX_CC_WRAPPER_@infixSalt@_FLAGS_SET=1

--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -1,3 +1,77 @@
+# N.B. It may be a surprise that the derivation-specific variables are exported,
+# since this is just sourced by the wrapped binaries---the end consumers. This
+# is because one wrapper binary may invoke another (e.g. cc invoking ld). In
+# that case, it is cheaper/better to not repeat this step and let the forked
+# wrapped binary just inherit the work of the forker's wrapper script.
+
+# Accumulate prefixes for taking in the right input parameters. See setup-hook
+# for details.
+declare -a role_prefixes=()
+if [[ -n "${NIX_CC_WRAPPER_@infixSalt@_TARGET_BUILD:-}" ]]; then
+    role_prefixes+=(_BUILD)
+fi
+if [[ -n "${NIX_CC_WRAPPER_@infixSalt@_TARGET_HOST:-}" ]]; then
+    role_prefixes+=('')
+fi
+if [[ -n "${NIX_CC_WRAPPER_@infixSalt@_TARGET_TARGET:-}" ]]; then
+    role_prefixes+=(_TARGET)
+fi
+
+# For each role we serve, we accumulate the input parameters into our own
+# cc-wrapper-derivation-specific environment variables.
+for pre in "${role_prefixes[@]}"; do
+    # We need to mangle names for hygiene, but also take parameters/overrides
+    # from the environment.
+    slurpUnsalted () {
+        case "$1" in
+            CC_WRAPPER_*)
+                local firstPre=NIX_CC_WRAPPER_
+                local varname="${1#CC_WRAPPER_}"
+                ;;
+            LD_WRAPPER_*)
+                local firstPre=NIX_LD_WRAPPER_
+                local varname="${1#LD_WRAPPER_}"
+                ;;
+            *)
+                local firstPre=NIX_
+                local varname="$1"
+                ;;
+        esac
+        local inputVar="${firstPre}${pre}${varname}"
+        local outputVar="${firstPre}@infixSalt@_${varname}"
+        local delimiter=''
+        if [[ -n "${!outputVar:-}" && -n "${!inputVar:-}" ]]; then
+            delimiter=' '
+        fi
+        # Easiest to just do this to deal with either the input or (old) output.
+        set +u
+        export ${outputVar}+="${delimiter}${!inputVar}"
+        set -u
+    }
+
+    slurpUnsalted CC_WRAPPER_START_HOOK
+    slurpUnsalted CC_WRAPPER_EXEC_HOOK
+    slurpUnsalted LD_WRAPPER_START_HOOK
+    slurpUnsalted LD_WRAPPER_EXEC_HOOK
+
+    slurpUnsalted CFLAGS_COMPILE
+    slurpUnsalted CFLAGS_LINK
+    slurpUnsalted CXXSTDLIB_COMPILE
+    slurpUnsalted CXXSTDLIB_LINK
+    slurpUnsalted DONT_SET_RPATH
+    slurpUnsalted GNATFLAGS_COMPILE
+    slurpUnsalted IGNORE_LD_THROUGH_GCC
+    slurpUnsalted LDFLAGS
+    slurpUnsalted LDFLAGS_BEFORE
+    slurpUnsalted LDFLAGS_AFTER
+    slurpUnsalted LDFLAGS_HARDEN
+
+    slurpUnsalted SET_BUILD_ID
+    slurpUnsalted DONT_SET_RPATH
+    slurpUnsalted ENFORCE_NO_NATIVE
+done
+unset -f slurpUnsalted
+
 # `-B@out@/bin' forces cc to use ld-wrapper.sh when calling ld.
 export NIX_@infixSalt@_CFLAGS_COMPILE="-B@out@/bin/ $NIX_@infixSalt@_CFLAGS_COMPILE"
 
@@ -34,4 +108,5 @@ if [ -e @out@/nix-support/libc-ldflags-before ]; then
     NIX_@infixSalt@_LDFLAGS_BEFORE="$(< @out@/nix-support/libc-ldflags-before) $NIX_@infixSalt@_LDFLAGS_BEFORE"
 fi
 
+# That way forked processes don't againt extend these environment variables
 export NIX_CC_WRAPPER_@infixSalt@_FLAGS_SET=1

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -1,67 +1,69 @@
 hardeningFlags=(fortify stackprotector pic strictoverflow format relro bindnow)
-# Intentionally word-split in case 'hardeningEnable' is defined in Nix.
-hardeningFlags+=(${hardeningEnable[@]})
+# Intentionally word-split in case 'hardeningEnable' is defined in
+# Nix. Also, our bootstrap tools version of bash is old enough that
+# undefined arrays trip `set -u`.
+if [[ -v hardeningEnable[@] ]]; then
+  hardeningFlags+=(${hardeningEnable[@]})
+fi
 hardeningCFlags=()
 hardeningLDFlags=()
 
 declare -A hardeningDisableMap
 
-# Intentionally word-split in case 'hardeningDisable' is defined in Nix. The
-# array expansion also prevents undefined variables from causing trouble with
-# `set -u`.
-for flag in ${hardeningDisable[@]} @hardening_unsupported_flags@
+# Intentionally word-split in case 'hardeningDisable' is defined in Nix.
+for flag in ${hardeningDisable[@]:-IGNORED_KEY} @hardening_unsupported_flags@
 do
   hardeningDisableMap[$flag]=1
 done
 
-if [[ -n "$NIX_DEBUG" ]]; then
+if [[ -n "${NIX_DEBUG:-}" ]]; then
   printf 'HARDENING: disabled flags:' >&2
   (( "${#hardeningDisableMap[@]}" )) && printf ' %q' "${!hardeningDisableMap[@]}" >&2
   echo >&2
 fi
 
-if [[ -z "${hardeningDisableMap[all]}" ]]; then
-  if [[ -n "$NIX_DEBUG" ]]; then
+if [[ -z "${hardeningDisableMap[all]:-}" ]]; then
+  if [[ -n "${NIX_DEBUG:-}" ]]; then
     echo 'HARDENING: Is active (not completely disabled with "all" flag)' >&2;
   fi
   for flag in "${hardeningFlags[@]}"
   do
-    if [[ -z "${hardeningDisableMap[$flag]}" ]]; then
+    if [[ -z "${hardeningDisableMap[$flag]:-}" ]]; then
       case $flag in
         fortify)
-          if [[ -n "$NIX_DEBUG" ]]; then echo HARDENING: enabling fortify >&2; fi
+          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling fortify >&2; fi
           hardeningCFlags+=('-O2' '-D_FORTIFY_SOURCE=2')
           ;;
         stackprotector)
-          if [[ -n "$NIX_DEBUG" ]]; then echo HARDENING: enabling stackprotector >&2; fi
+          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling stackprotector >&2; fi
           hardeningCFlags+=('-fstack-protector-strong' '--param' 'ssp-buffer-size=4')
           ;;
         pie)
-          if [[ -n "$NIX_DEBUG" ]]; then echo HARDENING: enabling CFlags -fPIE >&2; fi
+          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling CFlags -fPIE >&2; fi
           hardeningCFlags+=('-fPIE')
           if [[ ! ("$*" =~ " -shared " || "$*" =~ " -static ") ]]; then
-            if [[ -n "$NIX_DEBUG" ]]; then echo HARDENING: enabling LDFlags -pie >&2; fi
+            if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling LDFlags -pie >&2; fi
             hardeningLDFlags+=('-pie')
           fi
           ;;
         pic)
-          if [[ -n "$NIX_DEBUG" ]]; then echo HARDENING: enabling pic >&2; fi
+          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling pic >&2; fi
           hardeningCFlags+=('-fPIC')
           ;;
         strictoverflow)
-          if [[ -n "$NIX_DEBUG" ]]; then echo HARDENING: enabling strictoverflow >&2; fi
+          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling strictoverflow >&2; fi
           hardeningCFlags+=('-fno-strict-overflow')
           ;;
         format)
-          if [[ -n "$NIX_DEBUG" ]]; then echo HARDENING: enabling format >&2; fi
+          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling format >&2; fi
           hardeningCFlags+=('-Wformat' '-Wformat-security' '-Werror=format-security')
           ;;
         relro)
-          if [[ -n "$NIX_DEBUG" ]]; then echo HARDENING: enabling relro >&2; fi
+          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling relro >&2; fi
           hardeningLDFlags+=('-z' 'relro')
           ;;
         bindnow)
-          if [[ -n "$NIX_DEBUG" ]]; then echo HARDENING: enabling bindnow >&2; fi
+          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling bindnow >&2; fi
           hardeningLDFlags+=('-z' 'now')
           ;;
         *)

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -11,11 +11,11 @@ if [[ -n "@coreutils_bin@" && -n "@gnugrep_bin@" ]]; then
     PATH="@coreutils_bin@/bin:@gnugrep_bin@/bin"
 fi
 
-if [ -n "$NIX_CC_WRAPPER_START_HOOK" ]; then
-    source "$NIX_CC_WRAPPER_START_HOOK"
+if [ -n "$NIX_CC_WRAPPER_@infixSalt@_START_HOOK" ]; then
+    source "$NIX_CC_WRAPPER_@infixSalt@_START_HOOK"
 fi
 
-if [ -z "$NIX_CC_WRAPPER_FLAGS_SET" ]; then
+if [ -z "$NIX_CC_WRAPPER_@infixSalt@_FLAGS_SET" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 
@@ -63,7 +63,7 @@ while [ "$n" -lt "$nParams" ]; do
         nonFlagArgs=1
     elif [ "$p" = -m32 ]; then
         if [ -e @out@/nix-support/dynamic-linker-m32 ]; then
-            NIX_LDFLAGS+=" -dynamic-linker $(< @out@/nix-support/dynamic-linker-m32)"
+            NIX_@infixSalt@_LDFLAGS+=" -dynamic-linker $(< @out@/nix-support/dynamic-linker-m32)"
         fi
     fi
     n+=1
@@ -106,7 +106,7 @@ fi
 
 
 # Clear march/mtune=native -- they bring impurity.
-if [ "$NIX_ENFORCE_NO_NATIVE" = 1 ]; then
+if [ "$NIX_@infixSalt@_ENFORCE_NO_NATIVE" = 1 ]; then
     rest=()
     for p in "${params[@]}"; do
         if [[ "$p" = -m*=native ]]; then
@@ -120,36 +120,36 @@ fi
 
 if [[ "$isCpp" = 1 ]]; then
     if [[ "$cppInclude" = 1 ]]; then
-        NIX_CFLAGS_COMPILE+=" ${NIX_CXXSTDLIB_COMPILE-@default_cxx_stdlib_compile@}"
+        NIX_@infixSalt@_CFLAGS_COMPILE+=" ${NIX_@infixSalt@_CXXSTDLIB_COMPILE-@default_cxx_stdlib_compile@}"
     fi
-    NIX_CFLAGS_LINK+=" $NIX_CXXSTDLIB_LINK"
+    NIX_@infixSalt@_CFLAGS_LINK+=" $NIX_@infixSalt@_CXXSTDLIB_LINK"
 fi
 
 source @out@/nix-support/add-hardening.sh
 
 # Add the flags for the C compiler proper.
-extraAfter=($NIX_CFLAGS_COMPILE "${hardeningCFlags[@]}")
+extraAfter=($NIX_@infixSalt@_CFLAGS_COMPILE "${hardeningCFlags[@]}")
 extraBefore=()
 
 if [ "$dontLink" != 1 ]; then
 
     # Add the flags that should only be passed to the compiler when
     # linking.
-    extraAfter+=($NIX_CFLAGS_LINK "${hardeningLDFlags[@]}")
+    extraAfter+=($NIX_@infixSalt@_CFLAGS_LINK "${hardeningLDFlags[@]}")
 
     # Add the flags that should be passed to the linker (and prevent
-    # `ld-wrapper' from adding NIX_LDFLAGS again).
-    for i in $NIX_LDFLAGS_BEFORE; do
+    # `ld-wrapper' from adding NIX_@infixSalt@_LDFLAGS again).
+    for i in $NIX_@infixSalt@_LDFLAGS_BEFORE; do
         extraBefore+=("-Wl,$i")
     done
-    for i in $NIX_LDFLAGS; do
+    for i in $NIX_@infixSalt@_LDFLAGS; do
         if [ "${i:0:3}" = -L/ ]; then
             extraAfter+=("$i")
         else
             extraAfter+=("-Wl,$i")
         fi
     done
-    export NIX_LDFLAGS_SET=1
+    export NIX_@infixSalt@_LDFLAGS_SET=1
 fi
 
 # As a very special hack, if the arguments are just `-v', then don't
@@ -171,8 +171,8 @@ if [ -n "$NIX_DEBUG" ]; then
     printf "  %q\n" "${extraAfter[@]}" >&2
 fi
 
-if [ -n "$NIX_CC_WRAPPER_EXEC_HOOK" ]; then
-    source "$NIX_CC_WRAPPER_EXEC_HOOK"
+if [ -n "$NIX_CC_WRAPPER_@infixSalt@_EXEC_HOOK" ]; then
+    source "$NIX_CC_WRAPPER_@infixSalt@_EXEC_HOOK"
 fi
 
 PATH="$path_backup"

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -53,42 +53,13 @@ let
     "-isystem $(echo -n ${cc.gcc}/include/c++/*) -isystem $(echo -n ${cc.gcc}/include/c++/*)/$(${cc.gcc}/bin/gcc -dumpmachine)";
 
   dashlessTarget = stdenv.lib.replaceStrings ["-"] ["_"] targetPlatform.config;
-  # TODO(@Ericson2314) Make unconditional
-  infixSalt  = stdenv.lib.optionalString (targetPlatform != hostPlatform) dashlessTarget;
-  infixSalt_ = stdenv.lib.optionalString (targetPlatform != hostPlatform) (dashlessTarget + "_");
-  _infixSalt = stdenv.lib.optionalString (targetPlatform != hostPlatform) ("_" + dashlessTarget);
 
-  # We want to prefix all NIX_ flags with the target triple
-  preWrap = textFile:
-    # TODO: Do even when not cross on next mass-rebuild
-    # TODO: use @target_tripple@ for consistency
-    if targetPlatform == hostPlatform
-    then textFile
-    else runCommand "sed-nix-env-vars" {} (''
-      cp --no-preserve=mode ${textFile} $out
-
-      sed -i $out \
-        -e 's^NIX_^NIX_${infixSalt_}^g' \
-        -e 's^addCVars^addCVars${_infixSalt}^g' \
-        -e 's^\[ -z "\$crossConfig" \]^\[\[ "${builtins.toString (targetPlatform != hostPlatform)}" || -z "$crossConfig" \]\]^g'
-
-      # NIX_ things which we don't both use and define, we revert them
-      #asymmetric=$(
-      #  for pre in "" "\\$"
-      #  do
-      #    grep -E -ho $pre'NIX_[a-zA-Z_]*' ./* | sed 's/\$//' | sort | uniq
-      #  done | sort | uniq -c | sort -nr | sed -n 's/^1 NIX_//gp')
-
-      # hard-code for now
-      asymmetric=("CXXSTDLIB_COMPILE" "CC")
-
-      # The ([^a-zA-Z_]|$) bussiness is to ensure environment variables that
-      # begin with `NIX_CC` don't also get blacklisted.
-      for var in "''${asymmetric[@]}"
-      do
-        sed -i $out -E -e "s~NIX_${infixSalt_}$var([^a-zA-Z_]|$)~NIX_$var\1~g"
-      done
-    '');
+  # The "infix salt" is a arbitrary string added in the middle of env vars
+  # defined by cc-wrapper's hooks so that multiple cc-wrappers can be used
+  # without interfering. For the moment, it is defined as the target triple,
+  # adjusted to be a valid bash identifier. This should be considered an
+  # unstable implementation detail, however.
+  infixSalt = dashlessTarget;
 
   # The dynamic linker has different names on different platforms. This is a
   # shell glob that ought to match it.
@@ -129,20 +100,21 @@ stdenv.mkDerivation {
   gnugrep_bin = if nativeTools then "" else gnugrep;
 
   binPrefix = prefix;
+  inherit infixSalt;
 
   passthru = {
     inherit libc nativeTools nativeLibc nativePrefix isGNU isClang default_cxx_stdlib_compile
-            prefix infixSalt infixSalt_ _infixSalt;
+            prefix;
 
     emacsBufferSetup = pkgs: ''
       ; We should handle propagation here too
       (mapc (lambda (arg)
         (when (file-directory-p (concat arg "/include"))
-          (setenv "NIX_${infixSalt_}CFLAGS_COMPILE" (concat (getenv "NIX_${infixSalt_}CFLAGS_COMPILE") " -isystem " arg "/include")))
+          (setenv "NIX_${infixSalt}_CFLAGS_COMPILE" (concat (getenv "NIX_${infixSalt}_CFLAGS_COMPILE") " -isystem " arg "/include")))
         (when (file-directory-p (concat arg "/lib"))
-          (setenv "NIX_${infixSalt_}LDFLAGS" (concat (getenv "NIX_${infixSalt_}LDFLAGS") " -L" arg "/lib")))
+          (setenv "NIX_${infixSalt}_LDFLAGS" (concat (getenv "NIX_${infixSalt}_LDFLAGS") " -L" arg "/lib")))
         (when (file-directory-p (concat arg "/lib64"))
-          (setenv "NIX_${infixSalt_}LDFLAGS" (concat (getenv "NIX_${infixSalt_}LDFLAGS") " -L" arg "/lib64")))) '(${concatStringsSep " " (map (pkg: "\"${pkg}\"") pkgs)}))
+          (setenv "NIX_${infixSalt}_LDFLAGS" (concat (getenv "NIX_${infixSalt}_LDFLAGS") " -L" arg "/lib64")))) '(${concatStringsSep " " (map (pkg: "\"${pkg}\"") pkgs)}))
     '';
   };
 
@@ -268,7 +240,7 @@ stdenv.mkDerivation {
       # Solaris needs an additional ld wrapper.
       ldPath="${nativePrefix}/bin"
       exec="$ldPath/${prefix}ld"
-      wrap ld-solaris ${preWrap ./ld-solaris-wrapper.sh}
+      wrap ld-solaris ${./ld-solaris-wrapper.sh}
     '')
 
     + ''
@@ -282,7 +254,6 @@ stdenv.mkDerivation {
     '' + (if !useMacosReexportHack then ''
       wrap ${prefix}ld ${./ld-wrapper.sh} ''${ld:-$ldPath/${prefix}ld}
     '' else ''
-      export binPrefix=${prefix}
       ldInner="${prefix}ld-reexport-delegate"
       wrap "$ldInner" ${./macos-sierra-reexport-hack.bash} ''${ld:-$ldPath/${prefix}ld}
       wrap "${prefix}ld" ${./ld-wrapper.sh} "$out/bin/$ldInner"
@@ -290,11 +261,11 @@ stdenv.mkDerivation {
     '') + ''
 
       if [ -e ${binutils_bin}/bin/${prefix}ld.gold ]; then
-        wrap ${prefix}ld.gold ${preWrap ./ld-wrapper.sh} ${binutils_bin}/bin/${prefix}ld.gold
+        wrap ${prefix}ld.gold ${./ld-wrapper.sh} ${binutils_bin}/bin/${prefix}ld.gold
       fi
 
       if [ -e ${binutils_bin}/bin/ld.bfd ]; then
-        wrap ${prefix}ld.bfd ${preWrap ./ld-wrapper.sh} ${binutils_bin}/bin/${prefix}ld.bfd
+        wrap ${prefix}ld.bfd ${./ld-wrapper.sh} ${binutils_bin}/bin/${prefix}ld.bfd
       fi
 
       # We export environment variables pointing to the wrapped nonstandard
@@ -306,49 +277,49 @@ stdenv.mkDerivation {
       export default_cxx_stdlib_compile="${default_cxx_stdlib_compile}"
 
       if [ -e $ccPath/${prefix}gcc ]; then
-        wrap ${prefix}gcc ${preWrap ./cc-wrapper.sh} $ccPath/${prefix}gcc
+        wrap ${prefix}gcc ${./cc-wrapper.sh} $ccPath/${prefix}gcc
         ln -s ${prefix}gcc $out/bin/${prefix}cc
         export named_cc=${prefix}gcc
         export named_cxx=${prefix}g++
       elif [ -e $ccPath/clang ]; then
-        wrap ${prefix}clang ${preWrap ./cc-wrapper.sh} $ccPath/clang
+        wrap ${prefix}clang ${./cc-wrapper.sh} $ccPath/clang
         ln -s ${prefix}clang $out/bin/${prefix}cc
         export named_cc=${prefix}clang
         export named_cxx=${prefix}clang++
       fi
 
       if [ -e $ccPath/${prefix}g++ ]; then
-        wrap ${prefix}g++ ${preWrap ./cc-wrapper.sh} $ccPath/${prefix}g++
+        wrap ${prefix}g++ ${./cc-wrapper.sh} $ccPath/${prefix}g++
         ln -s ${prefix}g++ $out/bin/${prefix}c++
       elif [ -e $ccPath/clang++ ]; then
-        wrap ${prefix}clang++ ${preWrap ./cc-wrapper.sh} $ccPath/clang++
+        wrap ${prefix}clang++ ${./cc-wrapper.sh} $ccPath/clang++
         ln -s ${prefix}clang++ $out/bin/${prefix}c++
       fi
 
       if [ -e $ccPath/cpp ]; then
-        wrap ${prefix}cpp ${preWrap ./cc-wrapper.sh} $ccPath/cpp
+        wrap ${prefix}cpp ${./cc-wrapper.sh} $ccPath/cpp
       fi
     ''
 
     + optionalString cc.langFortran or false ''
-      wrap ${prefix}gfortran ${preWrap ./cc-wrapper.sh} $ccPath/${prefix}gfortran
+      wrap ${prefix}gfortran ${./cc-wrapper.sh} $ccPath/${prefix}gfortran
       ln -sv ${prefix}gfortran $out/bin/${prefix}g77
       ln -sv ${prefix}gfortran $out/bin/${prefix}f77
     ''
 
     + optionalString cc.langJava or false ''
-      wrap ${prefix}gcj ${preWrap ./cc-wrapper.sh} $ccPath/${prefix}gcj
+      wrap ${prefix}gcj ${./cc-wrapper.sh} $ccPath/${prefix}gcj
     ''
 
     + optionalString cc.langGo or false ''
-      wrap ${prefix}gccgo ${preWrap ./cc-wrapper.sh} $ccPath/${prefix}gccgo
+      wrap ${prefix}gccgo ${./cc-wrapper.sh} $ccPath/${prefix}gccgo
     ''
 
     + optionalString cc.langAda or false ''
-      wrap ${prefix}gnatgcc ${preWrap ./cc-wrapper.sh} $ccPath/${prefix}gnatgcc
-      wrap ${prefix}gnatmake ${preWrap ./gnat-wrapper.sh} $ccPath/${prefix}gnatmake
-      wrap ${prefix}gnatbind ${preWrap ./gnat-wrapper.sh} $ccPath/${prefix}gnatbind
-      wrap ${prefix}gnatlink ${preWrap ./gnatlink-wrapper.sh} $ccPath/${prefix}gnatlink
+      wrap ${prefix}gnatgcc ${./cc-wrapper.sh} $ccPath/${prefix}gnatgcc
+      wrap ${prefix}gnatmake ${./gnat-wrapper.sh} $ccPath/${prefix}gnatmake
+      wrap ${prefix}gnatbind ${./gnat-wrapper.sh} $ccPath/${prefix}gnatbind
+      wrap ${prefix}gnatlink ${./gnatlink-wrapper.sh} $ccPath/${prefix}gnatlink
     ''
 
     + optionalString cc.langVhdl or false ''
@@ -356,7 +327,7 @@ stdenv.mkDerivation {
     ''
 
     + ''
-      substituteAll ${preWrap ./setup-hook.sh} $out/nix-support/setup-hook.tmp
+      substituteAll ${./setup-hook.sh} $out/nix-support/setup-hook.tmp
       cat $out/nix-support/setup-hook.tmp >> $out/nix-support/setup-hook
       rm $out/nix-support/setup-hook.tmp
 
@@ -375,9 +346,9 @@ stdenv.mkDerivation {
     ''
 
     + ''
-      substituteAll ${preWrap ./add-flags.sh} $out/nix-support/add-flags.sh
-      substituteAll ${preWrap ./add-hardening.sh} $out/nix-support/add-hardening.sh
-      substituteAll ${preWrap ./utils.sh} $out/nix-support/utils.sh
+      substituteAll ${./add-flags.sh} $out/nix-support/add-flags.sh
+      substituteAll ${./add-hardening.sh} $out/nix-support/add-hardening.sh
+      substituteAll ${./utils.sh} $out/nix-support/utils.sh
     ''
     + extraBuildCommands;
 

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -1,6 +1,9 @@
 #! @shell@
-set -e -o pipefail
+set -eu -o pipefail
 shopt -s nullglob
+
+# N.B. Gnat is not used during bootstrapping, so we don't need to
+# worry about the old bash empty array `set -u` workarounds.
 
 path_backup="$PATH"
 
@@ -10,12 +13,12 @@ if [ -n "@coreutils_bin@" ]; then
     PATH="@coreutils_bin@/bin"
 fi
 
-if [ -n "$NIX_@infixSalt@_GNAT_WRAPPER_START_HOOK" ]; then
-    source "$NIX_@infixSalt@_GNAT_WRAPPER_START_HOOK"
+if [ -z "${NIX_@infixSalt@_GNAT_WRAPPER_FLAGS_SET:-}" ]; then
+    source @out@/nix-support/add-flags.sh
 fi
 
-if [ -z "$NIX_@infixSalt@_GNAT_WRAPPER_FLAGS_SET" ]; then
-    source @out@/nix-support/add-flags.sh
+if [ -n "$NIX_@infixSalt@_GNAT_WRAPPER_START_HOOK" ]; then
+    source "$NIX_@infixSalt@_GNAT_WRAPPER_START_HOOK"
 fi
 
 source @out@/nix-support/utils.sh
@@ -52,7 +55,7 @@ fi
 
 # Optionally filter out paths not refering to the store.
 params=("$@")
-if [[ "$NIX_ENFORCE_PURITY" = 1 && -n "$NIX_STORE" ]]; then
+if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "$NIX_STORE" ]]; then
     rest=()
     for p in "${params[@]}"; do
         if [ "${p:0:3}" = -L/ ] && badPath "${p:2}"; then
@@ -110,7 +113,7 @@ fi
 #fi
 
 # Optionally print debug info.
-if [ -n "$NIX_DEBUG" ]; then
+if [ -n "${NIX_DEBUG:-}" ]; then
     echo "extra flags before to @prog@:" >&2
     printf "  %q\n" "${extraBefore[@]}"  >&2
     echo "original flags to @prog@:" >&2

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -10,11 +10,11 @@ if [ -n "@coreutils_bin@" ]; then
     PATH="@coreutils_bin@/bin"
 fi
 
-if [ -n "$NIX_GNAT_WRAPPER_START_HOOK" ]; then
-    source "$NIX_GNAT_WRAPPER_START_HOOK"
+if [ -n "$NIX_@infixSalt@_GNAT_WRAPPER_START_HOOK" ]; then
+    source "$NIX_@infixSalt@_GNAT_WRAPPER_START_HOOK"
 fi
 
-if [ -z "$NIX_GNAT_WRAPPER_FLAGS_SET" ]; then
+if [ -z "$NIX_@infixSalt@_GNAT_WRAPPER_FLAGS_SET" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 
@@ -35,7 +35,7 @@ for i in "$@"; do
         nonFlagArgs=1
     elif [ "$i" = -m32 ]; then
         if [ -e @out@/nix-support/dynamic-linker-m32 ]; then
-            NIX_LDFLAGS+=" -dynamic-linker $(< @out@/nix-support/dynamic-linker-m32)"
+            NIX_@infixSalt@_LDFLAGS+=" -dynamic-linker $(< @out@/nix-support/dynamic-linker-m32)"
         fi
     fi
 done
@@ -72,7 +72,7 @@ fi
 
 
 # Clear march/mtune=native -- they bring impurity.
-if [ "$NIX_ENFORCE_NO_NATIVE" = 1 ]; then
+if [ "$NIX_@infixSalt@_ENFORCE_NO_NATIVE" = 1 ]; then
     rest=()
     for p in "${params[@]}"; do
         if [[ "$p" = -m*=native ]]; then
@@ -86,7 +86,7 @@ fi
 
 
 # Add the flags for the GNAT compiler proper.
-extraAfter=($NIX_GNATFLAGS_COMPILE)
+extraAfter=($NIX_@infixSalt@_GNATFLAGS_COMPILE)
 extraBefore=()
 
 if [ "$(basename "$0")x" = "gnatmakex" ]; then
@@ -95,18 +95,18 @@ fi
 
 #if [ "$dontLink" != 1 ]; then
 #    # Add the flags that should be passed to the linker (and prevent
-#    # `ld-wrapper' from adding NIX_LDFLAGS again).
-#    for i in $NIX_LDFLAGS_BEFORE; do
+#    # `ld-wrapper' from adding NIX_@infixSalt@_LDFLAGS again).
+#    for i in $NIX_@infixSalt@_LDFLAGS_BEFORE; do
 #        extraBefore+=("-largs" "$i")
 #    done
-#    for i in $NIX_LDFLAGS; do
+#    for i in $NIX_@infixSalt@_LDFLAGS; do
 #        if [ "${i:0:3}" = -L/ ]; then
 #            extraAfter+=("$i")
 #        else
 #            extraAfter+=("-largs" "$i")
 #        fi
 #    done
-#    export NIX_LDFLAGS_SET=1
+#    export NIX_@infixSalt@_LDFLAGS_SET=1
 #fi
 
 # Optionally print debug info.
@@ -119,8 +119,8 @@ if [ -n "$NIX_DEBUG" ]; then
     printf "  %q\n" "${extraAfter[@]}" >&2
 fi
 
-if [ -n "$NIX_GNAT_WRAPPER_EXEC_HOOK" ]; then
-    source "$NIX_GNAT_WRAPPER_EXEC_HOOK"
+if [ -n "$NIX_@infixSalt@_GNAT_WRAPPER_EXEC_HOOK" ]; then
+    source "$NIX_@infixSalt@_GNAT_WRAPPER_EXEC_HOOK"
 fi
 
 PATH="$path_backup"

--- a/pkgs/build-support/cc-wrapper/gnatlink-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnatlink-wrapper.sh
@@ -1,6 +1,9 @@
 #! @shell@
-set -e -o pipefail
+set -eu -o pipefail
 shopt -s nullglob
+
+# N.B. Gnat is not used during bootstrapping, so we don't need to
+# worry about the old bash empty array `set -u` workarounds.
 
 # Add the flags for the GNAT compiler proper.
 extraAfter=("--GCC=@out@/bin/gcc")
@@ -21,7 +24,7 @@ extraBefore=()
 #export NIX_@infixSalt@_LDFLAGS_SET=1
 
 # Optionally print debug info.
-if [ -n "$NIX_DEBUG" ]; then
+if [ -n "${NIX_DEBUG:-}" ]; then
     echo "extra flags before to @prog@:" >&2
     printf "  %q\n" "${extraBefore[@]}"  >&2
     echo "original flags to @prog@:" >&2

--- a/pkgs/build-support/cc-wrapper/gnatlink-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnatlink-wrapper.sh
@@ -7,18 +7,18 @@ extraAfter=("--GCC=@out@/bin/gcc")
 extraBefore=()
 
 ## Add the flags that should be passed to the linker (and prevent
-## `ld-wrapper' from adding NIX_LDFLAGS again).
-#for i in $NIX_LDFLAGS_BEFORE; do
+## `ld-wrapper' from adding NIX_@infixSalt@_LDFLAGS again).
+#for i in $NIX_@infixSalt@_LDFLAGS_BEFORE; do
 #    extraBefore+=("-largs" "$i")
 #done
-#for i in $NIX_LDFLAGS; do
+#for i in $NIX_@infixSalt@_LDFLAGS; do
 #    if [ "${i:0:3}" = -L/ ]; then
 #        extraAfter+=("$i")
 #    else
 #        extraAfter+=("-largs" "$i")
 #    fi
 #done
-#export NIX_LDFLAGS_SET=1
+#export NIX_@infixSalt@_LDFLAGS_SET=1
 
 # Optionally print debug info.
 if [ -n "$NIX_DEBUG" ]; then
@@ -30,8 +30,8 @@ if [ -n "$NIX_DEBUG" ]; then
     printf "  %q\n" "${extraAfter[@]}" >&2
 fi
 
-if [ -n "$NIX_GNAT_WRAPPER_EXEC_HOOK" ]; then
-    source "$NIX_GNAT_WRAPPER_EXEC_HOOK"
+if [ -n "$NIX_@infixSalt@_GNAT_WRAPPER_EXEC_HOOK" ]; then
+    source "$NIX_@infixSalt@_GNAT_WRAPPER_EXEC_HOOK"
 fi
 
 exec @prog@ "${extraBefore[@]}" "$@" "${extraAfter[@]}"

--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -1,5 +1,5 @@
 #! @shell@
-set -e -o pipefail
+set -eu -o pipefail
 shopt -s nullglob
 
 path_backup="$PATH"
@@ -10,11 +10,11 @@ if [ -n "@coreutils_bin@" ]; then
     PATH="@coreutils_bin@/bin"
 fi
 
-if [ -n "$NIX_LD_WRAPPER_START_HOOK" ]; then
-    source "$NIX_LD_WRAPPER_START_HOOK"
+if [ -n "$NIX_LD_WRAPPER_@infixSalt@_START_HOOK" ]; then
+    source "$NIX_LD_WRAPPER_@infixSalt@_START_HOOK"
 fi
 
-if [ -z "$NIX_CC_WRAPPER_FLAGS_SET" ]; then
+if [ -z "$NIX_CC_WRAPPER_@infixSalt@_FLAGS_SET" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 
@@ -24,7 +24,7 @@ source @out@/nix-support/utils.sh
 # Optionally filter out paths not refering to the store.
 expandResponseParams "$@"
 if [[ "$NIX_ENFORCE_PURITY" = 1 && -n "$NIX_STORE"
-        && ( -z "$NIX_IGNORE_LD_THROUGH_GCC" || -z "$NIX_LDFLAGS_SET" ) ]]; then
+        && ( -z "$NIX_@infixSalt@_IGNORE_LD_THROUGH_GCC" || -z "$NIX_@infixSalt@_LDFLAGS_SET" ) ]]; then
     rest=()
     nParams=${#params[@]}
     declare -i n=0
@@ -59,19 +59,19 @@ source @out@/nix-support/add-hardening.sh
 extraAfter=("${hardeningLDFlags[@]}")
 extraBefore=()
 
-if [ -z "$NIX_LDFLAGS_SET" ]; then
-    extraAfter+=($NIX_LDFLAGS)
-    extraBefore+=($NIX_LDFLAGS_BEFORE)
+if [ -z "$NIX_@infixSalt@_LDFLAGS_SET" ]; then
+    extraAfter+=($NIX_@infixSalt@_LDFLAGS)
+    extraBefore+=($NIX_@infixSalt@_LDFLAGS_BEFORE)
 fi
 
-extraAfter+=($NIX_LDFLAGS_AFTER $NIX_LDFLAGS_HARDEN)
+extraAfter+=($NIX_@infixSalt@_LDFLAGS_AFTER $NIX_@infixSalt@_LDFLAGS_HARDEN)
 
 declare -a libDirs
 declare -A libs
 relocatable=
 
 # Find all -L... switches for rpath, and relocatable flags for build id.
-if [ "$NIX_DONT_SET_RPATH" != 1 ] || [ "$NIX_SET_BUILD_ID" = 1 ]; then
+if [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ] || [ "$NIX_@infixSalt@_SET_BUILD_ID" = 1 ]; then
     prev=
     for p in "${extraBefore[@]}" "${params[@]}" "${extraAfter[@]}"; do
         case "$prev" in
@@ -108,7 +108,7 @@ fi
 
 
 # Add all used dynamic libraries to the rpath.
-if [ "$NIX_DONT_SET_RPATH" != 1 ]; then
+if [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ]; then
     # For each directory in the library search path (-L...),
     # see if it contains a dynamic library used by a -l... flag.  If
     # so, add the directory to the rpath.
@@ -141,7 +141,7 @@ fi
 
 # Only add --build-id if this is a final link. FIXME: should build gcc
 # with --enable-linker-build-id instead?
-if [ "$NIX_SET_BUILD_ID" = 1 ] && [ ! "$relocatable" ]; then
+if [ "$NIX_@infixSalt@_SET_BUILD_ID" = 1 ] && [ ! "$relocatable" ]; then
     extraAfter+=(--build-id)
 fi
 
@@ -156,8 +156,8 @@ if [ -n "$NIX_DEBUG" ]; then
     printf "  %q\n" "${extraAfter[@]}" >&2
 fi
 
-if [ -n "$NIX_LD_WRAPPER_EXEC_HOOK" ]; then
-    source "$NIX_LD_WRAPPER_EXEC_HOOK"
+if [ -n "$NIX_LD_WRAPPER_@infixSalt@_EXEC_HOOK" ]; then
+    source "$NIX_LD_WRAPPER_@infixSalt@_EXEC_HOOK"
 fi
 
 PATH="$path_backup"

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -1,21 +1,111 @@
+# CC Wrapper hygiene
+#
+# For at least cross compilation, we need to depend on multiple cc-wrappers at
+# once---specifically up to one per sort of dependency. This follows from having
+# different tools targeting different platforms, and different flags for those
+# tools. For example:
+#
+#   # Flags for compiling (whether or not linking) C code for the...
+#   NIX_BUILD_CFLAGS_COMPILE  # ...build platform
+#   NIX_CFLAGS_COMPILE        # ...host platform
+#   NIX_TARGET_CFLAGS_COMPILE # ...target platform
+#
+# Notice that these platforms are the 3 *relative* to the package using
+# cc-wrapper, not absolute like `x86_64-pc-linux-gnu`.
+#
+# The simplest solution would be to have separate cc-wrappers per (3 intended
+# use-cases * n absolute concrete platforms). For the use-case axis, we would
+# @-splice in 'BUILD_' '' 'TARGET_' to use the write environment variables when
+# building the cc-wrapper, and likewise prefix the binaries' names so they didn't
+# clobber each other on the PATH. But the need for 3x cc-wrappers, along with
+# non-standard name prefixes, is annoying and liable to break packages' build
+# systems.
+#
+# Instead, we opt to have just one cc-wrapper per absolute platform. Matching
+# convention, the binaries' names can just be prefixed with their target
+# platform. On the other hand, that means packages will depend on not just
+# multiple cc-wrappers, but the exact same cc-wrapper derivation multiple ways.
+# That means the exact same cc-wrapper derivation must be able to avoid
+# conflicting with itself, despite the fact that `setup-hook.sh`, the `addCvars`
+# function, and `add-flags.sh` are all communicating with each other with
+# environment variables. Yuck.
+#
+# The basic strategy is:
+#
+#  - Everyone exclusively *adds information* to relative-platform-specific
+#    environment variables, like `NIX_TARGET_CFLAGS_COMPILE`, to communicate
+#    with the wrapped binaries.
+#
+#  - The wrapped binaries will exclusively *read* cc-wrapper-derivation-specific
+#    environment variables distinguished with with `infixSalt`, like
+#    `NIX_@infixSalt@_CFLAGS_COMPILE`.
+#
+#  - `add-flags`, beyond its old task of reading extra flags stuck inside the
+#    cc-wrapper derivation, will convert the relative-platform-specific
+#    variables to cc-wrapper-derivation-specific variables. This conversion is
+#    the only time all but one of the cc-wrapper-derivation-specific variables
+#    are set.
+#
+# This ensures the flow of information is exclusive from
+# relative-platform-specific variables to cc-wrapper-derivation-specific
+# variables. This allows us to support the general case of a many--many relation
+# between relative platforms and cc-wrapper derivations.
+#
+# For more details, read the individual files where the mechanisms used to
+# accomplish this will be individually documented.
+
+
+# It's fine that any other cc-wrapper will redefine this. Bash functions close
+# over no state, and there's no @-substitutions within, so any redefined
+# function is guaranteed to be exactly the same.
 ccWrapper_addCVars () {
+    # The `depOffset` describes how the platforms of the dependencies are slid
+    # relative to the depending package. It is brought into scope of the
+    # environment hook defined as the role of the dependency being applied.
+    case $depOffset in
+        -1) local role='BUILD_' ;;
+        0)  local role='' ;;
+        1)  local role='TARGET_' ;;
+        *)  echo "cc-wrapper: Error: Cannot be used with $depOffset-offset deps, " >2;
+            return 1 ;;
+    esac
+
     if [[ -d "$1/include" ]]; then
-        export NIX_CFLAGS_COMPILE+=" ${ccIncludeFlag:--isystem} $1/include"
+        export NIX_${role}CFLAGS_COMPILE+=" ${ccIncludeFlag:--isystem} $1/include"
     fi
 
     if [[ -d "$1/lib64" && ! -L "$1/lib64" ]]; then
-        export NIX_LDFLAGS+=" -L$1/lib64"
+        export NIX_${role}LDFLAGS+=" -L$1/lib64"
     fi
 
     if [[ -d "$1/lib" ]]; then
-        export NIX_LDFLAGS+=" -L$1/lib"
+        export NIX_${role}LDFLAGS+=" -L$1/lib"
     fi
 
     if [[ -d "$1/Library/Frameworks" ]]; then
-        export NIX_CFLAGS_COMPILE+=" -F$1/Library/Frameworks"
+        export NIX_${role}CFLAGS_COMPILE+=" -F$1/Library/Frameworks"
     fi
 }
 
+# Since the same cc-wrapper derivation can be depend on in multiple ways, we
+# need to accumulate *each* role (i.e. target platform relative the depending
+# derivation) in which the cc-wrapper derivation is used.
+# `NIX_CC_WRAPPER_@infixSalt@_TARGET_*` tracks this (needs to be an exported env
+# var so can't use fancier data structures).
+#
+# We also need to worry about what role is being added on *this* invocation of
+# setup-hook, which `role` tracks.
+if [ -n "${crossConfig:-}" ]; then
+    export NIX_CC_WRAPPER_@infixSalt@_TARGET_BUILD=1
+    role="BUILD_"
+else
+    export NIX_CC_WRAPPER_@infixSalt@_TARGET_HOST=1
+    role=""
+fi
+
+# Eventually the exact sort of env-hook we create will depend on the role. This
+# is because based on what relative platform we are targeting, we use different
+# dependencies.
 envHooks+=(ccWrapper_addCVars)
 
 # Note 1: these come *after* $out in the PATH (see setup.sh).
@@ -41,16 +131,12 @@ if [ -n "@coreutils_bin@" ]; then
     addToSearchPath _PATH @coreutils_bin@/bin
 fi
 
-if [ -z "${crossConfig:-}" ]; then
-    ENV_PREFIX=""
-else
-    ENV_PREFIX="BUILD_"
-fi
+# Export tool environment variables so various build systems use the right ones.
 
-export NIX_${ENV_PREFIX}CC=@out@
+export NIX_${role}CC=@out@
 
-export ${ENV_PREFIX}CC=@named_cc@
-export ${ENV_PREFIX}CXX=@named_cxx@
+export ${role}CC=@named_cc@
+export ${role}CXX=@named_cxx@
 
 for CMD in \
     cpp \
@@ -59,9 +145,9 @@ do
     if
         PATH=$_PATH type -p "@binPrefix@$CMD" > /dev/null
     then
-        export "${ENV_PREFIX}$(echo "$CMD" | tr "[:lower:]" "[:upper:]")=@binPrefix@${CMD}";
+        export "${role}$(echo "$CMD" | tr "[:lower:]" "[:upper:]")=@binPrefix@${CMD}";
     fi
 done
 
-# No local scope available for sourced files
-unset ENV_PREFIX
+# No local scope in sourced file
+unset role

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -1,4 +1,4 @@
-addCVars () {
+ccWrapper_addCVars () {
     if [[ -d "$1/include" ]]; then
         export NIX_CFLAGS_COMPILE+=" ${ccIncludeFlag:--isystem} $1/include"
     fi
@@ -16,7 +16,7 @@ addCVars () {
     fi
 }
 
-envHooks+=(addCVars)
+envHooks+=(ccWrapper_addCVars)
 
 # Note 1: these come *after* $out in the PATH (see setup.sh).
 # Note 2: phase separation makes this look useless to shellcheck.

--- a/pkgs/build-support/cc-wrapper/utils.sh
+++ b/pkgs/build-support/cc-wrapper/utils.sh
@@ -1,5 +1,5 @@
 skip () {
-    if [ -n "$NIX_DEBUG" ]; then
+    if [ -n "${NIX_DEBUG:-}" ]; then
         echo "skipping impure path $1" >&2
     fi
 }

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -336,8 +336,20 @@ fi
 
 # Set the relevant environment variables to point to the build inputs
 # found above.
+#
+# These `depOffset`s tell the env hook what sort of dependency
+# (ignoring propagatedness) is being passed to the env hook. In a real
+# language, we'd append a closure with this information to the
+# relevant env hook array, but bash doesn't have closures, so it's
+# easier to just pass this in.
+
 _addToNativeEnv() {
     local pkg="$1"
+    if [[ -n "${crossConfig:-}" ]]; then
+        local -i depOffset=-1
+    else
+        local -i depOffset=0
+    fi
 
     # Run the package-specific hooks set by the setup-hook scripts.
     runHook envHook "$pkg"
@@ -349,6 +361,7 @@ done
 
 _addToCrossEnv() {
     local pkg="$1"
+    local -i depOffset=0
 
     # Run the package-specific hooks set by the setup-hook scripts.
     runHook crossEnvHook "$pkg"

--- a/pkgs/tools/archivers/unzip/default.nix
+++ b/pkgs/tools/archivers/unzip/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
 
   makefile = "unix/Makefile";
 
-  ${"NIX_${stdenv.cc.infixSalt_}LDFLAGS"} = [ "-lbz2" ] ++ stdenv.lib.optional enableNLS "-lnatspec";
+  NIX_LDFLAGS = [ "-lbz2" ] ++ stdenv.lib.optional enableNLS "-lnatspec";
 
   buildFlags = "generic D_USE_BZ2=-DUSE_BZIP2 L_BZ2=-lbz2";
 


### PR DESCRIPTION
###### Motivation for this change

For cross compilation, we need to have multiple cc-wrappers in use at once (usually so we can generate built-tools on the fly along with building the derivation itself). But cc-wrapper leaks a bunch of environment variables in its setup hook to be picked up by the wrapper scripts, so multiple cc-wrappers would stomp all over each other. The hack solution to that alone is simple---make sure the two cc-wrapper don't use the same identifiers, which `${infixSalt}` accomplishes.

The catch is that many derivations try to mess with this process by modifying those variables. I specially modified the setup hook to pick up "unsalted" environment variables from derivation itself (or an earlier setup hook...yikes), but derivations (like glibc; see the last commit) also inject bash to modify these too. `git grep 'export NIX_'` can give one a scale of this. ~~I do not yet have a general solution for how not to break these packages...~~

...Now I do. I do the conversion in add-flags instead. Also, normal host-platform-targetting env vars keep their existing notation, so this (at least by the standards of my recent PRs :D) is *highly* backwards compatible. The only semantics change I remember off-hand is that the `START_HOOK`s are now evaluated after `add-flags.sh`, but those are probably dead code---unused in nixpkgs at least.

This is best reviewed commit-by-commit, as some commits are basically seddish and bump up the diff count. Also start with #27879

[Longer term,  instead of an unconditional `envHook`, I'd like to use pkg-config. By default, cc-wrapper will inject the appropriate `pkg-config` invocations, but this can be disabled per-derivation. Derivations like `glibc` that want to be tricky instead call it or do a deferred injection themselves.]

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built stdenv on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Evaluated all of nixpkgs
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @orivej, as you have been working on this a fair amount lately. 