### PR TITLE
Gwyddion: init at 2.48

### DIFF
--- a/pkgs/applications/science/chemistry/gwyddion/default.nix
+++ b/pkgs/applications/science/chemistry/gwyddion/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, gtk2, pkgconfig }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation {
+  name = "gwyddion";
+  version = "2.48";
+  src = fetchurl {
+    url = "http://sourceforge.net/projects/gwyddion/files/gwyddion/2.48/gwyddion-2.48.tar.xz";
+    sha256 = "119iw58ac2wn4cas6js8m7r1n4gmmkga6b1y711xzcyjp9hshgwx";
+  };
+  buildInputs = [ gtk2 pkgconfig ];
+  meta = {
+    homepage = http://gwyddion.net/;
+
+    description = "Scanning probe microscopy data visualization and analysis";
+
+    longDescription = ''
+      A modular program for SPM (scanning probe microscopy) data
+      visualization and analysis. Primarily it is intended for the
+      analysis of height fields obtained by scanning probe microscopy
+      techniques (AFM, MFM, STM, SNOM/NSOM) and it supports a lot of
+      SPM data formats. However, it can be used for general height
+      field and (greyscale) image processing, for instance for the
+      analysis of profilometry data or thickness maps from imaging
+      spectrophotometry.
+    '';
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2372,6 +2372,8 @@ with pkgs;
 
   gvolicon = callPackage ../tools/audio/gvolicon {};
 
+  gwyddion = callPackage ../applications/science/chemistry/gwyddion {};
+
   gzip = callPackage ../tools/compression/gzip { };
 
   gzrt = callPackage ../tools/compression/gzrt { };


### PR DESCRIPTION
###### Motivation for this change
Adding gwyddion, a tool to read images from several microscopy techniques.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

