### PR TITLE
babelstone-han: 9.0.2 -> 10.0.0

### DIFF
--- a/pkgs/data/fonts/babelstone-han/default.nix
+++ b/pkgs/data/fonts/babelstone-han/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "babelstone-han-${version}";
-  version = "9.0.2";
+  version = "10.0.0";
 
   src = fetchurl {
-    url = "http://www.babelstone.co.uk/Fonts/8672/BabelStoneHan.zip";
-    sha256 = "09zlrp3mqdsbxpq4sssd8gj5isnxfbr56pcdp7mnr27nv4pvp6ha";
+    url = http://www.babelstone.co.uk/Fonts/0816/BabelStoneHan.zip;
+    sha256 = "1vccpyk5fd35fq2mk48cdhzy5q6id1pzlski1knsiqamvyys4ykd";
   };
 
   buildInputs = [ unzip ];
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/fonts/truetype
     cp -v *.ttf $out/share/fonts/truetype
   '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "0648hv5c1hq3bq7mlk7bnmflzzqj4wh137bjqyrwj5hy3nqzvl5r";
 
   meta = with stdenv.lib; {
     description = "Unicode CJK font with over 32600 Han characters";

--- a/pkgs/data/fonts/babelstone-han/default.nix
+++ b/pkgs/data/fonts/babelstone-han/default.nix
@@ -1,18 +1,15 @@
-{stdenv, fetchurl, unzip}:
+{stdenv, fetchzip}:
 
 let
   version = "10.0.0";
-in fetchurl {
+in fetchzip {
   name = "babelstone-han-${version}";
 
   url = http://www.babelstone.co.uk/Fonts/0816/BabelStoneHan.zip;
-  downloadToTemp = true;
   postFetch = ''
-    ${unzip}/bin/unzip $downloadedFile
     mkdir -p $out/share/fonts/truetype
-    cp -v *.ttf $out/share/fonts/truetype
+    unzip $downloadedFile '*.ttf' -d $out/share/fonts/truetype
   '';
-  recursiveHash = true;
   sha256 = "0648hv5c1hq3bq7mlk7bnmflzzqj4wh137bjqyrwj5hy3nqzvl5r";
 
   meta = with stdenv.lib; {

--- a/pkgs/data/fonts/babelstone-han/default.nix
+++ b/pkgs/data/fonts/babelstone-han/default.nix
@@ -1,26 +1,19 @@
 {stdenv, fetchurl, unzip}:
 
-stdenv.mkDerivation rec {
-  name = "babelstone-han-${version}";
+let
   version = "10.0.0";
+in fetchurl {
+  name = "babelstone-han-${version}";
 
-  src = fetchurl {
-    url = http://www.babelstone.co.uk/Fonts/0816/BabelStoneHan.zip;
-    sha256 = "1vccpyk5fd35fq2mk48cdhzy5q6id1pzlski1knsiqamvyys4ykd";
-  };
-
-  buildInputs = [ unzip ];
-
-  sourceRoot = ".";
-
-  installPhase = ''
+  url = http://www.babelstone.co.uk/Fonts/0816/BabelStoneHan.zip;
+  downloadToTemp = true;
+  postFetch = ''
+    ${unzip}/bin/unzip $downloadedFile
     mkdir -p $out/share/fonts/truetype
     cp -v *.ttf $out/share/fonts/truetype
   '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "0648hv5c1hq3bq7mlk7bnmflzzqj4wh137bjqyrwj5hy3nqzvl5r";
+  recursiveHash = true;
+  sha256 = "0648hv5c1hq3bq7mlk7bnmflzzqj4wh137bjqyrwj5hy3nqzvl5r";
 
   meta = with stdenv.lib; {
     description = "Unicode CJK font with over 32600 Han characters";


### PR DESCRIPTION
Update version because the old version was removed from the upstream site.

Also the derivation was made fixed-output because the font is big and there is no point to have different outputs for each platform (https://github.com/NixOS/nixpkgs/issues/27754)