### PR TITLE
Enable BGSCAN for wpa_supplicant

### DIFF
--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
     CONFIG_HS20=y
     CONFIG_P2P=y
     CONFIG_TDLS=y
+    CONFIG_BGSCAN_SIMPLE=y
   '' + optionalString (pcsclite != null) ''
     CONFIG_EAP_SIM=y
     CONFIG_EAP_AKA=y


### PR DESCRIPTION
###### Motivation for this change
Compile wpa_supplicant with the BGSCAN module enabled.  This allows the user to configure an SSID to use the bgscan module like so (excerpt from wpa_supplicant.conf):

```
network={
	...network config...
	bgscan="simple:30:-75:500"
}
```
The module supports the following configuration:
```
# bgscan: Background scanning
# wpa_supplicant behavior for background scanning can be specified by
# configuring a bgscan module. These modules are responsible for requesting
# background scans for the purpose of roaming within an ESS (i.e., within a
# single network block with all the APs using the same SSID). The bgscan
# parameter uses following format: "<bgscan module name>:<module parameters>"
# Following bgscan modules are available:
# simple - Periodic background scans based on signal strength
# bgscan="simple:<short bgscan interval in seconds>:<signal strength threshold>:
# <long interval>"
# bgscan="simple:30:-45:300"
# learn - Learn channels used by the network and try to avoid bgscans on other
# channels (experimental)
# bgscan="learn:<short bgscan interval in seconds>:<signal strength threshold>:
# <long interval>[:<database file name>]"
# bgscan="learn:30:-45:300:/etc/wpa_supplicant/network1.bgscan"
# Explicitly disable bgscan by setting
# bgscan=""
```

I have been running with this module enabled on my wpa_supplicant for around 4 months.  I waited this long to ensure that there were no negative effects with the module disabled.  At this point I am fairly confident that this is a safe thing to enable globally, and should only take effect if the user specifies a bgscan configuration in their wpa_supplicant.conf.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

