### PR TITLE
packer: add missing go-dependency

### DIFF
--- a/pkgs/development/tools/packer/default.nix
+++ b/pkgs/development/tools/packer/default.nix
@@ -14,6 +14,8 @@ buildGoPackage rec {
     sha256 = "1bd0rv93pxlv58c0x1d4dsjq4pg5qwrm2p7qw83pca7izlncgvfr";
   };
 
+  goDeps = ./deps.nix;
+
   meta = with stdenv.lib; {
     description = "A tool for creating identical machine images for multiple platforms from a single source configuration";
     homepage    = http://www.packer.io;

--- a/pkgs/development/tools/packer/deps.nix
+++ b/pkgs/development/tools/packer/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "github.com/hashicorp/packer";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/packer";
+      rev = "07decf99adc272a386e3a013846248810d9aa690";
+      sha256 = "17rrzrlr48spadb9fymn1a0blqggs2mfmqbwfxs0pnw66mhd0fzz";
+    };
+  }
+]


### PR DESCRIPTION
###### Motivation for this change
the missing dependency prevented a successful build 

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

