### PR TITLE
fenics: init at 2017.1.0

### DIFF
--- a/pkgs/development/libraries/science/math/fenics/default.nix
+++ b/pkgs/development/libraries/science/math/fenics/default.nix
@@ -1,0 +1,164 @@
+{ stdenv
+, fetchurl
+, boost
+, cmake
+, doxygen
+, eigen
+, numpy
+, pkgconfig
+, pytest
+, pythonPackages
+, six
+, sympy
+, gtest ? null
+, hdf5 ? null
+, mpi ? null
+, ply ? null
+, python ? null
+, sphinx ? null
+, suitesparse ? null
+, swig ? null
+, vtk ? null
+, zlib ? null
+, docs ? false
+, pythonBindings ? false
+, doCheck ? true }:
+
+assert pythonBindings -> python != null && ply != null && swig != null;
+
+let
+  version = "2017.1.0";
+
+  dijitso = pythonPackages.buildPythonPackage {
+    name = "dijitso-${version}";
+    src = fetchurl {
+      url = "https://bitbucket.org/fenics-project/dijitso/downloads/dijitso-${version}.tar.gz";
+      sha256 = "0mw6mynjmg6yl3l2k33yra2x84s4r6mh44ylhk9znjfk74jra8zg";
+    };
+    buildInputs = [ numpy pytest six ];
+    checkPhase = ''
+      export HOME=$PWD
+      py.test test/
+    '';
+    meta = {
+      description = "Distributed just-in-time shared library building";
+      homepage = http://fenicsproject.org/;
+      platforms = stdenv.lib.platforms.all;
+      license = stdenv.lib.licenses.lgpl3;
+    };
+  };
+
+  fiat = pythonPackages.buildPythonPackage {
+    name = "fiat-${version}";
+    src = fetchurl {
+      url = "https://bitbucket.org/fenics-project/fiat/downloads/fiat-${version}.tar.gz";
+      sha256 = "156ybz70n4n7p88q4pfkvbmg1xr2ll80inzr423mki0nml0q8a6l";
+    };
+    buildInputs = [ numpy pytest six sympy ];
+    checkPhase = ''
+      py.test test/unit/
+    '';
+    meta = {
+      description = "Automatic generation of finite element basis functions";
+      homepage = http://fenicsproject.org/;
+      platforms = stdenv.lib.platforms.all;
+      license = stdenv.lib.licenses.lgpl3;
+    };
+  };
+
+  ufl = pythonPackages.buildPythonPackage {
+    name = "ufl-${version}";
+    src = fetchurl {
+      url = "https://bitbucket.org/fenics-project/ufl/downloads/ufl-${version}.tar.gz";
+      sha256 = "13ysimmwad429fjjs07j1fw1gq196p021j7mv66hwrljyh8gm1xg";
+    };
+    buildInputs = [ numpy pytest six ];
+    checkPhase = ''
+      py.test test/
+    '';
+    meta = {
+      description = "A domain-specific language for finite element variational forms";
+      homepage = http://fenicsproject.org/;
+      platforms = stdenv.lib.platforms.all;
+      license = stdenv.lib.licenses.lgpl3;
+    };
+  };
+
+  ffc = pythonPackages.buildPythonPackage {
+    name = "ffc-${version}";
+    src = fetchurl {
+      url = "https://bitbucket.org/fenics-project/ffc/downloads/ffc-${version}.tar.gz";
+      sha256 = "1cw7zsrjms11xrfg7x9wjd90x3w4v5s1wdwa18xqlycqz7cc8wr0";
+    };
+    buildInputs = [ dijitso fiat numpy pytest six sympy ufl ];
+    checkPhase = ''
+      export HOME=$PWD
+      py.test test/unit/
+    '';
+    meta = {
+      description = "A compiler for finite element variational forms";
+      homepage = http://fenicsproject.org/;
+      platforms = stdenv.lib.platforms.all;
+      license = stdenv.lib.licenses.lgpl3;
+    };
+  };
+
+  instant = pythonPackages.buildPythonPackage {
+    name = "instant-${version}";
+    src = fetchurl {
+      url = "https://bitbucket.org/fenics-project/instant/downloads/instant-${version}.tar.gz";
+      sha256 = "1rsyh6n04w0na2zirfdcdjip8k8ikb8fc2x94fq8ylc3lpcnpx9q";
+    };
+    buildInputs = [ numpy six ];
+    meta = {
+      description = "Instant inlining of C and C++ code in Python";
+      homepage = http://fenicsproject.org/;
+      platforms = stdenv.lib.platforms.all;
+      license = stdenv.lib.licenses.lgpl3;
+    };
+  };
+
+in
+stdenv.mkDerivation {
+  name = "dolfin-${version}";
+  src = fetchurl {
+    url = "https://bitbucket.org/fenics-project/dolfin/downloads/dolfin-${version}.tar.gz";
+    sha256 = "14hfb5q6rz79zmy742s2fiqkb9j2cgh5bsg99v76apcr84nklyds";
+  };
+  propagatedBuildInputs = [ dijitso fiat numpy six ufl ];
+  buildInputs = [
+    boost cmake dijitso doxygen eigen ffc fiat gtest hdf5 instant mpi
+    numpy pkgconfig six sphinx suitesparse sympy ufl vtk zlib
+    ] ++ stdenv.lib.optionals pythonBindings [ ply python numpy swig ];
+  patches = [ ./unicode.patch ];
+  cmakeFlags = "-DDOLFIN_CXX_FLAGS=-std=c++11"
+    + " -DDOLFIN_AUTO_DETECT_MPI=OFF"
+    + " -DDOLFIN_ENABLE_CHOLMOD=" + (if suitesparse != null then "ON" else "OFF")
+    + " -DDOLFIN_ENABLE_DOCS=" + (if docs then "ON" else "OFF")
+    + " -DDOLFIN_ENABLE_GTEST=" + (if gtest != null then "ON" else "OFF")
+    + " -DDOLFIN_ENABLE_HDF5=" + (if hdf5 != null then "ON" else "OFF")
+    + " -DDOLFIN_ENABLE_MPI=" + (if mpi != null then "ON" else "OFF")
+    + " -DDOLFIN_ENABLE_PARMETIS=OFF"
+    + " -DDOLFIN_ENABLE_PETSC4PY=OFF"
+    + " -DDOLFIN_ENABLE_PETSC=OFF"
+    + " -DDOLFIN_ENABLE_PYTHON=" + (if pythonBindings then "ON" else "OFF")
+    + " -DDOLFIN_ENABLE_SCOTCH=OFF"
+    + " -DDOLFIN_ENABLE_SLEPC4PY=OFF"
+    + " -DDOLFIN_ENABLE_SLEPC=OFF"
+    + " -DDOLFIN_ENABLE_SPHINX=" + (if sphinx != null then "ON" else "OFF")
+    + " -DDOLFIN_ENABLE_TESTING=" + (if doCheck then "ON" else "OFF")
+    + " -DDOLFIN_ENABLE_TRILINOS=OFF"
+    + " -DDOLFIN_ENABLE_UMFPACK=" + (if suitesparse != null then "ON" else "OFF")
+    + " -DDOLFIN_ENABLE_VTK=" + (if vtk != null then "ON" else "OFF")
+    + " -DDOLFIN_ENABLE_ZLIB=" + (if zlib != null then "ON" else "OFF");
+  checkPhase = ''
+    make runtests
+  '';
+  postInstall = "source $out/share/dolfin/dolfin.conf";
+  meta = {
+    description = "The FEniCS Problem Solving Environment in Python and C++";
+    homepage = http://fenicsproject.org/;
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.lgpl3;
+  };
+}

--- a/pkgs/development/libraries/science/math/fenics/unicode.patch
+++ b/pkgs/development/libraries/science/math/fenics/unicode.patch
@@ -1,0 +1,67 @@
+From 0cc9e68de1181d950d4185bf3a87b69a87e4358f Mon Sep 17 00:00:00 2001
+From: "James D. Trotter" <james@simula.no>
+Date: Mon, 14 Aug 2017 16:43:53 +0200
+Subject: [PATCH] Use a UTF-8 encoding to avoid errors with decoding non-ascii
+ characters
+
+---
+ cmake/scripts/generate-swig-interface.py |  6 +++---
+ utils/pylit/pylit.py                     | 10 +++++++---
+ 2 files changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/cmake/scripts/generate-swig-interface.py b/cmake/scripts/generate-swig-interface.py
+index 843a49229..7b85453d0 100644
+--- a/cmake/scripts/generate-swig-interface.py
++++ b/cmake/scripts/generate-swig-interface.py
+@@ -212,10 +212,10 @@ def extract_swig_modules_dependencies(module_to_submodules, submodule_info):
+                     continue
+ 
+                 # Read code
+-                with open(header_file) as f:
+-                    code = f.read()
+-
+                 try:
++                    with open(header_file, encoding='utf-8') as f:
++                        code = f.read()
++
+                     # Extract type info
+                     used_types, declared_types = parse_and_extract_type_info(code)
+                 except Exception as e:
+diff --git a/utils/pylit/pylit.py b/utils/pylit/pylit.py
+index bcd8ec5e0..8c2964fbd 100755
+--- a/utils/pylit/pylit.py
++++ b/utils/pylit/pylit.py
+@@ -1496,7 +1496,7 @@ def open_streams(infile = '-', outfile = '-', overwrite='update', **keyw):
+     if infile == '-':
+         in_stream = sys.stdin
+     else:
+-        in_stream = open(infile, 'r')
++        in_stream = open(infile, 'r', encoding='utf-8')
+ 
+     if outfile == '-':
+         out_stream = sys.stdout
+@@ -1505,7 +1505,7 @@ def open_streams(infile = '-', outfile = '-', overwrite='update', **keyw):
+     elif overwrite == 'update' and is_newer(outfile, infile):
+         raise IOError((1, "Output file is newer than input file!", outfile))
+     else:
+-        out_stream = open(outfile, 'w')
++        out_stream = open(outfile, 'w', encoding='utf-8')
+     return (in_stream, out_stream)
+ 
+ # is_newer
+@@ -1731,7 +1731,11 @@ def main(args=sys.argv[1:], **defaults):
+ 
+ # Convert and write to out_stream::
+ 
+-    out_stream.write(str(converter))
++    try:
++        out_stream.write(str(converter))
++    except Exception as e:
++        print("Failed to write extract to", out_stream.name)
++        raise
+ 
+     if out_stream is not sys.stdout:
+         print("extract written to", out_stream.name)
+-- 
+2.14.0
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17910,6 +17910,13 @@ with pkgs;
 
   openspecfun = callPackage ../development/libraries/science/math/openspecfun {};
 
+  fenics = callPackage ../development/libraries/science/math/fenics {
+    inherit (python3Packages) numpy ply pytest python six sympy;
+    pythonPackages = python3Packages;
+    pythonBindings = true;
+    docs = true;
+  };
+
   lie = callPackage ../applications/science/math/LiE { };
 
   magma = callPackage ../development/libraries/science/math/magma { };


### PR DESCRIPTION
###### Motivation for this change

Add the FEniCS computing platform for solving partial differential equations (PDEs).  See https://fenicsproject.org.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
