### PR TITLE
tinc: allow the daemon to write to files in /etc/tinc/${network}/hosts

### DIFF
--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -172,6 +172,7 @@ in
         };
         preStart = ''
           mkdir -p /etc/tinc/${network}/hosts
+          chown tinc.${network} /etc/tinc/${network}/hosts
 
           # Determine how we should generate our keys
           if type tinc >/dev/null 2>&1; then


### PR DESCRIPTION
Follow up https://github.com/NixOS/nixpkgs/pull/27756: tinc daemon may also create new files in ```/etc/tinc/$network/hosts```

