### PR TITLE
firefox syncserver service: run as non-root user by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -154,6 +154,14 @@ rmdir /var/lib/ipfs/.ipfs
       variables as parameters.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      <literal>services.firefox.syncserver</literal> now runs by default as a
+      non-root user. To accomodate this change, the default sqlite database
+      location has also been changed. Migration should work automatically.
+      Refer to the description of the options for more details.
+    </para>
+  </listitem>
 </itemizedlist>
 
 <para>Other notable improvements:</para>


### PR DESCRIPTION
###### Motivation for this change

For security reasons, it is better to run services under a non-privileged user.

###### Things done

The `syncserver` service now runs as a user by default. This is a breaking change since there might be permission problems for people migrating. I have updated the release notes accordingly.
Also, the service has been broken for a few months (see https://github.com/NixOS/nixpkgs/issues/25530), so it might be a good time for a breaking change.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

