### PR TITLE
ponyc: 0.15.0 -> 0.16.1

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation ( rec {
   name = "ponyc-${version}";
-  version = "0.15.0";
+  version = "0.16.1";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "ponyc";
     rev = version;
-    sha256 = "02hmn066jswaij2ib0faabm2i9cqz562z6s0vakgwnxyrk4qayif";
+    sha256 = "175yivc5vjwfdcqcpkdqmdfy72pn4k62n4j3qagfbwya7frq2car";
   };
 
   buildInputs = [ llvm makeWrapper which ];

--- a/pkgs/development/compilers/ponyc/pony-stable.nix
+++ b/pkgs/development/compilers/ponyc/pony-stable.nix
@@ -1,13 +1,13 @@
 {stdenv, fetchFromGitHub, ponyc }:
 
 stdenv.mkDerivation {
-  name = "pony-stable-unstable-2017-04-20";
+  name = "pony-stable-unstable-2017-07-26";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "pony-stable";
-    rev = "b2ea566b02ec40480f888652b04eaa5f191a241e";
-    sha256 = "1bixkxccsrnyip3yp42r14rbhk832pvzwbkh6ash4ip2isxa6b19";
+    rev = "4016f9253a4e3114ee69100d3d02154ffd3fd7e4";
+    sha256 = "0xz5syjn2f8k31vny49k3jm8zisa15ly4hbcb3rh4jvq8jjp1ldr";
   };
 
   buildInputs = [ ponyc ];


### PR DESCRIPTION
pony-stable: unstable-2017-04-20 -> unstable-2017-07-26

###### Motivation for this change

https://github.com/ponylang/ponyc/issues/2101

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

