### PR TITLE
nixos,nixpkgs: only build essentials on i686

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -1,6 +1,6 @@
 { nixpkgs ? { outPath = ./..; revCount = 56789; shortRev = "gfedcba"; }
 , stableBranch ? false
-, supportedSystems ? [ "x86_64-linux" "i686-linux" ]
+, supportedSystems ? [ "x86_64-linux" ]
 }:
 
 with import ../lib;

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -2,7 +2,7 @@
    the load on Hydra when testing the `stdenv-updates' branch. */
 
 { nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
-, supportedSystems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" ]
+, supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 }:
 
 with import ./release-lib.nix { inherit supportedSystems; };

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -8,20 +8,23 @@
 
    $ nix-build pkgs/top-level/release.nix -A coreutils.x86_64-linux
 */
-
 { nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
 , officialRelease ? false
-, # The platforms for which we build Nixpkgs.
-  supportedSystems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" ]
-, # Strip most of attributes when evaluating to spare memory usage
-  scrubJobs ? true
-, # Attributes passed to nixpkgs. Don't build packages marked as unfree.
-  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
+  # The platforms for which we build Nixpkgs.
+, supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarchh64-linux" ]
+, limitedSupportedSystems ? [ "i686-linux" ]
+  # Strip most of attributes when evaluating to spare memory usage
+,  scrubJobs ? true
+  # Attributes passed to nixpkgs. Don't build packages marked as unfree.
+,  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
 
 with import ./release-lib.nix { inherit supportedSystems scrubJobs nixpkgsArgs; };
 
 let
+
+  systemsWithAnySupport = supportedSystems ++ limitedSupportedSystems;
+
   jobs =
     { tarball = import ./make-tarball.nix { inherit pkgs nixpkgs officialRelease; };
 
@@ -54,43 +57,36 @@ let
               jobs.manual
               jobs.lib-tests
               jobs.stdenv.x86_64-linux
-              jobs.stdenv.i686-linux
               jobs.stdenv.x86_64-darwin
               jobs.linux.x86_64-linux
-              jobs.linux.i686-linux
               jobs.python.x86_64-linux
-              jobs.python.i686-linux
               jobs.python.x86_64-darwin
               jobs.python3.x86_64-linux
-              jobs.python3.i686-linux
               jobs.python3.x86_64-darwin
               # Many developers use nix-repl
               jobs.nix-repl.x86_64-linux
-              jobs.nix-repl.i686-linux
               jobs.nix-repl.x86_64-darwin
               # Needed by travis-ci to test PRs
-              jobs.nox.i686-linux
               jobs.nox.x86_64-linux
               jobs.nox.x86_64-darwin
               # Ensure that X11/GTK+ are in order.
               jobs.thunderbird.x86_64-linux
-              jobs.thunderbird.i686-linux
               # Ensure that basic stuff works on darwin
               jobs.git.x86_64-darwin
               jobs.mysql.x86_64-darwin
               jobs.vim.x86_64-darwin
             ] ++ lib.collect lib.isDerivation jobs.stdenvBootstrapTools;
         };
-    } // (lib.optionalAttrs (builtins.elem "i686-linux" supportedSystems) {
+    } // (lib.optionalAttrs (builtins.elem "i686-linux" systemsWithAnySupport) {
       stdenvBootstrapTools.i686-linux =
         { inherit (import ../stdenv/linux/make-bootstrap-tools.nix { system = "i686-linux"; }) dist test; };
-    }) // (lib.optionalAttrs (builtins.elem "x86_64-linux" supportedSystems) {
+    }) // (lib.optionalAttrs (builtins.elem "x86_64-linux" systemsWithAnySupport) {
       stdenvBootstrapTools.x86_64-linux =
         { inherit (import ../stdenv/linux/make-bootstrap-tools.nix { system = "x86_64-linux"; }) dist test; };
-    }) // (lib.optionalAttrs (builtins.elem "aarch64-linux" supportedSystems) {
+    }) // (lib.optionalAttrs (builtins.elem "aarch64-linux" systemsWithAnySupport) {
       stdenvBootstrapTools.aarch64-linux =
         { inherit (import ../stdenv/linux/make-bootstrap-tools.nix { system = "aarch64-linux"; }) dist test; };
-    }) // (lib.optionalAttrs (builtins.elem "x86_64-darwin" supportedSystems) {
+    }) // (lib.optionalAttrs (builtins.elem "x86_64-darwin" systemsWithAnySupport) {
       stdenvBootstrapTools.x86_64-darwin =
         let
           bootstrap = import ../stdenv/darwin/make-bootstrap-tools.nix { system = "x86_64-darwin"; };


### PR DESCRIPTION
###### Motivation for this change

Only build a bare minimum of packages for i686 for 17.09 and beyond.

NixOS evaluation: https://hydra.nixos.org/jobset/nixos/grahamc-i686 (cuts out about 12,000 jobs)
Nixpkgs evaluation: https://hydra.nixos.org/jobset/nixpkgs/graham-i686 (cuts out about 21,000 jobs... is this right?)

NixOS still builds the same jobs in `tested` to be sure we don't kill anyone's system, but we no longer span out and build everything.

Nixpkgs won't build i686 at all, except for jobs where it is _mandatory_ like Skype.

cc @FRidh @domenkozar @globin @edolstra 

Related discussion on mailing list: https://groups.google.com/forum/#!topic/nix-devel/m7ikFjor24Y

see https://github.com/NixOS/nixpkgs/pull/27731


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

