### PR TITLE
geogebra: make language configurable via `config.nix`

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18312,7 +18312,9 @@ with pkgs;
 
   gap = callPackage ../applications/science/math/gap { };
 
-  geogebra = callPackage ../applications/science/math/geogebra { };
+  geogebra = callPackage ../applications/science/math/geogebra {
+    language = config.geogebra.language or "en";
+  };
 
   maxima = callPackage ../applications/science/math/maxima {
     sbcl = sbcl_1_3_12;


### PR DESCRIPTION
###### Motivation for this change

I think it might be way easier to configure geogebra using `config.nix` rather than building an overlay to pass the modified `language` parameter to the derivation.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

