### PR TITLE
nixos/tinc: remove Device from tinc.conf

### DIFF
--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -141,7 +141,6 @@ in
               ${optionalString (data.ed25519PrivateKeyFile != null) "Ed25519PrivateKeyFile = ${data.ed25519PrivateKeyFile}"}
               ${optionalString (data.listenAddress != null) "ListenAddress = ${data.listenAddress}"}
               ${optionalString (data.bindToAddress != null) "BindToAddress = ${data.bindToAddress}"}
-              Device = /dev/net/tun
               Interface = tinc.${network}
               ${data.extraConfig}
             '';


### PR DESCRIPTION
###### Motivation for this change

```Device``` in ```tinc.conf``` has no value but has a drawback.
[This 10 years old bug](https://www.tinc-vpn.org/pipermail/tinc/2007-June/001667.html) still happens on NixOS 17.09 and can be avoided by removing ```Device```

