### PR TITLE
restic: enable darwin builds

### DIFF
--- a/pkgs/tools/backup/restic/default.nix
+++ b/pkgs/tools/backup/restic/default.nix
@@ -26,7 +26,7 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     homepage = https://restic.github.io;
     description = "A backup program that is fast, efficient and secure";
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     license = licenses.bsd2;
     maintainers = [ maintainers.mbrgm ];
   };


### PR DESCRIPTION
###### Motivation for this change

I want to use restic on OS X :)

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

