### PR TITLE
git: fix ssh-path patch which was broken during the update to 2.14.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/ssh-path.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/ssh-path.patch
@@ -1,18 +1,18 @@
 diff --git a/connect.c b/connect.c
-index fd7ffe1..20cd992 100644
+index 49b28b83b..fad9047b5 100644
 --- a/connect.c
 +++ b/connect.c
-@@ -768,7 +768,7 @@ struct child_process *git_connect(int fd[2], const char *url,
+@@ -882,7 +882,7 @@ struct child_process *git_connect(int fd[2], const char *url,
  
  				ssh = getenv("GIT_SSH");
  				if (!ssh)
 -					ssh = "ssh";
 +					ssh = "@ssh@";
- 
- 				ssh_dup = xstrdup(ssh);
- 				base = basename(ssh_dup);
+ 				else
+ 					handle_ssh_variant(ssh, 0,
+ 							   &port_option,
 diff --git a/git-gui/lib/remote_add.tcl b/git-gui/lib/remote_add.tcl
-index 50029d0..17b9594 100644
+index 480a6b30d..781720424 100644
 --- a/git-gui/lib/remote_add.tcl
 +++ b/git-gui/lib/remote_add.tcl
 @@ -139,7 +139,7 @@ method _add {} {


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
