### PR TITLE
QT5.6: Fixes compile error with wrong LD env variable

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/default.nix
@@ -103,6 +103,8 @@ stdenv.mkDerivation {
   preConfigure = ''
     export LD_LIBRARY_PATH="$PWD/lib:$PWD/plugins/platforms:$LD_LIBRARY_PATH"
     export MAKEFLAGS=-j$NIX_BUILD_CORES
+    # We need to set LD to CXX or otherwise we get nasty compile errors
+    export LD=$CXX
 
     configureFlags+="\
         -plugindir $out/$qtPluginPrefix \


### PR DESCRIPTION
QT uses -Wl linker flags and these flags only work with gcc/g++
and not with LD directly.

###### Motivation for this change


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

