### PR TITLE
wireguard: add per-peer routing table option

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -250,8 +250,7 @@ in
             peers = [
               { allowedIPs = [ "192.168.20.1/32" ];
                 publicKey  = "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=";
-                endpoint   = "demo.wireguard.io:12913";
-                table      = "42"; }
+                endpoint   = "demo.wireguard.io:12913"; }
             ];
           };
         };

--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -79,6 +79,16 @@ let
         description = "A list of commands called after shutting down the interface.";
       };
 
+      table = mkOption {
+        default = "main";
+        type = types.str;
+        description = ''The kernel routing table to add this interface's
+        associated routes to. Setting this is useful for e.g. policy routing
+        ("ip rule") or virtual routing and forwarding ("ip vrf"). Both numeric
+        table IDs and table names (/etc/rt_tables) can be used. Defaults to
+        "main".'';
+      };
+
       peers = mkOption {
         default = [];
         description = "Peers linked to the interface.";
@@ -160,14 +170,6 @@ let
         interval of 25 seconds; however, most users will not need this.'';
       };
 
-      table = mkOption {
-        default = "main";
-        type = types.str;
-        description = ''The kernel routing table to add this peer's associated
-        routes to. Setting this is useful for e.g. policy routing ("ip rule")
-        or virtual routing and forwarding ("ip vrf"). Both numeric table IDs
-        and table names (/etc/rt_tables) can be used. Defaults to "main".'';
-      };
     };
 
   };
@@ -217,7 +219,7 @@ let
 
             (map (peer:
             (map (allowedIP:
-            "${ipCommand} route replace ${allowedIP} dev ${name} table ${peer.table}"
+            "${ipCommand} route replace ${allowedIP} dev ${name} table ${values.table}"
             ) peer.allowedIPs)
             ) values.peers)
 

--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -160,6 +160,14 @@ let
         interval of 25 seconds; however, most users will not need this.'';
       };
 
+      table = mkOption {
+        default = "main";
+        type = types.str;
+        description = ''The kernel routing table to add this peer's associated
+        routes to. Setting this is useful for e.g. policy routing ("ip rule")
+        or virtual routing and forwarding ("ip vrf"). Both numeric table IDs
+        and table names (/etc/rt_tables) can be used. Defaults to "main".'';
+      };
     };
 
   };
@@ -207,9 +215,11 @@ let
 
             "${ipCommand} link set up dev ${name}"
 
-            (map (peer: (map (ip:
-            "${ipCommand} route replace ${ip} dev ${name}"
-            ) peer.allowedIPs)) values.peers)
+            (map (peer:
+            (map (allowedIP:
+            "${ipCommand} route replace ${allowedIP} dev ${name} table ${peer.table}"
+            ) peer.allowedIPs)
+            ) values.peers)
 
             values.postSetup
           ]);
@@ -240,7 +250,8 @@ in
             peers = [
               { allowedIPs = [ "192.168.20.1/32" ];
                 publicKey  = "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=";
-                endpoint   = "demo.wireguard.io:12913"; }
+                endpoint   = "demo.wireguard.io:12913";
+                table      = "42"; }
             ];
           };
         };


### PR DESCRIPTION
This adds a convenient per-peer option to set the routing table that associated routes are added to. This functionality is very useful for isolating interfaces from the kernel's global routing and forcing all traffic of a virtual interface (or a group of processes, via e.g. "ip rule add uidrange 10000-10009 lookup 42") through Wireguard.

###### Motivation for this change


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

