### PR TITLE
oraclejdk: 8u141 -> 8u144

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "141";
+  patchVersion = "144";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "0jq8zq7hgjqbza1wmc1s8r4iz1r1s631snacn29wdsb5i2yg4qk5";
-  sha256_x86_64 = "0kxs765dra47cw39xmifmxrib49j1lfya5cc3kldfv7azcc54784";
+  sha256_i686 = "1i5pginc65xl5vxzwid21ykakmfkqn59v3g01vpr94v28w30jk32";
+  sha256_x86_64 = "1r5axvr8dg2qmr4zjanj73sk9x50m7p0w3vddz8c6ckgav7438z8";
   sha256_armv7l = "0ja97nqn4x0ji16c7r6i9nnnj3745br7qlbj97jg1s8m2wk7f9jd";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "141";
+  patchVersion = "144";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "0jq8zq7hgjqbza1wmc1s8r4iz1r1s631snacn29wdsb5i2yg4qk5";
-  sha256_x86_64 = "0kxs765dra47cw39xmifmxrib49j1lfya5cc3kldfv7azcc54784";
+  sha256_i686 = "1i5pginc65xl5vxzwid21ykakmfkqn59v3g01vpr94v28w30jk32";
+  sha256_x86_64 = "1r5axvr8dg2qmr4zjanj73sk9x50m7p0w3vddz8c6ckgav7438z8";
   sha256_armv7l = "0ja97nqn4x0ji16c7r6i9nnnj3745br7qlbj97jg1s8m2wk7f9jd";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;


### PR DESCRIPTION
###### Motivation for this change

- Jar file verification failing with SecurityException: digest missing xxx

http://www.oracle.com/technetwork/java/javase/8u144-relnotes-3838694.html
http://www.oracle.com/technetwork/java/javase/2col/8u144-bugfixes-3839149.html

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

