### PR TITLE
nixos/tinc: do not tell systemd where is pidfile

### DIFF
--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -166,7 +166,6 @@ in
         path = [ data.package ];
         serviceConfig = {
           Type = "simple";
-          PIDFile = "/run/tinc.${network}.pid";
           Restart = "always";
           RestartSec = "3";
         };


### PR DESCRIPTION
```Tinc```'s pidfile has more info than just a pid

```
# cat /run/tinc.dmz.pid
12209 7BD4A657B4A04364D268D188A0F4AA972A05247D802149246BBE1F1E689CABA1 127.0.0.1 port 656
```

```systemd``` fails to parse it.
It results in long (re)start times when ```systemd``` waits for a correct pidfile to appear.

It is especially visible if you set ```Type="forking"``` (and remove ```-D``` from command line):
the Tinc service will stuck in the ```activating``` state and never reach the ```active``` state.
