### PR TITLE
pcmanfm: build with gtk3

### DIFF
--- a/pkgs/applications/misc/pcmanfm/default.nix
+++ b/pkgs/applications/misc/pcmanfm/default.nix
@@ -1,5 +1,11 @@
-{ stdenv, fetchurl, glib, gtk2, intltool, libfm, libX11, pango, pkgconfig }:
+{ stdenv, fetchurl, glib, intltool, libfm, libX11, pango, pkgconfig
+, withGtk3 ? true, gtk2, gtk3 }:
 
+let
+  libfm' = libfm.override { inherit withGtk3; };
+  gtk = if withGtk3 then gtk3 else gtk2;
+  inherit (stdenv.lib) optional;
+in
 stdenv.mkDerivation rec {
   name = "pcmanfm-1.2.5";
   src = fetchurl {
@@ -7,7 +13,9 @@ stdenv.mkDerivation rec {
     sha256 = "0rxdh0dfzc84l85c54blq42gczygq8adhr3l9hqzy1dp530cm1hc";
   };
 
-  buildInputs = [ glib gtk2 intltool libfm libX11 pango pkgconfig ];
+  buildInputs = [ glib gtk intltool libfm' libX11 pango pkgconfig ];
+
+  configureFlags = optional withGtk3 "--with-gtk=3";
 
   meta = with stdenv.lib; {
     homepage = http://blog.lxde.org/?cat=28/;

--- a/pkgs/applications/misc/pcmanfm/default.nix
+++ b/pkgs/applications/misc/pcmanfm/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, glib, intltool, libfm, libX11, pango, pkgconfig
-, withGtk3 ? true, gtk2, gtk3 }:
+, wrapGAppsHook, gnome3, withGtk3 ? true, gtk2, gtk3 }:
 
 let
   libfm' = libfm.override { inherit withGtk3; };
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "0rxdh0dfzc84l85c54blq42gczygq8adhr3l9hqzy1dp530cm1hc";
   };
 
-  buildInputs = [ glib gtk intltool libfm' libX11 pango pkgconfig ];
+  buildInputs = [ glib gtk libfm' libX11 pango gnome3.defaultIconTheme ];
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook intltool ];
 
   configureFlags = optional withGtk3 "--with-gtk=3";
 

--- a/pkgs/development/libraries/libfm/default.nix
+++ b/pkgs/development/libraries/libfm/default.nix
@@ -1,6 +1,8 @@
-{ stdenv, fetchurl, glib, gtk2, intltool, menu-cache, pango, pkgconfig, vala_0_34
-, extraOnly ? false }:
+{ stdenv, fetchurl, glib, intltool, menu-cache, pango, pkgconfig, vala_0_34
+, extraOnly ? false
+, withGtk3 ? false, gtk2, gtk3 }:
 let
+    gtk = if withGtk3 then gtk3 else gtk2;
     inherit (stdenv.lib) optional;
 in
 stdenv.mkDerivation rec {
@@ -14,10 +16,13 @@ stdenv.mkDerivation rec {
     sha256 = "0nlvfwh09gbq8bkbvwnw6iqr918rrs9gc9ljb9pjspyg408bn1n7";
   };
 
-  buildInputs = [ glib gtk2 intltool pango pkgconfig vala_0_34 ]
+  buildInputs = [ glib gtk intltool pango pkgconfig vala_0_34 ]
                 ++ optional (!extraOnly) menu-cache;
 
-  configureFlags = optional extraOnly "--with-extra-only";
+  configureFlags = [ (optional extraOnly "--with-extra-only")
+                     (optional withGtk3 "--with-gtk=3") ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = http://blog.lxde.org/?cat=28/;


### PR DESCRIPTION
###### Motivation for this change

pcmanfm works with both GTK 2 and 3. As recommended by #18559, I set it to build with GTK 3 per default.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

