### PR TITLE
higan: 102 -> 103

### DIFF
--- a/pkgs/misc/emulators/higan/default.nix
+++ b/pkgs/misc/emulators/higan/default.nix
@@ -10,12 +10,12 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "higan-${version}";
-  version = "102";
+  version = "103";
   sourceName = "higan_v${version}-source";
 
   src = fetchurl {
     urls = [ "http://download.byuu.org/${sourceName}.7z" ];
-    sha256 = "1wcr2sxk0n4rngnf9g2qcjcv70s8rf5cqj195sav1yjwxkrdrnjj";
+    sha256 = "0xj2k5g1zyl71hk3kwaixk1axbi6s9kqq31c702rl7qkljv6lfp6";
     curlOpts = "--user-agent 'Mozilla/5.0'"; # the good old user-agent trick...
   };
 
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
     make compiler=c++ -C higan
   '';
 
+  # Now the cheats file will be distributed separately
   installPhase = ''
     install -dm 755 $out/bin $out/share/applications $out/share/higan $out/share/pixmaps
     install -m 755 icarus/out/icarus $out/bin/
@@ -42,8 +43,6 @@ stdenv.mkDerivation rec {
     install -m 644 higan/data/higan.desktop $out/share/applications/
     install -m 644 higan/data/higan.png $out/share/pixmaps/higan-icon.png
     install -m 644 higan/resource/logo/higan.png $out/share/pixmaps/higan-logo.png
-    cp --recursive --no-dereference --preserve='links' --no-preserve='ownership' \
-      higan/data/cheats.bml  $out/share/higan/
     cp --recursive --no-dereference --preserve='links' --no-preserve='ownership' \
       higan/systems/* $out/share/higan/
   '';
@@ -57,7 +56,6 @@ stdenv.mkDerivation rec {
     cat <<EOF > $out/bin/higan-init.sh
     #!${stdenv.shell}
 
-    cp --update $out/share/higan/cheats.bml \$HOME/.config/
     cp --recursive --update $out/share/higan/*.sys \$HOME/.local/share/higan/
 
     EOF
@@ -68,7 +66,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "An open-source, cycle-accurate Nintendo multi-system emulator";
     longDescription = ''
-      Higan (formerly bsnes) is a Nintendo multi-system emulator.
+      Higan (formerly bsnes) is a multi-system game console emulator.
       It currently supports the following systems:
         - Nintendo's Famicom, Super Famicom (with subsystems: 
           Super Game Boy, BS-X Satellaview, Sufami Turbo); 


### PR DESCRIPTION
###### Motivation for this change

Update.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

