### PR TITLE
fgallery: enable face detection

### DIFF
--- a/pkgs/tools/graphics/fgallery/default.nix
+++ b/pkgs/tools/graphics/fgallery/default.nix
@@ -1,6 +1,5 @@
-{ stdenv, fetchurl, unzip, makeWrapper, perl, ImageExifTool, JSON
-, coreutils, zip, imagemagick, pngcrush, lcms2, fbida
-}:
+{ stdenv, fetchurl, unzip, makeWrapper, perl, ImageExifTool
+, CpanelJSONXS, coreutils, zip, imagemagick, pngcrush, lcms2, fbida }:
 
 # TODO: add optional dependencies (snippet from fgallery source):
 #
@@ -11,14 +10,14 @@
 #   fatal("cannot run \"facedetect\" (see http://www.thregr.org/~wavexx/hacks/facedetect/)");
 
 stdenv.mkDerivation rec {
-  name = "fgallery-1.8";
+  name = "fgallery-1.8.2";
 
   src = fetchurl {
     url = "http://www.thregr.org/~wavexx/software/fgallery/releases/${name}.zip";
-    sha256 = "1n237sk7fm4yrpn69qaz9fwbjl6i94y664q7d16bhngrcil3bq1d";
+    sha256 = "18wlvqbxcng8pawimbc8f2422s8fnk840hfr6946lzsxr0ijakvf";
   };
 
-  buildInputs = [ unzip makeWrapper perl ImageExifTool JSON ];
+  buildInputs = [ unzip makeWrapper perl ImageExifTool CpanelJSONXS ];
 
   installPhase = ''
     mkdir -p "$out/bin"

--- a/pkgs/tools/graphics/fgallery/default.nix
+++ b/pkgs/tools/graphics/fgallery/default.nix
@@ -1,13 +1,12 @@
 { stdenv, fetchurl, unzip, makeWrapper, perl, ImageExifTool
-, CpanelJSONXS, coreutils, zip, imagemagick, pngcrush, lcms2, fbida }:
+, CpanelJSONXS, coreutils, zip, imagemagick, pngcrush, lcms2
+, facedetect, fbida }:
 
 # TODO: add optional dependencies (snippet from fgallery source):
 #
 # if(system("jpegoptim -V >/dev/null 2>&1")) {
 #   $jpegoptim = 0;
 # }
-# if($facedet && system("facedetect -h >/dev/null 2>&1")) {
-#   fatal("cannot run \"facedetect\" (see http://www.thregr.org/~wavexx/hacks/facedetect/)");
 
 stdenv.mkDerivation rec {
   name = "fgallery-1.8.2";
@@ -34,7 +33,7 @@ stdenv.mkDerivation rec {
     wrapProgram "$out/share/fgallery/fgallery" \
         --set PERL5LIB "$PERL5LIB" \
         --set PATH "${stdenv.lib.makeBinPath
-                     [ coreutils zip imagemagick pngcrush lcms2 fbida ]}"
+                     [ coreutils zip imagemagick pngcrush lcms2 facedetect fbida ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1911,7 +1911,7 @@ with pkgs;
   ferm = callPackage ../tools/networking/ferm { };
 
   fgallery = callPackage ../tools/graphics/fgallery {
-    inherit (perlPackages) ImageExifTool JSON;
+    inherit (perlPackages) ImageExifTool CpanelJSONXS;
   };
 
   flannel = callPackage ../tools/networking/flannel { };


### PR DESCRIPTION
###### Motivation for this change

To enable face detection in fgallery. I also bumped the package to the latest version.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).