### PR TITLE
glslviewer: init at 1.2

### DIFF
--- a/pkgs/development/tools/glslviewer/default.nix
+++ b/pkgs/development/tools/glslviewer/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, glfw, pkgconfig, libXrandr, libXdamage,
+  libXext, libXrender, libXinerama, libXcursor, libXxf86vm, libXi,
+  libX11, mesa_glu }:
+
+stdenv.mkDerivation rec {
+  name = "glslviewer-${version}";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "patriciogonzalezvivo";
+    repo = "glslViewer";
+    rev = version;
+    sha256 = "05ya821l2pd58anyx21mgmlm2bv78rz8cnbvqw4d9pfhq40z9psw";
+  };
+
+  # Makefile has /usr/local/bin hard-coded for 'make install'
+  preConfigure = ''
+    sed s,/usr/local,$out, -i Makefile
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+  
+  buildInputs = [ glfw mesa_glu pkgconfig glfw libXrandr libXdamage
+                  libXext libXrender libXinerama libXcursor libXxf86vm
+                  libXi libX11 ];
+  
+  meta = with stdenv.lib; {
+    description = "Live GLSL coding renderer";
+    homepage = http://patriciogonzalezvivo.com/2015/glslViewer/;
+    license = licenses.bsd3;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = [ maintainers.hodapp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1051,6 +1051,8 @@ with pkgs;
 
   glock = callPackage ../development/tools/glock { };
 
+  glslviewer = callPackage ../development/tools/glslviewer { };
+  
   gmic = callPackage ../tools/graphics/gmic { };
 
   goa = callPackage ../development/tools/goa { };


### PR DESCRIPTION
###### Motivation for this change

Adding glslViewer, which is not in nixpkgs presently.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

