### PR TITLE
seafile-client: 5.0.7 -> 6.1.0

### DIFF
--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -1,39 +1,28 @@
-{stdenv, fetchurl, writeScript, pkgconfig, cmake, qt4, seafile-shared, ccnet, makeWrapper}:
+{ stdenv, fetchurl, writeScript, pkgconfig, cmake, qtbase, qttools
+, seafile-shared, ccnet, makeWrapper }:
 
-stdenv.mkDerivation rec
-{
-  version = "5.0.7";
+stdenv.mkDerivation rec {
+  version = "6.1.0";
   name = "seafile-client-${version}";
 
-  src = fetchurl
-  {
+  src = fetchurl {
     url = "https://github.com/haiwen/seafile-client/archive/v${version}.tar.gz";
-    sha256 = "ae6975bc1adf45d09cf9f6332ceac7cf285f8191f6cf50c6291ed45f8cf4ffa5";
+    sha256 = "16rn6b9ayaccgwx8hs3yh1wb395pp8ffh8may8a8bpcc4gdry7bd";
   };
 
-  buildInputs = [ pkgconfig cmake qt4 seafile-shared makeWrapper ];
+  nativeBuildInputs = [ pkgconfig cmake makeWrapper ];
+  buildInputs = [ qtbase qttools seafile-shared ];
 
-  builder = writeScript "${name}-builder.sh" ''
-    source $stdenv/setup
-
-    tar xvfz $src
-    cd seafile-client-*
-
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON -DCMAKE_INSTALL_PREFIX="$out" .
-    make -j1
-
-    make install
-
+  postInstall = ''
     wrapProgram $out/bin/seafile-applet \
       --suffix PATH : ${stdenv.lib.makeBinPath [ ccnet seafile-shared ]}
-    '';
+  '';
 
-  meta =
-  {
-    homepage = https://github.com/haiwen/seafile-clients;
+  meta = with stdenv.lib; {
+    homepage = https://github.com/haiwen/seafile-client;
     description = "Desktop client for Seafile, the Next-generation Open Source Cloud Storage";
-    license = stdenv.lib.licenses.asl20;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.calrama ];
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.calrama ];
   };
 }

--- a/pkgs/development/libraries/libsearpc/default.nix
+++ b/pkgs/development/libraries/libsearpc/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec
 {
   version = "3.0.7";
-  seafileVersion = "5.0.7";
+  seafileVersion = "6.1.0";
   name = "libsearpc-${version}";
 
   src = fetchurl

--- a/pkgs/misc/seafile-shared/default.nix
+++ b/pkgs/misc/seafile-shared/default.nix
@@ -2,20 +2,20 @@
 
 stdenv.mkDerivation rec
 {
-  version = "5.0.7";
+  version = "6.1.0";
   name = "seafile-shared-${version}";
 
   src = fetchurl
   {
     url = "https://github.com/haiwen/seafile/archive/v${version}.tar.gz";
-    sha256 = "ec166c86a41e7ab3b1ae97a56326ab4a2b1ec38686486b956c3d153b8023c670";
+    sha256 = "03zvxk25311xgn383k54qvvpr8xbnl1vxd99fg4ca9yg5rmir1q6";
   };
 
   buildInputs = [ which automake autoconf pkgconfig libtool vala_0_23 python intltool fuse ];
   propagatedBuildInputs = [ ccnet curl ];
 
   preConfigure = ''
-  sed -ie 's|/bin/bash|/bin/sh|g' ./autogen.sh
+  sed -ie 's|/bin/bash|${stdenv.shell}|g' ./autogen.sh
   ./autogen.sh
   '';
 

--- a/pkgs/tools/networking/ccnet/default.nix
+++ b/pkgs/tools/networking/ccnet/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec
 {
-  version = "5.0.7";
-  seafileVersion = "5.0.7";
+  version = "6.1.0";
+  seafileVersion = "6.1.0";
   name = "ccnet-${version}";
 
   src = fetchurl
   {
     url = "https://github.com/haiwen/ccnet/archive/v${version}.tar.gz";
-    sha256 = "1e1c670a85619b174328a15925a050c7a8b323fecd13434992332f5c15e05de1";
+    sha256 = "0q4a102xlcsxlr53h4jr4w8qzkbzvm2f3nk9fsha48h6l2hw34bb";
   };
 
   buildInputs = [ which automake autoconf pkgconfig libtool vala_0_23 python ];
   propagatedBuildInputs = [ libsearpc libzdb libuuid libevent sqlite openssl ];
 
   preConfigure = ''
-  sed -ie 's|/bin/bash|/bin/sh|g' ./autogen.sh
+  sed -ie 's|/bin/bash|${stdenv.shell}|g' ./autogen.sh
   ./autogen.sh
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15976,7 +15976,7 @@ with pkgs;
     inherit (gnome2) libart_lgpl;
   };
 
-  seafile-client = callPackage ../applications/networking/seafile-client { };
+  seafile-client = libsForQt5.callPackage ../applications/networking/seafile-client { };
 
   seeks = callPackage ../tools/networking/p2p/seeks {
     protobuf = protobuf2_5;


### PR DESCRIPTION
fixes ccnet openssl1.1 build issues, bumps to qt5

###### Motivation for this change
ccnet didn't build anymore, and the seafile client was in need of a version bump to the current release anyways. Incorporated the proposed changes from #183 for purity as well.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

