### PR TITLE
Python wrapper: undo change package accumulators

### DIFF
--- a/pkgs/development/interpreters/python/wrap.sh
+++ b/pkgs/development/interpreters/python/wrap.sh
@@ -86,7 +86,7 @@ wrapPythonProgramsIn() {
 _addToPythonPath() {
     local dir="$1"
     # Stop if we've already visited here.
-    [ -n "${pythonPathsSeen[$dir]}" ] || return 0
+    if [ -n "${pythonPathsSeen[$dir]}" ]; then return; fi
     pythonPathsSeen[$dir]=1
     # addToSearchPath is defined in stdenv/generic/setup.sh. It will have
     # the effect of calling `export program_X=$dir/...:$program_X`.


### PR DESCRIPTION
because we would otherwise end up with broken wrappers because PATH and
PTYHONPATH weren't set.

Partially reverts 8d76effc178747f0c8f456fe619c1b014736a6af.

cc @Ericson2314 