### PR TITLE
pythonPackages.gst-python: Use correct package set

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6438,6 +6438,7 @@ in {
 
   gst-python = callPackage ../development/libraries/gstreamer/python {
     gst-plugins-base = pkgs.gst_all_1.gst-plugins-base;
+    pythonPackages = self;
   };
 
   gtimelog = buildPythonPackage rec {


### PR DESCRIPTION
Previously this was using pkgs.pythonPackages. This was leading to
a build with an incorrect version of python.

It might be worth having the `pythonPackages = self` attribute for
all pythonPackages instead of just specific packages as it is at the
moment.

This fixes packages which depend on the python3 version of gst-python
such as pitivi.