### PR TITLE
docs: fix error in nix expression

### DIFF
--- a/doc/languages-frameworks/python.md
+++ b/doc/languages-frameworks/python.md
@@ -340,7 +340,7 @@ other packages we like to have in the environment, all specified with `propagate
 Indeed, we can just add any package we like to have in our environment to `propagatedBuildInputs`.
 
 ```nix
-with import <nixpkgs>;
+with import <nixpkgs> {};
 with pkgs.python35Packages;
 
 buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change
Someone in IRC following the docs ran into a problem due this nix expression having an error.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

