### PR TITLE
graylog: 2.2.3 -> 2.3.0 

### DIFF
--- a/nixos/modules/services/logging/graylog.nix
+++ b/nixos/modules/services/logging/graylog.nix
@@ -11,9 +11,7 @@ let
     password_secret = ${cfg.passwordSecret}
     root_username = ${cfg.rootUsername}
     root_password_sha2 = ${cfg.rootPasswordSha2}
-    elasticsearch_cluster_name = ${cfg.elasticsearchClusterName}
-    elasticsearch_discovery_zen_ping_multicast_enabled = ${boolToString cfg.elasticsearchDiscoveryZenPingMulticastEnabled}
-    elasticsearch_discovery_zen_ping_unicast_hosts = ${cfg.elasticsearchDiscoveryZenPingUnicastHosts}
+    elasticsearch_hosts = ${concatStringsSep "," cfg.elasticsearchHosts}
     message_journal_dir = ${cfg.messageJournalDir}
     mongodb_uri = ${cfg.mongodbUri}
     plugin_dir = /var/lib/graylog/plugins
@@ -91,22 +89,10 @@ in
         '';
       };
 
-      elasticsearchClusterName = mkOption {
-        type = types.str;
-        example = "graylog";
-        description = "This must be the same as for your Elasticsearch cluster";
-      };
-
-      elasticsearchDiscoveryZenPingMulticastEnabled = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to use elasticsearch multicast discovery";
-      };
-
-      elasticsearchDiscoveryZenPingUnicastHosts = mkOption {
-        type = types.str;
-        default = "127.0.0.1:9300";
-        description = "Tells Graylogs Elasticsearch client how to find other cluster members. See Elasticsearch documentation for details";
+      elasticsearchHosts = mkOption {
+        type = types.listOf types.str;
+        example = literalExample ''[ "http://node1:9200" "http://user:password@node2:19200" ]'';
+        description = "List of valid URIs of the http ports of your elastic nodes. If one or more of your elasticsearch hosts require authentication, include the credentials in each node URI that requires authentication";
       };
 
       messageJournalDir = mkOption {

--- a/pkgs/tools/misc/graylog/default.nix
+++ b/pkgs/tools/misc/graylog/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "2.2.3";
+  version = "2.3.0";
   name = "graylog-${version}";
 
   src = fetchurl {
     url = "https://packages.graylog2.org/releases/graylog/graylog-${version}.tgz";
-    sha256 = "02x8brzlyx7qpxb1pgs74iv1gdykvs7cihff0rzjmh7bp1y1xq1x";
+    sha256 = "03jv8l5hj3hw91vk69pxhc2zvxyzc5sfvxf700rq83wsjh6gb5iz";
   };
 
   dontBuild = true;

--- a/pkgs/tools/misc/graylog/plugins.nix
+++ b/pkgs/tools/misc/graylog/plugins.nix
@@ -22,13 +22,26 @@ let
       };
     });
 in {
+  aggregates = glPlugin rec {
+    name = "graylog-aggregates-${version}";
+    pluginName = "graylog-plugin-aggregates";
+    version = "1.1.1";
+    src = fetchurl {
+      url = "https://github.com/cvtienhoven/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "1wx5i8ls7dgffsy35i91gkrj6p9nh2jbar9pgas190lfb9yk45bx";
+    };
+    meta = {
+      homepage = https://github.com/cvtienhoven/graylog-plugin-aggregates;
+      description = "SSO support for Graylog through trusted HTTP headers set by load balancers or authentication proxies";
+    };
+  };
   auth_sso = glPlugin rec {
     name = "graylog-auth-sso-${version}";
     pluginName = "graylog-plugin-auth-sso";
-    version = "1.0.6";
+    version = "2.3.0";
     src = fetchurl {
       url = "https://github.com/Graylog2/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
-      sha256 = "0wvdf2rnjrhdw1vp7bc7008s45rggzq57lh8k6s3q35rppligaqd";
+      sha256 = "110ag10y0xyf3za6663vf68r5rwdi92315a37vysqvj00y7yak0l";
     };
     meta = {
       homepage = https://github.com/Graylog2/graylog-plugin-auth-sso;
@@ -64,13 +77,13 @@ in {
   jabber = glPlugin rec {
     name = "graylog-jabber-${version}";
     pluginName = "graylog-plugin-jabber";
-    version = "1.2.1";
+    version = "2.0.0";
     src = fetchurl {
-      url = "https://github.com/Graylog2/${pluginName}/releases/download/v${version}/${pluginName}-${version}.jar";
-      sha256 = "1r12hpjp2ggmhsapgrk829va94aw44qi2kqqkgf1fj9ih4k0c837";
+      url = "https://github.com/graylog-labs/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "1bqj5g9zjnw08bva7379c2ar3nhmyiilj7kjxd16qvfdn2674r5h";
     };
     meta = {
-      homepage = https://github.com/Graylog2/graylog-plugin-jabber;
+      homepage = https://github.com/graylog-labs/graylog-plugin-jabber;
       description = "Jabber Alarmcallback Plugin for Graylog";
     };
   };
@@ -103,13 +116,13 @@ in {
   redis = glPlugin rec {
     name = "graylog-redis-${version}";
     pluginName = "graylog-plugin-redis";
-    version = "0.1.0";
+    version = "0.1.1";
     src = fetchurl {
-      url = "https://github.com/Graylog2/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
-      sha256 = "0hwz83m9gwx0fdapc63v3lr1q6acbphssqwp4qqzz78wg2w79xgi";
+      url = "https://github.com/graylog-labs/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "0dfgh6w293ssagas5y0ixwn0vf54i5iv61r5p2q0rbv2da6xvhbw";
     };
     meta = {
-      homepage = https://github.com/Graylog2/graylog-plugin-redis;
+      homepage = https://github.com/graylog-labs/graylog-plugin-redis;
       description = "Redis plugin for Graylog";
     };
   };


### PR DESCRIPTION
###### Motivation for this change
Graylog 2.3.0 has been released for over 2 weeks now. This PR updates all the relevant parts.
Most significant change is the removal of some options as Graylog no longer becomes part of the Elastic cluster but now communicates with it via HTTP.


###### Things done
* Bump Graylog to current version
* Bump plugins to compatible versions
* Adapt graylog module to new version

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] YOLOed it in production without breaking anything ;)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

