### PR TITLE
android-sdk: 25.2.3 -> 25.2.5

### DIFF
--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -11,16 +11,16 @@ let inherit (stdenv.lib) makeLibraryPath; in
 
 stdenv.mkDerivation rec {
   name = "android-sdk-${version}";
-  version = "25.2.3";
+  version = "25.2.5";
 
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "http://dl.google.com/android/repository/tools_r${version}-linux.zip";
-      sha256 = "0q5m8lqhj07c6izhc0b0d73820ma0flvrj30ckznss4s9swvqd8v";
+      sha256 = "0gnk49pkwy4m0nqwm1xnf3w4mfpi9w0kk7841xlawpwbkj0icxap";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "http://dl.google.com/android/repository/tools_r${version}-macosx.zip";
-      sha256 = "1ihxd2a37ald3sdd04i4yk85prw81h6gnch0bmq65cbsrba48dar";
+      sha256 = "0yg7wjmyw70xsh8k4hgbqb5rilam2a94yc8dwbh7fjwqcmpxgwqb";
     }
     else throw "platform not ${stdenv.system} supported!";
 

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -1,16 +1,16 @@
 {stdenv, stdenv_32bit, fetchurl, unzip, zlib_32bit, ncurses_32bit, file, zlib, ncurses}:
 
 stdenv.mkDerivation rec {
-  version = "25.0.1";
+  version = "26.0.1";
   name = "android-build-tools-r${version}";
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "https://dl.google.com/android/repository/build-tools_r${version}-linux.zip";
-      sha256 = "0kyrazmcckikn6jiz9hwy6nlqjssf95h5iq7alswg1mryl04w6v7";
+      sha256 = "1sp0ir1d88ffw0gz78zlbvnxalz02fsaxwdcvjfynanylwjpyqf8";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "https://dl.google.com/android/repository/build-tools_r${version}-macosx.zip";
-      sha256 = "116i5xxbwz229m9z98n6bfkjk2xf3kbhdnqhbbnaagjsjzqdirki";
+      sha256 = "1ns6c8361l18s3a5x0jc2m3qr06glsb6ak7csrrw6dkzlv8cj5dk";
     }
     else throw "System ${stdenv.system} not supported!";
 

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -195,6 +195,20 @@ rec {
     useGooglePlayServices = true;
   };
 
+  androidsdk_8_0 = androidsdk {
+    platformVersions = [ "26" ];
+    abiVersions = [ "x86" "x86_64"];
+    useGoogleAPIs = true;
+  };
+
+  androidsdk_8_0_extras = androidsdk {
+    platformVersions = [ "26" ];
+    abiVersions = [ "x86" "x86_64"];
+    useGoogleAPIs = true;
+    useExtraSupportLibs = true;
+    useGooglePlayServices = true;
+  };
+
   androidndk = import ./androidndk.nix {
     inherit (pkgs) stdenv fetchurl zlib ncurses p7zip lib makeWrapper;
     inherit (pkgs) coreutils file findutils gawk gnugrep gnused jdk which;

--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -1,16 +1,16 @@
 {stdenv, zlib, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "25.0.1";
+  version = "26.0.0";
   name = "android-platform-tools-r${version}";
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "https://dl.google.com/android/repository/platform-tools_r${version}-linux.zip";
-      sha256 = "0r8ix3jjqpk6wyxm8f6az9r4z5a1lnb3b9hzh8ay4ayidwhn8isx";
+      sha256 = "02z5fxxdwd6359wmqdag9vvszdq49sm78cvfskqap18xa83q484h";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
-      url = "https://dl.google.com/android/repository/platform-tools_r${version}-macosx.zip";
-      sha256 = "18pzwpr6fbxlw782j65clwz9kvdgvb04jpr2z12bbwyd8wqc4yln";
+      url = "https://dl.google.com/android/repository/platform-tools_r${version}-darwin.zip";
+      sha256 = "13mcyi9l0mmmjr056z1i3rhpb4641iv0a5ky7ij0v8hwsb5r5lwq";
     }
     else throw "System ${stdenv.system} not supported!";
 

--- a/pkgs/development/mobile/androidenv/support-repository.nix
+++ b/pkgs/development/mobile/androidenv/support-repository.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "40";
+  version = "47";
   name = "android-support-repository-r${version}";
   src = fetchurl {
     url = "http://dl.google.com/android/repository/android_m2repository_r${version}.zip";
-    sha1 = "782e7233f18c890463e8602571d304e680ce354c";
+    sha256 = "1l13a6myff6i8x99h1ky2j5sglwy8wc0rsbxfcbif375vh41iyd3";
   };
 
   buildCommand = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -611,9 +611,9 @@ with pkgs;
 
   inherit (androidenv) androidndk;
 
-  androidsdk = androidenv.androidsdk_7_1_1;
+  androidsdk = androidenv.androidsdk_8_0;
 
-  androidsdk_extras = self.androidenv.androidsdk_7_1_1_extras;
+  androidsdk_extras = self.androidenv.androidsdk_8_0_extras;
 
   arc-theme = callPackage ../misc/themes/arc { };
 


### PR DESCRIPTION
###### Motivation for this change

Using the latest SDK.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

