### PR TITLE
bubblewrap: init at 0.1.8

### DIFF
--- a/pkgs/tools/admin/bubblewrap/default.nix
+++ b/pkgs/tools/admin/bubblewrap/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, libxslt, docbook_xsl, libcap }:
+
+stdenv.mkDerivation rec {
+  name = "bubblewrap-${version}";
+  version = "0.1.8";
+
+  src = fetchurl {
+    url = "https://github.com/projectatomic/bubblewrap/releases/download/v${version}/${name}.tar.xz";
+    sha256 = "1gyy7paqwdrfgxamxya991588ryj9q9c3rhdh31qldqyh9qpy72c";
+  };
+
+  nativeBuildInputs = [ libcap libxslt docbook_xsl ];
+
+  meta = with stdenv.lib; {
+    description = "Unprivileged sandboxing tool";
+    homepage = "https://github.com/projectatomic/bubblewrap";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ konimex ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -722,6 +722,8 @@ with pkgs;
 
   bochs = callPackage ../applications/virtualization/bochs { };
 
+  bubblewrap = callPackage ../tools/admin/bubblewrap { };
+
   borgbackup = callPackage ../tools/backup/borg {
     python3Packages = python34Packages;
   };


### PR DESCRIPTION
###### Motivation for this change

Bubblewrap is a setuid wrapper for unprivileged chroot and namespace manipulation. I'm still not sure where to put it and for now I'll put it in tools/admin.

This is also one of the required dependencies of Flatpak.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

