### PR TITLE
gcc-arm-embedded: 5-2016-q2-update -> 6-2017-q2-update

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -602,6 +602,7 @@
   vdemeester = "Vincent Demeester <vincent@sbr.pm>";
   veprbl = "Dmitry Kalinkin <veprbl@gmail.com>";
   vifino = "Adrian Pistol <vifino@tty.sh>";
+  vinymeuh = "VinyMeuh <vinymeuh@gmail.com>";
   viric = "Lluís Batlle i Rossell <viric@viric.name>";
   vizanto = "Danny Wilson <danny@prime.vc>";
   vklquevs = "vklquevs <vklquevs@gmail.com>";

--- a/pkgs/development/compilers/gcc-arm-embedded/6/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/6/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl, ncurses5, python27 }:
+
+stdenv.mkDerivation rec {
+  name = "gcc-arm-embedded-${version}";
+  version = "6-2017-q2-update";
+  subdir = "6-2017q2";
+
+  platformString =
+    if stdenv.isLinux then "linux"
+    else if stdenv.isDarwin then "mac"
+    else throw "unsupported platform";
+
+  urlString = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-${platformString}.tar.bz2";
+
+  src =
+    if stdenv.isLinux then fetchurl { url=urlString; sha256="1hvwi02mx34al525sngnl0cm7dkmzxfkb1brq9kvbv28wcplp3p6"; }
+    else if stdenv.isDarwin then fetchurl { url=urlString; sha256="0019ylpq4inq7p5gydpmc9m8ni72fz2csrjlqmgx1698998q0c3x"; }
+    else throw "unsupported platform";
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r * $out
+  '';
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  preFixup = ''
+    find $out -type f | while read f; do
+      patchelf $f > /dev/null 2>&1 || continue
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+      patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python27 ]} "$f" || true
+    done
+  '';
+
+  meta = {
+    description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors (Cortex-M0/M0+/M3/M4/M7, Cortex-R4/R5/R7/R8)";
+    homepage = https://developer.arm.com/open-source/gnu-toolchain/gnu-rm;
+    license = with stdenv.lib.licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
+    maintainers = with stdenv.lib.maintainers; [ vinymeuh ];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5541,7 +5541,8 @@ with pkgs;
     sha256 = "1r0rqbnw7rf94f5bsa3gi8bick4xb7qnp1dkvdjfbvqjvysvc44r";
     ncurses = pkgsi686Linux.ncurses5;
   };
-  gcc-arm-embedded = gcc-arm-embedded-5;
+  gcc-arm-embedded-6 = callPackage ../development/compilers/gcc-arm-embedded/6 {};
+  gcc-arm-embedded = gcc-arm-embedded-6;
 
   gforth = callPackage ../development/compilers/gforth {};
 


### PR DESCRIPTION
###### Motivation for this change

Update version, add macOS support and resolve issue #26545.

I don't known if it is necessary to keep all the olds versions (4.7, 4.8, 4.9, 5) but at least I can cleanup their expressions on the same model.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

