### PR TITLE
fix most: supported on all unix, not only gnu

### DIFF
--- a/pkgs/tools/misc/most/default.nix
+++ b/pkgs/tools/misc/most/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
       -e "s|/bin/cp|cp|"  \
       -e "s|/bin/rm|rm|"
   '';
-  
+
   configureFlags = "--with-slang=${slang.dev}";
 
   buildInputs = [ slang ncurses ];
@@ -28,6 +28,6 @@ stdenv.mkDerivation {
     '';
     homepage = http://www.jedsoft.org/most/index.html;
     license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.gnu; # random choice
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

fix "most is not supported on ‘x86_64-darwin’"

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

