### PR TITLE
gdouros: x.xx -> x.17

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13095,7 +13095,7 @@ with pkgs;
   stix-two = callPackage ../data/fonts/stix-two { };
 
   inherit (callPackages ../data/fonts/gdouros { })
-    symbola aegyptus akkadian anatolian maya unidings musica analecta;
+    symbola aegyptus akkadian anatolian maya unidings musica analecta textfonts aegan abydos;
 
   iana-etc = callPackage ../data/misc/iana-etc { };
 


### PR DESCRIPTION
- [x] minor version bump (old versions removed from upstream website)
- [x] make the font derivations fixed-output (https://github.com/NixOS/nixpkgs/issues/27754)
