### PR TITLE
cassandra: clean up installed documentation

### DIFF
--- a/pkgs/servers/nosql/cassandra/generic.nix
+++ b/pkgs/servers/nosql/cassandra/generic.nix
@@ -26,6 +26,21 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir $out
     mv * $out
+
+    # Clean up documentation.
+    mkdir -p $out/share/doc/${name}
+    mv $out/CHANGES.txt \
+       $out/LICENSE.txt \
+       $out/NEWS.txt \
+       $out/NOTICE.txt \
+       $out/javadoc \
+       $out/share/doc/${name}
+
+    if [[ -d $out/doc ]]; then
+      mv "$out/doc/"* $out/share/doc/${name}
+      rmdir $out/doc
+    fi
+
     for cmd in bin/cassandra bin/nodetool bin/sstablekeys \
       bin/sstableloader bin/sstableupgrade \
       tools/bin/cassandra-stress tools/bin/cassandra-stressd \


### PR DESCRIPTION
###### Motivation for this change

To fix #28281 by not having documentation in the root directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).