### PR TITLE
Python: build 2.7 and 3.6 packages on Hydra again

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -108,24 +108,6 @@ let
       #rPackages = packagePlatforms pkgs.rPackages;
       ocamlPackages = { };
       perlPackages = { };
-      pythonPackages = {
-        blaze = unix;
-        pandas = unix;
-        scikitlearn = unix;
-      };
-      python2Packages = { };
-      python27Packages = { };
-      python3Packages = { };
-      python35Packages = {
-        blaze = unix;
-        pandas = unix;
-        scikitlearn = unix;
-      };
-      python36Packages = {
-        blaze = unix;
-        pandas = unix;
-        scikitlearn = unix;
-      };
 
       # hack around broken eval of non-linux packages for now.
       tests.macOSSierraShared = darwin;


### PR DESCRIPTION
The builds were disabled in https://github.com/NixOS/nixpkgs/commit/ccd1029f58a3bb9eca32d81bf3f33cb4be25cc66 because of evaluations that timed out. Since then SSD's are used and the amount of evaluations has dropped considerably since we stopped building all of i686.