### PR TITLE
nixos/piwik: clarifies setup documentation

### DIFF
--- a/nixos/modules/services/web-apps/piwik-doc.xml
+++ b/nixos/modules/services/web-apps/piwik-doc.xml
@@ -23,16 +23,24 @@
       and enter those credentials in your browser.
       You can use passwordless database authentication via the UNIX_SOCKET authentication plugin
       with the following SQL commands:
+
       <programlisting>
+        # For MariaDB
         INSTALL PLUGIN unix_socket SONAME 'auth_socket';
-        ALTER USER root IDENTIFIED VIA unix_socket;
         CREATE DATABASE piwik;
-        CREATE USER 'piwik'@'localhost' IDENTIFIED VIA unix_socket;
+        CREATE USER 'piwik'@'localhost' IDENTIFIED WITH unix_socket;
+        GRANT ALL PRIVILEGES ON piwik.* TO 'piwik'@'localhost';
+
+        # For MySQL
+        INSTALL PLUGIN auth_socket SONAME 'auth_socket.so';
+        CREATE DATABASE piwik;
+        CREATE USER 'piwik'@'localhost' IDENTIFIED WITH auth_socket;
         GRANT ALL PRIVILEGES ON piwik.* TO 'piwik'@'localhost';
       </programlisting>
+
       Then fill in <literal>piwik</literal> as database user and database name, and leave the password field blank.
-      This works with MariaDB and MySQL. This authentication works by allowing only the <literal>piwik</literal> unix
-      user to authenticate as <literal>piwik</literal> database (without needing a password), but no other users.
+      This authentication works by allowing only the <literal>piwik</literal> unix user to authenticate as the 
+      <literal>piwik</literal> database user (without needing a password), but no other users.
       For more information on passwordless login, see
       <link xlink:href="https://mariadb.com/kb/en/mariadb/unix_socket-authentication-plugin/" />.
     </para>


### PR DESCRIPTION
###### Motivation for this change

This is a proposed documentation fix for #27703.  If folks want changes, I'm happy to make them.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

