### PR TITLE
xtermcontrol: init at 3.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -136,6 +136,7 @@
   dbrock = "Daniel Brockman <daniel@brockman.se>";
   deepfire = "Kosyrev Serge <_deepfire@feelingofgreen.ru>";
   demin-dmitriy = "Dmitriy Demin <demindf@gmail.com>";
+  derchris = "Christian Gerbrandt <derchris@me.com>";
   DerGuteMoritz = "Moritz Heidkamp <moritz@twoticketsplease.de>";
   dermetfan = "Robin Stumm <serverkorken@gmail.com>";
   DerTim1 = "Tim Digel <tim.digel@active-group.de>";

--- a/pkgs/applications/misc/xtermcontrol/default.nix
+++ b/pkgs/applications/misc/xtermcontrol/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "3.3";
+  name = "xtermcontrol-${version}";
+
+  src = fetchurl {
+    url = "http://thrysoee.dk/xtermcontrol/xtermcontrol-${version}.tar.gz";
+    sha256 = "1v2c1cnx43apmspga7icssh5ndbhzy5h82y6vm8fda40flq9mxj5";
+  };
+
+  meta = {
+    description = "Enables dynamic control of xterm properties";
+    longDescription = ''
+      Enables dynamic control of xterm properties.
+      It makes it easy to change colors, title, font and geometry of a running xterm, as well as to report the current settings of these properties.
+      Window manipulations de-/iconify, raise/lower, maximize/restore and reset are also supported.
+      To complete the feature set; xtermcontrol lets advanced users issue any xterm control sequence of their choosing.
+    '';
+    homepage = http://thrysoee.dk/xtermcontrol;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.derchris ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19224,4 +19224,6 @@ with pkgs;
   undaemonize = callPackage ../tools/system/undaemonize {};
 
   houdini = callPackage ../applications/misc/houdini {};
+
+  xtermcontrol = callPackage ../applications/misc/xtermcontrol {};
 }


### PR DESCRIPTION
###### Motivation for this change

init xtermcontrol at version 3.3

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

