### PR TITLE
ncurses: put tic binary in bin

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -115,6 +115,7 @@ stdenv.mkDerivation rec {
     moveToOutput "bin/clear" "$out"
     moveToOutput "bin/reset" "$out"
     moveToOutput "bin/tabs" "$out"
+    moveToOutput "bin/tic" "$out"
     moveToOutput "bin/tput" "$out"
     moveToOutput "bin/tset" "$out"
   '';


### PR DESCRIPTION
The `tic` binary wasn't being exported from the ncurses package. `tic` is the terminfo compiler, needed if one wants to compile new entries for the terminfo datbase.

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux

Tested by compiling a new terminfo entry and confirming that it worked.