### PR TITLE
nodePackages.jsonlint init : at 1.6.2

### DIFF
--- a/pkgs/development/node-packages/node-packages-v6.json
+++ b/pkgs/development/node-packages/node-packages-v6.json
@@ -33,6 +33,7 @@
 , "jshint"
 , "json"
 , "js-beautify"
+, "jsonlint"
 , "jsontool"
 , "json-refs"
 , "json-server"

--- a/pkgs/development/node-packages/node-packages-v6.nix
+++ b/pkgs/development/node-packages/node-packages-v6.nix
@@ -25643,6 +25643,30 @@ in
     };
     production = true;
   };
+  jsonlint = nodeEnv.buildNodePackage {
+    name = "jsonlint";
+    packageName = "jsonlint";
+    version = "1.6.2";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.2.tgz";
+      sha1 = "5737045085f55eb455c68b1ff4ebc01bd50e8830";
+    };
+    dependencies = [
+      sources."nomnom-1.8.1"
+      sources."JSV-4.0.2"
+      sources."underscore-1.6.0"
+      sources."chalk-0.4.0"
+      sources."has-color-0.1.7"
+      sources."ansi-styles-1.0.0"
+      sources."strip-ansi-0.1.1"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Validate JSON";
+      homepage = http://zaach.github.com/jsonlint/;
+    };
+    production = true;
+  };
   jsontool = nodeEnv.buildNodePackage {
     name = "jsontool";
     packageName = "jsontool";


### PR DESCRIPTION
###### Motivation for this change
add [jsonlint](https://www.npmjs.com/package/jsonlint)

I use this linter with nvovim via [ale](https://github.com/w0rp/ale)

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

