### PR TITLE
influxdb (on nixos): reduce closure size by 99.99% (and a bit)

### DIFF
--- a/nixos/modules/services/databases/influxdb.nix
+++ b/nixos/modules/services/databases/influxdb.nix
@@ -68,7 +68,7 @@ let
 
     collectd = [{
       enabled = false;
-      typesdb = "${pkgs.collectd}/share/collectd/types.db";
+      typesdb = "${pkgs.collectd-data}/share/collectd/types.db";
       database = "collectd_db";
       port = 25826;
     }];
@@ -149,7 +149,6 @@ in
         type = types.attrs;
       };
     };
-
   };
 
 

--- a/pkgs/tools/system/collectd/data.nix
+++ b/pkgs/tools/system/collectd/data.nix
@@ -1,0 +1,14 @@
+{ stdenv, collectd }:
+
+stdenv.mkDerivation rec {
+  inherit (collectd) meta version;
+
+  name = "collectd-data-${version}";
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/share/collectd
+    cp ${collectd}/share/collectd/*.{db,conf} $out/share/collectd/
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1362,6 +1362,8 @@ with pkgs;
     libsigrok = libsigrok-0-3-0; # not compatible with >= 0.4.0 yet
   };
 
+  collectd-data = callPackage ../tools/system/collectd/data.nix { };
+
   colormake = callPackage ../development/tools/build-managers/colormake { };
 
   cpuminer = callPackage ../tools/misc/cpuminer { };


### PR DESCRIPTION
###### Motivation for this change

The influxdb nixos module pulls in ```collectd``` in order to fetch a single file which pulls in a number of other things (java, gtk and loads more).

This PR creates a separate derivation for the just the data bits and makes it configurable for influxdb.

Closure size before: 897M
Closure size after: 36K

My question is - should we instead change the collectd derivation to properly use multiple outputs and then stick the data bits in there instead of making the separate ```collectd-data``` derivation?

@joachifm @fpletz 

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

