### PR TITLE
poretools: init at 0.6.0

### DIFF
--- a/pkgs/applications/science/biology/poretools/default.nix
+++ b/pkgs/applications/science/biology/poretools/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, pythonPackages, fetchFromGitHub }:
+
+pythonPackages.buildPythonPackage rec {
+  pname = "poretools";
+  version = "0.6.0";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "arq5x";
+    rev = "e426b1f09e86ac259a00c261c79df91510777407";
+    sha256 = "0bglj833wxpp3cq430p1d3xp085ls221js2y90w7ir2x5ay8l7am";
+  };
+
+  propagatedBuildInputs = [pythonPackages.h5py pythonPackages.matplotlib pythonPackages.seaborn pythonPackages.pandas];
+
+  meta = {
+    description = "a toolkit for working with nanopore sequencing data from Oxford Nanopore";
+    license = stdenv.lib.licenses.mit;
+    homepage = http://poretools.readthedocs.io/en/latest/;
+    maintainers = [stdenv.lib.maintainers.rybern];
+  };
+}

--- a/pkgs/applications/science/biology/poretools/default.nix
+++ b/pkgs/applications/science/biology/poretools/default.nix
@@ -2,7 +2,7 @@
 
 pythonPackages.buildPythonPackage rec {
   pname = "poretools";
-  version = "0.6.0";
+  version = "unstable-2016-07-10";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3827,6 +3827,8 @@ with pkgs;
 
   popfile = callPackage ../tools/text/popfile { };
 
+  poretools = callPackage ../applications/science/biology/poretools { };
+
   postscript-lexmark = callPackage ../misc/drivers/postscript-lexmark { };
 
   povray = callPackage ../tools/graphics/povray { };


### PR DESCRIPTION
###### Motivation for this change
Added poretools, a bioinformatics application for dealing with nanopore sequencing data

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

