### PR TITLE
[staging] set-source-date-epoch-to-latest.sh: ignore generated files

### DIFF
--- a/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
+++ b/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
@@ -4,7 +4,7 @@ updateSourceDateEpoch() {
     # Get the last modification time of all regular files, sort them,
     # and get the most recent. Maybe we should use
     # https://github.com/0-wiz-0/findnewest here.
-    local -a res=($(find "$path" -type f -not -newer "$NIX_BUILD_TOP/.." -printf '%T@ %p\n' | sort -n | tail -n1))
+    local -a res=($(find "$path" -type f -not -newer "$NIX_BUILD_TOP/.." -printf '%T@ %p\0' | sort -n --zero-terminated | tail -n1 --zero-terminated))
     local time="${res[0]//\.[0-9]*/}" # remove the fraction part
     local newestFile="${res[1]}"
 

--- a/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
+++ b/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
@@ -4,8 +4,8 @@ updateSourceDateEpoch() {
     # Get the last modification time of all regular files, sort them,
     # and get the most recent. Maybe we should use
     # https://github.com/0-wiz-0/findnewest here.
-    local -a res=($(find "$path" -type f -print0 | xargs -0 -r stat -c '%Y %n' | sort -n | tail -n1))
-    local time="${res[0]}"
+    local -a res=($(find "$path" -type f -not -newer "$NIX_BUILD_TOP/.." -printf '%T@ %p\n' | sort -n | tail -n1))
+    local time="${res[0]//\.[0-9]*/}" # remove the fraction part
     local newestFile="${res[1]}"
 
     # Update $SOURCE_DATE_EPOCH if the most recent file we found is newer.


### PR DESCRIPTION
set-source-date-epoch-to-latest.sh to ignore files newer than ```$NIX_BUILD_TOP/..``` (unlike ```$NIX_BUILD_TOP``` it is root-owned and cannot be touched by ```nixbld1```).

Fixes https://github.com/NixOS/nixpkgs/issues/28218

mass-rebuild
