### PR TITLE
orackejdk: untie from gnome2

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -27,7 +27,8 @@
 , mesa_noglu
 , freetype
 , fontconfig
-, gnome2
+, gtk2
+, pango
 , cairo
 , alsaLib
 , atk
@@ -196,7 +197,7 @@ let result = stdenv.mkDerivation rec {
    * libXt is only needed on amd64
    */
   libraries =
-    [stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt mesa_noglu xorg.libXxf86vm alsaLib fontconfig freetype gnome2.pango gnome2.gtk cairo gdk_pixbuf atk] ++
+    [stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt mesa_noglu xorg.libXxf86vm alsaLib fontconfig freetype pango gtk2 cairo gdk_pixbuf atk] ++
     (if swingSupport then [xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXp xorg.libXt xorg.libXrender stdenv.cc.cc] else []);
 
   rpath = stdenv.lib.strings.makeLibraryPath libraries;


### PR DESCRIPTION
Nothing should change unless you override ```gtk2``` or ```gnome2.gtk``` in overlays so they become different
