### PR TITLE
libsass & sassc: 3.3.2 -> 3.4.5

### DIFF
--- a/pkgs/development/libraries/libsass/default.nix
+++ b/pkgs/development/libraries/libsass/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libsass-${version}";
-  version = "3.3.2";
+  version = "3.4.5";
 
   src = fetchurl {
     url = "https://github.com/sass/libsass/archive/${version}.tar.gz";
-    sha256 = "affb7efaa7e152e576cc1d510c662ebe067b0b9e9228ad2937dcafdd4431b573";
+    sha256 = "1j22138l5ymqjfj5zan9d2hipa3ahjmifgpjahqy1smlg5sb837x";
   };
 
   patchPhase = ''

--- a/pkgs/development/tools/sassc/default.nix
+++ b/pkgs/development/tools/sassc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "sassc-${version}";
-  version = "3.3.2";
+  version = "3.4.5";
 
   src = fetchurl {
     url = "https://github.com/sass/sassc/archive/${version}.tar.gz";
-    sha256 = "15a2b2698639dfdc7bd6a5ba7a9ecdaf8ebb9f15503fb04dea1be3133308e41d";
+    sha256 = "1xk4kmmvziz9sal3swpqa10q0s289xjpcz8aggmly8mvxvmngsi9";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Update

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

