### PR TITLE
qemu: Fix HDA recording latency

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -55,7 +55,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   patches = [ ./no-etc-install.patch ]
-    ++ optional nixosTestRunner ./force-uid0-on-9p.patch;
+    ++ optional nixosTestRunner ./force-uid0-on-9p.patch
+    ++ optional pulseSupport ./fix-hda-recording.patch;
 
   hardeningDisable = [ "stackprotector" ];
 

--- a/pkgs/applications/virtualization/qemu/fix-hda-recording.patch
+++ b/pkgs/applications/virtualization/qemu/fix-hda-recording.patch
@@ -1,0 +1,34 @@
+diff --git a/audio/paaudio.c b/audio/paaudio.c
+index fea6071..c1169d4 100644
+--- a/audio/paaudio.c
++++ b/audio/paaudio.c
+@@ -608,6 +608,7 @@ static int qpa_init_in(HWVoiceIn *hw, struct audsettings *as, void *drv_opaque)
+ {
+     int error;
+     pa_sample_spec ss;
++    pa_buffer_attr ba;
+     struct audsettings obt_as = *as;
+     PAVoiceIn *pa = (PAVoiceIn *) hw;
+     paaudio *g = pa->g = drv_opaque;
+@@ -616,6 +617,12 @@ static int qpa_init_in(HWVoiceIn *hw, struct audsettings *as, void *drv_opaque)
+     ss.channels = as->nchannels;
+     ss.rate = as->freq;
+
++    ba.fragsize = pa_frame_size (&ss) * g->conf.samples;
++    ba.maxlength = 5 * ba.fragsize;
++    ba.tlength = -1;
++    ba.prebuf = -1;
++    ba.minreq = -1;
++
+     obt_as.fmt = pa_to_audfmt (ss.format, &obt_as.endianness);
+
+     pa->stream = qpa_simple_new (
+@@ -625,7 +632,7 @@ static int qpa_init_in(HWVoiceIn *hw, struct audsettings *as, void *drv_opaque)
+         g->conf.source,
+         &ss,
+         NULL,                   /* channel map */
+-        NULL,                   /* buffering attributes */
++        &ba,                    /* buffering attributes */
+         &error
+         );
+     if (!pa->stream) {


### PR DESCRIPTION
Patch courtesy of Volker Rümeling.
https://lists.gnu.org/archive/html/qemu-devel/2015-09/msg03336.html

###### Motivation for this change
There was an extremely high latency for audio input to arrive in a VM. Apparently, this is due to a bug in QEMU that no one bothered to incorporate the fix for.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

