### PR TITLE
libtorrentRasterbar 1.1.1 -> 1.1.4

### DIFF
--- a/pkgs/development/libraries/libtorrent-rasterbar/default.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/default.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "1.1.1";
-  sha256 = "1185ixlhhwpkqvwhnhrzgply03zq8mycj25m1am9aad8nshiaw3j";
+  version = "1.1.4";
+  sha256 = "1rrp4b7zfz0fnjvax2r9r5rrh6z1s4xqb9dx20gzr4gs8x5v5jws";
 })

--- a/pkgs/tools/networking/p2p/libtorrent/default.nix
+++ b/pkgs/tools/networking/p2p/libtorrent/default.nix
@@ -1,3 +1,5 @@
+# NOTE: this is rakshava's version of libtorrent, used mainly by rtorrent
+# This is NOT libtorrent-rasterbar, used by Deluge, qbitttorent, and others
 { stdenv, fetchFromGitHub, pkgconfig
 , libtool, autoconf, automake, cppunit
 , openssl, libsigcxx, zlib }:


### PR DESCRIPTION
###### Motivation for this change

Bump the libtorrentRasterbar version from 1.1.1 to 1.1.4; fixes some version mismatch bugs on startup in Deluge.

Add a note to libtorrent that it is not the same thing as libtorrentRasterbar - this conflation wasted about an hour of my time as I made https://github.com/NixOS/nixpkgs/pull/28058

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

