### PR TITLE
sqlite3_analyzer: 3.19.2 -> 3.20.0

### DIFF
--- a/pkgs/development/libraries/sqlite/sqlite3_analyzer.nix
+++ b/pkgs/development/libraries/sqlite/sqlite3_analyzer.nix
@@ -1,11 +1,11 @@
 { lib, stdenv, fetchurl, unzip, tcl }:
 
 stdenv.mkDerivation {
-  name = "sqlite3_analyzer-3.19.2";
+  name = "sqlite3_analyzer-3.20.0";
 
   src = fetchurl {
-    url = "https://www.sqlite.org/2017/sqlite-src-3190200.zip";
-    sha256 = "1hdbs41mdyyy641gix87pllsd29p8dim7gj4qvmiyfra2q5kg749";
+    url = "https://www.sqlite.org/2017/sqlite-src-3200000.zip";
+    sha256 = "1vjbc5i95wildrdfzalrsgai1ziz4m4gbah4wm8qc4jxm1vqwdab";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

Update sqlite3_analyzer to the last version

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

