### PR TITLE
zexy: fix build

### DIFF
--- a/pkgs/applications/audio/pd-plugins/zexy/default.nix
+++ b/pkgs/applications/audio/pd-plugins/zexy/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ autoconf automake puredata ];
 
   patchPhase = ''
+    export LD=$CXX
     cd src/
     for i in ${puredata}/include/pd/*; do
       ln -s $i .


### PR DESCRIPTION
###### Motivation for this change

Not sure if it is correct what I did, but at least it builds again...
Some testing leads me to believe all pd-externals are broken in NixOS.

###### Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

