### PR TITLE
replace "Mac OS X" and "OS X" with "macOS"

### DIFF
--- a/doc/languages-frameworks/haskell.md
+++ b/doc/languages-frameworks/haskell.md
@@ -827,7 +827,7 @@ the work to be licensed" under the terms of the LGPL (including for free).
 
 The LGPL licensing for GMP is a problem for the overall licensing of binary
 programs compiled with GHC because most distributions (and builds) of GHC use
-static libraries. (Dynamic libraries are currently distributed only for OS X.)
+static libraries. (Dynamic libraries are currently distributed only for macOS.)
 The LGPL licensing situation may be worse: even though
 [The Glasgow Haskell Compiler License](https://www.haskell.org/ghc/license)
 is essentially a "free software" license (BSD3), according to

--- a/nixos/doc/manual/installation/installing-usb.xml
+++ b/nixos/doc/manual/installation/installing-usb.xml
@@ -11,7 +11,7 @@ a USB stick. You can use the <command>dd</command> utility to write the image:
 <command>dd if=<replaceable>path-to-image</replaceable>
 of=<replaceable>/dev/sdb</replaceable></command>. Be careful about specifying the
 correct drive; you can use the <command>lsblk</command> command to get a list of
-block devices. If you're on OS X you can run <command>diskutil list</command>
+block devices. If you're on macOS you can run <command>diskutil list</command>
 to see the list of devices; the device you'll use for the USB must be ejected
 before writing the image.</para>
 

--- a/nixos/modules/services/editors/emacs.xml
+++ b/nixos/modules/services/editors/emacs.xml
@@ -24,7 +24,7 @@
   <para>
     Emacs runs within a graphical desktop environment using the X
     Window System, but works equally well on a text terminal. Under
-    <productname>OS X</productname>, a "Mac port" edition is
+    <productname>macOS</productname>, a "Mac port" edition is
     available, which uses Apple's native GUI frameworks.
   </para>
 
@@ -84,7 +84,7 @@
             <listitem>
               <para>
                 Emacs 25 with the "Mac port" patches, providing a more
-                native look and feel under OS X.
+                native look and feel under macOS.
               </para>
             </listitem>
           </varlistentry>

--- a/pkgs/applications/audio/freewheeling/default.nix
+++ b/pkgs/applications/audio/freewheeling/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
         improv. We leave mice and menus, and dive into our own process
         of making sound.
 
-        Freewheeling runs under Mac OS X and Linux, and is open source
+        Freewheeling runs under macOS and Linux, and is open source
         software, released under the GNU GPL license.
     '' ;
 

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -21,7 +21,7 @@ let
         inherit description license;
         longDescription = ''
           Enhancing productivity for every C and C++
-          developer on Linux, OS X and Windows.
+          developer on Linux, macOS and Windows.
         '';
         maintainers = with maintainers; [ edwtjo mic92 ];
         platforms = platforms.linux;

--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -89,7 +89,7 @@ composableDerivation {
           NIX_LDFLAGS = stdenv.lib.optional stdenv.isDarwin
             "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation";
         };
-      } #Disable Darwin (Mac OS X) support.
+      } #Disable Darwin (macOS) support.
       // edf { name = "xsmp"; } #Disable XSMP session management
       // edf { name = "xsmp_interact"; } #Disable XSMP interaction
       // edf { name = "mzscheme"; feat = "mzschemeinterp";} #Include MzScheme interpreter.

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Vim - the text editor - for Mac OS X";
+    description = "Vim - the text editor - for macOS";
     homepage    = https://github.com/b4winckler/macvim;
     license = licenses.vim;
     maintainers = with maintainers; [ cstrahan ];

--- a/pkgs/applications/editors/vim/qvim.nix
+++ b/pkgs/applications/editors/vim/qvim.nix
@@ -43,7 +43,7 @@ composableDerivation {
           '';
         };
       }
-      // edf { name = "darwin"; } #Disable Darwin (Mac OS X) support.
+      // edf { name = "darwin"; } #Disable Darwin (macOS) support.
       // edf { name = "xsmp"; } #Disable XSMP session management
       // edf { name = "xsmp_interact"; } #Disable XSMP interaction
       // edf { name = "mzscheme"; } #Include MzScheme interpreter.

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -77,11 +77,11 @@ in
     meta = with stdenv.lib; {
       description = ''
         Open source source code editor developed by Microsoft for Windows,
-        Linux and OS X
+        Linux and macOS
       '';
       longDescription = ''
         Open source source code editor developed by Microsoft for Windows,
-        Linux and OS X. It includes support for debugging, embedded Git
+        Linux and macOS. It includes support for debugging, embedded Git
         control, syntax highlighting, intelligent code completion, snippets,
         and code refactoring. It is also customizable, so users can change the
         editor's theme, keyboard shortcuts, and preferences

--- a/pkgs/applications/graphics/openscad/default.nix
+++ b/pkgs/applications/graphics/openscad/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "3D parametric model compiler";
     longDescription = ''
       OpenSCAD is a software for creating solid 3D CAD objects. It is free
-      software and available for Linux/UNIX, MS Windows and Mac OS X.
+      software and available for Linux/UNIX, MS Windows and macOS.
 
       Unlike most free software for creating 3D models (such as the famous
       application Blender) it does not focus on the artistic aspects of 3D

--- a/pkgs/applications/misc/gqrx/default.nix
+++ b/pkgs/applications/misc/gqrx/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     # Some of the code comes from the Cutesdr project, with a BSD license, but
     # it's currently unknown which version of the BSD license that is.
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;  # should work on Darwin / OS X too
+    platforms = platforms.linux;  # should work on Darwin / macOS too
     maintainers = with maintainers; [ bjornfor the-kenny fpletz ];
   };
 }

--- a/pkgs/applications/misc/qsyncthingtray/default.nix
+++ b/pkgs/applications/misc/qsyncthingtray/default.nix
@@ -49,7 +49,7 @@ mkDerivation rec {
     description = "A Traybar Application for Syncthing written in C++";
     longDescription = ''
         A cross-platform status bar for Syncthing.
-        Currently supports OS X, Windows and Linux.
+        Currently supports macOS, Windows and Linux.
         Written in C++ with Qt.
     '';
     license = licenses.lgpl3;

--- a/pkgs/applications/misc/sequelpro/default.nix
+++ b/pkgs/applications/misc/sequelpro/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "MySQL database management for Mac OS X";
+    description = "MySQL database management for macOS";
     homepage = http://www.sequelpro.com/;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.darwin;

--- a/pkgs/applications/misc/truecrypt/default.nix
+++ b/pkgs/applications/misc/truecrypt/default.nix
@@ -1,17 +1,17 @@
 /*
-Requirements for Building TrueCrypt for Linux and Mac OS X:
+Requirements for Building TrueCrypt for Linux and macOS:
 -----------------------------------------------------------
 
 - GNU Make
 - GNU C++ Compiler 4.0 or compatible
-- Apple XCode (Mac OS X only)
+- Apple XCode (macOS only)
 - pkg-config
 - wxWidgets 2.8 library source code (available at http://www.wxwidgets.org)
 - FUSE library (available at http://fuse.sourceforge.net and
   http://code.google.com/p/macfuse)
 
 
-Instructions for Building TrueCrypt for Linux and Mac OS X:
+Instructions for Building TrueCrypt for Linux and macOS:
 -----------------------------------------------------------
 
 1) Change the current directory to the root of the TrueCrypt source code.

--- a/pkgs/applications/networking/ftp/filezilla/default.nix
+++ b/pkgs/applications/networking/ftp/filezilla/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     longDescription = ''
       FileZilla Client is a free, open source FTP client. It supports
       FTP, SFTP, and FTPS (FTP over SSL/TLS). The client is available
-      under many platforms, binaries for Windows, Linux and Mac OS X are
+      under many platforms, binaries for Windows, Linux and macOS are
       provided.
     '';
     platforms = platforms.linux;

--- a/pkgs/applications/networking/instant-messengers/messenger-for-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/messenger-for-desktop/default.nix
@@ -89,7 +89,7 @@ in stdenv.mkDerivation {
     description = "Bring messenger.com to your Linux desktop.";
     longDescription = ''
       A simple & beautiful desktop client for Facebook Messenger. Chat without
-      distractions on OS X, Windows and Linux. Not affiliated with Facebook.
+      distractions on macOS, Windows and Linux. Not affiliated with Facebook.
       This is NOT an official product.
     '';
     homepage = https://messengerfordesktop.org;

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -61,7 +61,7 @@ in stdenv.mkDerivation {
     longDescription = ''
       Wireshark (formerly known as "Ethereal") is a powerful network
       protocol analyzer developed by an international team of networking
-      experts. It runs on UNIX, OS X and Windows.
+      experts. It runs on UNIX, macOS and Windows.
     '';
 
     platforms = platforms.unix;

--- a/pkgs/applications/office/gnucash/2.6.nix
+++ b/pkgs/applications/office/gnucash/2.6.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
     longDescription = ''
       GnuCash is personal and small-business financial-accounting software,
       freely licensed under the GNU GPL and available for GNU/Linux, BSD,
-      Solaris, Mac OS X and Microsoft Windows.
+      Solaris, macOS and Microsoft Windows.
 
       Designed to be easy to use, yet powerful and flexible, GnuCash allows
       you to track bank accounts, stocks, income and expenses.  As quick and

--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     longDescription = ''
       GnuCash is personal and small-business financial-accounting software,
       freely licensed under the GNU GPL and available for GNU/Linux, BSD,
-      Solaris, Mac OS X and Microsoft Windows.
+      Solaris, macOS and Microsoft Windows.
 
       Designed to be easy to use, yet powerful and flexible, GnuCash allows
       you to track bank accounts, stocks, income and expenses.  As quick and

--- a/pkgs/applications/science/astronomy/gravit/default.nix
+++ b/pkgs/applications/science/astronomy/gravit/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
     longDescription = ''
       Gravit is a gravity simulator which runs under Linux, Windows and
-      Mac OS X. It uses Newtonian physics using the Barnes-Hut N-body
+      macOS. It uses Newtonian physics using the Barnes-Hut N-body
       algorithm. Although the main goal of Gravit is to be as accurate
       as possible, it also creates beautiful looking gravity patterns.
       It records the history of each particle so it can animate and

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -23,7 +23,7 @@ rec {
       description = "A program launcher for Kodi";
       longDescription = ''
         Advanced Launcher allows you to start any Linux, Windows and
-        OS X external applications (with command line support or not)
+        macOS external applications (with command line support or not)
         directly from the Kodi GUI. Advanced Launcher also give you
         the possibility to edit, download (from Internet resources)
         and manage all the meta-data (informations and images) related

--- a/pkgs/applications/video/mediathekview/default.nix
+++ b/pkgs/applications/video/mediathekview/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation {
     homepage = http://zdfmediathk.sourceforge.net/;
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ maintainers.chaoflow ];
-    platforms = platforms.linux;  #  also OS X and cygwin, but not investigated, yet
+    platforms = platforms.linux;  #  also macOS and cygwin, but not investigated, yet
   };
 }

--- a/pkgs/applications/virtualization/xhyve/default.nix
+++ b/pkgs/applications/virtualization/xhyve/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Lightweight Virtualization on OS X Based on bhyve";
+    description = "Lightweight Virtualization on macOS Based on bhyve";
     homepage = https://github.com/mist64/xhyve;
     maintainers = [ lib.maintainers.lnl7 ];
     platforms = lib.platforms.darwin;

--- a/pkgs/build-support/setup-hooks/fix-darwin-dylib-names.sh
+++ b/pkgs/build-support/setup-hooks/fix-darwin-dylib-names.sh
@@ -1,4 +1,4 @@
-# On Mac OS X, binaries refer to dynamic library dependencies using
+# On macOS, binaries refer to dynamic library dependencies using
 # either relative paths (e.g. "libicudata.dylib", searched relative to
 # $DYLD_LIBRARY_PATH) or absolute paths
 # (e.g. "/nix/store/.../lib/libicudata.dylib").  In Nix, the latter is

--- a/pkgs/build-support/setup-hooks/fix-darwin-frameworks.sh
+++ b/pkgs/build-support/setup-hooks/fix-darwin-frameworks.sh
@@ -1,4 +1,4 @@
-# On Mac OS X, frameworks are linked to the system CoreFoundation but
+# On macOS, frameworks are linked to the system CoreFoundation but
 # dynamic libraries built with nix use a pure version of CF this
 # causes segfaults for binaries that depend on it at runtime.  This
 # can be solved in two ways.

--- a/pkgs/data/documentation/zeal/default.nix
+++ b/pkgs/data/documentation/zeal/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A simple offline API documentation browser";
     longDescription = ''
-      Zeal is a simple offline API documentation browser inspired by Dash (OS X
+      Zeal is a simple offline API documentation browser inspired by Dash (macOS
       app), available for Linux and Windows.
     '';
     homepage = http://zealdocs.org/;

--- a/pkgs/development/compilers/chicken/default.nix
+++ b/pkgs/development/compilers/chicken/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation {
       CHICKEN is a compiler for the Scheme programming language.
       CHICKEN produces portable and efficient C, supports almost all
       of the R5RS Scheme language standard, and includes many
-      enhancements and extensions. CHICKEN runs on Linux, MacOS X,
+      enhancements and extensions. CHICKEN runs on Linux, macOS,
       Windows, and many Unix flavours.
     '';
   };

--- a/pkgs/development/compilers/llvm/3.8/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.8/llvm.nix
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
   patches = [ ./D17533-1.patch ] ++
     stdenv.lib.optionals (!stdenv.isDarwin) [./fix-llvm-config.patch];
 
-  # hacky fix: New LLVM releases require a newer OS X SDK than
+  # hacky fix: New LLVM releases require a newer macOS SDK than
   # 10.9. This is a temporary measure until nixpkgs darwin support is
   # updated.
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/ocaml/configure-3.08.0
+++ b/pkgs/development/compilers/ocaml/configure-3.08.0
@@ -45,7 +45,7 @@ gcc_warnings="-Wall"
 unset LANG
 unset LC_ALL LC_CTYPE LC_COLLATE LC_MESSAGES LC_MONETARY LC_NUMERIC LC_TIME 
 
-# Turn off some MacOS X debugging stuff, same reason
+# Turn off some macOS debugging stuff, same reason
 unset RC_TRACE_ARCHIVES RC_TRACE_DYLIBS RC_TRACE_PREBINDING_DISABLED
 
 # Parse command-line arguments

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -231,10 +231,10 @@ stdenv.mkDerivation ({
       fi
     done
   '' + (optionalString stdenv.isDarwin ''
-    # Work around a limit in the Mac OS X Sierra linker on the number of paths
+    # Work around a limit in the macOS Sierra linker on the number of paths
     # referenced by any one dynamic library:
     #
-    # Create a local directory with symlinks of the *.dylib (Mac OS X shared
+    # Create a local directory with symlinks of the *.dylib (macOS shared
     # libraries) from all the dependencies.
     local dynamicLinksDir="$out/lib/links"
     mkdir -p $dynamicLinksDir

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -97,7 +97,7 @@ symlinkJoin {
       fi
     done
   '' + (lib.optionalString stdenv.isDarwin ''
-    # Work around a linker limit in Mac OS X Sierra (see generic-builder.nix):
+    # Work around a linker limit in macOS Sierra (see generic-builder.nix):
     local packageConfDir="$out/lib/${ghc.name}/package.conf.d";
     local dynamicLinksDir="$out/lib/links"
     mkdir -p $dynamicLinksDir

--- a/pkgs/development/libraries/freenect/default.nix
+++ b/pkgs/development/libraries/freenect/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   meta = {
-    description = "Drivers and libraries for the Xbox Kinect device on Windows, Linux, and OS X";
+    description = "Drivers and libraries for the Xbox Kinect device on Windows, Linux, and macOS";
     inherit version;
     homepage = http://openkinect.org;
     license = with stdenv.lib.licenses; [ gpl2 asl20 ];

--- a/pkgs/development/libraries/hunspell/default.nix
+++ b/pkgs/development/libraries/hunspell/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     longDescription = ''
       Hunspell is the spell checker of LibreOffice, OpenOffice.org, Mozilla
       Firefox 3 & Thunderbird, Google Chrome, and it is also used by
-      proprietary software packages, like Mac OS X, InDesign, memoQ, Opera and
+      proprietary software packages, like macOS, InDesign, memoQ, Opera and
       SDL Trados.
 
       Main features:
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
       * C++ library under GPL/LGPL/MPL tri-license.
       * Interfaces and ports:
         * Enchant (Generic spelling library from the Abiword project),
-        * XSpell (Mac OS X port, but Hunspell is part of the OS X from version 10.6 (Snow Leopard), and
+        * XSpell (macOS port, but Hunspell is part of the macOS from version 10.6 (Snow Leopard), and
             now it is enough to place Hunspell dictionary files into
             ~/Library/Spelling or /Library/Spelling for spell checking),
         * Delphi, Java (JNA, JNI), Perl, .NET, Python, Ruby ([1], [2]), UNO.

--- a/pkgs/development/libraries/libmemcached/default.nix
+++ b/pkgs/development/libraries/libmemcached/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   # Fix linking against libpthread (patch from Fedora)
   # https://bugzilla.redhat.com/show_bug.cgi?id=1037707
   # https://bugs.launchpad.net/libmemcached/+bug/1281907
-  # Fix building on OS X (patch from Homebrew)
+  # Fix building on macOS (patch from Homebrew)
   # https://bugs.launchpad.net/libmemcached/+bug/1245562
   patches = stdenv.lib.optional stdenv.isLinux ./libmemcached-fix-linking-with-libpthread.patch
     ++ stdenv.lib.optional stdenv.isDarwin (fetchpatch {

--- a/pkgs/development/libraries/libserialport/default.nix
+++ b/pkgs/development/libraries/libserialport/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     description = "Cross-platform shared library for serial port access";
     homepage = http://sigrok.org/;
     license = licenses.gpl3Plus;
-    # Mac OS X, Windows and Android is also supported (according to upstream).
+    # macOS, Windows and Android is also supported (according to upstream).
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];
   };

--- a/pkgs/development/libraries/libsndfile/default.nix
+++ b/pkgs/development/libraries/libsndfile/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
       code format under the GNU Lesser General Public License.
 
       The library was written to compile and run on a Linux system but
-      should compile and run on just about any Unix (including MacOS X).
+      should compile and run on just about any Unix (including macOS).
       There are also pre-compiled binaries available for 32 and 64 bit
       windows.
 

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -37,7 +37,7 @@ let
     sha256 = "1lynpbxz1jay3ya5y45zac5v8c6ifgk4ssn8d1chfdk3spi691jj";
   };
 
-  # This fixes the build on OS X.
+  # This fixes the build on macOS.
   # See: https://github.com/opencv/opencv_contrib/pull/926
   contribOSXFix = fetchpatch {
     url = "https://github.com/opencv/opencv_contrib/commit/abf44fcccfe2f281b7442dac243e37b7f436d961.patch";
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     (lib.optionalString enableContrib ''
       cp --no-preserve=mode -r "${contribSrc}/modules" "$NIX_BUILD_TOP/opencv_contrib"
 
-      # This fixes the build on OS X.
+      # This fixes the build on macOS.
       patch -d "$NIX_BUILD_TOP/opencv_contrib" -p2 < "${contribOSXFix}"
 
       for name in vgg_generated_48.i \

--- a/pkgs/development/libraries/wxwidgets/2.8/default.nix
+++ b/pkgs/development/libraries/wxwidgets/2.8/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.wxWindows;
     homepage = https://www.wxwidgets.org/;
-    description = "a C++ library that lets developers create applications for Windows, Mac OS X, Linux and other platforms with a single code base";
+    description = "a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base";
     longDescription = "wxWidgets gives you a single, easy-to-use API for writing GUI applications on multiple platforms that still utilize the native platform's controls and utilities. Link with the appropriate library for your platform and compiler, and your application will adopt the look and feel appropriate to that platform. On top of great GUI functionality, wxWidgets gives you: online help, network programming, streams, clipboard and drag and drop, multithreading, image loading and saving in a variety of popular formats, database support, HTML viewing and printing, and much more.";
   };
 }

--- a/pkgs/development/libraries/wxwidgets/2.9/default.nix
+++ b/pkgs/development/libraries/wxwidgets/2.9/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation {
     platforms = with platforms; darwin ++ linux;
     license = licenses.wxWindows;
     homepage = https://www.wxwidgets.org/;
-    description = "a C++ library that lets developers create applications for Windows, Mac OS X, Linux and other platforms with a single code base";
+    description = "a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base";
     longDescription = "wxWidgets gives you a single, easy-to-use API for writing GUI applications on multiple platforms that still utilize the native platform's controls and utilities. Link with the appropriate library for your platform and compiler, and your application will adopt the look and feel appropriate to that platform. On top of great GUI functionality, wxWidgets gives you: online help, network programming, streams, clipboard and drag and drop, multithreading, image loading and saving in a variety of popular formats, database support, HTML viewing and printing, and much more.";
   };
 }

--- a/pkgs/development/libraries/wxwidgets/3.0/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation {
     platforms = with platforms; darwin ++ linux;
     license = licenses.wxWindows;
     homepage = https://www.wxwidgets.org/;
-    description = "a C++ library that lets developers create applications for Windows, Mac OS X, Linux and other platforms with a single code base";
+    description = "a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base";
     longDescription = "wxWidgets gives you a single, easy-to-use API for writing GUI applications on multiple platforms that still utilize the native platform's controls and utilities. Link with the appropriate library for your platform and compiler, and your application will adopt the look and feel appropriate to that platform. On top of great GUI functionality, wxWidgets gives you: online help, network programming, streams, clipboard and drag and drop, multithreading, image loading and saving in a variety of popular formats, database support, HTML viewing and printing, and much more.";
   };
 }

--- a/pkgs/development/libraries/wxwidgets/3.0/mac.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/mac.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation rec {
     license = licenses.wxWindows;
     maintainers = [ maintainers.lnl7 ];
     homepage = https://www.wxwidgets.org/;
-    description = "a C++ library that lets developers create applications for Windows, Mac OS X, Linux and other platforms with a single code base";
+    description = "a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base";
     longDescription = "wxWidgets gives you a single, easy-to-use API for writing GUI applications on multiple platforms that still utilize the native platform's controls and utilities. Link with the appropriate library for your platform and compiler, and your application will adopt the look and feel appropriate to that platform. On top of great GUI functionality, wxWidgets gives you: online help, network programming, streams, clipboard and drag and drop, multithreading, image loading and saving in a variety of popular formats, database support, HTML viewing and printing, and much more.";
   };
 }

--- a/pkgs/development/mobile/titaniumenv/build-app.nix
+++ b/pkgs/development/mobile/titaniumenv/build-app.nix
@@ -21,7 +21,7 @@ let
     security delete-keychain $keychainName
   '';
   
-  # On Mac OS X, the java executable shows an -unoffical postfix in the version
+  # On macOS, the java executable shows an -unoffical postfix in the version
   # number. This confuses the build script's version detector.
   # We fix this by creating a wrapper that strips it out of the output.
   
@@ -72,7 +72,7 @@ stdenv.mkDerivation {
     ${if target == "android" then
         ''
           ${stdenv.lib.optionalString (stdenv.system == "x86_64-darwin") ''
-            # Hack to make version detection work with OpenJDK on Mac OS X
+            # Hack to make version detection work with OpenJDK on macOS
             export PATH=${javaVersionFixWrapper}/bin:$PATH
             export JAVA_HOME=${javaVersionFixWrapper}
             javac -version

--- a/pkgs/development/ocaml-modules/ocamlnat/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnat/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       but up to 100 times faster. It is based on the optimizing native code
       compiler, the native runtime and an earlier prototype by Alain
       Frisch. It is build upon Just-In-Time techniques and currently
-      supports Unix-like systems (i.e. Linux, BSD or Mac OS X) running on
+      supports Unix-like systems (i.e. Linux, BSD or macOS) running on
       x86 or x86-64 processors. Support for additional architectures and
       operating systems is planned, but not yet available.
     '';

--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
     homepage = http://pharo.org;
     license = stdenv.lib.licenses.mit;
     maintainers = [ ];
-    # Pharo VM sources are packaged separately for darwin (OS X)
+    # Pharo VM sources are packaged separately for darwin (macOS)
     platforms = with stdenv.lib;
                   intersectLists
                     platforms.mesaPlatforms

--- a/pkgs/development/python-modules/pyqt/4.x.nix
+++ b/pkgs/development/python-modules/pyqt/4.x.nix
@@ -19,7 +19,7 @@ in buildPythonPackage {
 
     export PYTHONPATH=$PYTHONPATH:$out/lib/${python.libPrefix}/site-packages
     ${stdenv.lib.optionalString stdenv.isDarwin ''
-      export QMAKESPEC="unsupported/macx-clang-libc++" # OS X target after bootstrapping phase \
+      export QMAKESPEC="unsupported/macx-clang-libc++" # macOS target after bootstrapping phase \
     ''}
 
     substituteInPlace configure.py \

--- a/pkgs/development/tools/gtk-mac-bundler/default.nix
+++ b/pkgs/development/tools/gtk-mac-bundler/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "a helper script that creates application bundles form GTK+ executables for Mac OS X";
+    description = "a helper script that creates application bundles form GTK+ executables for macOS";
     maintainers = [ maintainers.matthewbauer ];
     platforms = platforms.darwin;
     homepage = https://wiki.gnome.org/Projects/GTK+/OSX/Bundling;

--- a/pkgs/games/tintin/default.nix
+++ b/pkgs/games/tintin/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A free MUD client for Mac OS X, Linux and Windows";
+    description = "A free MUD client for macOS, Linux and Windows";
     homepage    = http://tintin.sourceforge.net;
     license     = licenses.gpl2;
     maintainers = with maintainers; [ lovek323 ];

--- a/pkgs/games/unvanquished/default.nix
+++ b/pkgs/games/unvanquished/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     longDescription = ''
       Unvanquished is a free, open-source first-person shooter
       combining real-time strategy elements with a futuristic, sci-fi
-      setting. It is available for Windows, Linux, and Mac OS X.
+      setting. It is available for Windows, Linux, and macOS.
 
       Features:
 

--- a/pkgs/games/warsow/default.nix
+++ b/pkgs/games/warsow/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
       Set in a futuristic cartoon-like world where rocketlauncher-wielding
       pigs and lasergun-carrying cyberpunks roam the streets, Warsow is a
       completely free fast-paced first-person shooter (FPS) for Windows, Linux
-      and Mac OS X.
+      and macOS.
     '';
     homepage = http://www.warsow.net;
     # Engine is under GPLv2, everything else is under

--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     description = "A free fast-paced first-person shooter";
     longDescription = ''
       Xonotic is a free, fast-paced first-person shooter that works on
-      Windows, OS X and Linux. The project is geared towards providing
+      Windows, macOS and Linux. The project is geared towards providing
       addictive arena shooter gameplay which is all spawned and driven
       by the community itself. Xonotic is a direct successor of the
       Nexuiz project with years of development between them, and it

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -109,7 +109,7 @@ let
 
     meta = {
       homepage = http://www.opensource.apple.com/source/cctools/;
-      description = "Mac OS X Compiler Tools (cross-platform port)";
+      description = "MacOS Compiler Tools (cross-platform port)";
       license = stdenv.lib.licenses.apsl20;
     };
   };

--- a/pkgs/os-specific/darwin/opencflite/default.nix
+++ b/pkgs/os-specific/darwin/opencflite/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    description = "Cross platform port of the OS X CoreFoundation";
+    description = "Cross platform port of the macOS CoreFoundation";
     homepage = http://sourceforge.net/projects/opencflite/;
     license = stdenv.lib.licenses.apsl20;
   };

--- a/pkgs/os-specific/darwin/security-tool/default.nix
+++ b/pkgs/os-specific/darwin/security-tool/default.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Command line interface to Mac OS X keychains and Security framework";
+    description = "Command line interface to macOS keychains and Security framework";
     maintainers = with maintainers; [
       copumpkin
       joelteon

--- a/pkgs/os-specific/darwin/usr-include/default.nix
+++ b/pkgs/os-specific/darwin/usr-include/default.nix
@@ -4,7 +4,7 @@
  * This is needed to build GCC on Darwin.
  *
  * These are the collection of headers that would normally be available under
- * /usr/include in OS X machines with command line tools installed. They need
+ * /usr/include in macOS machines with command line tools installed. They need
  * to be in one folder for gcc to use them correctly.
  */
 

--- a/pkgs/servers/cloud-print-connector/default.nix
+++ b/pkgs/servers/cloud-print-connector/default.nix
@@ -24,11 +24,11 @@ buildGoPackage rec {
   buildInputs = [ avahi cups ];
 
   meta = with stdenv.lib; {
-    description = "Share printers from your Windows, Linux, FreeBSD or OS X computer with ChromeOS and Android devices, using the Cloud Print Connector";
+    description = "Share printers from your Windows, Linux, FreeBSD or macOS computer with ChromeOS and Android devices, using the Cloud Print Connector";
     homepage = https://github.com/google/cloud-print-connector;
     license = licenses.bsd3;
     maintainers = with maintainers; [ hodapp ];
-    # TODO: Fix broken build on OS X.  The GitHub presently lists the
+    # TODO: Fix broken build on macOS.  The GitHub presently lists the
     # FreeBSD build as broken too, but this may change in the future.
     platforms = platforms.linux;
   };

--- a/pkgs/tools/filesystems/darling-dmg/default.nix
+++ b/pkgs/tools/filesystems/darling-dmg/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.darlinghq.org/;
-    description = "Darling lets you open OS X dmgs on Linux";
+    description = "Darling lets you open macOS dmgs on Linux";
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl3;
   };

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -26,7 +26,7 @@ python3.pkgs.buildPythonApplication rec {
     sed -i setup.py -e "/'rpm-python',/d"
   '';
 
-  # Still missing these tools: enjarify, otool & lipo (maybe OS X only), showttf
+  # Still missing these tools: enjarify, otool & lipo (maybe macOS only), showttf
   # Also these libraries: python3-guestfs
   # FIXME: move xxd into a separate package so we don't have to pull in all of vim.
   pythonPath = with python3.pkgs;

--- a/pkgs/tools/misc/umlet/default.nix
+++ b/pkgs/tools/misc/umlet/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       draw UML diagrams fast, produce sequence and activity diagrams from
       plain text, export diagrams to eps, pdf, jpg, svg, and clipboard,
       share diagrams using Eclipse, and create new, custom UML elements.
-      UMLet runs stand-alone or as Eclipse plug-in on Windows, OS X and
+      UMLet runs stand-alone or as Eclipse plug-in on Windows, macOS and
       Linux.
     '';
     homepage = http://www.umlet.com;

--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   #doCheck = !stdenv.isDarwin && !stdenv.isSunOS && !stdenv.isCygwin && !stdenv.isFreeBSD;
   doCheck = false;
 
-  # On Mac OS X, force use of mkdir -p, since Grep's fallback
+  # On macOS, force use of mkdir -p, since Grep's fallback
   # (./install-sh) is broken.
   preConfigure = ''
     export MKDIR_P="mkdir -p"

--- a/pkgs/tools/text/popfile/default.nix
+++ b/pkgs/tools/text/popfile/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     homepage = http://getpopfile.org;
     license = stdenv.lib.licenses.gpl2;
 
-    # Should work on OS X, but havent tested it.
+    # Should work on macOS, but havent tested it.
     # Windows support is more complicated.
     # http://getpopfile.org/docs/faq:systemrequirements
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -618,7 +618,7 @@ in {
     };
 
     meta = {
-      description = "Disable App Nap on OS X";
+      description = "Disable App Nap on macOS";
       homepage    = https://pypi.python.org/pypi/appnope;
       platforms   = platforms.darwin;
       license     = licenses.bsd3;
@@ -756,7 +756,7 @@ in {
       sha256 = "136f2ec0f94ec77ff2990830feee965d608cab1e8922370e3abdded383d52001";
     };
 
-    # Mac OS X needs clang for testing
+    # macOS needs clang for testing
     buildInputs = with self; [ pytest hypothesis zope_interface
     pympler coverage ]
      ++ optionals (stdenv.isDarwin) [ pkgs.clang ];
@@ -28416,7 +28416,7 @@ EOF
     doCheck = false;
 
     meta = {
-      description = "Send file to trash natively under Mac OS X, Windows and Linux";
+      description = "Send file to trash natively under macOS, Windows and Linux";
       homepage = https://github.com/hsoft/send2trash;
       license = licenses.bsd3;
     };


### PR DESCRIPTION
as it is the official name since 2016

https://en.wikipedia.org/wiki/Macintosh_operating_systems#Desktop

exception are parts refering to older versions of macOS like

"GUI support for Mac OS X 10.6 - 10.12. Note that Emacs 23 and later [...]"

or patches.

###### Motivation for this change

make it a little more correct while not breaking anything.

i'm not sure if this changes trigger a mass rebuild since mostly descriptions or comments are changed.

please review carefully!

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

