### PR TITLE
zoom-us: 2.0.91373.0502 -> 2.0.98253.0707, and minor cleanups

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -95,7 +95,7 @@ in stdenv.mkDerivation {
     homepage = https://zoom.us/;
     description = "zoom.us video conferencing application";
     license = stdenv.lib.licenses.unfree;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = builtins.attrNames srcs;
     maintainers = with stdenv.lib.maintainers; [ danbst ];
   };
 

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -4,11 +4,11 @@
 
 let
 
-  version = "2.0.91373.0502";
+  version = "2.0.98253.0707";
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${version}/zoom_x86_64.tar.xz";
-      sha256 = "0gcbfsvybkvnyklm82irgz19x3jl0hz9bwf2l9jga188057pfj7a";
+      sha256 = "1znw7459pzfl2jzmj9akfwq3z10sndfb1swdr1p3rrjpiwqh3p7r";
     };
   };
 

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -75,13 +75,12 @@ in stdenv.mkDerivation {
     #paxmark m $packagePath/QtWebEngineProcess # is this what dtzWill talked about?
 
     # RUNPATH set via patchelf is used only for half of libraries (why?), so wrap it
-    wrapProgram $packagePath/zoom \
+    makeWrapper $packagePath/zoom $out/bin/zoom-us \
         --prefix LD_LIBRARY_PATH : "$packagePath:$libPath" \
         --prefix LD_PRELOAD : "${libv4l}/lib/v4l1compat.so" \
         --set QT_PLUGIN_PATH "$packagePath/platforms" \
         --set QT_XKB_CONFIG_ROOT "${xorg.xkeyboardconfig}/share/X11/xkb" \
         --set QTCOMPOSE "${xorg.libX11.out}/share/X11/locale"
-    ln -s "$packagePath/zoom" "$out/bin/zoom-us"
 
     cat > $packagePath/qt.conf <<EOF
     [Paths]

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -92,7 +92,7 @@ in stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = http://zoom.us;
+    homepage = https://zoom.us/;
     description = "zoom.us video conferencing application";
     license = stdenv.lib.licenses.unfree;
     platforms = stdenv.lib.platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

- Upgrade to newer upstream version;
- Update homepage;
- Only declare platform support for systems we have a source URL available for;
- Generate a simpler wrapper by using `makeWrapper` directly instead of the `wrapProgram` helper.

As maintainer, could you review these patches @danbst?

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

