### PR TITLE
gnupg: 2.1.22 -> 2.1.23

### DIFF
--- a/pkgs/applications/misc/gpg-mdp/default.nix
+++ b/pkgs/applications/misc/gpg-mdp/default.nix
@@ -19,11 +19,11 @@ in stdenv.mkDerivation {
       --replace "alias echo=/bin/echo" ""
 
     substituteInPlace ./src/config.c \
-      --replace "/usr/bin/gpg" "${gnupg}/bin/gpg2" \
+      --replace "/usr/bin/gpg" "${gnupg}/bin/gpg" \
       --replace "/usr/bin/vi" "vi"
 
     substituteInPlace ./mdp.1 \
-      --replace "/usr/bin/gpg" "${gnupg}/bin/gpg2"
+      --replace "/usr/bin/gpg" "${gnupg}/bin/gpg"
   '';
   # we add symlinks to the binary and man page with the name 'gpg-mdp', in case
   # the completely unrelated program also named 'mdp' is already installed.

--- a/pkgs/applications/networking/browsers/firefox-bin/update.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/update.nix
@@ -22,7 +22,7 @@ in writeScript "update-${name}" ''
   pushd ${basePath}
 
   HOME=`mktemp -d`
-  cat ${./firefox.key} | gpg2 --import
+  cat ${./firefox.key} | gpg --import
 
   tmpfile=`mktemp`
   url=${baseUrl}
@@ -47,7 +47,7 @@ in writeScript "update-${name}" ''
 
   curl --silent -o $HOME/shasums "$url$version/SHA512SUMS"
   curl --silent -o $HOME/shasums.asc "$url$version/SHA512SUMS.asc"
-  gpgv2 --keyring=$HOME/.gnupg/pubring.kbx $HOME/shasums.asc $HOME/shasums
+  gpgv --keyring=$HOME/.gnupg/pubring.kbx $HOME/shasums.asc $HOME/shasums
 
   # this is a list of sha512 and tarballs for both arches
   shasums=`cat $HOME/shasums`

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -48,11 +48,11 @@ stdenv.mkDerivation rec {
     find test -type f -exec \
       sed -i \
         -e "1s|#!/usr/bin/env bash|#!${bash}/bin/bash|" \
-        -e "s|gpg |${gnupg}/bin/gpg2 |" \
-        -e "s| gpg| ${gnupg}/bin/gpg2|" \
+        -e "s|gpg |${gnupg}/bin/gpg |" \
+        -e "s| gpg| ${gnupg}/bin/gpg|" \
         -e "s|gpgsm |${gnupg}/bin/gpgsm |" \
         -e "s| gpgsm| ${gnupg}/bin/gpgsm|" \
-        -e "s|crypto.gpg_path=gpg|crypto.gpg_path=${gnupg}/bin/gpg2|" \
+        -e "s|crypto.gpg_path=gpg|crypto.gpg_path=${gnupg}/bin/gpg|" \
         "{}" ";"
 
     for src in \
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
       emacs/notmuch-crypto.el
     do
       substituteInPlace "$src" \
-        --replace \"gpg\" \"${gnupg}/bin/gpg2\"
+        --replace \"gpg\" \"${gnupg}/bin/gpg\"
     done
   '';
 

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -242,7 +242,7 @@ in
 
       substituteInPlace lib/sup/crypto.rb \
         --replace 'which gpg2' \
-                  '${which}/bin/which gpg2'
+                  '${which}/bin/which gpg'
     '';
   };
 

--- a/pkgs/os-specific/linux/tomb/default.nix
+++ b/pkgs/os-specific/linux/tomb/default.nix
@@ -28,8 +28,7 @@ stdenv.mkDerivation rec {
     install -Dm755 tomb       $out/bin/tomb
     install -Dm644 doc/tomb.1 $out/share/man/man1/tomb.1
 
-    # it works fine with gnupg v2, but it looks for an executable named gpg
-    ln -s ${gnupg}/bin/gpg2 $out/bin/gpg
+    ln -s ${gnupg}/bin/gpg $out/bin/gpg
 
     wrapProgram $out/bin/tomb \
       --prefix PATH : $out/bin:${lib.makeBinPath [ cryptsetup gettext pinentry ]}

--- a/pkgs/tools/misc/debian-devscripts/default.nix
+++ b/pkgs/tools/misc/debian-devscripts/default.nix
@@ -27,10 +27,10 @@ in stdenv.mkDerivation rec {
     mkdir -p "$tgtpy"
     export PYTHONPATH="$PYTHONPATH''${PYTHONPATH:+:}$tgtpy"
     find po4a scripts -type f -exec sed -r \
-      -e "s@/usr/bin/gpg(2|)@${gnupg}/bin/gpg2@g" \
+      -e "s@/usr/bin/gpg(2|)@${gnupg}/bin/gpg@g" \
       -e "s@/usr/(s|)bin/sendmail@${sendmailPath}@g" \
       -e "s@/usr/bin/diff@${diffutils}/bin/diff@g" \
-      -e "s@/usr/bin/gpgv(2|)@${gnupg}/bin/gpgv2@g" \
+      -e "s@/usr/bin/gpgv(2|)@${gnupg}/bin/gpgv@g" \
       -e "s@(command -v|/usr/bin/)curl@${curl.bin}/bin/curl@g" \
       -i {} +
     sed -e "s@/usr/share/sgml/[^ ]*/manpages/docbook.xsl@${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl@" -i scripts/Makefile

--- a/pkgs/tools/misc/pipelight/default.nix
+++ b/pkgs/tools/misc/pipelight/default.nix
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
       --prefix=$out \
       --moz-plugin-path=$out/${mozillaPluginPath} \
       --wine-path=${wine_custom} \
-      --gpg-exec=${gnupg}/bin/gpg2 \
+      --gpg-exec=${gnupg}/bin/gpg \
       --bash-interp=${bash}/bin/bash \
       --downloader=${curl.bin}/bin/curl
       $configureFlags

--- a/pkgs/tools/misc/pipelight/pipelight.patch
+++ b/pkgs/tools/misc/pipelight/pipelight.patch
@@ -62,7 +62,7 @@ diff -urN pipelight.old/configure pipelight.new/configure
 -	gpg_exec="/usr/bin/gpg"
 -fi
 +bash_interp=bash
-+gpg_exec=gpg2
++gpg_exec=gpg
  moz_plugin_path=""
  gcc_runtime_dlls=""
  so_mode="0644"

--- a/pkgs/tools/security/gnupg/1compat.nix
+++ b/pkgs/tools/security/gnupg/1compat.nix
@@ -12,10 +12,6 @@ stdenv.mkDerivation {
     ${coreutils}/bin/rm $out/bin
     ${coreutils}/bin/mkdir -p $out/bin
     ${coreutils}/bin/ln -s "${gnupg}/bin/"* $out/bin
-
-    # Add gpg->gpg2 and gpgv->gpgv2 symlinks
-    ${coreutils}/bin/ln -s gpg2 $out/bin/gpg
-    ${coreutils}/bin/ln -s gpgv2 $out/bin/gpgv
   '';
 
   meta = gnupg.meta // {

--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -15,11 +15,11 @@ assert guiSupport -> pinentry != null;
 stdenv.mkDerivation rec {
   name = "gnupg-${version}";
 
-  version = "2.1.22";
+  version = "2.1.23";
 
   src = fetchurl {
     url = "mirror://gnupg/gnupg/${name}.tar.bz2";
-    sha256 = "1msazgy1q1pp7y2xr46z0il4pfzmzgzkp7v0hv5cz4hvkspnywa6";
+    sha256 = "0xqd5nm4j3w9lwk35vg57gl2i8bfkmx7d24i44gkbscm2lwpci59";
   };
 
   buildInputs = [

--- a/pkgs/tools/security/gnupg/gpgkey2ssh-20.patch
+++ b/pkgs/tools/security/gnupg/gpgkey2ssh-20.patch
@@ -7,7 +7,7 @@ index 903fb5b..d5611dc 100644
  
    ret = asprintf (&command,
 -		  "gpg --list-keys --with-colons --with-key-data '%s'",
-+		  "@out@/bin/gpg2 --list-keys --with-colons --with-key-data '%s'",
++		  "@out@/bin/gpg --list-keys --with-colons --with-key-data '%s'",
  		  keyid);
    assert (ret > 0);
  

--- a/pkgs/tools/security/pius/default.nix
+++ b/pkgs/tools/security/pius/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   buildInputs = [ python ];
 
   patchPhase = ''
-    sed -i "pius" -e's|/usr/bin/gpg|${gnupg}/bin/gpg2|g'
+    sed -i "pius" -e's|/usr/bin/gpg|${gnupg}/bin/gpg|g'
   '';
 
   dontBuild = true;


### PR DESCRIPTION
###### Motivation for this change

This release in a RC for gnupg-2.2. The main difference as far as
nixpkgs is concerned is that the binary `gpg2` is now called `gpg` and
`gpgv2` is called `gpgv`.

This update fixed all explicit use of `gpg2` and `gpgv2` across nixpkgs,
but there might be some packaged software that internally use `gpg2`.

It could be possible to use the `--enable-gpg-is-gpg2` configure flag to keep the old binary names, but in the long run I think everyone should converge to the new naming. We could use this while waiting for the 2.2 release but this would only postpone the work.

It could however be reasonable to use the `--enable-gpg-is-gpg2` until the `17.09` branch of, and then have a 6 month window to be sure this renaming does not cause issue for next stable release.

I am of course open to discussions on this subject.

See http://lists.gnu.org/archive/html/info-gnu/2017-08/msg00001.html
for full release information

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

