### PR TITLE
aescrypt: use https to fetch archive

### DIFF
--- a/pkgs/tools/misc/aescrypt/default.nix
+++ b/pkgs/tools/misc/aescrypt/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   name = "aescrypt-${version}";
 
   src = fetchurl {
-    url = "http://www.aescrypt.com/download/v3/linux/${name}.tgz";
+    url = "https://www.aescrypt.com/download/v3/linux/${name}.tgz";
     sha256 = "1a1rs7xmbxh355qg3v02rln3gshvy3j6wkx4g9ir72l22mp6zkc7";
   };
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Encrypt files with Advanced Encryption Standard (AES)";
-    homepage    = http://www.aescrypt.com/;
+    homepage    = https://www.aescrypt.com/;
     license     = licenses.gpl2;
     maintainers = with maintainers; [ lovek323 qknight ];
     platforms   = stdenv.lib.platforms.all;


### PR DESCRIPTION
###### Motivation for this change

Use HTTPS instead of HTTP where available.

###### Things done

- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

cc @lovek323  @qknight

---

