### PR TITLE
gist: 4.5.0 -> 4.6.1

### DIFF
--- a/pkgs/tools/text/gist/default.nix
+++ b/pkgs/tools/text/gist/default.nix
@@ -4,8 +4,8 @@ buildRubyGem rec {
   inherit ruby;
   name = "${gemName}-${version}";
   gemName = "gist";
-  version = "4.5.0";
-  sha256 = "0k9bgjdmnr14whmjx6c8d5ak1dpazirj96hk5ds69rl5d9issw0l";
+  version = "4.6.1";
+  sha256 = "16qvmn7syvcf4lnblngzvq8xynvb62h1xhfc7xfb0c1sjh166hff";
 
   buildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
###### Motivation for this change
`gist -s` which is supposed to shorten the URL to a git.io one doesn't work anymore with version 4.5.0. A fix for it is in the latest version, making `-s` work again.

###### Things done

Shortened a link with -s, it worked


- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

