### PR TITLE
Create a keybase-bin nixpkg based on the keybase binary releases

### DIFF
--- a/pkgs/tools/security/keybase-bin/default.nix
+++ b/pkgs/tools/security/keybase-bin/default.nix
@@ -59,8 +59,8 @@ in
 
     meta = with stdenv.lib; {
       homepage = https://www.keybase.io/;
-      description = "The Keybase official GUI.";
+      description = "The full Keybase client (CLI, GUI, and filesystem) updated nightly-ish";
       platforms = platforms.linux;
-      maintainers = with maintainers; [ puffnfresh np ];
+      maintainers = with maintainers; [ mpcsh ];
     };
   }

--- a/pkgs/tools/security/keybase-bin/default.nix
+++ b/pkgs/tools/security/keybase-bin/default.nix
@@ -1,0 +1,66 @@
+with import <nixpkgs> { };
+
+let
+  libPath = stdenv.lib.makeLibraryPath [
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gcc.cc
+    gdk_pixbuf
+    glib
+    gnome2.GConf
+    gtk2
+    nspr
+    nss
+    pango
+    systemd
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXScrnSaver
+    xorg.libXtst
+  ];
+in
+  stdenv.mkDerivation rec {
+    name = "keybase-bin-${version}";
+    # version = "1.0.25-20170714172717.73f9070";
+    version = with builtins; replaceStrings ["+"] ["."] (fromJSON (readFile (fetchurl "http://prerelease.keybase.io.s3.amazonaws.com/update-linux-prod.json"))).version;
+    src = builtins.fetchurl "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version}_amd64.deb";
+    phases = ["unpackPhase" "installPhase" "fixupPhase"];
+    unpackPhase = ''
+      ar xf $src
+      tar xf data.tar.xz
+    '';
+    installPhase = ''
+      mkdir -p $out/{bin,share/keybase}
+
+      substitute usr/bin/run_keybase $out/bin/run_keybase --replace /opt $out/share
+      rm usr/bin/run_keybase
+      chmod +x $out/bin/run_keybase
+
+      mv usr/bin/* $out/bin/
+      mv opt/keybase/* $out/share/keybase/
+    '';
+    postFixup = ''
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath "${libPath}:\$ORIGIN" "$out/share/keybase/Keybase"
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = https://www.keybase.io/;
+      description = "The Keybase official GUI.";
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ puffnfresh np ];
+    };
+  }


### PR DESCRIPTION
###### Motivation for this change
The current state of Keybase on NixOS isn't quite ideal, in my mind. In order to use all of the components (the CLI, the GUI, and the filesystem), one must install three packages (`keybase`, `kbfs`, and `keybase-gui`. While some might like the separation of components, for those of us who want to use all three components, I feel that it's better to unify under one package. Furthermore, those three existing packages are pinned at an old version (1.0.22), and are missing a few features that the Keybase team has since added.

So, for those who want to install just one (or two) components of Keybase, the original packages still exist. But for those who want the latest releases and all the components, I have added this `keybase-bin` package.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~ N/A
- [ ] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~ N/A
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

