### PR TITLE
dockerTools: fix image json and image manifest

### DIFF
--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -358,8 +358,8 @@
 <para>
   <varname>pkgs.dockerTools</varname> is a set of functions for creating and
   manipulating Docker images according to the
-  <link xlink:href="https://github.com/docker/docker/blob/master/image/spec/v1.md#docker-image-specification-v100">
-  Docker Image Specification v1.0.0
+  <link xlink:href="https://github.com/moby/moby/blob/master/image/spec/v1.2.md#docker-image-specification-v120">
+  Docker Image Specification v1.2.0
   </link>. Docker itself is not used to perform any of the operations done by these
   functions.
 </para>
@@ -493,8 +493,8 @@
     <varname>config</varname> is used to specify the configuration of the
     containers that will be started off the built image in Docker.
     The available options are listed in the
-    <link xlink:href="https://github.com/docker/docker/blob/master/image/spec/v1.md#container-runconfig-field-descriptions">
-      Docker Image Specification v1.0.0
+    <link xlink:href="https://github.com/moby/moby/blob/master/image/spec/v1.2.md#image-json-field-descriptions">
+      Docker Image Specification v1.2.0
     </link>.
     </para>
   </callout>


### PR DESCRIPTION
###### Motivation for this change

The image json is not exactly the same as the layer json, therefore I changed the implementation to use the `baseJson` which doesn’t include layer specific details like `id`, `size` or the checksum of the layer.

Also the `history` entry was missing in the image json. I’m not totally sure if this field is required, but I got an error from a docker registry when I’ve tried to receive the distribution manifest of an
image without this `history` entry:

GET: `http://<registry-host>/v2/<imageName>/manifests/<imageTag>`

```json
{
  "errors": [
    {
      "code": "MANIFEST_INVALID",
      "message": "manifest invalid",
      "detail": {}
    }
  ]
}
```

I’ve also used a while loop to iterate over all layers which should make sure that the order of the layers is correct. Previously `find` was used and I’m not sure if the order was always correct.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

PTAL: @nlewo, @globin 