### PR TITLE
numix-sx-gtk-theme: init at 2017-04-24

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -510,6 +510,7 @@
   samuelrivas = "Samuel Rivas <samuelrivas@gmail.com>";
   sander = "Sander van der Burg <s.vanderburg@tudelft.nl>";
   sargon = "Daniel Ehlers <danielehlers@mindeye.net>";
+  sauyon = "Sauyon Lee <s@uyon.co>";
   schmitthenner = "Fabian Schmitthenner <development@schmitthenner.eu>";
   schneefux = "schneefux <schneefux+nixos_pkg@schneefux.xyz>";
   schristo = "Scott Christopher <schristopher@konputa.com>";

--- a/pkgs/misc/themes/numix-sx/default.nix
+++ b/pkgs/misc/themes/numix-sx/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  version = "2017-04-24";
+  name = "numix-sx-gtk-theme-${version}";
+
+  src = fetchurl {
+    url = "https://dl.opendesktop.org/api/files/download/id/1493077417/Numix-SX.tar.xz";
+    sha256 = "7e1983924b2d90e89eddb3da8f4c43dc1326fe138fd191c8212c7904dcd618b0";
+  };
+
+  buildInputs = [ gtk-engine-murrine ];
+
+  dontBuild = true;
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    install -dm 755 "$out/share/themes/"
+    cp -dr --no-preserve='ownership' Numix-SX-{Dark,FullDark,Light} "$out/share/themes/"
+  '';
+
+  meta = {
+    description = "Gray variation of Numix theme";
+    homepage = https://www.gnome-look.org/p/1117412/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ stdenv.lib.maintainers.sauyon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17801,6 +17801,8 @@ with pkgs;
 
   numix-gtk-theme = callPackage ../misc/themes/numix { };
 
+  numix-sx-gtk-theme = callPackage ../misc/themes/numix-sx { };
+
   theme-vertex = callPackage ../misc/themes/vertex { };
 
   rox-filer = callPackage ../desktops/rox/rox-filer {


### PR DESCRIPTION
###### Motivation for this change

Add a package

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

