### PR TITLE
rsync service: allow running as user (plus some tweaks)

### DIFF
--- a/nixos/modules/services/network-filesystems/rsyncd.nix
+++ b/nixos/modules/services/network-filesystems/rsyncd.nix
@@ -83,6 +83,24 @@ in
           };
       };
 
+      user = mkOption {
+        type = types.str;
+        default = "root";
+        description = ''
+          The user to run the daemon as.
+          By default the daemon runs as root.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "root";
+        description = ''
+          The group to run the daemon as.
+          By default the daemon runs as root.
+        '';
+      };
+
     };
   };
 
@@ -96,8 +114,11 @@ in
       description = "Rsync daemon";
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ config.environment.etc."rsyncd.conf".source ];
-      serviceConfig.ExecStart = "${pkgs.rsync}/bin/rsync --daemon --no-detach";
+      serviceConfig = {
+        ExecStart = "${pkgs.rsync}/bin/rsync --daemon --no-detach";
+        User = cfg.user;
+        Group = cfg.group;
+      };
     };
-
   };
 }

--- a/nixos/modules/services/network-filesystems/rsyncd.nix
+++ b/nixos/modules/services/network-filesystems/rsyncd.nix
@@ -95,6 +95,7 @@ in
     systemd.services.rsyncd = {
       description = "Rsync daemon";
       wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ config.environment.etc."rsyncd.conf".source ];
       serviceConfig.ExecStart = "${pkgs.rsync}/bin/rsync --daemon --no-detach";
     };
 


### PR DESCRIPTION
It is useful to be able to run rsync as a non-root user.
I also cleaned a bit the config file generation.


- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

