### PR TITLE
cc-wrapper: Pass shellcheck and other cleanups

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -1,28 +1,37 @@
 # `-B@out@/bin' forces cc to use ld-wrapper.sh when calling ld.
 export NIX_CFLAGS_COMPILE="-B@out@/bin/ $NIX_CFLAGS_COMPILE"
 
+# Export and assign separately in order that a failing $(..) will fail
+# the script.
+
 if [ -e @out@/nix-support/libc-cflags ]; then
-    export NIX_CFLAGS_COMPILE="$(cat @out@/nix-support/libc-cflags) $NIX_CFLAGS_COMPILE"
+    export NIX_CFLAGS_COMPILE
+    NIX_CFLAGS_COMPILE="$(< @out@/nix-support/libc-cflags) $NIX_CFLAGS_COMPILE"
 fi
 
 if [ -e @out@/nix-support/cc-cflags ]; then
-    export NIX_CFLAGS_COMPILE="$(cat @out@/nix-support/cc-cflags) $NIX_CFLAGS_COMPILE"
+    export NIX_CFLAGS_COMPILE
+    NIX_CFLAGS_COMPILE="$(< @out@/nix-support/cc-cflags) $NIX_CFLAGS_COMPILE"
 fi
 
 if [ -e @out@/nix-support/gnat-cflags ]; then
-    export NIX_GNATFLAGS_COMPILE="$(cat @out@/nix-support/gnat-cflags) $NIX_GNATFLAGS_COMPILE"
+    export NIX_GNATFLAGS_COMPILE
+    NIX_GNATFLAGS_COMPILE="$(< @out@/nix-support/gnat-cflags) $NIX_GNATFLAGS_COMPILE"
 fi
 
 if [ -e @out@/nix-support/libc-ldflags ]; then
-    export NIX_LDFLAGS+=" $(cat @out@/nix-support/libc-ldflags)"
+    export NIX_LDFLAGS
+    NIX_LDFLAGS+=" $(< @out@/nix-support/libc-ldflags)"
 fi
 
 if [ -e @out@/nix-support/cc-ldflags ]; then
-    export NIX_LDFLAGS+=" $(cat @out@/nix-support/cc-ldflags)"
+    export NIX_LDFLAGS
+    NIX_LDFLAGS+=" $(< @out@/nix-support/cc-ldflags)"
 fi
 
 if [ -e @out@/nix-support/libc-ldflags-before ]; then
-    export NIX_LDFLAGS_BEFORE="$(cat @out@/nix-support/libc-ldflags-before) $NIX_LDFLAGS_BEFORE"
+    export NIX_LDFLAGS_BEFORE
+    NIX_LDFLAGS_BEFORE="$(< @out@/nix-support/libc-ldflags-before) $NIX_LDFLAGS_BEFORE"
 fi
 
 export NIX_CC_WRAPPER_FLAGS_SET=1

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -1,7 +1,14 @@
-#! @shell@ -e
+#! @shell@
+set -e -o pipefail
+shopt -s nullglob
+
 path_backup="$PATH"
-if [ -n "@coreutils_bin@" ]; then
-  PATH="@coreutils_bin@/bin:@gnugrep_bin@/bin"
+
+# That @-vars are substituted separately from bash evaluation makes
+# shellcheck think this, and others like it, are useless conditionals.
+# shellcheck disable=SC2157
+if [[ -n "@coreutils_bin@" && -n "@gnugrep_bin@" ]]; then
+    PATH="@coreutils_bin@/bin:@gnugrep_bin@/bin"
 fi
 
 if [ -n "$NIX_CC_WRAPPER_START_HOOK" ]; then
@@ -19,16 +26,17 @@ source @out@/nix-support/utils.sh
 # For instance, figure out if linker flags should be passed.
 # GCC prints annoying warnings when they are not needed.
 dontLink=0
-getVersion=0
 nonFlagArgs=0
+# shellcheck disable=SC2193
 [[ "@prog@" = *++ ]] && isCpp=1 || isCpp=0
 cppInclude=1
 
 expandResponseParams "$@"
-n=0
-while [ $n -lt ${#params[*]} ]; do
+declare -i n=0
+nParams=${#params[@]}
+while [ "$n" -lt "$nParams" ]; do
     p=${params[n]}
-    p2=${params[$((n+1))]}
+    p2=${params[n+1]}
     if [ "$p" = -c ]; then
         dontLink=1
     elif [ "$p" = -S ]; then
@@ -55,10 +63,10 @@ while [ $n -lt ${#params[*]} ]; do
         nonFlagArgs=1
     elif [ "$p" = -m32 ]; then
         if [ -e @out@/nix-support/dynamic-linker-m32 ]; then
-            NIX_LDFLAGS+=" -dynamic-linker $(cat @out@/nix-support/dynamic-linker-m32)"
+            NIX_LDFLAGS+=" -dynamic-linker $(< @out@/nix-support/dynamic-linker-m32)"
         fi
     fi
-    n=$((n + 1))
+    n+=1
 done
 
 # If we pass a flag like -Wl, then gcc will call the linker unless it
@@ -71,26 +79,27 @@ if [ "$nonFlagArgs" = 0 ]; then
 fi
 
 # Optionally filter out paths not refering to the store.
-if [ "$NIX_ENFORCE_PURITY" = 1 -a -n "$NIX_STORE" ]; then
+if [[ "$NIX_ENFORCE_PURITY" = 1 && -n "$NIX_STORE" ]]; then
     rest=()
-    n=0
-    while [ $n -lt ${#params[*]} ]; do
+    nParams=${#params[@]}
+    declare -i n=0
+    while [ "$n" -lt "$nParams" ]; do
         p=${params[n]}
-        p2=${params[$((n+1))]}
+        p2=${params[n+1]}
         if [ "${p:0:3}" = -L/ ] && badPath "${p:2}"; then
-            skip $p
+            skip "${p:2}"
         elif [ "$p" = -L ] && badPath "$p2"; then
-            n=$((n + 1)); skip $p2
+            n+=1; skip "$p2"
         elif [ "${p:0:3}" = -I/ ] && badPath "${p:2}"; then
-            skip $p
+            skip "${p:2}"
         elif [ "$p" = -I ] && badPath "$p2"; then
-            n=$((n + 1)); skip $p2
+            n+=1; skip "$p2"
         elif [ "$p" = -isystem ] && badPath "$p2"; then
-            n=$((n + 1)); skip $p2
+            n+=1; skip "$p2"
         else
             rest+=("$p")
         fi
-        n=$((n + 1))
+        n+=1
     done
     params=("${rest[@]}")
 fi
@@ -99,11 +108,11 @@ fi
 # Clear march/mtune=native -- they bring impurity.
 if [ "$NIX_ENFORCE_NO_NATIVE" = 1 ]; then
     rest=()
-    for i in "${params[@]}"; do
-        if [[ "$i" = -m*=native ]]; then
-            skip $i
+    for p in "${params[@]}"; do
+        if [[ "$p" = -m*=native ]]; then
+            skip "$p"
         else
-            rest+=("$i")
+            rest+=("$p")
         fi
     done
     params=("${rest[@]}")
@@ -116,23 +125,22 @@ if [[ "$isCpp" = 1 ]]; then
     NIX_CFLAGS_LINK+=" $NIX_CXXSTDLIB_LINK"
 fi
 
-LD=@ldPath@/ld
 source @out@/nix-support/add-hardening.sh
 
 # Add the flags for the C compiler proper.
-extraAfter=($NIX_CFLAGS_COMPILE ${hardeningCFlags[@]})
+extraAfter=($NIX_CFLAGS_COMPILE "${hardeningCFlags[@]}")
 extraBefore=()
 
 if [ "$dontLink" != 1 ]; then
 
     # Add the flags that should only be passed to the compiler when
     # linking.
-    extraAfter+=($NIX_CFLAGS_LINK ${hardeningLDFlags[@]})
+    extraAfter+=($NIX_CFLAGS_LINK "${hardeningLDFlags[@]}")
 
     # Add the flags that should be passed to the linker (and prevent
     # `ld-wrapper' from adding NIX_LDFLAGS again).
     for i in $NIX_LDFLAGS_BEFORE; do
-        extraBefore=(${extraBefore[@]} "-Wl,$i")
+        extraBefore+=("-Wl,$i")
     done
     for i in $NIX_LDFLAGS; do
         if [ "${i:0:3}" = -L/ ]; then
@@ -155,18 +163,12 @@ fi
 
 # Optionally print debug info.
 if [ -n "$NIX_DEBUG" ]; then
-  echo "original flags to @prog@:" >&2
-  for i in "${params[@]}"; do
-      echo "  $i" >&2
-  done
-  echo "extraBefore flags to @prog@:" >&2
-  for i in ${extraBefore[@]}; do
-      echo "  $i" >&2
-  done
-  echo "extraAfter flags to @prog@:" >&2
-  for i in ${extraAfter[@]}; do
-      echo "  $i" >&2
-  done
+    echo "extra flags before to @prog@:" >&2
+    printf "  %q\n" "${extraBefore[@]}"  >&2
+    echo "original flags to @prog@:" >&2
+    printf "  %q\n" "${params[@]}" >&2
+    echo "extra flags after to @prog@:" >&2
+    printf "  %q\n" "${extraAfter[@]}" >&2
 fi
 
 if [ -n "$NIX_CC_WRAPPER_EXEC_HOOK" ]; then
@@ -174,4 +176,4 @@ if [ -n "$NIX_CC_WRAPPER_EXEC_HOOK" ]; then
 fi
 
 PATH="$path_backup"
-exec @prog@ ${extraBefore[@]} "${params[@]}" "${extraAfter[@]}"
+exec @prog@ "${extraBefore[@]}" "${params[@]}" "${extraAfter[@]}"

--- a/pkgs/build-support/cc-wrapper/gnatlink-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnatlink-wrapper.sh
@@ -1,33 +1,37 @@
-#! @shell@ -e
+#! @shell@
+set -e -o pipefail
+shopt -s nullglob
 
 # Add the flags for the GNAT compiler proper.
-extraAfter="--GCC=@out@/bin/gcc"
+extraAfter=("--GCC=@out@/bin/gcc")
 extraBefore=()
 
-# Add the flags that should be passed to the linker (and prevent
-# `ld-wrapper' from adding NIX_LDFLAGS again).
+## Add the flags that should be passed to the linker (and prevent
+## `ld-wrapper' from adding NIX_LDFLAGS again).
 #for i in $NIX_LDFLAGS_BEFORE; do
-#    extraBefore=(${extraBefore[@]} "-largs $i")
+#    extraBefore+=("-largs" "$i")
 #done
+#for i in $NIX_LDFLAGS; do
+#    if [ "${i:0:3}" = -L/ ]; then
+#        extraAfter+=("$i")
+#    else
+#        extraAfter+=("-largs" "$i")
+#    fi
+#done
+#export NIX_LDFLAGS_SET=1
 
 # Optionally print debug info.
 if [ -n "$NIX_DEBUG" ]; then
-  echo "original flags to @prog@:" >&2
-  for i in "$@"; do
-      echo "  $i" >&2
-  done
-  echo "extraBefore flags to @prog@:" >&2
-  for i in ${extraBefore[@]}; do
-      echo "  $i" >&2
-  done
-  echo "extraAfter flags to @prog@:" >&2
-  for i in ${extraAfter[@]}; do
-      echo "  $i" >&2
-  done
+    echo "extra flags before to @prog@:" >&2
+    printf "  %q\n" "${extraBefore[@]}"  >&2
+    echo "original flags to @prog@:" >&2
+    printf "  %q\n" "$@" >&2
+    echo "extra flags after to @prog@:" >&2
+    printf "  %q\n" "${extraAfter[@]}" >&2
 fi
 
 if [ -n "$NIX_GNAT_WRAPPER_EXEC_HOOK" ]; then
     source "$NIX_GNAT_WRAPPER_EXEC_HOOK"
 fi
 
-exec @prog@ ${extraBefore[@]} "$@" ${extraAfter[@]}
+exec @prog@ "${extraBefore[@]}" "$@" "${extraAfter[@]}"

--- a/pkgs/build-support/cc-wrapper/ld-solaris-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-solaris-wrapper.sh
@@ -1,40 +1,25 @@
 #!@shell@
+set -eu -o pipefail
+shopt -s nullglob
 
-set -e
-set -u
-
+declare -a args=("$@")
 # I've also tried adding -z direct and -z lazyload, but it gave too many problems with C++ exceptions :'(
 # Also made sure libgcc would not be lazy-loaded, as suggested here: https://www.illumos.org/issues/2534#note-3
 #   but still no success.
-cmd="@ld@ -z ignore"
-
-args=("$@");
+declare -a argsBefore=(-z ignore) argsAfter=()
 
 # This loop makes sure all -L arguments are before -l arguments, or ld may complain it cannot find a library.
 # GNU binutils does not have this problem:
 #   http://stackoverflow.com/questions/5817269/does-the-order-of-l-and-l-options-in-the-gnu-linker-matter
-i=0;
-while [[ $i -lt $# ]]; do
+while (( $# )); do
     case "${args[$i]}" in
-        -L)  cmd="$cmd ${args[$i]} ${args[($i+1)]}"; i=($i+1); ;;
-        -L*) cmd="$cmd ${args[$i]}" ;;
-        *)   ;;
+        -L)   argsBefore+=("$1" "$2"); shift ;;
+        -L?*) argsBefore+=("$1") ;;
+        *)    argsAfter+=("$1") ;;
     esac
-    i=($i+1);
-done
-
-i=0;
-while [[ $i -lt $# ]]; do
-    case "${args[$i]}" in
-        -L)  i=($i+1); ;;
-        -L*) ;;
-        *)   cmd="$cmd ${args[$i]}" ;;
-    esac
-    i=($i+1);
+    shift
 done
 
 # Trace:
 set -x
-exec $cmd
-
-exit 0
+exec "@ld@" "${argsBefore[@]}" "${argsAfter[@]}"

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -1,45 +1,50 @@
 addCVars () {
-    if [ -d $1/include ]; then
+    if [[ -d "$1/include" ]]; then
         export NIX_CFLAGS_COMPILE+=" ${ccIncludeFlag:--isystem} $1/include"
     fi
 
-    if [ -d $1/lib64 -a ! -L $1/lib64 ]; then
+    if [[ -d "$1/lib64" && ! -L "$1/lib64" ]]; then
         export NIX_LDFLAGS+=" -L$1/lib64"
     fi
 
-    if [ -d $1/lib ]; then
+    if [[ -d "$1/lib" ]]; then
         export NIX_LDFLAGS+=" -L$1/lib"
     fi
 
-    if test -d $1/Library/Frameworks; then
-        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -F$1/Library/Frameworks"
+    if [[ -d "$1/Library/Frameworks" ]]; then
+        export NIX_CFLAGS_COMPILE+=" -F$1/Library/Frameworks"
     fi
 }
 
 envHooks+=(addCVars)
 
-# Note: these come *after* $out in the PATH (see setup.sh).
+# Note 1: these come *after* $out in the PATH (see setup.sh).
+# Note 2: phase separation makes this look useless to shellcheck.
 
+# shellcheck disable=SC2157
 if [ -n "@cc@" ]; then
     addToSearchPath _PATH @cc@/bin
 fi
 
+# shellcheck disable=SC2157
 if [ -n "@binutils_bin@" ]; then
     addToSearchPath _PATH @binutils_bin@/bin
 fi
 
+# shellcheck disable=SC2157
 if [ -n "@libc_bin@" ]; then
     addToSearchPath _PATH @libc_bin@/bin
 fi
 
+# shellcheck disable=SC2157
 if [ -n "@coreutils_bin@" ]; then
     addToSearchPath _PATH @coreutils_bin@/bin
 fi
 
-if [ -z "$crossConfig" ]; then
-  ENV_PREFIX=""
+if [ -z "${crossConfig:-}" ]; then
+    ENV_PREFIX=""
 else
-  ENV_PREFIX="BUILD_"
+    ENV_PREFIX="BUILD_"
 fi
 
 export NIX_${ENV_PREFIX}CC=@out@

--- a/pkgs/build-support/cc-wrapper/utils.sh
+++ b/pkgs/build-support/cc-wrapper/utils.sh
@@ -24,11 +24,15 @@ badPath() {
 }
 
 expandResponseParams() {
-    params=("$@")
+    declare -g params=("$@")
     local arg
     for arg in "$@"; do
         if [[ "$arg" == @* ]]; then
+            # phase separation makes this look useless
+            # shellcheck disable=SC2157
             if [ -n "@expandResponseParams@" ]; then
+                # params is used by caller
+                #shellcheck disable=SC2034
                 readarray -d '' params < <("@expandResponseParams@" "$@")
                 return 0
             else


### PR DESCRIPTION
###### Motivation for this change

In many cases, this involved taking @orivej's and @edolstra's recent ld-wrapper improvements, and applying then elsewhere.

The only semantics changes I know of are

 - Fix bad word-splitting---already done with ld-wrapper with no issues

 - Remove unused and probably wrong `LD=`---didn't take into account cross and in cc-wrapper pointed to unwrapped ld while in ld-wrapper pointed to wrapped ld.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built stdenv on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @orivej 