### PR TITLE
networkmanager_iodine: init at 1.2.0

### DIFF
--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -34,6 +34,7 @@ with lib;
       networkmanager_openvpn = pkgs.networkmanager_openvpn.override { withGnome = false; };
       networkmanager_pptp = pkgs.networkmanager_pptp.override { withGnome = false; };
       networkmanager_vpnc = pkgs.networkmanager_vpnc.override { withGnome = false; };
+      networkmanager_iodine = pkgs.networkmanager_iodine.override { withGnome = false; };
       pinentry = pkgs.pinentry.override { gtk2 = null; qt4 = null; };
     };
   };

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -130,7 +130,8 @@ in {
         default = { inherit networkmanager modemmanager wpa_supplicant
                             networkmanager_openvpn networkmanager_vpnc
                             networkmanager_openconnect networkmanager_fortisslvpn
-                            networkmanager_pptp networkmanager_l2tp; };
+                            networkmanager_pptp networkmanager_l2tp
+                            networkmanager_iodine; };
         internal = true;
       };
 
@@ -255,6 +256,9 @@ in {
       { source = "${networkmanager_strongswan}/etc/NetworkManager/VPN/nm-strongswan-service.name";
         target = "NetworkManager/VPN/nm-strongswan-service.name";
       }
+      { source = "${networkmanager_iodine}/etc/NetworkManager/VPN/nm-iodine-service.name";
+        target = "NetworkManager/VPN/nm-iodine-service.name";
+      }
     ] ++ optional (cfg.appendNameservers == [] || cfg.insertNameservers == [])
            { source = overrideNameserversScript;
              target = "NetworkManager/dispatcher.d/02overridedns";
@@ -278,6 +282,11 @@ in {
       name = "nm-openvpn";
       uid = config.ids.uids.nm-openvpn;
       extraGroups = [ "networkmanager" ];
+    }
+    {
+      name = "nm-iodine";
+      isSystemUser = true;
+      group = "networkmanager";
     }];
 
     systemd.packages = cfg.packages;

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -186,7 +186,8 @@ in {
     networking.networkmanager.basePackages =
       { inherit (pkgs) networkmanager modemmanager wpa_supplicant;
         inherit (gnome3) networkmanager_openvpn networkmanager_vpnc
-                         networkmanager_openconnect networkmanager_fortisslvpn networkmanager_pptp
+                         networkmanager_openconnect networkmanager_fortisslvpn
+                         networkmanager_pptp networkmanager_iodine
                          networkmanager_l2tp; };
 
     # Needed for themes and backgrounds

--- a/pkgs/desktops/gnome-3/3.22/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/default.nix
@@ -220,6 +220,10 @@ let
     inherit gnome3;
   };
 
+  networkmanager_iodine = pkgs.networkmanager_iodine.override {
+    inherit gnome3;
+  };
+
   networkmanagerapplet = pkgs.networkmanagerapplet.override {
     inherit gnome3 gsettings_desktop_schemas glib_networking;
   };

--- a/pkgs/tools/networking/network-manager/iodine.nix
+++ b/pkgs/tools/networking/network-manager/iodine.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, iodine, intltool, pkgconfig, networkmanager, libsecret
+, withGnome ? true, gnome3 }:
+
+stdenv.mkDerivation rec {
+  name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
+  pname   = "NetworkManager-iodine";
+  major   = "1.2";
+  version = "${major}.0";
+
+  src = fetchurl {
+    url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
+    sha256 = "0njdigakidji6mfmbsp8lfi8wl88z1dk8cljbva2w0xazyddbwyh";
+  };
+
+  buildInputs = [ iodine networkmanager libsecret ]
+    ++ stdenv.lib.optionals withGnome [ gnome3.gtk gnome3.libgnome_keyring
+                                        gnome3.networkmanagerapplet ];
+
+  nativeBuildInputs = [ intltool pkgconfig ];
+
+  configureFlags = [
+    "${if withGnome then "--with-gnome" else "--without-gnome"}"
+    "--disable-static"
+    "--localstatedir=/" # needed for the management socket under /run/NetworkManager
+  ];
+
+  preConfigure = ''
+     substituteInPlace "src/nm-iodine-service.c" \
+       --replace "/usr/bin/iodine" "${iodine}/bin/iodine"
+  '';
+
+  meta = {
+    description = "NetworkManager's iodine plugin";
+    inherit (networkmanager.meta) maintainers platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3370,6 +3370,8 @@ with pkgs;
 
   networkmanager = callPackage ../tools/networking/network-manager { };
 
+  networkmanager_iodine = callPackage ../tools/networking/network-manager/iodine.nix { };
+
   networkmanager_openvpn = callPackage ../tools/networking/network-manager/openvpn.nix { };
 
   networkmanager_pptp = callPackage ../tools/networking/network-manager/pptp.nix { };


### PR DESCRIPTION
###### Motivation for this change

make the nm-iodine plugin available on nixos

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

