### PR TITLE
samtools: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/applications/science/biology/bcftools/default.nix
+++ b/pkgs/applications/science/biology/bcftools/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "bcftools";
-  major = "1.4";
+  major = "1.5";
   version = "${major}.0";
 
   src = fetchurl {
     url = "https://github.com/samtools/bcftools/releases/download/${major}/bcftools-${major}.tar.bz2";
-    sha256 = "0k93mq3lf73dch81p4zxi0bdll567acxfa81qzbzkqflgsjb1ccg";
+    sha256 = "0093hkkvxmbwfaa7905s6185jymynvg42kq6sxv7fili11l5mxwz";
   };
 
   buildInputs = [ zlib bzip2 lzma perl ];

--- a/pkgs/applications/science/biology/samtools/default.nix
+++ b/pkgs/applications/science/biology/samtools/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "samtools";
-  major = "1.4";
+  major = "1.5";
   version = "${major}.0";
 
   src = fetchurl {
     url = "https://github.com/samtools/samtools/releases/download/${major}/samtools-${major}.tar.bz2";
-    sha256 = "1x73c0lxvd58ghrmaqqyp56z7bkmp28a71fk4ap82j976pw5pbls";
+    sha256 = "1xidmv0jmfy7l0kb32hdnlshcxgzi1hmygvig0cqrq1fhckdlhl5";
   };
 
   buildInputs = [ zlib ncurses ];

--- a/pkgs/development/libraries/science/biology/htslib/default.nix
+++ b/pkgs/development/libraries/science/biology/htslib/default.nix
@@ -4,11 +4,11 @@ stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   version = "${major}.0";
   pname = "htslib";
-  major = "1.4";
+  major = "1.5";
 
   src = fetchurl {
     url = "https://github.com/samtools/htslib/releases/download/${major}/htslib-${major}.tar.bz2";
-    sha256 = "0l1ki3sqfhawfn7fx9v7i2pm725jki4c5zij9j96xka5zwc8iz2w";
+    sha256 = "0bcjmnbwp2bib1z1bkrp95w9v2syzdwdfqww10mkb1hxlmg52ax0";
   };
 
   buildInputs = [ zlib bzip2 lzma curl ];


### PR DESCRIPTION
###### Motivation for this change

Update htslib, samtools and bcftools to the last versions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

