### PR TITLE
Add desktop entry files for FreeCAD and ddccontrol

### DIFF
--- a/pkgs/tools/misc/ddccontrol/default.nix
+++ b/pkgs/tools/misc/ddccontrol/default.nix
@@ -1,9 +1,10 @@
 { stdenv, fetchurl, autoreconfHook, intltool, perl, perlPackages, libxml2
 , pciutils, pkgconfig, gtk2, ddccontrol-db
+, makeDesktopItem
 }:
 
 let version = "0.4.2"; in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "ddccontrol-${version}";
 
   src = fetchurl {
@@ -31,6 +32,24 @@ stdenv.mkDerivation {
 
       sed -e "s/chmod 4711/chmod 0711/" -i src/ddcpci/Makefile*
   '';
+
+  postInstall = ''
+    mkdir -p $out/share/applications/
+    cp $desktopItem/share/applications/* $out/share/applications/
+    for entry in $out/share/applications/*.desktop; do
+      substituteAllInPlace $entry
+    done
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = "gddccontrol";
+    desktopName = "gddccontrol";
+    genericName = "DDC/CI control";
+    comment = meta.description;
+    exec = "@out@/bin/gddccontrol";
+    icon = "gddccontrol";
+    categories = "Settings;HardwareSettings;";
+  };
 
   meta = with stdenv.lib; {
     description = "A program used to control monitor parameters by software";


### PR DESCRIPTION
###### Motivation for this change

Upstream does not provide FreeCAD and gddccontrol with desktop entry files.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @viric @pakhfn