### PR TITLE
alt-ergo: use https instead of http to fetch archive

### DIFF
--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.30";
 
   src = fetchurl {
-    url    = "http://alt-ergo.ocamlpro.com/download_manager.php?target=${name}.tar.gz";
+    url    = "https://alt-ergo.ocamlpro.com/download_manager.php?target=${name}.tar.gz";
     name   = "${name}.tar.gz";
     sha256 = "025pacb4ax864fn5x8k78mw6hiig4jcazblj18gzxspg4f1l5n1g";
   };
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "High-performance theorem prover and SMT solver";
-    homepage    = "http://alt-ergo.ocamlpro.com/";
+    homepage    = "https://alt-ergo.ocamlpro.com/";
     license     = stdenv.lib.licenses.cecill-c; # LGPL-2 compatible
     platforms   = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];


### PR DESCRIPTION
###### Things done

In URL, http prefix was replaced by https.

- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @thoughtpolice 

---

