### PR TITLE
alacritty: use patchelf instead of LD_LIBRARY_PATH

### DIFF
--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -47,7 +47,7 @@ buildRustPackage rec {
     for f in $(find target/release -maxdepth 1 -type f); do
       cp $f $out/bin
     done;
-    wrapProgram $out/bin/alacritty --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath buildInputs}"
+    patchelf --set-rpath "${stdenv.lib.makeLibraryPath buildInputs}" $out/bin/alacritty
   '';
 
 


### PR DESCRIPTION
If we use LD_LIBRARY_PATH then anything typed into Alacritty inherits it. This
breaks a lot of applications if the versions are different. For me this breaks
everything from Git to every program which uses Gtk.

###### Motivation for this change


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

