### PR TITLE
moon-buggy: init at 1.0.51

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -508,6 +508,7 @@
   ryanartecona = "Ryan Artecona <ryanartecona@gmail.com>";
   ryansydnor = "Ryan Sydnor <ryan.t.sydnor@gmail.com>";
   ryantm = "Ryan Mulligan <ryan@ryantm.com>";
+  rybern = "Ryan Bernstein <ryan.bernstein@columbia.edu>";
   rycee = "Robert Helgesson <robert@rycee.net>";
   ryneeverett = "Ryne Everett <ryneeverett@gmail.com>";
   rzetterberg = "Richard Zetterberg <richard.zetterberg@gmail.com>";

--- a/pkgs/games/moon-buggy/default.nix
+++ b/pkgs/games/moon-buggy/default.nix
@@ -1,4 +1,5 @@
 {stdenv, fetchurl, ncurses}:
+
 stdenv.mkDerivation rec {
   baseName = "moon-buggy";
   version = "1.0.51";
@@ -9,8 +10,8 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "http://m.seehuhn.de/programs/moon-buggy-1.0.51.tar.gz";
-    sha256 = "352dc16ccae4c66f1e87ab071e6a4ebeb94ff4e4f744ce1b12a769d02fe5d23f";
+    url = "http://m.seehuhn.de/programs/${name}.tar.gz";
+    sha256 = "0gyjwlpx0sd728dwwi7pwks4zfdy9rm1w1xbhwg6zip4r9nc2b9m";
   };
 
   meta = {

--- a/pkgs/games/moon-buggy/default.nix
+++ b/pkgs/games/moon-buggy/default.nix
@@ -1,29 +1,22 @@
 {stdenv, fetchurl, ncurses}:
-let
-  s = 
-  rec {
-    baseName = "moon-buggy";
-    version = "1.0.51";
-    name = "${baseName}-${version}";
-    url = "http://m.seehuhn.de/programs/moon-buggy-1.0.51.tar.gz";
-    sha256 = "352dc16ccae4c66f1e87ab071e6a4ebeb94ff4e4f744ce1b12a769d02fe5d23f";
-  };
+stdenv.mkDerivation rec {
+  baseName = "moon-buggy";
+  version = "1.0.51";
+  name = "${baseName}-${version}";
+
   buildInputs = [
     ncurses
   ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
+
   src = fetchurl {
-    inherit (s) url sha256;
+    url = "http://m.seehuhn.de/programs/moon-buggy-1.0.51.tar.gz";
+    sha256 = "352dc16ccae4c66f1e87ab071e6a4ebeb94ff4e4f744ce1b12a769d02fe5d23f";
   };
 
   meta = {
-    inherit (s) version;
     description = ''A simple character graphics game where you drive some kind of car across the moon's surface'';
     license = stdenv.lib.licenses.gpl2;
-    maintainers = [];
+    maintainers = [stdenv.lib.maintainers.rybern];
     platforms = stdenv.lib.platforms.linux;
     homepage = http://www.seehuhn.de/pages/moon-buggy;
   };

--- a/pkgs/games/moon-buggy/default.nix
+++ b/pkgs/games/moon-buggy/default.nix
@@ -1,0 +1,30 @@
+{stdenv, fetchurl, ncurses}:
+let
+  s = 
+  rec {
+    baseName = "moon-buggy";
+    version = "1.0.51";
+    name = "${baseName}-${version}";
+    url = "http://m.seehuhn.de/programs/moon-buggy-1.0.51.tar.gz";
+    sha256 = "352dc16ccae4c66f1e87ab071e6a4ebeb94ff4e4f744ce1b12a769d02fe5d23f";
+  };
+  buildInputs = [
+    ncurses
+  ];
+in
+stdenv.mkDerivation {
+  inherit (s) name version;
+  inherit buildInputs;
+  src = fetchurl {
+    inherit (s) url sha256;
+  };
+
+  meta = {
+    inherit (s) version;
+    description = ''A simple character graphics game where you drive some kind of car across the moon's surface'';
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [];
+    platforms = stdenv.lib.platforms.linux;
+    homepage = http://www.seehuhn.de/pages/moon-buggy;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17339,6 +17339,8 @@ with pkgs;
 
   minecraft-server = callPackage ../games/minecraft-server { };
 
+  moon-buggy = callPackage ../games/moon-buggy {};
+
   multimc = libsForQt5.callPackage ../games/multimc { };
 
   minetest = callPackage ../games/minetest {


### PR DESCRIPTION
###### Motivation for this change
moon-buggy is fun

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is my first pull request. Please let me know anything I can improve on, because I'd like to contribute more in the future.
