### PR TITLE
Convert libs to a fixed-point

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1,11 +1,11 @@
+{ lib }:
 # Operations on attribute sets.
 
 let
   inherit (builtins) head tail length;
-  inherit (import ./trivial.nix) and or;
-  inherit (import ./default.nix) fold;
-  inherit (import ./strings.nix) concatStringsSep;
-  inherit (import ./lists.nix) concatMap concatLists all deepSeqList;
+  inherit (lib.trivial) and or;
+  inherit (lib.strings) concatStringsSep;
+  inherit (lib.lists) fold concatMap concatLists all deepSeqList;
 in
 
 rec {

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -1,6 +1,6 @@
+{ lib }:
 let
 
-  lib = import ./default.nix;
   inherit (builtins) attrNames isFunction;
 
 in

--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -1,4 +1,6 @@
-let lib = import ./default.nix;
+{ lib }:
+
+let
 
 inherit (builtins) trace attrNamesToStr isAttrs isFunction isList isInt
         isString isBool head substring attrNames;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -5,58 +5,127 @@
  */
 let
 
-  # often used, or depending on very little
-  trivial = import ./trivial.nix;
-  fixedPoints = import ./fixed-points.nix;
+  callLibs = file: import file { inherit lib; };
 
-  # datatypes
-  attrsets = import ./attrsets.nix;
-  lists = import ./lists.nix;
-  strings = import ./strings.nix;
-  stringsWithDeps = import ./strings-with-deps.nix;
+  lib = rec {
 
-  # packaging
-  customisation = import ./customisation.nix;
-  maintainers = import ./maintainers.nix;
-  meta = import ./meta.nix;
-  sources = import ./sources.nix;
+    # often used, or depending on very little
+    trivial = callLibs ./trivial.nix;
+    fixedPoints = callLibs ./fixed-points.nix;
 
-  # module system
-  modules = import ./modules.nix;
-  options = import ./options.nix;
-  types = import ./types.nix;
+    # datatypes
+    attrsets = callLibs ./attrsets.nix;
+    lists = callLibs ./lists.nix;
+    strings = callLibs ./strings.nix;
+    stringsWithDeps = callLibs ./strings-with-deps.nix;
 
-  # constants
-  licenses = import ./licenses.nix;
-  systems = import ./systems;
+    # packaging
+    customisation = callLibs ./customisation.nix;
+    maintainers = callLibs ./maintainers.nix;
+    meta = callLibs ./meta.nix;
+    sources = callLibs ./sources.nix;
 
-  # misc
-  debug = import ./debug.nix;
-  generators = import ./generators.nix;
-  misc = import ./deprecated.nix;
 
-  # domain-specific
-  sandbox = import ./sandbox.nix;
-  fetchers = import ./fetchers.nix;
+    # module system
+    modules = callLibs ./modules.nix;
+    options = callLibs ./options.nix;
+    types = callLibs ./types.nix;
 
-  # Eval-time filesystem handling
-  filesystem = import ./filesystem.nix;
+    # constants
+    licenses = callLibs ./licenses.nix;
+    systems = callLibs ./systems;
 
-in
-  { inherit trivial fixedPoints
-            attrsets lists strings stringsWithDeps
-            customisation maintainers meta sources
-            modules options types
-            licenses systems
-            debug generators misc
-            sandbox fetchers filesystem;
+    # misc
+    debug = callLibs ./debug.nix;
+
+    generators = callLibs ./generators.nix;
+    misc = callLibs ./deprecated.nix;
+    # domain-specific
+    sandbox = callLibs ./sandbox.nix;
+    fetchers = callLibs ./fetchers.nix;
+
+    # Eval-time filesystem handling
+    filesystem = callLibs ./filesystem.nix;
 
     # back-compat aliases
     platforms = systems.doubles;
-  }
-  # !!! don't include everything at top-level; perhaps only the most
-  # commonly used functions.
-  // trivial // fixedPoints
-  // lists // strings // stringsWithDeps // attrsets // sources
-  // options // types // meta // debug // misc // modules
-  // customisation
+
+    inherit (builtins) add addErrorContext attrNames
+      concatLists deepSeq elem elemAt filter genericClosure genList
+      getAttr hasAttr head isAttrs isBool isFunction isInt isList
+      isString length lessThan listToAttrs pathExists readFile
+      replaceStrings seq stringLength sub substring tail;
+    inherit (trivial) id const concat or and boolToString mergeAttrs
+      flip mapNullable inNixShell min max importJSON warn info
+      nixpkgsVersion mod;
+
+    inherit (fixedPoints) fix fix' extends composeExtensions
+      makeExtensible makeExtensibleWithCustomName;
+    inherit (attrsets) attrByPath hasAttrByPath setAttrByPath
+      getAttrFromPath attrVals attrValues catAttrs filterAttrs
+      filterAttrsRecursive foldAttrs collect nameValuePair mapAttrs
+      mapAttrs' mapAttrsToList mapAttrsRecursive mapAttrsRecursiveCond
+      genAttrs isDerivation toDerivation optionalAttrs
+      zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
+      recursiveUpdate matchAttrs overrideExisting getOutput getBin
+      getLib getDev chooseDevOutputs zipWithNames zip;
+    inherit (lists) singleton foldr fold foldl foldl' imap0 imap1
+      concatMap flatten remove findSingle findFirst any all count
+      optional optionals toList range partition zipListsWith zipLists
+      reverseList listDfs toposort sort take drop sublist last init
+      crossLists unique intersectLists subtractLists
+      mutuallyExclusive;
+    inherit (strings) concatStrings concatMapStrings concatImapStrings
+      intersperse concatStringsSep concatMapStringsSep
+      concatImapStringsSep makeSearchPath makeSearchPathOutput
+      makeLibraryPath makeBinPath makePerlPath optionalString
+      hasPrefix hasSuffix stringToCharacters stringAsChars escape
+      escapeShellArg escapeShellArgs replaceChars lowerChars upperChars
+      toLower toUpper addContextFrom splitString removePrefix
+      removeSuffix versionOlder versionAtLeast getVersion nameFromURL
+      enableFeature fixedWidthString fixedWidthNumber isStorePath
+      toInt readPathsFromFile fileContents;
+    inherit (stringsWithDeps) textClosureList textClosureMap
+      noDepEntry fullDepEntry packEntry stringAfter;
+    inherit (customisation) overrideDerivation makeOverridable
+      callPackageWith callPackagesWith addPassthru hydraJob makeScope;
+    inherit (meta) addMetaAttrs dontDistribute setName updateName
+      appendToName mapDerivationAttrset lowPrio lowPrioSet hiPrio
+      hiPrioSet;
+    inherit (sources) pathType pathIsDirectory cleanSourceFilter
+      cleanSource sourceByRegex sourceFilesBySuffices
+      commitIdFromGitRepo;
+    inherit (modules) evalModules closeModules unifyModuleSyntax
+      applyIfFunction unpackSubmodule packSubmodule mergeModules
+      mergeModules' mergeOptionDecls evalOptionValue mergeDefinitions
+      pushDownProperties dischargeProperties filterOverrides
+      sortProperties fixupOptionType mkIf mkAssert mkMerge mkOverride
+      mkOptionDefault mkDefault mkForce mkVMOverride mkStrict
+      mkFixStrictness mkOrder mkBefore mkAfter mkAliasDefinitions
+      mkAliasAndWrapDefinitions fixMergeModules mkRemovedOptionModule
+      mkRenamedOptionModule mkMergedOptionModule mkChangedOptionModule
+      mkAliasOptionModule doRename filterModules;
+    inherit (options) isOption mkEnableOption mkSinkUndeclaredOptions
+      mergeDefaultOption mergeOneOption mergeEqualOption getValues
+      getFiles optionAttrSetToDocList optionAttrSetToDocList'
+      scrubOptionValue literalExample showOption showFiles
+      unknownModule mkOption;
+    inherit (types) isType setType defaultTypeMerge defaultFunctor
+      isOptionType mkOptionType;
+    inherit (debug) addErrorContextToAttrs traceIf traceVal
+      traceXMLVal traceXMLValMarked traceSeq traceSeqN traceValSeq
+      traceValSeqN traceShowVal traceShowValMarked
+      showVal traceCall traceCall2 traceCall3 traceValIfNot runTests
+      testAllTrue strict traceCallXml attrNamesToStr;
+    inherit (misc) maybeEnv defaultMergeArg defaultMerge foldArgs
+      defaultOverridableDelayableArgs composedArgsAndFun
+      maybeAttrNullable maybeAttr ifEnable checkFlag getValue
+      checkReqs uniqList uniqListExt condConcat lazyGenericClosure
+      innerModifySumArgs modifySumArgs innerClosePropagation
+      closePropagation mapAttrsFlatten nvs setAttr setAttrMerge
+      mergeAttrsWithFunc mergeAttrsConcatenateValues
+      mergeAttrsNoOverride mergeAttrByFunc mergeAttrsByFuncDefaults
+      mergeAttrsByFuncDefaultsClean mergeAttrBy
+      prepareDerivationArgs nixType imap overridableDelayableArgs;
+  };
+in lib

--- a/lib/deprecated.nix
+++ b/lib/deprecated.nix
@@ -1,11 +1,12 @@
-let lib = import ./default.nix;
+{ lib }:
+let
     inherit (builtins) isFunction head tail isList isAttrs isInt attrNames;
 
 in
 
-with import ./lists.nix;
-with import ./attrsets.nix;
-with import ./strings.nix;
+with lib.lists;
+with lib.attrsets;
+with lib.strings;
 
 rec {
 

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -1,4 +1,5 @@
 # snippets that can be shared by multiple fetchers (pkgs/build-support)
+{ lib }:
 {
 
   proxyImpureEnvVars = [

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -1,3 +1,4 @@
+{ lib }:
 { # haskellPathsInDir : Path -> Map String Path
   # A map of all haskell packages defined in the given path,
   # identified by having a cabal file with the same name as the

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -1,3 +1,4 @@
+{ ... }:
 rec {
   # Compute the fixed point of the given function `f`, which is usually an
   # attribute set that expects its final, non-recursive representation as an

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -7,10 +7,11 @@
  * Tests can be found in ./tests.nix
  * Documentation in the manual, #sec-generators
  */
-with import ./trivial.nix;
+{ lib }:
+with (lib).trivial;
 let
-  libStr = import ./strings.nix;
-  libAttr = import ./attrsets.nix;
+  libStr = lib.strings;
+  libAttr = lib.attrsets;
 
   flipMapAttrs = flip libAttr.mapAttrs;
 in

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -1,6 +1,5 @@
+{ lib }:
 let
-
-  lib = import ./default.nix;
 
   spdx = lic: lic // {
     url = "http://spdx.org/licenses/${lic.spdxId}";
@@ -408,7 +407,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     url = "https://raw.githubusercontent.com/raboof/notion/master/LICENSE";
     fullName = "Notion modified LGPL";
   };
-  
+
   ofl = spdx {
     spdxId = "OFL-1.1";
     fullName = "SIL Open Font License 1.1";

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1,6 +1,6 @@
 # General list operations.
-
-with import ./trivial.nix;
+{ lib }:
+with lib.trivial;
 
 rec {
 

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -1,3 +1,4 @@
+{ ...}:
 /* List of NixOS maintainers. The format is:
 
     handle = "Real Name <address@example.org>";

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -1,8 +1,7 @@
 /* Some functions for manipulating meta attributes, as well as the
    name attribute. */
 
-let lib = import ./default.nix;
-in
+{ lib }:
 
 rec {
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1,10 +1,12 @@
-with import ./lists.nix;
-with import ./strings.nix;
-with import ./trivial.nix;
-with import ./attrsets.nix;
-with import ./options.nix;
-with import ./debug.nix;
-with import ./types.nix;
+{ lib }:
+
+with lib.lists;
+with lib.strings;
+with lib.trivial;
+with lib.attrsets;
+with lib.options;
+with lib.debug;
+with lib.types;
 
 rec {
 

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -1,11 +1,10 @@
 # Nixpkgs/NixOS option handling.
+{ lib }:
 
-let lib = import ./default.nix; in
-
-with import ./trivial.nix;
-with import ./lists.nix;
-with import ./attrsets.nix;
-with import ./strings.nix;
+with lib.trivial;
+with lib.lists;
+with lib.attrsets;
+with lib.strings;
 
 rec {
 

--- a/lib/sandbox.nix
+++ b/lib/sandbox.nix
@@ -1,4 +1,5 @@
-with import ./strings.nix;
+{ lib }:
+with lib.strings;
 
 /* Helpers for creating lisp S-exprs for the Apple sandbox
 

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -1,6 +1,5 @@
 # Functions for copying sources to the Nix store.
-
-let lib = import ./default.nix; in
+{ lib }:
 
 rec {
 

--- a/lib/strings-with-deps.nix
+++ b/lib/strings-with-deps.nix
@@ -1,3 +1,4 @@
+{ lib }:
 /*
 Usage:
 
@@ -40,9 +41,9 @@ Usage:
   [1] maybe this behaviour should be removed to keep things simple (?)
 */
 
-with import ./lists.nix;
-with import ./attrsets.nix;
-with import ./strings.nix;
+with lib.lists;
+with lib.attrsets;
+with lib.strings;
 
 rec {
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1,6 +1,6 @@
 /* String manipulation functions. */
-
-let lib = import ./default.nix;
+{ lib }:
+let
 
 inherit (builtins) length;
 

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -1,11 +1,12 @@
-let inherit (import ../attrsets.nix) mapAttrs; in
+{ lib }:
+  let inherit (lib.attrsets) mapAttrs; in
 
 rec {
-  doubles = import ./doubles.nix;
-  parse = import ./parse.nix;
-  inspect = import ./inspect.nix;
-  platforms = import ./platforms.nix;
-  examples = import ./examples.nix;
+  doubles = import ./doubles.nix { inherit lib; };
+  parse = import ./parse.nix { inherit lib; };
+  inspect = import ./inspect.nix { inherit lib; };
+  platforms = import ./platforms.nix { inherit lib; };
+  examples = import ./examples.nix { inherit lib; };
 
   # Elaborate a `localSystem` or `crossSystem` so that it contains everything
   # necessary.

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -1,8 +1,9 @@
+{ lib }:
 let
-  lists = import ../lists.nix;
-  parse = import ./parse.nix;
-  inherit (import ./inspect.nix) predicates;
-  inherit (import ../attrsets.nix) matchAttrs;
+  inherit (lib) lists;
+  parse = import ./parse.nix { inherit lib; };
+  inherit (import ./inspect.nix { inherit lib; }) predicates;
+  inherit (lib.attrsets) matchAttrs;
 
   all = [
     "aarch64-linux"

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -1,8 +1,8 @@
 # These can be passed to nixpkgs as either the `localSystem` or
 # `crossSystem`. They are put here for user convenience, but also used by cross
 # tests and linux cross stdenv building, so handle with care!
-
-let platforms = import ./platforms.nix; in
+{ lib }:
+let platforms = import ./platforms.nix { inherit lib; }; in
 
 rec {
   #

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -1,6 +1,7 @@
-with import ./parse.nix;
-with import ../attrsets.nix;
-with import ../lists.nix;
+{ lib }:
+with import ./parse.nix { inherit lib; };
+with lib.attrsets;
+with lib.lists;
 
 rec {
   patterns = rec {

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -4,14 +4,13 @@
 # http://llvm.org/docs/doxygen/html/Triple_8cpp_source.html especially
 # Triple::normalize. Parsing should essentially act as a more conservative
 # version of that last function.
-
-with import ../lists.nix;
-with import ../types.nix;
-with import ../attrsets.nix;
-with (import ./inspect.nix).predicates;
+{ lib }:
+with lib.lists;
+with lib.types;
+with lib.attrsets;
+with (import ./inspect.nix { inherit lib; }).predicates;
 
 let
-  lib = import ../default.nix;
   setTypesAssert = type: pred:
     mapAttrs (name: value:
       assert pred value;

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -1,3 +1,4 @@
+{ lib }:
 rec {
   pcBase = {
     name = "pc";

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1,3 +1,4 @@
+{ lib }:
 rec {
 
   /* The identity function
@@ -55,7 +56,7 @@ rec {
     isInt add sub lessThan
     seq deepSeq genericClosure;
 
-  inherit (import ./strings.nix) fileContents;
+  inherit (lib.strings) fileContents;
 
   # Return the Nixpkgs version number.
   nixpkgsVersion =

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1,15 +1,16 @@
 # Definitions related to run-time type checking.  Used in particular
 # to type-check NixOS configurations.
+{ lib }:
+with lib.lists;
+with lib.attrsets;
+with lib.options;
+with lib.trivial;
+with lib.strings;
+let
 
-with import ./lists.nix;
-with import ./attrsets.nix;
-with import ./options.nix;
-with import ./trivial.nix;
-with import ./strings.nix;
-let inherit (import ./modules.nix) mergeDefinitions filterOverrides; in
-
+  inherit (lib.modules) mergeDefinitions filterOverrides;
+  outer_types =
 rec {
-
   isType = type: x: (x._type or "") == type;
 
   setType = typeName: value: value // {
@@ -95,7 +96,6 @@ rec {
   # When adding new types don't forget to document them in
   # nixos/doc/manual/development/option-types.xml!
   types = rec {
-
     unspecified = mkOptionType {
       name = "unspecified";
     };
@@ -291,7 +291,7 @@ rec {
     submodule = opts:
       let
         opts' = toList opts;
-        inherit (import ./modules.nix) evalModules;
+        inherit (lib.modules) evalModules;
       in
       mkOptionType rec {
         name = "submodule";
@@ -395,5 +395,6 @@ rec {
     addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 
   };
+};
 
-}
+in outer_types // outer_types.types


### PR DESCRIPTION
This does break the API of being able to import any lib file and get
its libs, however I'm not sure people did this.

I made this while exploring being able to swap out docFn with a stub
in #2305, to avoid functor performance problems. I don't know if that
is going to move forward (or if it is a problem or not,) but after
doing all this work figured I'd put it up anyway :)

Two notable advantages to this approach:

1. when a lib inherits another lib's functions, it doesn't
   automatically get put in to the scope of lib
2. when a lib implements a new obscure functions, it doesn't
   automatically get put in to the scope of lib


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

