### PR TITLE
cloud-utils: fix build recipe

### DIFF
--- a/pkgs/tools/misc/cloud-utils/default.nix
+++ b/pkgs/tools/misc/cloud-utils/default.nix
@@ -12,10 +12,7 @@ stdenv.mkDerivation {
   buildPhase = ''
     mkdir -p $out/bin
     cp bin/growpart $out/bin/growpart
-    sed -i 's|awk|gawk|' $out/bin/growpart
-    sed -i 's|sed|gnused|' $out/bin/growpart
-    ln -s sed $out/bin/gnused
-    wrapProgram $out/bin/growpart --prefix PATH : "${stdenv.lib.makeBinPath [ gnused gawk utillinux ]}:$out/bin"
+    wrapProgram $out/bin/growpart --prefix PATH : "${stdenv.lib.makeBinPath [ gnused gawk utillinux ]}"
   '';
   dontInstall = true;
   dontPatchShebangs = true;


### PR DESCRIPTION

###### Motivation for this change

The substitutions of sed and awk are unnecessary.  The symlink for
gnused is actually broken. This has also been discussed in #23024.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

