### PR TITLE
Fix taskwarrior fish completions

### DIFF
--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p "$out/share/bash-completion/completions"
     ln -s "../../doc/task/scripts/bash/task.sh" "$out/share/bash-completion/completions/"
-    mkdir -p "$out/etc/fish/completions"
-    ln -s "../../../share/doc/task/scripts/fish/task.fish" "$out/etc/fish/completions/"
+    mkdir -p "$out/share/fish/vendor_completions.d"
+    ln -s "../../../share/doc/task/scripts/fish/task.fish" "$out/share/fish/vendor_completions.d/"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Fish expects third party completions to be in a directory called
`vendor_completions.d` rather than `completions`.

###### Motivation for this change

taskwarrior's fish completions don't work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

