### PR TITLE
dropbox: 30.4.22 -> 31.4.24

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -24,11 +24,11 @@
 let
   # NOTE: When updating, please also update in current stable,
   # as older versions stop working
-  version = "30.4.22";
+  version = "31.4.24";
   sha256 =
     {
-      "x86_64-linux" = "0qc99j6hpd1k5bmvcll3rjglksrjw0mw2nrwj3s3kh55j6fy8a0r";
-      "i686-linux"   = "0zyl1q76cpwly4k7h4klnyrv50nyxi2wpz5sii1a00jbmr7snhab";
+      "x86_64-linux" = "195k8nq1ssrw6zxp78njclaj8a1cs73kika6b7pg58m5lr3qlqnm";
+      "i686-linux"   = "0rr4dxns9gkha42y0aqd7l657q9wxdzdkf3ckyiw9bh27y8jp36m";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =


### PR DESCRIPTION
Dropbox client required an update again.

Tested on x86_64, not tested on i686, but url fetched and updated.

This should probably be cherry picked to the 17.03 branch.

###### Motivation for this change

Client stopped working and required an upgrade.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

