### PR TITLE
tinc_pre: avoid infinite loop with EBADFD on network restart

### DIFF
--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -160,7 +160,8 @@ in
         serviceConfig = {
           Type = "simple";
           PIDFile = "/run/tinc.${network}.pid";
-          Restart = "on-failure";
+          Restart = "always";
+          RestartSec = "3";
         };
         preStart = ''
           mkdir -p /etc/tinc/${network}/hosts

--- a/pkgs/tools/networking/tinc/pre.nix
+++ b/pkgs/tools/networking/tinc/pre.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, autoreconfHook, texinfo, ncurses, readline, zlib, lzo, openssl }:
+{ stdenv, fetchgit, fetchpatch, autoreconfHook, texinfo, ncurses, readline, zlib, lzo, openssl }:
 
 stdenv.mkDerivation rec {
   name = "tinc-${version}";
@@ -18,6 +18,14 @@ stdenv.mkDerivation rec {
   prePatch = ''
     substituteInPlace configure.ac --replace UNKNOWN ${version}
   '';
+
+  patches = [
+    # Avoid infinite loop with "Error while reading from Linux tun/tap device (tun mode) /dev/net/tun: File descriptor in bad state" on network restart
+    (fetchpatch {
+      url = https://github.com/gsliepen/tinc/compare/acefa66...e4544db.patch;
+      sha256 = "1jz7anqqzk7j96l5ifggc2knp14fmbsjdzfrbncxx0qhb6ihdcvn";
+    })
+  ];
 
   postInstall = ''
     rm $out/bin/tinc-gui


### PR DESCRIPTION
###### Motivation for this change

The problem is: on ```nixos-rebuild```, Tinc stops working and spams log with

```
Jul 27 05:38:20 x1 tinc.lan-start[1054]: Error while reading from Linux tun/tap device (tun mode) /dev/net/tun: File descriptor in bad state
Jul 27 05:38:20 x1 tinc.lan-start[1054]: Error while reading from Linux tun/tap device (tun mode) /dev/net/tun: File descriptor in bad state
Jul 27 05:38:20 x1 systemd-journald[599]: Suppressed 489664 messages from /system.slice/tinc.lan.service
```

PR has been submitted to upstream and accepted: https://github.com/gsliepen/tinc/issues/146


###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

