### PR TITLE
switch-to-configuration: use Net::DBus to retrieve the list of units

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -127,7 +127,8 @@ let
       configurationName = config.boot.loader.grub.configurationName;
 
       # Needed by switch-to-configuration.
-      perl = "${pkgs.perl}/bin/perl -I${pkgs.perlPackages.FileSlurp}/lib/perl5/site_perl";
+
+      perl = "${pkgs.perl}/bin/perl " + (concatMapStringsSep " " (lib: "-I${lib}/${pkgs.perl.libPrefix}") (with perlPackages; [ FileSlurp NetDBus XMLParser XMLTwig ]));
   } else throw "\nFailed assertions:\n${concatStringsSep "\n" (map (x: "- ${x}") failed)}");
 
   # Replace runtime dependencies


### PR DESCRIPTION
###### Motivation for this change

This resolves the FIXME, and opens up the possibility of using more of
the systemd DBus interface to make things more robust.

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).