### PR TITLE
grml-zsh-config: 0.12.4 -> 0.14.2

### DIFF
--- a/pkgs/shells/grml-zsh-config/default.nix
+++ b/pkgs/shells/grml-zsh-config/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchurl, lib
+{ stdenv, fetchFromGitHub, lib
 , zsh, coreutils, inetutils, procps, txt2tags }:
 
 with lib;
 
 stdenv.mkDerivation rec {
   name = "grml-zsh-config-${version}";
-  version = "0.12.4";
+  version = "0.14.2";
 
-  src = fetchurl {
-    url = "http://deb.grml.org/pool/main/g/grml-etc-core/grml-etc-core_${version}.tar.gz";
-    sha256 = "1cbedc41e32787c37c2ed546355a26376dacf2ae1fab9551c9ace3e46d236b72";
+  src = fetchFromGitHub {
+    owner = "grml";
+    repo = "grml-etc-core";
+    rev = "v${version}";
+    sha256 = "1xvv2mnkfqa657w8y4q2zrchhindngdzij9fbalcg1gggz4zdwcm";
   };
 
   buildInputs = [ zsh coreutils inetutils procps txt2tags ];
@@ -33,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = http://grml.org/zsh/;
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.msteen ];
+    maintainers = with maintainters; [ msteen rvolosatovs ];
   };
 }

--- a/pkgs/shells/grml-zsh-config/default.nix
+++ b/pkgs/shells/grml-zsh-config/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = http://grml.org/zsh/;
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainters; [ msteen rvolosatovs ];
+    maintainers = with maintainers; [ msteen rvolosatovs ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Upstream update

###### Things done
Switched to `fetchFromGitHub`,

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

