### PR TITLE
blueman: fix python wrapper mockup

### DIFF
--- a/pkgs/tools/bluetooth/blueman/default.nix
+++ b/pkgs/tools/bluetooth/blueman/default.nix
@@ -31,10 +31,11 @@ in stdenv.mkDerivation rec {
 
   configureFlags = [ (lib.enableFeature withPulseAudio "pulseaudio") ];
 
-  preFixup = ''
+  postFixup = ''
     makeWrapperArgs="--prefix PATH ':' ${binPath}"
-    wrapPythonProgramsIn "$out/bin" "$pythonPath"
-    wrapPythonProgramsIn "$out/libexec" "$pythonPath"
+    # This mimics ../../../development/interpreters/python/wrap.sh
+    wrapPythonProgramsIn "$out/bin" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/libexec" "$out $pythonPath"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
The wrapper missed $out in the python path, producing weird errors where
blueman could not find itself :-).

Fixes #28260.
/cc @abbradar as potential reviewer.