### PR TITLE
python36 and python35: Don't use ldconfig and speed up uuid load

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -70,6 +70,7 @@ in stdenv.mkDerivation {
       url = https://github.com/python/cpython/commit/035ba5da3e53e.patch;
       sha256 = "1y74ir1w5cq542w27rgzgp70chhq2x047db9911mihpab8p2nj71";
     })
+    ./no-ldconfig.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/interpreters/python/cpython/3.5/no-ldconfig.patch
+++ b/pkgs/development/interpreters/python/cpython/3.5/no-ldconfig.patch
@@ -1,0 +1,164 @@
+From f0ed87f4066296b7aa3c095d04672c138506fa45 Mon Sep 17 00:00:00 2001
+From: Frederik Rietdijk <fridh@fridh.nl>
+Date: Sat, 29 Jul 2017 20:33:56 +0200
+Subject: [PATCH] Don't use ldconfig and speed up uuid load
+
+---
+ Lib/ctypes/util.py | 70 ++----------------------------------------------------
+ Lib/uuid.py        | 52 ----------------------------------------
+ 2 files changed, 2 insertions(+), 120 deletions(-)
+
+diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
+index 7684eab81d..e9957d7951 100644
+--- a/Lib/ctypes/util.py
++++ b/Lib/ctypes/util.py
+@@ -95,46 +95,7 @@ elif os.name == "posix":
+     import re, tempfile
+ 
+     def _findLib_gcc(name):
+-        # Run GCC's linker with the -t (aka --trace) option and examine the
+-        # library name it prints out. The GCC command will fail because we
+-        # haven't supplied a proper program with main(), but that does not
+-        # matter.
+-        expr = os.fsencode(r'[^\(\)\s]*lib%s\.[^\(\)\s]*' % re.escape(name))
+-
+-        c_compiler = shutil.which('gcc')
+-        if not c_compiler:
+-            c_compiler = shutil.which('cc')
+-        if not c_compiler:
+-            # No C compiler available, give up
+-            return None
+-
+-        temp = tempfile.NamedTemporaryFile()
+-        try:
+-            args = [c_compiler, '-Wl,-t', '-o', temp.name, '-l' + name]
+-
+-            env = dict(os.environ)
+-            env['LC_ALL'] = 'C'
+-            env['LANG'] = 'C'
+-            try:
+-                proc = subprocess.Popen(args,
+-                                        stdout=subprocess.PIPE,
+-                                        stderr=subprocess.STDOUT,
+-                                        env=env)
+-            except OSError:  # E.g. bad executable
+-                return None
+-            with proc:
+-                trace = proc.stdout.read()
+-        finally:
+-            try:
+-                temp.close()
+-            except FileNotFoundError:
+-                # Raised if the file was already removed, which is the normal
+-                # behaviour of GCC if linking fails
+-                pass
+-        res = re.search(expr, trace)
+-        if not res:
+-            return None
+-        return os.fsdecode(res.group(0))
++        return None
+ 
+ 
+     if sys.platform == "sunos5":
+@@ -256,34 +217,7 @@ elif os.name == "posix":
+     else:
+ 
+         def _findSoname_ldconfig(name):
+-            import struct
+-            if struct.calcsize('l') == 4:
+-                machine = os.uname().machine + '-32'
+-            else:
+-                machine = os.uname().machine + '-64'
+-            mach_map = {
+-                'x86_64-64': 'libc6,x86-64',
+-                'ppc64-64': 'libc6,64bit',
+-                'sparc64-64': 'libc6,64bit',
+-                's390x-64': 'libc6,64bit',
+-                'ia64-64': 'libc6,IA-64',
+-                }
+-            abi_type = mach_map.get(machine, 'libc6')
+-
+-            # XXX assuming GLIBC's ldconfig (with option -p)
+-            regex = os.fsencode(
+-                '\s+(lib%s\.[^\s]+)\s+\(%s' % (re.escape(name), abi_type))
+-            try:
+-                with subprocess.Popen(['/sbin/ldconfig', '-p'],
+-                                      stdin=subprocess.DEVNULL,
+-                                      stderr=subprocess.DEVNULL,
+-                                      stdout=subprocess.PIPE,
+-                                      env={'LC_ALL': 'C', 'LANG': 'C'}) as p:
+-                    res = re.search(regex, p.stdout.read())
+-                    if res:
+-                        return os.fsdecode(res.group(1))
+-            except OSError:
+-                pass
++            return None
+ 
+         def find_library(name):
+             return _findSoname_ldconfig(name) or _get_soname(_findLib_gcc(name))
+diff --git a/Lib/uuid.py b/Lib/uuid.py
+index e96e7e034c..a099ab4b4a 100644
+--- a/Lib/uuid.py
++++ b/Lib/uuid.py
+@@ -455,58 +455,6 @@ def _netbios_getnode():
+             continue
+         return int.from_bytes(bytes, 'big')
+ 
+-# Thanks to Thomas Heller for ctypes and for his help with its use here.
+-
+-# If ctypes is available, use it to find system routines for UUID generation.
+-# XXX This makes the module non-thread-safe!
+-_uuid_generate_time = _UuidCreate = None
+-try:
+-    import ctypes, ctypes.util
+-    import sys
+-
+-    # The uuid_generate_* routines are provided by libuuid on at least
+-    # Linux and FreeBSD, and provided by libc on Mac OS X.
+-    _libnames = ['uuid']
+-    if not sys.platform.startswith('win'):
+-        _libnames.append('c')
+-    for libname in _libnames:
+-        try:
+-            lib = ctypes.CDLL(ctypes.util.find_library(libname))
+-        except Exception:
+-            continue
+-        if hasattr(lib, 'uuid_generate_time'):
+-            _uuid_generate_time = lib.uuid_generate_time
+-            break
+-    del _libnames
+-
+-    # The uuid_generate_* functions are broken on MacOS X 10.5, as noted
+-    # in issue #8621 the function generates the same sequence of values
+-    # in the parent process and all children created using fork (unless
+-    # those children use exec as well).
+-    #
+-    # Assume that the uuid_generate functions are broken from 10.5 onward,
+-    # the test can be adjusted when a later version is fixed.
+-    if sys.platform == 'darwin':
+-        import os
+-        if int(os.uname().release.split('.')[0]) >= 9:
+-            _uuid_generate_time = None
+-
+-    # On Windows prior to 2000, UuidCreate gives a UUID containing the
+-    # hardware address.  On Windows 2000 and later, UuidCreate makes a
+-    # random UUID and UuidCreateSequential gives a UUID containing the
+-    # hardware address.  These routines are provided by the RPC runtime.
+-    # NOTE:  at least on Tim's WinXP Pro SP2 desktop box, while the last
+-    # 6 bytes returned by UuidCreateSequential are fixed, they don't appear
+-    # to bear any relationship to the MAC address of any network device
+-    # on the box.
+-    try:
+-        lib = ctypes.windll.rpcrt4
+-    except:
+-        lib = None
+-    _UuidCreate = getattr(lib, 'UuidCreateSequential',
+-                          getattr(lib, 'UuidCreate', None))
+-except:
+-    pass
+ 
+ def _unixdll_getnode():
+     """Get the hardware address on Unix using ctypes."""
+-- 
+2.13.3
+

--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -64,6 +64,10 @@ in stdenv.mkDerivation {
     substituteInPlace configure --replace '-Wl,-stack_size,1000000' ' '
   '';
 
+  patches = [
+    ./no-ldconfig.patch
+  ];
+
   postPatch = ''
     # Determinism
     substituteInPlace "Lib/py_compile.py" --replace "source_stats['mtime']" "(1 if 'DETERMINISTIC_BUILD' in os.environ else source_stats['mtime'])"

--- a/pkgs/development/interpreters/python/cpython/3.6/no-ldconfig.patch
+++ b/pkgs/development/interpreters/python/cpython/3.6/no-ldconfig.patch
@@ -1,0 +1,163 @@
+From a831df344ec1c883a0ef04d8cc8f5c53a942f6de Mon Sep 17 00:00:00 2001
+From: Frederik Rietdijk <fridh@fridh.nl>
+Date: Sat, 29 Jul 2017 20:17:40 +0200
+Subject: [PATCH] Don't use ldconfig and speed up uuid load
+
+---
+ Lib/ctypes/util.py | 70 ++----------------------------------------------------
+ Lib/uuid.py        | 51 ---------------------------------------
+ 2 files changed, 2 insertions(+), 119 deletions(-)
+
+diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
+index 339ae8aa8a..2944985c30 100644
+--- a/Lib/ctypes/util.py
++++ b/Lib/ctypes/util.py
+@@ -85,46 +85,7 @@ elif os.name == "posix":
+     import re, tempfile
+ 
+     def _findLib_gcc(name):
+-        # Run GCC's linker with the -t (aka --trace) option and examine the
+-        # library name it prints out. The GCC command will fail because we
+-        # haven't supplied a proper program with main(), but that does not
+-        # matter.
+-        expr = os.fsencode(r'[^\(\)\s]*lib%s\.[^\(\)\s]*' % re.escape(name))
+-
+-        c_compiler = shutil.which('gcc')
+-        if not c_compiler:
+-            c_compiler = shutil.which('cc')
+-        if not c_compiler:
+-            # No C compiler available, give up
+-            return None
+-
+-        temp = tempfile.NamedTemporaryFile()
+-        try:
+-            args = [c_compiler, '-Wl,-t', '-o', temp.name, '-l' + name]
+-
+-            env = dict(os.environ)
+-            env['LC_ALL'] = 'C'
+-            env['LANG'] = 'C'
+-            try:
+-                proc = subprocess.Popen(args,
+-                                        stdout=subprocess.PIPE,
+-                                        stderr=subprocess.STDOUT,
+-                                        env=env)
+-            except OSError:  # E.g. bad executable
+-                return None
+-            with proc:
+-                trace = proc.stdout.read()
+-        finally:
+-            try:
+-                temp.close()
+-            except FileNotFoundError:
+-                # Raised if the file was already removed, which is the normal
+-                # behaviour of GCC if linking fails
+-                pass
+-        res = re.search(expr, trace)
+-        if not res:
+-            return None
+-        return os.fsdecode(res.group(0))
++        return None
+ 
+ 
+     if sys.platform == "sunos5":
+@@ -246,34 +207,7 @@ elif os.name == "posix":
+     else:
+ 
+         def _findSoname_ldconfig(name):
+-            import struct
+-            if struct.calcsize('l') == 4:
+-                machine = os.uname().machine + '-32'
+-            else:
+-                machine = os.uname().machine + '-64'
+-            mach_map = {
+-                'x86_64-64': 'libc6,x86-64',
+-                'ppc64-64': 'libc6,64bit',
+-                'sparc64-64': 'libc6,64bit',
+-                's390x-64': 'libc6,64bit',
+-                'ia64-64': 'libc6,IA-64',
+-                }
+-            abi_type = mach_map.get(machine, 'libc6')
+-
+-            # XXX assuming GLIBC's ldconfig (with option -p)
+-            regex = r'\s+(lib%s\.[^\s]+)\s+\(%s'
+-            regex = os.fsencode(regex % (re.escape(name), abi_type))
+-            try:
+-                with subprocess.Popen(['/sbin/ldconfig', '-p'],
+-                                      stdin=subprocess.DEVNULL,
+-                                      stderr=subprocess.DEVNULL,
+-                                      stdout=subprocess.PIPE,
+-                                      env={'LC_ALL': 'C', 'LANG': 'C'}) as p:
+-                    res = re.search(regex, p.stdout.read())
+-                    if res:
+-                        return os.fsdecode(res.group(1))
+-            except OSError:
+-                pass
++            return None
+ 
+         def _findLib_ld(name):
+             # See issue #9998 for why this is needed
+diff --git a/Lib/uuid.py b/Lib/uuid.py
+index 200c800b34..a099ab4b4a 100644
+--- a/Lib/uuid.py
++++ b/Lib/uuid.py
+@@ -455,57 +455,6 @@ def _netbios_getnode():
+             continue
+         return int.from_bytes(bytes, 'big')
+ 
+-# Thanks to Thomas Heller for ctypes and for his help with its use here.
+-
+-# If ctypes is available, use it to find system routines for UUID generation.
+-# XXX This makes the module non-thread-safe!
+-_uuid_generate_time = _UuidCreate = None
+-try:
+-    import ctypes, ctypes.util
+-    import sys
+-
+-    # The uuid_generate_* routines are provided by libuuid on at least
+-    # Linux and FreeBSD, and provided by libc on Mac OS X.
+-    _libnames = ['uuid']
+-    if not sys.platform.startswith('win'):
+-        _libnames.append('c')
+-    for libname in _libnames:
+-        try:
+-            lib = ctypes.CDLL(ctypes.util.find_library(libname))
+-        except Exception:
+-            continue
+-        if hasattr(lib, 'uuid_generate_time'):
+-            _uuid_generate_time = lib.uuid_generate_time
+-            break
+-    del _libnames
+-
+-    # The uuid_generate_* functions are broken on MacOS X 10.5, as noted
+-    # in issue #8621 the function generates the same sequence of values
+-    # in the parent process and all children created using fork (unless
+-    # those children use exec as well).
+-    #
+-    # Assume that the uuid_generate functions are broken from 10.5 onward,
+-    # the test can be adjusted when a later version is fixed.
+-    if sys.platform == 'darwin':
+-        if int(os.uname().release.split('.')[0]) >= 9:
+-            _uuid_generate_time = None
+-
+-    # On Windows prior to 2000, UuidCreate gives a UUID containing the
+-    # hardware address.  On Windows 2000 and later, UuidCreate makes a
+-    # random UUID and UuidCreateSequential gives a UUID containing the
+-    # hardware address.  These routines are provided by the RPC runtime.
+-    # NOTE:  at least on Tim's WinXP Pro SP2 desktop box, while the last
+-    # 6 bytes returned by UuidCreateSequential are fixed, they don't appear
+-    # to bear any relationship to the MAC address of any network device
+-    # on the box.
+-    try:
+-        lib = ctypes.windll.rpcrt4
+-    except:
+-        lib = None
+-    _UuidCreate = getattr(lib, 'UuidCreateSequential',
+-                          getattr(lib, 'UuidCreate', None))
+-except:
+-    pass
+ 
+ def _unixdll_getnode():
+     """Get the hardware address on Unix using ctypes."""
+-- 
+2.13.3
+


### PR DESCRIPTION
###### Motivation for this change

See  de1b4e7.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
