### PR TITLE
jsonnet: 0.8.9 -> 0.9.4

### DIFF
--- a/pkgs/development/compilers/jsonnet/default.nix
+++ b/pkgs/development/compilers/jsonnet/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, emscripten }:
 
-let version = "0.8.9"; in
+let version = "0.9.4"; in
 
 stdenv.mkDerivation {
   name = "jsonnet-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     rev = "v${version}";
     owner = "google";
     repo = "jsonnet";
-    sha256 = "0phk8dzby5v60r7fwd1qf4as2jdpmdmksjw3g4p3mkkr7sc81119";
+    sha256 = "1bh9x8d3mxnic31b6gh4drn5l6qpyqfgsn2l48sv0jknhinm1a7l";
   };
 
   buildInputs = [ emscripten ];


### PR DESCRIPTION
###### Motivation for this change
New upstream version

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

