### PR TITLE
flockit: init at 2012-08-11

### DIFF
--- a/pkgs/tools/backup/flockit/default.nix
+++ b/pkgs/tools/backup/flockit/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "flockit-${version}";
+  version = "2012-08-11";
+
+  src = fetchFromGitHub {
+    owner  = "smerritt";
+    repo   = "flockit";
+    rev    = "5c2b2092f8edcc8e3e2eb6ef66c968675dbfa686";
+    sha256 = "0vajck9q2677gpn9a4flkyz7mw69ql1647cjwqh834nrcr2b5164";
+  };
+
+  installPhase = ''
+    mkdir -p $out/lib $out/bin
+    cp ./libflockit.so $out/lib
+
+    (cat <<EOI
+    #!/bin/sh
+    env LD_PRELOAD="$out/lib/libflockit.so" FLOCKIT_FILE_PREFIX=\$1 \''${@:2}
+    EOI
+    ) > $out/bin/flockit
+    chmod +x $out/bin/flockit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "LD_PRELOAD shim to add file locking to programs that don't do it (I'm looking at you, rsync!)";
+    longDescription = ''
+      This library and tool exists solely because rsync doesn't have file locking.
+
+      It's not used like a normal library; you don't link against it, and you
+      don't have to patch your source code to use it. It's inserted between your
+      program and its libraries by use of LD_PRELOAD.
+
+      For example:
+
+        $ env LD_PRELOAD=$(nix-build -A pkgs.flockit)/lib/libflockit.so FLOCKIT_FILE_PREFIX=test rsync SRC DEST
+
+      Besides the library a handy executable is provided which can simplify the above to:
+
+        $ $(nix-build -A pkgs.flockit)/bin/flockit test rsync SRC DEST
+
+      Also see the following blog post:
+      https://www.swiftstack.com/blog/2012/08/15/old-school-monkeypatching/
+    '';
+    homepage = https://github.com/smerritt/flockit;
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.basvandijk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18615,6 +18615,8 @@ with pkgs;
 
   flat-plat = callPackage ../misc/themes/flat-plat { };
 
+  flockit = callPackage ../tools/backup/flockit { };
+
   foldingathome = callPackage ../misc/foldingathome { };
 
   foo2zjs = callPackage ../misc/drivers/foo2zjs {};


### PR DESCRIPTION
###### Motivation for this change

flockit is a LD_PRELOAD shim to add file locking to programs that don't do it (I'm looking at you, rsync!)

I use it to backup graphite databases using rsync.

See [this blog post](https://www.swiftstack.com/blog/2012/08/15/old-school-monkeypatching/) for the motivation and an example.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

