### PR TITLE
flex_2_5_35: fix 404

### DIFF
--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation {
   name = "flex-2.5.35";
 
   src = fetchurl {
-    url = mirror://sourceforge/flex/flex-2.5.35.tar.bz2;
-    sha256 = "0ysff249mwhq0053bw3hxh58djc0gy7vjan2z1krrf9n5d5vvv0b";
+    url = https://github.com/westes/flex/archive/flex-2-5-35.tar.gz;
+    sha256 = "0wh06nix8bd4w1aq4k2fbbkdq5i30a9lxz3xczf3ff28yy0kfwzm";
   };
 
   buildInputs = [ bison ];

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoreconfHook, bison, m4 }:
+{ stdenv, fetchurl, autoreconfHook, flex, bison, texinfo, help2man, m4 }:
 
 stdenv.mkDerivation {
   name = "flex-2.5.35";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "0wh06nix8bd4w1aq4k2fbbkdq5i30a9lxz3xczf3ff28yy0kfwzm";
   };
 
-  buildInputs = [ bison autoreconfHook ];
+  nativeBuildInputs = [ flex bison texinfo help2man autoreconfHook ];
 
   propagatedNativeBuildInputs = [ m4 ];
 

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bison, m4 }:
+{ stdenv, fetchurl, autoreconfHook, bison, m4 }:
 
 stdenv.mkDerivation {
   name = "flex-2.5.35";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "0wh06nix8bd4w1aq4k2fbbkdq5i30a9lxz3xczf3ff28yy0kfwzm";
   };
 
-  buildInputs = [ bison ];
+  buildInputs = [ bison autoreconfHook ];
 
   propagatedNativeBuildInputs = [ m4 ];
 


### PR DESCRIPTION
###### Motivation for this change

because of this 404,  NixOS cannot be bootstrapped without access to the binary cache with pre-compiled version from the times when there was no 404.

(yes, it needs another flex to build; no, I cannot squash or rebase - it was done with github webinterface)

