### PR TITLE
faac: 1.28 -> 1.29.3

### DIFF
--- a/pkgs/development/libraries/faac/default.nix
+++ b/pkgs/development/libraries/faac/default.nix
@@ -8,26 +8,12 @@ assert mp4v2Support -> (mp4v2 != null);
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "faac-${version}";
-  version = "1.28";
+  version = "1.29.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/faac/${name}.tar.gz";
-    sha256 = "1pqr7nf6p2r283n0yby2czd3iy159gz8rfinkis7vcfgyjci2565";
+    sha256 = "0gssrz2vq52mj8x2hvdqc9bwkp64s4f4g7yj7ac6dwxs8dw8kwnf";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "faac-mp4v2-1.9.patch";
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/mp4v2-1.9.patch?h=packages/faac";
-      sha256 = "1pja822zw9q3cg8bjkw5z0bpxsk4q92qix26zpiqbvi7vg314hyc";
-    })
-    (fetchpatch {
-      name = "faac-mp4v2-2.0.0.patch";
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/mp4v2-2.0.0.patch?h=packages/faac";
-      sha256 = "07kmkrl0600rs01xqpkkw9n8p1215n485xqf8hwimp60dw3vc0wn";
-      addPrefixes = true;
-    })
-  ];
 
   configureFlags = [ ]
     ++ optional mp4v2Support "--with-external-mp4v2"


### PR DESCRIPTION
###### Motivation for this change

previous version doesn't build anymore: patch is 404

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

