### PR TITLE
dRonin: init at 26-06-2017

### DIFF
--- a/pkgs/applications/science/robotics/dronin/default.nix
+++ b/pkgs/applications/science/robotics/dronin/default.nix
@@ -1,0 +1,96 @@
+{ stdenv, fetchgit, which, python2, gcc-arm-embedded, git, zip, unzip
+, file, dpkg , fakeroot, breakpad, zlib, libudev, qt58, overrideCC, gcc_multi
+}:
+
+let
+  # The simulator is a 32 bit executable
+  stdenv_multi = overrideCC stdenv gcc_multi;
+
+in
+
+stdenv_multi.mkDerivation rec {
+  name = "dRonin-${version}";
+
+  version = "26-06-2017";
+
+  src = fetchgit {
+    url = "https://github.com/d-ronin/dRonin.git";
+    rev = "595661cb0b3d0bce75828664e3bb84f2445066a6";
+    sha256 = "0fn6jxpp854v7jf55nj3mzz965r8727p1smjkd9gn86sazkdfdhs";
+    leaveDotGit = true;
+  };
+
+  # The build requires the hash of the ancestor for some reason, replace that
+  # with zeros
+  patches = [ ./git-hash.patch ];
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    which
+    python2
+    gcc-arm-embedded
+    git
+    zip
+    unzip
+    file
+    dpkg
+    fakeroot
+  ];
+
+  buildInputs = [
+    breakpad
+    zlib
+    libudev
+  ];
+
+  postPatch = ''
+    # The simulator builds as a 32 bit executable, make the 32 bit library and
+    # header available as $NIX_LDFLAGS contains only 64-bit ones.
+    substituteInPlace flight/PiOS/posix/library.mk --replace '-m32' \
+      '-m32 -L${stdenv_multi.cc.libc.out}/lib/32 -I${stdenv_multi.cc.libc.dev}/include'
+  '';
+
+  preBuild = ''
+    mkdir -p tools
+    ln -s ${gcc-arm-embedded} tools/gcc-arm-none-eabi-5_2-2015q4
+
+    mkdir -p tools/breakpad
+    ln -s ${breakpad} tools/breakpad/20170224
+
+    mkdir -p tools/Qt5.8.0/5.8/gcc_64
+    ln -s ${qt58.full}/lib/qt5/* tools/Qt5.8.0/5.8/gcc_64/
+    ln -s ${qt58.full}/bin tools/Qt5.8.0/5.8/gcc_64/bin
+  '';
+
+  buildPhase = ''
+    export PACKAGE_DIR="$out"
+    runHook preBuild
+
+    # The makefiles seem to be a little broken, and don't specify these
+    # dependencies of package_all_compress correctly, build them explicitly
+    # here
+    make simulation -j $NIX_BUILD_CORES
+    make gcs -j $NIX_BUILD_CORES
+    make package_flight -j $NIX_BUILD_CORES
+
+    make package_all_compress -j $NIX_BUILD_CORES
+  '';
+
+  installPhase = ''
+    cp -r build/package-linux_*-dirty/dronin_linux_*-dirty "$out"
+    cp -r build/package-linux_*-dirty/rules.udev "$out"
+  '';
+
+  meta = {
+    description = "An autopilot/flight controller firmware for controllers in the OpenPilot/Tau Labs family";
+    longDescription = ''
+      dRonin is an autopilot/flight controller firmware for controllers in the OpenPilot/Tau Labs family.
+      It's aimed at a variety of use cases: acro/racing, autonomous flight, and vehicle research.
+    '';
+    homepage = https://dronin.org;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.expipiplus1 ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/science/robotics/dronin/git-hash.patch
+++ b/pkgs/applications/science/robotics/dronin/git-hash.patch
@@ -1,0 +1,15 @@
+diff --git a/make/scripts/version-info.py b/make/scripts/version-info.py
+index eaa60774f..b4465c8bb 100644
+--- a/make/scripts/version-info.py
++++ b/make/scripts/version-info.py
+@@ -462,8 +462,8 @@ string given.
+         ORIGIN = r.origin(),
+         HASH = r.hash(),
+         HASH8 = r.hash(8),
+-        ANCESTOR16 = r.ancestor(16),
+-        ANCESTOR = r.ancestor(),
++        ANCESTOR16 = r.ancestor(16, none = '0' * 16),
++        ANCESTOR = r.ancestor(none = '0' * 40),
+         TAG = r.tag(''),
+         TAG_OR_BRANCH = r.tag(r.branch('unreleased')),
+         TAG_OR_HASH8 = r.tag(r.hash(8, 'untagged')),

--- a/pkgs/development/libraries/qt-5/5.8/default.nix
+++ b/pkgs/development/libraries/qt-5/5.8/default.nix
@@ -70,6 +70,7 @@ let
         inherit developerBuild decryptSslTraffic;
       };
 
+      qtcharts = callPackage ./qtcharts.nix {};
       qtconnectivity = callPackage ./qtconnectivity.nix {};
       qtdeclarative = callPackage ./qtdeclarative {};
       qtdoc = callPackage ./qtdoc.nix {};
@@ -99,10 +100,10 @@ let
 
       env = callPackage ../qt-env.nix {};
       full = env "qt-${qtbase.version}" ([
-        qtconnectivity qtdeclarative qtdoc qtgraphicaleffects
+        qtcharts qtconnectivity qtdeclarative qtdoc qtgraphicaleffects
         qtimageformats qtlocation qtmultimedia qtquickcontrols qtscript
-        qtsensors qtserialport qtsvg qttools qttranslations
-        qtwebsockets qtx11extras qtxmlpatterns
+        qtsensors qtserialport qtsvg qttools qttranslations qtwebsockets
+        qtx11extras qtxmlpatterns
       ] ++ optional (!stdenv.isDarwin) qtwayland
         ++ optional (stdenv.isDarwin) qtmacextras);
 

--- a/pkgs/development/libraries/qt-5/5.8/qtcharts.nix
+++ b/pkgs/development/libraries/qt-5/5.8/qtcharts.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase }:
+
+qtSubmodule {
+  name = "qtcharts";
+  qtInputs = [ qtbase ];
+}

--- a/pkgs/development/tools/build-managers/qbs/default.nix
+++ b/pkgs/development/tools/build-managers/qbs/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, qt5, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "qbs-${version}";
+
+  version = "1.8";
+
+  src = fetchFromGitHub {
+    owner = "qt-labs";
+    repo = "qbs";
+    rev = "fa9c21d6908e0dad805113f570ac883c1dc5067a";
+    sha256 = "1manriz75rav1vldkk829yk1la9md4m872l5ykl9m982i9801d9g";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = with qt5; [
+    qtbase
+    qtscript
+  ];
+
+  installFlags = [ "INSTALL_ROOT=$(out)" ];
+
+  buildPhase = ''
+    # From http://doc.qt.io/qbs/building.html
+    qmake -r qbs.pro
+    make
+  '';
+
+  postInstall = ''
+    mv $out/usr/local/* "$out"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Qbs is a tool that helps simplify the build process for developing projects across multiple platforms";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ expipiplus1 ];
+    inherit version;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9430,6 +9430,8 @@ with pkgs;
 
   re2 = callPackage ../development/libraries/re2 { };
 
+  qbs = callPackage ../development/tools/build-managers/qbs { };
+
   qca2 = callPackage ../development/libraries/qca2 { qt = qt4; };
   qca2-qt5 = callPackage ../development/libraries/qca2 { qt = qt5.qtbase; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15165,6 +15165,8 @@ with pkgs;
 
   qgroundcontrol = libsForQt56.callPackage ../applications/science/robotics/qgroundcontrol { };
 
+  dronin = callPackage ../applications/science/robotics/dronin { };
+
   qjackctl = libsForQt5.callPackage ../applications/audio/qjackctl { };
 
   qmetro = callPackage ../applications/misc/qmetro { };


### PR DESCRIPTION
This requires Qt 5.8 which is no longer present in nixpkgs thus can't be merged
at the moment. It should be a good starting point for packaging dRonin when it
updates to our qt version.

Nix packages in the air!
![Unfortunately this screen appeared after an unexpected midair reboot, oops!](https://gist.githubusercontent.com/expipiplus1/2318dcc27b0fd1ab68d2a1e796d167e8/raw/e7a68bb4bd27f6c351fab621685bdab9d88f47d2/vlcsnap-2017-08-07-23h50m41s647.png)