### PR TITLE
pg_repack: 1.3.4 -> 1.4.0.1

### DIFF
--- a/pkgs/servers/sql/postgresql/pg_repack/default.nix
+++ b/pkgs/servers/sql/postgresql/pg_repack/default.nix
@@ -1,16 +1,17 @@
 { stdenv, fetchFromGitHub, postgresql, openssl, zlib, readline }:
 
 stdenv.mkDerivation rec {
-    name = "pg_repack-${version}";
-    version = "1.3.4";
+    name = "pg_repack-${version}.1";
+    version = "1.4.0";
+    rev = "ver_${version}.1";
 
     buildInputs = [ postgresql openssl zlib readline ];
 
     src = fetchFromGitHub {
       owner = "reorg";
       repo = "pg_repack";
-      rev = "ver_${version}";
-      sha256 = "1hig4x8iycchlp42q8565jzi6hkj8gpbhl9kpn73jvk7afl7z0c8";
+      inherit rev;
+      sha256 = "1ym2dlhgcizyy4p5dcfw7kadrq6g34pv3liyfx604irprzhw9k74";
     };
 
     installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Adds support for Amazon RDS (pg 9.6.3) when used as client, a longtime wanted feature.

Maintainers somehow didn't change version correctly, so some parts use version 1.4.0, and some use 1.4.0.1. I think, 1.4.0.1 is more correct, because there actually was a code change (despite what maintainer says).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
