### PR TITLE
nixos/varnish: made compatible with varnish 5.1.2, add modules

### DIFF
--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -7,14 +7,10 @@ with lib;
 {
   options = {
     services.varnish = {
-      enable = mkOption {
-        default = false;
-        description = "
-          Enable the Varnish Server.
-        ";
-      };
+      enable = mkEnableOption "Varnish Server";
 
       http_address = mkOption {
+        type = types.str;
         default = "*:6081";
         description = "
           HTTP listen address and port.
@@ -22,15 +18,35 @@ with lib;
       };
 
       config = mkOption {
+        type = types.lines;
         description = "
           Verbatim default.vcl configuration.
         ";
       };
 
       stateDir = mkOption {
+        type = types.path;
         default = "/var/spool/varnish/${config.networking.hostName}";
         description = "
           Directory holding all state for Varnish to run.
+        ";
+      };
+
+      extraModules = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        example = literalExample "[ pkgs.varnish-geoip ]";
+        description = "
+          Varnish modules (except 'std').
+        ";
+      };
+
+      extraCommandLine = mkOption {
+        type = types.str;
+        default = "";
+        example = "-s malloc,256M";
+        description = "
+          Command line switches for varnishd (run 'varnishd -?' to get list of options)
         ";
       };
     };
@@ -42,6 +58,7 @@ with lib;
     systemd.services.varnish = {
       description = "Varnish";
       wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
       preStart = ''
         mkdir -p ${cfg.stateDir}
         chown -R varnish:varnish ${cfg.stateDir}
@@ -49,8 +66,19 @@ with lib;
       postStop = ''
         rm -rf ${cfg.stateDir}
       '';
-      serviceConfig.ExecStart = "${pkgs.varnish}/sbin/varnishd -a ${cfg.http_address} -f ${pkgs.writeText "default.vcl" cfg.config} -n ${cfg.stateDir} -u varnish";
-      serviceConfig.Type = "forking";
+      serviceConfig = {
+        Type = "simple";
+        PermissionsStartOnly = true;
+        ExecStart = "${pkgs.varnish}/sbin/varnishd -a ${cfg.http_address} -f ${pkgs.writeText "default.vcl" cfg.config} -n ${cfg.stateDir} -F ${cfg.extraCommandLine}"
+          + optionalString (cfg.extraModules != []) " -p vmod_path='${makeSearchPathOutput "lib" "lib/varnish/vmods" ([pkgs.varnish] ++ cfg.extraModules)}' -r vmod_path";
+        Restart = "always";
+        RestartSec = "5s";
+        User = "varnish";
+        Group = "varnish";
+        AmbientCapabilities = "cap_net_bind_service";
+        NoNewPrivileges = true;
+        LimitNOFILE = 131072;
+      };
     };
 
     environment.systemPackages = [ pkgs.varnish ];

--- a/pkgs/servers/varnish/digest.nix
+++ b/pkgs/servers/varnish/digest.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, libmhash, docutils }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.1";
+  name = "varnish-digest-${version}";
+
+  src = fetchFromGitHub {
+    owner = "varnish";
+    repo = "libvmod-digest";
+    rev = "libvmod-digest-${version}";
+    sha256 = "0v18bqbsblhajpx5qvczic3psijhx5l2p2qlw1dkd6zl33hhppy7";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig docutils ];
+  buildInputs = [ varnish libmhash ];
+
+  postPatch = ''
+    substituteInPlace autogen.sh  --replace "-I \''${dataroot}/aclocal"                  ""
+    substituteInPlace Makefile.am --replace "-I \''${LIBVARNISHAPI_DATAROOTDIR}/aclocal" ""
+  '';
+
+  configureFlags = [ "VMOD_DIR=$(out)/lib/varnish/vmods" ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Digest and HMAC vmod";
+    homepage = https://github.com/varnish/libvmod-digest;
+    inherit (varnish.meta) license platforms maintainers;
+  };
+}

--- a/pkgs/servers/varnish/geoip.nix
+++ b/pkgs/servers/varnish/geoip.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchpatch, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, geoip, docutils }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.2";
+  name = "varnish-geoip-${version}";
+
+  src = fetchFromGitHub {
+    owner = "varnish";
+    repo = "libvmod-geoip";
+    rev = "libvmod-geoip-${version}";
+    sha256 = "1gmadayqh3dais14c4skvd47w8h4kyifg7kcw034i0777z5hfpyn";
+  };
+
+  patches = [
+    # IPv6 support
+    (fetchpatch {
+      url = https://github.com/volth/libvmod-geoip-1/commit/0966fe8.patch;
+      sha256 = "053im8h2y8qzs37g95ksr00sf625p23r5ps1j0a2h4lfg70vf4ry";
+    })
+  ];
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig docutils ];
+  buildInputs = [ varnish geoip ];
+  configureFlags = [ "VMOD_DIR=$(out)/lib/varnish/vmods" ];
+
+  meta = with stdenv.lib; {
+    description = "GeoIP Varnish module by Varnish Software";
+    homepage = https://github.com/varnish/libvmod-geoip;
+    inherit (varnish.meta) license platforms maintainers;
+  };
+}

--- a/pkgs/servers/varnish/modules.nix
+++ b/pkgs/servers/varnish/modules.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, pkgconfig, varnish, python, docutils }:
+
+stdenv.mkDerivation rec {
+  version = "0.10.2";
+  name = "varnish-modules-${version}";
+
+  src = fetchurl {
+    url = "https://download.varnish-software.com/varnish-modules/varnish-modules-${version}.tar.gz";
+    sha256 = "0inw76pm8kcidh0lq7gm3c3bh8v6yps0z7j6ar617b8wf730w1im";
+  };
+
+  nativeBuildInputs = [ pkgconfig docutils ];
+  buildInputs = [ varnish python ];
+
+  meta = with stdenv.lib; {
+    description = "Collection of Varnish Cache modules (vmods) by Varnish Software";
+    homepage = https://github.com/varnish/varnish-modules;
+    inherit (varnish.meta) license platforms maintainers;
+  };
+}

--- a/pkgs/servers/varnish/rtstatus.nix
+++ b/pkgs/servers/varnish/rtstatus.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, pkgconfig, varnish, python, docutils }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.0";
+  name = "varnish-rtstatus-${version}";
+
+  src = fetchurl {
+    url = "https://download.varnish-software.com/libvmod-rtstatus/libvmod-rtstatus-${version}.tar.gz";
+    sha256 = "0hll1aspgpv1daw5sdbn5w1d6birchxgapzb6zi1nhahjlimy4ly";
+  };
+
+  nativeBuildInputs = [ pkgconfig docutils ];
+  buildInputs = [ varnish python ];
+  configureFlags = [ "VMOD_DIR=$(out)/lib/varnish/vmods" ];
+
+  meta = with stdenv.lib; {
+    description = "Varnish realtime status page";
+    homepage = https://github.com/varnish/libvmod-rtstatus;
+    inherit (varnish.meta) license platforms maintainers;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4839,6 +4839,10 @@ with pkgs;
   };
 
   varnish = callPackage ../servers/varnish { };
+  varnish-modules = callPackage ../servers/varnish/modules.nix { };
+  varnish-digest = callPackage ../servers/varnish/digest.nix { };
+  varnish-geoip = callPackage ../servers/varnish/geoip.nix { };
+  varnish-rtstatus = callPackage ../servers/varnish/rtstatus.nix { };
 
   venus = callPackage ../tools/misc/venus {
     python = python27;


### PR DESCRIPTION

* nixos/varnish: command line compatible with varnish 5.2.1, fixes
https://github.com/NixOS/nixpkgs/issues/27409
* nixos/varnish: add support for modules (services.varnish.extraModules)
* varnish-modules: init at 0.10.2
* varnish-geoip: init at 1.0.2
* varnish-rtstatus: init at 1.2.0
* varnish-digest: init at 1.0.1
* added services.varnish.extraCommandLine option

###### Motivation for this change

it is https://github.com/NixOS/nixpkgs/pull/27413 squashed in another branch


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

