### PR TITLE
python: Don't link python3 executables if they don't exist

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.4/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.4/default.nix
@@ -125,13 +125,17 @@ in stdenv.mkDerivation {
     # We're also not interested in building Windows installers.
     find "$out" -name 'wininst*.exe' | xargs -r rm -f
 
+    linkIfExists () {
+      if [ -e "$1" ]; then ln -s "$1" "$2"; fi
+    }
+
     # Use Python3 as default python
-    ln -s "$out/bin/idle3" "$out/bin/idle"
-    ln -s "$out/bin/pip3" "$out/bin/pip"
-    ln -s "$out/bin/pydoc3" "$out/bin/pydoc"
-    ln -s "$out/bin/python3" "$out/bin/python"
-    ln -s "$out/bin/python3-config" "$out/bin/python-config"
-    ln -s "$out/lib/pkgconfig/python3.pc" "$out/lib/pkgconfig/python.pc"
+    linkIfExists "$out/bin/idle3" "$out/bin/idle"
+    linkIfExists "$out/bin/pip3" "$out/bin/pip"
+    linkIfExists "$out/bin/pydoc3" "$out/bin/pydoc"
+    linkIfExists "$out/bin/python3" "$out/bin/python"
+    linkIfExists "$out/bin/python3-config" "$out/bin/python-config"
+    linkIfExists "$out/lib/pkgconfig/python3.pc" "$out/lib/pkgconfig/python.pc"
 
     # Get rid of retained dependencies on -dev packages, and remove
     # some $TMPDIR references to improve binary reproducibility.

--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -119,13 +119,17 @@ in stdenv.mkDerivation {
     # We're also not interested in building Windows installers.
     find "$out" -name 'wininst*.exe' | xargs -r rm -f
 
+    linkIfExists () {
+      if [ -e "$1" ]; then ln -s "$1" "$2"; fi
+    }
+
     # Use Python3 as default python
-    ln -s "$out/bin/idle3" "$out/bin/idle"
-    ln -s "$out/bin/pip3" "$out/bin/pip"
-    ln -s "$out/bin/pydoc3" "$out/bin/pydoc"
-    ln -s "$out/bin/python3" "$out/bin/python"
-    ln -s "$out/bin/python3-config" "$out/bin/python-config"
-    ln -s "$out/lib/pkgconfig/python3.pc" "$out/lib/pkgconfig/python.pc"
+    linkIfExists "$out/bin/idle3" "$out/bin/idle"
+    linkIfExists "$out/bin/pip3" "$out/bin/pip"
+    linkIfExists "$out/bin/pydoc3" "$out/bin/pydoc"
+    linkIfExists "$out/bin/python3" "$out/bin/python"
+    linkIfExists "$out/bin/python3-config" "$out/bin/python-config"
+    linkIfExists "$out/lib/pkgconfig/python3.pc" "$out/lib/pkgconfig/python.pc"
 
     # Get rid of retained dependencies on -dev packages, and remove
     # some $TMPDIR references to improve binary reproducibility.

--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -123,13 +123,17 @@ in stdenv.mkDerivation {
     # We're also not interested in building Windows installers.
     find "$out" -name 'wininst*.exe' | xargs -r rm -f
 
+    linkIfExists () {
+      if [ -e "$1" ]; then ln -s "$1" "$2"; fi
+    }
+
     # Use Python3 as default python
-    ln -s "$out/bin/idle3" "$out/bin/idle"
-    ln -s "$out/bin/pip3" "$out/bin/pip"
-    ln -s "$out/bin/pydoc3" "$out/bin/pydoc"
-    ln -s "$out/bin/python3" "$out/bin/python"
-    ln -s "$out/bin/python3-config" "$out/bin/python-config"
-    ln -s "$out/lib/pkgconfig/python3.pc" "$out/lib/pkgconfig/python.pc"
+    linkIfExists "$out/bin/idle3" "$out/bin/idle"
+    linkIfExists "$out/bin/pip3" "$out/bin/pip"
+    linkIfExists "$out/bin/pydoc3" "$out/bin/pydoc"
+    linkIfExists "$out/bin/python3" "$out/bin/python"
+    linkIfExists "$out/bin/python3-config" "$out/bin/python-config"
+    linkIfExists "$out/lib/pkgconfig/python3.pc" "$out/lib/pkgconfig/python.pc"
 
     # Get rid of retained dependencies on -dev packages, and remove
     # some $TMPDIR references to improve binary reproducibility.


### PR DESCRIPTION
This means that if python is built without pip we don't try to link pip3 -> pip

###### Motivation for this change
Currently it is not possible to create a python 3 environment with pip package in it, because there is a dead symlink in the deriviation of python3.x called $out/bin/pip which prevents building said environment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

