### PR TITLE
rgbds: 0.2.4 -> 0.3.2

### DIFF
--- a/pkgs/development/compilers/rgbds/default.nix
+++ b/pkgs/development/compilers/rgbds/default.nix
@@ -1,18 +1,20 @@
-{stdenv, fetchFromGitHub, yacc}:
+{stdenv, lib, fetchFromGitHub, yacc, flex, pkgconfig, libpng}:
 
 stdenv.mkDerivation rec {
   name = "rgbds-${version}";
-  version = "0.2.4";
+  version = "0.3.2";
   src = fetchFromGitHub {
     owner = "bentley";
     repo = "rgbds";
     rev = "v${version}";
-    sha256 = "0dwq0p9g1lci8sm12a2rfk0g33z2vr75x78zdf1g84djwbz8ipc6";
+    sha256 = "034l1xqp46h7yjgbvszyky2gmvyy8cq1fcqsnj9c92mbsv81g9qh";
   };
-  nativeBuildInputs = [ yacc ];
+
+  buildInputs = [ libpng ];
+  nativeBuildInputs = [ yacc flex pkgconfig ];
   installFlags = "PREFIX=\${out}";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://www.anjbe.name/rgbds/;
     description = "An assembler/linker package that produces Game Boy programs";
     license = licenses.free;


### PR DESCRIPTION
###### Motivation for this change

Update one of my packages.


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

