### PR TITLE
gpy: init at 1.7.7

### DIFF
--- a/pkgs/development/python-modules/gpy/default.nix
+++ b/pkgs/development/python-modules/gpy/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, numpy, scipy, six, paramz, nose, matplotlib, cython }:
+
+buildPythonPackage rec {
+  pname = "GPy";
+  version = "1.7.7";
+  name  = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b4siirlkqic1lsn9bi9mnp8fpbpw1ijwv0z2i6r2zdrk3d6szs1";
+  };
+
+  # running tests produces "ImportError: cannot import name 'linalg_cython'"
+  # even though Cython has run
+  checkPhase = "nosetests -d";
+  doCheck = false;
+
+  checkInputs = [ nose ];
+
+  buildInputs = [ cython ];
+
+  propagatedBuildInputs = [ numpy scipy six paramz matplotlib ];
+
+  meta = with stdenv.lib; {
+    description = "Gaussian process framework in Python";
+    homepage = https://sheffieldml.github.io/GPy;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6406,6 +6406,8 @@ in {
     '';
   };
 
+  gpy = callPackage ../development/python-modules/gpy { };
+
   gitdb = buildPythonPackage rec {
     name = "gitdb-0.6.4";
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [N/A] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [N/A] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

