### PR TITLE
freerdp: 20170502 -> 20170724

### DIFF
--- a/pkgs/applications/networking/remote/freerdp/default.nix
+++ b/pkgs/applications/networking/remote/freerdp/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   name = "freerdp-git-${version}";
-  version = "20170502";
+  version = "20170724";
 
   src = fetchFromGitHub {
     owner  = "FreeRDP";
     repo   = "FreeRDP";
-    rev    = "8569102c3a011602de3a1cdf69f7c69adbb864ee";
-    sha256 = "0m61aiy8l3ybnk2d2kjmpp9ql31zfs63gjixyj9x95jd4m507j67";
+    rev    = "2.0.0-rc0";
+    sha256 = "0ngwdy0lfv2k59z1z8yq1wj5zbhqigpyfqbgh38m9p35yzh33lv1";
   };
 
   # outputs = [ "bin" "out" "dev" ];


### PR DESCRIPTION
Fixes multiple security issues:
 * TALOS-2017-0336 CVE-2017-2834
 * TALOS-2017-0337 CVE-2017-2834
 * TALOS-2017-0338 CVE-2017-2836
 * TALOS-2017-0339 CVE-2017-2837
 * TALOS-2017-0340 CVE-2017-2838
 * TALOS-2017-0341 CVE-2017-2839

See http://www.freerdp.com/2017/07/24/freerdp-security for announcement.

This will also have to be backported to `release-17.03` I think.

###### Motivation for this change


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

