### PR TITLE
postfix service: fix extraMasterConf

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -267,7 +267,7 @@ let
       lines = [ sep (formatLine labels) (formatLine labelDefaults) sep ];
     in concatStringsSep "\n" lines;
 
-  in formattedLabels + "\n" + concatMapStringsSep "\n" formatLine masterCf + "\n";
+  in formattedLabels + "\n" + concatMapStringsSep "\n" formatLine masterCf + "\n" + cfg.extraMasterConf;
 
   headerCheckOptions = { ... }:
   {
@@ -838,6 +838,9 @@ in
     })
     (mkIf (cfg.extraConfig != "") {
       warnings = [ "The services.postfix.extraConfig option was deprecated. Please use services.postfix.config instead." ];
+    })
+    (mkIf (cfg.extraMasterConf != "") {
+      warnings = [ "The services.postfix.extraMasterConf option was deprecated. Please use services.postfix.masterConfig instead." ];
     })
   ]);
 }


### PR DESCRIPTION
###### Motivation for this change

Fix broken configuration option.

BTW, there should be a change in the changelog about new escaping of parameters. I had `destination = [ "$mydomain" ];` in my configuration before and it silently broke my server after update.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

