### PR TITLE
fontforge: 20160404 -> 20170730 + support reproducible builds of fonts

### DIFF
--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, lib, runCommand
+{ stdenv, fetchFromGitHub, fetchpatch, lib
 , autoconf, automake, gnum4, libtool, perl, gnulib, uthash, pkgconfig, gettext
 , python, freetype, zlib, glib, libungif, libpng, libjpeg, libtiff, libxml2, pango
 , withSpiro ? false, libspiro
@@ -10,9 +10,6 @@
 stdenv.mkDerivation rec {
   name = "fontforge-${version}";
   version = "20170730";
-
-  # The way $version propagates to $version of .pe-scripts (https://github.com/dejavu-fonts/dejavu-fonts/blob/358190f/scripts/generate.pe#L19)
-  SOURCE_DATE_EPOCH = lib.fileContents (runCommand "unixtime-of-${version}" {} "date -d ${version} +%s > $out");
 
   src = fetchFromGitHub {
     owner = "fontforge";
@@ -49,6 +46,9 @@ stdenv.mkDerivation rec {
 
   # work-around: git isn't really used, but configuration fails without it
   preConfigure = ''
+    # The way $version propagates to $version of .pe-scripts (https://github.com/dejavu-fonts/dejavu-fonts/blob/358190f/scripts/generate.pe#L19)
+    export SOURCE_DATE_EPOCH=$(date -d ${version} +%s)
+
     export GIT="$(type -P true)"
     cp -r "${gnulib}" ./gnulib
     chmod +w -R ./gnulib

--- a/pkgs/tools/misc/fontforge/fontforge-20140813-use-system-uthash.patch
+++ b/pkgs/tools/misc/fontforge/fontforge-20140813-use-system-uthash.patch
@@ -1,0 +1,30 @@
+--- a/Makefile.am.old	2014-08-12 10:07:32.000000000 +0530
++++ b/Makefile.am	2014-09-08 16:23:56.046996941 +0530
+@@ -43,7 +43,6 @@
+ AM_CPPFLAGS =
+ AM_LDFLAGS =
+ 
+-BUILT_SOURCES = uthash/src
+ EXTRA_DIST =
+ CLEANFILES =
+ MOSTLYCLEANFILES =
+@@ -113,7 +112,6 @@
+ 	Packaging/FontForge-doc.spec \
+ 	Packaging/FontForge.spec \
+ 	Packaging/FontForge.static.spec \
+-	uthash/src \
+ 	$(NULL)
+ 
+ #--------------------------------------------------------------------------
+@@ -129,11 +127,6 @@
+ 
+ 
+ #--------------------------------------------------------------------------
+-uthash/src:
+-	if [ ! -e uthash/src ]; then \
+-	if [ -e uthash ] ; then rm -r uthash ; fi ; \
+-	git clone https://github.com/troydhanson/uthash ; \
+-	fi ;
+ 
+ # We import a selection of targets from Frank's standard packaging Makefile.
+ 

--- a/pkgs/tools/misc/fontforge/fontforge-fonttools.nix
+++ b/pkgs/tools/misc/fontforge/fontforge-fonttools.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = ''Small font tools shipped in FontForge contrib'';
-    license = fontforge.meta.license;
+    license = licenses.bsd3;
     maintainers = with maintainers; [ raskin ];
     platforms = with platforms; unix;
   };

--- a/pkgs/tools/misc/fontforge/fontforge-fonttools.nix
+++ b/pkgs/tools/misc/fontforge/fontforge-fonttools.nix
@@ -1,7 +1,15 @@
-{stdenv, fontforge, zlib}:
+{stdenv, fetchFromGitHub, zlib}:
+
 stdenv.mkDerivation rec {
-  name = "fontforge-fonttools-${fontforge.version}";
-  src = fontforge.src;
+  version = "20160404";
+  name = "fontforge-fonttools-${version}";
+
+  src = fetchFromGitHub {
+    owner = "fontforge";
+    repo = "fontforge";
+    rev = version;
+    sha256 = "15nacq84n9gvlzp3slpmfrrbh57kfb6lbdlc46i7aqgci4qv6fg0";
+  };
 
   buildInputs = [zlib];
 


### PR DESCRIPTION
###### Motivation for this change

- [x] fontforge: 20160404 -> 20170730
- [ ] fontforge-fontutils: untied from ```fontforge``` and not upgraded, kept 20160404 (its build procedure changed).
@7c6f434c: should it be in sync with ```fontforge```?
- [x] Fixes https://github.com/NixOS/nixpkgs/issues/28270: ```fontforge-20140813-use-system-uthash.patch``` landed into nixpkgs (it disappeared from Fedora website and also needs ```patchFlags = "-p0"``` which is not compatible with another patch)
- [x] added support for reproducible builds (https://github.com/fontforge/fontforge/pull/3134): when ```$SOURCE_DATE_EPOCH``` is set, its value propagates to the fonts instead of the current time.
Note there are two different ```$SOURCE_DATE_EPOCH``` - when fontforge is compiled from the sources, and when fontforge compiles fonts. It is about the latter.
- [x] on ```i686``` fontforge should be compiled with ```-mfpmath=sse``` instead of default ```-mfpmath=387```. because the difference between 64- and 80-bit rouding results in different font binaries
For example, current ```pkgs.inconsolata-lgc``` and ```pkgs.pkgsi686Linux.inconsolata-lgc``` are very different, even in the file sizes.
I hope supporting pre-SSE i686 platforms (older than Pentium-4 of year 2001) is not on the agenda? if so, then ```softfloat``` would be the option.
