### PR TITLE
calc: 2.12.5.3 -> 2.12.6.1

### DIFF
--- a/pkgs/applications/science/math/calc/default.nix
+++ b/pkgs/applications/science/math/calc/default.nix
@@ -12,11 +12,11 @@ in
 stdenv.mkDerivation rec {
 
   name = "calc-${version}";
-  version = "2.12.5.3";
+  version = "2.12.6.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/calc/${name}.tar.bz2";
-    sha256 = "14mnz6smhi3a0rgmwvddk9w3vdisi8khq67i8nqsl47vgs8n1kqg";
+    url = "https://github.com/lcn2/calc/releases/download/${version}/${name}.tar.bz2";
+    sha256 = "1vy4jmhmpl3gzgpkpv0kqwjv8hn1cza8cn1g8c69gq3inqvr4fvd";
   };
 
   buildInputs = [ makeWrapper readline ncurses utillinux ];


### PR DESCRIPTION
###### Motivation for this change

Update calc to the last version

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

