### PR TITLE
xfce4-session: fix lock screen not working with light-locker

### DIFF
--- a/pkgs/desktops/xfce/core/xfce4-light-locker.patch
+++ b/pkgs/desktops/xfce/core/xfce4-light-locker.patch
@@ -1,0 +1,16 @@
+--- ./scripts/xflock4.orig	2017-08-06 23:05:53.807688995 +0100
++++ ./scripts/xflock4	2017-08-06 23:09:06.171789989 +0100
+@@ -24,10 +24,11 @@
+ PATH=/bin:/usr/bin
+ export PATH
+
+-# Lock by xscreensaver or gnome-screensaver, if a respective daemon is running
++# Lock by xscreensaver, gnome-screensaver or light-locker, if a respective daemon is running
+ for lock_cmd in \
+     "xscreensaver-command -lock" \
+-    "gnome-screensaver-command --lock"
++    "gnome-screensaver-command --lock" \
++    "light-locker-command -l"
+ do
+     $lock_cmd >/dev/null 2>&1 && exit
+ done

--- a/pkgs/desktops/xfce/core/xfce4-session.nix
+++ b/pkgs/desktops/xfce/core/xfce4-session.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation rec {
     sha256 = "97d7f2a2d0af7f3623b68d1f04091e02913b28f9555dab8b0d26c8a1299d08fd";
   };
 
+  patches = [
+    # Fix "lock screen" not working for light-locker
+    ./xfce4-light-locker.patch
+  ];
+
   buildInputs =
     [ pkgconfig intltool gtk libxfce4util libxfce4ui libwnck dbus_glib
       xfconf xfce4panel libglade xorg.iceauth xorg.libSM


### PR DESCRIPTION
###### Motivation for this change
Light-locker enables to unlock with just single password as it uses lightdm login screen. However the "Lock Screen" menu option in xfce4 doesn't work with light-locker, which is fixed by this patch.

Minor change that builds and works for me.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

