### PR TITLE
mpd: add lame support

### DIFF
--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -18,6 +18,7 @@
 , mmsSupport ? true, libmms
 , mpg123Support ? true, mpg123
 , aacSupport ? true, faad2
+, lameSupport ? true, lame
 , pulseaudioSupport ? true, libpulseaudio
 , jackSupport ? true, libjack2
 , gmeSupport ? true, game-music-emu
@@ -72,6 +73,7 @@ in stdenv.mkDerivation rec {
     ++ opt mmsSupport libmms
     ++ opt mpg123Support mpg123
     ++ opt aacSupport faad2
+    ++ opt lameSupport lame
     ++ opt zipSupport zziplib
     ++ opt (!stdenv.isDarwin && pulseaudioSupport) libpulseaudio
     ++ opt (!stdenv.isDarwin && jackSupport) libjack2
@@ -105,6 +107,7 @@ in stdenv.mkDerivation rec {
       (mkFlag mmsSupport "mms")
       (mkFlag mpg123Support "mpg123")
       (mkFlag aacSupport "aac")
+      (mkFlag lameSupport "lame-encoder")
       (mkFlag (!stdenv.isDarwin && pulseaudioSupport) "pulse")
       (mkFlag (!stdenv.isDarwin && jackSupport) "jack")
       (mkFlag stdenv.isDarwin "osx")


### PR DESCRIPTION
###### Motivation for this change
mp3 lame is one of the two encodings supported by the mpd httpd server, the other being vorbis. As I discovered, a lot of players don't like vorbis, the Sonos sound system being one of them.

###### Things done

Having a working mpd server streaming via HTTP to my Sonos system, I can confirm that it definitely works.

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

