### PR TITLE
cc-wrapper: Fix standalone gcc

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -4,108 +4,85 @@
 # that case, it is cheaper/better to not repeat this step and let the forked
 # wrapped binary just inherit the work of the forker's wrapper script.
 
-# Accumulate prefixes for taking in the right input parameters. See setup-hook
+var_templates=(
+    NIX_CC_WRAPPER+START_HOOK
+    NIX_CC_WRAPPER+EXEC_HOOK
+    NIX_LD_WRAPPER+START_HOOK
+    NIX_LD_WRAPPER+EXEC_HOOK
+
+    NIX+CFLAGS_COMPILE
+    NIX+CFLAGS_LINK
+    NIX+CXXSTDLIB_COMPILE
+    NIX+CXXSTDLIB_LINK
+    NIX+GNATFLAGS_COMPILE
+    NIX+IGNORE_LD_THROUGH_GCC
+    NIX+LDFLAGS
+    NIX+LDFLAGS_BEFORE
+    NIX+LDFLAGS_AFTER
+    NIX+LDFLAGS_HARDEN
+
+    NIX+SET_BUILD_ID
+    NIX+DONT_SET_RPATH
+    NIX+ENFORCE_NO_NATIVE
+)
+
+# Accumulate infixes for taking in the right input parameters. See setup-hook
 # for details.
-declare -a role_prefixes=()
-if [[ -n "${NIX_CC_WRAPPER_@infixSalt@_TARGET_BUILD:-}" ]]; then
-    role_prefixes+=(_BUILD)
+declare -a role_infixes=()
+if [ "${NIX_CC_WRAPPER_@infixSalt@_TARGET_BUILD:-}" ]; then
+    role_infixes+=(_BUILD_)
 fi
-if [[ -n "${NIX_CC_WRAPPER_@infixSalt@_TARGET_HOST:-}" ]]; then
-    role_prefixes+=('')
+if [ "${NIX_CC_WRAPPER_@infixSalt@_TARGET_HOST:-}" ]; then
+    role_infixes+=(_)
 fi
-if [[ -n "${NIX_CC_WRAPPER_@infixSalt@_TARGET_TARGET:-}" ]]; then
-    role_prefixes+=(_TARGET)
+if [ "${NIX_CC_WRAPPER_@infixSalt@_TARGET_TARGET:-}" ]; then
+    role_infixes+=(_TARGET_)
 fi
 
-# For each role we serve, we accumulate the input parameters into our own
-# cc-wrapper-derivation-specific environment variables.
-for pre in "${role_prefixes[@]}"; do
-    # We need to mangle names for hygiene, but also take parameters/overrides
-    # from the environment.
-    slurpUnsalted () {
-        case "$1" in
-            CC_WRAPPER_*)
-                local firstPre=NIX_CC_WRAPPER_
-                local varname="${1#CC_WRAPPER_}"
-                ;;
-            LD_WRAPPER_*)
-                local firstPre=NIX_LD_WRAPPER_
-                local varname="${1#LD_WRAPPER_}"
-                ;;
-            *)
-                local firstPre=NIX_
-                local varname="$1"
-                ;;
-        esac
-        local inputVar="${firstPre}${pre}${varname}"
-        local outputVar="${firstPre}@infixSalt@_${varname}"
-        local delimiter=''
-        if [[ -n "${!outputVar:-}" && -n "${!inputVar:-}" ]]; then
-            delimiter=' '
+# We need to mangle names for hygiene, but also take parameters/overrides
+# from the environment.
+for var in "${var_templates[@]}"; do
+    outputVar="${var/+/_@infixSalt@_}"
+    export ${outputVar}+=''
+    # For each role we serve, we accumulate the input parameters into our own
+    # cc-wrapper-derivation-specific environment variables.
+    for infix in "${role_infixes[@]}"; do
+        inputVar="${var/+/${infix}}"
+        if [ -v "$inputVar" ]; then
+            export ${outputVar}+="${!outputVar:+ }${!inputVar}"
         fi
-        # Easiest to just do this to deal with either the input or (old) output.
-        set +u
-        export ${outputVar}+="${delimiter}${!inputVar}"
-        set -u
-    }
-
-    slurpUnsalted CC_WRAPPER_START_HOOK
-    slurpUnsalted CC_WRAPPER_EXEC_HOOK
-    slurpUnsalted LD_WRAPPER_START_HOOK
-    slurpUnsalted LD_WRAPPER_EXEC_HOOK
-
-    slurpUnsalted CFLAGS_COMPILE
-    slurpUnsalted CFLAGS_LINK
-    slurpUnsalted CXXSTDLIB_COMPILE
-    slurpUnsalted CXXSTDLIB_LINK
-    slurpUnsalted GNATFLAGS_COMPILE
-    slurpUnsalted IGNORE_LD_THROUGH_GCC
-    slurpUnsalted LDFLAGS
-    slurpUnsalted LDFLAGS_BEFORE
-    slurpUnsalted LDFLAGS_AFTER
-    slurpUnsalted LDFLAGS_HARDEN
-
-    slurpUnsalted SET_BUILD_ID
-    slurpUnsalted DONT_SET_RPATH
-    slurpUnsalted ENFORCE_NO_NATIVE
+    done
 done
-unset -f slurpUnsalted
 
 # `-B@out@/bin' forces cc to use ld-wrapper.sh when calling ld.
-export NIX_@infixSalt@_CFLAGS_COMPILE="-B@out@/bin/ $NIX_@infixSalt@_CFLAGS_COMPILE"
+NIX_@infixSalt@_CFLAGS_COMPILE="-B@out@/bin/ $NIX_@infixSalt@_CFLAGS_COMPILE"
 
 # Export and assign separately in order that a failing $(..) will fail
 # the script.
 
 if [ -e @out@/nix-support/libc-cflags ]; then
-    export NIX_@infixSalt@_CFLAGS_COMPILE
     NIX_@infixSalt@_CFLAGS_COMPILE="$(< @out@/nix-support/libc-cflags) $NIX_@infixSalt@_CFLAGS_COMPILE"
 fi
 
 if [ -e @out@/nix-support/cc-cflags ]; then
-    export NIX_@infixSalt@_CFLAGS_COMPILE
     NIX_@infixSalt@_CFLAGS_COMPILE="$(< @out@/nix-support/cc-cflags) $NIX_@infixSalt@_CFLAGS_COMPILE"
 fi
 
 if [ -e @out@/nix-support/gnat-cflags ]; then
-    export NIX_@infixSalt@_GNATFLAGS_COMPILE
     NIX_@infixSalt@_GNATFLAGS_COMPILE="$(< @out@/nix-support/gnat-cflags) $NIX_@infixSalt@_GNATFLAGS_COMPILE"
 fi
 
 if [ -e @out@/nix-support/libc-ldflags ]; then
-    export NIX_@infixSalt@_LDFLAGS
     NIX_@infixSalt@_LDFLAGS+=" $(< @out@/nix-support/libc-ldflags)"
 fi
 
 if [ -e @out@/nix-support/cc-ldflags ]; then
-    export NIX_@infixSalt@_LDFLAGS
     NIX_@infixSalt@_LDFLAGS+=" $(< @out@/nix-support/cc-ldflags)"
 fi
 
 if [ -e @out@/nix-support/libc-ldflags-before ]; then
-    export NIX_@infixSalt@_LDFLAGS_BEFORE
     NIX_@infixSalt@_LDFLAGS_BEFORE="$(< @out@/nix-support/libc-ldflags-before) $NIX_@infixSalt@_LDFLAGS_BEFORE"
 fi
 
-# That way forked processes don't againt extend these environment variables
+# That way forked processes will not extend these environment variables again.
 export NIX_CC_WRAPPER_@infixSalt@_FLAGS_SET=1

--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -129,7 +129,7 @@ if [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ]; then
             # copied to $out/lib.  If not, we're screwed.
             continue
         fi
-        for path in "$dir"/lib*.so; do
+        for path in "$dir"/*; do
             file="${path##*/}"
             if [ "${libs[$file]:-}" ]; then
                 libs["$file"]=

--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -23,7 +23,7 @@ source @out@/nix-support/utils.sh
 
 # Optionally filter out paths not refering to the store.
 expandResponseParams "$@"
-if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "$NIX_STORE"
+if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "${NIX_STORE:-}"
         && ( -z "$NIX_@infixSalt@_IGNORE_LD_THROUGH_GCC" || -z "${NIX_@infixSalt@_LDFLAGS_SET:-}" ) ]]; then
     rest=()
     nParams=${#params[@]}
@@ -96,7 +96,7 @@ if [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ] || [ "$NIX_@infixSalt@_SET_BUILD_I
                     -l?*)
                         libs["lib${p:2}.so"]=1
                         ;;
-                    "$NIX_STORE"/*.so | "$NIX_STORE"/*.so.*)
+                    "${NIX_STORE:-}"/*.so | "${NIX_STORE:-}"/*.so.*)
                         # This is a direct reference to a shared library.
                         libDirs+=("${p%/*}")
                         libs["${p##*/}"]=1
@@ -123,7 +123,7 @@ if [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ]; then
         if [[ "$dir" =~ [/.][/.] ]] && dir2=$(readlink -f "$dir"); then
             dir="$dir2"
         fi
-        if [ -n "${rpaths[$dir]:-}" ] || [[ "$dir" != "$NIX_STORE"/* ]]; then
+        if [ -n "${rpaths[$dir]:-}" ] || [[ "$dir" != "${NIX_STORE:-}"/* ]]; then
             # If the path is not in the store, don't add it to the rpath.
             # This typically happens for libraries in /tmp that are later
             # copied to $out/lib.  If not, we're screwed.


### PR DESCRIPTION
This refactors changes to `add-flags.sh` introduced in #27672 to ensure that all salted variables are defined even if the wrapped program is invoked outside nix-build environment to address https://github.com/NixOS/nixpkgs/pull/27672#issuecomment-320763781 .

This pull request incorporates #28012 .

Currently I'm testing if this can build `kdeFrameworks.kidletime` on Linux.