### PR TITLE
asciidoctor: use ruby 2.3

### DIFF
--- a/pkgs/tools/typesetting/asciidoctor/default.nix
+++ b/pkgs/tools/typesetting/asciidoctor/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, lib, bundlerEnv, ruby_2_2, curl }:
+{ stdenv, lib, bundlerEnv, ruby, curl }:
 
-bundlerEnv rec {
+bundlerEnv {
   pname = "asciidoctor";
-  ruby = ruby_2_2;
+
+  inherit ruby;
+
   gemdir = ./.;
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Fix asciidoctor runtime, see #28075 for details.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

cc @yacinehmito

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

