### PR TITLE
fix `hoogleLocal` and `hoogle.nix` WIP

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -34,7 +34,7 @@ self: super: {
   jailbreak-cabal = (disableSharedExecutables super.jailbreak-cabal).override { Cabal = self.Cabal_1_20_0_4; };
 
   # enable using a local hoogle with extra packagages in the database
-  # nix-shell -p "haskellPackages.hoogleLocal (with haskellPackages; [ mtl lens ])"
+  # nix-shell -p "haskellPackages.hoogleLocal { packages = with haskellPackages; [ mtl lens ]; }"
   # $ hoogle server
   hoogleLocal = { packages ? [] }: self.callPackage ./hoogle.nix { inherit packages; };
 

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, ghc, pkgconfig, glibcLocales, coreutils, gnugrep, gnused
 , jailbreak-cabal, hscolour, cpphs, nodejs, lib, removeReferencesTo
-}: let isCross = (ghc.cross or null) != null; in
+}:
+let isCross = (ghc.cross or null) != null; in
 
 { pname
 , dontStrip ? (ghc.isGhcjs or false)

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -25,7 +25,9 @@
 }:
 
 # return value: a function from self to the package set
-self: let
+self:
+
+let
 
   inherit (stdenv.lib) fix' extends makeOverridable;
   inherit (haskellLib) overrideCabal;


### PR DESCRIPTION
###### Motivation for this change

The location of haddocks changed once again, `hoogle.nix` broke once again.
This intends to solve the problem by replacing the globbing shell code with a direct identifier and some nixexpr-level logic.

There are still a few TODOs in the code that need feedback by @cleverca22 and @peti if possible. See commit messages and diff.