### PR TITLE
libtorrentRasterbar_1_0 1.0.10 -> 1.0.11

### DIFF
--- a/pkgs/development/libraries/libtorrent-rasterbar/1.0.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/1.0.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "1.0.10";
-  sha256 = "1x5gvajplmwx869avlpx8p3c12pzi6wkgqaxmj5049nvw57l00kl";
+  version = "1.0.11";
+  sha256 = "17p34d3n29q04pvz975gfl1fyj3sg9cl5l6j673xqfq3fpyis58i";
 })


### PR DESCRIPTION
###### Motivation for this change
Bump version for the 1.0 series for libtorrentRasterbar

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

