### PR TITLE
cc-wrapper: Improve `set -u` compliance

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -34,7 +34,7 @@ cppInclude=1
 expandResponseParams "$@"
 declare -i n=0
 nParams=${#params[@]}
-while [ "$n" -lt "$nParams" ]; do
+while (( "$n" < "$nParams" )); do
     p=${params[n]}
     p2=${params[n+1]:-} # handle `p` being last one
     if [ "$p" = -c ]; then
@@ -83,7 +83,7 @@ if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "$NIX_STORE" ]]; then
     rest=()
     nParams=${#params[@]}
     declare -i n=0
-    while [ "$n" -lt "$nParams" ]; do
+    while (( "$n" < "$nParams" )); do
         p=${params[n]}
         p2=${params[n+1]:-} # handle `p` being last one
         if [ "${p:0:3}" = -L/ ] && badPath "${p:2}"; then
@@ -101,21 +101,24 @@ if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "$NIX_STORE" ]]; then
         fi
         n+=1
     done
-    params=("${rest[@]}")
+    # Old bash empty array hack
+    params=(${rest+"${rest[@]}"})
 fi
 
 
 # Clear march/mtune=native -- they bring impurity.
 if [ "$NIX_@infixSalt@_ENFORCE_NO_NATIVE" = 1 ]; then
     rest=()
-    for p in "${params[@]}"; do
+    # Old bash empty array hack
+    for p in ${params+"${params[@]}"}; do
         if [[ "$p" = -m*=native ]]; then
             skip "$p"
         else
             rest+=("$p")
         fi
     done
-    params=("${rest[@]}")
+    # Old bash empty array hack
+    params=(${rest+"${rest[@]}"})
 fi
 
 if [[ "$isCpp" = 1 ]]; then
@@ -163,14 +166,13 @@ fi
 
 # Optionally print debug info.
 if [ -n "${NIX_DEBUG:-}" ]; then
-    set +u # Old bash workaround, see ld-wrapper for explanation.
+    # Old bash workaround, see ld-wrapper for explanation.
     echo "extra flags before to @prog@:" >&2
-    printf "  %q\n" "${extraBefore[@]}"  >&2
+    printf "  %q\n" ${extraBefore+"${extraBefore[@]}"}  >&2
     echo "original flags to @prog@:" >&2
-    printf "  %q\n" "${params[@]}" >&2
+    printf "  %q\n" ${params+"${params[@]}"} >&2
     echo "extra flags after to @prog@:" >&2
-    printf "  %q\n" "${extraAfter[@]}" >&2
-    set -u
+    printf "  %q\n" ${extraAfter+"${extraAfter[@]}"} >&2
 fi
 
 if [ -n "$NIX_CC_WRAPPER_@infixSalt@_EXEC_HOOK" ]; then
@@ -178,5 +180,8 @@ if [ -n "$NIX_CC_WRAPPER_@infixSalt@_EXEC_HOOK" ]; then
 fi
 
 PATH="$path_backup"
-set +u # Old bash workaround, see above.
-exec @prog@ "${extraBefore[@]}" "${params[@]}" "${extraAfter[@]}"
+# Old bash workaround, see above.
+exec @prog@ \
+    ${extraBefore+"${extraBefore[@]}"} \
+    ${params+"${params[@]}"} \
+    ${extraAfter+"${extraAfter[@]}"}

--- a/pkgs/build-support/cc-wrapper/utils.sh
+++ b/pkgs/build-support/cc-wrapper/utils.sh
@@ -24,7 +24,7 @@ badPath() {
 }
 
 expandResponseParams() {
-    declare -g params=("$@")
+    declare -ga params=("$@")
     local arg
     for arg in "$@"; do
         if [[ "$arg" == @* ]]; then


### PR DESCRIPTION
###### Motivation for this change

While working on https://github.com/NixOS/nixpkgs/pull/26805 I hit a bug in cc-wrapper. Not sure whether anything in practice would excise the bug, but this should fix it.

Also changed the others to use `${foo+"${foo[@]}"}` in lieu of `set +u`. While this is more noisy, I think it is more maintainable as the hack isn't control-flow based.

When we fix `nix-shell` and update the bootstrap tools, we can get rid of these.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built stdenv on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @orivej
