### PR TITLE
igv: 2.3.89 -> 2.3.98

### DIFF
--- a/pkgs/applications/science/biology/igv/default.nix
+++ b/pkgs/applications/science/biology/igv/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "igv-${version}";
-  version = "2.3.89";
+  version = "2.3.98";
 
   src = fetchurl {
     url = "http://data.broadinstitute.org/igv/projects/downloads/IGV_${version}.zip";
-    sha256 = "06bmj9jsnk5010ipv0w4qlcvgw67dy8hsvgcx9l74v3s0zp5di3y";
+    sha256 = "1bjdsvx8jsbcry6v7yfclh3vrlsvaw38f3s9587lklj63zj638l2";
   };
 
   buildInputs = [ unzip jre ];


### PR DESCRIPTION
###### Motivation for this change

Update igv to the last version

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

