### PR TITLE
ruby docs: improve example

### DIFF
--- a/doc/languages-frameworks/ruby.xml
+++ b/doc/languages-frameworks/ruby.xml
@@ -20,7 +20,7 @@ $ cd sensu
 $ cat > Gemfile
 source 'https://rubygems.org'
 gem 'sensu'
-$ $(nix-build '<nixpkgs>' -A bundix)/bin/bundix --magic
+$ $(nix-build '<nixpkgs>' -A bundix --no-out-link)/bin/bundix --magic
 $ cat > default.nix
 { lib, bundlerEnv, ruby }:
 
@@ -114,6 +114,7 @@ in stdenv.mkDerivation {
   script = ./my-script.rb;
   buildCommand = ''
     install -D -m755 $script $out/bin/my-script
+    patchShebangs $out/bin/my-script
   '';
 }]]>
 </programlisting>


### PR DESCRIPTION
1. Call `nix-build` with `--no-out-link` to avoid cluttering the source dir.
2. Re-add `patchShebangs`, since `buildCommand` doesn't imply a patch phase. (It was my fault to remove this in the first place, sorry!)