### PR TITLE
xrdp: abs path to garbage directory

### DIFF
--- a/pkgs/applications/networking/remote/xrdp/default.nix
+++ b/pkgs/applications/networking/remote/xrdp/default.nix
@@ -58,7 +58,7 @@ let
       ./bootstrap
     '';
     dontDisableStatic = true;
-    configureFlags = [ "--with-systemdsystemunitdir=./do-not-install" "--enable-ipv6" "--enable-jpeg" "--enable-fuse" "--enable-rfxcodec" "--enable-opus" ];
+    configureFlags = [ "--with-systemdsystemunitdir=/var/empty" "--enable-ipv6" "--enable-jpeg" "--enable-fuse" "--enable-rfxcodec" "--enable-opus" ];
 
     installFlags = [ "DESTDIR=$(out)" "prefix=" ];
 


### PR DESCRIPTION
###### Motivation for this change

It created ```/nix/store/vdhg5dclbnhfhpad40zvxcgi1hsvnavy-xrdp-0.9.3./do-not-install```
