### PR TITLE
Fix #27757: Make Deluge only available under Python 2

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, intltool, libtorrentRasterbar_1_0, pythonPackages }:
+pythonPackages.buildPythonPackage rec {
+  name = "deluge-${version}";
+  version = "1.3.15";
+
+  src = fetchurl {
+    url = "http://download.deluge-torrent.org/source/${name}.tar.bz2";
+    sha256 = "1467b9hmgw59gf398mhbf40ggaka948yz3afh6022v753c9j7y6w";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [
+    pyGtkGlade libtorrentRasterbar_1_0 twisted Mako chardet pyxdg pyopenssl service-identity
+  ];
+
+  nativeBuildInputs = [ intltool ];
+
+  postInstall = ''
+     mkdir -p $out/share/applications
+     cp -R deluge/data/pixmaps $out/share/
+     cp -R deluge/data/icons $out/share/
+     cp deluge/data/share/applications/deluge.desktop $out/share/applications
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://deluge-torrent.org;
+    description = "Torrent client";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ domenkozar ebzzry ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1635,7 +1635,9 @@ with pkgs;
 
   ddrescue = callPackage ../tools/system/ddrescue { };
 
-  deluge = python2Packages.deluge; # Package should be moved out of python-packages.nix
+  deluge = callPackage ../applications/networking/p2p/deluge {
+    pythonPackages = python2Packages;
+  };
 
   desktop_file_utils = callPackage ../tools/misc/desktop-file-utils { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8775,37 +8775,6 @@ in {
     };
   };
 
-  deluge = buildPythonPackage rec {
-    name = "deluge-${version}";
-    version = "1.3.13";
-
-    src = pkgs.fetchurl {
-      url = "http://download.deluge-torrent.org/source/${name}.tar.bz2";
-      sha256 = "1ig8kv22009f0ny6n77a4lcfddhdsxrdklpmhdqvis1wx8na5crp";
-    };
-
-    propagatedBuildInputs = with self; [
-      pyGtkGlade pkgs.libtorrentRasterbar twisted Mako chardet pyxdg self.pyopenssl service-identity
-    ];
-
-    nativeBuildInputs = [ pkgs.intltool ];
-
-    postInstall = ''
-       mkdir -p $out/share/applications
-       cp -R deluge/data/pixmaps $out/share/
-       cp -R deluge/data/icons $out/share/
-       cp deluge/data/share/applications/deluge.desktop $out/share/applications
-    '';
-
-    meta = {
-      homepage = http://deluge-torrent.org;
-      description = "Torrent client";
-      license = licenses.gpl3Plus;
-      maintainers = with maintainers; [ domenkozar ebzzry ];
-      platforms = platforms.all;
-    };
-  };
-
   pyxdg = buildPythonPackage rec {
     name = "pyxdg-0.25";
 


### PR DESCRIPTION
###### Motivation for this change
Fix #27757 

###### Things done
Moved Deluge out of pythonPackages into its own .nix, because it does not support Python 3 yet: http://dev.deluge-torrent.org/wiki/Plan/Python3

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

