### PR TITLE
mpDris2: add mutagen for cover art support

### DIFF
--- a/pkgs/tools/audio/mpdris2/default.nix
+++ b/pkgs/tools/audio/mpdris2/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ intltool autoreconfHook pythonPackages.wrapPython ];
-  propagatedBuildInputs = with pythonPackages; [ python pygtk dbus-python ];
+  propagatedBuildInputs = with pythonPackages; [ python pygtk dbus-python mutagen ];
   pythonPath = with pythonPackages; [ mpd pygtk dbus-python notify ];
   postInstall = "wrapPythonPrograms";
 

--- a/pkgs/tools/audio/mpdris2/default.nix
+++ b/pkgs/tools/audio/mpdris2/default.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ intltool autoreconfHook pythonPackages.wrapPython ];
-  propagatedBuildInputs = with pythonPackages; [ python pygtk dbus-python mutagen ];
-  pythonPath = with pythonPackages; [ mpd pygtk dbus-python notify ];
+  propagatedBuildInputs = with pythonPackages; [ python pygtk dbus-python  ];
+  pythonPath = with pythonPackages; [ mpd pygtk dbus-python notify mutagen ];
   postInstall = "wrapPythonPrograms";
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Building mpDris2 with mutagen allows it to extract cover art from songs.

I added mutagen as a build input; mpDris2 autodetects this and enables cover art support.

I tested it with:

`nix-shell --option build-use-sandbox true -I nixpkgs=. -p mpdris2`

And confirmed that cover art support was enabled.

The reason why some packages are in `propagatedBuildInputs` and some are in `pythonPath` is a bit mysterious to me, but I tested if it worked without putting mutagen in`pythonPath` and it was fine, so I left it out.

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [N/A] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).