### PR TITLE
urxvt_autocomplete_all_the_things: init at 1.6.0

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode-plugins/urxvt-autocomplete-all-the-things/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode-plugins/urxvt-autocomplete-all-the-things/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "urxvt-autocomplete-all-the-things-${version}";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "Vifon";
+    repo = "autocomplete-ALL-the-things";
+    rev = version;
+    sha256 = "06xd59c6gd9rglwq4km93n2p078k7v4x300lqrg1f32vvnjvs7sr";
+  };
+
+  installPhase = ''
+    mkdir -p $out/lib/urxvt/perl
+    cp autocomplete-ALL-the-things $out/lib/urxvt/perl
+  '';
+
+  meta = with stdenv.lib; {
+    description = "urxvt plugin allowing user to easily complete arbitrary text";
+    homepage = "https://github.com/Vifon/autocomplete-ALL-the-things";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ nickhu ];
+    platforms = with platforms; unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15925,6 +15925,7 @@ with pkgs;
 
   rxvt_unicode-with-plugins = callPackage ../applications/misc/rxvt_unicode/wrapper.nix {
     plugins = [
+      urxvt_autocomplete_all_the_things
       urxvt_perl
       urxvt_perls
       urxvt_tabbedex
@@ -15935,6 +15936,7 @@ with pkgs;
   };
 
   # urxvt plugins
+  urxvt_autocomplete_all_the_things = callPackage ../applications/misc/rxvt_unicode-plugins/urxvt-autocomplete-all-the-things { };
   urxvt_perl = callPackage ../applications/misc/rxvt_unicode-plugins/urxvt-perl { };
   urxvt_perls = callPackage ../applications/misc/rxvt_unicode-plugins/urxvt-perls { };
   urxvt_tabbedex = callPackage ../applications/misc/rxvt_unicode-plugins/urxvt-tabbedex { };


### PR DESCRIPTION
A really useful plugin for urxvt autocompletion


Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---