### PR TITLE
munin-node: scripts need to be executable to build a wrapper

### DIFF
--- a/nixos/modules/services/monitoring/munin.nix
+++ b/nixos/modules/services/monitoring/munin.nix
@@ -26,7 +26,12 @@ let
 
       for file in $out/*; do
         case "$file" in
-            plugin.sh) continue;;
+            */plugin.sh)
+              chmod +x $file
+              continue;;
+            */plugins.history)
+              chmod +x $file
+              continue;;
         esac
 
         # read magic makers from the file


### PR DESCRIPTION
###### Motivation for this change

Munin service can't build.

"Builder called die: Cannot wrap
/nix/store/XXX-munin-available-plugins/plugin.sh because it is not an executable file"

###### Things done
- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files : service is running locally with same pluging

---

