### PR TITLE
notmuch-addrlookup: fix build with notmuch 0.25

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch-addrlookup/0001-notmuch-0.25-compatibility-fix.patch
+++ b/pkgs/applications/networking/mailreaders/notmuch-addrlookup/0001-notmuch-0.25-compatibility-fix.patch
@@ -1,0 +1,44 @@
+From a736c0dfd22cd4ab0da86c30a664c91843df1b98 Mon Sep 17 00:00:00 2001
+From: Adam Ruzicka <a.ruzicka@outlook.com>
+Date: Sat, 29 Jul 2017 12:16:29 +0200
+Subject: [PATCH] notmuch-0.25 compatibility fix
+
+---
+ notmuch-addrlookup.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/notmuch-addrlookup.c b/notmuch-addrlookup.c
+index c5cf5b4..a95ded0 100644
+--- a/notmuch-addrlookup.c
++++ b/notmuch-addrlookup.c
+@@ -171,6 +171,13 @@ create_queries (notmuch_database_t *db,
+       count += tmp;
+   if (notmuch_query_count_messages_st (queries[1], &tmp) == NOTMUCH_STATUS_SUCCESS)
+       count += tmp;
++#elif LIBNOTMUCH_MAJOR_VERSION >= 5
++  unsigned int count = 0;
++  unsigned int tmp;
++  if (notmuch_query_count_messages (queries[0], &tmp) == NOTMUCH_STATUS_SUCCESS)
++      count += tmp;
++  if (notmuch_query_count_messages (queries[1], &tmp) == NOTMUCH_STATUS_SUCCESS)
++      count += tmp;
+ #else
+   unsigned int count = notmuch_query_count_messages (queries[0])
+                      + notmuch_query_count_messages (queries[1]);
+@@ -233,6 +240,13 @@ run_queries (notmuch_database_t *db,
+ #if LIBNOTMUCH_MAJOR_VERSION >= 4 && LIBNOTMUCH_MINOR_VERSION >= 3
+       if (notmuch_query_search_messages_st (queries[i], &messages) != NOTMUCH_STATUS_SUCCESS)
+           continue;
++#elif LIBNOTMUCH_MAJOR_VERSION >= 5
++  unsigned int count = 0;
++  unsigned int tmp;
++  if (notmuch_query_count_messages (queries[0], &tmp) == NOTMUCH_STATUS_SUCCESS)
++      count += tmp;
++  if (notmuch_query_count_messages (queries[1], &tmp) == NOTMUCH_STATUS_SUCCESS)
++      count += tmp;
+ #else
+       if (!(messages = notmuch_query_search_messages (queries[i])))
+           continue;
+--
+2.13.3
+

--- a/pkgs/applications/networking/mailreaders/notmuch-addrlookup/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch-addrlookup/default.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig glib notmuch ];
 
+  # Required until notmuch-addrlookup can be compiled against notmuch >= 0.25
+  patches = [ ./0001-notmuch-0.25-compatibility-fix.patch ];
+
   installPhase = ''
     mkdir -p "$out/bin"
     cp notmuch-addrlookup "$out/bin"


### PR DESCRIPTION
###### Motivation for this change


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

