### PR TITLE
docker-edge: 17.06 -> 17.07

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -169,10 +169,25 @@ rec {
     };
   };
 
+  # Get revisions from
+  # https://github.com/docker/docker-ce/blob/v${version}/components/engine/hack/dockerfile/binaries-commits
+
   docker_17_06 = dockerGen rec {
     version = "17.06.1-ce";
     rev = "874a7374f31c77aca693d025101b2de1b20b96c2"; # git commit
     sha256 = "08xhww2rhpyj73zgh5maycs85zpc0sm3ak8yyyd92dwgncmyi2im";
+    runcRev = "2d41c047c83e09a6d61d464906feb2a2f3c52aa4";
+    runcSha256 = "0v5iv29ck6lkxvxh7a56gfrlgfs0bjvjhrq3p6qqv9qjzv825byq";
+    containerdRev = "3addd840653146c90a254301d6c3a663c7fd6429";
+    containerdSha256 = "0as4s5wd57pdh1cyavkccpgs46kvlhr41v07qrv0phzffdhq3d5j";
+    tiniRev = "949e6facb77383876aeff8a6944dde66b3089574";
+    tiniSha256 = "0zj4kdis1vvc6dwn4gplqna0bs7v6d1y2zc8v80s3zi018inhznw";
+  };
+
+  docker_17_07 = dockerGen rec {
+    version = "17.07.0-ce";
+    rev = "87847530f7176a48348d196f7c23bbd058052af1"; # git commit
+    sha256 = "0zw9zlzbd7il33ch17ypwpa73gsb930sf2njnphg7ylvnqp8qzsp";
     runcRev = "2d41c047c83e09a6d61d464906feb2a2f3c52aa4";
     runcSha256 = "0v5iv29ck6lkxvxh7a56gfrlgfs0bjvjhrq3p6qqv9qjzv825byq";
     containerdRev = "3addd840653146c90a254301d6c3a663c7fd6429";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13808,10 +13808,11 @@ with pkgs;
   };
 
   inherit (callPackage ../applications/virtualization/docker { })
-    docker_17_06;
+    docker_17_06
+    docker_17_07;
 
   docker = docker_17_06;
-  docker-edge = docker_17_06;
+  docker-edge = docker_17_07;
 
   docker-proxy = callPackage ../applications/virtualization/docker/proxy.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
Update.

WIP until 17.07 is actually out, using the RC to see if everything compiles.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

