### PR TITLE
influxdb module: collectd.port is now called bind-address

### DIFF
--- a/nixos/modules/services/databases/influxdb.nix
+++ b/nixos/modules/services/databases/influxdb.nix
@@ -70,7 +70,7 @@ let
       enabled = false;
       typesdb = "${pkgs.collectd}/share/collectd/types.db";
       database = "collectd_db";
-      port = 25826;
+      bind-address = ":25826";
     }];
 
     opentsdb = [{


### PR DESCRIPTION


###### Motivation for this change

with the influxdb release we have packaged (and newer releases)
collectd.port has been streamlined to bind-address which takes a string
instead of a number.

ref: https://github.com/influxdata/influxdb/blob/master/services/collectd/README.md

###### Things done

- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

