### PR TITLE
Literate: init at 2017-05-28

### DIFF
--- a/pkgs/development/tools/literate-programming/Literate/default.nix
+++ b/pkgs/development/tools/literate-programming/Literate/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchgit, dmd, dub }:
+
+stdenv.mkDerivation {
+  name = "Literate";
+  src = fetchgit {
+    url = "https://github.com/zyedidia/Literate.git";
+    rev = "23928d64bb19b5101dbcc794da6119beaf59f679";
+    sha256 = "094lramvacarzj8443ns18zyv7dxnivwi7kdk5xi5r2z4gx338iq";
+  };
+  buildInputs = [dmd dub];
+  preInstall = ''
+  # Gross, but the Makefile doesn't provide an install target
+  mkdir $out
+  cp -R bin $out/bin
+  '';
+  phases = "unpackPhase patchPhase buildPhase checkPhase preInstall fixupPhase";
+}

--- a/pkgs/development/tools/literate-programming/Literate/default.nix
+++ b/pkgs/development/tools/literate-programming/Literate/default.nix
@@ -1,17 +1,22 @@
 { stdenv, fetchgit, dmd, dub }:
 
 stdenv.mkDerivation {
-  name = "Literate";
+  name = "Literate-2017-05-28";
+
   src = fetchgit {
     url = "https://github.com/zyedidia/Literate.git";
     rev = "23928d64bb19b5101dbcc794da6119beaf59f679";
     sha256 = "094lramvacarzj8443ns18zyv7dxnivwi7kdk5xi5r2z4gx338iq";
   };
-  buildInputs = [dmd dub];
-  preInstall = ''
-  # Gross, but the Makefile doesn't provide an install target
-  mkdir $out
-  cp -R bin $out/bin
-  '';
-  phases = "unpackPhase patchPhase buildPhase checkPhase preInstall fixupPhase";
+
+  buildInputs = [ dmd dub ];
+
+  installPhase = "install -D bin/lit $out/bin/lit";
+
+  meta = with stdenv.lib; {
+    description = "A literate programming tool for any language";
+    homepage    = http://literate.zbyedidia.webfactional.com/;
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7019,6 +7019,8 @@ with pkgs;
 
   kube-aws = callPackage ../development/tools/kube-aws { };
 
+  Literate = callPackage ../development/tools/literate-programming/Literate {};
+
   lcov = callPackage ../development/tools/analysis/lcov { };
 
   leiningen = callPackage ../development/tools/build-managers/leiningen { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

