### PR TITLE
Removed deprecation warning for networking.extraHosts

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -199,9 +199,6 @@ in
 
   config = {
 
-    warnings = optional (cfg.extraHosts != "")
-      "networking.extraHosts is deprecated, please use networking.hosts instead";
-
     environment.etc =
       { # /etc/services: TCP/UDP port assignments.
         "services".source = pkgs.iana-etc + "/etc/services";


### PR DESCRIPTION
###### Motivation for this change

It is a follow-up of #27105 
It added `networking.hosts` option as an upgrade of `networking.extraHosts`, which recieved a deprecation warning. However, @NeQuissimus stated a clear use-case for `networking.extraHosts`. This PR removes warning. No other changes needed.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

