### PR TITLE
twisted: update to 17.5.0

### DIFF
--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -1,17 +1,17 @@
 { stdenv, buildPythonPackage, fetchurl, python,
-  zope_interface, incremental, automat, constantly
+  zope_interface, incremental, automat, constantly, hyperlink
 }:
 buildPythonPackage rec {
   pname = "Twisted";
   name = "${pname}-${version}";
-  version = "17.1.0";
+  version = "17.5.0";
 
   src = fetchurl {
     url = "mirror://pypi/T/Twisted/${name}.tar.bz2";
-    sha256 = "1p245mg15hkxp7hy5cyq2fgvlgjkb4cg0gwkwd148nzy1bbi3wnv";
+    sha256 = "1sh2h23nnizcdyrl2rn7zxijglikxwz7z7grqpvq496zy2aa967i";
   };
 
-  propagatedBuildInputs = [ zope_interface incremental automat constantly ];
+  propagatedBuildInputs = [ zope_interface incremental automat constantly hyperlink ];
 
   # Patch t.p._inotify to point to libc. Without this,
   # twisted.python.runtime.platform.supportsINotify() == False


### PR DESCRIPTION
###### Motivation for this change

There is a newer version of Twisted, 17.5.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
    - **Note:** some utilities require additional dependencies, don't think that this is necessary since Twisted is usually used as a library
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

