### PR TITLE
bitwig-studio: 2.0 -> 2.1.3, fix desktop file

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/default.nix
+++ b/pkgs/applications/audio/bitwig-studio/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "bitwig-studio-${version}";
-  version = "2.0";
+  version = "2.1.3";
 
   src = fetchurl {
     url = "https://downloads.bitwig.com/stable/${version}/bitwig-studio-${version}.deb";
-    sha256 = "1m7wdr0f9xi9s7q8vd66hy7fj1k0j3y5ln2yqbjwr76r9g6gkzas";
+    sha256 = "0blfw7dayl1wzys11mdixlkbr1p1d5rnwrvim1hblfpnw2zmlslb";
   };
 
   nativeBuildInputs = [ dpkg makeWrapper ];
@@ -80,6 +80,9 @@ stdenv.mkDerivation rec {
     ln -s $out/libexec/bitwig-studio $out/bin/bitwig-studio
 
     cp -r usr/share $out/share
+    substitute usr/share/applications/bitwig-studio.desktop \
+      $out/share/applications/bitwig-studio.desktop \
+      --replace /usr/bin/bitwig-studio $out/bin/bitwig-studio
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Bitwig Studio derivation comes with a broken .desktop file (points to /usr/bin/bitwig-studio) and hasn't been updated in a while.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

