### PR TITLE
par2cmdline: 0.6.13 -> 0.7.3

### DIFF
--- a/pkgs/tools/networking/par2cmdline/default.nix
+++ b/pkgs/tools/networking/par2cmdline/default.nix
@@ -2,19 +2,19 @@
 
 stdenv.mkDerivation rec {
   name    = "par2cmdline-${version}";
-  version = "0.6.13";
+  version = "0.7.3";
 
   src = fetchFromGitHub {
     owner = "Parchive";
     repo = "par2cmdline";
     rev = "v${version}";
-    sha256 = "0jxixkc8vid933nph2mvhgz58my42kwjlzbir38hml2xrzq00d8f";
+    sha256 = "1hkb1brz70p79rv7dlzhnl1invjmkll81rcpnhwvafv1yriklfai";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/BlackIkeEagle/par2cmdline;
+    homepage = https://github.com/Parchive/par2cmdline;
     description = "PAR 2.0 compatible file verification and repair tool";
     longDescription = ''
       par2cmdline is a program for creating and using PAR2 files to detect


### PR DESCRIPTION
###### Motivation for this change

update

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- n/a Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

