### PR TITLE
pkgs/haskellPackages: add nativeBuildInputs to shell env

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -349,7 +349,7 @@ stdenv.mkDerivation ({
 
     env = stdenv.mkDerivation {
       name = "interactive-${pname}-${version}-environment";
-      nativeBuildInputs = [ ghcEnv systemBuildInputs ]
+      nativeBuildInputs = [ ghcEnv systemBuildInputs nativeBuildInputs ]
         ++ optional isGhcjs ghc."socket.io"; # for ghcjsi
       LANG = "en_US.UTF-8";
       LOCALE_ARCHIVE = optionalString stdenv.isLinux "${glibcLocales}/lib/locale/locale-archive";


### PR DESCRIPTION
When in an env, the user normally wants to do a manual (incremental) build,
build tools are needed.