### PR TITLE
Revert "buildenv: read propagated-user-env-packages line-by-line"

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -141,11 +141,12 @@ sub addPkg {
     my $propagatedFN = "$pkgDir/nix-support/propagated-user-env-packages";
     if (-e $propagatedFN) {
         open PROP, "<$propagatedFN" or die;
-        while (my $p = <PROP>) {
-            chomp $p;
+        my $propagated = <PROP>;
+        close PROP;
+        my @propagated = split ' ', $propagated;
+        foreach my $p (@propagated) {
             $postponed{$p} = 1 unless defined $done{$p};
         }
-        close PROP;
     }
 }
 


### PR DESCRIPTION
This reverts commit dce958ac396e88c09d5b19c284f41eef68f54ce7.

###### Motivation for this change
This change was originally a fix for https://github.com/NixOS/nixpkgs/commit/3cb745d5a69018829ac15f7d5a508135f6bda123 which was reverted in https://github.com/NixOS/nixpkgs/commit/b087618ac06256cb3c06278e7eaba45841f4ea91

Since the revert https://github.com/NixOS/nixpkgs/commit/dce958ac396e88c09d5b19c284f41eef68f54ce7 breaks Qt applications.

I don't know if this is the correct fix or if https://github.com/NixOS/nixpkgs/commit/3cb745d5a69018829ac15f7d5a508135f6bda123 should be reinstated, the commit message in the revert made me lean towards just restoring the old behaviour.
Either solution would work fine, I have tested both.
If that solution is preferable I can close this one and create a new PR.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @ttuegel 

---