### PR TITLE
pythonPackages.paramz: fix URL

### DIFF
--- a/pkgs/development/python-modules/paramz/default.nix
+++ b/pkgs/development/python-modules/paramz/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Parameterization framework for parameterized model creation and handling";
-    homepage = https://github.com/sodz/paramz;
+    homepage = https://github.com/sods/paramz;
     license = licenses.bsd3;
     maintainers = with maintainers; [ bcdarwin ];
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

