### PR TITLE
ghcjs / nodejs: Add back older 6.x node version for GHCJS

### DIFF
--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -1,6 +1,6 @@
-{ bootPkgs }:
+{ bootPkgs, nodejs }:
 
 bootPkgs.callPackage ./base.nix {
-  inherit bootPkgs;
+  inherit bootPkgs nodejs;
   broken = false;
 }

--- a/pkgs/development/compilers/ghcjs/head.nix
+++ b/pkgs/development/compilers/ghcjs/head.nix
@@ -1,9 +1,9 @@
-{ fetchgit, fetchFromGitHub, bootPkgs }:
+{ fetchgit, fetchFromGitHub, bootPkgs, nodejs }:
 
 bootPkgs.callPackage ./base.nix {
   version = "0.2.020170323";
 
-  inherit bootPkgs;
+  inherit bootPkgs nodejs;
 
   ghcjsSrc = fetchFromGitHub {
     # TODO: switch back to the regular ghcjs repo

--- a/pkgs/development/web/nodejs/v6-ghcjs.nix
+++ b/pkgs/development/web/nodejs/v6-ghcjs.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
+, pkgconfig, runCommand, which, libtool, fetchpatch
+, callPackage
+, darwin ? null
+, enableNpm ? true
+}@args:
+
+let
+  nodejs = import ./nodejs.nix args;
+  baseName = if enableNpm then "nodejs" else "nodejs-slim";
+in
+  stdenv.mkDerivation (nodejs // rec {
+    version = "6.9.5";
+    name = "${baseName}-${version}";
+    src = fetchurl {
+      url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
+      sha256 = "1cxnsprv2sy2djskx6yfw14f578s1fwzvmvnw7rh75djajix3znp";
+    };
+  })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2628,6 +2628,12 @@ with pkgs;
     libtool = darwin.cctools;
   };
 
+  # Per https://github.com/ghcjs/ghcjs/issues/588#issuecomment-302891368 ghcjs
+  # is picky about the nodejs version.
+  nodejs-ghcjs = callPackage ../development/web/nodejs/v6-ghcjs.nix {
+    libtool = darwin.cctools;
+  };
+
   nodejs-slim-6_x = callPackage ../development/web/nodejs/v6.nix {
     libtool = darwin.cctools;
     enableNpm = false;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -91,9 +91,11 @@ in rec {
     };
     ghcjs = packages.ghc7103.callPackage ../development/compilers/ghcjs {
       bootPkgs = packages.ghc7103;
+      nodejs = pkgs.nodejs-ghcjs;
     };
     ghcjsHEAD = packages.ghc802.callPackage ../development/compilers/ghcjs/head.nix {
       bootPkgs = packages.ghc802;
+      nodejs = pkgs.nodejs-ghcjs;
     };
     ghcHaLVM240 = callPackage ../development/compilers/halvm/2.4.0.nix rec {
       bootPkgs = packages.ghc802;


### PR DESCRIPTION
###### Motivation for this change

GHCJS seems to rely on it, otherwise the TH evaluator fails with an unexpectedly closed file descriptor. Not sure how unstable has dealt with this.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS -- cached
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

