### PR TITLE
python.pkgs.feedgen: init at 0.5.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -94,6 +94,7 @@
   campadrenalin = "Philip Horger <campadrenalin@gmail.com>";
   canndrew = "Andrew Cann <shum@canndrew.org>";
   carlsverre = "Carl Sverre <accounts@carlsverre.com>";
+  casey = "Casey Rodarmor <casey@rodarmor.net>";
   cdepillabout = "Dennis Gosnell <cdep.illabout@gmail.com>";
   cfouche = "Chaddaï Fouché <chaddai.fouche@gmail.com>";
   changlinli = "Changlin Li <mail@changlinli.com>";

--- a/pkgs/development/python-modules/feedgen/default.nix
+++ b/pkgs/development/python-modules/feedgen/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, fetchurl, dateutil, lxml }:
+
+buildPythonPackage rec {
+  pname = "feedgen";
+  version = "0.5.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3a344b5e3662e9012d095a081a7f216f188dccf3a8f44ad7882960fef05e6787";
+  };
+
+  propagatedBuildInputs = [ dateutil lxml ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Python module to generate ATOM feeds, RSS feeds and Podcasts.";
+    downloadPage = https://github.com/lkiesow/python-feedgen/releases;
+    homepage = https://github.com/lkiesow/python-feedgen;
+    license = with licenses; [ bsd2 lgpl3 ];
+    maintainers = with maintainers; [ casey ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9795,6 +9795,8 @@ in {
     };
   };
 
+  feedgen = callPackage ../development/python-modules/feedgen { };
+
   feedgenerator = callPackage ../development/python-modules/feedgenerator {
     inherit (pkgs) glibcLocales;
   };


### PR DESCRIPTION
###### Motivation for this change

Needed the feedgen package for development. First nixpkg, so I'm sure I messed something up.

###### Things done

Added the python feedgen. Used name `feedgen` since that's what it's called on pypi.

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [N/A] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [N/A] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).