### PR TITLE
oil: init at 0.0.0

### DIFF
--- a/pkgs/shells/oil/default.nix
+++ b/pkgs/shells/oil/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchurl, coreutils }:
+let
+  version = "0.0.0";
+in
+stdenv.mkDerivation {
+  name = "oil-${version}";
+
+  src = fetchurl {
+    url = "https://www.oilshell.org/download/oil-${version}.tar.xz";
+    sha256 = "1mvyvvzw149piwa7xdl3byyn7h31p4cnrf3w9dxr5qfd9vc4gmsm";
+  };
+
+  postPatch = ''
+    patchShebangs build
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  # Stripping breaks the bundles by removing the zip file from the end.
+  dontStrip = true;
+
+  meta = {
+    homepage = https://www.oilshell.org/;
+
+    description = "A new unix shell, still in its early stages";
+
+    license = with lib.licenses; [
+      psfl # Includes a portion of the python interpreter and standard library
+      asl20 # Licence for Oil itself
+    ];
+
+    maintainers = with lib.maintainers; [ lheckemann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5106,6 +5106,8 @@ with pkgs;
 
   oh = callPackage ../shells/oh { };
 
+  oil = callPackage ../shells/oil { };
+
   pash = callPackage ../shells/pash { };
 
   tcsh = callPackage ../shells/tcsh { };


### PR DESCRIPTION
###### Motivation for this change
oil seems to be a cool project and since it aims to be a nicer language, maybe it could even replace bash in nixpkgs one day!

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).