### PR TITLE
efl: add version 1.20.2

### DIFF
--- a/pkgs/desktops/enlightenment/default.nix
+++ b/pkgs/desktops/enlightenment/default.nix
@@ -2,6 +2,7 @@
 rec {
   #### CORE EFL
   efl = callPackage ./efl.nix { openjpeg = pkgs.openjpeg_1; };
+  efl_1_19 = callPackage ./efl.nix { eflVersion = "1.19.1"; openjpeg = pkgs.openjpeg_1; };
 
   #### WINDOW MANAGER
   enlightenment = callPackage ./enlightenment.nix { };
@@ -10,5 +11,5 @@ rec {
   econnman = callPackage ./econnman.nix { };
   terminology = callPackage ./terminology.nix { };
   rage = callPackage ./rage.nix { };
-  ephoto = callPackage ./ephoto.nix { };
+  ephoto = callPackage ./ephoto.nix { efl = efl_1_19; };
 }

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -4,15 +4,20 @@
 , python27Packages, openjpeg, doxygen, expat, harfbuzz, jbig2dec, librsvg
 , dbus_libs, alsaLib, poppler, ghostscript, libraw, libspectre, xineLib, libwebp
 , curl, libinput, systemd, writeText
+# Support more than one version because for now ephoto does not work with efl-1.20.x
+, eflVersion ? "1.20.2"
 }:
 
 stdenv.mkDerivation rec {
   name = "efl-${version}";
-  version = "1.19.1";
+  version = eflVersion;
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/efl/${name}.tar.xz";
-    sha256 = "0fndwraca9rg0bz3al4isdprvyw56szr88qiyvglb4j8ygsylscc";
+    sha256 = {
+      "1.19.1" = "0fndwraca9rg0bz3al4isdprvyw56szr88qiyvglb4j8ygsylscc";
+      "1.20.2" = "0zll6k4xbbdsxqg53g8jddgv889g5m1xh20i03iz5a52y2bcnh55";
+    }.${version};
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/desktops/enlightenment/enlightenment.nix
+++ b/pkgs/desktops/enlightenment/enlightenment.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, pkgconfig, efl, xcbutilkeysyms, libXrandr, libXdmcp,
 libxcb, libffi, pam, alsaLib, luajit, bzip2, libpthreadstubs, gdbm, libcap,
-mesa_glu , xkeyboard_config }:
+mesa_glu, xkeyboard_config }:
 
 stdenv.mkDerivation rec {
   name = "enlightenment-${version}";
-  version = "0.21.8";
+  version = "0.21.9";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/enlightenment/${name}.tar.xz";
-    sha256 = "0cjjiip12hd8bfjl9ccl3vzl81pxh1wpymxk2yvrzf6ap5girhps";
+    sha256 = "0w5f3707hyfc20i6xqh4jlr5p2yhy1z794061mjsz2rp4w00qmpb";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26490,11 +26490,13 @@ EOF
   # Should be bumped along with EFL!
   pythonefl = buildPythonPackage rec {
     name = "python-efl-${version}";
-    version = "1.19.0";
+    version = "1.20.0";
     src = pkgs.fetchurl {
       url = "http://download.enlightenment.org/rel/bindings/python/${name}.tar.xz";
-      sha256 = "105qykdd04mlyzwzyscw6mlc7ajl4wbwhq87ncy1jvw8jjh6jads";
+      sha256 = "18qfqdkkjydqjk0nxs7wnnzdnqlbj3fhkjm0bbd927myzbihxpkh";
     };
+
+    hardeningDisable = [ "format" ];
 
     preConfigure = ''
       export NIX_CFLAGS_COMPILE="$(pkg-config --cflags efl) -I${self.dbus-python}/include/dbus-1.0 $NIX_CFLAGS_COMPILE"


### PR DESCRIPTION

###### Motivation for this change

Update to new versions:

- [Enlightenment DR 0.21.9 Release](https://www.enlightenment.org/news/e0.21.9_release)
- Python-EFL 1.20.0 Release
- [EFL 1.20.2 release](https://www.enlightenment.org/news/efl-1.20.2)
- [EFL 1.20.1 release](https://www.enlightenment.org/news/efl-1.20.1)

For new keep also EFL 1.19.x because EPhoto does not work with EFL 1.20.x yet.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).