### PR TITLE
 firefox: 54.0.1 -> 55.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,945 +1,955 @@
 {
-  version = "54.0.1";
+  version = "55.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ach/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ach/firefox-55.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "60057e48d8bda98dc63597aa795899ca1fa856f8a9f9380a8de91d0ca0641dd291a3fb27bd1f69b1effebc5288575c0a0661199e8e8e95ef8d924fad25831678";
+      sha512 = "0ce9a2852a86553f96018e8873e966996f5386204065200f0b24dd0b939aa815efda0fde06133974d79ae4f944c5a77ef4d91929baddc6d72a5a457203ef7784";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/af/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/af/firefox-55.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "08a2cb7ee7bfdd4a5c205a38e1d966bbf8c67a3a5abf52bdfc73dcb527cf0dbe361bec4996d52e33321180f5c1778e8304f1b377bce04e62fca7457df8ee69b5";
+      sha512 = "97c01c8794e2ffe0cc25e6352ba4c6155ea1e1dfc8bcec669036ffda1aec943326ac38c43eb8260a55d46a264858144bdf0cceb9912c4f2d0d373d4d0d4256b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/an/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/an/firefox-55.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "200f10de4f714afb10a9c6d1b4ac8488d5bdc18673b8db9aae51b8d0e8b14fc3f5f6211447abd10e13704b07499fc1a273d9ee060329d8337cc413d7ed6d19b3";
+      sha512 = "f30070803ac80d00e4fb248f0c1e871b51bb4c78f8c3b12923d6b96c9686ea22768aeb9204da880647893524aa68e44576be4092d44a6b189b5cf01f493f9c82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ar/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ar/firefox-55.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "564c72c485c593342c7056bec7dfa7a0cafbfb26eff278e08b0938194b311633b3e3275fd0eeaabc63eace36712efb194ecb700f61957bf0553b79a71977132f";
+      sha512 = "213d73338a3087f925a5137432e84f1c0f881d37c33c109d9ab6e2744556341697e56c7efcd7f4d5011cdb6fec03de072afbf14c34a30770456f71c8971d4b6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/as/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/as/firefox-55.0.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "84d14f6152bbc17caaf4ac8d421835032da45dfbb34dd198ea5ec65d972e10a774aeba830eba5256933f3df395b5aef71aede2e334fb35aee8f9f27771d65dce";
+      sha512 = "1d33b5602db1a326be0ac9ed726e38b5e871904685e6586211caf6b330417d33c717399663d94d725d4f8784591c5b7eaf4b4ecb867b8d99e2c85671b31f5877";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ast/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ast/firefox-55.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "f5851e28972b5e87b48e8498a01c685790e4ace5e3d0f4c286953d6fe417495a9fb26ca3bd962d1f798a178115d2bb60367c48057c55b2e601dcf208ad146cb4";
+      sha512 = "93a08c86dac4a81fee72cd4c35f39f578222ef11e28e503851c9a7ad7cffec3e3324c32374ed851094b8ae91c642a2d726b98cade60fb4511a935320ba790faa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/az/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/az/firefox-55.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "6ed4bb73da6362ed4598d5c6de8b072e919894778ecdec49b2e8e406d0c68b88c32f0b208a546834cba7ebbbee9a09595a67473e29a5c11bc2390d3a1721aa42";
+      sha512 = "4661628ea83c2101481bf08c1484952a30c27b9cd1d169bacd96fb6416ef77321e7e606e989521189c5135c63b2b82b7fbd3e85d0f50919f6c9c277176aa34df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/bg/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/be/firefox-55.0.tar.bz2";
+      locale = "be";
+      arch = "linux-x86_64";
+      sha512 = "7062919a385600ed74972b1851ab7bd20a46003c37e058b93cf8fdb853ebb890b173aa6cc572d2f51661b571d3efbc189d04abff4dbbd9e93398ad5a55015e7f";
+    }
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/bg/firefox-55.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "bbcd618c9bf86c7ee49a3ee1a3aa799c72ffb048d694ba0e97ca8c4a9341d1ee109265529aeb23f578aaf66d34ef3a81a7031033421933c0f6d5d0ce136c3d68";
+      sha512 = "d58389193c33aa24aac09ad286b83f0f808116f20907506d2d37a3cc45ae43223784fc12face495cbba34be24358584e38add83048b477a27a93f8934c86c82e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/bn-BD/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/bn-BD/firefox-55.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "9c3114291cac3b6df9bb92b398ed644f4851baaf99b6db9959e5fa841dd535da39cd3aae343226ae5fd713ab872efb4d4902f4a4f85e836372c67a416134c03c";
+      sha512 = "9d552eec9497565bcd71faba474338e97465d1902280972a04f4f7e5fae88cdeac144b12fd1bc80d079b8c16b0c7e5a4dd5da6e56486e688820653cff35ae517";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/bn-IN/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/bn-IN/firefox-55.0.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "5662dc48972153cc67034b148d96e120c802ade4d7ef532fb2964f8ffcbec30878489c81d758e729135488d39123bd404ab53e1ae1389b0c4e22303096c7e3cb";
+      sha512 = "4f150944cc42c829fc619e3a20fbca9f5116180b5c2e160d48c8b9f42325898847abbc0bb0724343527e97cbb74b7286dd8b7901c0ee9ce83559198994486505";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/br/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/br/firefox-55.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "166dca485d947bb42b1b5ac9781d48104d876f952cd8ceb4006f7e0f79773aa2f285413088cc535610e6209538c03bbeb63f91255712466a50a12cddf747f0bd";
+      sha512 = "18f0d851b249c7bb8979499b146756efbad587ce48ded72a58bbfa2dd1fe951d5ee6d1188f6e659c760aa4e60095b481921feb016e69f78e439de18f7ecc0bcf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/bs/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/bs/firefox-55.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "81226d4550310d61d2198298bbc859406ee7f14e98ccab326b83bd51c8c33305771e9353d0609477eb381083f1e0f1a8bc0c0bbd085a738cfe00697877051516";
+      sha512 = "b0b838026b932d558ff3af52bca708e3f60929c2928c17c956b1d4f2e023edd45d98d65b7ea268c2ae04299944d26cf19d9a9deecabfe447c8548cd8afe98b28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ca/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ca/firefox-55.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "833096d35ca517d21b45e78d895bd4f535a55fff7a9990e22c684fba8549d2207317a715e2a42b7ecebf1ab474df262f2c25c9e44863cf167dad70f191ad39c5";
+      sha512 = "fd700550d5983f53d80330d08754c84e7683f965316f738e9ca5d45176d7fd42ec57a02aaef3e82358d8c7913cce9284e04299d32cac443063184c41e5c7b0a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/cak/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/cak/firefox-55.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "5b05bf2b0a256e135e7d687520b901caaedd66593ca3cb458c01f8ddf85149144f75c24f8b0fd4bbe2d9cbeafedbb569f080970601c40895db96e7a14aa3c5d4";
+      sha512 = "4cfc69ef47fee1a8a2127be92cef59d2dfb40c99ac172eb78de978e7cd7aced093a7c1da91fdf518a0c9b23a81f393919c44c353b52fcb71b53b41ffe88fa22f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/cs/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/cs/firefox-55.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "63ea3c524c3e91504fe1b0d5cd1b74fbfe9b22cbfb18d9aec73569452a2766b90f29e2793f6bd235d68854d16b8862f46bf3ead132cd693866bd70502e0b8b39";
+      sha512 = "33c912c591e8856bad1130281db996c82df28fff10d7f7031ababeb7acd385df6ef14165c491b48edd285cd8086071dbf41e3448431f028364d62810b3fe4a34";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/cy/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/cy/firefox-55.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "c804908472ab1a59b6a24e448b9bf37ded669dbf2d0a4fe0993ff2dba666e804b0fb846efe6c7f1923e4472a3735f9f33876dc015826b03790f4c445ab6215e5";
+      sha512 = "5cdc13b0317d7b0998c534a92e094374ffedea9f430e0f27c97b972985ca050abb7ddecff60f87ccc0d6c240db453b335fba12eec3e8448f0f830b402dfa6171";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/da/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/da/firefox-55.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "c289354eb5443b9f5e3027e80974af9aa9a5da045034ee147cf75d52de16a1e35328027fdcde149f2ef1d3a72213e3837668fdab4b610949b36e180aaa1dac56";
+      sha512 = "c0cfc7e4a398d5004c1a3f1afb3ee5c32502e7929cd7ff7cbdced2f9104452a6754db8c22764cdaa90885698cdf40379016f866595f98adf1498f48576a1fc86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/de/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/de/firefox-55.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "99f214b83822243530a8194edbf50284bb703ba07695c1c5f7bd3cfe87fce64477806cbff852af92ad6eef16c85329c1b04608490fda12bac27300daef23778a";
+      sha512 = "544e6069c5f2c92b80f804d105d4a198ca360415701d9a9ebb08044cd877a2e0793b03381bdab55e31649b021a1343647ae8f21844915096347fdc2e8280ed45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/dsb/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/dsb/firefox-55.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "96682d6d27e4d2c57930059a6cabe2649d4a52e006eddcfd4f940ed816f448e3d476488ab23de6a1106c66007268aaaea21ce3f621ce7e21aabca1ec00a5f0bd";
+      sha512 = "53e7bbac4a479e06a14dc91313b66f28c5731b88faea2254c0e72e40ef4eb772c61bf494557474f03e1b52d3d85f8cfd2785085b4d7324907107080342899a56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/el/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/el/firefox-55.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "122c72046a3cc621da62432fbaea9ef690a5e1930e8ca3214333fd05cc397419eeb8e7f46e7998fd12f2fa17fa780d7a0df0cebd50ab81a677a363855f4dd818";
+      sha512 = "304085e04c30b73476ffc84da692d9e08c3edfebb31e7e9777afa7a1e12ee0d15c5d9bc4124edade6701833de02813c0549d8a731a58e824b00e483f4965f49c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/en-GB/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/en-GB/firefox-55.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "bfcde5aefcfbbf6021f6c3085f27a5c9b88cb11b33a132d0a05c6b6f39a32aae8e140b3e73d2e09d6719d00fbb9c9998a27cd6897bb7e2e5c01f37190522320f";
+      sha512 = "237cc95b7c83b2e76627fcd2f417d21868d62398dd5477bcb9355bc0c73f53e9e595e95bf9de0597c15f7eec836aa9e3f9b1fab29309599cd4ec1c7b69b938d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/en-US/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/en-US/firefox-55.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "59416ec212626d225db0f12037eb68c98f564252c5f62743ec884af259d705a9310d9758bfd37bfb33c792eebb37d07824a197aff1261aa0496896482f6539cb";
+      sha512 = "1d86223b3f56266eb83307e92c4d39c0d765b94015b089bef8eec5730e0a8e4aeb7cd06e4cbd43b445ac4d24cccabebfae02f003b791d1be03dbec3c9a46c9ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/en-ZA/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/en-ZA/firefox-55.0.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "a03e96de441a3f390c96b1bf2484dde6d423fe1f0b9d7e518d8d6d99a6e61d6e44dca2cdd212a74f935c8e94aee00c3bd48b7fba9624ff17cfbcceea70802637";
+      sha512 = "8411248503638d44933c38bc105874befc160e90f2323764c7bc02667c634456c7c79cc8a7931e10ccdbaf4e20e3b2d5098b9b87ec63f75ffa56b6c62aa5b746";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/eo/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/eo/firefox-55.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "e54744f4d412f2db9f78f518479cd457953f9a29c6ce0fd32aead8c04951337b72c6fb149c0d90ec3dd1e93bb6dbfff57d46c29dd526e1b9c406a3018677a65e";
+      sha512 = "fe376d69e5a8100e3ae70036d875019b04ff2c8d62d7caf32adf528fa90f78a0d16c986b7077c61c38be5331f3413777028a853681b090d42bb3e09475a5b5ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/es-AR/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/es-AR/firefox-55.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "d9d3cdd8c38605f0738ff95f5f2cd2188f1058709fc63f21d06c14f6e593150918b793c8f3c291c8d208afb398efbfc7ffc2509f5f47091abcb804fc7b47df5d";
+      sha512 = "7ee72d922075b528dbef56bcf784690bb54582094a113c9ff0dec0f8ef64ec214f2ee16e930f8ba7963c4bffb4a8d5fd23e5cd76ad8557d70b1632a6124ca6f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/es-CL/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/es-CL/firefox-55.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "ceaa8bc10238996fdbc0552e4eda3edbfbb5e89b70166393e638cf4267d8077df0179213e1e692cb5798e6fb77f590f151535d2e40b4c278cccee9df8a776057";
+      sha512 = "d03c2d4fb96b2d64c263fea62ac3cd643648baeadc4091238fff87cbc2fc37cad3069e1e4fe949a4ff7162fedc85dfaeafe49326aa5de780c96a0160e91ee9f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/es-ES/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/es-ES/firefox-55.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "a75745381f0ff97fb298923a6c2c83a734ae1ab7b873e22e9d840cd5854ab8af01269214b844d0fbe1cb1ae4cd083c2c4e02779088280e82310535d9359a83de";
+      sha512 = "6893e72c09cea00bf2b7e05f0e170e97967868675d8d9752c18bae61a5f147b60db5ef165138a3355b0221515838d526b14f09cc1f99ee893b7c9cfc618ddfe0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/es-MX/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/es-MX/firefox-55.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "381ae266297cfc6fd0d05785b2a6c945da20d368754521cf358ae4c4e7dda3a473086bf9a2679716f2b15b01413574ed413fd7f610a795a3536baadaabc926d4";
+      sha512 = "ba8469977b4f61df8165b09d333fa6ffb718d7e3710f62a459bd0da3a80a63b947ef1cac26704b5c4e9f4eb2380b2047e500fae372a82808cc7e5fa4ab9b0e62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/et/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/et/firefox-55.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "7c0151ada40b55e96ea2c36a98ef6de954287e2ee808e0387080816fec1329313e0e8ae5b613300c806c17f6b31752443e7f1f4ca6782b96826af23d3173abe7";
+      sha512 = "07f6ac8fab7a73fde5c607b31be1630fc2c01778808259f0f1472ad3bde56dfcdbaa584de0f9fe1fba6a540fbea6709d124daf64bdd89f755ae98884c971cfc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/eu/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/eu/firefox-55.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "a080119cbd5c60499c7e9fcd55275f37d771ac4a352ef48088352b59bf86858b3cf70a5f6ef5b1b0e9e90ad9058e548393e9739cbfadbce1eaa95b39240c0a76";
+      sha512 = "4f26a97eef55cb6cb4b236fb69dab897b9263ace1de3ac9fca099118b7f96db41e5b8f1dc371e636715ab2aa078d2e5e76c88fb907234d7a206e8a96f8dc9a21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/fa/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/fa/firefox-55.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "aa537898df126eb699dd91146e579afceaa9283c15d7b4d436f2078363a7b9b7dd63e0278d197d8efe004ea81fb0401653395f8d7550da884d0af80c32baa981";
+      sha512 = "86a1accb6903fc0f2cf49cc86920e5e4b4a20a610c6a212864ae83e2bece1d818be515fcf9823bcb1c31ae748776514ce54fe6a1a57c728d1745d67c45856a66";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ff/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ff/firefox-55.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "2998dcbead43b03d7e1b2cb9e6318aef185425de3401f89c875736fb124af2d126d482bdabb81535e5b5a46d68213574515d55410a6c6d9a60fe71afff64efe3";
+      sha512 = "b33df9a1488989cefb5bc849d44c5194c25874c679e48634673ccf8cd32cee3274b6417de6b58bdc45a68c58adbeb3e0fe36dffd9b0526b9c79a902cb7b5077c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/fi/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/fi/firefox-55.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "9ab8eeceb5f22e138550ef149cbd8c46e0c09bbf32e07ebc0b5abd3e5a460bf5f58608fa8e92401f68e915de7e83bfc592b5e3680f779a5b514fe4c71be56cfb";
+      sha512 = "c03b784f3d13078fdc760f07f5bdc2352e5e3ea2d8d49931f6ca6a9ce91b787d85624cb1f2d6bcb624cab6a3c018669c1f47443e2a32fc0472d2139623275885";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/fr/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/fr/firefox-55.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "bddc6e30f0d210009aa5d2d76ea15d9dd429c1b027f1d6104a51a69f364c8d9e985c33816daacaf2712c34c6743ea14197ea28934eb37340ccda21e2c3bfcf4f";
+      sha512 = "d9f0baca6f54ec4bd60c33ec87bc7bb307054c5214182ba7c14ddbfba6748e77f87914b6373d288f8514361dc2627ca75cba9bb97038f183787dca07ecc629a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/fy-NL/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/fy-NL/firefox-55.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "9fbc84c8aa485f55319138518eba1bd020870193432cafd0ed01e08663298ec29b21a571b808fcb90d73ed052554defb11796d1fb1dec016472ebb79afd78e17";
+      sha512 = "8452dfef5134afe2184cb8d2589d95fc75bb9bd487a2451fbbcb873f72b3612f7eb552772e4b9957060d506274d2655505838628d468efcc1b534697734466d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ga-IE/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ga-IE/firefox-55.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "4188f5c0eb666cccccb3e343cd3e4921bb168107e63727d67aa040b002f544724fba25a17d787cf8e1377f5947ba8fc124512e651ef3acf8157c072f5f02a4fa";
+      sha512 = "ca465448eb5ca014579e73c5e9aa09129f7ac3725f90e6ba8bc96f67ee74e5bf916050d968ed91d52b60cd8f291f5553bd66ab4373af6537c43fce4e8a526c5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/gd/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/gd/firefox-55.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "2e3407d0d1c22f4b451b1c56a871f94deee43d0d4aed22ad90dd0643dd75b7d512c58a6245b51dde6a19330ee154304e6b577b82f01869d222bf89fb8cd6b9b2";
+      sha512 = "c79b3c9c3970cc3eb8d0de8004479e1d6832d8b1c40640112e508ddc3db36a318f620c519a11914d5a103e01d8227016e4a57c41474aae346af15cdd5d5754e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/gl/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/gl/firefox-55.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "5fc10425d2f8bb1d53d2e5f9b9d65f0ffb01609c018a06b850195f01f8feb200e15ac36fb2e03031bc776453220fd2af200ce26a21c9a30eb4b4f54caaa6de34";
+      sha512 = "ed98aef69f2aa9de72508e6860935b4465777cf26252c4a4233a4809e1e5f91e44d737bfa13d2705bae2e0c250cd9b4a92711cb022d84c109dbcf61a47286a85";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/gn/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/gn/firefox-55.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "92f46e7931cbc8a7d4786800838fa9f4af9baae2d8a4aecef82034a9875b8f16fc813781146dabd7c31ea1e0a3505bf3b2040ed305bee17a3dac9a00eb3560ff";
+      sha512 = "0c6eb876fa8ab4c0896d96cf87e52eb43f0ded62c93770ad3f59ed7c2e81bb7a231d4d698e83aead3f557e7c3443cb105860b2f98998804ae14e49c3ab3bafc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/gu-IN/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/gu-IN/firefox-55.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "e1e41c981d4f690c0b239917e06b1405a796e43d5ea419287cd353ee2bb0f8bbe04f0f7c94ea4b3a600e362577dfeefb12f286c311becbaef1ff840b20fd766b";
+      sha512 = "3a57b1adba2f9fe33f91ac645665ab8301b1adc5a22f2f1a04d1a3c3947c25499b9d14a3e00b8f147ecc2664a3ef5ee1c4f5b397283c5fad454dcde94c261932";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/he/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/he/firefox-55.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "11545bc832cec83171a00c7500a220fb64815e514cce017fb6e60e549e43472aff8914e19818401aca20730fd8d063a05051fd53ecaffc790b982ac9bd63463e";
+      sha512 = "46002542fa8baec217d26a1b246e2e2403cbe3af1a471da0fcb936c67e63bdf547577bb9655d1df414bfba8a16d2abd29954697dc967328f77678d08196ead3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/hi-IN/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/hi-IN/firefox-55.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "63507d0994eb52893daedfa3fadcdc9ae1ca27608149d51132fda86616a45aaf4d114936fb6305ce12d75a9aa5ee5779db6def3866a8037c18e055734b0ddda6";
+      sha512 = "c905d2044a685dda24288c3729261f58e1d896c71a8d437471dca5457676e9a77d2a112252f2482ffd744c08f6c8090541c53f8c27f85a609557603ddd114025";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/hr/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/hr/firefox-55.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "8274ba4fd8bb881bbb788cd402a3fa49cdbec8d777e003c63dd425ba8693fd8e26a88533dc7c839f0bfbc47d16a72105e4099e67c0473e6b8c6aa29ce75a6b83";
+      sha512 = "f4a0084786f61e6586f0cf4f534c4402b66c82654d95db92fadadeb743766a976a4c349097633a536aad8f5dafb25127c4366ed002cdcf93f0a963ed431d827b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/hsb/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/hsb/firefox-55.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "c956043fdde6ff492a687447c01ab15e874756d6c249c7751d4255f99ad60b21bb898c1472eaea73c91a1467e6a6b239ff60a36333da1fee21bb3dc5d2da1a37";
+      sha512 = "d1366512fbb61a283f363a29ebf8e8570844ebe29bc0068a68837261181f44aca5e8fb5c3ade82d930b624e1ae7dc2cf30a0e6e0d830a60c529f6fa9d2bae1b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/hu/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/hu/firefox-55.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "28efaf842c1afd6ccd7882dd257ee9234015e641091c39c1b954d458a543fd9e0d6ac472d23953948fca69f5a62583b5120093f7186d1cc36a345adb166b4d17";
+      sha512 = "d76a3a892c22efa04e84ae9c66ee76494709b1185f8d1033fc3bffbe67e433607edd152277218501ca94d5cfc88f8e9de356176c7ac2204ceab18eddf51cac75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/hy-AM/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/hy-AM/firefox-55.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "2aba8bced1431caee4d9d70d515027e3d08a7175b1d28b9f743e63d25983a52a8934e7e3155a5b220d0cbfdd61c76438bde56ed2c29ff2eaa46afcef6db75117";
+      sha512 = "f771b69e18434a8f9a5fe5e381702e078e37c87c4bc1cc4e0fa30be0c46f3eaf36462e6d4dfc1e12d5896ac6a5597f5987477fb8aaa5a5a5f0648c92d159cbe8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/id/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/id/firefox-55.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "e2925f40f632aa14ba25bc40246a9c06b833062bf30d5e9666c87c22db436229f2b36730f6330a77fad58ec05a1589efd8353c2000cae45c7b322b32d1823559";
+      sha512 = "6fb40ff190d292d18da43a769aa679da1ed6510f185023ba08e749af46b4b0fecb3d305d9dface2ea1c2096bd8176add235daebcfde6bfae767407d57e040ba5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/is/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/is/firefox-55.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "0e56ab6054de54804a1f094f81c9180c58116e6786de47306f000e69f656e039aacd447d74f2119836c0f4d4d65e6841f94e527f8524ab7529461ab35b0e55c5";
+      sha512 = "47f51627d21b803477b237b8f3599cb02efe107687fc25ca14c82a7d1413a0b49f3f47cadd42a937e10142ec0db6e538f2fd17ec1fabbb868e0db45011ce1365";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/it/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/it/firefox-55.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "449bdbc26af56503bc1a480baa7a98d4de9f745e85c443d2d0726bed16a676f4ba8bcf738c94aab42d4e79c96f1dc9de7b1117d72a953bafa9bb24f87fcef25c";
+      sha512 = "5707b17aac678c28ebfef28b062799f4683c2f2192de7b305b8699ed788de54aead0012c1a41c999a2270a30e368dbf25d53bc887f5249279220ffcff143dab4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ja/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ja/firefox-55.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "47b417a6683be3329218c0b0894086acf588eb15a979e65f7102540d51e59b744878d2b5802036f5bc4534f8b253e26b6a947fa49a18e6f659122f2f193e18e4";
+      sha512 = "9290d777a33e434c587c19b5193a32c2130662c0c74917dc1c298b0f906aa3ccfd8631dfc3c396ec771efbddb254fe603ea9adf42524e72c9b607a7eaa81485f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ka/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ka/firefox-55.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "4796dacf4b8d180e0995b1b743d8d076d68c23031407f8d475107bc79c7773734e80c37d870c38f60de4115873fb872bbcf7e7862526aa5101c3b1a6d8e720f2";
+      sha512 = "4ffddb53f2f9ed891aa75ff92dee070fbed1570585bdd8d1517af6cb604fef9ef98e4efa0ff5672a911e2934e91b8e74ef808826b6f4a7c08ffba45bc1e2df1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/kab/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/kab/firefox-55.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "674b955f5f474c2d76efae044d1ff95069315447d370cad182e09b0a2b5360efaa1eeeb33e59adfc7754619538ec6acac661f61c805e04b94c5092999f68edd9";
+      sha512 = "6cf1f5f445a99a90bb509e9f962f63c3674d1f621c469b354044f2ecf30f756599d1c920b34e4665412694da7d6f85729608522b5f7e6c3c0b02ae23b0b12fc9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/kk/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/kk/firefox-55.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "a647e65b76c203a42a8edd47c67b849877f2ea4cee467ee3203554cf02de5787b72cc245e4f83ba0bc8011b26bfc6991326c2593973b746cdb69762e35fcd5da";
+      sha512 = "0b5810e34c15a1152524e4a437399e627edce29bf9edad54cb4731f23ff3fe06fa94fd750f35398ee2577dbb0abf94d9f965c90520e1cc24bfcb97aa5bc2696d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/km/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/km/firefox-55.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "c644399b50b16ecc3b021fcd8325a18f7fe293155187d59ed99768756f9e493c51e54e5b77ab38485f4479b09af396355340ebb2e597cda9d9780532b7a5ebd4";
+      sha512 = "86ffecf5a046d4084bb991e527e3fa009dc4a228f4f9595fa594967652fa926ac3c126b9848002b856b9c7a0295d757311b4475a88f42f6e9087df6dd29886cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/kn/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/kn/firefox-55.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "7991b8118e773c1adc0473ed2b08ae50fcac57c9ca3b5bee67779f64c8034bca64500db90efa052547a05866d5f5f6f5156db18d3ee84a54cf8562187bb3fbc0";
+      sha512 = "ada203b9d3edcb87fa87f421509738dd023c0be9444ecdb411c66d6f3dce567a1720b1bf013fbaa259628b399f117e20d365ab6d2e5a2b02d1ac93d7b857a0e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ko/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ko/firefox-55.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "98bc9ef98c94c9e4c7746fcbb8f45c5e24bd01280c2573e2a0019ccbfcadb4689b93c183abd8afdecd97f490342295c278282beb0b2d3fb2bc14d988fc5048a1";
+      sha512 = "ea8aef83aab3b5f8c6d1add9c7be91f883253c2042312daedccace4254e64cc352f45b1ff0b18c1f20fcce852bf3a203e579660acd9c15f90a27b6002670c626";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/lij/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/lij/firefox-55.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "f7e82f1ea02935eabf2b9f525f89d14bace88069bc5f3572202c2795cfda4bff25d2edc89c31ae0edce7d16ec127941a64f362f8899bbabadd5a7d871447bd47";
+      sha512 = "43a44b2f0c0626399593b386c8ecd278248bf63ce2646dcb1a2bd28c3da32d99bb7fecfddf42097f7f89966bbbc78094f04b0ce2771f2319f83d19f1e0aa6e44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/lt/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/lt/firefox-55.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "8b19b7e8134772186a14f0880f96f4af407dd6c081f9995d032c66cf1c9776529b5d5a08cd3a0f2a42f63cedb5b2ef94da0414fd194c19d6976f3ac4e22d0470";
+      sha512 = "959869c39df29073c5a10ea314884d474b77c0c40832651083932785db629b0dc7dec8554da33306bd8db588c1a54cd042443970fa7c8aef26ef7f218ec49719";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/lv/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/lv/firefox-55.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "3e4f978cb253014cf3a46747c11606a2be484f5e4866ce26a979329a4c5f9256135d40e0596d1a9c23bd6fe51a27019d23599a8535c71a1e0ec3e9a26eee95e8";
+      sha512 = "594a01d1b5dfc77082696b754065e4b6b5543ed5e4d356dd38255d323b8c1803447734ea631b5d5e5a9b4f8611167c3bd6527e076d546731f9a8b406c8afbc23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/mai/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/mai/firefox-55.0.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "9a1205743ad46b39e6e05860d6152004fe6c5995d2817416020574b706ce194ff44414c7e5ea5c3c2b39f62fcc6d17b2bd2f85b249aea9803b1a1722b9d91c2f";
+      sha512 = "90d6997dc57a5986d62760d6d163c0a56460959964f0c2e9acda5570cb768e95be04b5b8648437df9845169262954d2b411656d3a054e2fec408f71453928c21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/mk/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/mk/firefox-55.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "96bae83111abc01ac9a20a1f55a990f3c856fdc5f4302215e861457e737e2ba5de40af76a2024fa6878c129a3864b0c689fbdf5e6c2c67c0a1e06fb594997f96";
+      sha512 = "06c3a0a722059ef6db6cdd5cb38875c1916dfa2a8bf7c27b0eca2e9ae893348cd935f208dc1e09c7760dfe3dd63428e83b1f8b2a364394507188cdc4eb86763d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ml/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ml/firefox-55.0.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "b55f6b4eae279811e461a84cbd32c78827090f8950af4327c0fa31056c04b7105757f6cbd70034c6c12887a0e60a326ae6635179c289ee0890446dd8404136a1";
+      sha512 = "8d51b7daa4fc768752dc9a48ca9c38c62e0dd35925518ac4f4d80ff6178789205a7c2c8935b5336751106d8504900bfcd2af8aff2f977c7b35d1295071581c87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/mr/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/mr/firefox-55.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "3b3f98606d66e68a4d45f5029eae89d7a1e838c6f0bfdef5a551d11b9fc28c64455b28d742705bdce8748844cb869fab21c5b2164bd441a78998bdd1efe9d6fb";
+      sha512 = "f9aec2aa02c336c8699b4420abe7e7a94e0d376529275e24a57e8158c99e472e3fb78d757782ab9510abe6e0272a66865e7e84ab599e3d5477c2af91f079bb0f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ms/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ms/firefox-55.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "6619ffd4aa274511a7b10c6c3d869045f1b394b286001cad53f3f8f7fbf797a1d0d3e1c099e9cd95edf678c4e2f49251a5eecb94b6c0821d84ba075f04d1574b";
+      sha512 = "3e6879f56f8e4b85c306c73a5c59ef463ed287793ff2bca0834b2640070eff9417d4c59bdad4963229d3c3e38fde67386531ac69abcd3164adfabc668d68003b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/my/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/my/firefox-55.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "ee500522c7fcbf4b8e9b86162c869c6238978b0b9e68b3588d79f1030f304c5d56a37db0775b9aa5edc40e1571d10245ee805bb8a90fff2dab436742676dd4f9";
+      sha512 = "64c34b420d5e9e0cee53486947dd634ef015a2c043601e3ff040b08a840375755390ed6b2898e8024f9c6a87e367d7dadfe04f26bb6c500c391056100eb01fc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/nb-NO/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/nb-NO/firefox-55.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "780dcdee5c19295e367d659820e59a9f60fc712c00214f9d8caa64647cf399411cb74460b88ac521a1c23738357770cad1def1c1bf840a3676db5819272ed8c9";
+      sha512 = "17e1ea276a3000105018046f53752c0b4498d701844aa29ad7cfe5857ada0c3ecfe29f9bc11bf09801db35b0c58be030069229096e01eddbc702e6f8917b5167";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/nl/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/nl/firefox-55.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "487685f711257e285bf1f8a508d4167e6bdfd081ea30f560a5700b9ca487e110463ae6d8d607cfdff9349d7c1f2dd3c8e57e8fb30b49200e17754a596d2716f3";
+      sha512 = "70fe41e9c3f6bb8d5fc3be480a469bde02197036c763839021ff38c25050be3a4b0f15f71b16ddd4c0827fbc635be81751e1d679e6445f509b2b8cc30d70a5a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/nn-NO/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/nn-NO/firefox-55.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "5db13d9e1db3331943c19be06849dee993726e99e519e1c03f8e3db9e44f9a4d2d8ef7c82e77c814654e66991352c94979754ef4f8b18295fe9c4ef0bf965bbd";
+      sha512 = "803390f1850a286531046e3d3d9499050680f8ec8d8f727f0755b69af833fef7aa1bc841566809d38dfdbff0433b20853e4cd64ff0648789279b1cf9181e64fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/or/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/or/firefox-55.0.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "98c90abd9abb1d34816fcd98ba96bb9f4fdec070d9a37b536bca1f7fbd75f95c7b0e58b7a02725e4f8b3a1b545e6da54cb7ff0b716319bb25e4ca64da616fe6b";
+      sha512 = "79d474b2c0e3dd1b09f42895370ac7cccaa7ce71f1d1154665865114dc6db2a165e099de03f064ad6603e7fba967f85865070184ae7d478940d250c0579a8b14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/pa-IN/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/pa-IN/firefox-55.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "01e67b60bf6d2b7a8ab6dbba92678af6102173443ee938ca3f236403169b90d00aa3696af2ae445d0a21f25695e768968bd4f7769c9b63dd5c2ec06b7320459c";
+      sha512 = "958cf459da7c99979c2684bce55f47ba5bfcc3ba908bf11f3c981bec565406aedeeef2ab691e28bd35b7763695fe1cccb9ed76de9442612c99e01960925758a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/pl/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/pl/firefox-55.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "af44cadc8a4032c5ec6e6cb2d502e59f11d43a474806c4f7b98259023ceac8d196633f4a6f6c6f247a042eabcf204ac4310b885d0d47a42e58cf91d81626f3b4";
+      sha512 = "a3c0c0b388ab02a2014a7a1ba18d373557e1828f449fd5ed713c8ea2ed110e3450fca2efe093a0e9ba0893fc447e5189ae7afdc77ba3eb1b7c5eb416b4efc50d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/pt-BR/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/pt-BR/firefox-55.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "24d95447c5d4d117b1ccdd415157015b473e01489cc768403edb794eb409fbeba0e35ed74f2d6c5668d9853ada5ea04bb94fc2240d01252f7f51c3982896601f";
+      sha512 = "5ea81d1719cfbb161ce4a27a72bef3d579850bc26f911729bfc46cf495d680898746361fd3e73d0096b962c498ed9cf7706d6fd940f04d1f6a2b81f0790001b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/pt-PT/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/pt-PT/firefox-55.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "7d6871788279c9ccb54a62a8eac5a6dcd69481a993a8c76dd3a31bf94e2cd5e8c4abeafee5bc6e0f0724419d7a38d6680720bb9ba8c68c8dbccd2dff46be6fcb";
+      sha512 = "460393c862a11816d7b3bbbaeb3fef4c566c1fb4c479ddbafa4edadc1f085e00bf8e9b01e5d5342058fa384512701e48745015d3a56d98a8e954679e0258c703";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/rm/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/rm/firefox-55.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "be2420b9cb9956a7c8145bbb5ec0fa841621cb0672141ddc0c8c0c3135c9372e7e5b82387a2a123c5f838393bf5e22e14edf127325e6767461e758a4aee6fb36";
+      sha512 = "0dd87197bf700923f771fe96bbabddd209f5022ca6248599beaec3f32d86559b560342989d24612977c30f61797a02d453e0e36259496128314a87f8a8b3aab1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ro/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ro/firefox-55.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "65dd955dec8460892869e3fcc555e153bc51af059fafaa1cd7a250441f166ad2c5aac2cfbb573f7320badde424c84007d121b88bbcff09ca2f474db84524de53";
+      sha512 = "60f1d69e881aabb32b40566f907560eb17d5b700fede8ecc1b5c8d198041cefa774b953dceb69e30c0d5ee57ef32b27b9cb4f43d550452b43414a8d712943c8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ru/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ru/firefox-55.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "ebb48f14805236b8cd36de37e514b0738f7d49b93713d536b1f2deafc1abdb67ebfce74629c131304eb440032563f17260ee319be133f0fdeadbae5bd93cd2ea";
+      sha512 = "fe4c0ada1acf61cf784ecd6975d3c49a897285f2f816d60c33b82f8c4f0cdcc221bfc5032381488202454ecfef5bda99de12eca7336ea1028c2c13f2c2d052bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/si/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/si/firefox-55.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "5be8bfe9ef8f1096983d087c1e61ec197c2b1cf0388175724480898ab48ea0511127356a041045ddef7afc61d65e568b8c19bc5041a06b575f76338c88d1130c";
+      sha512 = "ee52d9a71535bb8df0101a91b414e5a60b2f4d3db9e2ef65a1dc737d2f81d20bce6813968c5f8d25db40b14dd253149fd7511505ac43f2bdede7363df8e1f594";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/sk/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/sk/firefox-55.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "b70627c2fa4d5b4bb90b919cf1324b3463e28ebf918b000a64ffb0ac64c997a370042d8e7029dd2fa749206645a381126ec5d24a952226c876d788d0af6f9cb3";
+      sha512 = "be8e5677c9e244ef4f8c660380f3e2c141b80534685079c8a76f6d74a12defe5517de04a2504dbf5c4027dfcf76e4c80414320f36dac8701c8baf16ca75740bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/sl/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/sl/firefox-55.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "a0ba640ba12ad5b0477942e4eb91c9e9ee1f602d5e51999ced88be2f150311b15e72d70d0de2295916b82ea577d8e07cc33b7ff4a8425a886ea4dc3a6f6634bb";
+      sha512 = "cc693f834b5017fac4c2655b3b362cf54a0920dd25194a5c1fbd8af8c68a9d130d0dd055eaa9fb4c4348b0bd479da517e6b3546190f83222f2ac2fcbf411f19f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/son/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/son/firefox-55.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "e2dfc2ff732a3ded0465ae50879e4ac6c180040a24391b8e7e879051edd7b67c4022eaf03d5abbb21d0baccec795ca10b811fb14a5ffc823d860255871265873";
+      sha512 = "39618b1e8d08c7ef70ee7873daccfbcc41d0ede0a3a39dd861bd3155e82f1104b72d4ee7193fc30b4f53aa9f6ca12209a68b68470bb319189c5dffd7a9db4d1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/sq/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/sq/firefox-55.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "3e56f0d47c77c6cfc65f40088cad10bf513369a78b1d2a1ceff7e92e798f136f93333dcec4bf780598b3e8ce47a55cdd47696f20337d27ad2e2908bb6c047052";
+      sha512 = "e518cbd7d40c96dd2ce6171bbfa76b946cf4d397790b4b9ae8f00691cdeaa95d3104bf174900b18115eb07c8ac5d6158ab5aa01533f9bf06d435ebccc1a034a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/sr/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/sr/firefox-55.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "aae94358f83f888c3ff8fab2a55e4239d2f280813534d21f199f89b8fd95cd7a37b2862becfb7e1c14a9b180cf1844df59689fe818df8ae490786a5dd65921f8";
+      sha512 = "9ac9d605aaf3982ce6ff4d76ce54b30bce251e9739061607377483663b1654805b818d08b29a636b8a9f8b83bed38d8f91d2d48f29e39b4caf03fc895b7ea605";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/sv-SE/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/sv-SE/firefox-55.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "5c672bc0ea10b65eb93077e0f23e52fa081b49e12760e2d9167026d8d208710916b38b56dc24c5a78378e3f7646dffb77b3cef49923028889324ec7da39bd842";
+      sha512 = "7bad9194fa09f4785317488b430b1cfc3add9b460d340756477631b8f2d05b9ade9326cacd735f804fd26f702152906cbab844d9b7abc7ee7f68a7e52e6d60a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ta/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ta/firefox-55.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "6649f6153c6b173d13dfa5f6bf7017102645b54d9c847bdc01d155ac005fa2ee5c997eeec13fe7897b55468912b70105c449e51947af270ceb44fa1ad02fb1f6";
+      sha512 = "501093bddb36797bc4e6b97e5101dcb5f7c630aad13db5c8b4c3cf8db3d8182a4b9c68c43835c9366db72ea4dd6cef2b1d3c429c28d104a107e969bf852ea318";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/te/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/te/firefox-55.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "5c0836df0350d5b282420d96ea2886c2343641c3ecb2daf91a81b67dcdda6145532f2efd480fbc7be412bb8332247a49ef48958157b33c33c444c55ce85c06a6";
+      sha512 = "d3bb8e779529649794daa3efc52fca016195da4afba374500951d87dbe74f4ad2856e7549c959eef4e5711e7b1d1f66e04f6e7e622ba9a3c27b2f7e769f00496";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/th/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/th/firefox-55.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "6c0a888749580afef4946b4037d722d736d654f2748827af42794ae452c6ba4eed6b0889dd20435201e19f629d5104389f42a384b637d6241fc9c0b8f22935d3";
+      sha512 = "7fd54688fd6fcfe3042d02b4204d82ebf11391784c36be3f479f41a32f1e7fde704773345f16a562044da5bac02302722ae248aaac5a4b2cb8add484939c8d51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/tr/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/tr/firefox-55.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "1301f85151378f74a7de1a33c42373feebca433f1cd6d0aa5daae229271741561bef2bbb214a104195d93664f802fc8b233d5b60913f901583eee68827643537";
+      sha512 = "1d4fcec068163b55461d082f87c070a4a04db04e0b9d292a29e41baaeb3a44415f60338174a7589876bb98ff271bd0b4e1fe58a794053d534e27bffc522ad599";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/uk/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/uk/firefox-55.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "d178ac2bd9b3c7a29b14effb005d046f43e78867e560ae38be3f5f55c39447d100d18958aeb9c4894579fce4a46849d7dd8a5c4951ee1bbcc4ccf4fa269da744";
+      sha512 = "2f048f195269c652e642250014ba6b3012ef0e212ea794a989ecbafedc6fee27976869b807c87411896da344fcc81b3803f226a70f881f2d66dd517c86f98511";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/ur/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ur/firefox-55.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "2de7c4b29a6f897fe2df48e070164b2963a8117c1628f233d6ab93b1dc32660d957ba557f78344ab1588acb5144460068d34e4c804475813e9a39f4fed6780dd";
+      sha512 = "0700f646fb81bb96a7aafe0c8246fab8cc39200e34fda0b89535d026e6ea71d3216679f13867a8fd6f43c2efa23902e926f68ec15ec65aa1d5f67373ea3b7341";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/uz/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/uz/firefox-55.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "a3b720e1c50bfded6d44dab4044fe283b1f718e600879663658d5d99fdc5ca36a996b79149434c71dfb951523525b59757b84dcb383ee7673c3e6e2d719048ac";
+      sha512 = "17c0be62adaa2f3a930e727910f0ffd9dae03eb53ef6fb72ce3fcbf9b6facf49e12164632acd8446c24560f2d8a233ee946ffdbcb270c815b9beee146e93875b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/vi/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/vi/firefox-55.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "6e53d4418ce4d325e705e32ca215e12c97daecb81ae5a2bd0531ae4043878a9c2fab006652f08e0eaf8ddb2893fdf4aef8b0157f04e6b9be4b63e5e191028f24";
+      sha512 = "8b120d1ec2fdbcd7b0276975842604c41f840e59739166f32c35a8ec93805b6220e3570fa6c5cbea66dc988e354d4fb5f900b5a359a784279f1ee78a32a7ae15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/xh/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/xh/firefox-55.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "fec4dd19fd5e109d1fcbb62538d1a0b9ad7867b111effba8fa4ca09921cc0d3d224e33016a60056e2d556c2cac4127587fcd379f8b023749355eb47ca92dc337";
+      sha512 = "9b981b60acc1d5fb66208279a3dc5ed113c3b1cf8c2169d5ad7ea258654b311f2338afdf9fae38c88b1c575cbe0f00b2359f928beb90288ad5b456e9f956c19b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/zh-CN/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/zh-CN/firefox-55.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "78c162de2ecd7e698ae59f7d814f333885fdb4d5bbce2890f493008c709a3057524f098a36f437ffce0ffd7856ce5ca527bd2c03265abbf76c106ac8446d4442";
+      sha512 = "5148d542265e62ba50129526bed91f15ae06018e097fe0afcea228d183b38521a6025e83ac7325f8db991c3517ec38b4590b6065028abcce011cb1ff3f89e8bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-x86_64/zh-TW/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/zh-TW/firefox-55.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "2e6e0084a37129adbafd524f0a8353ff0e26c4a59726be90a7c8bbedcba84d20a72d3c66c21335e302d929c5ed5aae9b67134a840a31c887c45363f957172f1e";
+      sha512 = "466f5e6edf90c6e2864d234cad8271cc9e278dce0748054b109fad9f0c2f5df75ae6b50098a4130a55355dc7cf65556a3cd1a1b3d62e6fc5551317b86b464263";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ach/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ach/firefox-55.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "2710b4a940c3df0eb4f4a5a00e857b030ea4126bfd1d1154f169865e31597ef0f17c8e328d87bc68afbdc19a0dfd980464c1254df15dc69eed952da2c57f947d";
+      sha512 = "c0fecaed3198f68ff1504be584fc74d6c4efa3ed785eeb330c65ff2f8a4c3979efb01ddf9e6dca047db6efbcdcdb51720bc2612ea0954b340e20c5d9f90cde04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/af/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/af/firefox-55.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "aae3f0465180bb14983d6fcbcf29d2f361e4c9703f37806889c35e60d7645dfd344aaf33a2fbac276ced63d906eb29452303ded125d86878d6c3492077d8868f";
+      sha512 = "b9a1ba9d7b48997fa4ed799276da18cfadcaa29a206c135c7c7d74bf677f5f40621feb50fe258bd341fa57840dcd3d5144ddc5385f408a6200e8f5ddbc5c02eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/an/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/an/firefox-55.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "7f02c46293d5c6baeb75b80f3d5fdeeba5112ea350c5b04dc5750f5410be39fe4d0b9f03d21e8855922b97e1a6684b90f6eccd06d198c9f9b259b42fc51d9e46";
+      sha512 = "205d0f8893cd5d90eb0b5bd34341bfd7857c88089685d7560a57e6a46e65e03bbd447e8b3b9471f1bb2f0a69c2abbb9ee96d0aacd5d544053dd7f33842402e7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ar/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ar/firefox-55.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "7c4fc8f0276029deab6756a6442cc29d75e8a31a0d62d045023c68c4f80878b920a34faee8a3e40f823de67015aca6f32567b6cf57f9a593aa1ce6ed5fbabae4";
+      sha512 = "3db4dae2cd2a4fc51792f8bb398b47c91e13fc5dfeeb8ad14c7bc101b55d14f1d75e719d5ce03e96d29245805471ce0ad2f38663b3dc837d83a16a365bc1de05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/as/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/as/firefox-55.0.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "e6825cbb7d228a1b8354b6030724f9e3407b7e5a33f1fe59e7b19fc71f0c28bab2db649314edff5bfab3c37b154ba9847b77fbe8e0038a7a3565c3136115862e";
+      sha512 = "5b06bd9944c38dfc8c5c92930e2d3c2470d8cadcb11cb97d1ac98426624e4082fb0f61ce27a70572967525166b1343d84ae4cf9c46c4aba9c9afb4e4513c74fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ast/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ast/firefox-55.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "8a1e64a1afe3b22349b1cad0d51ec299e02c5a9ed330792d4820bd0be4ab33cff6f05d03ce4441e2b2b757f45d23e6760d2bc370fb13d8dd1417cf562e82f331";
+      sha512 = "5653c855893160419dedf857b6568f9c1bd122da27593f749e81389aef248eb4f1d57b85de70c2a122ba2d941a8da3cb320975ffbb9b56d7647e5bfc18ea7c0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/az/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/az/firefox-55.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "cf72d9045c2dd9e9c6da619ccf9fe537ae4823b3623e9873bb8ea12ba1881fdff3b05264908fa5738e0c2ee0d119ebb5799b32c90ae37186284a60cacd75b7b5";
+      sha512 = "dd6b4c7ff6362710dd631f40a33b5c97f3e3cdd245443ae9a8ba03e31335ff73c9ab695addea10b83733bbc6b65dc68ffa54315c50602661ab447a25cf58912d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/bg/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/be/firefox-55.0.tar.bz2";
+      locale = "be";
+      arch = "linux-i686";
+      sha512 = "3688df68952a358e7005ccd64c2b0912d9b113dc146ecce19739043ccfd37f92fc2b470d47c2723a24c8b53d113f705afe56d1fdc3c1b7304c3ed4546b9d347f";
+    }
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/bg/firefox-55.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "686ca0b866d1e9504f21adec227396ebb6c6957b6d4aa9a3a74249d4ac8c23f1556bd1282f54abd82ffedf89e2852794014c5bf7bc46bd1d0df4dd5352e34725";
+      sha512 = "b3ef5094491445ba3544a8a4880f8474cd9d7092cd67184acbebf4e3768b6a0bd43e03938120f3d67ac519e86f3c538c26458963c1c32ed3bd89e9f8019cb5e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/bn-BD/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/bn-BD/firefox-55.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "f0e7bc6ae6297cf9e83cbdb8366def1885b96ff64a855b312d31346e9fc476f4f80877f9251520c77845fe1f695f39a757dbab2411a42e694de27f1772cba085";
+      sha512 = "3584ed2d1eb05f217cd475edaaf1869ae3e564af8738cfeca7d0484dee12abb4040c56d4e7c20cf15c983cb2245fd84e9ba1561b27f4dee57a50549fa07c20ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/bn-IN/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/bn-IN/firefox-55.0.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "6caf0d5f71c1135272072439c0e2c84bdcd967cb23c51d980c47d3c6a3748e90e041e89eeaa88a42063dfa0d3369597c8eface6593d91ba1d604882e16b4cd5b";
+      sha512 = "0632856baad0891c3d22454146e64e884828d7aaabb58c1f1fb3c45314eec95765df9bf6bcf68e1edbc5873c93d0d99135f71f7ffe979ff656c2748df1305edd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/br/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/br/firefox-55.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "10cc66d62e68346b896c0fa081f8d8c1ebbfbfa364a52bbef5c7f368aa854afb7e968cfc344378707b93b2cf478fd74d4ee97f9b7bd160199533f26df222ea66";
+      sha512 = "dae7d1bdd93492303adf1ebe37b92fb3400437911ee0c8bda33840c5cd1fd0307d631a65300dcade93c116fcd3c85d04c518d2aa2ca792eaf20a7d10d99ce3d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/bs/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/bs/firefox-55.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "6c87de221bbda9639d5751f8e8ea2f4aa5be191dce18f0b4f038f8a2fec989eb4cd3ae3b2ff36ca13c168a8ce92b6ac6a60b46ec6cb022ce6a95e921856973b6";
+      sha512 = "d9fbb02a07176a8063c8317f795859e2bce1ec56f63742cbbe88fce9b07f03ad3b536ba459a1d655b50f3a867e84f8f56dc041a9f57ee93eebd14f174b938d6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ca/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ca/firefox-55.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "67ca5ea84b6243bc8869b96fb9dcecbc0a8e7018e256101874791444d57b5fd61a69d7ed064df41faf9ef3cc9059777412fa86ed445e9e40a3570d030f776d68";
+      sha512 = "cd93cc44280eb61b2958e745ce27b94fe583535ccb7dc7788f0f74c625a0189db6515328f479224dd3899beaf9a878969ea945da053f2819510b1a9584ced229";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/cak/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/cak/firefox-55.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "b343dea962cd69bcec30b5a274a118e6ed2740120cd09d8155d0ad32e55730d9bc223a213df447ae50ec6bab67f5be2b910feebb73b4b57b30ecef49a3b0803c";
+      sha512 = "14c43245c2f91db0d7ccaf010572fad29f29687156ae21abaf98bcdac578d49673342fb4ba7143aa5d6268c03d37169d7fcf95dfaf48cb494ea721657f66d0b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/cs/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/cs/firefox-55.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "e4f55216ef51ba1232e15b1b842c3964a49aa31a9bff2cf292bb7cb913891057ab4cb3e351ceb57d3024f2854defd693a75aeb23431a7b7e8fb82c41f500507d";
+      sha512 = "40c11bc35d1d781cc8c76f7bf42997a0781627c0385fc67b0562edcac04d8bf6f2a4217702ef4ea681f4e39147afbc814a89e23df46b561b1a4f5149404fc955";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/cy/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/cy/firefox-55.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "4d4340737549368855b21f11a27073c60112cfb7aa0b5e1329b27402ffcdd222eb009bb13e81a8403a72ed67b57d2ba2ff349fe0255d1cf11f32f4f32a73986d";
+      sha512 = "9a946b301e70e7afccbb599e4d4c4d43645cfee27d3e3afbf5862ebb36436c66e0a59a5136ab9729e9d2e01f752feaa2ea341726b41fa03e91d7e909b0dd0b95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/da/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/da/firefox-55.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "4ab3cd2e39cd13608331c13bf788ebb5a75600cdc3e5bcced2adeaee3d1c70fde0b57e93be9d8ecc72bedcf14560129246baa8b6fe5549de5614dcd14bbd76a7";
+      sha512 = "cf42e36971c0d743daca66b5355ccfeff994094bda6ad3526af76c89818f8335af49d0dfb520d2b58d40da64587f85588cd4c61eafdd12a0763ce1034bf44fb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/de/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/de/firefox-55.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "5b4ec879e8bab2bb4233da0745a4e905736d98816377458333d0d5a9b8a72e6cec8f450e8a4ed49f69d75b3a5b1c223bfe96844cadad2919044c637d78a13f04";
+      sha512 = "7cec9410debcbf95489e3d9a8129a53507de27fce635cff7a60b7f977f6407f7396d03ee5570528eb4524901a1703b2ce7798a637711c9166d3789e95e4b6d35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/dsb/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/dsb/firefox-55.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "0ff0443ec9dcd3cb11978bf8689d41ef69db93d8b50b6dd53f4d31fcbdab2e459aa93427bce476ec989e907d743fd392add82426c002aa604fbe251ae438e912";
+      sha512 = "387ccb1bea5c49115a89c6b64399647e9df08c3b4c2997c9aee761ca73bdacb6a3a05a594453f44aae119512cd5dc62a1adda94ee1974a8809fd9ac6907a5562";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/el/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/el/firefox-55.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "5cc24ec6bd4823e5360b56ce78a97319e15c8f2a47f7138033dbc52e7df001d09577de3d9e8cac6314cb7809da0e7674faf8845e4610d6ea08e47cbc9fde7f03";
+      sha512 = "b894fcd577e94288d785eaf058707a456841b2a50786de9a8e9324008e76e29bcd83960f4e292d046f304d90b1d95c941e126d701417b58708a68a85c0f25496";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/en-GB/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/en-GB/firefox-55.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "0b8a1576ce8b112ae35ef388191d2308aa2c7222f575bf354d3d6654c05f073429af8ec9b1a1a77a268b9191d2fb8b758a38609c6432dbe827b739b3ba25ec61";
+      sha512 = "74b06f6c1d61ea89994df6ed8716b72e9b8cb256bc4420e6011600aee9f161287250baa9f39ad7f8b806fdecfc60c4d7e5bd31e6b02a2f2fbd20fda09c2da2ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/en-US/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/en-US/firefox-55.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "9b28b30e136b9bd89b4b374a9a6c8e6efef936354b7eaaecfaee2efca6381abec646627c57856f64b96ba5a8f771a411c4164f3a54b783a8e3e197c0a78d1622";
+      sha512 = "d40f8913e3a280f846c8507ef55d934b5e183ad16e01c27d05767ab660235673a4615a8a10f52d5562912f4e88d4c0d4be3ee6a3ab13508a0bf9a8768a06743a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/en-ZA/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/en-ZA/firefox-55.0.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "360a4048ea81b10b5b834f3c2ef21776cfbaf372f3a329ec9da016728e1b83f956476ec98295e70ae3a9fe63a5f4f87b6be8d47627d6f36eff9b2909073fa70a";
+      sha512 = "eeab81e4954ac3ad4ecb1d973d592f137c59fbb62190e6128c6728c78a3ffbcd0ab053a31529bf6a4b2c59787c25e3c62b41e6de682cad7530a40bfe34f83f86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/eo/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/eo/firefox-55.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "23e95684f5bbf6b209a3077e173c3212b77e89dd64f22fd378ddbb8eaa43682c50f4021e743e25189b2d1cc6754bce6d0c8604d3884ec1b32cd7c51c0dee5f0c";
+      sha512 = "471b7b8ade86cc0584d3354e074acbdcdfb1afd048e6b6532e10c664668fd3d42d3c57412befa7905d9eec60b4aa2e484982e72e3f2d1c10c4a2f8025083c8db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/es-AR/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/es-AR/firefox-55.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "88b7085fa2b4b1013a7242ca293197d0d26916f2ffbe1f1a4e8a1d2000e45705301ee83b0de8daa271111f586c3e5fad54c8e241da17f3f8cb9912b50e61538d";
+      sha512 = "7f8ba4fdfa1114c52dafc0b20aae6decdaf79d273494f9a758172d0a66f38b77a1eac6470afbf5f1bdca0844ac43be6b59d70ad24992146959c358e6732b4400";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/es-CL/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/es-CL/firefox-55.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "990214ab2abaee7b607ac0a46fadc7c8be0fa12ecc5c0819f58324175381309742e0972ba54c144ad1dbbe0ceca076621aee0480e9e954f593c841d58f1a174f";
+      sha512 = "85705a9875897c45fcf0ec1edc87cd3b7f68d4bdc271a9a998609d71ea49e58ab5440913ba33e09153d7095d4303572be84c01f1d7ea1d08251c5194b983de34";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/es-ES/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/es-ES/firefox-55.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "7dce1007e0c52e048d441405a1a6c02863da24b8b8c4b7f3afd61f2c866ee6b19f29c82dd6efe34badf52df9a66c76fd56e788d047c3eac0503e3a74e41240a5";
+      sha512 = "5d900419effda0612c0f45a0c8023938f2d8b60cd240d71f5b334b2f903e3c4fad8c7ee548431bb85f3868af844b7214ef67ccd9b7a3775f8bbbe0cddcd53ebe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/es-MX/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/es-MX/firefox-55.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "80b3ebb80a3682b6588175fee7243bbed87312463ea4bfa02d52be21b1e889208e8aedded74e9a94968969a2ede82fe63c83f742ed7c5754984f38b3f83a379f";
+      sha512 = "054cf514419b9b30fee31554ea08aa58d8d36b6b1b51c1bb91cb2436dd26db349b31a1ee807906b113536d94a73c352430f3044b32a0e582c0ff328ac10d518f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/et/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/et/firefox-55.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "0d31b34100214a588fc2ce5a217fde7a41f484344662e3402b69daca937e73213ae7ecfcd081437f3f4afd4bb8ad2f3810ee9e6cc160c24d81b81e20013176dd";
+      sha512 = "af38aefbf277b85fff536a35a4138354ce12ac8b3536f7c0cf5a1a3d5ecf79f138adbcdda1f68cfefcf137c1aa1581fe34749d1d005ffcf369db8561bf2ae536";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/eu/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/eu/firefox-55.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "b8ee5dc7124e8115af11d58770562d51bf7356992e84c443e4974b096dbe2e47f4f57f90ad238a68d712d9fc7c27c399719a8c4f8a4726fafb9220e448ee69ad";
+      sha512 = "04176bc464fa903a4a04c9e3ded80dd909d5820ef75bd2bd9ecdcb703cdb19675430d9561e2bc49338ca59eac1be1cdfda9d4acbc4ca5ff61893d32882161dba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/fa/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/fa/firefox-55.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "5bf7b9f0db610f5e1033f38e65bc86308b26c1dd6f51b0ba01064b9a0e0debc288aa5f34e7346aa68bb8eec6b81d104ee84d475968cb0a3946767f311dd85332";
+      sha512 = "ef46e0a4b523b3ba883e07b79ebbb343caaec7675b5f6aa456b13b3e362c17069a563c18ce0692fb7854e2f6c72ca880130bf9ae0671177262027564803f971c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ff/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ff/firefox-55.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "f7d57a36612a82f94aaa5a05ee6764863ecc7c769880aceffe572ddb738cc899cfdfc68aa15cffbbe687d0413d38cd87483e78711f075eaac063d7f5f0b2d29b";
+      sha512 = "fbeb3f00058cece9df5181aac388f57a60dc9bfb2c5971af6d96e2fa876e7d55a43aed82e56eab302e470c67831c84785dce08ba926e1649c13e0641675bb325";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/fi/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/fi/firefox-55.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "9f58c3a937ea4d7eaca80c63c2ec822511335f27c254fd086ab2583a55e457dd1da98fc1e2bb8d299010e59c982b54441cf157afe3aefb9778877d25f43f545b";
+      sha512 = "4af7d213d3fe7e30940adeaa5ac59d1c7b20bd243935684a83ce746576ea68347c41cb897fee50636852402f05aab757208db03a7c746025212dd028b43b7f4b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/fr/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/fr/firefox-55.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "8179c3840850a6c353834f052fd8d4529423311385fc39d0d73d6c97082573c5035cf7714a167bb3d9f0c77e64c9fbecac30bf53a03f6c01c338ac538a23e0f4";
+      sha512 = "09c81a787cfde2292b88960a7b95a2e5c18e9f0c40a5972f18580c27fe3d2140c4295282e8b8ac2b3ec1b1dcafe1244b7392832805878d7231e1531ddf1c923c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/fy-NL/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/fy-NL/firefox-55.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "819d140b832ea5820804b0d888f96b82737926a08854c4e93d133636c633a52433e8246a0ce187cfbfa56ab4bf09a4b4c000efea697c0d50f22edb02ef756f87";
+      sha512 = "e495c0b559da6d9173786af68760a4fb0b25f4e5d504a9a8e58b21e37903336e4eb15c4beed8a5a791f8c25da0d46ba95256cf5edd31fdcc2acb47ffa85a1b87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ga-IE/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ga-IE/firefox-55.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "c71d04d8ec3e7dc07eb909192c176b456daae54cc105199f675fd8e612c0f6527cda0635c0e1aa6221e2d5ef3f6c8168491b02571054ab0d4b7beab59ef692f4";
+      sha512 = "29b28a8c717660ff3b0f07b330ee377927b17deaa887802615e447544b88279871e72a4c73441d9bb76eb6a60e85907ca94ac8375c0125eeaed2500e815f9a6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/gd/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/gd/firefox-55.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "98bc4b44b2075d615e682b7649a0a0cc696013b908aaef11a60bb299881e0ba243e70ec2e6e9205c965d31c68c6a8a66e9826fdb711676aa0cc3c8f4c44935d5";
+      sha512 = "2e3d7902773255a69990d1f5176637aa45753eac4d6c903bd8dfdea505f2a07d714181bb4662bae4591b4155fb04a87e09d65eb19476ce2c4d0143b7f8f2641d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/gl/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/gl/firefox-55.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "034b22ffe1a16ee330a8c85c18975d541b27d5ae1e5e3cba3796307c641af14797b329162a6e3f4f642de711a9f0ffe5b2fd274a90a396190ba176c5c26790e5";
+      sha512 = "5af911b6e1bacef308491b10b21592f06539f4360a84d126d0f78fb43196029ec352f8aeb9fa6180899f5d74334ae002602aa70e1b4112ed4cbe79b00bc4a929";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/gn/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/gn/firefox-55.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "85ba634e0b991b582ad0795c368d5df28d5e2fe773525792ab071752ac773d0d81dd3991996d6e9db7745707cbea8ccf86784b6a8f117d97e08b5ac88902d5bd";
+      sha512 = "721330e35f1632969c92cb732af6a1873c0516292f58e04db3d0c7a96d1cca2ffdcbbacdfb65ff3a958f8757fbf788dd7e667e3037f3b1505a1cb5c34114e02d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/gu-IN/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/gu-IN/firefox-55.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "92561dd2d270c01d9e2a1568fa9fa0e75bed2d5ac2ea49d965fa2aed6f32bfa8639cd57d564d310198796621fc1696444f976e12a26fa96b55aa7b445f81afe1";
+      sha512 = "c56f1f632cf4bc89c5f2ae69c375878d9f4aadb3ace0c228f36ab42311ea41eb2aaa4b858596e820729a7474a568c57f6a259a2745902243c5cd21b94ea59fa4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/he/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/he/firefox-55.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "d1f67f3e34bd67f993177ea9cc62ba432eebdd1169ded1b6ef58e9cb07a62a0ce38afecf001680b8ff6a401950ce9c13834345d7481301d59d024572fd2b8ed3";
+      sha512 = "69336ba52a347549bf684bb5238ab14dda633d485de617262fc9377572b7c77cfd024cae9f299ff58425d95984939b95cd02f2a3a23ee07879ebc5455a7f7adc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/hi-IN/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/hi-IN/firefox-55.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "8a10d69c6baebd21b2988a42979ec675e6ca29c96299407bd307a33c0bda11b6626cbb69bd6ab64a55f347be30d5fbbc64078b6e33209c26139efa050050541c";
+      sha512 = "a141064e138094b02989aec9c3801dfbb6dd70869e3fd590325e6fa4b84968d73270a6559156e774ed27f42062b0fa5f78f0c0a373bfa2a02ae2525d3b516781";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/hr/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/hr/firefox-55.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "667411553ac3e00e7040ff2b6f350a6586498a38409380d5c822bd1bdf2989e2e34b9b83ac2ffb00c7d3cbd57d2cae4450cd208ca1fb89480d91df1981d2802f";
+      sha512 = "1547872d6d1535cd106b0627830c093d33622f42ff01a419695422af5c030a54996c8b9c95e89589c8ec75eed68485e3ae78bc7cfc0a3b09d303e3a1c0bbbe76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/hsb/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/hsb/firefox-55.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "8becf0d2f7a0c208ac38d390be0114159d208931da07b996e1f05138fa06f07f027c1ea429153823c580217a5d3e855f50570a5c5c2e4f264164d59b0f5cc9bf";
+      sha512 = "796500589c98757a7986158bd08f12ff76ccc09aa4d6132b78c011cb58ecd4d5d0798d780e6178a0597bf5c921e6168e606df56106c8ddbc49262991e10233b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/hu/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/hu/firefox-55.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "494144c9c2a3d06d4bc8126e106e74d72b3ec5992dbbd47a4b618a1a30905ef59e550bb4bf8a698c69d4dac09a1bb7c78b5580f77d00f103918d6d58ae74be73";
+      sha512 = "7801da792cca62683a7d1ab812fb831ea80d90994b18a151623c05d2f30979d557cc1a6aa0a7ecd44f440c76e71cec9a4749fdd4c49442ea151c1720a7a5d988";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/hy-AM/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/hy-AM/firefox-55.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "4d8160d109ccd6fdd407673c855b445eb287aaaf09c55e11b277249b54129721c60596139860cd578b297415383ebc83a9f95feec3b5deb229e5f5834df5f94a";
+      sha512 = "d47fccbc883ca137200c613aa96899e356cfb09190952805c20d36653d3477abee4db49471a1416ce13455ad5bb6836a7217ae51fce77dd0fb12f1187e11bae9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/id/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/id/firefox-55.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "faf8df37c2b7ff621d9dc73fa225ffeb9263a6de05ce540fa4f7482b26df153c75cad46e395cd4c3994598dd42943eae7e552836d3afdb1fab56bd55e73f7207";
+      sha512 = "41e111080bed45b7783cd50e7069811b17b35eb0268a92f901531dc1e0a7e7fe07b94ac325f5b5b436b71ceffc1d329837c74875a32e13d3205537b750fbee58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/is/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/is/firefox-55.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "a0a5fdfa889d61365c9da182ab7364f3eef51ce7bfe75273a9cc50b948cb5b979629972171dfa3812edeafba76ab71b3780f11265b2026cbb70fb8c2e1bbc7a8";
+      sha512 = "9172c69ae72fa83a05f0926cbf87ed4694653395027b91f441ab976790c581b9383dbe62bfc74a425279ef68f8c6f6d2ef003b20aa241be6269c34bbab147150";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/it/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/it/firefox-55.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "59530850ea817f7bcf0ebe8813aa9b653fca3127139e8b97ba7f9fcca16848c272681b59409c0dfd1b10a1e75ae6b1d0bb46bae628fb0c95daeb198189c8a173";
+      sha512 = "daaade14d2dafbb76e021f87773a535783e533474138652fcb0b25bc41a1ad4f13d7cf65119730fed56c43116a3392f3adc435a7f8e8326ee8ea4d9e9cf19ef9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ja/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ja/firefox-55.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "67501fac457e820f2e731a77095f37817e8a44693d740cfb540d48dda8e1b10d93eb578b7d94c5efb0812688728745cbb508f497c02bc74b50fb514f8da4551b";
+      sha512 = "6741bb18a17559482f8b95c1fc6acfce6b0e31e474e5d88905bdf3b939967c0ba625cea7e1f1b2f2ce6e77f3128f1f85069e946e7e6a16fbf4a637cac7e79565";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ka/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ka/firefox-55.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "dd9dc48dd50cce43b48dd1a17aef95c89dbdda8e4b670044c422085ceaebca7410c24b157213acf4592c007ada45e6fdb154e690f6ba626b81ec3f8a099f205d";
+      sha512 = "c1849ec6d69ffc87918515a7de95e0405a14b1cc268e68dfa11f8c832ced907e73a021b5c9b5f1839e99d692c13fd3f33197eb91de98f588f5750de03fe098f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/kab/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/kab/firefox-55.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "51dd94346d62fe810208e6bcfb930880ef14fafe2b859af80da4b494563db38b4226ad43b602ac86f426c6a731cb135ac674ef65bdb2039e0aaccde0956c616f";
+      sha512 = "aaa9a9d415f39dc957ec59becf3b649c650cce619417dd5182835190aa8bf361bfd048ff647099320cbda296c9a992927de9c6a90e84dace4a1e5cbed0b9758a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/kk/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/kk/firefox-55.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "604b59670103ce78e3ef4db5a209d68981e1168415ca4512a1edf15fb4b2554b9f655985b2a0921cca44a4c51742155822b0b6514e91b1a5fec43be57b36bc44";
+      sha512 = "e7f47f9270c909135dcaea2e4a47e1e16a6a0d3b886ef9f4ff0e3e750cd8b6b253eb7944c6f7155df6e91c838bc84544c2880f9c75eff12c97f68ef8da098575";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/km/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/km/firefox-55.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "a81f6b44bbc9669af09b212d1960ca93e70ac085d20c37db52a474b81072a06165312207567ca4351bd110ee7e4125fbfd67981996c08b0a19c7c6669db16cb6";
+      sha512 = "3e46f8ffba4f93450dcc2aadd010ce0b181e1461902a517c4d6030baaf6814debd2280202308980b3e02879d23144aa186af5c9af6e53e8d6b8d5e5b430bfc26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/kn/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/kn/firefox-55.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "7a54f78285290d3a9062d71a5b1de69a3a98ea95a1593b5a0a0c2b69098c55ec054c8575361bd5cfb67b7558b411b8b83861ecd5605906b15a06311f477bb0c6";
+      sha512 = "8de3d801bfe8a1b87719715982cc9eba3b39158a8933b26379884d795bd2eecd43578197165a97f514c50286713bb83c06e200818c2e4ff2714baea72b8a3dc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ko/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ko/firefox-55.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "6a97670f62f70422f0d5d02091fa6ccda700705a248831d55c95034a1a63bced1bd0f282e938855a751eedf0f897be71f7257aa5ab3f8f7162ec756511f15830";
+      sha512 = "5991b9223486acba78015b19d6d0e32dc28aa0e341b4b11928a9f28b1a6f4d366c38690d311ee15ceb607933887cbd8c93940ef0dbab8fb129c94868a5a5d27d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/lij/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/lij/firefox-55.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "c4b4bd74169731d6909acc76c40ceaaddd853e03eefad27233c05dc869ab66a208f072dfe538f1f8e2323feba021f6b3aef73d81d02ff69d31feab688838424b";
+      sha512 = "c5ce8dbb363667ef0b037c5022404b756a360272505d756593860598e8d08a04bebb45edd9a27ebc279547658f142ec1e65798c2e2d13ebbfdfee56cd30e20c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/lt/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/lt/firefox-55.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "319bb6442b6dfa25551dfcb5704241de8b248659cfdbcfa0124c6332ff828e793ddc007f3be57d51033e334c3bf504d0a1330b1cc539e8a5a0d2587bf14604cd";
+      sha512 = "131d67e7bfcaba8ff55d7fbde587aaa1039cb73980e728b29a445acb4bc8f2f17f97802e03a400ef3d6933c2475fe35e7a3acb1b30f949ad71dc054b8d496c36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/lv/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/lv/firefox-55.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "cd255f0922a1cd2c13baddb350082b3ef7fa130e28cf5bb1811345bce3a9d4e65aeba188304c8fdc8336b5e35c280d2a298bea39567d5309fa37e35d191ac18c";
+      sha512 = "7e9b614dbb86ef76fd752180c5b633345d37d24e731eeb10ded7694278903d42f5beaab8a17c5a6472401754b582687595f34233058bacca00dbf3d1f774a5d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/mai/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/mai/firefox-55.0.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "5f44ecbd0dc239f3ed77871d548a894996192398dd845882a7c6cdaeeeb18dfde369b2e8e6d0b56883b494f537f5e0b115665d1411c1de4295c5cacb07021c54";
+      sha512 = "cdf641eadf20fa21c5384377183c7797d199c3232f55dc1377d52e330d1ca2d0b1478e3301fef696726a4094284a94d77257462d4a5447ec2ea6b99e2d009e67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/mk/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/mk/firefox-55.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "de8a9ea6a75a4d597442e0116c70de5342f7270b2f41e9a889c7f71a44f41753d1fd0d1c029cb86a5958f8a2642ad8bd8943c30f5f3534d38d0428c83697a351";
+      sha512 = "ed8d29a7a6a0c255a24be9c6c670677b2cb081129b36490ff59eceae374e2da3911cc279975c55b5ecc8fe7988364b069145b16633ab6c4c945f35c91772c484";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ml/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ml/firefox-55.0.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "86f7a299f66f4d5c074b59f5512571c78fe924792815a0dc2ecb9b2f5e1c0a10d798bbb16c03f912051ab014c102b8e428f98ca29eeff2c30ce72962b50109f5";
+      sha512 = "a4a4758635913dc8a4b5d55df97fc9e1141a7120541a0a962aa4b2c566d0985a6500bd25319b0a5f81821c22ee3745e12603499d8f996276db9df07033741f0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/mr/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/mr/firefox-55.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "a3e79a8f6b03e63f91c69232467704e91c73e1a4b6085a0b979f15bfb67b63bac7637130783d47755b50179a15f894223b76f572941464963bfd61e073ed1886";
+      sha512 = "59144a70caf75fcdb3b7b4898899e0e3f48449d2b0ae0a92ac5cb022ba8a72e076b53c59bc7dab61dbad17561930b0e1182e47081712bbee66f5beaaef84206e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ms/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ms/firefox-55.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "65ca4ef417722cf12b3c7dc7081b374caa3626ddaef5ff2a0b929fd5d1b6716c4e020ac8eab9cdd4dd161d990d0bb3633757c03995426e18e0d23b1e20e0e21b";
+      sha512 = "833f8d447913836f26588aa0e5054658cc38b986b72385486cce8a2c9e7e7519615149e7a4da4eee64f83bacd24c924a4cbb5c7f5b8450b75070f28fc558dcb6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/my/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/my/firefox-55.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "200008b97d3a811533d97e96cdbe8b7f1ce30ea5b7cebe3a77f58269d2ee871b8591907f2975377e655fb01bf267e69851ec3b3680de2796183b3ceccec8f471";
+      sha512 = "d44980bbf4e9498eba7cc0170a558a0ed1a6e3fb9d4e55cbe4250d35e9a06c1a7e221f2f81e51733e28662ddb64a5de9833e78068390087d42ff8a7a10e3527a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/nb-NO/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/nb-NO/firefox-55.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "03d502600bf3edd8890a6d3bb394acd4c2f310d762870784192e3515b9908f14c2db4b7e5762a323b73b4c68c13cdcee9bb952fc503421f41b59f9d2bdd3e617";
+      sha512 = "757b17a9e585bfdedfa6d72860903e7b6430a434a747cfe590f3886f846e03f5f584b62b4e6caa73840260a82d7a9709f99b2a321bfe872f4a81859ae1d3f5e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/nl/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/nl/firefox-55.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "4bbdc99d32f2d576db66e2aa5a12d568e17f3d544e5ef613286e2d3620d4f833ed4b7385a9091fbb72e8bbc423e8e383c9b4e616f562a83c2dbfc606056f97ac";
+      sha512 = "7c4289a63586f2420609f525b28a01ce19943afd8b9417583a51afc50bf741439cfc8a2aa706c6d2230f45c6603a86a595a1525dc1abddef1496737bb321b01d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/nn-NO/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/nn-NO/firefox-55.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "e0267e22ed0041d8a436bb38b9641481889b716632cdeb50bc1761bceda8d0dc6065937d15be56622cee5d4c73ba3e6f96c7fc00ceeef85ea9d852954ebf2d16";
+      sha512 = "5508f9dd6102f45694c2a7145b9b58f35ba2f0d2703f9e8bbb84094b81f384a2c7cad6df4de245dd87b1dee379d7fc202a66b46be8cad50de94f37afc1e51e63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/or/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/or/firefox-55.0.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "faef925bcd51fa0851e2583e590bfe6c194c8f64f8d13a3a3f13f2129571ba7d9a403c0caefd933e94e1d312b39d1d051c5e2a1e6bdcf4b7a1962080d3874dae";
+      sha512 = "a5acda036bfaeb2c06c9b8f2e74475f67624416cb41069654b5dd104e353d2f84ee9a51a036a828355aaf6bdfa9f8f3f9495a287f2c237dd9b15e06d2a774272";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/pa-IN/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/pa-IN/firefox-55.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "e95ba361380a8061fdcb4fd336fc5bd906666873f4ea84af6b5d21c05fa1691fa395bd0fe4529778d91e5d500aa162da09660854867ccf4734c737b0b4ccbd55";
+      sha512 = "a3e807fe14653a8d55925f2c7ca8e963534b14fd5163b1eb168aa9de31f39da90b1a01c2510cd91117e3949b90bdded0666397d7383c4ea20a70fece438ab7ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/pl/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/pl/firefox-55.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "780079a117734ed5528b8efea3d0a7914cb8e8e1e81aaef33f877317bc18fafea8ce2433ffb69bccff01fa75e97e40048ed22805bcf781216116a76472f3260d";
+      sha512 = "5f256d8ad06ad7dcb8898ad5b7abac13c01ad34f94a2c1a457199a61e94e5b89f76f271f17d90d9686eb49055ef14dc222773d33fd3f53617b2a2f51577bd9db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/pt-BR/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/pt-BR/firefox-55.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "d0243251d0793d5e3202e45e596eecde6362af25d95b8640fc5d69d3983ac4899249da9a1d5099522fbae9fd5ccb08d024ecab018fac8f0858a4f1bf201e00f0";
+      sha512 = "e36673066bc2d6c68b0c4eb1b6e493d5d5f7f14c29c3c117c76057168f35bc5b7d5966d9f310930e1f8172baa8ca2ed3f04afefa9a752648867c3a3dce48fff1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/pt-PT/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/pt-PT/firefox-55.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "337c792cd35fcc6bde89fbba2da9a42846af371b741c79e1226adbdfa801914bc39323b0ba2e600ebe1b12191f746b524421c8ea6e5a03f1875cf4ba24369d9a";
+      sha512 = "d57456e2da3f1c0287554cf2a1aca6b19e99a08c34423711e13176ac8d47da25f2856cab56ad0daa99c60ed0fce417af2447fed1d94c2d0daf4b35f22a9b889b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/rm/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/rm/firefox-55.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "e316df164058d8f380274958b17a3812a6e31d9da6eb2fd0373e7bf2befc45a668a572ad4f8f8c33a7aafb5d1f8b7331fca00e12d7ef511017b1a002811040e4";
+      sha512 = "036a41157ba884430046fdcead68a37fe254447016cef723754f70cfd88f2fd385ac7c374e82adb06556c541f0ae82ee5f739d1a190ba06a1cf04405e4669b1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ro/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ro/firefox-55.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "04717cd979c8440639b407e919bf2d61814d24ea9969438397fa56fc73b5a8104d8a448c40cb0b3923ece0a61b5d232a8b94eab456f1b89fb4e24bcb0a525b64";
+      sha512 = "ac349bd51e8fd251f9581ba96c4ca6c69e24e736e44d28c9661e5163a3893ec9ae42c437a0a5b465266a35b966bff0bed8ae081fc93b56d59134fec4ff38cda3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ru/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ru/firefox-55.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "e0f76ebbe996f9989b00faabc08931873490c4048453ed4f32f0461c6ee977cbcf4b2ff4ff650a39e1a536f7bb214c6821c099a1f212cb4600187c698130bb2d";
+      sha512 = "dde58da3b6789ab33fdd8982d328412ac9c6821fd59268dca2fae0bc8dfb8558dfaec4a1d3c9802b33e2c10f7cb0bdf5480dcbbb1fe8e6b8be1774064ca5b85d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/si/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/si/firefox-55.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "f98a42fa1faee4be0a141d2dcd5e88641e89baae55d70440c1fc7f92cd12bf9f3d7954c23b42b16c02052f79f9451f76074c1a7aa0993ff84bde64ae12267e68";
+      sha512 = "41b96f0c5c4dea98296f791e121e2421545b04995d92326176561f0c034c261e19bb2a7db9e72df52a9285ad5d1ff96a4e38559a386212c7267ccf475764b281";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/sk/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/sk/firefox-55.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "fad8a8c70e8f354e87b19fa9387c81b685c79b133ab03dad937e84e2c927d814844d281e39c45016a51056bca56cfca357ec10250035dc07b831a4e4c83ff147";
+      sha512 = "c19fb32205523afb74ac7edf29f3e55a9ffef4e24d18c47cca493b38d5e1bab8fda308f6c5889a64b8a8ed266c8795a67bbfd690bc381c02405be1ff6cb5e9e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/sl/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/sl/firefox-55.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "39f8670cbcf942210336477cb153b7b2b39a7692103a76a476a820f2b8b9809da65351e02b4f80da7ccae3e9cd18ecb7fa1af292f507e9920f50261ab67b81d1";
+      sha512 = "490c0174c5d6bb8cdf0619eaf00b87fd15d5365b40680786943cc7c775ba14cadd21e5aa6948b82f0f45bbf17d747f0217ec43b3da8c523b1acff60c3a6c7c63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/son/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/son/firefox-55.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "7eb79e3638c0820b1db421e13f71805d24e2147ebe78f48497ff574058a3da91f9afb40d050801711550283b692972f4b973ea8579376bea03059d70557c20f9";
+      sha512 = "b0e9ad5e3b2c0c274d70a048855c2a923304be5464ddc7066f64cd20833929702c413816f466c98693fab9c7167f4343a12a7d528bd499d3c4d7fd3b268c4a49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/sq/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/sq/firefox-55.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "84c410d7f7dc4524c4e8a7ff3fc186afcf922d8ca843bd81de83c1ce1d22aa2c07fdd57d1594a49aab014b07f1902c929bb9aa8d55b00b323f06ee70907b4a08";
+      sha512 = "285224e3a62ad4c93f63c24757e4d3d973a2c599baa7cb8729c3e4446e7ca054b38f80dcfec26b52491631f04aa10406b4fe25bd9e9d60174609ff6c446036f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/sr/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/sr/firefox-55.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "9f91c5c33e3d0f01ab28601fa41c02a048a3ef3899481c6ff5858a176b72e05f8113c2fa2dfff2527ad3477a7d2bc7df5fbaa1096b1765113da855da710d7abc";
+      sha512 = "3a4b5082d7f9afe834ff3236304b6a50a5b2262f9024ba8477bf6b2d25908d0aa440432b093a5e2d6a7c698a683e00ac299ffb1913d28298005dbbc38c8c1515";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/sv-SE/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/sv-SE/firefox-55.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "35c8fd0980cc641fd7bd4fd084f3d308840279ece55a33243396bbd0a3d9e500a3aab797fda63ff5d551acd82e21e48c152ff218e1a97ab395b009bea124df43";
+      sha512 = "dcad45f1cfa03e12c594665666d715310d29f0984ef4af446356c9d030decd9551782a1b591fad218c2421edafe7f2262200a2e6a1672ac41d7f16a9664ebd7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ta/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ta/firefox-55.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "037257799dd7cd3383a35c334ec99f53be8682ac14020c7f96426a7885d9257519e3d5ab8643045e97df703a4bc63424db9dfa29cd65d6291402a034000fcf21";
+      sha512 = "a351f1850772b6086a70d6c8f6edc5b0906b8b5a9dbb8c05dea8a75f4ebeb46b1e9077f2c145b5b557acf3e7382d72f94949a1a0420c5c04d9e7b17292ef5d63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/te/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/te/firefox-55.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "f0216fd72eba20ae094c54a4654356947441564661f6ecf5de399f55f05f7cb60370ac0072b2721d74cb40cf4c938cd3736cbd9b3a93cd641e3ef1a9089b4502";
+      sha512 = "8f1a725b309eff87d1ba130d02e6807a7202d91f0d7cee73672e6dd0dcc90b92b5a7aa73150d9c69140e9c27140b364557d289a644c1131c57d19a34d96acecd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/th/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/th/firefox-55.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "ff62cc5280928c0d9aad58c3b7fc52435f09e08d65e89ab0b7fb7280f3e61289d513f893dca2746e913121753c0f15e5a34c675c4074a0ff159e790d2bfad0f0";
+      sha512 = "95f20d59433954c0b26a709378a853f6297028126ffaf2beabbe0332acc9df3089dfbc0095f3aac503a04b0cdfce9f79199eed9ca04b810f213f5692a1fc4cad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/tr/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/tr/firefox-55.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "fc7f8d5120fb3b3c3699f13870fadf265ce7a43a1adadee89457a7df863d6da0f4d64b7f0b633d3526da39d825f30fbec3b9f1ae09bffb4c61681f4105bb5db7";
+      sha512 = "6eb68dc198c1106d48ea93b924dc961aaa10a7e89a74f7ffcd219f1de4952c403b19062bd23fa625f82cc9cdad0506f777aa57da6fb106050e962deffa79cc76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/uk/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/uk/firefox-55.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "f0fb3de841925f81c64877efbc8b151cec744bd0b4997bdb9a086413e7106cf05c1dca49ee797dbd2d80bd1603554e006f47b21217e60d390ae91c6a1badac47";
+      sha512 = "c43f597db5027f6c1ba76e4308a7e733a78f1d3711a4529b5cc8f51eebe7bd2a55007975f248be698485fecb91ecbc43a141a94869e41445a07f90fa81d70cb0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/ur/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ur/firefox-55.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "3480fca8ef85b5db62b471c2986f124b92bd17c5682d57276b3f30fe0d3fde02f3d2a6e044f6c5157fc2bd3ab882e235f264aaeb319e09d234492c1aed674b92";
+      sha512 = "2d7af1f97cf035519c43e57ba4be3f95f64e2da816d01c924e82dd4c442d767098247f1bd7535f3d5c658254ba7a9ade752f97ca4951a6a0989f6303cfeb3354";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/uz/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/uz/firefox-55.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "2460a419db6406542279daae938882fcc3ac29446b88a6315f3f7626925b906aed2d8a6250dfcc50c7eb87da3d57d231e4fcb5659a0fdc84ac188d4bbaf436aa";
+      sha512 = "f5173c595187661731aa3e4edb3fa35f3be9c0f494882a06e765142e193488e50538b1558ae094b8a0c462758601a89dc9105ecee6ed485435083f5c9ea67f6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/vi/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/vi/firefox-55.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "0e54d8a00a734b4fee5ef7cc2a831453c732573d53477e53bb202311de5524839ed2290f5ed6d93a20d5b63da765f7a621d8bafaf0150d522c755347ca49ff6f";
+      sha512 = "2b30eea824bf032526033203798ad34337e7151c45cc055ad7eba9def8f46b6108de2730ae5dea45627b65ed7ec617ca15b5372f23e3e4a33a303bb51ac4983b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/xh/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/xh/firefox-55.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "67950de9da98ae7bf867079f831cdcdcb5aca1f9caf951813f394e1e266787d90777e95fb33f46351086b25927ef108ee78f34b8152084410f8727ad7f3579ae";
+      sha512 = "2d098f192bfee274dd9c4cd806bf35bd311c50eb73a45e23eb5e497e636617e020c518f131520f5f0ba3d23864c97f09b4d9b46db9cc4d55c63be3731e990aa6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/zh-CN/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/zh-CN/firefox-55.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "56b6bf4bdb5994f2550a47a0d6a6e5bf4eb5d456fc30e3472adb3efa909aeea17b86e24d799bc5eea11e60046afcb0eac61fe601c6e1c795ebb5a5440fc32738";
+      sha512 = "f89e61ad4c1b44d48e0e0e7be3dcd80df548e5f0d0932b915a2c37b36bd882cfd4d19c2d2261b64266a8317acb066b2c48db0348dbe37c14b748d5832f6c0e84";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/54.0.1/linux-i686/zh-TW/firefox-54.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/zh-TW/firefox-55.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "22fff4e32f6451b4378b45007c0fa7a1170a6897d13dfa1b0f814ac0ec9f48ea4dd5439a14aa7e9b1dabea19d0dbacd22f23dc431c38e023958692c5073147fb";
+      sha512 = "c8547fe1196a6b0ef8644edf69cdd68b74e208260c7e51f51a03d854374b0ed8623ebfb1e7c6e6c4d05edbc13e7862d0fdf260d77b7f2e125379258c4b3d44c6";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -25,10 +25,10 @@ rec {
 
   firefox-esr = common rec {
     pname = "firefox-esr";
-    version = "52.2.1esr";
+    version = "52.3.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "1d79e6e4625cf7994f6d6bbdf227e483fc407bcdb20e0296ea604969e701f551b5df32f578d4669cf654b65927328c8eb0f717c7a12399bf1b02a6ac7a0cd1d3";
+      sha512 = "36da8f14b50334e36fca06e09f15583101cadd10e510268255587ea9b09b1fea918da034d6f1d439ab8c34612f6cebc409a0b8d812dddb3f997afebe64d09fe9";
     };
 
     meta = firefox.meta // {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "54.0.1";
+    version = "55.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "43607c2c0af995a21dc7f0f68b24b7e5bdb3faa5ee06025901c826bfe4d169256ea1c9eb5fcc604c4d6426ced53e80787c12fc07cda014eca09199ef3df783a2";
+      sha512 = "b3ca0a926faedfc12c859965629330489ac6c05730a0dc38748704a1a25e876decfba78a3d665e22a6773b0a3bfed3109cd624be77d130785b4097d6d9f9c94b";
     };
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

- Improved address bar functionality
- Updated Sidebar for bookmarks, history, and synced tabs so it can appear at the right edge of the window as well as the left
- Added support for stereo microphones with WebRTC
- Simplified printing from Reader Mode
- Browsing sessions with a high number of tabs are now restored in an instant
- Make screenshots of webpages, and save them locally or upload them to the cloud. This feature will undergo A/B testing and will not be visible for some users.
- Added Belarusian (be) locale
- Breaking profile changes
- Made the Adobe Flash plugin click-to-activate by default and allowed only on http:// and https:// URL schemes. (This change will not be visible to all users immediately.

https://www.mozilla.org/en-US/firefox/55.0/releasenotes/

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

