### PR TITLE
distrho: unstable-2016-06-26 -> unstable-2017-08-04

### DIFF
--- a/pkgs/applications/audio/distrho/default.nix
+++ b/pkgs/applications/audio/distrho/default.nix
@@ -2,12 +2,12 @@
 , libxslt, lv2, pkgconfig, premake3, xorg, ladspa-sdk }:
 
 stdenv.mkDerivation rec {
-  name = "distrho-ports-unstable-2016-06-26";
+  name = "distrho-ports-unstable-2017-08-04";
 
   src = fetchgit {
     url = "https://github.com/DISTRHO/DISTRHO-Ports.git";
-    rev = "e3969853ec9ba897c50ac060f0167313e2a18b29";
-    sha256 = "0id4p8dlnlv5271yvmyawfr754nzah7xhvjkj633lw5yr3mq707m";
+    rev = "f591a1066cd3929536699bb516caa4b5efd9d025";
+    sha256 = "1qjnmpmwbq2zpwn8v1dmqn3bjp2ykj5p89fkjax7idgpx1cg7pp9";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

the previous version didn't work anymore in NixOS, see:
https://github.com/DISTRHO/DISTRHO-Ports/issues/17

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

