### PR TITLE
git-cola: 2.10 -> 2.11

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
@@ -4,13 +4,13 @@ let
   inherit (pythonPackages) buildPythonApplication pyqt4 sip pyinotify python mock;
 in buildPythonApplication rec {
   name = "git-cola-${version}";
-  version = "2.10";
+  version = "2.11";
 
   src = fetchFromGitHub {
     owner = "git-cola";
     repo = "git-cola";
     rev = "v${version}";
-    sha256 = "067g0yya6718kxagf5qm59zizp0lizca4m3ih85y732i6rqpgwv8";
+    sha256 = "1prv8ib9jdkj5rgixj3hvkivwmbz5xvh8bmllrb1sb301yzi1s0g";
   };
 
   buildInputs = [ git gettext ];


### PR DESCRIPTION
###### Motivation for this change

Update git-cola to the last version

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

