### PR TITLE
zsnes: remove $STRIP from compiler options

### DIFF
--- a/pkgs/misc/emulators/zsnes/default.nix
+++ b/pkgs/misc/emulators/zsnes/default.nix
@@ -34,6 +34,7 @@ in stdenv.mkDerivation {
   preConfigure = ''
     cd src
     sed -i "/^STRIP/d" configure
+    sed -i "/\$STRIP/d" configure
   '';
 
   configureFlags = [ "--enable-release" ];


### PR DESCRIPTION
In ab70693 @viric says zsnes works better without stripping. But the
build expression kept the $STRIP in the compiler options, so if it is
set to something it will show up in there. For example:

g++  -pipe -I. -I/usr/local/include -I/usr/include -D__UNIXSDL__ -I/nix/store/04qgmdpmalgsy92zgs2z896jx073hcn2-SDL-1.2.15-dev/include/SDL -I/nix/store/04qgmdpmalgsy92zgs2z896jx073hcn2-SDL-1.2.15-dev/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT  -DNCURSES -D__OPENGL__ -march=native -O3 -fomit-frame-pointer -fprefetch-loop-arrays -fforce-addr strip -D__RELEASE__ -fno-rtti -o tools/fileutil.o -c tools/fileutil.cpp

g++: error: strip: No such file or directory

This commit removes that reference to $STRIP too.


###### Motivation for this change

package did not compile for me on nixos with nixpkgs git rev acf05ea

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

