### PR TITLE
ruby docs: fix text and example

### DIFF
--- a/doc/languages-frameworks/ruby.xml
+++ b/doc/languages-frameworks/ruby.xml
@@ -82,7 +82,7 @@ versions available from various packages.
 </para>
 
 <para>Resulting derivations for both builders also have two helpful
-attributes, <literal>env</literal> and <literal>wrapper</literal>.
+attributes, <literal>env</literal> and <literal>wrappedRuby</literal>.
 The first one allows one to quickly drop into
 <command>nix-shell</command> with the specified environment present.
 E.g. <command>nix-shell -A sensu.env</command> would give you an
@@ -110,15 +110,11 @@ the needed dependencies. For example, to make a derivation
 
 in stdenv.mkDerivation {
   name = "my-script";
-
-  buildInputs = [ env.wrapper ];
-
+  buildInputs = [ env.wrappedRuby ];
+  phases = [ "installPhase" "fixupPhase" ];
   script = ./my-script.rb;
-
   buildCommand = ''
-    mkdir -p $out/bin
     install -D -m755 $script $out/bin/my-script
-    patchShebangs $out/bin/my-script
   '';
 }]]>
 </programlisting>


### PR DESCRIPTION
1. 'wrapper' has been renamed to 'wrappedRuby', so use this instead.
2. mkDerivation isn't called with a 'src' attribute, so skip the 'unpackPhase' to avoid an error.
3. Simplify the build command. 'mkdir' and 'patchShebangs' don't need to be called explicitly.
