### PR TITLE
Fix so that ucl compiles with gcc6 [staging branch]

### DIFF
--- a/pkgs/development/libraries/ucl/default.nix
+++ b/pkgs/development/libraries/ucl/default.nix
@@ -7,6 +7,9 @@ stdenv.mkDerivation {
     sha256 = "b865299ffd45d73412293369c9754b07637680e5c826915f097577cd27350348";
   };
 
+  # needed to successfully compile with gcc 6
+  NIX_CFLAGS_COMPILE = "-std=c90 -fPIC";
+
   meta = {
     homepage = http://www.oberhumer.com/opensource/ucl/;
     description = "Portable lossless data compression library";


### PR DESCRIPTION
###### Motivation for this change
As of the gcc6 branch merge, I noticed ucl does not compile anymore. Upstream of ucl added these cflags, but a new version has not been released yet, so manually specifying them works for now.

Also wanted to say thank you very much for merging the gcc6 branch into staging! Very happy that we have a newer gcc version :+1: 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

