### PR TITLE
Update homepage attributes: http -> https

### DIFF
--- a/pkgs/applications/audio/flac/default.nix
+++ b/pkgs/applications/audio/flac/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" "doc" ];
 
   meta = with stdenv.lib; {
-    homepage = http://xiph.org/flac/;
+    homepage = https://xiph.org/flac/;
     description = "Library and tools for encoding and decoding the FLAC lossless audio file format";
     platforms = platforms.all;
     maintainers = [ maintainers.mornfall ];

--- a/pkgs/applications/audio/fldigi/default.nix
+++ b/pkgs/applications/audio/fldigi/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Digital modem program";
-    homepage = http://sourceforge.net/projects/fldigi/;
+    homepage = https://sourceforge.net/projects/fldigi/;
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = with stdenv.lib.maintainers; [ relrod ftrvxmtrx ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/audio/iannix/default.nix
+++ b/pkgs/applications/audio/iannix/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Graphical open-source sequencer,";
-    homepage = http://www.iannix.org/;
+    homepage = https://www.iannix.org/;
     license = stdenv.lib.licenses.lgpl3;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.nico202 ];

--- a/pkgs/applications/audio/mp3splt/default.nix
+++ b/pkgs/applications/audio/mp3splt/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Utility to split mp3, ogg vorbis and FLAC files without decoding";
-    homepage = http://sourceforge.net/projects/mp3splt/;
+    homepage = https://sourceforge.net/projects/mp3splt/;
     license = licenses.gpl2;
     maintainers = [ maintainers.bosu ];
     platforms = platforms.unix;

--- a/pkgs/applications/editors/aseprite/default.nix
+++ b/pkgs/applications/editors/aseprite/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Animated sprite editor & pixel art tool";
-    homepage = http://www.aseprite.org/;
+    homepage = https://www.aseprite.org/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/applications/editors/focuswriter/default.nix
+++ b/pkgs/applications/editors/focuswriter/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.madjar ];
     platforms = stdenv.lib.platforms.all;
-    homepage = http://gottcode.org/focuswriter/;
+    homepage = https://gottcode.org/focuswriter/;
   };
 }

--- a/pkgs/applications/graphics/fontmatrix/default.nix
+++ b/pkgs/applications/graphics/fontmatrix/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Fontmatrix is a free/libre font explorer for Linux, Windows and Mac";
-    homepage = http://github.com/fontmatrix/fontmatrix;
+    homepage = https://github.com/fontmatrix/fontmatrix;
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "General purpose Open Source 3D CAD/MCAD/CAx/CAE/PLM modeler";
-    homepage = http://www.freecadweb.org/;
+    homepage = https://www.freecadweb.org/;
     license = licenses.lgpl2Plus;
     maintainers = [ maintainers.viric ];
     platforms = platforms.linux;

--- a/pkgs/applications/graphics/gimp/2.8.nix
+++ b/pkgs/applications/graphics/gimp/2.8.nix
@@ -51,7 +51,7 @@ in stdenv.mkDerivation rec {
 
   meta = {
     description = "The GNU Image Manipulation Program";
-    homepage = http://www.gimp.org/;
+    homepage = https://www.gimp.org/;
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/applications/misc/cdrtools/default.nix
+++ b/pkgs/applications/misc/cdrtools/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "INS_BASE=/" "INS_RBASE=/" "DESTDIR=$(out)" ];
 
   meta = with stdenv.lib; {
-    homepage = http://sourceforge.net/projects/cdrtools/;
+    homepage = https://sourceforge.net/projects/cdrtools/;
     description = "Highly portable CD/DVD/BluRay command line recording software";
     license = with licenses; [ gpl2 lgpl2 cddl ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/dockbarx/default.nix
+++ b/pkgs/applications/misc/dockbarx/default.nix
@@ -29,7 +29,7 @@ pythonPackages.buildPythonApplication rec {
     ++ [ keybinder ];
 
   meta = with stdenv.lib; {
-    homepage = http://launchpad.net/dockbar/;
+    homepage = https://launchpad.net/dockbar/;
     description = "DockBarX is a lightweight taskbar / panel replacement for Linux which works as a stand-alone dock";
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/applications/misc/far2l/default.nix
+++ b/pkgs/applications/misc/far2l/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An orthodox file manager";
-    homepage = http://github.com/elfmz/far2l;
+    homepage = https://github.com/elfmz/far2l;
     license = licenses.gpl2;
     maintainers = [ maintainers.volth ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/gammu/default.nix
+++ b/pkgs/applications/misc/gammu/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://wammu.eu/gammu/;
+    homepage = https://wammu.eu/gammu/;
     description = "Command line utility and library to control mobile phones";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/applications/misc/girara/default.nix
+++ b/pkgs/applications/misc/girara/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    homepage = http://pwmt.org/projects/girara/;
+    homepage = https://pwmt.org/projects/girara/;
     description = "User interface library";
     longDescription = ''
       girara is a library that implements a GTK+ based VIM-like user interface

--- a/pkgs/applications/misc/gmrun/default.nix
+++ b/pkgs/applications/misc/gmrun/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       Also, supports CTRL-R / CTRL-S / "!" for searching through history.
       Running commands in a terminal with CTRL-Enter. URL handlers.
     '';
-    homepage = http://sourceforge.net/projects/gmrun/;
+    homepage = https://sourceforge.net/projects/gmrun/;
     license = "GPL";
     maintainers = [];
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/applications/misc/gpsprune/default.nix
+++ b/pkgs/applications/misc/gpsprune/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Application for viewing, editing and converting GPS coordinate data";
-    homepage = http://activityworkshop.net/software/gpsprune/;
+    homepage = https://activityworkshop.net/software/gpsprune/;
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.rycee ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/keepassx/2.0.nix
+++ b/pkgs/applications/misc/keepassx/2.0.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Qt password manager compatible with its Win32 and Pocket PC versions";
-    homepage = http://www.keepassx.org/;
+    homepage = https://www.keepassx.org/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ qknight jgeerds ];
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/applications/misc/keepassx/default.nix
+++ b/pkgs/applications/misc/keepassx/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Qt password manager compatible with its Win32 and Pocket PC versions";
-    homepage = http://www.keepassx.org/;
+    homepage = https://www.keepassx.org/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ qknight jgeerds ];
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/applications/networking/browsers/dillo/default.nix
+++ b/pkgs/applications/networking/browsers/dillo/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   configureFlags =  "--enable-ssl";
 
   meta = with stdenv.lib; {
-    homepage = http://www.dillo.org/;
+    homepage = https://www.dillo.org/;
     description = "A fast graphical web browser with a small footprint";
     longDescription = ''
       Dillo is a small, fast web browser, tailored for older machines.

--- a/pkgs/applications/networking/browsers/jumanji/default.nix
+++ b/pkgs/applications/networking/browsers/jumanji/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Minimal web browser";
-    homepage = http://pwmt.org/projects/jumanji/;
+    homepage = https://pwmt.org/projects/jumanji/;
     platforms = platforms.all;
     maintainers = [ maintainers.koral ];
   };

--- a/pkgs/applications/networking/feedreaders/canto-curses/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-curses/default.nix
@@ -24,7 +24,7 @@ python34Packages.buildPythonApplication rec {
       unreadable white text. An interface with almost infinite customization
       and extensibility using the excellent Python programming language.
     '';
-    homepage = http://codezen.org/canto-ng/;
+    homepage = https://codezen.org/canto-ng/;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.devhell ];

--- a/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
@@ -24,7 +24,7 @@ python34Packages.buildPythonApplication rec {
       unreadable white text. An interface with almost infinite customization
       and extensibility using the excellent Python programming language.
     '';
-    homepage = http://codezen.org/canto-ng/;
+    homepage = https://codezen.org/canto-ng/;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.devhell ];

--- a/pkgs/applications/networking/flexget/default.nix
+++ b/pkgs/applications/networking/flexget/default.nix
@@ -53,7 +53,7 @@ buildPythonApplication rec {
   ++ lib.optional (transmission != null) transmissionrpc;
 
   meta = {
-    homepage = http://flexget.com/;
+    homepage = https://flexget.com/;
     description = "Multipurpose automation tool for content like torrents";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ domenkozar tari ];

--- a/pkgs/applications/networking/ftp/filezilla/default.nix
+++ b/pkgs/applications/networking/ftp/filezilla/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     pugixml libfilezilla nettle ];
 
   meta = with stdenv.lib; {
-    homepage = http://filezilla-project.org/;
+    homepage = https://filezilla-project.org/;
     description = "Graphical FTP, FTPS and SFTP client";
     license = licenses.gpl2;
     longDescription = ''

--- a/pkgs/applications/networking/ids/bro/default.nix
+++ b/pkgs/applications/networking/ids/bro/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Powerful network analysis framework that is much different from the typical IDS you may know";
-    homepage = http://www.bro.org/;
+    homepage = https://www.bro.org/;
     license = licenses.bsd3;
     maintainers = with maintainers; [ pSub ];
     platforms = with platforms; linux;

--- a/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
       Messenger, AIM and ICQ.
     '';
 
-    homepage = http://www.bitlbee.org/;
+    homepage = https://www.bitlbee.org/;
     license = licenses.gpl2Plus;
 
     maintainers = with maintainers; [ wkennington pSub ];

--- a/pkgs/applications/networking/irc/hexchat/default.nix
+++ b/pkgs/applications/networking/irc/hexchat/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A popular and easy to use graphical IRC (chat) client";
-    homepage = http://hexchat.github.io/;
+    homepage = https://hexchat.github.io/;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ romildo jgeerds ];

--- a/pkgs/applications/networking/p2p/gnunet/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
       network are rewarded with better service.
     '';
 
-    homepage = http://gnunet.org/;
+    homepage = https://gnunet.org/;
 
     license = licenses.gpl2Plus;
 

--- a/pkgs/applications/networking/p2p/gnunet/svn.nix
+++ b/pkgs/applications/networking/p2p/gnunet/svn.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
       network are rewarded with better service.
     '';
 
-    homepage = http://gnunet.org/;
+    homepage = https://gnunet.org/;
 
     license = stdenv.lib.licenses.gpl2Plus;
 

--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "High-performance theorem prover and SMT solver";
-    homepage    = "http://alt-ergo.ocamlpro.com/";
+    homepage    = "https://alt-ergo.ocamlpro.com/";
     license     = stdenv.lib.licenses.cecill-c; # LGPL-2 compatible
     platforms   = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];

--- a/pkgs/applications/version-management/git-and-tools/cgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/cgit/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://git.zx2c4.com/cgit/about/;
+    homepage = https://git.zx2c4.com/cgit/about/;
     repositories.git = git://git.zx2c4.com/cgit;
     description = "Web frontend for git repositories";
     license = stdenv.lib.licenses.gpl2;

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -198,7 +198,7 @@ EOF
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://git-scm.com/;
+    homepage = https://git-scm.com/;
     description = "Distributed version control system";
     license = stdenv.lib.licenses.gpl2;
 

--- a/pkgs/applications/version-management/git-up/default.nix
+++ b/pkgs/applications/version-management/git-up/default.nix
@@ -26,7 +26,7 @@ python2Packages.buildPythonApplication rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/msiemens/PyGitUp;
+    homepage = https://github.com/msiemens/PyGitUp;
     description = "A git pull replacement that rebases all local branches when pulling.";
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/applications/video/coriander/default.nix
+++ b/pkgs/applications/video/coriander/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig glib gtk2 libgnomeui libXv libraw1394 libdc1394 SDL GConf ];
   
   meta = {
-    homepage = http://damien.douxchamps.net/ieee1394/coriander/;
+    homepage = https://damien.douxchamps.net/ieee1394/coriander/;
     description = "GUI for controlling a Digital Camera through the IEEE1394 bus";
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = with stdenv.lib.maintainers; [viric];

--- a/pkgs/applications/video/dvb-apps/default.nix
+++ b/pkgs/applications/video/dvb-apps/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Linux DVB API applications and utilities";
-    homepage = http://linuxtv.org/;
+    homepage = https://linuxtv.org/;
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2;
   };

--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -138,7 +138,7 @@ in stdenv.mkDerivation rec {
     '';
 
     meta = with stdenv.lib; {
-      homepage = http://kodi.tv/;
+      homepage = https://kodi.tv/;
       description = "Media center";
       license = licenses.gpl2;
       platforms = platforms.linux;

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -19,7 +19,7 @@ rec {
     };
 
     meta = with stdenv.lib; {
-      homepage = http://forum.kodi.tv/showthread.php?tid=85724;
+      homepage = https://forum.kodi.tv/showthread.php?tid=85724;
       description = "A program launcher for Kodi";
       longDescription = ''
         Advanced Launcher allows you to start any Linux, Windows and
@@ -49,7 +49,7 @@ rec {
     };
 
     meta = with stdenv.lib; {
-      homepage = http://forum.kodi.tv/showthread.php?tid=287826;
+      homepage = https://forum.kodi.tv/showthread.php?tid=287826;
       description = "A program launcher for Kodi";
       longDescription = ''
         Advanced Emulator Launcher is a multi-emulator front-end for Kodi
@@ -129,7 +129,7 @@ rec {
       sha256 = "1dvff24fbas25k5kvca4ssks9l1g5rfa3hl8lqxczkaqi3pp41j5";
     };
     meta = with stdenv.lib; {
-      homepage = http://forum.kodi.tv/showthread.php?tid=258159;
+      homepage = https://forum.kodi.tv/showthread.php?tid=258159;
       description = "A ROM launcher for Kodi that uses HyperSpin assets.";
       maintainers = with maintainers; [ edwtjo ];
     };
@@ -184,7 +184,7 @@ rec {
     };
 
     meta = with stdenv.lib; {
-      homepage = http://forum.kodi.tv/showthread.php?tid=67110;
+      homepage = https://forum.kodi.tv/showthread.php?tid=67110;
       description = "Watch content from SVT Play";
       longDescription = ''
         With this addon you can stream content from SVT Play
@@ -234,7 +234,7 @@ rec {
     };
 
     meta = with stdenv.lib; {
-      homepage = http://forum.kodi.tv/showthread.php?tid=157499;
+      homepage = https://forum.kodi.tv/showthread.php?tid=157499;
       description = "Launch Steam in Big Picture Mode from Kodi";
       longDescription = ''
         This add-on will close/minimise Kodi, launch Steam in Big
@@ -263,7 +263,7 @@ rec {
     };
 
     meta = with stdenv.lib; {
-      homepage = http://forum.kodi.tv/showthread.php?tid=187421;
+      homepage = https://forum.kodi.tv/showthread.php?tid=187421;
       descritpion = "A comic book reader";
       maintainers = with maintainers; [ edwtjo ];
     };

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -161,7 +161,7 @@ rec {
     '';
 
     meta = {
-      homepage = http://www.docker.com/;
+      homepage = https://www.docker.com/;
       description = "An open source project to pack, ship and run any application as a lightweight container";
       license = licenses.asl20;
       maintainers = with maintainers; [ offline tailhook vdemeester ];

--- a/pkgs/applications/window-managers/bspwm/default.nix
+++ b/pkgs/applications/window-managers/bspwm/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A tiling window manager based on binary space partitioning";
-    homepage = http://github.com/baskerville/bspwm;
+    homepage = https://github.com/baskerville/bspwm;
     maintainers = with maintainers; [ meisternu epitrochoid ];
     license = licenses.bsd2;
     platforms = platforms.linux;

--- a/pkgs/applications/window-managers/compiz/default.nix
+++ b/pkgs/applications/window-managers/compiz/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Compoziting window manager";
-    homepage = http://launchpad.net/compiz/;
+    homepage = https://launchpad.net/compiz/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/window-managers/i3/lock-color.nix
+++ b/pkgs/applications/window-managers/i3/lock-color.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
   meta = with stdenv.lib; {
     description = "A simple screen locker like slock";
-    homepage = http://i3wm.org/i3lock/;
+    homepage = https://i3wm.org/i3lock/;
     maintainers = with maintainers; [ garbas malyn ];
     license = licenses.bsd3;
     platforms = platforms.all;

--- a/pkgs/applications/window-managers/i3/lock.nix
+++ b/pkgs/applications/window-managers/i3/lock.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A simple screen locker like slock";
-    homepage = http://i3wm.org/i3lock/;
+    homepage = https://i3wm.org/i3lock/;
     maintainers = with maintainers; [ garbas malyn domenkozar ];
     license = licenses.bsd3;
     platforms = platforms.all;

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -132,7 +132,7 @@ rec {
     http://ftp.riken.jp/net/samba
   ];
 
-  # BitlBee mirrors, see http://www.bitlbee.org/main.php/mirrors.html .
+  # BitlBee mirrors, see https://www.bitlbee.org/main.php/mirrors.html .
   bitlbee = [
     http://get.bitlbee.org/
     http://get.bitlbee.be/

--- a/pkgs/data/documentation/man-pages/default.nix
+++ b/pkgs/data/documentation/man-pages/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Linux development manual pages";
-    homepage = http://www.kernel.org/doc/man-pages/;
+    homepage = https://www.kernel.org/doc/man-pages/;
     repositories.git = http://git.kernel.org/pub/scm/docs/man-pages/man-pages;
     maintainers = with maintainers; [ nckx ];
     platforms = with platforms; unix;

--- a/pkgs/data/fonts/anonymous-pro/default.nix
+++ b/pkgs/data/fonts/anonymous-pro/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.marksimonson.com/fonts/view/anonymous-pro;
+    homepage = https://www.marksimonson.com/fonts/view/anonymous-pro;
     description = "TrueType font set intended for source code";
     longDescription = ''
       Anonymous Pro (2009) is a family of four fixed-width fonts

--- a/pkgs/data/fonts/iosevka/default.nix
+++ b/pkgs/data/fonts/iosevka/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://be5invis.github.io/Iosevka/;
+    homepage = https://be5invis.github.io/Iosevka/;
     downloadPage = "https://github.com/be5invis/Iosevka/releases";
     description = ''
       Slender monospace sans-serif and slab-serif typeface inspired by Pragmata

--- a/pkgs/data/fonts/kawkab-mono/default.nix
+++ b/pkgs/data/fonts/kawkab-mono/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "An arab fixed-width font";
-    homepage = http://makkuk.com/kawkab-mono/;
+    homepage = https://makkuk.com/kawkab-mono/;
     license = stdenv.lib.licenses.ofl;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/data/fonts/open-dyslexic/default.nix
+++ b/pkgs/data/fonts/open-dyslexic/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = http://opendyslexic.org/;
     description = "Font created to increase readability for readers with dyslexia";
-    license = "Bitstream Vera License (http://www.gnome.org/fonts/#Final_Bitstream_Vera_Fonts)";
+    license = "Bitstream Vera License (https://www.gnome.org/fonts/#Final_Bitstream_Vera_Fonts)";
     platforms = platforms.all;
     maintainers = [maintainers.rycee];
   };

--- a/pkgs/data/fonts/opensans-ttf/default.nix
+++ b/pkgs/data/fonts/opensans-ttf/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       Open Sans is a humanist sans serif typeface designed by Steve Matteson,
       Type Director of Ascender Corp.
     '';
-    homepage = http://en.wikipedia.org/wiki/Open_Sans;
+    homepage = https://en.wikipedia.org/wiki/Open_Sans;
     license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.all;
     maintainers = [ ];

--- a/pkgs/data/fonts/source-code-pro/default.nix
+++ b/pkgs/data/fonts/source-code-pro/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     description = "A set of monospaced OpenType fonts designed for coding environments";
     maintainers = with stdenv.lib.maintainers; [ relrod ];
     platforms = with stdenv.lib.platforms; all;
-    homepage = http://blog.typekit.com/2012/09/24/source-code-pro/;
+    homepage = https://blog.typekit.com/2012/09/24/source-code-pro/;
     license = stdenv.lib.licenses.ofl;
   };
 }

--- a/pkgs/data/icons/hicolor-icon-theme/default.nix
+++ b/pkgs/data/icons/hicolor-icon-theme/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Default fallback theme used by implementations of the icon theme specification";
-    homepage = http://icon-theme.freedesktop.org/releases/;
+    homepage = https://icon-theme.freedesktop.org/releases/;
     platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://curl.haxx.se/docs/caextract.html;
+    homepage = https://curl.haxx.se/docs/caextract.html;
     description = "A bundle of X.509 certificates of public Certificate Authorities (CA)";
     platforms = platforms.all;
     maintainers = with maintainers; [ wkennington fpletz ];

--- a/pkgs/desktops/gnome-2/desktop/vte/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/vte/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.gnome.org/;
+    homepage = https://www.gnome.org/;
     description = "A library implementing a terminal emulator widget for GTK+";
     longDescription = ''
       VTE is a library (libvte) implementing a terminal emulator widget for

--- a/pkgs/desktops/gnome-2/platform/gtkglext/default.nix
+++ b/pkgs/desktops/gnome-2/platform/gtkglext/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   CPPFLAGS = "-UGTK_DISABLE_DEPRECATED";
 
   meta = with stdenv.lib; {
-    homepage = http://projects.gnome.org/gtkglext/;
+    homepage = https://projects.gnome.org/gtkglext/;
     description = "GtkGLExt, an OpenGL extension to GTK+";
     longDescription =
       '' GtkGLExt is an OpenGL extension to GTK+. It provides additional GDK

--- a/pkgs/desktops/gnome-3/3.22/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/evince/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
   doCheck = false; # would need pythonPackages.dogTail, which is missing
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnome.org/projects/evince/;
+    homepage = https://www.gnome.org/projects/evince/;
     description = "GNOME's document viewer";
 
     longDescription = ''

--- a/pkgs/desktops/gnome-3/3.22/core/gconf/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gconf/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   meta = with stdenv.lib; {
-    homepage = http://projects.gnome.org/gconf/;
+    homepage = https://projects.gnome.org/gconf/;
     description = "A system for storing application preferences";
     platforms = platforms.linux;
   };

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-disk-utility/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-disk-utility/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://en.wikipedia.org/wiki/GNOME_Disks;
+    homepage = https://en.wikipedia.org/wiki/GNOME_Disks;
     description = "A udisks graphical front-end";
     maintainers = gnome3.maintainers;
     license = licenses.gpl2;

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-screenshot/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-screenshot/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://en.wikipedia.org/wiki/GNOME_Screenshot;
+    homepage = https://en.wikipedia.org/wiki/GNOME_Screenshot;
     description = "Utility used in the GNOME desktop environment for taking screenshots";
     maintainers = gnome3.maintainers;
     license = licenses.gpl2;

--- a/pkgs/desktops/gnome-3/3.22/core/vte/2.90.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/vte/2.90.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnome.org/;
+    homepage = https://www.gnome.org/;
     description = "A library implementing a terminal emulator widget for GTK+";
     longDescription = ''
       VTE is a library (libvte) implementing a terminal emulator widget for

--- a/pkgs/desktops/gnome-3/3.22/core/vte/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/vte/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnome.org/;
+    homepage = https://www.gnome.org/;
     description = "A library implementing a terminal emulator widget for GTK+";
     longDescription = ''
       VTE is a library (libvte) implementing a terminal emulator widget for

--- a/pkgs/development/compilers/ccl/default.nix
+++ b/pkgs/development/compilers/ccl/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Clozure Common Lisp";
-    homepage    = http://ccl.clozure.com/;
+    homepage    = https://ccl.clozure.com/;
     maintainers = with maintainers; [ raskin muflax tohl ];
     platforms   = attrNames options;
     license     = licenses.lgpl21;

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -34,7 +34,7 @@ edk2 = stdenv.mkDerivation {
 
   meta = {
     description = "Intel EFI development kit";
-    homepage = http://sourceforge.net/projects/edk2/;
+    homepage = https://sourceforge.net/projects/edk2/;
     license = stdenv.lib.licenses.bsd2;
     platforms = ["x86_64-linux" "i686-linux"];
   };

--- a/pkgs/development/compilers/elm/packages/elm-package.nix
+++ b/pkgs/development/compilers/elm/packages/elm-package.nix
@@ -29,7 +29,7 @@ mkDerivation {
     zip-archive
   ];
   jailbreak = true;
-  homepage = http://github.com/elm-lang/elm-package;
+  homepage = https://github.com/elm-lang/elm-package;
   description = "Package manager for Elm libraries";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/pkgs/development/compilers/gnu-cobol/default.nix
+++ b/pkgs/development/compilers/gnu-cobol/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An open-source COBOL compiler";
-    homepage = http://sourceforge.net/projects/open-cobol/;
+    homepage = https://sourceforge.net/projects/open-cobol/;
     license = licenses.gpl3;
     maintainers = with maintainers; [ ericsagnes ];
     platforms = platforms.linux;

--- a/pkgs/development/compilers/julia/0.5.nix
+++ b/pkgs/development/compilers/julia/0.5.nix
@@ -179,7 +179,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "High-level performance-oriented dynamical language for technical computing";
-    homepage = http://julialang.org/;
+    homepage = https://julialang.org/;
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ raskin ];
     platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];

--- a/pkgs/development/compilers/julia/default.nix
+++ b/pkgs/development/compilers/julia/default.nix
@@ -160,7 +160,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "High-level performance-oriented dynamical language for technical computing";
-    homepage = http://julialang.org/;
+    homepage = https://julialang.org/;
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ raskin ];
     platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];

--- a/pkgs/development/compilers/julia/git.nix
+++ b/pkgs/development/compilers/julia/git.nix
@@ -171,7 +171,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "High-level performance-oriented dynamical language for technical computing";
-    homepage = http://julialang.org/;
+    homepage = https://julialang.org/;
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ raskin ];
     platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];

--- a/pkgs/development/interpreters/clojure/default.nix
+++ b/pkgs/development/interpreters/clojure/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "A Lisp dialect for the JVM";
-    homepage = http://clojure.org/;
+    homepage = https://clojure.org/;
     license = stdenv.lib.licenses.bsd3;
     longDescription = ''
       Clojure is a dynamic programming language that targets the Java

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -59,7 +59,7 @@ in
     '';
 
     meta = with stdenv.lib; {
-      homepage = http://elixir-lang.org/;
+      homepage = https://elixir-lang.org/;
       description = "A functional, meta-programming aware language built on top of the Erlang VM";
 
       longDescription = ''

--- a/pkgs/development/libraries/blitz/default.nix
+++ b/pkgs/development/libraries/blitz/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Fast multi-dimensional array library for C++";
-    homepage = http://sourceforge.net/projects/blitz/;
+    homepage = https://sourceforge.net/projects/blitz/;
     license = stdenv.lib.licenses.lgpl3;
     platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
     maintainers = [ stdenv.lib.maintainers.aherrmann ];

--- a/pkgs/development/libraries/buddy/default.nix
+++ b/pkgs/development/libraries/buddy/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    homepage = http://sourceforge.net/projects/buddy/;
+    homepage = https://sourceforge.net/projects/buddy/;
     description = "Binary decision diagram package";
     license = "as-is";
 

--- a/pkgs/development/libraries/cfitsio/default.nix
+++ b/pkgs/development/libraries/cfitsio/default.nix
@@ -14,7 +14,7 @@
    '';
 
   meta = with stdenv.lib; {
-    homepage = http://heasarc.gsfc.nasa.gov/fitsio/;
+    homepage = https://heasarc.gsfc.nasa.gov/fitsio/;
     description = "Library for reading and writing FITS data files";
     longDescription =
       '' CFITSIO is a library of C and Fortran subroutines for reading and

--- a/pkgs/development/libraries/chromaprint/default.nix
+++ b/pkgs/development/libraries/chromaprint/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DBUILD_EXAMPLES=ON" ];
 
   meta = with stdenv.lib; {
-    homepage = http://acoustid.org/chromaprint;
+    homepage = https://acoustid.org/chromaprint;
     description = "AcoustID audio fingerprinting library";
     maintainers = with maintainers; [ ehmry ];
     license = licenses.lgpl21Plus;

--- a/pkgs/development/libraries/cppunit/default.nix
+++ b/pkgs/development/libraries/cppunit/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   };
 
   meta = {
-    homepage = http://sourceforge.net/apps/mediawiki/cppunit/;
+    homepage = https://sourceforge.net/apps/mediawiki/cppunit/;
     description = "C++ unit testing framework";
     platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
   };

--- a/pkgs/development/libraries/exempi/default.nix
+++ b/pkgs/development/libraries/exempi/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.CoreServices ];
 
   meta = with stdenv.lib; {
-    homepage = http://libopenraw.freedesktop.org/wiki/Exempi/;
+    homepage = https://libopenraw.freedesktop.org/wiki/Exempi/;
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.bsd3;
   };

--- a/pkgs/development/libraries/fdk-aac/default.nix
+++ b/pkgs/development/libraries/fdk-aac/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A high-quality implementation of the AAC codec from Android";
-    homepage    = http://sourceforge.net/projects/opencore-amr/;
+    homepage    = https://sourceforge.net/projects/opencore-amr/;
     license     = licenses.asl20;
     maintainers = with maintainers; [ codyopel ];
     platforms   = platforms.all;

--- a/pkgs/development/libraries/ffms/default.nix
+++ b/pkgs/development/libraries/ffms/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ zlib ffmpeg ];
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/FFMS/ffms2/;
+    homepage = https://github.com/FFMS/ffms2/;
     description = "Libav/ffmpeg based source library for easy frame accurate access";
     license = licenses.mit;
     maintainers = with maintainers; [ fuuzetsu ];

--- a/pkgs/development/libraries/ftgl/2.1.2.nix
+++ b/pkgs/development/libraries/ftgl/2.1.2.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = http://sourceforge.net/apps/mediawiki/ftgl/;
+    homepage = https://sourceforge.net/apps/mediawiki/ftgl/;
     description = "Font rendering library for OpenGL applications";
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/development/libraries/ftgl/default.nix
+++ b/pkgs/development/libraries/ftgl/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   buildInputs = [freetype mesa];
 
   meta = {
-    homepage = http://sourceforge.net/apps/mediawiki/ftgl/;
+    homepage = https://sourceforge.net/apps/mediawiki/ftgl/;
     description = "Font rendering library for OpenGL applications";
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (rec {
 
   meta = {
     description = "The Git linkable library";
-    homepage = http://libgit2.github.com/;
+    homepage = https://libgit2.github.com/;
     license = stdenv.lib.licenses.gpl2;
     platforms = with stdenv.lib.platforms; all;
   };

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -135,7 +135,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "C library of programming buildings blocks";
-    homepage    = http://www.gtk.org/;
+    homepage    = https://www.gtk.org/;
     license     = licenses.lgpl2Plus;
     maintainers = with maintainers; [ lovek323 raskin ];
     platforms   = platforms.unix;

--- a/pkgs/development/libraries/glibmm/default.nix
+++ b/pkgs/development/libraries/glibmm/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "C++ interface to the GLib library";
 
-    homepage = http://gtkmm.org/;
+    homepage = https://gtkmm.org/;
 
     license = licenses.lgpl2Plus;
 

--- a/pkgs/development/libraries/gmp/4.3.2.nix
+++ b/pkgs/development/libraries/gmp/4.3.2.nix
@@ -60,7 +60,7 @@ let self = stdenv.mkDerivation rec {
          asymptotically faster algorithms.
       '';
 
-    homepage = http://gmplib.org/;
+    homepage = https://gmplib.org/;
     license = stdenv.lib.licenses.lgpl3Plus;
 
     maintainers = [ ];

--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -51,7 +51,7 @@ let self = stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://gmplib.org/;
+    homepage = https://gmplib.org/;
     description = "GNU multiple precision arithmetic library";
     license = licenses.gpl3Plus;
 

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -50,7 +50,7 @@ let self = stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://gmplib.org/;
+    homepage = https://gmplib.org/;
     description = "GNU multiple precision arithmetic library";
     license = licenses.gpl3Plus;
 

--- a/pkgs/development/libraries/gnu-efi/default.nix
+++ b/pkgs/development/libraries/gnu-efi/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "GNU EFI development toolchain";
-    homepage = http://sourceforge.net/projects/gnu-efi/;
+    homepage = https://sourceforge.net/projects/gnu-efi/;
     license = licenses.bsd3;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
+++ b/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "C++ interface for GStreamer";
-    homepage = http://gstreamer.freedesktop.org/bindings/cplusplus.html;
+    homepage = https://gstreamer.freedesktop.org/bindings/cplusplus.html;
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ romildo ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/gstreamer/legacy/gnonlin/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gnonlin/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gst-plugins-base gstreamer pkgconfig ];
 
   meta = {
-    homepage = http://gstreamer.freedesktop.org/modules/gnonlin.html;
+    homepage = https://gstreamer.freedesktop.org/modules/gnonlin.html;
     description = "Gstreamer Non-Linear Multimedia Editing Plugins";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/gstreamer/legacy/gst-ffmpeg/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-ffmpeg/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     ++ (if useInternalFfmpeg then [ yasm ] else [ ffmpeg ]);
 
   meta = {
-    homepage = http://gstreamer.freedesktop.org/releases/gst-ffmpeg;
+    homepage = https://gstreamer.freedesktop.org/releases/gst-ffmpeg;
     description = "GStreamer's plug-in using FFmpeg";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/gstreamer/legacy/gstreamermm/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gstreamermm/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "C++ bindings for the GStreamer streaming multimedia library";
-    homepage = http://www.gtkmm.org/;
+    homepage = https://www.gtkmm.org/;
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ plcplc ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -4,7 +4,7 @@
 }:
 
 # Note that since gst-libav-1.6, libav is actually ffmpeg. See
-# http://gstreamer.freedesktop.org/releases/1.6/ for more info.
+# https://gstreamer.freedesktop.org/releases/1.6/ for more info.
 
 assert withSystemLibav -> libav != null;
 

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A multi-platform toolkit for creating graphical user interfaces";
-    homepage    = http://www.gtk.org/;
+    homepage    = https://www.gtk.org/;
     license     = licenses.lgpl2Plus;
     maintainers = with maintainers; [ lovek323 raskin ];
     platforms   = platforms.all;

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
       royalties.
     '';
 
-    homepage = http://www.gtk.org/;
+    homepage = https://www.gtk.org/;
 
     license = licenses.lgpl2Plus;
 

--- a/pkgs/development/libraries/gtkmm/2.x.nix
+++ b/pkgs/development/libraries/gtkmm/2.x.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
       tutorial.
     '';
 
-    homepage = http://gtkmm.org/;
+    homepage = https://gtkmm.org/;
 
     license = stdenv.lib.licenses.lgpl2Plus;
 

--- a/pkgs/development/libraries/gtkmm/3.x.nix
+++ b/pkgs/development/libraries/gtkmm/3.x.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
       tutorial.
     '';
 
-    homepage = http://gtkmm.org/;
+    homepage = https://gtkmm.org/;
 
     license = licenses.lgpl2Plus;
 

--- a/pkgs/development/libraries/gusb/default.nix
+++ b/pkgs/development/libraries/gusb/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "GLib libusb wrapper";
-    homepage = http://people.freedesktop.org/~hughsient/releases/;
+    homepage = https://people.freedesktop.org/~hughsient/releases/;
     license = stdenv.lib.licenses.lgpl21;
     maintainers = [stdenv.lib.maintainers.marcweber];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -75,7 +75,7 @@ let
       meta = with stdenv.lib; {
         inherit longDescription;
         description = "Hunspell dictionary for ${shortDescription} from Dicollecte";
-        homepage = http://www.dicollecte.org/home.php?prj=fr;
+        homepage = https://www.dicollecte.org/home.php?prj=fr;
         license = licenses.mpl20;
         maintainers = with maintainers; [ renzo ];
         platforms = platforms.all;
@@ -118,7 +118,7 @@ let
       name = "hunspell-dict-${shortName}-linguistico-${version}";
       readmeFile = dictFileName + "_README.txt";
       meta = with stdenv.lib; {
-        homepage = http://sourceforge.net/projects/linguistico/;
+        homepage = https://sourceforge.net/projects/linguistico/;
         license = licenses.gpl3;
         maintainers = with maintainers; [ renzo ];
         platforms = platforms.all;

--- a/pkgs/development/libraries/libao/default.nix
+++ b/pkgs/development/libraries/libao/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       programs to output audio using a simple API on a wide variety of
       platforms.
     '';
-    homepage = http://xiph.org/ao/;
+    homepage = https://xiph.org/ao/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
     platforms = with stdenv.lib.platforms; unix;

--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -118,7 +118,7 @@ let
     passthru = { inherit vdpauSupport; };
 
     meta = with stdenv.lib; {
-      homepage = http://libav.org/;
+      homepage = https://libav.org/;
       description = "A complete, cross-platform solution to record, convert and stream audio and video (fork of ffmpeg)";
       license = with licenses; if enableUnfree then unfree #ToDo: redistributable or not?
         else if enableGPL then gpl2Plus else lgpl21Plus;

--- a/pkgs/development/libraries/libavc1394/default.nix
+++ b/pkgs/development/libraries/libavc1394/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = { 
     description = "Programming interface for the 1394 Trade Association AV/C (Audio/Video Control) Digital Interface Command Set";
-    homepage = http://sourceforge.net/projects/libavc1394/;
+    homepage = https://sourceforge.net/projects/libavc1394/;
     license = stdenv.lib.licenses.lgpl21Plus;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/development/libraries/libbap/default.nix
+++ b/pkgs/development/libraries/libbap/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://github.com/binaryanalysisplatform/bap-bindings;
+    homepage = https://github.com/binaryanalysisplatform/bap-bindings;
     description = "A C library for interacting with BAP";
     maintainers = [ stdenv.lib.maintainers.maurer ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/libbsd/default.nix
+++ b/pkgs/development/libraries/libbsd/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Common functions found on BSD systems";
-    homepage = http://libbsd.freedesktop.org/;
+    homepage = https://libbsd.freedesktop.org/;
     license = licenses.bsd3;
     platforms = platforms.linux ++ platforms.darwin;
   };

--- a/pkgs/development/libraries/libcue/default.nix
+++ b/pkgs/development/libraries/libcue/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
       a file pointer. For handling of the parsed data a convenient API is
       available.
     '';
-    homepage = http://sourceforge.net/projects/libcue/;
+    homepage = https://sourceforge.net/projects/libcue/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ astsmtl ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/development/libraries/libdap/default.nix
+++ b/pkgs/development/libraries/libdap/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A C++ SDK which contains an implementation of DAP";
-    homepage = http://www.opendap.org/download/libdap;
+    homepage = https://www.opendap.org/download/libdap;
     license = licenses.lgpl2;
     maintainers = [ maintainers.bzizou ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libdbusmenu-qt/qt-5.5.nix
+++ b/pkgs/development/libraries/libdbusmenu-qt/qt-5.5.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   cmakeFlags = "-DWITH_DOC=OFF";
 
   meta = with stdenv.lib; {
-    homepage = http://launchpad.net/libdbusmenu-qt;
+    homepage = https://launchpad.net/libdbusmenu-qt;
     description = "Provides a Qt implementation of the DBusMenu spec";
     maintainers = [ maintainers.ttuegel ];
     inherit (qtbase.meta) platforms;

--- a/pkgs/development/libraries/libdc1394/default.nix
+++ b/pkgs/development/libraries/libdc1394/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   patches = stdenv.lib.optional stdenv.isDarwin ./darwin-fixes.patch;
 
   meta = with stdenv.lib; {
-    homepage = http://sourceforge.net/projects/libdc1394/;
+    homepage = https://sourceforge.net/projects/libdc1394/;
     description = "Capture and control API for IIDC compliant cameras";
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.viric ];

--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   crossAttrs.configureFlags = configureFlags ++ [ "--disable-intel" ];
 
   meta = {
-    homepage = http://dri.freedesktop.org/libdrm/;
+    homepage = https://dri.freedesktop.org/libdrm/;
     description = "Library for accessing the kernel's Direct Rendering Manager";
     license = "bsd";
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/libdv/default.nix
+++ b/pkgs/development/libraries/libdv/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Software decoder for DV format video, as defined by the IEC 61834 and SMPTE 314M standards";
-    homepage = http://sourceforge.net/projects/libdv/;
+    homepage = https://sourceforge.net/projects/libdv/;
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/libeatmydata/default.nix
+++ b/pkgs/development/libraries/libeatmydata/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.flamingspork.com/projects/libeatmydata/;
+    homepage = https://www.flamingspork.com/projects/libeatmydata/;
     license = stdenv.lib.licenses.gpl3Plus;
     description = "Small LD_PRELOAD library to disable fsync and friends";
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/libebml/default.nix
+++ b/pkgs/development/libraries/libebml/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Extensible Binary Meta Language library";
     license = licenses.lgpl21;
-    homepage = http://dl.matroska.org/downloads/libebml/;
+    homepage = https://dl.matroska.org/downloads/libebml/;
     maintainers = [ maintainers.spwhitt ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/libewf/default.nix
+++ b/pkgs/development/libraries/libewf/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Library for support of the Expert Witness Compression Format";
-    homepage = http://sourceforge.net/projects/libewf/;
+    homepage = https://sourceforge.net/projects/libewf/;
     license = stdenv.lib.licenses.lgpl3;
     maintainers = [ stdenv.lib.maintainers.raskin ] ;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/libffcall/default.nix
+++ b/pkgs/development/libraries/libffcall/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Foreign function call library";
-    homepage = http://www.haible.de/bruno/packages-ffcall.html;
+    homepage = https://www.haible.de/bruno/packages-ffcall.html;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/libftdi/1.x.nix
+++ b/pkgs/development/libraries/libftdi/1.x.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A library to talk to FTDI chips using libusb";
-    homepage = http://www.intra2net.com/en/developer/libftdi/;
+    homepage = https://www.intra2net.com/en/developer/libftdi/;
     license = with licenses; [ lgpl2 gpl2 ];
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/libraries/libftdi/default.nix
+++ b/pkgs/development/libraries/libftdi/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A library to talk to FTDI chips using libusb";
-    homepage = http://www.intra2net.com/en/developer/libftdi/;
+    homepage = https://www.intra2net.com/en/developer/libftdi/;
     license = stdenv.lib.licenses.lgpl21;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/libgeotiff/default.nix
+++ b/pkgs/development/libraries/libgeotiff/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Library implementing attempt to create a tiff based interchange format for georeferenced raster imagery";
-    homepage = http://www.remotesensing.org/geotiff/geotiff.html;
+    homepage = https://www.remotesensing.org/geotiff/geotiff.html;
     license = stdenv.lib.licenses.mit;
     maintainers = [stdenv.lib.maintainers.marcweber];
     platforms = with stdenv.lib.platforms; linux ++ darwin;

--- a/pkgs/development/libraries/libgsf/default.nix
+++ b/pkgs/development/libraries/libgsf/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "GNOME's Structured File Library";
-    homepage    = http://www.gnome.org/projects/libgsf;
+    homepage    = https://www.gnome.org/projects/libgsf;
     license     = licenses.lgpl2Plus;
     maintainers = with maintainers; [ lovek323 ];
     platforms   = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/libibmad/default.nix
+++ b/pkgs/development/libraries/libibmad/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libibumad ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.openfabrics.org/;
+    homepage = https://www.openfabrics.org/;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ wkennington ];

--- a/pkgs/development/libraries/libibumad/default.nix
+++ b/pkgs/development/libraries/libibumad/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://www.openfabrics.org/;
+    homepage = https://www.openfabrics.org/;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ wkennington ];

--- a/pkgs/development/libraries/liblastfm/default.nix
+++ b/pkgs/development/libraries/liblastfm/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   buildInputs = stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.SystemConfiguration;
 
   meta = {
-    homepage = http://github.com/lastfm/liblastfm;
+    homepage = https://github.com/lastfm/liblastfm;
     repositories.git = git://github.com/lastfm/liblastfm.git;
     description = "Official LastFM library";
     inherit (qt4.meta) platforms;

--- a/pkgs/development/libraries/libmad/default.nix
+++ b/pkgs/development/libraries/libmad/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage    = http://sourceforge.net/projects/mad/;
+    homepage    = https://sourceforge.net/projects/mad/;
     description = "A high-quality, fixed-point MPEG audio decoder supporting MPEG-1 and MPEG-2";
     license     = licenses.gpl2;
     maintainers = with maintainers; [ lovek323 ];

--- a/pkgs/development/libraries/libmatroska/default.nix
+++ b/pkgs/development/libraries/libmatroska/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A library to parse Matroska files";
-    homepage = http://matroska.org/;
+    homepage = https://matroska.org/;
     license = licenses.lgpl21;
     maintainers = [ maintainers.spwhitt ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libmesode/default.nix
+++ b/pkgs/development/libraries/libmesode/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
       Whilst Profanity will run against libstrophe, libmesode provides extra
       TLS functionality such as manual SSL certificate verification.
     '';
-    homepage = http://github.com/boothj5/libmesode/;
+    homepage = https://github.com/boothj5/libmesode/;
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.devhell ];

--- a/pkgs/development/libraries/libmp3splt/default.nix
+++ b/pkgs/development/libraries/libmp3splt/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   configureFlags = "--disable-pcre";
 
   meta = with stdenv.lib; {
-    homepage    = http://sourceforge.net/projects/mp3splt/;
+    homepage    = https://sourceforge.net/projects/mp3splt/;
     description = "Utility to split mp3, ogg vorbis and FLAC files without decoding";
     maintainers = with maintainers; [ bosu ];
     platforms   = platforms.unix;

--- a/pkgs/development/libraries/libmspack/default.nix
+++ b/pkgs/development/libraries/libmspack/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "A de/compression library for various Microsoft formats";
-    homepage = http://www.cabextract.org.uk/libmspack;
+    homepage = https://www.cabextract.org.uk/libmspack;
     license = stdenv.lib.licenses.lgpl2;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/libnet/default.nix
+++ b/pkgs/development/libraries/libnet/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/sam-github/libnet;
+    homepage = https://github.com/sam-github/libnet;
     description = "Portable framework for low-level network packet construction";
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libnice/default.nix
+++ b/pkgs/development/libraries/libnice/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ glib gupnp_igd ];
 
   meta = {
-    homepage = http://nice.freedesktop.org/wiki/;
+    homepage = https://nice.freedesktop.org/wiki/;
     description = "The GLib ICE implementation";
     longDescription = ''
       Libnice is an implementation of the IETF's Interactice Connectivity

--- a/pkgs/development/libraries/libogg/default.nix
+++ b/pkgs/development/libraries/libogg/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "doc" ];
 
   meta = with stdenv.lib; {
-    homepage = http://xiph.org/ogg/;
+    homepage = https://xiph.org/ogg/;
     license = licenses.bsd3;
     maintainers = [ maintainers.ehmry ];
     platforms = platforms.all;

--- a/pkgs/development/libraries/liboggz/default.nix
+++ b/pkgs/development/libraries/liboggz/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig ];
 
   meta = {
-    homepage = http://xiph.org/oggz/;
+    homepage = https://xiph.org/oggz/;
     description = "A C library and tools for manipulating with Ogg files and streams";
     longDescription = ''
       Oggz comprises liboggz and the tool oggz, which provides commands to

--- a/pkgs/development/libraries/libomxil-bellagio/default.nix
+++ b/pkgs/development/libraries/libomxil-bellagio/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   patches = [ ./fedora-fixes.patch ];
 
   meta = with stdenv.lib; {
-    homepage = http://sourceforge.net/projects/omxil/;
+    homepage = https://sourceforge.net/projects/omxil/;
     description = "An opensource implementation of the Khronos OpenMAX Integration Layer API to access multimedia components";
     license = licenses.lgpl21;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libplist/default.nix
+++ b/pkgs/development/libraries/libplist/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
   };
 
   meta = {
-    homepage = http://github.com/JonathanBeck/libplist;
+    homepage = https://github.com/JonathanBeck/libplist;
     platforms = stdenv.lib.platforms.all;
     maintainers = [ ];
   };

--- a/pkgs/development/libraries/libqrencode/default.nix
+++ b/pkgs/development/libraries/libqrencode/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with stdenv.lib; {
-    homepage = http://fukuchi.org/works/qrencode/;
+    homepage = https://fukuchi.org/works/qrencode/;
     description = "A C library for encoding data in a QR Code symbol";
 
     longDescription = ''

--- a/pkgs/development/libraries/libraw/default.nix
+++ b/pkgs/development/libraries/libraw/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Library for reading RAW files obtained from digital photo cameras (CRW/CR2, NEF, RAF, DNG, and others)";
-    homepage = http://www.libraw.org/;
+    homepage = https://www.libraw.org/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/librdf/default.nix
+++ b/pkgs/development/libraries/librdf/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Lightweight RDF library with special support for LADSPA plugins";
-    homepage = http://sourceforge.net/projects/lrdf/;
+    homepage = https://sourceforge.net/projects/lrdf/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.marcweber ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/mesa-glu/default.nix
+++ b/pkgs/development/libraries/mesa-glu/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "OpenGL utility library";
-    homepage = http://cgit.freedesktop.org/mesa/glu/;
+    homepage = https://cgit.freedesktop.org/mesa/glu/;
     license = stdenv.lib.licenses.sgi-b-20;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = http://github.com/opencollab/arpack-ng;
+    homepage = https://github.com/opencollab/arpack-ng;
     description = ''
       A collection of Fortran77 subroutines to solve large scale eigenvalue
       problems.

--- a/pkgs/development/libraries/utf8proc/default.nix
+++ b/pkgs/development/libraries/utf8proc/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A clean C library for processing UTF-8 Unicode data";
-    homepage = http://julialang.org/utf8proc;
+    homepage = https://julialang.org/utf8proc;
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = [ maintainers.ftrvxmtrx ];

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.4.5";
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/bazelbuild/bazel/;
+    homepage = https://github.com/bazelbuild/bazel/;
     description = "Build tool that builds code quickly and reliably";
     license = licenses.asl20;
     maintainers = [ maintainers.philandstuff ];

--- a/pkgs/development/tools/build-managers/leiningen/default.nix
+++ b/pkgs/development/tools/build-managers/leiningen/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://leiningen.org/;
+    homepage = https://leiningen.org/;
     description = "Project automation for Clojure";
     license = stdenv.lib.licenses.epl10;
     platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;

--- a/pkgs/development/tools/dcadec/default.nix
+++ b/pkgs/development/tools/dcadec/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "DTS Coherent Acoustics decoder with support for HD extensions";
     maintainers = with maintainers; [ edwtjo ];
-    homepage = http://github.com/foo86/dcadec;
+    homepage = https://github.com/foo86/dcadec;
     license = licenses.lgpl21;
     platforms = platforms.linux;
   };

--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
    ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.gtk.org/gtk-doc;
+    homepage = https://www.gtk.org/gtk-doc;
     description = "Tools to extract documentation embedded in GTK+ and GNOME source code";
     license = licenses.gpl2;
     maintainers = with maintainers; [ pSub ];

--- a/pkgs/development/tools/misc/automoc4/default.nix
+++ b/pkgs/development/tools/misc/automoc4/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmake qt4 ];
   
   meta = with stdenv.lib; {
-    homepage = http://techbase.kde.org/Development/Tools/Automoc4;
+    homepage = https://techbase.kde.org/Development/Tools/Automoc4;
     description = "KDE Meta Object Compiler";
     license = licenses.bsd2;
     maintainers = [ maintainers.sander ];

--- a/pkgs/development/tools/misc/avarice/default.nix
+++ b/pkgs/development/tools/misc/avarice/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   meta = {
     license = stdenv.lib.licenses.gpl2;
     description = "Translator between GDB's remote debug protocol and the AVR JTAG ICE protocol";
-    homepage = http://sourceforge.net/projects/avarice/files/avarice/;
+    homepage = https://sourceforge.net/projects/avarice/files/avarice/;
     maintainers = [ stdenv.lib.maintainers.smironov ];
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/development/tools/misc/cbrowser/default.nix
+++ b/pkgs/development/tools/misc/cbrowser/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl2Plus;
 
-    homepage = http://sourceforge.net/projects/cbrowser/;
+    homepage = https://sourceforge.net/projects/cbrowser/;
 
     maintainers = with stdenv.lib.maintainers; [viric];
 

--- a/pkgs/development/tools/misc/checkbashisms/default.nix
+++ b/pkgs/development/tools/misc/checkbashisms/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://sourceforge.net/projects/checkbaskisms/;
+    homepage = https://sourceforge.net/projects/checkbaskisms/;
     description = "Check shell scripts for non-portable syntax";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/tools/misc/drush/default.nix
+++ b/pkgs/development/tools/misc/drush/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Command-line shell and Unix scripting interface for Drupal";
-    homepage    = http://github.com/drush-ops/drush;
+    homepage    = https://github.com/drush-ops/drush;
     license     = licenses.gpl2;
     maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.all;

--- a/pkgs/development/tools/misc/eggdbus/default.nix
+++ b/pkgs/development/tools/misc/eggdbus/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig glib dbus dbus_glib ];
 
   meta = {
-    homepage = http://hal.freedesktop.org/releases/;
+    homepage = https://hal.freedesktop.org/releases/;
     description = "D-Bus bindings for GObject";
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/development/tools/misc/intltool/default.nix
+++ b/pkgs/development/tools/misc/intltool/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Translation helper tool";
-    homepage = http://launchpad.net/intltool/;
+    homepage = https://launchpad.net/intltool/;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.unix;

--- a/pkgs/development/web/grails/default.nix
+++ b/pkgs/development/web/grails/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
       over configuration to provide a productive and stream-lined development
       experience.
     '';
-    homepage = http://grails.org/;
+    homepage = https://grails.org/;
     license = licenses.asl20;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/games/0ad/data.nix
+++ b/pkgs/games/0ad/data.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A free, open-source game of ancient warfare -- data files";
-    homepage = http://wildfiregames.com/0ad/;
+    homepage = https://wildfiregames.com/0ad/;
     license = licenses.cc-by-sa-30;
     platforms = platforms.linux;
     hydraPlatforms = [];

--- a/pkgs/games/0ad/game.nix
+++ b/pkgs/games/0ad/game.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A free, open-source game of ancient warfare";
-    homepage = http://wildfiregames.com/0ad/;
+    homepage = https://wildfiregames.com/0ad/;
     license = with licenses; [
       gpl2 lgpl21 mit cc-by-sa-30
       licenses.zlib # otherwise masked by pkgs.zlib

--- a/pkgs/games/btanks/default.nix
+++ b/pkgs/games/btanks/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://sourceforge.net/projects/btanks/;
+    homepage = https://sourceforge.net/projects/btanks/;
     description = "Fast 2d tank arcade game";
     license = stdenv.lib.licenses.gpl2Plus;
   };

--- a/pkgs/games/extremetuxracer/default.nix
+++ b/pkgs/games/extremetuxracer/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       ExtremeTuxRacer - Tux lies on his belly and accelerates down ice slopes.
     '';
     license = stdenv.lib.licenses.gpl2Plus;
-    homepage = http://sourceforge.net/projects/extremetuxracer/;
+    homepage = https://sourceforge.net/projects/extremetuxracer/;
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
     platforms = with stdenv.lib.platforms; linux;
   };

--- a/pkgs/games/quake3/ioquake/default.nix
+++ b/pkgs/games/quake3/ioquake/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://ioquake3.org/;
+    homepage = https://ioquake3.org/;
     description = "First person shooter engine based on the Quake 3: Arena and Quake 3: Team Arena";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/misc/drivers/gutenprint/default.nix
+++ b/pkgs/misc/drivers/gutenprint/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Ghostscript and cups printer drivers";
-    homepage = http://sourceforge.net/projects/gimp-print/;
+    homepage = https://sourceforge.net/projects/gimp-print/;
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/misc/emulators/higan/default.nix
+++ b/pkgs/misc/emulators/higan/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
         - NEC's PC Engine, SuperGrafx;
         - Bandai' WonderSwan, WonderSwan Color.
     '';
-    homepage = http://byuu.org/higan/;
+    homepage = https://byuu.org/higan/;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = with platforms; unix;

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -33,7 +33,7 @@ let
 
     meta = with stdenv.lib; {
       inherit description;
-      homepage = http://www.libretro.com/;
+      homepage = https://www.libretro.com/;
       license = licenses.gpl3Plus;
       maintainers = with maintainers; [ edwtjo hrdinka MP2E ];
       platforms = platforms.linux;

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
   passthru = { inherit version; };
 
   meta = {
-    homepage = http://www.ghostscript.com/;
+    homepage = https://www.ghostscript.com/;
     description = "PostScript interpreter (mainline version)";
 
     longDescription = ''

--- a/pkgs/misc/themes/blackbird/default.nix
+++ b/pkgs/misc/themes/blackbird/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Dark Desktop Suite for Gtk, Xfce and Metacity";
-    homepage = http://github.com/shimmerproject/Blackbird;
+    homepage = https://github.com/shimmerproject/Blackbird;
     license = with stdenv.lib.licenses; [ gpl2Plus cc-by-nc-sa-30 ];
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.romildo ];

--- a/pkgs/os-specific/linux/acpi/default.nix
+++ b/pkgs/os-specific/linux/acpi/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
       the "old" `apm' command on ACPI systems.  It includes
       battery and thermal information.
     '';
-    homepage = http://sourceforge.net/projects/acpiclient/;
+    homepage = https://sourceforge.net/projects/acpiclient/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.mornfall ];

--- a/pkgs/os-specific/linux/batman-adv/alfred.nix
+++ b/pkgs/os-specific/linux/batman-adv/alfred.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.open-mesh.org/projects/batman-adv/wiki/Wiki;
+    homepage = https://www.open-mesh.org/projects/batman-adv/wiki/Wiki;
     description = "B.A.T.M.A.N. routing protocol in a linux kernel module for layer 2, information distribution tool";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ fpletz ];

--- a/pkgs/os-specific/linux/batman-adv/batctl.nix
+++ b/pkgs/os-specific/linux/batman-adv/batctl.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.open-mesh.org/projects/batman-adv/wiki/Wiki;
+    homepage = https://www.open-mesh.org/projects/batman-adv/wiki/Wiki;
     description = "B.A.T.M.A.N. routing protocol in a linux kernel module for layer 2, control tool";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ viric fpletz ];

--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.open-mesh.org/projects/batman-adv/wiki/Wiki;
+    homepage = https://www.open-mesh.org/projects/batman-adv/wiki/Wiki;
     description = "B.A.T.M.A.N. routing protocol in a linux kernel module for layer 2";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ viric fpletz ];

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Tiny versions of common UNIX utilities in a single small executable";
-    homepage = http://busybox.net/;
+    homepage = https://busybox.net/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ viric ];
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/edac-utils/default.nix
+++ b/pkgs/os-specific/linux/edac-utils/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/grondo/edac-utils;
+    homepage = https://github.com/grondo/edac-utils;
     description = "Handles the reporting of hardware-related memory errors";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/eudev/default.nix
+++ b/pkgs/os-specific/linux/eudev/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.gpl2Plus ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
-    homepage = ''http://www.gentoo.org/proj/en/eudev/'';
+    homepage = ''https://www.gentoo.org/proj/en/eudev/'';
     downloadPage = ''http://dev.gentoo.org/~blueness/eudev/'';
     updateWalker = true;
   };

--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.gpl2Plus ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
-    homepage = http://l3net.wordpress.com/projects/firejail/;
+    homepage = https://l3net.wordpress.com/projects/firejail/;
     downloadPage = "http://sourceforge.net/projects/firejail/files/firejail/";
   };
 }

--- a/pkgs/os-specific/linux/hdparm/default.nix
+++ b/pkgs/os-specific/linux/hdparm/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A tool to get/set ATA/SATA drive parameters under Linux";
-    homepage = http://sourceforge.net/projects/hdparm/;
+    homepage = https://sourceforge.net/projects/hdparm/;
     platforms = platforms.linux;
     license = licenses.bsd2;
     maintainers = [ maintainers.fuuzetsu ];

--- a/pkgs/os-specific/linux/ima-evm-utils/default.nix
+++ b/pkgs/os-specific/linux/ima-evm-utils/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "evmctl utility to manage digital signatures of the Linux kernel integrity subsystem (IMA/EVM)";
-    homepage = http://sourceforge.net/projects/linux-ima/;
+    homepage = https://sourceforge.net/projects/linux-ima/;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ tstrobel ];

--- a/pkgs/os-specific/linux/jfbview/default.nix
+++ b/pkgs/os-specific/linux/jfbview/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
       - Asynchronous background rendering of the next page
       - Customizable multi-threaded caching
     '';
-    homepage = http://seasonofcode.com/pages/jfbview.html;
+    homepage = https://seasonofcode.com/pages/jfbview.html;
     license = licenses.asl20;
     platforms = platforms.linux;
     maintainers = with maintainers; [ nckx ];

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -207,7 +207,7 @@ let
             + stdenv.lib.concatStrings (stdenv.lib.intersperse ", " (map (x: x.name) kernelPatches))
             + ")");
         license = stdenv.lib.licenses.gpl2;
-        homepage = http://www.kernel.org/;
+        homepage = https://www.kernel.org/;
         repositories.git = https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;
         maintainers = [
           maintainers.thoughtpolice

--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.kernel.org/pub/linux/utils/kernel/kmod/;
+    homepage = https://www.kernel.org/pub/linux/utils/kernel/kmod/;
     description = "Tools for loading and managing Linux kernel modules";
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/os-specific/linux/v4l-utils/default.nix
+++ b/pkgs/os-specific/linux/v4l-utils/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "V4L utils and libv4l, provide common image formats regardless of the v4l device";
-    homepage = http://linuxtv.org/projects.php;
+    homepage = https://linuxtv.org/projects.php;
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ codyopel viric ];
     platforms = platforms.linux;

--- a/pkgs/servers/brickd/default.nix
+++ b/pkgs/servers/brickd/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.tinkerforge.com/;
+    homepage = https://www.tinkerforge.com/;
     description = "A daemon (or service on Windows) that acts as a bridge between the Bricks/Bricklets and the API bindings for the different programming languages";
     maintainers = [ stdenv.lib.maintainers.qknight ];
     license = stdenv.lib.licenses.gpl2;

--- a/pkgs/servers/consul/ui.nix
+++ b/pkgs/servers/consul/ui.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    homepage    = http://www.consul.io/;
+    homepage    = https://www.consul.io/;
     description = "A tool for service discovery, monitoring and configuration";
     maintainers = with maintainers; [ cstrahan wkennington ];
     license     = licenses.mpl20 ;

--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "MediaBrowser - Bring together your videos, music, photos, and live television";
-    homepage = http://emby.media/;
+    homepage = https://emby.media/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.fadenb ];
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/servers/fleet/default.nix
+++ b/pkgs/servers/fleet/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A distributed init system";
-    homepage = http://coreos.com/using-coreos/clustering/;
+    homepage = https://coreos.com/using-coreos/clustering/;
     license = licenses.asl20;
     maintainers = with maintainers; [
       cstrahan

--- a/pkgs/servers/mpd/clientlib.nix
+++ b/pkgs/servers/mpd/clientlib.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Client library for MPD (music player daemon)";
-    homepage = http://www.musicpd.org/libs/libmpdclient/;
+    homepage = https://www.musicpd.org/libs/libmpdclient/;
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ mornfall ehmry ];

--- a/pkgs/servers/sip/freeswitch/default.nix
+++ b/pkgs/servers/sip/freeswitch/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Cross-Platform Scalable FREE Multi-Protocol Soft Switch";
-    homepage = http://freeswitch.org/;
+    homepage = https://freeswitch.org/;
     license = stdenv.lib.licenses.mpl11;
     maintainers = with stdenv.lib.maintainers; [ viric ];
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/tools/X11/bumblebee/default.nix
+++ b/pkgs/tools/X11/bumblebee/default.nix
@@ -141,7 +141,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/Bumblebee-Project/Bumblebee;
+    homepage = https://github.com/Bumblebee-Project/Bumblebee;
     description = "Daemon for managing Optimus videocards (power-on/off, spawns xservers)";
     platforms = platforms.linux;
     license = licenses.gpl3;

--- a/pkgs/tools/X11/hsetroot/default.nix
+++ b/pkgs/tools/X11/hsetroot/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Allows you to compose wallpapers ('root pixmaps') for X";
-    homepage = http://thegraveyard.org/hsetroot.html;
+    homepage = https://thegraveyard.org/hsetroot.html;
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.henrytill ];
     platforms = platforms.unix;

--- a/pkgs/tools/archivers/cabextract/default.nix
+++ b/pkgs/tools/archivers/cabextract/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://www.cabextract.org.uk/;
+    homepage = https://www.cabextract.org.uk/;
     description = "Free Software for extracting Microsoft cabinet files";
     platforms = platforms.all;
     license = licenses.gpl3;

--- a/pkgs/tools/audio/acoustid-fingerprinter/default.nix
+++ b/pkgs/tools/audio/acoustid-fingerprinter/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   }) ];
 
   meta = with stdenv.lib; {
-    homepage = http://acoustid.org/fingerprinter;
+    homepage = https://acoustid.org/fingerprinter;
     description = "Audio fingerprinting tool using chromaprint";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with maintainers; [ ehmry ];

--- a/pkgs/tools/compression/dtrx/default.nix
+++ b/pkgs/tools/compression/dtrx/default.nix
@@ -26,7 +26,7 @@ in pythonPackages.buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     description = "Do The Right Extraction: A tool for taking the hassle out of extracting archives";
-    homepage = http://brettcsmith.org/2007/dtrx/;
+    homepage = https://brettcsmith.org/2007/dtrx/;
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.spwhitt ];
     platforms = platforms.all;

--- a/pkgs/tools/filesystems/bcache-tools/default.nix
+++ b/pkgs/tools/filesystems/bcache-tools/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
       User documentation is in Documentation/bcache.txt in the Linux kernel
       tree.
     '';
-    homepage = http://bcache.evilpiepirate.org/;
+    homepage = https://bcache.evilpiepirate.org/;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/tools/filesystems/dosfstools/default.nix
+++ b/pkgs/tools/filesystems/dosfstools/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Utilities for creating and checking FAT and VFAT file systems";
     repositories.git = git://daniel-baumann.ch/git/software/dosfstools.git;
-    homepage = http://www.daniel-baumann.ch/software/dosfstools/;
+    homepage = https://www.daniel-baumann.ch/software/dosfstools/;
     platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
   };
 }

--- a/pkgs/tools/graphics/briss/default.nix
+++ b/pkgs/tools/graphics/briss/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = http://sourceforge.net/projects/briss/;
+    homepage = https://sourceforge.net/projects/briss/;
     description = "Java application for cropping PDF files";
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/tools/graphics/cfdg/default.nix
+++ b/pkgs/tools/graphics/cfdg/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     description = "Context-free design grammar - a tool for graphics generation";
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
-    homepage = http://contextfreeart.org/;
-    downloadPage = "http://contextfreeart.org/mediawiki/index.php/Download_page";
+    homepage = https://contextfreeart.org/;
+    downloadPage = "https://contextfreeart.org/mediawiki/index.php/Download_page";
   };
 }

--- a/pkgs/tools/graphics/cfdg/src-info-for-default.nix
+++ b/pkgs/tools/graphics/cfdg/src-info-for-default.nix
@@ -1,5 +1,5 @@
 {
-  downloadPage = "http://contextfreeart.org/mediawiki/index.php/Download_page";
+  downloadPage = "https://contextfreeart.org/mediawiki/index.php/Download_page";
   baseName = "cfdg";
   sourceRegexp = ''.*[.]tgz'';
   versionExtractorSedScript = ''s/[^0-9]*([0-9.]*)[.]tgz/\1/'';

--- a/pkgs/tools/graphics/editres/default.nix
+++ b/pkgs/tools/graphics/editres/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   meta = {
-    homepage = http://cgit.freedesktop.org/xorg/app/editres/;
+    homepage = https://cgit.freedesktop.org/xorg/app/editres/;
     description = "A dynamic resource editor for X Toolkit applications";
 
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/graphics/pngtoico/default.nix
+++ b/pkgs/tools/graphics/pngtoico/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libpng ];
 
   meta = {
-    homepage = http://www.kernel.org/pub/software/graphics/pngtoico/;
+    homepage = https://www.kernel.org/pub/software/graphics/pngtoico/;
     description = "Small utility to convert a set of PNG images to Microsoft ICO format";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/tools/graphics/qrencode/default.nix
+++ b/pkgs/tools/graphics/qrencode/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
 
   meta = {
-    homepage = http://fukuchi.org/works/qrencode/;
+    homepage = https://fukuchi.org/works/qrencode/;
     description = "QR code encoder";
     platforms = stdenv.lib.platforms.all;
     maintainers = [ ];

--- a/pkgs/tools/misc/aescrypt/default.nix
+++ b/pkgs/tools/misc/aescrypt/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Encrypt files with Advanced Encryption Standard (AES)";
-    homepage    = http://www.aescrypt.com/;
+    homepage    = https://www.aescrypt.com/;
     license     = licenses.gpl2;
     maintainers = with maintainers; [ lovek323 qknight ];
     platforms   = stdenv.lib.platforms.all;

--- a/pkgs/tools/misc/autorandr/default.nix
+++ b/pkgs/tools/misc/autorandr/default.nix
@@ -44,7 +44,7 @@ in
     };
 
     meta = {
-      homepage = http://github.com/phillipberndt/autorandr/;
+      homepage = https://github.com/phillipberndt/autorandr/;
       description = "Auto-detect the connect display hardware and load the appropiate X11 setup using xrandr";
       license = stdenv.lib.licenses.gpl3Plus;
       maintainers = [ stdenv.lib.maintainers.coroa ];

--- a/pkgs/tools/misc/fluentd/default.nix
+++ b/pkgs/tools/misc/fluentd/default.nix
@@ -8,7 +8,7 @@ bundlerEnv {
 
   meta = with lib; {
     description = "A data collector";
-    homepage    = http://www.fluentd.org/;
+    homepage    = https://www.fluentd.org/;
     license     = licenses.asl20;
     maintainers = with maintainers; [ offline ];
     platforms   = platforms.unix;

--- a/pkgs/tools/misc/hakuneko/default.nix
+++ b/pkgs/tools/misc/hakuneko/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Manga downloader";
-    homepage = http://sourceforge.net/projects/hakuneko/;
+    homepage = https://sourceforge.net/projects/hakuneko/;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
       applications to evolve in their use of HDF5. The HDF5 Technology suite includes tools and 
       applications for managing, manipulating, viewing, and analyzing data in the HDF5 format.
     '';
-    homepage = http://www.hdfgroup.org/HDF5/;
+    homepage = https://www.hdfgroup.org/HDF5/;
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/misc/mstflint/default.nix
+++ b/pkgs/tools/misc/mstflint/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ zlib libibmad ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.openfabrics.org/;
+    homepage = https://www.openfabrics.org/;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ wkennington ];

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     optional gnutlsSupport gnutls ++
     optional scpSupport libssh2;
 
-  # for the second line see http://curl.haxx.se/mail/tracker-2014-03/0087.html
+  # for the second line see https://curl.haxx.se/mail/tracker-2014-03/0087.html
   preConfigure = ''
     sed -e 's|/usr/bin|/no-such-path|g' -i.bak configure
     rm src/tool_hugehelp.c
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A command line tool for transferring files with URL syntax";
-    homepage    = http://curl.haxx.se/;
+    homepage    = https://curl.haxx.se/;
     maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.all;
   };

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A client for the Dynamic Host Configuration Protocol (DHCP)";
-    homepage = http://roy.marples.name/projects/dhcpcd;
+    homepage = https://roy.marples.name/projects/dhcpcd;
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ eelco fpletz ];
   };

--- a/pkgs/tools/networking/email/default.nix
+++ b/pkgs/tools/networking/email/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Command line SMTP client";
     license = with lib.licenses; [ gpl2 ];
-    homepage = http://deanproxy.com/code;
+    homepage = https://deanproxy.com/code;
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/networking/httpie/default.nix
+++ b/pkgs/tools/networking/httpie/default.nix
@@ -15,7 +15,7 @@ pythonPackages.buildPythonApplication rec {
 
   meta = {
     description = "A command line HTTP client whose goal is to make CLI human-friendly";
-    homepage = http://httpie.org/;
+    homepage = https://httpie.org/;
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ antono relrod schneefux ];
   };

--- a/pkgs/tools/networking/hyenae/default.nix
+++ b/pkgs/tools/networking/hyenae/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "";
-    homepage = http://sourceforge.net/projects/hyenae/;
+    homepage = https://sourceforge.net/projects/hyenae/;
     license = stdenv.lib.licenses.gpl3;
     maintainers = [stdenv.lib.maintainers.marcweber];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/networking/iperf/2.nix
+++ b/pkgs/tools/networking/iperf/2.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   meta = with stdenv.lib; {
-    homepage = http://sourceforge.net/projects/iperf/;
+    homepage = https://sourceforge.net/projects/iperf/;
     description = "Tool to measure IP bandwidth using UDP or TCP";
     platforms = platforms.unix;
     license = licenses.mit;

--- a/pkgs/tools/networking/tftp-hpa/default.nix
+++ b/pkgs/tools/networking/tftp-hpa/default.nix
@@ -13,12 +13,12 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
     license = licenses.bsd3;
-    homepage = http://www.kernel.org/pub/software/network/tftp/;
+    homepage = https://www.kernel.org/pub/software/network/tftp/;
   };
 
   passthru = {
     updateInfo = {
-      downloadPage = "http://www.kernel.org/pub/software/network/tftp/";
+      downloadPage = "https://www.kernel.org/pub/software/network/tftp/";
     };
   };
 }

--- a/pkgs/tools/package-management/dpkg/default.nix
+++ b/pkgs/tools/package-management/dpkg/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The Debian package manager";
-    homepage = http://wiki.debian.org/Teams/Dpkg;
+    homepage = https://wiki.debian.org/Teams/Dpkg;
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ mornfall nckx ];

--- a/pkgs/tools/security/hashcat/default.nix
+++ b/pkgs/tools/security/hashcat/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Fast password cracker";
-    homepage    = "http://hashcat.net/hashcat/";
+    homepage    = "https://hashcat.net/hashcat/";
     license     = stdenv.lib.licenses.mit;
     platforms   = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];

--- a/pkgs/tools/security/hashcat/hashcat3/default.nix
+++ b/pkgs/tools/security/hashcat/hashcat3/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Fast password cracker";
-    homepage    = http://hashcat.net/hashcat/;
+    homepage    = https://hashcat.net/hashcat/;
     license     = stdenv.lib.licenses.mit;
     platforms   = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.kierdavis ];

--- a/pkgs/tools/system/at/default.nix
+++ b/pkgs/tools/system/at/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   meta = {
     description = ''The classical Unix `at' job scheduling command'';
     license = stdenv.lib.licenses.gpl2Plus;
-    homepage = http://packages.qa.debian.org/at;
+    homepage = https://packages.qa.debian.org/at;
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/tools/system/datefudge/default.nix
+++ b/pkgs/tools/system/datefudge/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       different by pre-loading a small library which modifies the time,
       gettimeofday and clock_gettime system calls.
     '';
-    homepage = http://packages.qa.debian.org/d/datefudge.html;
+    homepage = https://packages.qa.debian.org/d/datefudge.html;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ leenaars ];

--- a/pkgs/tools/system/dfc/default.nix
+++ b/pkgs/tools/system/dfc/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmake gettext ];
 
   meta = {
-    homepage = http://projects.gw-computing.net/projects/dfc;
+    homepage = https://projects.gw-computing.net/projects/dfc;
     description = "Displays file system space usage using graphs and colors";
     license="free";
     maintainers = with stdenv.lib.maintainers; [qknight];

--- a/pkgs/tools/text/colordiff/default.nix
+++ b/pkgs/tools/text/colordiff/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Wrapper for 'diff' that produces the same output but with pretty 'syntax' highlighting";
-    homepage = http://www.colordiff.org/;
+    homepage = https://www.colordiff.org/;
     license = licenses.gpl3;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ nckx ];

--- a/pkgs/tools/typesetting/fop/default.nix
+++ b/pkgs/tools/typesetting/fop/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
       This package contains the fop command line tool.
     '';
-    homepage = http://xmlgraphics.apache.org/fop/;
+    homepage = https://xmlgraphics.apache.org/fop/;
     license = licenses.asl20;
     platforms = platforms.linux;
     maintainers = with maintainers; [ bjornfor ndowens ];

--- a/pkgs/tools/typesetting/halibut/default.nix
+++ b/pkgs/tools/typesetting/halibut/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "halibut-1.2";
 
   src = fetchurl {
-    url = "http://www.chiark.greenend.org.uk/~sgtatham/halibut/${name}/${name}.tar.gz";
+    url = "http://ww.chiark.greenend.org.uk/~sgtatham/halibut/${name}/${name}.tar.gz";
     sha256 = "0gqnhfqf555rfpk5xj1imbdxnbkkrv4wl3rrdb1r0wgj81igpv8s";
   };
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Documentation production system for software manuals";
-    homepage = http://www.chiark.greenend.org.uk/~sgtatham/halibut/;
+    homepage = https://www.chiark.greenend.org.uk/~sgtatham/halibut/;
     license = licenses.mit;
     maintainers = with maintainers; [ pSub ];
     platforms = with platforms; unix;

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -443,7 +443,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
 
     meta = {
       description = "Excel-DNA is an independent project to integrate .NET into Excel";
-      homepage = "http://excel-dna.net/";
+      homepage = "https://excel-dna.net/";
       license = stdenv.lib.licenses.mit;
       maintainers = with stdenv.lib.maintainers; [ obadz ];
       platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3376,7 +3376,7 @@ in {
     doCheck = false;
 
     meta = {
-      description = "Python client for Consul (http://www.consul.io/)";
+      description = "Python client for Consul (https://www.consul.io/)";
       homepage = https://github.com/cablehead/python-consul;
       license = licenses.mit;
       maintainers = with maintainers; [ desiderius ];


### PR DESCRIPTION
###### Motivation for this change

Update Homepages and urls attributres from http to https thanks to https://repology.org/repository/nix_stable/problems
Homepage link "http://.../" is a permanent redirect to "https://.../" and should be updated

I hope to be useful :/

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

