### PR TITLE
Nixpkgs config: NIXPKGS_CONFIG -> <nixpkgs-config>

### DIFF
--- a/doc/configuration.xml
+++ b/doc/configuration.xml
@@ -48,10 +48,13 @@ configuration.</para>
   </listitem>
 
   <listitem>
-    <para>Otherwise, if the environment variable <varname>NIXPKGS_CONFIG</varname> is set and the path
-    exists, then it is imported and used as the nixpkgs configuration.</para>
+    <para>Otherwise, if the Nix path entry <literal>&lt;nixpkgs-config></literal> exists, 
+    then it is imported and used as the nixpkgs configuration.</para>
 
-    <para>On a NixOS system <varname>NIXPKGS_CONFIG</varname> is set to <filename>/etc/nix/nixpkgs-config.nix</filename>.
+    <para>See the section on <literal>NIX_PATH</literal> in the Nix manual for more details on how to 
+    set a value for <literal>&lt;nixpkgs-config></literal>.</para>
+
+    <para>On a NixOS system <literal>&lt;nixpkgs-config></literal> is set to <filename>/etc/nix/nixpkgs-config.nix</filename>.
     This can be used to set a global nixpkgs configuration for all users of that system.</para>
   </listitem>
 

--- a/doc/configuration.xml
+++ b/doc/configuration.xml
@@ -33,27 +33,39 @@ that would be refused.
 <para>Each of these criteria can be altered in the nixpkgs
 configuration.</para>
 
-<para>The nixpkgs configuration for a NixOS system is set in the
-<literal>configuration.nix</literal>, as in the following example:
-<programlisting>
-{
-  nixpkgs.config = {
-    allowUnfree = true;
-  };
-}
-</programlisting>
-However, this does not allow unfree software for individual users.
-Their configurations are managed separately.</para>
+<para>The nixpkgs configuration to use is determined as follows:
 
-<para>A user's of nixpkgs configuration is stored in a user-specific
-configuration file located at
-<filename>~/.config/nixpkgs/config.nix</filename>. For example:
-<programlisting>
-{
-  allowUnfree = true;
-}
-</programlisting>
+<orderedlist>
+  <listitem>
+    <para>First, if a <varname>config</varname> argument is passed to the
+    nixpkgs function itself, then that is used. This can be passed explicitly
+    when importing nixpkgs, for example
+    <literal>import &lt;nixpkgs> { config = { allowUnfree = true; } }</literal>.</para> 
+
+    <para>On a NixOS system the value of the <literal>nixpkgs.config</literal> option, if present, 
+    is passed to the system Nixpkgs in this way. Note that this does not affect the config for
+    non-NixOS operations (e.g. <literal>nix-env</literal>), which are looked up independently.</para>
+  </listitem>
+
+  <listitem>
+    <para>Otherwise, if the environment variable <varname>NIXPKGS_CONFIG</varname> is set and the path
+    exists, then it is imported and used as the nixpkgs configuration.</para>
+
+    <para>On a NixOS system <varname>NIXPKGS_CONFIG</varname> is set to <filename>/etc/nix/nixpkgs-config.nix</filename>.
+    This can be used to set a global nixpkgs configuration for all users of that system.</para>
+  </listitem>
+
+  <listitem>
+    <para>Otherwise, if <filename>~/.config/nixpkgs/config.nix</filename> exists, then it is imported
+    and used as the nixpkgs configuration.</para>
+  </listitem>
+
+</orderedlist>
 </para>
+
+<para>This means that users should typically manage their nixpkgs config via <filename>~/.config/nixpkgs/config.nix</filename>,
+and NixOS system administrators should use <literal>nixpkgs.config</literal> and <filename>/etc/nix/nixpkgs-config.nix</filename>
+as appropriate.</para>
 
 <section xml:id="sec-allow-broken">
   <title>Installing broken packages</title>
@@ -226,8 +238,8 @@ configuration file located at
 packages via <literal>packageOverrides</literal></title>
 
 <para>You can define a function called
-<varname>packageOverrides</varname> in your local
-<filename>~/.config/nixpkgs/config.nix</filename> to override nix packages.  It
+<varname>packageOverrides</varname> in your nixpkgs config
+to override nix packages.  It
 must be a function that takes pkgs as an argument and return modified
 set of packages.
 

--- a/maintainers/scripts/test-eval-release.sh
+++ b/maintainers/scripts/test-eval-release.sh
@@ -3,5 +3,5 @@
 if [[ -z "$VERBOSE" ]]; then
   echo "You may set VERBOSE=1 to see debug output or to any other non-empty string to make this script completely silent"
 fi
-unset HOME NIXPKGS_CONFIG # Force empty config
+unset HOME # Force empty config
 nix-instantiate --strict --eval-only --xml --show-trace "$(dirname "$0")"/eval-release.nix 2>&1 > /dev/null

--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -154,6 +154,23 @@ rmdir /var/lib/ipfs/.ipfs
       variables as parameters.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      The environment variable <varname>NIXPKGS_CONFIG</varname> is no longer 
+      used by Nixpkgs when determining its configuration, and so is no longer 
+      set by default in the NixOS environment.
+    </para>
+    <para>
+      The replacement in Nixpkgs is the Nix search path entry 
+      <literal>&lt;nixpkgs-config></literal>. This is now set by default in the
+      NixOS environment to be <filename>/etc/nix/nixpkgs-config.nix</filename>,
+      as <varname>NIXPKGS_CONFIG</varname> was.
+    </para>
+    <para>
+      Most users should not notice a difference, however, if you set 
+      <literal>nix.nixPath</literal> you may wish to include the new entry.
+    </para>
+  </listitem>
 </itemizedlist>
 
 <para>Other notable improvements:</para>

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -17,8 +17,7 @@ in
   config = {
 
     environment.variables =
-      { NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
-        PAGER = mkDefault "less -R";
+      { PAGER = mkDefault "less -R";
         EDITOR = mkDefault "nano";
         XCURSOR_PATH = [ "$HOME/.icons" ];
       };

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -330,6 +330,7 @@ in
         type = types.listOf types.str;
         default =
           [ "nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos/nixpkgs"
+            "nixpkgs-config=/etc/nix/nixpkgs-config.nix"
             "nixos-config=/etc/nixos/configuration.nix"
             "/nix/var/nix/profiles/per-user/root/channels"
           ];

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -24,11 +24,11 @@ in
 , platform ? localSystem.platform
 , crossSystem ? null
 
-, # Fallback: The contents of the configuration file found at $NIXPKGS_CONFIG or
+, # Fallback: The contents of the configuration file found at <nixpkgs-config> or
   # $HOME/.config/nixpkgs/config.nix.
   config ? let
       isDir = path: pathExists (path + "/.");
-      configFile = getEnv "NIXPKGS_CONFIG";
+      configFile = try <nixpkgs-config> "";
       configFile2 = homeDir + "/.config/nixpkgs/config.nix";
       configFile3 = homeDir + "/.nixpkgs/config.nix"; # obsolete
     in

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -27,13 +27,23 @@ in
 , # Fallback: The contents of the configuration file found at $NIXPKGS_CONFIG or
   # $HOME/.config/nixpkgs/config.nix.
   config ? let
+      isDir = path: pathExists (path + "/.");
       configFile = getEnv "NIXPKGS_CONFIG";
       configFile2 = homeDir + "/.config/nixpkgs/config.nix";
       configFile3 = homeDir + "/.nixpkgs/config.nix"; # obsolete
     in
-      if configFile != "" && pathExists configFile then import configFile
-      else if homeDir != "" && pathExists configFile2 then import configFile2
-      else if homeDir != "" && pathExists configFile3 then import configFile3
+      if configFile != "" && pathExists configFile then
+        if isDir configFile then 
+          throw (configFile + " must be a file")
+        else import configFile
+      else if configFile2 != "" && pathExists configFile2 then
+        if isDir configFile2 then 
+          throw (configFile2 + " must be a file")
+        else import configFile2
+      else if configFile3 != "" && pathExists configFile3 then 
+        if isDir configFile3 then
+          throw (configFile3 + " must be a file")
+        else import configFile3
       else {}
 
 , # Overlays are used to extend Nixpkgs collection with additional


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/28085.

- Expand documentation for nixpkgs config in a similar fashion to https://github.com/NixOS/nixpkgs/pull/28082
- Throw an error if potential config files are not files as expected.
- Change `NIXPKGS_CONFIG` to `<nixpkgs-config>` throughout.

I believe this is behaviour preserving except for:
- Anyone who consumes `NIXPKGS_CONFIG` (not clear why you would do this)
- Anyone who separately sets `NIXPKGS_CONFIG`.
- Anyone who clears their `NIX_PATH` on a NixOS system rather than extending it. In particular, users of the `nix.nixPath` option.

Possibly we could make things easier for the second set of people by continuing to honour `NIXPKGS_CONFIG` for a while with a warning, but I'm not sure if it's worth it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

