### PR TITLE
shairport-sync: 2.3.6.5 -> 3.0.2

### DIFF
--- a/pkgs/servers/shairport-sync/default.nix
+++ b/pkgs/servers/shairport-sync/default.nix
@@ -2,23 +2,23 @@
 , libdaemon, popt, pkgconfig, libconfig, libpulseaudio, soxr }:
 
 stdenv.mkDerivation rec {
-  version = "2.3.6.5";
+  version = "3.0.2";
   name = "shairport-sync-${version}";
 
   src = fetchFromGitHub {
-    sha256 = "1337y62pnch27s2gr47miip3na1am24xprlc5a27lbr764nr85s3";
+    sha256 = "1lpfl591lhk66a5jfp86j669iswjzj503x02hg9h3211vxv3h9pa";
     rev = version;
     repo = "shairport-sync";
     owner = "mikebrady";
   };
 
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
   buildInputs = [
-    autoreconfHook
     openssl
     avahi
     alsaLib
     libdaemon
-    pkgconfig
     popt
     libconfig
     libpulseaudio
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
     inherit (src.meta) homepage;
     description = "Airtunes server and emulator with multi-room capabilities";
     license = licenses.mit;
+    maintainers =  with maintainers; [ lnl7 ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes runtime issues when using the shairport-sync service.


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] ~~macOS~~
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

