### PR TITLE
Channels i686: build nixos-unstable-small with tests but not nixpkgs-unstable-(small)

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -4,7 +4,7 @@
 
 { nixpkgs ? { outPath = ./..; revCount = 56789; shortRev = "gfedcba"; }
 , stableBranch ? false
-, supportedSystems ? [ "x86_64-linux" "i686-linux" ]
+, supportedSystems ? [ "x86_64-linux" ]
 }:
 
 let

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -4,7 +4,7 @@
 
 { nixpkgs ? { outPath = ./..; revCount = 56789; shortRev = "gfedcba"; }
 , stableBranch ? false
-, supportedSystems ? [ "x86_64-linux" ] # no i686-linux
+, supportedSystems ? [ "x86_64-linux" "i686-linux" ]
 }:
 
 let

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -12,7 +12,7 @@
 { nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
 , officialRelease ? false
 , # The platforms for which we build Nixpkgs.
-  supportedSystems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" ]
+  supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ]
 , # Strip most of attributes when evaluating to spare memory usage
   scrubJobs ? true
 , # Attributes passed to nixpkgs. Don't build packages marked as unfree.


### PR DESCRIPTION
This PR modifies three channels:

- nixos-unstable-small will provide binaries for i686. Failing tests
will also be blockers.
- nixpkgs-unstable(-small) no longer provides binaries for i686.

These changes will also have effect on 17.09 stable.