### PR TITLE
fzf: add script for finding 'share' folder

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -366,15 +366,33 @@ it. Place the resulting <filename>package.nix</filename> file into
 
 </section>
 
-<section xml:id="sec-autojump">
+<section xml:id="sec-shell-helpers">
 
-<title>Autojump</title>
+<title>Interactive shell helpers</title>
 
 <para>
-  autojump needs the shell integration to be useful but unlike other systems,
-  nix doesn't have a standard share directory location. This is why a
-  <command>autojump-share</command> script is shipped that prints the location
-  of the shared folder. This can then be used in the .bashrc like this:
+  Some packages provide the shell integration to be more useful. But
+  unlike other systems, nix doesn't have a standard share directory
+  location. This is why a bunch <command>PACKAGE-share</command>
+  scripts are shipped that print the location of the corresponding
+  shared folder.
+
+  Current list of such packages is as following:
+
+  <itemizedlist>
+    <listitem>
+      <para>
+        <literal>autojump</literal>: <command>autojump-share</command>
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        <literal>fzf</literal>: <command>fzf-share</command>
+      </para>
+    </listitem>
+  </itemizedlist>
+
+  E.g. <literal>autojump</literal> can then used in the .bashrc like this:
 <screen>
   source "$(autojump-share)/autojump.bash"
 </screen>

--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -39,7 +39,15 @@ buildGoPackage rec {
     cp -r $src/man/man1 $man/share/man
     mkdir -p $out/share/vim-plugins
     ln -s $out/share/go/src/github.com/junegunn/fzf $out/share/vim-plugins/${name}
-    cp -R $src/shell $out/share/shell
+
+    cp -R $src/shell $bin/share/fzf
+    cat <<SCRIPT > $bin/bin/fzf-share
+    #!/bin/sh
+    # Run this script to find the fzf shared folder where all the shell
+    # integration scripts are living.
+    echo $bin/share/fzf
+    SCRIPT
+    chmod +x $bin/bin/fzf-share
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

So that helper scripts can be easily sourced in interactive shell
configuration. `autojump` package was already present and had the same
requirements for findind a `share` folders, so I took an inspiration
there.

I beleive this is a better alternative to:
- https://github.com/NixOS/nixpkgs/pull/25080
- https://github.com/NixOS/nixpkgs/pull/27058

Replacing `$out/share/shell` with `$bin/share/fzf` was necessary to
prevent dependency loop in produced derivations.




###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

