### PR TITLE
nixos/pulseaudio: Fix for missing zeroconf module

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -224,7 +224,7 @@ in {
       # Allow PulseAudio to get realtime priority using rtkit.
       security.rtkit.enable = true;
 
-      systemd.packages = [ cfg.package ];
+      systemd.packages = [ overriddenPackage ];
     })
 
     (mkIf hasZeroconf {


### PR DESCRIPTION
###### Motivation for this change

With `hardware.pulseaudio.zeroconf.publish.enable = true`, the user `pulseaudio.{service,socket}` systemd units fail and the following lines show up in the journal.

> Jul 30 17:40:50 bellman pulseaudio[2653]: E: [pulseaudio] ltdl-bind-now.c: Failed to open module module-zeroconf-publish.so: module-zeroconf-publish.so: cannot open shared ob
> Jul 30 17:40:50 bellman pulseaudio[2653]: E: [pulseaudio] module.c: Failed to open module "module-zeroconf-publish".
> Jul 30 17:40:50 bellman pulseaudio[2653]: E: [pulseaudio] main.c: Module load failed.
> Jul 30 17:40:50 bellman pulseaudio[2653]: E: [pulseaudio] main.c: Failed to initialize daemon.

This pull request instead uses the overridden pulseaudio package with zeroconf support enabled, so the proper .so files are available to pulseaudio. Previously, this module would bring in two versions of pulseaudio, one for `environment.systemPackages`  with zeroconf support enabled and one for systemd without zeroconf support.

CC @peterhoeg @Profpatsch 

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

