### PR TITLE
stdenvs: Distinguish between `extraBuildInputs` and `extraNativeBuildInputs`

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -59,11 +59,12 @@ in rec {
   stageFun = step: last: {shell             ? "${bootstrapTools}/bin/bash",
                           overrides         ? (self: super: {}),
                           extraPreHook      ? "",
+                          extraNativeBuildInputs,
                           extraBuildInputs,
                           allowedRequisites ? null}:
     let
       thisStdenv = import ../generic {
-        inherit config shell extraBuildInputs;
+        inherit config shell extraNativeBuildInputs extraBuildInputs;
         allowedRequisites = if allowedRequisites == null then null else allowedRequisites ++ [
           thisStdenv.cc.expand-response-params
         ];
@@ -162,6 +163,7 @@ in rec {
 
     };
 
+    extraNativeBuildInputs = [];
     extraBuildInputs = [];
   };
 
@@ -169,6 +171,7 @@ in rec {
 
   stage1 = prevStage: with prevStage; stageFun 1 prevStage {
     extraPreHook = "export NIX_CFLAGS_COMPILE+=\" -F${bootstrapTools}/Library/Frameworks\"";
+    extraNativeBuildInputs = [];
     extraBuildInputs = [ pkgs.libcxx ];
 
     allowedRequisites =
@@ -195,7 +198,8 @@ in rec {
       export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
     '';
 
-    extraBuildInputs = with pkgs; [ xz darwin.CF libcxx ];
+    extraNativeBuildInputs = [ pkgs.xz ];
+    extraBuildInputs = with pkgs; [ darwin.CF libcxx ];
 
     allowedRequisites =
       [ bootstrapTools ] ++
@@ -226,7 +230,8 @@ in rec {
     # enables patchShebangs above. Unfortunately, patchShebangs ignores our $SHELL setting
     # and instead goes by $PATH, which happens to contain bootstrapTools. So it goes and
     # patches our shebangs back to point at bootstrapTools. This makes sure bash comes first.
-    extraBuildInputs = with pkgs; [ xz darwin.CF libcxx pkgs.bash ];
+    extraNativeBuildInputs = with pkgs; [ xz pkgs.bash ];
+    extraBuildInputs = with pkgs; [ darwin.CF libcxx ];
 
     extraPreHook = ''
       export PATH=${pkgs.bash}/bin:$PATH
@@ -260,7 +265,8 @@ in rec {
 
   stage4 = prevStage: with prevStage; stageFun 4 prevStage {
     shell = "${pkgs.bash}/bin/bash";
-    extraBuildInputs = with pkgs; [ xz darwin.CF libcxx pkgs.bash ];
+    extraNativeBuildInputs = with pkgs; [ xz pkgs.bash ];
+    extraBuildInputs = with pkgs; [ darwin.CF libcxx ];
     extraPreHook = ''
       export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
     '';
@@ -321,6 +327,7 @@ in rec {
       libc = pkgs.darwin.Libsystem;
     };
 
+    extraNativeBuildInputs = [];
     extraBuildInputs = with pkgs; [ darwin.CF libcxx ];
 
     extraAttrs = {

--- a/pkgs/stdenv/generic/builder.sh
+++ b/pkgs/stdenv/generic/builder.sh
@@ -6,15 +6,20 @@ done
 
 mkdir $out
 
+# Buid the setup script
 echo "export SHELL=$shell" > $out/setup
 echo "initialPath=\"$initialPath\"" >> $out/setup
-echo "defaultNativeBuildInputs=\"$defaultNativeBuildInputs\"" >> $out/setup
 echo "$preHook" >> $out/setup
 cat "$setup" >> $out/setup
 
 # Allow the user to install stdenv using nix-env and get the packages
 # in stdenv.
-mkdir $out/nix-support
+mkdir -p "$out/nix-support"
+echo '# Hack to induce runtime dependencies on the default inputs' \
+    > "$out/nix-support/default-inputs.txt"
+printf '%s\n' $defaultNativeBuildInputs $defaultBuildInputs \
+    >> "$out/nix-support/default-inputs.txt"
 if [ "$propagatedUserEnvPkgs" ]; then
-    printf '%s ' $propagatedUserEnvPkgs > $out/nix-support/propagated-user-env-packages
+    printf '%s ' $propagatedUserEnvPkgs \
+        > "$out/nix-support/propagated-user-env-packages"
 fi

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -9,6 +9,7 @@ let lib = import ../../../lib; in lib.makeOverridable (
 
 , setupScript ? ./setup.sh
 
+, extraNativeBuildInputs ? []
 , extraBuildInputs ? []
 , __stdenvImpureHostDeps ? []
 , __extraImpureHostDeps ? []
@@ -41,7 +42,7 @@ let lib = import ../../../lib; in lib.makeOverridable (
 }:
 
 let
-  defaultNativeBuildInputs = extraBuildInputs ++
+  defaultNativeBuildInputs = extraNativeBuildInputs ++
     [ ../../build-support/setup-hooks/move-docs.sh
       ../../build-support/setup-hooks/compress-man-pages.sh
       ../../build-support/setup-hooks/strip.sh
@@ -58,11 +59,16 @@ let
       cc
     ];
 
+  defaultBuildInputs = extraBuildInputs;
+
   # The stdenv that we are producing.
   stdenv =
     derivation (
-    (if isNull allowedRequisites then {} else { allowedRequisites = allowedRequisites ++ defaultNativeBuildInputs; }) //
-    {
+    lib.optionalAttrs (allowedRequisites != null) {
+      allowedRequisites = allowedRequisites
+        ++ defaultNativeBuildInputs ++ defaultBuildInputs;
+    }
+    // {
       inherit name;
 
       # Nix itself uses the `system` field of a derivation to decide where to
@@ -75,7 +81,8 @@ let
 
       setup = setupScript;
 
-      inherit preHook initialPath shell defaultNativeBuildInputs;
+      inherit preHook initialPath shell
+        defaultNativeBuildInputs defaultBuildInputs;
     }
     // lib.optionalAttrs buildPlatform.isDarwin {
       __sandboxProfile = stdenvSandboxProfile;
@@ -91,7 +98,8 @@ let
 
       inherit buildPlatform hostPlatform targetPlatform;
 
-      inherit extraBuildInputs __extraImpureHostDeps extraSandboxProfile;
+      inherit extraNativeBuildInputs extraBuildInputs
+        __extraImpureHostDeps extraSandboxProfile;
 
       # Utility flags to test the type of platform.
       inherit (hostPlatform)

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -44,10 +44,10 @@ rec {
     , ... } @ attrs:
     let
       dependencies = map lib.chooseDevOutputs [
-        (map (drv: drv.nativeDrv or drv) nativeBuildInputs
+        (map (drv: drv.nativeDrv or drv) (nativeBuildInputs ++ stdenv.defaultNativeBuildInputs)
            ++ lib.optional separateDebugInfo ../../build-support/setup-hooks/separate-debug-info.sh
            ++ lib.optional stdenv.hostPlatform.isWindows ../../build-support/setup-hooks/win-dll-link.sh)
-        (map (drv: drv.crossDrv or drv) buildInputs)
+        (map (drv: drv.crossDrv or drv) (buildInputs ++ stdenv.defaultBuildInputs))
       ];
       propagatedDependencies = map lib.chooseDevOutputs [
         (map (drv: drv.nativeDrv or drv) propagatedNativeBuildInputs)
@@ -65,11 +65,11 @@ rec {
            "sandboxProfile" "propagatedSandboxProfile"])
         // (let
           computedSandboxProfile =
-            lib.concatMap (input: input.__propagatedSandboxProfile or []) (stdenv.extraBuildInputs ++ lib.concatLists dependencies);
+            lib.concatMap (input: input.__propagatedSandboxProfile or []) (lib.concatLists dependencies);
           computedPropagatedSandboxProfile =
             lib.concatMap (input: input.__propagatedSandboxProfile or []) (lib.concatLists propagatedDependencies);
           computedImpureHostDeps =
-            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (stdenv.extraBuildInputs ++ lib.concatLists dependencies));
+            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (lib.concatLists dependencies));
           computedPropagatedImpureHostDeps =
             lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (lib.concatLists propagatedDependencies));
         in

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -317,18 +317,17 @@ if [ -z "$crossConfig" ]; then
     # are handled identically to nativeBuildInputs
     declare -a nativePkgs
     for i in $nativeBuildInputs $buildInputs \
-             $defaultNativeBuildInputs $defaultBuildInputs \
              $propagatedNativeBuildInputs $propagatedBuildInputs; do
         findInputs "$i" nativePkgs propagated-native-build-inputs
     done
 else
     declare -a crossPkgs
-    for i in $buildInputs $defaultBuildInputs $propagatedBuildInputs; do
+    for i in $buildInputs $propagatedBuildInputs; do
         findInputs "$i" crossPkgs propagated-build-inputs
     done
 
     declare -a nativePkgs
-    for i in $nativeBuildInputs $defaultNativeBuildInputs $propagatedNativeBuildInputs; do
+    for i in $nativeBuildInputs $propagatedNativeBuildInputs; do
         findInputs "$i" nativePkgs propagated-native-build-inputs
     done
 fi

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -47,7 +47,7 @@ let
   # the bootstrap.  In all stages, we build an stdenv and the package
   # set that can be built with that stdenv.
   stageFun = prevStage:
-    { name, overrides ? (self: super: {}), extraBuildInputs ? [] }:
+    { name, overrides ? (self: super: {}), extraNativeBuildInputs ? [] }:
 
     let
 
@@ -56,7 +56,7 @@ let
         buildPlatform = localSystem;
         hostPlatform = localSystem;
         targetPlatform = localSystem;
-        inherit config extraBuildInputs;
+        inherit config extraNativeBuildInputs;
         preHook =
           ''
             # Don't patch #!/interpreter because it leads to retained
@@ -219,7 +219,7 @@ in
         isl = isl_0_14;
       };
     };
-    extraBuildInputs = [ prevStage.patchelf prevStage.paxctl ] ++
+    extraNativeBuildInputs = [ prevStage.patchelf prevStage.paxctl ] ++
       # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
       lib.optional (system == "aarch64-linux") prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
@@ -253,7 +253,7 @@ in
         shell = self.bash + "/bin/bash";
       };
     };
-    extraBuildInputs = [ prevStage.patchelf prevStage.xz ] ++
+    extraNativeBuildInputs = [ prevStage.patchelf prevStage.xz ] ++
       # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
       lib.optional (system == "aarch64-linux") prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
@@ -283,7 +283,7 @@ in
       initialPath =
         ((import ../common-path.nix) {pkgs = prevStage;});
 
-      extraBuildInputs = [ prevStage.patchelf prevStage.paxctl ] ++
+      extraNativeBuildInputs = [ prevStage.patchelf prevStage.paxctl ] ++
         # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
         lib.optional (system == "aarch64-linux") prevStage.updateAutotoolsGnuConfigScriptsHook;
 

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -66,7 +66,7 @@ let
     export lt_cv_deplibs_check_method=pass_all
   '';
 
-  extraBuildInputsCygwin = [
+  extraNativeBuildInputsCygwin = [
     ../cygwin/all-buildinputs-as-runtimedep.sh
     ../cygwin/wrap-exes-to-find-dlls.sh
   ] ++ (if system == "i686-cygwin" then [
@@ -94,9 +94,9 @@ let
         if system == "x86_64-cygwin" then prehookCygwin else
         prehookBase;
 
-      extraBuildInputs =
-        if system == "i686-cygwin" then extraBuildInputsCygwin else
-        if system == "x86_64-cygwin" then extraBuildInputsCygwin else
+      extraNativeBuildInputs =
+        if system == "i686-cygwin" then extraNativeBuildInputsCygwin else
+        if system == "x86_64-cygwin" then extraNativeBuildInputsCygwin else
         [];
 
       initialPath = extraPath ++ path;

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./memory-leak.patch ./no-install-statedir.patch ];
 
-  buildInputs = optionals (hostPlatform == buildPlatform) [ coreutils ]; # bin/updatedb script needs to call sort
+  buildInputs = [ coreutils ]; # bin/updatedb script needs to call sort
 
   # Since glibc-2.25 the i686 tests hang reliably right after test-sleep.
   doCheck
@@ -25,7 +25,12 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "info" ];
 
-  configureFlags = [ "--localstatedir=/var/cache" ];
+  configureFlags = [
+    # "sort" need not be on the PATH as a run-time dep, so we need to tell
+    # configure where it is. Covers the cross and native case alike.
+    "SORT=${coreutils}/bin/sort"
+    "--localstatedir=/var/cache"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/text/diffutils/default.nix
+++ b/pkgs/tools/text/diffutils/default.nix
@@ -10,8 +10,14 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "info" ];
 
+  nativeBuildInputs = [ xz.bin ];
   /* If no explicit coreutils is given, use the one from stdenv. */
-  nativeBuildInputs = [ xz.bin coreutils ];
+  buildInputs = [ coreutils ];
+
+  configureFlags =
+    # "pr" need not be on the PATH as a run-time dep, so we need to tell
+    # configure where it is. Covers the cross and native case alike.
+    stdenv.lib.optional (coreutils != null) "PR_PROGRAM=${coreutils}/bin/pr";
 
   meta = {
     homepage = http://www.gnu.org/software/diffutils/diffutils.html;


### PR DESCRIPTION
###### Motivation for this change

Additionally, instead of pulling them from `setup.sh`, route them via Nix. This gets us one step closer to making stdenv be a plain attribute set instead of a derivation. Also, moves complexity from bash to Nix, which is an improvement.

###### Things done

Currently the Linux stdenv fails to build, saying `xz -5` results in an `xz` been unrecognized. I'm guessing this is because dependencies are processed in a slightly different order. I can try tweaking the order, but think the underlying conflict is best fixed first.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

