### PR TITLE
vivaldi: 1.10.867.48-1 -> 1.11.917.39-1

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -13,11 +13,11 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "vivaldi";
-  version = "1.10.867.48-1";
+  version = "1.11.917.39-1";
 
   src = fetchurl {
     url = "https://downloads.vivaldi.com/stable/${product}-stable_${version}_amd64.deb";
-    sha256 = "1han45swvv0y2i2kg7xhml1wj5zyrf2c2hc5b07kqsjkfg9iz1lc";
+    sha256 = "0rsggp4ayj462g217zb9y9grhvbrcxa51a77l8l4qzhd9lg7zvx6";
   };
 
   unpackPhase = ''

--- a/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
@@ -6,11 +6,11 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "vivaldi-ffmpeg-codecs";
-  version = "59.0.3071.104";
+  version = "60.0.3112.90";
 
   src = fetchurl {
     url = "https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz";
-    sha512 = "419cf5bafa80f190cd301c2933502351929c1ef1d5cfedc720ce6762674a0e6af3b4246a8f92e0c29743420338b056061d4e7f9f4a4066a5bdd4d2ee8db3ddbf";
+    sha512 = "2p7pjjsxpglxjmh0asyykagqh33ccrjwj4b2aski4h31wkxv9b9najy8aqk6j1bi06n9wd35vis4hz4fr6kvgckllg1pjqrb3bpwmq5";
   };
 
   buildInputs = [ ];
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     dbus_glib gtk2 gtk3 libexif libpulseaudio libXScrnSaver ninja nss pciutils pkgconfig
     python2 xdg_utils
+  ];
+
+  patches = [
+    ../chromium/patches/chromium-gn-bootstrap-r8.patch
   ];
 
   configurePhase = ''


### PR DESCRIPTION
###### Motivation for this change
Vivaldi update

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

