### PR TITLE
Fix ruby built

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -49,12 +49,12 @@ let
           rev    = tag;
           sha256 = sha256.git;
         } else fetchurl {
-          url = "http://cache.ruby-lang.org/pub/ruby/${ver.majMin}/ruby-${ver}.tar.gz";
+          url = "http://cache.ruby-lang.org/pub/ruby/${ver.majMin}/ruby-${ver.majMinTiny}.tar.gz";
           sha256 = sha256.src;
         };
       in
       stdenv.mkDerivation rec {
-        name = "ruby-${version}";
+        name = "ruby-${ver.majMinTiny}";
 
         srcs = [ rubySrc rubygemsSrc ];
         sourceRoot =


### PR DESCRIPTION
###### Motivation for this change

When trying to build package ruby from master, I got the following error:

```
$ sudo nix-build -A ruby
error: cannot coerce a set to a string, at /home/dpino/workspace/nixpkgs/pkgs/development/interpreters/ruby/default.nix:57:17
```

Actually I for this error after upgrading from 16.09 to 17.03. Running a nix-env command returned the same error:

```bash
$ nix-env -qaP ruby
error: cannot coerce a set to a string, at /nix/store/v1zvii5pzvx76dgkb8ifdsyp8fwj6ng6-nixos-17.03.1661.1f7114aec3/nixos/pkgs/development/interpreters/ruby/default.nix:57:17
```

This happened not only when searching package ruby, but any other package.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

