### PR TITLE
Document timezone changes in release notes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -190,12 +190,10 @@ rmdir /var/lib/ipfs/.ipfs
   <listitem>
     <para>
       The <option>time.timeZone</option> option now allows the value
-      <literal>null</literal> in addition to timezone strings, which sets the
-      timezone to UTC by default and allows changing it imperatively using
-      <command>timedatectl set-timezone</command>. This is additionally now the
-      default value for the option, which means that systems where the option
-      has not been set explicitly will continue to use UTC but allow imperative
-      timezone adjustments now.
+      <literal>null</literal> in addition to timezone strings. This value
+      allows changing the timezone of a system imperatively using
+      <command>timedatectl set-timezone</command>. The default timezone
+      is still UTC.
     </para>
   </listitem>
 

--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -187,6 +187,17 @@ rmdir /var/lib/ipfs/.ipfs
       have therefore been removed.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      The <option>time.timeZone</option> option now allows the value
+      <literal>null</literal> in addition to timezone strings, which sets the
+      timezone to UTC by default and allows changing it imperatively using
+      <command>timedatectl set-timezone</command>. This is additionally now the
+      default value for the option, which means that systems where the option
+      has not been set explicitly will continue to use UTC but allow imperative
+      timezone adjustments now.
+    </para>
+  </listitem>
 
 </itemizedlist>
 


### PR DESCRIPTION
###### Motivation for this change
#26608 has been merged but the fairly significant change is not yet mentioned in the release notes.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
