### PR TITLE
nixos-artwork: Fix URL to gnome-dark

### DIFF
--- a/pkgs/data/misc/nixos-artwork/icons.nix
+++ b/pkgs/data/misc/nixos-artwork/icons.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "nixos-icons-2017-03-16";
   srcs = fetchFromGitHub {
-    owner = "nixos";
+    owner = "NixOS";
     repo = "nixos-artwork";
     rev = "783ca1249fc4cfe523ad4e541f37e2229891bc8b";
     sha256 = "0wp08b1gh2chs1xri43wziznyjcplx0clpsrb13wzyscv290ay5a";

--- a/pkgs/data/misc/nixos-artwork/wallpapers.nix
+++ b/pkgs/data/misc/nixos-artwork/wallpapers.nix
@@ -29,7 +29,7 @@ in
     name = "gnome-dark-2015-02-27";
     description = "Gnome Dark background for Nix";
     src = fetchurl {
-      url = https://raw.githubusercontent.com/Nix/nixos-artwork/7ece5356398db14b5513392be4b31f8aedbb85a2/gnome/Gnome_Dark.png;
+      url = https://raw.githubusercontent.com/NixOS/nixos-artwork/7ece5356398db14b5513392be4b31f8aedbb85a2/gnome/Gnome_Dark.png;
       sha256 = "0c7sl9k4zdjwvdz3nhlm8i4qv4cjr0qagalaa1a438jigixx27l7";
     };
   };


### PR DESCRIPTION
###### Motivation for this change
I really don't know how this has gone unnoticed for over a month, the URL for the gnome-dark wallpaper has been changed mistakenly in [this commit](https://github.com/NixOS/nixpkgs/commit/aa8018103c75df14ff7e4f424c6b30f21df080cc).

(I also fixed the capitalization of another link, even though github allows it)

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

