### PR TITLE
haskell: fix build of ghcjs and ghcjsHEAD

### DIFF
--- a/pkgs/development/compilers/ghcjs/ghcjs.patch
+++ b/pkgs/development/compilers/ghcjs/ghcjs.patch
@@ -2,7 +2,7 @@ diff --git a/src-bin/Boot.hs b/src-bin/Boot.hs
 index db8b12e..7b815c5 100644
 --- a/src-bin/Boot.hs
 +++ b/src-bin/Boot.hs
-@@ -526,9 +526,7 @@ initPackageDB :: B ()
+@@ -540,9 +540,7 @@ initPackageDB :: B ()
  initPackageDB = do
    msg info "creating package databases"
    initDB "--global" <^> beLocations . blGlobalDB
@@ -12,7 +12,7 @@ index db8b12e..7b815c5 100644
      initDB dbName db = do
        rm_rf db >> mkdir_p db
        ghcjs_pkg_ ["init", toTextI db] `catchAny_` return ()
-@@ -552,29 +550,22 @@ installDevelopmentTree = subTop $ do
+@@ -566,29 +564,22 @@ installDevelopmentTree = subTop $ do
    msgD info $ "preparing development boot tree"
    checkpoint' "ghcjs-boot-git" "ghcjs-boot repository already cloned and prepared" $ do
      testGit "ghcjs-boot" >>= \case
@@ -46,7 +46,25 @@ index db8b12e..7b815c5 100644
        mapM_ patchPackage =<< allPackages
        preparePrimops
        buildGenPrim
-@@ -1110,14 +1101,14 @@ cabalInstallFlags parmakeGhcjs = do
+@@ -1141,7 +1132,7 @@ cabalStage1 pkgs = sub $ do
+   globalFlags <- cabalGlobalFlags
+   flags <- cabalInstallFlags (length pkgs == 1)
+   let args = globalFlags ++ ("install" : pkgs) ++
+-             [ "--solver=topdown" -- the modular solver refuses to install stage1 packages
++             [ "--allow-boot-library-installs"
+              ] ++ map ("--configure-option="<>) configureOpts ++ flags
+   checkInstallPlan pkgs args
+   cabal_ args
+@@ -1162,7 +1153,7 @@ cabalInstall pkgs = do
+ -- uses somewhat fragile parsing of --dry-run output, find a better way
+ checkInstallPlan :: [Package] -> [Text] -> B ()
+ checkInstallPlan pkgs opts = do
+-  plan <- cabal (opts ++ ["-v2", "--dry-run"])
++  plan <- cabal (opts ++ ["-vverbose+nowrap", "--dry-run"])
+   when (hasReinstalls plan || hasUnexpectedInstalls plan || hasNewVersion plan) (err plan)
+   where
+     hasReinstalls = T.isInfixOf "(reinstall)"   -- reject reinstalls
+@@ -1201,14 +1192,14 @@ cabalInstallFlags parmakeGhcjs = do
             , "--avoid-reinstalls"
             , "--builddir",      "dist"
             , "--with-compiler", ghcjs ^. pgmLocText


### PR DESCRIPTION
###### Motivation for this change
`ghcjs` and `ghcjsHEAD` can’t built with `cabal-install` 2.0, see #28037.

###### Things done
Patch `ghcjs-boot` to support `cabal-install` 2.0.

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---