### PR TITLE
exhibitor: Fix bug with automatic instance management

### DIFF
--- a/nixos/modules/services/misc/exhibitor.nix
+++ b/nixos/modules/services/misc/exhibitor.nix
@@ -15,9 +15,12 @@ let
     election-port=${toString cfg.zkElectionPort}
     cleanup-period-ms=${toString cfg.zkCleanupPeriod}
     servers-spec=${concatStringsSep "," cfg.zkServersSpec}
-    auto-manage-instances=${lib.boolToString cfg.autoManageInstances}
+    auto-manage-instances=${toString cfg.autoManageInstances}
     ${cfg.extraConf}
   '';
+  # NB: toString rather than lib.boolToString on cfg.autoManageInstances is intended.
+  # Exhibitor tests if it's an integer not equal to 0, so the empty string (toString false)
+  # will operate in the same fashion as a 0.
   configDir = pkgs.writeTextDir "exhibitor.properties" exhibitorConfig;
   cliOptionsCommon = {
     configtype = cfg.configType;


### PR DESCRIPTION
Exhibitor expects the auto-manage-instances config value to be an
integer of 0 or 1, rather than a true/false string, which was getting
printed before.

###### Motivation for this change

Current NixOS module has a bug that prevents automatic instance management from working properly.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @copumpkin 