### PR TITLE
java: fix dtrace detection

### DIFF
--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -97,6 +97,7 @@ let
       chmod +x configure
       substituteInPlace configure --replace /bin/bash "$shell"
       substituteInPlace hotspot/make/linux/adlc_updater --replace /bin/sh "$shell"
+      substituteInPlace hotspot/make/linux/makefiles/dtrace.make --replace /usr/include/sys/sdt.h "/no-such-path"
     '';
 
     configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

Building `openjdk` on my Linux box failed because the build process wrongly took the existence of `/usr/include/sys/sdt.h` as a sign that `dtrace` should be enabled. Which then failed because `sys/sdt.h` cannot be found during build.

`hotspot/make/linux/makefiles/dtrace.make` contains:

```
# But it does have a SystemTap dtrace compatible sys/sdt.h
ifneq ($(ALT_SDT_H),)
  SDT_H_FILE = $(ALT_SDT_H)
else
  SDT_H_FILE = /usr/include/sys/sdt.h
endif
DTRACE_ENABLED = $(shell test -f $(SDT_H_FILE) && echo $(SDT_H_FILE))
REASON = "$(SDT_H_FILE) not found"

ifneq ($(DTRACE_ENABLED),)
  CFLAGS += -DDTRACE_ENABLED
endif
```

It's not a problem on NixOS because `/usr/include/sys/sdt.h` doesn't exist there. So let's not even try to find that file, it shouldn't be used anyway.

###### Things done

Please check what applies. Note that these are not hard requirements but mereley serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

