### PR TITLE
nixos/tor: add tor hidden service options

### DIFF
--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -378,7 +378,8 @@ in
             };
           };
         }));
-        default = {
+        default = {};
+        example = {
           "/path/to/hidden/service/dir/" = {
             hiddenServicePorts = [ { virtualPort = 80; } ];
           };

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -51,7 +51,7 @@ let
 
   hiddenServices = concatStrings (mapAttrsToList (hiddenServiceDir: hs:
     let
-      hsports = concatStrings (map mkHiddenServicePort hs.hiddenServicePorts);
+      hsports = concatStringsSep "\n" (map mkHiddenServicePort hs.hiddenServicePorts);
     in
       "HiddenServiceDir ${hiddenServiceDir}\n${hsports}\n${hs.extraConfig}\n"
     ) cfg.hiddenServices);

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -381,7 +381,7 @@ in
         }));
         default = {};
         example = {
-          "/path/to/hidden/service/dir/" = {
+          "/var/lib/tor/webserver" = {
             hiddenServicePorts = [ { virtualPort = 80; } ];
           };
         };

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -57,9 +57,7 @@ let
     ) cfg.hiddenServices);
 
     mkHiddenServicePort = hsport: let
-      trgt = if (hsport.target != null) then
-        " " + hsport.target
-      else "";
+      trgt = optionalString (hsport.target != null) (" " + hsport.target);
     in "HiddenServicePort ${toString hsport.virtualPort}${trgt}";
 
   torRcFile = pkgs.writeText "torrc" torRc;
@@ -243,11 +241,11 @@ in
           default = null;
           example = "450 GBytes";
           description = ''
-            Specify maximum bandwidth allowed during an accounting
-            period. This allows you to limit overall tor bandwidth
-            over some time period. See the
-            <literal>AccountingMax</literal> option by looking at the
-            tor manual (<literal>man tor</literal>) for more.
+            Specify maximum bandwidth allowed during an accounting period. This
+            allows you to limit overall tor bandwidth over some time period.
+            See the <literal>AccountingMax</literal> option by looking at the
+            tor manual <citerefentry><refentrytitle>tor</refentrytitle>
+            <manvolnum>1</manvolnum></citerefentry> for more.
 
             Note this limit applies individually to upload and
             download; if you specify <literal>"500 GBytes"</literal>
@@ -261,10 +259,11 @@ in
           default = null;
           example = "month 1 1:00";
           description = ''
-            Specify length of an accounting period. This allows you to
-            limit overall tor bandwidth over some time period. See the
-            <literal>AccountingStart</literal> option by looking at
-            the tor manual (<literal>man tor</literal>) for more.
+            Specify length of an accounting period. This allows you to limit
+            overall tor bandwidth over some time period. See the
+            <literal>AccountingStart</literal> option by looking at the tor
+            manual <citerefentry><refentrytitle>tor</refentrytitle>
+            <manvolnum>1</manvolnum></citerefentry> for more.
           '';
         };
 
@@ -293,9 +292,10 @@ in
           type    = types.str;
           example = "143";
           description = ''
-            What port to advertise for Tor connections. This corresponds
-            to the <literal>ORPort</literal> section in the Tor manual; see
-            <literal>man tor</literal> for more details.
+            What port to advertise for Tor connections. This corresponds to the
+            <literal>ORPort</literal> section in the Tor manual; see
+            <citerefentry><refentrytitle>tor</refentrytitle>
+            <manvolnum>1</manvolnum></citerefentry> for more details.
 
             At a minimum, you should just specify the port for the
             relay to listen on; a common one like 143, 22, 80, or 443
@@ -365,7 +365,8 @@ in
 
                 This corresponds to the <literal>HiddenServicePort VIRTPORT
                 [TARGET]</literal> option by looking at the tor manual
-                (<literal>man tor</literal>) for more information.
+                <citerefentry><refentrytitle>tor</refentrytitle>
+                <manvolnum>1</manvolnum></citerefentry> for more information.
               '';
             };
             extraConfig = mkOption {
@@ -387,8 +388,10 @@ in
         description = ''
           Configure hidden services.
 
-          Please consult the tor manual (<literal>man tor</literal>) for a more
-          detailed explanation. (search for 'HIDDEN').
+          Please consult the tor manual
+          <citerefentry><refentrytitle>tor</refentrytitle>
+          <manvolnum>1</manvolnum></citerefentry> for a more detailed
+          explanation. (search for 'HIDDEN').
         '';
       };
     };


### PR DESCRIPTION
###### Motivation for this change

Having to configure tor hidden services via the `extraConfig` did not look as nice in the configuration.
This change allows to configure hidden services more conveniently.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

Since all changes are only related to generating torrc files i tested it on my local machine.
I was able to generate valid torrc files and host hidden services using those.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


---

