### PR TITLE
haskell infra: Misc cleanups

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -9,9 +9,9 @@
 #
 # See comment at the top of configuration-nix.nix for more information about this
 # distinction.
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super: {
 

--- a/pkgs/development/haskell-modules/configuration-ghc-6.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-6.12.x.nix
@@ -1,6 +1,6 @@
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super: {
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.0.x.nix
@@ -1,6 +1,6 @@
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super: {
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -1,6 +1,6 @@
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super: {
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.2.x.nix
@@ -1,6 +1,6 @@
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super: {
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.4.x.nix
@@ -1,6 +1,6 @@
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super: {
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.6.x.nix
@@ -1,6 +1,6 @@
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super: {
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
@@ -1,6 +1,6 @@
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super: {
 

--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -1,6 +1,6 @@
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super: {
 

--- a/pkgs/development/haskell-modules/configuration-ghc-8.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.2.x.nix
@@ -1,6 +1,6 @@
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super: {
 

--- a/pkgs/development/haskell-modules/configuration-ghc-head.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-head.nix
@@ -1,6 +1,6 @@
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super: {
 

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -2,14 +2,14 @@
 #
 # Please insert new packages *alphabetically*
 # in the OTHER PACKAGES section.
-{ pkgs }:
+{ pkgs, haskellLib }:
 
 let
   removeLibraryHaskellDepends = pnames: depends:
     builtins.filter (e: !(builtins.elem (e.pname or "") pnames)) depends;
 in
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super:
 

--- a/pkgs/development/haskell-modules/configuration-halvm-2.4.0.nix
+++ b/pkgs/development/haskell-modules/configuration-halvm-2.4.0.nix
@@ -1,6 +1,6 @@
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 self: super: {
 

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -25,9 +25,9 @@
 # * enabling/disabling certain features in packages
 #
 # If you have an override of this kind, see configuration-common.nix instead.
-{ pkgs }:
+{ pkgs, haskellLib }:
 
-with import ./lib.nix { inherit pkgs; };
+with haskellLib;
 
 # All of the overrides in this set should look like:
 #

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, ghc, all-cabal-hashes
+{ pkgs, stdenv, lib, haskellLib, ghc, all-cabal-hashes
 , compilerConfig ? (self: super: {})
 , packageSetConfig ? (self: super: {})
 , overrides ? (self: super: {})
@@ -9,16 +9,16 @@
 
 let
 
-  inherit (stdenv.lib) extends makeExtensible;
-  inherit (import ./lib.nix { inherit pkgs; }) overrideCabal makePackageSet;
+  inherit (lib) extends makeExtensible;
+  inherit (haskellLib) overrideCabal makePackageSet;
 
-  haskellPackages = makePackageSet {
+  haskellPackages = pkgs.callPackage makePackageSet {
     package-set = initialPackages;
-    inherit ghc extensible-self;
+    inherit stdenv haskellLib ghc extensible-self;
   };
 
-  commonConfiguration = configurationCommon { inherit pkgs; };
-  nixConfiguration = configurationNix { inherit pkgs; };
+  commonConfiguration = configurationCommon { inherit pkgs haskellLib; };
+  nixConfiguration = configurationNix { inherit pkgs haskellLib; };
 
   extensible-self = makeExtensible
     (extends overrides

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -1,7 +1,9 @@
-{ pkgs }:
+# TODO(@Ericson2314): Remove `pkgs` param, which is only used for
+# `buildStackProject` and `justStaticExecutables`
+{ pkgs, lib }:
 
 rec {
-  makePackageSet = pkgs.callPackage ./make-package-set.nix {};
+  makePackageSet = import ./make-package-set.nix;
 
   overrideCabal = drv: f: (drv.override (args: args // {
     mkDerivation = drv: (args.mkDerivation drv).override f;
@@ -25,7 +27,7 @@ rec {
   dontDistribute = drv: overrideCabal drv (drv: { hydraPlatforms = []; });
 
   appendConfigureFlag = drv: x: overrideCabal drv (drv: { configureFlags = (drv.configureFlags or []) ++ [x]; });
-  removeConfigureFlag = drv: x: overrideCabal drv (drv: { configureFlags = pkgs.stdenv.lib.remove x (drv.configureFlags or []); });
+  removeConfigureFlag = drv: x: overrideCabal drv (drv: { configureFlags = lib.remove x (drv.configureFlags or []); });
 
   addBuildTool = drv: x: addBuildTools drv [x];
   addBuildTools = drv: xs: overrideCabal drv (drv: { buildTools = (drv.buildTools or []) ++ xs; });
@@ -71,7 +73,7 @@ rec {
 
   disableHardening = drv: flags: overrideCabal drv (drv: { hardeningDisable = flags; });
 
-  sdistTarball = pkg: pkgs.lib.overrideDerivation pkg (drv: {
+  sdistTarball = pkg: lib.overrideDerivation pkg (drv: {
     name = "${drv.pname}-source-${drv.version}";
     buildPhase = "./Setup sdist";
     haddockPhase = ":";
@@ -89,12 +91,11 @@ rec {
     isLibrary = false;
     doHaddock = false;
     postFixup = "rm -rf $out/lib $out/nix-support $out/share/doc";
-  } // (if pkgs.stdenv.isDarwin then {
+  } // lib.optionalAttrs (pkgs.hostPlatform.isDarwin) {
     configureFlags = (drv.configureFlags or []) ++ ["--ghc-option=-optl=-dead_strip"];
-  } else {})
-  );
+  });
 
-  buildFromSdist = pkg: pkgs.lib.overrideDerivation pkg (drv: {
+  buildFromSdist = pkg: lib.overrideDerivation pkg (drv: {
     unpackPhase = let src = sdistTarball pkg; tarname = "${pkg.pname}-${pkg.version}"; in ''
       echo "Source tarball is at ${src}/${tarname}.tar.gz"
       tar xf ${src}/${tarname}.tar.gz

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -1,20 +1,34 @@
 # This expression takes a file like `hackage-packages.nix` and constructs
 # a full package set out of that.
 
-# required dependencies:
-{ pkgs, stdenv, all-cabal-hashes }:
+{ # package-set used for non-haskell dependencies (all of nixpkgs)
+  pkgs
 
-# arguments:
-#  * ghc package to use
-#  * package-set: a function that takes { pkgs, stdenv, callPackage } as first arg and `self` as second
-#  * extensible-self: the final, fully overriden package set usable with the nixpkgs fixpoint overriding functionality
-{ ghc, package-set, extensible-self }:
+, # stdenv to use for building haskell packages
+  stdenv
+
+, haskellLib
+
+, # hashes for downloading Hackage packages
+  all-cabal-hashes
+
+, # compiler to use
+  ghc
+
+, # A function that takes `{ pkgs, stdenv, callPackage }` as the first arg and `self`
+  # as second, and returns a set of haskell packages
+  package-set
+
+, # The final, fully overriden package set usable with the nixpkgs fixpoint
+  # overriding functionality
+  extensible-self
+}:
 
 # return value: a function from self to the package set
 self: let
 
   inherit (stdenv.lib) fix' extends makeOverridable;
-  inherit (import ./lib.nix { inherit pkgs; }) overrideCabal;
+  inherit (haskellLib) overrideCabal;
 
   mkDerivationImpl = pkgs.callPackage ./generic-builder.nix {
     inherit stdenv;

--- a/pkgs/development/tools/haskell/lambdabot/default.nix
+++ b/pkgs/development/tools/haskell/lambdabot/default.nix
@@ -1,4 +1,4 @@
-{ lib, haskell-lib, fetchpatch, makeWrapper, haskellPackages
+{ lib, haskellLib, fetchpatch, makeWrapper, haskellPackages
 , mueval
 , withDjinn ? true
 , aspell ? null
@@ -25,7 +25,7 @@ let allPkgs = pkgs: mueval.defaultPkgs pkgs ++ [ pkgs.lambdabot-trusted ] ++ pac
     modulesStr = lib.replaceChars ["\n"] [" "] modules;
     configStr = lib.replaceChars ["\n"] [" "] configuration;
 
-in haskell-lib.overrideCabal haskellPackages.lambdabot (self: {
+in haskellLib.overrideCabal haskellPackages.lambdabot (self: {
   patches = (self.patches or []) ++ [ ./custom-config.patch ];
   postPatch = (self.postPatch or "") + ''
     substituteInPlace src/Main.hs \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10057,7 +10057,7 @@ with pkgs;
   readosm = callPackage ../development/libraries/readosm { };
 
   lambdabot = callPackage ../development/tools/haskell/lambdabot {
-    haskell-lib = haskell.lib;
+    haskellLib = haskell.lib;
   };
 
   lambda-mod-zsh-theme = callPackage ../shells/lambda-mod-zsh-theme/default.nix { };

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1,24 +1,32 @@
-{ pkgs, callPackage, stdenv, buildPlatform, targetPlatform }:
+{ pkgs, lib, newScope, stdenv, buildPlatform, targetPlatform }:
 
-let # These are attributes in compiler and packages that don't support integer-simple.
-    integerSimpleExcludes = [
-      "ghc6102Binary"
-      "ghc704Binary"
-      "ghc742Binary"
-      "ghc6104"
-      "ghc6123"
-      "ghc704"
-      "ghc763"
-      "ghcjs"
-      "ghcjsHEAD"
-      "ghcCross"
-      "jhc"
-      "uhc"
-      "integer-simple"
-    ];
+let
+  # These are attributes in compiler and packages that don't support integer-simple.
+  integerSimpleExcludes = [
+    "ghc6102Binary"
+    "ghc704Binary"
+    "ghc742Binary"
+    "ghc6104"
+    "ghc6123"
+    "ghc704"
+    "ghc763"
+    "ghcjs"
+    "ghcjsHEAD"
+    "ghcCross"
+    "jhc"
+    "uhc"
+    "integer-simple"
+  ];
+
+  haskellLib = import ../development/haskell-modules/lib.nix {
+    inherit (pkgs) lib;
+    inherit pkgs;
+  };
+
+  callPackage = newScope { inherit haskellLib; };
+
 in rec {
-
-  lib = import ../development/haskell-modules/lib.nix { inherit pkgs; };
+  lib = haskellLib;
 
   compiler = {
 


### PR DESCRIPTION
###### Motivation for this change

 - The haskell lib is very close to not relying on Nixpkgs. I think this is good---simpler to think about and matches Nixpkgs's lib.

 - stdenv is exposed more shallowly so it can be overriden more easily. I'll eventually use this on Darwin to avoid the Sierra shared library problems (unless changes are to be made system-wide).

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

