### PR TITLE
keybase: 1.0.22 -> 1.0.27-20170726114412.8169d66

### DIFF
--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "keybase-${version}";
-  version = "1.0.22";
+  version = "1.0.27-20170726114412.8169d66";
 
   goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/keybase" ];
@@ -12,8 +12,8 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner  = "keybase";
     repo   = "client";
-    rev    = "v${version}";
-    sha256 = "1642d11gjgkdklppmm1j3vwc2r3qg9qqw5x07jnqs819i57mr47f";
+    rev    = "8169d666e2a4d920da7025170baccde336fce11d";
+    sha256 = "1nnfyvbmn6cy0g4dy0ayg17jblxkyck0097f7bbmwbnrplaj2w6h";
   };
 
   buildFlags = [ "-tags production" ];

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -2,6 +2,9 @@
 
 buildGoPackage rec {
   name = "keybase-${version}";
+  # The latest version 'blessed' by upstream can be extracted from:
+  #     https://aur.archlinux.org/packages/keybase-git/
+  # `version` partially reuses `pkgver`; `nix-prefetch-git` provides the date.
   version = "1.0.27-20170726114412.8169d66";
 
   goPackagePath = "github.com/keybase/client";
@@ -12,6 +15,7 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner  = "keybase";
     repo   = "client";
+    # `pkgver` in the PKGBUILD provides the short hash.
     rev    = "8169d666e2a4d920da7025170baccde336fce11d";
     sha256 = "1nnfyvbmn6cy0g4dy0ayg17jblxkyck0097f7bbmwbnrplaj2w6h";
   };


### PR DESCRIPTION
As indicated in https://news.ycombinator.com/item?id=14926441, Keybase's client and kbfs releases are not tagged in a consistent way. (For example, the newest tagged release is 1.0.22.) In Keybase's POV, the best way for unsupported distributions to package Keybase software is mangling their binary releases so as to ensure that built code has passed the defined CI pipeline.

AFAICT, this is already done for keybase-gui in Nixpkgs.

Until keybase in Nixpkgs is reworked, it seems silly to keep the package version at 1.0.22. Let's use a version "blessed" by "Keybase Linux Build" in https://aur.archlinux.org/packages/keybase-git/ – in this case, 1.0.27+15115, or commit 8169d666e2a4d920da7025170baccde336fce11d – and go from there. No dependencies (apart from gtk2, ostensibly for the -gui portion) have been added since 1.0.21/1.0.22.

###### Motivation for this change


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

