### PR TITLE
fontforge: reduce nondetermenism

### DIFF
--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -10,6 +10,8 @@
 stdenv.mkDerivation rec {
   name = "fontforge-${version}";
   version = "20160404";
+  versionModtime = "1459728000"; # unix timestamp of ${version}
+  versionModtimeStr = "00:00 UTC 04-Apr-2016";
 
   src = fetchFromGitHub {
     owner = "fontforge";
@@ -25,6 +27,15 @@ stdenv.mkDerivation rec {
     sha256 = "0n8i62qv2ygfii535rzp09vvjx4qf9zp5qq7qirrbzm1l9gykcjy";
   })];
   patchFlags = "-p0";
+
+  # fontforge's compilation timestamp leaks to font files it creates
+  # 1970-01-01 won't work here because font build scripts may check if fontforge is too old
+  # (yes, what they actually check is when fontforge was compiled)
+  postPatch = ''
+    sed -i -r 's@^FONTFORGE_VERSIONDATE=.+$@FONTFORGE_VERSIONDATE="${version}"@'           configure.ac
+    sed -i -r 's@^FONTFORGE_MODTIME=.+$@FONTFORGE_MODTIME="${versionModtime}"@'            configure.ac
+    sed -i -r 's@^FONTFORGE_MODTIME_STR=.+$@FONTFORGE_MODTIME_STR="${versionModtimeStr}"@' configure.ac
+  '';
 
   buildInputs = [
     autoconf automake gnum4 libtool perl pkgconfig gettext uthash


### PR DESCRIPTION
Fontforge [captures current time at ```configurePhase```](https://github.com/fontforge/fontforge/blob/20160404/configure.ac#L794-L796) and then exposes the captured time as the version of ```fontforge```.

The value leaks to the font files (nixpkgs uses fontforge to compile some fonts), making it dependent not only on the time of the font compilation (which is fixable by ```libfaketime```), but also on the compilation time of ```fontforge```.

The value is used by [some scripts](https://github.com/dejavu-fonts/dejavu-fonts/blob/master/scripts/generate.pe#L19-L21) to check if the fontforge fresh enough, so it cannot be set to the usual "19700101".

<hr/>

This is fixed upstream (https://github.com/fontforge/fontforge/issues/2711 https://github.com/fontforge/fontforge/pull/2943) but ```nixpkgs``` uses older version
