### PR TITLE
Initial attempt to update libtorrent

### DIFF
--- a/pkgs/tools/networking/p2p/libtorrent/default.nix
+++ b/pkgs/tools/networking/p2p/libtorrent/default.nix
@@ -1,21 +1,21 @@
 { stdenv, fetchFromGitHub, pkgconfig
 , libtool, autoconf, automake, cppunit
-, openssl, libsigcxx, zlib }:
+, openssl, libsigcxx, zlib, boost }:
 
 stdenv.mkDerivation rec {
   name = "libtorrent-${version}";
-  version = "0.13.6";
+  version = "1.1.14";
 
   src = fetchFromGitHub rec {
-    owner = "rakshasa";
+    owner = "arvidn";
     repo = "libtorrent";
-    rev = "${version}";
-    sha256 = "1rvrxgb131snv9r6ksgzmd74rd9z7q46bhky0zazz7dwqqywffcp";
+    rev = "libtorrent-1_1_4";
+    sha256 = "0h6gfj0swhjzxmpqgdma4i9kr99gsfhb6j3icpfbg09hcza3zhiv";
   };
 
-  buildInputs = [ pkgconfig libtool autoconf automake cppunit openssl libsigcxx zlib ];
+  buildInputs = [ pkgconfig libtool autoconf automake cppunit openssl libsigcxx zlib boost ];
 
-  preConfigure = "./autogen.sh";
+  preConfigure = "./autotool.sh";
 
   meta = with stdenv.lib; {
     homepage = http://www.libtorrent.org/;

--- a/pkgs/tools/networking/p2p/libtorrent/default.nix
+++ b/pkgs/tools/networking/p2p/libtorrent/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pkgconfig
 , libtool, autoconf, automake, cppunit
-, openssl, libsigcxx, zlib, boost }:
+, openssl, libsigcxx, zlib, boost, boost-build }:
 
 stdenv.mkDerivation rec {
   name = "libtorrent-${version}";
@@ -13,9 +13,13 @@ stdenv.mkDerivation rec {
     sha256 = "0h6gfj0swhjzxmpqgdma4i9kr99gsfhb6j3icpfbg09hcza3zhiv";
   };
 
-  buildInputs = [ pkgconfig libtool autoconf automake cppunit openssl libsigcxx zlib boost ];
+  buildInputs = [ pkgconfig libtool autoconf automake cppunit openssl libsigcxx zlib boost boost-build ];
 
-  preConfigure = "./autotool.sh";
+  # preConfigure = "./autotool.sh";
+
+  buildPhase = "bjam release";
+
+  installPhase = "bjam --prefix=$out release install";
 
   meta = with stdenv.lib; {
     homepage = http://www.libtorrent.org/;


### PR DESCRIPTION
###### Motivation for this change

Libtorrent is several years out of date.  Initial source for noticing this was googling some errors Deluge was raising at startup.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

