### PR TITLE
liquibase: clean up installed documentation

### DIFF
--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -35,6 +35,15 @@ stdenv.mkDerivation rec {
       mkdir -p $out/{bin,lib,sdk}
       mv ./* $out/
 
+      # Clean up documentation.
+      mkdir -p $out/share/doc/${name}
+      mv $out/LICENSE.txt \
+         $out/README.txt \
+         $out/share/doc/${name}
+
+      # Remove silly files.
+      rm $out/liquibase.bat $out/liquibase.spec
+
       # we provide our own script
       rm $out/liquibase
 


### PR DESCRIPTION
###### Motivation for this change

To fix #28281 by not having documentation in the root directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).