### PR TITLE
alacritty: Don't use xclip from PATH

### DIFF
--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -47,6 +47,11 @@ buildRustPackage rec {
     pkgconfig
   ] ++ rpathLibs;
 
+  patchPhase = ''
+    substituteInPlace copypasta/src/x11.rs \
+      --replace Command::new\(\"xclip\"\) Command::new\(\"${xclip}/bin/xclip\"\)
+  '';
+
   installPhase = ''
     mkdir -p $out/bin
     for f in $(find target/release -maxdepth 1 -type f); do

--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -43,7 +43,6 @@ buildRustPackage rec {
   buildInputs = [
     cmake
     makeWrapper
-    xclip
     pkgconfig
   ] ++ rpathLibs;
 


### PR DESCRIPTION
###### Motivation for this change
Tried to use alacritty. Copy/paste was not working since it looks on the PATH.
This patches the code to look at the buildInput xclip.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@Mic92 @puffnfresh 