### PR TITLE
openelec-dvb-firmware: init at 0.0.51

### DIFF
--- a/pkgs/os-specific/linux/firmware/openelec-dvb-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/openelec-dvb-firmware/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "openelec-dvb-firmware-${version}";
+  version = "0.0.51";
+
+  src = fetchurl {
+    url = "https://github.com/OpenELEC/dvb-firmware/archive/${version}.tar.gz";
+    sha256 = "cef3ce537d213e020af794cecf9de207e2882c375ceda39102eb6fa2580bad8d";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    DESTDIR="$out" ./install
+    find $out \( -name 'README.*' -or -name 'LICEN[SC]E.*' -or -name '*.txt' \) | xargs rm
+  '';
+
+  meta = with stdenv.lib; {
+    description = "DVB firmware from OpenELEC";
+    homepage = https://github.com/OpenELEC/dvb-firmware;
+    license = licenses.unfreeRedistributableFirmware;
+    platforms = platforms.linux;
+    priority = 7;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11991,6 +11991,8 @@ with pkgs;
 
   linuxConsoleTools = callPackage ../os-specific/linux/consoletools { };
 
+  openelec-dvb-firmware = callPackage ../os-specific/linux/firmware/openelec-dvb-firmware { };
+
   openiscsi = callPackage ../os-specific/linux/open-iscsi { };
 
   openisns = callPackage ../os-specific/linux/open-isns { };


### PR DESCRIPTION
###### Motivation for this change

This package provides additional firmware for DVB devices.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

