### PR TITLE
firefox: 55.0 -> 55.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "55.0";
+  version = "55.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ach/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ach/firefox-55.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "0ce9a2852a86553f96018e8873e966996f5386204065200f0b24dd0b939aa815efda0fde06133974d79ae4f944c5a77ef4d91929baddc6d72a5a457203ef7784";
+      sha512 = "c991a8c53d1f415253a66fdf337e082a3cb75f30b9b340ed29b059e2a6f50d67c320bcfa9584206f1e23c1af5d3e8b825e30ee009f7d8130318cc356d8550316";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/af/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/af/firefox-55.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "97c01c8794e2ffe0cc25e6352ba4c6155ea1e1dfc8bcec669036ffda1aec943326ac38c43eb8260a55d46a264858144bdf0cceb9912c4f2d0d373d4d0d4256b8";
+      sha512 = "8112c343179b1bd61f03cb67a0712ef5584848bd2dfb28dc46ccabfc66eb803ef9f23d023c6f22c6cadf715ba459f36e99bae5be8f6c62af772a7f67f724767e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/an/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/an/firefox-55.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "f30070803ac80d00e4fb248f0c1e871b51bb4c78f8c3b12923d6b96c9686ea22768aeb9204da880647893524aa68e44576be4092d44a6b189b5cf01f493f9c82";
+      sha512 = "41899ad93e627e851423ec8b5acd6bd940a10dbe80e98377e7d4080b31e9a8f5ceb51eec46931429688a4b56065af2a3595f51c3ef2c51561dd5a06d0c0cb347";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ar/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ar/firefox-55.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "213d73338a3087f925a5137432e84f1c0f881d37c33c109d9ab6e2744556341697e56c7efcd7f4d5011cdb6fec03de072afbf14c34a30770456f71c8971d4b6d";
+      sha512 = "ba4bf0c1ede64f3c11d00b5ef3b193d4e36bfc49687572050b22cbd0bc30be050a7df3401eb20e869b1f33ab16988701392b845f89d4693a589be589eda54ecd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/as/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/as/firefox-55.0.1.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "1d33b5602db1a326be0ac9ed726e38b5e871904685e6586211caf6b330417d33c717399663d94d725d4f8784591c5b7eaf4b4ecb867b8d99e2c85671b31f5877";
+      sha512 = "b3ae2fad8940ddaa16102f9d43bc5113a5f4f38a4527c43e1a4b88a63015d128a201b68b72377c23274023b7486829181bb44ecec43ba50fe1bc438d30da8349";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ast/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ast/firefox-55.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "93a08c86dac4a81fee72cd4c35f39f578222ef11e28e503851c9a7ad7cffec3e3324c32374ed851094b8ae91c642a2d726b98cade60fb4511a935320ba790faa";
+      sha512 = "80688f5eb65f4fe09a840d5f3ba2516bbe45dbb2f2b96cb4f8af38900880dea22f3b8e040491d81c96abb4fa1d50815e86b5806dc8e31148c0235b0a72bafb12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/az/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/az/firefox-55.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "4661628ea83c2101481bf08c1484952a30c27b9cd1d169bacd96fb6416ef77321e7e606e989521189c5135c63b2b82b7fbd3e85d0f50919f6c9c277176aa34df";
+      sha512 = "0e8d42394d79c3a8f8f9f7a7ddf5894adbd89627832908e2f82b4712bd3260e8b10e04eb0166ee8c2a1010cd9dc4836ccbf99d3af794187ee90f06142286bed1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/be/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/be/firefox-55.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "7062919a385600ed74972b1851ab7bd20a46003c37e058b93cf8fdb853ebb890b173aa6cc572d2f51661b571d3efbc189d04abff4dbbd9e93398ad5a55015e7f";
+      sha512 = "c13a53874775cf3e2da703dc7ca5c1f9d69e3af9050b7f58cf903f87a2ee7643e7db361d3d3628e470d808ce1b412d355653cf2d67691e1e89c584a9709cfe41";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/bg/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/bg/firefox-55.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "d58389193c33aa24aac09ad286b83f0f808116f20907506d2d37a3cc45ae43223784fc12face495cbba34be24358584e38add83048b477a27a93f8934c86c82e";
+      sha512 = "8a6a34f0a31793e70edfd44edb54d3709a3960c3625f5856626c28f0df0e93d18d0190d3161c18315df678328918fd4029de9be9db7a6ee426a9054dc5d9c50e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/bn-BD/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/bn-BD/firefox-55.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "9d552eec9497565bcd71faba474338e97465d1902280972a04f4f7e5fae88cdeac144b12fd1bc80d079b8c16b0c7e5a4dd5da6e56486e688820653cff35ae517";
+      sha512 = "17e2b8046b6dfe2bef7c8dd7027fa2fe2c008672b7d5a9676a9b6ece12b7b3bf7fe61a5d5378f1974f530199739982a83b421b7cf4643c9bd654a4b2235f3bc2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/bn-IN/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/bn-IN/firefox-55.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "4f150944cc42c829fc619e3a20fbca9f5116180b5c2e160d48c8b9f42325898847abbc0bb0724343527e97cbb74b7286dd8b7901c0ee9ce83559198994486505";
+      sha512 = "39a5c15019881507552a583053fe601dbc04e0de410dad3ce7727ddcdb128b28c5becfc748a1c5b89bb272db66f2bcb4eb6ea1b8a3cd37c1d10156ba29b3165d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/br/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/br/firefox-55.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "18f0d851b249c7bb8979499b146756efbad587ce48ded72a58bbfa2dd1fe951d5ee6d1188f6e659c760aa4e60095b481921feb016e69f78e439de18f7ecc0bcf";
+      sha512 = "7ee7d1fcffbaa0791c88338a8b471bc20747abed505ece15f74f58b747eb56b300b71ff15e72e56d5deaf75d98ccbe93bf8c1e0ad3038238913f72f9156f8790";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/bs/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/bs/firefox-55.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "b0b838026b932d558ff3af52bca708e3f60929c2928c17c956b1d4f2e023edd45d98d65b7ea268c2ae04299944d26cf19d9a9deecabfe447c8548cd8afe98b28";
+      sha512 = "038c185cd6fd2efb1dc51c9e2275d98fa0040e68de306d5cc3d799893a69f937353c94c00bfb9fcfef2a2c6099149926ce30ecfbd972170cea501f9c44c836c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ca/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ca/firefox-55.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "fd700550d5983f53d80330d08754c84e7683f965316f738e9ca5d45176d7fd42ec57a02aaef3e82358d8c7913cce9284e04299d32cac443063184c41e5c7b0a5";
+      sha512 = "be717242a9c93705234d87d0b091925f1b07e60130aa06ef19b72283f0594abafed577b6d98eaa9fab6941d1f8c2f43292de20b9476312aebe0fc51d368ac50d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/cak/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/cak/firefox-55.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "4cfc69ef47fee1a8a2127be92cef59d2dfb40c99ac172eb78de978e7cd7aced093a7c1da91fdf518a0c9b23a81f393919c44c353b52fcb71b53b41ffe88fa22f";
+      sha512 = "1b9ea57bd4164862c9c29e3fa16200aa7ca15c277f00b838439edba4256e323aff97d27264bbd20a5e08ed70e4f897611505570eb01a2ce0f9cb30c2c611d065";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/cs/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/cs/firefox-55.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "33c912c591e8856bad1130281db996c82df28fff10d7f7031ababeb7acd385df6ef14165c491b48edd285cd8086071dbf41e3448431f028364d62810b3fe4a34";
+      sha512 = "ee32ed99d5d4b05d6a9ca4d6d274e16ada833dfc9f5735898eebcffa7925d1ac1229ab671af9f8eaad7d4fd6d2135e58c8f6266e1173a8797a513b977235ec0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/cy/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/cy/firefox-55.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "5cdc13b0317d7b0998c534a92e094374ffedea9f430e0f27c97b972985ca050abb7ddecff60f87ccc0d6c240db453b335fba12eec3e8448f0f830b402dfa6171";
+      sha512 = "29302ad22573fc52e0764b89848ea43ebff98ffe94d3d91d1aafa05e063cf9c5580c9e79e0b987f18a87a648a6076f98c48d20d5621ebd46be02fcf41ce19779";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/da/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/da/firefox-55.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "c0cfc7e4a398d5004c1a3f1afb3ee5c32502e7929cd7ff7cbdced2f9104452a6754db8c22764cdaa90885698cdf40379016f866595f98adf1498f48576a1fc86";
+      sha512 = "25f8252bac8b1b4e353dc8be0945820bb9e013dfb30866b14d6109026c122cd9038e0e70d54f959a59dbf99fbbee48d0e3254f7e1091b2e2e2811b83498e36d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/de/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/de/firefox-55.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "544e6069c5f2c92b80f804d105d4a198ca360415701d9a9ebb08044cd877a2e0793b03381bdab55e31649b021a1343647ae8f21844915096347fdc2e8280ed45";
+      sha512 = "2d013bd921ea9758807e64588f887fd841c6b8b32a18b9eab3b2ac1f598c4d7acb27b2defd4a836bedac238c96cc7bf700ef87f973a39d21e87ddbb7e27be1ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/dsb/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/dsb/firefox-55.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "53e7bbac4a479e06a14dc91313b66f28c5731b88faea2254c0e72e40ef4eb772c61bf494557474f03e1b52d3d85f8cfd2785085b4d7324907107080342899a56";
+      sha512 = "f640fd20c2beb5cf6aaf402fa220a01176e0eb74d4429cc10f76bfca9a8579e17e490bb2f045ca6e61de4ab49703c68571c4dd7ee82c438b2f8ab94ecf53ec0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/el/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/el/firefox-55.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "304085e04c30b73476ffc84da692d9e08c3edfebb31e7e9777afa7a1e12ee0d15c5d9bc4124edade6701833de02813c0549d8a731a58e824b00e483f4965f49c";
+      sha512 = "6d1f68305ef9faf6c0d304b8ed4b4c093375c03b95b01ea7c61fd421cefbc84b8fb878cf49fdc5f3ec8552b277dc351f201470c5c4f45a249b3e010a863dd65b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/en-GB/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/en-GB/firefox-55.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "237cc95b7c83b2e76627fcd2f417d21868d62398dd5477bcb9355bc0c73f53e9e595e95bf9de0597c15f7eec836aa9e3f9b1fab29309599cd4ec1c7b69b938d6";
+      sha512 = "e4bb9746e00490bac82750130284847d845ee8c85d48d84b799d725a3dd82ce68046bb2c9bcfa4c92070383a4f439766abe58dbfc9346cb51aabdc730b3e8ea8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/en-US/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/en-US/firefox-55.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "1d86223b3f56266eb83307e92c4d39c0d765b94015b089bef8eec5730e0a8e4aeb7cd06e4cbd43b445ac4d24cccabebfae02f003b791d1be03dbec3c9a46c9ce";
+      sha512 = "13598109ae60682bfa122925874173749114a093f7989bf0a4cac4def59db5ad53db61546d28ce09482cab1225924c7d35bf4efa8b3051e78ad760f892050a35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/en-ZA/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/en-ZA/firefox-55.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "8411248503638d44933c38bc105874befc160e90f2323764c7bc02667c634456c7c79cc8a7931e10ccdbaf4e20e3b2d5098b9b87ec63f75ffa56b6c62aa5b746";
+      sha512 = "5d7dd0d6b2e06dc2c3ab94cdeefd168c005703cc3c632aafd7896bc631002ebe26c1c0103307f3165b720cfe79e63fdc9b37429885a2eefdba492b714ab308ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/eo/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/eo/firefox-55.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "fe376d69e5a8100e3ae70036d875019b04ff2c8d62d7caf32adf528fa90f78a0d16c986b7077c61c38be5331f3413777028a853681b090d42bb3e09475a5b5ee";
+      sha512 = "1f67bfb98891effb2ecfb127b9ab9ffda714187a34265277fb7841f41d5a4ddfb81ead7f4cc1d38af290feaeb36c315b2050a889b6e9b9bd7b9cdd51ba0cbb6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/es-AR/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/es-AR/firefox-55.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "7ee72d922075b528dbef56bcf784690bb54582094a113c9ff0dec0f8ef64ec214f2ee16e930f8ba7963c4bffb4a8d5fd23e5cd76ad8557d70b1632a6124ca6f6";
+      sha512 = "011b4f49e90ad091be5e8d932ee9a76b1653f307db328ee6770b99ef37f57e62477ca7529d182f328203523f9d0160f337748166691921d5720640c634522515";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/es-CL/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/es-CL/firefox-55.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "d03c2d4fb96b2d64c263fea62ac3cd643648baeadc4091238fff87cbc2fc37cad3069e1e4fe949a4ff7162fedc85dfaeafe49326aa5de780c96a0160e91ee9f7";
+      sha512 = "ef29baee74951692720c32522bec81330911ac0366e9bbd816a5bdf0738e064268af2f63ea5b3542e51eed21775cde8b4d60f6cb47bb18b94315afcd078a1c84";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/es-ES/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/es-ES/firefox-55.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "6893e72c09cea00bf2b7e05f0e170e97967868675d8d9752c18bae61a5f147b60db5ef165138a3355b0221515838d526b14f09cc1f99ee893b7c9cfc618ddfe0";
+      sha512 = "8f21e0632e2b4d86883b139f5992becd89a8c243afd131e2f9dd863e2fb21279bd858f618789a73d46218de3bd59a5c4b017dcdda5b1db9a3400e0e0ace3c9c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/es-MX/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/es-MX/firefox-55.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "ba8469977b4f61df8165b09d333fa6ffb718d7e3710f62a459bd0da3a80a63b947ef1cac26704b5c4e9f4eb2380b2047e500fae372a82808cc7e5fa4ab9b0e62";
+      sha512 = "9d59bfffc685aee31004894e81dda5efa3c512bfe61dbf5d224b31cdff6a859598287a8a80e7d96645718689df2dfee3b4a79c064e789d246cf32138b9346f5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/et/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/et/firefox-55.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "07f6ac8fab7a73fde5c607b31be1630fc2c01778808259f0f1472ad3bde56dfcdbaa584de0f9fe1fba6a540fbea6709d124daf64bdd89f755ae98884c971cfc0";
+      sha512 = "a833839e8243760942337161192fdcddcdd7ccffd3b5ce3c7dc939492366e8579e0deabc933a607885f20059e40dabffd389a52db05ea6bdbc794d9e15a1c9e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/eu/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/eu/firefox-55.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "4f26a97eef55cb6cb4b236fb69dab897b9263ace1de3ac9fca099118b7f96db41e5b8f1dc371e636715ab2aa078d2e5e76c88fb907234d7a206e8a96f8dc9a21";
+      sha512 = "0415c1f00f612d080dccfc3829c3f89de4fc5921ad8603c7eda0aaf9ca57b055c66a4a0f44782a8b381e4e166964f5cc805b65b84525a073a1fa3e605bd07aaa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/fa/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/fa/firefox-55.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "86a1accb6903fc0f2cf49cc86920e5e4b4a20a610c6a212864ae83e2bece1d818be515fcf9823bcb1c31ae748776514ce54fe6a1a57c728d1745d67c45856a66";
+      sha512 = "699be76441b245de502cf0b9ac44fe3c454fd11fa00d6ad590b2a393a31f4f291c3b5b7075741c82c28a721eb38a11a3627e71b42e910fbc2f474f2284820f86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ff/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ff/firefox-55.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "b33df9a1488989cefb5bc849d44c5194c25874c679e48634673ccf8cd32cee3274b6417de6b58bdc45a68c58adbeb3e0fe36dffd9b0526b9c79a902cb7b5077c";
+      sha512 = "910928159d16269784d3a41b8a423138060bdedc7e190c80e5bc95bb9358b6e8fd08c519106d68326eea4bc8f5c54157cda151fcb72d5bb1d19f82696297760b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/fi/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/fi/firefox-55.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "c03b784f3d13078fdc760f07f5bdc2352e5e3ea2d8d49931f6ca6a9ce91b787d85624cb1f2d6bcb624cab6a3c018669c1f47443e2a32fc0472d2139623275885";
+      sha512 = "1085f674e3fd557d62d29c81d52dbabbf09229a03d38d8eba1886a98937c560e91b8a5cd5fac1d313946eba6622eb21462bb1227cd35dfef523b34e8928b7f3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/fr/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/fr/firefox-55.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "d9f0baca6f54ec4bd60c33ec87bc7bb307054c5214182ba7c14ddbfba6748e77f87914b6373d288f8514361dc2627ca75cba9bb97038f183787dca07ecc629a2";
+      sha512 = "038f8198004d38ad9e2814bd55b2ef1d6e3af3f8f3369a90b41e44421b94ae960380ab65367375e15eeb1d0af72343874314c1005aee18dc86cf079fdc19fb80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/fy-NL/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/fy-NL/firefox-55.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "8452dfef5134afe2184cb8d2589d95fc75bb9bd487a2451fbbcb873f72b3612f7eb552772e4b9957060d506274d2655505838628d468efcc1b534697734466d7";
+      sha512 = "83eb5df7022ad9adce4ab7966fc4979aad7f6d1bf2b47001105d67d7933feb8c264708938b87fac3908a65adcebf72f6af9d5623fa6026458dad76a360f0608d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ga-IE/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ga-IE/firefox-55.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "ca465448eb5ca014579e73c5e9aa09129f7ac3725f90e6ba8bc96f67ee74e5bf916050d968ed91d52b60cd8f291f5553bd66ab4373af6537c43fce4e8a526c5b";
+      sha512 = "34f3bf3ecfc264bcbde3bbca80bf138d1f7f925ce6606d6c588f0df25f22eb912dd3d0388a6798091cb88b51a22380e01fe984bc80edf95c76e301e7cac2b2cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/gd/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/gd/firefox-55.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "c79b3c9c3970cc3eb8d0de8004479e1d6832d8b1c40640112e508ddc3db36a318f620c519a11914d5a103e01d8227016e4a57c41474aae346af15cdd5d5754e1";
+      sha512 = "4d2f04c7cf06c6f8efed7abe74f8ab27794c01aba57ae2f45bbd1a749295ed7b6db4389b1c93148330695c6d213642dd9046068f0bd23ed3920bfcc7fb9dd4f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/gl/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/gl/firefox-55.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "ed98aef69f2aa9de72508e6860935b4465777cf26252c4a4233a4809e1e5f91e44d737bfa13d2705bae2e0c250cd9b4a92711cb022d84c109dbcf61a47286a85";
+      sha512 = "d70c3cd99be7dd1d80c070d5301a1d84f33f1b626e0471861980512c81672066a7869a5d289cf862ff4d0ff6f488b0a7cc298675aa9afb0a62a191ac476b71b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/gn/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/gn/firefox-55.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "0c6eb876fa8ab4c0896d96cf87e52eb43f0ded62c93770ad3f59ed7c2e81bb7a231d4d698e83aead3f557e7c3443cb105860b2f98998804ae14e49c3ab3bafc1";
+      sha512 = "f183e3c3ef451367362aad3bc96cf1500fce451d3c0f467822e756266bc48d7d9d7952e82f171db2d8bf23d41bf58cef34f67da7211d31335f86574abaee567f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/gu-IN/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/gu-IN/firefox-55.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "3a57b1adba2f9fe33f91ac645665ab8301b1adc5a22f2f1a04d1a3c3947c25499b9d14a3e00b8f147ecc2664a3ef5ee1c4f5b397283c5fad454dcde94c261932";
+      sha512 = "31afdd21bc2d9af1a52cd24f74c76480658fb0506f38e6fd5f5f85bd66eedae49cef89aed9060f1255c515d24b2998cbf9eb449b5083bc6f2bf1805d152197ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/he/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/he/firefox-55.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "46002542fa8baec217d26a1b246e2e2403cbe3af1a471da0fcb936c67e63bdf547577bb9655d1df414bfba8a16d2abd29954697dc967328f77678d08196ead3e";
+      sha512 = "c68c416515336a6c2c8ae69151c1b8c972f24671d354929eaf3eb647944d6e99085b5768a8156e59015401a33174fac774f0bdacc6005c3ad23a008009653fb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/hi-IN/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/hi-IN/firefox-55.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "c905d2044a685dda24288c3729261f58e1d896c71a8d437471dca5457676e9a77d2a112252f2482ffd744c08f6c8090541c53f8c27f85a609557603ddd114025";
+      sha512 = "2e62b66e9d34c9a7d9472726dc322746ef399b24400b9315dcd15f010d0bdf80d8f0c1ca912ce3275770ad925f47d576b59484b3acd861d1f3fae9e2ffe5277f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/hr/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/hr/firefox-55.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "f4a0084786f61e6586f0cf4f534c4402b66c82654d95db92fadadeb743766a976a4c349097633a536aad8f5dafb25127c4366ed002cdcf93f0a963ed431d827b";
+      sha512 = "a5caa5839d7ba556314c513a9599ebdae05de41f5b3289987a1f1d1dee030b53da07773fd6517f42899ef443770ec3549f4160c77e26f68a1e1bb3ca598bd866";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/hsb/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/hsb/firefox-55.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "d1366512fbb61a283f363a29ebf8e8570844ebe29bc0068a68837261181f44aca5e8fb5c3ade82d930b624e1ae7dc2cf30a0e6e0d830a60c529f6fa9d2bae1b8";
+      sha512 = "df83ae1a93cbed29c85d75add44b70fde9c187953fa169cbdc106ecb722ec845b129fb762325f08d0ecca188ac6bac43c6662059a6694d43ed90472ee8eb23de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/hu/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/hu/firefox-55.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "d76a3a892c22efa04e84ae9c66ee76494709b1185f8d1033fc3bffbe67e433607edd152277218501ca94d5cfc88f8e9de356176c7ac2204ceab18eddf51cac75";
+      sha512 = "c5787634d4fcff538423fdd9761989ef341058fb129f33bb729686cbe5319aad7d67c8d19d9e42b7d81ac08381cd0d07504fe413a9c38c310ba3d7440ceb6934";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/hy-AM/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/hy-AM/firefox-55.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "f771b69e18434a8f9a5fe5e381702e078e37c87c4bc1cc4e0fa30be0c46f3eaf36462e6d4dfc1e12d5896ac6a5597f5987477fb8aaa5a5a5f0648c92d159cbe8";
+      sha512 = "6318a512fee633ce49a2ac6cf3b3295e74624bd935e9979193796956c11239f1da3ebeb99b5547e3aaaf339c4f87d0e4501edacc13fd11435abf000a9e119ed2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/id/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/id/firefox-55.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "6fb40ff190d292d18da43a769aa679da1ed6510f185023ba08e749af46b4b0fecb3d305d9dface2ea1c2096bd8176add235daebcfde6bfae767407d57e040ba5";
+      sha512 = "2c7d0de71a675a0d6abe14037db11087ad9a2825bc2d9bbd863f209b86d9875da08eb2005590418262b63bdb12a9b122e54230824d5916059f3855b628eec8de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/is/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/is/firefox-55.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "47f51627d21b803477b237b8f3599cb02efe107687fc25ca14c82a7d1413a0b49f3f47cadd42a937e10142ec0db6e538f2fd17ec1fabbb868e0db45011ce1365";
+      sha512 = "a1dc23e047cb7bc21f3c1a888cd8f9168161296a47148c2296e4f033d7038fed83566a429610fb35b514aa8a902839a00201901d46361205e5e292eca7418813";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/it/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/it/firefox-55.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "5707b17aac678c28ebfef28b062799f4683c2f2192de7b305b8699ed788de54aead0012c1a41c999a2270a30e368dbf25d53bc887f5249279220ffcff143dab4";
+      sha512 = "cb2bd028873e28aa197e3f599b2d1aed913273f888cc2eb69775b1936763011baec1f03bc57e3da6b2088a8ff37d08ab014bdce8161bf6929c57f658772af8fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ja/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ja/firefox-55.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "9290d777a33e434c587c19b5193a32c2130662c0c74917dc1c298b0f906aa3ccfd8631dfc3c396ec771efbddb254fe603ea9adf42524e72c9b607a7eaa81485f";
+      sha512 = "dda54f19f4a5a493b7ae6167955c9ff4c503d8cf239fe6b993a87d3f73171162e29270366bb3f2f1f1afea80e3332928417bb3e26fc414d6543e9ab2e1a2008a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ka/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ka/firefox-55.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "4ffddb53f2f9ed891aa75ff92dee070fbed1570585bdd8d1517af6cb604fef9ef98e4efa0ff5672a911e2934e91b8e74ef808826b6f4a7c08ffba45bc1e2df1e";
+      sha512 = "9e0a7042225361addf1fe41c13e0e3df869e41c1a88b4adfa64cd4912c4cc113804dac23ef5ac7a8a196ebb8552a2baf988aa9da618ab1a64e307d02c15177c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/kab/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/kab/firefox-55.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "6cf1f5f445a99a90bb509e9f962f63c3674d1f621c469b354044f2ecf30f756599d1c920b34e4665412694da7d6f85729608522b5f7e6c3c0b02ae23b0b12fc9";
+      sha512 = "27f319c418dc54296f616b9fc2b6069f1f0da92b2eb95d872b4fa582f494f0339cbe40fe0427ae1cf8a1ddb1ee436ae56773c7413591f4bd76f027916bcef187";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/kk/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/kk/firefox-55.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "0b5810e34c15a1152524e4a437399e627edce29bf9edad54cb4731f23ff3fe06fa94fd750f35398ee2577dbb0abf94d9f965c90520e1cc24bfcb97aa5bc2696d";
+      sha512 = "7d5664fb243b214846fbf2a1772be96df94345bbc6cb076b9e75ea0dc126e3113faab67ee935792df48a915aa7274acc1d4ce48bf09f17f662341b2235ef6d1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/km/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/km/firefox-55.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "86ffecf5a046d4084bb991e527e3fa009dc4a228f4f9595fa594967652fa926ac3c126b9848002b856b9c7a0295d757311b4475a88f42f6e9087df6dd29886cf";
+      sha512 = "7df87f956678f7f90df95f5bbe1309eba7f89ec2e1030746f56df0e14cdce200a1204bb73f8db68b02655db36d13941cd0887116e974df2e11d8d222f5dfb6b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/kn/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/kn/firefox-55.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "ada203b9d3edcb87fa87f421509738dd023c0be9444ecdb411c66d6f3dce567a1720b1bf013fbaa259628b399f117e20d365ab6d2e5a2b02d1ac93d7b857a0e9";
+      sha512 = "532c5d7a67d6508188628b9728fb6a1339ed9c789fd8cc58c33a9b9495e8ba8b979c631bfae66096b164c277dc0eeca167911aa4b856a1d6d437bd5a60103a3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ko/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ko/firefox-55.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "ea8aef83aab3b5f8c6d1add9c7be91f883253c2042312daedccace4254e64cc352f45b1ff0b18c1f20fcce852bf3a203e579660acd9c15f90a27b6002670c626";
+      sha512 = "c1170288dfe6d2ea418d93e3d401a2746c88df77cd8ededd70b17dac4652488b20966aa472f7e929662a8305fc03f7153b534d79d6e8dc62dfb0b468a417317c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/lij/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/lij/firefox-55.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "43a44b2f0c0626399593b386c8ecd278248bf63ce2646dcb1a2bd28c3da32d99bb7fecfddf42097f7f89966bbbc78094f04b0ce2771f2319f83d19f1e0aa6e44";
+      sha512 = "3f2b8227f04064ea5507774848296fb12d4e17b806cea7a356c36995648a4db740d68382ab6d6417d745dc278b6cddc6f18cfc6fbbeb60480106d726715c0d1d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/lt/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/lt/firefox-55.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "959869c39df29073c5a10ea314884d474b77c0c40832651083932785db629b0dc7dec8554da33306bd8db588c1a54cd042443970fa7c8aef26ef7f218ec49719";
+      sha512 = "24d0621a76f53b2a4fc7f3b4d97a1a066ff6fb7c7e1dba9028ef719a38042271412068a7a874862ccbbaf010a7491088e231036271c54e51c624bb82937b139f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/lv/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/lv/firefox-55.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "594a01d1b5dfc77082696b754065e4b6b5543ed5e4d356dd38255d323b8c1803447734ea631b5d5e5a9b4f8611167c3bd6527e076d546731f9a8b406c8afbc23";
+      sha512 = "c36c40e21e305373e7d4ddb67702055cdef28f880739c2339c5e75a0f1d30c2e73316f65badd69dc93552ae33a1f493658002d73caac5a97b8d03e3e4365e6fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/mai/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/mai/firefox-55.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "90d6997dc57a5986d62760d6d163c0a56460959964f0c2e9acda5570cb768e95be04b5b8648437df9845169262954d2b411656d3a054e2fec408f71453928c21";
+      sha512 = "f033e7d1cf52486775ec614bf6272cdde3cbb17a00aad49c8c7739d72488c03d9803c860aed581640689e336bc55799521da4bb0b3a6c9cedd3af38f94c944f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/mk/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/mk/firefox-55.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "06c3a0a722059ef6db6cdd5cb38875c1916dfa2a8bf7c27b0eca2e9ae893348cd935f208dc1e09c7760dfe3dd63428e83b1f8b2a364394507188cdc4eb86763d";
+      sha512 = "d01f9acf588e5067681422daff9be1f2e033b91ab2dba9a979dfd9bd918b1a20e5ace64739ebccffe025e03b80a2f3a955cbf5940ee9341e2f62053ffcbdc408";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ml/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ml/firefox-55.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "8d51b7daa4fc768752dc9a48ca9c38c62e0dd35925518ac4f4d80ff6178789205a7c2c8935b5336751106d8504900bfcd2af8aff2f977c7b35d1295071581c87";
+      sha512 = "95a6cabe1b0fa984de1df148207d22b570a09a5c1fe95e898a33e0e0c905b9f868586294032712339562d8f5cc78961a7fed5aa3c1a5c1a77ea5a5f3197b520d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/mr/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/mr/firefox-55.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "f9aec2aa02c336c8699b4420abe7e7a94e0d376529275e24a57e8158c99e472e3fb78d757782ab9510abe6e0272a66865e7e84ab599e3d5477c2af91f079bb0f";
+      sha512 = "59053496d9d37cec07ed1dde98ae07db593726d49fe97399e97e4a6ac667835cb34db4864c5e67bffd1a9c1727c1af2feb19fea0685fdd2f6b5226ad24022656";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ms/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ms/firefox-55.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "3e6879f56f8e4b85c306c73a5c59ef463ed287793ff2bca0834b2640070eff9417d4c59bdad4963229d3c3e38fde67386531ac69abcd3164adfabc668d68003b";
+      sha512 = "c3a23a7165b0f233fa606e622868690f696b262f33a2c1f2b23ab37f392e71bac7cfd04f9e240660ed5f6075cd3192d9ce1be46a649d5abfb7beb9a16ff91e7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/my/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/my/firefox-55.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "64c34b420d5e9e0cee53486947dd634ef015a2c043601e3ff040b08a840375755390ed6b2898e8024f9c6a87e367d7dadfe04f26bb6c500c391056100eb01fc0";
+      sha512 = "493e5d971b55696121edcd72712120caf638aa13d2654e8f4db4e814a7b8c4cc2c7b89622b385029ed1a9ca14294cc39d8522784000708f418205c36b1f2fa64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/nb-NO/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/nb-NO/firefox-55.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "17e1ea276a3000105018046f53752c0b4498d701844aa29ad7cfe5857ada0c3ecfe29f9bc11bf09801db35b0c58be030069229096e01eddbc702e6f8917b5167";
+      sha512 = "c7c3e85d2749bbdc75a359ff5285ef3cee14b710aaa6e0f39415cd72693f219589b64d26cbf15020c380b51ac0d4a6d41e730af9991cca1b4d5f1ddae4c63dee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/nl/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/nl/firefox-55.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "70fe41e9c3f6bb8d5fc3be480a469bde02197036c763839021ff38c25050be3a4b0f15f71b16ddd4c0827fbc635be81751e1d679e6445f509b2b8cc30d70a5a2";
+      sha512 = "1d77c158ebfdb65004f5c999e6da15ba2cef2dc998c69bbf5477bdb8b41131e968187017783c65103f2040db2154833857790ab9c6aa705b866b60683f0c4ac5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/nn-NO/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/nn-NO/firefox-55.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "803390f1850a286531046e3d3d9499050680f8ec8d8f727f0755b69af833fef7aa1bc841566809d38dfdbff0433b20853e4cd64ff0648789279b1cf9181e64fc";
+      sha512 = "37630d6abf1db435bbff8ea2821966ea58fcc3326199dcfc0e95833732c9ad767610781046ba4b031b516f5dc301e7a7d699699ad7b39efd2e9cf3df05bc3637";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/or/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/or/firefox-55.0.1.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "79d474b2c0e3dd1b09f42895370ac7cccaa7ce71f1d1154665865114dc6db2a165e099de03f064ad6603e7fba967f85865070184ae7d478940d250c0579a8b14";
+      sha512 = "bec28704aff4671d2ee5413a29335f84bb04b4d5dfbd108988e1772c68486e1f5bdb2b7b799792343b1191b768cee7cda59aad0efbc0dbc45def3149e7eb41a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/pa-IN/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/pa-IN/firefox-55.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "958cf459da7c99979c2684bce55f47ba5bfcc3ba908bf11f3c981bec565406aedeeef2ab691e28bd35b7763695fe1cccb9ed76de9442612c99e01960925758a4";
+      sha512 = "eeb9a7a8400e14241296ea75c55fbc17461d298bf7d4a4b57e26cec434e398d070b9207d6d19a3038b65fec4792f9eff47b758f5e5b0ff373b349f67f44ee1c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/pl/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/pl/firefox-55.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "a3c0c0b388ab02a2014a7a1ba18d373557e1828f449fd5ed713c8ea2ed110e3450fca2efe093a0e9ba0893fc447e5189ae7afdc77ba3eb1b7c5eb416b4efc50d";
+      sha512 = "560a7fe08b460f99e6d166caa8fd442ea343a1eff9c5643b96ce9085fbd76cc27eb3b2ccda59172c5e7542bfecdc3cad39257506531c51350f655744bfe166f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/pt-BR/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/pt-BR/firefox-55.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "5ea81d1719cfbb161ce4a27a72bef3d579850bc26f911729bfc46cf495d680898746361fd3e73d0096b962c498ed9cf7706d6fd940f04d1f6a2b81f0790001b2";
+      sha512 = "452bdb25f38b31af0ed6cb1f2636ce238ab898065b8f61f505206e1dde12555a18d491b5895b549e1d5efef94144b99988a69e19f9ccc068c76474bc0898aca2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/pt-PT/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/pt-PT/firefox-55.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "460393c862a11816d7b3bbbaeb3fef4c566c1fb4c479ddbafa4edadc1f085e00bf8e9b01e5d5342058fa384512701e48745015d3a56d98a8e954679e0258c703";
+      sha512 = "54c6b9bae229fbdbe366fac25e9a3b89f48d85f41f715f9db1f3f1b4fd210056f642549a982eff9ac4e2b68640ab01517ff9756cd63b72045f11c07619b59761";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/rm/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/rm/firefox-55.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "0dd87197bf700923f771fe96bbabddd209f5022ca6248599beaec3f32d86559b560342989d24612977c30f61797a02d453e0e36259496128314a87f8a8b3aab1";
+      sha512 = "075a161ab0cbc6417dbfb4873c8ade404a2fc911f2da9e0149d90b04b32f6c9ccbf42b22f2abaf13ef4f9cb4d8330a90054517a651d0c0f1f940431ece8b2518";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ro/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ro/firefox-55.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "60f1d69e881aabb32b40566f907560eb17d5b700fede8ecc1b5c8d198041cefa774b953dceb69e30c0d5ee57ef32b27b9cb4f43d550452b43414a8d712943c8f";
+      sha512 = "5c1eea33100fe2bd020f9d1ac2bb781ec04b25a12d271d3dbc311319f7a688f245e2d7357055bd8321ead58923857f689e417827ac3125ec206975134e4203cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ru/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ru/firefox-55.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "fe4c0ada1acf61cf784ecd6975d3c49a897285f2f816d60c33b82f8c4f0cdcc221bfc5032381488202454ecfef5bda99de12eca7336ea1028c2c13f2c2d052bb";
+      sha512 = "c9d99eaa7ad17a29cfd860c343581654da5daf15db5bf653a3d0b13b03d1914fafe7f6801810b3ee06abcf687c71cc1f9d20cd727b10cbe91e7bb6c977aa279b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/si/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/si/firefox-55.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "ee52d9a71535bb8df0101a91b414e5a60b2f4d3db9e2ef65a1dc737d2f81d20bce6813968c5f8d25db40b14dd253149fd7511505ac43f2bdede7363df8e1f594";
+      sha512 = "e36e3e4767f9afd211dd4333bee2ca4ad3d9ccc7081b1cd008098263570aad4272eab91032527c3f6f0a70e54953dc806cfc00a08627ebd81943195add184603";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/sk/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/sk/firefox-55.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "be8e5677c9e244ef4f8c660380f3e2c141b80534685079c8a76f6d74a12defe5517de04a2504dbf5c4027dfcf76e4c80414320f36dac8701c8baf16ca75740bf";
+      sha512 = "148b8ebbaba7d111234108758fb48ddc883c6d9094e8f22680d65cb9ef05fb34eeec4e09c141e7523ff511fbbc2db84b0eef31efa92730ab30a4830192875c51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/sl/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/sl/firefox-55.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "cc693f834b5017fac4c2655b3b362cf54a0920dd25194a5c1fbd8af8c68a9d130d0dd055eaa9fb4c4348b0bd479da517e6b3546190f83222f2ac2fcbf411f19f";
+      sha512 = "fd0f058fb2a7fd304d08fc4966c7235c557d869b0a02955a3459b354793a1c2245e45ecffe9d0b251357062cd81db10b5d3f982ab15abcdf275af31d91038f9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/son/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/son/firefox-55.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "39618b1e8d08c7ef70ee7873daccfbcc41d0ede0a3a39dd861bd3155e82f1104b72d4ee7193fc30b4f53aa9f6ca12209a68b68470bb319189c5dffd7a9db4d1f";
+      sha512 = "4e6bc840e788b0a3a9cbeca86969d3a37afcf600b583777de84cd77d21010360afa39dc2ab4809b12cd798307cb84c6f10e7760395b2fd2aedabfc6419b02d18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/sq/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/sq/firefox-55.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "e518cbd7d40c96dd2ce6171bbfa76b946cf4d397790b4b9ae8f00691cdeaa95d3104bf174900b18115eb07c8ac5d6158ab5aa01533f9bf06d435ebccc1a034a0";
+      sha512 = "e852af7925a2a5a0c59cc54137d1a574d5cadd831929ddbf375b726b1241dcf901b18f97f030a5ca08283453ee86ddfa113488adeac6fb974524911e354cb763";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/sr/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/sr/firefox-55.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "9ac9d605aaf3982ce6ff4d76ce54b30bce251e9739061607377483663b1654805b818d08b29a636b8a9f8b83bed38d8f91d2d48f29e39b4caf03fc895b7ea605";
+      sha512 = "99b3f089f8c17701ddedb41add217ff5395b3f942e7f455c19f63e49a499282a2432d9f198eb4ca219cf25656ac90c803c4cb7be01975be307b7835b2ad0561b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/sv-SE/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/sv-SE/firefox-55.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "7bad9194fa09f4785317488b430b1cfc3add9b460d340756477631b8f2d05b9ade9326cacd735f804fd26f702152906cbab844d9b7abc7ee7f68a7e52e6d60a0";
+      sha512 = "f5f91a85e7ed10c2734779586e69856903051074ac76dd186d1816253e4d7441d60cad5172c1dc2496e0cb660dbc40fef4bc586e8e7bd19f7145f3b53f2c2736";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ta/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ta/firefox-55.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "501093bddb36797bc4e6b97e5101dcb5f7c630aad13db5c8b4c3cf8db3d8182a4b9c68c43835c9366db72ea4dd6cef2b1d3c429c28d104a107e969bf852ea318";
+      sha512 = "291bd760b10656f5cf7df91e5c978e3caf8748180aa98507e378ee90033df8b971a020b253d5ea691067eb7d08a3ac3f998b64860b49bdf7b2b8eeb29d18b737";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/te/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/te/firefox-55.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "d3bb8e779529649794daa3efc52fca016195da4afba374500951d87dbe74f4ad2856e7549c959eef4e5711e7b1d1f66e04f6e7e622ba9a3c27b2f7e769f00496";
+      sha512 = "4b24c2f7a8e9b660285a9a8e14789bf18fe42bdd484dabf68a99b502a52eacce81df5d5375321cdc5c1b69988e35f0e9e3d2d2cfacaee72033a2c68af0b25a6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/th/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/th/firefox-55.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "7fd54688fd6fcfe3042d02b4204d82ebf11391784c36be3f479f41a32f1e7fde704773345f16a562044da5bac02302722ae248aaac5a4b2cb8add484939c8d51";
+      sha512 = "a479f709c4c512dd3906e9694ffc454ae315855b4a37740619b8536d1dd98764ad191944617351243eba474ec44c95d3153efb69d4dc13aa8047bbc477feabec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/tr/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/tr/firefox-55.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "1d4fcec068163b55461d082f87c070a4a04db04e0b9d292a29e41baaeb3a44415f60338174a7589876bb98ff271bd0b4e1fe58a794053d534e27bffc522ad599";
+      sha512 = "1e12a004cd63cd547cd925736a2cec78ffb98d5f395474c9e8fc96752cf621a2311d638d96444afb593f113c6ec46a892fe96fba882ed7b7c49aa05d4685e70c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/uk/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/uk/firefox-55.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "2f048f195269c652e642250014ba6b3012ef0e212ea794a989ecbafedc6fee27976869b807c87411896da344fcc81b3803f226a70f881f2d66dd517c86f98511";
+      sha512 = "0634489527974d7c7afbe2c55d054f9dd50ebfeb2777944dcb8d4a14ba5171230540c17172c5b0d5df64d99fd23d7b9ce384657e1e1b25b73118b9b66b748613";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/ur/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ur/firefox-55.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "0700f646fb81bb96a7aafe0c8246fab8cc39200e34fda0b89535d026e6ea71d3216679f13867a8fd6f43c2efa23902e926f68ec15ec65aa1d5f67373ea3b7341";
+      sha512 = "8a519683ea1d611f6932e651dd0e400596529ae428700ddf8929924910614598f8d8c660e317357520d31bf1347d1f90c1e89b91eb74b339eedb981da032af4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/uz/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/uz/firefox-55.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "17c0be62adaa2f3a930e727910f0ffd9dae03eb53ef6fb72ce3fcbf9b6facf49e12164632acd8446c24560f2d8a233ee946ffdbcb270c815b9beee146e93875b";
+      sha512 = "964afe349e8b7f908f520d039fd1da6c8ee245b68dc8957a04222ff281a077f86e7b8185850ef7a4b741a697832bc36bbfda39051409a9c3adb74f2def64b621";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/vi/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/vi/firefox-55.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "8b120d1ec2fdbcd7b0276975842604c41f840e59739166f32c35a8ec93805b6220e3570fa6c5cbea66dc988e354d4fb5f900b5a359a784279f1ee78a32a7ae15";
+      sha512 = "ae9dc4d2be8d82cd82dbcfe638d021713e8559fae2d14847aec687fa90d90afbbb206bfbabaa15ed00ba8c4ac058f4c950bfd320c307b968246968fdd30748de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/xh/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/xh/firefox-55.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "9b981b60acc1d5fb66208279a3dc5ed113c3b1cf8c2169d5ad7ea258654b311f2338afdf9fae38c88b1c575cbe0f00b2359f928beb90288ad5b456e9f956c19b";
+      sha512 = "f9f0c35d0446da3bcc57b0b2dd9cd622de5a3fbb0a6daa987d2de6fcb2804be9020ca190c8b318375fb255d7ff86b265a65e7d0fd819f9004fbeab1546cb62c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/zh-CN/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/zh-CN/firefox-55.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "5148d542265e62ba50129526bed91f15ae06018e097fe0afcea228d183b38521a6025e83ac7325f8db991c3517ec38b4590b6065028abcce011cb1ff3f89e8bb";
+      sha512 = "f67ba436854973c9a809b78c3a2511aed27b6c4532304464220841a2159f851e84bdf0fe394527aeea48238802fc5c7336b2399078a8891d4c76554e8067038e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/zh-TW/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/zh-TW/firefox-55.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "466f5e6edf90c6e2864d234cad8271cc9e278dce0748054b109fad9f0c2f5df75ae6b50098a4130a55355dc7cf65556a3cd1a1b3d62e6fc5551317b86b464263";
+      sha512 = "ef0e3fc59630c9ab9072142651420151b897b048af3eac878c8222bdba76d47e2e45160227a2a58862a55ccce954451b892b4f5b5c6062d769dbd940edfefdfe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ach/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ach/firefox-55.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "c0fecaed3198f68ff1504be584fc74d6c4efa3ed785eeb330c65ff2f8a4c3979efb01ddf9e6dca047db6efbcdcdb51720bc2612ea0954b340e20c5d9f90cde04";
+      sha512 = "cfd977fb5aea5c5b707df817993d547aae8b8c04293c3f57dfb630fcb2a0e85b5deb79253da544b7c3a92ec5319989fa148ad3b1ce950d6bafc7d4fe8f1bd2d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/af/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/af/firefox-55.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "b9a1ba9d7b48997fa4ed799276da18cfadcaa29a206c135c7c7d74bf677f5f40621feb50fe258bd341fa57840dcd3d5144ddc5385f408a6200e8f5ddbc5c02eb";
+      sha512 = "b6c671a746691cea4d4cf6d5b9932b0f1c025f04e11e7ecd38a53c0c2759d3a3ca82e6d00febd1f644fc18730b2f6538734adc02c9e18094f7533f81a955088d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/an/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/an/firefox-55.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "205d0f8893cd5d90eb0b5bd34341bfd7857c88089685d7560a57e6a46e65e03bbd447e8b3b9471f1bb2f0a69c2abbb9ee96d0aacd5d544053dd7f33842402e7c";
+      sha512 = "51f824b2208b18939ac12a6d63507186d20e8e66e0fd9ff030c1bc637a14d987ba85ad5b2425883d90f88952fde84f43e291e68da004e8114d854965421ba9b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ar/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ar/firefox-55.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "3db4dae2cd2a4fc51792f8bb398b47c91e13fc5dfeeb8ad14c7bc101b55d14f1d75e719d5ce03e96d29245805471ce0ad2f38663b3dc837d83a16a365bc1de05";
+      sha512 = "411b0f01d5f6a4f8915f51960b0d7d62a1b9cd9c3de665674a019d356677e9ea82720df4b715523ddc87458dc3edabd8945b7d1e41574a22dc4df5c0b62ed869";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/as/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/as/firefox-55.0.1.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "5b06bd9944c38dfc8c5c92930e2d3c2470d8cadcb11cb97d1ac98426624e4082fb0f61ce27a70572967525166b1343d84ae4cf9c46c4aba9c9afb4e4513c74fd";
+      sha512 = "18d6094a2780759e97b4556fad1d504ee1c1cb41a5ceb8481599f2a41458b5c0100b1fd2a0911f1e125b4089b093f1a306bf838e1c00bbd1bd5c482e0f894881";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ast/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ast/firefox-55.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "5653c855893160419dedf857b6568f9c1bd122da27593f749e81389aef248eb4f1d57b85de70c2a122ba2d941a8da3cb320975ffbb9b56d7647e5bfc18ea7c0a";
+      sha512 = "ec88a6ae8ef64aa01b2c03feed80ece24ddbe19f2c1abe38f5e2b21554b782ee52331175ccada48f47d60c56d4c9a36b28b6d62b332dfe64f033ff9a90581449";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/az/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/az/firefox-55.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "dd6b4c7ff6362710dd631f40a33b5c97f3e3cdd245443ae9a8ba03e31335ff73c9ab695addea10b83733bbc6b65dc68ffa54315c50602661ab447a25cf58912d";
+      sha512 = "e58a646b68a068de0c5b96f088770383345fe46661d667e6d9cc1b7fb0384351dbb10caca6eec618303ab8dfaa82708a71d9376e16017173710f41e0b7d55357";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/be/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/be/firefox-55.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "3688df68952a358e7005ccd64c2b0912d9b113dc146ecce19739043ccfd37f92fc2b470d47c2723a24c8b53d113f705afe56d1fdc3c1b7304c3ed4546b9d347f";
+      sha512 = "e4d8d905eab7b69c78864cbf268ff8e8246f5792e3e55d28e8a44c12027ae8269738a0ddd0fddd4282dd7536e1266e58461553334f1287f7416c9fd5dd29e2d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/bg/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/bg/firefox-55.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "b3ef5094491445ba3544a8a4880f8474cd9d7092cd67184acbebf4e3768b6a0bd43e03938120f3d67ac519e86f3c538c26458963c1c32ed3bd89e9f8019cb5e9";
+      sha512 = "62ae8fab0c91d585234f7eda98a4a7075956b00bbcee5ba06d1dacc2262b32eae37ef3cd1b66da34b02bc309b1b704a2b97c297e3c189de6eb2c969dc1100626";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/bn-BD/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/bn-BD/firefox-55.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "3584ed2d1eb05f217cd475edaaf1869ae3e564af8738cfeca7d0484dee12abb4040c56d4e7c20cf15c983cb2245fd84e9ba1561b27f4dee57a50549fa07c20ed";
+      sha512 = "0cce61b9d0f88911abe306140de86964808d8e94880287e1d3ca6dec6b3c36b79143d03d46bc366809e69b70492ae648aa80bc57897d38c92bd76ab56b36a24e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/bn-IN/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/bn-IN/firefox-55.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "0632856baad0891c3d22454146e64e884828d7aaabb58c1f1fb3c45314eec95765df9bf6bcf68e1edbc5873c93d0d99135f71f7ffe979ff656c2748df1305edd";
+      sha512 = "53f25ae4f49e125b7757740a5f5ec9d08687871d4ab56ae3f4f4506bee2d1453c24c99022a4be0e07f6376bce3b0c0063b7155ec7decff8e2ad61ca456def7e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/br/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/br/firefox-55.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "dae7d1bdd93492303adf1ebe37b92fb3400437911ee0c8bda33840c5cd1fd0307d631a65300dcade93c116fcd3c85d04c518d2aa2ca792eaf20a7d10d99ce3d1";
+      sha512 = "98d83c45d5599bbc62db2204f177b2ff4b710a75ccbbe6d67c8d16829504b8f4a2dbfd2940e583514e41147811c4b3cc4f74637b3212e018eacad85f6f56e892";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/bs/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/bs/firefox-55.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "d9fbb02a07176a8063c8317f795859e2bce1ec56f63742cbbe88fce9b07f03ad3b536ba459a1d655b50f3a867e84f8f56dc041a9f57ee93eebd14f174b938d6c";
+      sha512 = "7691546b4cb9cc4de8f0544e42528704f5c204b382b195da7ef2764faf5e2b6cc58285da890e800ed83e82be01924db0e219d1523959c04faa24a11e3e16b04b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ca/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ca/firefox-55.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "cd93cc44280eb61b2958e745ce27b94fe583535ccb7dc7788f0f74c625a0189db6515328f479224dd3899beaf9a878969ea945da053f2819510b1a9584ced229";
+      sha512 = "21d664d5a589ef1f0f41a936d8e46a3b220d7b1c6e996f639556986e36097144b82dce5dcec1807b3191e5dc3835df6007e845c847bafcffb0e456777cfcbb67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/cak/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/cak/firefox-55.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "14c43245c2f91db0d7ccaf010572fad29f29687156ae21abaf98bcdac578d49673342fb4ba7143aa5d6268c03d37169d7fcf95dfaf48cb494ea721657f66d0b9";
+      sha512 = "a2a289569ed8ce5fd9916d11bab43a0f4166c2878095f2a30fc8ed587eabad7ddcd5fa7a43070eb54daf8549e5f19a3c12d103d1cee493eac2e1adc3b536a952";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/cs/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/cs/firefox-55.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "40c11bc35d1d781cc8c76f7bf42997a0781627c0385fc67b0562edcac04d8bf6f2a4217702ef4ea681f4e39147afbc814a89e23df46b561b1a4f5149404fc955";
+      sha512 = "a24dcacc4f5de63f335e44087f40c203de5ffd482232e691f1f1cd576bd4d41ab949c3d07ad8c1aeeba38863b1a9ce69380079a3cfa0ae7ea3dffebe7d964972";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/cy/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/cy/firefox-55.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "9a946b301e70e7afccbb599e4d4c4d43645cfee27d3e3afbf5862ebb36436c66e0a59a5136ab9729e9d2e01f752feaa2ea341726b41fa03e91d7e909b0dd0b95";
+      sha512 = "7e961c9366d3c0fb2668d6f8d9d874bd7d52e28ed53a461afc234375a5d06239fdb866c12d53f41027672afb889e257075bb59ad869c56a54b409bcb3a4e0ab0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/da/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/da/firefox-55.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "cf42e36971c0d743daca66b5355ccfeff994094bda6ad3526af76c89818f8335af49d0dfb520d2b58d40da64587f85588cd4c61eafdd12a0763ce1034bf44fb4";
+      sha512 = "a058ea5cde4277a26d6f3592b281212087511e8efd79dbd05a59696c81e762949709e12f94f794b252abbfb810a410f95c103b52cfcba34d2397a0b0ca51ad96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/de/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/de/firefox-55.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "7cec9410debcbf95489e3d9a8129a53507de27fce635cff7a60b7f977f6407f7396d03ee5570528eb4524901a1703b2ce7798a637711c9166d3789e95e4b6d35";
+      sha512 = "22788aa3f8bf59a1366ef4bcf3250f2d6155d7ee3de8b2b019dda6a294e6fef58ce1ec6bd0d54b41e8618491de872249f4fe1618779edc418a43d2a5189f4b99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/dsb/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/dsb/firefox-55.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "387ccb1bea5c49115a89c6b64399647e9df08c3b4c2997c9aee761ca73bdacb6a3a05a594453f44aae119512cd5dc62a1adda94ee1974a8809fd9ac6907a5562";
+      sha512 = "bbafd69ddb7f73c4b3fa272fdf91352a9db8b9ab57d56d2d5e743738026e6e5f811c0bda9a69b1db4d533ca8c6de1b5bece1f0f4784092b3b3e8672bb30c3876";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/el/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/el/firefox-55.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "b894fcd577e94288d785eaf058707a456841b2a50786de9a8e9324008e76e29bcd83960f4e292d046f304d90b1d95c941e126d701417b58708a68a85c0f25496";
+      sha512 = "650b3add1753bbad904bb2c1577ee28598f0a0588e38a219b29ca1cb333e9e561c17e560e4e00ba6c861d89ddb70bd7352289b5711c0e24f6f78d37e53e02683";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/en-GB/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/en-GB/firefox-55.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "74b06f6c1d61ea89994df6ed8716b72e9b8cb256bc4420e6011600aee9f161287250baa9f39ad7f8b806fdecfc60c4d7e5bd31e6b02a2f2fbd20fda09c2da2ff";
+      sha512 = "e82dc2a34212a8346bee261ecfb07e82aca6b09582a652f1f9ff90df6f5a5fb9f44c284eb27db4aeba743239262a87faa0e4f6ee3fec66fa97788e66c4e83bfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/en-US/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/en-US/firefox-55.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "d40f8913e3a280f846c8507ef55d934b5e183ad16e01c27d05767ab660235673a4615a8a10f52d5562912f4e88d4c0d4be3ee6a3ab13508a0bf9a8768a06743a";
+      sha512 = "763f0b2294085215282852ce482f2be625efe355138ae709c84ed65ef4ba28908115fe3027eece41e3b5fd1fc164c050d150fefb4fb142eb6652229c021bfe7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/en-ZA/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/en-ZA/firefox-55.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "eeab81e4954ac3ad4ecb1d973d592f137c59fbb62190e6128c6728c78a3ffbcd0ab053a31529bf6a4b2c59787c25e3c62b41e6de682cad7530a40bfe34f83f86";
+      sha512 = "9ca62fc6eac9050a7141ad4025e6fd6e3a703e18c3a184ecd1620fa8cf098867ce4886774673e0c10833ca1312b555f02d436b5d8088b78963b682a5de1537bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/eo/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/eo/firefox-55.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "471b7b8ade86cc0584d3354e074acbdcdfb1afd048e6b6532e10c664668fd3d42d3c57412befa7905d9eec60b4aa2e484982e72e3f2d1c10c4a2f8025083c8db";
+      sha512 = "3dd8d02a132d96913e017aa4194ab496c21a7b708c5ee1e02bec3c7bcc769a7f53c8908bd56a71918e55b49201f645f68ece3e0eb522fe0719a152bd6067245b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/es-AR/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/es-AR/firefox-55.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "7f8ba4fdfa1114c52dafc0b20aae6decdaf79d273494f9a758172d0a66f38b77a1eac6470afbf5f1bdca0844ac43be6b59d70ad24992146959c358e6732b4400";
+      sha512 = "aa8ab141a092b481cfb9fa72f2226913ab7672260b2fd0dbee894215ce373d7cbc1ed7451cd1c1010ff079d14cf9f2e992cc32e981b44360b82d867fb4709d85";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/es-CL/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/es-CL/firefox-55.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "85705a9875897c45fcf0ec1edc87cd3b7f68d4bdc271a9a998609d71ea49e58ab5440913ba33e09153d7095d4303572be84c01f1d7ea1d08251c5194b983de34";
+      sha512 = "73d2ae9ad8442a49700341127e7ba31ecba568e558d27b607c5a6bf8e89a9e515c3bf6b9946f094ba4640cf5bea970e5f8473a5ce953a09c1fdcabd2a68d7a7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/es-ES/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/es-ES/firefox-55.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "5d900419effda0612c0f45a0c8023938f2d8b60cd240d71f5b334b2f903e3c4fad8c7ee548431bb85f3868af844b7214ef67ccd9b7a3775f8bbbe0cddcd53ebe";
+      sha512 = "213f71697b99bb7dcc978bca57fe119940f8197b75b5aed3964db89859fdbaaa0968829269c5a8d6f01bf21f670f85bcbdc9f7d4f6b111971636e44580b67003";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/es-MX/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/es-MX/firefox-55.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "054cf514419b9b30fee31554ea08aa58d8d36b6b1b51c1bb91cb2436dd26db349b31a1ee807906b113536d94a73c352430f3044b32a0e582c0ff328ac10d518f";
+      sha512 = "d12e8f13fd94c3c6f93f5e20ef5cfeb5c3f82a479baa5bca5a5517dd55bd048db59454a56730e69f6bf051a81b5d2bad239ce0fe8975aa00c863667b464503cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/et/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/et/firefox-55.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "af38aefbf277b85fff536a35a4138354ce12ac8b3536f7c0cf5a1a3d5ecf79f138adbcdda1f68cfefcf137c1aa1581fe34749d1d005ffcf369db8561bf2ae536";
+      sha512 = "8f6a6393f009b19743debdaf1bf3cbe12e566a4288f8fdacbb0119961542fcbf082aff03ebe79f54311ba00017851ca4ec4efab9553ea2e1178b6dba9677e31e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/eu/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/eu/firefox-55.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "04176bc464fa903a4a04c9e3ded80dd909d5820ef75bd2bd9ecdcb703cdb19675430d9561e2bc49338ca59eac1be1cdfda9d4acbc4ca5ff61893d32882161dba";
+      sha512 = "7b1f3af68205e3688bfc0e519f9cc6f796477d2f8b11f0c7e035fab1ce917e713b6b18dd498c5d04da3c51a50dda01132268a24180ebcdc15f452bb25d0dab0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/fa/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/fa/firefox-55.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "ef46e0a4b523b3ba883e07b79ebbb343caaec7675b5f6aa456b13b3e362c17069a563c18ce0692fb7854e2f6c72ca880130bf9ae0671177262027564803f971c";
+      sha512 = "1379243d07c5216b31ae2689b11d8729d0905ace42e4bc8ba40289bd39509020ae551e2fd0f5a16b883486ae0bc20c33ee2902650304cf628a239ce3071ed683";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ff/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ff/firefox-55.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "fbeb3f00058cece9df5181aac388f57a60dc9bfb2c5971af6d96e2fa876e7d55a43aed82e56eab302e470c67831c84785dce08ba926e1649c13e0641675bb325";
+      sha512 = "3bf4eec5d5a3c4da765db6997a57dca3f67d52ef302cd38db759592b9904e7b357870d39920bd75b805700ec4b9f4a94400111a321518c5d4f31690ece946289";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/fi/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/fi/firefox-55.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "4af7d213d3fe7e30940adeaa5ac59d1c7b20bd243935684a83ce746576ea68347c41cb897fee50636852402f05aab757208db03a7c746025212dd028b43b7f4b";
+      sha512 = "1a33cd82fbda2554fa76684afbf3a843babd5872459026f1f32fe496e99ed631252ec63933a291214535476f8858d03aea26b7cf2108a029ab5f99ea8c229650";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/fr/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/fr/firefox-55.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "09c81a787cfde2292b88960a7b95a2e5c18e9f0c40a5972f18580c27fe3d2140c4295282e8b8ac2b3ec1b1dcafe1244b7392832805878d7231e1531ddf1c923c";
+      sha512 = "c92bf5cfce5b5114342d98d526e287ded4d82516f008e705ded1ddbf11c1cccd8ba3d3ba777f6be0727f7aca776ac7312fc7e5ce3c2f77ae69420541471d0289";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/fy-NL/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/fy-NL/firefox-55.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "e495c0b559da6d9173786af68760a4fb0b25f4e5d504a9a8e58b21e37903336e4eb15c4beed8a5a791f8c25da0d46ba95256cf5edd31fdcc2acb47ffa85a1b87";
+      sha512 = "16973677379fa16283956fd31a73da2697c4f38b41618e14bcaef4fd3e68430c15ca5327f6752d8123c137b3e026ff682d534e7819f87d8cc3ebe7a7ca865b87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ga-IE/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ga-IE/firefox-55.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "29b28a8c717660ff3b0f07b330ee377927b17deaa887802615e447544b88279871e72a4c73441d9bb76eb6a60e85907ca94ac8375c0125eeaed2500e815f9a6f";
+      sha512 = "a26c96dccb61b5e7685a9914f68e40e3ca468438438bbb07f9b524a9a2f3b26959b7a359b332eeb7da47f7a8ffee5f8811115e857406e99abd7f170b64fa26b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/gd/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/gd/firefox-55.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "2e3d7902773255a69990d1f5176637aa45753eac4d6c903bd8dfdea505f2a07d714181bb4662bae4591b4155fb04a87e09d65eb19476ce2c4d0143b7f8f2641d";
+      sha512 = "d2e4578150f8ad0166c48f6fcad2f735ddc982af2cca30aa694e44e593f4033c259e7f7aee1fd1941fded86d2937464bf11e8a906fb732ca2084632ffc7d642a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/gl/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/gl/firefox-55.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "5af911b6e1bacef308491b10b21592f06539f4360a84d126d0f78fb43196029ec352f8aeb9fa6180899f5d74334ae002602aa70e1b4112ed4cbe79b00bc4a929";
+      sha512 = "999546c43bb56cf95509a8e9b122e649e4ca608fc4e0a3b8e82e9f58c334460420c58650a8837e4247b63eee6f840def3bb80e6c517badd50449e0dfc471d661";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/gn/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/gn/firefox-55.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "721330e35f1632969c92cb732af6a1873c0516292f58e04db3d0c7a96d1cca2ffdcbbacdfb65ff3a958f8757fbf788dd7e667e3037f3b1505a1cb5c34114e02d";
+      sha512 = "caeec1355d3bd3331241fec97b0c6008b8f3c42c1d56b1796a7be4c2ae994569a5d2011fd5b723ca3e560bf07fb1de50523ad2736345aee753f37d6cf5ae7f09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/gu-IN/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/gu-IN/firefox-55.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "c56f1f632cf4bc89c5f2ae69c375878d9f4aadb3ace0c228f36ab42311ea41eb2aaa4b858596e820729a7474a568c57f6a259a2745902243c5cd21b94ea59fa4";
+      sha512 = "1e3feebb32c4240d5c15b0c915b92eff9f63b266ed74b32e1df9fe824b27a3c4d2d06492c9b9d47ba22460e0c2cc854322250edcc1a54e4b6346ac9ee0048b51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/he/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/he/firefox-55.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "69336ba52a347549bf684bb5238ab14dda633d485de617262fc9377572b7c77cfd024cae9f299ff58425d95984939b95cd02f2a3a23ee07879ebc5455a7f7adc";
+      sha512 = "5d83b761b3f8653e1701e75a66c3741a9dc7e377fdb2d7b66a23bcf314f3993e45293d8682e65fb58f2d6a720ecffb0b2568aedcc89804da1efad0590629c3a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/hi-IN/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/hi-IN/firefox-55.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "a141064e138094b02989aec9c3801dfbb6dd70869e3fd590325e6fa4b84968d73270a6559156e774ed27f42062b0fa5f78f0c0a373bfa2a02ae2525d3b516781";
+      sha512 = "9c59cba32c02786bed46c01797e7bbf3d745f90da98cd07ce6ccb578c402bdc8cf3d8887a57b5523a072ddc6d98dcd9761862f32c59570160c732b8408f182c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/hr/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/hr/firefox-55.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "1547872d6d1535cd106b0627830c093d33622f42ff01a419695422af5c030a54996c8b9c95e89589c8ec75eed68485e3ae78bc7cfc0a3b09d303e3a1c0bbbe76";
+      sha512 = "20684ed388fffc81fd7b8d88f4d57f4bb130ea4671a60d4dd70d1bd5250b491a36cb0eff0b7820a26f24695d30afd5c909709b6e8ab27f9e24ae1381a8b4dbc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/hsb/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/hsb/firefox-55.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "796500589c98757a7986158bd08f12ff76ccc09aa4d6132b78c011cb58ecd4d5d0798d780e6178a0597bf5c921e6168e606df56106c8ddbc49262991e10233b6";
+      sha512 = "996ee7693cdb808ede4df1c6d8533a964f0bd98a4026067bfcdad8d1c78b232cdd83f1fa7fceb532deb9197ccde437d42d13449c8ad0fe9cde3dec1f3006a775";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/hu/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/hu/firefox-55.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "7801da792cca62683a7d1ab812fb831ea80d90994b18a151623c05d2f30979d557cc1a6aa0a7ecd44f440c76e71cec9a4749fdd4c49442ea151c1720a7a5d988";
+      sha512 = "faaf14a3f2aaefdada31761bca2056d2592bdb6ec5a053d7c8efe871b0b2ff191b152fc240782b24f3954b4913501efd303bdb301b4a69140e6c47a3fa6856a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/hy-AM/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/hy-AM/firefox-55.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "d47fccbc883ca137200c613aa96899e356cfb09190952805c20d36653d3477abee4db49471a1416ce13455ad5bb6836a7217ae51fce77dd0fb12f1187e11bae9";
+      sha512 = "9190ade1a9885ebbfd0090ee926e0d5e31da61a7c98f874916c423a60328c5f936f29fb60949c1ebf9d726f07f097312c64a67dc193d71537d4adf4a9b7729c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/id/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/id/firefox-55.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "41e111080bed45b7783cd50e7069811b17b35eb0268a92f901531dc1e0a7e7fe07b94ac325f5b5b436b71ceffc1d329837c74875a32e13d3205537b750fbee58";
+      sha512 = "88fe78ccc643a704e068a32d2fc60624a23c269b85bf0c96c8538fb5243c1db93578f1a91993537bd7dc672acb9dc6f4cc75ed444774ff74c7abaf621226b43e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/is/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/is/firefox-55.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "9172c69ae72fa83a05f0926cbf87ed4694653395027b91f441ab976790c581b9383dbe62bfc74a425279ef68f8c6f6d2ef003b20aa241be6269c34bbab147150";
+      sha512 = "969e28b5d8696fe735063161b4848fb3a8cc400ca2f2e3db246dbe68d301c7da3adad7bfda61eed10c85ac028582b2568f57d0c727abd184be2850d44bea427e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/it/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/it/firefox-55.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "daaade14d2dafbb76e021f87773a535783e533474138652fcb0b25bc41a1ad4f13d7cf65119730fed56c43116a3392f3adc435a7f8e8326ee8ea4d9e9cf19ef9";
+      sha512 = "59b389ae6710bfe3d8c62b9b482bf44af419446db0ff5278b1c18bb45eaf122f5b3b47d32b19eb3686cd965bf1e51643221bb01fd6be6990f8ef14159ae6477a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ja/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ja/firefox-55.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "6741bb18a17559482f8b95c1fc6acfce6b0e31e474e5d88905bdf3b939967c0ba625cea7e1f1b2f2ce6e77f3128f1f85069e946e7e6a16fbf4a637cac7e79565";
+      sha512 = "f79c322f4d2d23efc682ca4e02d114583008f2797e5672022d412b27356a1bd34f4c216545ef8c8f00fef17be0fb405384d98f4e44679372b9cf7953e2e8af78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ka/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ka/firefox-55.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "c1849ec6d69ffc87918515a7de95e0405a14b1cc268e68dfa11f8c832ced907e73a021b5c9b5f1839e99d692c13fd3f33197eb91de98f588f5750de03fe098f6";
+      sha512 = "a5f440758bc4607955911d0fb2320036b4d9a06dea07c7cbfe9fd67b767a544cc0df582af329e4c99f3eeb065627e90a989368d26a14530fc94a28d6fe65c7c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/kab/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/kab/firefox-55.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "aaa9a9d415f39dc957ec59becf3b649c650cce619417dd5182835190aa8bf361bfd048ff647099320cbda296c9a992927de9c6a90e84dace4a1e5cbed0b9758a";
+      sha512 = "1f9d2fd390226d06f0165d9a5f53c5b9d67a424969b7881b91374867179ed09efd05cf404de086734165312cfe09131692874632359c9a9fd323a6a9b7dec101";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/kk/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/kk/firefox-55.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "e7f47f9270c909135dcaea2e4a47e1e16a6a0d3b886ef9f4ff0e3e750cd8b6b253eb7944c6f7155df6e91c838bc84544c2880f9c75eff12c97f68ef8da098575";
+      sha512 = "faa9e21a95a41d8c846a5cec6f7cd0d2cdb0a382593e91e824e1d8013af146378c965b28cd44953702167e2e355436a2f5042ae727cf6c95ca75d0eb57f92119";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/km/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/km/firefox-55.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "3e46f8ffba4f93450dcc2aadd010ce0b181e1461902a517c4d6030baaf6814debd2280202308980b3e02879d23144aa186af5c9af6e53e8d6b8d5e5b430bfc26";
+      sha512 = "514bccf7cf2c433d846c7307c75b512f20c6ca4deef5f8f59f744656a81e514a9e62fd4336e223fdb59698b6dc00db0aeec51da4518f0d3467b5a3f06598ef42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/kn/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/kn/firefox-55.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "8de3d801bfe8a1b87719715982cc9eba3b39158a8933b26379884d795bd2eecd43578197165a97f514c50286713bb83c06e200818c2e4ff2714baea72b8a3dc7";
+      sha512 = "814b1fcdd19fa4044ab760818ffc6e246ea2cea36b89785069af857763b23623f4e9cc50a6aa19a77a00a61b501c26182d7296706b7d01bc9a25006c03580058";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ko/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ko/firefox-55.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "5991b9223486acba78015b19d6d0e32dc28aa0e341b4b11928a9f28b1a6f4d366c38690d311ee15ceb607933887cbd8c93940ef0dbab8fb129c94868a5a5d27d";
+      sha512 = "462747db276da856fffb562036367b947822f18513c2eb7cf70d6d3ac31438b59896ebf9c12e9e61abd5adb0b761774ad90cb41eb59789beb994c8dba11fe8bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/lij/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/lij/firefox-55.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "c5ce8dbb363667ef0b037c5022404b756a360272505d756593860598e8d08a04bebb45edd9a27ebc279547658f142ec1e65798c2e2d13ebbfdfee56cd30e20c1";
+      sha512 = "04802af2002399a7540f7ea5e5dbb23cb02d30f567a0afb64fdbc45645251d8bdd6e9563f4b5f5c324c267828115c719b161b074b80f7b9ba8ad4a1a0b24f371";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/lt/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/lt/firefox-55.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "131d67e7bfcaba8ff55d7fbde587aaa1039cb73980e728b29a445acb4bc8f2f17f97802e03a400ef3d6933c2475fe35e7a3acb1b30f949ad71dc054b8d496c36";
+      sha512 = "968e19afc7f0613fc184632529b379334d2409d5d0da5b24117748cbdfac714e8465267b65d2674f8721b47e969279c054add60f2a060331617ac2a02e97d032";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/lv/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/lv/firefox-55.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "7e9b614dbb86ef76fd752180c5b633345d37d24e731eeb10ded7694278903d42f5beaab8a17c5a6472401754b582687595f34233058bacca00dbf3d1f774a5d7";
+      sha512 = "b6ec789c77040508706702d1fff20f0a277c8a5a1f28a375eedef91e0d7cf29a58b3f2027ce1ad2bf8a25ea5043751ee52b8468c4cfc516e1859570a1dad02d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/mai/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/mai/firefox-55.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "cdf641eadf20fa21c5384377183c7797d199c3232f55dc1377d52e330d1ca2d0b1478e3301fef696726a4094284a94d77257462d4a5447ec2ea6b99e2d009e67";
+      sha512 = "1ca567163688b14cfd4deb5cd2f0739807807060dde26508d87c8590cb8ebc9010edd7dc92869de6af2928eab32d42fad5da94a74ebb3bf96cdb7883cf2f9225";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/mk/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/mk/firefox-55.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "ed8d29a7a6a0c255a24be9c6c670677b2cb081129b36490ff59eceae374e2da3911cc279975c55b5ecc8fe7988364b069145b16633ab6c4c945f35c91772c484";
+      sha512 = "87ad815c0aa9e45507ef044248fb961b7bb98b4d4b10426aa448f41d129a162bc1d3f6106016c7cd92cf03b63c1682224aedfea9093030561b13dca79c6d11f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ml/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ml/firefox-55.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "a4a4758635913dc8a4b5d55df97fc9e1141a7120541a0a962aa4b2c566d0985a6500bd25319b0a5f81821c22ee3745e12603499d8f996276db9df07033741f0b";
+      sha512 = "85fe206ba0b20d8eb6c3846685c851ec579d8f188a5d6626ec56c9840bf8a76a0616457ee687cb4d395ac0e71978f9403832207a4675c560546c7ea813014aca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/mr/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/mr/firefox-55.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "59144a70caf75fcdb3b7b4898899e0e3f48449d2b0ae0a92ac5cb022ba8a72e076b53c59bc7dab61dbad17561930b0e1182e47081712bbee66f5beaaef84206e";
+      sha512 = "c41938fdc8a19a49a6100ebf2d452750069e3038d8dbaeab4397f2289622963fa6d74a3c96419eb6cfe7e14bafcbf4b3b4a1f85638f1a402c2cb69daf720b740";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ms/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ms/firefox-55.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "833f8d447913836f26588aa0e5054658cc38b986b72385486cce8a2c9e7e7519615149e7a4da4eee64f83bacd24c924a4cbb5c7f5b8450b75070f28fc558dcb6";
+      sha512 = "f37a606f1713e2f680b32ebcd5bb90f68cf324f26512bfeb628a4d9e71d138004bf08082fad8fa961b2ff28ae3d34c453d890c37b9f775fe27944bb7a5c013f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/my/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/my/firefox-55.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "d44980bbf4e9498eba7cc0170a558a0ed1a6e3fb9d4e55cbe4250d35e9a06c1a7e221f2f81e51733e28662ddb64a5de9833e78068390087d42ff8a7a10e3527a";
+      sha512 = "fa730b3568f06a8350372ac88d3ed7738cd254406a65c36570efbb502a61a60a1a4ab14bf587b4ffe365d3133eb76c841540248402dc87db0d3607235f2878c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/nb-NO/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/nb-NO/firefox-55.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "757b17a9e585bfdedfa6d72860903e7b6430a434a747cfe590f3886f846e03f5f584b62b4e6caa73840260a82d7a9709f99b2a321bfe872f4a81859ae1d3f5e4";
+      sha512 = "5e1fb7632da3755454deca4169802694051c769b0da75978b1762694e0516b202198b74b306d2670c9d05f7237faead7ba15cb55272cc8b3c7cdf14c0a44ce8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/nl/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/nl/firefox-55.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "7c4289a63586f2420609f525b28a01ce19943afd8b9417583a51afc50bf741439cfc8a2aa706c6d2230f45c6603a86a595a1525dc1abddef1496737bb321b01d";
+      sha512 = "5e6dc41cb51190786724b34a566ffa8b16314f54200b7bc2130a6178f0d3693df0fefc7a3935db13e9cd27ff5ade21927900680e9cd6c964ac7a23961d72214d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/nn-NO/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/nn-NO/firefox-55.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "5508f9dd6102f45694c2a7145b9b58f35ba2f0d2703f9e8bbb84094b81f384a2c7cad6df4de245dd87b1dee379d7fc202a66b46be8cad50de94f37afc1e51e63";
+      sha512 = "2d95d711b99a9e94bcb0e2cb923fa584d7a1e7ca2d2b3d289b20f78a8f8c0bf909a26d45a1feb540bcc4c9e983e40d0eecd24b16d0227d5155f7ad684705215c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/or/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/or/firefox-55.0.1.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "a5acda036bfaeb2c06c9b8f2e74475f67624416cb41069654b5dd104e353d2f84ee9a51a036a828355aaf6bdfa9f8f3f9495a287f2c237dd9b15e06d2a774272";
+      sha512 = "d9bb706c45c5e7a822f106888f47615c1948ee74d8bb5a179ba838634262862a561fcf8d0b79a86089b08f0213cf1ee21387bd4e7de1b47719fd76ef607234ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/pa-IN/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/pa-IN/firefox-55.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "a3e807fe14653a8d55925f2c7ca8e963534b14fd5163b1eb168aa9de31f39da90b1a01c2510cd91117e3949b90bdded0666397d7383c4ea20a70fece438ab7ca";
+      sha512 = "ca8121c9ab978cd044bf8efd5c0ad07d7e790cfd1cd6121413d2508d6ddf8fa75e510cf866b5e8506312b1b22fdbc95e3af9008440fdfb8c392dbefeb81ad3a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/pl/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/pl/firefox-55.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "5f256d8ad06ad7dcb8898ad5b7abac13c01ad34f94a2c1a457199a61e94e5b89f76f271f17d90d9686eb49055ef14dc222773d33fd3f53617b2a2f51577bd9db";
+      sha512 = "d83d65bf5f0ed37a7f5a2b66e075aaf4caea91240763e537d0198369e93d0c64b1526f14023d7daa697ac6678728f6d7520aa66bcec7ea282760116642b00c05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/pt-BR/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/pt-BR/firefox-55.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "e36673066bc2d6c68b0c4eb1b6e493d5d5f7f14c29c3c117c76057168f35bc5b7d5966d9f310930e1f8172baa8ca2ed3f04afefa9a752648867c3a3dce48fff1";
+      sha512 = "2184c06f9f205b624f2fa7e9437311c9dd3100135061cb0eb94dabafa27e9b5c5da5aa31e97a70e6f8b773b1c1704472a4cd87d30d6dd463eaad3d8eda009254";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/pt-PT/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/pt-PT/firefox-55.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "d57456e2da3f1c0287554cf2a1aca6b19e99a08c34423711e13176ac8d47da25f2856cab56ad0daa99c60ed0fce417af2447fed1d94c2d0daf4b35f22a9b889b";
+      sha512 = "c40aea22fe64588eae5510b0c047c2d42673b7f22ef17a126bd642a2cfa9fa6ee27e7480089b381d4ceaedec2508ca6685f8301631948624f85b024403456d6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/rm/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/rm/firefox-55.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "036a41157ba884430046fdcead68a37fe254447016cef723754f70cfd88f2fd385ac7c374e82adb06556c541f0ae82ee5f739d1a190ba06a1cf04405e4669b1f";
+      sha512 = "235cf224fa8f78561ce0f1178dbaf3ac0798cbfd3c3da97069e74aadfb38c6fdc90c3e01d45a5346588bc001f5f82e5fbed73672e7bae6fd2ce721d99416c1ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ro/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ro/firefox-55.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "ac349bd51e8fd251f9581ba96c4ca6c69e24e736e44d28c9661e5163a3893ec9ae42c437a0a5b465266a35b966bff0bed8ae081fc93b56d59134fec4ff38cda3";
+      sha512 = "f6f3ba58b8241678c4a82d03433e2f58ead36037068809c404e930afb335fcd4057f3db6a5266785fd573271e66dd98d4987d6524c2b0fa2d01fb05b5671432f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ru/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ru/firefox-55.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "dde58da3b6789ab33fdd8982d328412ac9c6821fd59268dca2fae0bc8dfb8558dfaec4a1d3c9802b33e2c10f7cb0bdf5480dcbbb1fe8e6b8be1774064ca5b85d";
+      sha512 = "c7f9833724b30b81a58c6efb00ae57a69b32c2e7590d6ca0ccdc65d8960336068daf7b8f4e305a466c054f8f4897464cadb3fea48ac05aecef14e18c121a64ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/si/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/si/firefox-55.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "41b96f0c5c4dea98296f791e121e2421545b04995d92326176561f0c034c261e19bb2a7db9e72df52a9285ad5d1ff96a4e38559a386212c7267ccf475764b281";
+      sha512 = "669762fb074a3d7da7ae00c753863519e1d8afe68a183e7f6bd83d8e4305f2db7e1bb8b9a8e64aec20d3b735196bd55874573cca257d4a2de5f59b3d6d7aaee2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/sk/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/sk/firefox-55.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "c19fb32205523afb74ac7edf29f3e55a9ffef4e24d18c47cca493b38d5e1bab8fda308f6c5889a64b8a8ed266c8795a67bbfd690bc381c02405be1ff6cb5e9e2";
+      sha512 = "beb2861f5127b121fce3ef6811de7d801c5ec3cd05c832c16b2839c08a925d2e34a8106270ec956e5f45d6062e9d5cbf72ae4d7d9ed894d9cb44d5914f0a41dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/sl/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/sl/firefox-55.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "490c0174c5d6bb8cdf0619eaf00b87fd15d5365b40680786943cc7c775ba14cadd21e5aa6948b82f0f45bbf17d747f0217ec43b3da8c523b1acff60c3a6c7c63";
+      sha512 = "687b20e50fae586cfff1426e189f28d54aecdeacef80b3f68caacf002f52cb7141fe34803dd1e1d8664efc8500987c752e616e26aaa15b3f051afe878e3a82af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/son/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/son/firefox-55.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "b0e9ad5e3b2c0c274d70a048855c2a923304be5464ddc7066f64cd20833929702c413816f466c98693fab9c7167f4343a12a7d528bd499d3c4d7fd3b268c4a49";
+      sha512 = "92b0b4353fb0e858e3998903c5d2ef82e38259ce1d9560abf06ec6b55174d17db871d967cdb62b4ad23bfbcbb10a2541d14f0b2886f73d6b2d670c93fc48220d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/sq/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/sq/firefox-55.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "285224e3a62ad4c93f63c24757e4d3d973a2c599baa7cb8729c3e4446e7ca054b38f80dcfec26b52491631f04aa10406b4fe25bd9e9d60174609ff6c446036f5";
+      sha512 = "d9ec031149f9a845e6f11c34a96aa54cc14566e569b1395a83158fe32f433c51a95b1e16e99706f92973661c48856372b134c43b2ebbdc8d358108dc0998033c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/sr/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/sr/firefox-55.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "3a4b5082d7f9afe834ff3236304b6a50a5b2262f9024ba8477bf6b2d25908d0aa440432b093a5e2d6a7c698a683e00ac299ffb1913d28298005dbbc38c8c1515";
+      sha512 = "cbb81a562427e4773a4c971d24bfc5f9ac689f8f85b6edc2a2b32572f10b202e8b16de562cae85cfe1a9e86eafa3bd60c8bcbfc2b3675128c96c73c223894f08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/sv-SE/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/sv-SE/firefox-55.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "dcad45f1cfa03e12c594665666d715310d29f0984ef4af446356c9d030decd9551782a1b591fad218c2421edafe7f2262200a2e6a1672ac41d7f16a9664ebd7b";
+      sha512 = "f46223ace271fcd4ca96ac6724bf60d99da5e80dcf00d6f2889cfdb41d1ca8c03ea3ca5ba61f6cc855c9cc2b62e4602628847d641f85d8bf2c6dd33cdd208b0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ta/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ta/firefox-55.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "a351f1850772b6086a70d6c8f6edc5b0906b8b5a9dbb8c05dea8a75f4ebeb46b1e9077f2c145b5b557acf3e7382d72f94949a1a0420c5c04d9e7b17292ef5d63";
+      sha512 = "cd3297d41e6524eb7ce5d398b8a95ee0ab008a626b1846e50096343aa5f469149a2a5c0f3d452d0f10ebe6f397e68d76dda4eaa9f3c10b0fa2b6a0d5d60bfa2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/te/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/te/firefox-55.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "8f1a725b309eff87d1ba130d02e6807a7202d91f0d7cee73672e6dd0dcc90b92b5a7aa73150d9c69140e9c27140b364557d289a644c1131c57d19a34d96acecd";
+      sha512 = "ac7a7ffe87187610a861e32a1a314ab0dc3141eb0910a1987946adccc686cbd1b58ccd996009fef49d642f3ae0568cf429811e652f4fa23b1f5381f3511fb65c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/th/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/th/firefox-55.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "95f20d59433954c0b26a709378a853f6297028126ffaf2beabbe0332acc9df3089dfbc0095f3aac503a04b0cdfce9f79199eed9ca04b810f213f5692a1fc4cad";
+      sha512 = "2dc3ed9875d863b27151ae75dc83b5f2f738f0fac24f5fd1b3ba9f7a4aed1c2e77aaaf588bdca534b2a4078a086558ed820cbfd6e852244897dda7601bd5091f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/tr/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/tr/firefox-55.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "6eb68dc198c1106d48ea93b924dc961aaa10a7e89a74f7ffcd219f1de4952c403b19062bd23fa625f82cc9cdad0506f777aa57da6fb106050e962deffa79cc76";
+      sha512 = "869d654afeb246281be5b287ae76749e25da2e15d7d456cb5848281153307ca50f35a2c62dba0014b90ecf322a85ae8b7daa12ca156e8f5ac33854f6a890f19e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/uk/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/uk/firefox-55.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "c43f597db5027f6c1ba76e4308a7e733a78f1d3711a4529b5cc8f51eebe7bd2a55007975f248be698485fecb91ecbc43a141a94869e41445a07f90fa81d70cb0";
+      sha512 = "709a5b8889c4a871dfa15c46bc7eee38986f4b76eef4bade78daf88f46e0ee50a815c54c0bf1e77924d1ae04d464de3a4d1c03494bb2781df11ab32d9e4766ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/ur/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ur/firefox-55.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "2d7af1f97cf035519c43e57ba4be3f95f64e2da816d01c924e82dd4c442d767098247f1bd7535f3d5c658254ba7a9ade752f97ca4951a6a0989f6303cfeb3354";
+      sha512 = "d7a0481116d791eebc511ef35a79dad263bcbcde54838a03b86fd5864746c4353cea4e8ee7998b18b266509e2ce584da0cfed39c324c79b847b44ecb043ccf8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/uz/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/uz/firefox-55.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "f5173c595187661731aa3e4edb3fa35f3be9c0f494882a06e765142e193488e50538b1558ae094b8a0c462758601a89dc9105ecee6ed485435083f5c9ea67f6c";
+      sha512 = "5102829f08869d90f362c8da8a6947c23b23c616b6c3cca58e4a8fc9ba68573e8d74238029ad51ca2439f7946359903bbf03c2468c86bfa7f7679580f9a60649";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/vi/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/vi/firefox-55.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "2b30eea824bf032526033203798ad34337e7151c45cc055ad7eba9def8f46b6108de2730ae5dea45627b65ed7ec617ca15b5372f23e3e4a33a303bb51ac4983b";
+      sha512 = "a4a936439a729142af19aa2db02a6e769bfe6c653e6d54381b7d80756968b6ebe6dbad51a267936e173b49d3f92b94e89012fd35c54aa790f17217b001b7dc3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/xh/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/xh/firefox-55.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "2d098f192bfee274dd9c4cd806bf35bd311c50eb73a45e23eb5e497e636617e020c518f131520f5f0ba3d23864c97f09b4d9b46db9cc4d55c63be3731e990aa6";
+      sha512 = "9ac4a54cb66cdbc720e263277dbeee14d243c025ee63f6a1ee4990575fbbb333a0979a19615c226fe1486d9896d6754b5485dedcffb576511754d6781c572dc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/zh-CN/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/zh-CN/firefox-55.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "f89e61ad4c1b44d48e0e0e7be3dcd80df548e5f0d0932b915a2c37b36bd882cfd4d19c2d2261b64266a8317acb066b2c48db0348dbe37c14b748d5832f6c0e84";
+      sha512 = "e007854739c12502665418c3e0470940cb9df0314537275dac5d3c80923a756dda14b7161196b7289187d6706d58f887f59f47e07f764714298e5da1a41a0979";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0/linux-i686/zh-TW/firefox-55.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/zh-TW/firefox-55.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "c8547fe1196a6b0ef8644edf69cdd68b74e208260c7e51f51a03d854374b0ed8623ebfb1e7c6e6c4d05edbc13e7862d0fdf260d77b7f2e125379258c4b3d44c6";
+      sha512 = "f414e7c6da2b2b5a1871f25def1ee055f7cdb66a6e76ee66848c26e2eb2d999e65070a816067990cb9d855420392e4b84b52b957e6dca063f8a011f2ddb4bbe6";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "55.0";
+    version = "55.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "b3ca0a926faedfc12c859965629330489ac6c05730a0dc38748704a1a25e876decfba78a3d665e22a6773b0a3bfed3109cd624be77d130785b4097d6d9f9c94b";
+      sha512 = "2c15cb3e1a9f464f63ff7ac8ccf0625ed845a5cb9b186d7acf121c439cec38bcdeee93630e99dbfd336f1b7e60a7c09822a1eba59f308bba8866f155b2ed1c47";
     };
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

- Bug fixes.

https://www.mozilla.org/en-US/firefox/55.0.1/releasenotes/

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
