### PR TITLE
fetchbower: handle packages with slashes in their name

### DIFF
--- a/pkgs/build-support/fetchbower/default.nix
+++ b/pkgs/build-support/fetchbower/default.nix
@@ -7,8 +7,10 @@ let
       ver = if builtins.length components == 1 then version else hash;
     in ver;
 
+  bowerName = name: lib.replaceStrings ["/"] ["-"] name;
+
   fetchbower = name: version: target: outputHash: stdenv.mkDerivation {
-    name = "${name}-${bowerVersion version}";
+    name = "${bowerName name}-${bowerVersion version}";
     SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
     buildCommand = ''
       fetch-bower --quiet --out=$PWD/out "${name}" "${target}" "${version}"


### PR DESCRIPTION
###### Motivation for this change

Fixes the fetchbower function in the case where bower packages refer to github repos (rvl/bower2nix#13).

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
