### PR TITLE
masterpdfeditor: init at 4.2.70

### DIFF
--- a/pkgs/applications/misc/masterpdfeditor/default.nix
+++ b/pkgs/applications/misc/masterpdfeditor/default.nix
@@ -22,13 +22,23 @@
       ];
       dontStrip = true;
       installPhase = ''
-        mkdir -pv $out/bin
+        mkdir -p $out/bin $out/share/applications $out/share/pixmaps
+
+        substituteInPlace masterpdfeditor4.desktop \
+          --replace 'Exec=/opt/master-pdf-editor-4' "Exec=$out/bin" \
+          --replace 'Path=/opt/master-pdf-editor-4' "Path=$out/bin" \
+          --replace 'Icon=/opt/master-pdf-editor-4' "Icon=$out/share/pixmaps"
+
         cp -v masterpdfeditor4 $out/bin/masterpdfeditor4
-        cp -v masterpdfeditor4.png $out/bin/masterpdfeditor4.png
+        cp -v masterpdfeditor4.png $out/share/pixmaps/
+        cp -v masterpdfeditor4.desktop $out/share/applications
+
         cp -v -r stamps $out/bin/stamps
         cp -v -r templates $out/bin/templates
         cp -v -r lang $out/bin/lang
         cp -v -r fonts $out/bin/fonts
+        install -D license.txt $out/share/$name/LICENSE
+
         patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
                  --set-rpath $libPath \
                  $out/bin/masterpdfeditor4

--- a/pkgs/applications/misc/masterpdfeditor/default.nix
+++ b/pkgs/applications/misc/masterpdfeditor/default.nix
@@ -22,26 +22,25 @@
       ];
       dontStrip = true;
       installPhase = ''
-        mkdir -p $out/bin $out/share/applications $out/share/pixmaps
+        p=$out/opt/masterpdfeditor
+        mkdir -p $out/bin $p $out/share/applications $out/share/pixmaps
 
         substituteInPlace masterpdfeditor4.desktop \
           --replace 'Exec=/opt/master-pdf-editor-4' "Exec=$out/bin" \
           --replace 'Path=/opt/master-pdf-editor-4' "Path=$out/bin" \
           --replace 'Icon=/opt/master-pdf-editor-4' "Icon=$out/share/pixmaps"
-
-        cp -v masterpdfeditor4 $out/bin/masterpdfeditor4
         cp -v masterpdfeditor4.png $out/share/pixmaps/
         cp -v masterpdfeditor4.desktop $out/share/applications
 
-        cp -v -r stamps $out/bin/stamps
-        cp -v -r templates $out/bin/templates
-        cp -v -r lang $out/bin/lang
-        cp -v -r fonts $out/bin/fonts
+        cp -v masterpdfeditor4 $p/
+        ln -s $p/masterpdfeditor4 $out/bin/masterpdfeditor4
+        cp -v -r stamps templates lang fonts $p
+
         install -D license.txt $out/share/$name/LICENSE
 
         patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
                  --set-rpath $libPath \
-                 $out/bin/masterpdfeditor4
+                 $p/masterpdfeditor4
       '';
       meta = with stdenv.lib; {
         description = "Master PDF Editor";

--- a/pkgs/applications/misc/masterpdfeditor/default.nix
+++ b/pkgs/applications/misc/masterpdfeditor/default.nix
@@ -47,7 +47,7 @@
         description = "Master PDF Editor";
         homepage = "https://code-industry.net/free-pdf-editor/";
         license = licenses.unfreeRedistributable;
-        platforms = platforms.linux;
+        platforms = with platforms; [ "x86_64-linux" ];
         maintainers = with maintainers; [ cmcdragonkai flokli ];
       };
     }

--- a/pkgs/applications/misc/masterpdfeditor/default.nix
+++ b/pkgs/applications/misc/masterpdfeditor/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, glibc, sane-backends, qtbase, qtsvg, libXext, libX11, libXdmcp, libXau, libxcb }:
   let
-    version = "4.2.70";
+    version = "4.3.61";
   in
     stdenv.mkDerivation {
       name = "masterpdfeditor-${version}";
       src = fetchurl {
         url = "http://get.code-industry.net/public/master-pdf-editor-${version}_qt5.amd64.tar.gz";
-        sha256 = "0vl5gc1fzsmzl56vd9g3av48557if8a04vhhl5yna8by26h6xz0c";
+        sha256 = "1g6mx8nch6ypf78h6xsb673wim19wn5ni5840armzg0pvi3sfknm";
       };
       libPath = stdenv.lib.makeLibraryPath [
         stdenv.cc.cc
@@ -34,10 +34,10 @@
                  $out/bin/masterpdfeditor4
       '';
       meta = with stdenv.lib; {
-        description = "PDF Editor";
+        description = "Master PDF Editor";
         homepage = "https://code-industry.net/free-pdf-editor/";
         license = licenses.unfreeRedistributable;
         platforms = platforms.linux;
-        maintainers = maintainers.cmcdragonkai;
+        maintainers = with maintainers; [ cmcdragonkai flokli ];
       };
     }

--- a/pkgs/applications/misc/masterpdfeditor/default.nix
+++ b/pkgs/applications/misc/masterpdfeditor/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, glibc, sane-backends, qtbase, qtsvg, libXext, libX11, libXdmcp, libXau, libxcb }:
+  let
+    version = "4.2.70";
+  in
+    stdenv.mkDerivation {
+      name = "masterpdfeditor-${version}";
+      src = fetchurl {
+        url = "http://get.code-industry.net/public/master-pdf-editor-${version}_qt5.amd64.tar.gz";
+        sha256 = "0vl5gc1fzsmzl56vd9g3av48557if8a04vhhl5yna8by26h6xz0c";
+      };
+      libPath = stdenv.lib.makeLibraryPath [
+        stdenv.cc.cc
+        glibc
+        sane-backends
+        qtbase
+        qtsvg
+        libXext
+        libX11
+        libXdmcp
+        libXau
+        libxcb
+      ];
+      dontStrip = true;
+      installPhase = ''
+        mkdir -pv $out/bin
+        cp -v masterpdfeditor4 $out/bin/masterpdfeditor4
+        cp -v masterpdfeditor4.png $out/bin/masterpdfeditor4.png
+        cp -v -r stamps $out/bin/stamps
+        cp -v -r templates $out/bin/templates
+        cp -v -r lang $out/bin/lang
+        cp -v -r fonts $out/bin/fonts
+        patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+                 --set-rpath $libPath \
+                 $out/bin/masterpdfeditor4
+      '';
+      meta = with stdenv.lib; {
+        description = "PDF Editor";
+        homepage = "https://code-industry.net/free-pdf-editor/";
+        license = licenses.unfreeRedistributable;
+        platforms = platforms.linux;
+        maintainers = maintainers.cmcdragonkai;
+      };
+    }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13669,6 +13669,8 @@ with pkgs;
 
   adobe-reader = callPackage_i686 ../applications/misc/adobe-reader { };
 
+  masterpdfeditor = libsForQt5.callPackage ../applications/misc/masterpdfeditor { };
+
   aeolus = callPackage ../applications/audio/aeolus { };
 
   aewan = callPackage ../applications/editors/aewan { };


### PR DESCRIPTION
###### Motivation for this change

Added masterpdfeditor.

This is the best PDF editor available on Linux. I've tried them all but only this one allows me to add text into unfillable forms.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I had some code here for 32 bit, but since I don't have a 32 bit machine I can't test the build of it. What's the right way to specify that this package is only for 64 bit?

I tested this on nix-shell, but not part of main nixpkgs.
