### PR TITLE
gti: 2016-12-07 -> 1.6.1

### DIFF
--- a/pkgs/tools/misc/gti/default.nix
+++ b/pkgs/tools/misc/gti/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gti-${version}";
-  version = "2016-12-07";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "rwos";
     repo = "gti";
-    rev = "d78001bd5b4b6f6ad853b4ec810e9a1ecde1ee32";
-    sha256 = "0449h9m16x542fy6gmhqqkvkg7z7brxw5vmb85nkk1gdlr9pl1mr";
+    rev = "v${version}";
+    sha256 = "19q3r4v22z2q1j4njap356f3mcq6kwh6v8nbbq2rw4x3cdxwdv51";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Support for `gti push` and `gti pull`


###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

