### PR TITLE
pythonPackages.cryptop: init at 0.1.0

### DIFF
--- a/pkgs/applications/altcoins/cryptop/default.nix
+++ b/pkgs/applications/altcoins/cryptop/default.nix
@@ -1,0 +1,24 @@
+{ lib, python2}:
+
+python2.pkgs.buildPythonApplication rec {
+  pname = "cryptop";
+  version = "0.1.0";
+  name = "${pname}-${version}";
+
+  src = python2.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "00glnlyig1aajh30knc5rnfbamwfxpg29js2db6mymjmfka8lbhh";
+  };
+
+  propagatedBuildInputs = [ python2.pkgs.requests ];
+
+  # No tests in archive
+  doCheck = false;
+
+  meta = {
+    homepage = "http://github.com/huwwp/cryptop";
+    description = "Command line Cryptocurrency Portfolio";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13382,6 +13382,8 @@ with pkgs;
   bitcoin = altcoins.bitcoin;
   bitcoin-xt = altcoins.bitcoin-xt;
 
+  cryptop = callPackage ../applications/altcoins/cryptop { };
+
   libbitcoin = callPackage ../tools/misc/libbitcoin/libbitcoin.nix {
     secp256k1 = secp256k1.override { enableECDH = true; };
   };


### PR DESCRIPTION
This commit adds the python application cryptop, which is a small curses
application for viewing cryptocurrency portfolio values.

###### Motivation for this change
New application.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

