### PR TITLE
geekbench: init at 4.1.1

### DIFF
--- a/pkgs/tools/misc/geekbench/default.nix
+++ b/pkgs/tools/misc/geekbench/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "geekbench-${version}";
+  version = "4.1.1";
+
+  src = fetchurl {
+    url = "http://cdn.primatelabs.com/Geekbench-${version}-Linux.tar.gz";
+    sha256 = "1n9jyzf0a0w37hb30ip76hz73bvim76jd2fgd6131hh0shp1s4v6";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r dist/Geekbench-${version}-Linux/. $out/bin
+    rm $out/bin/geekbench_x86_32
+
+    for f in geekbench4 geekbench_x86_64 ; do
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) $out/bin/$f
+      wrapProgram $out/bin/$f --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cross-platform benchmark";
+    homepage = http://geekbench.com/;
+    license = licenses.unfree;
+    maintainers = [ maintainers.michalrus ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1031,6 +1031,8 @@ with pkgs;
 
   go-dependency-manager = callPackage ../development/tools/gdm { };
 
+  geekbench = callPackage ../tools/misc/geekbench { };
+
   gencfsm = callPackage ../tools/security/gencfsm { };
 
   genromfs = callPackage ../tools/filesystems/genromfs { };


### PR DESCRIPTION
###### Motivation for this change

It’s a nice (the most popular?) tool to benchmark your hardware across different OSes.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).