### PR TITLE
qt5: Fallback to mktemp -d for temporary QT root.

### DIFF
--- a/pkgs/development/libraries/qt-5/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/qtbase-setup-hook.sh
@@ -116,7 +116,11 @@ fi
 
 if [ -z "$NIX_QT5_TMP" ]; then
     if [ -z "$NIX_QT_SUBMODULE" ]; then
-        NIX_QT5_TMP=$(pwd)/__nix_qt5__
+        if [ -z "$IN_NIX_SHELL" ]; then
+            NIX_QT5_TMP=$(pwd)/__nix_qt5__
+        else
+            NIX_QT5_TMP=$(mktemp -d)
+        fi
     else
         NIX_QT5_TMP=$out
     fi

--- a/pkgs/development/libraries/qt-5/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/qtbase-setup-hook.sh
@@ -146,3 +146,10 @@ EOF
     export QMAKE="$NIX_QT5_TMP/bin/qmake"
 fi
 
+_qtShellCleanupHook () {
+    rm -fr $NIX_QT5_TMP
+}
+
+if [ -n "$IN_NIX_SHELL" ]; then
+    trap _qtShellCleanupHook EXIT
+fi


### PR DESCRIPTION
Fallback to `mktemp -d` for temporary QT root, if invoked in shell mode.
Should fix problem from #27174.

###### Motivation for this change

Folks often complains on __qt5_nix__ dropped into source dir, when nix-shell -p qt5.qtbase invoked, so little hack was added,  to fallback to old solution with mktemp -d in shell mode. 

Thing to be done -- figure out, why this dir not properly removed on shell exit.

PS Tested against master,  but PR to staging, to avoid unnessesary mass-rebuild.
(at least qastools and virtualbox builds with this patch applied).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

