### PR TITLE
gcc and gdb: fix clang build

### DIFF
--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -325,7 +325,13 @@ stdenv.mkDerivation ({
 
   NIX_LDFLAGS = stdenv.lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
 
-  preConfigure = stdenv.lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
+  preConfigure =
+    # Not sure why this is causing problems, now that the stdenv
+    # exports CPP=cpp the build fails with strange errors on darwin.
+    # https://github.com/NixOS/nixpkgs/issues/27889
+    stdenv.lib.optionalString stdenv.cc.isClang ''
+    unset CPP
+  '' + stdenv.lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
     export NIX_LDFLAGS=`echo $NIX_LDFLAGS | sed -e s~$prefix/lib~$prefix/lib/amd64~g`
     export LDFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $LDFLAGS_FOR_TARGET"
     export CXXFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CXXFLAGS_FOR_TARGET"

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -66,6 +66,13 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional (!pythonSupport) "--without-python"
     ++ stdenv.lib.optional multitarget "--enable-targets=all";
 
+  preConfigure =
+    # Not sure why this is causing problems, now that the stdenv
+    # exports CPP=cpp the build fails with strange errors on darwin.
+    stdenv.lib.optionalString stdenv.cc.isClang ''
+      unset CPP
+    '';
+
   postInstall =
     '' # Remove Info files already provided by Binutils and other packages.
        rm -v $out/share/info/bfd.info


### PR DESCRIPTION
###### Motivation for this change

Fixes #27889

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] ~~NixOS~~
   - [x] macOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  - [x] `gcc`
  - [x] `gfortran`
  - [x] `gdb`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
