### PR TITLE
pythonPackages.hyperlink: init at 17.3.0

### DIFF
--- a/pkgs/development/python-modules/hyperlink/default.nix
+++ b/pkgs/development/python-modules/hyperlink/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchurl, pytest }:
+buildPythonPackage rec {
+  name = "hyperlink-${version}";
+  version = "17.3.0";
+
+  src = fetchurl {
+    url = "mirror://pypi/h/hyperlink/${name}.tar.gz";
+    sha256 = "06mgnxwjzx8hv34bifc7jvgxz21ixhk5s6xy2kd84hdrlbfvpbfx";
+  };
+
+  buildInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A featureful, correct URL for Python";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ apeschar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8355,6 +8355,7 @@ in {
     };
   };
 
+  hyperlink = callPackage ../development/python-modules/hyperlink {};
 
   zope_copy = buildPythonPackage rec {
     name = "zope.copy-4.0.2";


### PR DESCRIPTION
###### Motivation for this change

Hyperlink is a new dependency for Twisted (v17.5.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

