### PR TITLE
dosbox-unstable: init at 2017-07-02

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -75,6 +75,7 @@
   berdario = "Dario Bertini <berdario@gmail.com>";
   bergey = "Daniel Bergey <bergey@teallabs.org>";
   bhipple = "Benjamin Hipple <bhipple@protonmail.com>";
+  binarin = "Alexey Lebedeff <binarin@binarin.ru>";
   bjg = "Brian Gough <bjg@gnu.org>";
   bjornfor = "Bjørn Forsman <bjorn.forsman@gmail.com>";
   bluescreen303 = "Mathijs Kwik <mathijs@bluescreen303.nl>";

--- a/pkgs/misc/emulators/dosbox/unstable.nix
+++ b/pkgs/misc/emulators/dosbox/unstable.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, fetchsvn, SDL, SDL_net, SDL_sound, libpng, makeDesktopItem, mesa, autoreconfHook }:
+
+let revision = "4025";
+    revisionDate = "2017-07-02";
+    revisionSha = "0hbghdlvm6qibp0df35qxq35km4nza3sm301x380ghamxq2vgy6a";
+in stdenv.mkDerivation rec {
+  name = "dosbox-unstable-${revisionDate}";
+
+  src = fetchsvn {
+    url = "https://dosbox.svn.sourceforge.net/svnroot/dosbox/dosbox/trunk";
+    rev = revision;
+    sha256 = revisionSha;
+  };
+
+  hardeningDisable = [ "format" ];
+
+  buildInputs = [ SDL SDL_net SDL_sound libpng mesa autoreconfHook ];
+
+  desktopItem = makeDesktopItem {
+    name = "dosbox";
+    exec = "dosbox";
+    comment = "x86 emulator with internal DOS";
+    desktopName = "DOSBox (SVN)";
+    genericName = "DOS emulator";
+    categories = "Application;Emulator;";
+  };
+
+  postInstall = ''
+     mkdir -p $out/share/applications
+     cp ${desktopItem}/share/applications/* $out/share/applications
+  '';
+
+  meta = {
+    homepage = http://www.dosbox.com/;
+    description = "A DOS emulator";
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ binarin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18537,6 +18537,7 @@ with pkgs;
   dell-530cdn = callPackage ../misc/drivers/dell-530cdn {};
 
   dosbox = callPackage ../misc/emulators/dosbox { };
+  dosbox-unstable = callPackage ../misc/emulators/dosbox/unstable.nix { };
 
   dpkg = callPackage ../tools/package-management/dpkg { };
 


### PR DESCRIPTION
Instead of https://github.com/NixOS/nixpkgs/pull/26763

As current stable version segfaults when playing HoMM2, as described at
https://www.reddit.com/r/linux_gaming/comments/4dxfei/dosbox_segmentation_fault_core_dumped/

Also some missing dependencies (compared to stable version) were added:
- SDL_sound - for mounting .cue files with compressed sound
- SDL_net - for IPX support
- libpng - for making screenshots

###### Motivation for this change


###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

