### PR TITLE
eom: init at 1.18.2

### DIFF
--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -2,6 +2,7 @@
 rec {
   atril = callPackage ./atril { };
   caja = callPackage ./caja { };
+  eom = callPackage ./eom { };
   mate-common = callPackage ./mate-common { };
   mate-desktop = callPackage ./mate-desktop { };
   mate-icon-theme = callPackage ./mate-icon-theme { };

--- a/pkgs/desktops/mate/eom/default.nix
+++ b/pkgs/desktops/mate/eom/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, dbus_glib, exempi, lcms2, libexif, libjpeg, librsvg, libxml2, shared_mime_info, gnome3, mate, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "eom-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "2";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "00ns7g7qykakc89lijrw2vwy9x9ijqiyvmnd4sw0j6py90zs8m87";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    itstool
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    dbus_glib
+    exempi
+    lcms2
+    libexif
+    libjpeg
+    librsvg
+    libxml2
+    shared_mime_info
+    gnome3.gtk
+    gnome3.libpeas
+    mate.mate-desktop
+  ];
+
+  meta = {
+    description = "An image viewing and cataloging program for the MATE desktop";
+    homepage = http://mate-desktop.org;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Add Eye of MATE (eom) package.

[eom](https://github.com/mate-desktop/eom) is an image viewer for [MATE](http://www.mate-desktop.org/).

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).