### PR TITLE
radicale: update to version 2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -101,6 +101,9 @@ rmdir /var/lib/ipfs/.ipfs
     <para>
       The <literal>mysql</literal> default <literal>dataDir</literal> has changed from <literal>/var/mysql</literal> to <literal>/var/lib/mysql</literal>.
     </para>
+    <para>
+      Radicale's default package has changed from 1.x to 2.x. Instructions to migrate can be found <link xlink:href="http://radicale.org/1to2/"> here </link>. It is also possible to use the newer version by setting the <literal>package</literal> to <literal>radicale2</literal>, which is done automatically when <literal>stateVersion</literal> is 17.09 or higher.
+    </para>
   </listitem>
   <listitem>
     <para>

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -297,6 +297,7 @@ in rec {
   tests.pumpio = callTest tests/pump.io.nix {};
   # tests.quagga = callTest tests/quagga.nix {};
   tests.quake3 = callTest tests/quake3.nix {};
+  tests.radicale = callTest tests/radicale.nix {};
   tests.runInMachine = callTest tests/run-in-machine.nix {};
   tests.samba = callTest tests/samba.nix {};
   tests.sddm = callSubTests tests/sddm.nix {};

--- a/nixos/tests/radicale.nix
+++ b/nixos/tests/radicale.nix
@@ -1,80 +1,39 @@
 let
-  port = 5232;
-  radicaleOverlay = self: super: {
-    radicale = super.radicale.overrideAttrs (oldAttrs: {
-      propagatedBuildInputs = with self.pythonPackages;
-        (oldAttrs.propagatedBuildInputs or []) ++ [
-          passlib
-        ];
-    });
-  };
-  common = { config, pkgs, ...}: {
+  user = "someuser";
+  password = "some_password";
+  port = builtins.toString 5232;
+in
+  import ./make-test.nix ({ pkgs, lib, ... }: {
+  name = "radicale";
+  meta.maintainers = with lib.maintainers; [ aneeshusa infinisil ];
+
+  machine = {
     services.radicale = {
       enable = true;
-      config = let home = config.users.extraUsers.radicale.home; in ''
-        [server]
-        hosts = 127.0.0.1:${builtins.toString port}
-        daemon = False
-        [encoding]
-        [well-known]
+      config = ''
         [auth]
         type = htpasswd
         htpasswd_filename = /etc/radicale/htpasswd
         htpasswd_encryption = bcrypt
-        [git]
-        [rights]
+
         [storage]
-        type = filesystem
-        filesystem_folder = ${home}/collections
+        filesystem_folder = /tmp/collections
+
         [logging]
-        [headers]
+        debug = True
       '';
     };
     # WARNING: DON'T DO THIS IN PRODUCTION!
     # This puts secrets (albeit hashed) directly into the Nix store for ease of testing.
-    environment.etc."radicale/htpasswd".source = with pkgs; let
-      py = python.withPackages(ps: with ps; [ passlib ]);
-    in runCommand "htpasswd" {} ''
-        ${py}/bin/python -c "
-from passlib.apache import HtpasswdFile
-ht = HtpasswdFile(
-    '$out',
-    new=True,
-    default_scheme='bcrypt'
-)
-ht.set_password('someuser', 'really_secret_password')
-ht.save()
-"
+    environment.etc."radicale/htpasswd".source = pkgs.runCommand "htpasswd" {} ''
+      ${pkgs.apacheHttpd}/bin/htpasswd -bcB "$out" ${user} ${password}
     '';
   };
-
-in import ./make-test.nix ({ lib, ... }: {
-  name = "radicale";
-  meta.maintainers = with lib.maintainers; [ aneeshusa ];
-
-  # Test radicale with bcrypt-based htpasswd authentication
-  nodes = {
-    py2 = { config, pkgs, ... }@args: (common args) // {
-      nixpkgs.overlays = [
-        radicaleOverlay
-      ];
-    };
-    py3 = { config, pkgs, ... }@args: (common args) // {
-      nixpkgs.overlays = [
-        (self: super: {
-          python = self.python3;
-          pythonPackages = self.python3.pkgs;
-        })
-        radicaleOverlay
-      ];
-    };
-  };
-
+  
+  # This tests whether the web interface is accessible to an authenticated user
   testScript = ''
-    for my $machine ($py2, $py3) {
-      $machine->waitForUnit('radicale.service');
-      $machine->waitForOpenPort(${builtins.toString port});
-      $machine->succeed('curl -s http://someuser:really_secret_password@127.0.0.1:${builtins.toString port}/someuser/calendar.ics/');
-    }
+    $machine->waitForUnit('radicale.service');
+    $machine->waitForOpenPort(${port});
+    $machine->succeed('curl --fail http://${user}:${password}@localhost:${port}/.web/');
   '';
 })

--- a/pkgs/servers/radicale/1.x.nix
+++ b/pkgs/servers/radicale/1.x.nix
@@ -1,27 +1,21 @@
-{ stdenv, fetchFromGitHub, python3Packages }:
+{ stdenv, fetchurl, pythonPackages }:
 
-let
-  version = "2.1.2";
-  sha256 = "0gmbnvm17j0ilcnci1k2jh0vkbz5g8xlk9lgia5mlx790048hlm8";
-in
-
-python3Packages.buildPythonApplication {
+pythonPackages.buildPythonApplication rec {
   name = "radicale-${version}";
-  inherit version;
+  version = "1.1.6";
 
-  src = fetchFromGitHub {
-    owner = "Kozea";
-    repo = "Radicale";
-    rev = version;
-    inherit sha256;
+  src = fetchurl {
+    url = "mirror://pypi/R/Radicale/Radicale-${version}.tar.gz";
+    sha256 = "0ay90nj6fmr2aq8imi0mbjl4m2rzq7a83ikj8qs9gxsylj71j1y0";
   };
 
-  doCheck = false;
-
-  propagatedBuildInputs = with python3Packages; [
-    vobject
-    passlib
+  propagatedBuildInputs = stdenv.lib.optionals (!pythonPackages.isPy3k) [
+    pythonPackages.flup
+    pythonPackages.ldap
+    pythonPackages.sqlalchemy
   ];
+
+  doCheck = !pythonPackages.isPy3k;
 
   meta = with stdenv.lib; {
     homepage = http://www.radicale.org/;
@@ -35,6 +29,6 @@ python3Packages.buildPythonApplication {
     '';
     license = licenses.gpl3Plus;
     platforms = platforms.all;
-    maintainers = with maintainers; [ edwtjo pSub aneeshusa infinisil ];
+    maintainers = with maintainers; [ edwtjo pSub aneeshusa ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11468,7 +11468,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon Cocoa;
   };
 
-  radicale = callPackage ../servers/radicale { };
+  radicale1 = callPackage ../servers/radicale/1.x.nix { };
+  radicale2 = callPackage ../servers/radicale/default.nix { };
+
+  radicale = radicale2;
 
   rake = callPackage ../development/tools/build-managers/rake { };
 


### PR DESCRIPTION
###### Motivation for this change
It has been long overdue for a radicale update, this PR does that. I also modified the test to work, it seemed to be disabled for not working.

###### <s>ToDo</s>Done: Backwards-compatibility
The 2.x releases of radicale are NOT backwards compatible. There should be two derivations for `radicale1` and `radicale2`, while `radicale = radicale2`. To not mess with previously working radicale setups, there should be a `package` option for the radicale module, defaulting to `radicale1` if `systemVersion <= 17.03` and `radicale2` otherwise. Users can then manually upgrade to 2.x by setting `package = radicale2`, adjusting the config and following the [official guide for migration](http://radicale.org/1to2/). This should be added to the release notes.

Edit: This has been done

###### Things done

I have been running this version for a few days now and haven't run into any problems.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

