### PR TITLE
Update subversion to 1.9.7

### DIFF
--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -109,7 +109,7 @@ in {
   };
 
   subversion19 = common {
-    version = "1.9.6";
-    sha256 = "06dfram53lyfyyqgz1r7c5323qqc6mjcpwi1j402y21lnqgwbjyv";
+    version = "1.9.7";
+    sha256 = "c3b118333ce12e501d509e66bb0a47bcc34d053990acab45559431ac3e491623";
   };
 }

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -110,6 +110,6 @@ in {
 
   subversion19 = common {
     version = "1.9.7";
-    sha256 = "c3b118333ce12e501d509e66bb0a47bcc34d053990acab45559431ac3e491623";
+    sha256 = "08qn94zaqcclam2spb4h742lvhxw8w5bnrlya0fm0bp17hriicf3";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Updating to subversion 1.9.7, to fix vulnerability. Take a look at : https://subversion.apache.org/security/CVE-2017-9800-advisory.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

