### PR TITLE
flashplayer: 26.0.0.137 -> 26.0.0.151 [Critical security fixes]

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -94,12 +94,12 @@ let
 
   flash = stdenv.mkDerivation rec {
     name = "flashplayer-ppapi-${version}";
-    version = "26.0.0.137";
+    version = "26.0.0.151";
 
     src = fetchzip {
       url = "https://fpdownload.adobe.com/pub/flashplayer/pdc/"
           + "${version}/flash_player_ppapi_linux.x86_64.tar.gz";
-      sha256 = "0zmslmy7i7ywb2frckg5afkmfqb2lm2mahq0qs8msjzcx9jk4pyx";
+      sha256 = "0l15k2ws3256zyvbfx66j8p1liqv4k2m8hhw2jz8nzza7q6il35p";
       stripRoot = false;
     };
 

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
@@ -73,7 +73,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-${version}";
-  version = "26.0.0.137";
+  version = "26.0.0.151";
 
   src = fetchurl {
     url =
@@ -84,14 +84,14 @@ stdenv.mkDerivation rec {
     sha256 =
       if debug then
         if arch == "x86_64" then
-          "1kdwprrrxbdgll05x148vhg86ph77ygr99ycfblblj8wjkcz9s0z"
+          "0dlgardgrd8a18b48b0l6xk68dqi39yndv05phrypsxzr00p23q8"
         else
-          "1ldv0fca43kdda949095r3gk1bc9p8n94z61qijkmrpv91zv5qvl"
+          "0dbvsww4v6hlqn4yhdmzs335inim5iq0ym998x8zpavilqq51y0d"
       else
         if arch == "x86_64" then
-          "0db6dcqal7p79q26kglnsbiv3ysx9r3c7rkdiynww18gzr40vwls"
+          "1yywffslh5px15w62wck1rnlp317jr6a334r409q7hxqc3x90z8l"
         else
-          "1fm6p91c63pyr0lra29vcq2dplb2c7a5114nm4r9rrrzjxakqw5w";
+          "1f1czbx14nvgr1qlzcp03nhj6c55wra8l6f4bsig691n3hfpb6hp";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
@@ -55,7 +55,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-standalone-${version}";
-  version = "26.0.0.137";
+  version = "26.0.0.151";
 
   src = fetchurl {
     url =
@@ -65,9 +65,9 @@ stdenv.mkDerivation rec {
         "https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flash_player_sa_linux.x86_64.tar.gz";
     sha256 =
       if debug then
-        "095457h83zs6cvdyyrh01069kgg8cnhgs1by6s9xpdxgc851n8gp"
+        "0pfb217bg0v9hq0cbyndhmhkba16nhz2rasl7kk4ppxcfcjhr5pb"
       else
-        "1zw3f612cfb8lr331hwqzlpd0gn3r0139bq76pbbbahh2chq99f8";
+        "0a9ayylkpjprad1al7ddplxrpymd181a9gmw9hhk78s11v2zvwn8";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

- Critical security fixes.
- Other bug fixes.

https://helpx.adobe.com/flash-player/release-note/fp_26_air_26_release_notes.html
https://helpx.adobe.com/security/products/flash-player/apsb17-23.html

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

- Built packages
  - `nix-env -i -f . -A pkgs.flashplayer`
  - `nix-build -I nixpkgs=. -A pkgsi686Linux.flashplayer`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).flashplayer.override { debug = true; }"`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).pkgsi686Linux.flashplayer.override { debug = true; }"`
  - `nix-build -I nixpkgs=. -A pkgs.flashplayer-standalone`
  - `nix-build -I nixpkgs=. -A pkgs.flashplayer-standalone-debugger`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).chromium.override { enablePepperFlash = true; }"`
- Played a video with Firefox (x86_64)
- Played a video with Chromium (x86_64)
- Played a video with `flashplayer-standalone` and `flashplayer-standalone-debugger` (x86_64).
- Checked the version with Firefox (x86_64) http://www.adobe.com/software/flash/about/
- Checked the version with Chromium (x86_64) http://www.adobe.com/software/flash/about/
- Checked the version with with `flashplayer-standalone` and `flashplayer-standalone-debugger` (x86_64).

The standalone players are unstable. I could play http://www.dhs.state.il.us/accessibility/tests/flash/video.swf only after playing http://wwwimages.adobe.com/www.adobe.com/swf/software/flash/about/flash_about_793x170.swf.

---

