### PR TITLE
nawk: init at 20121220

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -291,6 +291,7 @@
   kierdavis = "Kier Davis <kierdavis@gmail.com>";
   kkallio = "Karn Kallio <tierpluspluslists@gmail.com>";
   knedlsepp = "Josef Kemetmüller <josef.kemetmueller@gmail.com>";
+  konimex = "Muhammad Herdiansyah <herdiansyah@openmailbox.org>";
   koral = "Koral <koral@mailoo.org>";
   kovirobi = "Kovacsics Robert <kovirobi@gmail.com>";
   kragniz = "Louis Taylor <louis@kragniz.eu>";

--- a/pkgs/tools/text/nawk/default.nix
+++ b/pkgs/tools/text/nawk/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, yacc }:
+
+stdenv.mkDerivation rec {
+  name = "nawk-20121220";
+
+  src = fetchurl {
+    url = "https://www.cs.princeton.edu/~bwk/btl.mirror/awk.tar.gz";
+    sha256 = "10wvdn7xwc5bbp5h7l0b9fxby3bds21n8a34z54i8kjsbhb95h4d";
+  };
+
+  nativeBuildInputs = [ yacc ];
+
+  unpackPhase = ''
+    mkdir build
+    cd build
+    tar xvf ${src}
+  '';
+
+  patchPhase = ''
+    substituteInPlace ./makefile \
+    --replace "YACC = yacc -d -S" ""
+  '';
+
+  installPhase = ''
+    install -Dm755 a.out "$out/bin/nawk"
+    install -Dm644 awk.1 "$out/share/man/man1/nawk.1"
+  '';
+
+  meta = {
+    description = "The one, true implementation of AWK";
+    longDescription = ''
+       This is the version of awk described in "The AWK Programming
+       Language", by Al Aho, Brian Kernighan, and Peter Weinberger
+       (Addison-Wesley, 1988, ISBN 0-201-07981-X).
+    '';
+    homepage = https://www.cs.princeton.edu/~bwk/btl.mirror/;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.konimex ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3288,6 +3288,8 @@ with pkgs;
 
   nasty = callPackage ../tools/security/nasty { };
 
+  nawk = callPackage ../tools/text/nawk { };
+
   nbd = callPackage ../tools/networking/nbd { };
 
   ndjbdns = callPackage ../tools/networking/ndjbdns { };


### PR DESCRIPTION
###### Motivation for this change

This is the "one true" AWK implementation as described in the book "The AWK Programming Language".

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

