### PR TITLE
acoustid-fingerprinter: use https to fetch package

### DIFF
--- a/pkgs/tools/audio/acoustid-fingerprinter/default.nix
+++ b/pkgs/tools/audio/acoustid-fingerprinter/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.6";
 
   src = fetchurl {
-    url = "http://bitbucket.org/acoustid/acoustid-fingerprinter/downloads/"
+    url = "https://bitbucket.org/acoustid/acoustid-fingerprinter/downloads/"
         + "${name}.tar.gz";
     sha256 = "0ckglwy95qgqvl2l6yd8ilwpd6qs7yzmj8g7lnxb50d12115s5n0";
   };
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   }) ];
 
   meta = with stdenv.lib; {
-    homepage = http://acoustid.org/fingerprinter;
+    homepage = https://acoustid.org/fingerprinter;
     description = "Audio fingerprinting tool using chromaprint";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with maintainers; [ ehmry ];


### PR DESCRIPTION
###### Motivation for this change

Use HTTPS to retreive package.

###### Things done

- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @ehmry 

---

