### PR TITLE
networkmanager_dmenu: unstable-2017-05-28 -> 1.1

### DIFF
--- a/pkgs/tools/networking/networkmanager_dmenu/default.nix
+++ b/pkgs/tools/networking/networkmanager_dmenu/default.nix
@@ -3,14 +3,14 @@
 
 let inherit (python3Packages) python pygobject3;
 in stdenv.mkDerivation rec {
-  name = "networkmanager_dmenu-unstable-${version}";
-  version = "2017-05-28";
+  name = "networkmanager_dmenu-${version}";
+  version = "1.1";
 
   src = fetchFromGitHub {
     owner = "firecat53";
     repo = "networkmanager-dmenu";
-    rev = "eeb8e6922dee887890884f129b51bb21b0047d30";
-    sha256 = "00n82sjjqk76sfxi92f5vnzpngk66cqwyzqdanbszpl019ajr5h6";
+    rev = "v${version}";
+    sha256 = "1z6151z7c4jv5k2i50zr7ld4k3m07dgpmss9f3hsav95cv55dcnb";
   };
 
   buildInputs = [ glib python pygobject3 gobjectIntrospection networkmanager python3Packages.wrapPython ];


### PR DESCRIPTION
###### Motivation for this change
Stable release

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

