### PR TITLE
factorio: 0.15.30 -> 0.15.31

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -10,7 +10,7 @@ assert releaseType == "alpha" || releaseType == "headless" || releaseType == "de
 
 with stdenv.lib;
 let
-  version = if releaseType != "demo" then "0.15.30" else "0.15.25";
+  version = if releaseType != "demo" then "0.15.31" else "0.15.31";
 
   arch = if stdenv.system == "x86_64-linux" then {
     inUrl = "linux64";
@@ -26,9 +26,9 @@ let
     url = "https://www.factorio.com/get-download/${version}/${releaseType}/${arch.inUrl}";
     name = "factorio_${releaseType}_${arch.inTar}-${version}.tar.xz";
     x64 = {
-      headless =           fetchurl { inherit name url; sha256 = "0nmr73i9acnqgphfmsps7f8jlw0f2gyal9l8pldlp4rk0cjgvszy"; };
-      alpha    = authenticatedFetch { inherit name url; sha256 = "1ydh44na2lbvdv4anrblym7d6wxwapfbwap40n3722llrsad0zsz"; };
-      demo     =           fetchurl { inherit name url; sha256 = "1qz6g8mf221ic663zk92l6rs77ggfydaw2d8g2s7wy0j9097qbsl"; };
+      headless =           fetchurl { inherit name url; sha256 = "1kbf6pj0rdiydx7g3xaqhnvvjr01g1afys2flw8x5myanffhql9x"; };
+      alpha    = authenticatedFetch { inherit name url; sha256 = "0mz7x0hc3kvs6l1isnryld08sfy8gkgq81vvmmssa3ayp5y67rh4"; };
+      demo     =           fetchurl { inherit name url; sha256 = "0zsjlgys96qlqs79m634wh36vx5d7faq4749i9lsxm88b6fylfaf"; };
     };
     i386 = {
       headless = abort "Factorio 32-bit headless binaries are not available for download.";


### PR DESCRIPTION
###### Motivation for this change

This release has been declared "stable" by the upstream devs, so there probably won't be any more updates for a while, and more importantly, the binary distribution should persist for a very long time.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

