### PR TITLE
swi-prolog: 7.2.3 -> 7.4.2

### DIFF
--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -4,14 +4,14 @@
 }:
 
 let
-  version = "7.2.3";
+  version = "7.4.2";
 in
 stdenv.mkDerivation {
   name = "swi-prolog-${version}";
 
   src = fetchurl {
     url = "http://www.swi-prolog.org/download/stable/src/swipl-${version}.tar.gz";
-    sha256 = "1da6sr8pz1zffs79nfa1d25a11ibhalm1vdwsb17p265nx8psra3";
+    sha256 = "12yzy3w2l1p9fv77lv20xbqq47d0zjw5rkz96mx1xg1lldyja5vz";
   };
 
   buildInputs = [ gmp readline openssl libjpeg unixODBC libXinerama


### PR DESCRIPTION
###### Motivation for this change

Update swi-prolog to the last version

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

