### PR TITLE
Removed networking.fqdn option

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -20,15 +20,6 @@ in
 
   options = {
 
-    networking.fqdn = lib.mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "foo.example.com";
-      description = ''
-        Fully qualified domain name, if any.
-      '';
-    };
-
     networking.hosts = lib.mkOption {
       type = types.attrsOf ( types.listOf types.str );
       default = {};
@@ -220,12 +211,11 @@ in
                 ( builtins.hasAttr "::1" cfg.hosts )
                 ( concatStringsSep " " ( remove "localhost" cfg.hosts."::1" ));
               otherHosts = allToString ( removeAttrs cfg.hosts [ "127.0.0.1" "::1" ]);
-              maybeFQDN = optionalString ( cfg.fqdn != null ) cfg.fqdn;
           in
           ''
-            127.0.0.1 ${maybeFQDN} ${userLocalHosts} localhost
+            127.0.0.1 ${userLocalHosts} localhost
             ${optionalString cfg.enableIPv6 ''
-              ::1 ${maybeFQDN} ${userLocalHosts6} localhost
+              ::1 ${userLocalHosts6} localhost
             ''}
             ${otherHosts}
             ${cfg.extraHosts}


### PR DESCRIPTION
###### Motivation for this change

Adding it was a mistake which can only lead to problems and confusion.
A cleanup after #27105. See discussion with @edolstra in #27105 for details.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

