### PR TITLE
opencv: Work around build failure with enableContrib & Python

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -90,9 +90,14 @@ stdenv.mkDerivation rec {
       done
     '');
 
-  # This prevents cmake from using libraries in impure paths (which causes build failure on non NixOS)
+  # This prevents cmake from using libraries in impure paths (which
+  # causes build failure on non NixOS)
+  # Also, work around https://github.com/NixOS/nixpkgs/issues/26304 with
+  # what appears to be some stray headers in dnn/misc/tensorflow
+  # in contrib when generating the Python bindings:
   postPatch = ''
     sed -i '/Add these standard paths to the search paths for FIND_LIBRARY/,/^\s*$/{d}' CMakeLists.txt
+    sed -i -e 's|if len(decls) == 0:|if len(decls) == 0 or "opencv2/" not in hdr:|' ./modules/python/src2/gen2.py
   '';
 
   preConfigure =


### PR DESCRIPTION
###### Motivation for this change

This is in regards to https://github.com/NixOS/nixpkgs/issues/26304. It may not be the best solution, but as I am unable to see how the OpenCV build could work on any platform with these options set, I am not sure of the "correct" course of action. The only possible consequence to this incorrectness that I'm aware of is that Python wrappers to OpenCV's support for TensorFlow and Caffe may not be generated properly... but the nixpkgs build of OpenCV isn't even equipped to build with these two optional packages.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

