### PR TITLE
rftg: init at 0.9.4

### DIFF
--- a/pkgs/games/rftg/default.nix
+++ b/pkgs/games/rftg/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, gtk2, pkgconfig }:
+
+stdenv.mkDerivation rec {
+
+  name = "rftg-${version}";
+  version = "0.9.4";
+
+  src = fetchurl {
+    url = "http://keldon.net/rftg/rftg-${version}.tar.bz2";
+    sha256 = "0j2y6ggpwdlvyqhirp010aix2g6aacj3kvggvpwzxhig30x9vgq8";
+  };
+
+  buildInputs = [ gtk2.dev pkgconfig ];
+
+  meta = {
+    homepage = http://keldon.net/rftg/;
+    description = "Implementation of the card game Race for the Galaxy, including an AI";
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.falsifian ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17450,6 +17450,8 @@ with pkgs;
     openglSupport = mesaSupported;
   };
 
+  rftg = callPackage ../games/rftg { };
+
   rigsofrods = callPackage ../games/rigsofrods {
     angelscript = angelscript_2_22;
     mygui = mygui.override {


### PR DESCRIPTION
###### Motivation for this change

Adds an implementation of the commercial card game "Race for the Galaxy".

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

