### PR TITLE
rtl8812au driver fixes

### DIFF
--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, kernel }:
+{ stdenv, fetchFromGitHub, fetchpatch, kernel }:
 
 stdenv.mkDerivation rec {
   name = "rtl8812au-${kernel.version}-${version}";
@@ -11,11 +11,29 @@ stdenv.mkDerivation rec {
     sha256 = "01z5p2vps3an69bbzca7ig14llc5rd6067pgs47kkhfjbsbws4ry";
   };
 
+  patches = [
+    (fetchpatch { # From PR # 42
+      name = "rtl8812au-4.11.x-fix.patch";
+      url = https://github.com/Grawp/rtl8812au_rtl8821au/commit/3224e74ad9c230b74a658e80dad66ab95c9e2ef5.patch;
+      sha256 = "12g4yvivg4d0qm5cgxs7k54p3y7h1dc2jw6rp1xbppwf3j1z6xks";
+    })
+    (fetchpatch { # From PR #46
+      name = "rtl8812au-4.11.9-fix.patch";
+      url = https://github.com/Grawp/rtl8812au_rtl8821au/commit/58fc45a4511b8b9d6b52813168e3eee657517b1f.patch;
+      sha256 = "18bag2mif5112lap2xvx2bb0wxrd13f9y9cwqv1qzp5nyqiniziz";
+    })
+    (fetchpatch { # From PR #43
+      name = "rtl8812au-4.12-fix.patch";
+      url = https://github.com/Grawp/rtl8812au_rtl8821au/commit/a5475c9f1f54099ca35c8680f2dedee11fa9edec.patch;
+      sha256 = "01xa51whq1xa0sh3y2bhm65f0cryzmv46v530axqjrpnd924432d";
+    })
+  ];
+
   hardeningDisable = [ "pic" ];
 
   NIX_CFLAGS_COMPILE="-Wno-error=incompatible-pointer-types";
 
-  patchPhase = ''
+  prePatch = ''
     substituteInPlace ./Makefile --replace /lib/modules/ "${kernel.dev}/lib/modules/"
     substituteInPlace ./Makefile --replace '$(shell uname -r)' "${kernel.modDirVersion}"
     substituteInPlace ./Makefile --replace /sbin/depmod \#

--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     substituteInPlace ./Makefile --replace /lib/modules/ "${kernel.dev}/lib/modules/"
     substituteInPlace ./Makefile --replace '$(shell uname -r)' "${kernel.modDirVersion}"
-    substituteInPlace ./Makefile --replace /sbin/depmod #
+    substituteInPlace ./Makefile --replace /sbin/depmod \#
     substituteInPlace ./Makefile --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

This PR has two commits, one to fix a regression caused by a 5d693c8, which cleaned up the
substitute() function in stdenv and caused a line in this derivation to fail.
The other commit includes patches to fix compilation against 4.12.

I've tested this against both 4.9 and 4.12 and it works with fine with my AC1200 wireless USB adapter.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

