### PR TITLE
Kdeconnect: add sshfs dependency and provide NixOS module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -86,6 +86,7 @@
   ./programs/info.nix
   ./programs/java.nix
   ./programs/kbdlight.nix
+  ./programs/kdeconnect.nix
   ./programs/light.nix
   ./programs/man.nix
   ./programs/mosh.nix

--- a/nixos/modules/programs/kdeconnect.nix
+++ b/nixos/modules/programs/kdeconnect.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg  = config.programs.kdeconnect;
+
+in
+{
+  options.programs.kdeconnect = {
+    enable = mkOption {
+      description = ''
+        KDE Connect provides several features to integrate your phone and your computer.
+        Enabling KDE Connect will install it and open the required UDP and TCP ports.
+      '';
+      default = false;
+      type = lib.types.bool;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ kdeconnect ];
+    networking.firewall.allowedUDPPortRanges = [ { from = 1714; to = 1764; } ];
+    networking.firewall.allowedTCPPortRanges = [ { from = 1714; to = 1764; } ];
+  };
+}

--- a/pkgs/applications/misc/kdeconnect/default.nix
+++ b/pkgs/applications/misc/kdeconnect/default.nix
@@ -12,6 +12,8 @@
 , libfakekey
 , libXtst
 , qtx11extras
+, sshfs-fuse
+, makeWrapper
 }:
 
 stdenv.mkDerivation rec {
@@ -34,9 +36,14 @@ stdenv.mkDerivation rec {
     libfakekey
     libXtst
     qtx11extras
+    makeWrapper
   ];
 
   nativeBuildInputs = [ extra-cmake-modules ];
+
+  postInstall = ''
+    wrapProgram $out/lib/libexec/kdeconnectd --prefix PATH : ${lib.makeBinPath [ sshfs-fuse ]}
+  '';
 
   meta = {
     description = "KDE Connect provides several features to integrate your phone and your computer";


### PR DESCRIPTION
- Adds sshfs as runtime dependency with makeWrapper
- Adds programs.kdeconnect to open required UDP/TCP ports

###### Motivation for this change
Kdeconnect requires sshfs for opening filesystem connections to android devices. The UDP/TCP ports are required that Kdeconnect can find other devices.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

