### PR TITLE
calibre: 3.3.0 -> 3.5.0

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.3.0";
+  version = "3.5.0";
   name = "calibre-${version}";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${name}.tar.xz";
-    sha256 = "1zq3aihnyxdczdz8b0w02xfw4b0l9i23f6ljpmsmm69jyh4j3m0c";
+    sha256 = "1al0vy11zvlxlrf03i631p6b419hy47pbzmgydswrii4prndj4xv";
   };
 
   patches = [
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
     # Remove unneeded files and libs
     rm -rf resources/calibre-portable.* \
-           src/{chardet,cherrypy,html5lib,odf,routes}
+           src/odf
   '';
 
   dontUseQmakeConfigure = true;
@@ -49,12 +49,11 @@ stdenv.mkDerivation rec {
     poppler_utils libpng imagemagick libjpeg
     fontconfig podofo qtbase chmlib icu sqlite libusb1 libmtp xdg_utils wrapGAppsHook
   ] ++ (with python2Packages; [
-    html5lib_0_9999999 # needs to be before mechanize ?
-    apsw cssselect cssutils dateutil lxml mechanize netifaces pillow
+    apsw cssselect cssutils dateutil html5-parser lxml mechanize netifaces pillow
     python pyqt5 sip
     regex msgpack
     # the following are distributed with calibre, but we use upstream instead
-    chardet cherrypy odfpy routes
+    odfpy
   ]);
 
   installPhase = ''
@@ -90,6 +89,9 @@ stdenv.mkDerivation rec {
     for entry in $out/share/applications/*.desktop; do
       substituteAllInPlace $entry
     done
+
+    mkdir -p $out/share
+    cp -a man-pages $out/share/man
 
     runHook postInstall
   '';

--- a/pkgs/development/python-modules/html5-parser/default.nix
+++ b/pkgs/development/python-modules/html5-parser/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, pkgs, pkgconfig, chardet, lxml }:
+
+buildPythonPackage rec {
+  pname = "html5-parser";
+  version = "0.4.3";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "173vzg214x7qfq201m4b09wg5nszdgwjw5q02v23k54iqm3kcpnx";
+  };
+
+  buildInputs = [ pkgconfig ];
+  propagatedBuildInputs = [ chardet lxml pkgs.libxml2 ];
+
+  doCheck = false; # No such file or directory: 'run_tests.py'
+
+  meta = with stdenv.lib; {
+    description = "Fast C based HTML 5 parsing for python";
+    homepage = https://html5-parser.readthedocs.io;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12650,11 +12650,11 @@ in {
 
 
   lxml = buildPythonPackage ( rec {
-    name = "lxml-3.7.2";
+    name = "lxml-3.8.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/l/lxml/${name}.tar.gz";
-      sha256 = "02j1wf3sh2qmswcz3rh0xvsb8jm63ifaiz2bkng93hyvc1iignar";
+      sha256 = "15nvf6n285n282682qyw3wihsncb0x5amdhyi4b83bfa2nz74vvk";
     };
 
     buildInputs = with self; [ pkgs.libxml2 pkgs.libxslt ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2352,6 +2352,8 @@ in {
     };
   };
 
+  html5-parser = callPackage ../development/python-modules/html5-parser {};
+
   httpserver = callPackage ../development/python-modules/httpserver {};
 
   bleach = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Update.

Calibre now uses the new html5-parser package instead of html5lib. I have also removed some unused dependencies and installed the man pages.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @viric @domenkozar @pSub @AndersonTorres
