### PR TITLE
Update {fork,power}stat to latest upstream

### DIFF
--- a/pkgs/os-specific/linux/forkstat/default.nix
+++ b/pkgs/os-specific/linux/forkstat/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "forkstat-${version}";
-  version = "0.01.17";
+  version = "0.02.00";
   src = fetchurl {
     url = "http://kernel.ubuntu.com/~cking/tarballs/forkstat/forkstat-${version}.tar.gz";
-    sha256 = "0plm2409mmp6n2fjj6bb3z7af2cnh5lg3czlylhgaki9zd0cyb7w";
+    sha256 = "07df2lb32lbr2ggi84h9pjy6ig18n2961ksji4x1hhb4cvc175dg";
   };
   installFlags = [ "DESTDIR=$(out)" ];
   postInstall = ''

--- a/pkgs/os-specific/linux/powerstat/default.nix
+++ b/pkgs/os-specific/linux/powerstat/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "powerstat-${version}";
-  version = "0.02.11";
+  version = "0.02.12";
   src = fetchurl {
     url = "http://kernel.ubuntu.com/~cking/tarballs/powerstat/powerstat-${version}.tar.gz";
-    sha256 = "0iid3b3284sf89pfp68i1k5mwmr31bqjzasb8clm2sa45ivafx52";
+    sha256 = "16ls3rs1wfckl0b2szqqgiv072afy4qjd3r4kz4vf2qj77kjm06w";
   };
   installFlags = [ "DESTDIR=$(out)" ];
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

update to latest upstream versions

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

