### PR TITLE
data/fonts: make derivations fixed-outputs (group 2)

### DIFF
--- a/pkgs/data/fonts/clearlyU/default.nix
+++ b/pkgs/data/fonts/clearlyU/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation {
       mkfontdir 
       mkfontscale
     '';
+  
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "127zrg65s90ksj99kr9hxny40rbxvpai62mf5nqk853hcd1bzpr6";
 
   meta = {
     description = "A Unicode font";

--- a/pkgs/data/fonts/dina-pcf/default.nix
+++ b/pkgs/data/fonts/dina-pcf/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     for i in Dina_r700-*.bdf; do
         bdftopcf -t -o DinaBold$(_get_font_size $i).pcf $i
     done
-    gzip *.pcf
+    gzip -n *.pcf
 
     fontDir="$out/share/fonts/misc"
     mkdir -p "$fontDir"
@@ -44,6 +44,10 @@ stdenv.mkDerivation rec {
   '';
 
   preferLocalBuild = true;
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "0v0qn5zwq4j1yx53ypg6w6mqx6dk8l1xix0188b0k4z3ivgnflyb";
 
   meta = with stdenv.lib; {
     description = "A monospace bitmap font aimed at programmers";

--- a/pkgs/data/fonts/dosemu-fonts/default.nix
+++ b/pkgs/data/fonts/dosemu-fonts/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     for i in */etc/*.bdf; do
       fontOut="$out/share/fonts/X11/misc/dosemu/$(basename "$i" .bdf).pcf.gz"
       echo -n "Installing font $fontOut..." >&2
-      ${bdftopcf}/bin/bdftopcf $i | gzip -c -9 > "$fontOut"
+      ${bdftopcf}/bin/bdftopcf $i | gzip -c -9 -n > "$fontOut"
       echo " done." >&2
     done
     cp */etc/dosemu.alias "$fontPath/fonts.alias"
@@ -24,6 +24,10 @@ stdenv.mkDerivation rec {
     ${mkfontdir}/bin/mkfontdir
     ${mkfontscale}/bin/mkfontscale
   '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "1miqv0ral5vazx721wildjlzvji5r7pbgm39c0cpj5ywafaikxr8";
 
   meta = {
     description = "Various fonts from the DOSEmu project";

--- a/pkgs/data/fonts/envypn-font/default.nix
+++ b/pkgs/data/fonts/envypn-font/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
     mkfontscale
   '';
 
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "04sjxfrlvjc2f0679cy4w366mpzbn3fp6gnrjb8vy12vjd1ffnc1";
+
   meta = with stdenv.lib; {
     description = ''
       Readable bitmap font inspired by Envy Code R

--- a/pkgs/data/fonts/gohufont/default.nix
+++ b/pkgs/data/fonts/gohufont/default.nix
@@ -50,6 +50,10 @@ stdenv.mkDerivation rec {
     mkfontscale
   '';
 
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "0msl5y9q6hjbhc85v121x1b1rhsh2rbqqy4k234i5mpp8l3087r7";
+
   meta = with stdenv.lib; {
     description = ''
       A monospace bitmap font well suited for programming and terminal use

--- a/pkgs/data/fonts/proggyfonts/default.nix
+++ b/pkgs/data/fonts/proggyfonts/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   name = "proggyfonts-0.1";
 
   src = fetchurl {
-    url = "http://kaictl.net/software/${name}.tar.gz";
+    url = "http://web.archive.org/web/20150801042353/http://kaictl.net/software/proggyfonts-0.1.tar.gz";
     sha256 = "1plcm1sjpa3hdqhhin48fq6zmz3ndm4md72916hd8ff0w6596q0n";
   };
 
@@ -30,6 +30,10 @@ stdenv.mkDerivation rec {
         mkfontdir
       done
     '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "06jsf3rw6q4l1jrw1161h4vxa1xbvpry5x12d8sh5g7hjk88p77g";
 
   meta = with stdenv.lib; {
     homepage = http://upperbounds.net;

--- a/pkgs/data/fonts/tewi/default.nix
+++ b/pkgs/data/fonts/tewi/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
         bdftopcf -o ''${i/bdf/pcf} $i
     done
 
-    gzip *.pcf
+    gzip -n *.pcf
   '';
 
   installPhase = ''
@@ -28,6 +28,10 @@ stdenv.mkDerivation rec {
     mkfontdir
     mkfontscale
   '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "14dv3m1svahjyb9c1x1570qrmlnynzg0g36b10bqqs8xvhix34yq";
 
   meta = with stdenv.lib; {
     description = "A nice bitmap font, readable even at small sizes";

--- a/pkgs/data/fonts/ucs-fonts/default.nix
+++ b/pkgs/data/fonts/ucs-fonts/default.nix
@@ -33,6 +33,10 @@ stdenv.mkDerivation rec {
     mkfontscale
   '';
 
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "12fh3kbsib0baqwk6148fnzqrj9gs4vnl7yd5n9km72sic1z1xwk";
+
   meta = with stdenv.lib; {
     description = "Unicode bitmap fonts";
     maintainers = [ maintainers.raskin ];

--- a/pkgs/data/fonts/uni-vga/default.nix
+++ b/pkgs/data/fonts/uni-vga/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation {
     mkfontscale
   '';
 
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  sha256 = "0rfly7r6blr2ykxlv0f6my2w41vvxcw85chspljd2p1fxlr28jd7";
+
   meta = {
     description = "Unicode VGA font";
     maintainers = [stdenv.lib.maintainers.ftrvxmtrx];

--- a/pkgs/data/fonts/unifont/default.nix
+++ b/pkgs/data/fonts/unifont/default.nix
@@ -28,6 +28,10 @@ stdenv.mkDerivation rec {
       mkfontscale
     '';
 
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "1s7gpxxj760aw3rpk760s3w8qdkn819rs7si1qj4grm3s6hb2gd8";
+
   meta = with stdenv.lib; {
     description = "Unicode font for Base Multilingual Plane";
     homepage = http://unifoundry.com/unifont.html;


### PR DESCRIPTION
follow up https://github.com/NixOS/nixpkgs/pull/28161

fonts refactorings, the group of not so trivial fonts.

I decided to keep post-download ```sha256``` in this group to ease debugging why ```outputHash``` may be not stable. it could be removed later to reduce the code size.

cc: @fpletz @Mic92 

This PR does not depend on https://github.com/NixOS/nixpkgs/pull/28161 and may be merged earlier.