### PR TITLE
faker: add ipaddress dependency for Python 2

### DIFF
--- a/pkgs/development/python-modules/faker/default.nix
+++ b/pkgs/development/python-modules/faker/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi,
+{ lib, buildPythonPackage, fetchPypi, pythonOlder,
   # Build inputs
-  dateutil, six,
+  dateutil, six, ipaddress ? null,
   # Test inputs
   email_validator, nose, mock, ukpostcodeparser }:
+
+assert pythonOlder "3.3" -> ipaddress != null;
 
 buildPythonPackage rec {
   pname = "Faker";
@@ -24,7 +26,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     dateutil
     six
-  ];
+  ] ++ lib.optional (pythonOlder "3.3") ipaddress;
 
   meta = with lib; {
     description = "A Python library for generating fake user data";


### PR DESCRIPTION
###### Motivation for this change

Faker requires ipaddress package on Python < 3.3:

https://github.com/joke2k/faker/blob/v0.7.18/setup.py#L66-L76

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

