### PR TITLE
enable hydra jobs for packages x86_64-linux does not support

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -40,6 +40,8 @@ let
 
   allowBroken = config.allowBroken or false || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
 
+  allowUnsupportedSystem = config.allowUnsupportedSystem or false;
+
   isUnfree = licenses: lib.lists.any (l:
     !l.free or true || l == "unfree" || l == "unfree-redistributable") licenses;
 
@@ -177,7 +179,7 @@ let
       { valid = false; reason = "blacklisted"; errormsg = "has a blacklisted license (‘${showLicense attrs.meta.license}’)"; }
     else if !allowBroken && attrs.meta.broken or false then
       { valid = false; reason = "broken"; errormsg = "is marked as broken"; }
-    else if !allowBroken && attrs.meta.platforms or null != null && !lib.lists.elem system attrs.meta.platforms then
+    else if !allowUnsupportedSystem && !allowBroken && attrs.meta.platforms or null != null && !lib.lists.elem system attrs.meta.platforms then
       { valid = false; reason = "broken"; errormsg = "is not supported on ‘${system}’"; }
     else if !(hasAllowedInsecure attrs) then
       { valid = false; reason = "insecure"; errormsg = "is marked as insecure"; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11763,7 +11763,7 @@ with pkgs;
 
   darwin = let
     apple-source-releases = callPackage ../os-specific/darwin/apple-source-releases { };
-  in apple-source-releases // rec {
+  in recurseIntoAttrs (apple-source-releases // rec {
     cctools = callPackage ../os-specific/darwin/cctools/port.nix {
       inherit libobjc;
       stdenv = if stdenv.isDarwin then stdenv else libcxxStdenv;
@@ -11807,7 +11807,7 @@ with pkgs;
     usr-include = callPackage ../os-specific/darwin/usr-include {};
 
     DarwinTools = callPackage ../os-specific/darwin/DarwinTools {};
-  };
+  });
 
   devicemapper = lvm2;
 

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -13,7 +13,7 @@ rec {
 
   allPackages = args: packageSet (args // nixpkgsArgs);
 
-  pkgs = pkgsFor "x86_64-linux";
+  pkgs = packageSet (lib.recursiveUpdate { system = "x86_64-linux"; config.allowUnsupportedSystem = true; } nixpkgsArgs);
   inherit lib;
 
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -126,9 +126,6 @@ let
         pandas = unix;
         scikitlearn = unix;
       };
-
-      # hack around broken eval of non-linux packages for now.
-      tests.macOSSierraShared = darwin;
     } ));
 
 in jobs

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -126,6 +126,12 @@ let
         pandas = unix;
         scikitlearn = unix;
       };
+
+      darwin = packagePlatforms pkgs.darwin // {
+        cf-private = {};
+        osx_private_sdk = {};
+        xcode = {};
+      };
     } ));
 
 in jobs


### PR DESCRIPTION
###### Motivation for this change
Right now, Hydra will only list packages that actually support x86_64-linux. This allows "broken" packages on x86_64-linux to be listed for the purpose of having Darwin-only packages built, available, and listed on Hydra.

This was based on @dezgeg's commits and rebased onto latest staging. I'm not sure how Hydra works in this regard, but hopefully the missing packages will show up in staging as soon as it is merged.

/cc @dezgeg @LnL7 @Ericson2314 

related to #25930
Fixes #25200