### PR TITLE
linux-common-config: add CONFIG_HOTPLUG_PCI_ACPI

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -450,8 +450,11 @@ with stdenv.lib;
   X86_CHECK_BIOS_CORRUPTION y
   X86_MCE y
 
-  # PCI-Expresscard hotplug support
-  ${optionalString (versionAtLeast version "3.12") "HOTPLUG_PCI_PCIE y"}
+  ${optionalString (versionAtLeast version "3.12") ''
+    HOTPLUG_PCI_ACPI y # PCI hotplug using ACPI
+    HOTPLUG_PCI_PCIE y # PCI-Expresscard hotplug support
+  ''}
+
 
   # Linux containers.
   NAMESPACES? y #  Required by 'unshare' used by 'nixos-install'


### PR DESCRIPTION
###### Motivation for this change

Without this config option, my Dell XPS 9350 doesn't recognise any devices when plugged into the USB-C port.

I've checked Arch Linux, Debian, Fedora and Ubuntu and they all have this config option set to yes.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

