### PR TITLE
cucumber: init at 2.4.0

### DIFF
--- a/pkgs/development/tools/cucumber/Gemfile
+++ b/pkgs/development/tools/cucumber/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'cucumber'

--- a/pkgs/development/tools/cucumber/Gemfile.lock
+++ b/pkgs/development/tools/cucumber/Gemfile.lock
@@ -1,0 +1,28 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.3)
+    cucumber (2.4.0)
+      builder (>= 2.1.2)
+      cucumber-core (~> 1.5.0)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 4.0)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    cucumber-core (1.5.0)
+      gherkin (~> 4.0)
+    cucumber-wire (0.0.1)
+    diff-lcs (1.3)
+    gherkin (4.1.3)
+    multi_json (1.12.1)
+    multi_test (0.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cucumber
+
+BUNDLED WITH
+   1.14.4

--- a/pkgs/development/tools/cucumber/default.nix
+++ b/pkgs/development/tools/cucumber/default.nix
@@ -1,0 +1,19 @@
+{ lib, bundlerEnv, ruby }:
+
+bundlerEnv rec {
+  name = "cucumber-${version}";
+
+  version = (import gemset).cucumber.version;
+  inherit ruby;
+  # expects Gemfile, Gemfile.lock and gemset.nix in the same directory
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+
+  meta = with lib; {
+    description = "A tool for executable specifications";
+    homepage    = https://cucumber.io/;
+    license     = with licenses; mit;
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/cucumber/gemset.nix
+++ b/pkgs/development/tools/cucumber/gemset.nix
@@ -1,0 +1,66 @@
+{
+  builder = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qibi5s67lpdv1wgcj66wcymcr04q6j4mzws6a479n0mlrmh5wr1";
+      type = "gem";
+    };
+    version = "3.2.3";
+  };
+  cucumber = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1k4j31a93r0zhvyq2mm2k8irppbvkzbsg44r3mf023959v18fzih";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  cucumber-core = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qj2fsqvp94nggnikbnrfvnmzr1pl6ifmdsxj69kdw1kkab30jjr";
+      type = "gem";
+    };
+    version = "1.5.0";
+  };
+  cucumber-wire = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09ymvqb0sbw2if1nxg8rcj33sf0va88ancq5nmp8g01dfwzwma2f";
+      type = "gem";
+    };
+    version = "0.0.1";
+  };
+  diff-lcs = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18w22bjz424gzafv6nzv98h0aqkwz3d9xhm7cbr1wfbyas8zayza";
+      type = "gem";
+    };
+    version = "1.3";
+  };
+  gherkin = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d18r8mf2qyd9jbq9xxvca8adyysdzvwdy8v9c2s5hrd6p02kg79";
+      type = "gem";
+    };
+    version = "4.1.3";
+  };
+  multi_json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wpc23ls6v2xbk3l1qncsbz16npvmw8p0b38l8czdzri18mp51xk";
+      type = "gem";
+    };
+    version = "1.12.1";
+  };
+  multi_test = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1sx356q81plr67hg16jfwz9hcqvnk03bd9n75pmdw8pfxjfy1yxd";
+      type = "gem";
+    };
+    version = "0.1.2";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -898,6 +898,8 @@ with pkgs;
 
   crudini = callPackage ../tools/misc/crudini { };
 
+  cucumber = callPackage ../development/tools/cucumber {};
+
   daemontools = callPackage ../tools/admin/daemontools { };
 
   dale = callPackage ../development/compilers/dale { };


### PR DESCRIPTION
###### Motivation for this change

Cucumber is used for unit test automation in some projects, and I ran across one of them.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

