### PR TITLE
17.09 release-notes: New breaking change: cc-wrapper exports more env vars

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -142,6 +142,18 @@ rmdir /var/lib/ipfs/.ipfs
       being dead and not building with openssl 1.1.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      <literal>cc-wrapper</literal>'s setup-hook now exports a number of
+      environment variables corresponding to binutils binaries,
+      (e.g. <envar>LD</envar>, <envar>STRIP</envar>, <envar>RANLIB</envar>,
+      etc). This is done to prevent packages' build systems guessing, which is
+      harder to predict, especially when cross-compiling. However, some packages
+      have broken due to this—their build systems either not supporting, or
+      claiming to support without adequate testing, taking such environment
+      variables as parameters.
+    </para>
+  </listitem>
 </itemizedlist>
 
 <para>Other notable improvements:</para>


### PR DESCRIPTION
###### Motivation for this change

Best to come clean about this! @LnL7 @copumpkin @globin @bkch

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

