### PR TITLE
mcelog: 148 -> 153

### DIFF
--- a/nixos/modules/hardware/mcelog.nix
+++ b/nixos/modules/hardware/mcelog.nix
@@ -3,7 +3,7 @@
 with lib;
 
 {
-  meta.maintainers = [ maintainers.grahamc ];
+  meta.maintainers = with maintainers; [ grahamc ];
   options = {
 
     hardware.mcelog = {
@@ -19,19 +19,17 @@ with lib;
   };
 
   config = mkIf config.hardware.mcelog.enable {
-    systemd.services.mcelog = {
-      description = "Machine Check Exception Logging Daemon";
-      wantedBy = [ "multi-user.target" ];
+    systemd = {
+      packages = [ pkgs.mcelog ];
 
-      serviceConfig = {
-        ExecStart = "${pkgs.mcelog}/bin/mcelog --daemon --foreground";
-        SuccessExitStatus = [ 0 15 ];
-
-        ProtectHome = true;
-        PrivateNetwork = true;
-        PrivateTmp = true;
+      services.mcelog = {
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ProtectHome = true;
+          PrivateNetwork = true;
+          PrivateTmp = true;
+        };
       };
     };
   };
-
 }

--- a/pkgs/os-specific/linux/mcelog/default.nix
+++ b/pkgs/os-specific/linux/mcelog/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "mcelog-${version}";
-  version = "148";
+  version = "153";
 
   src = fetchFromGitHub {
-    sha256 = "04mzscvr38r2q9da9wmv3cxb99vrkxks1mzgvwsxk753xan3p42c";
-    rev = "v${version}";
-    repo = "mcelog";
-    owner = "andikleen";
+    owner  = "andikleen";
+    repo   = "mcelog";
+    rev    = "v${version}";
+    sha256 = "1wz55dzqdiam511d6p1958al6vzlhrhs73s7gly0mzm6kpji0gxa";
   };
 
   postPatch = ''
@@ -27,6 +27,12 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   installFlags = [ "DESTDIR=$(out)" "prefix=" "DOCDIR=/share/doc" ];
+
+  postInstall = ''
+    mkdir -p $out/lib/systemd/system
+    substitute mcelog.service $out/lib/systemd/system/mcelog.service \
+      --replace /usr/sbin $out/bin
+  '';
 
   meta = with stdenv.lib; {
     description = "Log x86 machine checks: memory, IO, and CPU hardware errors";


### PR DESCRIPTION
###### Motivation for this change

Regular package update and start using the mcelog.service provided by upstream.

The machine on which I am working now doesn't support it so I cannot test it but I will give it a go later when on other hardware.

Cc: @grahamc


###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
