### PR TITLE
Update some mate packages

### DIFF
--- a/pkgs/desktops/mate/caja/default.nix
+++ b/pkgs/desktops/mate/caja/default.nix
@@ -4,11 +4,11 @@ stdenv.mkDerivation rec {
   name = "caja-${version}";
   version = "${major-ver}.${minor-ver}";
   major-ver = "1.18";
-  minor-ver = "0";
+  minor-ver = "3";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "1fc7dxj9hw8fffrcnwxbj8pq7gl08il68rkpk92rv3qm7siv1606";
+    sha256 = "0mljqcx7k8p27854zm7qzzn8ca6hs7hva9p43hp4p507z52caqmm";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
@@ -4,11 +4,11 @@ stdenv.mkDerivation rec {
   name = "mate-icon-theme-faenza-${version}";
   version = "${major-ver}.${minor-ver}";
   major-ver = "1.18";
-  minor-ver = "0";
+  minor-ver = "1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "1crfv6s3ljbc7a7m229bvs3qbjzlp8cgvyhqmdaa9npd5lxmk88v";
+    sha256 = "0vc3wg9l5yrxm0xmligz4lw2g3nqj1dz8fwv90xvym8pbjds2849";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/desktops/mate/mate-icon-theme/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme/default.nix
@@ -4,11 +4,11 @@ stdenv.mkDerivation rec {
   name = "mate-icon-theme-${version}";
   version = "${major-ver}.${minor-ver}";
   major-ver = "1.18";
-  minor-ver = "1";
+  minor-ver = "2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "1217nza3ilmy6x3b9i1b75lpq7lpvhs18s0c2n3j6zhxdqy61nlm";
+    sha256 = "0si3li3kza7s45zhasjvqn5f85zpkn0x8i4kq1dlnqvjjqzkg4ch";
   };
 
   nativeBuildInputs = [ pkgconfig intltool iconnamingutils ];

--- a/pkgs/desktops/mate/mate-terminal/default.nix
+++ b/pkgs/desktops/mate/mate-terminal/default.nix
@@ -4,11 +4,11 @@ stdenv.mkDerivation rec {
   name = "mate-terminal-${version}";
   version = "${major-ver}.${minor-ver}";
   major-ver = "1.18";
-  minor-ver = "0";
+  minor-ver = "1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "07z8g8zkc8k6d7xqdlg18cjnwg7zzv5hbgwma5y9mh8zx9xsqz92";
+    sha256 = "1zihm609d2d9cw53ry385whshjl1dnkifpk41g1ddm9f58hv4da1";
   };
 
   buildInputs = [

--- a/pkgs/desktops/mate/mate-themes/default.nix
+++ b/pkgs/desktops/mate/mate-themes/default.nix
@@ -6,15 +6,15 @@ stdenv.mkDerivation rec {
   version = "${major-ver}.${minor-ver}";
   major-ver = gnome3.version;
   minor-ver = {
-    "3.20" = "19";
-    "3.22" = "10";
+    "3.20" = "22";
+    "3.22" = "13";
   }."${major-ver}";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/themes/${major-ver}/${name}.tar.xz";
     sha256 = {
-      "3.20" = "11b8g374dkjhbs7x7khpriabvkip4dmfkma5myzfv6m54qlj3b8g";
-      "3.22" = "03ficjfxa4qpx4vcshhk2zxryivckxpw7wcjgbn8xqnjk3lgzjcb";
+      "3.20" = "1yjj5w7zvyjyg0k21nwk438jjsnj0qklsf0z5pmmp1jff1vxyck4";
+      "3.22" = "1p7w63an8qs15hkj79nppy7471glv0rm1b0himn3c4w69q8qdc9i";
     }."${major-ver}";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Update some Mate packages:

- mate-icon-theme: 1.18.1 -> 1.18.2
- mate-icon-theme-faenza: 1.18.0 -> 1.18.1
- mate-themes: 3.20.19 -> 3.20.22, 3.22.10 -> 3.22.13
- caja: 1.18.0 -> 1.18.3
- mate-terminal: 1.18.0 -> 1.18.1

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).