### PR TITLE
elementary-icon-theme: 4.1.0 -> 4.2.0

### DIFF
--- a/pkgs/data/icons/elementary-icon-theme/default.nix
+++ b/pkgs/data/icons/elementary-icon-theme/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "4.1.0";
+  version = "4.2.0";
 
   package-name = "elementary-icon-theme";
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://launchpad.net/elementaryicons/4.x/${version}/+download/${name}.tar.xz";
-    sha256 = "08pkk4299dj442dby15lwxwz7bax5d3828v1f81mbll084k7vssm";
+    sha256 = "0w1l9hlih4ddkdjpha5lsyf6iagv436nhm4aphak8w8jyycg81bm";
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Motivation for this change

Update to version 4.2.0.

[Changes](https://github.com/elementary/icons/milestone/3?closed=1)

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).