### PR TITLE
nixos/cloud-image: add module

### DIFF
--- a/nixos/modules/virtualisation/cloud-image.nix
+++ b/nixos/modules/virtualisation/cloud-image.nix
@@ -1,0 +1,44 @@
+# Usage:
+# $ NIX_PATH=`pwd`:nixos-config=`pwd`/nixpkgs/nixos/modules/virtualisation/cloud-image.nix nix-build '<nixpkgs/nixos>' -A config.system.build.cloudImage
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  system.build.cloudImage = import ../../lib/make-disk-image.nix {
+    inherit pkgs lib config;
+    partitioned = true;
+    diskSize = 1 * 1024;
+    configFile = pkgs.writeText "configuration.nix"
+      ''
+        { config, lib, pkgs, ... }:
+
+        with lib;
+
+        {
+          imports = [ <nixpkgs/nixos/modules/virtualisation/cloud-image.nix> ];
+        }
+      '';
+  };
+
+  imports = [ ../profiles/qemu-guest.nix ];
+
+  fileSystems."/".device = "/dev/disk/by-label/nixos";
+
+  boot = {
+    kernelParams = [ "console=ttyS0" ];
+    loader.grub.device = "/dev/vda";
+    loader.timeout = 0;
+  };
+
+  networking.hostName = mkDefault "";
+
+  services.openssh = {
+    enable = true;
+    permitRootLogin = "without-password";
+    passwordAuthentication = mkDefault false;
+  };
+
+  services.cloud-init.enable = true;
+}


### PR DESCRIPTION
###### Motivation for this change

The module creates an image for an openstack-based cloud using the
cloud-init package.

The image has been tested on an openstack infrastructure.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

