### PR TITLE
Python: disable user site-packages for programs and environments.

### DIFF
--- a/pkgs/development/interpreters/python/wrap.sh
+++ b/pkgs/development/interpreters/python/wrap.sh
@@ -66,7 +66,9 @@ wrapPythonProgramsIn() {
                     # above. The script will set PYTHONPATH and PATH variables.!
                     # (see pkgs/build-support/setup-hooks/make-wrapper.sh)
                     local -a wrap_args=("$f"
-                                    --prefix PATH ':' "$program_PATH")
+                                    --prefix PATH ':' "$program_PATH"
+                                    --set PYTHONNOUSERSITE "true"
+                                    )
 
                     # Add any additional arguments provided by makeWrapperArgs
                     # argument to buildPythonPackage.

--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -29,7 +29,7 @@ let
           for prg in *; do
             if [ -f "$prg" ]; then
               rm -f "$out/bin/$prg"
-              makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set PYTHONHOME "$out"
+              makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set PYTHONHOME "$out" --set PYTHONNOUSERSITE "true"
             fi
           done
         fi


### PR DESCRIPTION
Python by default checks a `site-packages` folder in the user's home
folder. We do not want such an impurity and therefore disable it.
Fixes #26846.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

