### PR TITLE
bitcoinarmory: init at 0.96.1

### DIFF
--- a/pkgs/applications/misc/bitcoinarmory/default.nix
+++ b/pkgs/applications/misc/bitcoinarmory/default.nix
@@ -1,0 +1,87 @@
+{ stdenv, fetchFromGitHub, pythonPackages
+, pkgconfig, autoreconfHook, rsync
+, swig, qt4, fcgi
+, bitcoin, procps, utillinux
+}:
+let
+
+  version = "0.96.1";
+  sitePackages = pythonPackages.python.sitePackages;
+  inherit (pythonPackages) mkPythonDerivation pyqt4 psutil twisted;
+
+in mkPythonDerivation {
+
+  name = "bitcoinarmory-${version}";
+
+  src = fetchFromGitHub {
+    owner = "goatpig";
+    repo = "BitcoinArmory";
+    rev = "v${version}";
+    #sha256 = "023c7q1glhrkn4djz3pf28ckd1na52lsagv4iyfgchqvw7qm7yx2";
+    sha256 = "0pjk5qx16n3kvs9py62666qkwp2awkgd87by4karbj7vk6p1l14h"; fetchSubmodules = true;
+  };
+
+  # FIXME bitcoind doesn't die on shutdown. Need some sort of patch to fix that.
+  #patches = [ ./shutdown-fix.patch ];
+
+  buildInputs = [
+    pkgconfig
+    autoreconfHook
+    swig
+    qt4
+    fcgi
+    rsync # used by silly install script (TODO patch upstream)
+  ];
+
+  propagatedBuildInputs = [
+    pyqt4
+    psutil
+    twisted
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  makeWrapperArgs = [
+    "--prefix            PATH : ${bitcoin}/bin"   # for `bitcoind`
+    "--prefix            PATH : ${procps}/bin"    # for `free`
+    "--prefix            PATH : ${utillinux}/bin" # for `whereis`
+    "--suffix LD_LIBRARY_PATH : $out/lib"         # for python bindings built as .so files
+    "--run    cd\\ $out/lib/armory"               # so that GUI resources can be loaded
+  ];
+
+  # auditTmpdir runs during fixupPhase, so patchelf before that
+  preFixup = ''
+    newRpath=$(patchelf --print-rpath $out/bin/ArmoryDB | sed -r 's|(.*)(/tmp/nix-build-.*libfcgi/.libs:?)(.*)|\1\3|')
+    patchelf --set-rpath $out/lib:$newRpath $out/bin/ArmoryDB
+  '';
+
+  # fixupPhase of mkPythonDerivation wraps $out/bin/*, so this needs to come after
+  postFixup = ''
+    wrapPythonProgramsIn $out/lib/armory "$out $pythonPath"
+    ln -sf $out/lib/armory/ArmoryQt.py $out/bin/armory
+  '';
+
+  meta = {
+    description = "Bitcoin wallet with cold storage and multi-signature support";
+    longDescription = ''
+      Armory is the most secure and full featured solution available for users
+      and institutions to generate and store Bitcoin private keys. This means
+      users never have to trust the Armory team and can use it with the Glacier
+      Protocol. Satoshi would be proud!
+
+      Users are empowered with multiple encrypted Bitcoin wallets and permanent
+      one-time ‘paper backups’. Armory pioneered cold storage and distributed
+      multi-signature. Bitcoin cold storage is a system for securely storing
+      Bitcoins on a completely air-gapped offline computer.
+
+      Maintainer's note: The original authors at https://bitcoinarmory.com/
+      discontinued development. I elected instead to package GitHub user
+      @goatpig's fork, as it's the most active, at time of this writing.
+    '';
+    homepage = https://github.com/goatpig/BitcoinArmory;
+    license = stdenv.lib.licenses.agpl3Plus;
+    maintainers = with stdenv.lib.maintainers; [ elitak ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13401,6 +13401,8 @@ with pkgs;
 
   bibletime = callPackage ../applications/misc/bibletime { };
 
+  bitcoinarmory = callPackage ../applications/misc/bitcoinarmory { pythonPackages = python2Packages; };
+
   bitkeeper = callPackage ../applications/version-management/bitkeeper {
     gperf = gperf_3_0;
   };


### PR DESCRIPTION
###### Motivation for this change

This is a bitcoin wallet app. The original (corporate) authors abandoned it; this is instead the most active fork of it that I could find on github.

###### Things done

~~I managed to switch the libfcgi dep from inside the repository to Nix's. There are many more  lib deps that ought to be switched over still, but I don't know if they're worth it. Libfcgi was the only one tracked as a submodule, which is why I fixed that one.~~ There's still a shutdown bug, where bitcoind stays running in the background. I've filed that here: https://github.com/goatpig/BitcoinArmory/issues/287

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

