### PR TITLE
vscode-with-extensions: init at 1.10.2

### DIFF
--- a/pkgs/applications/editors/vscode-with-extensions/default.nix
+++ b/pkgs/applications/editors/vscode-with-extensions/default.nix
@@ -1,0 +1,82 @@
+{ stdenv, lib, fetchurl, runCommand, buildEnv, vscode, which, writeScript
+, vscodeExtensions ? [] }:
+
+/*
+  `vsixExtensions`
+   :  A set of vscode extensions to be installed alongside the editor. Here's a an
+      example:
+
+      ~~~
+      vscode-with-extensions.override {
+
+        # When the extension is already available in the default extensions set.
+        vscodeExtensions = with vscodeExtensions; [
+          nix
+        ]   
+
+        # Concise version from the vscode market place when not available in the default set.
+        ++ vscodeUtils.extensionsFromVscodeMarketplace [
+          {
+            name = "code-runner";
+            publisher = "formulahendry";
+            version = "0.6.33";
+            sha256 = "166ia73vrcl5c9hm4q1a73qdn56m0jc7flfsk5p5q41na9f10lb0";
+          }
+        ];
+      }
+      ~~~
+
+      This expression should fetch 
+       -  the *nix* vscode extension from whatever source defined in the
+          default nixpkgs extensions set `vscodeExtensions`.
+
+       -  the *code-runner* vscode extension from the marketplace using the 
+          following url:
+
+          ~~~
+          https://bbenoist.gallery.vsassets.io/_apis/public/gallery/publisher/bbenoist/extension/nix/1.0.1/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage
+          ~~~
+
+      The original `code` executable will be wrapped so that it uses the set of pre-installed / unpacked
+      extensions as its `--extensions-dir`.
+*/
+
+let
+
+  wrappedPkgVersion = lib.getVersion vscode;
+  wrappedPkgName = lib.removeSuffix "-${wrappedPkgVersion}" vscode.name;
+
+  combinedExtensionsDrv = buildEnv {
+    name = "${wrappedPkgName}-extensions-${wrappedPkgVersion}";
+    paths = vscodeExtensions;
+  };
+
+  wrappedExeName = "code";
+  exeName = wrappedExeName;
+
+  wrapperExeFile = writeScript "${exeName}" ''
+    #!${stdenv.shell}
+    exec ${vscode}/bin/${wrappedExeName} \
+      --extensions-dir "${combinedExtensionsDrv}/share/${wrappedPkgName}/extensions" \
+      "$@"
+  '';
+
+in
+
+# When no extensions are requested, we simply redirect to the original
+# non-wrapped vscode executable.
+runCommand "${wrappedPkgName}-with-extensions-${wrappedPkgVersion}" {
+  buildInputs = [ vscode which ];
+  dontPatchELF = true;
+  dontStrip = true;
+  meta = vscode.meta;
+} ''
+  mkdir -p "$out/bin"
+  ${if [] == vscodeExtensions
+    then ''
+      ln -sT "${vscode}/bin/${wrappedExeName}" "$out/bin/${exeName}"
+    ''
+    else ''
+      ln -sT "${wrapperExeFile}" "$out/bin/${exeName}"
+    ''}
+''

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, lib, fetchurl, vscode-utils }:
+
+let
+  inherit (vscode-utils) buildVscodeExtension buildVscodeMarketplaceExtension;
+in
+
+rec {
+  nix = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+        name = "nix";
+        publisher = "bbenoist";
+        version = "1.0.1";
+        sha256 = "0zd0n9f5z1f0ckzfjr38xw2zzmcxg1gjrava7yahg5cvdcw6l35b";
+    };
+
+    # TODO: Fill meta with appropriate information.
+  };
+}

--- a/pkgs/misc/vscode-extensions/vscode-utils.nix
+++ b/pkgs/misc/vscode-extensions/vscode-utils.nix
@@ -1,0 +1,92 @@
+{ stdenv, lib, fetchurl, runCommand, vscode, which }:
+
+let
+  extendedPkgVersion = lib.getVersion vscode;
+  extendedPkgName = lib.removeSuffix "-${extendedPkgVersion}" vscode.name;
+
+  mktplcExtRefToFetchArgs = ext: {
+    url = "https://${ext.publisher}.gallery.vsassets.io/_apis/public/gallery/publisher/${ext.publisher}/extension/${ext.name}/${ext.version}/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
+    sha256 = ext.sha256;
+    name = "${ext.name}.vsix";
+  };
+
+  buildVscodeExtension = a@{
+    name,
+    namePrefix ? "${extendedPkgName}-extension-",
+    src,
+    configurePhase ? ":",
+    buildPhase ? ":",
+    dontPatchELF ? true,
+    dontStrip ? true,
+    buildInputs ? [],
+    ...
+  }:
+  stdenv.mkDerivation (a // {
+
+    name = namePrefix + name;
+
+    inherit configurePhase buildPhase dontPatchELF dontStrip;
+
+    # TODO: `which` is an encapsulation leak. It should have been hardwired
+    #       as part of the `code` wrapper. 
+    buildInputs = [ vscode which ] ++ buildInputs;
+
+    unpackPhase = ''
+      # TODO: Unfortunately, 'code' systematically creates its '.vscode' directory
+      # even tough it has nothing to write in it. We need to redirect this
+      # to a writeable location as the nix environment already has (but
+      # to a non writeable one) otherwise the write will fail.
+      # It would be preferrable if we could intercept / fix this at the source.
+      HOME="$PWD/code_null_home" code \
+        --extensions-dir "$PWD" \
+        --install-extension "${toString src}"
+
+      rm -Rf "$PWD/code_null_home"
+      cd "$(find . -mindepth 1 -type d -print -quit)"
+      ls -la
+    '';
+
+
+    installPhase = ''
+      mkdir -p "$out/share/${extendedPkgName}/extensions/${name}"
+      find . -mindepth 1 -maxdepth 1 | xargs mv -t "$out/share/${extendedPkgName}/extensions/${name}/"
+    '';
+
+  });
+
+
+  fetchVsixFromVscodeMarketplace = mktplcExtRef:
+    fetchurl((mktplcExtRefToFetchArgs mktplcExtRef));
+
+  buildVscodeMarketplaceExtension = a@{
+    name ? "",
+    src ? null,
+    mktplcRef,
+    ...
+  }: assert "" == name; assert null == src;
+  buildVscodeExtension ((removeAttrs a [ "mktplcRef" ]) // {
+    name = "${mktplcRef.name}-${mktplcRef.version}";
+    src = fetchVsixFromVscodeMarketplace mktplcRef;
+  });
+
+  mktplcRefAttrList = [
+    "name"
+    "publisher"
+    "version"
+    "sha256"
+  ];
+
+  mktplcExtRefToExtDrv = ext: 
+    buildVscodeMarketplaceExtension ((removeAttrs ext mktplcRefAttrList) // { 
+      mktplcRef = ext; 
+    }); 
+
+  extensionsFromVscodeMarketplace = mktplcExtRefList:
+    builtins.map mktplcExtRefToExtDrv mktplcExtRefList;
+
+in
+
+{
+  inherit fetchVsixFromVscodeMarketplace buildVscodeExtension 
+          buildVscodeMarketplaceExtension extensionsFromVscodeMarketplace;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16565,6 +16565,12 @@ with pkgs;
 
   vscode = callPackage ../applications/editors/vscode { };
 
+  vscode-with-extensions = callPackage ../applications/editors/vscode-with-extensions {};
+
+  vscode-utils = callPackage ../misc/vscode-extensions/vscode-utils.nix {};
+
+  vscode-extensions = recurseIntoAttrs (callPackage ../misc/vscode-extensions {});
+
   vue = callPackage ../applications/misc/vue { };
 
   vwm = callPackage ../applications/window-managers/vwm { };


### PR DESCRIPTION
###### Motivation for this change

Wanted to optimize my vscode extension installation process using nix. 

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

See `vscode-with-extension.nix` for an example of use.