### PR TITLE
nixos/environment: make default shell aliases overridable

### DIFF
--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -106,22 +106,29 @@ in
       type = types.lines;
     };
 
-    environment.shellAliases = mkOption rec {
+    environment.shellAliases = mkOption {
       default = {
         ls = "ls --color=tty";
         ll = "ls -l";
         l  = "ls -alh";
       };
-      example = { ll = "ls -l"; };
+      example = { gst = "git status"; };
       description = ''
         An attribute set that maps aliases (the top level attribute names in
         this option) to command strings or directly to build outputs. The
         aliases are added to all users' shells.
+
+        <note><para>
+        The defaults are there only as a suggestion and disappear when any alias is set.
+        To include the default aliases in your configuration use:
+        <code>
+        environment.shellAliases = {
+          gst = "git status";
+        } // options.environment.shellAliases.default;
+        </code>
+        </para></note>
       '';
-      type = types.attrs // {
-        # merge aliases defined by the user and the defaults
-        merge = loc: defs: default // types.attrs.merge loc defs;
-      };
+      type = types.attrs;
     };
 
     environment.binsh = mkOption {

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -106,15 +106,22 @@ in
       type = types.lines;
     };
 
-    environment.shellAliases = mkOption {
-      default = {};
+    environment.shellAliases = mkOption rec {
+      default = {
+        ls = "ls --color=tty";
+        ll = "ls -l";
+        l  = "ls -alh";
+      };
       example = { ll = "ls -l"; };
       description = ''
         An attribute set that maps aliases (the top level attribute names in
         this option) to command strings or directly to build outputs. The
         aliases are added to all users' shells.
       '';
-      type = types.attrs; # types.attrsOf types.stringOrPath;
+      type = types.attrs // {
+        # merge aliases defined by the user and the defaults
+        merge = loc: defs: default // types.attrs.merge loc defs;
+      };
     };
 
     environment.binsh = mkOption {

--- a/nixos/modules/programs/shell.nix
+++ b/nixos/modules/programs/shell.nix
@@ -14,12 +14,6 @@ in
 
   config = {
 
-    environment.shellAliases =
-      { ls = "ls --color=tty";
-        ll = "ls -l";
-        l  = "ls -alh";
-      };
-
     environment.shellInit =
       ''
         # Set up the per-user profile.


### PR DESCRIPTION
###### Motivation for this change

This fixes issue #24560 by moving the predefined shellAliases to the `environment.shellAliases` option definition.

I also used a custom merge function, such that the defaults only get overridden when the user defines an alternative.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

