### PR TITLE
ardour: 5.10 -> 5.11

### DIFF
--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -16,7 +16,7 @@ let
   # "git describe" when _not_ on an annotated tag(!): MAJOR.MINOR-REV-HASH.
 
   # Version to build.
-  tag = "5.10";
+  tag = "5.11";
 
 in
 
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = "git://git.ardour.org/ardour/ardour.git";
-    rev = "9c629c0c76808cc3e8f05e43bc760f849566dce6";
-    sha256 = "062igiaaj18kbismrpzbafyq1ryyqj3lh0ajqqs2s8ms675x33sl";
+    rev = "bd40b9132cbac2d2b79ba0ef480bd41d837f8f71";
+    sha256 = "0xxxjg90jzj5cj364mlhk8srkgaghxif2jj1015bra25pffk41ay";
   };
 
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

