### PR TITLE
nixos/networking-scripted: restore bridge slaves dynamically added by…

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -253,8 +253,12 @@ let
 
               ${optionalString config.virtualisation.libvirtd.enable ''
                   # Enslave dynamically added interfaces which may be lost on nixos-rebuild
-                  for dom in $(${pkgs.libvirt}/bin/virsh list --name); do
-                    ${pkgs.libvirt}/bin/virsh dumpxml "$dom" | ${pkgs.xmlstarlet}/bin/xmlstarlet sel -t -m "//domain/devices/interface[@type='bridge']"  -v "concat('ip link set ',target/@dev,' master ',source/@bridge)" | ${pkgs.bash}/bin/bash
+                  for uri in qemu:///system lxc:///; do
+                    for dom in $(${pkgs.libvirt}/bin/virsh -c $uri list --name); do
+                      ${pkgs.libvirt}/bin/virsh -c $uri dumpxml "$dom" | \
+                      ${pkgs.xmlstarlet}/bin/xmlstarlet sel -t -m "//domain/devices/interface[@type='bridge'][target/@dev][source/@bridge]" -v "concat('ip link set ',target/@dev,' master ',source/@bridge)" | \
+                      ${pkgs.bash}/bin/bash
+                    done
                   done
                 ''}
 

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -251,6 +251,13 @@ let
                 ${i}
               '')}" > /run/${n}.interfaces
 
+              ${optionalString config.virtualisation.libvirtd.enable ''
+                  # Enslave dynamically added interfaces which may be lost on nixos-rebuild
+                  for dom in $(${pkgs.libvirt}/bin/virsh list --name); do
+                    ${pkgs.libvirt}/bin/virsh dumpxml "$dom" | ${pkgs.xmlstarlet}/bin/xmlstarlet sel -t -m "//domain/devices/interface[@type='bridge']"  -v "concat('ip link set ',target/@dev,' master ',source/@bridge)" | ${pkgs.bash}/bin/bash
+                  done
+                ''}
+
               # Enable stp on the interface
               ${optionalString v.rstp ''
                 echo 2 >/sys/class/net/${n}/bridge/stp_state

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -256,7 +256,7 @@ let
                   for uri in qemu:///system lxc:///; do
                     for dom in $(${pkgs.libvirt}/bin/virsh -c $uri list --name); do
                       ${pkgs.libvirt}/bin/virsh -c $uri dumpxml "$dom" | \
-                      ${pkgs.xmlstarlet}/bin/xmlstarlet sel -t -m "//domain/devices/interface[@type='bridge'][target/@dev][source/@bridge]" -v "concat('ip link set ',target/@dev,' master ',source/@bridge)" | \
+                      ${pkgs.xmlstarlet}/bin/xmlstarlet sel -t -m "//domain/devices/interface[@type='bridge'][source/@bridge='${n}'][target/@dev]" -v "concat('ip link set ',target/@dev,' master ',source/@bridge,';')" | \
                       ${pkgs.bash}/bin/bash
                     done
                   done


### PR DESCRIPTION
###### Motivation for this change

Another attempt to do something with disappearing slaves
History is here https://github.com/NixOS/nixpkgs/pull/26765 and https://github.com/NixOS/nixpkgs/issues/26342

The use case is not to destroy VM's network on ```nixos-rebuild switch``` on the host, when ```network-setup.service``` stops then starts, not just reloads.

```
['ssh',
 '-oControlPath=/run/user/1000/nixops-ssh-tmpqgre9163/master-socket',
 '-oLogLevel=quiet',
 '-oUserKnownHostsFile=/dev/null',
 '-oGlobalKnownHostsFile=/dev/null',
 '-oStrictHostKeyChecking=no',
 '-oCheckHostIP=no',
 '-X',
 '-t', 'root@10.8.0.1',
 '--',
 '/nix/store/dz2yl580fbs7h1qq0m1z9fpm28c5472x-nixos-system-x1-17.09.git.d9ad651/bin/switch-to-configuration switch']
updating GRUB 2 menu...
stopping the following units: network-setup.service                                                                                                                                                                                                                               
activating the configuration...
setting up /etc...                                                                                                                                                                                                                                                                
setting up tmpfiles
starting the following units: network-setup.service
```

This fix is for ```libvirt``` only, ```nixos-container``` is not covered (here is a [similar fix for containers](https://github.com/NixOS/nixpkgs/pull/22547/files#diff-0346c64733c3dc6b8b853e265bb1e4f1R229)). 

There is also https://github.com/NixOS/nixpkgs/pull/26765 which helps for both ```libvirt``` and ```nixos-container``` (and any not yet known software which enslaves interfaces dynamically), which might be a better option. I stuck to this ```libvirt```-bound solution because of ease of existing installations upgrade: it works right from the first ```nixos-rebuild switch```, while upgrading networking scripts to ones with saving-support requires an extra restart on which the slaves will be lost.

cc @globin @fpletz @kampfschlaefer @mxxz
