### PR TITLE
sublime3: fix package re-zipping

### DIFF
--- a/pkgs/applications/editors/sublime3/default.nix
+++ b/pkgs/applications/editors/sublime3/default.nix
@@ -31,20 +31,19 @@ in let
 
     dontStrip = true;
     dontPatchELF = true;
-    buildInputs = [ makeWrapper ];
+    buildInputs = [ makeWrapper zip unzip ];
 
     # make exec.py in Default.sublime-package use own bash with
     # an LD_PRELOAD instead of "/bin/bash"
     patchPhase = ''
       mkdir Default.sublime-package-fix
       ( cd Default.sublime-package-fix
-        ${unzip}/bin/unzip ../Packages/Default.sublime-package > /dev/null
+        unzip -q ../Packages/Default.sublime-package
         substituteInPlace "exec.py" --replace \
           "[\"/bin/bash\"" \
           "[\"$out/sublime_bash\""
+        zip -q ../Packages/Default.sublime-package **/*
       )
-      ${zip}/bin/zip -j Default.sublime-package.zip Default.sublime-package-fix/* > /dev/null
-      mv Default.sublime-package.zip Packages/Default.sublime-package
       rm -r Default.sublime-package-fix
     '';
 
@@ -85,14 +84,17 @@ in stdenv.mkDerivation {
   name = "sublimetext3-${build}";
 
   phases = [ "installPhase" ];
+
+  inherit sublime;
+
   installPhase = ''
     mkdir -p $out/bin
-    ln -s ${sublime}/sublime_text $out/bin/subl
-    ln -s ${sublime}/sublime_text $out/bin/sublime
-    ln -s ${sublime}/sublime_text $out/bin/sublime3
+    ln -s $sublime/sublime_text $out/bin/subl
+    ln -s $sublime/sublime_text $out/bin/sublime
+    ln -s $sublime/sublime_text $out/bin/sublime3
     mkdir -p $out/share/applications
-    ln -s ${sublime}/sublime_text.desktop $out/share/applications/sublime_text.desktop
-    ln -s ${sublime}/Icon/256x256/ $out/share/icons
+    ln -s $sublime/sublime_text.desktop $out/share/applications/sublime_text.desktop
+    ln -s $sublime/Icon/256x256/ $out/share/icons
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

The previous zip command wasn't including directories. This Sublime package only has one directory in it, so the resulting bug was subtle. The directory contained the send2trash Python package, so the result was that file deletion didn't work.

This diff also includes a few minor shufflings-around to make the Nix package slightly easier to debug.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
