### PR TITLE
fd: init at 2.0.0

### DIFF
--- a/pkgs/tools/misc/fd/default.nix
+++ b/pkgs/tools/misc/fd/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "fd-${version}";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "sharkdp";
+    repo = "fd";
+    rev = "v${version}";
+    sha256 = "1xs4y9zf5m0ykl95787jv98xg0a60gkcyyh7kg7qg4xrcgf4qz4j";
+  };
+
+  depsSha256 = "1hxf3j4584jgpwrwykx6yil6q6ka9l81qvx6zrbprdxk3pslp049";
+
+  meta = {
+    description = "A simple, fast and user-friendly alternative to find";
+    longDescription = ''
+      `fd` is a simple, fast and user-friendly alternative to `find`.
+
+      While it does not seek to mirror all of `find`'s powerful functionality,
+      it provides sensible (opinionated) defaults for 80% of the use cases.
+    '';
+    homepage = "https://github.com/sharkdp/fd";
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1011,6 +1011,8 @@ with pkgs;
     buildInputs = old.buildInputs ++ [phantomjs2];
   });
 
+  fd = callPackage ../tools/misc/fd { };
+
   filebench = callPackage ../tools/misc/filebench { };
 
   fsmon = callPackage ../tools/misc/fsmon { };


### PR DESCRIPTION
Add the package `fd`, a simpler alternative to `find`, at version
2.0.0.

I have tested this change per nixpkgs manual section 13.1 ("Making
patches").

