### PR TITLE
bashSnippets: 1.12.0 -> 1.17.3

### DIFF
--- a/pkgs/applications/misc/bashSnippets/default.nix
+++ b/pkgs/applications/misc/bashSnippets/default.nix
@@ -1,10 +1,9 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper
-, curl, netcat, mpv, python, bind, iproute, bc, gitMinimal }:
+, curl, netcat, python, bind, iproute, bc, gitMinimal }:
 let
-  version = "1.12.0";
+  version = "1.17.3";
   deps = lib.makeBinPath [
     curl
-    mpv
     python
     bind.dnsutils
     iproute
@@ -19,7 +18,7 @@ stdenv.mkDerivation {
     owner = "alexanderepstein";
     repo = "Bash-Snippets";
     rev = "v${version}";
-    sha256 = "0kx2a8z3jbmmardw9z8fpghbw5mrbz4knb3wdihq35iarcbrddrg";
+    sha256 = "1xdjk8bjh7l6h7gdqrra1dh4wdq89wmd0jsirsvqa3bmcsb2wz1r";
   };
 
   buildInputs = [ makeWrapper ];
@@ -32,7 +31,7 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p "$out"/bin "$out"/man/man1
+    mkdir -p "$out"/bin "$out"/share/man/man1
     ./install.sh all
     for file in "$out"/bin/*; do
       wrapProgram "$file" --prefix PATH : "${deps}"


### PR DESCRIPTION
###### Motivation for this change
Updating the package. I also removed the mpv dependency, because it's kinda too big.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

