### PR TITLE
[staging] binutils: 2.28 -> 2.29

### DIFF
--- a/pkgs/development/libraries/glibc/avoid-semver-on-common.patch
+++ b/pkgs/development/libraries/glibc/avoid-semver-on-common.patch
@@ -1,0 +1,65 @@
+From 0edeadc0d396aa713b808ae50a0058aca5d3837e Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Wed, 26 Jul 2017 10:08:46 -0700
+Subject: [PATCH] Avoid .symver on common symbols [BZ #21666]
+
+The .symver directive on common symbol just creates a new common symbol,
+not an alias and the newer assembler with the bug fix for
+
+https://sourceware.org/bugzilla/show_bug.cgi?id=21661
+
+will issue an error.  Before the fix, we got
+
+$ readelf -sW libc.so | grep "loc[12s]"
+  5109: 00000000003a0608     8 OBJECT  LOCAL  DEFAULT   36 loc1
+  5188: 00000000003a0610     8 OBJECT  LOCAL  DEFAULT   36 loc2
+  5455: 00000000003a0618     8 OBJECT  LOCAL  DEFAULT   36 locs
+  6575: 00000000003a05f0     8 OBJECT  GLOBAL DEFAULT   36 locs@GLIBC_2.2.5
+  7156: 00000000003a05f8     8 OBJECT  GLOBAL DEFAULT   36 loc1@GLIBC_2.2.5
+  7312: 00000000003a0600     8 OBJECT  GLOBAL DEFAULT   36 loc2@GLIBC_2.2.5
+
+in libc.so.  The versioned loc1, loc2 and locs have the wrong addresses.
+After the fix, we got
+
+$ readelf -sW libc.so | grep "loc[12s]"
+  6570: 000000000039e3b8     8 OBJECT  GLOBAL DEFAULT   34 locs@GLIBC_2.2.5
+  7151: 000000000039e3c8     8 OBJECT  GLOBAL DEFAULT   34 loc1@GLIBC_2.2.5
+  7307: 000000000039e3c0     8 OBJECT  GLOBAL DEFAULT   34 loc2@GLIBC_2.2.5
+
+	[BZ #21666]
+	* misc/regexp.c (loc1): Add __attribute__ ((nocommon));
+	(loc2): Likewise.
+	(locs): Likewise.
+
+(cherry picked from commit 388b4f1a02f3a801965028bbfcd48d905638b797)
+---
+ ChangeLog     | 7 +++++++
+ misc/regexp.c | 9 +++++----
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/misc/regexp.c b/misc/regexp.c
+index 19d76c0..eaea7c3 100644
+--- a/misc/regexp.c
++++ b/misc/regexp.c
+@@ -29,14 +29,15 @@
+
+ #if SHLIB_COMPAT (libc, GLIBC_2_0, GLIBC_2_23)
+
+-/* Define the variables used for the interface.  */
+-char *loc1;
+-char *loc2;
++/* Define the variables used for the interface.  Avoid .symver on common
++   symbol, which just creates a new common symbol, not an alias.  */
++char *loc1 __attribute__ ((nocommon));
++char *loc2 __attribute__ ((nocommon));
+ compat_symbol (libc, loc1, loc1, GLIBC_2_0);
+ compat_symbol (libc, loc2, loc2, GLIBC_2_0);
+
+ /* Although we do not support the use we define this variable as well.  */
+-char *locs;
++char *locs __attribute__ ((nocommon));
+ compat_symbol (libc, locs, locs, GLIBC_2_0);
+
+
+--
+2.9.3

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -64,6 +64,9 @@ stdenv.mkDerivation ({
       ./CVE-2017-1000366-rtld-LD_LIBRARY_PATH.patch
       ./CVE-2017-1000366-rtld-LD_PRELOAD.patch
       ./CVE-2017-1000366-rtld-LD_AUDIT.patch
+
+      /* https://sourceware.org/bugzilla/show_bug.cgi?id=21666 */
+      ./avoid-semver-on-common.patch
     ]
     ++ lib.optionals stdenv.isi686 [
       ./fix-i686-memchr.patch

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  version = "2.28";
+  version = "2.29";
   basename = "binutils-${version}";
   inherit (stdenv.lib) optional optionals optionalString;
   # The prefix prepended to binary names to allow multiple binuntils on the
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnu/binutils/${basename}.tar.bz2";
-    sha256 = "0wiasgns7i8km8nrxas265sh2dfpsw93b3qw195ipc90w4z475v2";
+    sha256 = "1gqfyksdnj3iir5gzyvlp785mnk60g1pll6zbzbslfchhr4rb8i9";
   };
 
   patches = [


### PR DESCRIPTION
.semver symbols are no longer allowed, so we need to patch glibc to avoid them

See https://sourceware.org/bugzilla/show_bug.cgi?id=21666

###### Motivation for this change
Update

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

