### PR TITLE
sqlmap: 1.0.11 -> 1.1

### DIFF
--- a/pkgs/applications/misc/sqlmap/default.nix
+++ b/pkgs/applications/misc/sqlmap/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, pythonPackages, pkgs }:
+
+pythonPackages.buildPythonPackage {
+  name = "sqlmap-1.1";
+
+  disabled = pythonPackages.isPy3k;
+
+  src = pkgs.fetchurl {
+    url = "mirror://pypi/s/sqlmap/sqlmap-1.1.tar.gz";
+    sha256 = "0px72p52w76cylr68i69kz0kagmbrslgx2221yi77322fih0mngi";
+  };
+
+  meta = with pkgs.stdenv.lib; {
+    homepage = "http://sqlmap.org";
+    license = licenses.gpl2;
+    description = "Automatic SQL injection and database takeover tool";
+    maintainers = with stdenv.lib.maintainers; [ bennofs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4281,6 +4281,8 @@ with pkgs;
 
   sqliteman = callPackage ../applications/misc/sqliteman { };
 
+  sqlmap = callPackage ../applications/misc/sqlmap { };
+
   stdman = callPackage ../data/documentation/stdman { };
 
   storebrowse = callPackage ../tools/system/storebrowse { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21393,22 +21393,6 @@ in {
     };
   };
 
-  sqlmap = buildPythonPackage {
-    name = "sqlmap-1.0.11";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/sqlmap/sqlmap-1.0.11.tar.gz";
-      sha256 = "1x4amyjqnd9j5g2kp9nvg8pr5sqzbhr8gd0m6d671bshvgj568vr";
-    };
-
-    meta = with pkgs.stdenv.lib; {
-      homepage = "http://sqlmap.org";
-      license = licenses.gpl2;
-      description = "Automatic SQL injection and database takeover tool";
-      maintainers = with stdenv.lib.maintainers; [ bennofs ];
-    };
-  };
-
   pgpdump = self.buildPythonPackage rec {
     name = "pgpdump-1.5";
 


### PR DESCRIPTION
Additionally disable sqlmap for python3 as it is incompatible:
"[CRITICAL] incompatible Python version detected ('3.6.1'). For successfully running sqlmap you'll have to use version 2.6 or 2.7 (visit 'http://www.python.org/download/')"

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

