### PR TITLE
ld-wrapper: Fix adding directories to rpath

### DIFF
--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -129,7 +129,7 @@ if [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ]; then
             # copied to $out/lib.  If not, we're screwed.
             continue
         fi
-        for path in "$dir"/lib*.so; do
+        for path in "$dir"/*; do
             file="${path##*/}"
             if [ "${libs[$file]:-}" ]; then
                 libs["$file"]=


### PR DESCRIPTION
This fixes a bug introduced in #27831: `for path in "$dir"/lib*.so` assumed that all libs match `lib*.so`, but 07674788d6932fe702117649b4cd16512d2da8a9 started adding libs that match `*.so` and `*.so.*`.

Reported by @globin at https://github.com/NixOS/nixpkgs/pull/27657#issuecomment-320639867