### PR TITLE
axel: 2.12 -> 2.13.1

### DIFF
--- a/pkgs/tools/networking/axel/default.nix
+++ b/pkgs/tools/networking/axel/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "axel-${version}";
-  version = "2.12";
+  version = "2.13.1";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/a/axel/axel_${version}.orig.tar.gz";
-    sha256 = "12sa5whd5mjn1idd83hbhm0rmsh5bvhhgvv03fk5cgxynwkbprr8";
+    sha256 = "15bi5wx6fyf9k0y03dy5mk2rv06mrfgiyrlh44add9n07wi574p1";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

Update axel to the last version

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

