### PR TITLE
cron service: fix reliance on etc.timezone

### DIFF
--- a/nixos/modules/services/scheduling/cron.nix
+++ b/nixos/modules/services/scheduling/cron.nix
@@ -122,7 +122,7 @@ in
               fi
             '';
 
-          restartTriggers = [ config.environment.etc.localtime.source ];
+          restartTriggers = [ config.time.timeZone ];
           serviceConfig.ExecStart = "${cronNixosPkg}/bin/cron -n";
         };
 


### PR DESCRIPTION
###### Motivation for this change
#28116

This does not fully address the issue, as cron will not restart when
the timezone is changed imperatively as it presumably needs to — see discussion in issue.


###### Things done

**NOT TESTED**

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).