### PR TITLE
pinentry: fix keyboard/pointer grabbing bugs

### DIFF
--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig
+{ fetchurl, fetchpatch, stdenv, lib, pkgconfig
 , libgpgerror, libassuan, libcap ? null, ncurses ? null, gtk2 ? null, qt4 ? null
 }:
 
@@ -22,6 +22,15 @@ stdenv.mkDerivation rec {
   prePatch = ''
     substituteInPlace pinentry/pinentry-curses.c --replace ncursesw ncurses
   '';
+
+  patches = lib.optionals (gtk2 != null) [
+    (fetchpatch {
+       url = https://anonscm.debian.org/cgit/pkg-gnupg/pinentry.git/plain/debian/patches/0006-gtk2-Fix-a-problem-with-fvwm.patch;
+       sha256 = "1w3y4brqp74hy3fbfxqnqp6jf985bd6667ivy1crz50r3z9zsy09";
+  })(fetchpatch {
+       url = https://anonscm.debian.org/cgit/pkg-gnupg/pinentry.git/plain/debian/patches/0007-gtk2-When-X11-input-grabbing-fails-try-again-over-0..patch;
+       sha256 = "046jy7k0n7fj74s5w1h6sq1ljg8y77i0xwi301kv53bhsp0xsirx";
+  })];
 
   # configure cannot find moc on its own
   preConfigure = stdenv.lib.optionalString (qt4 != null) ''


### PR DESCRIPTION
Related reports:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850708
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=851707
https://github.com/ch11ng/exwm/issues/263
https://github.com/ch11ng/exwm/issues/279

###### Motivation for this change

This fixes pinentry for a variety of tiling window managers. Tested on exwm.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

